### PR TITLE
Added axis read token to Tinybird pipes

### DIFF
--- a/ghost/core/core/server/data/tinybird/endpoints/api_active_visitors.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_active_visitors.pipe
@@ -1,4 +1,5 @@
 TOKEN "stats_page" READ
+TOKEN "axis" READ
 
 NODE _active_visitors_0
 SQL >

--- a/ghost/core/core/server/data/tinybird/endpoints/api_kpis.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_kpis.pipe
@@ -1,4 +1,5 @@
 TOKEN "stats_page" READ
+TOKEN "axis" READ
 
 NODE timeseries
 SQL >

--- a/ghost/core/core/server/data/tinybird/endpoints/api_monitoring_ingestion.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_monitoring_ingestion.pipe
@@ -1,4 +1,5 @@
 TOKEN "monitoring" READ
+TOKEN "axis" READ
 
 NODE ingestion_latency
 SQL >

--- a/ghost/core/core/server/data/tinybird/endpoints/api_monitoring_ingestion_aggregated.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_monitoring_ingestion_aggregated.pipe
@@ -1,4 +1,5 @@
 TOKEN "monitoring" READ
+TOKEN "axis" READ
 
 NODE ingestion_latency
 SQL >

--- a/ghost/core/core/server/data/tinybird/endpoints/api_post_visitor_counts.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_post_visitor_counts.pipe
@@ -1,4 +1,5 @@
 TOKEN "stats_page" READ
+TOKEN "axis" READ
 
 NODE _post_visitor_counts_0
 SQL >

--- a/ghost/core/core/server/data/tinybird/endpoints/api_top_browsers.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_top_browsers.pipe
@@ -1,4 +1,5 @@
 TOKEN "stats_page" READ
+TOKEN "axis" READ
 
 NODE _top_browsers_0
 SQL >

--- a/ghost/core/core/server/data/tinybird/endpoints/api_top_devices.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_top_devices.pipe
@@ -1,4 +1,5 @@
 TOKEN "stats_page" READ
+TOKEN "axis" READ
 
 NODE _top_devices_0
 SQL >

--- a/ghost/core/core/server/data/tinybird/endpoints/api_top_locations.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_top_locations.pipe
@@ -1,4 +1,5 @@
 TOKEN "stats_page" READ
+TOKEN "axis" READ
 
 NODE _top_locations_0
 SQL >

--- a/ghost/core/core/server/data/tinybird/endpoints/api_top_os.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_top_os.pipe
@@ -1,4 +1,5 @@
 TOKEN "stats_page" READ
+TOKEN "axis" READ
 
 NODE _top_os_0
 SQL >

--- a/ghost/core/core/server/data/tinybird/endpoints/api_top_pages.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_top_pages.pipe
@@ -1,4 +1,5 @@
 TOKEN "stats_page" READ
+TOKEN "axis" READ
 
 NODE _top_pages_0
 SQL >

--- a/ghost/core/core/server/data/tinybird/endpoints/api_top_sources.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_top_sources.pipe
@@ -1,4 +1,5 @@
 TOKEN "stats_page" READ
+TOKEN "axis" READ
 
 NODE top_sources
 SQL >

--- a/ghost/core/core/server/data/tinybird/endpoints/api_top_utm_campaigns.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_top_utm_campaigns.pipe
@@ -1,4 +1,5 @@
 TOKEN "stats_page" READ
+TOKEN "axis" READ
 
 NODE top_utm_campaigns
 SQL >

--- a/ghost/core/core/server/data/tinybird/endpoints/api_top_utm_contents.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_top_utm_contents.pipe
@@ -1,4 +1,5 @@
 TOKEN "stats_page" READ
+TOKEN "axis" READ
 
 NODE top_utm_content
 SQL >

--- a/ghost/core/core/server/data/tinybird/endpoints/api_top_utm_mediums.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_top_utm_mediums.pipe
@@ -1,4 +1,5 @@
 TOKEN "stats_page" READ
+TOKEN "axis" READ
 
 NODE top_utm_mediums
 SQL >

--- a/ghost/core/core/server/data/tinybird/endpoints/api_top_utm_sources.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_top_utm_sources.pipe
@@ -1,4 +1,5 @@
-TOKEN "stats_page" READ
+TOKEN "stats_page" READ 
+TOKEN "axis" READ
 
 NODE top_utm_sources
 SQL >

--- a/ghost/core/core/server/data/tinybird/endpoints/api_top_utm_terms.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_top_utm_terms.pipe
@@ -1,4 +1,5 @@
 TOKEN "stats_page" READ
+TOKEN "axis" READ
 
 NODE top_utm_terms
 SQL >


### PR DESCRIPTION
no ref

Tinybird will not allow creation of a token without a deployment using `tb token create`. For now, I'll manually list it while figuring out what other options we have to create these without requiring maintaining them in every endpoint.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds the "axis" READ token across Tinybird analytics and monitoring endpoint pipes.
> 
> - **Tinybird endpoints**:
>   - Add `TOKEN "axis" READ` to:
>     - Analytics: `api_active_visitors.pipe`, `api_kpis.pipe`, `api_post_visitor_counts.pipe`, `api_top_browsers.pipe`, `api_top_devices.pipe`, `api_top_locations.pipe`, `api_top_os.pipe`, `api_top_pages.pipe`, `api_top_sources.pipe`, `api_top_utm_campaigns.pipe`, `api_top_utm_contents.pipe`, `api_top_utm_mediums.pipe`, `api_top_utm_sources.pipe`, `api_top_utm_terms.pipe`.
>     - Monitoring: `api_monitoring_ingestion.pipe`, `api_monitoring_ingestion_aggregated.pipe`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 01f9982df08f6e44a60fa3a1c9a3a7a3f4cbc52b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->