### PR TITLE
Merged visitors and views in Web traffic charts

### DIFF
--- a/apps/shade/src/components/ui/gh-chart.stories.tsx
+++ b/apps/shade/src/components/ui/gh-chart.stories.tsx
@@ -155,3 +155,31 @@ export const MultiSeries: Story = {
         }
     }
 };
+
+// Multi-series data with zero values
+const multiSeriesZeroData: GhAreaChartDataItem[] = [
+    {date: '2024-01-01', value: 0, formattedValue: '', label: '', visits: 0, pageviews: 0},
+    {date: '2024-01-02', value: 0, formattedValue: '', label: '', visits: 0, pageviews: 0},
+    {date: '2024-01-03', value: 0, formattedValue: '', label: '', visits: 0, pageviews: 0},
+    {date: '2024-01-04', value: 0, formattedValue: '', label: '', visits: 0, pageviews: 0},
+    {date: '2024-01-05', value: 0, formattedValue: '', label: '', visits: 0, pageviews: 0},
+    {date: '2024-01-06', value: 0, formattedValue: '', label: '', visits: 0, pageviews: 0},
+    {date: '2024-01-07', value: 0, formattedValue: '', label: '', visits: 0, pageviews: 0}
+];
+
+export const MultiSeriesWithZeroValues: Story = {
+    args: {
+        data: multiSeriesZeroData,
+        range: 7,
+        id: 'multi-series-zero-chart',
+        className: 'h-[300px]',
+        series: webAnalyticsSeries
+    },
+    parameters: {
+        docs: {
+            description: {
+                story: 'Edge case: Multi-series chart with all zero values. The chart gracefully handles this by setting Y-axis range to [0, 1] to prevent a degenerate domain where min equals max.'
+            }
+        }
+    }
+};

--- a/apps/shade/src/components/ui/gh-chart.stories.tsx
+++ b/apps/shade/src/components/ui/gh-chart.stories.tsx
@@ -1,5 +1,5 @@
 import type {Meta, StoryObj} from '@storybook/react-vite';
-import {GhAreaChart, type GhAreaChartDataItem} from './gh-chart';
+import {GhAreaChart, type GhAreaChartDataItem, type GhAreaChartSeries} from './gh-chart';
 
 const meta = {
     title: 'Components / Ghost Chart',
@@ -112,5 +112,46 @@ export const HourlyData: Story = {
         id: 'hourly-chart',
         className: 'h-[200px]',
         showHours: true
+    }
+};
+
+// Multi-series data
+const multiSeriesData: GhAreaChartDataItem[] = [
+    {date: '2024-01-01', value: 0, formattedValue: '', label: '', visits: 120, pageviews: 280},
+    {date: '2024-01-02', value: 0, formattedValue: '', label: '', visits: 95, pageviews: 220},
+    {date: '2024-01-03', value: 0, formattedValue: '', label: '', visits: 180, pageviews: 410},
+    {date: '2024-01-04', value: 0, formattedValue: '', label: '', visits: 220, pageviews: 520},
+    {date: '2024-01-05', value: 0, formattedValue: '', label: '', visits: 160, pageviews: 350},
+    {date: '2024-01-06', value: 0, formattedValue: '', label: '', visits: 310, pageviews: 680},
+    {date: '2024-01-07', value: 0, formattedValue: '', label: '', visits: 250, pageviews: 590}
+];
+
+const webAnalyticsSeries: GhAreaChartSeries[] = [
+    {
+        dataKey: 'visits',
+        label: 'Unique visitors',
+        color: 'hsl(var(--chart-blue))'
+    },
+    {
+        dataKey: 'pageviews',
+        label: 'Total views',
+        color: 'hsl(var(--chart-teal))'
+    }
+];
+
+export const MultiSeries: Story = {
+    args: {
+        data: multiSeriesData,
+        range: 7,
+        id: 'multi-series-chart',
+        className: 'h-[300px]',
+        series: webAnalyticsSeries
+    },
+    parameters: {
+        docs: {
+            description: {
+                story: 'Display multiple data series on the same chart. Each series has its own color and appears in the tooltip. Perfect for comparing related metrics like visitors vs page views.'
+            }
+        }
     }
 };

--- a/apps/shade/src/components/ui/gh-chart.tsx
+++ b/apps/shade/src/components/ui/gh-chart.tsx
@@ -161,12 +161,15 @@ const GhAreaChart: React.FC<GhAreaChartProps> = ({
             });
         });
 
-        // Apply the same padding logic as single-series (2% padding)
-        const padding = 0.02;
-        const paddedMax = max === -Infinity ? 0 : max + (max * padding);
-
-        // Always start at 0 for multi-series charts
-        yRange = [0, paddedMax];
+        // Handle case when max is 0 or -Infinity (all values are zero or no data)
+        if (max <= 0) {
+            yRange = [0, 1];
+        } else {
+            // Apply the same padding logic as single-series (2% padding)
+            const padding = 0.02;
+            const paddedMax = max + (max * padding);
+            yRange = [0, paddedMax];
+        }
     } else {
         yRange = [getYRange(data).min, getYRange(data).max];
     }

--- a/apps/shade/src/components/ui/gh-chart.tsx
+++ b/apps/shade/src/components/ui/gh-chart.tsx
@@ -8,12 +8,16 @@ import {TrendingDown, TrendingUp} from 'lucide-react';
 
 interface TooltipPayload {
     value: number;
+    dataKey: string;
+    name: string;
+    color: string;
     payload: {
         date?: string;
         formattedValue?: string;
         label?: string;
         diffValue?: null | number;
         formattedDiffValue?: null | string;
+        [key: string]: string | number | null | undefined;
     };
 }
 
@@ -23,21 +27,50 @@ interface TooltipProps {
     range?: number;
     showHours?: boolean;
     color?: string;
+    series?: GhAreaChartSeries[];
 }
 
-const GhCustomTooltipContent = ({active, payload, range, showHours, color}: TooltipProps) => {
+const GhCustomTooltipContent = ({active, payload, range, showHours, color, series}: TooltipProps) => {
     if (!active || !payload?.length) {
         return null;
     }
 
     const {date, formattedValue, label, diffValue, formattedDiffValue} = payload[0].payload;
+
+    // Multi-series mode: show all series in tooltip
+    if (series && series.length > 1) {
+        return (
+            <div className="min-w-[120px] rounded-lg border bg-background px-3 py-2 shadow-lg">
+                {date && <div className="mb-2 text-sm text-foreground">{formatDisplayDateWithRange(date, range || 0, showHours)}</div>}
+                {payload.map((entry) => {
+                    const seriesConfig = series.find(s => s.dataKey === entry.dataKey);
+                    const entryColor = seriesConfig?.color || entry.color;
+                    const entryLabel = seriesConfig?.label || entry.name;
+
+                    return (
+                        <div key={entry.dataKey} className='mb-1 flex items-start gap-2 last:mb-0'>
+                            <span className='mt-1.5 inline-block size-2 rounded-full opacity-70' style={{backgroundColor: entryColor}}></span>
+                            <div className='flex grow items-start justify-between gap-5'>
+                                <div className="text-sm text-muted-foreground">{entryLabel}</div>
+                                <div className="font-mono font-medium">
+                                    {formatNumber(entry.value)}
+                                </div>
+                            </div>
+                        </div>
+                    );
+                })}
+            </div>
+        );
+    }
+
+    // Single-series mode (backward compatible)
     const displayValue = formattedValue || payload[0].value;
 
     return (
         <div className="min-w-[120px] rounded-lg border bg-background px-3 py-2 shadow-lg">
             {date && <div className="text-sm text-foreground">{formatDisplayDateWithRange(date, range || 0, showHours)}</div>}
             <div className='flex items-start gap-2'>
-                <span className='mt-1.5 inline-block size-2 rounded-full opacity-50' style={{backgroundColor: color || 'hsl(var(--chart-blue))'}}></span>
+                <span className='mt-1.5 inline-block size-2 rounded-full opacity-70' style={{backgroundColor: color || 'hsl(var(--chart-blue))'}}></span>
                 <div className='flex grow items-start justify-between gap-5'>
                     {label && <div className="text-sm text-muted-foreground">{label}</div>}
                     <div className="flex flex-col items-end font-mono font-medium">
@@ -70,6 +103,13 @@ export type GhAreaChartDataItem = {
     value: number;
     formattedValue: string;
     label: string;
+    [key: string]: string | number; // Allow additional data keys for multiple series
+}
+
+export type GhAreaChartSeries = {
+    dataKey: string;
+    label: string;
+    color: string;
 }
 
 interface GhAreaChartProps {
@@ -85,6 +125,7 @@ interface GhAreaChartProps {
     showHorizontalLines?: boolean;
     dataFormatter?: (value: number) => string;
     showHours?: boolean;
+    series?: GhAreaChartSeries[]; // Optional array of series for multi-series charts
 }
 
 const GhAreaChart: React.FC<GhAreaChartProps> = ({
@@ -99,14 +140,48 @@ const GhAreaChart: React.FC<GhAreaChartProps> = ({
     showYAxisValues = true,
     showHorizontalLines = true,
     dataFormatter = formatNumber,
-    showHours = false
+    showHours = false,
+    series
 }) => {
-    const yRange = yAxisRange || [getYRange(data).min, getYRange(data).max];
-    const chartConfig = {
-        value: {
-            label: data[0]?.label || 'Value'
-        }
-    } satisfies ChartConfig;
+    // Determine if this is multi-series mode
+    const isMultiSeries = series && series.length > 1;
+
+    // Calculate yRange based on all series if multi-series
+    let yRange: [number, number];
+    if (yAxisRange) {
+        yRange = yAxisRange;
+    } else if (isMultiSeries) {
+        let max = -Infinity;
+        data.forEach((item) => {
+            series.forEach((s) => {
+                const value = Number(item[s.dataKey]);
+                if (!isNaN(value)) {
+                    max = Math.max(max, value);
+                }
+            });
+        });
+
+        // Apply the same padding logic as single-series (2% padding)
+        const padding = 0.02;
+        const paddedMax = max === -Infinity ? 0 : max + (max * padding);
+
+        // Always start at 0 for multi-series charts
+        yRange = [0, paddedMax];
+    } else {
+        yRange = [getYRange(data).min, getYRange(data).max];
+    }
+
+    // Build chart config for single or multiple series
+    const chartConfig = isMultiSeries
+        ? series.reduce((acc, s) => {
+            acc[s.dataKey] = {label: s.label};
+            return acc;
+        }, {} as ChartConfig)
+        : {
+            value: {
+                label: data[0]?.label || 'Value'
+            }
+        } satisfies ChartConfig;
 
     // Use yRange as domain and set baseValue to the minimum
     const baseValue = yRange[0];
@@ -155,35 +230,72 @@ const GhAreaChart: React.FC<GhAreaChartProps> = ({
                     width={showYAxisValues ? calculateYAxisWidth(yRange, dataFormatter) : 0}
                 />
                 <ChartTooltip
-                    content={<GhCustomTooltipContent color={color} range={range} showHours={showHours} />}
+                    content={<GhCustomTooltipContent color={color} range={range} series={series} showHours={showHours} />}
                     cursor={true}
                     isAnimationActive={false}
                     position={{y: 10}}
                 />
                 <defs>
-                    <linearGradient id={`fillChart-${id}`} x1="0" x2="0" y1="0" y2="1">
-                        <stop
-                            offset='5%'
-                            stopColor={color}
-                            stopOpacity={0.8}
-                        />
-                        <stop
-                            offset='95%'
-                            stopColor={color}
-                            stopOpacity={0.1}
-                        />
-                    </linearGradient>
+                    {isMultiSeries ? (
+                        // Create gradients for each series
+                        series.map(s => (
+                            <linearGradient key={s.dataKey} id={`fillChart-${id}-${s.dataKey}`} x1="0" x2="0" y1="0" y2="1">
+                                <stop
+                                    offset='5%'
+                                    stopColor={s.color}
+                                    stopOpacity={0.8}
+                                />
+                                <stop
+                                    offset='95%'
+                                    stopColor={s.color}
+                                    stopOpacity={0.1}
+                                />
+                            </linearGradient>
+                        ))
+                    ) : (
+                        // Single series gradient (backward compatible)
+                        <linearGradient id={`fillChart-${id}`} x1="0" x2="0" y1="0" y2="1">
+                            <stop
+                                offset='5%'
+                                stopColor={color}
+                                stopOpacity={0.8}
+                            />
+                            <stop
+                                offset='95%'
+                                stopColor={color}
+                                stopOpacity={0.1}
+                            />
+                        </linearGradient>
+                    )}
                 </defs>
-                <Area
-                    baseValue={baseValue}
-                    dataKey="value"
-                    fill={`url(#fillChart-${id})`}
-                    fillOpacity={0.2}
-                    isAnimationActive={false}
-                    stroke={color}
-                    strokeWidth={1.5}
-                    type="linear"
-                />
+                {isMultiSeries ? (
+                    // Render multiple Area components
+                    series.map(s => (
+                        <Area
+                            key={s.dataKey}
+                            baseValue={baseValue}
+                            dataKey={s.dataKey}
+                            fill={`url(#fillChart-${id}-${s.dataKey})`}
+                            fillOpacity={0.2}
+                            isAnimationActive={false}
+                            stroke={s.color}
+                            strokeWidth={1.5}
+                            type="linear"
+                        />
+                    ))
+                ) : (
+                    // Single Area component (backward compatible)
+                    <Area
+                        baseValue={baseValue}
+                        dataKey="value"
+                        fill={`url(#fillChart-${id})`}
+                        fillOpacity={0.2}
+                        isAnimationActive={false}
+                        stroke={color}
+                        strokeWidth={1.5}
+                        type="linear"
+                    />
+                )}
             </AreaChart>
         </ChartContainer>
     );

--- a/apps/shade/src/components/ui/tabs.tsx
+++ b/apps/shade/src/components/ui/tabs.tsx
@@ -211,12 +211,12 @@ const KpiTabValue: React.FC<KpiTabValueProps> = ({
     return (
         <div className={cn('group flex w-full flex-col items-start gap-2', className)}>
             <div className='flex h-[22px] items-center gap-1.5 text-base font-medium text-muted-foreground transition-all group-hover:text-foreground' data-type="value">
-                {color && <div className='ml-1 size-2 rounded-full opacity-50' style={{backgroundColor: color}}></div>}
+                {color && <div className='ml-1 size-2 rounded-full opacity-70' style={{backgroundColor: color}}></div>}
                 {IconComponent && <IconComponent size={16} strokeWidth={1.5} />}
                 {label}
             </div>
             <div className='flex flex-col items-start gap-2 xl:flex-row xl:gap-3'>
-                <div className='text-[2.3rem] font-semibold leading-none tracking-tighter xl:text-[2.6rem]' data-testid={testId}>
+                <div className='text-[2.3rem] font-semibold leading-none tracking-tighter' data-testid={testId}>
                     {value}
                 </div>
                 {diffDirection && diffDirection !== 'hidden' &&

--- a/apps/stats/src/views/Stats/Web/web.tsx
+++ b/apps/stats/src/views/Stats/Web/web.tsx
@@ -23,33 +23,6 @@ interface SourcesData {
     percentage?: number;
 }
 
-export const KPI_METRICS: Record<string, KpiMetric> = {
-    visits: {
-        dataKey: 'visits',
-        label: 'Visitors',
-        chartColor: 'hsl(var(--chart-blue))',
-        formatter: formatNumber
-    },
-    views: {
-        dataKey: 'pageviews',
-        label: 'Pageviews',
-        chartColor: 'hsl(var(--chart-teal))',
-        formatter: formatNumber
-    },
-    'bounce-rate': {
-        dataKey: 'bounce_rate',
-        label: 'Bounce rate',
-        chartColor: 'hsl(var(--chart-teal))',
-        formatter: formatPercentage
-    },
-    'visit-duration': {
-        dataKey: 'avg_session_sec',
-        label: 'Visit duration',
-        chartColor: 'hsl(var(--chart-teal))',
-        formatter: formatDuration
-    }
-};
-
 const Web: React.FC = () => {
     const {statsConfig, isLoading: isConfigLoading, range, audience: globalAudience, data} = useGlobalData();
     const {startDate, endDate, timezone} = getRangeDates(range);


### PR DESCRIPTION
ref https://linear.app/ghost/issue/NY-831/combine-visitors-and-views-in-a-single-chart-on-web-tabs-in-analytics

- Visitors and views on web traffic charts were shown on separate charts which made usability a bit cumbersome by having to click to see the charts. Since these numbers co-relate to each other and are usually in the same ballpark, we decided to merge them in a single chart.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Combine visitors and views into a single multi-series chart for Web and Post analytics, adding multi-series support (series, tooltip, gradients, y-axis) to GhAreaChart with new stories.
> 
> - **Charts**
>   - `GhAreaChart`:
>     - Add multi-series support via `series: GhAreaChartSeries[]` prop and flexible data items with extra keys.
>     - Tooltip shows all series with labels/colors; retains single-series compatibility.
>     - Per-series gradients and multiple `Area` renders; compute Y-axis range across series with zero-value fallback.
>     - Export new `GhAreaChartSeries` type.
>   - Storybook (`gh-chart.stories.tsx`): add `MultiSeries` and `MultiSeriesWithZeroValues` stories with sample data.
> - **Analytics UI**
>   - Web KPIs (`apps/stats/.../web-kpis.tsx`) and Post KPIs (`apps/posts/.../kpis.tsx`):
>     - Build combined dataset for `visits` and `pageviews`; render `GhAreaChart` with `series`.
>     - Disable tab switching (visitors/views) and update chart `id`s; remove single-series color/y-axis usage.
> - **UI tweaks**
>   - `tabs.tsx`: adjust KPI dot opacity and typography in `KpiTabValue`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aa23f43e15a8bf38db3cb0030384dcd0a0bc45ba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->