### PR TITLE
🐛 Fixed email analytics job timestamp not updating on recurrence

### DIFF
--- a/ghost/core/core/server/services/email-analytics/EmailAnalyticsService.js
+++ b/ghost/core/core/server/services/email-analytics/EmailAnalyticsService.js
@@ -451,7 +451,7 @@ module.exports = class EmailAnalyticsService {
         // Small trick: if reached the end of new events, we are going to keep
         // fetching the same events because 'begin' won't change
         // So if we didn't have errors while fetching, and total events < maxEvents, increase lastEventTimestamp with one second
-        if (!error && eventCount > 0 && eventCount < maxEvents && fetchData.lastEventTimestamp && fetchData.lastEventTimestamp.getTime() < Date.now() - 2000) {
+        if (!error && eventCount > 0 && fetchData.lastEventTimestamp && fetchData.lastEventTimestamp.getTime() < Date.now() - 2000) {
             // set the data on the db so we can store it for fetching after reboot
             await this.queries.setJobTimestamp(fetchData.jobName, 'finished', new Date(fetchData.lastEventTimestamp.getTime()));
             // increment and store in local memory


### PR DESCRIPTION
no ref

The email analytics job would not set the latest event timestamp when doing back-to-back processing of batches (ie during high volume events). If a site got rebooted during this period, it would necessitate processing all of those events *again*, unnecessarily.