### PR TITLE
Fixed email preview limiter to use a single limit site-wide

### DIFF
--- a/ghost/core/core/server/web/shared/middleware/brute.js
+++ b/ghost/core/core/server/web/shared/middleware/brute.js
@@ -170,7 +170,7 @@ module.exports = {
 
     previewEmailLimiter(req, res, next) {
         return spamPrevention.emailPreviewBlock().getMiddleware({
-            ignoreIP: false,
+            ignoreIP: true,
             key(_req, _res, _next) {
                 return _next('preview_email_blocked');
             }

--- a/ghost/core/core/server/web/shared/middleware/brute.js
+++ b/ghost/core/core/server/web/shared/middleware/brute.js
@@ -170,7 +170,7 @@ module.exports = {
 
     previewEmailLimiter(req, res, next) {
         return spamPrevention.emailPreviewBlock().getMiddleware({
-            ignoreIP: true,
+            ignoreIP: false,
             key(_req, _res, _next) {
                 return _next('preview_email_blocked');
             }


### PR DESCRIPTION
no issue

There is a limit on the number of preview emails a Ghost instance can send per hour to prevent abuse, but it is currently enforced per IP address. This changes the limit to be effectively site-wide, regardless of IP address.