### PR TITLE
Added Tinybird datasources to axis readonly token

### DIFF
--- a/ghost/core/core/server/data/tinybird/pipes/filtered_sessions.pipe
+++ b/ghost/core/core/server/data/tinybird/pipes/filtered_sessions.pipe
@@ -1,3 +1,5 @@
+TOKEN "axis" READ
+
 NODE query_filters
 DESCRIPTION >
     Get sessions that match the filter criteria

--- a/ghost/core/core/server/data/tinybird/pipes/mv_hits.pipe
+++ b/ghost/core/core/server/data/tinybird/pipes/mv_hits.pipe
@@ -1,3 +1,5 @@
+TOKEN "axis" READ
+
 NODE mv_hits_0
 SQL >
 

--- a/ghost/core/core/server/data/tinybird/pipes/mv_session_data.pipe
+++ b/ghost/core/core/server/data/tinybird/pipes/mv_session_data.pipe
@@ -1,3 +1,5 @@
+TOKEN "axis" READ
+
 NODE mv_hits_0
 SQL >
 


### PR DESCRIPTION
no ref

This allows us to construct queries directly from the datasources, in the event we need to.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Grants read access to Tinybird pipes (`filtered_sessions`, `mv_hits`, `mv_session_data`) using the "axis" token.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 35c8c2cff530cacf0f9b19f9510bfaeb168209eb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->