### PR TITLE
Fixed What's New changelog entry format and tests

### DIFF
--- a/apps/admin/src/layout/app-sidebar/UserMenu.tsx
+++ b/apps/admin/src/layout/app-sidebar/UserMenu.tsx
@@ -42,19 +42,31 @@ function UserMenu(props: UserMenuProps) {
                     size="lg"
                     className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
                 >
-                <Avatar>
-                    {currentUser.data?.profile_image && <AvatarImage src={currentUser.data?.profile_image} />}
-                    <AvatarFallback className="text-foreground-muted hover:text-foreground">
-                        <LucideIcon.User />
-                    </AvatarFallback>
-                </Avatar>
+                <div className="relative">
+                    <Avatar>
+                        {currentUser.data?.profile_image && <AvatarImage src={currentUser.data?.profile_image} />}
+                        <AvatarFallback className="text-foreground-muted hover:text-foreground">
+                            <LucideIcon.User />
+                        </AvatarFallback>
+                    </Avatar>
+                    {whatsNewData?.hasNew && (
+                        <span className="absolute -top-0.5 -right-0.5">
+                            <Indicator
+                                variant="success"
+                                size="sm"
+                                label="New updates available"
+                                data-test-whats-new-avatar-badge
+                            />
+                        </span>
+                    )}
+                </div>
                 <div className="grid flex-1 text-left text-base leading-tight">
                     <span className="truncate font-semibold">{currentUser.data?.name}</span>
                     <span className="text-muted-foreground truncate text-xs -mt-px">
                         {currentUser.data?.email}
                     </span>
                 </div>
-                <LucideIcon.ChevronsUpDown className="ml-auto size-4 text-grey-700" />
+                <LucideIcon.ChevronsUpDown className="ml-auto size-4 text-grey-700" data-test-nav="arrow-down" />
                 </SidebarMenuButton>
             </DropdownMenuTrigger>
             <DropdownMenuContent
@@ -92,7 +104,7 @@ function UserMenu(props: UserMenuProps) {
                     }}
                 >
                     <LucideIcon.Sparkles />
-                    <span>What's new?</span>
+                    <span>What’s new?</span>
                     {whatsNewData?.hasNew && (
                         <div className="flex-1 flex justify-end">
                             <Indicator

--- a/apps/admin/src/whats-new/components/whats-new-banner.tsx
+++ b/apps/admin/src/whats-new/components/whats-new-banner.tsx
@@ -24,29 +24,32 @@ function WhatsNewBanner() {
         dismissWhatsNew();
     };
 
-    const handleClick = () => {
+    const handleLinkClick = () => {
         // Mark as seen when navigating to the changelog
         dismissWhatsNew();
-        // Open the changelog entry in a new tab
-        window.open(latestEntry.url, '_blank', 'noopener,noreferrer');
     };
 
     return (
         <Banner
-            className="cursor-pointer"
             data-test-toast="whats-new"
             role="status"
-            aria-label="What's new notification"
+            aria-label="What’s new notification"
             aria-live="polite"
             variant="gradient"
             dismissible
             onDismiss={handleDismiss}
-            onClick={handleClick}
         >
-            <div className="pr-8" data-test-toast-link>
+            <a
+                href={latestEntry.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="block pr-8"
+                onClick={handleLinkClick}
+                data-test-toast-link
+            >
                 <div className="flex items-center gap-2 mb-2">
                     <LucideIcon.Sparkles className="size-4 text-purple-600" />
-                    <span className="text-xs font-semibold text-gray-700 uppercase tracking-wide">What's new?</span>
+                    <span className="text-xs font-semibold text-gray-700 uppercase tracking-wide">What’s new?</span>
                 </div>
                 <div className="text-base font-semibold text-gray-900 mb-1" data-test-toast-title>
                     {latestEntry.title}
@@ -54,7 +57,7 @@ function WhatsNewBanner() {
                 <div className="text-sm text-gray-700" data-test-toast-excerpt>
                     {latestEntry.customExcerpt}
                 </div>
-            </div>
+            </a>
         </Banner>
     );
 }

--- a/apps/admin/src/whats-new/components/whats-new-dialog.tsx
+++ b/apps/admin/src/whats-new/components/whats-new-dialog.tsx
@@ -31,7 +31,7 @@ function WhatsNewDialog({ open, onOpenChange }: WhatsNewDialogProps) {
             >
                 <DialogHeader>
                     <DialogTitle id="whats-new-modal-title" data-test-modal-title className="text-2xl tracking-tighter">
-                        What's new?
+                        What’s new?
                     </DialogTitle>
                 </DialogHeader>
 

--- a/e2e/helpers/pages/admin/whats-new/whats-new-menu.ts
+++ b/e2e/helpers/pages/admin/whats-new/whats-new-menu.ts
@@ -11,10 +11,14 @@ export class WhatsNewMenu extends AdminPage {
     constructor(page: Page) {
         super(page);
 
-        this.userMenuTrigger = page.locator('[data-test-nav="arrow-down"]');
-        this.whatsNewMenuItem = page.getByRole('menuitem', {name: 'What’s new?'});
-        this.avatarBadge = page.locator('[data-test-whats-new-avatar-badge]');
-        this.menuBadge = page.locator('[data-test-whats-new-menu-badge]');
+        // TODO: Remove .first() after React shell fully replaces Ember admin
+        // During migration, both shells render the arrow-down icon
+        this.userMenuTrigger = page.locator('[data-test-nav="arrow-down"]').first();
+        this.whatsNewMenuItem = page.getByRole('menuitem', {name: /What’s new\?/i});
+        // TODO: Remove .first() after React shell fully replaces Ember admin
+        // During migration, both shells render badges - .first() selects React's
+        this.avatarBadge = page.locator('[data-test-whats-new-avatar-badge]').first();
+        this.menuBadge = page.locator('[data-test-whats-new-menu-badge]').first();
     }
 
     async openUserMenu(): Promise<void> {

--- a/e2e/tests/admin/whats-new.test.ts
+++ b/e2e/tests/admin/whats-new.test.ts
@@ -2,14 +2,17 @@ import {WhatsNewBanner, WhatsNewMenu} from '@/admin-pages';
 import {expect, test} from '@/helpers/playwright/fixture';
 import type {Page} from '@playwright/test';
 
-interface ChangelogEntry {
+// Local type definition matching the API response format
+type RawChangelogEntry = {
+    slug: string;
     title: string;
     custom_excerpt: string;
     published_at: string;
     url: string;
-    featured: boolean;
+    featured: string;
     feature_image?: string;
-}
+    html?: string;
+};
 
 function daysAgo(days: number): Date {
     const date = new Date();
@@ -28,19 +31,21 @@ function createEntry(publishedAt: Date, options: {
     title?: string;
     excerpt?: string;
     feature_image?: string;
-} = {}): ChangelogEntry {
+} = {}): RawChangelogEntry {
     const title = options.title ?? 'Test Update';
+    const slug = title.toLowerCase().replace(/\s+/g, '-');
     return {
+        slug,
         title,
         custom_excerpt: options.excerpt ?? 'Test feature',
         published_at: publishedAt.toISOString(),
-        url: `https://ghost.org/changelog/${title.toLowerCase().replace(/\s+/g, '-')}`,
-        featured: options.featured ?? false,
+        url: `https://ghost.org/changelog/${slug}`,
+        featured: (options.featured ?? false) ? 'true' : 'false',
         ...(options.feature_image && {feature_image: options.feature_image})
     };
 }
 
-async function mockChangelog(page: Page, entries: ChangelogEntry[]): Promise<void> {
+async function mockChangelog(page: Page, entries: RawChangelogEntry[]): Promise<void> {
     await page.route('https://ghost.org/changelog.json', async (route) => {
         await route.fulfill({
             status: 200,

--- a/ghost/admin/app/services/whats-new.js
+++ b/ghost/admin/app/services/whats-new.js
@@ -46,7 +46,7 @@ export default Service.extend({
         }
 
         let [latestEntry] = this.entries;
-        return latestEntry.featured;
+        return latestEntry.featured === 'true';
     }),
 
     seen: action(function () {

--- a/ghost/admin/mirage/routes-test.js
+++ b/ghost/admin/mirage/routes-test.js
@@ -129,17 +129,16 @@ export default function () {
 
     this.get('https://ghost.org/changelog.json', function () {
         return {
-            changelog: [
+            posts: [
                 {
                     title: 'Custom image alt tags',
-                    custom_excerpt: null,
-                    html: '<p>We just shipped custom image alt tag support in the Ghost editor. This is one of our most requested features - and great news for accessibility and search engine optimisation for your Ghost publication.</p><p>Previously, you\'d need to use a Markdown card to add an image alt tag. Now you can create alt tags on the go directly from the editor, without the need to add any additional cards or custom tags.</p><!--kg-card-begin: image--><figure class="kg-card kg-image-card"><img src="https://ghost.org/changelog/content/images/2019/08/image-alt-tag.gif" class="kg-image"></figure><!--kg-card-end: image--><p>To write your alt tag, hit the <code>alt</code> button on the right in the caption line, type your alt text and then hit the button again to return to the caption text. </p><p><em><strong><strong><strong><strong><strong><strong><strong><strong><strong><strong><strong><strong><strong><strong><strong><strong><a href="https://ghost.org/pricing/">Ghost(Pro)</a></strong></strong></strong></strong></strong></strong></strong></strong></strong></strong></strong></strong></strong></strong></strong></strong> users already have access to custom image alt tags. Self hosted developers can use <a href="https://ghost.org/docs/ghost-cli/">Ghost-CLI</a> to install the latest release!</em></p>',
+                    custom_excerpt: 'Alt tag support for images in the Ghost editor',
                     slug: 'image-alt-text-support',
                     published_at: '2019-08-05T07:46:16.000+00:00',
-                    url: 'https://ghost.org/changelog/image-alt-text-support/'
+                    url: 'https://ghost.org/changelog/image-alt-text-support/',
+                    featured: 'false'
                 }
             ],
-            changelogMajor: [],
             changelogUrl: 'https://ghost.org/changelog/'
         };
     });

--- a/ghost/admin/tests/acceptance/whats-new-test.js
+++ b/ghost/admin/tests/acceptance/whats-new-test.js
@@ -73,35 +73,35 @@ describe('Acceptance: What\'s new', function () {
             custom_excerpt: 'This is an exciting new feature',
             published_at: '2024-01-15T12:00:00.000+00:00',
             url: 'https://ghost.org/changelog/new-feature',
-            featured: true
+            featured: 'true'
         },
         old: {
             title: 'Old Update',
             custom_excerpt: 'This is old',
             published_at: '2018-12-01T12:00:00.000+00:00',
             url: 'https://ghost.org/changelog/old-feature',
-            featured: true
+            featured: 'true'
         },
         newNonFeatured: {
             title: 'Non-Featured Update',
             custom_excerpt: 'This is not featured',
             published_at: '2024-01-15T12:00:00.000+00:00',
             url: 'https://ghost.org/changelog/regular-feature',
-            featured: false
+            featured: 'false'
         },
         newRegular: {
             title: 'New Update',
             custom_excerpt: 'New feature',
             published_at: '2024-01-15T12:00:00.000+00:00',
             url: 'https://ghost.org/changelog/new',
-            featured: false
+            featured: 'false'
         },
         latest: {
             title: 'Latest Update',
             custom_excerpt: 'Latest feature',
             published_at: '2024-01-15T12:00:00.000+00:00',
             url: 'https://ghost.org/changelog/latest',
-            featured: true,
+            featured: 'true',
             feature_image: 'https://ghost.org/image1.jpg'
         },
         previous: {
@@ -109,14 +109,14 @@ describe('Acceptance: What\'s new', function () {
             custom_excerpt: 'Previous feature',
             published_at: '2024-01-10T12:00:00.000+00:00',
             url: 'https://ghost.org/changelog/previous',
-            featured: false
+            featured: 'false'
         },
         latestNonFeatured: {
             title: 'Latest Update',
             custom_excerpt: 'Latest feature',
             published_at: '2024-01-15T12:00:00.000+00:00',
             url: 'https://ghost.org/changelog/latest',
-            featured: false
+            featured: 'false'
         }
     };
 

--- a/ghost/admin/tests/unit/services/whats-new-test.js
+++ b/ghost/admin/tests/unit/services/whats-new-test.js
@@ -84,12 +84,12 @@ describe('Unit: Service: whats-new', function () {
         newFeaturedEntry: [{
             title: 'Featured Update',
             published_at: '2024-01-15T12:00:00.000+00:00',
-            featured: true
+            featured: 'true'
         }],
         newNonFeaturedEntry: [{
             title: 'Regular Update',
             published_at: '2024-01-15T12:00:00.000+00:00',
-            featured: false
+            featured: 'false'
         }],
         oldEntry: [{
             title: 'Old Update',
@@ -98,7 +98,7 @@ describe('Unit: Service: whats-new', function () {
         oldFeaturedEntry: [{
             title: 'Old Featured Update',
             published_at: '2018-12-01T12:00:00.000+00:00',
-            featured: true
+            featured: 'true'
         }],
         multipleEntries: [
             {
@@ -148,7 +148,7 @@ describe('Unit: Service: whats-new', function () {
                     title: 'Test Update',
                     published_at: '2024-01-15T12:00:00.000+00:00',
                     url: 'https://ghost.org/changelog/test',
-                    featured: true
+                    featured: 'true'
                 }]
             });
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-2920

## Summary

- Fixed changelog entry `featured` field to use string `'true'` instead of boolean
- Added avatar badge indicator for new changelog entries
- Updated What's New banner to use proper anchor link
- Aligned React component data-test attributes with Ember patterns
- Added `.first()` selector for badge/menu locators due to dual-shell element overlap during migration