### PR TITLE
Added permissions for `automated_emails`

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/6.10/2025-12-01-21-04-37-add-automated-email-permissions.js
+++ b/ghost/core/core/server/data/migrations/versions/6.10/2025-12-01-21-04-37-add-automated-email-permissions.js
@@ -1,0 +1,44 @@
+const {combineTransactionalMigrations, addPermissionWithRoles} = require('../../utils');
+
+module.exports = combineTransactionalMigrations(
+    addPermissionWithRoles({
+        name: 'Browse automated emails',
+        action: 'browse',
+        object: 'automated_email'
+    }, [
+        'Administrator',
+        'Admin Integration'
+    ]),
+    addPermissionWithRoles({
+        name: 'Read automated emails',
+        action: 'read',
+        object: 'automated_email'
+    }, [
+        'Administrator',
+        'Admin Integration'
+    ]),
+    addPermissionWithRoles({
+        name: 'Edit automated emails',
+        action: 'edit',
+        object: 'automated_email'
+    }, [
+        'Administrator',
+        'Admin Integration'
+    ]),
+    addPermissionWithRoles({
+        name: 'Add automated emails',
+        action: 'add',
+        object: 'automated_email'
+    }, [
+        'Administrator',
+        'Admin Integration'
+    ]),
+    addPermissionWithRoles({
+        name: 'Delete automated emails',
+        action: 'destroy',
+        object: 'automated_email'
+    }, [
+        'Administrator',
+        'Admin Integration'
+    ])
+);

--- a/ghost/core/core/server/data/schema/fixtures/fixtures.json
+++ b/ghost/core/core/server/data/schema/fixtures/fixtures.json
@@ -512,6 +512,31 @@
                     "object_type": "label"
                 },
                 {
+                    "name": "Browse automated emails",
+                    "action_type": "browse",
+                    "object_type": "automated_email"
+                },
+                {
+                    "name": "Read automated emails",
+                    "action_type": "read",
+                    "object_type": "automated_email"
+                },
+                {
+                    "name": "Edit automated emails",
+                    "action_type": "edit",
+                    "object_type": "automated_email"
+                },
+                {
+                    "name": "Add automated emails",
+                    "action_type": "add",
+                    "object_type": "automated_email"
+                },
+                {
+                    "name": "Delete automated emails",
+                    "action_type": "destroy",
+                    "object_type": "automated_email"
+                },
+                {
                     "name": "Read member signin urls",
                     "action_type": "read",
                     "object_type": "member_signin_url"
@@ -859,6 +884,7 @@
                     "member": "all",
                     "product": "all",
                     "label": "all",
+                    "automated_email": "all",
                     "email_preview": "all",
                     "email": "all",
                     "member_signin_url": "read",
@@ -907,6 +933,7 @@
                     "action": "all",
                     "member": "all",
                     "label": "all",
+                    "automated_email": "all",
                     "email_preview": "all",
                     "email": "all",
                     "snippet": "all",

--- a/ghost/core/test/integration/migrations/migration.test.js
+++ b/ghost/core/test/integration/migrations/migration.test.js
@@ -99,7 +99,7 @@ describe('Migrations', function () {
             const permissions = this.obj;
 
             // If you have to change this number, please add the relevant `havePermission` checks below
-            permissions.length.should.eql(120);
+            permissions.length.should.eql(125);
 
             permissions.should.havePermission('Export database', ['Administrator', 'DB Backup Integration']);
             permissions.should.havePermission('Import database', ['Administrator', 'Self-Serve Migration Integration', 'DB Backup Integration']);

--- a/ghost/core/test/integration/migrations/migration.test.js
+++ b/ghost/core/test/integration/migrations/migration.test.js
@@ -243,6 +243,12 @@ describe('Migrations', function () {
             permissions.should.havePermission('Add collections', ['Administrator', 'Editor', 'Author', 'Admin Integration', 'Super Editor']);
             permissions.should.havePermission('Delete collections', ['Administrator', 'Editor', 'Admin Integration', 'Super Editor']);
             permissions.should.havePermission('Read member signin urls', ['Administrator', 'Admin Integration', 'Super Editor']);
+
+            permissions.should.havePermission('Browse automated emails', ['Administrator', 'Admin Integration']);
+            permissions.should.havePermission('Read automated emails', ['Administrator', 'Admin Integration']);
+            permissions.should.havePermission('Edit automated emails', ['Administrator', 'Admin Integration']);
+            permissions.should.havePermission('Add automated emails', ['Administrator', 'Admin Integration']);
+            permissions.should.havePermission('Delete automated emails', ['Administrator', 'Admin Integration']);
         });
 
         describe('Populate', function () {

--- a/ghost/core/test/unit/server/data/schema/fixtures/fixture-manager.test.js
+++ b/ghost/core/test/unit/server/data/schema/fixtures/fixture-manager.test.js
@@ -409,7 +409,7 @@ describe('Migration Fixture Utils', function () {
             const rolesAllStub = sinon.stub(models.Role, 'findAll').returns(Promise.resolve(dataMethodStub));
 
             fixtureManager.addFixturesForRelation(fixtures.relations[0]).then(function (result) {
-                const FIXTURE_COUNT = 135;
+                const FIXTURE_COUNT = 137;
                 should.exist(result);
                 result.should.be.an.Object();
                 result.should.have.property('expected', FIXTURE_COUNT);

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -36,7 +36,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
 describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = '840147221764a9de1b3807e3abb61df2';
-    const currentFixturesHash = '0877727032b8beddbaedc086a8acf1a2';
+    const currentFixturesHash = 'c583f33910bb84a70847303b323be2db';
     const currentSettingsHash = 'bb8be7d83407f2b4fa2ad68c19610579';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';
 
@@ -63,10 +63,10 @@ describe('DB version integrity', function () {
         settingsHash = crypto.createHash('md5').update(JSON.stringify(defaultSettings), 'binary').digest('hex');
         routesHash = crypto.createHash('md5').update(JSON.stringify(defaultRoutes), 'binary').digest('hex');
 
-        schemaHash.should.eql(currentSchemaHash);
-        fixturesHash.should.eql(currentFixturesHash);
-        settingsHash.should.eql(currentSettingsHash);
-        routesHash.should.eql(currentRoutesHash);
+        schemaHash.should.eql(currentSchemaHash, 'Database schema has changed, please ensure a proper migration has been created if necessary and update the hash in this test.');
+        fixturesHash.should.eql(currentFixturesHash, 'Fixtures have changed, please ensure a proper migration has been created if necessary and update the hash in this test.');
+        settingsHash.should.eql(currentSettingsHash, 'Default settings have changed, please ensure a proper migration has been created if necessary and update the hash in this test.');
+        routesHash.should.eql(currentRoutesHash, 'Default routes have changed, please ensure a proper migration has been created if necessary and update the hash in this test.');
         routesHash.should.eql(routeSettings.getDefaultHash());
     });
 });

--- a/ghost/core/test/utils/fixtures/fixtures.json
+++ b/ghost/core/test/utils/fixtures/fixtures.json
@@ -517,6 +517,31 @@
                     "object_type": "label"
                 },
                 {
+                    "name": "Browse automated emails",
+                    "action_type": "browse",
+                    "object_type": "automated_email"
+                },
+                {
+                    "name": "Read automated emails",
+                    "action_type": "read",
+                    "object_type": "automated_email"
+                },
+                {
+                    "name": "Edit automated emails",
+                    "action_type": "edit",
+                    "object_type": "automated_email"
+                },
+                {
+                    "name": "Add automated emails",
+                    "action_type": "add",
+                    "object_type": "automated_email"
+                },
+                {
+                    "name": "Delete automated emails",
+                    "action_type": "destroy",
+                    "object_type": "automated_email"
+                },
+                {
                     "name": "Read member signin urls",
                     "action_type": "read",
                     "object_type": "member_signin_url"
@@ -1019,6 +1044,7 @@
                     "member": "all",
                     "product": "all",
                     "label": "all",
+                    "automated_email": "all",
                     "email_preview": "all",
                     "email": "all",
                     "member_signin_url": "read",
@@ -1068,6 +1094,7 @@
                     "member": "all",
                     "member_signin_url": "read",
                     "label": "all",
+                    "automated_email": "all",
                     "email_preview": "all",
                     "email": "all",
                     "snippet": "all",


### PR DESCRIPTION
ref https://linear.app/ghost/issue/NY-772/add-automated-emails-crud-api-endpoints

The new `automated_emails` model should only be accessible by Administrators+ in Ghost. This adds the appropriate permissions to Ghost's DB to enforce these permissions in the API endpoints, which will be included in a subsequent commit.