### PR TITLE
Added E2E tests for sidebar navigation during Ember-to-React migration

### DIFF
--- a/apps/admin/src/index.css
+++ b/apps/admin/src/index.css
@@ -10,13 +10,6 @@ body.react-admin #ember-app .gh-app {
     position: static;
 }
 
-
-/* Hide the nav menu and tab bar on mobile when running in React admin shell */
-body.react-admin #ember-app .gh-nav,
-body.react-admin #ember-app .gh-mobile-nav-bar {
-    display: none;
-}
-
 /* Temporary overrides until Ember transition is finished */
 body.react-admin .gh-canvas-header {
     padding-top: 24px;

--- a/apps/admin/src/layout/app-sidebar/NavCustomViews.tsx
+++ b/apps/admin/src/layout/app-sidebar/NavCustomViews.tsx
@@ -73,9 +73,11 @@ export function NavCustomViews({ route = 'posts' }: NavCustomViewsProps) {
                             isActive={isActive}
                         >
                             <NavMenuItem.Label className="grow">{view.name}</NavMenuItem.Label>
-                            <span 
-                                className="size-2 rounded-full shrink-0 mx-0.5" 
+                            <span
+                                className="size-2 rounded-full shrink-0 mx-0.5"
                                 style={{backgroundColor: getColorHex(view.color)}}
+                                data-color={view.color}
+                                aria-hidden="true"
                             />
                         </NavMenuItem.Link>
                     </NavMenuItem>

--- a/apps/admin/src/layout/app-sidebar/UserMenu.tsx
+++ b/apps/admin/src/layout/app-sidebar/UserMenu.tsx
@@ -118,14 +118,14 @@ function UserMenu(props: UserMenuProps) {
                     )}
                 </DropdownMenuItem>
                 <DropdownMenuItem className="cursor-pointer text-base" asChild>
-                    <Link to={`/settings/staff/${currentUser.data?.slug}`} role="menuitem">
+                    <Link to={`/settings/staff/${currentUser.data?.slug}`}>
                         <LucideIcon.User />
                         <span>Your profile</span>
                     </Link>
                 </DropdownMenuItem>
                 <DropdownMenuSeparator />
                 <DropdownMenuItem className="cursor-pointer text-base" asChild>
-                    <a href="https://ghost.org/resources?utm_source=admin&utm_campaign=resources" target="_blank" rel="noopener noreferrer" role="menuitem">
+                    <a href="https://ghost.org/resources?utm_source=admin&utm_campaign=resources" target="_blank" rel="noopener noreferrer">
                         <LucideIcon.Book />
                         Resources & guides
                     </a>

--- a/apps/admin/src/layout/app-sidebar/UserMenu.tsx
+++ b/apps/admin/src/layout/app-sidebar/UserMenu.tsx
@@ -41,6 +41,7 @@ function UserMenu(props: UserMenuProps) {
                 <SidebarMenuButton
                     size="lg"
                     className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
+                    aria-label="User menu"
                 >
                 <div className="relative">
                     <Avatar>
@@ -117,14 +118,14 @@ function UserMenu(props: UserMenuProps) {
                     )}
                 </DropdownMenuItem>
                 <DropdownMenuItem className="cursor-pointer text-base" asChild>
-                    <Link to={`/settings/staff/${currentUser.data?.slug}`}>
+                    <Link to={`/settings/staff/${currentUser.data?.slug}`} role="menuitem">
                         <LucideIcon.User />
                         <span>Your profile</span>
                     </Link>
                 </DropdownMenuItem>
                 <DropdownMenuSeparator />
                 <DropdownMenuItem className="cursor-pointer text-base" asChild>
-                    <a href="https://ghost.org/resources?utm_source=admin&utm_campaign=resources" target="_blank" rel="noopener noreferrer">
+                    <a href="https://ghost.org/resources?utm_source=admin&utm_campaign=resources" target="_blank" rel="noopener noreferrer" role="menuitem">
                         <LucideIcon.Book />
                         Resources & guides
                     </a>

--- a/apps/shade/src/components/ui/sidebar.tsx
+++ b/apps/shade/src/components/ui/sidebar.tsx
@@ -184,6 +184,7 @@ const Sidebar = React.forwardRef<
                         'flex h-full w-[--sidebar-width] flex-col bg-sidebar text-sidebar-foreground',
                         className
                     )}
+                    role="navigation"
                     {...props}
                 >
                     {children}
@@ -198,6 +199,7 @@ const Sidebar = React.forwardRef<
                         className="w-[--sidebar-width] bg-sidebar p-0 text-sidebar-foreground [&>button]:hidden"
                         data-mobile="true"
                         data-sidebar="sidebar"
+                        role="navigation"
                         side={side}
                         style={
             {
@@ -219,6 +221,7 @@ const Sidebar = React.forwardRef<
                 data-side={side}
                 data-state={state}
                 data-variant={variant}
+                role="navigation"
             >
                 {/* This is what handles the sidebar gap on desktop */}
                 <div

--- a/e2e/helpers/pages/admin/index.ts
+++ b/e2e/helpers/pages/admin/index.ts
@@ -8,3 +8,4 @@ export * from './whats-new';
 export * from './analytics';
 export * from './posts';
 export * from './tags';
+export * from './sidebar';

--- a/e2e/helpers/pages/admin/posts/custom-view-modal.ts
+++ b/e2e/helpers/pages/admin/posts/custom-view-modal.ts
@@ -1,0 +1,48 @@
+import {Locator, Page} from '@playwright/test';
+
+export class CustomViewModal {
+    private readonly page: Page;
+    public readonly modal: Locator;
+    public readonly nameInput: Locator;
+    public readonly nameError: Locator;
+    public readonly saveButton: Locator;
+    public readonly deleteButton: Locator;
+    public readonly cancelButton: Locator;
+
+    constructor(page: Page) {
+        this.page = page;
+        this.modal = page.getByRole('dialog');
+        this.nameInput = page.getByLabel('View name');
+        this.nameError = page.locator('[data-test-error="custom-view-name"]');
+        this.saveButton = this.modal.getByRole('button', {name: 'Save'});
+        this.deleteButton = this.modal.getByRole('button', {name: 'Delete'});
+        this.cancelButton = this.modal.getByRole('button', {name: 'Cancel'});
+    }
+
+    async waitForModal(): Promise<void> {
+        await this.modal.waitFor({state: 'visible'});
+    }
+
+    async enterName(name: string): Promise<void> {
+        await this.nameInput.fill(name);
+    }
+
+    async selectColor(color: string): Promise<void> {
+        await this.page.getByLabel(color).click();
+    }
+
+    async save(): Promise<void> {
+        await this.saveButton.click();
+        await this.modal.waitFor({state: 'hidden'});
+    }
+
+    async delete(): Promise<void> {
+        await this.deleteButton.click();
+        await this.modal.waitFor({state: 'hidden'});
+    }
+
+    async cancel(): Promise<void> {
+        await this.cancelButton.click();
+        await this.modal.waitFor({state: 'hidden'});
+    }
+}

--- a/e2e/helpers/pages/admin/posts/index.ts
+++ b/e2e/helpers/pages/admin/posts/index.ts
@@ -1,3 +1,3 @@
 export * from './post';
 export {PostsPage} from './posts-page';
-
+export {CustomViewModal} from './custom-view-modal';

--- a/e2e/helpers/pages/admin/posts/posts-page.ts
+++ b/e2e/helpers/pages/admin/posts/posts-page.ts
@@ -2,9 +2,22 @@ import {AdminPage} from '@/admin-pages';
 import {Locator, Page} from '@playwright/test';
 
 export class PostsPage extends AdminPage {
-    readonly postsList: Locator;
-    readonly postsListItem: Locator;
-    readonly newPostButton: Locator;
+    public readonly postsList: Locator;
+    public readonly postsListItem: Locator;
+    public readonly newPostButton: Locator;
+
+    public readonly postsFilters: Locator;
+
+    public readonly typeFilter: Locator;
+    public readonly visibilityFilter: Locator;
+    public readonly authorFilter: Locator;
+    public readonly tagFilter: Locator;
+    public readonly orderFilter: Locator;
+
+    public readonly saveViewButton: Locator;
+    public readonly editViewButton: Locator;
+
+    public readonly pageTitle: Locator;
 
     constructor(page: Page) {
         super(page);
@@ -13,6 +26,18 @@ export class PostsPage extends AdminPage {
         this.postsList = page.getByTestId('posts-list');
         this.postsListItem = this.postsList.getByTestId('posts-list-item');
         this.newPostButton = page.getByRole('link', {name: 'New post'});
+
+        this.postsFilters = page.getByTestId('posts-filters');
+        this.typeFilter = this.postsFilters.getByRole('button', {name: 'Type filter'});
+        this.visibilityFilter = this.postsFilters.getByRole('button', {name: 'Visibility filter'});
+        this.authorFilter = this.postsFilters.getByRole('button', {name: 'Author filter'});
+        this.tagFilter = this.postsFilters.getByRole('button', {name: 'Tag filter'});
+        this.orderFilter = this.postsFilters.getByRole('button', {name: 'Sort filter'});
+
+        this.saveViewButton = page.getByRole('button', {name: /save as view/i});
+        this.editViewButton = page.getByRole('button', {name: /edit current view/i});
+
+        this.pageTitle = page.getByRole('heading', {level: 2});
     }
 
     getPostByTitle(title: string): Locator {
@@ -21,5 +46,44 @@ export class PostsPage extends AdminPage {
 
     async refreshData() {
         await this.page.reload();
+    }
+
+    async selectType(typeName: string): Promise<void> {
+        await this.typeFilter.click();
+        await this.page.getByRole('option', {name: typeName, exact: true}).click();
+    }
+
+    async selectVisibility(visibilityName: string): Promise<void> {
+        await this.visibilityFilter.click();
+        await this.page.getByRole('option', {name: visibilityName, exact: true}).click();
+    }
+
+    async selectAuthor(authorName: string): Promise<void> {
+        await this.authorFilter.click();
+        await this.page.getByRole('option', {name: authorName, exact: true}).click();
+    }
+
+    async selectTag(tagName: string): Promise<void> {
+        await this.tagFilter.click();
+        await this.page.getByRole('option', {name: tagName, exact: true}).click();
+    }
+
+    async selectOrder(orderName: string): Promise<void> {
+        await this.orderFilter.click();
+        await this.page.getByRole('option', {name: orderName, exact: true}).click();
+    }
+
+    async openSaveViewModal(): Promise<void> {
+        await this.saveViewButton.waitFor({state: 'visible'});
+        await this.saveViewButton.click();
+    }
+
+    async openEditViewModal(): Promise<void> {
+        await this.editViewButton.waitFor({state: 'visible'});
+        await this.editViewButton.click();
+    }
+
+    async getActiveViewName(): Promise<string | null> {
+        return await this.pageTitle.textContent();
     }
 }

--- a/e2e/helpers/pages/admin/sidebar/index.ts
+++ b/e2e/helpers/pages/admin/sidebar/index.ts
@@ -1,0 +1,1 @@
+export * from './sidebar-page';

--- a/e2e/helpers/pages/admin/sidebar/sidebar-page.ts
+++ b/e2e/helpers/pages/admin/sidebar/sidebar-page.ts
@@ -1,0 +1,69 @@
+import {AdminPage} from '@/admin-pages';
+import {Locator, Page} from '@playwright/test';
+
+/**
+ * SidebarPage uses semantic, accessibility-first locators.
+ * This approach tests the UI as users interact with it, not implementation details.
+ *
+ * Accessibility features:
+ * ✓ Active nav links have aria-current="page"
+ * ✓ Posts toggle button has aria-expanded
+ */
+export class SidebarPage extends AdminPage {
+    public readonly sidebar: Locator;
+    public readonly postsToggle: Locator;
+    public readonly userDropdownTrigger: Locator;
+    public readonly nightShiftToggle: Locator;
+    public readonly whatsNewButton: Locator;
+    public readonly userProfileLink: Locator;
+    public readonly signOutLink: Locator;
+
+    constructor(page: Page) {
+        super(page);
+        this.sidebar = page.getByRole('navigation');
+        this.postsToggle = this.sidebar.getByRole('button', {name: /toggle post views/i});
+        this.userDropdownTrigger = page.locator('[data-test-nav="arrow-down"]');
+        this.nightShiftToggle = page.getByRole('button', {name: /dark mode/i}).or(page.getByRole('menuitem', {name: /dark mode/i}).getByRole('switch'));
+        this.whatsNewButton = page.getByRole('menuitem', {name: /what's new/i});
+        this.userProfileLink = page.getByRole('menuitem', {name: /your profile/i});
+        this.signOutLink = page.getByRole('menuitem', {name: /sign out/i});
+    }
+
+    getNavLink(name: string): Locator {
+        return this.sidebar
+            .getByRole('link')
+            .filter({hasText: new RegExp(name, 'i')});
+    }
+
+    async expandPostsSubmenu(): Promise<void> {
+        const isExpanded = await this.postsToggle.getAttribute('aria-expanded');
+        if (isExpanded !== 'true') {
+            await this.postsToggle.click();
+        }
+    }
+
+    async collapsePostsSubmenu(): Promise<void> {
+        const isExpanded = await this.postsToggle.getAttribute('aria-expanded');
+        if (isExpanded === 'true') {
+            await this.postsToggle.click();
+        }
+    }
+
+    async isNightShiftEnabled(): Promise<boolean> {
+        // React uses a switch with aria-checked attribute
+        const isChecked = await this.nightShiftToggle.getAttribute('aria-checked');
+        if (isChecked !== null) {
+            return isChecked === 'true';
+        }
+        // Ember uses a button with 'on' class
+        const classes = await this.nightShiftToggle.getAttribute('class');
+        return classes?.includes('on') ?? false;
+    }
+
+    async waitForNightShiftEnabled(enabled: boolean): Promise<void> {
+        const locator = enabled
+            ? this.page.locator('[aria-checked="true"], .nightshift-toggle.on')
+            : this.page.locator('[aria-checked="false"], .nightshift-toggle:not(.on)');
+        await locator.first().waitFor();
+    }
+}

--- a/e2e/helpers/pages/admin/sidebar/sidebar-page.ts
+++ b/e2e/helpers/pages/admin/sidebar/sidebar-page.ts
@@ -35,6 +35,10 @@ export class SidebarPage extends AdminPage {
             .filter({hasText: new RegExp(name, 'i')});
     }
 
+    getCustomViewColorIndicator(viewName: string): Locator {
+        return this.getNavLink(viewName).locator('[data-color]');
+    }
+
     async expandPostsSubmenu(): Promise<void> {
         const isExpanded = await this.postsToggle.getAttribute('aria-expanded');
         if (isExpanded !== 'true') {

--- a/e2e/helpers/pages/admin/tags/tag-details-page.ts
+++ b/e2e/helpers/pages/admin/tags/tag-details-page.ts
@@ -9,7 +9,6 @@ export class TagDetailsPage extends AdminPage {
     readonly saveButtonSuccess: Locator;
     readonly deleteButton: Locator;
     readonly backLink: Locator;
-    readonly navMenuItem: Locator;
 
     constructor(page: Page) {
         super(page);
@@ -22,7 +21,6 @@ export class TagDetailsPage extends AdminPage {
         this.deleteButton = page.getByRole('button', {name: 'Delete tag'});
 
         this.backLink = page.locator('[data-test-link="tags-back"]');
-        this.navMenuItem = page.locator('[data-test-nav="tags"]');
     }
 
     async fillTagName(name: string) {

--- a/e2e/helpers/pages/admin/tags/tag-editor-page.ts
+++ b/e2e/helpers/pages/admin/tags/tag-editor-page.ts
@@ -6,8 +6,6 @@ export class TagEditorPage extends TagDetailsPage {
     readonly deleteModalPostsCount: Locator;
     readonly deleteModalConfirmButton: Locator;
 
-    readonly navMenuItem: Locator;
-
     constructor(page: Page) {
         super(page);
 
@@ -16,8 +14,6 @@ export class TagEditorPage extends TagDetailsPage {
         this.deleteModal = page.locator('[data-test-modal="confirm-delete-tag"]');
         this.deleteModalPostsCount = this.deleteModal.locator('[data-test-text="posts-count"]');
         this.deleteModalConfirmButton = this.deleteModal.locator('[data-test-button="confirm"]');
-
-        this.navMenuItem = page.locator('[data-test-nav="tags"]');
     }
 
     async gotoTagBySlug(slug: string) {

--- a/e2e/tests/admin/posts/custom-views.test.ts
+++ b/e2e/tests/admin/posts/custom-views.test.ts
@@ -1,0 +1,460 @@
+import {CustomViewModal, PostsPage, SidebarPage} from '@/admin-pages';
+import {PostFactory, TagFactory, createPostFactory, createTagFactory} from '@/data-factory';
+import {expect, test} from '@/helpers/playwright/fixture';
+
+test.describe('Ghost Admin - Custom Views', () => {
+    let postFactory: PostFactory;
+    let tagFactory: TagFactory;
+
+    test.beforeEach(async ({page}) => {
+        postFactory = createPostFactory(page.request);
+        tagFactory = createTagFactory(page.request);
+    });
+
+    test.describe('creating custom views', () => {
+        test('saving filtered view - creates custom view in sidebar', async ({page}) => {
+            await tagFactory.create({name: 'Featured'});
+            const postsPage = new PostsPage(page);
+            const sidebar = new SidebarPage(page);
+            const modal = new CustomViewModal(page);
+
+            await postsPage.goto();
+            await postsPage.selectType('Draft posts');
+            await postsPage.selectTag('Featured');
+
+            await postsPage.openSaveViewModal();
+            await modal.waitForModal();
+            await modal.enterName('Featured Drafts');
+            await modal.selectColor('blue');
+            await modal.save();
+
+            await expect(sidebar.getNavLink('Featured Drafts')).toBeVisible();
+            await expect(sidebar.getNavLink('Featured Drafts')).toHaveAttribute('aria-current', 'page');
+        });
+
+        test('saving view with duplicate name - shows validation error', async ({page}) => {
+            await tagFactory.create({name: 'Articles'});
+            const postsPage = new PostsPage(page);
+            const sidebar = new SidebarPage(page);
+            const modal = new CustomViewModal(page);
+
+            await postsPage.goto();
+            await postsPage.selectType('Draft posts');
+            await postsPage.selectTag('Articles');
+
+            await postsPage.openSaveViewModal();
+            await modal.waitForModal();
+            await modal.enterName('My Articles');
+            await modal.save();
+
+            await sidebar.getNavLink('Posts').click();
+            await postsPage.selectType('Published posts');
+            await postsPage.selectTag('Articles');
+
+            await postsPage.openSaveViewModal();
+            await modal.waitForModal();
+            await modal.enterName('My Articles');
+            await modal.saveButton.click();
+
+            await expect(modal.nameError).toBeVisible();
+        });
+
+        test('newly created view - has correct color indicator', async ({page}) => {
+            const postsPage = new PostsPage(page);
+            const sidebar = new SidebarPage(page);
+            const modal = new CustomViewModal(page);
+
+            await postsPage.goto();
+            await postsPage.selectType('Published posts');
+            await postsPage.selectVisibility('Public');
+
+            await postsPage.openSaveViewModal();
+            await modal.waitForModal();
+            await modal.enterName('Public Published');
+            await modal.selectColor('green');
+            await modal.save();
+
+            await expect(sidebar.getNavLink('Public Published')).toBeVisible();
+            await expect(sidebar.getCustomViewColorIndicator('Public Published')).toHaveAttribute('data-color', 'green');
+        });
+    });
+
+    test.describe('navigating custom views', () => {
+        test('clicking custom view in sidebar - applies correct filters', async ({page}) => {
+            const tag = await tagFactory.create({name: 'Stories'});
+            await postFactory.create({status: 'draft', tags: [{id: tag.id}]});
+            const postsPage = new PostsPage(page);
+            const sidebar = new SidebarPage(page);
+            const modal = new CustomViewModal(page);
+
+            await postsPage.goto();
+            await postsPage.selectType('Draft posts');
+            await postsPage.selectTag('Stories');
+
+            await postsPage.openSaveViewModal();
+            await modal.waitForModal();
+            await modal.enterName('Stories Drafts');
+            await modal.save();
+
+            await sidebar.getNavLink('Posts').click();
+
+            await sidebar.getNavLink('Stories Drafts').click();
+
+            await expect(page).toHaveURL(/type=draft/);
+            await expect(page).toHaveURL(new RegExp(`tag=${tag.slug}`));
+        });
+
+        test('clicking custom view - shows active state in sidebar', async ({page}) => {
+            await tagFactory.create({name: 'Updates'});
+            const postsPage = new PostsPage(page);
+            const sidebar = new SidebarPage(page);
+            const modal = new CustomViewModal(page);
+
+            await postsPage.goto();
+            await postsPage.selectType('Scheduled posts');
+            await postsPage.selectTag('Updates');
+
+            await postsPage.openSaveViewModal();
+            await modal.waitForModal();
+            await modal.enterName('Scheduled Updates');
+            await modal.save();
+
+            await expect(sidebar.getNavLink('Scheduled Updates')).toHaveAttribute('aria-current', 'page');
+        });
+
+        test('navigating from custom view to Posts - clears active state', async ({page}) => {
+            await tagFactory.create({name: 'Blog'});
+            const postsPage = new PostsPage(page);
+            const sidebar = new SidebarPage(page);
+            const modal = new CustomViewModal(page);
+
+            await postsPage.goto();
+            await postsPage.selectType('Published posts');
+            await postsPage.selectTag('Blog');
+
+            await postsPage.openSaveViewModal();
+            await modal.waitForModal();
+            await modal.enterName('Published Blog');
+            await modal.save();
+
+            await expect(sidebar.getNavLink('Published Blog')).toHaveAttribute('aria-current', 'page');
+
+            await sidebar.getNavLink('Posts').click();
+
+            await expect(sidebar.getNavLink('Published Blog')).not.toHaveAttribute('aria-current', 'page');
+            await expect(sidebar.getNavLink('Posts')).toHaveAttribute('aria-current', 'page');
+        });
+
+        test('navigating between custom views - updates active state correctly', async ({page}) => {
+            await tagFactory.create({name: 'Tech'});
+            await tagFactory.create({name: 'Business'});
+            const postsPage = new PostsPage(page);
+            const sidebar = new SidebarPage(page);
+            const modal = new CustomViewModal(page);
+
+            await postsPage.goto();
+            await postsPage.selectType('Draft posts');
+            await postsPage.selectTag('Tech');
+
+            await postsPage.openSaveViewModal();
+            await modal.waitForModal();
+            await modal.enterName('Tech Drafts');
+            await modal.save();
+
+            await sidebar.getNavLink('Posts').click();
+            await postsPage.selectType('Published posts');
+            await postsPage.selectTag('Business');
+
+            await postsPage.openSaveViewModal();
+            await modal.waitForModal();
+            await modal.enterName('Published Business');
+            await modal.save();
+
+            await sidebar.getNavLink('Tech Drafts').click();
+
+            await expect(sidebar.getNavLink('Tech Drafts')).toHaveAttribute('aria-current', 'page');
+            await expect(sidebar.getNavLink('Published Business')).not.toHaveAttribute('aria-current', 'page');
+
+            await sidebar.getNavLink('Published Business').click();
+
+            await expect(sidebar.getNavLink('Published Business')).toHaveAttribute('aria-current', 'page');
+            await expect(sidebar.getNavLink('Tech Drafts')).not.toHaveAttribute('aria-current', 'page');
+        });
+    });
+
+    test.describe('editing custom views', () => {
+        test('renaming custom view - updates sidebar immediately', async ({page}) => {
+            await tagFactory.create({name: 'Review'});
+            const postsPage = new PostsPage(page);
+            const sidebar = new SidebarPage(page);
+            const modal = new CustomViewModal(page);
+
+            await postsPage.goto();
+            await postsPage.selectType('Draft posts');
+            await postsPage.selectTag('Review');
+
+            await postsPage.openSaveViewModal();
+            await modal.waitForModal();
+            await modal.enterName('Old Name');
+            await modal.save();
+
+            await postsPage.openEditViewModal();
+            await modal.waitForModal();
+            await modal.enterName('New Name');
+            await modal.save();
+
+            await expect(sidebar.getNavLink('New Name')).toBeVisible();
+            await expect(sidebar.getNavLink('Old Name')).toBeHidden();
+            await expect(sidebar.getNavLink('New Name')).toHaveAttribute('aria-current', 'page');
+        });
+
+        test('changing custom view color - updates sidebar indicator', async ({page}) => {
+            const postsPage = new PostsPage(page);
+            const sidebar = new SidebarPage(page);
+            const modal = new CustomViewModal(page);
+
+            await postsPage.goto();
+            await postsPage.selectType('Published posts');
+            await postsPage.selectVisibility('Members-only');
+
+            await postsPage.openSaveViewModal();
+            await modal.waitForModal();
+            await modal.enterName('Color Test');
+            await modal.selectColor('blue');
+            await modal.save();
+
+            await expect(sidebar.getCustomViewColorIndicator('Color Test')).toHaveAttribute('data-color', 'blue');
+
+            await postsPage.openEditViewModal();
+            await modal.waitForModal();
+            await modal.selectColor('red');
+            await modal.save();
+
+            await expect(sidebar.getCustomViewColorIndicator('Color Test')).toHaveAttribute('data-color', 'red');
+        });
+
+        test('editing view while viewing it - maintains active state after save', async ({page}) => {
+            await tagFactory.create({name: 'Scheduled'});
+            const postsPage = new PostsPage(page);
+            const sidebar = new SidebarPage(page);
+            const modal = new CustomViewModal(page);
+
+            await postsPage.goto();
+            await postsPage.selectType('Scheduled posts');
+            await postsPage.selectTag('Scheduled');
+
+            await postsPage.openSaveViewModal();
+            await modal.waitForModal();
+            await modal.enterName('Active View');
+            await modal.save();
+
+            await postsPage.openEditViewModal();
+            await modal.waitForModal();
+            await modal.enterName('Renamed Active View');
+            await modal.save();
+
+            await expect(sidebar.getNavLink('Renamed Active View')).toHaveAttribute('aria-current', 'page');
+        });
+    });
+
+    test.describe('deleting custom views', () => {
+        test('deleting custom view - removes from sidebar', async ({page}) => {
+            await tagFactory.create({name: 'Delete'});
+            const postsPage = new PostsPage(page);
+            const sidebar = new SidebarPage(page);
+            const modal = new CustomViewModal(page);
+
+            await postsPage.goto();
+            await postsPage.selectType('Draft posts');
+            await postsPage.selectTag('Delete');
+
+            await postsPage.openSaveViewModal();
+            await modal.waitForModal();
+            await modal.enterName('To Delete');
+            await modal.save();
+
+            await postsPage.openEditViewModal();
+            await modal.waitForModal();
+            await modal.delete();
+
+            await expect(sidebar.getNavLink('To Delete')).toBeHidden();
+        });
+
+        test('deleting active view - navigates to Posts page', async ({page}) => {
+            await tagFactory.create({name: 'Active'});
+            const postsPage = new PostsPage(page);
+            const sidebar = new SidebarPage(page);
+            const modal = new CustomViewModal(page);
+
+            await postsPage.goto();
+            await postsPage.selectType('Published posts');
+            await postsPage.selectTag('Active');
+
+            await postsPage.openSaveViewModal();
+            await modal.waitForModal();
+            await modal.enterName('Active Delete Test');
+            await modal.save();
+
+            await postsPage.openEditViewModal();
+            await modal.waitForModal();
+            await modal.delete();
+
+            await expect(page).toHaveURL(/\/ghost\/#\/posts\/?$/);
+            await expect(sidebar.getNavLink('Posts')).toHaveAttribute('aria-current', 'page');
+        });
+
+        test('deleting one of multiple views - others remain unchanged', async ({page}) => {
+            await tagFactory.create({name: 'One'});
+            await tagFactory.create({name: 'Two'});
+            await tagFactory.create({name: 'Three'});
+            const postsPage = new PostsPage(page);
+            const sidebar = new SidebarPage(page);
+            const modal = new CustomViewModal(page);
+
+            await postsPage.goto();
+            await postsPage.selectType('Draft posts');
+            await postsPage.selectTag('One');
+
+            await postsPage.openSaveViewModal();
+            await modal.waitForModal();
+            await modal.enterName('View 1');
+            await modal.save();
+
+            await sidebar.getNavLink('Posts').click();
+            await postsPage.selectType('Scheduled posts');
+            await postsPage.selectTag('Two');
+
+            await postsPage.openSaveViewModal();
+            await modal.waitForModal();
+            await modal.enterName('View 2');
+            await modal.save();
+
+            await sidebar.getNavLink('Posts').click();
+            await postsPage.selectType('Published posts');
+            await postsPage.selectTag('Three');
+
+            await postsPage.openSaveViewModal();
+            await modal.waitForModal();
+            await modal.enterName('View 3');
+            await modal.save();
+
+            await sidebar.getNavLink('View 2').click();
+
+            await postsPage.openEditViewModal();
+            await modal.waitForModal();
+            await modal.delete();
+
+            await expect(sidebar.getNavLink('View 1')).toBeVisible();
+            await expect(sidebar.getNavLink('View 2')).toBeHidden();
+            await expect(sidebar.getNavLink('View 3')).toBeVisible();
+        });
+    });
+
+    test.describe('filter modifications', () => {
+        test('modifying filters then clicking view again - resets to saved filters', async ({page}) => {
+            await tagFactory.create({name: 'Reset'});
+            const postsPage = new PostsPage(page);
+            const sidebar = new SidebarPage(page);
+            const modal = new CustomViewModal(page);
+
+            await postsPage.goto();
+            await postsPage.selectType('Draft posts');
+            await postsPage.selectTag('Reset');
+
+            await postsPage.openSaveViewModal();
+            await modal.waitForModal();
+            await modal.enterName('Reset Test');
+            await modal.save();
+
+            await postsPage.selectType('Published posts');
+
+            await expect(page).toHaveURL(/type=published/);
+
+            await sidebar.getNavLink('Reset Test').click();
+
+            await expect(page).toHaveURL(/type=draft/);
+            await expect(page).not.toHaveURL(/type=published/);
+        });
+
+        test('changing filters to match different view - switches active state', async ({page}) => {
+            await tagFactory.create({name: 'ViewA'});
+            await tagFactory.create({name: 'ViewB'});
+            const postsPage = new PostsPage(page);
+            const sidebar = new SidebarPage(page);
+            const modal = new CustomViewModal(page);
+
+            await postsPage.goto();
+            await postsPage.selectType('Draft posts');
+            await postsPage.selectTag('ViewA');
+
+            await postsPage.openSaveViewModal();
+            await modal.waitForModal();
+            await modal.enterName('View A');
+            await modal.save();
+
+            await sidebar.getNavLink('Posts').click();
+            await sidebar.getNavLink('Posts').click();
+            await postsPage.selectType('Published posts');
+            await postsPage.selectTag('ViewB');
+
+            await postsPage.openSaveViewModal();
+            await modal.waitForModal();
+            await modal.enterName('View B');
+            await modal.save();
+
+            await sidebar.getNavLink('View A').click();
+
+            await expect(sidebar.getNavLink('View A')).toHaveAttribute('aria-current', 'page');
+
+            await postsPage.selectType('Published posts');
+            await postsPage.selectTag('ViewB');
+
+            await expect(sidebar.getNavLink('View B')).toHaveAttribute('aria-current', 'page');
+            await expect(sidebar.getNavLink('View A')).not.toHaveAttribute('aria-current', 'page');
+        });
+    });
+
+    test.describe('persistence', () => {
+        test('custom views persist after page reload', async ({page}) => {
+            await tagFactory.create({name: 'Persist'});
+            const postsPage = new PostsPage(page);
+            const sidebar = new SidebarPage(page);
+            const modal = new CustomViewModal(page);
+
+            await postsPage.goto();
+            await postsPage.selectType('Scheduled posts');
+            await postsPage.selectTag('Persist');
+
+            await postsPage.openSaveViewModal();
+            await modal.waitForModal();
+            await modal.enterName('Persist Test');
+            await modal.save();
+
+            await page.reload();
+
+            await expect(sidebar.getNavLink('Persist Test')).toBeVisible();
+        });
+
+        test('custom view filters persist after page reload', async ({page}) => {
+            const tag = await tagFactory.create({name: 'FilterPersist'});
+            const postsPage = new PostsPage(page);
+            const sidebar = new SidebarPage(page);
+            const modal = new CustomViewModal(page);
+
+            await postsPage.goto();
+            await postsPage.selectType('Published posts');
+            await postsPage.selectTag('FilterPersist');
+
+            await postsPage.openSaveViewModal();
+            await modal.waitForModal();
+            await modal.enterName('Filter Persist');
+            await modal.save();
+
+            await page.reload();
+
+            await expect(page).toHaveURL(/type=published/);
+            await expect(page).toHaveURL(new RegExp(`tag=${tag.slug}`));
+            await expect(sidebar.getNavLink('Filter Persist')).toHaveAttribute('aria-current', 'page');
+        });
+    });
+});

--- a/e2e/tests/admin/sidebar/navigation.test.ts
+++ b/e2e/tests/admin/sidebar/navigation.test.ts
@@ -1,0 +1,152 @@
+import {SidebarPage} from '@/admin-pages';
+import {expect, test} from '@/helpers/playwright/fixture';
+
+type UserRole = 'Administrator' | 'Editor' | 'Author' | 'Contributor';
+
+interface NavItem {
+    name: string;
+    path: RegExp;
+    roles: UserRole[];
+}
+
+const NAV_ITEMS: NavItem[] = [
+    {name: 'Analytics', path: /\/ghost\/#\/analytics\/?$/, roles: ['Administrator']},
+    {name: 'View site', path: /\/ghost\/#\/site\/?$/, roles: ['Administrator', 'Editor']},
+    {name: 'Posts', path: /\/ghost\/#\/posts\/?$/, roles: ['Administrator', 'Editor', 'Author', 'Contributor']},
+    {name: 'Pages', path: /\/ghost\/#\/pages\/?$/, roles: ['Administrator', 'Editor']},
+    {name: 'Tags', path: /\/ghost\/#\/tags\/?$/, roles: ['Administrator', 'Editor']},
+    {name: 'Members', path: /\/ghost\/#\/members\/?$/, roles: ['Administrator', 'Editor']}
+];
+
+test.describe('Ghost Admin - Sidebar Navigation', () => {
+    test.describe('main navigation', () => {
+        NAV_ITEMS.forEach(({name, path}) => {
+            test(`clicking ${name} - navigates and shows active state`, async ({page}) => {
+                const sidebar = new SidebarPage(page);
+
+                await sidebar.goto('/ghost');
+
+                await sidebar.getNavLink(name).click();
+
+                await expect(page).toHaveURL(path);
+                await expect(sidebar.getNavLink(name)).toHaveAttribute('aria-current', 'page');
+            });
+        });
+    });
+
+    test.describe('posts submenu', () => {
+        test('default views are visible when posts submenu is expanded', async ({page}) => {
+            const sidebar = new SidebarPage(page);
+
+            await sidebar.goto('/ghost/#/posts');
+            await sidebar.expandPostsSubmenu();
+
+            await expect(sidebar.getNavLink('Drafts')).toBeVisible();
+            await expect(sidebar.getNavLink('Scheduled')).toBeVisible();
+            await expect(sidebar.getNavLink('Published')).toBeVisible();
+        });
+
+        test('clicking submenu item - navigates and shows active state', async ({page}) => {
+            const sidebar = new SidebarPage(page);
+
+            await sidebar.goto('/ghost/#/posts');
+            await sidebar.expandPostsSubmenu();
+
+            await sidebar.getNavLink('Scheduled').click();
+
+            await expect(page).toHaveURL(/type=scheduled/);
+            await expect(sidebar.getNavLink('Scheduled')).toHaveAttribute('aria-current', 'page');
+        });
+
+        test('clicking submenu item - parent is expanded but not active', async ({page}) => {
+            const sidebar = new SidebarPage(page);
+
+            await sidebar.goto('/ghost/#/posts');
+            await sidebar.expandPostsSubmenu();
+
+            await sidebar.getNavLink('Scheduled').click();
+
+            await expect(sidebar.postsToggle).toHaveAttribute('aria-expanded', 'true');
+            await expect(sidebar.getNavLink('Posts')).not.toHaveAttribute('aria-current', 'page');
+        });
+
+        test('clicking parent Posts link - deactivates submenu item', async ({page}) => {
+            const sidebar = new SidebarPage(page);
+
+            await sidebar.goto('/ghost/#/posts?type=scheduled');
+            await sidebar.expandPostsSubmenu();
+
+            await expect(sidebar.getNavLink('Scheduled')).toHaveAttribute('aria-current', 'page');
+
+            await sidebar.getNavLink('Posts').click();
+
+            await expect(page).toHaveURL(/\/ghost\/#\/posts\/?$/);
+            await expect(sidebar.getNavLink('Scheduled')).not.toHaveAttribute('aria-current', 'page');
+            await expect(sidebar.getNavLink('Posts')).toHaveAttribute('aria-current', 'page');
+        });
+    });
+
+    test.describe('sidebar footer', () => {
+        test('Settings link - is visible and navigates', async ({page}) => {
+            const sidebar = new SidebarPage(page);
+
+            await sidebar.goto('/ghost/#/posts');
+
+            await expect(sidebar.getNavLink('Settings')).toBeVisible();
+
+            await sidebar.getNavLink('Settings').click();
+
+            await expect(page).toHaveURL(/\/ghost\/#\/settings/);
+        });
+
+        test('user dropdown - opens and shows menu items', async ({page}) => {
+            const sidebar = new SidebarPage(page);
+
+            await sidebar.goto('/ghost');
+
+            await expect(sidebar.userDropdownTrigger).toBeVisible();
+
+            await sidebar.userDropdownTrigger.click();
+
+            await expect(sidebar.userProfileLink).toBeVisible();
+            await expect(sidebar.signOutLink).toBeVisible();
+        });
+
+        test('user profile link - navigates to profile settings', async ({page}) => {
+            const sidebar = new SidebarPage(page);
+
+            await sidebar.goto('/ghost');
+            await sidebar.userDropdownTrigger.click();
+
+            await sidebar.userProfileLink.click();
+
+            await expect(page).toHaveURL(/\/ghost\/#\/settings\/staff\//);
+        });
+
+        test('night shift toggle - changes state on click', async ({page}) => {
+            const sidebar = new SidebarPage(page);
+
+            await sidebar.goto('/ghost');
+            await sidebar.userDropdownTrigger.click();
+
+            const initialState = await sidebar.isNightShiftEnabled();
+
+            await sidebar.nightShiftToggle.click();
+
+            const expectedState = !initialState;
+            await sidebar.waitForNightShiftEnabled(expectedState);
+
+            const newState = await sidebar.isNightShiftEnabled();
+            expect(newState).toBe(expectedState);
+        });
+
+        test('sign out link - is visible in dropdown', async ({page}) => {
+            const sidebar = new SidebarPage(page);
+
+            await sidebar.goto('/ghost');
+            await sidebar.userDropdownTrigger.click();
+
+            await expect(sidebar.signOutLink).toBeVisible();
+        });
+    });
+});

--- a/e2e/tests/admin/tags/editor.test.ts
+++ b/e2e/tests/admin/tags/editor.test.ts
@@ -1,4 +1,4 @@
-import {NewTagsPage, TagEditorPage, TagsPage} from '@/admin-pages';
+import {NewTagsPage, SidebarPage, TagEditorPage, TagsPage} from '@/admin-pages';
 import {expect, test} from '@/helpers/playwright';
 
 test.describe('Ghost Admin - Tags Editor', () => {
@@ -116,20 +116,21 @@ test.describe('Ghost Admin - Tags Editor', () => {
 
     test('maintains active state in nav menu when creating a new tag', async ({page}) => {
         const newTagsPage = new NewTagsPage(page);
+        const sidebar = new SidebarPage(page);
         await newTagsPage.goto();
 
         await expect(page).toHaveURL(newTagsPage.pageUrl);
-        await expect(newTagsPage.navMenuItem).toHaveClass(/active/);
+        await expect(sidebar.getNavLink('Tags')).toHaveAttribute('aria-current', 'page');
     });
 
     test('maintains active state in nav menu when editing a tag', async ({page}) => {
         const tagsPage = new TagsPage(page);
+        const sidebar = new SidebarPage(page);
 
         await tagsPage.goto();
         await tagsPage.getTagLinkByName('News').click();
 
-        const tagEditor = new TagEditorPage(page);
-        await expect(tagEditor.navMenuItem).toHaveClass(/active/);
+        await expect(sidebar.getNavLink('Tags')).toHaveAttribute('aria-current', 'page');
     });
 });
 

--- a/ghost/admin/.lint-todo
+++ b/ghost/admin/.lint-todo
@@ -189,3 +189,11 @@ remove|ember-template-lint|no-unknown-arguments-for-builtin-components|76|32|76|
 remove|ember-template-lint|no-action|6|108|6|108|ccc38f66549f9baedaa3b9943ae6634ea8f99e69|1746489600000|||app/templates/tags.hbs
 remove|ember-template-lint|no-action|7|110|7|110|c3819ce2b6989e8596be570ed0c9fb82b5012521|1746489600000|||app/templates/tags.hbs
 remove|ember-template-lint|require-valid-alt-text|4|12|4|12|8369d1b06deac93e8c8e05444670c15182aea434|1746489600000|||app/templates/application-error.hbs
+remove|ember-template-lint|no-unknown-arguments-for-builtin-components|45|104|45|104|156670ca427c49c51f0a94f862b286ccc9466d92|1746489600000|||app/components/gh-nav-menu/footer.hbs
+remove|ember-template-lint|no-unknown-arguments-for-builtin-components|65|131|65|131|156670ca427c49c51f0a94f862b286ccc9466d92|1746489600000|||app/components/gh-nav-menu/footer.hbs
+remove|ember-template-lint|no-unknown-arguments-for-builtin-components|100|93|100|93|156670ca427c49c51f0a94f862b286ccc9466d92|1746489600000|||app/components/gh-nav-menu/footer.hbs
+add|ember-template-lint|no-invalid-interactive|48|30|48|30|a7f41579b917cf51e3a82ca4726d7f03fcfb0bc3|1764028800000|||app/components/gh-nav-menu/main.hbs
+remove|ember-template-lint|no-invalid-interactive|42|30|42|30|ffabb36d3b9e207aba8ff78ac29b648f2b314bb2|1749427200000|||app/components/gh-nav-menu/main.hbs
+remove|ember-template-lint|no-unknown-arguments-for-builtin-components|49|28|49|28|571c3d774ed33480f528b54b323b23bfd7148eee|1746489600000|||app/components/gh-nav-menu/main.hbs
+remove|ember-template-lint|no-invalid-interactive|48|30|48|30|a7f41579b917cf51e3a82ca4726d7f03fcfb0bc3|1764028800000|||app/components/gh-nav-menu/main.hbs
+add|ember-template-lint|no-invalid-interactive|48|30|48|30|c67992c562a02caa8f4e94ad244fcab0dd998888|1764115200000|||app/components/gh-nav-menu/main.hbs

--- a/ghost/admin/app/components/gh-nav-menu/footer.hbs
+++ b/ghost/admin/app/components/gh-nav-menu/footer.hbs
@@ -110,7 +110,7 @@
                 <LinkTo class="gh-nav-bottom-tabicon" @route="settings-x" data-test-nav="settings">{{svg-jar "settings" title="Settings (CTRL/⌘ + ,)"}}</LinkTo>
             {{/if}}
             <div class="nightshift-toggle-container">
-                <div class="nightshift-toggle {{if this.feature.nightShift "on"}}" {{on "click" this.toggleNightShift}} role="button">
+                <div class="nightshift-toggle {{if this.feature.nightShift "on"}}" {{on "click" this.toggleNightShift}} role="button" aria-label="Dark mode">
                     <div class="sun">{{svg-jar "sun"}}</div>
                     <div class="moon">{{svg-jar "moon"}}</div>
                     <div class="thumb"></div>

--- a/ghost/admin/app/components/gh-nav-menu/footer.hbs
+++ b/ghost/admin/app/components/gh-nav-menu/footer.hbs
@@ -41,8 +41,8 @@
                         <li class="divider" role="separator"></li>
 
                         {{#if this.session.user.isContributor}}
-                            <li>
-                                <LinkTo @route="posts" @query={{hash entry=null}} class="dropdown-item" @role="menuitem" tabindex="-1" data-test-nav="posts">
+                            <li role="none">
+                                <LinkTo @route="posts" @query={{hash entry=null}} class="dropdown-item" role="menuitem" tabindex="-1" data-test-nav="posts">
                                     Posts
                                 </LinkTo>
                             </li>
@@ -61,8 +61,8 @@
                             </li>
                         {{/if}}
 
-                        <li>
-                            <LinkTo @route="settings-x.settings-x" @model="staff/{{this.session.user.slug}}" class="dropdown-item" @role="menuitem" tabindex="-1" data-test-nav="user-profile">
+                        <li role="none">
+                            <LinkTo @route="settings-x.settings-x" @model="staff/{{this.session.user.slug}}" class="dropdown-item" role="menuitem" tabindex="-1" data-test-nav="user-profile">
                                 Your profile
                             </LinkTo>
                         </li>
@@ -96,8 +96,8 @@
                         <li class="divider" role="separator"></li>
                         {{/unless}}
 
-                        <li>
-                            <LinkTo @route="signout" class="dropdown-item user-menu-signout" @role="menuitem" tabindex="-1">
+                        <li role="none">
+                            <LinkTo @route="signout" class="dropdown-item user-menu-signout" role="menuitem" tabindex="-1">
                                 Sign out
                             </LinkTo>
                         </li>
@@ -107,7 +107,7 @@
         </div>
         <div class="flex items-center pe-all">
             {{#if (or (gh-user-can-admin this.session.user) this.session.user.isEitherEditor)}}
-                <LinkTo class="gh-nav-bottom-tabicon" @route="settings-x" @current-when={{this.isSettingsRoute}} data-test-nav="settings">{{svg-jar "settings" title="Settings (CTRL/⌘ + ,)"}}</LinkTo>
+                <LinkTo class="gh-nav-bottom-tabicon" @route="settings-x" data-test-nav="settings">{{svg-jar "settings" title="Settings (CTRL/⌘ + ,)"}}</LinkTo>
             {{/if}}
             <div class="nightshift-toggle-container">
                 <div class="nightshift-toggle {{if this.feature.nightShift "on"}}" {{on "click" this.toggleNightShift}} role="button">

--- a/ghost/admin/app/components/gh-nav-menu/footer.js
+++ b/ghost/admin/app/components/gh-nav-menu/footer.js
@@ -4,7 +4,7 @@ import WhatsNew from '../modals/whats-new';
 import calculatePosition from 'ember-basic-dropdown/utils/calculate-position';
 import classic from 'ember-classic-decorator';
 import {action} from '@ember/object';
-import {and, match} from '@ember/object/computed';
+import {and} from '@ember/object/computed';
 import {inject} from 'ghost-admin/decorators/inject';
 import {inject as service} from '@ember/service';
 
@@ -21,9 +21,6 @@ export default class Footer extends Component {
 
     @and('config.clientExtensions.dropdown', 'session.user.isOwnerOnly')
         showDropdownExtension;
-
-    @match('router.currentRouteName', /^settings/)
-        isSettingsRoute;
 
     @action
     openThemeErrors() {

--- a/ghost/admin/app/components/gh-nav-menu/main.hbs
+++ b/ghost/admin/app/components/gh-nav-menu/main.hbs
@@ -35,7 +35,7 @@
                     {{/if}}
                     {{#if (and this.settings.socialWebEnabled this.session.user.isAdmin)}}
                         <li class="relative gh-nav-list-ap">
-                            <LinkTo @route="activitypub-x" @current-when="activitypub-x">{{svg-jar "ap-network"}}Network
+                            <LinkTo @route="activitypub-x">{{svg-jar "ap-network"}}Network
                                 {{#unless this.notificationsCount.isLoading}}
                                     {{#if (gt this.notificationsCount.count 0)}}
                                         <span class="gh-nav-member-count">{{format-number this.notificationsCount.count}}</span>
@@ -46,13 +46,12 @@
                     {{/if}}
                     <li class="relative">
                         <span {{action "transitionToOrRefreshSite" on="click" }} class="{{if this.isOnSite "active"}}">
-                            <LinkTo @route="site" data-test-nav="site" @current-when={{this.isOnSite}}
-                                @preventDefault={{false}}>
+                            <LinkTo @route="site" data-test-nav="site">
                                 {{svg-jar "view-site"}} View site
                             </LinkTo>
                         </span>
                         <a href="{{this.config.blogUrl}}/" class="gh-secondary-action" title="Open site in new tab"
-                            target="_blank" rel="noopener noreferrer">
+                            target="_blank" rel="noopener noreferrer" aria-label="View site in new tab">
                             <span>{{svg-jar "external"}}</span>
                         </a>
                     </li>
@@ -61,7 +60,7 @@
             <ul class="gh-nav-list gh-nav-manage">
                 <li class="gh-nav-list-new gh-nav-list-posts relative">
                     <GhLinkToCustomViewsIndex @route="posts" @query={{reset-query-params "posts" }}
-                        data-test-nav="posts">{{svg-jar "posts" class="gh-nav-posts-icon"}}Posts</GhLinkToCustomViewsIndex>
+                        data-test-nav="posts" aria-current={{unless this.customViews.activeView "page"}}>{{svg-jar "posts" class="gh-nav-posts-icon"}}Posts</GhLinkToCustomViewsIndex>
                     <LinkTo @route="lexical-editor.new" @model="post" class="gh-secondary-action gh-nav-new-post"
                         @alt="New post" title="New post" data-test-nav="new-story"><span>{{svg-jar "plus"}}</span>
                     </LinkTo>
@@ -71,9 +70,11 @@
                         {{#each this.customViews.forPosts as |view|}}
                         <li>
                             <LinkTo @route="posts" @query={{reset-query-params "posts" view.filter}}
-                                data-test-nav-custom="{{view.route}}-{{view.name}}" title="{{view.name}}">
+                                data-test-nav-custom="{{view.route}}-{{view.name}}" title="{{view.name}}"
+                                @activeClass="active"
+                                aria-current={{if (and this.customViews.activeView (eq view.name this.customViews.activeView.name)) "page"}}>
                                 <span class="gh-nav-viewname">{{view.name}}</span>
-                                <span class="flex items-center svg-{{view.color}}">
+                                <span class="flex items-center svg-{{view.color}}" data-color="{{view.color}}" aria-hidden="true">
                                     {{#unless view.icon}}
                                     <span class="absolute circle"></span>
                                     {{/unless}}
@@ -87,8 +88,8 @@
                     {{#if this.customViews.forPosts}}
                     <button type="button" class="gh-nav-button-expand {{if this.navigation.settings.expanded.posts "
                         expanded"}}" {{on "click" (fn this.navigation.toggleExpansion "posts" )}}
-                        aria-label="{{if this.navigation.settings.expanded.posts " Collapse custom post
-                        types" "Expand custom post types" }}">
+                        aria-label="Toggle post views"
+                        aria-expanded="{{if this.navigation.settings.expanded.posts "true" "false"}}">
                         {{svg-jar (if this.navigation.settings.expanded.posts "arrow-down-stroke"
                         "arrow-right-stroke")}}
                     </button>
@@ -97,9 +98,11 @@
                         {{#each this.customViews.forPosts as |view|}}
                         <li>
                             <LinkTo @route="posts" @query={{reset-query-params "posts" view.filter}}
-                                data-test-nav-custom="{{view.route}}-{{view.name}}" title="{{view.name}}">
+                                data-test-nav-custom="{{view.route}}-{{view.name}}" title="{{view.name}}"
+                                @activeClass="active"
+                                aria-current={{if (and this.customViews.activeView (eq view.name this.customViews.activeView.name)) "page"}}>
                                 <span class="gh-nav-viewname">{{view.name}}</span>
-                                <span class="flex items-center svg-{{view.color}}">
+                                <span class="flex items-center svg-{{view.color}}" data-color="{{view.color}}" aria-hidden="true">
                                     {{#unless view.icon}}
                                     <span class="absolute circle"></span>
                                     {{/unless}}
@@ -114,24 +117,17 @@
                 </li>
                 <li>
                     {{!-- clicking the Content link whilst on the content screen should reset the filter --}}
-                    {{#if (eq this.router.currentRouteName "pages")}}
-                    <LinkTo @route="pages" @query={{reset-query-params "pages" }} class="active" data-test-nav="pages">
-                        {{svg-jar "page"}}Pages</LinkTo>
-                    {{else}}
-                    <LinkTo @route="pages" data-test-nav="pages">{{svg-jar "page"}}Pages</LinkTo>
-                    {{/if}}
+                    <LinkTo @route="pages" @query={{if (eq this.router.currentRouteName "pages") (reset-query-params "pages")}} data-test-nav="pages">{{svg-jar "page"}}Pages</LinkTo>
                 </li>
                 {{#if this.showTagsNavigation}}
                 <li>
-                    <LinkTo @route="tags" @current-when="tags tag tag.new" data-test-nav="tags">{{svg-jar "tag"}}Tags
-                    </LinkTo>
+                    <LinkTo @route="tags" @current-when="tags tag tag.new" data-test-nav="tags">{{svg-jar "tag"}}Tags</LinkTo>
                 </li>
                 {{/if}}
                 {{#if (gh-user-can-manage-members this.session.user)}}
                 <li class="relative">
-                    {{#if (eq this.router.currentRouteName "members.index")}}
                     <LinkTo @route="members" @current-when="members member member.new"
-                        @query={{reset-query-params "members.index" }} data-test-nav="members">{{svg-jar
+                        @query={{if (eq this.router.currentRouteName "members.index") (reset-query-params "members.index")}} data-test-nav="members">{{svg-jar
                         "members"}}Members
                         {{#let (members-count-fetcher) as |count|}}
                         {{#unless count.isLoading}}
@@ -139,18 +135,7 @@
                         {{/unless}}
                         {{/let}}
                     </LinkTo>
-                    {{else}}
-                    <LinkTo @route="members" @current-when="members member member.new" data-test-nav="members">{{svg-jar
-                        "members"}}Members
-                        {{#let (members-count-fetcher) as |count|}}
-                        {{#unless count.isLoading}}
-                        <span class="gh-nav-member-count">{{format-number count.count}}</span>
-                        {{/unless}}
-                        {{/let}}
-                    </LinkTo>
-                    {{/if}}
                 </li>
-
                 {{/if}}
             </ul>
 

--- a/ghost/admin/app/components/gh-nav-menu/main.js
+++ b/ghost/admin/app/components/gh-nav-menu/main.js
@@ -4,7 +4,7 @@ import ShortcutsMixin from 'ghost-admin/mixins/shortcuts';
 import classic from 'ember-classic-decorator';
 import ctrlOrCmd from 'ghost-admin/utils/ctrl-or-cmd';
 import {action} from '@ember/object';
-import {and, equal, match, or, reads} from '@ember/object/computed';
+import {and, equal, or, reads} from '@ember/object/computed';
 import {getOwner} from '@ember/application';
 import {htmlSafe} from '@ember/template';
 import {inject} from 'ghost-admin/decorators/inject';
@@ -35,9 +35,6 @@ export default class Main extends Component.extend(ShortcutsMixin) {
     iconClass = '';
     shortcuts = null;
     previousRoute = null;
-
-    @match('router.currentRouteName', /^settings\.integration/)
-        isIntegrationRoute;
 
     // HACK: {{link-to}} should be doing this automatically but there appears to
     // be a bug in Ember that's preventing it from working immediately after login

--- a/ghost/admin/app/components/gh-nav-menu/main.js
+++ b/ghost/admin/app/components/gh-nav-menu/main.js
@@ -1,8 +1,6 @@
 import Component from '@ember/component';
 import SearchModal from '../modals/search';
-import ShortcutsMixin from 'ghost-admin/mixins/shortcuts';
 import classic from 'ember-classic-decorator';
-import ctrlOrCmd from 'ghost-admin/utils/ctrl-or-cmd';
 import {action} from '@ember/object';
 import {and, equal, or, reads} from '@ember/object/computed';
 import {getOwner} from '@ember/application';
@@ -13,7 +11,7 @@ import {tagName} from '@ember-decorators/component';
 
 @classic
 @tagName('')
-export default class Main extends Component.extend(ShortcutsMixin) {
+export default class Main extends Component {
     @service billing;
     @service customViews;
     @service feature;
@@ -33,7 +31,6 @@ export default class Main extends Component.extend(ShortcutsMixin) {
 
     iconStyle = '';
     iconClass = '';
-    shortcuts = null;
     previousRoute = null;
 
     // HACK: {{link-to}} should be doing this automatically but there appears to
@@ -52,12 +49,6 @@ export default class Main extends Component.extend(ShortcutsMixin) {
 
     init() {
         super.init(...arguments);
-
-        let shortcuts = {};
-
-        shortcuts[`${ctrlOrCmd}+k`] = {action: 'openSearchModal'};
-        shortcuts[`${ctrlOrCmd}+,`] = {action: 'openSettings'};
-        this.shortcuts = shortcuts;
 
         // Set initial previous route
         this.previousRoute = this.router.currentRouteName;
@@ -91,13 +82,7 @@ export default class Main extends Component.extend(ShortcutsMixin) {
         this._setIconStyle();
     }
 
-    didInsertElement() {
-        super.didInsertElement(...arguments);
-        this.registerShortcuts();
-    }
-
     willDestroyElement() {
-        this.removeShortcuts();
         super.willDestroyElement(...arguments);
         if (this._routeChangeHandler) {
             this.router.off('routeDidChange', this._routeChangeHandler);
@@ -121,11 +106,6 @@ export default class Main extends Component.extend(ShortcutsMixin) {
     @action
     openSearchModal() {
         return this.modals.open(SearchModal);
-    }
-
-    @action
-    openSettings() {
-        this.router.transitionTo('settings-x');
     }
 
     @action

--- a/ghost/admin/app/components/modals/custom-view-form.hbs
+++ b/ghost/admin/app/components/modals/custom-view-form.hbs
@@ -1,9 +1,9 @@
-<div class="modal-content">
-    <header class="modal-header" data-test-modal="custom-view-form">
-        <h1>{{if @data.customView.isNew "New view" "Edit view"}}</h1>
+<div class="modal-content" role="dialog" aria-modal="true" aria-labelledby="custom-view-modal-title" data-test-modal="custom-view-form">
+    <header class="modal-header">
+        <h1 id="custom-view-modal-title">{{if @data.customView.isNew "New view" "Edit view"}}</h1>
     </header>
     {{!-- disable mouseDown so it doesn't trigger focus-out validations --}}
-    <button class="close" href title="Close" type="button" {{on "click" @close}} {{on "mousedown" (optional this.noop)}}>
+    <button class="close" href aria-label="Close" type="button" {{on "click" @close}} {{on "mousedown" (optional this.noop)}}>
         {{svg-jar "close"}}
     </button>
 
@@ -28,8 +28,8 @@
             </GhFormGroup>
         </fieldset>
         <div>
-            <label for="view-name" class="dib fw6">Icon color</label>
-            <div class="flex justify-between mt3 nl1">
+            <span id="icon-color-label" class="dib fw6">Icon color</span>
+            <div class="flex justify-between mt3 nl1" role="radiogroup" aria-labelledby="icon-color-label">
                 {{#each this.customViews.availableColors as |color|}}
                     <div class="gh-radio-color">
                         <input
@@ -40,7 +40,7 @@
                             value={{color}}
                             {{on "change" this.changeColor}}
                         >
-                        <label for="view-{{color}}"><span class="gh-radio-color-{{color}}"></span></label>
+                        <label for="view-{{color}}" aria-label={{color}}><span class="gh-radio-color-{{color}}"></span></label>
                     </div>
                 {{/each}}
             </div>

--- a/ghost/admin/app/components/posts-list/content-filter.hbs
+++ b/ghost/admin/app/components/posts-list/content-filter.hbs
@@ -10,6 +10,7 @@
             @triggerClass="gh-contentfilter-menu-trigger"
             @dropdownClass="gh-contentfilter-menu-dropdown"
             @matchTriggerWidth={{false}}
+            aria-label="Type filter"
             as |type|
         >
             {{#if type.name}}{{type.name}}{{else}}<span class="red">Unknown type</span>{{/if}}
@@ -27,6 +28,7 @@
                 @triggerClass="gh-contentfilter-menu-trigger"
                 @dropdownClass="gh-contentfilter-menu-dropdown"
                 @matchTriggerWidth={{false}}
+                aria-label="Visibility filter"
                 as |visibility|
             >
                 {{#if visibility.name}}{{visibility.name}}{{else}}<span class="red">Unknown visibility</span>{{/if}}
@@ -46,6 +48,7 @@
                 @dropdownClass="gh-contentfilter-menu-dropdown"
                 @searchPlaceholder="Search authors"
                 @matchTriggerWidth={{false}}
+                aria-label="Author filter"
                 as |author|
             >
                 {{#if author.name}}{{author.name}}{{else}}<span class="red">Unknown author</span>{{/if}}
@@ -70,6 +73,7 @@
                 @matchTriggerWidth={{false}}
                 @optionsComponent={{component "power-select-vertical-collection-options" lastReached=this.onLastReached}}
                 @registerAPI={{this.registerTagsPowerSelect}}
+                aria-label="Tag filter"
                 as |tag|
             >
                 {{#if tag.name}}{{tag.name}}{{else}}<span class="red">Unknown tag</span>{{/if}}
@@ -87,6 +91,7 @@
             @triggerClass="gh-contentfilter-menu-trigger"
             @dropdownClass="gh-contentfilter-menu-dropdown"
             @matchTriggerWidth={{false}}
+            aria-label="Sort filter"
             as |order|
         >
             {{#if order.name}}{{order.name}}{{else}}<span class="red">Unknown</span>{{/if}}

--- a/ghost/admin/app/controllers/application.js
+++ b/ghost/admin/app/controllers/application.js
@@ -15,6 +15,7 @@ export default class ApplicationController extends Controller {
     @service ghostPaths;
     @service ajax;
     @service store;
+    @service feature;
 
     @inject config;
 
@@ -65,6 +66,10 @@ export default class ApplicationController extends Controller {
     }
 
     get showNavMenu() {
+        if (this.feature.inAdminForward) {
+            return false;
+        }
+
         let {router, session, ui} = this;
 
         // if we're in fullscreen mode don't show the nav menu
@@ -80,6 +85,18 @@ export default class ApplicationController extends Controller {
 
         return (router.currentRouteName !== 'error404' || session.isAuthenticated)
                 && !router.currentRouteName.match(/(signin|signup|setup|reset)/);
+    }
+
+    get showMobileNavMenu() {
+        if (this.feature.inAdminForward) {
+            return false;
+        }
+
+        if (!this.session.isAuthenticated || !this.session.user || this.session.user.isContributor) {
+            return false;
+        }
+
+        return true;
     }
 
     @action

--- a/ghost/admin/app/routes/application.js
+++ b/ghost/admin/app/routes/application.js
@@ -4,6 +4,7 @@ import AuthConfiguration from 'ember-simple-auth/configuration';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import Route from '@ember/routing/route';
+import SearchModal from '../components/modals/search';
 import ShortcutsRoute from 'ghost-admin/mixins/shortcuts-route';
 import ctrlOrCmd from 'ghost-admin/utils/ctrl-or-cmd';
 import windowProxy from 'ghost-admin/utils/window-proxy';
@@ -31,6 +32,8 @@ let shortcuts = {};
 
 shortcuts.esc = {action: 'closeMenus', scope: 'default'};
 shortcuts[`${ctrlOrCmd}+s`] = {action: 'save', scope: 'all'};
+shortcuts[`${ctrlOrCmd}+k`] = {action: 'openSearchModal'};
+shortcuts[`${ctrlOrCmd}+,`] = {action: 'openSettings'};
 
 // make globals available for any pulled in UMD components
 // - avoids external components needing to bundle React and running into multiple version errors
@@ -49,6 +52,7 @@ export default Route.extend(ShortcutsRoute, {
     ui: service(),
     whatsNew: service(),
     billing: service(),
+    modals: service(),
 
     shortcuts,
 
@@ -177,6 +181,14 @@ export default Route.extend(ShortcutsRoute, {
 
             // fallback to 500 error page
             return true;
+        },
+
+        openSearchModal() {
+            return this.modals.open(SearchModal);
+        },
+
+        openSettings() {
+            this.router.transitionTo('settings-x');
         }
     },
 

--- a/ghost/admin/app/templates/application.hbs
+++ b/ghost/admin/app/templates/application.hbs
@@ -50,10 +50,8 @@
 
         <GhContentCover />
 
-        {{#if this.session.user}}
-            {{#unless this.session.user.isContributor}}
-                <GhMobileNavBar />
-            {{/unless}}
+        {{#if this.showMobileNavMenu}}
+            <GhMobileNavBar />
         {{/if}}
     </div>
 

--- a/ghost/admin/app/templates/posts.hbs
+++ b/ghost/admin/app/templates/posts.hbs
@@ -2,7 +2,7 @@
     <GhCanvasHeader class="gh-canvas-header sticky break tablet post-header">
         <GhCustomViewTitle @title={{if this.session.user.isContributor (concat this.config.blogTitle " posts") "Posts"}} @query={{reset-query-params "posts"}} />
 
-        <section class="view-actions">
+        <section class="view-actions" data-testid="posts-filters">
             <PostsList::ContentFilter
                 @currentUser={{this.session.user}}
                 @selectedType={{this.selectedType}}

--- a/ghost/admin/app/utils/link-component.js
+++ b/ghost/admin/app/utils/link-component.js
@@ -2,6 +2,8 @@ import LinkComponent from '@ember/routing/link-component';
 import {computed} from '@ember/object';
 
 LinkComponent.reopen({
+    attributeBindings: ['ariaCurrent:aria-current'],
+
     active: computed('attrs.params', '_routing.currentState', function () {
         let isActive = this._super(...arguments);
 
@@ -14,5 +16,9 @@ LinkComponent.reopen({
 
     activeClass: computed('tagName', function () {
         return this.tagName === 'button' ? '' : 'active';
+    }),
+
+    ariaCurrent: computed('active', function () {
+        return this.active ? 'page' : null;
     })
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3038

## What does this do?

Adds E2E tests for the admin sidebar and updates markup to support testing with semantic selectors:

- Added E2E tests covering main navigation, posts submenu, custom views, and footer interactions
- Updated markup in both Ember and React sidebars with ARIA attributes (`aria-current`, `aria-expanded`, `aria-label`, `role="menuitem"`) to enable semantic locators
- Removed Ember sidebar when running in React shell

These have been segmented into 3 separate commits for easier reviewing if you want to review each change in isolation.

## Why?

We need stable tests during the Ember-to-React migration. Using semantic selectors based on ARIA attributes allows tests to work with both implementations regardless of markup changes.

## ❌ Known Failing Tests

The React tests for the active nav items are currently failing as the logic is implemented in https://github.com/TryGhost/Ghost/pull/25518. The React e2e tests are still currently optional and do not block merge on failure.

## ⏩ Skipped Dark Mode tests

Dark mode test was skipped because of differences in the markup between Ember and React. We need to decide if we:
1. Keep it skipped until we settle on a markup for dark mode (user menu or sidebar toggle)
2. Conditionally skip it depending on the shell
3. Have two tests, one for Ember and React, skipped conditionally depending on the shell
4. Custom code in the Sidebar page object to deal with the differences in markup