### PR TITLE
🐛 Fixed monthly summaries not including high volume days

### DIFF
--- a/apps/stats/src/utils/chart-helpers.ts
+++ b/apps/stats/src/utils/chart-helpers.ts
@@ -188,13 +188,10 @@ function aggregateByMonth<T extends {date: string}>(data: T[], fieldName: keyof 
     data.forEach((item, index) => {
         const itemDate = moment(item.date);
         const value = Number(item[fieldName]);
-        const isLikelyOutlier = aggregationType === 'sum' && value > 10000;
 
         if (isInSameMonth(itemDate.format('YYYY-MM-DD'), currentMonth.format('YYYY-MM-DD'))) {
-            if (!isLikelyOutlier) {
-                monthTotal += value;
-                monthCount += 1;
-            }
+            monthTotal += value;
+            monthCount += 1;
             lastValue = value;
             lastItem = item;
         } else {
@@ -212,8 +209,8 @@ function aggregateByMonth<T extends {date: string}>(data: T[], fieldName: keyof 
             }
 
             currentMonth = itemDate.startOf('month');
-            monthTotal = isLikelyOutlier ? 0 : value;
-            monthCount = isLikelyOutlier ? 0 : 1;
+            monthTotal = value;
+            monthCount = 1;
             lastValue = value;
             lastItem = item;
         }


### PR DESCRIPTION
ref https://linear.app/ghost/issue/NY-799/
- removed naive 'outlier' logic from summations

Our YTD and monthly summaries were excluding days of high traffic (>10k). I don't recall why this check was in here, and it's not something we should have.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes outlier exclusion from monthly sum aggregation so high-traffic days are included, and updates tests with a regression check to preserve YTD totals.
> 
> - **Utils (`apps/stats/src/utils/chart-helpers.ts`)**:
>   - **Monthly aggregation (`aggregateByMonth`)**: Remove outlier-based exclusion; always include all daily values in `sum` and `avg` calculations; reset month totals/counts without special-casing large values.
> - **Tests (`apps/stats/test/unit/utils/chart-helpers.test.ts`)**:
>   - Update monthly sum tests to include high-traffic days and expect full sums.
>   - Add regression test ensuring monthly aggregation preserves total sums for high-traffic YTD scenarios.
>   - Minor test description tweaks to reflect new behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit da2ae058524ea322bbb72446268d30f0ab74fe41. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->