### PR TITLE
Upgraded @eslint/js to 9.37.0 in e2e package

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -23,7 +23,7 @@
     "build"
   ],
   "devDependencies": {
-    "@eslint/js": "9.18.0",
+    "@eslint/js": "9.37.0",
     "@faker-js/faker": "8.4.1",
     "@playwright/test": "1.55.1",
     "@tryghost/debug": "0.1.35",


### PR DESCRIPTION
no issue

The canary build was failing to resolve the dependency for @eslint/js 9.18.0, because it was added to the e2e package, but not the `yarn.lock`. This updates it to the same version that's used in admin, which incidentally fixes the canary build.