### PR TITLE
Added "[Optional]" prefix to continue-on-error CI jobs

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -286,7 +286,7 @@ jobs:
           } >> $GITHUB_STEP_SUMMARY
 
   test_e2e:
-    name: E2E Tests (${{ matrix.shell == 'react' && 'React' || 'Ember' }} ${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
+    name: ${{matrix.shell == 'react' && '[Optional] ' || ''}}E2E Tests (${{ matrix.shell == 'react' && 'React' || 'Ember' }} ${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
     runs-on: ubuntu-latest
     needs: [build, setup]
     strategy:


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost-Release/pull/122

- having a prefix allows our release script to ignore failed steps when deciding if commit status is green and makes status clearer for anyone viewing job status in GitHub
