### PR TITLE
Fixed invisible Ember alerts and banners in React admin shell

### DIFF
--- a/apps/admin/index.html
+++ b/apps/admin/index.html
@@ -15,6 +15,7 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="black" />
   </head>
   <body class="react-admin">
+    <div id="ember-alerts-wormhole"></div>
     <div id="root"></div>
     <div id="ember-app">
       <div class="ember-load-indicator">

--- a/apps/admin/src/ember-bridge/ember-root.tsx
+++ b/apps/admin/src/ember-bridge/ember-root.tsx
@@ -24,5 +24,5 @@ export const EmberRoot = React.memo(function EmberRoot() {
         };
     }, []);
 
-    return <div ref={ref} hidden={!isFallbackPresent} className="h-[calc(100svh-var(--mobile-navbar-height))] w-full sidebar:h-screen overflow-auto"></div>;
+    return <div ref={ref} hidden={!isFallbackPresent} className="h-full w-full"></div>;
 });

--- a/apps/admin/src/index.css
+++ b/apps/admin/src/index.css
@@ -1,13 +1,55 @@
 @import "@tryghost/shade/styles.css";
 
-/* Ensure the Ember app renders in the correct position */
+/* Base layout - grid structure for alerts and main content */
+body.react-admin {
+    height: 100svh;
+    display: grid;
+    grid-template-rows: auto 1fr;
+    grid-template-columns: 100%;
+    overflow: hidden; /* Prevent body scroll */
+}
+
+/* Alerts show at the top and push content down */
+body.react-admin #ember-alerts-wormhole {
+    grid-row: 1;
+    grid-column: 1;
+    z-index: 0; /* Hide alerts when settings app modal is open */
+}
+
+/* Main app container - pass through to children (.shade.shade-admin) */
+body.react-admin #root {
+    display: contents;
+}
+
+/* Ensure ShadeApp takes full grid space */
+body.react-admin #root .shade.shade-admin {
+    grid-row: 2;
+    grid-column: 1;
+    min-height: 0;
+    overflow: hidden;
+}
+
+/* iOS safe area handling for mobile navbar */
+body.react-admin .safe-area-inset-bottom {
+    padding-bottom: env(safe-area-inset-bottom);
+}
+
+/* Ensure the Ember app renders in the correct position and takes full width/height */
 body.react-admin #ember-app {
     width: 100%;
     height: 100%;
 }
 
+/* Override Ember's fixed positioning to work within our flex layout */
 body.react-admin #ember-app .gh-app {
     position: static;
+    width: 100%;
+    height: 100%;
+}
+
+/* Remove Ember's overflow since we handle scrolling at the SidebarInset level */
+body.react-admin .gh-main {
+    overflow-y: visible;
 }
 
 /* Temporary overrides until Ember transition is finished */

--- a/apps/admin/src/layout/admin-layout.tsx
+++ b/apps/admin/src/layout/admin-layout.tsx
@@ -22,7 +22,7 @@ export function AdminLayout({ children }: AdminLayoutProps) {
     // Contributors get a floating profile menu instead of the full sidebar
     if (isContributor) {
         return (
-            <div className="relative h-screen bg-background">
+            <div className="relative h-full bg-background">
                 <main className="h-full overflow-auto">{children}</main>
                 <div className="fixed bottom-3.5 left-3.5 lg:bottom-8 lg:left-8 z-20">
                     <ContributorUserMenu />
@@ -34,7 +34,7 @@ export function AdminLayout({ children }: AdminLayoutProps) {
     return (
         <SidebarProvider open={!!currentUser && sidebarVisible}>
             <AppSidebar />
-            <SidebarInset className="bg-background">
+            <SidebarInset className="bg-background overflow-y-scroll max-h-[calc(100%-var(--mobile-navbar-height))] sidebar:max-h-full">
                 <main className="flex-1">{children}</main>
                 <MobileNavBar />
             </SidebarInset>

--- a/apps/admin/src/layout/app-sidebar/mobile-nav-bar.tsx
+++ b/apps/admin/src/layout/app-sidebar/mobile-nav-bar.tsx
@@ -40,8 +40,8 @@ export function MobileNavBar() {
     }
 
     return (
-        <div className="sticky flex justify-center max-w-[100vw] bottom-0 w-full h-[var(--mobile-navbar-height)] bg-sidebar/80 backdrop-blur-md border-t border-sidebar-border px-5 z-50">
-            <div className="grid grid-cols-4 items-center w-full justify-items-center max-w-[300px]">
+        <div className="fixed sidebar:hidden bottom-0 left-0 right-0 h-[var(--mobile-navbar-height)] bg-sidebar/80 backdrop-blur-md border-t border-sidebar-border z-50 safe-area-inset-bottom">
+            <div className="grid grid-cols-4 items-center w-full justify-items-center max-w-[300px] h-full mx-auto px-5">
                 <MobileNavBarButton
                     activeOnSubpath
                     to="analytics"

--- a/apps/posts/src/components/layout/main-layout.tsx
+++ b/apps/posts/src/components/layout/main-layout.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 
 const MainLayout: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({children, ...props}) => {
     return (
-        <div className='h-[calc(100svh-var(--mobile-navbar-height))] w-full overflow-y-scroll sidebar:h-screen'>
-            <div className='relative mx-auto flex h-screen max-w-page flex-col' {...props}>
+        <div className='h-full w-full'>
+            <div className='relative mx-auto flex h-full max-w-page flex-col' {...props}>
                 {children}
             </div>
         </div>

--- a/apps/shade/src/components/ui/sidebar.tsx
+++ b/apps/shade/src/components/ui/sidebar.tsx
@@ -134,7 +134,7 @@ React.ComponentProps<'div'> & {
                         <div
                             ref={ref}
                             className={cn(
-                                'group/sidebar-wrapper flex min-h-svh w-full has-[[data-variant=inset]]:bg-sidebar',
+                                'group/sidebar-wrapper relative flex h-full w-full has-[[data-variant=inset]]:bg-sidebar',
                                 className
                             )}
                             style={
@@ -226,7 +226,7 @@ const Sidebar = React.forwardRef<
                 {/* This is what handles the sidebar gap on desktop */}
                 <div
                     className={cn(
-                        'relative h-svh w-[--sidebar-width] bg-transparent',
+                        'relative h-full w-[--sidebar-width] bg-transparent',
                         'group-data-[collapsible=offcanvas]:w-0',
                         'group-data-[side=right]:rotate-180',
                         variant === 'floating' || variant === 'inset'
@@ -236,7 +236,7 @@ const Sidebar = React.forwardRef<
                 />
                 <div
                     className={cn(
-                        'fixed inset-y-0 z-10 hidden h-svh w-[--sidebar-width] md:flex',
+                        'absolute inset-y-0 z-10 hidden h-full w-[--sidebar-width] md:flex',
                         side === 'left'
                             ? 'left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]'
                             : 'right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]',
@@ -330,8 +330,8 @@ const SidebarInset = React.forwardRef<
         <main
             ref={ref}
             className={cn(
-                'relative flex min-h-svh flex-1 flex-col bg-background',
-                'peer-data-[variant=inset]:min-h-[calc(100svh-theme(spacing.4))] md:peer-data-[variant=inset]:m-2 md:peer-data-[state=collapsed]:peer-data-[variant=inset]:ml-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow',
+                'relative flex h-full flex-1 flex-col bg-background',
+                'md:peer-data-[variant=inset]:m-2 md:peer-data-[state=collapsed]:peer-data-[variant=inset]:ml-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow',
                 className
             )}
             {...props}

--- a/apps/shade/src/hooks/use-mobile.tsx
+++ b/apps/shade/src/hooks/use-mobile.tsx
@@ -2,18 +2,22 @@ import * as React from 'react';
 
 const MOBILE_BREAKPOINT = 801;
 
+function getIsMobile() {
+    return window.innerWidth < MOBILE_BREAKPOINT;
+}
+
 export function useIsMobile() {
-    const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined);
+    const [isMobile, setIsMobile] = React.useState<boolean>(getIsMobile());
 
     React.useEffect(() => {
         const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
         const onChange = () => {
-            setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+            setIsMobile(getIsMobile());
         };
         mql.addEventListener('change', onChange);
-        setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+        setIsMobile(getIsMobile());
         return () => mql.removeEventListener('change', onChange);
     }, []);
 
-    return !!isMobile;
+    return isMobile;
 }

--- a/apps/stats/src/components/layout/main-layout.tsx
+++ b/apps/stats/src/components/layout/main-layout.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 
 const MainLayout: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({children, ...props}) => {
     return (
-        <div className='h-[calc(100svh-var(--mobile-navbar-height))] w-full overflow-y-scroll sidebar:h-screen'>
-            <div className='relative h-screen w-full' {...props}>
+        <div className='h-full w-full'>
+            <div className='relative h-full w-full' {...props}>
                 <div className='mx-auto flex size-full max-w-page flex-col'>
                     {children}
                 </div>

--- a/ghost/admin/app/components/alerts-wormhole.hbs
+++ b/ghost/admin/app/components/alerts-wormhole.hbs
@@ -1,0 +1,7 @@
+{{#if this.destinationElement}}
+    {{#in-element this.destinationElement insertBefore=null}}
+        {{yield}}
+    {{/in-element}}
+{{else}}
+    {{yield}}
+{{/if}}

--- a/ghost/admin/app/components/alerts-wormhole.js
+++ b/ghost/admin/app/components/alerts-wormhole.js
@@ -1,0 +1,7 @@
+import Component from '@glimmer/component';
+
+export default class AlertsWormholeComponent extends Component {
+    get destinationElement() {
+        return document.getElementById('ember-alerts-wormhole');
+    }
+}

--- a/ghost/admin/app/templates/application.hbs
+++ b/ghost/admin/app/templates/application.hbs
@@ -1,35 +1,37 @@
 <GhApp>
     <GhSkipLink @anchor=".gh-main">Skip to main content</GhSkipLink>
 
-    {{#if this.upgradeStatus.refreshRequired}}
-        <div class="gh-update-banner">
-            {{!-- template-lint-disable no-invalid-link-text --}}
-            <span>Ghost has been updated! To get access to the latest features, refresh or <a href="javascript:window.location.reload(true)">click here</a>.</span>
-        </div>
-    {{/if}}
-
-    {{#if (and this.session.user.isAdmin this.showUpdateBanner)}}
-    <aside class="gh-update-banner">
-        {{#if this.session.user.isOwnerOnly}}
-            <div class="gh-alert-content">
-                A new major version of Ghost is available!&nbsp;
-            </div>
-            <a href="#" {{on "click" this.openUpdateTab}}>Update to Ghost 6.0 &rarr;</a>
-        {{else}}
-            <div class="gh-alert-content">
-                Your Ghost install is ready for a major update!
-                {{#if this.ownerUserNameOrEmail}}
-                    {{this.ownerUserNameOrEmail}}
-                {{else}}
-                    Your site owner
-                {{/if}}
-                will need to log in to do this.
+    <AlertsWormhole>
+        {{#if this.upgradeStatus.refreshRequired}}
+            <div class="gh-update-banner">
+                {{!-- template-lint-disable no-invalid-link-text --}}
+                <span>Ghost has been updated! To get access to the latest features, refresh or <a href="javascript:window.location.reload(true)">click here</a>.</span>
             </div>
         {{/if}}
-    </aside>
-    {{/if}}
 
-    <GhAlerts />
+        {{#if (and this.session.user.isAdmin this.showUpdateBanner)}}
+        <aside class="gh-update-banner">
+            {{#if this.session.user.isOwnerOnly}}
+                <div class="gh-alert-content">
+                    A new major version of Ghost is available!&nbsp;
+                </div>
+                <a href="#" {{on "click" this.openUpdateTab}}>Update to Ghost 6.0 &rarr;</a>
+            {{else}}
+                <div class="gh-alert-content">
+                    Your Ghost install is ready for a major update!
+                    {{#if this.ownerUserNameOrEmail}}
+                        {{this.ownerUserNameOrEmail}}
+                    {{else}}
+                        Your site owner
+                    {{/if}}
+                    will need to log in to do this.
+                </div>
+            {{/if}}
+        </aside>
+        {{/if}}
+
+        <GhAlerts />
+    </AlertsWormhole>
 
     <div class="gh-viewport {{if this.ui.showMobileMenu 'mobile-menu-expanded'}}">
         {{#if this.showNavMenu}}


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-2999/

## Summary

- Fixed Ember alerts and banners being invisible or overlaying content in the React admin shell
- Alerts now properly push content down and take up space at the top of the viewport

## Changes

**Ember side:**
- Created a new `AlertsWormhole` component that uses `{{#in-element}}` to render alerts into a dedicated `#ember-alerts-wormhole` element when running inside the React shell
- Wrapped all alert/banner components (upgrade banners, `GhAlerts`) in the wormhole component

**React layout restructuring:**
- Added a `#ember-alerts-wormhole` container to `apps/admin/index.html`
- Converted from flexbox to CSS grid layout on the body element (`grid-template-rows: auto 1fr`) so alerts in row 1 can push the main content in row 2 down
- Replaced viewport-based heights (`h-svh`) with container-based heights (`h-full`) throughout sidebar and layout components to work within the grid hierarchy
- Changed sidebar from `fixed` to `absolute` positioning so it respects the grid layout
- Fixed mobile navbar by making it `fixed` positioned at the bottom with proper z-index handling
- Added `overflow-y-scroll` at the `SidebarInset` level for proper content scrolling