### PR TITLE
New admin local dev setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,6 +126,7 @@ test/functional/*.png
 # Caddyfile - for local development with ssl + caddy
 Caddyfile
 !docker/caddy/Caddyfile
+!docker/dev-gateway/Caddyfile
 
 # Playwright state with cookies it keeps across tests
 /ghost/core/playwright-state.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,10 +44,9 @@ Two categories of apps:
 ```bash
 yarn                           # Install dependencies
 yarn setup                     # First-time setup (installs deps + submodules)
-yarn dev                       # Run Ghost + Admin in parallel
-yarn dev:admin                 # Run only Ember admin + React apps (watch mode)
-yarn dev:ghost                 # Run only Ghost backend
-yarn dev:debug                 # Run with DEBUG=@tryghost*,ghost:* enabled
+yarn dev                       # Local dev (no Docker)
+yarn dev:debug                 # yarn dev with DEBUG=@tryghost*,ghost:* enabled
+yarn dev:forward               # Run Ghost backend with deps in Docker + frontend dev servers
 ```
 
 ### Building
@@ -100,6 +99,39 @@ yarn docker:mysql              # Open MySQL CLI
 yarn docker:test:unit          # Run unit tests in Docker
 yarn docker:reset              # Reset all Docker volumes (including database) and restart
 ```
+
+### Local development in Docker
+
+The `yarn dev:forward` command uses a **hybrid Docker + host development** setup:
+
+**What runs in Docker:**
+- Ghost Core backend (with hot-reload via mounted source)
+- MySQL, Redis, Mailpit
+- Caddy gateway/reverse proxy
+
+**What runs on host:**
+- Frontend dev servers (Admin, Portal, Comments UI, etc.) in watch mode with HMR
+- Foundation libraries (shade, admin-x-framework, etc.)
+
+**Setup:**
+```bash
+# Start everything (Docker + frontend dev servers)
+yarn dev:forward
+
+# With optional services (uses Docker Compose file composition)
+yarn dev:analytics             # Include Tinybird analytics
+yarn dev:storage               # Include MinIO S3-compatible object storage
+yarn dev:all                   # Include all optional services
+```
+
+**Accessing Services:**
+- Ghost: `http://localhost:2368` (database: `ghost_dev`)
+- Mailpit UI: `http://localhost:8025` (email testing)
+- MySQL: `localhost:3306`
+- Redis: `localhost:6379`
+- Tinybird: `http://localhost:7181` (when analytics enabled)
+- MinIO Console: `http://localhost:9001` (when storage enabled)
+- MinIO S3 API: `http://localhost:9000` (when storage enabled)
 
 ## Architecture Patterns
 

--- a/apps/admin-x-design-system/package.json
+++ b/apps/admin-x-design-system/package.json
@@ -9,6 +9,7 @@
     "types": "types/index.d.ts",
     "sideEffects": false,
     "scripts": {
+        "dev": "vite build --watch",
         "build": "tsc -p tsconfig.declaration.json && vite build",
         "prepare": "yarn build",
         "test": "yarn test:unit",
@@ -92,11 +93,6 @@
     "nx": {
         "targets": {
             "build": {
-                "dependsOn": [
-                    "^build"
-                ]
-            },
-            "dev": {
                 "dependsOn": [
                     "^build"
                 ]

--- a/apps/admin-x-framework/package.json
+++ b/apps/admin-x-framework/package.json
@@ -59,6 +59,7 @@
     },
     "sideEffects": false,
     "scripts": {
+        "dev": "vite build --watch",
         "build": "tsc -p tsconfig.declaration.json && vite build",
         "prepare": "yarn build",
         "test": "yarn test:types && yarn test:unit",
@@ -106,11 +107,6 @@
     "nx": {
         "targets": {
             "build": {
-                "dependsOn": [
-                    "^build"
-                ]
-            },
-            "dev": {
                 "dependsOn": [
                     "^build"
                 ]

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -44,6 +44,14 @@
   },
   "nx": {
     "targets": {
+      "dev": {
+        "dependsOn": [
+          "ghost-admin:dev",
+          "@tryghost/admin-x-framework:dev",
+          "@tryghost/admin-x-design-system:dev",
+          "@tryghost/shade:dev"
+        ]
+      },
       "build:dev": {
         "dependsOn": [
           "build",

--- a/apps/admin/vite.config.ts
+++ b/apps/admin/vite.config.ts
@@ -15,6 +15,15 @@ export default defineConfig({
     define: {
         "process.env.DEBUG": false, // Shim env var utilized by the @tryghost/nql package
     },
+    server: {
+        host: true,
+        allowedHosts: [
+            "localhost",
+            "127.0.0.1",
+            "::1",
+            "host.docker.internal",
+        ]
+    },
     resolve: {
         alias: {
             "@ghost-cards": GHOST_CARDS_PATH,

--- a/apps/shade/package.json
+++ b/apps/shade/package.json
@@ -9,6 +9,7 @@
     "types": "types/index.d.ts",
     "sideEffects": false,
     "scripts": {
+        "dev": "vite build --watch",
         "build": "tsc -p tsconfig.declaration.json && vite build",
         "prepare": "yarn build",
         "test": "yarn test:types && vitest run --coverage",
@@ -116,11 +117,6 @@
     "nx": {
         "targets": {
             "build": {
-                "dependsOn": [
-                    "^build"
-                ]
-            },
-            "dev": {
                 "dependsOn": [
                     "^build"
                 ]

--- a/compose.dev.analytics.yaml
+++ b/compose.dev.analytics.yaml
@@ -1,0 +1,72 @@
+# Analytics (Tinybird) configuration for Ghost development environment
+# Use with: docker compose -f compose.dev.yaml -f compose.dev.analytics.yaml up
+#
+# This file adds Tinybird analytics services and configuration to ghost-dev.
+
+services:
+  analytics:
+    image: ghost/traffic-analytics:1.0.20
+    container_name: ghost-dev-analytics
+    platform: linux/amd64
+    command: ["node", "--enable-source-maps", "dist/server.js"]
+    entrypoint: ["/app/entrypoint.sh"]
+    expose:
+      - "3000"
+    healthcheck:
+      test: ["CMD-SHELL", "node -e \"fetch('http://localhost:3000').then(r=>process.exit(r.status<500?0:1)).catch(()=>process.exit(1))\""]
+      interval: 1s
+      retries: 120
+    volumes:
+      - ./docker/analytics/entrypoint.sh:/app/entrypoint.sh:ro
+      - shared-config:/mnt/shared-config:ro
+    environment:
+      - PROXY_TARGET=http://tinybird-local:7181/v0/events
+      - TINYBIRD_WAIT=true
+    depends_on:
+      tinybird-local:
+        condition: service_healthy
+      tb-cli:
+        condition: service_completed_successfully
+
+  tinybird-local:
+    image: tinybirdco/tinybird-local:latest
+    container_name: ghost-dev-tinybird
+    platform: linux/amd64
+    stop_grace_period: 2s
+    ports:
+      - "7181:7181"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:7181/v0/health"]
+      interval: 1s
+      timeout: 5s
+      retries: 120
+
+  tb-cli:
+    build:
+      context: ./
+      dockerfile: docker/tb-cli/Dockerfile
+    container_name: ghost-dev-tb-cli
+    working_dir: /home/tinybird
+    environment:
+      - TB_HOST=http://tinybird-local:7181
+      - TB_LOCAL_HOST=tinybird-local
+    volumes:
+      - ./ghost/core/core/server/data/tinybird:/home/tinybird
+      - shared-config:/mnt/shared-config
+    depends_on:
+      tinybird-local:
+        condition: service_healthy
+
+  ghost-dev:
+    environment:
+      # Analytics configuration
+      analytics__url: http://analytics:3000
+      analytics__enabled: "true"
+    depends_on:
+      analytics:
+        condition: service_healthy
+
+volumes:
+  shared-config:
+
+

--- a/compose.dev.storage.yaml
+++ b/compose.dev.storage.yaml
@@ -1,0 +1,66 @@
+# Object Storage configuration for Ghost development environment
+# Use with: docker compose -f compose.dev.yaml -f compose.dev.storage.yaml up
+#
+# This file adds MinIO (S3-compatible storage) and configures ghost-dev to use it.
+# Without this file, Ghost uses local filesystem storage (the default).
+
+services:
+  minio:
+    image: minio/minio:RELEASE.2024-12-13T22-19-12Z
+    container_name: ghost-dev-minio
+    command: server /data --console-address ':9001'
+    ports:
+      - "9000:9000"  # S3 API
+      - "9001:9001"  # Web console
+    environment:
+      - MINIO_ROOT_USER=minio-user
+      - MINIO_ROOT_PASSWORD=minio-pass
+    volumes:
+      - minio-data:/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/ready"]
+      interval: 1s
+      retries: 120
+
+  minio-setup:
+    image: minio/mc
+    container_name: ghost-dev-minio-setup
+    entrypoint: ["/bin/sh", "/setup.sh"]
+    environment:
+      - MINIO_ROOT_USER=minio-user
+      - MINIO_ROOT_PASSWORD=minio-pass
+      - MINIO_BUCKET=ghost-dev
+    volumes:
+      - ./.docker/minio/setup.sh:/setup.sh:ro
+    depends_on:
+      minio:
+        condition: service_healthy
+    restart: "no"
+
+  ghost-dev:
+    environment:
+      # Object Storage - S3Storage adapter with MinIO backend
+      storage__media__adapter: S3Storage
+      storage__media__staticFileURLPrefix: content/media
+      storage__files__adapter: S3Storage
+      storage__files__staticFileURLPrefix: content/files
+      storage__S3Storage__bucket: ghost-dev
+      storage__S3Storage__region: us-east-1
+      storage__S3Storage__tenantPrefix: ab/ab1234567890abcdef1234567890abcd
+      storage__S3Storage__forcePathStyle: "true"
+      storage__S3Storage__cdnUrl: http://127.0.0.1:9000/ghost-dev
+      storage__S3Storage__staticFileURLPrefix: content/images
+      storage__S3Storage__endpoint: http://minio:9000
+      storage__S3Storage__accessKeyId: minio-user
+      storage__S3Storage__secretAccessKey: minio-pass
+      urls__media: http://127.0.0.1:9000/ghost-dev/ab/ab1234567890abcdef1234567890abcd
+      urls__files: http://127.0.0.1:9000/ghost-dev/ab/ab1234567890abcdef1234567890abcd
+    depends_on:
+      minio:
+        condition: service_healthy
+      minio-setup:
+        condition: service_completed_successfully
+
+volumes:
+  minio-data:
+

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -1,0 +1,134 @@
+name: ghost-dev
+
+services:
+  mysql:
+    image: mysql:8.4.5
+    container_name: ghost-dev-mysql
+    command: --innodb-buffer-pool-size=1G --innodb-log-buffer-size=500M --innodb-change-buffer-max-size=50 --innodb-flush-log-at-trx_commit=0 --innodb-flush-method=O_DIRECT
+    ports:
+      - "3306:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-root}
+      MYSQL_DATABASE: ${MYSQL_DATABASE:-ghost_dev}
+      MYSQL_USER: ghost
+      MYSQL_PASSWORD: ghost
+    volumes:
+      - mysql-data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysql", "-h", "127.0.0.1", "-uroot", "-p${MYSQL_ROOT_PASSWORD:-root}", "-e", "SELECT 1"]
+      interval: 1s
+      retries: 120
+      timeout: 5s
+      start_period: 10s
+
+  redis:
+    image: redis:7.0
+    container_name: ghost-dev-redis
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis-data:/data
+    healthcheck:
+      test:
+        - CMD
+        - redis-cli
+        - --raw
+        - incr
+        - ping
+      interval: 1s
+      retries: 120
+
+  mailpit:
+    image: axllent/mailpit
+    container_name: ghost-dev-mailpit
+    ports:
+      - "1025:1025"  # SMTP server
+      - "8025:8025"  # Web interface
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:8025"]
+      interval: 1s
+      retries: 30
+
+  # Main development Ghost instance
+  # Additional instances can be created programmatically via E2E GhostManager
+  ghost-dev:
+    build:
+      context: ./
+      dockerfile: docker/ghost-dev/Dockerfile
+    container_name: ghost-dev
+    working_dir: /home/ghost/ghost/core
+    command: ["yarn", "dev"]
+    volumes:
+      - ./ghost:/home/ghost/ghost
+      # Mount specific content subdirectories to preserve themes/adapters from source
+      - ghost-dev-data:/home/ghost/ghost/core/content/data
+      - ghost-dev-images:/home/ghost/ghost/core/content/images
+      - ghost-dev-media:/home/ghost/ghost/core/content/media
+      - ghost-dev-files:/home/ghost/ghost/core/content/files
+      - ghost-dev-logs:/home/ghost/ghost/core/content/logs
+    environment:
+      NODE_ENV: development
+      NODE_TLS_REJECT_UNAUTHORIZED: "0"
+      database__client: mysql2
+      database__connection__host: mysql
+      database__connection__user: root
+      database__connection__password: ${MYSQL_ROOT_PASSWORD:-root}
+      database__connection__database: ${MYSQL_DATABASE:-ghost_dev}
+      server__host: 0.0.0.0
+      server__port: 2368
+      mail__transport: SMTP
+      mail__options__host: mailpit
+      mail__options__port: 1025
+      # Redis cache (optional)
+      adapters__cache__Redis__host: redis
+      adapters__cache__Redis__port: 6379
+      # Public app assets - proxied through Caddy gateway to host dev servers
+      # Using /ghost/assets/* paths
+      portal__url: /ghost/assets/portal/portal.min.js
+      comments__url: /ghost/assets/comments-ui/comments-ui.min.js
+      sodoSearch__url: /ghost/assets/sodo-search/sodo-search.min.js
+      sodoSearch__styles: /ghost/assets/sodo-search/main.css
+      signupForm__url: /ghost/assets/signup-form/signup-form.min.js
+      announcementBar__url: /ghost/assets/announcement-bar/announcement-bar.min.js
+    depends_on:
+      mysql:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      mailpit:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "node", "-e", "fetch('http://localhost:2368',{redirect:'manual'}).then(r=>process.exit(r.status<500?0:1)).catch(()=>process.exit(1))"]
+      timeout: 5s
+      retries: 10
+      start_period: 5s
+
+  # Caddy reverse proxy for the main dev instance
+  # Routes Ghost backend + proxies asset requests to host dev servers
+  ghost-dev-gateway:
+    build:
+      context: ./docker/dev-gateway
+      dockerfile: Dockerfile
+    container_name: ghost-dev-gateway
+    ports:
+      - "2368:80"
+      - "80:80"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    depends_on:
+      ghost-dev:
+        condition: service_healthy
+
+
+volumes:
+  mysql-data:
+  redis-data:
+  ghost-dev-data:
+  ghost-dev-images:
+  ghost-dev-media:
+  ghost-dev-files:
+  ghost-dev-logs:
+
+networks:
+  default:
+    name: ghost_dev

--- a/docker/dev-gateway/Caddyfile
+++ b/docker/dev-gateway/Caddyfile
@@ -1,0 +1,159 @@
+{
+    admin off
+} 
+
+:80 {
+    # Compact log format for development
+    log {
+        output stdout
+        format transform "{common_log}"
+    }
+
+    # Ember live reload (runs on separate port 4201)
+    # This handles both the script injection and WebSocket connections
+    handle /ember-cli-live-reload.js {
+        reverse_proxy {env.ADMIN_LIVE_RELOAD_SERVER} {
+            header_up Host {http.reverse_proxy.upstream.hostport}
+            header_up X-Forwarded-Host {host}
+            # Enable WebSocket support for live reload
+            header_up Connection {>Connection}
+            header_up Upgrade {>Upgrade}
+        }
+    }
+
+    # Ghost API - must go to Ghost backend, not admin dev server
+    handle /ghost/api/* {
+        reverse_proxy {env.GHOST_BACKEND} {
+            header_up Host {host}
+            header_up X-Real-IP {remote_host}
+            header_up X-Forwarded-For {remote_host}
+
+            # Always tell Ghost requests are HTTPS to prevent redirects
+            header_up X-Forwarded-Proto https
+        }
+    }
+
+    # Public app dev server assets - must come BEFORE general /ghost/* handler
+    # Ghost is configured to load these from /ghost/assets/* via compose.dev.yaml
+    handle /ghost/assets/* {
+        # Strip /ghost/assets/ prefix
+        uri strip_prefix /ghost/assets
+
+        # Koenig Lexical Editor (optional - for developing Lexical in separate Koenig repo)
+        # Requires EDITOR_URL=/ghost/assets/koenig-lexical/ when starting admin dev server
+        # Falls back to Ghost backend (built package) via handle_errors if dev server isn't running
+        @lexical path /koenig-lexical/*
+        handle @lexical {
+            uri strip_prefix /koenig-lexical
+            reverse_proxy {env.LEXICAL_DEV_SERVER} {
+                header_up Host {http.reverse_proxy.upstream.hostport}
+                header_up X-Forwarded-Host {host}
+                # Fail quickly if dev server is down
+                fail_duration 1s
+                unhealthy_request_count 1
+            }
+        }
+
+        # Portal
+        @portal path /portal/*
+        handle @portal {
+            uri strip_prefix /portal
+            reverse_proxy {env.PORTAL_DEV_SERVER} {
+                header_up Host {http.reverse_proxy.upstream.hostport}
+                header_up X-Forwarded-Host {host}
+            }
+        }
+
+        # Comments UI
+        @comments path /comments-ui/*
+        handle @comments {
+            uri strip_prefix /comments-ui
+            reverse_proxy {env.COMMENTS_DEV_SERVER} {
+                header_up Host {http.reverse_proxy.upstream.hostport}
+                header_up X-Forwarded-Host {host}
+            }
+        }
+
+        # Signup Form
+        @signup path /signup-form/*
+        handle @signup {
+            uri strip_prefix /signup-form
+            reverse_proxy {env.SIGNUP_DEV_SERVER} {
+                header_up Host {http.reverse_proxy.upstream.hostport}
+                header_up X-Forwarded-Host {host}
+            }
+        }
+
+        # Sodo Search
+        @search path /sodo-search/*
+        handle @search {
+            uri strip_prefix /sodo-search
+            reverse_proxy {env.SEARCH_DEV_SERVER} {
+                header_up Host {http.reverse_proxy.upstream.hostport}
+                header_up X-Forwarded-Host {host}
+            }
+        }
+
+        # Announcement Bar
+        @announcement path /announcement-bar/*
+        handle @announcement {
+            uri strip_prefix /announcement-bar
+            reverse_proxy {env.ANNOUNCEMENT_DEV_SERVER} {
+                header_up Host {http.reverse_proxy.upstream.hostport}
+                header_up X-Forwarded-Host {host}
+            }
+        }
+
+        # Everything else under /ghost/assets/* goes to admin dev server
+        handle {
+            # Re-add the prefix we stripped for admin dev server
+            rewrite * /ghost/assets{path}
+            reverse_proxy {env.ADMIN_DEV_SERVER} {
+                header_up Host {http.reverse_proxy.upstream.hostport}
+                header_up X-Forwarded-Host {host}
+            }
+        }
+    }
+
+    # Admin interface - served from admin dev server
+    # This includes /ghost/, etc. (but /ghost/assets/* is handled above)
+    # Also handles WebSocket upgrade requests for live reload
+    handle /ghost/* {
+        reverse_proxy {env.ADMIN_DEV_SERVER} {
+            header_up Host {http.reverse_proxy.upstream.hostport}
+            header_up X-Forwarded-Host {host}
+            # Enable WebSocket support
+            header_up Connection {>Connection}
+            header_up Upgrade {>Upgrade}
+        }
+    }
+
+    # Everything else goes to Ghost backend
+    handle {
+        reverse_proxy {env.GHOST_BACKEND} {
+            header_up Host {host}
+            header_up X-Real-IP {remote_host}
+            header_up X-Forwarded-For {remote_host}
+
+            # Always tell Ghost requests are HTTPS to prevent redirects
+            header_up X-Forwarded-Proto https
+        }
+    }
+
+    # Handle errors
+    handle_errors {
+        # Fallback for Lexical when dev server is unavailable (502/503/504)
+        # Forwards to Ghost backend which serves the built koenig-lexical package
+        @lexical_fallback `{http.request.orig_uri.path}.startsWith("/ghost/assets/koenig-lexical/")`
+        handle @lexical_fallback {
+            rewrite * {http.request.orig_uri.path}
+            reverse_proxy {env.GHOST_BACKEND} {
+                header_up Host {host}
+                header_up X-Forwarded-Proto https
+            }
+        }
+
+        # Default error response
+        respond "{err.status_code} {err.status_text}"
+    }
+}

--- a/docker/dev-gateway/Dockerfile
+++ b/docker/dev-gateway/Dockerfile
@@ -1,0 +1,17 @@
+FROM caddy:2-alpine
+
+RUN caddy add-package github.com/caddyserver/transform-encoder
+
+# Default proxy targets (can be overridden via environment variables)
+ENV GHOST_BACKEND=ghost-dev:2368 \
+    ADMIN_DEV_SERVER=host.docker.internal:5173 \
+    ADMIN_LIVE_RELOAD_SERVER=host.docker.internal:4201 \
+    PORTAL_DEV_SERVER=host.docker.internal:4175 \
+    COMMENTS_DEV_SERVER=host.docker.internal:7173 \
+    SIGNUP_DEV_SERVER=host.docker.internal:6174 \
+    SEARCH_DEV_SERVER=host.docker.internal:4178 \
+    ANNOUNCEMENT_DEV_SERVER=host.docker.internal:4177 \
+    LEXICAL_DEV_SERVER=host.docker.internal:4173
+
+COPY Caddyfile /etc/caddy/Caddyfile
+EXPOSE 80 2368

--- a/docker/dev-gateway/README.md
+++ b/docker/dev-gateway/README.md
@@ -1,0 +1,49 @@
+# Dev Gateway (Caddy)
+This directory contains the Caddy reverse proxy configuration for the Ghost development environment.
+
+## Purpose
+The Caddy reverse proxy container:
+1. **Routes Ghost requests** to the Ghost container backend
+2. **Proxies asset requests** to local dev servers running on the host
+3. **Enables hot-reload** for frontend development without rebuilding Ghost
+
+## Configuration
+### Environment Variables
+Caddy uses environment variables (set in `compose.dev.yaml`) to configure proxy targets:
+
+- `GHOST_BACKEND` - Ghost container hostname (e.g., `ghost-dev:2368`)
+- `ADMIN_DEV_SERVER` - React admin dev server (e.g., `host.docker.internal:5173`)
+- `ADMIN_LIVE_RELOAD_SERVER` - Ember live reload WebSocket (e.g., `host.docker.internal:4201`)
+- `PORTAL_DEV_SERVER` - Portal dev server (e.g., `host.docker.internal:4175`)
+- `COMMENTS_DEV_SERVER` - Comments UI (e.g., `host.docker.internal:7173`)
+- `SIGNUP_DEV_SERVER` - Signup form (e.g., `host.docker.internal:6174`)
+- `SEARCH_DEV_SERVER` - Sodo search (e.g., `host.docker.internal:4178`)
+- `ANNOUNCEMENT_DEV_SERVER` - Announcement bar (e.g., `host.docker.internal:4177`)
+- `LEXICAL_DEV_SERVER` - *Optional:* Local Koenig Lexical editor dev server (e.g., `host.docker.internal:4173`)
+  - For developing Lexical in the separate [Koenig repository](https://github.com/TryGhost/Koenig)
+  - Requires `EDITOR_URL=/ghost/assets/koenig-lexical/` when starting admin dev server
+  - Automatically falls back to Ghost backend (built package) if dev server is not running
+
+**Note:** AdminX React apps (admin-x-settings, activitypub, posts, stats) are served through the admin dev server so they don't need separate proxy entries.
+
+### Ghost Configuration
+Ghost is configured via environment variables in `compose.dev.yaml` to load public app assets from `/ghost/assets/*` (e.g., `portal__url: /ghost/assets/portal/portal.min.js`). This uses the same path structure as built admin assets.
+
+### Routing Rules
+The Caddyfile defines these routing rules:
+
+| Path Pattern                         | Target                              | Purpose                                                                |
+|--------------------------------------|-------------------------------------|------------------------------------------------------------------------|
+| `/ember-cli-live-reload.js`          | Admin live reload (port 4201)       | Ember hot-reload script and WebSocket                                  |
+| `/ghost/api/*`                       | Ghost backend                       | Ghost API (bypasses admin dev server)                                  |
+| `/ghost/assets/koenig-lexical/*`     | Lexical dev server (port 4173)      | *Optional:* Koenig Lexical editor (falls back to Ghost if not running) |
+| `/ghost/assets/portal/*`             | Portal dev server (port 4175)       | Membership UI                                                          |
+| `/ghost/assets/comments-ui/*`        | Comments dev server (port 7173)     | Comments widget                                                        |
+| `/ghost/assets/signup-form/*`        | Signup dev server (port 6174)       | Signup form widget                                                     |
+| `/ghost/assets/sodo-search/*`        | Search dev server (port 4178)       | Search widget (JS + CSS)                                               |
+| `/ghost/assets/announcement-bar/*`   | Announcement dev server (port 4177) | Announcement widget                                                    |
+| `/ghost/assets/*`                    | Admin dev server (port 5173)        | Other admin assets (fallback)                                          |
+| `/ghost/*`                           | Admin dev server (port 5173)        | Admin interface                                                        |
+| Everything else                      | Ghost backend                       | Main Ghost application                                                 |
+
+**Note:** All port numbers listed are the host ports where dev servers run by default.

--- a/docker/ghost-dev/Dockerfile
+++ b/docker/ghost-dev/Dockerfile
@@ -1,0 +1,36 @@
+# Minimal Development Dockerfile for Ghost Core
+# Source code is mounted at runtime for hot-reload support
+
+ARG NODE_VERSION=22.13.1
+
+FROM node:$NODE_VERSION-bullseye-slim
+
+# Install system dependencies needed for building native modules
+RUN apt-get update && \
+    apt-get install -y \
+    build-essential \
+    curl \
+    python3 \
+    git && \
+    rm -rf /var/lib/apt/lists/* && \
+    apt clean
+
+WORKDIR /home/ghost
+
+# Copy package files for dependency installation
+COPY package.json yarn.lock ./
+COPY ghost/core/package.json ghost/core/package.json
+COPY ghost/i18n/package.json ghost/i18n/package.json
+COPY patches patches
+
+# Install dependencies
+# Note: Dependencies are installed at build time, but source code is mounted at runtime
+RUN --mount=type=cache,target=/usr/local/share/.cache/yarn,id=yarn-cache \
+    yarn install --frozen-lockfile
+
+# Source code will be mounted from host at /home/ghost/ghost/core
+# This allows node --watch to pick up file changes for hot-reload
+WORKDIR /home/ghost/ghost/core
+
+CMD ["node", "--watch", "--import=tsx", "index.js"]
+

--- a/docker/ghost-dev/README.md
+++ b/docker/ghost-dev/README.md
@@ -1,0 +1,33 @@
+# Ghost Core Dev Docker Image
+
+Minimal Docker image for running Ghost Core in development with hot-reload support.
+
+## Purpose
+
+This lightweight image:
+- Installs only Ghost Core dependencies
+- Mounts source code from the host at runtime
+- Enables `node --watch` for automatic restarts on file changes
+- Works with the Caddy gateway to proxy frontend assets from host dev servers
+
+## Key Differences from Main Dockerfile
+
+**Main `Dockerfile`** (for E2E tests, full builds):
+- Builds all frontend apps (Admin, Portal, AdminX apps, etc.)
+- Bundles everything into the image
+- ~15 build stages, 5-10 minute build time
+
+**This `Dockerfile`** (for local development):
+- Only installs dependencies
+- No frontend builds or bundling
+- Source code mounted at runtime 
+- Used for: Local development with `yarn dev`
+
+## Usage
+
+This image is used automatically when running:
+
+```bash
+yarn dev              # Starts Docker + frontend dev servers
+yarn dev:ghost        # Starts only Docker services
+```

--- a/nx.json
+++ b/nx.json
@@ -30,6 +30,10 @@
         },
         "test:unit": {
             "cache": true
+        },
+        "dev": {
+          "dependsOn": ["^dev"],
+          "continuous": true
         }
     },
     "cacheDirectory": ".nxcache"

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "dev:debug": "DEBUG_COLORS=true DEBUG=@tryghost*,ghost:* yarn dev",
     "dev:admin": "node .github/scripts/dev.js --admin",
     "dev:ghost": "node .github/scripts/dev.js --ghost",
+    "dev:forward": "yarn nx run-many -t dev -p ghost @tryghost/admin",
     "dev": "node .github/scripts/dev.js",
     "dev:tinybird": "node .github/scripts/dev-with-tinybird.js --tinybird",
     "fix": "yarn cache clean && rimraf -g '**/node_modules' && yarn && yarn nx reset",

--- a/package.json
+++ b/package.json
@@ -25,10 +25,13 @@
     "build": "nx run-many -t build",
     "build:clean": "nx reset && rimraf -g 'ghost/*/build' && rimraf -g 'ghost/*/tsconfig.tsbuildinfo'",
     "clean:hard": "node ./.github/scripts/clean.js",
+    "dev:forward": "nx run ghost-monorepo:docker:dev",
+    "dev:analytics": "DEV_COMPOSE_FILES='-f compose.dev.analytics.yaml' nx run ghost-monorepo:docker:dev",
+    "dev:storage": "DEV_COMPOSE_FILES='-f compose.dev.storage.yaml' nx run ghost-monorepo:docker:dev",
+    "dev:all": "DEV_COMPOSE_FILES='-f compose.dev.analytics.yaml -f compose.dev.storage.yaml' nx run ghost-monorepo:docker:dev",
     "dev:debug": "DEBUG_COLORS=true DEBUG=@tryghost*,ghost:* yarn dev",
     "dev:admin": "node .github/scripts/dev.js --admin",
     "dev:ghost": "node .github/scripts/dev.js --ghost",
-    "dev:forward": "yarn nx run-many -t dev -p ghost @tryghost/admin",
     "dev": "node .github/scripts/dev.js",
     "dev:tinybird": "node .github/scripts/dev-with-tinybird.js --tinybird",
     "fix": "yarn cache clean && rimraf -g '**/node_modules' && yarn && yarn nx reset",
@@ -103,5 +106,52 @@
     "rimraf": "5.0.10",
     "typescript": "5.8.3"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "nx": {
+    "includedScripts": [],
+    "targets": {
+      "docker:up": {
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "docker compose -f compose.dev.yaml ${DEV_COMPOSE_FILES} up -d --force-recreate --wait"
+        },
+        "dependsOn": [
+          "docker:build"
+        ]
+      },
+      "docker:down": {
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "docker compose -f compose.dev.yaml ${DEV_COMPOSE_FILES} down"
+        }
+      },
+      "docker:build": {
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "docker compose -f compose.dev.yaml ${DEV_COMPOSE_FILES} build"
+        }
+      },
+      "docker:dev": {
+        "continuous": true,
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "trap 'docker compose -f compose.dev.yaml ${DEV_COMPOSE_FILES} down' EXIT; docker compose -f compose.dev.yaml ${DEV_COMPOSE_FILES} logs -f"
+        },
+        "dependsOn": [
+          "docker:up",
+          {
+            "target": "dev",
+            "projects": [
+              "@tryghost/admin",
+              "@tryghost/portal",
+              "@tryghost/comments-ui",
+              "@tryghost/signup-form",
+              "@tryghost/sodo-search",
+              "@tryghost/announcement-bar"
+            ]
+          }
+        ]
+      }
+    }
+  }
 }


### PR DESCRIPTION
This PR adds a unified Ghost local development setup that leverages NX for orchestration and Docker to for running the Ghost backend and it's dependencies. As we migrate the Traffic Analytics and ActivityPub backends to this repository, they can be integrated alongside the Ghost core backend. 

**New Docker Setup (`compose.dev.yaml`):**
- Minimal Ghost Core image with mounted source for hot-reload
- Managed MySQL, Redis, Mailpit and Caddy gateway
- Separate start commands that enable `analytics` (Tinybird) and `storage` (MinIO)

**Caddy Reverse Proxy (`docker/dev-gateway/`):**
- Routes `/ghost/*` → Admin dev server (host:5173)
- Routes frontend assets → Host dev servers (Portal, Comments UI, etc.)
- Proxies Ghost API → Docker container
- WebSocket support for HMR across the stack

**NX Orchestration:**
- `yarn dev:forward` → Starts Docker services + frontend dev servers
- `yarn dev:analytics` → Includes Tinybird
- `yarn dev:storage` → Includes MinIO S3

### Benefits

- **Fast Docker builds:** deps only, source mounted
- **Hot reload everywhere:** Ghost via `--watch`, frontend via HMR
- **No host dependencies:** MySQL, Redis, Mailpit, etc in containers
- **Consistent environment:** Same setup for all developers
- **Profile-based features:** Optional analytics/storage services
