### PR TITLE
Fixed loading orb not displaying on React admin startup

### DIFF
--- a/apps/admin/index.html
+++ b/apps/admin/index.html
@@ -16,7 +16,16 @@
   </head>
   <body class="react-admin">
     <div id="root"></div>
-    <div id="ember-app"></div>
+    <div id="ember-app">
+      <div class="ember-load-indicator">
+        <div class="gh-loading-content">
+          <video width="100" height="100" loop autoplay muted playsinline preload="metadata" style="width: 100px; height: 100px;">
+            <source src="assets/videos/logo-loader.mp4" type="video/mp4" />
+            <div class="gh-loading-spinner"></div>
+          </video>
+        </div>
+      </div>
+    </div>
     <div id="ember-basic-dropdown-wormhole"></div>
     <div id="ember-modal-wormhole"></div>
     <script type="module" src="/src/main.tsx"></script>


### PR DESCRIPTION
closes https://linear.app/ghost/issue/BER-3048/the-ghost-loading-orb-isnt-displayed-on-startup

The React admin index.html was missing the loading indicator that exists in the Ember admin, causing a blank page while waiting for assets to load.
