### PR TITLE
Added `--ignore-scripts` to yarn install in CI and Docker containers

### DIFF
--- a/.github/actions/restore-cache/action.yml
+++ b/.github/actions/restore-cache/action.yml
@@ -22,7 +22,7 @@ runs:
       run: |
         echo "::warning::Cache miss detected, waiting 10 seconds and retrying..."
         sleep 10
-      
+
     - name: Check dependency cache (retry)
       id: dep-cache-retry-attempt
       if: steps.dep-cache.outputs.cache-hit != 'true'
@@ -36,7 +36,7 @@ runs:
       shell: bash
       run: |
         echo "::warning::Dependency cache could not be restored after retry - installing dependencies from scratch"
-        yarn install --prefer-offline --frozen-lockfile
+        yarn install --prefer-offline --frozen-lockfile --ignore-scripts
 
     - name: Set cache miss output
       id: check-cache

--- a/.github/actions/restore-cache/action.yml
+++ b/.github/actions/restore-cache/action.yml
@@ -36,7 +36,7 @@ runs:
       shell: bash
       run: |
         echo "::warning::Dependency cache could not be restored after retry - installing dependencies from scratch"
-        yarn install --prefer-offline --frozen-lockfile --ignore-scripts
+        bash .github/scripts/install-deps.sh
 
     - name: Set cache miss output
       id: check-cache

--- a/.github/scripts/install-deps.sh
+++ b/.github/scripts/install-deps.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -euo pipefail
+
+# Install dependencies with --ignore-scripts and selectively run sqlite3 postinstall
+# This maintains security while ensuring sqlite3 binaries are built when needed
+
+echo "Installing dependencies with --ignore-scripts..."
+yarn install --frozen-lockfile --prefer-offline --ignore-scripts
+
+# Check if sqlite3 binary already exists (from cache or previous build)
+if [ -d "node_modules/sqlite3" ]; then
+    # Check both possible binary locations:
+    # 1. build/Release/node_sqlite3.node (built by node-gyp rebuild)
+    # 2. lib/binding/*/node_sqlite3.node (downloaded by prebuild-install)
+    if [ -f "node_modules/sqlite3/build/Release/node_sqlite3.node" ]; then
+        echo "✓ sqlite3 binary found in build/Release/, skipping rebuild"
+    elif find node_modules/sqlite3/lib/binding -name "node_sqlite3.node" 2>/dev/null | grep -q .; then
+        echo "✓ sqlite3 prebuilt binary found in lib/binding/, skipping rebuild"
+    else
+        echo "Building sqlite3 native module..."
+        (cd node_modules/sqlite3 && npm run install)
+    fi
+else
+    echo "⚠ sqlite3 package not found in node_modules"
+fi

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -106,7 +106,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Install dependencies
-        run: yarn install --prefer-offline --frozen-lockfile --ignore-scripts
+        run: bash .github/scripts/install-deps.sh
 
     outputs:
       dependency_cache_key: ${{ env.cachekey }}

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -106,7 +106,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Install dependencies
-        run: yarn install --prefer-offline --frozen-lockfile
+        run: yarn install --prefer-offline --frozen-lockfile --ignore-scripts
 
     outputs:
       dependency_cache_key: ${{ env.cachekey }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,7 +194,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Install dependencies
-        run: yarn install --prefer-offline --frozen-lockfile --ignore-scripts
+        run: bash .github/scripts/install-deps.sh
 
 
     outputs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,7 +194,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Install dependencies
-        run: yarn install --prefer-offline --frozen-lockfile
+        run: yarn install --prefer-offline --frozen-lockfile --ignore-scripts
 
 
     outputs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ COPY ghost/core/package.json ghost/core/package.json
 COPY ghost/i18n/package.json ghost/i18n/package.json
 
 RUN --mount=type=cache,target=/usr/local/share/.cache/yarn,id=yarn-cache \
-    yarn install --frozen-lockfile --prefer-offline
+    yarn install --frozen-lockfile --prefer-offline --ignore-scripts
 
 # --------------------
 # Shade Builder

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,8 +58,9 @@ COPY ghost/admin/package.json ghost/admin/package.json
 COPY ghost/core/package.json ghost/core/package.json
 COPY ghost/i18n/package.json ghost/i18n/package.json
 
+COPY .github/scripts/install-deps.sh .github/scripts/install-deps.sh
 RUN --mount=type=cache,target=/usr/local/share/.cache/yarn,id=yarn-cache \
-    yarn install --frozen-lockfile --prefer-offline --ignore-scripts
+    bash .github/scripts/install-deps.sh
 
 # --------------------
 # Shade Builder

--- a/docker/development.entrypoint.sh
+++ b/docker/development.entrypoint.sh
@@ -14,13 +14,13 @@ set -euo pipefail
         stored_hash=$(cat "$yarn_lock_hash_file_path")
         if [ "$calculated_hash" != "$stored_hash" ]; then
             echo "INFO: yarn.lock has changed. Running yarn install..."
-            yarn install --frozen-lockfile
+            yarn install --frozen-lockfile --ignore-scripts
             mkdir -p .yarnhash
             echo "$calculated_hash" > "$yarn_lock_hash_file_path"
         fi
     else
         echo "WARNING: yarn.lock hash file ($yarn_lock_hash_file_path) not found. Running yarn install as a precaution."
-        yarn install --frozen-lockfile
+        yarn install --frozen-lockfile --ignore-scripts
         mkdir -p .yarnhash
         echo "$calculated_hash" > "$yarn_lock_hash_file_path"
     fi

--- a/docker/development.entrypoint.sh
+++ b/docker/development.entrypoint.sh
@@ -14,13 +14,13 @@ set -euo pipefail
         stored_hash=$(cat "$yarn_lock_hash_file_path")
         if [ "$calculated_hash" != "$stored_hash" ]; then
             echo "INFO: yarn.lock has changed. Running yarn install..."
-            yarn install --frozen-lockfile --ignore-scripts
+            bash .github/scripts/install-deps.sh
             mkdir -p .yarnhash
             echo "$calculated_hash" > "$yarn_lock_hash_file_path"
         fi
     else
         echo "WARNING: yarn.lock hash file ($yarn_lock_hash_file_path) not found. Running yarn install as a precaution."
-        yarn install --frozen-lockfile --ignore-scripts
+        bash .github/scripts/install-deps.sh
         mkdir -p .yarnhash
         echo "$calculated_hash" > "$yarn_lock_hash_file_path"
     fi

--- a/docker/ghost-dev/Dockerfile
+++ b/docker/ghost-dev/Dockerfile
@@ -24,8 +24,9 @@ COPY ghost/i18n/package.json ghost/i18n/package.json
 
 # Install dependencies
 # Note: Dependencies are installed at build time, but source code is mounted at runtime
+COPY .github/scripts/install-deps.sh .github/scripts/install-deps.sh
 RUN --mount=type=cache,target=/usr/local/share/.cache/yarn,id=yarn-cache \
-    yarn install --frozen-lockfile --ignore-scripts
+    bash .github/scripts/install-deps.sh
 
 # Source code will be mounted from host at /home/ghost/ghost/core
 # This allows node --watch to pick up file changes for hot-reload

--- a/docker/ghost-dev/Dockerfile
+++ b/docker/ghost-dev/Dockerfile
@@ -25,7 +25,7 @@ COPY ghost/i18n/package.json ghost/i18n/package.json
 # Install dependencies
 # Note: Dependencies are installed at build time, but source code is mounted at runtime
 RUN --mount=type=cache,target=/usr/local/share/.cache/yarn,id=yarn-cache \
-    yarn install --frozen-lockfile
+    yarn install --frozen-lockfile --ignore-scripts
 
 # Source code will be mounted from host at /home/ghost/ghost/core
 # This allows node --watch to pick up file changes for hot-reload


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PRO-1540/

- running scripts during yarn install has been a recent/recurring security issue with compromised npm packages, we want to remove avenues for that to occur
- adding `--ignore-scripts` to all `yarn install` commands avoids running malicious commands in compromised packages but it introduces problems with sqlite3 as it uses a postinstall script to download/build the required binaries
  - one problem with running `npm run install` in `sqlite3` manually is that we lose yarn's intelligent postinstall skip meaning we need to run our own check for binaries being present to avoid re-building on every install
  - extracted that logic to a script to avoid repeating everywhere we install dependencies within CI/Docker and replaced all `yarn install` commands with a run of our new `install-deps.sh` script