### PR TITLE
Fixed yarn dev:analytics

### DIFF
--- a/compose.dev.analytics.yaml
+++ b/compose.dev.analytics.yaml
@@ -58,13 +58,27 @@ services:
         condition: service_healthy
 
   ghost-dev:
+    volumes:
+      # Mount shared-config volume to access Tinybird tokens created by tb-cli
+      - shared-config:/mnt/shared-config:ro
     environment:
       # Analytics configuration
       analytics__url: http://analytics:3000
       analytics__enabled: "true"
+      # Tinybird configuration
+      # These static values are set here; workspaceId and adminToken are sourced from
+      # /mnt/shared-config/.env.tinybird by docker/ghost-dev/entrypoint.sh
+      TB_HOST: http://tinybird-local:7181
+      TB_LOCAL_HOST: tinybird-local
+      tinybird__stats__endpoint: http://tinybird-local:7181
+      tinybird__stats__endpointBrowser: http://localhost:7181
+      tinybird__tracker__endpoint: http://localhost:2368/.ghost/analytics/api/v1/page_hit
+      tinybird__tracker__datasource: analytics_events
     depends_on:
       analytics:
         condition: service_healthy
+      tb-cli:
+        condition: service_completed_successfully
 
 volumes:
   shared-config:

--- a/docker/dev-gateway/Caddyfile
+++ b/docker/dev-gateway/Caddyfile
@@ -33,6 +33,19 @@
         }
     }
 
+    # Analytics API - proxy analytics requests to analytics service
+    # Handles paths like /.ghost/analytics/* or /blog/.ghost/analytics/*
+    @analytics_paths path_regexp analytics_match ^(.*)/\.ghost/analytics(.*)$
+    handle @analytics_paths {
+        rewrite * {re.analytics_match.2}
+        reverse_proxy {env.ANALYTICS_PROXY_TARGET} {
+            header_up Host {host}
+            header_up X-Forwarded-Host {host}
+            header_up X-Real-IP {remote_host}
+            header_up X-Forwarded-For {remote_host}
+        }
+    }
+
     # Public app dev server assets - must come BEFORE general /ghost/* handler
     # Ghost is configured to load these from /ghost/assets/* via compose.dev.yaml
     handle /ghost/assets/* {

--- a/docker/dev-gateway/Dockerfile
+++ b/docker/dev-gateway/Dockerfile
@@ -11,7 +11,8 @@ ENV GHOST_BACKEND=ghost-dev:2368 \
     SIGNUP_DEV_SERVER=host.docker.internal:6174 \
     SEARCH_DEV_SERVER=host.docker.internal:4178 \
     ANNOUNCEMENT_DEV_SERVER=host.docker.internal:4177 \
-    LEXICAL_DEV_SERVER=host.docker.internal:4173
+    LEXICAL_DEV_SERVER=host.docker.internal:4173 \
+    ANALYTICS_PROXY_TARGET=analytics:3000
 
 COPY Caddyfile /etc/caddy/Caddyfile
 EXPOSE 80 2368

--- a/docker/ghost-dev/Dockerfile
+++ b/docker/ghost-dev/Dockerfile
@@ -28,9 +28,14 @@ COPY .github/scripts/install-deps.sh .github/scripts/install-deps.sh
 RUN --mount=type=cache,target=/usr/local/share/.cache/yarn,id=yarn-cache \
     bash .github/scripts/install-deps.sh
 
+# Copy entrypoint script that optionally loads Tinybird config
+COPY docker/ghost-dev/entrypoint.sh entrypoint.sh
+RUN chmod +x entrypoint.sh
+
 # Source code will be mounted from host at /home/ghost/ghost/core
 # This allows node --watch to pick up file changes for hot-reload
 WORKDIR /home/ghost/ghost/core
 
+ENTRYPOINT ["/home/ghost/entrypoint.sh"]
 CMD ["node", "--watch", "--import=tsx", "index.js"]
 

--- a/docker/ghost-dev/entrypoint.sh
+++ b/docker/ghost-dev/entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Configure Ghost to use Tinybird Local
+# Sources tokens from /mnt/shared-config/.env.tinybird created by tb-cli
+if [ -f /mnt/shared-config/.env.tinybird ]; then
+    source /mnt/shared-config/.env.tinybird
+    if [ -n "${TINYBIRD_WORKSPACE_ID:-}" ] && [ -n "${TINYBIRD_ADMIN_TOKEN:-}" ]; then
+        export tinybird__workspaceId="$TINYBIRD_WORKSPACE_ID"
+        export tinybird__adminToken="$TINYBIRD_ADMIN_TOKEN"
+        echo "Tinybird configuration loaded successfully"
+    else
+        echo "WARNING: Tinybird not enabled: Missing required environment variables in .env.tinybird" >&2
+    fi
+else
+    echo "WARNING: Tinybird not enabled: .env.tinybird file not found at /mnt/shared-config/.env.tinybird" >&2
+fi
+
+# Execute the CMD
+exec "$@"
+


### PR DESCRIPTION
refs https://linear.app/ghost/issue/BER-3077/improve-e2e-testing-integration

While working on improving the E2E testing integration with the new dev env I found that the Tinybird and analytics integration was incomplete. 

These changes ensure we're properly configuring the necessary environment variables when running `yarn dev:analytics`.