### PR TITLE
Fixed theme error banner bottom margin

### DIFF
--- a/ghost/admin/app/components/gh-nav-menu/footer.hbs
+++ b/ghost/admin/app/components/gh-nav-menu/footer.hbs
@@ -7,7 +7,7 @@
             </div>
             <div>
                 <span class="gh-sidebar-banner-subhead">Your theme has errors</span>
-                <p class="gh-sidebar-banner-msg">Some functionality on your site may be limited &rarr;</p>
+                <div class="gh-sidebar-banner-msg">Some functionality on your site may be limited &rarr;</div>
             </div>
         </button>
     </div>


### PR DESCRIPTION
ref https://linear.app/ghost/issue/DES-1250/toast-notification-spacing-bug-without-action-component

- Removed bottom margin from theme error banner message
- Prevents unnecessary white space below toast notifications