### PR TITLE
Added `/` at the end of each path

### DIFF
--- a/apps/activitypub/package.json
+++ b/apps/activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/activitypub",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/activitypub/src/hooks/use-activity-pub-queries.ts
+++ b/apps/activitypub/src/hooks/use-activity-pub-queries.ts
@@ -33,7 +33,7 @@ let SITE_URL: string;
 
 async function getSiteUrl() {
     if (!SITE_URL) {
-        const response = await fetch('/ghost/api/admin/site');
+        const response = await fetch('/ghost/api/admin/site/');
         const json = await response.json();
         SITE_URL = json.site.url;
     }

--- a/apps/activitypub/test/utils/initial-api-requests.ts
+++ b/apps/activitypub/test/utils/initial-api-requests.ts
@@ -13,7 +13,7 @@ const initialAdminApiRequests = {
     },
     getSite: {
         method: 'GET',
-        path: '/site',
+        path: '/site/',
         response: site
     },
     getIdentities: {

--- a/apps/admin/vite-backend-proxy.ts
+++ b/apps/admin/vite-backend-proxy.ts
@@ -11,7 +11,7 @@ async function resolveGhostSiteUrl() {
     const MAX_ATTEMPTS = 20;
     for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
         try {
-            const siteEndpoint = new URL("/ghost/api/admin/site", GHOST_URL);
+            const siteEndpoint = new URL("/ghost/api/admin/site/", GHOST_URL);
             const response = await fetch(siteEndpoint);
             const data = (await response.json()) as { site: { url: string } };
             return {

--- a/ghost/admin/app/services/notifications-count.js
+++ b/ghost/admin/app/services/notifications-count.js
@@ -21,7 +21,7 @@ export default class NotificationsCountService extends Service {
                 return 0;
             }
 
-            const siteInfoResponse = await this.ajax.request('/ghost/api/admin/site');
+            const siteInfoResponse = await this.ajax.request('/ghost/api/admin/site/');
             const siteUrl = siteInfoResponse?.site?.url;
 
             if (!siteUrl) {

--- a/ghost/admin/tests/unit/services/notifications-count-test.js
+++ b/ghost/admin/tests/unit/services/notifications-count-test.js
@@ -51,7 +51,7 @@ describe('Unit: Service: notifications-count', function () {
                 })];
             });
 
-            server.get('/ghost/api/admin/site', function () {
+            server.get('/ghost/api/admin/site/', function () {
                 return [200, {'Content-Type': 'application/json'}, JSON.stringify({
                     site: {}
                 })];
@@ -76,7 +76,7 @@ describe('Unit: Service: notifications-count', function () {
                 })];
             });
 
-            server.get('/ghost/api/admin/site', function () {
+            server.get('/ghost/api/admin/site/', function () {
                 return [200, {'Content-Type': 'application/json'}, JSON.stringify({
                     site: {url: siteUrl}
                 })];
@@ -124,7 +124,7 @@ describe('Unit: Service: notifications-count', function () {
                 })];
             });
 
-            server.get('/ghost/api/admin/site', function () {
+            server.get('/ghost/api/admin/site/', function () {
                 return [200, {'Content-Type': 'application/json'}, JSON.stringify({
                     site: {url: siteUrl}
                 })];


### PR DESCRIPTION
ref no-issue

- Ghost redirects paths not ending with `/`. This avoids the redirect.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure all calls to the admin site endpoint use `/ghost/api/admin/site/` (with trailing slash) and update related tests and proxy config; bump activitypub package to 2.0.3.
> 
> - **Routing/Endpoints**
>   - Standardize admin site endpoint to `'/ghost/api/admin/site/'` in `apps/activitypub/src/hooks/use-activity-pub-queries.ts`, `apps/admin/vite-backend-proxy.ts`, and `ghost/admin/app/services/notifications-count.js`.
> - **Tests**
>   - Update mocks to expect `'/ghost/api/admin/site/'` in `ghost/admin/tests/unit/services/notifications-count-test.js`.
>   - Adjust initial API request paths to `'/site/'` in `apps/activitypub/test/utils/initial-api-requests.ts`.
> - **Package**
>   - Bump `@tryghost/activitypub` version from `2.0.2` to `2.0.3`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ebba2faa3e3e788fdf3c21c6d7c8e580ea592f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->