### PR TITLE
Skipped tests with convention that alings better with playwright

### DIFF
--- a/e2e/tests/admin/analytics/utm-tracking.test.ts
+++ b/e2e/tests/admin/analytics/utm-tracking.test.ts
@@ -2,7 +2,7 @@ import {AnalyticsWebTrafficPage} from '@/admin-pages';
 import {HomePage} from '@/public-pages';
 import {expect, test, withIsolatedPage} from '@/helpers/playwright';
 
-test.skip('Ghost Admin - Analytics UTM Tracking', () => {
+test.describe.fixme('Ghost Admin - Analytics UTM Tracking', () => {
     test.describe('utmTracking flag disabled', () => {
         test('utm components hidden', async ({page}) => {
             const analyticsWebTrafficPage = new AnalyticsWebTrafficPage(page);


### PR DESCRIPTION
* aligned closer to playwright conventions
* with this update, it shows clearer that we will check these tests later, and we will keep linter warnings low (previous version adds 2 linting warnings)