### PR TITLE
Added handling for apple-app-site-association files

### DIFF
--- a/ghost/core/test/unit/frontend/web/middleware/static-theme.test.js
+++ b/ghost/core/test/unit/frontend/web/middleware/static-theme.test.js
@@ -327,6 +327,41 @@ describe('staticTheme', function () {
         });
     });
 
+    describe('apple-app-site-association handling', function () {
+        beforeEach(function () {
+            activeThemeStub.returns({
+                path: 'my/fake/path'
+            });
+        });
+
+        it('should serve .well-known/apple-app-site-association despite missing extension', function (done) {
+            req.path = '/.well-known/apple-app-site-association';
+
+            staticTheme()(req, res, function next() {
+                activeThemeStub.called.should.be.true();
+                expressStaticStub.called.should.be.true();
+
+                const options = expressStaticStub.firstCall.args[1];
+                should.exist(options.setHeaders);
+
+                const setHeaderStub = sinon.stub();
+                options.setHeaders({setHeader: setHeaderStub});
+                setHeaderStub.calledWith('Content-Type', 'application/json').should.be.true();
+
+                done();
+            });
+        });
+
+        it('should fall through when request differs from exact path', function (done) {
+            req.path = '/.WELL-KNOWN/apple-app-site-association.json';
+
+            staticTheme()(req, res, function next() {
+                expressStaticStub.called.should.be.false();
+                done();
+            });
+        });
+    });
+
     describe('fallthrough behavior', function () {
         it('should set fallthrough to true for /robots.txt', function (done) {
             req.path = '/robots.txt';


### PR DESCRIPTION
fixes https://linear.app/ghost/issue/ONC-1251/universal-linking-no-longer-work-on-ios#comment-c26d5224

- In Ghost v6 we removed support for serving files from the root of a theme if they don't have an extension
- Apple's apple-app-site-association file is needed for universal linking in apps
- This file is a JSON file, it must not have a file extension but it must be served with a JSON content type
- This requirement from apple is very specific and creates a unique exception case
- We'll solve it by having a unique exception in the code just to support this one file


