### PR TITLE
Changed logging to support custom filenames for file based logging

### DIFF
--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -102,7 +102,7 @@
     "@tryghost/kg-markdown-html-renderer": "7.1.3",
     "@tryghost/kg-mobiledoc-html-renderer": "7.1.3",
     "@tryghost/limit-service": "1.4.1",
-    "@tryghost/logging": "2.4.23",
+    "@tryghost/logging": "2.5.0",
     "@tryghost/members-csv": "2.0.3",
     "@tryghost/metrics": "1.0.38",
     "@tryghost/mw-error-handler": "1.0.7",
@@ -270,7 +270,7 @@
   },
   "resolutions": {
     "@tryghost/errors": "1.3.8",
-    "@tryghost/logging": "2.4.23",
+    "@tryghost/logging": "2.5.0",
     "jackspeak": "2.3.6",
     "moment": "2.24.0",
     "moment-timezone": "0.5.45"

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   },
   "resolutions": {
     "@tryghost/errors": "^1.3.7",
-    "@tryghost/logging": "2.4.23",
+    "@tryghost/logging": "2.5.0",
     "jackspeak": "2.3.6",
     "moment": "2.24.0",
     "moment-timezone": "0.5.45",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9203,10 +9203,10 @@
     lodash "^4.17.21"
     luxon "^1.26.0"
 
-"@tryghost/logging@2.4.19", "@tryghost/logging@2.4.23", "@tryghost/logging@^2.4.23", "@tryghost/logging@^2.4.7":
-  version "2.4.23"
-  resolved "https://registry.yarnpkg.com/@tryghost/logging/-/logging-2.4.23.tgz#a2351b55c0d413e3f06ee41cbcfe7bbdff785972"
-  integrity sha512-xmindrXwW0zKvuxdTNkyK3TM1exPvgkqqSRXOdf8G1SDZpuvemWGlrllAFQuj2J/K4dy9CWcYl9GpM1wYaG1CQ==
+"@tryghost/logging@2.4.19", "@tryghost/logging@2.4.23", "@tryghost/logging@2.5.0", "@tryghost/logging@^2.4.23", "@tryghost/logging@^2.4.7":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@tryghost/logging/-/logging-2.5.0.tgz#239fc3518cba48ff18794dfa24be44c5d2ba7a45"
+  integrity sha512-fLPWNbghbdsUIH/7+CPmhT8l1MhZPI6za1Zm65rcwjGpaX+1Cr1ehcj22rMm91sl4A8AVe8vpYofRKM3UL8GIQ==
   dependencies:
     "@tryghost/bunyan-rotating-filestream" "^0.0.7"
     "@tryghost/elasticsearch" "^3.0.24"


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PRO-1533

- Currently when a Ghost site changes its domain the log file changes along with it
- When sites change their domains frequently (eg staging -> shared domain -> custom domain) this results in 6 separate log files in a short span of time
- On small deployments this is fine but when you in the hundreds this is a large amount of log files that aren't required
- This change will let us use something like `{env}` as we have sparate log dirs at another level
