### PR TITLE
Added S3 compatible storage adapter

### DIFF
--- a/ghost/core/core/server/adapters/storage/S3Storage.ts
+++ b/ghost/core/core/server/adapters/storage/S3Storage.ts
@@ -1,0 +1,261 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import StorageBase from 'ghost-storage-base';
+import tpl from '@tryghost/tpl';
+import errors from '@tryghost/errors';
+import {
+    DeleteObjectCommand,
+    HeadObjectCommand,
+    NotFound,
+    NoSuchKey,
+    PutObjectCommand,
+    S3Client,
+    S3ClientConfig
+} from '@aws-sdk/client-s3';
+
+const messages = {
+    invalidUrlParameter: 'The URL "{url}" is not a valid URL for this site.',
+    missingBucket: 'S3Storage requires a bucket name',
+    missingStaticFileURLPrefix: 'S3Storage requires a staticFileURLPrefix',
+    missingCdnUrl: 'S3Storage requires a cdnUrl option',
+    missingTenantPrefix: 'URL is missing expected tenant prefix "{tenantPrefix}": {url}',
+    missingStoragePath: 'URL is missing expected storagePath "{storagePath}": {url}',
+    emptyTargetPath: 'S3Storage.saveRaw requires a non-empty targetPath',
+    emptyFileName: 'S3Storage.{method} requires a non-empty fileName',
+    emptyRelativePath: 'S3Storage.buildKey requires a non-empty relativePath',
+    readNotSupported: 'read() is not supported by S3Storage. S3Storage is designed for media and files, not images. Use LocalImagesStorage for image storage.'
+};
+
+const stripLeadingAndTrailingSlashes = (value = '') => value.replace(/^\/+|\/+$/g, '');
+
+const stripTrailingSlash = (value = '') => value.replace(/\/+$/, '');
+
+interface UploadFile {
+    name: string;
+    path: string;
+    type?: string;
+}
+
+export interface S3StorageOptions {
+    bucket: string;
+    cdnUrl: string;
+    staticFileURLPrefix: string;
+    region?: string;
+    endpoint?: string;
+    forcePathStyle?: boolean;
+    accessKeyId?: string;
+    secretAccessKey?: string;
+    sessionToken?: string;
+    tenantPrefix?: string;
+    s3Client?: S3Client;
+}
+
+export default class S3Storage extends StorageBase {
+    private readonly client: S3Client;
+
+    private readonly bucket: string;
+
+    private readonly tenantPrefix: string;
+
+    private readonly cdnUrl: string;
+
+    public readonly staticFileURLPrefix: string;
+
+    constructor(options: S3StorageOptions) {
+        super();
+
+        if (!options.bucket) {
+            throw new errors.IncorrectUsageError({
+                message: tpl(messages.missingBucket)
+            });
+        }
+
+        this.bucket = options.bucket;
+        this.tenantPrefix = stripLeadingAndTrailingSlashes(options.tenantPrefix);
+
+        const staticFileURLPrefix = stripLeadingAndTrailingSlashes(options.staticFileURLPrefix);
+        if (!staticFileURLPrefix) {
+            throw new errors.IncorrectUsageError({
+                message: tpl(messages.missingStaticFileURLPrefix)
+            });
+        }
+
+        // Required by ImporterContentFileHandler
+        this.staticFileURLPrefix = staticFileURLPrefix;
+
+        // Required by ExternalMediaInliner
+        this.storagePath = staticFileURLPrefix;
+
+        this.cdnUrl = stripTrailingSlash(options.cdnUrl || '');
+        if (!this.cdnUrl) {
+            throw new errors.IncorrectUsageError({
+                message: tpl(messages.missingCdnUrl)
+            });
+        }
+
+        const clientConfig: S3ClientConfig = {
+            region: options.region,
+            endpoint: options.endpoint,
+            forcePathStyle: options.forcePathStyle
+        };
+
+        if (options.accessKeyId && options.secretAccessKey) {
+            clientConfig.credentials = {
+                accessKeyId: options.accessKeyId,
+                secretAccessKey: options.secretAccessKey,
+                sessionToken: options.sessionToken
+            };
+        }
+
+        this.client = options.s3Client || new S3Client(clientConfig);
+    }
+
+    async save(file: UploadFile, targetDir?: string): Promise<string> {
+        const dir = targetDir || this.getTargetDir();
+        const relativePath = await this.getUniqueFileName(file, dir);
+
+        const key = this.buildKey(relativePath);
+        const body = fs.createReadStream(file.path);
+
+        await this.client.send(new PutObjectCommand({
+            Bucket: this.bucket,
+            Key: key,
+            Body: body,
+            ContentType: file.type
+        }));
+
+        return `${this.cdnUrl}/${key}`;
+    }
+
+    async saveRaw(buffer: Buffer, targetPath: string): Promise<string> {
+        if (!targetPath?.trim()) {
+            throw new errors.IncorrectUsageError({
+                message: tpl(messages.emptyTargetPath)
+            });
+        }
+
+        const key = this.buildKey(targetPath);
+
+        await this.client.send(new PutObjectCommand({
+            Bucket: this.bucket,
+            Key: key,
+            Body: buffer
+        }));
+
+        return `${this.cdnUrl}/${key}`;
+    }
+
+    /**
+     * Converts a CDN URL to a relative path, stripping CDN URL, tenant prefix, and storagePath.
+     *
+     * Example: 'https://cdn.example.com/tenant/content/files/2024/06/video.mp4' → '2024/06/video.mp4'
+     */
+    urlToPath(url: string): string {
+        if (!url.startsWith(`${this.cdnUrl}/`)) {
+            throw new errors.IncorrectUsageError({
+                message: tpl(messages.invalidUrlParameter, {url})
+            });
+        }
+
+        let relativePath = url.slice(this.cdnUrl.length + 1);
+
+        if (this.tenantPrefix) {
+            if (!relativePath.startsWith(`${this.tenantPrefix}/`)) {
+                throw new errors.IncorrectUsageError({
+                    message: tpl(messages.missingTenantPrefix, {tenantPrefix: this.tenantPrefix, url})
+                });
+            }
+            relativePath = relativePath.slice(this.tenantPrefix.length + 1);
+        }
+
+        if (!relativePath.startsWith(`${this.storagePath}/`)) {
+            throw new errors.IncorrectUsageError({
+                message: tpl(messages.missingStoragePath, {storagePath: this.storagePath, url})
+            });
+        }
+
+        return relativePath.slice(this.storagePath.length + 1);
+    }
+
+    async exists(fileName: string, targetDir: string): Promise<boolean> {
+        if (!fileName?.trim()) {
+            throw new errors.IncorrectUsageError({
+                message: tpl(messages.emptyFileName, {method: 'exists'})
+            });
+        }
+
+        const relativePath = path.posix.join(targetDir, fileName);
+        const key = this.buildKey(relativePath);
+
+        try {
+            await this.client.send(new HeadObjectCommand({
+                Bucket: this.bucket,
+                Key: key
+            }));
+            return true;
+        } catch (error) {
+            if (this.isNotFound(error)) {
+                return false;
+            }
+
+            throw error;
+        }
+    }
+
+    serve() {
+        return function (_req: unknown, _res: unknown, next: (err?: unknown) => void) {
+            next();
+        };
+    }
+
+    async delete(fileName: string, targetDir: string): Promise<void> {
+        if (!fileName?.trim()) {
+            throw new errors.IncorrectUsageError({
+                message: tpl(messages.emptyFileName, {method: 'delete'})
+            });
+        }
+
+        const relativePath = path.posix.join(targetDir, fileName);
+        const key = this.buildKey(relativePath);
+
+        try {
+            await this.client.send(new DeleteObjectCommand({
+                Bucket: this.bucket,
+                Key: key
+            }));
+        } catch (error) {
+            if (!this.isNotFound(error)) {
+                throw error;
+            }
+        }
+    }
+
+    /**
+     * Not supported - S3Storage is for media/files only. Images use LocalImagesStorage.
+     */
+    async read(): Promise<Buffer> {
+        throw new errors.IncorrectUsageError({
+            message: tpl(messages.readNotSupported)
+        });
+    }
+
+    private buildKey(relativePath: string): string {
+        if (!relativePath) {
+            throw new errors.IncorrectUsageError({
+                message: tpl(messages.emptyRelativePath)
+            });
+        }
+
+        const pathWithStorage = path.posix.join(this.storagePath, relativePath);
+
+        if (!this.tenantPrefix) {
+            return pathWithStorage;
+        }
+
+        return `${this.tenantPrefix}/${pathWithStorage}`;
+    }
+
+    private isNotFound(error: unknown): boolean {
+        return error instanceof NotFound || error instanceof NoSuchKey;
+    }
+}

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -66,6 +66,7 @@
     "cli": "^1.27.0"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "3.864.0",
     "@extractus/oembed-extractor": "3.2.1",
     "@faker-js/faker": "7.6.0",
     "@isaacs/ttlcache": "1.4.1",

--- a/ghost/core/test/unit/server/adapters/storage/S3Storage.test.ts
+++ b/ghost/core/test/unit/server/adapters/storage/S3Storage.test.ts
@@ -1,0 +1,321 @@
+import assert from 'assert/strict';
+import sinon from 'sinon';
+import {Readable} from 'stream';
+import fs from 'fs';
+import path from 'path';
+import {
+    DeleteObjectCommand,
+    NotFound,
+    PutObjectCommand,
+    S3Client
+} from '@aws-sdk/client-s3';
+import S3Storage, {type S3StorageOptions} from '../../../../../core/server/adapters/storage/S3Storage';
+
+const baseOptions: S3StorageOptions = {
+    staticFileURLPrefix: 'content/files',
+    bucket: 'test-bucket',
+    region: 'us-east-1',
+    tenantPrefix: 'configurable/prefix',
+    cdnUrl: 'https://cdn.example.com'
+};
+
+type StubbedClient = Pick<S3Client, 'send'>;
+
+const createNotFoundError = () => {
+    return new NotFound({
+        $metadata: {
+            httpStatusCode: 404
+        },
+        message: 'The specified key does not exist.'
+    });
+};
+
+describe('S3Storage', function () {
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    function createStorage(overrides: Record<string, unknown> = {}) {
+        const sendStub = sinon.stub().resolves({});
+        const client: StubbedClient = {
+            send: sendStub
+        };
+
+        const storage = new S3Storage({
+            ...baseOptions,
+            ...overrides,
+            s3Client: client as S3Client
+        });
+
+        return {storage, sendStub};
+    }
+
+    it('throws when required constructor options are missing', function () {
+        assert.throws(() => {
+            const options: any = {...baseOptions};
+            delete options.bucket;
+            new S3Storage(options);
+        }, /requires a bucket name/);
+
+        assert.throws(() => {
+            const options: any = {...baseOptions};
+            delete options.staticFileURLPrefix;
+            new S3Storage(options);
+        }, /requires a staticFileURLPrefix/);
+
+        assert.throws(() => {
+            const options: any = {...baseOptions};
+            delete options.cdnUrl;
+            new S3Storage(options);
+        }, /requires a cdnUrl option/);
+    });
+
+    it('strips leading and trailing slashes from config options', function () {
+        const {storage} = createStorage({
+            tenantPrefix: '/client-a/',
+            staticFileURLPrefix: '/content/files/',
+            cdnUrl: 'https://cdn.example.com/'
+        });
+
+        assert.equal((storage as any).tenantPrefix, 'client-a');
+        assert.equal((storage as any).storagePath, 'content/files');
+        assert.equal((storage as any).cdnUrl, 'https://cdn.example.com');
+    });
+
+    it('uploads files with prefix and returns cdn url', async function () {
+        const {storage, sendStub} = createStorage();
+
+        sinon.stub(storage, 'exists').resolves(false);
+        sinon.stub(fs, 'createReadStream').returns(Readable.from('file-data') as unknown as fs.ReadStream);
+
+        const url = await storage.save({
+            path: '/tmp/test-image.jpg',
+            name: 'test-image.jpg'
+        }, '2024/06');
+
+        assert.equal(url, 'https://cdn.example.com/configurable/prefix/content/files/2024/06/test-image.jpg');
+        sinon.assert.calledOnce(sendStub);
+        const command = sendStub.firstCall.args[0] as PutObjectCommand;
+        assert.equal(command.input.Bucket, 'test-bucket');
+        assert.equal(command.input.Key, 'configurable/prefix/content/files/2024/06/test-image.jpg');
+    });
+
+    it('save() uses getTargetDir() when targetDir not provided', async function () {
+        const {storage, sendStub} = createStorage();
+
+        sinon.stub(storage, 'exists').resolves(false);
+        sinon.stub(fs, 'createReadStream').returns(Readable.from('file-data') as unknown as fs.ReadStream);
+
+        const url = await storage.save({
+            path: '/tmp/test-image.jpg',
+            name: 'test-image.jpg'
+        });
+
+        assert.ok(url.startsWith('https://cdn.example.com/configurable/prefix/content/files/'));
+        sinon.assert.calledOnce(sendStub);
+    });
+
+    it('saves raw buffers relative to storagePath', async function () {
+        const {storage, sendStub} = createStorage();
+
+        const url = await storage.saveRaw(Buffer.from('raw-data'), 'thumbnails/raw-image.jpg');
+
+        assert.equal(url, 'https://cdn.example.com/configurable/prefix/content/files/thumbnails/raw-image.jpg');
+        sinon.assert.calledOnce(sendStub);
+        const command = sendStub.firstCall.args[0] as PutObjectCommand;
+        assert.equal(command.input.Key, 'configurable/prefix/content/files/thumbnails/raw-image.jpg');
+    });
+
+    it('converts CDN urls back to relative paths (strips prefix and storagePath)', function () {
+        const {storage} = createStorage();
+
+        const key = storage.urlToPath('https://cdn.example.com/configurable/prefix/content/files/2024/06/test-image.jpg');
+
+        assert.equal(key, '2024/06/test-image.jpg');
+    });
+
+    it('throws if url does not match CDN', function () {
+        const {storage} = createStorage();
+
+        assert.throws(() => {
+            storage.urlToPath('https://malicious.example.com/evil.jpg');
+        }, /not a valid URL/);
+    });
+
+    it('throws if url is missing expected tenant prefix', function () {
+        const {storage} = createStorage();
+
+        assert.throws(() => {
+            storage.urlToPath('https://cdn.example.com/content/files/2024/06/image.jpg');
+        }, /missing expected tenant prefix/);
+    });
+
+    it('throws if url is missing expected storagePath', function () {
+        const {storage} = createStorage();
+
+        assert.throws(() => {
+            storage.urlToPath('https://cdn.example.com/configurable/prefix/2024/06/image.jpg');
+        }, /missing expected storagePath/);
+    });
+
+    it('serve middleware short-circuits to next handler', function (done) {
+        const {storage} = createStorage();
+
+        const middleware = storage.serve();
+        middleware({} as any, {} as any, () => {
+            done();
+        });
+    });
+
+    it('exists resolves based on S3 head object responses', async function () {
+        const {storage, sendStub} = createStorage();
+
+        sendStub.resolves({});
+        const exists = await storage.exists('test-image.jpg', '2024/06');
+        assert.equal(exists, true);
+
+        sendStub.resetHistory();
+        sendStub.rejects(createNotFoundError());
+        const missing = await storage.exists('missing.jpg', '2024/06');
+        assert.equal(missing, false);
+    });
+
+    it('delete removes objects using derived key', async function () {
+        const {storage, sendStub} = createStorage();
+
+        await storage.delete('test-image.jpg', '2024/06');
+
+        sinon.assert.calledOnce(sendStub);
+        const command = sendStub.firstCall.args[0] as DeleteObjectCommand;
+        assert.equal(command.input.Key, 'configurable/prefix/content/files/2024/06/test-image.jpg');
+    });
+
+    it('delete ignores missing objects', async function () {
+        const {storage, sendStub} = createStorage();
+
+        sendStub.rejects(createNotFoundError());
+
+        await storage.delete('ghost.txt', 'content/files');
+        assert.equal(sendStub.callCount, 1);
+    });
+
+    it('exists rethrows unexpected S3 errors', async function () {
+        const {storage, sendStub} = createStorage();
+        sendStub.rejects(new Error('boom'));
+
+        await assert.rejects(storage.exists('bad.txt', '2024/06'), /boom/);
+    });
+
+    it('saveRaw throws when targetPath is empty', async function () {
+        const {storage} = createStorage();
+
+        await assert.rejects(
+            storage.saveRaw(Buffer.from('data'), ''),
+            /requires a non-empty targetPath/
+        );
+    });
+
+    it('exists throws when fileName is empty', async function () {
+        const {storage} = createStorage();
+
+        await assert.rejects(
+            storage.exists('', '2024/06'),
+            /requires a non-empty fileName/
+        );
+    });
+
+    it('delete throws when fileName is empty', async function () {
+        const {storage} = createStorage();
+
+        await assert.rejects(
+            storage.delete('', '2024/06'),
+            /requires a non-empty fileName/
+        );
+    });
+
+    it('handles thumbnail upload flow (urlToPath → dirname → save)', async function () {
+        const {storage, sendStub} = createStorage();
+
+        sinon.stub(storage, 'exists').resolves(false);
+        sinon.stub(fs, 'createReadStream').returns(Readable.from('file-data') as unknown as fs.ReadStream);
+
+        const videoUrl = await storage.save({
+            path: '/tmp/video.mp4',
+            name: 'video.mp4'
+        });
+
+        assert.ok(videoUrl.includes('/content/files/'));
+
+        const videoCommand = sendStub.firstCall.args[0] as PutObjectCommand;
+        const videoKey = videoCommand.input.Key;
+
+        const videoPath = storage.urlToPath(videoUrl);
+        const targetDir = path.dirname(videoPath);
+
+        sendStub.resetHistory();
+        await storage.save({
+            path: '/tmp/thumbnail.jpg',
+            name: 'thumbnail.jpg'
+        }, targetDir);
+
+        const thumbnailCommand = sendStub.firstCall.args[0] as PutObjectCommand;
+        const expectedThumbnailKey = videoKey?.replace('video.mp4', 'thumbnail.jpg');
+
+        assert.equal(thumbnailCommand.input.Key, expectedThumbnailKey);
+    });
+
+    it('handles ExternalMediaInliner flow (getTargetDir → getUniqueFileName → path.relative → saveRaw)', async function () {
+        const {storage, sendStub} = createStorage();
+
+        sinon.stub(storage, 'exists').resolves(false);
+
+        const storagePath = (storage as any).storagePath;
+        const targetDir = storage.getTargetDir(storagePath);
+        const uniqueFileName = await storage.getUniqueFileName({
+            name: 'external-image.jpg',
+            path: '/tmp/external-image.jpg'
+        }, targetDir);
+        const targetPath = path.relative(storagePath, uniqueFileName);
+
+        await storage.saveRaw(Buffer.from('external-data'), targetPath);
+
+        const command = sendStub.firstCall.args[0] as PutObjectCommand;
+        assert.ok(command.input.Key?.startsWith('configurable/prefix/content/files/'));
+        assert.ok(!command.input.Key?.includes('content/files/content/files'));
+    });
+
+    it('buildKey always adds storagePath and tenant prefix', function () {
+        const {storage} = createStorage();
+
+        const relativePath = '2024/06/image.jpg';
+        const key = (storage as any).buildKey(relativePath);
+
+        assert.equal(key, 'configurable/prefix/content/files/2024/06/image.jpg');
+    });
+
+    it('buildKey works without tenant prefix', function () {
+        const {storage} = createStorage({tenantPrefix: ''});
+
+        const relativePath = '2024/06/image.jpg';
+        const key = (storage as any).buildKey(relativePath);
+
+        assert.equal(key, 'content/files/2024/06/image.jpg');
+    });
+
+    it('buildKey throws on empty path', function () {
+        const {storage} = createStorage();
+
+        assert.throws(() => {
+            (storage as any).buildKey('');
+        }, /requires a non-empty relativePath/);
+    });
+
+    it('read() throws as it is not supported', async function () {
+        const {storage} = createStorage();
+
+        await assert.rejects(
+            storage.read(),
+            /read\(\) is not supported by S3Storage/
+        );
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -52,6 +52,36 @@
     "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.24"
 
+"@aws-crypto/crc32@5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/crc32/-/crc32-5.2.0.tgz#cfcc22570949c98c6689cfcbd2d693d36cdae2e1"
+  integrity sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==
+  dependencies:
+    "@aws-crypto/util" "^5.2.0"
+    "@aws-sdk/types" "^3.222.0"
+    tslib "^2.6.2"
+
+"@aws-crypto/crc32c@5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/crc32c/-/crc32c-5.2.0.tgz#4e34aab7f419307821509a98b9b08e84e0c1917e"
+  integrity sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==
+  dependencies:
+    "@aws-crypto/util" "^5.2.0"
+    "@aws-sdk/types" "^3.222.0"
+    tslib "^2.6.2"
+
+"@aws-crypto/sha1-browser@5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/sha1-browser/-/sha1-browser-5.2.0.tgz#b0ee2d2821d3861f017e965ef3b4cb38e3b6a0f4"
+  integrity sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==
+  dependencies:
+    "@aws-crypto/supports-web-crypto" "^5.2.0"
+    "@aws-crypto/util" "^5.2.0"
+    "@aws-sdk/types" "^3.222.0"
+    "@aws-sdk/util-locate-window" "^3.0.0"
+    "@smithy/util-utf8" "^2.0.0"
+    tslib "^2.6.2"
+
 "@aws-crypto/sha256-browser@5.2.0":
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz#153895ef1dba6f9fce38af550e0ef58988eb649e"
@@ -81,7 +111,7 @@
   dependencies:
     tslib "^2.6.2"
 
-"@aws-crypto/util@^5.2.0":
+"@aws-crypto/util@5.2.0", "@aws-crypto/util@^5.2.0":
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/@aws-crypto/util/-/util-5.2.0.tgz#71284c9cffe7927ddadac793c14f14886d3876da"
   integrity sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==
@@ -89,6 +119,70 @@
     "@aws-sdk/types" "^3.222.0"
     "@smithy/util-utf8" "^2.0.0"
     tslib "^2.6.2"
+
+"@aws-sdk/client-s3@3.864.0":
+  version "3.864.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-s3/-/client-s3-3.864.0.tgz#ffbcbf0ba861fad711261b4174da3be19b1c7d5f"
+  integrity sha512-QGYi9bWliewxumsvbJLLyx9WC0a4DP4F+utygBcq0zwPxaM0xDfBspQvP1dsepi7mW5aAjZmJ2+Xb7X0EhzJ/g==
+  dependencies:
+    "@aws-crypto/sha1-browser" "5.2.0"
+    "@aws-crypto/sha256-browser" "5.2.0"
+    "@aws-crypto/sha256-js" "5.2.0"
+    "@aws-sdk/core" "3.864.0"
+    "@aws-sdk/credential-provider-node" "3.864.0"
+    "@aws-sdk/middleware-bucket-endpoint" "3.862.0"
+    "@aws-sdk/middleware-expect-continue" "3.862.0"
+    "@aws-sdk/middleware-flexible-checksums" "3.864.0"
+    "@aws-sdk/middleware-host-header" "3.862.0"
+    "@aws-sdk/middleware-location-constraint" "3.862.0"
+    "@aws-sdk/middleware-logger" "3.862.0"
+    "@aws-sdk/middleware-recursion-detection" "3.862.0"
+    "@aws-sdk/middleware-sdk-s3" "3.864.0"
+    "@aws-sdk/middleware-ssec" "3.862.0"
+    "@aws-sdk/middleware-user-agent" "3.864.0"
+    "@aws-sdk/region-config-resolver" "3.862.0"
+    "@aws-sdk/signature-v4-multi-region" "3.864.0"
+    "@aws-sdk/types" "3.862.0"
+    "@aws-sdk/util-endpoints" "3.862.0"
+    "@aws-sdk/util-user-agent-browser" "3.862.0"
+    "@aws-sdk/util-user-agent-node" "3.864.0"
+    "@aws-sdk/xml-builder" "3.862.0"
+    "@smithy/config-resolver" "^4.1.5"
+    "@smithy/core" "^3.8.0"
+    "@smithy/eventstream-serde-browser" "^4.0.5"
+    "@smithy/eventstream-serde-config-resolver" "^4.1.3"
+    "@smithy/eventstream-serde-node" "^4.0.5"
+    "@smithy/fetch-http-handler" "^5.1.1"
+    "@smithy/hash-blob-browser" "^4.0.5"
+    "@smithy/hash-node" "^4.0.5"
+    "@smithy/hash-stream-node" "^4.0.5"
+    "@smithy/invalid-dependency" "^4.0.5"
+    "@smithy/md5-js" "^4.0.5"
+    "@smithy/middleware-content-length" "^4.0.5"
+    "@smithy/middleware-endpoint" "^4.1.18"
+    "@smithy/middleware-retry" "^4.1.19"
+    "@smithy/middleware-serde" "^4.0.9"
+    "@smithy/middleware-stack" "^4.0.5"
+    "@smithy/node-config-provider" "^4.1.4"
+    "@smithy/node-http-handler" "^4.1.1"
+    "@smithy/protocol-http" "^5.1.3"
+    "@smithy/smithy-client" "^4.4.10"
+    "@smithy/types" "^4.3.2"
+    "@smithy/url-parser" "^4.0.5"
+    "@smithy/util-base64" "^4.0.0"
+    "@smithy/util-body-length-browser" "^4.0.0"
+    "@smithy/util-body-length-node" "^4.0.0"
+    "@smithy/util-defaults-mode-browser" "^4.0.26"
+    "@smithy/util-defaults-mode-node" "^4.0.26"
+    "@smithy/util-endpoints" "^3.0.7"
+    "@smithy/util-middleware" "^4.0.5"
+    "@smithy/util-retry" "^4.0.7"
+    "@smithy/util-stream" "^4.2.4"
+    "@smithy/util-utf8" "^4.0.0"
+    "@smithy/util-waiter" "^4.0.7"
+    "@types/uuid" "^9.0.1"
+    tslib "^2.6.2"
+    uuid "^9.0.1"
 
 "@aws-sdk/client-ses@^3.31.0", "@aws-sdk/client-ses@^3.731.1":
   version "3.864.0"
@@ -303,6 +397,48 @@
     "@smithy/types" "^4.3.2"
     tslib "^2.6.2"
 
+"@aws-sdk/middleware-bucket-endpoint@3.862.0":
+  version "3.862.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.862.0.tgz#8d318eccfa987cfa4e6c5f62539d99bcbe6dec30"
+  integrity sha512-Wcsc7VPLjImQw+CP1/YkwyofMs9Ab6dVq96iS8p0zv0C6YTaMjvillkau4zFfrrrTshdzFWKptIFhKK8Zsei1g==
+  dependencies:
+    "@aws-sdk/types" "3.862.0"
+    "@aws-sdk/util-arn-parser" "3.804.0"
+    "@smithy/node-config-provider" "^4.1.4"
+    "@smithy/protocol-http" "^5.1.3"
+    "@smithy/types" "^4.3.2"
+    "@smithy/util-config-provider" "^4.0.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/middleware-expect-continue@3.862.0":
+  version "3.862.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.862.0.tgz#f53c28c41f63859362797fd76e993365b598d0ba"
+  integrity sha512-oG3AaVUJ+26p0ESU4INFn6MmqqiBFZGrebST66Or+YBhteed2rbbFl7mCfjtPWUFgquQlvT1UP19P3LjQKeKpw==
+  dependencies:
+    "@aws-sdk/types" "3.862.0"
+    "@smithy/protocol-http" "^5.1.3"
+    "@smithy/types" "^4.3.2"
+    tslib "^2.6.2"
+
+"@aws-sdk/middleware-flexible-checksums@3.864.0":
+  version "3.864.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.864.0.tgz#fcbb40ae1513f96185ec961693c0f55ec1f4da18"
+  integrity sha512-MvakvzPZi9uyP3YADuIqtk/FAcPFkyYFWVVMf5iFs/rCdk0CUzn02Qf4CSuyhbkS6Y0KrAsMgKR4MgklPU79Wg==
+  dependencies:
+    "@aws-crypto/crc32" "5.2.0"
+    "@aws-crypto/crc32c" "5.2.0"
+    "@aws-crypto/util" "5.2.0"
+    "@aws-sdk/core" "3.864.0"
+    "@aws-sdk/types" "3.862.0"
+    "@smithy/is-array-buffer" "^4.0.0"
+    "@smithy/node-config-provider" "^4.1.4"
+    "@smithy/protocol-http" "^5.1.3"
+    "@smithy/types" "^4.3.2"
+    "@smithy/util-middleware" "^4.0.5"
+    "@smithy/util-stream" "^4.2.4"
+    "@smithy/util-utf8" "^4.0.0"
+    tslib "^2.6.2"
+
 "@aws-sdk/middleware-host-header@3.862.0":
   version "3.862.0"
   resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-host-header/-/middleware-host-header-3.862.0.tgz#9b5fa0ad4c17a84816b4bfde7cda949116374042"
@@ -310,6 +446,15 @@
   dependencies:
     "@aws-sdk/types" "3.862.0"
     "@smithy/protocol-http" "^5.1.3"
+    "@smithy/types" "^4.3.2"
+    tslib "^2.6.2"
+
+"@aws-sdk/middleware-location-constraint@3.862.0":
+  version "3.862.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.862.0.tgz#d55babadc9f9b7150c56b028fc6953021a5a565a"
+  integrity sha512-MnwLxCw7Cc9OngEH3SHFhrLlDI9WVxaBkp3oTsdY9JE7v8OE38wQ9vtjaRsynjwu0WRtrctSHbpd7h/QVvtjyA==
+  dependencies:
+    "@aws-sdk/types" "3.862.0"
     "@smithy/types" "^4.3.2"
     tslib "^2.6.2"
 
@@ -329,6 +474,35 @@
   dependencies:
     "@aws-sdk/types" "3.862.0"
     "@smithy/protocol-http" "^5.1.3"
+    "@smithy/types" "^4.3.2"
+    tslib "^2.6.2"
+
+"@aws-sdk/middleware-sdk-s3@3.864.0":
+  version "3.864.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.864.0.tgz#5142210471ed702452277ad653af483147c42598"
+  integrity sha512-GjYPZ6Xnqo17NnC8NIQyvvdzzO7dm+Ks7gpxD/HsbXPmV2aEfuFveJXneGW9e1BheSKFff6FPDWu8Gaj2Iu1yg==
+  dependencies:
+    "@aws-sdk/core" "3.864.0"
+    "@aws-sdk/types" "3.862.0"
+    "@aws-sdk/util-arn-parser" "3.804.0"
+    "@smithy/core" "^3.8.0"
+    "@smithy/node-config-provider" "^4.1.4"
+    "@smithy/protocol-http" "^5.1.3"
+    "@smithy/signature-v4" "^5.1.3"
+    "@smithy/smithy-client" "^4.4.10"
+    "@smithy/types" "^4.3.2"
+    "@smithy/util-config-provider" "^4.0.0"
+    "@smithy/util-middleware" "^4.0.5"
+    "@smithy/util-stream" "^4.2.4"
+    "@smithy/util-utf8" "^4.0.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/middleware-ssec@3.862.0":
+  version "3.862.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-ssec/-/middleware-ssec-3.862.0.tgz#d6c7d03c966cb6642acec8c7f046afd3a72c0f7c"
+  integrity sha512-72VtP7DZC8lYTE2L3Efx2BrD98oe9WTK8X6hmd3WTLkbIjvgWQWIdjgaFXBs8WevsXkewIctfyA3KEezvL5ggw==
+  dependencies:
+    "@aws-sdk/types" "3.862.0"
     "@smithy/types" "^4.3.2"
     tslib "^2.6.2"
 
@@ -401,6 +575,18 @@
     "@smithy/util-middleware" "^4.0.5"
     tslib "^2.6.2"
 
+"@aws-sdk/signature-v4-multi-region@3.864.0":
+  version "3.864.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.864.0.tgz#75e24f5382aa77b7e629f8feb366bcf2a358ffb8"
+  integrity sha512-w2HIn/WIcUyv1bmyCpRUKHXB5KdFGzyxPkp/YK5g+/FuGdnFFYWGfcO8O+How4jwrZTarBYsAHW9ggoKvwr37w==
+  dependencies:
+    "@aws-sdk/middleware-sdk-s3" "3.864.0"
+    "@aws-sdk/types" "3.862.0"
+    "@smithy/protocol-http" "^5.1.3"
+    "@smithy/signature-v4" "^5.1.3"
+    "@smithy/types" "^4.3.2"
+    tslib "^2.6.2"
+
 "@aws-sdk/token-providers@3.864.0":
   version "3.864.0"
   resolved "https://registry.yarnpkg.com/@aws-sdk/token-providers/-/token-providers-3.864.0.tgz#c5f88c34bf268435a5b64b7814193c63ae330a68"
@@ -420,6 +606,13 @@
   integrity sha512-Bei+RL0cDxxV+lW2UezLbCYYNeJm6Nzee0TpW0FfyTRBhH9C1XQh4+x+IClriXvgBnRquTMMYsmJfvx8iyLKrg==
   dependencies:
     "@smithy/types" "^4.3.2"
+    tslib "^2.6.2"
+
+"@aws-sdk/util-arn-parser@3.804.0":
+  version "3.804.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-arn-parser/-/util-arn-parser-3.804.0.tgz#d0b52bf5f9ae5b2c357a635551e5844dcad074c8"
+  integrity sha512-wmBJqn1DRXnZu3b4EkE6CWnoWMo1ZMvlfkqU5zPz67xx1GMaXlDCchFvKAXMjk4jn/L1O3tKnoFDNsoLV1kgNQ==
+  dependencies:
     tslib "^2.6.2"
 
 "@aws-sdk/util-endpoints@3.862.0":
@@ -6147,6 +6340,21 @@
     "@smithy/types" "^4.3.2"
     tslib "^2.6.2"
 
+"@smithy/chunked-blob-reader-native@^4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-4.2.1.tgz#380266951d746b522b4ab2b16bfea6b451147b41"
+  integrity sha512-lX9Ay+6LisTfpLid2zZtIhSEjHMZoAR5hHCR4H7tBz/Zkfr5ea8RcQ7Tk4mi0P76p4cN+Btz16Ffno7YHpKXnQ==
+  dependencies:
+    "@smithy/util-base64" "^4.3.0"
+    tslib "^2.6.2"
+
+"@smithy/chunked-blob-reader@^5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@smithy/chunked-blob-reader/-/chunked-blob-reader-5.2.0.tgz#776fec5eaa5ab5fa70d0d0174b7402420b24559c"
+  integrity sha512-WmU0TnhEAJLWvfSeMxBNe5xtbselEO8+4wG0NtZeL8oR21WgH1xiO37El+/Y+H/Ie4SCwBy3MxYWmOYaGgZueA==
+  dependencies:
+    tslib "^2.6.2"
+
 "@smithy/config-resolver@^4.1.5":
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/@smithy/config-resolver/-/config-resolver-4.1.5.tgz#3cb7cde8d13ca64630e5655812bac9ffe8182469"
@@ -6186,6 +6394,51 @@
     "@smithy/url-parser" "^4.0.5"
     tslib "^2.6.2"
 
+"@smithy/eventstream-codec@^4.2.4":
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/@smithy/eventstream-codec/-/eventstream-codec-4.2.4.tgz#f9cc680b156d3fac4cc631a8b0159f5e87205143"
+  integrity sha512-aV8blR9RBDKrOlZVgjOdmOibTC2sBXNiT7WA558b4MPdsLTV6sbyc1WIE9QiIuYMJjYtnPLciefoqSW8Gi+MZQ==
+  dependencies:
+    "@aws-crypto/crc32" "5.2.0"
+    "@smithy/types" "^4.8.1"
+    "@smithy/util-hex-encoding" "^4.2.0"
+    tslib "^2.6.2"
+
+"@smithy/eventstream-serde-browser@^4.0.5":
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.4.tgz#6aa94f14dd4d3376cb3389a0f6f245994e9e97c7"
+  integrity sha512-d5T7ZS3J/r8P/PDjgmCcutmNxnSRvPH1U6iHeXjzI50sMr78GLmFcrczLw33Ap92oEKqa4CLrkAPeSSOqvGdUA==
+  dependencies:
+    "@smithy/eventstream-serde-universal" "^4.2.4"
+    "@smithy/types" "^4.8.1"
+    tslib "^2.6.2"
+
+"@smithy/eventstream-serde-config-resolver@^4.1.3":
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.4.tgz#6ddd88c57274a6fe72e11bfd5ac858977573dc46"
+  integrity sha512-lxfDT0UuSc1HqltOGsTEAlZ6H29gpfDSdEPTapD5G63RbnYToZ+ezjzdonCCH90j5tRRCw3aLXVbiZaBW3VRVg==
+  dependencies:
+    "@smithy/types" "^4.8.1"
+    tslib "^2.6.2"
+
+"@smithy/eventstream-serde-node@^4.0.5":
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.4.tgz#61934c44c511bec5b07cfbbf59a2282806cd2ff8"
+  integrity sha512-TPhiGByWnYyzcpU/K3pO5V7QgtXYpE0NaJPEZBCa1Y5jlw5SjqzMSbFiLb+ZkJhqoQc0ImGyVINqnq1ze0ZRcQ==
+  dependencies:
+    "@smithy/eventstream-serde-universal" "^4.2.4"
+    "@smithy/types" "^4.8.1"
+    tslib "^2.6.2"
+
+"@smithy/eventstream-serde-universal@^4.2.4":
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.4.tgz#7c19762047b429d53af4664dc1168482706b4ee7"
+  integrity sha512-GNI/IXaY/XBB1SkGBFmbW033uWA0tj085eCxYih0eccUe/PFR7+UBQv9HNDk2fD9TJu7UVsCWsH99TkpEPSOzQ==
+  dependencies:
+    "@smithy/eventstream-codec" "^4.2.4"
+    "@smithy/types" "^4.8.1"
+    tslib "^2.6.2"
+
 "@smithy/fetch-http-handler@^5.1.1":
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/@smithy/fetch-http-handler/-/fetch-http-handler-5.1.1.tgz#a444c99bffdf314deb447370429cc3e719f1a866"
@@ -6197,6 +6450,16 @@
     "@smithy/util-base64" "^4.0.0"
     tslib "^2.6.2"
 
+"@smithy/hash-blob-browser@^4.0.5":
+  version "4.2.5"
+  resolved "https://registry.yarnpkg.com/@smithy/hash-blob-browser/-/hash-blob-browser-4.2.5.tgz#c82e032747b72811f735c2c1f0ed0c1aeb4de910"
+  integrity sha512-kCdgjD2J50qAqycYx0imbkA9tPtyQr1i5GwbK/EOUkpBmJGSkJe4mRJm+0F65TUSvvui1HZ5FFGFCND7l8/3WQ==
+  dependencies:
+    "@smithy/chunked-blob-reader" "^5.2.0"
+    "@smithy/chunked-blob-reader-native" "^4.2.1"
+    "@smithy/types" "^4.8.1"
+    tslib "^2.6.2"
+
 "@smithy/hash-node@^4.0.5":
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/@smithy/hash-node/-/hash-node-4.0.5.tgz#16cf8efe42b8b611b1f56f78464b97b27ca6a3ec"
@@ -6205,6 +6468,15 @@
     "@smithy/types" "^4.3.2"
     "@smithy/util-buffer-from" "^4.0.0"
     "@smithy/util-utf8" "^4.0.0"
+    tslib "^2.6.2"
+
+"@smithy/hash-stream-node@^4.0.5":
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/@smithy/hash-stream-node/-/hash-stream-node-4.2.4.tgz#553fa9a8fe567b0018cf99be3dafb920bc241a7f"
+  integrity sha512-amuh2IJiyRfO5MV0X/YFlZMD6banjvjAwKdeJiYGUbId608x+oSNwv3vlyW2Gt6AGAgl3EYAuyYLGRX/xU8npQ==
+  dependencies:
+    "@smithy/types" "^4.8.1"
+    "@smithy/util-utf8" "^4.2.0"
     tslib "^2.6.2"
 
 "@smithy/invalid-dependency@^4.0.5":
@@ -6227,6 +6499,22 @@
   resolved "https://registry.yarnpkg.com/@smithy/is-array-buffer/-/is-array-buffer-4.0.0.tgz#55a939029321fec462bcc574890075cd63e94206"
   integrity sha512-saYhF8ZZNoJDTvJBEWgeBccCg+yvp1CX+ed12yORU3NilJScfc6gfch2oVb4QgxZrGUx3/ZJlb+c/dJbyupxlw==
   dependencies:
+    tslib "^2.6.2"
+
+"@smithy/is-array-buffer@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz#b0f874c43887d3ad44f472a0f3f961bcce0550c2"
+  integrity sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==
+  dependencies:
+    tslib "^2.6.2"
+
+"@smithy/md5-js@^4.0.5":
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/@smithy/md5-js/-/md5-js-4.2.4.tgz#e012464383ffde0bd423d38ef9b5caf720ee90eb"
+  integrity sha512-h7kzNWZuMe5bPnZwKxhVbY1gan5+TZ2c9JcVTHCygB14buVGOZxLl+oGfpY2p2Xm48SFqEWdghpvbBdmaz3ncQ==
+  dependencies:
+    "@smithy/types" "^4.8.1"
+    "@smithy/util-utf8" "^4.2.0"
     tslib "^2.6.2"
 
 "@smithy/middleware-content-length@^4.0.5":
@@ -6388,6 +6676,13 @@
   dependencies:
     tslib "^2.6.2"
 
+"@smithy/types@^4.8.1":
+  version "4.8.1"
+  resolved "https://registry.yarnpkg.com/@smithy/types/-/types-4.8.1.tgz#0ecad4e329340c8844e38a18c7608d84cc1c853c"
+  integrity sha512-N0Zn0OT1zc+NA+UVfkYqQzviRh5ucWwO7mBV3TmHHprMnfcJNfhlPicDkBHi0ewbh+y3evR6cNAW0Raxvb01NA==
+  dependencies:
+    tslib "^2.6.2"
+
 "@smithy/url-parser@^4.0.5":
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/@smithy/url-parser/-/url-parser-4.0.5.tgz#1824a9c108b85322c5a31f345f608d47d06f073a"
@@ -6404,6 +6699,15 @@
   dependencies:
     "@smithy/util-buffer-from" "^4.0.0"
     "@smithy/util-utf8" "^4.0.0"
+    tslib "^2.6.2"
+
+"@smithy/util-base64@^4.3.0":
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/@smithy/util-base64/-/util-base64-4.3.0.tgz#5e287b528793aa7363877c1a02cd880d2e76241d"
+  integrity sha512-GkXZ59JfyxsIwNTWFnjmFEI8kZpRNIBfxKjv09+nkAWPt/4aGaEWMM04m4sxgNVWkbt2MdSvE3KF/PfX4nFedQ==
+  dependencies:
+    "@smithy/util-buffer-from" "^4.2.0"
+    "@smithy/util-utf8" "^4.2.0"
     tslib "^2.6.2"
 
 "@smithy/util-body-length-browser@^4.0.0":
@@ -6434,6 +6738,14 @@
   integrity sha512-9TOQ7781sZvddgO8nxueKi3+yGvkY35kotA0Y6BWRajAv8jjmigQ1sBwz0UX47pQMYXJPahSKEKYFgt+rXdcug==
   dependencies:
     "@smithy/is-array-buffer" "^4.0.0"
+    tslib "^2.6.2"
+
+"@smithy/util-buffer-from@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz#7abd12c4991b546e7cee24d1e8b4bfaa35c68a9d"
+  integrity sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==
+  dependencies:
+    "@smithy/is-array-buffer" "^4.2.0"
     tslib "^2.6.2"
 
 "@smithy/util-config-provider@^4.0.0":
@@ -6480,6 +6792,13 @@
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@smithy/util-hex-encoding/-/util-hex-encoding-4.0.0.tgz#dd449a6452cffb37c5b1807ec2525bb4be551e8d"
   integrity sha512-Yk5mLhHtfIgW2W2WQZWSg5kuMZCVbvhFmC7rV4IO2QqnZdbEFPmQnCcGMAX2z/8Qj3B9hYYNjZOhWym+RwhePw==
+  dependencies:
+    tslib "^2.6.2"
+
+"@smithy/util-hex-encoding@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.0.tgz#1c22ea3d1e2c3a81ff81c0a4f9c056a175068a7b"
+  integrity sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==
   dependencies:
     tslib "^2.6.2"
 
@@ -6535,6 +6854,14 @@
   integrity sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==
   dependencies:
     "@smithy/util-buffer-from" "^4.0.0"
+    tslib "^2.6.2"
+
+"@smithy/util-utf8@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@smithy/util-utf8/-/util-utf8-4.2.0.tgz#8b19d1514f621c44a3a68151f3d43e51087fed9d"
+  integrity sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==
+  dependencies:
+    "@smithy/util-buffer-from" "^4.2.0"
     tslib "^2.6.2"
 
 "@smithy/util-waiter@^4.0.7":


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PRO-1534

This will only work for files and media at the moment, because images have the extra complexity of the dynamic resizing.

The `read` method is not required for the files & media flows, so has been left for now, as it reduces complexity of reading files from S3 and converting them into buffers.

We've added explicit tests for the ExternalMediaInliner usage of storage adapters (which is non-standard) as well as the media endpoint usage which ensures thumbnails are uploaded to the same directory.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce `S3Storage` adapter using AWS SDK v3 for uploading, checking, and deleting media/files with CDN URL mapping and tenant-aware paths, plus comprehensive unit tests.
> 
> - **Backend**:
>   - **New Storage Adapter**: Adds `S3Storage` in `core/server/adapters/storage/S3Storage.ts`.
>     - Supports `save`, `saveRaw`, `exists`, `delete`, `serve` (no-op), and `urlToPath`.
>     - Uses `@aws-sdk/client-s3` (v3) with configurable region/endpoint/credentials and optional path-style.
>     - Enforces `bucket`, `cdnUrl`, and `staticFileURLPrefix`; handles `tenantPrefix` and path normalization.
>     - Builds keys as ``[tenantPrefix/]storagePath/...`` and returns CDN URLs; `read()` intentionally unsupported.
> - **Tests**:
>   - Adds unit tests in `test/unit/server/adapters/storage/S3Storage.test.ts` covering constructor validation, path normalization, uploads, raw saves, URL-to-path conversion and errors, existence checks, deletion (including NotFound), thumbnail co-location flow, ExternalMediaInliner flow, and key building with/without tenant prefix.
> - **Dependencies**:
>   - Adds `@aws-sdk/client-s3` to `ghost/core/package.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ac69d88dffa7df7667da1733c94ea92e9dbe3cd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->