### PR TITLE
Fixed race condition in member export download handling

### DIFF
--- a/e2e/helpers/pages/admin/members/MembersPage.ts
+++ b/e2e/helpers/pages/admin/members/MembersPage.ts
@@ -143,7 +143,8 @@ export class MembersPage extends AdminPage {
     }
 
     async exportMembersData(): Promise<Download> {
+        const downloadPromise = this.page.waitForEvent('download');
         await this.exportMembersButton.click();
-        return await this.page.waitForEvent('download');
+        return await downloadPromise;
     }
 }


### PR DESCRIPTION
ref https://linear.app/ghost/issue/NY-741/fix-sporadical-issue-with-new-export-members-test

* moved waitForEvent('download') before click action to prevent race condition
* this ensures the download event listener is registered before the download starts