### PR TITLE
Added aggregator job for Docker CI E2E tests

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -430,3 +430,16 @@ jobs:
           \`\`\`bash
           REPORT_DIR=\$(mktemp -d) && gh run download ${{ github.run_id }} -n playwright-report -D \"\$REPORT_DIR\" && npx playwright show-report \"\$REPORT_DIR\"
           \`\`\`"
+
+  job_required_tests:
+    name: All required tests passed or skipped
+    needs: [test_e2e]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check test results
+        run: |
+          if [[ "${{ needs.test_e2e.result }}" != "success" ]]; then
+            echo "E2E tests did not succeed (result: ${{ needs.test_e2e.result }})"
+            exit 1
+          fi


### PR DESCRIPTION
## What does this PR do?

Adds an aggregator job (`job_required_tests`) to the Docker CI workflow that depends on all E2E test matrix jobs. This provides a single status check that can be added to branch protection rules to enforce Docker E2E tests pass before merging.

## Why is this needed?

Currently the `ci-docker.yml` E2E tests are not included in any required status checks - the existing "All required tests passed or skipped" job in `ci.yml` only aggregates jobs from that workflow. This means Docker E2E test failures don't block merges.

## How to use

After merging, add `CI (Docker) / All required tests passed or skipped` as a required status check in branch protection settings for `main`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `job_required_tests` to aggregate E2E matrix results and provide a single required status check that fails if E2E tests aren’t successful.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea14a54684c6b239ab1cc2d181d7bd5a1cc5395d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->