### PR TITLE
Fixed S3Storage uploads to Google Cloud Storage (GCS)

### DIFF
--- a/ghost/core/core/server/adapters/storage/S3Storage.ts
+++ b/ghost/core/core/server/adapters/storage/S3Storage.ts
@@ -115,7 +115,7 @@ export default class S3Storage extends StorageBase {
         const relativePath = await this.getUniqueFileName(file, dir);
 
         const key = this.buildKey(relativePath);
-        const body = fs.createReadStream(file.path);
+        const body = await fs.promises.readFile(file.path);
 
         await this.client.send(new PutObjectCommand({
             Bucket: this.bucket,

--- a/ghost/core/test/unit/server/adapters/storage/S3Storage.test.ts
+++ b/ghost/core/test/unit/server/adapters/storage/S3Storage.test.ts
@@ -1,6 +1,5 @@
 import assert from 'assert/strict';
 import sinon from 'sinon';
-import {Readable} from 'stream';
 import fs from 'fs';
 import path from 'path';
 import {
@@ -86,7 +85,7 @@ describe('S3Storage', function () {
         const {storage, sendStub} = createStorage();
 
         sinon.stub(storage, 'exists').resolves(false);
-        sinon.stub(fs, 'createReadStream').returns(Readable.from('file-data') as unknown as fs.ReadStream);
+        sinon.stub(fs.promises, 'readFile').resolves(Buffer.from('file-data'));
 
         const url = await storage.save({
             path: '/tmp/test-image.jpg',
@@ -104,7 +103,7 @@ describe('S3Storage', function () {
         const {storage, sendStub} = createStorage();
 
         sinon.stub(storage, 'exists').resolves(false);
-        sinon.stub(fs, 'createReadStream').returns(Readable.from('file-data') as unknown as fs.ReadStream);
+        sinon.stub(fs.promises, 'readFile').resolves(Buffer.from('file-data'));
 
         const url = await storage.save({
             path: '/tmp/test-image.jpg',
@@ -237,7 +236,7 @@ describe('S3Storage', function () {
         const {storage, sendStub} = createStorage();
 
         sinon.stub(storage, 'exists').resolves(false);
-        sinon.stub(fs, 'createReadStream').returns(Readable.from('file-data') as unknown as fs.ReadStream);
+        sinon.stub(fs.promises, 'readFile').resolves(Buffer.from('file-data'));
 
         const videoUrl = await storage.save({
             path: '/tmp/video.mp4',


### PR DESCRIPTION
The PutObjectCommand doesn't play with streams on GCS as there are some incompatibilities with signatures.

By using `readFile` we can pull the whole file into a buffer in memory and upload it in a single chunk - which fixes the errors. This does increase the memory footprint with larger files, but it's simpler and it unblocks us for now and we will monitor memory usage and switch to a chunk based approach if it's necessary
