### PR TITLE
🐛 Fixed Admin visual regressions with hidden text being visible

### DIFF
--- a/ghost/admin/app/styles/patterns/global.css
+++ b/ghost/admin/app/styles/patterns/global.css
@@ -640,7 +640,10 @@ input[type="image"] {
 .hidden {
     display: none;
 }
-.gh-app .hidden {
+.gh-app .hidden,
+.ember-basic-dropdown-wormhole .hidden,
+.ember-modal-wormhole .hidden,
+.liquid-destination .hidden {
     visibility: hidden !important;
     display: none !important;
 }


### PR DESCRIPTION
closes https://linear.app/tryghost/issue/DES-1251/
closes https://linear.app/ghost/issue/ONC-1291/

- regression was introduced when we increased specificity of Ember Admin's `.hidden` class
- some wormholed/animated content gets rendered outside of the main `.gh-app` element meaning content that was hidden is now visible, resulting in text like "Photo of Staff Name" overlaying staff user images in the post history revisions list or delete icons in members filters not showing correctly
