### PR TITLE
Updated Tailwind config to include adminx-design-system

### DIFF
--- a/apps/admin/tailwind.config.js
+++ b/apps/admin/tailwind.config.js
@@ -10,5 +10,6 @@ export default {
         "../stats/src/**/*.{js,ts,jsx,tsx}",
         "../activitypub/src/**/*.{js,ts,jsx,tsx}",
         "../admin-x-settings/src/**/*.{js,ts,jsx,tsx}",
+        "../admin-x-design-system/src/**/*.{js,ts,jsx,tsx}",
     ],
 };


### PR DESCRIPTION
resolves https://linear.app/ghost/issue/BER-3085/css-conflict-affecting-settings-styles-in-local-dev

The config already included settings, but since settings in turn depend on components from the adminx-design-system, these also need to be included.