### PR TITLE
🐛 Fixed very large post count formatting in post publish dialog

### DIFF
--- a/apps/posts/src/hooks/use-post-success-modal.ts
+++ b/apps/posts/src/hooks/use-post-success-modal.ts
@@ -47,7 +47,7 @@ export const usePostSuccessModal = () => {
 
     // Helper functions for formatting
     const formatSubscriberCount = (count: number) => {
-        return `${count} subscriber${count !== 1 ? 's' : ''}`;
+        return `${count.toLocaleString()} subscriber${count !== 1 ? 's' : ''}`;
     };
 
     const formatPublicationTime = (publishedAt: string) => {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/NY-710/

We weren't formatting all of the text using `toLocaleString`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use locale-aware number formatting for subscriber counts in the post publish success modal.
> 
> - **Frontend**
>   - **Post Publish Success Modal (`apps/posts/src/hooks/use-post-success-modal.ts`)**:
>     - Format subscriber counts with `toLocaleString()` in `formatSubscriberCount` for better readability.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 46c09c56986ae5c3058e67b722ab6d30a4cfbb90. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->