### PR TITLE
Allow all complementary members to upgrade to a paid plan

### DIFF
--- a/apps/portal/src/App.js
+++ b/apps/portal/src/App.js
@@ -935,10 +935,6 @@ export default class App extends React.Component {
             page = member ? 'accountHome' : loggedOutPage;
         }
 
-        if (page === 'accountPlan' && isComplimentaryMember({member}) && !allowCompMemberUpgrade({member})) {
-            page = 'accountHome';
-        }
-
         return getActivePage({page});
     }
 

--- a/apps/portal/src/App.js
+++ b/apps/portal/src/App.js
@@ -14,7 +14,7 @@ import {transformPortalAnchorToRelative} from './utils/transform-portal-anchor-t
 import {getActivePage, isAccountPage, isOfferPage} from './pages';
 import ActionHandler from './actions';
 import './App.css';
-import {hasRecommendations, allowCompMemberUpgrade, createPopupNotification, hasAvailablePrices, getCurrencySymbol, getFirstpromoterId, getPriceIdFromPageQuery, getProductCadenceFromPrice, getProductFromId, getQueryPrice, getSiteDomain, isActiveOffer, isComplimentaryMember, isInviteOnly, isPaidMember, isRecentMember, isSentryEventAllowed, removePortalLinkFromUrl} from './utils/helpers';
+import {hasRecommendations, createPopupNotification, hasAvailablePrices, getCurrencySymbol, getFirstpromoterId, getPriceIdFromPageQuery, getProductCadenceFromPrice, getProductFromId, getQueryPrice, getSiteDomain, isActiveOffer, isInviteOnly, isPaidMember, isRecentMember, isSentryEventAllowed, removePortalLinkFromUrl} from './utils/helpers';
 import {handleDataAttributes} from './data-attributes';
 
 const DEV_MODE_DATA = {

--- a/apps/portal/src/utils/helpers.js
+++ b/apps/portal/src/utils/helpers.js
@@ -91,7 +91,7 @@ export function hasNewsletterSendingEnabled({site}) {
 }
 
 export function allowCompMemberUpgrade({member}) {
-    return member?.subscriptions?.[0]?.tier?.expiry_at !== undefined;
+    return isComplimentaryMember({member});
 }
 
 export function getCompExpiry({member}) {

--- a/apps/portal/src/utils/helpers.test.js
+++ b/apps/portal/src/utils/helpers.test.js
@@ -1,4 +1,4 @@
-import {hasAvailablePrices, getAllProductsForSite, getAvailableProducts, getCurrencySymbol, getFreeProduct, getMemberName, getMemberSubscription, getPriceFromSubscription, getPriceIdFromPageQuery, getSupportAddress, getDefaultNewsletterSender, getUrlHistory, hasMultipleProducts, isActiveOffer, isInviteOnly, isPaidMember, isPaidMembersOnly, isSameCurrency, transformApiTiersData, isSigninAllowed, isSignupAllowed, getCompExpiry, isInThePast, hasNewsletterSendingEnabled} from './helpers';
+import {allowCompMemberUpgrade, hasAvailablePrices, getAllProductsForSite, getAvailableProducts, getCurrencySymbol, getFreeProduct, getMemberName, getMemberSubscription, getPriceFromSubscription, getPriceIdFromPageQuery, getSupportAddress, getDefaultNewsletterSender, getUrlHistory, hasMultipleProducts, isActiveOffer, isInviteOnly, isPaidMember, isPaidMembersOnly, isSameCurrency, transformApiTiersData, isSigninAllowed, isSignupAllowed, getCompExpiry, isInThePast, hasNewsletterSendingEnabled} from './helpers';
 import * as Fixtures from './fixtures-generator';
 import {site as FixturesSite, member as FixtureMember, offer as FixtureOffer, transformTierFixture as TransformFixtureTiers} from '../utils/test-fixtures';
 import {isComplimentaryMember} from '../utils/helpers';
@@ -45,6 +45,31 @@ describe('Helpers - ', () => {
         test('returns false for free member', () => {
             const value = isPaidMember({member: FixtureMember.free});
             expect(value).toBe(false);
+        });
+    });
+
+    describe('allowCompMemberUpgrade -', () => {
+        [
+            {
+                name: 'complimentary member with subscription expiry',
+                member: FixtureMember.complimentaryWithSubscription,
+                expected: true
+            },
+            {
+                name: 'complimentary member without subscription',
+                member: FixtureMember.complimentary,
+                expected: true
+            },
+            {
+                name: 'free member',
+                member: FixtureMember.free,
+                expected: false
+            }
+        ].forEach(({name, member, expected}) => {
+            test(`returns ${expected} for ${name}`, () => {
+                const value = allowCompMemberUpgrade({member});
+                expect(value).toBe(expected);
+            });
         });
     });
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-2985/

Some publishers would like to allow complimentary plans to upgrade to paid. This was already possible for complimentary members WITH an expiry date (expiry_at field). This PR makes it possible for complimentary members WITHOUT an expiry date, too. We're also adding a small test for the `isComplimentaryMember` function. 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables upgrades for all complimentary members and removes the block preventing them from accessing the account plan page, with tests added for the new logic.
> 
> - **Behavior**:
>   - `allowCompMemberUpgrade` now returns `true` for any complimentary member via `isComplimentaryMember`.
>   - Removed logic in `App.js` that redirected complimentary members away from `accountPlan`.
> - **Tests**:
>   - Added tests for `allowCompMemberUpgrade` (complimentary with/without subscription, free member).
>   - Ensured complimentary membership logic is covered in `helpers.test.js`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 32370b7ad6e4d0fff95278b96619d39503d179a4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->