### PR TITLE
Added USE_REACT_SHELL support for e2e tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ COPY package.json yarn.lock ./
 RUN mkdir -p .yarnhash && md5sum yarn.lock | awk '{print $1}' > .yarnhash/yarn.lock.md5
 
 # Copy all package.json files
+COPY apps/admin/package.json apps/admin/package.json
 COPY apps/stats/package.json apps/stats/package.json
 COPY apps/activitypub/package.json apps/activitypub/package.json
 COPY apps/admin-x-design-system/package.json apps/admin-x-design-system/package.json
@@ -168,6 +169,25 @@ COPY --from=activitypub-builder /home/ghost/apps/activitypub/dist apps/activityp
 RUN mkdir -p ghost/core/core/built/admin && cd ghost/admin && yarn build
 
 # --------------------
+# Admin React Builder
+# --------------------
+FROM development-base AS admin-react-builder
+WORKDIR /home/ghost
+COPY apps/admin apps/admin
+COPY ghost/core/core/frontend/src/cards ghost/core/core/frontend/src/cards
+# React admin needs full dependencies for workspace linking
+COPY --from=shade-builder /home/ghost/apps/shade apps/shade
+COPY --from=admin-x-design-system-builder /home/ghost/apps/admin-x-design-system apps/admin-x-design-system
+COPY --from=admin-x-framework-builder /home/ghost/apps/admin-x-framework apps/admin-x-framework
+COPY --from=posts-builder /home/ghost/apps/posts apps/posts
+COPY --from=stats-builder /home/ghost/apps/stats apps/stats
+COPY --from=admin-x-settings-builder /home/ghost/apps/admin-x-settings apps/admin-x-settings
+COPY --from=activitypub-builder /home/ghost/apps/activitypub apps/activitypub
+# React admin needs the built Ember admin (vite-ember-assets plugin reads it at build time)
+COPY --from=admin-ember-builder /home/ghost/ghost/core/core/built/admin ghost/core/core/built/admin
+RUN cd apps/admin && yarn build
+
+# --------------------
 # Ghost Assets Builder
 # --------------------
 FROM development-base AS ghost-assets-builder
@@ -194,5 +214,7 @@ COPY --from=admin-x-settings-builder /home/ghost/apps/admin-x-settings/dist apps
 COPY --from=activitypub-builder /home/ghost/apps/activitypub/dist apps/activitypub/dist
 COPY --from=admin-ember-builder /home/ghost/ghost/admin/dist ghost/admin/dist
 COPY --from=admin-ember-builder /home/ghost/ghost/core/core/built/admin ghost/core/core/built/admin
+RUN rm -rf apps/admin/dist
+COPY --from=admin-react-builder /home/ghost/apps/admin/dist apps/admin/dist
 
 CMD ["yarn", "dev"]

--- a/apps/admin/README.md
+++ b/apps/admin/README.md
@@ -13,7 +13,27 @@ Uses an **Ember Bridge** system for smooth migration:
 
 ```bash
 # Start development server
-yarn dev 
+yarn dev
 ```
 
 **Prerequisites:** Ghost and the existing Ember admin must be running on `localhost:2368` for API proxying.
+
+## Building for Production
+
+```bash
+# Build production bundle
+yarn nx run admin:build
+```
+
+This outputs to `apps/admin/dist/`.
+
+## Serving the React Admin
+
+To serve the built React admin instead of the Ember admin, set the `USE_REACT_SHELL` environment variable when starting Ghost from the **monorepo root**:
+
+```bash
+# From the monorepo root
+USE_REACT_SHELL=true yarn dev
+```
+
+This configures the Ghost backend to serve `apps/admin/dist/index.html` at `/ghost/` instead of the Ember admin. The environment variable affects `ghost/core`, not `apps/admin` directly.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -21,7 +21,7 @@ yarn test:e2e
 
 ### Running Specific Tests
 
-Within `e2e` folder, run one of the following commands: 
+Within `e2e` folder, run one of the following commands:
 
 ```bash
 # All tests
@@ -36,6 +36,18 @@ yarn test --grep "homepage"
 # With browser visible (for debugging)
 yarn test --debug
 ```
+
+### Testing with React Admin Shell
+
+To run e2e tests against the new React admin shell instead of the Ember admin:
+
+From the repository root:
+
+```bash
+USE_REACT_SHELL=true yarn test:e2e
+```
+
+This builds the React admin (`apps/admin`) and configures Ghost to serve it at `/ghost/` instead of the Ember admin.
 
 ## Tests Development
 

--- a/e2e/helpers/environment/service-managers/ghost-manager.ts
+++ b/e2e/helpers/environment/service-managers/ghost-manager.ts
@@ -71,7 +71,9 @@ export class GhostManager {
                 mail__options__port: `${MAILPIT.PORT}`,
                 mail__options__secure: 'false',
                 // other services configuration
-                portal__url: config.portalUrl || `http://localhost:${PORTAL.PORT}/portal.min.js`
+                portal__url: config.portalUrl || `http://localhost:${PORTAL.PORT}/portal.min.js`,
+                // Use React admin shell if specified
+                ...(process.env.USE_REACT_SHELL === 'true' ? {USE_REACT_SHELL: 'true'} : {})
             } as Record<string, string>;
 
             const containerConfig: ContainerCreateOptions = {

--- a/ghost/core/core/server/web/admin/app.js
+++ b/ghost/core/core/server/web/admin/app.js
@@ -23,8 +23,10 @@ module.exports = function setupAdminApp() {
     //        produced below should be split into separate 'Cache-Control' entry.
     //        For reference see: https://developer.mozilla.org/en-US/docs/Web/HTTP/Caching#validation_2
 
+    const adminAssetsPath = path.join(config.getAdminAssetsPath(), 'assets');
+
     adminApp.use('/assets', serveStatic(
-        path.join(config.get('paths').adminAssets, 'assets'), {
+        adminAssetsPath, {
             // @NOTE: the maxAge config passed below are in milliseconds and the config
             //        is specified in seconds. See https://github.com/expressjs/serve-static/issues/150 for more context
             maxAge: config.get('caching:admin:maxAge') * 1000,

--- a/ghost/core/core/server/web/admin/controller.js
+++ b/ghost/core/core/server/web/admin/controller.js
@@ -29,7 +29,8 @@ module.exports = function adminController(req, res) {
     // CASE: trigger update check unit and let it run in background, don't block the admin rendering
     updateCheck();
 
-    const templatePath = path.resolve(config.get('paths').adminAssets, 'index.html');
+    const adminAssetsPath = config.getAdminAssetsPath();
+    const templatePath = path.resolve(adminAssetsPath, 'index.html');
     const headers = {};
 
     try {

--- a/ghost/core/core/shared/config/helpers.js
+++ b/ghost/core/core/shared/config/helpers.js
@@ -98,6 +98,18 @@ const getContentPath = function getContentPath(type) {
 };
 
 /**
+ * Get the path to admin assets, switching between Ember and React admin based on USE_REACT_SHELL env var
+ * @returns {string}
+ */
+const getAdminAssetsPath = function getAdminAssetsPath() {
+    const useReactShell = process.env.USE_REACT_SHELL === 'true';
+    if (useReactShell) {
+        return path.join(this.get('paths:appRoot'), '../../apps/admin/dist');
+    }
+    return this.get('paths:adminAssets');
+};
+
+/**
  * @typedef ConfigHelpers
  * @property {isPrivacyDisabledFn} isPrivacyDisabled
  * @property {getContentPathFn} getContentPath
@@ -105,6 +117,7 @@ const getContentPath = function getContentPath(type) {
 module.exports.bindAll = (nconf) => {
     nconf.isPrivacyDisabled = isPrivacyDisabled.bind(nconf);
     nconf.getContentPath = getContentPath.bind(nconf);
+    nconf.getAdminAssetsPath = getAdminAssetsPath.bind(nconf);
     nconf.getBackendMountPath = getBackendMountPath.bind(nconf);
     nconf.getFrontendMountPath = getFrontendMountPath.bind(nconf);
 };


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-2920

## Why

As part of the React admin migration (BER-2613), we need to validate that the new React admin shell works correctly by running our e2e test suite against it. This requires infrastructure to serve the React admin build instead of the Ember admin when running tests.

## What

This PR adds support for running e2e tests against the React admin shell by introducing a `USE_REACT_SHELL` environment variable:

- Added `getAdminAssetsPath()` config helper that switches between Ember and React admin based on the environment variable
- Updated admin `app.js` and `controller.js` to use the new config helper
- Added Docker build stage for the React admin (`admin-react-builder`)
- Updated ghost-manager to pass the `USE_REACT_SHELL` env var to the container