### PR TITLE
Fixed welcome email test expecting wrong From name

### DIFF
--- a/e2e/tests/public/member-signup.test.ts
+++ b/e2e/tests/public/member-signup.test.ts
@@ -63,7 +63,7 @@ test.describe('Ghost Public - Member Signup', () => {
 
         latestMessage = await retrieveLatestEmailMessage(emailInbox);
 
-        expect(latestMessage.From.Name).toContain('Ghost');
+        expect(latestMessage.From.Name).toContain('Test Blog');
         expect(latestMessage.From.Address).toContain('test@example.com');
         expect(latestMessage.Subject).toContain('Welcome to Test Blog!');
         expect(latestMessage.Text).toContain('Welcome to Test Blog!');


### PR DESCRIPTION
## Summary
- Fixed member signup E2E test that was incorrectly asserting `From.Name` contains "Ghost"
- The `GhostMailer` uses the site title as the sender name, and the E2E environment uses "Test Blog"

## Test plan
- [x] Run `yarn test tests/public/member-signup.test.ts` to verify the test passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update member signup E2E test to expect "Test Blog" as the sender name in the welcome email instead of "Ghost".
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f3ff0dea61c52237ea2727bee346980e7d0697ac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->