### PR TITLE
Fixed flaky E2E tests by improving page navigation reliability

### DIFF
--- a/e2e/helpers/pages/admin/login-page.ts
+++ b/e2e/helpers/pages/admin/login-page.ts
@@ -36,9 +36,10 @@ export class LoginPage extends AdminPage {
     }
 
     async logoutByCookieClear() {
-        const context = await this.page.context();
+        const context = this.page.context();
         await context.clearCookies();
-        await this.page.reload();
+        await this.goto();
+        await this.refresh();
     }
 
     async waitForLoginPageAfterUserCreated(): Promise<void> {

--- a/e2e/helpers/pages/admin/login-page.ts
+++ b/e2e/helpers/pages/admin/login-page.ts
@@ -35,11 +35,8 @@ export class LoginPage extends AdminPage {
         await this.forgotButton.click();
     }
 
-    async logoutByCookieClear() {
-        const context = this.page.context();
-        await context.clearCookies();
-        await this.goto();
-        await this.refresh();
+    async logout() {
+        await this.page.goto('/ghost/#/signout');
     }
 
     async waitForLoginPageAfterUserCreated(): Promise<void> {

--- a/e2e/helpers/pages/admin/posts/post/post-preview-modal.ts
+++ b/e2e/helpers/pages/admin/posts/post/post-preview-modal.ts
@@ -37,7 +37,7 @@ export class PostPreviewModal {
 
     async switchToEmailTab(): Promise<void> {
         await this.emailTabButton.click();
-        await this.emailPreviewFrameBody.waitFor({state: 'attached'});
+        await this.emailPreviewFrameBody.waitFor({state: 'visible'});
     }
 
     async content(): Promise<string | null> {

--- a/e2e/tests/admin/analytics/newsletters.test.ts
+++ b/e2e/tests/admin/analytics/newsletters.test.ts
@@ -54,6 +54,7 @@ test.describe('Ghost Admin - Newsletters', () => {
         ];
         await membersService.import(members);
 
+        await newslettersPage.goto();
         await page.reload();
         await expect(newslettersPage.newslettersCard).toBeVisible();
         await expect(newslettersPage.totalSubscribers.value).toContainText('3');

--- a/e2e/tests/admin/reset-password.test.ts
+++ b/e2e/tests/admin/reset-password.test.ts
@@ -5,12 +5,11 @@ import {expect, test} from '@/helpers/playwright';
 import {extractPasswordResetLink} from '@/helpers/services/email/utils';
 
 test.describe('Ghost Admin - Reset Password', () => {
-    const emailClient:EmailClient = new MailPit();
+    const emailClient: EmailClient = new MailPit();
 
     async function logout(page: Page) {
         const loginPage = new LoginPage(page);
-        await loginPage.logoutByCookieClear();
-        await loginPage.goto();
+        await loginPage.logout();
     }
 
     test('resets account owner password', async ({page, ghostAccountOwner}) => {

--- a/e2e/tests/admin/two-factor-auth.test.ts
+++ b/e2e/tests/admin/two-factor-auth.test.ts
@@ -1,6 +1,6 @@
 import {AnalyticsOverviewPage, LoginPage, LoginVerifyPage} from '@/admin-pages';
-import {EmailClient, EmailMessage,MailPit} from '@/helpers/services/email/mail-pit';
-import {expect, test} from '@/helpers/playwright';
+import {EmailClient, EmailMessage, MailPit} from '@/helpers/services/email/mail-pit';
+import {expect, test, withIsolatedPage} from '@/helpers/playwright';
 
 test.describe('Two-Factor authentication', () => {
     const emailClient: EmailClient = new MailPit();
@@ -18,57 +18,60 @@ test.describe('Two-Factor authentication', () => {
 
     test.beforeEach(async ({page}) => {
         const loginPage = new LoginPage(page);
-        await loginPage.logoutByCookieClear();
         await loginPage.goto();
     });
 
-    test('authenticates with 2FA token', async ({page, ghostAccountOwner}) => {
-        const {email, password} = ghostAccountOwner;
-        const adminLoginPage = new LoginPage(page);
-        await adminLoginPage.goto();
-        await adminLoginPage.signIn(email, password);
+    test('authenticates with 2FA token', async ({browser, baseURL, ghostAccountOwner}) => {
+        await withIsolatedPage(browser, {baseURL}, async ({page: page}) => {
+            const {email, password} = ghostAccountOwner;
+            const adminLoginPage = new LoginPage(page);
+            await adminLoginPage.goto();
+            await adminLoginPage.signIn(email, password);
 
-        const messages = await emailClient.search({
-            subject: 'verification code',
-            to: ghostAccountOwner.email
+            const messages = await emailClient.search({
+                subject: 'verification code',
+                to: ghostAccountOwner.email
+            });
+            const code = parseCodeFromMessageSubject(messages[0]);
+
+            const verifyPage = new LoginVerifyPage(page);
+            await verifyPage.twoFactorTokenField.fill(code);
+            await verifyPage.twoFactorVerifyButton.click();
+
+            const adminAnalyticsPage = new AnalyticsOverviewPage(page);
+            await expect(adminAnalyticsPage.header).toBeVisible();
         });
-        const code = parseCodeFromMessageSubject(messages[0]);
-
-        const verifyPage = new LoginVerifyPage(page);
-        await verifyPage.twoFactorTokenField.fill(code);
-        await verifyPage.twoFactorVerifyButton.click();
-
-        const adminAnalyticsPage = new AnalyticsOverviewPage(page);
-        await expect(adminAnalyticsPage.header).toBeVisible();
     });
 
-    test('authenticates with 2FA token that was resent', async ({page, ghostAccountOwner}) => {
-        const {email, password} = ghostAccountOwner;
-        const adminLoginPage = new LoginPage(page);
-        await adminLoginPage.goto();
-        await adminLoginPage.signIn(email, password);
+    test('authenticates with 2FA token that was resent', async ({browser, baseURL,ghostAccountOwner}) => {
+        await withIsolatedPage(browser, {baseURL}, async ({page: page}) => {
+            const {email, password} = ghostAccountOwner;
+            const adminLoginPage = new LoginPage(page);
+            await adminLoginPage.goto();
+            await adminLoginPage.signIn(email, password);
 
-        let messages = await emailClient.search({
-            subject: 'verification code',
-            to: ghostAccountOwner.email
+            let messages = await emailClient.search({
+                subject: 'verification code',
+                to: ghostAccountOwner.email
+            });
+            expect(messages.length).toBe(1);
+
+            const verifyPage = new LoginVerifyPage(page);
+            await verifyPage.resendTwoFactorCodeButton.click();
+
+            messages = await emailClient.search({
+                subject: 'verification code',
+                to: ghostAccountOwner.email
+            }, {numberOfMessages: 2});
+
+            expect(messages.length).toBe(2);
+
+            const code = parseCodeFromMessageSubject(messages[0]);
+            await verifyPage.twoFactorTokenField.fill(code);
+            await verifyPage.twoFactorVerifyButton.click();
+
+            const adminAnalyticsPage = new AnalyticsOverviewPage(page);
+            await expect(adminAnalyticsPage.header).toBeVisible();
         });
-        expect(messages.length).toBe(1);
-
-        const verifyPage = new LoginVerifyPage(page);
-        await verifyPage.resendTwoFactorCodeButton.click();
-
-        messages = await emailClient.search({
-            subject: 'verification code',
-            to: ghostAccountOwner.email
-        }, {numberOfMessages: 2});
-
-        expect(messages.length).toBe(2);
-
-        const code = parseCodeFromMessageSubject(messages[0]);
-        await verifyPage.twoFactorTokenField.fill(code);
-        await verifyPage.twoFactorVerifyButton.click();
-
-        const adminAnalyticsPage = new AnalyticsOverviewPage(page);
-        await expect(adminAnalyticsPage.header).toBeVisible();
     });
 });


### PR DESCRIPTION
**what**

* Replaced page reload with visits to prevent that, especially after cookie clear
* Added explicit navigation before reload in newsletters test to ensure consistent page state
*  Replaced cookie clearing with proper signout navigation for logout
* Used isolated browser context for 2FA tests to trigger 2fa requirement without need of cookie clearing


**why**

* Test runs in CI fail randomly sometimes, with error like `net::ERR_ABORTED errors` 
* This update should improve the trust in the test suite

You can get something like this with cookie clear, if you reload pages too fast

<img width="1010" height="1176" alt="CleanShot 2025-11-26 at 16 00 54@2x" src="https://github.com/user-attachments/assets/b9cd74f8-d3b9-4b17-ac08-a86b8fe7bce7" />
