### PR TITLE
Made React E2E test shards required

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -295,7 +295,6 @@ jobs:
         shardIndex: [1, 2]
         shardTotal: [2]
         shell: [ember, react]
-    continue-on-error: ${{ matrix.shell == 'react' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- Removes `continue-on-error: true` from React E2E test matrix
- React admin E2E tests are now required and will block CI on failure

ref https://linear.app/ghost/issue/BER-2920

**Depends on:** #25479