### PR TITLE
Added USE_REACT_SHELL support for e2e tests

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -286,7 +286,7 @@ jobs:
           } >> $GITHUB_STEP_SUMMARY
 
   test_e2e:
-    name: E2E Tests (Shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
+    name: E2E Tests (${{ matrix.shell == 'react' && 'React' || 'Ember' }} ${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
     runs-on: ubuntu-latest
     needs: [build, setup]
     strategy:
@@ -294,6 +294,7 @@ jobs:
       matrix:
         shardIndex: [1, 2]
         shardTotal: [2]
+        shell: [ember, react]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -342,13 +343,14 @@ jobs:
       - name: Run e2e tests
         env:
           GHOST_IMAGE_TAG: ${{ steps.load.outputs.image-tag }}
+          USE_REACT_SHELL: ${{ matrix.shell == 'react' && 'true' || '' }}
         run: yarn test:e2e --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
 
       - name: Upload blob report to GitHub Actions Artifacts
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: blob-report-${{ matrix.shardIndex }}
+          name: blob-report-${{ matrix.shell }}-${{ matrix.shardIndex }}
           path: e2e/blob-report
           retention-days: 1
 
@@ -356,7 +358,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: test-results-${{ matrix.shardIndex }}
+          name: test-results-${{ matrix.shell }}-${{ matrix.shardIndex }}
           path: e2e/test-results
           retention-days: 7
 

--- a/apps/admin/README.md
+++ b/apps/admin/README.md
@@ -13,7 +13,26 @@ Uses an **Ember Bridge** system for smooth migration:
 
 ```bash
 # Start development server
-yarn dev 
+yarn dev
 ```
 
 **Prerequisites:** Ghost and the existing Ember admin must be running on `localhost:2368` for API proxying.
+
+## Building for Production
+
+```bash
+# Build production bundle
+yarn workspace @tryghost/admin vite build
+```
+
+This outputs to `apps/admin/dist/`.
+
+## Serving the React Admin
+
+To serve the built React admin instead of the Ember admin, set the `USE_REACT_SHELL` environment variable:
+
+```bash
+USE_REACT_SHELL=true yarn dev
+```
+
+This configures Ghost to serve `apps/admin/dist/index.html` at `/ghost/` instead of the Ember admin.

--- a/apps/admin/src/layout/app-sidebar/UserMenu.tsx
+++ b/apps/admin/src/layout/app-sidebar/UserMenu.tsx
@@ -41,13 +41,24 @@ function UserMenu(props: UserMenuProps) {
                 <SidebarMenuButton
                     size="lg"
                     className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
+                    data-test-nav="arrow-down"
                 >
-                <Avatar>
-                    {currentUser.data?.profile_image && <AvatarImage src={currentUser.data?.profile_image} />}
-                    <AvatarFallback className="text-foreground-muted hover:text-foreground">
-                        <LucideIcon.User />
-                    </AvatarFallback>
-                </Avatar>
+                <div className="relative">
+                    <Avatar>
+                        {currentUser.data?.profile_image && <AvatarImage src={currentUser.data?.profile_image} />}
+                        <AvatarFallback className="text-foreground-muted hover:text-foreground">
+                            <LucideIcon.User />
+                        </AvatarFallback>
+                    </Avatar>
+                    {whatsNewData?.hasNew && (
+                        <Indicator
+                            variant="success"
+                            size="sm"
+                            className="absolute -top-0.5 -right-0.5"
+                            data-test-whats-new-avatar-badge
+                        />
+                    )}
+                </div>
                 <div className="grid flex-1 text-left text-base leading-tight">
                     <span className="truncate font-semibold">{currentUser.data?.name}</span>
                     <span className="text-muted-foreground truncate text-xs -mt-px">

--- a/apps/admin/src/whats-new/components/whats-new-banner.tsx
+++ b/apps/admin/src/whats-new/components/whats-new-banner.tsx
@@ -24,16 +24,13 @@ function WhatsNewBanner() {
         dismissWhatsNew();
     };
 
-    const handleClick = () => {
+    const handleLinkClick = () => {
         // Mark as seen when navigating to the changelog
         dismissWhatsNew();
-        // Open the changelog entry in a new tab
-        window.open(latestEntry.url, '_blank', 'noopener,noreferrer');
     };
 
     return (
         <Banner
-            className="cursor-pointer"
             data-test-toast="whats-new"
             role="status"
             aria-label="What's new notification"
@@ -41,9 +38,15 @@ function WhatsNewBanner() {
             variant="gradient"
             dismissible
             onDismiss={handleDismiss}
-            onClick={handleClick}
         >
-            <div className="pr-8" data-test-toast-link>
+            <a
+                href={latestEntry.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="block pr-8"
+                onClick={handleLinkClick}
+                data-test-toast-link
+            >
                 <div className="flex items-center gap-2 mb-2">
                     <LucideIcon.Sparkles className="size-4 text-purple-600" />
                     <span className="text-xs font-semibold text-gray-700 uppercase tracking-wide">What's new?</span>
@@ -54,7 +57,7 @@ function WhatsNewBanner() {
                 <div className="text-sm text-gray-700" data-test-toast-excerpt>
                     {latestEntry.customExcerpt}
                 </div>
-            </div>
+            </a>
         </Banner>
     );
 }

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -21,7 +21,7 @@ yarn test:e2e
 
 ### Running Specific Tests
 
-Within `e2e` folder, run one of the following commands: 
+Within `e2e` folder, run one of the following commands:
 
 ```bash
 # All tests
@@ -36,6 +36,16 @@ yarn test --grep "homepage"
 # With browser visible (for debugging)
 yarn test --debug
 ```
+
+### Testing with React Admin Shell
+
+To run e2e tests against the new React admin shell instead of the Ember admin:
+
+```bash
+USE_REACT_SHELL=true yarn test:e2e
+```
+
+This builds the React admin (`apps/admin`) and configures Ghost to serve it at `/ghost/` instead of the Ember admin.
 
 ## Tests Development
 

--- a/e2e/helpers/environment/service-managers/ghost-manager.ts
+++ b/e2e/helpers/environment/service-managers/ghost-manager.ts
@@ -71,7 +71,9 @@ export class GhostManager {
                 mail__options__port: `${MAILPIT.PORT}`,
                 mail__options__secure: 'false',
                 // other services configuration
-                portal__url: config.portalUrl || `http://localhost:${PORTAL.PORT}/portal.min.js`
+                portal__url: config.portalUrl || `http://localhost:${PORTAL.PORT}/portal.min.js`,
+                // Use React admin shell if specified
+                ...(process.env.USE_REACT_SHELL === 'true' ? {USE_REACT_SHELL: 'true'} : {})
             } as Record<string, string>;
 
             const containerConfig: ContainerCreateOptions = {

--- a/e2e/tests/admin/whats-new.test.ts
+++ b/e2e/tests/admin/whats-new.test.ts
@@ -1,15 +1,7 @@
 import {WhatsNewBanner, WhatsNewMenu} from '../../helpers/pages/admin/whats-new';
 import {expect, test} from '../../helpers/playwright/fixture';
 import type {Page} from '@playwright/test';
-
-interface ChangelogEntry {
-    title: string;
-    custom_excerpt: string;
-    published_at: string;
-    url: string;
-    featured: boolean;
-    feature_image?: string;
-}
+import type {RawChangelogEntry} from '../../../../apps/admin/src/whats-new/hooks/use-changelog';
 
 function daysAgo(days: number): Date {
     const date = new Date();
@@ -28,19 +20,21 @@ function createEntry(publishedAt: Date, options: {
     title?: string;
     excerpt?: string;
     feature_image?: string;
-} = {}): ChangelogEntry {
+} = {}): RawChangelogEntry {
     const title = options.title ?? 'Test Update';
+    const slug = title.toLowerCase().replace(/\s+/g, '-');
     return {
+        slug,
         title,
         custom_excerpt: options.excerpt ?? 'Test feature',
         published_at: publishedAt.toISOString(),
-        url: `https://ghost.org/changelog/${title.toLowerCase().replace(/\s+/g, '-')}`,
-        featured: options.featured ?? false,
+        url: `https://ghost.org/changelog/${slug}`,
+        featured: (options.featured ?? false) ? 'true' : 'false',
         ...(options.feature_image && {feature_image: options.feature_image})
     };
 }
 
-async function mockChangelog(page: Page, entries: ChangelogEntry[]): Promise<void> {
+async function mockChangelog(page: Page, entries: RawChangelogEntry[]): Promise<void> {
     await page.route('https://ghost.org/changelog.json', async (route) => {
         await route.fulfill({
             status: 200,

--- a/ghost/admin/app/services/whats-new.js
+++ b/ghost/admin/app/services/whats-new.js
@@ -46,7 +46,7 @@ export default Service.extend({
         }
 
         let [latestEntry] = this.entries;
-        return latestEntry.featured;
+        return latestEntry.featured === 'true';
     }),
 
     seen: action(function () {

--- a/ghost/core/core/server/web/admin/app.js
+++ b/ghost/core/core/server/web/admin/app.js
@@ -23,8 +23,10 @@ module.exports = function setupAdminApp() {
     //        produced below should be split into separate 'Cache-Control' entry.
     //        For reference see: https://developer.mozilla.org/en-US/docs/Web/HTTP/Caching#validation_2
 
+    const adminAssetsPath = path.join(config.getAdminAssetsPath(), 'assets');
+
     adminApp.use('/assets', serveStatic(
-        path.join(config.get('paths').adminAssets, 'assets'), {
+        adminAssetsPath, {
             // @NOTE: the maxAge config passed below are in milliseconds and the config
             //        is specified in seconds. See https://github.com/expressjs/serve-static/issues/150 for more context
             maxAge: config.get('caching:admin:maxAge') * 1000,

--- a/ghost/core/core/server/web/admin/controller.js
+++ b/ghost/core/core/server/web/admin/controller.js
@@ -29,7 +29,10 @@ module.exports = function adminController(req, res) {
     // CASE: trigger update check unit and let it run in background, don't block the admin rendering
     updateCheck();
 
-    const templatePath = path.resolve(config.get('paths').adminAssets, 'index.html');
+    const adminAssetsPath = config.getAdminAssetsPath();
+    const templatePath = path.resolve(adminAssetsPath, 'index.html');
+
+    debug(`Serving admin from: ${adminAssetsPath}`);
     const headers = {};
 
     try {

--- a/ghost/core/core/shared/config/helpers.js
+++ b/ghost/core/core/shared/config/helpers.js
@@ -98,6 +98,18 @@ const getContentPath = function getContentPath(type) {
 };
 
 /**
+ * @callback getAdminAssetsPathFn
+ * @returns {string}
+ */
+const getAdminAssetsPath = function getAdminAssetsPath() {
+    const useReactShell = process.env.USE_REACT_SHELL === 'true';
+    if (useReactShell) {
+        return path.join(this.get('paths:appRoot'), '../../apps/admin/dist');
+    }
+    return this.get('paths:adminAssets');
+};
+
+/**
  * @typedef ConfigHelpers
  * @property {isPrivacyDisabledFn} isPrivacyDisabled
  * @property {getContentPathFn} getContentPath
@@ -105,6 +117,7 @@ const getContentPath = function getContentPath(type) {
 module.exports.bindAll = (nconf) => {
     nconf.isPrivacyDisabled = isPrivacyDisabled.bind(nconf);
     nconf.getContentPath = getContentPath.bind(nconf);
+    nconf.getAdminAssetsPath = getAdminAssetsPath.bind(nconf);
     nconf.getBackendMountPath = getBackendMountPath.bind(nconf);
     nconf.getFrontendMountPath = getFrontendMountPath.bind(nconf);
 };


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-2920

### Why

As we migrate the Ghost admin from Ember to React, we need the ability to run our e2e test suite against the new React admin shell to catch regressions early and validate the migration progress.

### What

This PR enables running e2e tests with the React admin shell by setting `USE_REACT_SHELL=true`. When enabled, Ghost serves the built React admin from `apps/admin/dist` instead of the Ember admin.

The implementation adds:
- A new `admin-react-builder` stage in the Dockerfile that builds the React admin
- A `getAdminAssetsPath()` config helper that resolves the correct admin path based on the environment variable
- Environment variable passthrough from the e2e test runner to Ghost containers
- A separate CI workflow job to run e2e tests with the React shell
- Documentation in the e2e and apps/admin READMEs

### Testing

Run the e2e tests with the React shell:

```bash
USE_REACT_SHELL=true yarn test:e2e
```