### PR TITLE
Wired up navigation state to user preferences

### DIFF
--- a/apps/admin/src/hooks/user-preferences.test.tsx
+++ b/apps/admin/src/hooks/user-preferences.test.tsx
@@ -218,6 +218,7 @@ describe("useUserPreferences", () => {
             // Should not error - catches and returns undefined for invalid fields
             expect(result.current.isError).toBe(false);
             expect(result.current.data).toEqual({
+                ...fixtures.defaults,
                 whatsNew: {
                     lastSeenDate: undefined,
                 },
@@ -292,7 +293,7 @@ describe("useEditUserPreferences", () => {
                     ...fixtures.defaults,
                     existing: "value",
                     shared: "new",
-                    additional: "data"
+                    additional: "data",
                 });
             });
         });

--- a/apps/admin/src/hooks/user-preferences.test.tsx
+++ b/apps/admin/src/hooks/user-preferences.test.tsx
@@ -1,7 +1,7 @@
 import { test as baseTest, describe, expect } from "vitest";
 import { renderHook, waitFor, act } from "@testing-library/react";
 import type { QueryClient } from "@tanstack/react-query";
-import { useUserPreferences, useEditUserPreferences } from "./user-preferences";
+import { useUserPreferences, useEditUserPreferences, DEFAULT_NAVIGATION_PREFERENCES } from "./user-preferences";
 import { HttpResponse, http } from "msw";
 import { mockUser } from "@test-utils/factories";
 import { waitForQuerySettled } from "@test-utils/test-helpers";
@@ -28,6 +28,9 @@ const fixtures = {
     singlePreference: {
         setting: "value",
     },
+    defaults: {
+        navigation: DEFAULT_NAVIGATION_PREFERENCES,
+    }
 };
 
 // Setup functions
@@ -178,10 +181,10 @@ describe("useUserPreferences", () => {
                 accessibility: "",
             },
         ].forEach(({ scenario, accessibility }) => {
-            queryTest(`returns empty object when accessibility is ${scenario}`, async ({ setup }) => {
+            queryTest(`returns object with defaults when accessibility is ${scenario}`, async ({ setup }) => {
                 const result = await setup({ accessibility });
 
-                expect(result.current.data).toEqual({});
+                expect(result.current.data).toEqual(fixtures.defaults);
             });
         });
 
@@ -190,7 +193,10 @@ describe("useUserPreferences", () => {
                 accessibility: JSON.stringify(fixtures.existingPreferences),
             });
 
-            expect(result.current.data).toEqual(fixtures.existingPreferences);
+            expect(result.current.data).toEqual({
+                ...fixtures.defaults,
+                ...fixtures.existingPreferences,
+            });
         });
 
         queryTest("errors when invalid JSON", async ({ setup }) => {
@@ -251,9 +257,10 @@ describe("useEditUserPreferences", () => {
 
             await waitFor(() => {
                 expect(query.current.data).toEqual({
+                    ...fixtures.defaults,
                     existing: "value",
                     shared: "new",
-                    additional: "data",
+                    additional: "data"
                 });
             });
         });
@@ -266,7 +273,10 @@ describe("useEditUserPreferences", () => {
             });
 
             await waitFor(() => {
-                expect(query.current.data).toEqual(fixtures.singlePreference);
+                expect(query.current.data).toEqual({
+                    ...fixtures.defaults,
+                    ...fixtures.singlePreference,
+                });
             });
         });
 

--- a/apps/admin/src/hooks/user-preferences.test.tsx
+++ b/apps/admin/src/hooks/user-preferences.test.tsx
@@ -242,6 +242,38 @@ describe("useUserPreferences", () => {
             expect(result.current.data).toBeUndefined();
         });
     });
+
+    describe("query options", () => {
+        queryTest("supports select option to transform data", async ({ server, wrapper }) => {
+            server.use(
+                http.get(USERS_API_URL, () => {
+                    return HttpResponse.json({
+                        users: [{
+                            ...mockUser,
+                            accessibility: JSON.stringify({
+                                navigation: {
+                                    expanded: { posts: false },
+                                    menu: { visible: true },
+                                },
+                                nightShift: true,
+                            }),
+                        }],
+                    });
+                })
+            );
+
+            const { result } = renderHook(() => useUserPreferences({
+                select: (data) => data.navigation,
+            }), { wrapper });
+
+            await waitForQuerySettled(result);
+
+            expect(result.current.data).toEqual({
+                expanded: { posts: false },
+                menu: { visible: true },
+            });
+        });
+    });
 });
 
 describe("useEditUserPreferences", () => {

--- a/apps/admin/src/hooks/user-preferences.test.tsx
+++ b/apps/admin/src/hooks/user-preferences.test.tsx
@@ -298,4 +298,34 @@ describe("useEditUserPreferences", () => {
             ).rejects.toThrow("User is not loaded");
         });
     });
+
+    describe("deep merge behavior", () => {
+        editTest("deep merges nested objects while preserving sibling properties", async ({ setup }) => {
+            const { query, mutation } = await setup({
+                accessibility: JSON.stringify({
+                    navigation: {
+                        expanded: { posts: false },
+                        menu: { visible: true },
+                    },
+                    nightShift: true,
+                }),
+            });
+
+            await act(async () => {
+                await mutation.current.mutateAsync({
+                    navigation: { expanded: { posts: true } },
+                });
+            });
+
+            await waitFor(() => {
+                expect(query.current.data).toEqual({
+                    navigation: {
+                        expanded: { posts: true },
+                        menu: { visible: true }, // Preserved
+                    },
+                    nightShift: true, // Preserved
+                });
+            });
+        });
+    });
 });

--- a/apps/admin/src/hooks/user-preferences.ts
+++ b/apps/admin/src/hooks/user-preferences.ts
@@ -61,13 +61,13 @@ export const useUserPreferences = (): UseQueryResult<Preferences> => {
     });
 };
 
-export const useEditUserPreferences = (): UseMutationResult<void, Error, Preferences, unknown> => {
+export const useEditUserPreferences = (): UseMutationResult<void, Error, Partial<Preferences>, unknown> => {
     const queryClient = useQueryClient();
     const { data: user } = useCurrentUser();
     const { mutateAsync: editUser } = useEditUser();
 
     return useMutation({
-        mutationFn: async (updatedPreferences: Preferences) => {
+        mutationFn: async (updatedPreferences: Partial<Preferences>) => {
             if (!user) {
                 throw new Error("User is not loaded");
             }

--- a/apps/admin/src/hooks/user-preferences.ts
+++ b/apps/admin/src/hooks/user-preferences.ts
@@ -18,10 +18,10 @@ const DEFAULT_NAVIGATION_PREFERENCES = {
 const NavigationPreferencesSchema = z.looseObject({
     expanded: z.object({
         posts: z.boolean(),
-    }).catch(DEFAULT_NAVIGATION_PREFERENCES.expanded),
+    }),
     menu: z.object({
         visible: z.boolean(),
-    }).catch(DEFAULT_NAVIGATION_PREFERENCES.menu),
+    }),
 });
 
 const PreferencesSchema = z.looseObject({

--- a/apps/admin/src/hooks/user-preferences.ts
+++ b/apps/admin/src/hooks/user-preferences.ts
@@ -1,4 +1,4 @@
-import { useQuery, useMutation, type UseQueryResult, type UseMutationResult } from "@tanstack/react-query";
+import { useQuery, useMutation, type UseQueryResult, type UseMutationResult, type UseQueryOptions } from "@tanstack/react-query";
 import { z } from "zod";
 import { useQueryClient } from "@tryghost/admin-x-framework";
 import { useCurrentUser } from "@tryghost/admin-x-framework/api/currentUser";
@@ -78,10 +78,13 @@ export type WhatsNewPreferences = z.infer<typeof WhatsNewPreferencesSchema>;
 
 export const userPreferencesQueryKey = (user: User | undefined) => ["userPreferences", user?.id, user?.accessibility] as const;
 
-export const useUserPreferences = (): UseQueryResult<Preferences> => {
+export function useUserPreferences<TData = Preferences>(
+    options?: Omit<UseQueryOptions<Preferences, Error, TData>, 'queryKey' | 'queryFn'>
+): UseQueryResult<TData> {
     const { data: user } = useCurrentUser();
 
-    return useQuery({
+    return useQuery<Preferences, Error, TData>({
+        ...options,
         queryKey: userPreferencesQueryKey(user),
         queryFn: () => {
             if (!user) {
@@ -102,7 +105,7 @@ export const useUserPreferences = (): UseQueryResult<Preferences> => {
         // the current active entry cached indefinitely.
         cacheTime: 0,
     });
-};
+}
 
 export const useEditUserPreferences = (): UseMutationResult<void, Error, DeepPartial<Preferences>, unknown> => {
     const queryClient = useQueryClient();

--- a/apps/admin/src/hooks/user-preferences.ts
+++ b/apps/admin/src/hooks/user-preferences.ts
@@ -1,6 +1,5 @@
 import { useQuery, useMutation, type UseQueryResult, type UseMutationResult } from "@tanstack/react-query";
 import { z } from "zod";
-
 import { useQueryClient } from "@tryghost/admin-x-framework";
 import { useCurrentUser } from "@tryghost/admin-x-framework/api/currentUser";
 import { useEditUser, type User } from "@tryghost/admin-x-framework/api/users";
@@ -29,7 +28,7 @@ export type NavigationPreferences = z.infer<typeof NavigationPreferencesSchema>;
 const PreferencesSchema = z.looseObject({
     whatsNew: WhatsNewPreferencesSchema.optional().catch(undefined),
     nightShift: z.boolean().optional(),
-    navigation: NavigationPreferencesSchema.optional().catch(DEFAULT_NAVIGATION_PREFERENCES),
+    navigation: NavigationPreferencesSchema.default(DEFAULT_NAVIGATION_PREFERENCES).catch(DEFAULT_NAVIGATION_PREFERENCES),
 });
 
 export type Preferences = z.infer<typeof PreferencesSchema>;
@@ -63,13 +62,13 @@ export const useUserPreferences = (): UseQueryResult<Preferences> => {
     });
 };
 
-export const useEditUserPreferences = (): UseMutationResult<void, Error, Preferences, unknown> => {
+export const useEditUserPreferences = (): UseMutationResult<void, Error, Partial<Preferences>, unknown> => {
     const queryClient = useQueryClient();
     const { data: user } = useCurrentUser();
     const { mutateAsync: editUser } = useEditUser();
 
     return useMutation({
-        mutationFn: async (updatedPreferences: Preferences) => {
+        mutationFn: async (updatedPreferences: Partial<Preferences>) => {
             if (!user) {
                 throw new Error("User is not loaded");
             }

--- a/apps/admin/src/hooks/user-preferences.ts
+++ b/apps/admin/src/hooks/user-preferences.ts
@@ -77,8 +77,9 @@ export const useEditUserPreferences = (): UseMutationResult<void, Error, DeepPar
                 throw new Error("User is not loaded");
             }
 
-            const currentPreferences = queryClient.getQueryData<Preferences>(userPreferencesQueryKey(user)) ?? {} as Preferences;
+            const currentPreferences = queryClient.getQueryData<Preferences>(userPreferencesQueryKey(user)) ?? PreferencesSchema.parse({});
 
+            // TODO: use zod to validate?
             const newPreferences = deepMerge(currentPreferences, updatedPreferences);
 
             const encodedForStorage = PreferencesSchema.encode(newPreferences);

--- a/apps/admin/src/hooks/user-preferences.ts
+++ b/apps/admin/src/hooks/user-preferences.ts
@@ -35,7 +35,7 @@ const PreferencesSchema = z.looseObject({
 export type Preferences = z.infer<typeof PreferencesSchema>;
 export type WhatsNewPreferences = z.infer<typeof WhatsNewPreferencesSchema>;
 
-const userPreferencesQueryKey = (user: User | undefined) => ["userPreferences", user?.id, user?.accessibility] as const;
+export const userPreferencesQueryKey = (user: User | undefined) => ["userPreferences", user?.id, user?.accessibility] as const;
 
 export const useUserPreferences = (): UseQueryResult<Preferences> => {
     const { data: user } = useCurrentUser();

--- a/apps/admin/src/hooks/user-preferences.ts
+++ b/apps/admin/src/hooks/user-preferences.ts
@@ -10,12 +10,12 @@ const WhatsNewPreferencesSchema = z.looseObject({
     lastSeenDate: isoDatetimeToDate.optional().catch(undefined),
 });
 
-const DEFAULT_NAVIGATION_PREFERENCES = {
+export const DEFAULT_NAVIGATION_PREFERENCES = {
     expanded: { posts: true },
     menu: { visible: true },
 } as const;
 
-const NavigationPreferencesSchema = z.looseObject({
+export const NavigationPreferencesSchema = z.looseObject({
     expanded: z.object({
         posts: z.boolean(),
     }),
@@ -23,6 +23,8 @@ const NavigationPreferencesSchema = z.looseObject({
         visible: z.boolean(),
     }),
 });
+
+export type NavigationPreferences = z.infer<typeof NavigationPreferencesSchema>;
 
 const PreferencesSchema = z.looseObject({
     whatsNew: WhatsNewPreferencesSchema.optional().catch(undefined),

--- a/apps/admin/src/hooks/user-preferences.ts
+++ b/apps/admin/src/hooks/user-preferences.ts
@@ -15,19 +15,19 @@ const DEFAULT_NAVIGATION_PREFERENCES = {
     menu: { visible: true },
 } as const;
 
-const NavigationPreferencesSchema = z.object({
+const NavigationPreferencesSchema = z.looseObject({
     expanded: z.object({
-        posts: z.boolean().catch(DEFAULT_NAVIGATION_PREFERENCES.expanded.posts),
+        posts: z.boolean(),
     }).catch(DEFAULT_NAVIGATION_PREFERENCES.expanded),
     menu: z.object({
-        visible: z.boolean().catch(DEFAULT_NAVIGATION_PREFERENCES.menu.visible),
+        visible: z.boolean(),
     }).catch(DEFAULT_NAVIGATION_PREFERENCES.menu),
-}).catch(DEFAULT_NAVIGATION_PREFERENCES);
+});
 
 const PreferencesSchema = z.looseObject({
     whatsNew: WhatsNewPreferencesSchema.optional().catch(undefined),
     nightShift: z.boolean().optional(),
-    navigation: NavigationPreferencesSchema,
+    navigation: NavigationPreferencesSchema.optional().catch(DEFAULT_NAVIGATION_PREFERENCES),
 });
 
 export type Preferences = z.infer<typeof PreferencesSchema>;
@@ -61,13 +61,13 @@ export const useUserPreferences = (): UseQueryResult<Preferences> => {
     });
 };
 
-export const useEditUserPreferences = (): UseMutationResult<void, Error, Partial<Preferences>, unknown> => {
+export const useEditUserPreferences = (): UseMutationResult<void, Error, Preferences, unknown> => {
     const queryClient = useQueryClient();
     const { data: user } = useCurrentUser();
     const { mutateAsync: editUser } = useEditUser();
 
     return useMutation({
-        mutationFn: async (updatedPreferences: Partial<Preferences>) => {
+        mutationFn: async (updatedPreferences: Preferences) => {
             if (!user) {
                 throw new Error("User is not loaded");
             }

--- a/apps/admin/src/hooks/user-preferences.ts
+++ b/apps/admin/src/hooks/user-preferences.ts
@@ -4,48 +4,7 @@ import { useQueryClient } from "@tryghost/admin-x-framework";
 import { useCurrentUser } from "@tryghost/admin-x-framework/api/currentUser";
 import { useEditUser, type User } from "@tryghost/admin-x-framework/api/users";
 import { isoDatetimeToDate } from "@/schemas/primitives";
-
-/**
- * Deep partial type that makes all properties optional recursively.
- */
-type DeepPartial<T> = T extends object ? {
-    [P in keyof T]?: DeepPartial<T[P]>;
-} : T;
-
-/**
- * Deep merge utility for preferences objects.
- * Recursively merges nested objects, with values from `source` taking precedence.
- */
-function deepMerge<T extends Record<string, unknown>>(target: T, source: DeepPartial<T>): T {
-    const result: Record<string, unknown> = { ...target };
-
-    for (const key in source) {
-        if (Object.prototype.hasOwnProperty.call(source, key)) {
-            const sourceValue = source[key];
-            const targetValue = target[key];
-
-            if (sourceValue !== undefined) {
-                if (
-                    typeof sourceValue === 'object' &&
-                    sourceValue !== null &&
-                    !Array.isArray(sourceValue) &&
-                    typeof targetValue === 'object' &&
-                    targetValue !== null &&
-                    !Array.isArray(targetValue)
-                ) {
-                    result[key] = deepMerge(
-                        targetValue as Record<string, unknown>,
-                        sourceValue as DeepPartial<Record<string, unknown>>
-                    );
-                } else {
-                    result[key] = sourceValue;
-                }
-            }
-        }
-    }
-
-    return result as T;
-}
+import { deepMerge, type DeepPartial } from "@/utils/deep-merge";
 
 const WhatsNewPreferencesSchema = z.looseObject({
     lastSeenDate: isoDatetimeToDate.optional().catch(undefined),

--- a/apps/admin/src/hooks/user-preferences.ts
+++ b/apps/admin/src/hooks/user-preferences.ts
@@ -10,9 +10,24 @@ const WhatsNewPreferencesSchema = z.looseObject({
     lastSeenDate: isoDatetimeToDate.optional().catch(undefined),
 });
 
+const DEFAULT_NAVIGATION_PREFERENCES = {
+    expanded: { posts: true },
+    menu: { visible: true },
+} as const;
+
+const NavigationPreferencesSchema = z.object({
+    expanded: z.object({
+        posts: z.boolean().catch(DEFAULT_NAVIGATION_PREFERENCES.expanded.posts),
+    }).catch(DEFAULT_NAVIGATION_PREFERENCES.expanded),
+    menu: z.object({
+        visible: z.boolean().catch(DEFAULT_NAVIGATION_PREFERENCES.menu.visible),
+    }).catch(DEFAULT_NAVIGATION_PREFERENCES.menu),
+}).catch(DEFAULT_NAVIGATION_PREFERENCES);
+
 const PreferencesSchema = z.looseObject({
     whatsNew: WhatsNewPreferencesSchema.optional().catch(undefined),
     nightShift: z.boolean().optional(),
+    navigation: NavigationPreferencesSchema,
 });
 
 export type Preferences = z.infer<typeof PreferencesSchema>;

--- a/apps/admin/src/hooks/user-preferences.ts
+++ b/apps/admin/src/hooks/user-preferences.ts
@@ -24,8 +24,6 @@ export const NavigationPreferencesSchema = z.looseObject({
     }),
 });
 
-export type NavigationPreferences = z.infer<typeof NavigationPreferencesSchema>;
-
 const PreferencesSchema = z.looseObject({
     whatsNew: WhatsNewPreferencesSchema.optional().catch(undefined),
     nightShift: z.boolean().optional(),
@@ -34,11 +32,12 @@ const PreferencesSchema = z.looseObject({
 
 export type Preferences = z.infer<typeof PreferencesSchema>;
 export type WhatsNewPreferences = z.infer<typeof WhatsNewPreferencesSchema>;
+export type NavigationPreferences = z.infer<typeof NavigationPreferencesSchema>;
 
-export const userPreferencesQueryKey = (user: User | undefined) => ["userPreferences", user?.id, user?.accessibility] as const;
+const userPreferencesQueryKey = (user: User | undefined) => ["userPreferences", user?.id, user?.accessibility] as const;
 
 export function useUserPreferences<TData = Preferences>(
-    options?: Omit<UseQueryOptions<Preferences, Error, TData>, 'queryKey' | 'queryFn'>
+    options?: Omit<UseQueryOptions<Preferences, Error, TData>, 'queryKey' | 'queryFn' | 'staleTime' | 'cacheTime'>
 ): UseQueryResult<TData> {
     const { data: user } = useCurrentUser();
 

--- a/apps/admin/src/hooks/user-preferences.ts
+++ b/apps/admin/src/hooks/user-preferences.ts
@@ -5,6 +5,48 @@ import { useCurrentUser } from "@tryghost/admin-x-framework/api/currentUser";
 import { useEditUser, type User } from "@tryghost/admin-x-framework/api/users";
 import { isoDatetimeToDate } from "@/schemas/primitives";
 
+/**
+ * Deep partial type that makes all properties optional recursively.
+ */
+type DeepPartial<T> = T extends object ? {
+    [P in keyof T]?: DeepPartial<T[P]>;
+} : T;
+
+/**
+ * Deep merge utility for preferences objects.
+ * Recursively merges nested objects, with values from `source` taking precedence.
+ */
+function deepMerge<T extends Record<string, unknown>>(target: T, source: DeepPartial<T>): T {
+    const result: Record<string, unknown> = { ...target };
+
+    for (const key in source) {
+        if (Object.prototype.hasOwnProperty.call(source, key)) {
+            const sourceValue = source[key];
+            const targetValue = target[key];
+
+            if (sourceValue !== undefined) {
+                if (
+                    typeof sourceValue === 'object' &&
+                    sourceValue !== null &&
+                    !Array.isArray(sourceValue) &&
+                    typeof targetValue === 'object' &&
+                    targetValue !== null &&
+                    !Array.isArray(targetValue)
+                ) {
+                    result[key] = deepMerge(
+                        targetValue as Record<string, unknown>,
+                        sourceValue as DeepPartial<Record<string, unknown>>
+                    );
+                } else {
+                    result[key] = sourceValue;
+                }
+            }
+        }
+    }
+
+    return result as T;
+}
+
 const WhatsNewPreferencesSchema = z.looseObject({
     lastSeenDate: isoDatetimeToDate.optional().catch(undefined),
 });
@@ -62,23 +104,20 @@ export const useUserPreferences = (): UseQueryResult<Preferences> => {
     });
 };
 
-export const useEditUserPreferences = (): UseMutationResult<void, Error, Partial<Preferences>, unknown> => {
+export const useEditUserPreferences = (): UseMutationResult<void, Error, DeepPartial<Preferences>, unknown> => {
     const queryClient = useQueryClient();
     const { data: user } = useCurrentUser();
     const { mutateAsync: editUser } = useEditUser();
 
     return useMutation({
-        mutationFn: async (updatedPreferences: Partial<Preferences>) => {
+        mutationFn: async (updatedPreferences: DeepPartial<Preferences>) => {
             if (!user) {
                 throw new Error("User is not loaded");
             }
 
-            const currentPreferences = queryClient.getQueryData<Preferences>(userPreferencesQueryKey(user)) ?? {};
+            const currentPreferences = queryClient.getQueryData<Preferences>(userPreferencesQueryKey(user)) ?? {} as Preferences;
 
-            const newPreferences: Preferences = {
-                ...currentPreferences,
-                ...updatedPreferences,
-            };
+            const newPreferences = deepMerge(currentPreferences, updatedPreferences);
 
             const encodedForStorage = PreferencesSchema.encode(newPreferences);
 

--- a/apps/admin/src/layout/app-sidebar/NavContent.tsx
+++ b/apps/admin/src/layout/app-sidebar/NavContent.tsx
@@ -13,14 +13,24 @@ import { canManageMembers, canManageTags } from "@tryghost/admin-x-framework/api
 import { NavMenuItem } from "./NavMenuItem";
 import NavSubMenu from "./NavSubMenu";
 import { useMemberCount } from "./hooks/useMemberCount";
+import { useEditNavigationPreferences, useNavigationPreferences } from "./hooks/use-navigation-preferences";
 
 function NavContent({ ...props }: React.ComponentProps<typeof SidebarGroup>) {
     const { data: currentUser } = useCurrentUser();
-    const [postsExpanded, setPostsExpanded] = useState(false);
+    const { data: navigationPreferences } = useNavigationPreferences();
+    const { mutateAsync: editNavigationPreferences } = useEditNavigationPreferences();
     const memberCount = useMemberCount();
 
     const showTags = currentUser && canManageTags(currentUser);
     const showMembers = currentUser && canManageMembers(currentUser);
+
+    const postsExpanded = navigationPreferences?.expanded.posts ?? true;
+
+    const togglePostsExpanded = () => {
+        void editNavigationPreferences({
+            expanded: { posts: !navigationPreferences?.expanded.posts },
+        });
+    };
 
     return (
         <SidebarGroup {...props}>
@@ -35,7 +45,7 @@ function NavContent({ ...props }: React.ComponentProps<typeof SidebarGroup>) {
                             size="icon"
                             className="!h-[34px] absolute sidebar:opacity-0 group-hover/menu-item:opacity-100 focus-visible:opacity-100 transition-all left-3 top-0 p-0 h-9 w-auto text-gray-800 hover:text-gray-black hover:bg-transparent"
                             onClick={() =>
-                                setPostsExpanded(!postsExpanded)
+                                togglePostsExpanded()
                             }
                         >
                             <LucideIcon.ChevronRight

--- a/apps/admin/src/layout/app-sidebar/NavContent.tsx
+++ b/apps/admin/src/layout/app-sidebar/NavContent.tsx
@@ -36,7 +36,7 @@ function NavContent({ ...props }: React.ComponentProps<typeof SidebarGroup>) {
                             size="icon"
                             className="!h-[34px] absolute sidebar:opacity-0 group-hover/menu-item:opacity-100 focus-visible:opacity-100 transition-all left-3 top-0 p-0 h-9 w-auto text-gray-800 hover:text-gray-black hover:bg-transparent"
                             onClick={() =>
-                                setPostsExpanded(!postsExpanded)
+                                void setPostsExpanded(!postsExpanded)
                             }
                         >
                             <LucideIcon.ChevronRight

--- a/apps/admin/src/layout/app-sidebar/NavContent.tsx
+++ b/apps/admin/src/layout/app-sidebar/NavContent.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react"
+import React from "react"
 
 import {
     Button,
@@ -13,24 +13,15 @@ import { canManageMembers, canManageTags } from "@tryghost/admin-x-framework/api
 import { NavMenuItem } from "./NavMenuItem";
 import NavSubMenu from "./NavSubMenu";
 import { useMemberCount } from "./hooks/useMemberCount";
-import { useEditNavigationPreferences, useNavigationPreferences } from "./hooks/use-navigation-preferences";
+import { useNavigationExpanded } from "./hooks/use-navigation-preferences";
 
 function NavContent({ ...props }: React.ComponentProps<typeof SidebarGroup>) {
     const { data: currentUser } = useCurrentUser();
-    const { data: navigationPreferences } = useNavigationPreferences();
-    const { mutateAsync: editNavigationPreferences } = useEditNavigationPreferences();
+    const [postsExpanded, setPostsExpanded] = useNavigationExpanded('posts');
     const memberCount = useMemberCount();
 
     const showTags = currentUser && canManageTags(currentUser);
     const showMembers = currentUser && canManageMembers(currentUser);
-
-    const postsExpanded = navigationPreferences?.expanded.posts ?? true;
-
-    const togglePostsExpanded = () => {
-        void editNavigationPreferences({
-            expanded: { posts: !navigationPreferences?.expanded.posts },
-        });
-    };
 
     return (
         <SidebarGroup {...props}>
@@ -45,7 +36,7 @@ function NavContent({ ...props }: React.ComponentProps<typeof SidebarGroup>) {
                             size="icon"
                             className="!h-[34px] absolute sidebar:opacity-0 group-hover/menu-item:opacity-100 focus-visible:opacity-100 transition-all left-3 top-0 p-0 h-9 w-auto text-gray-800 hover:text-gray-black hover:bg-transparent"
                             onClick={() =>
-                                togglePostsExpanded()
+                                setPostsExpanded(!postsExpanded)
                             }
                         >
                             <LucideIcon.ChevronRight

--- a/apps/admin/src/layout/app-sidebar/hooks/use-navigation-preferences.ts
+++ b/apps/admin/src/layout/app-sidebar/hooks/use-navigation-preferences.ts
@@ -20,13 +20,13 @@ export const useEditNavigationPreferences = (): UseMutationResult<void, Error, P
     });
 };
 
-export const useNavigationExpanded = (expandedKey: keyof NavigationPreferences['expanded']): [boolean, (value: boolean) => void] => {
+export const useNavigationExpanded = (expandedKey: keyof NavigationPreferences['expanded']): [boolean, (value: boolean) => Promise<void>] => {
     const { data: navigationPreferences } = useNavigationPreferences();
     const { mutateAsync: editNavigationPreferences } = useEditNavigationPreferences();
 
     const expanded = navigationPreferences?.expanded[expandedKey];
 
-    const setExpanded = (value: boolean) => {
+    const setExpanded = async (value: boolean) => {
         return editNavigationPreferences({
             expanded: {
                 [expandedKey]: value
@@ -37,13 +37,13 @@ export const useNavigationExpanded = (expandedKey: keyof NavigationPreferences['
     return [expanded ?? true, setExpanded];
 };
 
-export const useNavigationMenuVisibility = (): [boolean, (value: boolean) => void] => {
+export const useNavigationMenuVisibility = (): [boolean, (value: boolean) => Promise<void>] => {
     const { data: navigationPreferences } = useNavigationPreferences();
     const { mutateAsync: editNavigationPreferences } = useEditNavigationPreferences();
 
     const visible = navigationPreferences?.menu.visible;
 
-    const setVisible = (value: boolean) => {
+    const setVisible = async (value: boolean) => {
         return editNavigationPreferences({
             menu: { visible: value },
         });

--- a/apps/admin/src/layout/app-sidebar/hooks/use-navigation-preferences.ts
+++ b/apps/admin/src/layout/app-sidebar/hooks/use-navigation-preferences.ts
@@ -30,6 +30,14 @@ export const useEditNavigationPreferences = (): UseMutationResult<void, Error, P
             const newNavigationPreferences: NavigationPreferences = {
                 ...currentNavigation,
                 ...updatedNavigationPreferences,
+                expanded: {
+                    ...currentNavigation.expanded,
+                    ...updatedNavigationPreferences.expanded,
+                },
+                menu: {
+                    ...currentNavigation.menu,
+                    ...updatedNavigationPreferences.menu,
+                },
             };
 
             await editPreferences({

--- a/apps/admin/src/layout/app-sidebar/hooks/use-navigation-preferences.ts
+++ b/apps/admin/src/layout/app-sidebar/hooks/use-navigation-preferences.ts
@@ -38,3 +38,36 @@ export const useEditNavigationPreferences = (): UseMutationResult<void, Error, P
         },
     });
 };
+
+export const useNavigationExpanded = (expandedKey: keyof NavigationPreferences['expanded']): [boolean, (value: boolean) => void] => {
+    const { data: navigationPreferences } = useNavigationPreferences();
+    const { mutateAsync: editNavigationPreferences } = useEditNavigationPreferences();
+
+    const expanded = navigationPreferences?.expanded[expandedKey] ?? true;
+
+    const setExpanded = (value: boolean) => {
+        void editNavigationPreferences({
+            expanded: {
+                ...(navigationPreferences?.expanded ?? {}),
+                [expandedKey]: value
+            },
+        });
+    };
+
+    return [expanded, setExpanded];
+};
+
+export const useNavigationMenuVisibility = (): [boolean, (value: boolean) => void] => {
+    const { data: navigationPreferences } = useNavigationPreferences();
+    const { mutateAsync: editNavigationPreferences } = useEditNavigationPreferences();
+
+    const visible = navigationPreferences?.menu.visible ?? true;
+
+    const setVisible = (value: boolean) => {
+        void editNavigationPreferences({
+            menu: { visible: value },
+        });
+    };
+
+    return [visible, setVisible];
+};

--- a/apps/admin/src/layout/app-sidebar/hooks/use-navigation-preferences.ts
+++ b/apps/admin/src/layout/app-sidebar/hooks/use-navigation-preferences.ts
@@ -1,0 +1,40 @@
+import { DEFAULT_NAVIGATION_PREFERENCES, useEditUserPreferences, useUserPreferences, type NavigationPreferences } from "@/hooks/user-preferences";
+import { useQuery, useMutation, type UseMutationResult, type UseQueryResult } from "@tanstack/react-query";
+
+
+export const useNavigationPreferences = (): UseQueryResult<NavigationPreferences> => {
+    const preferencesQuery = useUserPreferences();
+
+    return useQuery({
+        queryKey: ['navigationPreferences', preferencesQuery.data],
+        queryFn: () => {
+            if (!preferencesQuery.data) {
+                throw new Error("Preferences not loaded");
+            }
+            return preferencesQuery.data.navigation ?? DEFAULT_NAVIGATION_PREFERENCES;
+        },
+        enabled: !!preferencesQuery.data,
+        staleTime: Infinity,
+        cacheTime: 0,
+    });
+};
+
+export const useEditNavigationPreferences = (): UseMutationResult<void, Error, Partial<NavigationPreferences>, unknown> => {
+    const { data: preferences } = useUserPreferences();
+    const { mutateAsync: editPreferences } = useEditUserPreferences();
+
+    return useMutation({
+        mutationFn: async (updatedNavigationPreferences: Partial<NavigationPreferences>) => {
+            const currentNavigation = preferences?.navigation ?? DEFAULT_NAVIGATION_PREFERENCES;
+
+            const newNavigationPreferences: NavigationPreferences = {
+                ...currentNavigation,
+                ...updatedNavigationPreferences,
+            };
+
+            await editPreferences({
+                navigation: newNavigationPreferences,
+            });
+        },
+    });
+};

--- a/apps/admin/src/layout/app-sidebar/hooks/use-navigation-preferences.ts
+++ b/apps/admin/src/layout/app-sidebar/hooks/use-navigation-preferences.ts
@@ -1,4 +1,4 @@
-import { NavigationPreferencesSchema, useEditUserPreferences, useUserPreferences, type NavigationPreferences } from "@/hooks/user-preferences";
+import { useEditUserPreferences, useUserPreferences, type NavigationPreferences } from "@/hooks/user-preferences";
 import { useQuery, useMutation, type UseMutationResult, type UseQueryResult } from "@tanstack/react-query";
 
 
@@ -20,32 +20,12 @@ export const useNavigationPreferences = (): UseQueryResult<NavigationPreferences
 };
 
 export const useEditNavigationPreferences = (): UseMutationResult<void, Error, Partial<NavigationPreferences>, unknown> => {
-    const { data: preferences } = useUserPreferences();
     const { mutateAsync: editPreferences } = useEditUserPreferences();
 
     return useMutation({
         mutationFn: async (updatedNavigationPreferences: Partial<NavigationPreferences>) => {
-            if (!preferences?.navigation) {
-                throw new Error("Navigation preferences not loaded");
-            }
-
-            const merged = {
-                ...preferences.navigation,
-                ...updatedNavigationPreferences,
-                expanded: {
-                    ...preferences.navigation.expanded,
-                    ...updatedNavigationPreferences.expanded,
-                },
-                menu: {
-                    ...preferences.navigation.menu,
-                    ...updatedNavigationPreferences.menu,
-                },
-            };
-
-            const newNavigationPreferences = NavigationPreferencesSchema.parse(merged);
-
             await editPreferences({
-                navigation: newNavigationPreferences,
+                navigation: updatedNavigationPreferences,
             });
         },
     });

--- a/apps/admin/src/layout/app-sidebar/hooks/use-navigation-preferences.ts
+++ b/apps/admin/src/layout/app-sidebar/hooks/use-navigation-preferences.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_NAVIGATION_PREFERENCES, useEditUserPreferences, useUserPreferences, type NavigationPreferences } from "@/hooks/user-preferences";
+import { DEFAULT_NAVIGATION_PREFERENCES, NavigationPreferencesSchema, useEditUserPreferences, useUserPreferences, type NavigationPreferences } from "@/hooks/user-preferences";
 import { useQuery, useMutation, type UseMutationResult, type UseQueryResult } from "@tanstack/react-query";
 
 
@@ -27,7 +27,7 @@ export const useEditNavigationPreferences = (): UseMutationResult<void, Error, P
         mutationFn: async (updatedNavigationPreferences: Partial<NavigationPreferences>) => {
             const currentNavigation = preferences?.navigation ?? DEFAULT_NAVIGATION_PREFERENCES;
 
-            const newNavigationPreferences: NavigationPreferences = {
+            const merged = {
                 ...currentNavigation,
                 ...updatedNavigationPreferences,
                 expanded: {
@@ -39,6 +39,8 @@ export const useEditNavigationPreferences = (): UseMutationResult<void, Error, P
                     ...updatedNavigationPreferences.menu,
                 },
             };
+
+            const newNavigationPreferences = NavigationPreferencesSchema.parse(merged);
 
             await editPreferences({
                 navigation: newNavigationPreferences,
@@ -56,7 +58,6 @@ export const useNavigationExpanded = (expandedKey: keyof NavigationPreferences['
     const setExpanded = (value: boolean) => {
         void editNavigationPreferences({
             expanded: {
-                ...(navigationPreferences?.expanded ?? {}),
                 [expandedKey]: value
             },
         });

--- a/apps/admin/src/layout/app-sidebar/hooks/use-navigation-preferences.ts
+++ b/apps/admin/src/layout/app-sidebar/hooks/use-navigation-preferences.ts
@@ -1,21 +1,10 @@
 import { useEditUserPreferences, useUserPreferences, type NavigationPreferences } from "@/hooks/user-preferences";
-import { useQuery, useMutation, type UseMutationResult, type UseQueryResult } from "@tanstack/react-query";
+import { useMutation, type UseMutationResult, type UseQueryResult } from "@tanstack/react-query";
 
 
 export const useNavigationPreferences = (): UseQueryResult<NavigationPreferences> => {
-    const preferencesQuery = useUserPreferences();
-
-    return useQuery({
-        queryKey: ['navigationPreferences', preferencesQuery.data],
-        queryFn: () => {
-            if (!preferencesQuery.data) {
-                throw new Error("Preferences not loaded");
-            }
-            return preferencesQuery.data.navigation;
-        },
-        enabled: !!preferencesQuery.data,
-        staleTime: Infinity,
-        cacheTime: 0,
+    return useUserPreferences({
+        select: (data) => data.navigation,
     });
 };
 

--- a/apps/admin/src/layout/app-sidebar/hooks/use-navigation-preferences.ts
+++ b/apps/admin/src/layout/app-sidebar/hooks/use-navigation-preferences.ts
@@ -27,7 +27,7 @@ export const useNavigationExpanded = (expandedKey: keyof NavigationPreferences['
     const expanded = navigationPreferences?.expanded[expandedKey];
 
     const setExpanded = (value: boolean) => {
-        void editNavigationPreferences({
+        return editNavigationPreferences({
             expanded: {
                 [expandedKey]: value
             },
@@ -44,7 +44,7 @@ export const useNavigationMenuVisibility = (): [boolean, (value: boolean) => voi
     const visible = navigationPreferences?.menu.visible;
 
     const setVisible = (value: boolean) => {
-        void editNavigationPreferences({
+        return editNavigationPreferences({
             menu: { visible: value },
         });
     };

--- a/apps/admin/src/layout/app-sidebar/hooks/use-navigation-preferences.ts
+++ b/apps/admin/src/layout/app-sidebar/hooks/use-navigation-preferences.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_NAVIGATION_PREFERENCES, NavigationPreferencesSchema, useEditUserPreferences, useUserPreferences, type NavigationPreferences } from "@/hooks/user-preferences";
+import { NavigationPreferencesSchema, useEditUserPreferences, useUserPreferences, type NavigationPreferences } from "@/hooks/user-preferences";
 import { useQuery, useMutation, type UseMutationResult, type UseQueryResult } from "@tanstack/react-query";
 
 
@@ -11,7 +11,7 @@ export const useNavigationPreferences = (): UseQueryResult<NavigationPreferences
             if (!preferencesQuery.data) {
                 throw new Error("Preferences not loaded");
             }
-            return preferencesQuery.data.navigation ?? DEFAULT_NAVIGATION_PREFERENCES;
+            return preferencesQuery.data.navigation;
         },
         enabled: !!preferencesQuery.data,
         staleTime: Infinity,
@@ -25,17 +25,19 @@ export const useEditNavigationPreferences = (): UseMutationResult<void, Error, P
 
     return useMutation({
         mutationFn: async (updatedNavigationPreferences: Partial<NavigationPreferences>) => {
-            const currentNavigation = preferences?.navigation ?? DEFAULT_NAVIGATION_PREFERENCES;
+            if (!preferences?.navigation) {
+                throw new Error("Navigation preferences not loaded");
+            }
 
             const merged = {
-                ...currentNavigation,
+                ...preferences.navigation,
                 ...updatedNavigationPreferences,
                 expanded: {
-                    ...currentNavigation.expanded,
+                    ...preferences.navigation.expanded,
                     ...updatedNavigationPreferences.expanded,
                 },
                 menu: {
-                    ...currentNavigation.menu,
+                    ...preferences.navigation.menu,
                     ...updatedNavigationPreferences.menu,
                 },
             };
@@ -53,7 +55,7 @@ export const useNavigationExpanded = (expandedKey: keyof NavigationPreferences['
     const { data: navigationPreferences } = useNavigationPreferences();
     const { mutateAsync: editNavigationPreferences } = useEditNavigationPreferences();
 
-    const expanded = navigationPreferences?.expanded[expandedKey] ?? true;
+    const expanded = navigationPreferences?.expanded[expandedKey];
 
     const setExpanded = (value: boolean) => {
         void editNavigationPreferences({
@@ -63,14 +65,14 @@ export const useNavigationExpanded = (expandedKey: keyof NavigationPreferences['
         });
     };
 
-    return [expanded, setExpanded];
+    return [expanded ?? true, setExpanded];
 };
 
 export const useNavigationMenuVisibility = (): [boolean, (value: boolean) => void] => {
     const { data: navigationPreferences } = useNavigationPreferences();
     const { mutateAsync: editNavigationPreferences } = useEditNavigationPreferences();
 
-    const visible = navigationPreferences?.menu.visible ?? true;
+    const visible = navigationPreferences?.menu.visible;
 
     const setVisible = (value: boolean) => {
         void editNavigationPreferences({
@@ -78,5 +80,5 @@ export const useNavigationMenuVisibility = (): [boolean, (value: boolean) => voi
         });
     };
 
-    return [visible, setVisible];
+    return [visible ?? true, setVisible];
 };

--- a/apps/admin/src/utils/deep-merge.ts
+++ b/apps/admin/src/utils/deep-merge.ts
@@ -1,0 +1,41 @@
+/**
+ * Deep partial type that makes all properties optional recursively.
+ */
+export type DeepPartial<T> = T extends object ? {
+    [P in keyof T]?: DeepPartial<T[P]>;
+} : T;
+
+/**
+ * Deep merge utility for preferences objects.
+ * Recursively merges nested objects, with values from `source` taking precedence.
+ */
+export function deepMerge<T extends Record<string, unknown>>(target: T, source: DeepPartial<T>): T {
+    const result: Record<string, unknown> = { ...target };
+
+    for (const key in source) {
+        if (Object.prototype.hasOwnProperty.call(source, key)) {
+            const sourceValue = source[key];
+            const targetValue = target[key];
+
+            if (sourceValue !== undefined) {
+                if (
+                    typeof sourceValue === 'object' &&
+                    sourceValue !== null &&
+                    !Array.isArray(sourceValue) &&
+                    typeof targetValue === 'object' &&
+                    targetValue !== null &&
+                    !Array.isArray(targetValue)
+                ) {
+                    result[key] = deepMerge(
+                        targetValue as Record<string, unknown>,
+                        sourceValue as DeepPartial<Record<string, unknown>>
+                    );
+                } else {
+                    result[key] = sourceValue;
+                }
+            }
+        }
+    }
+
+    return result as T;
+}

--- a/apps/admin/src/utils/deep-merge.ts
+++ b/apps/admin/src/utils/deep-merge.ts
@@ -6,8 +6,22 @@ export type DeepPartial<T> = T extends object ? {
 } : T;
 
 /**
+ * Check if a value is a plain object (not an instance of a class like Date, Map, etc.)
+ */
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+    if (typeof value !== 'object' || value === null) {
+        return false;
+    }
+
+    // Check if it's a plain object created with {} or new Object()
+    const proto = Object.getPrototypeOf(value) as object | null;
+    return proto === null || proto === Object.prototype;
+}
+
+/**
  * Deep merge utility for preferences objects.
  * Recursively merges nested objects, with values from `source` taking precedence.
+ * Only plain objects are recursively merged; complex objects (Date, Map, etc.) are copied as-is.
  */
 export function deepMerge<T extends Record<string, unknown>>(target: T, source: DeepPartial<T>): T {
     const result: Record<string, unknown> = { ...target };
@@ -19,12 +33,8 @@ export function deepMerge<T extends Record<string, unknown>>(target: T, source: 
 
             if (sourceValue !== undefined) {
                 if (
-                    typeof sourceValue === 'object' &&
-                    sourceValue !== null &&
-                    !Array.isArray(sourceValue) &&
-                    typeof targetValue === 'object' &&
-                    targetValue !== null &&
-                    !Array.isArray(targetValue)
+                    isPlainObject(sourceValue) &&
+                    isPlainObject(targetValue)
                 ) {
                     result[key] = deepMerge(
                         targetValue as Record<string, unknown>,

--- a/apps/admin/src/whats-new/hooks/use-whats-new.test.tsx
+++ b/apps/admin/src/whats-new/hooks/use-whats-new.test.tsx
@@ -10,6 +10,7 @@ import type { RawChangelogResponse, RawChangelogEntry } from "./use-changelog";
 import { serverFixture } from "@test-utils/fixtures/msw";
 import { queryClientFixtures, type TestWrapperComponent } from "@test-utils/fixtures/query-client";
 import type { SetupServer } from "msw/node";
+import { DEFAULT_NAVIGATION_PREFERENCES } from "@/hooks/user-preferences";
 
 // Constants
 const USERS_API_URL = "/ghost/api/admin/users/me/";
@@ -60,6 +61,9 @@ const fixtures = {
         withLastSeen: (date: string) => ({
             whatsNew: { lastSeenDate: date },
         }),
+        defaults: {
+            navigation: DEFAULT_NAVIGATION_PREFERENCES,
+        }
     },
 };
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3002/

Navigation menu state describing expanded sections and whether the menu is shown are stored on the `navigation` property of our `user.accessibility` (user preferences) JSON blob. In the Ember Admin app this is handled by the `navigation` service, for our React version we want to build on the user-preferences hooks.

- added zod schema for navigation preferences
  - this is a potentially user-modified JSON string so we want to be safe but also not spread knowledge/use of defaults across the codebase, so:
  - if not present, will return default navigation preferences when parsing
  - if anything within the parsed data doesn't match our expectations, will fall back to default preferences
- modified `useEditUserPreferences` to accept partial `UserPreferences` records and perform a deep merge
  - enables simpler consumers that only need to know about their own data within the overall preferences object
- modified `useUserPreferences` to accept a `UseQueryOptions` argument
  - enables consumers to adjust the query behaviour, by e.g. selecting particular keys from the overall preferences object
- added `useNavigationPreferences` and `useEditNavigationPreferences` hooks that wrap the user-preferences hooks for the specific `navigation` key
- added use-case specific hooks `useNavigationExpanded` and `useNavigationMenuVisibility`
  - avoids internal details of the navigation preferences data shape leaking out across consumers
  - provides a state-like `[data, setData]` return value for better DX
