### PR TITLE
Added URL routing to staff modal email notification tab

### DIFF
--- a/apps/admin-x-settings/src/components/providers/settings-router.tsx
+++ b/apps/admin-x-settings/src/components/providers/settings-router.tsx
@@ -9,8 +9,10 @@ export const modalPaths: {[key: string]: ModalName} = {
     'theme/install': 'DesignAndThemeModal', // this is a special route, because it can install a theme directly from the Ghost Marketplace
     'navigation/edit': 'NavigationModal',
     'staff/invite': 'InviteUserModal',
-    'staff/:slug': 'UserDetailModal',
+    'staff/:slug/social-links': 'UserDetailModal',
+    'staff/:slug/email-notifications': 'UserDetailModal',
     'staff/:slug/edit': 'UserDetailModal',
+    'staff/:slug': 'UserDetailModal',
     'portal/edit': 'PortalModal',
     'tiers/add': 'TierDetailModal',
     'tiers/:id': 'TierDetailModal',

--- a/apps/admin-x-settings/src/components/settings/general/user-detail-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/user-detail-modal.tsx
@@ -161,8 +161,8 @@ export interface UserDetailProps {
     clearError: (key: keyof User) => void;
 }
 
-const UserDetailModalContent: React.FC<{user: User; pathName: string}> = ({user, pathName}) => {
-    const {updateRoute} = useRouting();
+const UserDetailModalContent: React.FC<{user: User}> = ({user}) => {
+    const {updateRoute, route} = useRouting();
 
     const getTabFromPath = (path: string): string => {
         const lastSegment = path.split('/').pop() || '';
@@ -412,7 +412,7 @@ const UserDetailModalContent: React.FC<{user: User; pathName: string}> = ({user,
 
     const suspendedText = formState.status === 'inactive' ? ' (Suspended)' : '';
 
-    const initialTab = getTabFromPath(pathName);
+    const initialTab = getTabFromPath(route);
     const [selectedTab, setSelectedTab] = useState<string>(initialTab);
 
     const handleTabChange = (newTabId: string) => {
@@ -572,7 +572,7 @@ const UserDetailModalContent: React.FC<{user: User; pathName: string}> = ({user,
     );
 };
 
-const UserDetailModal: React.FC<RoutingModalProps> = ({params, pathName}) => {
+const UserDetailModal: React.FC<RoutingModalProps> = ({params}) => {
     const {currentUser} = useGlobalData();
 
     // Skip API call if it's the current user (we already have their data)
@@ -588,7 +588,7 @@ const UserDetailModal: React.FC<RoutingModalProps> = ({params, pathName}) => {
     const user = isCurrentUser ? currentUser : fetchedUserData?.users?.[0];
 
     if (user) {
-        return <UserDetailModalContent pathName={pathName} user={user} />;
+        return <UserDetailModalContent user={user} />;
     } else {
         return null;
     }

--- a/ghost/core/core/server/services/comments/CommentsServiceEmails.js
+++ b/ghost/core/core/server/services/comments/CommentsServiceEmails.js
@@ -45,7 +45,7 @@ class CommentsServiceEmails {
                 accentColor: this.settingsCache.get('accent_color'),
                 fromEmail: this.notificationFromAddress,
                 toEmail: to,
-                staffUrl: this.urlUtils.urlJoin(this.urlUtils.urlFor('admin', true), '#', `/settings/staff/${author.get('slug')}`)
+                staffUrl: this.urlUtils.urlJoin(this.urlUtils.urlFor('admin', true), '#', `/settings/staff/${author.get('slug')}/email-notifications`)
             };
 
             const {
@@ -160,7 +160,7 @@ class CommentsServiceEmails {
             accentColor: this.settingsCache.get('accent_color'),
             fromEmail: this.notificationFromAddress,
             toEmail: to,
-            staffUrl: this.urlUtils.urlJoin(this.urlUtils.urlFor('admin', true), '#', `/settings/staff/${owner.get('slug')}`)
+            staffUrl: this.urlUtils.urlJoin(this.urlUtils.urlFor('admin', true), '#', `/settings/staff/${owner.get('slug')}/email-notifications`)
         };
 
         const {html, text} = await this.commentsServiceEmailRenderer.renderEmailTemplate('report', templateData);

--- a/ghost/core/core/server/services/staff/StaffServiceEmails.js
+++ b/ghost/core/core/server/services/staff/StaffServiceEmails.js
@@ -37,7 +37,7 @@ class StaffServiceEmails {
                 attributionTitle = 'Homepage';
             }
 
-            let staffUrl = this.urlUtils.urlJoin(this.urlUtils.urlFor('admin', true), '#', `/settings/staff/${user.slug}`);
+            let staffUrl = this.urlUtils.urlJoin(this.urlUtils.urlFor('admin', true), '#', `/settings/staff/${user.slug}/email-notifications`);
 
             const templateData = {
                 memberData,
@@ -94,7 +94,7 @@ class StaffServiceEmails {
                 attributionTitle = 'Homepage';
             }
 
-            let staffUrl = this.urlUtils.urlJoin(this.urlUtils.urlFor('admin', true), '#', `/settings/staff/${user.slug}`);
+            let staffUrl = this.urlUtils.urlJoin(this.urlUtils.urlFor('admin', true), '#', `/settings/staff/${user.slug}/email-notifications`);
 
             const templateData = {
                 memberData,
@@ -149,7 +149,7 @@ class StaffServiceEmails {
                 cancellationReason: subscription.cancellationReason || ''
             };
 
-            let staffUrl = this.urlUtils.urlJoin(this.urlUtils.urlFor('admin', true), '#', `/settings/staff/${user.slug}`);
+            let staffUrl = this.urlUtils.urlJoin(this.urlUtils.urlFor('admin', true), '#', `/settings/staff/${user.slug}/email-notifications`);
 
             const templateData = {
                 memberData,
@@ -182,7 +182,7 @@ class StaffServiceEmails {
      * @param {string} recipient.slug
      */
     async getSharedData(recipient) {
-        let staffUrl = this.urlUtils.urlJoin(this.urlUtils.urlFor('admin', true), '#', `/settings/staff/${recipient.slug}`);
+        let staffUrl = this.urlUtils.urlJoin(this.urlUtils.urlFor('admin', true), '#', `/settings/staff/${recipient.slug}/email-notifications`);
 
         return {
             siteTitle: this.settingsCache.get('title'),
@@ -227,7 +227,7 @@ class StaffServiceEmails {
         for (const user of users) {
             const to = user.email;
 
-            let staffUrl = this.urlUtils.urlJoin(this.urlUtils.urlFor('admin', true), '#', `/settings/staff/${user.slug}`);
+            let staffUrl = this.urlUtils.urlJoin(this.urlUtils.urlFor('admin', true), '#', `/settings/staff/${user.slug}/email-notifications`);
 
             const templateData = {
                 siteTitle: this.settingsCache.get('title'),
@@ -282,7 +282,7 @@ class StaffServiceEmails {
         for (const user of users) {
             const to = user.email;
 
-            let staffUrl = this.urlUtils.urlJoin(this.urlUtils.urlFor('admin', true), '#', `/settings/staff/${user.slug}`);
+            let staffUrl = this.urlUtils.urlJoin(this.urlUtils.urlFor('admin', true), '#', `/settings/staff/${user.slug}/email-notifications`);
 
             const templateData = {
                 siteTitle: this.settingsCache.get('title'),

--- a/ghost/core/test/e2e-api/webmentions/__snapshots__/webmentions.test.js.snap
+++ b/ghost/core/test/e2e-api/webmentions/__snapshots__/webmentions.test.js.snap
@@ -1221,7 +1221,7 @@ exports[`Webmentions (receiving) can display page title in notification email 1:
                     </tr>
                     <tr>
                       <td style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top; padding-top: 2px\\">
-                        <p class=\\"small\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; line-height: 18px; font-size: 11px; color: #738A94; font-weight: normal; margin: 0; margin-bottom: 2px;\\">Don’t want to receive these emails? Manage your preferences <a class=\\"small\\" href=\\"http://127.0.0.1:2369/ghost/#/settings/staff/joe-bloggs\\" style=\\"text-decoration: underline; color: #738A94; font-size: 11px;\\">here</a>.</p>
+                        <p class=\\"small\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; line-height: 18px; font-size: 11px; color: #738A94; font-weight: normal; margin: 0; margin-bottom: 2px;\\">Don’t want to receive these emails? Manage your preferences <a class=\\"small\\" href=\\"http://127.0.0.1:2369/ghost/#/settings/staff/joe-bloggs/email-notifications\\" style=\\"text-decoration: underline; color: #738A94; font-size: 11px;\\">here</a>.</p>
                       </td>
                     </tr>
 
@@ -2466,7 +2466,7 @@ exports[`Webmentions (receiving) can display post title in notification email 1:
                     </tr>
                     <tr>
                       <td style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top; padding-top: 2px\\">
-                        <p class=\\"small\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; line-height: 18px; font-size: 11px; color: #738A94; font-weight: normal; margin: 0; margin-bottom: 2px;\\">Don’t want to receive these emails? Manage your preferences <a class=\\"small\\" href=\\"http://127.0.0.1:2369/ghost/#/settings/staff/joe-bloggs\\" style=\\"text-decoration: underline; color: #738A94; font-size: 11px;\\">here</a>.</p>
+                        <p class=\\"small\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; line-height: 18px; font-size: 11px; color: #738A94; font-weight: normal; margin: 0; margin-bottom: 2px;\\">Don’t want to receive these emails? Manage your preferences <a class=\\"small\\" href=\\"http://127.0.0.1:2369/ghost/#/settings/staff/joe-bloggs/email-notifications\\" style=\\"text-decoration: underline; color: #738A94; font-size: 11px;\\">here</a>.</p>
                       </td>
                     </tr>
 

--- a/ghost/core/test/e2e-server/services/__snapshots__/recommendation-emails.test.js.snap
+++ b/ghost/core/test/e2e-server/services/__snapshots__/recommendation-emails.test.js.snap
@@ -198,7 +198,7 @@ table.body a.small {
                     </tr>
                     <tr>
                       <td style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 12px; vertical-align: top;\\">
-                        <p class=\\"small\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; line-height: 18px; font-size: 12px; color: #7C8B9A; font-weight: normal; margin: 0;\\">Don’t want to receive these emails? Manage your preferences <a class=\\"small\\" href=\\"http://127.0.0.1:2369/ghost/#/settings/staff/joe-bloggs\\" style=\\"text-decoration: underline; color: #7C8B9A; font-size: 12px;\\">here</a>.</p>
+                        <p class=\\"small\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; line-height: 18px; font-size: 12px; color: #7C8B9A; font-weight: normal; margin: 0;\\">Don’t want to receive these emails? Manage your preferences <a class=\\"small\\" href=\\"http://127.0.0.1:2369/ghost/#/settings/staff/joe-bloggs/email-notifications\\" style=\\"text-decoration: underline; color: #7C8B9A; font-size: 12px;\\">here</a>.</p>
                       </td>
                     </tr>
 
@@ -229,7 +229,7 @@ You have been recommended by Other Ghost Site.
 ---
 
 Sent to jbloggs@example.com from 127.0.0.1.
-If you would no longer like to receive these notifications you can adjust your settings at http://127.0.0.1:2369/ghost/#/settings/staff/joe-bloggs.
+If you would no longer like to receive these notifications you can adjust your settings at http://127.0.0.1:2369/ghost/#/settings/staff/joe-bloggs/email-notifications.
     "
 `;
 
@@ -446,7 +446,7 @@ table.body a.small {
                     </tr>
                     <tr>
                       <td style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 12px; vertical-align: top;\\">
-                        <p class=\\"small\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; line-height: 18px; font-size: 12px; color: #7C8B9A; font-weight: normal; margin: 0;\\">Don’t want to receive these emails? Manage your preferences <a class=\\"small\\" href=\\"http://127.0.0.1:2369/ghost/#/settings/staff/joe-bloggs\\" style=\\"text-decoration: underline; color: #7C8B9A; font-size: 12px;\\">here</a>.</p>
+                        <p class=\\"small\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; line-height: 18px; font-size: 12px; color: #7C8B9A; font-weight: normal; margin: 0;\\">Don’t want to receive these emails? Manage your preferences <a class=\\"small\\" href=\\"http://127.0.0.1:2369/ghost/#/settings/staff/joe-bloggs/email-notifications\\" style=\\"text-decoration: underline; color: #7C8B9A; font-size: 12px;\\">here</a>.</p>
                       </td>
                     </tr>
 
@@ -669,7 +669,7 @@ table.body a.small {
                     </tr>
                     <tr>
                       <td style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 12px; vertical-align: top;\\">
-                        <p class=\\"small\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; line-height: 18px; font-size: 12px; color: #7C8B9A; font-weight: normal; margin: 0;\\">Don’t want to receive these emails? Manage your preferences <a class=\\"small\\" href=\\"http://127.0.0.1:2369/ghost/#/settings/staff/smith-wellingsworth\\" style=\\"text-decoration: underline; color: #7C8B9A; font-size: 12px;\\">here</a>.</p>
+                        <p class=\\"small\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; line-height: 18px; font-size: 12px; color: #7C8B9A; font-weight: normal; margin: 0;\\">Don’t want to receive these emails? Manage your preferences <a class=\\"small\\" href=\\"http://127.0.0.1:2369/ghost/#/settings/staff/smith-wellingsworth/email-notifications\\" style=\\"text-decoration: underline; color: #7C8B9A; font-size: 12px;\\">here</a>.</p>
                       </td>
                     </tr>
 
@@ -700,7 +700,7 @@ You have been recommended by Other Ghost Site.
 ---
 
 Sent to jbloggs@example.com from 127.0.0.1.
-If you would no longer like to receive these notifications you can adjust your settings at http://127.0.0.1:2369/ghost/#/settings/staff/joe-bloggs.
+If you would no longer like to receive these notifications you can adjust your settings at http://127.0.0.1:2369/ghost/#/settings/staff/joe-bloggs/email-notifications.
     "
 `;
 

--- a/ghost/core/test/unit/server/services/staff/staff-service.test.js
+++ b/ghost/core/test/unit/server/services/staff/staff-service.test.js
@@ -46,7 +46,7 @@ function testCommonMailData({mailStub, getEmailAlertUsersStub}) {
 
     // Has staff admin url
     mailStub.calledWith(
-        sinon.match.has('html', sinon.match('https://admin.ghost.example/#/settings/staff/ghost'))
+        sinon.match.has('html', sinon.match('https://admin.ghost.example/#/settings/staff/ghost/email-notifications'))
     ).should.be.true();
 }
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3080/manage-preferences-link-in-member-emails-opens-profile-instead

- Added routing support for staff modal tabs to enable direct navigation via URL
- Routes: `/staff/:slug` (profile), `/staff/:slug/social-links`, `/staff/:slug/email-notifications`
- Updated all staff notification email templates (member signups, subscriptions, milestones, donations, comments, mentions) to link to the email notifications tab