### PR TITLE
Released @tryghost/portal v2.56.3

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.56.2",
+  "version": "2.56.3",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Changelog for v2.56.2 -> 2.56.3:
  - Updated i18n translations


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bump `@tryghost/portal` version in `apps/portal/package.json` from `2.56.2` to `2.56.3`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a97557924eb336bea8fb9669585256cec5b99acb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->