### PR TITLE
🐛 Fixed missing member attribution stats on pages list view

### DIFF
--- a/ghost/core/core/server/services/stats/PostsStatsService.js
+++ b/ghost/core/core/server/services/stats/PostsStatsService.js
@@ -406,13 +406,13 @@ class PostsStatsService {
                         .andOn('mce.attribution_id', '=', 'msce.attribution_id');
                 })
                 .where('mce.attribution_id', postId)
-                .where('mce.attribution_type', 'post')
+                .whereIn('mce.attribution_type', ['post', 'page'])
                 .where('msce.id', null);
 
             const paidMembers = await this.knex('members_subscription_created_events as msce')
                 .countDistinct('msce.member_id as paid_members')
                 .where('msce.attribution_id', postId)
-                .where('msce.attribution_type', 'post');
+                .whereIn('msce.attribution_type', ['post', 'page']);
 
             const mrr = await this.knex('members_subscription_created_events as msce')
                 .sum('mpse.mrr_delta as mrr')
@@ -421,7 +421,7 @@ class PostsStatsService {
                     this.andOn('mpse.member_id', '=', 'msce.member_id');
                 })
                 .where('msce.attribution_id', postId)
-                .where('msce.attribution_type', 'post');
+                .whereIn('msce.attribution_type', ['post', 'page']);
 
             return {
                 data: [
@@ -1414,9 +1414,9 @@ class PostsStatsService {
                 .leftJoin('members_subscription_created_events as msce', function () {
                     this.on('mce.member_id', '=', 'msce.member_id')
                         .andOn('mce.attribution_id', '=', 'msce.attribution_id')
-                        .andOnVal('msce.attribution_type', '=', 'post');
+                        .andOnIn('msce.attribution_type', ['post', 'page']);
                 })
-                .where('mce.attribution_type', 'post')
+                .whereIn('mce.attribution_type', ['post', 'page'])
                 .whereIn('mce.attribution_id', postIds)
                 .whereNull('msce.id')
                 .groupBy('mce.attribution_id');
@@ -1429,7 +1429,7 @@ class PostsStatsService {
             let paidMembersQuery = this.knex('members_subscription_created_events as msce')
                 .select('msce.attribution_id as post_id')
                 .countDistinct('msce.member_id as paid_members')
-                .where('msce.attribution_type', 'post')
+                .whereIn('msce.attribution_type', ['post', 'page'])
                 .whereIn('msce.attribution_id', postIds)
                 .groupBy('msce.attribution_id');
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ONC-1266/analytics-data-missing-from-post-list-but-present-in-top-pages-section

The member attribution stats on the pages list view in Admin are currently always showing 0 new members, even though the "Top Posts" section of Analytics shows the correct number.

The stats API endpoint that returns the member counts for posts was specifically filtering for `attribution_type = 'post'`, which was filtering out the attribution rows for pages, resulting in 0 new members displaying for all pages on the pages list view in Admin.