### PR TITLE
Fixed unfollow action failing in ActivityPub

### DIFF
--- a/apps/activitypub/package.json
+++ b/apps/activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/activitypub",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/activitypub/src/api/activitypub.ts
+++ b/apps/activitypub/src/api/activitypub.ts
@@ -261,7 +261,7 @@ export class ActivityPubAPI {
         }
         const response = await this.fetch(url, options);
 
-        if (response.status === 204) {
+        if (response.status === 204 || response.status === 202) {
             return null;
         }
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-2924/clicking-unfollow-on-a-profile-flashes-and-then-says-youre-still

The unfollow API returns a `202 Accepted` status with an empty response body, but the fetchJSON method was only handling `204 No Content` responses. This caused the client to attempt parsing the empty response as JSON, throwing an error and triggering the mutation error callback, which reverted the button state back to "Following".