### PR TITLE
Set highWaterMark on createReadStream for multipart uploads

### DIFF
--- a/ghost/core/core/server/adapters/storage/S3Storage.ts
+++ b/ghost/core/core/server/adapters/storage/S3Storage.ts
@@ -174,7 +174,7 @@ export default class S3Storage extends StorageBase {
     }
 
     private async *readFileInChunks(filePath: string, chunkSize: number): AsyncGenerator<Buffer> {
-        const stream = fs.createReadStream(filePath);
+        const stream = fs.createReadStream(filePath, {highWaterMark: chunkSize});
         let buffer = Buffer.alloc(0);
 
         for await (const chunk of stream) {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PRO-1538/

- Setting highWaterMark to chunkSize so Node.js reads larger chunks from disk, reducing the number of Buffer.concat operations needed.
- This is a Node.js internal optimization that doesn't change functional behavior. Existing tests already verify chunks are yielded correctly and multipart uploads work as expected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Configures fs.createReadStream to use highWaterMark equal to the multipart chunk size in S3Storage’s chunk reader.
> 
> - **Storage**:
>   - Update `ghost/core/core/server/adapters/storage/S3Storage.ts`:
>     - In `readFileInChunks`, set `fs.createReadStream(filePath, {highWaterMark: chunkSize})` to align read size with multipart chunking.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c528110a133fc93108ed4f8e0cd03f50927bc297. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->