### PR TITLE
Updated HTML stripping to convert block tags to line breaks in ActivityPub

### DIFF
--- a/apps/activitypub/package.json
+++ b/apps/activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/activitypub",
-  "version": "1.0.36",
+  "version": "1.0.37",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/activitypub/src/views/Explore/ExploreByTopic.tsx
+++ b/apps/activitypub/src/views/Explore/ExploreByTopic.tsx
@@ -6,6 +6,7 @@ import React, {useEffect} from 'react';
 import TopicFilter, {type Topic} from '@src/components/TopicFilter';
 import {type Account, type ExploreAccount} from '@src/api/activitypub';
 import {Button, H4, LoadingIndicator, LucideIcon, Skeleton} from '@tryghost/shade';
+import {openLinksInNewTab, stripHtml} from '@src/utils/content-formatters';
 import {useAccountForUser, useExploreProfilesForUserByTopic} from '@hooks/use-activity-pub-queries';
 import {useNavigateWithBasePath} from '@src/hooks/use-navigate-with-base-path';
 import {useOnboardingStatus} from '@src/components/layout/Onboarding';
@@ -87,7 +88,7 @@ export const ExploreProfile: React.FC<ExploreProfileProps & {
                         :
                         profile.bio &&
                         <div
-                            dangerouslySetInnerHTML={{__html: profile.bio}}
+                            dangerouslySetInnerHTML={{__html: openLinksInNewTab(stripHtml(profile.bio, ['a', 'br']))}}
                             className='ap-profile-content pointer-events-none mt-0 line-clamp-2 max-w-[460px] break-anywhere'
                         />
                     }

--- a/apps/activitypub/src/views/Profile/components/ProfilePage.tsx
+++ b/apps/activitypub/src/views/Profile/components/ProfilePage.tsx
@@ -8,6 +8,7 @@ import {Account} from '@src/api/activitypub';
 import {Badge, Button, Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger, H2, H4, LucideIcon, NoValueLabel, NoValueLabelIcon, Skeleton, Tabs, TabsContent, TabsList, TabsTrigger, TabsTriggerCount, abbreviateNumber} from '@tryghost/shade';
 import {EmptyViewIcon, EmptyViewIndicator} from '@src/components/global/EmptyViewIndicator';
 import {SettingAction} from '@src/views/Preferences/components/Settings';
+import {openLinksInNewTab, stripHtml} from '@src/utils/content-formatters';
 import {toast} from 'sonner';
 import {useAccountForUser, useBlockDomainMutationForUser, useBlockMutationForUser, useUnblockDomainMutationForUser, useUnblockMutationForUser} from '@src/hooks/use-activity-pub-queries';
 import {useEffect, useMemo, useRef, useState} from 'react';
@@ -269,7 +270,7 @@ const ProfilePage:React.FC<ProfilePageProps> = ({
                             </div>
                             {(account?.bio || customFields?.length > 0) && (<div ref={contentRef} className={`ap-profile-content relative text-[1.5rem] break-anywhere [&>p]:mb-3 ${isExpanded ? 'max-h-none pb-7' : 'max-h-[160px] overflow-hidden'} relative`}>
                                 {!isLoadingAccount ?
-                                    <div dangerouslySetInnerHTML={{__html: account?.bio ?? ''}} /> :
+                                    <div dangerouslySetInnerHTML={{__html: openLinksInNewTab(stripHtml(account?.bio ?? '', ['a', 'br']))}} /> :
                                     <>
                                         <Skeleton />
                                         <Skeleton className='w-full max-w-48' />


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3042/handle-html-tags-in-profile-bios-to-prevent-ui-breakage

- Convert block-level HTML tags to line breaks instead of removing them
- Preserves the original line breaks and structure from HTML content
- Prevents block tags from breaking the UI while maintaining readability