### PR TITLE
fix: Use local data:image/png instead of spacergif.org

### DIFF
--- a/ghost/core/core/server/services/koenig/node-renderers/embed-renderer.js
+++ b/ghost/core/core/server/services/koenig/node-renderers/embed-renderer.js
@@ -29,15 +29,15 @@ function renderTemplate(node, document, options) {
     if (isEmail && isVideoWithThumbnail) {
         const emailTemplateMaxWidth = 600;
         const thumbnailAspectRatio = metadata.thumbnail_width / metadata.thumbnail_height;
-        const spacerWidth = Math.round(emailTemplateMaxWidth / 4);
         const spacerHeight = Math.round(emailTemplateMaxWidth / thumbnailAspectRatio);
+        const spacerSrc = `data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAFAwG7pWc1vwAAAABJRU5ErkJggg==`;
         const html = `
             <!--[if !mso !vml]-->
             <a class="kg-video-preview" href="${url}" aria-label="Play video" style="mso-hide: all">
                 <table cellpadding="0" cellspacing="0" border="0" width="100%" background="${metadata.thumbnail_url}" role="presentation" style="background: url('${metadata.thumbnail_url}') left top / cover; mso-hide: all">
                     <tr style="mso-hide: all">
                         <td width="25%" style="visibility: hidden; mso-hide: all">
-                            <img src="https://img.spacergif.org/v1/${spacerWidth}x${spacerHeight}/0a/spacer.png" alt="" width="100%" border="0" style="display:block; height: auto; opacity: 0; visibility: hidden; mso-hide: all;">
+                            <img src="${spacerSrc}" alt="" width="100%" border="0" style="display:block; height: auto; opacity: 0; visibility: hidden; mso-hide: all;">
                         </td>
                         <td width="50%" align="center" valign="middle" style="vertical-align: middle; mso-hide: all;">
                             <div class="kg-video-play-button" style="mso-hide: all"><div style="mso-hide: all"></div></div>

--- a/ghost/core/core/server/services/koenig/node-renderers/video-renderer.js
+++ b/ghost/core/core/server/services/koenig/node-renderers/video-renderer.js
@@ -25,7 +25,7 @@ function renderVideoNode(node, options = {}) {
 function cardTemplate({node, cardClasses}) {
     const width = node.width;
     const height = node.height;
-    const posterSpacerSrc = `https://img.spacergif.org/v1/${width}x${height}/0a/spacer.png`;
+    const posterSpacerSrc = `data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAFAwG7pWc1vwAAAABJRU5ErkJggg==`;
     const autoplayAttr = node.loop ? 'loop autoplay muted' : '';
     const thumbnailSrc = node.customThumbnailSrc || node.thumbnailSrc;
     const hideControlsClass = node.loop ? ' kg-video-hide' : '';
@@ -94,9 +94,8 @@ function emailCardTemplate({node, options, cardClasses}) {
     const thumbnailSrc = node.customThumbnailSrc || node.thumbnailSrc;
     const emailTemplateMaxWidth = 600;
     const aspectRatio = node.width / node.height;
-    const emailSpacerWidth = Math.round(emailTemplateMaxWidth / 4);
     const emailSpacerHeight = Math.round(emailTemplateMaxWidth / aspectRatio);
-    const posterSpacerSrc = `https://img.spacergif.org/v1/${emailSpacerWidth}x${emailSpacerHeight}/0a/spacer.png`;
+    const posterSpacerSrc = `data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAFAwG7pWc1vwAAAABJRU5ErkJggg==`;
     const outlookCircleLeft = Math.round((emailTemplateMaxWidth / 2) - 39);
     const outlookCircleTop = Math.round((emailSpacerHeight / 2) - 39);
     const outlookPlayLeft = Math.round((emailTemplateMaxWidth / 2) - 11);

--- a/ghost/core/test/unit/server/services/koenig/node-renderers/embed-renderer.test.js
+++ b/ghost/core/test/unit/server/services/koenig/node-renderers/embed-renderer.test.js
@@ -85,7 +85,7 @@ describe('services/koenig/node-renderers/embed-renderer', function () {
                                 <tr style="mso-hide: all">
                                     <td width="25%" style="visibility: hidden; mso-hide: all">
                                         <img
-                                            src="https://img.spacergif.org/v1/150x450/0a/spacer.png"
+                                            src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAFAwG7pWc1vwAAAABJRU5ErkJggg=="
                                             alt=""
                                             width="100%"
                                             border="0"

--- a/ghost/core/test/unit/server/services/koenig/node-renderers/video-renderer.test.js
+++ b/ghost/core/test/unit/server/services/koenig/node-renderers/video-renderer.test.js
@@ -36,7 +36,7 @@ describe('services/koenig/node-renderers/video-renderer', function () {
             assertPrettifiesTo(result.html, html`
                 <figure class="kg-card kg-video-card kg-card-hascaption" data-kg-thumbnail="/content/images/2022/11/koenig-lexical.jpg" data-kg-custom-thumbnail="/content/images/2022/11/koenig-lexical-custom.jpg">
                     <div class="kg-video-container">
-                        <video src="/content/images/2022/11/koenig-lexical.mp4" poster="https://img.spacergif.org/v1/200x100/0a/spacer.png" width="200" height="100" playsinline="" preload="metadata" style="background: transparent url('/content/images/2022/11/koenig-lexical-custom.jpg') 50% 50% / cover no-repeat;"></video>
+                        <video src="/content/images/2022/11/koenig-lexical.mp4" poster="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAFAwG7pWc1vwAAAABJRU5ErkJggg==" width="200" height="100" playsinline="" preload="metadata" style="background: transparent url('/content/images/2022/11/koenig-lexical-custom.jpg') 50% 50% / cover no-repeat;"></video>
                         <div class="kg-video-overlay">
                             <button class="kg-video-large-play-icon" aria-label="Play video">
                                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
@@ -100,7 +100,7 @@ describe('services/koenig/node-renderers/video-renderer', function () {
                             <tbody>
                                 <tr style="mso-hide: all">
                                     <td width="25%" style="visibility: hidden; mso-hide: all">
-                                        <img src="https://img.spacergif.org/v1/150x300/0a/spacer.png" alt="" width="100%" border="0" style="display: block; height: auto; opacity: 0; visibility: hidden; mso-hide: all;" />
+                                        <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAFAwG7pWc1vwAAAABJRU5ErkJggg==" alt="" width="100%" border="0" style="display: block; height: auto; opacity: 0; visibility: hidden; mso-hide: all;" />
                                     </td>
                                     <td width="50%" align="center" valign="middle" style="vertical-align: middle; mso-hide: all">
                                         <div class="kg-video-play-button" style="mso-hide: all">


### PR DESCRIPTION
This pull request removes the use of spacergif.org and thus eliminates an external dependency that can go offline. This makes it possible to host Ghost fully GDPR-compliant, as having an external dependency without consent from users will send their information (IP, user agent, etc.) to spacergif.org. As this can't be disabled using a cookie banner, this needs to be removed.

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [x] I've written an automated test to prove my change works

We appreciate your contribution! 🙏

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Inline 1x1 PNG data URIs replace external spacergif.org placeholders in Koenig embed/video renderers; tests updated accordingly.
> 
> - **Koenig renderers**
>   - `core/server/services/koenig/node-renderers/embed-renderer.js`: For email video previews, replace spacer image `src` with a base64 `data:image/png` and drop unused spacer width calc.
>   - `core/server/services/koenig/node-renderers/video-renderer.js`: Use base64 `data:image/png` for `poster`/spacer in web and email templates; remove external `spacergif.org` usage.
> - **Tests**
>   - Update expectations in `embed-renderer.test.js` and `video-renderer.test.js` to match inline data URI spacers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7759b0764a696335572472dc06b720924522a130. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->