### PR TITLE
Reduced e2e worker count on CI to 1

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -292,8 +292,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shardIndex: [1, 2]
-        shardTotal: [2]
+        shardIndex: [1, 2, 3, 4]
+        shardTotal: [4]
         shell: [ember, react]
     continue-on-error: ${{ matrix.shell == 'react' }}
     steps:
@@ -345,6 +345,7 @@ jobs:
         env:
           GHOST_IMAGE_TAG: ${{ steps.load.outputs.image-tag }}
           USE_REACT_SHELL: ${{ matrix.shell == 'react' && 'true' || '' }}
+          TEST_WORKERS_COUNT: 1
         run: yarn test:e2e --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
 
       - name: Upload blob report to GitHub Actions Artifacts

--- a/e2e/playwright.config.mjs
+++ b/e2e/playwright.config.mjs
@@ -22,7 +22,7 @@ const config = {
         timeout: process.env.CI ? 30 * 1000 : 10 * 1000
     },
     retries: 0, // Retries open the door to flaky tests. If the test needs retries, it's not a good test or the app is broken.
-    workers: process.env.CI ? 4 : parseInt(process.env.TEST_WORKERS_COUNT, 10) || getWorkerCount(),
+    workers: parseInt(process.env.TEST_WORKERS_COUNT, 10) || getWorkerCount(),
     fullyParallel: true,
     reporter: process.env.CI ? [['list', {printSteps: true}], ['blob']] : [['list', {printSteps: true}], ['html']],
     use: {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3096
closes https://github.com/TryGhost/Ghost/pull/25579

We observed a lot of flakiness when running multiple workers on a single CI e2e test runner. This change-set makes test worker counts depend on an environment variable, and sets that variable to 1 on CI which reduces the worker count.

In order to maintain CI test run durations, we increased the shards in the e2e matrix to 4.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Increase E2E shards to 4 and drive Playwright worker count from TEST_WORKERS_COUNT (set to 1 in CI).
> 
> - **CI: E2E workflow (`.github/workflows/ci-docker.yml`)**
>   - Increase sharding from `2` to `4` (`matrix.shardIndex`/`shardTotal`).
>   - Set `TEST_WORKERS_COUNT=1` for the "Run e2e tests" step.
> - **Testing: Playwright (`e2e/playwright.config.mjs`)**
>   - Update `workers` to `parseInt(process.env.TEST_WORKERS_COUNT, 10) || getWorkerCount()` (remove CI-specific value).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c74f0a7e47116792b8d53e2098484a1fa1b8a4e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->