### PR TITLE
Updated member welcome emails job to randomize job run

### DIFF
--- a/ghost/core/core/server/services/member-welcome-emails/jobs/index.js
+++ b/ghost/core/core/server/services/member-welcome-emails/jobs/index.js
@@ -17,7 +17,13 @@ module.exports = {
 
         const configValue = config.get('memberWelcomeEmailSendInstantly');
         const testEmailSendInstantly = configValue === true || configValue === 'true';
-        const cronSchedule = testEmailSendInstantly ? '*/3 * * * * *' : '0 */5 * * * *';
+
+        // use a random seconds value to avoid spikes to the database on the minute
+        const s = Math.floor(Math.random() * 60); // 0-59
+        // run every 5 minutes, on 1,6,11..., 2,7,12..., 3,8,13..., etc
+        const m = Math.floor(Math.random() * 5); // 0-4
+
+        const cronSchedule = testEmailSendInstantly ? '*/3 * * * * *' : `${s} ${m}/5 * * * *`;
 
         jobsService.addJob({
             at: cronSchedule,


### PR DESCRIPTION
ref https://linear.app/ghost/issue/NY-801

- Randomizes when the member welcome email job runs. Still every 5 minutes, but starts on a different minute/second
- This will help avoid a "thundering herd" problem on app servers running multiple Ghost instances, and is the same pattern we use for other jobs like email analytics

-------
below we can see what it looks like when the jobs get scheduled randomly. 4th row is site A, 3rd row is site B. i happened to get the 0 minute for both on the first try lol, so i restarted each site. Then 2nd row is site A, 1st row is site B, and you can see each time they're all getting scheduled differently
<img width="300" height="116" alt="Screenshot 2025-12-02 at 4 02 12 PM" src="https://github.com/user-attachments/assets/a9fa65cf-f6b6-4be6-87ac-0e4476d2fc28" />

Then in this image we can see site A and B running every 5 minutes, but at different times: 01,06,11 and 02,07,12 minutes respectively, as expected.
<img width="300" height="204" alt="Screenshot 2025-12-02 at 4 16 29 PM" src="https://github.com/user-attachments/assets/3e48e6e3-b4d8-4c3d-8f01-f81b4d46a73e" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Randomizes the non-instant member welcome email job to run every 5 minutes at a randomized second and minute offset, retaining the instant test schedule.
> 
> - **Backend · Jobs**
>   - **Member welcome emails (`core/server/services/member-welcome-emails/jobs/index.js`)**:
>     - Replace fixed cron with randomized schedule for non-instant mode: compute `s = Math.floor(Math.random() * 60)` and `m = Math.floor(Math.random() * 5)`, then use ``${s} ${m}/5 * * * *``.
>     - Keep instant test schedule as `*/3 * * * * *`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c24661471e80a46149911d716adabf3a4ae90ffd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->