### PR TITLE
Fixed email notifications when Stripe is disabled

### DIFF
--- a/apps/admin-x-settings/src/components/settings/general/users/EmailNotificationsTab.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/users/EmailNotificationsTab.tsx
@@ -73,7 +73,11 @@ const EmailNotificationsInputs: React.FC<{ user: User; setUserData: (user: User)
                 <Toggle
                     checked={user.milestone_notifications}
                     direction='rtl'
-                    hint={`Occasional summaries of your audience ${hasStripeEnabled ? '& revenue' : ''} growth`}
+                    hint={hasStripeEnabled ?
+                        'Occasional summaries of your audience & revenue growth'
+                        :
+                        'Occasional summaries of your audience growth'
+                    }
                     label='Milestones'
                     onChange={(e) => {
                         setUserData?.({...user, milestone_notifications: e.target.checked});

--- a/apps/admin-x-settings/src/components/settings/general/users/EmailNotificationsTab.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/users/EmailNotificationsTab.tsx
@@ -48,28 +48,32 @@ const EmailNotificationsInputs: React.FC<{ user: User; setUserData: (user: User)
                         setUserData?.({...user, free_member_signup_notification: e.target.checked});
                     }}
                 />
-                <Toggle
-                    checked={user.paid_subscription_started_notification}
-                    direction='rtl'
-                    hint='Every time a member starts a new paid subscription'
-                    label='New paid members'
-                    onChange={(e) => {
-                        setUserData?.({...user, paid_subscription_started_notification: e.target.checked});
-                    }}
-                />
-                <Toggle
-                    checked={user.paid_subscription_canceled_notification}
-                    direction='rtl'
-                    hint='Every time a member cancels their paid subscription'
-                    label='Paid member cancellations'
-                    onChange={(e) => {
-                        setUserData?.({...user, paid_subscription_canceled_notification: e.target.checked});
-                    }}
-                />
+                {hasStripeEnabled &&
+                <>
+                    <Toggle
+                        checked={user.paid_subscription_started_notification}
+                        direction='rtl'
+                        hint='Every time a member starts a new paid subscription'
+                        label='New paid members'
+                        onChange={(e) => {
+                            setUserData?.({...user, paid_subscription_started_notification: e.target.checked});
+                        }}
+                    />
+                    <Toggle
+                        checked={user.paid_subscription_canceled_notification}
+                        direction='rtl'
+                        hint='Every time a member cancels their paid subscription'
+                        label='Paid member cancellations'
+                        onChange={(e) => {
+                            setUserData?.({...user, paid_subscription_canceled_notification: e.target.checked});
+                        }}
+                    />
+                </>
+                }
                 <Toggle
                     checked={user.milestone_notifications}
                     direction='rtl'
-                    hint='Occasional summaries of your audience & revenue growth'
+                    hint={`Occasional summaries of your audience ${hasStripeEnabled ? '& revenue' : ''} growth`}
                     label='Milestones'
                     onChange={(e) => {
                         setUserData?.({...user, milestone_notifications: e.target.checked});

--- a/apps/admin-x-settings/test/acceptance/general/users/profile.test.ts
+++ b/apps/admin-x-settings/test/acceptance/general/users/profile.test.ts
@@ -201,6 +201,7 @@ test.describe('User profile', async () => {
 
         const {lastApiRequests} = await mockApi({page, requests: {
             ...globalDataRequests,
+            browseSettings: {...globalDataRequests.browseSettings, response: settingsWithStripe},
             getUserBySlug: {method: 'GET', path: `/users/slug/${userToEdit.slug}/?include=roles`, response: {
                 users: [userToEdit]
             }},
@@ -423,6 +424,67 @@ test.describe('User profile', async () => {
         await modal.getByTitle('Email Notifications').click();
 
         await expect(modal.getByLabel(/Tips & donations/)).not.toBeVisible();
+    });
+
+    test('Hides paid subscription notification options when Stripe disabled', async ({page}) => {
+        const admin = responseFixtures.users.users.find(user => user.email === 'administrator@test.com')!;
+
+        await mockApi({page, requests: {
+            ...globalDataRequests,
+            getUserBySlug: {method: 'GET', path: `/users/slug/${admin.slug}/?include=roles`, response: {
+                users: [admin]
+            }},
+            browseUsers: {method: 'GET', path: '/users/?limit=100&include=roles', response: responseFixtures.users}
+        }});
+
+        await page.goto('/');
+
+        const section = page.getByTestId('users');
+        const activeTab = section.locator('[role=tabpanel]:not(.hidden)');
+
+        await section.getByRole('tab', {name: 'Administrators'}).click();
+
+        const listItem = activeTab.getByTestId('user-list-item').last();
+        await listItem.hover();
+        await listItem.getByRole('button', {name: 'Edit'}).click();
+
+        const modal = page.getByTestId('user-detail-modal');
+
+        await modal.getByTitle('Email Notifications').click();
+
+        await expect(modal.getByLabel(/New paid members/)).not.toBeVisible();
+        await expect(modal.getByLabel(/Paid member cancellations/)).not.toBeVisible();
+    });
+
+    test('Shows paid subscription notification options when Stripe enabled', async ({page}) => {
+        const admin = responseFixtures.users.users.find(user => user.email === 'administrator@test.com')!;
+
+        await mockApi({page, requests: {
+            ...globalDataRequests,
+            browseSettings: {...globalDataRequests.browseSettings, response: settingsWithStripe},
+            getUserBySlug: {method: 'GET', path: `/users/slug/${admin.slug}/?include=roles`, response: {
+                users: [admin]
+            }},
+            browseUsers: {method: 'GET', path: '/users/?limit=100&include=roles', response: responseFixtures.users}
+        }});
+
+        await page.goto('/');
+
+        const section = page.getByTestId('users');
+        const activeTab = section.locator('[role=tabpanel]:not(.hidden)');
+
+        await section.getByRole('tab', {name: 'Administrators'}).click();
+
+        const listItem = activeTab.getByTestId('user-list-item').last();
+        await listItem.hover();
+        await listItem.getByRole('button', {name: 'Edit'}).click();
+
+        const modal = page.getByTestId('user-detail-modal');
+
+        await modal.getByTitle('Email Notifications').click();
+
+        await expect(modal.getByLabel(/New paid members/)).toBeVisible();
+        await expect(modal.getByLabel(/Paid member cancellations/)).toBeVisible();
     });
 
     test('Warns when leaving without saving', async ({page}) => {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/DES-1247/paid-member-notifications-visible-without-stripe-connection

- Email notification settings for paid members and revenue were visible on sites without Stripe connected