### PR TITLE
Improved topic filter UX in ActivityPub

### DIFF
--- a/apps/activitypub/package.json
+++ b/apps/activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/activitypub",
-  "version": "1.0.33",
+  "version": "1.0.34",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/activitypub/src/components/TopicFilter.tsx
+++ b/apps/activitypub/src/components/TopicFilter.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect, useRef} from 'react';
 import {Button} from '@tryghost/shade';
 
 export type Topic = 'following' | 'top' | 'technology' | 'business' | 'news' | 'culture' | 'art' | 'travel' | 'education' | 'finance' | 'entertainment' | 'productivity' | 'literature' | 'personal' | 'programming' | 'design' | 'sport' | 'faith-spirituality' | 'science' | 'crypto' | 'food-drink' | 'music' | 'nature-outdoors' | 'climate' | 'history' | 'gear-gadgets';
@@ -40,6 +40,17 @@ interface TopicFilterProps {
 
 const TopicFilter: React.FC<TopicFilterProps> = ({currentTopic, onTopicChange, excludeTopics = []}) => {
     const filteredTopics = TOPICS.filter(({value}) => !excludeTopics.includes(value));
+    const selectedButtonRef = useRef<HTMLButtonElement>(null);
+
+    useEffect(() => {
+        if (selectedButtonRef.current) {
+            selectedButtonRef.current.scrollIntoView({
+                behavior: 'smooth',
+                block: 'nearest',
+                inline: 'center'
+            });
+        }
+    }, [currentTopic]);
 
     return (
         <div className="relative w-full">
@@ -49,6 +60,7 @@ const TopicFilter: React.FC<TopicFilterProps> = ({currentTopic, onTopicChange, e
                 {filteredTopics.map(({value, label}) => (
                     <Button
                         key={value}
+                        ref={currentTopic === value ? selectedButtonRef : null}
                         className="h-8 snap-start rounded-full px-3.5 text-sm"
                         variant={currentTopic === value ? 'default' : 'secondary'}
                         onClick={() => onTopicChange(value)}

--- a/apps/activitypub/src/components/TopicFilter.tsx
+++ b/apps/activitypub/src/components/TopicFilter.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useRef} from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 import {Button} from '@tryghost/shade';
 
 export type Topic = 'following' | 'top' | 'technology' | 'business' | 'news' | 'culture' | 'art' | 'travel' | 'education' | 'finance' | 'entertainment' | 'productivity' | 'literature' | 'personal' | 'programming' | 'design' | 'sport' | 'faith-spirituality' | 'science' | 'crypto' | 'food-drink' | 'music' | 'nature-outdoors' | 'climate' | 'history' | 'gear-gadgets';
@@ -41,6 +41,13 @@ interface TopicFilterProps {
 const TopicFilter: React.FC<TopicFilterProps> = ({currentTopic, onTopicChange, excludeTopics = []}) => {
     const filteredTopics = TOPICS.filter(({value}) => !excludeTopics.includes(value));
     const selectedButtonRef = useRef<HTMLButtonElement>(null);
+    const scrollContainerRef = useRef<HTMLDivElement>(null);
+    const [showGradient, setShowGradient] = useState(true);
+
+    const handleScroll = (e: React.UIEvent<HTMLDivElement>) => {
+        const {scrollLeft, scrollWidth, clientWidth} = e.currentTarget;
+        setShowGradient(scrollLeft + clientWidth < scrollWidth - 1);
+    };
 
     useEffect(() => {
         if (selectedButtonRef.current) {
@@ -55,7 +62,9 @@ const TopicFilter: React.FC<TopicFilterProps> = ({currentTopic, onTopicChange, e
     return (
         <div className="relative w-full">
             <div
+                ref={scrollContainerRef}
                 className="flex w-full min-w-0 max-w-full snap-x snap-mandatory gap-2 overflow-x-auto [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+                onScroll={handleScroll}
             >
                 {filteredTopics.map(({value, label}) => (
                     <Button
@@ -69,7 +78,9 @@ const TopicFilter: React.FC<TopicFilterProps> = ({currentTopic, onTopicChange, e
                     </Button>
                 ))}
             </div>
-            <div className="pointer-events-none absolute right-0 top-0 h-full w-12 bg-gradient-to-l from-white to-transparent dark:from-black" />
+            {showGradient && (
+                <div className="pointer-events-none absolute right-0 top-0 h-full w-12 bg-gradient-to-l from-white to-transparent dark:from-black" />
+            )}
         </div>
     );
 };

--- a/apps/activitypub/src/components/TopicFilter.tsx
+++ b/apps/activitypub/src/components/TopicFilter.tsx
@@ -5,7 +5,7 @@ export type Topic = 'following' | 'top' | 'technology' | 'business' | 'news' | '
 
 const TOPICS: {value: Topic; label: string}[] = [
     {value: 'following', label: 'Following'},
-    {value: 'top', label: 'Featured'},
+    {value: 'top', label: 'Top'},
     {value: 'technology', label: 'Technology'},
     {value: 'business', label: 'Business'},
     {value: 'news', label: 'News'},

--- a/apps/activitypub/src/routes.tsx
+++ b/apps/activitypub/src/routes.tsx
@@ -73,6 +73,11 @@ export const routes: CustomRouteObject[] = [
                 pageTitle: 'Explore'
             },
             {
+                path: 'explore/:topic',
+                element: <Explore />,
+                pageTitle: 'Explore'
+            },
+            {
                 path: 'profile',
                 element: <Profile />,
                 pageTitle: 'Profile'

--- a/apps/activitypub/src/views/Explore/ExploreByTopic.tsx
+++ b/apps/activitypub/src/views/Explore/ExploreByTopic.tsx
@@ -2,13 +2,14 @@ import APAvatar from '@src/components/global/APAvatar';
 import FollowButton from '@src/components/global/FollowButton';
 import Layout from '@components/layout';
 import ProfilePreviewHoverCard from '@components/global/ProfilePreviewHoverCard';
-import React, {useEffect, useState} from 'react';
+import React, {useEffect} from 'react';
 import TopicFilter, {type Topic} from '@src/components/TopicFilter';
 import {type Account, type ExploreAccount} from '@src/api/activitypub';
 import {Button, H4, LoadingIndicator, LucideIcon, Skeleton} from '@tryghost/shade';
 import {useAccountForUser, useExploreProfilesForUserByTopic} from '@hooks/use-activity-pub-queries';
 import {useNavigateWithBasePath} from '@src/hooks/use-navigate-with-base-path';
 import {useOnboardingStatus} from '@src/components/layout/Onboarding';
+import {useParams} from '@tryghost/admin-x-framework';
 
 interface ExploreProfileProps {
     profile: ExploreAccount;
@@ -98,7 +99,11 @@ export const ExploreProfile: React.FC<ExploreProfileProps & {
 
 const ExploreByTopic: React.FC = () => {
     const {isExplainerClosed, setExplainerClosed} = useOnboardingStatus();
-    const [topic, setTopic] = useState<Topic>('top');
+    const params = useParams<{topic?: string}>();
+    const navigate = useNavigateWithBasePath();
+
+    const topic: Topic = (params.topic as Topic) || 'top';
+
     const {exploreProfilesQuery, updateExploreProfile} = useExploreProfilesForUserByTopic('index', topic);
     const {data: exploreProfilesData, isLoading: isLoadingExploreProfiles, fetchNextPage, hasNextPage, isFetchingNextPage} = exploreProfilesQuery;
 
@@ -147,7 +152,17 @@ const ExploreByTopic: React.FC = () => {
                     <Button className='absolute right-4 top-[17px] size-6 opacity-40' variant='link' onClick={() => setExplainerClosed(true)}><LucideIcon.X size={20} /></Button>
                 </div>
             }
-            <TopicFilter currentTopic={topic} excludeTopics={['following']} onTopicChange={setTopic} />
+            <TopicFilter
+                currentTopic={topic}
+                excludeTopics={['following']}
+                onTopicChange={(newTopic) => {
+                    if (newTopic === 'top') {
+                        navigate('/explore', {replace: true});
+                    } else {
+                        navigate(`/explore/${newTopic}`, {replace: true});
+                    }
+                }}
+            />
             <div className='mt-12 flex flex-col gap-12 pb-20 max-md:mt-5'>
                 {isLoadingExploreProfiles ? (
                     <div>
@@ -188,4 +203,3 @@ const ExploreByTopic: React.FC = () => {
 };
 
 export default ExploreByTopic;
-


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3032/topic-filter-ux-improvements

- Added routes to topics to preserve the last selection when navigating back
- Scroll to the selected topic when it's not visible in the viewport
- Removed the fade effect when the last topic is in viewport