### PR TITLE
Fixed tsc -b in react admin

### DIFF
--- a/apps/activitypub/tsconfig.declaration.json
+++ b/apps/activitypub/tsconfig.declaration.json
@@ -7,7 +7,7 @@
         "declarationMap": true,
         "declarationDir": "./types",
         "emitDeclarationOnly": true,
-        "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.tsbuildinfo",
+        "tsBuildInfoFile": "./types/tsconfig.tsbuildinfo",
         "rootDir": "./src"
     },
     "include": ["src"],

--- a/apps/admin-x-design-system/tsconfig.declaration.json
+++ b/apps/admin-x-design-system/tsconfig.declaration.json
@@ -7,7 +7,7 @@
     "declarationMap": true,
     "declarationDir": "./types",
     "emitDeclarationOnly": true,
-    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.tsbuildinfo",
+    "tsBuildInfoFile": "./types/tsconfig.tsbuildinfo",
     "rootDir": "./src"
   },
   "include": ["src"],

--- a/apps/admin-x-framework/tsconfig.declaration.json
+++ b/apps/admin-x-framework/tsconfig.declaration.json
@@ -7,7 +7,7 @@
     "declarationMap": true,
     "declarationDir": "./types",
     "emitDeclarationOnly": true,
-    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.tsbuildinfo",
+    "tsBuildInfoFile": "./types/tsconfig.tsbuildinfo",
     "rootDir": "./src"
   },
   "include": ["src"],

--- a/apps/admin-x-settings/tsconfig.declaration.json
+++ b/apps/admin-x-settings/tsconfig.declaration.json
@@ -7,7 +7,7 @@
     "declarationMap": true,
     "declarationDir": "./types",
     "emitDeclarationOnly": true,
-    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.tsbuildinfo",
+    "tsBuildInfoFile": "./types/tsconfig.tsbuildinfo",
     "rootDir": "./src"
   },
   "include": ["src"],

--- a/apps/posts/tsconfig.declaration.json
+++ b/apps/posts/tsconfig.declaration.json
@@ -7,7 +7,7 @@
     "declarationMap": true,
     "declarationDir": "./types",
     "emitDeclarationOnly": true,
-    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.tsbuildinfo",
+    "tsBuildInfoFile": "./types/tsconfig.tsbuildinfo",
     "rootDir": "./src"
   },
   "include": ["src"],

--- a/apps/shade/tsconfig.declaration.json
+++ b/apps/shade/tsconfig.declaration.json
@@ -7,7 +7,7 @@
         "declarationMap": true,
         "declarationDir": "./types",
         "emitDeclarationOnly": true,
-        "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.tsbuildinfo",
+        "tsBuildInfoFile": "./types/tsconfig.tsbuildinfo",
         "rootDir": "./src"
     },
     "include": ["src"],

--- a/apps/stats/tsconfig.declaration.json
+++ b/apps/stats/tsconfig.declaration.json
@@ -7,7 +7,7 @@
     "declarationMap": true,
     "declarationDir": "./types",
     "emitDeclarationOnly": true,
-    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.tsbuildinfo",
+    "tsBuildInfoFile": "./types/tsconfig.tsbuildinfo",
     "rootDir": "./src"
   },
   "include": ["src"],


### PR DESCRIPTION
closes https://linear.app/ghost/issue/BER-3047/fix-tsc-b-in-admin-shell

Running `tsc -b` in the React admin shell would sometimes fail as a result of `tsc` incorrectly assuming the types have been compiled. 

The location of the `tsbuildinfo` file was interacting weirdly with NX caching. Moving it so that it's in the types folder seems to have resolved the issue.
