### PR TITLE
Improved search UX in ActivityPub

### DIFF
--- a/apps/activitypub/package.json
+++ b/apps/activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/activitypub",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/activitypub/src/components/modals/Search.tsx
+++ b/apps/activitypub/src/components/modals/Search.tsx
@@ -128,7 +128,6 @@ const Search: React.FC<SearchProps> = ({onOpenChange, query, setQuery}) => {
     const {searchQuery, updateAccountSearchResult: updateResult} = useSearchForUser('index', shouldSearch ? debouncedQuery : '');
     const {data, isFetching, isFetched} = searchQuery;
 
-
     const [displayResults, setDisplayResults] = useState<AccountSearchResult[]>([]);
 
     useEffect(() => {

--- a/apps/activitypub/src/components/modals/Search.tsx
+++ b/apps/activitypub/src/components/modals/Search.tsx
@@ -2,7 +2,7 @@ import APAvatar from '@components/global/APAvatar';
 import ActivityItem from '@components/activities/ActivityItem';
 import FollowButton from '@components/global/FollowButton';
 import ProfilePreviewHoverCard from '../global/ProfilePreviewHoverCard';
-import React, {useEffect, useRef} from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 import {ActorProperties} from '@tryghost/admin-x-framework/api/activitypub';
 import {Button, H4, Input, LoadingIndicator, LucideIcon, NoValueLabel, NoValueLabelIcon} from '@tryghost/shade';
 import {SuggestedProfiles} from '../global/SuggestedProfiles';
@@ -128,11 +128,21 @@ const Search: React.FC<SearchProps> = ({onOpenChange, query, setQuery}) => {
     const {searchQuery, updateAccountSearchResult: updateResult} = useSearchForUser('index', shouldSearch ? debouncedQuery : '');
     const {data, isFetching, isFetched} = searchQuery;
 
-    const results = data?.accounts || [];
+
+    const [displayResults, setDisplayResults] = useState<AccountSearchResult[]>([]);
+
+    useEffect(() => {
+        if (data?.accounts && data.accounts.length > 0) {
+            setDisplayResults(data.accounts);
+        } else if (!isFetching && shouldSearch) {
+            setDisplayResults([]);
+        }
+    }, [data?.accounts, isFetching, shouldSearch]);
+
     const showLoading = isFetching && shouldSearch;
-    const showNoResults = !isFetching && isFetched && results.length === 0 && shouldSearch && debouncedQuery === query;
-    const showSuggested = query.length < 2;
-    const showSearchResults = shouldSearch && results.length > 0 && !showLoading;
+    const showNoResults = !isFetching && isFetched && displayResults.length === 0 && shouldSearch && debouncedQuery === query;
+    const showSuggested = query.length < 2 || (showLoading && displayResults.length === 0);
+    const showSearchResults = shouldSearch && displayResults.length > 0;
 
     // Focus the query input on initial render
     useEffect(() => {
@@ -170,7 +180,7 @@ const Search: React.FC<SearchProps> = ({onOpenChange, query, setQuery}) => {
                 )}
                 {showSearchResults && (
                     <SearchResults
-                        results={results}
+                        results={displayResults}
                         onOpenChange={onOpenChange}
                         onUpdate={updateResult}
                     />


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3081/slice-1-the-search-result-shouldnt-be-cleared-on-keystroke

Previously, when typing search queries in the search modal, there was a jarring flash where the UI would go blank while fetching results. This happened because the results state was cleared immediately when a new search started.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Preserves last search results while fetching to avoid blank UI flicker, refines loading/empty/suggested display logic, and bumps package version.
> 
> - **Frontend (ActivityPub Search modal)**:
>   - Maintain previous results via `useState` (`displayResults`) to avoid clearing during fetch in `apps/activitypub/src/components/modals/Search.tsx`.
>   - Update effect to set/clear `displayResults` based on `data.accounts`, `isFetching`, and `shouldSearch`.
>   - Refine visibility conditions: `showNoResults`, `showSuggested` (now also true while loading with no results), `showSearchResults`.
>   - Import `useState` and pass `displayResults` to `SearchResults`.
> - **Package**:
>   - Bump `@tryghost/activitypub` version to `2.0.4` in `apps/activitypub/package.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c7a5357a9cdf341454fc5ad5134e5be664114965. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->