### PR TITLE
Added member_welcome_emails_enabled setting

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/6.9/2025-11-19-14-53-37-add-member-welcome-emails-enabled-setting.js
+++ b/ghost/core/core/server/data/migrations/versions/6.9/2025-11-19-14-53-37-add-member-welcome-emails-enabled-setting.js
@@ -1,0 +1,8 @@
+const {addSetting} = require('../../utils');
+
+module.exports = addSetting({
+    key: 'member_welcome_emails_enabled',
+    value: 'false',
+    type: 'boolean',
+    group: 'automations'
+});

--- a/ghost/core/core/server/data/schema/default-settings/default-settings.json
+++ b/ghost/core/core/server/data/schema/default-settings/default-settings.json
@@ -637,5 +637,15 @@
             },
             "type": "boolean"
         }
+    },
+    "automations": {
+        "member_welcome_emails_enabled": {
+            "defaultValue": "false",
+            "validations": {
+                "isEmpty": false,
+                "isIn": [["true", "false"]]
+            },
+            "type": "boolean"
+        }
     }
 }

--- a/ghost/core/test/unit/server/data/exporter/index.test.js
+++ b/ghost/core/test/unit/server/data/exporter/index.test.js
@@ -236,7 +236,7 @@ describe('Exporter', function () {
 
             // NOTE: if default settings changed either modify the settings keys blocklist or increase allowedKeysLength
             //       This is a reminder to think about the importer/exporter scenarios ;)
-            const allowedKeysLength = 94;
+            const allowedKeysLength = 95;
             totalKeysLength.should.eql(SETTING_KEYS_BLOCKLIST.length + allowedKeysLength);
         });
     });

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -37,7 +37,7 @@ describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = '34938745eb81427846ddba92c31d1b16';
     const currentFixturesHash = '0877727032b8beddbaedc086a8acf1a2';
-    const currentSettingsHash = 'bb8be7d83407f2b4fa2ad68c19610579';
+    const currentSettingsHash = '59093cd15f52b1d68706ba0c860319c6';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';
 
     // If this test is failing, then it is likely a change has been made that requires a DB version bump,


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-762

- adds `member_welcome_emails_enabled` setting
- defaults to false
- eventually this will toggle whether member welcome emails will send, instead of the config we currently have set up for testing