### PR TITLE
Made admin forward feature flag work for self-hosting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -210,9 +210,6 @@ COPY --from=posts-builder /home/ghost/apps/posts/dist apps/posts/dist
 COPY --from=portal-builder /home/ghost/apps/portal/umd apps/portal/umd
 COPY --from=admin-x-settings-builder /home/ghost/apps/admin-x-settings/dist apps/admin-x-settings/dist
 COPY --from=activitypub-builder /home/ghost/apps/activitypub/dist apps/activitypub/dist
-COPY --from=admin-ember-builder /home/ghost/ghost/admin/dist ghost/admin/dist
-COPY --from=admin-ember-builder /home/ghost/ghost/core/core/built/admin ghost/core/core/built/admin
-RUN rm -rf apps/admin/dist
-COPY --from=admin-react-builder /home/ghost/apps/admin/dist apps/admin/dist
+COPY --from=admin-react-builder /home/ghost/ghost/core/core/built/admin ghost/core/core/built/admin
 
 CMD ["yarn", "dev"]

--- a/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
@@ -45,7 +45,7 @@ const features: Feature[] = [{
     flag: 'welcomeEmails'
 }, {
     title: 'New Admin Experience',
-    description: 'Try the new React-based admin interface. Only available on ghost.io',
+    description: 'Preview the next version of the admin interface',
     flag: 'adminForward'
 }, {
     title: 'Domain Warmup',

--- a/apps/admin/README.md
+++ b/apps/admin/README.md
@@ -16,24 +16,12 @@ Uses an **Ember Bridge** system for smooth migration:
 yarn dev
 ```
 
-**Prerequisites:** Ghost and the existing Ember admin must be running on `localhost:2368` for API proxying.
-
 ## Building for Production
 
 ```bash
 # Build production bundle
-yarn nx run admin:build
+yarn nx run @tryghost/admin:build
 ```
 
-This outputs to `apps/admin/dist/`.
+This outputs to `apps/admin/dist/` and updates the assets in `ghost/core/core/built/admin/`.
 
-## Serving the React Admin
-
-To serve the built React admin instead of the Ember admin, set the `USE_REACT_SHELL` environment variable when starting Ghost from the **monorepo root**:
-
-```bash
-# From the monorepo root
-USE_REACT_SHELL=true yarn dev
-```
-
-This configures the Ghost backend to serve `apps/admin/dist/index.html` at `/ghost/` instead of the Ember admin. The environment variable affects `ghost/core`, not `apps/admin` directly.

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -64,6 +64,10 @@
         ]
       },
       "build": {
+        "outputs": [
+          "{projectRoot}/dist",
+          "{workspaceRoot}/ghost/core/core/built/admin"
+        ],
         "dependsOn": [
           "build",
           {

--- a/e2e/helpers/environment/service-managers/ghost-manager.ts
+++ b/e2e/helpers/environment/service-managers/ghost-manager.ts
@@ -73,8 +73,8 @@ export class GhostManager {
                 mail__options__secure: 'false',
                 // other services configuration
                 portal__url: config.portalUrl || `http://localhost:${PORTAL.PORT}/portal.min.js`,
-                // Use React admin shell if specified
-                ...(process.env.USE_REACT_SHELL === 'true' ? {USE_REACT_SHELL: 'true'} : {}),
+                // Enable admin-forward feature flag if specified
+                ...(process.env.USE_REACT_SHELL === 'true' ? {labs__adminForward: 'true'} : {}),
                 ...(config.config ? config.config : {})
             } as Record<string, string>;
 

--- a/ghost/admin/app/services/feature.js
+++ b/ghost/admin/app/services/feature.js
@@ -127,12 +127,11 @@ export default class FeatureService extends Service {
     }
 
     _reconcileAdminForwardState() {
-        // Only proceed if we're on a *.ghost.io or *.ghost.is domain
-        const hostname = window.location.hostname;
-        if (!hostname.endsWith('.ghost.io') && !hostname.endsWith('.ghost.is')) {
+        // Skip in dev since we only serve one admin version at a time
+        if (this.config.environment === 'development') {
             return;
         }
-
+        
         const cookieName = 'ghost-admin-forward';
         const hasAdminForwardCookie = !!getCookie(cookieName);
 

--- a/ghost/core/core/server/web/admin/app.js
+++ b/ghost/core/core/server/web/admin/app.js
@@ -23,10 +23,8 @@ module.exports = function setupAdminApp() {
     //        produced below should be split into separate 'Cache-Control' entry.
     //        For reference see: https://developer.mozilla.org/en-US/docs/Web/HTTP/Caching#validation_2
 
-    const adminAssetsPath = path.join(config.getAdminAssetsPath(), 'assets');
-
     adminApp.use('/assets', serveStatic(
-        adminAssetsPath, {
+        path.join(config.get('paths').adminAssets, 'assets'), {
             // @NOTE: the maxAge config passed below are in milliseconds and the config
             //        is specified in seconds. See https://github.com/expressjs/serve-static/issues/150 for more context
             maxAge: config.get('caching:admin:maxAge') * 1000,

--- a/ghost/core/core/server/web/admin/controller.js
+++ b/ghost/core/core/server/web/admin/controller.js
@@ -5,6 +5,7 @@ const path = require('path');
 const fs = require('fs');
 const crypto = require('crypto');
 const config = require('../../../shared/config');
+const labs = require('../../../shared/labs');
 const updateCheck = require('../../services/update-check');
 
 const messages = {
@@ -29,8 +30,13 @@ module.exports = function adminController(req, res) {
     // CASE: trigger update check unit and let it run in background, don't block the admin rendering
     updateCheck();
 
-    const adminAssetsPath = config.getAdminAssetsPath();
-    const templatePath = path.resolve(adminAssetsPath, 'index.html');
+    const useAdminForward = labs.isSet('adminForward');
+    
+    // Choose the appropriate index file based on feature flag
+    // Default to Ember (index.html), use React (index-forward.html) when flag is enabled
+    const indexFilename = useAdminForward ? 'index-forward.html' : 'index.html';
+    const templatePath = path.resolve(config.get('paths').adminAssets, indexFilename);
+    
     const headers = {};
 
     try {

--- a/ghost/core/core/shared/config/helpers.js
+++ b/ghost/core/core/shared/config/helpers.js
@@ -98,18 +98,6 @@ const getContentPath = function getContentPath(type) {
 };
 
 /**
- * Get the path to admin assets, switching between Ember and React admin based on USE_REACT_SHELL env var
- * @returns {string}
- */
-const getAdminAssetsPath = function getAdminAssetsPath() {
-    const useReactShell = process.env.USE_REACT_SHELL === 'true';
-    if (useReactShell) {
-        return path.join(this.get('paths:appRoot'), '../../apps/admin/dist');
-    }
-    return this.get('paths:adminAssets');
-};
-
-/**
  * @typedef ConfigHelpers
  * @property {isPrivacyDisabledFn} isPrivacyDisabled
  * @property {getContentPathFn} getContentPath
@@ -117,7 +105,6 @@ const getAdminAssetsPath = function getAdminAssetsPath() {
 module.exports.bindAll = (nconf) => {
     nconf.isPrivacyDisabled = isPrivacyDisabled.bind(nconf);
     nconf.getContentPath = getContentPath.bind(nconf);
-    nconf.getAdminAssetsPath = getAdminAssetsPath.bind(nconf);
     nconf.getBackendMountPath = getBackendMountPath.bind(nconf);
     nconf.getFrontendMountPath = getFrontendMountPath.bind(nconf);
 };

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -279,7 +279,7 @@
           "build:tsc",
           {
             "projects": [
-              "ghost-admin"
+              "@tryghost/admin"
             ],
             "target": "build"
           }


### PR DESCRIPTION
This PR ensures we're copying the admin forward build assets to the location expected by Ghost core and conditionally serves the correct entrypoint based on the existing feature flag. Since the admin forward assets is a superset of the Ember assets, this should be safe. 

I've also updated the development Docker image as well as the archive script to correctly copy the assets. Finally, I removed some leftovers from a previous integration of the admin forward assets based on the `USE_REACT_SHELL` env var.