### PR TITLE
Fixed loading indicator spacing in Explore

### DIFF
--- a/apps/activitypub/package.json
+++ b/apps/activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/activitypub",
-  "version": "1.0.34",
+  "version": "1.0.35",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/activitypub/src/views/Explore/ExploreByTopic.tsx
+++ b/apps/activitypub/src/views/Explore/ExploreByTopic.tsx
@@ -191,7 +191,7 @@ const ExploreByTopic: React.FC = () => {
                         </div>
                         <div className='load-more-trigger h-4 w-full' />
                         {isFetchingNextPage && (
-                            <div className='flex w-full justify-center mt-2'>
+                            <div className='mt-2 flex w-full justify-center'>
                                 <LoadingIndicator size='sm' />
                             </div>
                         )}

--- a/apps/activitypub/src/views/Explore/ExploreByTopic.tsx
+++ b/apps/activitypub/src/views/Explore/ExploreByTopic.tsx
@@ -189,12 +189,12 @@ const ExploreByTopic: React.FC = () => {
                                 </React.Fragment>
                             ))}
                         </div>
-                    </div>
-                )}
-                <div className='load-more-trigger h-4 w-full' />
-                {isFetchingNextPage && (
-                    <div className='flex justify-center'>
-                        <LoadingIndicator size='sm' />
+                        <div className='load-more-trigger h-4 w-full' />
+                        {isFetchingNextPage && (
+                            <div className='flex w-full justify-center mt-2'>
+                                <LoadingIndicator size='sm' />
+                            </div>
+                        )}
                     </div>
                 )}
             </div>


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3037/the-loading-indicator-spacing-looks-odd-in-explore

- the loading indicator wasn't placed in the container, and the spacing and alignment were off
- this puts it in the container and adds some spacing