### PR TITLE
Fix visible hidden avatar text

### DIFF
--- a/ghost/admin/app/components/modal-post-history.hbs
+++ b/ghost/admin/app/components/modal-post-history.hbs
@@ -77,7 +77,7 @@
                             </div>
                             <div class="flex items-center mt2">
                                 <span class="user-list-item-figure" style={{background-image-style revision.author.profile_image_url}}>
-                                    <span class="hidden">Photo of {{revision.author.name}}</span>
+                                    <span class="sr-only">Photo of {{revision.author.name}}</span>
                                 </span>
                                 <span class="gh-post-history-version-meta {{if (eq revision.author.name "Deleted staff user") "deleted-user"}}">{{revision.author.name}}</span>
                             </div>


### PR DESCRIPTION
Got some code for us? Awesome 🎊!

Please take a minute to explain the change you're making:
- **Why are you making it?**
  To resolve a bug (DES-1251) where accessibility text, such as "Photo of Paul Davis", was unexpectedly visible in the post history avatar list. This text is intended to be hidden visually but available for screen readers.
- **What does it do?**
  It replaces the `class="hidden"` attribute with `class="sr-only"` on the `<span>` element containing the author's name within the post history modal.
- **Why is this something Ghost users or developers need?**
  This change improves the user experience by correctly hiding text meant only for screen readers, enhancing visual cleanliness and adhering to accessibility best practices. It ensures Ghost uses the appropriate and more robust pattern for visually hidden, screen-reader-accessible content.

Please check your PR against these items:

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [ ] I've written an automated test to prove my change works

We appreciate your contribution! 🙏

---
Linear Issue: [DES-1251](https://linear.app/ghost/issue/DES-1251/post-history-avatar-text-visible)

<a href="https://cursor.com/background-agent?bcId=bc-0a93699c-c256-42f8-bcd0-d2fcb142a9d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0a93699c-c256-42f8-bcd0-d2fcb142a9d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

