### PR TITLE
High water mark test

### DIFF
--- a/ghost/core/core/server/adapters/storage/S3Storage.ts
+++ b/ghost/core/core/server/adapters/storage/S3Storage.ts
@@ -196,7 +196,7 @@ export default class S3Storage extends StorageBase {
         const readStart = Date.now();
         logging.info(`[S3Storage] readFileInChunks() started: file=${filePath} targetChunkSize=${chunkSize}`);
 
-        const stream = fs.createReadStream(filePath);
+        const stream = fs.createReadStream(filePath, {highWaterMark: chunkSize});
         let buffer = Buffer.alloc(0);
         let streamChunksRead = 0;
         let totalStreamBytesRead = 0;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add comprehensive timing and progress logging to S3 storage uploads, including multipart, with chunk-sized stream reads.
> 
> - **Backend (storage)**:
>   - **Instrumentation**: Add detailed timing/progress logging in `core/server/adapters/storage/S3Storage.ts` for `save`, `readFileInChunks`, `uploadMultipart`, and `saveRaw`.
>     - Logs durations, sizes, part/chunk counts, and outcomes for S3 commands (`PutObject`, `CreateMultipartUpload`, `UploadPart`, `CompleteMultipartUpload`, `AbortMultipartUpload`).
>     - Configure `fs.createReadStream` with `highWaterMark` equal to multipart chunk size; track buffer concat/slice metrics.
>     - Standardize log prefixes to `[S3Storage]` and add start/completion logs for operations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a6ff96ae055b82c51e6873a4d8f0829111fa8afc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->