### PR TITLE
🎨 Added Analytics APIs to robots.txt

### DIFF
--- a/ghost/core/core/frontend/public/robots.txt
+++ b/ghost/core/core/frontend/public/robots.txt
@@ -5,3 +5,4 @@ Disallow: /email/
 Disallow: /members/api/comments/counts/
 Disallow: /r/
 Disallow: /webmentions/receive/
+Disallow: /.ghost/analytics/api/

--- a/ghost/core/test/e2e-frontend/default_routes.test.js
+++ b/ghost/core/test/e2e-frontend/default_routes.test.js
@@ -349,7 +349,8 @@ describe('Default Frontend routing', function () {
                 'Disallow: /email/\n' +
                 'Disallow: /members/api/comments/counts/\n' +
                 'Disallow: /r/\n' +
-                'Disallow: /webmentions/receive/\n'
+                'Disallow: /webmentions/receive/\n' +
+                'Disallow: /.ghost/analytics/api/\n'
             );
         });
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ONC-1256/
ref https://linear.app/ghost/issue/NY-705/

- Robots can (and currently do) browser + track hits against the Analytics Endpoints
- We filter this data out at different points but preventing it from being tracked at in the first place is easier
