### PR TITLE
Added number formatting to follow count in inline feed suggestion

### DIFF
--- a/apps/activitypub/package.json
+++ b/apps/activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/activitypub",
-  "version": "1.0.30",
+  "version": "1.0.31",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/activitypub/src/views/Feed/components/SuggestedProfiles.tsx
+++ b/apps/activitypub/src/views/Feed/components/SuggestedProfiles.tsx
@@ -2,7 +2,7 @@ import APAvatar from '@src/components/global/APAvatar';
 import FollowButton from '@src/components/global/FollowButton';
 import ProfilePreviewHoverCard from '@components/global/ProfilePreviewHoverCard';
 import {Account} from '@src/api/activitypub';
-import {Button, H4, LucideIcon, Separator, Skeleton} from '@tryghost/shade';
+import {Button, H4, LucideIcon, Separator, Skeleton, abbreviateNumber} from '@tryghost/shade';
 import {useEffect, useRef, useState} from 'react';
 import {useNavigateWithBasePath} from '@src/hooks/use-navigate-with-base-path';
 import {useSuggestedProfilesForUser} from '@src/hooks/use-activity-pub-queries';
@@ -165,7 +165,7 @@ const SuggestedProfiles: React.FC = () => {
                                         {isLoadingSuggestedProfiles ? (
                                             <Skeleton className='h-4 w-20' />
                                         ) : (
-                                            `${profile?.followerCount || 0} ${(profile?.followerCount || 0) === 1 ? 'follower' : 'followers'}`
+                                            `${abbreviateNumber(profile?.followerCount || 0)} ${(profile?.followerCount || 0) === 1 ? 'follower' : 'followers'}`
                                         )}
                                     </span>
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-2947/format-follower-number-on-inline-suggestion

- Used standardized number formatting for follow counts in feed suggestions
- Makes follow counts easier to read and consistent across the app

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Abbreviates follower counts in feed suggestions using `abbreviateNumber` and bumps the ActivityPub package to 1.0.31.
> 
> - **UI (ActivityPub feed)**:
>   - In `apps/activitypub/src/views/Feed/components/SuggestedProfiles.tsx`, use `abbreviateNumber` to format `followerCount` in suggested profile cards.
> - **Version**:
>   - Bump `@tryghost/activitypub` version to `1.0.31` in `apps/activitypub/package.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 261e37c42f0de98b1f0ef399db60c4f6355bb0e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->