### PR TITLE
Allowed args to be passed to `install-deps.sh` script

### DIFF
--- a/.github/scripts/install-deps.sh
+++ b/.github/scripts/install-deps.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # This maintains security while ensuring sqlite3 binaries are built when needed
 
 echo "Installing dependencies with --ignore-scripts..."
-yarn install --frozen-lockfile --prefer-offline --ignore-scripts
+yarn install --frozen-lockfile --prefer-offline --ignore-scripts "$@"
 
 # Check if sqlite3 binary already exists (from cache or previous build)
 if [ -d "node_modules/sqlite3" ]; then


### PR DESCRIPTION
no issue

- when using the `install-deps.sh` script from production Docker files we want to do `yarn install --production` but in order to do that we need to pass arguments through
