### PR TITLE
Integrate new admin shell with yarn dev

### DIFF
--- a/.github/scripts/dev.js
+++ b/.github/scripts/dev.js
@@ -104,10 +104,12 @@ const COMMAND_ADMIN = {
 };
 
 const COMMAND_ADMIN_REACT = {
-    name: 'admin-react',
+    name: 'admin-forward',
     command: 'nx run @tryghost/admin:dev',
     prefixColor: 'cyan',
-    env: {}
+    env: {
+        VITE_DISABLE_EMBER_ASSETS_PROXY: 'true'
+    }
 };
 
 const COMMAND_BROWSERTESTS = {
@@ -134,6 +136,11 @@ const COMMAND_ADMINX_APPS = {
 };
 
 const ADMIN_COMMANDS = [COMMAND_ADMIN, COMMAND_ADMINX_DEPS, GHOST_APP_FLAGS.includes('forward') ? COMMAND_ADMIN_REACT : COMMAND_ADMINX_APPS];
+
+// Set environment variable for Ghost to enable Vite proxy when forward flag is present
+if (GHOST_APP_FLAGS.includes('forward')) {
+    COMMAND_GHOST.env['ADMIN_VITE_DEV_SERVER_URL'] = 'http://localhost:5173';
+}
 
 if (GHOST_APP_FLAGS.includes('ghost')) {
     commands = [...commands, COMMAND_GHOST];

--- a/.github/scripts/dev.js
+++ b/.github/scripts/dev.js
@@ -30,6 +30,7 @@ const availableAppFlags = {
     ghost: 'Run only Ghost',
     admin: 'Run only Admin',
     'browser-tests': 'Run browser tests',
+    forward: 'Run the new React admin shell (skips AdminX app bundling)',
     announcementBar: 'Run Announcement Bar',
     announcementbar: 'Run Announcement Bar',
     'announcement-bar': 'Run Announcement Bar',
@@ -102,6 +103,13 @@ const COMMAND_ADMIN = {
     env: {}
 };
 
+const COMMAND_ADMIN_REACT = {
+    name: 'admin-react',
+    command: 'nx run @tryghost/admin:dev',
+    prefixColor: 'cyan',
+    env: {}
+};
+
 const COMMAND_BROWSERTESTS = {
     name: 'browser-tests',
     command: `nx run ghost:test:browser${PASS_THROUGH_FLAGS ? ` -- ${PASS_THROUGH_FLAGS}`: ''}`,
@@ -111,26 +119,30 @@ const COMMAND_BROWSERTESTS = {
 
 const adminXApps = '@tryghost/admin-x-settings,@tryghost/activitypub,@tryghost/posts,@tryghost/stats';
 
-const COMMANDS_ADMINX = [{
+const COMMAND_ADMINX_DEPS = {
     name: 'adminXDeps',
-    command: 'while [ 1 ]; do nx watch --projects=apps/admin-x-design-system,apps/admin-x-framework,apps/shade,apps/stats -- nx run \\$NX_PROJECT_NAME:build; done',
+    command: 'while [ 1 ]; do nx watch --projects=apps/admin-x-design-system,apps/admin-x-framework,apps/shade -- nx run \\$NX_PROJECT_NAME:build; done',
     prefixColor: '#C72AF7',
     env: {}
-}, {
+};
+
+const COMMAND_ADMINX_APPS = {
     name: 'adminX',
     command: `nx run-many --projects=${adminXApps} --parallel=${adminXApps.length} --targets=dev`,
     prefixColor: '#C72AF7',
     env: {}
-}];
+};
+
+const ADMIN_COMMANDS = [COMMAND_ADMIN, COMMAND_ADMINX_DEPS, GHOST_APP_FLAGS.includes('forward') ? COMMAND_ADMIN_REACT : COMMAND_ADMINX_APPS];
 
 if (GHOST_APP_FLAGS.includes('ghost')) {
-    commands = [COMMAND_GHOST];
+    commands = [...commands, COMMAND_GHOST];
 } else if (GHOST_APP_FLAGS.includes('admin')) {
-    commands = [COMMAND_ADMIN, ...COMMANDS_ADMINX];
+    commands = [...commands, ...ADMIN_COMMANDS];
 } else if (GHOST_APP_FLAGS.includes('browser-tests')) {
     commands = [COMMAND_BROWSERTESTS];
 } else {
-    commands = [COMMAND_GHOST, COMMAND_ADMIN, ...COMMANDS_ADMINX];
+    commands = [...commands, COMMAND_GHOST, ...ADMIN_COMMANDS];
 }
 
 if (GHOST_APP_FLAGS.includes('portal') || GHOST_APP_FLAGS.includes('all')) {

--- a/apps/admin/vite-backend-proxy.ts
+++ b/apps/admin/vite-backend-proxy.ts
@@ -128,10 +128,12 @@ Ensure the Ghost backend is running. If needed, set the GHOST_URL environment va
         configureServer(server) {
             if (!siteUrl) return;
 
+            const disableEmberAssetsProxy = process.env.VITE_DISABLE_EMBER_ASSETS_PROXY === 'true';
+
             server.config.server.proxy = {
                 ...server.config.server.proxy,
                 ...createAdminApiProxy(siteUrl),
-                ...createEmberAssetsProxy(siteUrl),
+                ...(disableEmberAssetsProxy ? {} : createEmberAssetsProxy(siteUrl)),
             };
         },
 

--- a/ghost/core/core/server/web/admin/middleware/vite-proxy.js
+++ b/ghost/core/core/server/web/admin/middleware/vite-proxy.js
@@ -1,0 +1,55 @@
+const debug = require('@tryghost/debug')('web:admin:vite-proxy');
+const httpProxy = require('http-proxy-3');
+
+/**
+ * Creates proxy middleware for forwarding requests to Vite dev server
+ * Includes WebSocket support for HMR (Hot Module Replacement)
+ * 
+ * @param {string} viteDevServerUrl - URL of the Vite dev server (e.g., http://localhost:5173)
+ * @returns {Object} Object containing middleware function and upgrade handler
+ */
+function createViteProxy(viteDevServerUrl) {
+    const proxy = httpProxy.createProxyServer({
+        target: viteDevServerUrl + '/ghost',
+        changeOrigin: true,
+        prependPath: true,
+        ws: true // Enable WebSocket proxying for HMR
+    });
+
+    /**
+     * Generic proxy middleware for all Vite requests
+     * Automatically prepends /ghost to URLs (except for Vite special routes starting with /@)
+     */
+    const proxyMiddleware = function proxyMiddleware(req, res, next) {
+        const originalUrl = req.url;
+        proxy.web(req, res, {}, (err) => {
+            if (err) {
+                debug('Vite proxy error:', err);
+                req.url = originalUrl; // Restore original URL
+                next(err);
+            }
+        });
+    };
+
+    /**
+     * WebSocket upgrade handler for HMR
+     * Should be attached to the server's 'upgrade' event
+     */
+    const upgradeHandler = function upgradeHandler(req, socket, head) {
+        if (req.url.startsWith('/ghost')) {
+            proxy.ws(req, socket, head, (err) => {
+                if (err) {
+                    debug('WebSocket proxy error:', err);
+                }
+            });
+        }
+    };
+
+    return {
+        middleware: proxyMiddleware,
+        upgradeHandler: upgradeHandler
+    };
+}
+
+module.exports = createViteProxy;
+

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -166,6 +166,7 @@
     "heic-convert": "2.1.0",
     "html-to-text": "5.1.1",
     "html5parser": "2.0.2",
+    "http-proxy-3": "1.22.0",
     "human-number": "2.0.7",
     "iconv-lite": "0.6.3",
     "image-size": "1.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19680,6 +19680,11 @@ follow-redirects@^1.0.0, follow-redirects@^1.15.6:
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.6.tgz#7f815c0cda4249c74ff09e95ef97c23b5fd0399b"
   integrity sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==
 
+follow-redirects@^1.15.9:
+  version "1.15.11"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.11.tgz#777d73d72a92f8ec4d2e410eb47352a56b8e8340"
+  integrity sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==
+
 for-each@^0.3.3, for-each@^0.3.5:
   version "0.3.5"
   resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.5.tgz#d650688027826920feeb0af747ee7b9421a41d47"
@@ -21047,6 +21052,14 @@ http-parser-js@>=0.5.1:
   version "0.5.8"
   resolved "https://registry.yarnpkg.com/http-parser-js/-/http-parser-js-0.5.8.tgz#af23090d9ac4e24573de6f6aecc9d84a48bf20e3"
   integrity sha512-SGeBX54F94Wgu5RH3X5jsDtf4eHyRogWX1XGT3b4HuW3tQPM4AaBzoUji/4AAJNXCEOWZ5O0DgZmJw1947gD5Q==
+
+http-proxy-3@1.22.0:
+  version "1.22.0"
+  resolved "https://registry.yarnpkg.com/http-proxy-3/-/http-proxy-3-1.22.0.tgz#351829d123507bd77d23a7dccc32d99d51c22282"
+  integrity sha512-qyYYKjmPW7kDiRBGzydmD5f5ckuniL9fY45EWP05YVDoR/02JjrVMGqdrO5O+OURU7imhF3WyiKwp++4A3KEbw==
+  dependencies:
+    debug "^4.4.0"
+    follow-redirects "^1.15.9"
 
 http-proxy-agent@^4.0.1:
   version "4.0.1"


### PR DESCRIPTION
Added --forward flag to dev command with Vite proxy integration

closes https://linear.app/ghost/issue/BER-2989/integrate-new-admin-shell-with-yarn-dev

Enables local development of the new React admin shell with a single command and integrates with existing tooling like Tailscale funnels. 

### Changes

- Added `--forward` flag to `yarn dev` that starts the React admin shell dev server
- Skips building AdminX apps (bundled by React shell) but builds dependencies (design-system, framework, shade)
- Created Vite proxy middleware using `http-proxy-3` to forward requests to localhost:5173
- Handles URL rewriting (`/ghost` prefix), WebSocket support for HMR, and fallthrough from Ember assets
- Skips `prettyUrls` and `redirectAdminUrls` middlewares when proxying (they interfere with Vite file serving)
- Prevents circular proxying by disabling Ember asset proxy in Vite when `VITE_DISABLE_EMBER_ASSETS_PROXY=true`

### Usage

```
yarn dev --forward
```

Runs Ghost backend with proxy, Ember admin, React admin shell, and AdminX dependencies.

### Notes

Initially tried embedding Vite as middleware, but `node --watch` that is used by the server dev command meant that the server restarted on every request due to Vite accessing the file system. Proxy approach keeps servers separate with full HMR support.