### PR TITLE
Added trailing slash to avoid unnecessary redirect in Pro

### DIFF
--- a/ghost/core/core/server/services/activitypub/ActivityPubService.ts
+++ b/ghost/core/core/server/services/activitypub/ActivityPubService.ts
@@ -83,7 +83,7 @@ export class ActivityPubService {
         try {
             const token = await this.getOwnerUserToken();
 
-            const res = await fetch(new URL('.ghost/activitypub/v1/site', this.siteUrl), {
+            const res = await fetch(new URL('.ghost/activitypub/v1/site/', this.siteUrl), {
                 headers: {
                     Authorization: `Bearer ${token}`
                 }
@@ -182,7 +182,7 @@ export class ActivityPubService {
         try {
             const token = await this.getOwnerUserToken();
 
-            await fetch(new URL('.ghost/activitypub/v1/site', this.siteUrl), {
+            await fetch(new URL('.ghost/activitypub/v1/site/', this.siteUrl), {
                 method: 'DELETE',
                 headers: {
                     Authorization: `Bearer ${token}`

--- a/ghost/core/test/unit/server/services/activitypub/ActivityPubService.test.ts
+++ b/ghost/core/test/unit/server/services/activitypub/ActivityPubService.test.ts
@@ -82,7 +82,7 @@ describe('ActivityPubService', function () {
 
         const siteUrl = new URL('http://fake-site-url');
         const scope = nock(siteUrl)
-            .get('/.ghost/activitypub/v1/site')
+            .get('/.ghost/activitypub/v1/site/')
             .matchHeader('authorization', 'Bearer token:owner@user.com:Owner')
             .reply(200, {
                 webhook_secret: 'webhook_secret_baby!!'
@@ -128,7 +128,7 @@ describe('ActivityPubService', function () {
 
         const siteUrl = new URL('http://fake-site-url');
         const scope = nock(siteUrl)
-            .get('/.ghost/activitypub/v1/site')
+            .get('/.ghost/activitypub/v1/site/')
             .matchHeader('authorization', 'Bearer token:owner@user.com:Owner')
             .reply(200, {
                 webhook_secret: 'webhook_secret_baby!!'
@@ -165,7 +165,7 @@ describe('ActivityPubService', function () {
         }
 
         nock(siteUrl)
-            .get('/.ghost/activitypub/v1/site')
+            .get('/.ghost/activitypub/v1/site/')
             .matchHeader('authorization', 'Bearer token:owner@user.com:Owner')
             .reply(200, {
                 webhook_secret: 'webhook_secret_baby!!'
@@ -187,7 +187,7 @@ describe('ActivityPubService', function () {
 
         const siteUrl = new URL('http://fake-site-url');
         const scope = nock(siteUrl)
-            .get('/.ghost/activitypub/v1/site')
+            .get('/.ghost/activitypub/v1/site/')
             .matchHeader('authorization', 'Bearer token:owner@user.com:Owner')
             .reply(200, {
                 webhook_secret: 'webhook_secret_baby!!'
@@ -226,7 +226,7 @@ describe('ActivityPubService', function () {
         await knexInstance('webhooks').update({event: 'wrong.event'}).limit(1);
 
         nock(siteUrl)
-            .get('/.ghost/activitypub/v1/site')
+            .get('/.ghost/activitypub/v1/site/')
             .matchHeader('authorization', 'Bearer token:owner@user.com:Owner')
             .reply(200, {
                 webhook_secret: 'webhook_secret_baby!!'
@@ -254,7 +254,7 @@ describe('ActivityPubService', function () {
 
         const siteUrl = new URL('http://fake-site-url');
         const scope = nock(siteUrl)
-            .get('/.ghost/activitypub/v1/site')
+            .get('/.ghost/activitypub/v1/site/')
             .matchHeader('authorization', 'Bearer token:owner@user.com:Owner')
             .reply(200, {
                 webhook_secret: 'webhook_secret_baby!!'
@@ -315,7 +315,7 @@ describe('ActivityPubService', function () {
 
         const siteUrl = new URL('http://fake-site-url');
         const scope = nock(siteUrl)
-            .delete('/.ghost/activitypub/v1/site')
+            .delete('/.ghost/activitypub/v1/site/')
             .matchHeader('authorization', 'Bearer token:owner@user.com:Owner')
             .reply(200);
 


### PR DESCRIPTION
ref https://app.incident.io/ghost/incidents/220
ref https://github.com/TryGhost/Ghost/pull/25590

- during incident INC-120, we noticed duplicate requests to the ActivityPub site registration endpoint (`./ghost/activitypub/v1/site`) on Ghost (Pro)
- Ghost (Pro) redirects requests without a trailing slash to the trailing slash version. Adding the trailing slash in the code avoids the unnecessary redirect
