### PR TITLE
Wired up Koenig editor to welcome emails modal

### DIFF
--- a/apps/admin-x-design-system/src/global/form/HtmlEditor.tsx
+++ b/apps/admin-x-design-system/src/global/form/HtmlEditor.tsx
@@ -14,6 +14,7 @@ export interface HtmlEditorProps {
     nodes?: 'DEFAULT_NODES' | 'BASIC_NODES' | 'MINIMAL_NODES'
     emojiPicker?: boolean;
     darkMode?: boolean;
+    singleParagraph?: boolean;
 }
 
 declare global {
@@ -63,7 +64,8 @@ const KoenigWrapper: React.FC<HtmlEditorProps & { editor: EditorResource }> = ({
     placeholder,
     nodes,
     emojiPicker = true,
-    darkMode = false
+    darkMode = false,
+    singleParagraph = true
 }) => {
     const onError = useCallback((error: unknown) => {
         try {
@@ -140,7 +142,7 @@ const KoenigWrapper: React.FC<HtmlEditorProps & { editor: EditorResource }> = ({
                 markdownTransformers={transformers[nodes || 'DEFAULT_NODES']}
                 placeholderClassName='koenig-lexical-editor-input-placeholder line-clamp-1'
                 placeholderText={placeholder}
-                singleParagraph={true}
+                singleParagraph={singleParagraph}
                 onBlur={handleBlur}
                 onFocus={handleFocus}
             >

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-modal.tsx
@@ -1,7 +1,7 @@
 import NiceModal from '@ebay/nice-modal-react';
 import {useEffect, useRef, useState} from 'react';
 
-import {Button, Modal, TextField} from '@tryghost/admin-x-design-system';
+import {Button, HtmlEditor, Modal, TextField} from '@tryghost/admin-x-design-system';
 import {useCurrentUser} from '@tryghost/admin-x-framework/api/currentUser';
 import {useRouting} from '@tryghost/admin-x-framework/routing';
 
@@ -9,12 +9,21 @@ interface WelcomeEmailModalProps {
     emailType?: 'free' | 'paid';
 }
 
+const getDefaultContent = () => {
+    return `<p><strong>Welcome! It's great to have you here.</strong></p>
+<p>You'll start getting updates right in your inbox. You can also log in any time to read the full archive or catch up on new posts as they go live.</p>
+<p>A quick heads-up: if the newsletter doesn't show up, check your <em>spam folder</em> or your Promotions tab and mark this address as not spam.</p>
+<p>And remember: everything is always available on <a href="https://example.com">publisherweekly.org</a>.</p>
+<p>Thanks for joining — feel free to share it with a friend or two if you think they'd enjoy it.</p>`;
+};
+
 const WelcomeEmailModal = NiceModal.create<WelcomeEmailModalProps>(({emailType = 'free'}) => {
     const modal = NiceModal.useModal();
     const {updateRoute} = useRouting();
     const {data: currentUser} = useCurrentUser();
     const [showTestDropdown, setShowTestDropdown] = useState(false);
     const [testEmail, setTestEmail] = useState(currentUser?.email || '');
+    const [emailContent, setEmailContent] = useState(getDefaultContent());
     const dropdownRef = useRef<HTMLDivElement>(null);
 
     // Update test email when current user data loads
@@ -121,13 +130,16 @@ const WelcomeEmailModal = NiceModal.create<WelcomeEmailModalProps>(({emailType =
                         </div>
                     </div>
                 </div>
-                <div className='px-10 py-5 text-lg tracking-[-0.01em] [&_a]:underline [&_p]:mb-5'>
-                    <p className='font-bold'>Welcome! It’s great to have you here.</p>
-                    <p>You’ll start getting updates right in your inbox. You can also log in any time to read the full archive or catch up on new posts as they go live.</p>
-                    <p>A quick heads-up:</p>
-                    <p>If the newsletter doesn’t show up, check your <i>spam folder</i> folder or your Promotions tab and mark this address as not spam.</p>
-                    <p>And remember: everything is always available on <a href="https://example.com">publisherweekly.org</a>.</p>
-                    <p>Thanks for joining — feel free to share it with a friend or two if you think they’d enjoy it.</p>
+                <div className='bg-grey-50 p-6'>
+                    <div className='mx-auto max-w-[600px] rounded border border-grey-200 bg-white p-8 text-[1.6rem] leading-[1.6] tracking-[-0.01em] shadow-sm [&_a]:text-black [&_a]:underline [&_p]:mb-4 [&_strong]:font-semibold'>
+                        <HtmlEditor
+                            nodes='BASIC_NODES'
+                            placeholder='Write your welcome email content...'
+                            singleParagraph={false}
+                            value={emailContent}
+                            onChange={setEmailContent}
+                        />
+                    </div>
                 </div>
             </div>
         </Modal>


### PR DESCRIPTION
ref https://linear.app/ghost/issue/NY-787/
- added Koenig editor to welcome emails modal

This editor allows the user to manipulate the content of the email. However, this isn't wired up to anything while we're waiting for the persistence changes to be merged.