### PR TITLE
🐛 Fixed false positive gscan errors for unused custom theme settings

### DIFF
--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -162,7 +162,7 @@
     "ghost-storage-base": "1.0.0",
     "glob": "8.1.0",
     "got": "11.8.6",
-    "gscan": "5.2.0",
+    "gscan": "5.2.1",
     "handlebars": "4.7.8",
     "heic-convert": "2.1.0",
     "html-to-text": "5.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -20931,10 +20931,10 @@ growly@^1.3.0:
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha512-+xGQY0YyAWCnqy7Cd++hc2JqMYzlm0dG30Jd0beaA64sROr8C4nt8Yc9V5Ro3avlSUDTN0ulqP/VBKi1/lLygw==
 
-gscan@5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/gscan/-/gscan-5.2.0.tgz#62947df15b3467b2a12a7e96b0aaf41b96b0c702"
-  integrity sha512-C+xr32TKsaOEetqO0k3BX+DB+nYuyeWJx7UdA/oRtKmX7YQ+z8SjH5AtDAqWr2zVaG/o79migjRHrXV0LOfRIQ==
+gscan@5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/gscan/-/gscan-5.2.1.tgz#cd73d17d78e71222dcd20f774624334b15600fc4"
+  integrity sha512-xDVZinlD4/C5Ru4uRWz9Z6RYyIppZqaO2C0S7znm0b5Nq1Y59SQWeKGRknqmcWcivv4HvfWv5xiaMwgVVwfGaA==
   dependencies:
     "@sentry/node" "^9.0.0"
     "@tryghost/config" "^0.2.18"


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ONC-1249/theme-scan-shows-error-on-custom-theme-setting-but-the-setting-works
ref https://github.com/TryGhost/gscan/issues/464

gscan has a rule that ensures all custom theme settings from the theme's `package.json` are used in the theme. When a custom theme setting was used in a get helper's filter attribute, gscan wouldn't recognize it as "used", and it would display an error in Ghost's admin.

This bumps gscan to the latest version, which includes a fix for these false positive errors.