### PR TITLE
✨ Added edit button to post publish confirmation modal

### DIFF
--- a/ghost/admin/app/components/modal-post-success.hbs
+++ b/ghost/admin/app/components/modal-post-success.hbs
@@ -162,6 +162,15 @@
                     <span>{{svg-jar "social-linkedin"}}</span>
                 </a>
             </div>
+                <button
+                    class="gh-btn gh-btn-icon edit-post"
+                    type="button"
+                    title="Go to Editor"
+                    {{on "click" this.goToEditor}}
+                    {{on "mousedown" (optional this.noop)}}
+                >
+                    <span>{{svg-jar "pen" title="Go to Editor"}}</span>
+                </button>
                 <GhTaskButton
                     @showIcon={{true}}
                     @idleIcon="link"

--- a/ghost/admin/app/components/modal-post-success.js
+++ b/ghost/admin/app/components/modal-post-success.js
@@ -1,5 +1,6 @@
 import Component from '@glimmer/component';
 import copyTextToClipboard from 'ghost-admin/utils/copy-text-to-clipboard';
+import {action} from '@ember/object';
 import {capitalize} from '@ember/string';
 import {inject as service} from '@ember/service';
 import {task, timeout} from 'ember-concurrency';
@@ -78,5 +79,11 @@ export default class PostSuccessModal extends Component {
             currentPost.publishedAtUTC = originalPublishedAtUTC;
             throw e;
         }
+    }
+
+    @action
+    goToEditor() {
+        this.args.close();
+        this.router.transitionTo('lexical-editor.edit', this.post.displayName, this.post.id);
     }
 }

--- a/ghost/admin/app/styles/app-dark.css
+++ b/ghost/admin/app/styles/app-dark.css
@@ -1506,11 +1506,11 @@ Onboarding checklist: Share publication modal */
 /* ---------------------------------
 Publish flow: Share modal */
 
-.modal-post-success .modal-footer .gh-btn:is(.twitter, .threads, .facebook, .linkedin) {
+.modal-post-success .modal-footer .gh-btn:is(.twitter, .threads, .facebook, .linkedin, .edit-post) {
     background: var(--lightgrey-l1)!important;
 }
 
-.modal-post-success .modal-footer .gh-btn:is(.twitter, .threads, .facebook, .linkedin, .copy-link, .copy-preview-link):hover {
+.modal-post-success .modal-footer .gh-btn:is(.twitter, .threads, .facebook, .linkedin, .edit-post, .copy-link, .copy-preview-link):hover {
     background: var(--lightgrey-l2)!important;
 }
 

--- a/ghost/admin/app/styles/components/publishmenu.css
+++ b/ghost/admin/app/styles/components/publishmenu.css
@@ -1061,18 +1061,19 @@
     flex-grow: 1;
 }
 
-.modal-post-success .modal-footer .gh-btn:is(.twitter, .threads, .facebook, .linkedin) {
+.modal-post-success .modal-footer .gh-btn:is(.twitter, .threads, .facebook, .linkedin, .edit-post) {
     width: 56px;
     background: var(--whitegrey-l1);
     border-color: transparent;
 }
 
-.modal-post-success .modal-footer .gh-btn:is(.twitter, .threads, .facebook, .linkedin, .copy-link, .copy-preview-link):hover {
+.modal-post-success .modal-footer .gh-btn:is(.twitter, .threads, .facebook, .linkedin, .edit-post, .copy-link, .copy-preview-link):hover {
     background: var(--whitegrey);
 }
 
-.modal-post-success .modal-footer .gh-btn:is(.twitter, .threads, .facebook, .linkedin) span {
+.modal-post-success .modal-footer .gh-btn:is(.twitter, .threads, .facebook, .linkedin, .edit-post) span {
     font-size: 0;
+    padding: 0;
 }
 
 .modal-post-success .modal-footer .gh-btn svg {
@@ -1114,7 +1115,7 @@
         flex-direction: column;
     }
 
-    .modal-post-success .modal-footer .gh-btn:is(.twitter, .threads, .facebook, .linkedin) {
+    .modal-post-success .modal-footer .gh-btn:is(.twitter, .threads, .facebook, .linkedin, .edit-post) {
         width: auto;
     }
 }


### PR DESCRIPTION
Closes FEA-366

## Overview
Adds an "Edit" button to the post publish confirmation modal, allowing users to quickly return to the editor without manually navigating.

## Changes
- Added icon-only edit button next to "Copy link" button in publish confirmation modal
- Button uses existing `pen` icon for consistency with posts list "Go to Editor" pattern
- Navigates to lexical editor with post ID when clicked
- Minimal size to avoid layout issues
- Includes styling for both light and dark modes

## Why
Based on customer feedback from Ghost(Pro) support (tracked in FEA-366), users frequently need to make small adjustments immediately after publishing. Currently they must:
1. Close the confirmation modal
2. Navigate back to the posts list
3. Find their post
4. Click edit

This adds a direct shortcut from the confirmation screen, improving the publishing workflow.

## Design Rationale
- Implementation reuses the existing "Go to Editor" button pattern from the posts list overview
- The pencil icon and button style are already familiar to users from the post management interface
- This consistency creates a recognizable pattern that reduces cognitive load
- Icon-only approach minimizes space usage while maintaining clarity

## Testing
- ✅ Tested locally with multiple post publishes
- ✅ Button appears and functions correctly in both light and dark modes
- ✅ Navigation to editor works as expected
- ✅ Layout remains intact (icon-only, minimal sizing)
- ✅ Passed linting checks

## Notes
- Open to design feedback on placement, sizing, and styling
- Functional implementation prioritized to address customer pain point quickly

---

**Checklist:**
- [x] I've read and followed the Contributor Guide
- [x] I've explained my change
- [ ] I've written an automated test to prove my change works *(Note: Manual testing completed; happy to add automated tests if required)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an icon-only Edit button in the publish confirmation modal that closes the modal and navigates directly to the editor, with matching light/dark styles.
> 
> - **UI (Publish Success Modal)**
>   - Add icon-only `Edit` button in `components/modal-post-success.hbs` beside share/copy actions; triggers `goToEditor`.
>   - `components/modal-post-success.js`: introduce `@action goToEditor` (closes modal, routes to `lexical-editor.edit`), add `action` import.
> - **Styles**
>   - Update `app/styles/app-dark.css` and `components/publishmenu.css` to include `.edit-post` in social/action button selector groups (default/hover states, sizing, responsive rules); set icon-only span padding to `0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8e30bbb987296ffa9928535ac36fecd92c1b7361. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->