### PR TITLE
Wired up automated_emails API to Member Welcome Emails UI

### DIFF
--- a/apps/admin-x-framework/src/api/automatedEmails.ts
+++ b/apps/admin-x-framework/src/api/automatedEmails.ts
@@ -1,0 +1,50 @@
+import {Meta, createMutation, createQuery} from '../utils/api/hooks';
+import {insertToQueryCache, updateQueryCache} from '../utils/api/updateQueries';
+
+export type AutomatedEmail = {
+    id: string;
+    status: 'active' | 'inactive';
+    name: string;
+    slug: string;
+    subject: string;
+    lexical: string | null;
+    sender_name: string | null;
+    sender_email: string | null;
+    sender_reply_to: string | null;
+    created_at: string;
+    updated_at: string | null;
+}
+
+export interface AutomatedEmailsResponseType {
+    meta?: Meta;
+    automated_emails: AutomatedEmail[];
+}
+
+const dataType = 'AutomatedEmailsResponseType';
+
+export const useBrowseAutomatedEmails = createQuery<AutomatedEmailsResponseType>({
+    dataType,
+    path: '/automated_emails/'
+});
+
+export const useAddAutomatedEmail = createMutation<AutomatedEmailsResponseType, Partial<AutomatedEmail>>({
+    method: 'POST',
+    path: () => '/automated_emails/',
+    body: automatedEmail => ({automated_emails: [automatedEmail]}),
+    updateQueries: {
+        dataType,
+        emberUpdateType: 'createOrUpdate',
+        update: insertToQueryCache('automated_emails')
+    }
+});
+
+export const useEditAutomatedEmail = createMutation<AutomatedEmailsResponseType, AutomatedEmail>({
+    method: 'PUT',
+    path: automatedEmail => `/automated_emails/${automatedEmail.id}/`,
+    body: automatedEmail => ({automated_emails: [automatedEmail]}),
+    updateQueries: {
+        dataType,
+        emberUpdateType: 'createOrUpdate',
+        update: updateQueryCache('automated_emails')
+    }
+});

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails.tsx
@@ -1,24 +1,31 @@
 import FakeLogo from '../../../assets/images/explore-default-logo.png';
 import NiceModal from '@ebay/nice-modal-react';
-import React, {useState} from 'react';
+import React from 'react';
 import TopLevelGroup from '../../top-level-group';
 import WelcomeEmailModal from './member-emails/welcome-email-modal';
+import {useAddAutomatedEmail, useBrowseAutomatedEmails, useEditAutomatedEmail} from '@tryghost/admin-x-framework/api/automatedEmails';
+import type {AutomatedEmail} from '@tryghost/admin-x-framework/api/automatedEmails';
 import {Button, Separator, SettingGroupContent, Toggle, withErrorBoundary} from '@tryghost/admin-x-design-system';
 import {getSettingValues} from '@tryghost/admin-x-framework/api/settings';
 import {useGlobalData} from '../../providers/global-data-provider';
 
-const DummyEmail: React.FC<{
-    sender: string,
-    title: string,
+// Default welcome email content in Lexical JSON format
+const DEFAULT_FREE_LEXICAL_CONTENT = '{"root":{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"Welcome! Thanks for subscribing — it\'s great to have you here.","type":"extended-text","version":1}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1},{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"You\'ll now receive new posts straight to your inbox. You can also log in any time to read the full archive [link] or catch up on new posts as they go live.","type":"extended-text","version":1}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1},{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"A little housekeeping: If this email landed in spam or promotions, try moving it to your primary inbox and adding this address to your contacts. Small signals like that helps your inbox recognize that these messages matter to you.","type":"extended-text","version":1}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1},{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"Have questions or just want to say hi? Feel free to reply directly to this email or any newsletter in the future.","type":"extended-text","version":1}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1},{"children":[],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}}';
+
+const DEFAULT_PAID_LEXICAL_CONTENT = '{"root":{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"Welcome, and thank you for your support — it means a lot.","type":"extended-text","version":1}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1},{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"As a paid member, you now have full access to everything: the complete archive, and any paid-only content going forward. New posts will land straight to your inbox, and you can log in any time to catch up [link] on anything you\'ve missed.","type":"extended-text","version":1}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1},{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"A little housekeeping: If this email landed in spam or promotions, try moving it to your primary inbox and adding this address to your contacts. Small signals like that helps your inbox recognize that these messages matter to you.","type":"extended-text","version":1}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1},{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"Have questions or just want to say hi? Feel free to reply directly to this email or any newsletter in the future.","type":"extended-text","version":1}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}}';
+
+const EmailPreview: React.FC<{
+    automatedEmail: AutomatedEmail,
     emailType: 'free' | 'paid'
 }> = ({
-    sender,
-    title,
+    automatedEmail,
     emailType
 }) => {
     const {settings} = useGlobalData();
-    const [accentColor, icon] = getSettingValues<string>(settings, ['accent_color', 'icon']);
+    const [accentColor, icon, siteTitle] = getSettingValues<string>(settings, ['accent_color', 'icon', 'title']);
     const color = accentColor || '#F6414E';
+
+    const senderName = automatedEmail.sender_name || siteTitle || 'Your Site';
 
     return (
         <div className='mb-5 flex items-center justify-between gap-3 rounded-lg border border-grey-100 bg-grey-50 p-5'>
@@ -35,8 +42,8 @@ const DummyEmail: React.FC<{
                     </div>
                 }
                 <div>
-                    <div className='font-semibold'>{sender}</div>
-                    <div className='text-sm'>{title}</div>
+                    <div className='font-semibold'>{senderName}</div>
+                    <div className='text-sm'>{automatedEmail.subject}</div>
                 </div>
             </div>
             <Button
@@ -45,7 +52,7 @@ const DummyEmail: React.FC<{
                 icon='pen'
                 label='Edit'
                 onClick={() => {
-                    NiceModal.show(WelcomeEmailModal, {emailType});
+                    NiceModal.show(WelcomeEmailModal, {emailType, automatedEmail});
                 }}
             />
         </div>
@@ -53,8 +60,47 @@ const DummyEmail: React.FC<{
 };
 
 const MemberEmails: React.FC<{ keywords: string[] }> = ({keywords}) => {
-    const [freeWelcomeEmailState, setFreeWelcomeEmailState] = useState(false);
-    const [paidWelcomeEmailState, setPaidWelcomeEmailState] = useState(false);
+    const {settings} = useGlobalData();
+    const [siteTitle] = getSettingValues<string>(settings, ['title']);
+
+    const {data: automatedEmailsData} = useBrowseAutomatedEmails();
+    const {mutateAsync: addAutomatedEmail} = useAddAutomatedEmail();
+    const {mutateAsync: editAutomatedEmail} = useEditAutomatedEmail();
+
+    const automatedEmails = automatedEmailsData?.automated_emails || [];
+
+    const freeWelcomeEmail = automatedEmails.find(email => email.slug === 'member-welcome-email-free');
+    const paidWelcomeEmail = automatedEmails.find(email => email.slug === 'member-welcome-email-paid');
+
+    const freeWelcomeEmailEnabled = freeWelcomeEmail?.status === 'active';
+    const paidWelcomeEmailEnabled = paidWelcomeEmail?.status === 'active';
+
+    const handleToggle = async (emailType: 'free' | 'paid') => {
+        const slug = `member-welcome-email-${emailType}`;
+        const existing = automatedEmails.find(email => email.slug === slug);
+
+        const defaultSubject = emailType === 'free'
+            ? `Welcome to ${siteTitle || 'our site'}`
+            : 'Welcome to your paid subscription';
+
+        if (!existing) {
+            // First toggle ON - create with defaults
+            const defaultContent = emailType === 'free' ? DEFAULT_FREE_LEXICAL_CONTENT : DEFAULT_PAID_LEXICAL_CONTENT;
+            await addAutomatedEmail({
+                name: emailType === 'free' ? 'Welcome Email (Free)' : 'Welcome Email (Paid)',
+                slug: slug,
+                subject: defaultSubject,
+                status: 'active',
+                lexical: defaultContent
+            });
+        } else if (existing.status === 'active') {
+            // Toggle OFF
+            await editAutomatedEmail({...existing, status: 'inactive'});
+        } else {
+            // Toggle ON (re-enable)
+            await editAutomatedEmail({...existing, status: 'active'});
+        }
+    };
 
     return (
         <TopLevelGroup
@@ -67,42 +113,36 @@ const MemberEmails: React.FC<{ keywords: string[] }> = ({keywords}) => {
             <SettingGroupContent className="!gap-y-0" columns={1}>
                 <Separator />
                 <Toggle
-                    checked={freeWelcomeEmailState}
+                    checked={Boolean(freeWelcomeEmailEnabled)}
                     containerClasses='items-center'
                     direction='rtl'
                     gap='gap-0'
                     hint='Email new free members receive when they join your site.'
                     label='Free members welcome email'
                     labelClasses='py-4 w-full'
-                    onChange={() => {
-                        setFreeWelcomeEmailState(!freeWelcomeEmailState);
-                    }}
+                    onChange={() => handleToggle('free')}
                 />
-                {freeWelcomeEmailState &&
-                    <DummyEmail
+                {freeWelcomeEmail && freeWelcomeEmailEnabled &&
+                    <EmailPreview
+                        automatedEmail={freeWelcomeEmail}
                         emailType='free'
-                        sender='Publisher Weekly'
-                        title='Welcome to Publisher Weekly'
                     />
                 }
                 <Separator />
                 <Toggle
-                    checked={paidWelcomeEmailState}
+                    checked={Boolean(paidWelcomeEmailEnabled)}
                     containerClasses='items-center'
                     direction='rtl'
                     gap='gap-0'
                     hint='Sent to new paid members as soon as they start their subscription.'
                     label='Paid members welcome email'
                     labelClasses='py-4 w-full'
-                    onChange={() => {
-                        setPaidWelcomeEmailState(!paidWelcomeEmailState);
-                    }}
+                    onChange={() => handleToggle('paid')}
                 />
-                {paidWelcomeEmailState &&
-                    <DummyEmail
+                {paidWelcomeEmail && paidWelcomeEmailEnabled &&
+                    <EmailPreview
+                        automatedEmail={paidWelcomeEmail}
                         emailType='paid'
-                        sender='Publisher Weekly'
-                        title='Welcome to your paid subscription'
                     />
                 }
             </SettingGroupContent>

--- a/ghost/admin/app/services/state-bridge.js
+++ b/ghost/admin/app/services/state-bridge.js
@@ -6,6 +6,7 @@ import {inject} from 'ghost-admin/decorators/inject';
 import {run} from '@ember/runloop';
 
 const emberDataTypeMapping = {
+    AutomatedEmailsResponseType: null, // automated emails only exist in React admin
     IntegrationsResponseType: {type: 'integration'},
     InvitesResponseType: {type: 'invite'},
     OffersResponseType: {type: 'offer'},


### PR DESCRIPTION
ref https://linear.app/ghost/issue/NY-791/wire-up-the-automated-emails-api-to-the-static-ui-in-settings

The Member Welcome Emails settings UI was previously static with no backend integration. Toggle states were not persisted and emails could not be created or managed. This connects the UI to the new automated_emails API endpoint, enabling users to toggle welcome emails on/off with state persisting across page refreshes. Different default Lexical content is used for free vs paid member emails

Note: this PR only includes the ability to toggle each type of welcome email on/off; the ability to edit the subject/content/sender info will be included in a subsequent PR. 