### PR TITLE
Serve Ember admin assets rather than proxy

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -35,6 +35,7 @@
     "globals": "16.4.0",
     "jest-extended": "^6.0.0",
     "jsdom": "24.1.0",
+    "sirv": "3.0.2",
     "typescript": "5.8.3",
     "typescript-eslint": "8.46.1",
     "vite": "7.1.12",

--- a/apps/admin/vite-backend-proxy.ts
+++ b/apps/admin/vite-backend-proxy.ts
@@ -68,19 +68,12 @@ function createAdminApiProxy(site: {
 }
 
 /**
- * Creates proxy configuration for Ember Admin assets.
+ * Creates proxy configuration for Ember CLI live reload script.
  */
-function createEmberAssetsProxy(site: {
-    url: string;
-    host: string;
-}): Record<string, ProxyOptions> {
+function createEmberLiveReloadProxy(): Record<string, ProxyOptions> {
     return {
-        "^/ghost/assets/.*": {
-            target: site.url,
-            changeOrigin: true,
-        },
-        "^/ghost/ember-cli-live-reload.js": {
-            target: site.url,
+        "^/ember-cli-live-reload.js": {
+            target: "http://localhost:4200",
             changeOrigin: true,
         },
     };
@@ -89,7 +82,7 @@ function createEmberAssetsProxy(site: {
 /**
  * Vite plugin that injects proxy configurations for:
  * 1. Ghost Admin API - proxies /ghost/api requests to the Ghost backend
- * 2. Ember Assets - proxies /ghost/assets and ember-cli-live-reload.js
+ * 2. Ember Live Reload - proxies ember-cli-live-reload.js to Ember dev server
  */
 export function ghostBackendProxyPlugin(): Plugin {
     let siteUrl!: { url: string; host: string };
@@ -131,7 +124,7 @@ Ensure the Ghost backend is running. If needed, set the GHOST_URL environment va
             server.config.server.proxy = {
                 ...server.config.server.proxy,
                 ...createAdminApiProxy(siteUrl),
-                ...createEmberAssetsProxy(siteUrl),
+                ...createEmberLiveReloadProxy(),
             };
         },
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -30994,7 +30994,7 @@ sinon@^9.0.0:
     nise "^4.0.4"
     supports-color "^7.1.0"
 
-sirv@^3.0.1:
+sirv@3.0.2, sirv@^3.0.1:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/sirv/-/sirv-3.0.2.tgz#f775fccf10e22a40832684848d636346f41cd970"
   integrity sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==


### PR DESCRIPTION
refs https://linear.app/ghost/issue/BER-2989/integrate-new-admin-shell-with-yarn-dev

As a part of integrating the new admin into the main dev workflow we will end up proxying the react admin dev server. Having the react dev server also proxy assets creates a circular request pattern that gets hard to reason about.

This PR tweaks our middleware setup so that we serve the assets directly using `sirv` which is the same static assets server Vite uses internally. 