### PR TITLE
Fixed search bar opening when using Cmd+K inside editor

### DIFF
--- a/ghost/admin/app/routes/application.js
+++ b/ghost/admin/app/routes/application.js
@@ -72,14 +72,14 @@ export default Route.extend(ShortcutsRoute, {
 
     async beforeModel(transition) {
         await this.session.setup();
-        
+
         // Intercept home route when unauthenticated to prevent decorator binding issues
         // Check AFTER session setup to ensure isAuthenticated is accurate
         if (transition.to?.name === 'home' && !this.session.isAuthenticated) {
             transition.abort();
             return this.transitionTo('signin');
         }
-        
+
         return this.prepareApp();
     },
 
@@ -184,10 +184,22 @@ export default Route.extend(ShortcutsRoute, {
         },
 
         openSearchModal() {
+            // Don't open the search modal if the sidebar is hidden
+            // e.g. in the editor or settings screens
+            if (this.ui.isFullScreen) {
+                return;
+            }
+
             return this.modals.open(SearchModal);
         },
 
         openSettings() {
+            // Don't open the settings screen if the sidebar is hidden
+            // e.g. in the editor or settings screens
+            if (this.ui.isFullScreen) {
+                return;
+            }
+
             this.router.transitionTo('settings-x');
         }
     },

--- a/ghost/admin/tests/acceptance/search-test.js
+++ b/ghost/admin/tests/acceptance/search-test.js
@@ -221,6 +221,17 @@ describe('Acceptance: Search', function () {
             await closeSearchWithBackdrop();
         });
 
+        it('does not open search modal if the sidebar is hidden', async function () {
+            const post = this.server.create('post', {title: 'Test post', slug: 'test-post', status: 'draft'});
+            await visit(`/editor/post/${post.id}`);
+            assertSearchModalClosed();
+            await triggerKeyEvent(document, 'keydown', 'K', {
+                metaKey: ctrlOrCmd === 'command',
+                ctrlKey: ctrlOrCmd === 'ctrl'
+            });
+            assertSearchModalClosed();
+        });
+
         it('finds all content types when searching for "first"', async function () {
             await visit('/analytics');
             await openSearch();


### PR DESCRIPTION
closes https://linear.app/ghost/issue/BER-3078/

- we moved search and settings keyboard shortcuts from the Ember sidebar component to the application route so we still have working shortcuts inside React shell where we don't render the Ember sidebar at all
- this caused a slight change in behaviour because the shortcuts are now always active, even when Ember wouldn't have rendered the sidebar such as inside the editor, resulting in duplicate keyboard shortcuts / unexpected search bar opening
- added an early return to the shortcut handlers that uses `ui.isFullScreen` as a proxy for the sidebar not being shown and therefore the shortcuts not being active
