### PR TITLE
Fixed external link href in React sidebar

### DIFF
--- a/apps/admin/src/layout/app-sidebar/NavMenuItem.tsx
+++ b/apps/admin/src/layout/app-sidebar/NavMenuItem.tsx
@@ -44,7 +44,7 @@ function NavMenuLink({
             isActive={isActive}
             {...props}>
             <a
-                href={href}
+                href={target === '_blank' ? to : href}
                 rel={target === '_blank' ? rel ?? 'noopener noreferrer' : rel}
                 target={target}
                 aria-current={isActive ? 'page' : undefined}


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-2913/port-sidebar

- External links in the navigation (like "Help") had the app path prefix which resulted in trying to open them inside the Admin. This ended up as a 404 for all these nav items

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes sidebar link href so external links (opened with target "_blank") use the raw `to` URL instead of the app-prefixed hash route.
> 
> - **Sidebar navigation**:
>   - In `apps/admin/src/layout/app-sidebar/NavMenuItem.tsx`, set `<a href>` to `to` when `target === '_blank'`, otherwise use internal `href` (`#/${to}`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a61f918dd34707ff1a4cae3a1f3b6835d37ade87. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->