### PR TITLE
Added utm filters to analytics (Tinybird) endpoints

### DIFF
--- a/ghost/core/core/server/data/tinybird/endpoints/api_kpis.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_kpis.pipe
@@ -84,6 +84,11 @@ SQL >
                 {% if defined(date_from) %} and toDate(toTimezone(first_pageview, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})) >= {{ Date(date_from) }} {% else %} and toDate(toTimezone(first_pageview, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})) >= timestampAdd(today(), interval -7 day) {% end %}
                 {% if defined(date_to) %} and toDate(toTimezone(first_pageview, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})) <= {{ Date(date_to) }} {% else %} and toDate(toTimezone(first_pageview, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})) <= today() {% end %}
             {% end %}
+            {% if defined(utm_source) %} and utm_source = {{ String(utm_source, description="UTM source to filter on", required=False) }} {% end %}
+            {% if defined(utm_medium) %} and utm_medium = {{ String(utm_medium, description="UTM medium to filter on", required=False) }} {% end %}
+            {% if defined(utm_campaign) %} and utm_campaign = {{ String(utm_campaign, description="UTM campaign to filter on", required=False) }} {% end %}
+            {% if defined(utm_term) %} and utm_term = {{ String(utm_term, description="UTM term to filter on", required=False) }} {% end %}
+            {% if defined(utm_content) %} and utm_content = {{ String(utm_content, description="UTM content to filter on", required=False) }} {% end %}
 
 
 NODE data
@@ -141,6 +146,11 @@ SQL >
                 {% if defined(location) %} and location = {{ String(location, description="Location to filter on", required=False) }} {% end %}
                 {% if defined(pathname) %} and pathname = {{ String(pathname, description="Pathname to filter on", required=False) }} {% end %}
                 {% if defined(post_uuid) %} and post_uuid = {{String(post_uuid, description="Post UUID to filter on", required=False) }} {% end %}
+                {% if defined(utm_source) %} and utm_source = {{ String(utm_source, description="UTM source to filter on", required=False) }} {% end %}
+                {% if defined(utm_medium) %} and utm_medium = {{ String(utm_medium, description="UTM medium to filter on", required=False) }} {% end %}
+                {% if defined(utm_campaign) %} and utm_campaign = {{ String(utm_campaign, description="UTM campaign to filter on", required=False) }} {% end %}
+                {% if defined(utm_term) %} and utm_term = {{ String(utm_term, description="UTM term to filter on", required=False) }} {% end %}
+                {% if defined(utm_content) %} and utm_content = {{ String(utm_content, description="UTM content to filter on", required=False) }} {% end %}
             group by date
             order by date
 

--- a/ghost/core/core/server/data/tinybird/endpoints/api_top_pages.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_top_pages.pipe
@@ -54,6 +54,11 @@ SQL >
                 and (post_type != 'post' or post_type is null)
             {% end %}
         {% end %}
+        {% if defined(utm_source) %} and utm_source = {{ String(utm_source, description="UTM source to filter on", required=False) }} {% end %}
+        {% if defined(utm_medium) %} and utm_medium = {{ String(utm_medium, description="UTM medium to filter on", required=False) }} {% end %}
+        {% if defined(utm_campaign) %} and utm_campaign = {{ String(utm_campaign, description="UTM campaign to filter on", required=False) }} {% end %}
+        {% if defined(utm_term) %} and utm_term = {{ String(utm_term, description="UTM term to filter on", required=False) }} {% end %}
+        {% if defined(utm_content) %} and utm_content = {{ String(utm_content, description="UTM content to filter on", required=False) }} {% end %}
     group by post_uuid, pathname
     order by visits desc
     limit {{ Int32(skip, 0) }},{{ Int32(limit, 50) }}

--- a/ghost/core/core/server/data/tinybird/endpoints/api_top_sources.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_top_sources.pipe
@@ -17,6 +17,11 @@ SQL >
             {% if defined(date_from) %} and toDate(toTimezone(first_pageview, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})) >= {{ Date(date_from) }} {% else %} and toDate(toTimezone(first_pageview, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})) >= timestampAdd(today(), interval -7 day) {% end %}
             {% if defined(date_to) %} and toDate(toTimezone(first_pageview, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})) <= {{ Date(date_to) }} {% else %} and toDate(toTimezone(first_pageview, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})) <= today() {% end %}
         {% end %}
+        {% if defined(utm_source) %} and utm_source = {{ String(utm_source, description="UTM source to filter on", required=False) }} {% end %}
+        {% if defined(utm_medium) %} and utm_medium = {{ String(utm_medium, description="UTM medium to filter on", required=False) }} {% end %}
+        {% if defined(utm_campaign) %} and utm_campaign = {{ String(utm_campaign, description="UTM campaign to filter on", required=False) }} {% end %}
+        {% if defined(utm_term) %} and utm_term = {{ String(utm_term, description="UTM term to filter on", required=False) }} {% end %}
+        {% if defined(utm_content) %} and utm_content = {{ String(utm_content, description="UTM content to filter on", required=False) }} {% end %}
     group by source
     order by visits desc
     limit {{ Int32(skip, 0) }},{{ Int32(limit, 50) }}

--- a/ghost/core/core/server/data/tinybird/tests/api_kpis.yaml
+++ b/ghost/core/core/server/data/tinybird/tests/api_kpis.yaml
@@ -217,3 +217,75 @@
     {"date":"2100-01-01 21:00:00","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
     {"date":"2100-01-01 22:00:00","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
     {"date":"2100-01-01 23:00:00","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+
+- name: Filtered by utm_source - google
+  description: Filtered by utm_source - google
+  parameters: site_uuid=mock_site_uuid&date_from=2100-01-01&date_to=2100-01-07&timezone=Etc/UTC&utm_source=google
+  expected_result: |
+    {"date":"2100-01-01","visits":1,"pageviews":1,"bounce_rate":1,"avg_session_sec":0}
+    {"date":"2100-01-02","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-03","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-04","visits":1,"pageviews":1,"bounce_rate":1,"avg_session_sec":0}
+    {"date":"2100-01-05","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-06","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-07","visits":1,"pageviews":1,"bounce_rate":1,"avg_session_sec":0}
+
+- name: Filtered by utm_medium - social
+  description: Filtered by utm_medium - social
+  parameters: site_uuid=mock_site_uuid&date_from=2100-01-01&date_to=2100-01-07&timezone=Etc/UTC&utm_medium=social
+  expected_result: |
+    {"date":"2100-01-01","visits":1,"pageviews":2,"bounce_rate":0,"avg_session_sec":1111}
+    {"date":"2100-01-02","visits":1,"pageviews":3,"bounce_rate":0,"avg_session_sec":1027}
+    {"date":"2100-01-03","visits":2,"pageviews":5,"bounce_rate":0,"avg_session_sec":3160}
+    {"date":"2100-01-04","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-05","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-06","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-07","visits":1,"pageviews":1,"bounce_rate":1,"avg_session_sec":0}
+
+- name: Filtered by utm_campaign - brand_awareness
+  description: Filtered by utm_campaign - brand_awareness
+  parameters: site_uuid=mock_site_uuid&date_from=2100-01-01&date_to=2100-01-07&timezone=Etc/UTC&utm_campaign=brand_awareness
+  expected_result: |
+    {"date":"2100-01-01","visits":1,"pageviews":2,"bounce_rate":0,"avg_session_sec":1111}
+    {"date":"2100-01-02","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-03","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-04","visits":1,"pageviews":3,"bounce_rate":0,"avg_session_sec":1149}
+    {"date":"2100-01-05","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-06","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-07","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+
+- name: Filtered by utm_term - discount
+  description: Filtered by utm_term - discount
+  parameters: site_uuid=mock_site_uuid&date_from=2100-01-01&date_to=2100-01-07&timezone=Etc/UTC&utm_term=discount
+  expected_result: |
+    {"date":"2100-01-01","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-02","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-03","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-04","visits":1,"pageviews":3,"bounce_rate":0,"avg_session_sec":567}
+    {"date":"2100-01-05","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-06","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-07","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+
+- name: Filtered by utm_content - post_123
+  description: Filtered by utm_content - post_123
+  parameters: site_uuid=mock_site_uuid&date_from=2100-01-01&date_to=2100-01-07&timezone=Etc/UTC&utm_content=post_123
+  expected_result: |
+    {"date":"2100-01-01","visits":1,"pageviews":2,"bounce_rate":0,"avg_session_sec":1111}
+    {"date":"2100-01-02","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-03","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-04","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-05","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-06","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-07","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+
+- name: Test with multiple UTM filters combined
+  description: Test with multiple UTM filters combined
+  parameters: site_uuid=mock_site_uuid&date_from=2100-01-01&date_to=2100-01-07&timezone=Etc/UTC&utm_source=google&utm_medium=cpc
+  expected_result: |
+    {"date":"2100-01-01","visits":1,"pageviews":1,"bounce_rate":1,"avg_session_sec":0}
+    {"date":"2100-01-02","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-03","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-04","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-05","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-06","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-07","visits":1,"pageviews":1,"bounce_rate":1,"avg_session_sec":0}

--- a/ghost/core/core/server/data/tinybird/tests/api_top_pages.yaml
+++ b/ghost/core/core/server/data/tinybird/tests/api_top_pages.yaml
@@ -110,3 +110,43 @@
   expected_result: |
     {"post_uuid":"06b1b0c9-fb53-4a15-a060-3db3fde7b1fc","pathname":"\/about\/","visits":8}
     {"post_uuid":"","pathname":"\/","visits":7}
+
+- name: Filtered by utm_source - google
+  description: Filtered by utm_source - google
+  parameters: site_uuid=mock_site_uuid&date_from=2100-01-01&date_to=2100-01-07&timezone=Etc/UTC&utm_source=google
+  expected_result: |
+    {"post_uuid":"6b8635fb-292f-4422-9fe4-d76cfab2ba31","pathname":"\/blog\/hello-world\/","visits":2}
+    {"post_uuid":"06b1b0c9-fb53-4a15-a060-3db3fde7b1dd","pathname":"\/blog\/hello-world\/","visits":1}
+
+- name: Filtered by utm_medium - social
+  description: Filtered by utm_medium - social
+  parameters: site_uuid=mock_site_uuid&date_from=2100-01-01&date_to=2100-01-07&timezone=Etc/UTC&utm_medium=social
+  expected_result: |
+    {"post_uuid":"06b1b0c9-fb53-4a15-a060-3db3fde7b1fc","pathname":"\/about\/","visits":3}
+    {"post_uuid":"","pathname":"\/","visits":2}
+
+- name: Filtered by utm_campaign - brand_awareness
+  description: Filtered by utm_campaign - brand_awareness
+  parameters: site_uuid=mock_site_uuid&date_from=2100-01-01&date_to=2100-01-07&timezone=Etc/UTC&utm_campaign=brand_awareness
+  expected_result: |
+    {"post_uuid":"","pathname":"\/","visits":1}
+    {"post_uuid":"6b8635fb-292f-4422-9fe4-d76cfab2ba31","pathname":"\/blog\/hello-world\/","visits":1}
+
+- name: Filtered by utm_term - discount
+  description: Filtered by utm_term - discount
+  parameters: site_uuid=mock_site_uuid&date_from=2100-01-01&date_to=2100-01-07&timezone=Etc/UTC&utm_term=discount
+  expected_result: |
+    {"post_uuid":"6b8635fb-292f-4422-9fe4-d76cfab2ba31","pathname":"\/blog\/hello-world\/","visits":1}
+
+- name: Filtered by utm_content - post_123
+  description: Filtered by utm_content - post_123
+  parameters: site_uuid=mock_site_uuid&date_from=2100-01-01&date_to=2100-01-07&timezone=Etc/UTC&utm_content=post_123
+  expected_result: |
+    {"post_uuid":"","pathname":"\/","visits":1}
+
+- name: Test with multiple UTM filters combined
+  description: Test with multiple UTM filters combined
+  parameters: site_uuid=mock_site_uuid&date_from=2100-01-01&date_to=2100-01-07&timezone=Etc/UTC&utm_source=google&utm_medium=cpc
+  expected_result: |
+    {"post_uuid":"6b8635fb-292f-4422-9fe4-d76cfab2ba31","pathname":"\/blog\/hello-world\/","visits":1}
+    {"post_uuid":"06b1b0c9-fb53-4a15-a060-3db3fde7b1dd","pathname":"\/blog\/hello-world\/","visits":1}

--- a/ghost/core/core/server/data/tinybird/tests/api_top_sources.yaml
+++ b/ghost/core/core/server/data/tinybird/tests/api_top_sources.yaml
@@ -125,3 +125,46 @@
     {"source":"wilted-tick.com","visits":1}
     {"source":"duckduckgo.com","visits":1}
     {"source":"my-ghost-site.com","visits":1}
+
+- name: Filtered by utm_source - google
+  description: Filtered by utm_source - google
+  parameters: site_uuid=mock_site_uuid&date_from=2100-01-01&date_to=2100-01-07&timezone=Etc/UTC&utm_source=google
+  expected_result: |
+    {"source":"","visits":1}
+    {"source":"petty-queen.com","visits":1}
+    {"source":"my-ghost-site.com","visits":1}
+
+- name: Filtered by utm_medium - social
+  description: Filtered by utm_medium - social
+  parameters: site_uuid=mock_site_uuid&date_from=2100-01-01&date_to=2100-01-07&timezone=Etc/UTC&utm_medium=social
+  expected_result: |
+    {"source":"","visits":1}
+    {"source":"bing.com","visits":1}
+    {"source":"google.com","visits":1}
+    {"source":"wilted-tick.com","visits":1}
+    {"source":"duckduckgo.com","visits":1}
+
+- name: Filtered by utm_campaign - brand_awareness
+  description: Filtered by utm_campaign - brand_awareness
+  parameters: site_uuid=mock_site_uuid&date_from=2100-01-01&date_to=2100-01-07&timezone=Etc/UTC&utm_campaign=brand_awareness
+  expected_result: |
+    {"source":"","visits":2}
+
+- name: Filtered by utm_term - discount
+  description: Filtered by utm_term - discount
+  parameters: site_uuid=mock_site_uuid&date_from=2100-01-01&date_to=2100-01-07&timezone=Etc/UTC&utm_term=discount
+  expected_result: |
+    {"source":"","visits":1}
+
+- name: Filtered by utm_content - post_123
+  description: Filtered by utm_content - post_123
+  parameters: site_uuid=mock_site_uuid&date_from=2100-01-01&date_to=2100-01-07&timezone=Etc/UTC&utm_content=post_123
+  expected_result: |
+    {"source":"","visits":1}
+
+- name: Test with multiple UTM filters combined
+  description: Test with multiple UTM filters combined
+  parameters: site_uuid=mock_site_uuid&date_from=2100-01-01&date_to=2100-01-07&timezone=Etc/UTC&utm_source=google&utm_medium=cpc
+  expected_result: |
+    {"source":"petty-queen.com","visits":1}
+    {"source":"my-ghost-site.com","visits":1}


### PR DESCRIPTION
ref https://linear.app/ghost/issue/NY-737/
- added utm fields as conditional filters to pipes available on the Web tabs
- updated tests

As we explore the `utm_{param}` data, it's become more apparent that we need a different way to display and drill down into the data. To that end, we're adding filters we can apply in the UI to the existing views on the Web tab.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds optional UTM filters to `api_kpis`, `api_top_pages`, and `api_top_sources`, and updates tests to cover them, including combined cases.
> 
> - **Tinybird endpoints**:
>   - `endpoints/api_kpis.pipe`: Add conditional filters for `utm_source`, `utm_medium`, `utm_campaign`, `utm_term`, `utm_content` in `session_metrics` and `pathname_pageviews` queries.
>   - `endpoints/api_top_pages.pipe`: Add the same UTM filters to the top pages query.
>   - `endpoints/api_top_sources.pipe`: Add the same UTM filters to the top sources query.
> - **Tests**:
>   - Update `tests/api_kpis.yaml`, `tests/api_top_pages.yaml`, and `tests/api_top_sources.yaml` with cases for each UTM filter and combined UTM filters.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ae2fa259cebe38f5072ebaf85b5cbc3cb4f6d520. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->