### PR TITLE
Fixed top sources endpoint filters for UTMs

### DIFF
--- a/ghost/core/core/server/data/tinybird/endpoints/api_top_pages.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_top_pages.pipe
@@ -55,7 +55,6 @@ SQL >
                 and (post_type != 'post' or post_type is null)
             {% end %}
         {% end %}
-        -- UTM filters are applied in filtered_sessions pipe at the session level (mv_session_data)
     group by post_uuid, pathname
     order by visits desc
     limit {{ Int32(skip, 0) }},{{ Int32(limit, 50) }}

--- a/ghost/core/core/server/data/tinybird/endpoints/api_top_pages.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_top_pages.pipe
@@ -55,11 +55,7 @@ SQL >
                 and (post_type != 'post' or post_type is null)
             {% end %}
         {% end %}
-        {% if defined(utm_source) %} and utm_source = {{ String(utm_source, description="UTM source to filter on", required=False) }} {% end %}
-        {% if defined(utm_medium) %} and utm_medium = {{ String(utm_medium, description="UTM medium to filter on", required=False) }} {% end %}
-        {% if defined(utm_campaign) %} and utm_campaign = {{ String(utm_campaign, description="UTM campaign to filter on", required=False) }} {% end %}
-        {% if defined(utm_term) %} and utm_term = {{ String(utm_term, description="UTM term to filter on", required=False) }} {% end %}
-        {% if defined(utm_content) %} and utm_content = {{ String(utm_content, description="UTM content to filter on", required=False) }} {% end %}
+        -- UTM filters are applied in filtered_sessions pipe at the session level (mv_session_data)
     group by post_uuid, pathname
     order by visits desc
     limit {{ Int32(skip, 0) }},{{ Int32(limit, 50) }}

--- a/ghost/core/core/server/data/tinybird/pipes/filtered_sessions.pipe
+++ b/ghost/core/core/server/data/tinybird/pipes/filtered_sessions.pipe
@@ -30,7 +30,7 @@ SQL >
 
 NODE sessions_filtered_by_source
 DESCRIPTION >
-    Further filter by source when using the source filter. This is necessary because the source is specific to the first hit in a session,
+    Further filter by source and UTM parameters when using those filters. This is necessary because source and UTM parameters are specific to the first hit in a session,
     whereas other filters are on hits.
 
 SQL >
@@ -42,3 +42,8 @@ SQL >
     where
         site_uuid = {{ String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True) }}
         {% if defined(source) %} and source = {{ String(source, description="Source to filter on", required=False) }} {% end %}
+        {% if defined(utm_source) %} and utm_source = {{ String(utm_source, description="UTM source to filter on", required=False) }} {% end %}
+        {% if defined(utm_medium) %} and utm_medium = {{ String(utm_medium, description="UTM medium to filter on", required=False) }} {% end %}
+        {% if defined(utm_campaign) %} and utm_campaign = {{ String(utm_campaign, description="UTM campaign to filter on", required=False) }} {% end %}
+        {% if defined(utm_term) %} and utm_term = {{ String(utm_term, description="UTM term to filter on", required=False) }} {% end %}
+        {% if defined(utm_content) %} and utm_content = {{ String(utm_content, description="UTM content to filter on", required=False) }} {% end %}


### PR DESCRIPTION
no ref

UTM data is a session-level attribute as we roll it up to the 'first hit'. As such, we should filter it at the session level, not the page hit level.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Move UTM filtering from hit-level to session-level and wire `api_top_pages` to rely on session-scoped filters.
> 
> - **Analytics/Tinybird**:
>   - `pipes/filtered_sessions.pipe`:
>     - Extend `sessions_filtered_by_source` to also filter by `utm_source`, `utm_medium`, `utm_campaign`, `utm_term`, `utm_content`.
>     - Update node description to mention UTM filtering at session level.
>   - `endpoints/api_top_pages.pipe`:
>     - Remove UTM filters from hit-level query; rely on `filtered_sessions` for session-scoped filtering.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69ebb6cd2368e87c823983124e43e27572eefaa0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->