### PR TITLE
Wired up local development for S3 adapter

### DIFF
--- a/.docker/minio/setup.sh
+++ b/.docker/minio/setup.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -euo pipefail
+
+BUCKET=${MINIO_BUCKET:-ghost-dev}
+
+echo "Configuring MinIO alias..."
+mc alias set local http://minio:9000 "${MINIO_ROOT_USER}" "${MINIO_ROOT_PASSWORD}"
+
+echo "Ensuring bucket '${BUCKET}' exists..."
+mc mb --ignore-existing "local/${BUCKET}"
+
+echo "Setting anonymous download policy on '${BUCKET}'..."
+mc anonymous set download "local/${BUCKET}"
+
+echo "MinIO bucket '${BUCKET}' ready."

--- a/compose.object-storage.yml
+++ b/compose.object-storage.yml
@@ -1,0 +1,64 @@
+services:
+  ghost:
+    extends:
+      file: compose.yml
+      service: ghost
+    profiles: [object-storage]
+    environment:
+      - storage__media__adapter=S3Storage
+      - storage__media__staticFileURLPrefix=content/media
+      - storage__files__adapter=S3Storage
+      - storage__files__staticFileURLPrefix=content/files
+      - storage__S3Storage__bucket=ghost-dev
+      - storage__S3Storage__region=us-east-1
+      - storage__S3Storage__tenantPrefix=ab/ab1234567890abcdef1234567890abcd
+      - storage__S3Storage__forcePathStyle=true
+      - storage__S3Storage__cdnUrl=http://127.0.0.1:9000/ghost-dev
+      - storage__S3Storage__staticFileURLPrefix=content/images
+      - storage__S3Storage__endpoint=http://minio:9000
+      - storage__S3Storage__accessKeyId=minio-user
+      - storage__S3Storage__secretAccessKey=minio-pass
+      - urls__media=http://127.0.0.1:9000/ghost-dev/ab/ab1234567890abcdef1234567890abcd
+      - urls__files=http://127.0.0.1:9000/ghost-dev/ab/ab1234567890abcdef1234567890abcd
+    depends_on:
+      minio:
+        condition: service_healthy
+      minio-setup:
+        condition: service_completed_successfully
+
+  minio:
+    profiles: [object-storage]
+    image: minio/minio:RELEASE.2024-12-13T22-19-12Z
+    container_name: ghost-minio
+    command: server /data --console-address ':9001'
+    restart: always
+    environment:
+      - MINIO_ROOT_USER=minio-user
+      - MINIO_ROOT_PASSWORD=minio-pass
+    ports:
+      - '9000:9000'
+      - '9001:9001'
+    volumes:
+      - minio-data:/data
+    healthcheck:
+      test: ['CMD', 'curl', '-f', 'http://localhost:9000/minio/health/ready']
+      interval: 1s
+      retries: 120
+
+  minio-setup:
+    profiles: [object-storage]
+    image: minio/mc
+    entrypoint: ['/bin/sh', '/setup.sh']
+    environment:
+      - MINIO_ROOT_USER=minio-user
+      - MINIO_ROOT_PASSWORD=minio-pass
+      - MINIO_BUCKET=ghost-dev
+    volumes:
+      - ./.docker/minio/setup.sh:/setup.sh:ro
+    depends_on:
+      minio:
+        condition: service_healthy
+    restart: 'no'
+
+volumes:
+  minio-data: {}

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "reset:data:analytics": "cd ghost/core/core/server/data/tinybird/scripts && node reset-data-tinybird.js",
     "docker": "COMPOSE_PROFILES=${COMPOSE_PROFILES:-ghost} docker compose run --rm -it ghost",
     "docker:dev": "COMPOSE_PROFILES=${COMPOSE_PROFILES:-ghost} docker compose up --attach=ghost --force-recreate --no-log-prefix",
+    "docker:dev:object-storage": "docker compose -f compose.yml -f compose.object-storage.yml --profile object-storage up --attach=ghost --force-recreate --no-log-prefix",
     "docker:dev:analytics": "docker compose --profile analytics up -d --wait",
     "docker:dev:analytics:stop": "docker compose --profile analytics down",
     "docker:dev:analytics:logs": "docker compose --profile analytics logs -f",


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PRO-1534

The idea behind this approach is to be non-intrusive to existing development flows, but allow a zero-config approach to run locally.

We're using MinIO as the S3 compatible backend, and all of the object storage related services and config is in a new compose file.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a MinIO-backed object storage profile with a setup script and compose file, wiring Ghost to the S3 storage adapter and adding a helper Docker script.
> 
> - **Object Storage (Docker Compose)**
>   - Adds `compose.object-storage.yml` with `minio` service (ports 9000/9001, healthcheck, volume) and `minio-setup` init job.
>   - Extends `ghost` service to use `S3Storage` via env vars (`bucket`, `region`, `endpoint`, `cdnUrl`, credentials, URL prefixes, `forcePathStyle`).
> - **MinIO Setup Script**
>   - Adds `.docker/minio/setup.sh` to configure `mc` alias, ensure `ghost-dev` bucket, and enable anonymous download.
> - **Dev Scripts**
>   - Adds `package.json` script `docker:dev:object-storage` to start Ghost with the object-storage profile.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f63925f0a02620db9318247a41094ac2462bb643. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->