### PR TITLE
Added email analytics for the fallback domain

### DIFF
--- a/ghost/core/core/server/services/email-analytics/EmailAnalyticsProviderMailgun.js
+++ b/ghost/core/core/server/services/email-analytics/EmailAnalyticsProviderMailgun.js
@@ -7,8 +7,8 @@ const DEFAULT_TAGS = ['bulk-email'];
 class EmailAnalyticsProviderMailgun {
     mailgunClient;
 
-    constructor({config, settings}) {
-        this.mailgunClient = new MailgunClient({config, settings});
+    constructor({config, settings, labs}) {
+        this.mailgunClient = new MailgunClient({config, settings, labs});
         this.tags = [...DEFAULT_TAGS];
 
         if (config.get('bulkEmail:mailgun:tag')) {

--- a/ghost/core/core/server/services/email-analytics/EmailAnalyticsServiceWrapper.js
+++ b/ghost/core/core/server/services/email-analytics/EmailAnalyticsServiceWrapper.js
@@ -16,6 +16,7 @@ class EmailAnalyticsServiceWrapper {
         const StartEmailAnalyticsJobEvent = require('./events/StartEmailAnalyticsJobEvent');
         const domainEvents = require('@tryghost/domain-events');
         const settings = require('../../../shared/settings-cache');
+        const labs = require('../../../shared/labs');
         const db = require('../../data/db');
         const queries = require('./lib/queries');
         const membersService = require('../members');
@@ -49,7 +50,7 @@ class EmailAnalyticsServiceWrapper {
             settings,
             eventProcessor,
             providers: [
-                new MailgunProvider({config, settings})
+                new MailgunProvider({config, settings, labs})
             ],
             queries,
             domainEvents,

--- a/ghost/core/core/server/services/email-service/EmailServiceWrapper.js
+++ b/ghost/core/core/server/services/email-service/EmailServiceWrapper.js
@@ -56,7 +56,7 @@ class EmailServiceWrapper {
 
         // Mailgun client instance for email provider
         const mailgunClient = new MailgunClient({
-            config: configService, settings: settingsCache
+            config: configService, settings: settingsCache, labs
         });
         const i18nLanguage = labs.isSet('i18n') ? settingsCache.get('locale') || 'en' : 'en';
         const i18n = i18nLib(i18nLanguage, 'ghost');

--- a/ghost/core/core/server/services/email-suppression-list/service.js
+++ b/ghost/core/core/server/services/email-suppression-list/service.js
@@ -1,12 +1,14 @@
 const models = require('../../models');
 const configService = require('../../../shared/config');
 const settingsCache = require('../../../shared/settings-cache');
+const labs = require('../../../shared/labs');
 const MailgunClient = require('../lib/MailgunClient');
 const MailgunEmailSuppressionList = require('./MailgunEmailSuppressionList');
 
 const mailgunClient = new MailgunClient({
     config: configService,
-    settings: settingsCache
+    settings: settingsCache,
+    labs
 });
 
 module.exports = new MailgunEmailSuppressionList({

--- a/ghost/core/core/server/services/lib/MailgunClient.js
+++ b/ghost/core/core/server/services/lib/MailgunClient.js
@@ -126,14 +126,14 @@ module.exports = class MailgunClient {
     }
 
     /**
-     * @param {import('mailgun.js').default} mailgunInstance
-     * @param {Object} mailgunConfig
+     * @param {import('mailgun.js').Interfaces.IMailgunClient} mailgunInstance
+     * @param {string} domain - The Mailgun domain to fetch events from
      * @param {Object} mailgunOptions
      */
-    async getEventsFromMailgun(mailgunInstance, mailgunConfig, mailgunOptions) {
+    async getEventsFromMailgun(mailgunInstance, domain, mailgunOptions) {
         const startTime = Date.now();
         try {
-            const page = await mailgunInstance.events.get(mailgunConfig.domain, mailgunOptions);
+            const page = await mailgunInstance.events.get(domain, mailgunOptions);
             metrics.metric('mailgun-get-events', {
                 value: Date.now() - startTime,
                 statusCode: 200
@@ -153,7 +153,7 @@ module.exports = class MailgunClient {
      * @param {Object} mailgunOptions
      * @param {Function} batchHandler
      * @param {Object} options
-     * @param {Number} options.maxEvents Not a strict maximum. We stop fetching after we reached the maximum AND received at least one event after begin (not equal) to prevent deadlocks.
+     * @param {number} [options.maxEvents] Not a strict maximum. We stop fetching after we reached the maximum AND received at least one event after begin (not equal) to prevent deadlocks.
      * @returns {Promise<void>}
      */
     async fetchEvents(mailgunOptions, batchHandler, {maxEvents = Infinity} = {}) {
@@ -163,8 +163,55 @@ module.exports = class MailgunClient {
             return;
         }
 
-        debug(`[MailgunClient fetchEvents]: starting fetching first events page`);
         const mailgunConfig = this.#getConfig();
+        if (!mailgunConfig) {
+            logging.warn(`Mailgun is not configured`);
+            return;
+        }
+
+        // Determine which domains to fetch from
+        const domains = this.#getDomainsToFetch(mailgunConfig);
+
+        // Fetch events from each domain
+        for (const domain of domains) {
+            await this.#fetchEventsFromDomain(domain, mailgunInstance, mailgunOptions, batchHandler, {maxEvents});
+        }
+    }
+
+    /**
+     * Get list of domains to fetch events from
+     * Returns primary domain, and fallback domain if domain warming is enabled
+     * @param {Object} mailgunConfig
+     * @returns {string[]}
+     */
+    #getDomainsToFetch(mailgunConfig) {
+        const domains = [mailgunConfig.domain];
+
+        // Check if domain warming is enabled
+        const fallbackDomain = this.#config.get('hostSettings:managedEmail:fallbackDomain');
+        if (fallbackDomain && fallbackDomain !== mailgunConfig.domain) {
+            const labs = require('../../../shared/labs');
+            if (labs.isSet('domainWarming')) {
+                domains.push(fallbackDomain);
+                logging.info(`[MailgunClient] Domain warming enabled, fetching from both primary (${mailgunConfig.domain}) and fallback (${fallbackDomain}) domains`);
+            }
+        }
+
+        return domains;
+    }
+
+    /**
+     * Fetches events from a specific Mailgun domain
+     * @param {string} domain - The domain to fetch from
+     * @param {import('mailgun.js').Interfaces.IMailgunClient} mailgunInstance
+     * @param {Object} mailgunOptions
+     * @param {Function} batchHandler
+     * @param {Object} options
+     * @param {Number} options.maxEvents
+     * @returns {Promise<void>}
+     */
+    async #fetchEventsFromDomain(domain, mailgunInstance, mailgunOptions, batchHandler, {maxEvents}) {
+        debug(`[MailgunClient fetchEventsFromDomain]: starting fetching from domain ${domain}`);
         const startDate = new Date();
         const overallStartTime = Date.now();
 
@@ -172,12 +219,12 @@ module.exports = class MailgunClient {
         let totalBatchTime = 0;
 
         try {
-            let page = await this.getEventsFromMailgun(mailgunInstance, mailgunConfig, mailgunOptions);
+            let page = await this.getEventsFromMailgun(mailgunInstance, domain, mailgunOptions);
 
             // By limiting the processed events to ones created before this job started we cancel early ready for the next job run.
             // Avoids chance of events being missed in long job runs due to mailgun's eventual-consistency creating events outside of our 30min sliding re-check window
             let events = (page?.items?.map(this.normalizeEvent) || []).filter(e => !!e && e.timestamp <= startDate);
-            debug(`[MailgunClient fetchEvents]: finished fetching first page with ${events.length} events`);
+            debug(`[MailgunClient fetchEventsFromDomain ${domain}]: finished fetching first page with ${events.length} events`);
 
             let eventCount = 0;
             const beginTimestamp = mailgunOptions.begin ? Math.ceil(mailgunOptions.begin * 1000) : undefined; // ceil here if we have rounding errors
@@ -198,26 +245,24 @@ module.exports = class MailgunClient {
                 }
 
                 const nextPageId = page.pages.next.page;
-                debug(`[MailgunClient fetchEvents]: starting fetching next page ${nextPageId}`);
-                page = await this.getEventsFromMailgun(mailgunInstance, mailgunConfig, {
+                debug(`[MailgunClient fetchEventsFromDomain ${domain}]: starting fetching next page ${nextPageId}`);
+                page = await this.getEventsFromMailgun(mailgunInstance, domain, {
                     page: nextPageId,
                     ...mailgunOptions
                 });
 
                 // We need to cap events at the time we started fetching them (see comment above)
                 events = (page?.items?.map(this.normalizeEvent) || []).filter(e => !!e && e.timestamp <= startDate);
-                debug(`[MailgunClient fetchEvents]: finished fetching next page with ${events.length} events`);
+                debug(`[MailgunClient fetchEventsFromDomain ${domain}]: finished fetching next page with ${events.length} events`);
             }
 
             const overallEndTime = Date.now();
             const totalDuration = overallEndTime - overallStartTime;
             const averageBatchTime = batchCount > 0 ? totalBatchTime / batchCount : 0;
 
-            // Only log if we actually processed batches
-            if (batchCount > 0) {
-                logging.info(`[MailgunClient fetchEvents]: Processed ${batchCount} batches in ${(totalDuration / 1000).toFixed(2)}s. Average batch time: ${(averageBatchTime / 1000).toFixed(2)}s`);
-            }
+            logging.info(`[MailgunClient fetchEventsFromDomain ${domain}]: Processed ${batchCount} batches in ${(totalDuration / 1000).toFixed(2)}s. Average batch time: ${(averageBatchTime / 1000).toFixed(2)}s`);
         } catch (error) {
+            logging.error(`[MailgunClient fetchEventsFromDomain ${domain}]: Error fetching events`);
             logging.error(error);
             throw error;
         }
@@ -309,7 +354,7 @@ module.exports = class MailgunClient {
      * Note: if the credentials are not configure, this method returns `null` and it is down to the
      * consumer to act upon this/log this out
      *
-     * @returns {import('mailgun.js')|null} the Mailgun client instance
+     * @returns {import('mailgun.js').Interfaces.IMailgunClient|null} the Mailgun client instance
      */
     getInstance() {
         const mailgunConfig = this.#getConfig();
@@ -318,7 +363,7 @@ module.exports = class MailgunClient {
         }
 
         const formData = require('form-data');
-        const Mailgun = require('mailgun.js');
+        const Mailgun = require('mailgun.js').default;
 
         const baseUrl = new URL(mailgunConfig.baseUrl);
         const mailgun = new Mailgun(formData);

--- a/ghost/core/core/server/services/lib/MailgunClient.js
+++ b/ghost/core/core/server/services/lib/MailgunClient.js
@@ -7,12 +7,14 @@ const errors = require('@tryghost/errors');
 module.exports = class MailgunClient {
     #config;
     #settings;
+    #labs;
 
     static DEFAULT_BATCH_SIZE = 1000;
 
-    constructor({config, settings}) {
+    constructor({config, settings, labs}) {
         this.#config = config;
         this.#settings = settings;
+        this.#labs = labs;
     }
 
     /**
@@ -188,10 +190,9 @@ module.exports = class MailgunClient {
         const domains = [mailgunConfig.domain];
 
         // Check if domain warming is enabled
-        const fallbackDomain = this.#config.get('hostSettings:managedEmail:fallbackDomain');
-        if (fallbackDomain && fallbackDomain !== mailgunConfig.domain) {
-            const labs = require('../../../shared/labs');
-            if (labs.isSet('domainWarming')) {
+        if (this.#labs.isSet('domainWarmup')) {
+            const fallbackDomain = this.#config.get('hostSettings:managedEmail:fallbackDomain');
+            if (fallbackDomain && fallbackDomain !== mailgunConfig.domain) {
                 domains.push(fallbackDomain);
                 logging.info(`[MailgunClient] Domain warming enabled, fetching from both primary (${mailgunConfig.domain}) and fallback (${fallbackDomain}) domains`);
             }

--- a/ghost/core/test/unit/server/services/lib/mailgun-client.test.js
+++ b/ghost/core/test/unit/server/services/lib/mailgun-client.test.js
@@ -31,12 +31,13 @@ const createBatchCounter = (customHandler) => {
 };
 
 describe('MailgunClient', function () {
-    let config, settings;
+    let config, settings, labs;
 
     beforeEach(function () {
         // options objects that can be stubbed or spied
         config = {get() {}};
         settings = {get() {}};
+        labs = {isSet() {}};
     });
 
     afterEach(function () {
@@ -54,7 +55,7 @@ describe('MailgunClient', function () {
             batchSize: 1000
         });
 
-        const mailgunClient = new MailgunClient({config, settings});
+        const mailgunClient = new MailgunClient({config, settings, labs});
         assert(typeof mailgunClient.getBatchSize() === 'number');
     });
 
@@ -70,7 +71,7 @@ describe('MailgunClient', function () {
             targetDeliveryWindow: 300
         });
 
-        const mailgunClient = new MailgunClient({config, settings});
+        const mailgunClient = new MailgunClient({config, settings, labs});
         assert.equal(mailgunClient.getTargetDeliveryWindow(), 300);
     });
 
@@ -85,7 +86,7 @@ describe('MailgunClient', function () {
             batchSize: 1000
         });
 
-        const mailgunClient = new MailgunClient({config, settings});
+        const mailgunClient = new MailgunClient({config, settings, labs});
         assert.equal(mailgunClient.getTargetDeliveryWindow(), 0);
     });
 
@@ -100,7 +101,7 @@ describe('MailgunClient', function () {
             batchSize: 1000,
             targetDeliveryWindow: 'invalid'
         });
-        const mailgunClient = new MailgunClient({config, settings});
+        const mailgunClient = new MailgunClient({config, settings, labs});
         assert.equal(mailgunClient.getTargetDeliveryWindow(), 0);
     });
 
@@ -115,7 +116,7 @@ describe('MailgunClient', function () {
             batchSize: 1000,
             targetDeliveryWindow: -3000
         });
-        const mailgunClient = new MailgunClient({config, settings});
+        const mailgunClient = new MailgunClient({config, settings, labs});
         assert.equal(mailgunClient.getTargetDeliveryWindow(), 0);
     });
 
@@ -130,7 +131,7 @@ describe('MailgunClient', function () {
             batchSize: 1000
         });
 
-        const mailgunClient = new MailgunClient({config, settings});
+        const mailgunClient = new MailgunClient({config, settings, labs});
         assert.equal(mailgunClient.isConfigured(), true);
     });
 
@@ -140,12 +141,12 @@ describe('MailgunClient', function () {
         settingsStub.withArgs('mailgun_domain').returns('settingsdomain.com');
         settingsStub.withArgs('mailgun_base_url').returns('https://example.com/v3');
 
-        const mailgunClient = new MailgunClient({config, settings});
+        const mailgunClient = new MailgunClient({config, settings, labs});
         assert.equal(mailgunClient.isConfigured(), true);
     });
 
     it('cannot configure Mailgun if config/settings missing', function () {
-        const mailgunClient = new MailgunClient({config, settings});
+        const mailgunClient = new MailgunClient({config, settings, labs});
         assert.equal(mailgunClient.isConfigured(), false);
     });
 
@@ -162,7 +163,7 @@ describe('MailgunClient', function () {
                 'Content-Type': 'application/json'
             });
 
-        const mailgunClient = new MailgunClient({config, settings});
+        const mailgunClient = new MailgunClient({config, settings, labs});
         await mailgunClient.fetchEvents(MAILGUN_OPTIONS, () => {});
 
         settingsStub.withArgs('mailgun_api_key').returns('settingsApiKey2');
@@ -212,7 +213,7 @@ describe('MailgunClient', function () {
                 'Content-Type': 'application/json'
             });
 
-        const mailgunClient = new MailgunClient({config, settings});
+        const mailgunClient = new MailgunClient({config, settings, labs});
         await mailgunClient.fetchEvents(MAILGUN_OPTIONS, () => {});
 
         assert.equal(configApiMock.isDone(), true);
@@ -221,7 +222,7 @@ describe('MailgunClient', function () {
 
     describe('send()', function () {
         it('does not send if not configured', async function () {
-            const mailgunClient = new MailgunClient({config, settings});
+            const mailgunClient = new MailgunClient({config, settings, labs});
             const response = await mailgunClient.send({}, {}, []);
 
             assert.equal(response, null);
@@ -271,7 +272,7 @@ describe('MailgunClient', function () {
                     'Content-Type': 'application/json'
                 });
 
-            const mailgunClient = new MailgunClient({config, settings});
+            const mailgunClient = new MailgunClient({config, settings, labs});
             const response = await mailgunClient.send(message, recipientData, []);
             assert(response.id === 'message-id');
             assert(sendMock.isDone());
@@ -306,7 +307,7 @@ describe('MailgunClient', function () {
                 }
             };
 
-            const mailgunClient = new MailgunClient({config, settings});
+            const mailgunClient = new MailgunClient({config, settings, labs});
 
             await assert.rejects(mailgunClient.send(message, recipientData, []));
         });
@@ -350,7 +351,7 @@ describe('MailgunClient', function () {
                     'Content-Type': 'application/json'
                 });
 
-            const mailgunClient = new MailgunClient({config, settings});
+            const mailgunClient = new MailgunClient({config, settings, labs});
             const response = await mailgunClient.send(message, recipientData, []);
             assert(response.id === 'message-id');
             assert(sendMock.isDone());
@@ -395,7 +396,7 @@ describe('MailgunClient', function () {
                     'Content-Type': 'application/json'
                 });
 
-            const mailgunClient = new MailgunClient({config, settings});
+            const mailgunClient = new MailgunClient({config, settings, labs});
             const response = await mailgunClient.send(message, recipientData, []);
             assert(response.id === 'message-id');
             assert(sendMock.isDone());
@@ -440,7 +441,7 @@ describe('MailgunClient', function () {
                     'Content-Type': 'application/json'
                 });
 
-            const mailgunClient = new MailgunClient({config, settings});
+            const mailgunClient = new MailgunClient({config, settings, labs});
             const response = await mailgunClient.send(message, recipientData, []);
             assert(response.id === 'message-id');
             assert(sendMock.isDone());
@@ -485,7 +486,7 @@ describe('MailgunClient', function () {
                     'Content-Type': 'application/json'
                 });
 
-            const mailgunClient = new MailgunClient({config, settings});
+            const mailgunClient = new MailgunClient({config, settings, labs});
             const response = await mailgunClient.send(message, recipientData, []);
             assert(response.id === 'message-id');
             assert(sendMock.isDone());
@@ -530,7 +531,7 @@ describe('MailgunClient', function () {
                     'Content-Type': 'application/json'
                 });
 
-            const mailgunClient = new MailgunClient({config, settings});
+            const mailgunClient = new MailgunClient({config, settings, labs});
             const response = await mailgunClient.send(message, recipientData, []);
             assert(response.id === 'message-id');
             assert(sendMock.isDone());
@@ -575,7 +576,7 @@ describe('MailgunClient', function () {
                     'Content-Type': 'application/json'
                 });
 
-            const mailgunClient = new MailgunClient({config, settings});
+            const mailgunClient = new MailgunClient({config, settings, labs});
             const response = await mailgunClient.send(message, recipientData, []);
             assert(response.id === 'message-id');
             assert(sendMock.isDone());
@@ -620,7 +621,7 @@ describe('MailgunClient', function () {
                     'Content-Type': 'application/json'
                 });
 
-            const mailgunClient = new MailgunClient({config, settings});
+            const mailgunClient = new MailgunClient({config, settings, labs});
             const response = await mailgunClient.send(message, recipientData, []);
             assert(response.id === 'message-id');
             assert(sendMock.isDone());
@@ -665,7 +666,7 @@ describe('MailgunClient', function () {
                     'Content-Type': 'application/json'
                 });
 
-            const mailgunClient = new MailgunClient({config, settings});
+            const mailgunClient = new MailgunClient({config, settings, labs});
             const response = await mailgunClient.send(message, recipientData, []);
             assert(response.id === 'message-id');
             assert(sendMock.isDone());
@@ -675,7 +676,7 @@ describe('MailgunClient', function () {
     describe('fetchEvents()', function () {
         it('does not fetch if not configured', async function () {
             const counter = createBatchCounter();
-            const mailgunClient = new MailgunClient({config, settings});
+            const mailgunClient = new MailgunClient({config, settings, labs});
             await mailgunClient.fetchEvents(MAILGUN_OPTIONS, counter.batchHandler);
             assert.equal(counter.events, 0);
             assert.equal(counter.batches, 0);
@@ -716,7 +717,7 @@ describe('MailgunClient', function () {
 
             const counter = createBatchCounter();
 
-            const mailgunClient = new MailgunClient({config, settings});
+            const mailgunClient = new MailgunClient({config, settings, labs});
             await mailgunClient.fetchEvents(MAILGUN_OPTIONS, counter.batchHandler);
 
             assert.equal(firstPageMock.isDone(), true);
@@ -763,7 +764,7 @@ describe('MailgunClient', function () {
 
             const maxEvents = 3;
 
-            const mailgunClient = new MailgunClient({config, settings});
+            const mailgunClient = new MailgunClient({config, settings, labs});
 
             await mailgunClient.fetchEvents(MAILGUN_OPTIONS, counter.batchHandler, {maxEvents});
             assert.equal(counter.batches, 2);
@@ -809,7 +810,7 @@ describe('MailgunClient', function () {
 
             const maxEvents = 3;
 
-            const mailgunClient = new MailgunClient({config, settings});
+            const mailgunClient = new MailgunClient({config, settings, labs});
 
             await mailgunClient.fetchEvents(MAILGUN_OPTIONS, counter.batchHandler, {maxEvents});
             assert.equal(counter.batches, 1);
@@ -855,7 +856,7 @@ describe('MailgunClient', function () {
                 throw new Error('test error');
             });
 
-            const mailgunClient = new MailgunClient({config, settings});
+            const mailgunClient = new MailgunClient({config, settings, labs});
 
             await assert.rejects(mailgunClient.fetchEvents(MAILGUN_OPTIONS, counter.batchHandler), /test error/);
             assert.equal(counter.batches, 1);
@@ -899,7 +900,7 @@ describe('MailgunClient', function () {
 
             const batchHandler = sinon.spy();
 
-            const mailgunClient = new MailgunClient({config, settings});
+            const mailgunClient = new MailgunClient({config, settings, labs});
             await mailgunClient.fetchEvents(MAILGUN_OPTIONS, batchHandler);
 
             assert.equal(firstPageMock.isDone(), true);
@@ -926,7 +927,7 @@ describe('MailgunClient', function () {
                 }
             };
 
-            const mailgunClient = new MailgunClient({config, settings});
+            const mailgunClient = new MailgunClient({config, settings, labs});
             const result = mailgunClient.normalizeEvent(event);
 
             assert.deepEqual(result, {
@@ -988,7 +989,7 @@ describe('MailgunClient', function () {
                 timestamp: 1614275662
             };
 
-            const mailgunClient = new MailgunClient({config, settings});
+            const mailgunClient = new MailgunClient({config, settings, labs});
             const result = mailgunClient.normalizeEvent(event);
 
             assert.deepEqual(result, {
@@ -1060,7 +1061,7 @@ describe('MailgunClient', function () {
                 timestamp: 1614275662
             };
 
-            const mailgunClient = new MailgunClient({config, settings});
+            const mailgunClient = new MailgunClient({config, settings, labs});
             const result = mailgunClient.normalizeEvent(event);
 
             assert.deepEqual(result, {
@@ -1096,10 +1097,9 @@ describe('MailgunClient', function () {
             });
             configStub.withArgs('hostSettings:managedEmail:fallbackDomain').returns(fallbackDomain);
 
-            // Stub the labs module that's required inside the method
-            const labs = require('../../../../../core/shared/labs');
+            // Stub the labs object that's passed to the constructor
             labsStub = sinon.stub(labs, 'isSet');
-            labsStub.withArgs('domainWarming').returns(domainWarmingEnabled);
+            labsStub.withArgs('domainWarmup').returns(domainWarmingEnabled);
 
             return configStub;
         };
@@ -1117,7 +1117,7 @@ describe('MailgunClient', function () {
             nock('https://api.mailgun.net').get('/v3/fallback.com/events/all-2-next').query(MAILGUN_OPTIONS).replyWithFile(200, `${__dirname}/fixtures/empty.json`);
 
             const counter = createBatchCounter();
-            const mailgunClient = new MailgunClient({config, settings});
+            const mailgunClient = new MailgunClient({config, settings, labs});
             await mailgunClient.fetchEvents(MAILGUN_OPTIONS, counter.batchHandler);
 
             assert.equal(primaryMock.isDone(), true);
@@ -1134,7 +1134,7 @@ describe('MailgunClient', function () {
             const fallbackMock = nock('https://api.mailgun.net').get('/v3/fallback.com/events').query(MAILGUN_OPTIONS).replyWithFile(200, `${__dirname}/fixtures/all-2.json`);
 
             const counter = createBatchCounter();
-            await new MailgunClient({config, settings}).fetchEvents(MAILGUN_OPTIONS, counter.batchHandler);
+            await new MailgunClient({config, settings, labs}).fetchEvents(MAILGUN_OPTIONS, counter.batchHandler);
 
             assert.equal(primaryMock.isDone(), true);
             assert.equal(fallbackMock.isDone(), false);
@@ -1148,7 +1148,7 @@ describe('MailgunClient', function () {
             nock('https://api.mailgun.net').get('/v3/primary.com/events/all-1-next').query(MAILGUN_OPTIONS).replyWithFile(200, `${__dirname}/fixtures/empty.json`);
 
             const counter = createBatchCounter();
-            await new MailgunClient({config, settings}).fetchEvents(MAILGUN_OPTIONS, counter.batchHandler);
+            await new MailgunClient({config, settings, labs}).fetchEvents(MAILGUN_OPTIONS, counter.batchHandler);
 
             assert.equal(primaryMock.isDone(), true);
             assert.equal(counter.events, 4);
@@ -1161,7 +1161,7 @@ describe('MailgunClient', function () {
             nock('https://api.mailgun.net').get('/v3/primary.com/events/all-1-next').query(MAILGUN_OPTIONS).replyWithFile(200, `${__dirname}/fixtures/empty.json`);
 
             const counter = createBatchCounter();
-            await new MailgunClient({config, settings}).fetchEvents(MAILGUN_OPTIONS, counter.batchHandler);
+            await new MailgunClient({config, settings, labs}).fetchEvents(MAILGUN_OPTIONS, counter.batchHandler);
 
             assert.equal(primaryMock.isDone(), true);
             assert.equal(counter.events, 4);
@@ -1174,7 +1174,7 @@ describe('MailgunClient', function () {
             const fallbackMock = nock('https://api.mailgun.net').get('/v3/fallback.com/events').query(MAILGUN_OPTIONS).replyWithFile(200, `${__dirname}/fixtures/all-2.json`);
 
             await assert.rejects(
-                new MailgunClient({config, settings}).fetchEvents(MAILGUN_OPTIONS, () => {})
+                new MailgunClient({config, settings, labs}).fetchEvents(MAILGUN_OPTIONS, () => {})
             );
 
             assert.equal(fallbackMock.isDone(), false);
@@ -1190,7 +1190,7 @@ describe('MailgunClient', function () {
             nock('https://api.mailgun.net').get('/v3/fallback.com/events/all-1-next').query(MAILGUN_OPTIONS).replyWithFile(200, `${__dirname}/fixtures/empty.json`);
 
             const counter = createBatchCounter();
-            await new MailgunClient({config, settings}).fetchEvents(MAILGUN_OPTIONS, counter.batchHandler);
+            await new MailgunClient({config, settings, labs}).fetchEvents(MAILGUN_OPTIONS, counter.batchHandler);
 
             assert.equal(counter.batches, 3);
             assert(counter.events >= 8);


### PR DESCRIPTION
closes [GVA-593](https://linear.app/ghost/issue/GVA-593/get-email-analytics-from-both-the-default-sending-domain-the-fallback)

Query both the primary domain and the fallback for email analytics events.