### PR TITLE
Added `--ignore-scripts` to yarn install in CI and Docker containers

### DIFF
--- a/.github/actions/restore-cache/action.yml
+++ b/.github/actions/restore-cache/action.yml
@@ -22,7 +22,7 @@ runs:
       run: |
         echo "::warning::Cache miss detected, waiting 10 seconds and retrying..."
         sleep 10
-      
+
     - name: Check dependency cache (retry)
       id: dep-cache-retry-attempt
       if: steps.dep-cache.outputs.cache-hit != 'true'
@@ -36,7 +36,7 @@ runs:
       shell: bash
       run: |
         echo "::warning::Dependency cache could not be restored after retry - installing dependencies from scratch"
-        yarn install --prefer-offline --frozen-lockfile
+        yarn install --prefer-offline --frozen-lockfile --ignore-scripts
 
     - name: Set cache miss output
       id: check-cache

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -106,7 +106,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Install dependencies
-        run: yarn install --prefer-offline --frozen-lockfile
+        run: yarn install --prefer-offline --frozen-lockfile --ignore-scripts
 
     outputs:
       dependency_cache_key: ${{ env.cachekey }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,7 +194,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Install dependencies
-        run: yarn install --prefer-offline --frozen-lockfile
+        run: yarn install --prefer-offline --frozen-lockfile --ignore-scripts
 
 
     outputs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ COPY ghost/core/package.json ghost/core/package.json
 COPY ghost/i18n/package.json ghost/i18n/package.json
 
 RUN --mount=type=cache,target=/usr/local/share/.cache/yarn,id=yarn-cache \
-    yarn install --frozen-lockfile --prefer-offline
+    yarn install --frozen-lockfile --prefer-offline --ignore-scripts
 
 # --------------------
 # Shade Builder

--- a/docker/development.entrypoint.sh
+++ b/docker/development.entrypoint.sh
@@ -14,13 +14,13 @@ set -euo pipefail
         stored_hash=$(cat "$yarn_lock_hash_file_path")
         if [ "$calculated_hash" != "$stored_hash" ]; then
             echo "INFO: yarn.lock has changed. Running yarn install..."
-            yarn install --frozen-lockfile
+            yarn install --frozen-lockfile --ignore-scripts
             mkdir -p .yarnhash
             echo "$calculated_hash" > "$yarn_lock_hash_file_path"
         fi
     else
         echo "WARNING: yarn.lock hash file ($yarn_lock_hash_file_path) not found. Running yarn install as a precaution."
-        yarn install --frozen-lockfile
+        yarn install --frozen-lockfile --ignore-scripts
         mkdir -p .yarnhash
         echo "$calculated_hash" > "$yarn_lock_hash_file_path"
     fi

--- a/docker/ghost-dev/Dockerfile
+++ b/docker/ghost-dev/Dockerfile
@@ -25,7 +25,7 @@ COPY ghost/i18n/package.json ghost/i18n/package.json
 # Install dependencies
 # Note: Dependencies are installed at build time, but source code is mounted at runtime
 RUN --mount=type=cache,target=/usr/local/share/.cache/yarn,id=yarn-cache \
-    yarn install --frozen-lockfile
+    yarn install --frozen-lockfile --ignore-scripts
 
 # Source code will be mounted from host at /home/ghost/ghost/core
 # This allows node --watch to pick up file changes for hot-reload


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PRO-1540/

- running scripts during yarn install has been a recent/recurring security issue with compromised npm packages, we want to remove avenues for that to occur
