### PR TITLE
Fixed incorrect link for Ghost(Pro) in navbar

### DIFF
--- a/apps/admin/src/layout/app-sidebar/NavGhostPro.tsx
+++ b/apps/admin/src/layout/app-sidebar/NavGhostPro.tsx
@@ -25,7 +25,7 @@ function NavGhostPro({ ...props }: React.ComponentProps<typeof SidebarGroup>) {
             <SidebarGroupContent>
                 <SidebarMenu>
                     <NavMenuItem>
-                        <NavMenuItem.Link to="billing">
+                        <NavMenuItem.Link to="pro">
                             <LucideIcon.CreditCard />
                             <NavMenuItem.Label>Ghost(Pro)</NavMenuItem.Label>
                         </NavMenuItem.Link>


### PR DESCRIPTION
fixes https://linear.app/ghost/issue/BER-3007/fix-incorrect-billing-link

The billing route was pointing to /billing instead of /pro, which is the correct route used throughout the Ember admin app.
