### PR TITLE
Fixed Bluebird promise warnings when saving models

### DIFF
--- a/ghost/core/core/server/models/base/plugins/actions.js
+++ b/ghost/core/core/server/models/base/plugins/actions.js
@@ -24,7 +24,7 @@ module.exports = function (Bookshelf) {
         }
 
         const insert = (action) => {
-            Bookshelf.model('Action')
+            return Bookshelf.model('Action')
                 .add(action, {autoRefresh: false})
                 .catch((err) => {
                     if (_.isArray(err)) {
@@ -46,7 +46,7 @@ module.exports = function (Bookshelf) {
                 insert(data);
             });
         } else {
-            insert(data);
+            return insert(data);
         }
     };
 
@@ -68,7 +68,7 @@ module.exports = function (Bookshelf) {
         }
 
         const data = model.getAction(event, options);
-        insertAction(data, options);
+        return insertAction(data, options);
     };
 
     Bookshelf.Model = Bookshelf.Model.extend({

--- a/ghost/core/core/server/models/base/plugins/events.js
+++ b/ghost/core/core/server/models/base/plugins/events.js
@@ -133,7 +133,7 @@ module.exports = function (Bookshelf) {
         },
 
         onCreated(model, options) {
-            this.addAction(model, 'added', options);
+            return this.addAction(model, 'added', options);
         },
 
         /**
@@ -180,7 +180,7 @@ module.exports = function (Bookshelf) {
         },
 
         onUpdated(model, options) {
-            this.addAction(model, 'edited', options);
+            return this.addAction(model, 'edited', options);
         },
 
         /**
@@ -242,7 +242,7 @@ module.exports = function (Bookshelf) {
             // @NOTE: Bookshelf returns ".changed = {empty...}" on destroying (https://github.com/bookshelf/bookshelf/issues/1943)
             Object.assign(model._changed, _.cloneDeep(model.changed));
 
-            this.addAction(model, 'deleted', options);
+            return this.addAction(model, 'deleted', options);
         }
     }, {
         generateId: function generateId() {

--- a/ghost/core/core/server/models/comment-like.js
+++ b/ghost/core/core/server/models/comment-like.js
@@ -28,9 +28,11 @@ const CommentLike = ghostBookshelf.Model.extend({
     },
 
     onCreated: function onCreated(model, options) {
-        ghostBookshelf.Model.prototype.onCreated.apply(this, arguments);
+        const result = ghostBookshelf.Model.prototype.onCreated.apply(this, arguments);
 
         model.emitChange('added', options);
+
+        return result;
     }
 }, {
 

--- a/ghost/core/core/server/models/comment-report.js
+++ b/ghost/core/core/server/models/comment-report.js
@@ -21,9 +21,11 @@ const CommentReport = ghostBookshelf.Model.extend({
     },
 
     onCreated: function onCreated(model, options) {
-        ghostBookshelf.Model.prototype.onCreated.apply(this, arguments);
+        const result = ghostBookshelf.Model.prototype.onCreated.apply(this, arguments);
 
         model.emitChange('added', options);
+
+        return result;
     }
 }, {
 

--- a/ghost/core/core/server/models/comment.js
+++ b/ghost/core/core/server/models/comment.js
@@ -170,9 +170,11 @@ const Comment = ghostBookshelf.Model.extend({
     },
 
     onCreated: function onCreated(model, options) {
-        ghostBookshelf.Model.prototype.onCreated.apply(this, arguments);
+        const result = ghostBookshelf.Model.prototype.onCreated.apply(this, arguments);
 
         model.emitChange('added', options);
+
+        return result;
     },
 
     enforcedFilters: function enforcedFilters(options) {

--- a/ghost/core/core/server/models/email.js
+++ b/ghost/core/core/server/models/email.js
@@ -67,21 +67,27 @@ const Email = ghostBookshelf.Model.extend({
     },
 
     onCreated: function onCreated(model, options) {
-        ghostBookshelf.Model.prototype.onCreated.apply(this, arguments);
+        const result = ghostBookshelf.Model.prototype.onCreated.apply(this, arguments);
 
         model.emitChange('added', options);
+
+        return result;
     },
 
     onUpdated: function onUpdated(model, options) {
-        ghostBookshelf.Model.prototype.onUpdated.apply(this, arguments);
+        const result = ghostBookshelf.Model.prototype.onUpdated.apply(this, arguments);
 
         model.emitChange('edited', options);
+
+        return result;
     },
 
     onDestroyed: function onDestroyed(model, options) {
-        ghostBookshelf.Model.prototype.onDestroyed.apply(this, arguments);
+        const result = ghostBookshelf.Model.prototype.onDestroyed.apply(this, arguments);
 
         model.emitChange('deleted', options);
+
+        return result;
     }
 }, {});
 

--- a/ghost/core/core/server/models/integration.js
+++ b/ghost/core/core/server/models/integration.js
@@ -50,9 +50,11 @@ const Integration = ghostBookshelf.Model.extend({
     },
 
     onCreated: function onCreated(model, options) {
-        ghostBookshelf.Model.prototype.onCreated.apply(this, arguments);
+        const result = ghostBookshelf.Model.prototype.onCreated.apply(this, arguments);
 
         model.emitChange('added', options);
+
+        return result;
     },
 
     permittedAttributes(...args) {

--- a/ghost/core/core/server/models/label.js
+++ b/ghost/core/core/server/models/label.js
@@ -22,21 +22,27 @@ Label = ghostBookshelf.Model.extend({
     },
 
     onCreated: function onCreated(model, options) {
-        ghostBookshelf.Model.prototype.onCreated.apply(this, arguments);
+        const result = ghostBookshelf.Model.prototype.onCreated.apply(this, arguments);
 
         model.emitChange('added', options);
+
+        return result;
     },
 
     onUpdated: function onUpdated(model, options) {
-        ghostBookshelf.Model.prototype.onUpdated.apply(this, arguments);
+        const result = ghostBookshelf.Model.prototype.onUpdated.apply(this, arguments);
 
         model.emitChange('edited', options);
+
+        return result;
     },
 
     onDestroyed: function onDestroyed(model, options) {
-        ghostBookshelf.Model.prototype.onDestroyed.apply(this, arguments);
+        const result = ghostBookshelf.Model.prototype.onDestroyed.apply(this, arguments);
 
         model.emitChange('deleted', options);
+
+        return result;
     },
 
     onSaving: function onSaving(newLabel, attr, options) {

--- a/ghost/core/core/server/models/member.js
+++ b/ghost/core/core/server/models/member.js
@@ -342,21 +342,27 @@ const Member = ghostBookshelf.Model.extend({
     },
 
     onCreated: function onCreated(model, options) {
-        ghostBookshelf.Model.prototype.onCreated.apply(this, arguments);
+        const result = ghostBookshelf.Model.prototype.onCreated.apply(this, arguments);
 
         model.emitChange('added', options);
+
+        return result;
     },
 
     onUpdated: function onUpdated(model, options) {
-        ghostBookshelf.Model.prototype.onUpdated.apply(this, arguments);
+        const result = ghostBookshelf.Model.prototype.onUpdated.apply(this, arguments);
 
         model.emitChange('edited', options);
+
+        return result;
     },
 
     onDestroyed: function onDestroyed(model, options) {
-        ghostBookshelf.Model.prototype.onDestroyed.apply(this, arguments);
+        const result = ghostBookshelf.Model.prototype.onDestroyed.apply(this, arguments);
 
         model.emitChange('deleted', options);
+
+        return result;
     },
 
     onDestroying: function onDestroyed(model) {

--- a/ghost/core/core/server/models/post.js
+++ b/ghost/core/core/server/models/post.js
@@ -393,7 +393,7 @@ Post = ghostBookshelf.Model.extend({
     },
 
     onUpdated: function onUpdated(model, options) {
-        ghostBookshelf.Model.prototype.onUpdated.apply(this, arguments);
+        const result = ghostBookshelf.Model.prototype.onUpdated.apply(this, arguments);
 
         model.statusChanging = model.get('status') !== model.previous('status');
         model.isPublished = model.get('status') === 'published';
@@ -462,16 +462,20 @@ Post = ghostBookshelf.Model.extend({
         if (model.statusChanging && (model.isPublished || model.wasPublished)) {
             this.handleStatusForAttachedModels(model, options);
         }
+
+        return result;
     },
 
-    onDestroyed: async function onDestroyed(model, options) {
-        ghostBookshelf.Model.prototype.onDestroyed.apply(this, arguments);
+    onDestroyed: function onDestroyed(model, options) {
+        const result = ghostBookshelf.Model.prototype.onDestroyed.apply(this, arguments);
 
         if (model.previous('status') === 'published') {
             model.emitChange('unpublished', Object.assign({usePreviousAttribute: true}, options));
         }
 
         model.emitChange('deleted', Object.assign({usePreviousAttribute: true}, options));
+
+        return result;
     },
 
     onDestroying: function onDestroyed(model) {

--- a/ghost/core/core/server/models/settings.js
+++ b/ghost/core/core/server/models/settings.js
@@ -109,24 +109,30 @@ Settings = ghostBookshelf.Model.extend({
     },
 
     onDestroyed: function onDestroyed(model, options) {
-        ghostBookshelf.Model.prototype.onDestroyed.apply(this, arguments);
+        const result = ghostBookshelf.Model.prototype.onDestroyed.apply(this, arguments);
 
         model.emitChange('deleted', options);
         model.emitChange(model._previousAttributes.key + '.' + 'deleted', options);
+
+        return result;
     },
 
     onCreated: function onCreated(model, options) {
-        ghostBookshelf.Model.prototype.onCreated.apply(this, arguments);
+        const result = ghostBookshelf.Model.prototype.onCreated.apply(this, arguments);
 
         model.emitChange('added', options);
         model.emitChange(model.attributes.key + '.' + 'added', options);
+
+        return result;
     },
 
     onUpdated: function onUpdated(model, options) {
-        ghostBookshelf.Model.prototype.onUpdated.apply(this, arguments);
+        const result = ghostBookshelf.Model.prototype.onUpdated.apply(this, arguments);
 
         model.emitChange('edited', options);
         model.emitChange(model.attributes.key + '.' + 'edited', options);
+
+        return result;
     },
 
     async onValidate(model, attr, options) {
@@ -315,7 +321,7 @@ Settings = ghostBookshelf.Model.extend({
     },
 
     validators: {
-        async all(model) {
+        all(model) {
             const settingName = model.get('key');
             const settingDefault = getDefaultSettings()[settingName];
 
@@ -335,7 +341,7 @@ Settings = ghostBookshelf.Model.extend({
                 throw new errors.ValidationError({message: validationErrors.join('\n')});
             }
         },
-        async labs(model) {
+        labs(model) {
             const flags = JSON.parse(model.get('value'));
 
             for (const flag in flags) {
@@ -346,7 +352,7 @@ Settings = ghostBookshelf.Model.extend({
                 }
             }
         },
-        async stripe_plans(model, options) {
+        stripe_plans(model, options) {
             const plans = JSON.parse(model.get('value'));
             for (const plan of plans) {
                 // Stripe plans used to be allowed (and defaulted to!) 0 amount plans
@@ -383,7 +389,7 @@ Settings = ghostBookshelf.Model.extend({
         },
         // @TODO: Maybe move some of the logic into the members service, exporting an isValidStripeKey
         // method which can be called here, cleaning up the duplication, but not removing control
-        async stripe_secret_key(model) {
+        stripe_secret_key(model) {
             const value = model.get('value');
             if (value === null) {
                 return;
@@ -397,7 +403,7 @@ Settings = ghostBookshelf.Model.extend({
                 });
             }
         },
-        async stripe_publishable_key(model) {
+        stripe_publishable_key(model) {
             const value = model.get('value');
             if (value === null) {
                 return;
@@ -411,7 +417,7 @@ Settings = ghostBookshelf.Model.extend({
                 });
             }
         },
-        async stripe_connect_secret_key(model) {
+        stripe_connect_secret_key(model) {
             const value = model.get('value');
             if (value === null) {
                 return;
@@ -425,7 +431,7 @@ Settings = ghostBookshelf.Model.extend({
                 });
             }
         },
-        async stripe_connect_publishable_key(model) {
+        stripe_connect_publishable_key(model) {
             const value = model.get('value');
             if (value === null) {
                 return;

--- a/ghost/core/core/server/models/tag.js
+++ b/ghost/core/core/server/models/tag.js
@@ -81,21 +81,27 @@ Tag = ghostBookshelf.Model.extend({
     },
 
     onCreated: function onCreated(model, options) {
-        ghostBookshelf.Model.prototype.onCreated.apply(this, arguments);
+        const result = ghostBookshelf.Model.prototype.onCreated.apply(this, arguments);
 
         model.emitChange('added', options);
+
+        return result;
     },
 
     onUpdated: function onUpdated(model, options) {
-        ghostBookshelf.Model.prototype.onUpdated.apply(this, arguments);
+        const result = ghostBookshelf.Model.prototype.onUpdated.apply(this, arguments);
 
         model.emitChange('edited', options);
+
+        return result;
     },
 
     onDestroyed: function onDestroyed(model, options) {
-        ghostBookshelf.Model.prototype.onDestroyed.apply(this, arguments);
+        const result = ghostBookshelf.Model.prototype.onDestroyed.apply(this, arguments);
 
         model.emitChange('deleted', options);
+
+        return result;
     },
 
     onSaving: function onSaving(newTag, attr, options) {

--- a/ghost/core/core/server/models/user.js
+++ b/ghost/core/core/server/models/user.js
@@ -141,17 +141,19 @@ User = ghostBookshelf.Model.extend({
     },
 
     onDestroyed: function onDestroyed(model, options) {
-        ghostBookshelf.Model.prototype.onDestroyed.apply(this, arguments);
+        const result = ghostBookshelf.Model.prototype.onDestroyed.apply(this, arguments);
 
         if (activeStates.includes(model.previous('status'))) {
             model.emitChange('deactivated', options);
         }
 
         model.emitChange('deleted', options);
+
+        return result;
     },
 
     onCreated: function onCreated(model, options) {
-        ghostBookshelf.Model.prototype.onCreated.apply(this, arguments);
+        const result = ghostBookshelf.Model.prototype.onCreated.apply(this, arguments);
 
         model.emitChange('added', options);
 
@@ -159,10 +161,12 @@ User = ghostBookshelf.Model.extend({
         if (!model.get('status') || activeStates.includes(model.get('status'))) {
             model.emitChange('activated', options);
         }
+
+        return result;
     },
 
     onUpdated: function onUpdated(model, options) {
-        ghostBookshelf.Model.prototype.onUpdated.apply(this, arguments);
+        const result = ghostBookshelf.Model.prototype.onUpdated.apply(this, arguments);
 
         model.statusChanging = model.get('status') !== model.previous('status');
         model.isActive = activeStates.includes(model.get('status'));
@@ -176,6 +180,8 @@ User = ghostBookshelf.Model.extend({
         }
 
         model.emitChange('edited', options);
+
+        return result;
     },
 
     isActive: function isActive() {

--- a/ghost/core/core/server/models/webhook.js
+++ b/ghost/core/core/server/models/webhook.js
@@ -26,21 +26,27 @@ Webhook = ghostBookshelf.Model.extend({
     },
 
     onCreated: function onCreated(model, options) {
-        ghostBookshelf.Model.prototype.onCreated.apply(this, arguments);
+        const result = ghostBookshelf.Model.prototype.onCreated.apply(this, arguments);
 
         model.emitChange('added', options);
+
+        return result;
     },
 
     onUpdated: function onUpdated(model, options) {
-        ghostBookshelf.Model.prototype.onUpdated.apply(this, arguments);
+        const result = ghostBookshelf.Model.prototype.onUpdated.apply(this, arguments);
 
         model.emitChange('edited', options);
+
+        return result;
     },
 
     onDestroyed: function onDestroyed(model, options) {
-        ghostBookshelf.Model.prototype.onDestroyed.apply(this, arguments);
+        const result = ghostBookshelf.Model.prototype.onDestroyed.apply(this, arguments);
 
         model.emitChange('deleted', options);
+
+        return result;
     }
 }, {
     findAllByEvent: function findAllByEvent(event, unfilteredOptions) {


### PR DESCRIPTION
no issue

## Problem

Saving settings (e.g. labs flags) and other models logged this Bluebird warning:

```
Warning: a promise was created in a Promise.each handler at node_modules/bookshelf/lib/base/events.js:101:64 but was not returned from it
```

The model lifecycle hooks (`onCreated`/`onUpdated`/`onDestroyed`) and the audit-log action helpers created promises inside Bookshelf's event handler chain without returning them, so Bluebird flagged them as dangling.

## Fix

- Model event handlers now capture and return the base prototype's result so the audit-log action insert is propagated through the chain instead of being created and forgotten.
- The `actions`/`events` base plugins return the insert promise rather than firing it and forgetting it.
- The seven settings validators (`all`, `labs`, `stripe_plans`, `stripe_secret_key`, `stripe_publishable_key`, `stripe_connect_secret_key`, `stripe_connect_publishable_key`) were marked `async` but contained only synchronous code. Removing `async` drops the unnecessary promise creation — callers already `await` them, so behaviour is unchanged.