### PR TITLE
Added What's New banner and dialog components

### DIFF
--- a/apps/admin/src/hooks/user-preferences.ts
+++ b/apps/admin/src/hooks/user-preferences.ts
@@ -4,11 +4,7 @@ import { z } from "zod";
 import { useQueryClient } from "@tryghost/admin-x-framework";
 import { useCurrentUser } from "@tryghost/admin-x-framework/api/currentUser";
 import { useEditUser, type User } from "@tryghost/admin-x-framework/api/users";
-
-const isoDatetimeToDate = z.codec(z.iso.datetime(), z.date(), {
-    decode: (isoString) => new Date(isoString),
-    encode: (date) => date.toISOString(),
-});
+import { isoDatetimeToDate } from "@/schemas/primitives";
 
 const WhatsNewPreferencesSchema = z.looseObject({
     lastSeenDate: isoDatetimeToDate.optional().catch(undefined),

--- a/apps/admin/src/layout/app-sidebar/AppSidebarContent.tsx
+++ b/apps/admin/src/layout/app-sidebar/AppSidebarContent.tsx
@@ -2,6 +2,8 @@ import {
     SidebarContent,
 } from "@tryghost/shade"
 
+import WhatsNewBanner from "@/whats-new/components/whats-new-banner";
+
 import NavMain from "./NavMain";
 import NavContent from "./NavContent";
 import NavGhostPro from "./NavGhostPro";
@@ -15,7 +17,10 @@ function AppSidebarContent() {
                 <NavContent />
                 <NavGhostPro />
             </div>
-            <NavSettings className="pb-0" />
+            <div className="flex flex-col gap-2 sidebar:gap-4">
+                <WhatsNewBanner />
+                <NavSettings className="pb-0" />
+            </div>
         </SidebarContent>
     )
 }

--- a/apps/admin/src/layout/app-sidebar/AppSidebarFooter.tsx
+++ b/apps/admin/src/layout/app-sidebar/AppSidebarFooter.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useState } from "react"
 
 import {
     SidebarFooter,
@@ -7,18 +7,26 @@ import {
     SidebarMenuItem
 } from "@tryghost/shade"
 import UserMenu from "./UserMenu";
+import WhatsNewDialog from "@/whats-new/components/whats-new-dialog";
 
 function AppSidebarFooter({ ...props }: React.ComponentProps<typeof SidebarFooter>) {
+    const [isWhatsNewDialogOpen, setIsWhatsNewDialogOpen] = useState(false);
     return (
-        <SidebarFooter {...props}>
-            <SidebarGroup>
-                <SidebarMenu>
-                    <SidebarMenuItem>
-                        <UserMenu />
-                    </SidebarMenuItem>
-                </SidebarMenu>
-            </SidebarGroup>
-        </SidebarFooter>
+        <>
+            <SidebarFooter {...props}>
+                <SidebarGroup>
+                    <SidebarMenu>
+                        <SidebarMenuItem>
+                            <UserMenu onOpenWhatsNew={() => setIsWhatsNewDialogOpen(true)} />
+                        </SidebarMenuItem>
+                    </SidebarMenu>
+                </SidebarGroup>
+            </SidebarFooter>
+            <WhatsNewDialog
+                open={isWhatsNewDialogOpen}
+                onOpenChange={setIsWhatsNewDialogOpen}
+            />
+        </>
     );
 }
 

--- a/apps/admin/src/schemas/primitives.test.ts
+++ b/apps/admin/src/schemas/primitives.test.ts
@@ -1,0 +1,40 @@
+import { describe, test, expect } from "vitest";
+import { isoDatetimeToDate } from "@/schemas/primitives";
+
+describe("isoDatetimeToDate codec", () => {
+    describe("decoding (parsing from API)", () => {
+        test.for([
+            ["UTC offset format (+00:00)", "2025-10-22T15:30:59.000+00:00"],
+            ["Z format", "2025-10-22T15:30:59.000Z"],
+            ["non-UTC timezone offset (-05:00)", "2025-10-22T10:30:59.000-05:00"],
+            ["format without milliseconds", "2025-10-22T15:30:59+00:00"]
+        ])("accepts %s", ([, input]) => {
+            const result = isoDatetimeToDate.parse(input);
+            expect(result.toISOString()).toBe("2025-10-22T15:30:59.000Z");
+        });
+    });
+
+    describe("encoding (sending to API)", () => {
+        test.for([
+            ["UTC offset format (+00:00)", "2025-10-22T15:30:59.000+00:00"],
+            ["Z format", "2025-10-22T15:30:59.000Z"],
+            ["non-UTC timezone offset (-05:00)", "2025-10-22T10:30:59.000-05:00"],
+            ["format without milliseconds", "2025-10-22T15:30:59+00:00"]
+        ])("encodes %s to ISO string", ([, input]) => {
+            const date = new Date(input);
+            const encoded = isoDatetimeToDate.encode(date);
+            expect(encoded).toBe("2025-10-22T15:30:59.000Z");
+        });
+    });
+
+    describe("round-trip", () => {
+        test("can round-trip through parse and encode", () => {
+            const original = "2025-10-22T15:30:59.000+00:00";
+            const decoded = isoDatetimeToDate.decode(original);
+            const encoded = isoDatetimeToDate.encode(decoded);
+
+            // Times should be equivalent even if format differs
+            expect(new Date(encoded).getTime()).toBe(new Date(original).getTime());
+        });
+    });
+});

--- a/apps/admin/src/schemas/primitives.ts
+++ b/apps/admin/src/schemas/primitives.ts
@@ -1,0 +1,53 @@
+import { z } from "zod";
+
+/**
+ * Schema primitives for reusable data type transformations.
+ * These are building blocks that can be composed into domain-specific schemas.
+ */
+
+/**
+ * Codec for ISO 8601 datetime strings with flexible precision and timezone support.
+ *
+ * Ghost's Content API returns dates via moment-timezone's `toISOString(true)`, which preserves
+ * timezone offset instead of normalizing to UTC. Different Ghost instances may return different
+ * offsets based on their timezone configuration.
+ *
+ * Uses `z.iso.datetime({ offset: true })` which is **permissive by default**:
+ * - Accepts arbitrary sub-second precision (no precision, seconds, milliseconds, etc.)
+ * - Accepts timezone offsets when `offset: true` is set
+ * - No `precision` parameter means it accepts all precision levels
+ *
+ * **Accepted formats:**
+ * - `2025-10-22T15:30:59.000+00:00` (milliseconds + offset)
+ * - `2025-10-22T15:30:59+00:00` (seconds + offset)
+ * - `2025-10-22T15:30+00:00` (minutes + offset)
+ * - `2025-10-22T15:30:59.000Z` (milliseconds + UTC)
+ * - `2025-10-22T15:30:59Z` (seconds + UTC)
+ * - Any timezone offset (e.g., `-05:00`, `+05:30`)
+ *
+ * **Encoding:**
+ * Always encodes to standard UTC format: `2025-10-22T15:30:59.000Z`
+ *
+ * This permissive decoding + consistent encoding approach handles dates from multiple sources
+ * (Ghost API, external APIs, user input) while maintaining predictable output.
+ *
+ * @example
+ * ```typescript
+ * const schema = z.object({
+ *   publishedAt: isoDatetimeToDate,
+ * });
+ *
+ * // All formats accepted
+ * schema.parse({ publishedAt: "2025-10-22T15:30:59.000+00:00" });
+ * schema.parse({ publishedAt: "2025-10-22T15:30:59Z" });
+ * schema.parse({ publishedAt: "2025-10-22T15:30+00:00" });
+ * ```
+ */
+export const isoDatetimeToDate = z.codec(
+    z.iso.datetime({ offset: true }),
+    z.date(),
+    {
+        decode: (isoString) => new Date(isoString),
+        encode: (date) => date.toISOString(),
+    }
+);

--- a/apps/admin/src/whats-new/components/changelog-entry.tsx
+++ b/apps/admin/src/whats-new/components/changelog-entry.tsx
@@ -1,0 +1,51 @@
+import type { ChangelogEntry as ChangelogEntryType } from "@/whats-new/hooks/use-changelog";
+
+interface ChangelogEntryProps {
+    entry: ChangelogEntryType;
+}
+
+/**
+ * Format date as "DD MMMM YYYY" (e.g., "29 October 2024")
+ * Matches the format used in Ember: {{moment-format entry.published_at "DD MMMM YYYY"}}
+ */
+function formatPublishedDate(date: Date): string {
+    return date.toLocaleDateString("en-GB", {
+        day: "2-digit",
+        month: "long",
+        year: "numeric",
+    });
+}
+
+function ChangelogEntry({ entry }: ChangelogEntryProps) {
+    return (
+        <a
+            className="flex items-start gap-6 p-2 -mx-2 rounded-md hover:bg-gray-50 transition-colors"
+            data-test-entry
+            href={entry.url}
+            rel="noopener noreferrer"
+            target="_blank"
+        >
+            {entry.featureImage && (
+                <img
+                    alt={entry.title}
+                    className="flex-shrink-0 w-40 h-[110px] object-cover rounded"
+                    data-test-entry-image
+                    src={entry.featureImage}
+                />
+            )}
+            <div className="flex flex-col gap-2 min-w-0 flex-1">
+                <h2 className="text-[17px] font-semibold text-gray-900 mt-1.5" data-test-entry-title>
+                    {entry.title}
+                </h2>
+                <p className="text-sm text-gray-700 leading-[1.45] line-clamp-2" data-test-entry-excerpt>
+                    {entry.customExcerpt}
+                </p>
+                <span className="text-sm text-gray-600" data-test-entry-date>
+                    {formatPublishedDate(entry.publishedAt)}
+                </span>
+            </div>
+        </a>
+    );
+}
+
+export default ChangelogEntry;

--- a/apps/admin/src/whats-new/components/index.ts
+++ b/apps/admin/src/whats-new/components/index.ts
@@ -1,0 +1,3 @@
+export { default as ChangelogEntry } from "./changelog-entry";
+export { default as WhatsNewBanner } from "./whats-new-banner";
+export { default as WhatsNewDialog } from "./whats-new-dialog";

--- a/apps/admin/src/whats-new/components/whats-new-banner.tsx
+++ b/apps/admin/src/whats-new/components/whats-new-banner.tsx
@@ -1,0 +1,62 @@
+import { useState } from "react";
+import { Banner, LucideIcon } from "@tryghost/shade";
+import { useWhatsNew, useDismissWhatsNew } from "@/whats-new/hooks/use-whats-new";
+import { useChangelog } from "@/whats-new/hooks/use-changelog";
+
+function WhatsNewBanner() {
+    const { data: whatsNewData } = useWhatsNew();
+    const { data: changelog } = useChangelog();
+    const { mutate: dismissWhatsNew } = useDismissWhatsNew();
+    const [isDismissed, setIsDismissed] = useState(false);
+
+    // Don't show if dismissed or no featured content
+    if (isDismissed || !whatsNewData?.hasNewFeatured) {
+        return null;
+    }
+
+    const latestEntry = changelog?.entries[0];
+    if (!latestEntry) {
+        return null;
+    }
+
+    const handleDismiss = () => {
+        setIsDismissed(true);
+        dismissWhatsNew();
+    };
+
+    const handleClick = () => {
+        // Mark as seen when navigating to the changelog
+        dismissWhatsNew();
+        // Open the changelog entry in a new tab
+        window.open(latestEntry.url, '_blank', 'noopener,noreferrer');
+    };
+
+    return (
+        <Banner
+            className="cursor-pointer"
+            data-test-toast="whats-new"
+            role="status"
+            aria-label="What's new notification"
+            aria-live="polite"
+            variant="gradient"
+            dismissible
+            onDismiss={handleDismiss}
+            onClick={handleClick}
+        >
+            <div className="pr-8" data-test-toast-link>
+                <div className="flex items-center gap-2 mb-2">
+                    <LucideIcon.Sparkles className="size-4 text-purple-600" />
+                    <span className="text-xs font-semibold text-gray-700 uppercase tracking-wide">What's new?</span>
+                </div>
+                <div className="text-base font-semibold text-gray-900 mb-1" data-test-toast-title>
+                    {latestEntry.title}
+                </div>
+                <div className="text-sm text-gray-700" data-test-toast-excerpt>
+                    {latestEntry.customExcerpt}
+                </div>
+            </div>
+        </Banner>
+    );
+}
+
+export default WhatsNewBanner;

--- a/apps/admin/src/whats-new/components/whats-new-dialog.tsx
+++ b/apps/admin/src/whats-new/components/whats-new-dialog.tsx
@@ -1,0 +1,69 @@
+import { useEffect } from "react";
+import { Button, Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle, LoadingIndicator } from "@tryghost/shade";
+import { useChangelog } from "@/whats-new/hooks/use-changelog";
+import { useDismissWhatsNew } from "@/whats-new/hooks/use-whats-new";
+import ChangelogEntry from "@/whats-new/components/changelog-entry";
+
+interface WhatsNewDialogProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+}
+
+function WhatsNewDialog({ open, onOpenChange }: WhatsNewDialogProps) {
+    const { data: changelog } = useChangelog();
+    const { mutate: dismissWhatsNew } = useDismissWhatsNew();
+
+    // Mark as seen when dialog opens
+    useEffect(() => {
+        if (open) {
+            dismissWhatsNew();
+        }
+    }, [open, dismissWhatsNew]);
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent
+                className="max-w-2xl max-h-[85vh] flex flex-col"
+                data-test-modal="whats-new"
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="whats-new-modal-title"
+            >
+                <DialogHeader>
+                    <DialogTitle id="whats-new-modal-title" data-test-modal-title>
+                        What's new?
+                    </DialogTitle>
+                </DialogHeader>
+
+                {!changelog ? (
+                    <div className="flex-1 flex items-center justify-center py-12">
+                        <LoadingIndicator size="lg" />
+                    </div>
+                ) : (
+                    <>
+                        <section className="flex-1 overflow-y-auto space-y-4 -mx-6 px-6" data-test-entries>
+                            {changelog.entries.map((entry) => (
+                                <ChangelogEntry key={entry.slug} entry={entry} />
+                            ))}
+                        </section>
+
+                        <DialogFooter className="flex-row justify-between sm:justify-between gap-3">
+                            <Button asChild variant="outline">
+                                <a href={`${changelog.changelogUrl}#/portal/signup`} rel="noopener noreferrer" target="_blank">
+                                    Turn on notifications
+                                </a>
+                            </Button>
+                            <Button asChild>
+                                <a href={changelog.changelogUrl} rel="noopener noreferrer" target="_blank">
+                                    All updates →
+                                </a>
+                            </Button>
+                        </DialogFooter>
+                    </>
+                )}
+            </DialogContent>
+        </Dialog>
+    );
+}
+
+export default WhatsNewDialog;

--- a/apps/admin/src/whats-new/hooks/use-changelog.ts
+++ b/apps/admin/src/whats-new/hooks/use-changelog.ts
@@ -1,13 +1,15 @@
 import { useQuery } from "@tanstack/react-query";
 import { z } from "zod";
 
+import { isoDatetimeToDate } from "@/schemas/primitives";
+
 const ChangelogEntrySchema = z
     .looseObject({
         slug: z.string(),
         title: z.string(),
         custom_excerpt: z.string(),
         url: z.string().url(),
-        published_at: z.string().datetime(),
+        published_at: isoDatetimeToDate,
         featured: z.stringbool(),
         feature_image: z.string().url().optional(),
         html: z.string().optional(),
@@ -17,7 +19,7 @@ const ChangelogEntrySchema = z
         title: data.title,
         customExcerpt: data.custom_excerpt,
         url: data.url,
-        publishedAt: new Date(data.published_at),
+        publishedAt: data.published_at,
         featured: data.featured,
         featureImage: data.feature_image,
         html: data.html,

--- a/apps/admin/src/whats-new/hooks/use-whats-new.test.tsx
+++ b/apps/admin/src/whats-new/hooks/use-whats-new.test.tsx
@@ -32,10 +32,10 @@ type SetupMutationTest = (options?: SetupMutationOptions) => ReturnType<typeof s
 
 // Test fixtures
 const dates = {
-    past: "2025-01-01T00:00:00Z",
-    recent: "2025-01-10T00:00:00Z",
-    current: "2025-01-15T10:00:00Z",
-    future: "2025-01-20T10:00:00Z",
+    past: "2025-01-01T00:00:00.000+00:00",
+    recent: "2025-01-10T00:00:00.000+00:00",
+    current: "2025-01-15T10:00:00.000+00:00",
+    future: "2025-01-20T10:00:00.000+00:00",
 };
 
 const fixtures = {

--- a/apps/admin/test-utils/factories/changelog.ts
+++ b/apps/admin/test-utils/factories/changelog.ts
@@ -3,13 +3,16 @@ import type { ChangelogEntry, RawChangelogEntry, RawChangelogResponse } from "@/
 /**
  * Creates a raw changelog entry matching the Ghost API response format.
  * Based on the real Ghost changelog API at https://ghost.org/changelog.json
+ *
+ * Note: Ghost returns dates in ISO 8601 format with timezone offset and milliseconds
+ * (via moment-timezone's toISOString(true)): "2025-01-15T10:00:00.000+00:00"
  */
 export const createRawChangelogEntry = (overrides: Partial<RawChangelogEntry> = {}): RawChangelogEntry => ({
     slug: "test-entry-1",
     title: "Test Entry",
     custom_excerpt: "Test excerpt",
     url: "https://ghost.org/changelog/test-entry-1",
-    published_at: "2025-01-15T10:00:00.000Z",
+    published_at: "2025-01-15T10:00:00.000+00:00",
     featured: "false",
     feature_image: "https://ghost.org/images/test-feature.png",
     html: "<p>Full HTML content here</p>",
@@ -25,7 +28,7 @@ export const createChangelogEntry = (overrides: Partial<ChangelogEntry> = {}): C
     title: "Test Entry",
     customExcerpt: "Test excerpt",
     url: "https://ghost.org/changelog/test-entry-1",
-    publishedAt: new Date("2025-01-15T10:00:00.000Z"),
+    publishedAt: new Date("2025-01-15T10:00:00.000+00:00"),
     featured: false,
     featureImage: "https://ghost.org/images/test-feature.png",
     html: "<p>Full HTML content here</p>",
@@ -59,7 +62,7 @@ export const changelogFixtures = {
             title: "Bug Fix",
             custom_excerpt: "Fixed issue",
             url: "https://ghost.org/changelog/bug-fix-update",
-            published_at: "2025-01-10T10:00:00.000Z",
+            published_at: "2025-01-10T10:00:00.000+00:00",
             featured: "false",
             feature_image: "https://ghost.org/images/bug-fix.png",
             html: "<p>Bug fix details</p>",
@@ -72,7 +75,7 @@ export const changelogFixtures = {
             title: "New Feature",
             customExcerpt: "Description",
             url: "https://ghost.org/changelog/new-feature-2025",
-            publishedAt: new Date("2025-01-15T10:00:00.000Z"),
+            publishedAt: new Date("2025-01-15T10:00:00.000+00:00"),
             featured: true,
             featureImage: "https://ghost.org/images/new-feature.png",
             html: "<p>Exciting new feature details</p>",
@@ -82,7 +85,7 @@ export const changelogFixtures = {
             title: "Bug Fix",
             customExcerpt: "Fixed issue",
             url: "https://ghost.org/changelog/bug-fix-update",
-            publishedAt: new Date("2025-01-10T10:00:00.000Z"),
+            publishedAt: new Date("2025-01-10T10:00:00.000+00:00"),
             featured: false,
             featureImage: "https://ghost.org/images/bug-fix.png",
             html: "<p>Bug fix details</p>",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3013,6 +3013,11 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.57.1.tgz#de633db3ec2ef6a3c89e2f19038063e8a122e2c2"
   integrity sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==
 
+"@eslint/js@9.18.0":
+  version "9.18.0"
+  resolved "https://registry.yarnpkg.com/@eslint/js/-/js-9.18.0.tgz#3356f85d18ed3627ab107790b53caf7e1e3d1e84"
+  integrity sha512-fK6L7rxcq6/z+AaQMtiFTkvbHkBLNlwyRxHpKawP0x3u9+NC6MQTnFW+AdpwC6gfHTW0051cokQgtTN2FqlxQA==
+
 "@eslint/js@9.37.0":
   version "9.37.0"
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-9.37.0.tgz#0cfd5aa763fe5d1ee60bedf84cd14f54bcf9e21b"


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-2610

This PR adds the UI components for the What's New feature to complete the Ember to React migration.

## What

Three new components have been added:

- **WhatsNewBanner** - Shows featured changelog entries in the sidebar using the gradient banner from Shade
- **WhatsNewDialog** - A modal displaying all recent changelog entries with formatting that matches the Ember version
- **UserMenu integration** - Wires up the existing "What's new?" menu item and adds a badge indicator when there's new content

The behaviour matches Ember exactly: clicking the banner opens the changelog URL in a new tab, while the dialog only opens from the user menu. All the E2E test data attributes are in place so existing tests should work.

## Testing

To see the What's New banner and badge, you'll need to set your lastSeenDate back. Paste this into Chrome DevTools console:

```javascript
fetch('/ghost/api/admin/users/me/', {method: 'PUT', headers: {'Content-Type': 'application/json'}, credentials: 'same-origin', body: JSON.stringify({users: [{accessibility: JSON.stringify({whatsNew: {lastSeenDate: new Date(Date.now() - 365 * 24 * 60 * 60 * 1000).toISOString()}})}]})}).then(r => r.json()).then(d => {console.log('Updated:', d); location.reload();})
```

This sets your lastSeenDate to a year ago and reloads the page so you see the banners and badges.