### PR TITLE
Fixed race conditions in E2E tests with React shell

### DIFF
--- a/e2e/helpers/pages/admin/posts/post/post-preview-modal.ts
+++ b/e2e/helpers/pages/admin/posts/post/post-preview-modal.ts
@@ -18,6 +18,7 @@ export class PostPreviewModal {
     readonly webTabButton: Locator;
     readonly emailTabButton: Locator;
     readonly emailPreviewBody: Locator;
+    private readonly emailPreviewFrameBody: Locator;
 
     constructor(page: Page) {
         this.page = page;
@@ -31,6 +32,12 @@ export class PostPreviewModal {
         this.webTabButton = this.modal.getByRole('button', {name: 'Web'});
         this.emailTabButton = this.modal.getByRole('button', {name: 'Email'});
         this.emailPreviewBody = this.emailPreviewFrame.getByTestId('email-preview-body');
+        this.emailPreviewFrameBody = this.emailPreviewFrame.locator('body');
+    }
+
+    async switchToEmailTab(): Promise<void> {
+        await this.emailTabButton.click();
+        await this.emailPreviewFrameBody.waitFor({state: 'attached'});
     }
 
     async content(): Promise<string | null> {

--- a/e2e/helpers/pages/portal/portal-page.ts
+++ b/e2e/helpers/pages/portal/portal-page.ts
@@ -4,15 +4,21 @@ import {FrameLocator, Locator, Page} from '@playwright/test';
 export class PortalPage extends BasePage {
     readonly portalFrame: FrameLocator;
     private readonly frameSelector = '[data-testid="portal-popup-frame"]';
+    private readonly portalPopupFrame: Locator;
     readonly closeButton: Locator;
     readonly portalFrameBody: Locator;
 
     constructor(page: Page) {
         super(page);
         this.portalFrame = page.frameLocator(this.frameSelector);
+        this.portalPopupFrame = page.locator(this.frameSelector);
 
         this.closeButton = this.portalFrame.getByRole('button', {name: 'Close'});
         this.portalFrameBody = this.portalFrame.locator('body');
+    }
+
+    async waitForPortalToOpen(): Promise<void> {
+        await this.portalPopupFrame.waitFor({state: 'visible'});
     }
 
     async closePortal(): Promise<void> {

--- a/e2e/helpers/pages/public/home-page.ts
+++ b/e2e/helpers/pages/public/home-page.ts
@@ -16,7 +16,8 @@ export class HomePage extends PublicPage {
     }
 
     async waitUntilLoaded(): Promise<void> {
-        return this.accountButton.waitFor({state: 'visible'});
+        await this.accountButton.waitFor({state: 'visible'});
+        await this.portal.waitForScript();
     }
 
     async gotoWithQueryParams(params: Record<string, string>): Promise<void> {

--- a/e2e/helpers/pages/public/public-page.ts
+++ b/e2e/helpers/pages/public/public-page.ts
@@ -24,11 +24,12 @@ class PortalSection extends BasePage {
 
     async waitForScript(): Promise<void> {
         await this.portalScript.waitFor({
-            state: 'attached',
-            timeout: 10000
+            state: 'attached'
         });
 
-        await this.page.waitForTimeout(500);
+        await this.portalRoot.waitFor({
+            state: 'attached'
+        });
     }
 
     async waitForIFrame(): Promise<void> {
@@ -61,7 +62,7 @@ export class PublicPage extends BasePage {
     private readonly subscribeLink: Locator;
     private readonly signInLink: Locator;
 
-    private readonly portal: PortalSection;
+    protected readonly portal: PortalSection;
 
     constructor(page: Page) {
         super(page, '/');

--- a/e2e/helpers/playwright/fixture.ts
+++ b/e2e/helpers/playwright/fixture.ts
@@ -81,8 +81,8 @@ export const test = base.extend<GhostInstanceFixture>({
     baseURL: async ({ghostInstance}, use) => {
         await use(ghostInstance.baseUrl);
     },
-    // Intermediate fixture that sets up the page and returns all setup data
-    pageWithAuthenticatedUser: async ({browser, baseURL}, use) => {
+    // Create user credentials only (no authentication)
+    ghostAccountOwner: async ({baseURL}, use) => {
         if (!baseURL) {
             throw new Error('baseURL is not defined');
         }
@@ -94,14 +94,17 @@ export const test = base.extend<GhostInstanceFixture>({
             password: 'test@123@test'
         };
         await setupUser(baseURL, ghostAccountOwner);
+        await use(ghostAccountOwner);
+    },
+    // Intermediate fixture that sets up the page and returns all setup data
+    pageWithAuthenticatedUser: async ({browser, baseURL, ghostAccountOwner}, use) => {
+        if (!baseURL) {
+            throw new Error('baseURL is not defined');
+        }
 
         const pageWithAuthenticatedUser = await setupNewAuthenticatedPage(browser, baseURL, ghostAccountOwner);
         await use(pageWithAuthenticatedUser);
         await pageWithAuthenticatedUser.context.close();
-    },
-    // Extract the created user from pageWithAuthenticatedUser
-    ghostAccountOwner: async ({pageWithAuthenticatedUser}, use) => {
-        await use(pageWithAuthenticatedUser.ghostAccountOwner);
     },
     // Extract the page from pageWithAuthenticatedUser and apply labs settings
     page: async ({pageWithAuthenticatedUser, labs}, use) => {

--- a/e2e/tests/admin/members/impersonation.test.ts
+++ b/e2e/tests/admin/members/impersonation.test.ts
@@ -26,9 +26,12 @@ test.describe('Ghost Admin - Member Impersonation', () => {
         await memberDetailsPage.goto(magicLink);
 
         const homePage = new HomePage(page);
+        await homePage.waitUntilLoaded();
         await homePage.accountButton.click();
 
         const portal = new PortalPage(page);
+        await portal.waitForPortalToOpen();
+
         await expect(portal.portalFrameBody).toContainText('Your account');
         await expect(portal.portalFrameBody).toContainText('impersonate@ghost.org');
     });

--- a/e2e/tests/admin/settings/publication-language.test.ts
+++ b/e2e/tests/admin/settings/publication-language.test.ts
@@ -23,7 +23,7 @@ test.describe('Ghost Admin - i18n Newsletter', () => {
         const postEditorPage = new PostEditorPage(page);
         await postEditorPage.gotoPost(post.id);
         await postEditorPage.previewButton.click();
-        await postEditorPage.previewModal.emailTabButton.click();
+        await postEditorPage.previewModal.switchToEmailTab();
 
         const emailPreviewContent = await postEditorPage.previewModal.content();
         expect(emailPreviewContent).toContain(`Par ${ghostAccountOwner.name}`);


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-2920

While trying to make the React e2e tests required for CI to pass, we also want to make sure there's no flakiness in the test suite, either pre-existing or freshly introduced with the React changes.

This PR was produced by running the E2E test suite 5x times and observing which tests failed at least once. We then fixed these tests in various ways (adding explicit waits, grouping actions and waits in page objects).

We have observed the test suite passing after 5x runs with no failures, so we're confident that this should have addressed flaky tests in the e2e suite as they exist today.