### PR TITLE
Fixed fallback from name & reply-to

### DIFF
--- a/ghost/core/core/server/services/email-address/EmailAddressService.ts
+++ b/ghost/core/core/server/services/email-address/EmailAddressService.ts
@@ -120,9 +120,13 @@ export class EmailAddressService {
         if (this.#labs.isSet('domainWarmup') && options.useFallbackAddress) {
             const fallbackEmail = this.fallbackEmail;
             if (fallbackEmail) {
+                if (!fallbackEmail.name) {
+                    fallbackEmail.name = preferred.from.name || this.defaultFromEmail.name;
+                }
+
                 return {
                     from: fallbackEmail,
-                    replyTo: preferred.replyTo || preferred.from
+                    replyTo: preferred.replyTo || preferred.from || this.defaultFromEmail
                 };
             } else {
                 logging.error('[EmailAddresses] Fallback email address is not configured, cannot use fallback address for sending email.');

--- a/ghost/core/core/server/services/email-service/EmailRenderer.js
+++ b/ghost/core/core/server/services/email-service/EmailRenderer.js
@@ -247,6 +247,12 @@ class EmailRenderer {
         return locale;
     }
 
+    /**
+     * @param {Post} post
+     * @param {Newsletter} newsletter
+     * @param {boolean} [useFallbackAddress]
+     * @returns {string|null}
+     */
     getFromAddress(post, newsletter, useFallbackAddress = false) {
         // Clean from address to ensure DMARC alignment
         const addresses = this.#emailAddressService.getAddress({
@@ -259,9 +265,10 @@ class EmailRenderer {
     /**
      * @param {Post} post
      * @param {Newsletter} newsletter
+     * @param {boolean} [useFallbackAddress]
      * @returns {string|null}
      */
-    getReplyToAddress(post, newsletter) {
+    getReplyToAddress(post, newsletter, useFallbackAddress = false) {
         const replyToAddress = newsletter.get('sender_reply_to');
 
         if (replyToAddress === 'support') {
@@ -269,13 +276,13 @@ class EmailRenderer {
         }
 
         if (replyToAddress === 'newsletter' && !this.#emailAddressService.managedEmailEnabled) {
-            return this.getFromAddress(post, newsletter);
+            return this.getFromAddress(post, newsletter, useFallbackAddress);
         }
 
         const addresses = this.#emailAddressService.getAddress({
             from: this.#getRawFromAddress(post, newsletter),
             replyTo: replyToAddress === 'newsletter' ? undefined : {address: replyToAddress}
-        });
+        }, {useFallbackAddress});
 
         if (addresses.replyTo) {
             return EmailAddressParser.stringify(addresses.replyTo);

--- a/ghost/core/core/server/services/email-service/SendingService.js
+++ b/ghost/core/core/server/services/email-service/SendingService.js
@@ -138,7 +138,7 @@ class SendingService {
         return await this.#emailProvider.send({
             subject: this.#emailRenderer.getSubject(post, isTestEmail),
             from: this.#emailRenderer.getFromAddress(post, newsletter, !!options.useFallbackAddress),
-            replyTo: this.#emailRenderer.getReplyToAddress(post, newsletter) ?? undefined,
+            replyTo: this.#emailRenderer.getReplyToAddress(post, newsletter, !!options.useFallbackAddress) ?? undefined,
             html: emailBody.html,
             plaintext: emailBody.plaintext,
             recipients,

--- a/ghost/core/test/unit/server/services/email-address/EmailAddressService.test.ts
+++ b/ghost/core/test/unit/server/services/email-address/EmailAddressService.test.ts
@@ -42,6 +42,7 @@ describe('EmailAddressService', function () {
             }, {useFallbackAddress: true});
 
             assert.equal(result.from.address, 'fallback@fallback.example.com');
+            assert.equal(result.from.name, 'Custom Sender');
             assert.equal(result.replyTo?.address, 'custom@custom.example.com');
             assert.equal(result.replyTo?.name, 'Custom Sender');
         });
@@ -99,8 +100,38 @@ describe('EmailAddressService', function () {
             }, {useFallbackAddress: true});
 
             assert.equal(result.from.address, 'fallback@fallback.example.com');
+            assert.equal(result.from.name, 'Custom Sender');
             assert.equal(result.replyTo?.address, 'support@custom.example.com');
             assert.equal(result.replyTo?.name, 'Support');
+        });
+
+        it('sets fallback from name to default email name when preferred from has no name', function () {
+            labsStub.isSet.withArgs('domainWarmup').returns(true);
+            const service = createService();
+
+            const result = service.getAddress({
+                from: {address: 'custom@custom.example.com'}
+            }, {useFallbackAddress: true});
+
+            assert.equal(result.from.address, 'fallback@fallback.example.com');
+            assert.equal(result.from.name, 'Ghost');
+            assert.equal(result.replyTo?.address, 'custom@custom.example.com');
+        });
+
+        it('preserves fallback email name when already set', function () {
+            labsStub.isSet.withArgs('domainWarmup').returns(true);
+            const service = createService({
+                getFallbackEmail: () => '"Fallback Sender" <fallback@fallback.example.com>'
+            });
+
+            const result = service.getAddress({
+                from: {address: 'custom@custom.example.com', name: 'Custom Sender'}
+            }, {useFallbackAddress: true});
+
+            assert.equal(result.from.address, 'fallback@fallback.example.com');
+            assert.equal(result.from.name, 'Fallback Sender');
+            assert.equal(result.replyTo?.address, 'custom@custom.example.com');
+            assert.equal(result.replyTo?.name, 'Custom Sender');
         });
     });
 

--- a/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
+++ b/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
@@ -1118,6 +1118,43 @@ describe('Email renderer', function () {
             const response = emailRenderer.getReplyToAddress({}, newsletter);
             assert.equal(response, null);
         });
+
+        it('passes useFallbackAddress parameter to getAddress', function () {
+            const newsletter = createModel({
+                sender_email: 'ghost@example.com',
+                sender_name: 'Ghost',
+                sender_reply_to: 'newsletter'
+            });
+            let capturedOptions;
+            emailAddressService.getAddress = (addresses, options) => {
+                capturedOptions = options;
+                return {
+                    from: addresses.from,
+                    replyTo: {address: 'fallback@fallback.example.com'}
+                };
+            };
+            const response = emailRenderer.getReplyToAddress({}, newsletter, true);
+            assert.equal(capturedOptions.useFallbackAddress, true);
+            assert.equal(response, 'fallback@fallback.example.com');
+        });
+
+        it('defaults useFallbackAddress to false when not provided', function () {
+            const newsletter = createModel({
+                sender_email: 'ghost@example.com',
+                sender_name: 'Ghost',
+                sender_reply_to: 'custom@example.com'
+            });
+            let capturedOptions;
+            emailAddressService.getAddress = (addresses, options) => {
+                capturedOptions = options;
+                return {
+                    from: addresses.from,
+                    replyTo: addresses.replyTo
+                };
+            };
+            emailRenderer.getReplyToAddress({}, newsletter);
+            assert.equal(capturedOptions.useFallbackAddress, false);
+        });
     });
 
     describe('getSegments', function () {


### PR DESCRIPTION
closes [GVA-603](https://linear.app/ghost/issue/GVA-603/fix-from-address-for-fallback-domain)

The fallback email doesn't have a name, and if there's no preferred address we weren't setting any reply-to. We'll always want a reply-to address if we're using the fallback.
