### PR TITLE
Fixed state bridge promise cleanup when unmounting hooks

### DIFF
--- a/apps/admin/src/ember-bridge/EmberBridge.tsx
+++ b/apps/admin/src/ember-bridge/EmberBridge.tsx
@@ -241,7 +241,7 @@ const defaultRouting: EmberRouting = {
 /**
  * Hook to access Ember routing state.
  * Returns routing methods that re-render when Ember's route changes.
- * 
+ *
  * @example
  * ```tsx
  * const routing = useEmberRouting();
@@ -257,19 +257,14 @@ export function useEmberRouting(): EmberRouting {
     useEffect(() => {
         // Wait for bridge to be available
         if (!bridge) {
-            void getStateBridge().then((stateBridge) => {
-                if (stateBridge) {
-                    setBridge(stateBridge);
-                }
-            });
-            return;
+            return waitForStateBridge(setBridge);
         }
-        
+
         // Subscribe to route changes to force re-renders
         const handleRouteChange = () => {
             forceUpdate(n => n + 1);
         };
-        
+
         bridge.on('routeChange', handleRouteChange);
         return () => bridge.off('routeChange', handleRouteChange);
     }, [bridge]);


### PR DESCRIPTION
no issue

If the `setInterval` pathway was hit by a state-bridge event hook then it would run indefinitely even if the hook that triggered it was unmounted. Aside from being a memory leak it also causes test flakiness because the `window` object used inside the timeout callback could have been torn down before the callback runs

- having a shared promise to avoid the possibility of multiple `setInterval` calls when multiple hooks are registered was a micro optimisation that complicates teardown significantly
- switched to each hook maintaining its own promise+setInterval with associated cleanup when unmounting