### PR TITLE
Added Indicator component to Shade design system

### DIFF
--- a/apps/shade/src/components/ui/indicator.stories.tsx
+++ b/apps/shade/src/components/ui/indicator.stories.tsx
@@ -1,0 +1,281 @@
+import type {Meta, StoryObj} from '@storybook/react-vite';
+import {Indicator} from './indicator';
+
+const meta = {
+    title: 'Components / Indicator',
+    component: Indicator,
+    tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component: 'A simple status dot primitive for showing status with small colored dots. Lighter weight than Badge component, designed for notification dots, connection status, and other minimal indicators.'
+            }
+        }
+    },
+    argTypes: {
+        variant: {
+            control: {type: 'select'},
+            options: ['neutral', 'info', 'success', 'error', 'warning']
+        },
+        state: {
+            control: {type: 'select'},
+            options: ['idle', 'active', 'inactive']
+        },
+        size: {
+            control: {type: 'select'},
+            options: ['sm', 'md', 'lg']
+        },
+        label: {
+            control: {type: 'text'},
+            description: 'Screen reader label for accessibility'
+        }
+    }
+} satisfies Meta<typeof Indicator>;
+
+export default meta;
+type Story = StoryObj<typeof Indicator>;
+
+export const Neutral: Story = {
+    args: {
+        variant: 'neutral',
+        state: 'idle',
+        label: 'Neutral status'
+    },
+    decorators: [
+        StoryComponent => (
+            <div className="flex items-center justify-center p-8">
+                <StoryComponent />
+            </div>
+        )
+    ]
+};
+
+export const Info: Story = {
+    args: {
+        variant: 'info',
+        state: 'idle',
+        label: 'Info status'
+    },
+    decorators: [
+        StoryComponent => (
+            <div className="flex items-center justify-center p-8">
+                <StoryComponent />
+            </div>
+        )
+    ]
+};
+
+export const Success: Story = {
+    args: {
+        variant: 'success',
+        state: 'idle',
+        label: 'Success status'
+    },
+    decorators: [
+        StoryComponent => (
+            <div className="flex items-center justify-center p-8">
+                <StoryComponent />
+            </div>
+        )
+    ]
+};
+
+export const Error: Story = {
+    args: {
+        variant: 'error',
+        state: 'idle',
+        label: 'Error status'
+    },
+    decorators: [
+        StoryComponent => (
+            <div className="flex items-center justify-center p-8">
+                <StoryComponent />
+            </div>
+        )
+    ]
+};
+
+export const Warning: Story = {
+    args: {
+        variant: 'warning',
+        state: 'idle',
+        label: 'Warning status'
+    },
+    decorators: [
+        StoryComponent => (
+            <div className="flex items-center justify-center p-8">
+                <StoryComponent />
+            </div>
+        )
+    ]
+};
+
+export const SuccessActive: Story = {
+    args: {
+        variant: 'success',
+        state: 'active',
+        label: 'Active'
+    },
+    decorators: [
+        StoryComponent => (
+            <div className="flex items-center justify-center p-8">
+                <StoryComponent />
+            </div>
+        )
+    ]
+};
+
+export const SuccessInactive: Story = {
+    args: {
+        variant: 'success',
+        state: 'inactive',
+        label: 'Inactive'
+    },
+    decorators: [
+        StoryComponent => (
+            <div className="flex items-center justify-center p-8">
+                <StoryComponent />
+            </div>
+        )
+    ]
+};
+
+export const AllVariants: Story = {
+    render: () => (
+        <div className="flex items-center gap-4">
+            <div className="flex items-center gap-2">
+                <Indicator label="Neutral" state="idle" variant="neutral" />
+                <span className="text-sm">Neutral</span>
+            </div>
+            <div className="flex items-center gap-2">
+                <Indicator label="Info" state="idle" variant="info" />
+                <span className="text-sm">Info</span>
+            </div>
+            <div className="flex items-center gap-2">
+                <Indicator label="Success" state="idle" variant="success" />
+                <span className="text-sm">Success</span>
+            </div>
+            <div className="flex items-center gap-2">
+                <Indicator label="Error" state="idle" variant="error" />
+                <span className="text-sm">Error</span>
+            </div>
+            <div className="flex items-center gap-2">
+                <Indicator label="Warning" state="idle" variant="warning" />
+                <span className="text-sm">Warning</span>
+            </div>
+        </div>
+    )
+};
+
+export const AllStates: Story = {
+    render: () => (
+        <div className="space-y-4">
+            <div className="flex items-center gap-4">
+                <div className="flex items-center gap-2">
+                    <Indicator label="Idle" state="idle" variant="neutral" />
+                    <span className="text-sm">Idle (solid)</span>
+                </div>
+                <div className="flex items-center gap-2">
+                    <Indicator label="Active" state="active" variant="neutral" />
+                    <span className="text-sm">Active (pulsing)</span>
+                </div>
+                <div className="flex items-center gap-2">
+                    <Indicator label="Inactive" state="inactive" variant="neutral" />
+                    <span className="text-sm">Inactive (outline)</span>
+                </div>
+            </div>
+            <div className="flex items-center gap-4">
+                <div className="flex items-center gap-2">
+                    <Indicator label="Idle" state="idle" variant="success" />
+                    <span className="text-sm">Idle (solid)</span>
+                </div>
+                <div className="flex items-center gap-2">
+                    <Indicator label="Active" state="active" variant="success" />
+                    <span className="text-sm">Active (pulsing)</span>
+                </div>
+                <div className="flex items-center gap-2">
+                    <Indicator label="Inactive" state="inactive" variant="success" />
+                    <span className="text-sm">Inactive (outline)</span>
+                </div>
+            </div>
+            <div className="flex items-center gap-4">
+                <div className="flex items-center gap-2">
+                    <Indicator label="Idle" state="idle" variant="error" />
+                    <span className="text-sm">Idle (solid)</span>
+                </div>
+                <div className="flex items-center gap-2">
+                    <Indicator label="Active" state="active" variant="error" />
+                    <span className="text-sm">Active (pulsing)</span>
+                </div>
+                <div className="flex items-center gap-2">
+                    <Indicator label="Inactive" state="inactive" variant="error" />
+                    <span className="text-sm">Inactive (outline)</span>
+                </div>
+            </div>
+            <div className="flex items-center gap-4">
+                <div className="flex items-center gap-2">
+                    <Indicator label="Idle" state="idle" variant="warning" />
+                    <span className="text-sm">Idle (solid)</span>
+                </div>
+                <div className="flex items-center gap-2">
+                    <Indicator label="Active" state="active" variant="warning" />
+                    <span className="text-sm">Active (pulsing)</span>
+                </div>
+                <div className="flex items-center gap-2">
+                    <Indicator label="Inactive" state="inactive" variant="warning" />
+                    <span className="text-sm">Inactive (outline)</span>
+                </div>
+            </div>
+        </div>
+    )
+};
+
+export const AllSizes: Story = {
+    render: () => (
+        <div className="flex items-center gap-4">
+            <div className="flex items-center gap-2">
+                <Indicator label="Small" size="sm" state="idle" variant="neutral" />
+                <span className="text-sm">Small (8px)</span>
+            </div>
+            <div className="flex items-center gap-2">
+                <Indicator label="Medium" size="md" state="idle" variant="neutral" />
+                <span className="text-sm">Medium (12px)</span>
+            </div>
+            <div className="flex items-center gap-2">
+                <Indicator label="Large" size="lg" state="idle" variant="neutral" />
+                <span className="text-sm">Large (16px)</span>
+            </div>
+        </div>
+    )
+};
+
+export const InContext: Story = {
+    render: () => (
+        <div className="space-y-4">
+            <div className="flex items-center gap-2 text-sm">
+                <span>Connected to Stripe</span>
+                <Indicator label="Connected" size="sm" state="idle" variant="success" />
+            </div>
+            <div className="flex items-center gap-2 text-sm">
+                <span>Database error</span>
+                <Indicator label="Error" size="sm" state="idle" variant="error" />
+            </div>
+            <div className="flex items-center gap-2 text-sm">
+                <span>Warning: API rate limit</span>
+                <Indicator label="Warning" size="sm" state="idle" variant="warning" />
+            </div>
+            <div className="flex items-center gap-2 text-sm">
+                <span>256 reading now</span>
+                <Indicator label="Active readers" size="sm" state="active" variant="success" />
+            </div>
+            <div className="flex items-center gap-2 text-sm">
+                <span>Syncing...</span>
+                <Indicator label="Syncing" size="sm" state="active" variant="success" />
+            </div>
+            <div className="flex items-center gap-2 text-sm">
+                <span>Disconnected</span>
+                <Indicator label="Disconnected" size="sm" state="inactive" variant="error" />
+            </div>
+        </div>
+    )
+};

--- a/apps/shade/src/components/ui/indicator.tsx
+++ b/apps/shade/src/components/ui/indicator.tsx
@@ -1,0 +1,86 @@
+import * as React from 'react';
+import {cva, type VariantProps} from 'class-variance-authority';
+
+import {cn} from '@/lib/utils';
+
+/**
+ * A lightweight status dot component for showing visual status indicators
+ * with semantic colors and animation states.
+ */
+const indicatorVariants = cva(
+    'rounded-full',
+    {
+        variants: {
+            variant: {
+                neutral: 'bg-muted',
+                info: 'bg-blue-500',
+                success: 'bg-green-500',
+                error: 'bg-red-500',
+                warning: 'bg-yellow-500'
+            },
+            state: {
+                idle: '',
+                active: 'animate-pulse',
+                inactive: 'border-2 bg-transparent'
+            },
+            size: {
+                sm: 'size-2',
+                md: 'size-3',
+                lg: 'size-4'
+            }
+        },
+        compoundVariants: [
+            // Inactive state borders match variant colors
+            {
+                variant: 'neutral',
+                state: 'inactive',
+                className: 'border-muted-foreground'
+            },
+            {
+                variant: 'info',
+                state: 'inactive',
+                className: 'border-blue-500'
+            },
+            {
+                variant: 'success',
+                state: 'inactive',
+                className: 'border-green-500'
+            },
+            {
+                variant: 'error',
+                state: 'inactive',
+                className: 'border-red-500'
+            },
+            {
+                variant: 'warning',
+                state: 'inactive',
+                className: 'border-yellow-500'
+            }
+        ],
+        defaultVariants: {
+            variant: 'success',
+            state: 'idle',
+            size: 'sm'
+        }
+    }
+);
+
+export interface IndicatorProps
+    extends React.HTMLAttributes<HTMLSpanElement>,
+        VariantProps<typeof indicatorVariants> {
+    label?: string;
+}
+
+function Indicator({className, variant, state, size, label, ...props}: IndicatorProps) {
+    return (
+        <span className="inline-flex items-center" {...props}>
+            <span
+                aria-hidden="true"
+                className={cn(indicatorVariants({variant, state, size}), className)}
+            />
+            {label && <span className="sr-only">{label}</span>}
+        </span>
+    );
+}
+
+export {Indicator, indicatorVariants};

--- a/apps/shade/src/index.ts
+++ b/apps/shade/src/index.ts
@@ -19,6 +19,7 @@ export * from './components/ui/flag';
 export * from './components/ui/form';
 export * from './components/ui/gh-chart';
 export * from './components/ui/hover-card';
+export * from './components/ui/indicator';
 export * from './components/ui/input';
 export * from './components/ui/input-group';
 export * from './components/ui/kbd';

--- a/apps/shade/test/unit/components/ui/indicator.test.tsx
+++ b/apps/shade/test/unit/components/ui/indicator.test.tsx
@@ -1,0 +1,194 @@
+import assert from 'assert/strict';
+import {describe, it} from 'vitest';
+import {screen} from '@testing-library/react';
+import {Indicator} from '../../../../src/components/ui/indicator';
+import {render} from '../../utils/test-utils';
+
+describe('Indicator Component', () => {
+    it('renders correctly with default props', () => {
+        render(<Indicator data-testid="indicator" />);
+        const container = screen.getByTestId('indicator');
+        const indicator = container.querySelector('[aria-hidden="true"]');
+
+        assert.ok(container, 'Indicator container should be rendered');
+        assert.ok(indicator, 'Indicator dot should be rendered');
+        assert.ok(indicator?.className.includes('bg-green-500'), 'Should have success variant class by default');
+        assert.ok(indicator?.className.includes('size-2'), 'Should have small size by default');
+        assert.ok(!indicator?.className.includes('animate-pulse'), 'Should not be pulsing in idle state');
+        assert.ok(!indicator?.className.includes('border'), 'Should not have border in idle state');
+    });
+
+    it('applies neutral variant correctly', () => {
+        render(<Indicator data-testid="indicator" variant="neutral" />);
+        const container = screen.getByTestId('indicator');
+        const indicator = container.querySelector('[aria-hidden="true"]');
+
+        assert.ok(indicator?.className.includes('bg-muted'), 'Should have neutral variant class');
+    });
+
+    it('applies info variant correctly', () => {
+        render(<Indicator data-testid="indicator" variant="info" />);
+        const container = screen.getByTestId('indicator');
+        const indicator = container.querySelector('[aria-hidden="true"]');
+
+        assert.ok(indicator?.className.includes('bg-blue-500'), 'Should have info variant class');
+    });
+
+    it('applies success variant correctly', () => {
+        render(<Indicator data-testid="indicator" variant="success" />);
+        const container = screen.getByTestId('indicator');
+        const indicator = container.querySelector('[aria-hidden="true"]');
+
+        assert.ok(indicator?.className.includes('bg-green-500'), 'Should have success variant class');
+    });
+
+    it('applies error variant correctly', () => {
+        render(<Indicator variant="error" data-testid="indicator" />);
+        const container = screen.getByTestId('indicator');
+        const indicator = container.querySelector('[aria-hidden="true"]');
+
+        assert.ok(indicator?.className.includes('bg-red-500'), 'Should have error variant class');
+    });
+
+    it('applies warning variant correctly', () => {
+        render(<Indicator variant="warning" data-testid="indicator" />);
+        const container = screen.getByTestId('indicator');
+        const indicator = container.querySelector('[aria-hidden="true"]');
+
+        assert.ok(indicator?.className.includes('bg-yellow-500'), 'Should have warning variant class');
+    });
+
+    it('applies idle state correctly', () => {
+        render(<Indicator variant="success" state="idle" data-testid="indicator" />);
+        const container = screen.getByTestId('indicator');
+        const indicator = container.querySelector('[aria-hidden="true"]');
+
+        assert.ok(indicator?.className.includes('bg-green-500'), 'Should have solid background');
+        assert.ok(!indicator?.className.includes('animate-pulse'), 'Should not be pulsing in idle state');
+        assert.ok(!indicator?.className.includes('border'), 'Should not have border');
+    });
+
+    it('applies active state correctly', () => {
+        render(<Indicator variant="success" state="active" data-testid="indicator" />);
+        const container = screen.getByTestId('indicator');
+        const indicator = container.querySelector('[aria-hidden="true"]');
+
+        assert.ok(indicator?.className.includes('animate-pulse'), 'Should have pulsing animation class');
+        assert.ok(indicator?.className.includes('bg-green-500'), 'Should maintain variant color');
+    });
+
+    it('applies inactive state with neutral variant correctly', () => {
+        render(<Indicator data-testid="indicator" state="inactive" variant="neutral" />);
+        const container = screen.getByTestId('indicator');
+        const indicator = container.querySelector('[aria-hidden="true"]');
+
+        assert.ok(indicator?.className.includes('border'), 'Should have border class');
+        assert.ok(indicator?.className.includes('bg-transparent'), 'Should have transparent background class');
+        assert.ok(indicator?.className.includes('border-muted-foreground'), 'Should have grey border for neutral variant');
+    });
+
+    it('applies inactive state with info variant correctly', () => {
+        render(<Indicator data-testid="indicator" state="inactive" variant="info" />);
+        const container = screen.getByTestId('indicator');
+        const indicator = container.querySelector('[aria-hidden="true"]');
+
+        assert.ok(indicator?.className.includes('border'), 'Should have border class');
+        assert.ok(indicator?.className.includes('bg-transparent'), 'Should have transparent background class');
+        assert.ok(indicator?.className.includes('border-blue-500'), 'Should have blue border for info variant');
+    });
+
+    it('applies inactive state with success variant correctly', () => {
+        render(<Indicator data-testid="indicator" state="inactive" variant="success" />);
+        const container = screen.getByTestId('indicator');
+        const indicator = container.querySelector('[aria-hidden="true"]');
+
+        assert.ok(indicator?.className.includes('border'), 'Should have border class');
+        assert.ok(indicator?.className.includes('bg-transparent'), 'Should have transparent background class');
+        assert.ok(indicator?.className.includes('border-green-500'), 'Should have green border for success variant');
+    });
+
+    it('applies inactive state with error variant correctly', () => {
+        render(<Indicator variant="error" state="inactive" data-testid="indicator" />);
+        const container = screen.getByTestId('indicator');
+        const indicator = container.querySelector('[aria-hidden="true"]');
+
+        assert.ok(indicator?.className.includes('border'), 'Should have border class');
+        assert.ok(indicator?.className.includes('bg-transparent'), 'Should have transparent background class');
+        assert.ok(indicator?.className.includes('border-red-500'), 'Should have red border for error variant');
+    });
+
+    it('applies inactive state with warning variant correctly', () => {
+        render(<Indicator variant="warning" state="inactive" data-testid="indicator" />);
+        const container = screen.getByTestId('indicator');
+        const indicator = container.querySelector('[aria-hidden="true"]');
+
+        assert.ok(indicator?.className.includes('border'), 'Should have border class');
+        assert.ok(indicator?.className.includes('bg-transparent'), 'Should have transparent background class');
+        assert.ok(indicator?.className.includes('border-yellow-500'), 'Should have yellow border for warning variant');
+    });
+
+    it('applies different sizes correctly', () => {
+        const {rerender} = render(<Indicator size="sm" data-testid="indicator" />);
+        let container = screen.getByTestId('indicator');
+        let indicator = container.querySelector('[aria-hidden="true"]');
+        assert.ok(indicator?.className.includes('size-2'), 'Should have small size class');
+
+        rerender(<Indicator size="md" data-testid="indicator" />);
+        container = screen.getByTestId('indicator');
+        indicator = container.querySelector('[aria-hidden="true"]');
+        assert.ok(indicator?.className.includes('size-3'), 'Should have medium size class');
+
+        rerender(<Indicator size="lg" data-testid="indicator" />);
+        container = screen.getByTestId('indicator');
+        indicator = container.querySelector('[aria-hidden="true"]');
+        assert.ok(indicator?.className.includes('size-4'), 'Should have large size class');
+    });
+
+    it('combines variant and state correctly', () => {
+        render(<Indicator variant="error" state="active" data-testid="indicator" />);
+        const container = screen.getByTestId('indicator');
+        const indicator = container.querySelector('[aria-hidden="true"]');
+
+        assert.ok(indicator?.className.includes('bg-red-500'), 'Should have error variant color');
+        assert.ok(indicator?.className.includes('animate-pulse'), 'Should have active animation');
+    });
+
+    it('applies custom className correctly', () => {
+        render(<Indicator className="custom-class" data-testid="indicator" />);
+        const container = screen.getByTestId('indicator');
+        const indicator = container.querySelector('[aria-hidden="true"]');
+
+        assert.ok(indicator?.className.includes('custom-class'), 'Should have custom class');
+    });
+
+    it('renders screen reader label when provided', () => {
+        render(<Indicator label="Test label" />);
+        const srLabel = screen.getByText('Test label');
+
+        assert.ok(srLabel, 'Screen reader label should be rendered');
+        assert.ok(srLabel.className.includes('sr-only'), 'Should have sr-only class');
+    });
+
+    it('does not render screen reader label when not provided', () => {
+        const {container} = render(<Indicator data-testid="indicator" />);
+        const srLabels = container.querySelectorAll('.sr-only');
+
+        assert.equal(srLabels.length, 0, 'Should not render screen reader label');
+    });
+
+    it('sets aria-hidden on the indicator dot', () => {
+        render(<Indicator data-testid="indicator" />);
+        const container = screen.getByTestId('indicator');
+        const indicator = container.querySelector('[aria-hidden="true"]');
+
+        assert.ok(indicator, 'Indicator dot should exist');
+        assert.equal(indicator?.getAttribute('aria-hidden'), 'true', 'Should have aria-hidden attribute on dot');
+    });
+
+    it('passes additional props to the container span element', () => {
+        render(<Indicator data-testid="indicator-test" data-custom="value" />);
+        const container = screen.getByTestId('indicator-test');
+
+        assert.equal(container.getAttribute('data-custom'), 'value', 'Should pass additional props to container');
+    });
+});


### PR DESCRIPTION
## Why?

We need a lightweight, reusable component for status dots across the admin interface. Currently, these are implemented as inline divs with conditional Tailwind classes in multiple places, making them harder to maintain and style consistently.

## What does it do?

Adds an `Indicator` component to Shade - a simple status dot primitive with:
- **Variants**: `neutral` (grey), `success` (green), `error` (red), `warning` (yellow)
- **States**: `idle` (solid), `active` (pulsing), `inactive` (outline)
- **Sizes**: `sm` (8px), `md` (12px), `lg` (16px)

The component is designed to be lighter weight than Badge - no text, no padding, just a minimal colored dot with semantic meaning.

## Why is this needed?

This provides a consistent primitive for existing patterns scattered across the codebase:

**Current implementations that could be replaced:**
- Active visitor indicators (`apps/posts/.../PostAnalyticsHeader.tsx:116`, `apps/stats/.../StatsHeader.tsx:61`) - currently inline divs with conditional classes
- What's New notification badge (immediate use case for this PR)
- Connection status indicators (Stripe, Bluesky, etc.)
- Theme validation errors/warnings

Having this as a design system component ensures consistency and makes these indicators easier to maintain and update across the application.

## Example

<img width="662" height="659" alt="Screenshot 2025-11-12 at 14 56 30" src="https://github.com/user-attachments/assets/efeb4834-599b-4066-b025-1d2c12252bc3" />
