### PR TITLE
Improved E2E settings page with better waits and locators

### DIFF
--- a/e2e/helpers/pages/admin/settings/sections/labs-section.ts
+++ b/e2e/helpers/pages/admin/settings/sections/labs-section.ts
@@ -15,7 +15,7 @@ export class LabsSection extends BasePage {
     constructor(page: Page) {
         super(page, '/ghost/#/settings/labs');
 
-        this.section = page.getByTestId('labs');
+        this.section = page.getByTestId('sidebar').getByText('Labs');
         this.heading = page.getByRole('heading', {level: 5, name: 'Labs'});
         this.content = this.section.locator('[role="tabpanel"]');
 

--- a/e2e/helpers/pages/admin/settings/sections/labs-section.ts
+++ b/e2e/helpers/pages/admin/settings/sections/labs-section.ts
@@ -15,7 +15,7 @@ export class LabsSection extends BasePage {
     constructor(page: Page) {
         super(page, '/ghost/#/settings/labs');
 
-        this.section = page.getByTestId('sidebar').getByText('Labs');
+        this.section = page.getByTestId('labs');
         this.heading = page.getByRole('heading', {level: 5, name: 'Labs'});
         this.content = this.section.locator('[role="tabpanel"]');
 

--- a/e2e/helpers/pages/admin/settings/settings-page.ts
+++ b/e2e/helpers/pages/admin/settings/settings-page.ts
@@ -13,14 +13,16 @@ export class SettingsPage extends BasePage {
     readonly staffSection: StaffSection;
 
     readonly staffSectionButton: Locator;
+    readonly sidebar: Locator;
 
     constructor(page: Page) {
         super(page, '/ghost/#/settings');
 
+        this.sidebar = page.getByTestId('sidebar');
         this.searchInput = page.locator('input[placeholder="Search settings"]');
         this.searchClearButton = page.locator('button[aria-label="close"]').first();
 
-        this.staffSectionButton = page.getByTestId('sidebar').getByText('Staff');
+        this.staffSectionButton = this.sidebar.getByText('Staff');
 
         this.publicationSection = new PublicationSection(page);
         this.labsSection = new LabsSection(page);
@@ -30,11 +32,10 @@ export class SettingsPage extends BasePage {
 
     async searchByInput(text: string) {
         await this.searchInput.fill(text);
-        await this.page.waitForTimeout(300);
     }
 
     async goto() {
         await super.goto();
-        await this.page.waitForSelector('h5', {timeout: 10000});
+        await this.sidebar.waitFor({state: 'visible'});
     }
 }

--- a/e2e/helpers/pages/admin/settings/settings-page.ts
+++ b/e2e/helpers/pages/admin/settings/settings-page.ts
@@ -12,17 +12,19 @@ export class SettingsPage extends BasePage {
     readonly labsSection: LabsSection;
     readonly staffSection: StaffSection;
 
-    readonly staffSectionButton: Locator;
     readonly sidebar: Locator;
+    readonly labsSidebarLink: Locator;
+    readonly staffSidebarLink: Locator;
 
     constructor(page: Page) {
         super(page, '/ghost/#/settings');
 
         this.sidebar = page.getByTestId('sidebar');
+        this.labsSidebarLink = this.sidebar.getByText('Labs');
+        this.staffSidebarLink = this.sidebar.getByText('Staff');
+
         this.searchInput = page.locator('input[placeholder="Search settings"]');
         this.searchClearButton = page.locator('button[aria-label="close"]').first();
-
-        this.staffSectionButton = this.sidebar.getByText('Staff');
 
         this.publicationSection = new PublicationSection(page);
         this.labsSection = new LabsSection(page);

--- a/e2e/tests/admin/settings/labs-search.test.ts
+++ b/e2e/tests/admin/settings/labs-search.test.ts
@@ -11,10 +11,12 @@ test.describe('Ghost Admin - settings search - labs auto-open', () => {
 
         await settingsPage.searchByInput('lab');
 
+        await expect(settingsPage.labsSidebarLink).toBeVisible();
         await expect(settingsPage.labsSection.section).toBeVisible();
         await expect(settingsPage.labsSection.closeButton).toBeVisible();
 
         await settingsPage.searchByInput('returnNoResultsInSearch');
-        await expect(settingsPage.labsSection.section).toBeHidden();
+        await expect(settingsPage.labsSidebarLink).toBeHidden();
+        await expect(settingsPage.labsSection.section).toBeVisible();
     });
 });

--- a/e2e/tests/admin/settings/labs-search.test.ts
+++ b/e2e/tests/admin/settings/labs-search.test.ts
@@ -13,5 +13,8 @@ test.describe('Ghost Admin - settings search - labs auto-open', () => {
 
         await expect(settingsPage.labsSection.section).toBeVisible();
         await expect(settingsPage.labsSection.closeButton).toBeVisible();
+
+        await settingsPage.searchByInput('returnNoResultsInSearch');
+        await expect(settingsPage.labsSection.section).toBeHidden();
     });
 });

--- a/e2e/tests/admin/settings/settings-search.test.ts
+++ b/e2e/tests/admin/settings/settings-search.test.ts
@@ -1,19 +1,32 @@
 import {SettingsPage} from '@/admin-pages';
 import {expect, test} from '@/helpers/playwright';
 
-test.describe('Ghost Admin - settings search - labs auto-open', () => {
-    test('display only Labs component and auto-open when searching for "lab"', async ({page}) => {
+test.describe('Ghost Admin - settings search sidebar', () => {
+    test('displays all section when not searching', async ({page}) => {
         const settingsPage = new SettingsPage(page);
         await settingsPage.goto();
 
         await expect(settingsPage.labsSection.section).toBeVisible();
         await expect(settingsPage.labsSection.openButton).toBeVisible();
+    });
 
+    test('displays only searched section', async ({page}) => {
+        const settingsPage = new SettingsPage(page);
+        await settingsPage.goto();
+        
         await settingsPage.searchByInput('lab');
-
         await expect(settingsPage.labsSidebarLink).toBeVisible();
         await expect(settingsPage.labsSection.section).toBeVisible();
         await expect(settingsPage.labsSection.closeButton).toBeVisible();
+
+        await settingsPage.searchByInput('staff');
+        await expect(settingsPage.staffSidebarLink).toBeVisible();
+        await expect(settingsPage.labsSection.section).toBeHidden();
+    });
+
+    test('displays all searched sections when no sections found', async ({page}) => {
+        const settingsPage = new SettingsPage(page);
+        await settingsPage.goto();
 
         await settingsPage.searchByInput('returnNoResultsInSearch');
         await expect(settingsPage.labsSidebarLink).toBeHidden();


### PR DESCRIPTION
no_ref

* Removed hard-coded waits in favor of semantic element waits  
* Improved Labs section locator specificity
* Improved settings search tests