### PR TITLE
Added network notification badge to new admin sidebar

### DIFF
--- a/apps/activitypub/src/hooks/use-activity-pub-queries.ts
+++ b/apps/activitypub/src/hooks/use-activity-pub-queries.ts
@@ -2365,7 +2365,7 @@ export async function uploadFile(file: File) {
     return api.upload(file);
 }
 
-export function useNotificationsCountForUser(handle: string) {
+export function useNotificationsCountForUser(handle: string, enabled: boolean = true) {
     const siteUrl = useCallback(async () => await getSiteUrl(), []);
     const api = useCallback(async () => {
         const url = await siteUrl();
@@ -2374,6 +2374,7 @@ export function useNotificationsCountForUser(handle: string) {
 
     return useQuery({
         queryKey: QUERY_KEYS.notificationsCount(handle),
+        enabled,
         async queryFn() {
             const activityPubAPI = await api();
             const response = await activityPubAPI.getNotificationsCount();

--- a/apps/admin/src/layout/app-sidebar/NavMain.tsx
+++ b/apps/admin/src/layout/app-sidebar/NavMain.tsx
@@ -20,14 +20,14 @@ import { useIsActiveLink } from "./useIsActiveLink";
 function NavMain({ ...props }: React.ComponentProps<typeof SidebarGroup>) {
     const { data: currentUser } = useCurrentUser();
     const { data: settings } = useBrowseSettings();
-    const networkEnabled = getSettingValue<boolean>(settings?.settings, 'social_web_enabled');
+    const networkEnabled = getSettingValue<boolean>(settings?.settings, 'social_web_enabled') ?? false;
     const site = useBrowseSite();
     const url = site.data?.site.url;
     
     
     // The network app has its own notification state, so we don't want to show
     // multiple indicators when you have navigated there. 
-    const { data: networkNotificationCount = 0 } = useNotificationsCountForUser(currentUser?.slug || '');
+    const { data: networkNotificationCount = 0 } = useNotificationsCountForUser(currentUser?.slug || '', networkEnabled);
     const isNetworkRouteActive = useIsActiveLink({ path: 'network', activeOnSubpath: true })
     const isActivitypubRouteActive = useIsActiveLink({ path: 'activitypub', activeOnSubpath: true });
     const showNetworkBadge = networkNotificationCount > 0 && !isNetworkRouteActive && !isActivitypubRouteActive;

--- a/e2e/helpers/pages/admin/sidebar/sidebar-page.ts
+++ b/e2e/helpers/pages/admin/sidebar/sidebar-page.ts
@@ -17,6 +17,7 @@ export class SidebarPage extends AdminPage {
     public readonly whatsNewButton: Locator;
     public readonly userProfileLink: Locator;
     public readonly signOutLink: Locator;
+    public readonly networkNotificationBadge: Locator;
 
     constructor(page: Page) {
         super(page);
@@ -27,6 +28,11 @@ export class SidebarPage extends AdminPage {
         this.whatsNewButton = page.getByRole('menuitem', {name: /what's new/i});
         this.userProfileLink = page.getByRole('menuitem', {name: /your profile/i});
         this.signOutLink = page.getByRole('menuitem', {name: /sign out/i});
+
+        // TODO: Remove .first() and .gh-nav-member-count after React shell fully replaces Ember admin
+        this.networkNotificationBadge = this.sidebar
+            .getByRole('listitem').filter({hasText: /network/i})
+            .locator('[data-sidebar="menu-badge"], .gh-nav-member-count').first();
     }
 
     getNavLink(name: string): Locator {

--- a/e2e/tests/admin/sidebar/navigation.test.ts
+++ b/e2e/tests/admin/sidebar/navigation.test.ts
@@ -6,7 +6,7 @@ type UserRole = 'Administrator' | 'Editor' | 'Author' | 'Contributor';
 
 // TODO: Remove this when the ActivityPub backend has been integrated with the E2E tests
 async function mockNotificationCount(page: Page, count: number) {
-    await page.route('**/.ghost/activitypub/v1/notifications/unread/count', async (route) => {
+    await page.route('**/.ghost/activitypub/*/notifications/unread/count', async (route) => {
         await route.fulfill({
             status: 200,
             contentType: 'application/activity+json',


### PR DESCRIPTION
closes https://linear.app/ghost/issue/BER-3070/ensure-we-fetch-and-display-notification-indicator-for-network-menu

This PR re-introduces the network app notification badge to the new sidebar. It displays conditionally when count > 0 and the network app isn't open, matching the previous Ember behavior. 

I've tested this manually for now by overriding the server response in the devtools and added some new E2E tests as well. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Displays a badge on the Network nav item with unread notification count, hidden when on network/activitypub routes, backed by an enabled toggle in the notifications count hook, with new E2E coverage.
> 
> - **Admin UI (apps/admin)**:
>   - Show unread notifications badge on `Network` menu item in `NavMain.tsx` using `SidebarMenuBadge` and `useNotificationsCountForUser`.
>   - Hide badge when on `network` or `activitypub` routes; set link active via `useIsActiveLink`.
> - **ActivityPub Hook (apps/activitypub)**:
>   - `useNotificationsCountForUser(handle, enabled = true)`: add `enabled` option and wire to React Query.
> - **E2E Tests**:
>   - Add `networkNotificationBadge` locator and route mock for notifications count.
>   - Extend navigation tests to include `Network` route and verify badge visibility/behavior (visible with count, hidden when on route, reappears after navigating away).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 06c89acca3cff4eeb01326f6b7b737fa11fac3ef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->