### PR TITLE
Hide sidebar in editor

### DIFF
--- a/apps/admin/src/layout/AdminLayout.tsx
+++ b/apps/admin/src/layout/AdminLayout.tsx
@@ -4,6 +4,7 @@ import {
     SidebarProvider,
 } from "@tryghost/shade";
 import { useCurrentUser } from "@tryghost/admin-x-framework/api/currentUser";
+import { useSidebarVisibility } from "@/ember-bridge/EmberBridge";
 import AppSidebar from "./app-sidebar";
 import { MobileNavBar } from "./app-sidebar/MobileNavBar";
 
@@ -13,9 +14,10 @@ interface AdminLayoutProps {
 
 export function AdminLayout({ children }: AdminLayoutProps) {
     const { data: currentUser } = useCurrentUser();
+    const sidebarVisible = useSidebarVisibility();
 
     return (
-        <SidebarProvider open={!!currentUser}>
+        <SidebarProvider open={!!currentUser && sidebarVisible}>
             <AppSidebar />
             <SidebarInset className="bg-background">
                 <main className="flex-1">{children}</main>

--- a/apps/shade/src/components/ui/sidebar.tsx
+++ b/apps/shade/src/components/ui/sidebar.tsx
@@ -223,7 +223,7 @@ const Sidebar = React.forwardRef<
                 {/* This is what handles the sidebar gap on desktop */}
                 <div
                     className={cn(
-                        'duration-200 relative h-svh w-[--sidebar-width] bg-transparent transition-[width] ease-linear',
+                        'relative h-svh w-[--sidebar-width] bg-transparent',
                         'group-data-[collapsible=offcanvas]:w-0',
                         'group-data-[side=right]:rotate-180',
                         variant === 'floating' || variant === 'inset'
@@ -233,7 +233,7 @@ const Sidebar = React.forwardRef<
                 />
                 <div
                     className={cn(
-                        'duration-200 fixed inset-y-0 z-10 hidden h-svh w-[--sidebar-width] transition-[left,right,width] ease-linear md:flex',
+                        'fixed inset-y-0 z-10 hidden h-svh w-[--sidebar-width] md:flex',
                         side === 'left'
                             ? 'left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]'
                             : 'right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]',

--- a/ghost/admin/app/routes/settings-x.js
+++ b/ghost/admin/app/routes/settings-x.js
@@ -9,12 +9,20 @@ export default class SettingsXRoute extends AuthenticatedRoute {
 
     activate() {
         super.activate(...arguments);
-        this.ui.set('isFullScreen', true);
+
+        // We dont want to go fullscreen if this route is mounted and we are in the new React admin
+        if (!this.feature.inAdminForward) {
+            this.ui.set('isFullScreen', true);
+        }
     }
 
     deactivate() {
         super.deactivate(...arguments);
-        this.ui.set('isFullScreen', false);
+
+        // We dont want to restore from fullscreen if we are in the new React admin
+        if (!this.feature.inAdminForward) {
+            this.ui.set('isFullScreen', false);
+        }
     }
 
     buildRouteInfoMetadata() {

--- a/ghost/admin/app/services/state-bridge.js
+++ b/ghost/admin/app/services/state-bridge.js
@@ -24,6 +24,7 @@ export default class StateBridgeService extends Service.extend(Evented) {
     @service settings;
     @service store;
     @service themeManagement;
+    @service ui;
 
     @inject config;
 
@@ -181,5 +182,17 @@ export default class StateBridgeService extends Service.extend(Evented) {
         this.trigger('subscriptionChange', {
             ...data
         });
+    }
+
+    @action
+    setSidebarVisible(isVisible) {
+        this.trigger('sidebarVisibilityChange', {
+            isVisible
+        });
+    }
+
+    get sidebarVisible() {
+        // Sidebar is visible when NOT in fullscreen mode
+        return !this.ui.isFullScreen;
     }
 }

--- a/ghost/admin/app/services/ui.js
+++ b/ghost/admin/app/services/ui.js
@@ -43,12 +43,23 @@ export default class UiService extends Service {
     @service feature;
     @service router;
     @service settings;
+    @service('state-bridge') stateBridge;
 
     @inject config;
 
-    @tracked isFullScreen = false;
+    @tracked _isFullScreen = false;
     @tracked mainClass = '';
     @tracked showMobileMenu = false;
+
+    get isFullScreen() {
+        return this._isFullScreen;
+    }
+
+    set isFullScreen(value) {
+        this._isFullScreen = value;
+        // Trigger sidebar visibility event whenever fullscreen mode changes
+        this.stateBridge.setSidebarVisible(!value);
+    }
 
     get backgroundColor() {
         // hardcoded background colors because

--- a/ghost/admin/tests/unit/services/state-bridge-test.js
+++ b/ghost/admin/tests/unit/services/state-bridge-test.js
@@ -22,7 +22,7 @@ const buildMockModelCollection = (models) => {
 describe('Unit: Service: state-bridge', function () {
     setupTest();
 
-    let service, store, config, settings, membersUtils, themeManagement;
+    let service, store, config, settings, membersUtils, themeManagement, ui;
 
     beforeEach(function () {
         service = this.owner.lookup('service:state-bridge');
@@ -31,6 +31,7 @@ describe('Unit: Service: state-bridge', function () {
         settings = this.owner.lookup('service:settings');
         membersUtils = this.owner.lookup('service:members-utils');
         themeManagement = this.owner.lookup('service:theme-management');
+        ui = this.owner.lookup('service:ui');
 
         // Set up basic spies
         sinon.spy(store, 'pushPayload');
@@ -430,6 +431,84 @@ describe('Unit: Service: state-bridge', function () {
             expect(handler.firstCall.args[0].operation).to.equal('create');
             expect(handler.secondCall.args[0].operation).to.equal('update');
             expect(handler.thirdCall.args[0].operation).to.equal('delete');
+        });
+    });
+
+    describe('#setSidebarVisible', function () {
+        it('triggers sidebarVisibilityChange event with correct parameters', function () {
+            const handler = sinon.spy();
+
+            service.on('sidebarVisibilityChange', handler);
+
+            service.setSidebarVisible(false);
+
+            expect(handler.calledOnce).to.be.true;
+            expect(handler.firstCall.args[0]).to.deep.equal({
+                isVisible: false
+            });
+        });
+
+        it('triggers event when setting sidebar to visible', function () {
+            const handler = sinon.spy();
+
+            service.on('sidebarVisibilityChange', handler);
+
+            service.setSidebarVisible(true);
+
+            expect(handler.calledOnce).to.be.true;
+            expect(handler.firstCall.args[0]).to.deep.equal({
+                isVisible: true
+            });
+        });
+
+        it('allows multiple handlers to be registered', function () {
+            const handler1 = sinon.spy();
+            const handler2 = sinon.spy();
+
+            service.on('sidebarVisibilityChange', handler1);
+            service.on('sidebarVisibilityChange', handler2);
+
+            service.setSidebarVisible(false);
+
+            expect(handler1.calledOnce).to.be.true;
+            expect(handler2.calledOnce).to.be.true;
+            expect(handler1.firstCall.args[0]).to.deep.equal(handler2.firstCall.args[0]);
+        });
+
+        it('handlers can be removed with off', function () {
+            const handler = sinon.spy();
+
+            service.on('sidebarVisibilityChange', handler);
+            service.off('sidebarVisibilityChange', handler);
+
+            service.setSidebarVisible(false);
+
+            expect(handler.called).to.be.false;
+        });
+    });
+
+    describe('#sidebarVisible', function () {
+        it('returns true when ui.isFullScreen is false', function () {
+            ui.set('isFullScreen', false);
+
+            expect(service.sidebarVisible).to.be.true;
+        });
+
+        it('returns false when ui.isFullScreen is true', function () {
+            ui.set('isFullScreen', true);
+
+            expect(service.sidebarVisible).to.be.false;
+        });
+
+        it('reflects changes to ui.isFullScreen', function () {
+            ui.set('isFullScreen', false);
+            expect(service.sidebarVisible).to.be.true;
+
+            ui.set('isFullScreen', true);
+            expect(service.sidebarVisible).to.be.false;
+
+            ui.set('isFullScreen', false);
+            expect(service.sidebarVisible).to.be.true;
         });
     });
 });


### PR DESCRIPTION
fixes https://linear.app/ghost/issue/BER-3009/hide-sidebar-in-editor

Implemented Ember-React state bridge for sidebar visibility to avoid timing issues between Ember and React Router. The Ember editor route controls visibility via state-bridge and React reads directly from Ember as source of truth using `useSyncExternalStore`.

I also removed the transition animations as it opens and closes to match the current Ember behavior. Also, that animation would stutter and not look very nice. 