### PR TITLE
Fixed broken member signup test, expecting wrong From name

### DIFF
--- a/e2e/tests/public/member-signup.test.ts
+++ b/e2e/tests/public/member-signup.test.ts
@@ -63,7 +63,7 @@ test.describe('Ghost Public - Member Signup', () => {
 
         latestMessage = await retrieveLatestEmailMessage(emailInbox);
 
-        expect(latestMessage.From.Name).toContain('Ghost');
+        expect(latestMessage.From.Name).toContain('Test Blog');
         expect(latestMessage.From.Address).toContain('test@example.com');
         expect(latestMessage.Subject).toContain('Welcome to Test Blog!');
         expect(latestMessage.Text).toContain('Welcome to Test Blog!');


### PR DESCRIPTION
**what**

* Fixed member signup test that was failing on welcome email since the following [PR got merged](https://github.com/TryGhost/Ghost/commit/0e08ace799ef8fd9da7b6a52f9e059f3157d4e27)
* The solution was to use blog title as a from name, instead of generic `Ghost` name that was used before