### PR TITLE
🐛 Fixed inconsistent 'member sources disabled' copy in analytics apps

### DIFF
--- a/apps/posts/src/views/PostAnalytics/Growth/components/growth-sources.tsx
+++ b/apps/posts/src/views/PostAnalytics/Growth/components/growth-sources.tsx
@@ -1,6 +1,7 @@
+import DisabledSourcesIndicator from '../../components/disabled-sources-indicator';
 import React from 'react';
 import SourceIcon from '../../components/source-icon';
-import {BaseSourceData, ProcessedSourceData, extendSourcesWithPercentages, processSources, useNavigate} from '@tryghost/admin-x-framework';
+import {BaseSourceData, ProcessedSourceData, extendSourcesWithPercentages, processSources} from '@tryghost/admin-x-framework';
 import {Button, Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle, EmptyIndicator, LucideIcon, Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle, SheetTrigger, Table, TableBody, TableCell, TableHead, TableHeader, TableRow, cn, formatNumber} from '@tryghost/shade';
 import {useAppContext} from '@src/providers/posts-app-context';
 
@@ -106,7 +107,6 @@ export const GrowthSources: React.FC<SourcesCardProps> = ({
     className
 }) => {
     const {appSettings} = useAppContext();
-    const navigate = useNavigate();
     // Process and group sources data with pre-computed icons and display values
     const processedData = React.useMemo(() => {
         return processSources({
@@ -151,18 +151,7 @@ export const GrowthSources: React.FC<SourcesCardProps> = ({
             }
             <CardContent>
                 {mode === 'growth' && !appSettings?.analytics.membersTrackSources ? (
-                    <EmptyIndicator
-                        actions={
-                            <Button variant='outline' onClick={() => navigate('/settings/analytics', {crossApp: true})}>
-                                Open settings
-                            </Button>
-                        }
-                        className='py-10'
-                        description='Enable member source tracking in settings to see which content drives member growth.'
-                        title='Member sources have been disabled'
-                    >
-                        <LucideIcon.Activity />
-                    </EmptyIndicator>
+                    <DisabledSourcesIndicator className='py-10' />
                 ) : topSources.length > 0 ? (
                     <SourcesTable
                         data={topSources}

--- a/apps/posts/src/views/PostAnalytics/components/disabled-sources-indicator.tsx
+++ b/apps/posts/src/views/PostAnalytics/components/disabled-sources-indicator.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import {Button, EmptyIndicator, LucideIcon} from '@tryghost/shade';
+import {useNavigate} from '@tryghost/admin-x-framework';
+
+interface DisabledSourcesIndicatorProps {
+    className?: string;
+}
+
+/**
+ * Shared component for displaying the disabled member sources indicator.
+ * Used to ensure consistent copy across the application.
+ */
+const DisabledSourcesIndicator: React.FC<DisabledSourcesIndicatorProps> = ({className}) => {
+    const navigate = useNavigate();
+
+    return (
+        <EmptyIndicator
+            actions={
+                <Button variant='outline' onClick={() => navigate('/settings/analytics', {crossApp: true})}>
+                    Open settings
+                </Button>
+            }
+            className={className}
+            description='Enable member source tracking in settings to see which content drives member growth.'
+            title='Member sources have been disabled'
+        >
+            <LucideIcon.Activity />
+        </EmptyIndicator>
+    );
+};
+
+export default DisabledSourcesIndicator;

--- a/apps/stats/src/views/Stats/Growth/components/growth-sources.tsx
+++ b/apps/stats/src/views/Stats/Growth/components/growth-sources.tsx
@@ -1,8 +1,9 @@
+import DisabledSourcesIndicator from '../../components/disabled-sources-indicator';
 import React, {useState} from 'react';
 import SortButton from '../../components/sort-button';
 import SourceIcon from '../../components/source-icon';
 import {Button, EmptyIndicator, LucideIcon, Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle, SheetTrigger, Skeleton, Table, TableBody, TableCell, TableFooter, TableHead, TableHeader, TableRow, centsToDollars, formatNumber} from '@tryghost/shade';
-import {getFaviconDomain, getSymbol, useAppContext, useNavigate} from '@tryghost/admin-x-framework';
+import {getFaviconDomain, getSymbol, useAppContext} from '@tryghost/admin-x-framework';
 import {getPeriodText} from '@src/utils/chart-helpers';
 import {useGlobalData} from '@src/providers/global-data-provider';
 import {useMrrHistory} from '@tryghost/admin-x-framework/api/stats';
@@ -94,7 +95,6 @@ export const GrowthSources: React.FC<GrowthSourcesProps> = ({
     const {data: globalData} = useGlobalData();
     const {data: mrrHistoryResponse} = useMrrHistory();
     const {appSettings} = useAppContext();
-    const navigate = useNavigate();
 
     // Use external sort state if provided, otherwise use internal state
     const [internalSortBy, setInternalSortBy] = useState<SourcesOrder>('free_members desc');
@@ -169,17 +169,7 @@ export const GrowthSources: React.FC<GrowthSourcesProps> = ({
             <TableBody>
                 <TableRow className='last:border-none'>
                     <TableCell className='border-none py-12 group-hover:!bg-transparent' colSpan={appSettings?.paidMembersEnabled ? 4 : 2}>
-                        <EmptyIndicator
-                            actions={
-                                <Button variant='outline' onClick={() => navigate('/settings/analytics', {crossApp: true})}>
-                                    Open settings
-                                </Button>
-                            }
-                            description='Enable member source tracking in settings to see which content drives member growth.'
-                            title='Member sources have been disabled'
-                        >
-                            <LucideIcon.Activity />
-                        </EmptyIndicator>
+                        <DisabledSourcesIndicator />
                     </TableCell>
                 </TableRow>
             </TableBody>

--- a/apps/stats/src/views/Stats/Growth/growth.tsx
+++ b/apps/stats/src/views/Stats/Growth/growth.tsx
@@ -1,4 +1,5 @@
 import DateRangeSelect from '../components/date-range-select';
+import DisabledSourcesIndicator from '../components/disabled-sources-indicator';
 import GrowthKPIs from './components/growth-kpis';
 import GrowthSources from './components/growth-sources';
 import React, {useMemo, useState} from 'react';
@@ -206,17 +207,7 @@ const Growth: React.FC = () => {
                                         !appSettings?.analytics.membersTrackSources ? (
                                             <TableRow className='last:border-none'>
                                                 <TableCell className='border-none py-12 group-hover:!bg-transparent' colSpan={appSettings?.paidMembersEnabled ? 4 : 2}>
-                                                    <EmptyIndicator
-                                                        actions={
-                                                            <Button variant='outline' onClick={() => navigate('/settings/analytics', {crossApp: true})}>
-                                                                Open settings
-                                                            </Button>
-                                                        }
-                                                        description='Enable member source tracking in settings to see which content drives member growth.'
-                                                        title='Member sources have been disabled'
-                                                    >
-                                                        <LucideIcon.Activity />
-                                                    </EmptyIndicator>
+                                                    <DisabledSourcesIndicator />
                                                 </TableCell>
                                             </TableRow>
                                         ) : transformedTopPosts.length > 0 ? (

--- a/apps/stats/src/views/Stats/components/disabled-sources-indicator.tsx
+++ b/apps/stats/src/views/Stats/components/disabled-sources-indicator.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import {Button, EmptyIndicator, LucideIcon} from '@tryghost/shade';
+import {useNavigate} from '@tryghost/admin-x-framework';
+
+interface DisabledSourcesIndicatorProps {
+    className?: string;
+}
+
+/**
+ * Shared component for displaying the disabled member sources indicator.
+ * Used in both the Sources tab and Posts & Pages tabs to ensure consistent copy.
+ */
+const DisabledSourcesIndicator: React.FC<DisabledSourcesIndicatorProps> = ({className}) => {
+    const navigate = useNavigate();
+
+    return (
+        <EmptyIndicator
+            actions={
+                <Button variant='outline' onClick={() => navigate('/settings/analytics', {crossApp: true})}>
+                    Open settings
+                </Button>
+            }
+            className={className}
+            description='Enable member source tracking in settings to see which content drives member growth.'
+            title='Member sources have been disabled'
+        >
+            <LucideIcon.Activity />
+        </EmptyIndicator>
+    );
+};
+
+export default DisabledSourcesIndicator;


### PR DESCRIPTION
ref https://linear.app/ghost/issue/NY-377/

For various reasons, we had a few different implementations of the 'member sources is disabled'. This commit unifies them to a common component.

Because we need to use framework and shade, we had to duplicate the component. This will be remediated when we eventually combine these apps.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces ad-hoc "member sources disabled" UI with a shared DisabledSourcesIndicator in Posts and Stats, removing local navigate logic and consolidating copy.
> 
> - **UI/UX**:
>   - Introduce shared `DisabledSourcesIndicator` in `apps/posts` and `apps/stats`.
>   - Replace inline `EmptyIndicator` implementations in:
>     - `apps/posts/.../Growth/components/growth-sources.tsx`
>     - `apps/stats/.../Growth/components/growth-sources.tsx`
>     - `apps/stats/.../Growth/growth.tsx`
> - **Cleanup**:
>   - Remove `useNavigate` imports/usages from updated components where navigation is now handled by `DisabledSourcesIndicator`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a1621f32f074499345ad4ea519eec2efe7912304. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->