### PR TITLE
Improving TypeScript support for Adapters

### DIFF
--- a/ghost/core/core/server/services/adapter-manager/AdapterManager.js
+++ b/ghost/core/core/server/services/adapter-manager/AdapterManager.js
@@ -1,6 +1,22 @@
 const path = require('path');
 const errors = require('@tryghost/errors');
 
+const resolveAdapterExport = (moduleExport) => {
+    if (!moduleExport) {
+        return moduleExport;
+    }
+
+    if (typeof moduleExport === 'function') {
+        return moduleExport;
+    }
+
+    if (typeof moduleExport === 'object' && typeof moduleExport.default === 'function') {
+        return moduleExport.default;
+    }
+
+    return moduleExport;
+};
+
 /**
  * @typedef { function(new: Adapter, object) } AdapterConstructor
  */
@@ -108,7 +124,8 @@ module.exports = class AdapterManager {
                 pathToAdapter = path.join(pathToAdapters, adapterClassName);
             }
             try {
-                Adapter = this.loadAdapterFromPath(pathToAdapter);
+                const adapterModule = this.loadAdapterFromPath(pathToAdapter);
+                Adapter = resolveAdapterExport(adapterModule);
                 if (Adapter) {
                     break;
                 }

--- a/ghost/core/tsconfig.json
+++ b/ghost/core/tsconfig.json
@@ -100,6 +100,7 @@
     },
     "include": [
         "core/**/*.ts",
-        "test/**/*.ts"
+        "test/**/*.ts",
+        "types/**/*.d.ts"
     ]
 }

--- a/ghost/core/types/ghost-storage-base.d.ts
+++ b/ghost/core/types/ghost-storage-base.d.ts
@@ -1,0 +1,22 @@
+declare module 'ghost-storage-base' {
+    import {RequestHandler} from 'express';
+
+    export type StorageFile = {
+        name: string;
+        path: string;
+        type?: string;
+    };
+
+    export default abstract class StorageBase {
+        protected storagePath: string;
+        getTargetDir(baseDir?: string): string;
+        getUniqueFileName(file: StorageFile, targetDir: string): Promise<string>;
+        abstract save(file: StorageFile, targetDir?: string): Promise<string>;
+        abstract saveRaw(buffer: Buffer, targetPath: string): Promise<string>;
+        abstract exists(fileName: string, targetDir: string): Promise<boolean>;
+        abstract delete(fileName: string, targetDir: string): Promise<void>;
+        abstract read(file: {path: string}): Promise<Buffer>;
+        abstract serve(): RequestHandler;
+        abstract urlToPath(url: string): string;
+    }
+}


### PR DESCRIPTION
When using `export default class` in TS the transpiled JS exposes the
class on `module.exports.default` rather than `module.exports`. We need
to be able to read from both in order to write new adapters in TS.

Migrating the whole of `ghost-storage-base` to TypeScript is outside the
scope of this work, but we do need to provide some types so that the S3
adapter implemntation can work correctly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adapter loading now resolves default exports for TS/ES modules; tsconfig includes local d.ts and new `ghost-storage-base` typings are added.
> 
> - **Adapter Loading**:
>   - Add `resolveAdapterExport` in `core/server/services/adapter-manager/AdapterManager.js` to handle function exports and `default` exports.
>   - Use resolved export when instantiating adapters, enabling TS `export default` classes.
> - **TypeScript**:
>   - Update `tsconfig.json` to include `types/**/*.d.ts`.
>   - Add `types/ghost-storage-base.d.ts` providing typings for `ghost-storage-base` (`StorageFile` type and `StorageBase` abstract class).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1d22aca7353372999372623eab64aa1157b1621e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->