### PR TITLE
Suppress auto-responders from Microsoft email servers for bulk email

### DIFF
--- a/ghost/core/core/server/services/lib/MailgunClient.js
+++ b/ghost/core/core/server/services/lib/MailgunClient.js
@@ -71,7 +71,8 @@ module.exports = class MailgunClient {
                 text: messageContent.plaintext,
                 'recipient-variables': JSON.stringify(recipientData),
                 'h:Sender': message.from,
-                'h:Auto-Submitted': 'auto-generated'
+                'h:Auto-Submitted': 'auto-generated',
+                'h:X-Auto-Response-Suppress': 'OOF, AutoReply'
             };
 
             // Do we have a custom List-Unsubscribe header set?


### PR DESCRIPTION
ref [ONC-1193](https://linear.app/ghost/issue/ONC-1193/increase-in-automatic-replies)

We can use this non-standard header (X-Auto-Response-Suppress) to prevent Outlook auto-responders, which should help with certain Outlook configurations not handled by the standard `Auto-Submitted` header.
