### PR TITLE
Added ingestion monitoring fields to tinybird materialized view

### DIFF
--- a/ghost/core/core/server/data/tinybird/datasources/_mv_hits.datasource
+++ b/ghost/core/core/server/data/tinybird/datasources/_mv_hits.datasource
@@ -3,7 +3,7 @@ SCHEMA >
     `timestamp` DateTime,
     `received_at` DateTime64(3),
     `inserted_at` DateTime64(3),
-    `ingestion_latency_ms` IntervalMillisecond,
+    `ingestion_latency_ms` Int64,
     `action` LowCardinality(String),
     `version` LowCardinality(String),
     `session_id` String,

--- a/ghost/core/core/server/data/tinybird/datasources/_mv_hits.datasource
+++ b/ghost/core/core/server/data/tinybird/datasources/_mv_hits.datasource
@@ -1,6 +1,7 @@
 SCHEMA >
     `site_uuid` LowCardinality(String),
     `timestamp` DateTime,
+    `received_timestamp` DateTime,
     `action` LowCardinality(String),
     `version` LowCardinality(String),
     `session_id` String,

--- a/ghost/core/core/server/data/tinybird/datasources/_mv_hits.datasource
+++ b/ghost/core/core/server/data/tinybird/datasources/_mv_hits.datasource
@@ -3,6 +3,7 @@ SCHEMA >
     `timestamp` DateTime,
     `received_at` DateTime64(3),
     `inserted_at` DateTime64(3),
+    `ingestion_latency_ms` IntervalMillisecond,
     `action` LowCardinality(String),
     `version` LowCardinality(String),
     `session_id` String,

--- a/ghost/core/core/server/data/tinybird/datasources/_mv_hits.datasource
+++ b/ghost/core/core/server/data/tinybird/datasources/_mv_hits.datasource
@@ -1,7 +1,8 @@
 SCHEMA >
     `site_uuid` LowCardinality(String),
     `timestamp` DateTime,
-    `received_timestamp` DateTime,
+    `received_at` DateTime64(3),
+    `inserted_at` DateTime64(3),
     `action` LowCardinality(String),
     `version` LowCardinality(String),
     `session_id` String,

--- a/ghost/core/core/server/data/tinybird/endpoints/api_monitoring_ingestion.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_monitoring_ingestion.pipe
@@ -9,11 +9,11 @@ SQL >
         site_uuid,
         inserted_at,
         received_at,
-        toUInt64(ingestion_latency_ms) as ingestion_latency_ms
+        ingestion_latency_ms
     FROM _mv_hits
     WHERE
-        -- If received_at is not set in payload, defaults to 1970-01-01T00:00:00Z
-        received_at > '1970-01-01 00:00:00'
+        -- ingestion_latency_ms is set to -1 if received_at is invalid
+        ingestion_latency_ms >= 0
         {% if defined(start_date) %}
             AND toDate(inserted_at) >= {{ Date(start_date, description="Start date for filtering", required=False) }}
         {% else %}

--- a/ghost/core/core/server/data/tinybird/endpoints/api_monitoring_ingestion.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_monitoring_ingestion.pipe
@@ -4,14 +4,14 @@ TOKEN "axis" READ
 NODE ingestion_latency
 SQL >
     %
-    SELECT
+    SELECT 
         toDate(inserted_at) as date,
         site_uuid,
         inserted_at,
-        received_timestamp,
+        parseDateTimeBestEffort(JSONExtractString(payload, 'meta', 'received_timestamp'), 3) as received_timestamp,
         dateDiff('millisecond', received_timestamp, inserted_at) as latency_ms
-    FROM _mv_hits
-    WHERE
+    FROM analytics_events
+    WHERE 
         JSONExtractString(payload, 'meta', 'received_timestamp') != ''
         {% if defined(start_date) %}
             AND toDate(inserted_at) >= {{ Date(start_date, description="Start date for filtering", required=False) }}
@@ -30,7 +30,7 @@ SQL >
 NODE ingestion_metrics
 SQL >
     %
-    SELECT
+    SELECT 
         date,
         {% if defined(site_uuid) %}
         site_uuid,

--- a/ghost/core/core/server/data/tinybird/endpoints/api_monitoring_ingestion.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_monitoring_ingestion.pipe
@@ -4,14 +4,14 @@ TOKEN "axis" READ
 NODE ingestion_latency
 SQL >
     %
-    SELECT 
+    SELECT
         toDate(inserted_at) as date,
         site_uuid,
         inserted_at,
-        parseDateTimeBestEffort(JSONExtractString(payload, 'meta', 'received_timestamp'), 3) as received_timestamp,
+        received_timestamp,
         dateDiff('millisecond', received_timestamp, inserted_at) as latency_ms
-    FROM analytics_events
-    WHERE 
+    FROM mv_hits
+    WHERE
         JSONExtractString(payload, 'meta', 'received_timestamp') != ''
         {% if defined(start_date) %}
             AND toDate(inserted_at) >= {{ Date(start_date, description="Start date for filtering", required=False) }}
@@ -30,7 +30,7 @@ SQL >
 NODE ingestion_metrics
 SQL >
     %
-    SELECT 
+    SELECT
         date,
         {% if defined(site_uuid) %}
         site_uuid,

--- a/ghost/core/core/server/data/tinybird/endpoints/api_monitoring_ingestion.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_monitoring_ingestion.pipe
@@ -10,7 +10,7 @@ SQL >
         inserted_at,
         received_timestamp,
         dateDiff('millisecond', received_timestamp, inserted_at) as latency_ms
-    FROM mv_hits
+    FROM _mv_hits
     WHERE
         JSONExtractString(payload, 'meta', 'received_timestamp') != ''
         {% if defined(start_date) %}

--- a/ghost/core/core/server/data/tinybird/endpoints/api_monitoring_ingestion.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_monitoring_ingestion.pipe
@@ -4,15 +4,16 @@ TOKEN "axis" READ
 NODE ingestion_latency
 SQL >
     %
-    SELECT 
+    SELECT
         toDate(inserted_at) as date,
         site_uuid,
         inserted_at,
-        parseDateTimeBestEffort(JSONExtractString(payload, 'meta', 'received_timestamp'), 3) as received_timestamp,
-        dateDiff('millisecond', received_timestamp, inserted_at) as latency_ms
-    FROM analytics_events
-    WHERE 
-        JSONExtractString(payload, 'meta', 'received_timestamp') != ''
+        received_at,
+        toUInt64(ingestion_latency_ms) as ingestion_latency_ms
+    FROM _mv_hits
+    WHERE
+        -- If received_at is not set in payload, defaults to 1970-01-01T00:00:00Z
+        received_at > '1970-01-01 00:00:00'
         {% if defined(start_date) %}
             AND toDate(inserted_at) >= {{ Date(start_date, description="Start date for filtering", required=False) }}
         {% else %}
@@ -30,17 +31,17 @@ SQL >
 NODE ingestion_metrics
 SQL >
     %
-    SELECT 
+    SELECT
         date,
         {% if defined(site_uuid) %}
         site_uuid,
         {% end %}
         count() as total_events,
-        round(avg(latency_ms)) as avg_latency_ms,
-        round(quantile(0.5)(latency_ms)) as p50_latency_ms,
-        round(quantile(0.95)(latency_ms)) as p95_latency_ms,
-        round(min(latency_ms)) as min_latency_ms,
-        round(max(latency_ms)) as max_latency_ms
+        round(avg(ingestion_latency_ms)) as avg_latency_ms,
+        round(quantile(0.5)(ingestion_latency_ms)) as p50_latency_ms,
+        round(quantile(0.95)(ingestion_latency_ms)) as p95_latency_ms,
+        round(min(ingestion_latency_ms)) as min_latency_ms,
+        round(max(ingestion_latency_ms)) as max_latency_ms
     FROM ingestion_latency
     GROUP BY date{% if defined(site_uuid) %}, site_uuid{% end %}
     ORDER BY date DESC{% if defined(site_uuid) %}, site_uuid{% end %}

--- a/ghost/core/core/server/data/tinybird/endpoints/api_monitoring_ingestion_aggregated.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_monitoring_ingestion_aggregated.pipe
@@ -4,13 +4,13 @@ TOKEN "axis" READ
 NODE ingestion_latency
 SQL >
     %
-    SELECT
+    SELECT 
         site_uuid,
         inserted_at,
-        received_timestamp,
+        parseDateTimeBestEffort(JSONExtractString(payload, 'meta', 'received_timestamp'), 3) as received_timestamp,
         dateDiff('millisecond', received_timestamp, inserted_at) as latency_ms
-    FROM _mv_hits
-    WHERE
+    FROM analytics_events
+    WHERE 
         JSONExtractString(payload, 'meta', 'received_timestamp') != ''
         {% if defined(start_date) %}
             AND toDate(inserted_at) >= {{ Date(start_date, description="Start date for filtering", required=False) }}
@@ -29,7 +29,7 @@ SQL >
 NODE ingestion_metrics
 SQL >
     %
-    SELECT
+    SELECT 
         {% if defined(site_uuid) %}
         site_uuid,
         {% end %}

--- a/ghost/core/core/server/data/tinybird/endpoints/api_monitoring_ingestion_aggregated.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_monitoring_ingestion_aggregated.pipe
@@ -9,7 +9,7 @@ SQL >
         inserted_at,
         received_timestamp,
         dateDiff('millisecond', received_timestamp, inserted_at) as latency_ms
-    FROM mv_hits
+    FROM _mv_hits
     WHERE
         JSONExtractString(payload, 'meta', 'received_timestamp') != ''
         {% if defined(start_date) %}

--- a/ghost/core/core/server/data/tinybird/endpoints/api_monitoring_ingestion_aggregated.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_monitoring_ingestion_aggregated.pipe
@@ -8,11 +8,11 @@ SQL >
         site_uuid,
         inserted_at,
         received_at,
-        toUInt64(ingestion_latency_ms) as ingestion_latency_ms
+        ingestion_latency_ms
     FROM _mv_hits
     WHERE
-        -- If received_at is not set in payload, defaults to 1970-01-01T00:00:00Z
-        received_at > '1970-01-01 00:00:00'
+        -- ingestion_latency_ms is set to -1 if received_at is invalid
+        ingestion_latency_ms >= 0
         {% if defined(start_date) %}
             AND toDate(inserted_at) >= {{ Date(start_date, description="Start date for filtering", required=False) }}
         {% else %}

--- a/ghost/core/core/server/data/tinybird/endpoints/api_monitoring_ingestion_aggregated.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_monitoring_ingestion_aggregated.pipe
@@ -4,14 +4,15 @@ TOKEN "axis" READ
 NODE ingestion_latency
 SQL >
     %
-    SELECT 
+    SELECT
         site_uuid,
         inserted_at,
-        parseDateTimeBestEffort(JSONExtractString(payload, 'meta', 'received_timestamp'), 3) as received_timestamp,
-        dateDiff('millisecond', received_timestamp, inserted_at) as latency_ms
-    FROM analytics_events
-    WHERE 
-        JSONExtractString(payload, 'meta', 'received_timestamp') != ''
+        received_at,
+        toUInt64(ingestion_latency_ms) as ingestion_latency_ms
+    FROM _mv_hits
+    WHERE
+        -- If received_at is not set in payload, defaults to 1970-01-01T00:00:00Z
+        received_at > '1970-01-01 00:00:00'
         {% if defined(start_date) %}
             AND toDate(inserted_at) >= {{ Date(start_date, description="Start date for filtering", required=False) }}
         {% else %}
@@ -29,16 +30,16 @@ SQL >
 NODE ingestion_metrics
 SQL >
     %
-    SELECT 
+    SELECT
         {% if defined(site_uuid) %}
         site_uuid,
         {% end %}
         count() as total_events,
-        round(avg(latency_ms)) as avg_latency_ms,
-        round(quantile(0.5)(latency_ms)) as p50_latency_ms,
-        round(quantile(0.95)(latency_ms)) as p95_latency_ms,
-        round(min(latency_ms)) as min_latency_ms,
-        round(max(latency_ms)) as max_latency_ms
+        round(avg(ingestion_latency_ms)) as avg_latency_ms,
+        round(quantile(0.5)(ingestion_latency_ms)) as p50_latency_ms,
+        round(quantile(0.95)(ingestion_latency_ms)) as p95_latency_ms,
+        round(min(ingestion_latency_ms)) as min_latency_ms,
+        round(max(ingestion_latency_ms)) as max_latency_ms
     FROM ingestion_latency
     {% if defined(site_uuid) %}
     GROUP BY site_uuid

--- a/ghost/core/core/server/data/tinybird/endpoints/api_monitoring_ingestion_aggregated.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_monitoring_ingestion_aggregated.pipe
@@ -4,13 +4,13 @@ TOKEN "axis" READ
 NODE ingestion_latency
 SQL >
     %
-    SELECT 
+    SELECT
         site_uuid,
         inserted_at,
-        parseDateTimeBestEffort(JSONExtractString(payload, 'meta', 'received_timestamp'), 3) as received_timestamp,
+        received_timestamp,
         dateDiff('millisecond', received_timestamp, inserted_at) as latency_ms
-    FROM analytics_events
-    WHERE 
+    FROM mv_hits
+    WHERE
         JSONExtractString(payload, 'meta', 'received_timestamp') != ''
         {% if defined(start_date) %}
             AND toDate(inserted_at) >= {{ Date(start_date, description="Start date for filtering", required=False) }}
@@ -29,7 +29,7 @@ SQL >
 NODE ingestion_metrics
 SQL >
     %
-    SELECT 
+    SELECT
         {% if defined(site_uuid) %}
         site_uuid,
         {% end %}

--- a/ghost/core/core/server/data/tinybird/pipes/mv_hits.pipe
+++ b/ghost/core/core/server/data/tinybird/pipes/mv_hits.pipe
@@ -5,7 +5,7 @@ SQL >
 
     SELECT timestamp,
         inserted_at,
-        parseDateTime64BestEffort(JSONExtractString(payload, 'meta', 'received_timestamp'), 3) as received_at,
+        parseDateTime64BestEffortOrZero(JSONExtractString(payload, 'meta', 'received_timestamp'), 3) as received_at,
         action,
         version,
         coalesce(session_id, '0') as session_id,
@@ -41,6 +41,7 @@ SQL >
         timestamp,
         received_at,
         inserted_at,
+        date_diff('millisecond', received_at, inserted_at) as ingestion_latency_ms,
         action,
         version,
         session_id,

--- a/ghost/core/core/server/data/tinybird/pipes/mv_hits.pipe
+++ b/ghost/core/core/server/data/tinybird/pipes/mv_hits.pipe
@@ -4,7 +4,8 @@ NODE mv_hits_0
 SQL >
 
     SELECT timestamp,
-        parseDateTimeBestEffort(JSONExtractString(payload, 'meta', 'received_timestamp'), 3) as received_timestamp,
+        inserted_at,
+        parseDateTime64BestEffort(JSONExtractString(payload, 'meta', 'received_timestamp'), 3) as received_at,
         action,
         version,
         coalesce(session_id, '0') as session_id,
@@ -38,6 +39,8 @@ SQL >
     SELECT
         site_uuid,
         timestamp,
+        received_at,
+        inserted_at,
         action,
         version,
         session_id,

--- a/ghost/core/core/server/data/tinybird/pipes/mv_hits.pipe
+++ b/ghost/core/core/server/data/tinybird/pipes/mv_hits.pipe
@@ -5,8 +5,8 @@ SQL >
 
     SELECT timestamp,
         inserted_at,
-        -- payload.meta.received_timestamp may be missing or null. Default to 0 (1970-01-01T:00:00:00Z) in this case.
-        -- Nullable fields incur performance penalty in clickhouse, so we default to zero instead of null.
+        -- payload.meta.received_timestamp may be missing or null
+        -- Nullable fields incur performance penalty in clickhouse, so we default to zero (unix epoch) instead of null.
         parseDateTime64BestEffortOrZero(JSONExtractString(payload, 'meta', 'received_timestamp'), 3) as received_at,
         action,
         version,
@@ -44,6 +44,7 @@ SQL >
         received_at,
         inserted_at,
         case
+            -- set to -1 if received_at is the unix epoch, or if received_at is after inserted_at
             when toUnixTimestamp(received_at) = 0 then -1
             when received_at > inserted_at then -1
             else date_diff('millisecond', received_at, inserted_at)

--- a/ghost/core/core/server/data/tinybird/pipes/mv_hits.pipe
+++ b/ghost/core/core/server/data/tinybird/pipes/mv_hits.pipe
@@ -5,6 +5,8 @@ SQL >
 
     SELECT timestamp,
         inserted_at,
+        -- payload.meta.received_timestamp may be missing or null. Default to 0 (1970-01-01T:00:00:00Z) in this case.
+        -- Nullable fields incur performance penalty in clickhouse, so we default to zero instead of null.
         parseDateTime64BestEffortOrZero(JSONExtractString(payload, 'meta', 'received_timestamp'), 3) as received_at,
         action,
         version,

--- a/ghost/core/core/server/data/tinybird/pipes/mv_hits.pipe
+++ b/ghost/core/core/server/data/tinybird/pipes/mv_hits.pipe
@@ -4,6 +4,7 @@ NODE mv_hits_0
 SQL >
 
     SELECT timestamp,
+        parseDateTimeBestEffort(JSONExtractString(payload, 'meta', 'received_timestamp'), 3) as received_timestamp,
         action,
         version,
         coalesce(session_id, '0') as session_id,
@@ -54,20 +55,20 @@ SQL >
             when referrer IN ('Instagram', 'www.instagram.com') then 'Instagram'
             when referrer IN ('LinkedIn', 'LINKEDIN_COMPANY') then 'LinkedIn'
             when referrer IN ('l.threads.com') then 'Threads'
-            
+
             -- Reddit Ecosystem
             when referrer IN ('www.reddit.com', 'out.reddit.com', 'old.reddit.com', 'com.reddit.frontpage') then 'Reddit'
-            
+
             -- Search Engines (keep distinctions)
             when referrer IN ('search.brave.com') then 'Brave Search'
             when referrer IN ('www.ecosia.org') then 'Ecosia'
-            
+
             -- Email Services
             when referrer IN ('Gmail', 'com.google.android.gm', 'mail.google.com') then 'Gmail'
             when referrer IN ('Outlook.com') then 'Outlook'
             when referrer IN ('Yahoo!', 'www.yahoo.com', 'Yahoo! Mail', 'r.search.yahoo.com') then 'Yahoo!'
             when referrer IN ('AOL Mail') then 'AOL Mail'
-            
+
             -- Content Platforms
             when referrer IN ('flipboard', 'flipboard.com', 'flipboard.app') then 'Flipboard'
             when referrer IN ('substack', 'substack.com') then 'Substack'
@@ -75,22 +76,22 @@ SQL >
             when referrer IN ('buffer') then 'Buffer'
             when referrer IN ('Taboola') then 'Taboola'
             when referrer IN ('AppNexus') then 'AppNexus'
-            
+
             -- Wikipedia
             when referrer IN ('en.wikipedia.org', 'en.m.wikipedia.org') then 'Wikipedia'
-            
+
             -- Mastodon Network
             when referrer IN ('mastodon.social', 'mastodon.online', 'org.joinmastodon.android', 'phanpy.social', 'dev.phanpy.social') then 'Mastodon'
-            
+
             -- News Aggregators
             when referrer IN ('www.memeorandum.com', 'memeorandum.com') then 'Memeorandum'
             when referrer IN ('ground.news') then 'Ground News'
             when referrer IN ('apple.news') then 'Apple News'
             when referrer IN ('www.smartnews.com') then 'SmartNews'
-            
+
             -- Keep other sources as-is
-            when domainWithoutWWW(referrer) != '' then domainWithoutWWW(referrer) 
-            else referrer 
+            when domainWithoutWWW(referrer) != '' then domainWithoutWWW(referrer)
+            else referrer
         end as source,
         pathname,
         href,

--- a/ghost/core/core/server/data/tinybird/pipes/mv_hits.pipe
+++ b/ghost/core/core/server/data/tinybird/pipes/mv_hits.pipe
@@ -43,7 +43,11 @@ SQL >
         timestamp,
         received_at,
         inserted_at,
-        date_diff('millisecond', received_at, inserted_at) as ingestion_latency_ms,
+        case
+            when toUnixTimestamp(received_at) = 0 then -1
+            when received_at > inserted_at then -1
+            else date_diff('millisecond', received_at, inserted_at)
+        end as ingestion_latency_ms,
         action,
         version,
         session_id,


### PR DESCRIPTION
ref https://linear.app/ghost/issue/NY-748/create-tinybird-mv-to-speed-up-monitoring-endpoints

## Problem
The Tinybird monitoring endpoints (and raw queries used in our monitoring dashboard) are slow enough that they frequently timeout. Part of the problem is the date parsing of the `payload.meta.received_timestamp` field at query time. 

## Solution
This change aims to improve the performance of these endpoints by parsing the `inserted_at` and `received_at` fields and pre-calculating the ingestion latency in the `mv_hits` materialized view, thereby moving the parsing & calculating to ingest time, rather than query time.

Now the monitoring endpoints or any ad-hoc monitoring queries can directly query `mv_hits`, rather than recalculating all these values at query time. 

---

- Adds `inserted_at`, `received_at`, `ingestion_latency_ms` fields to `_mv_hits` datasource with appropriate data types
- Adds above fields to `mv_hits` pipe to populate the materialized view
- Modifies `api_monitoring_ingestion` and `api_monitoring_ingestion_aggregated` to pull from `_mv_hits` instead of `analytics_events`

---

## Deployment
- This doesn't change any landing datasources, so the deployment should be simple
- The changes to the materialized view will be backfilled using the associated pipe
- The endpoints are stateless, so no data will need to change for it

```
» Validating deployment...


* Changes to be deployed:
--------------------------------------------------------
status: modified
name: _mv_hits
type: datasource
path: datasources/_mv_hits.datasource
--------------------------------------------------------
status: modified
name: api_monitoring_ingestion
type: endpoint
path: endpoints/api_monitoring_ingestion.pipe
--------------------------------------------------------
status: modified
name: api_monitoring_ingestion_aggregated
type: endpoint
path: endpoints/api_monitoring_ingestion_aggregated.pipe
--------------------------------------------------------
status: modified
name: mv_hits
type: materialization
path: pipes/mv_hits.pipe
--------------------------------------------------------
* No changes in tokens to be deployed

 Data that will be copied with this deployment:
------------------------------------------------
| Datasource | Backfill type                   |
------------------------------------------------
| _mv_hits   | Using Materialized Pipe mv_hits |
------------------------------------------------


✓ Deployment is valid
```