### PR TITLE
Fix amazon link card

### DIFF
--- a/ghost/core/core/server/services/oembed/oembed-service.js
+++ b/ghost/core/core/server/services/oembed/oembed-service.js
@@ -180,7 +180,7 @@ class OEmbedService {
                     'user-agent': USER_AGENT
                 },
                 timeout: {
-                    request: 10000
+                    request: 5000
                 },
                 followRedirect: true,
                 ...options

--- a/ghost/core/core/server/services/oembed/oembed-service.js
+++ b/ghost/core/core/server/services/oembed/oembed-service.js
@@ -294,6 +294,7 @@ class OEmbedService {
         };
 
         const metascraper = require('metascraper')([
+            require('metascraper-amazon')(),
             require('metascraper-url')(),
             require('metascraper-title')(),
             require('metascraper-description')(),

--- a/ghost/core/core/server/services/oembed/oembed-service.js
+++ b/ghost/core/core/server/services/oembed/oembed-service.js
@@ -180,7 +180,7 @@ class OEmbedService {
                     'user-agent': USER_AGENT
                 },
                 timeout: {
-                    request: 2000
+                    request: 10000
                 },
                 followRedirect: true,
                 ...options

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -201,6 +201,7 @@
     "luxon": "3.7.2",
     "mailgun.js": "10.4.0",
     "metascraper": "5.45.15",
+    "metascraper-amazon": "5.45.10",
     "metascraper-author": "5.45.10",
     "metascraper-description": "5.45.10",
     "metascraper-image": "5.45.10",

--- a/ghost/core/test/unit/server/services/oembed/oembed-service.test.js
+++ b/ghost/core/test/unit/server/services/oembed/oembed-service.test.js
@@ -104,6 +104,24 @@ describe('oembed-service', function () {
         });
     });
 
+    describe('fetchPage', function () {
+        it('requests pages with a 5 second timeout', async function () {
+            const externalRequest = sinon.stub().resolves({});
+
+            const service = new OembedService({
+                config: {get() {
+                    return true;
+                }},
+                externalRequest
+            });
+
+            await service.fetchPage('https://www.example.com', {});
+
+            const options = externalRequest.firstCall.args[1];
+            assert.equal(options.timeout.request, 5000);
+        });
+    });
+
     describe('fetchOembedData', function () {
         const pageHtml = `<html><head><link type="application/json+oembed" href="https://www.example.com/oembed"></head></html>`;
 
@@ -180,6 +198,24 @@ describe('oembed-service', function () {
             assert.equal(response.type, 'bookmark');
             assert.equal(response.url, 'https://www.example.com');
             assert.equal(response.metadata.title, 'Example');
+        });
+
+        it('extracts Amazon product metadata via the metascraper-amazon ruleset', async function () {
+            nock('https://www.amazon.com')
+                .get('/dp/B08N5WRWNW')
+                .query(true)
+                .reply(200, `<html><head><title>Amazon.com</title></head><body>
+                    <span id="productTitle">Example Product Title</span>
+                    <img class="a-dynamic-image" src="https://m.media-amazon.com/images/I/example.jpg" data-old-hires="https://m.media-amazon.com/images/I/example-hires.jpg">
+                </body></html>`);
+
+            const response = await oembedService.fetchOembedDataFromUrl('https://www.amazon.com/dp/B08N5WRWNW', 'bookmark');
+
+            assert.equal(response.version, '1.0');
+            assert.equal(response.type, 'bookmark');
+            assert.equal(response.metadata.title, 'Example Product Title');
+            assert.equal(response.metadata.publisher, 'Amazon');
+            assert.equal(response.metadata.thumbnail, 'https://m.media-amazon.com/images/I/example-hires.jpg');
         });
 
         it('should return a bookmark response when the oembed endpoint returns a link type', async function () {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2668,6 +2668,9 @@ importers:
       metascraper:
         specifier: 5.45.15
         version: 5.45.15(@noble/hashes@1.8.0)
+      metascraper-amazon:
+        specifier: 5.45.10
+        version: 5.45.10(@noble/hashes@1.8.0)
       metascraper-author:
         specifier: 5.45.10
         version: 5.45.10(@noble/hashes@1.8.0)
@@ -16844,6 +16847,10 @@ packages:
 
   merge@2.1.1:
     resolution: {integrity: sha512-jz+Cfrg9GWOZbQAnDQ4hlVnQky+341Yk5ru8bZSe6sIDTCIg8n9i/u7hSQGSVOF3C7lH6mGtqjkiT9G4wFLL0w==}
+
+  metascraper-amazon@5.45.10:
+    resolution: {integrity: sha512-dL4ZUOFWsfXlgROp9Eow8lgUAe4DkyaYOFAHQLekPMPE37cueAV+PM6fZNl2mwCd5hHlc0mjNNW3lf1Lf5KHrA==}
+    engines: {node: '>= 16'}
 
   metascraper-author@5.45.10:
     resolution: {integrity: sha512-S00rvCOqoHrM3WzTRzeIg/TP5Pi35IqtFjsmYIhiqIzTlHHHWvsV2ZBnHjPQkwyu90kADWQh3Cem2BYYk1fvDw==}
@@ -40241,6 +40248,16 @@ snapshots:
   merge2@1.4.1: {}
 
   merge@2.1.1: {}
+
+  metascraper-amazon@5.45.10(@noble/hashes@1.8.0):
+    dependencies:
+      '@metascraper/helpers': 5.50.1(@noble/hashes@1.8.0)
+    transitivePeerDependencies:
+      - '@noble/hashes'
+      - bufferutil
+      - canvas
+      - supports-color
+      - utf-8-validate
 
   metascraper-author@5.45.10(@noble/hashes@1.8.0):
     dependencies:


### PR DESCRIPTION
# Summary

This PR resolves the issue described below.

https://github.com/TryGhost/Ghost/issues/22417

As documented in the linked issue, images are not displayed in Amazon-embedded content.
This behavior also occurs in the latest version (current HEAD) of Ghost.

# Root Cause and Fix

I investigated the problem and confirmed that it can be resolved by introducing metascraper-amazon:

https://github.com/TryGhost/Ghost/issues/22417#issuecomment-2708304454

## Additional Timeout Issue

Large pages like Amazon sometimes cause fetch requests to time out at the default 2-second limit.
I described this problem in detail here, and extending the timeout resolves it:

https://github.com/TryGhost/Ghost/issues/22590#issuecomment-2742645723

--

Please check your PR against these items:

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [x] I've written an automated test to prove my change works

We appreciate your contribution! 🙏

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `metascraper-amazon` to metadata scraping and increases oEmbed page fetch timeout to 10s to improve Amazon link embeds.
> 
> - **OEmbed/Metadata fetching**:
>   - Update `core/server/services/oembed/OEmbedService.js`:
>     - Increase `fetchPage` request `timeout` from `2000` to `10000` ms.
>     - Include `metascraper-amazon` in metascraper pipeline for bookmark data extraction.
>   - Update `core/package.json`:
>     - Add dependency `metascraper-amazon@5.45.10`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit efe4c5392e803df1b20a8ea1c05677459c601a7a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->