### PR TITLE
🐛 Fixed query params being stripped on private site login

### DIFF
--- a/ghost/core/core/frontend/apps/private-blogging/lib/middleware.js
+++ b/ghost/core/core/frontend/apps/private-blogging/lib/middleware.js
@@ -28,12 +28,18 @@ function verifySessionHash(salt, hash) {
 function getRedirectUrl(query) {
     try {
         const redirect = decodeURIComponent(query.r || '/');
-        const pathname = new URL(redirect, config.get('url')).pathname;
+        const parsedUrl = new URL(redirect, config.get('url'));
+        const pathname = parsedUrl.pathname;
+        const search = parsedUrl.search;
 
         const base = new URL(config.get('url'));
         const target = new URL(pathname, config.get('url'));
         // Make sure we don't redirect outside of the instance
-        return target.host === base.host ? pathname : '/';
+        if (target.host !== base.host) {
+            return '/';
+        }
+        // Preserve query string (e.g., UTM parameters)
+        return pathname + search;
     } catch (e) {
         return '/';
     }

--- a/ghost/core/test/unit/frontend/apps/private-blogging/middleware.test.js
+++ b/ghost/core/test/unit/frontend/apps/private-blogging/middleware.test.js
@@ -280,6 +280,32 @@ describe('Private Blogging', function () {
                 res.redirect.args[0][0].should.be.equal('/test');
             });
 
+            it('doLoginToPrivateSite should preserve query string including UTM parameters', function () {
+                req.body = {password: 'rightpassword'};
+                req.session = {};
+                req.query = {
+                    r: encodeURIComponent('/?utm_source=twitter&utm_campaign=test')
+                };
+                res.redirect = sinon.spy();
+
+                privateBlogging.doLoginToPrivateSite(req, res, next);
+                res.redirect.called.should.be.true();
+                res.redirect.args[0][0].should.be.equal('/?utm_source=twitter&utm_campaign=test');
+            });
+
+            it('doLoginToPrivateSite should preserve query string on paths', function () {
+                req.body = {password: 'rightpassword'};
+                req.session = {};
+                req.query = {
+                    r: encodeURIComponent('/welcome/?ref=newsletter&utm_medium=email')
+                };
+                res.redirect = sinon.spy();
+
+                privateBlogging.doLoginToPrivateSite(req, res, next);
+                res.redirect.called.should.be.true();
+                res.redirect.args[0][0].should.be.equal('/welcome/?ref=newsletter&utm_medium=email');
+            });
+
             it('doLoginToPrivateSite should redirect to "/" if r param is redirecting to another domain than the current instance', function () {
                 req.body = {password: 'rightpassword'};
                 req.session = {};


### PR DESCRIPTION
ref https://linear.app/ghost/issue/NY-693/
- updated middleware to pass through query/search params with path

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Private login redirects now keep original query strings (e.g., UTM params) while still preventing cross-domain redirects.
> 
> - **Private blogging middleware (`core/frontend/apps/private-blogging/lib/middleware.js`)**
>   - Update `getRedirectUrl` to parse with `URL`, validate host, and return `pathname + search` to preserve query strings.
> - **Tests (`test/unit/frontend/apps/private-blogging/middleware.test.js`)**
>   - Add assertions ensuring redirects retain query params on root and nested paths.
>   - Maintain checks that full/external URLs redirect to `/`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b510f4c4b2751c9ab8c2ce2f36e2a3e0948201b3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->