### PR TITLE
Changed `servePublicFile` from middleware to router

### DIFF
--- a/ghost/core/core/frontend/services/theme-engine/active.js
+++ b/ghost/core/core/frontend/services/theme-engine/active.js
@@ -11,6 +11,7 @@
  * No properties marked with an _ should be used directly.
  *
  */
+const fs = require('fs-extra');
 const join = require('path').join;
 
 const _ = require('lodash');
@@ -54,6 +55,8 @@ class ActiveTheme {
         this._config = themeConfig.create(this._packageInfo);
 
         this.initI18n();
+
+        this._hasRobotsTxt = fs.existsSync(join(this._path, 'robots.txt'));
     }
 
     get name() {
@@ -82,6 +85,10 @@ class ActiveTheme {
 
     hasTemplate(templateName) {
         return this._templates.indexOf(templateName) > -1;
+    }
+
+    hasRobotsTxt() {
+        return this._hasRobotsTxt;
     }
 
     updateTemplateOptions(options) {

--- a/ghost/core/core/frontend/web/middleware/index.js
+++ b/ghost/core/core/frontend/web/middleware/index.js
@@ -4,6 +4,5 @@ module.exports = {
     frontendCaching: require('./frontend-caching'),
     handleImageSizes: require('./handle-image-sizes'),
     redirectGhostToAdmin: require('./redirect-ghost-to-admin'),
-    servePublicFile: require('./serve-public-file'),
     staticTheme: require('./static-theme')
 };

--- a/ghost/core/core/frontend/web/site.js
+++ b/ghost/core/core/frontend/web/site.js
@@ -10,13 +10,13 @@ const storage = require('../../server/adapters/storage');
 const urlUtils = require('../../shared/url-utils');
 const sitemapHandler = require('../services/sitemap/handler');
 const serveFavicon = require('./routers/serve-favicon');
+const servePublicFiles = require('./routers/serve-public-file');
 const themeEngine = require('../services/theme-engine');
 const themeMiddleware = themeEngine.middleware;
 const membersService = require('../../server/services/members');
 const offersService = require('../../server/services/offers');
 const customRedirects = require('../../server/services/custom-redirects');
 const linkRedirects = require('../../server/services/link-redirection');
-const {cardAssets} = require('../services/assets-minification');
 const siteRoutes = require('./routes');
 const shared = require('../../server/web/shared');
 const errorHandler = require('@tryghost/mw-error-handler');
@@ -65,25 +65,8 @@ module.exports = function setupSiteApp(routerConfig) {
     // Favicon
     serveFavicon(siteApp);
 
-    // Serve sitemap.xsl file
-    siteApp.use(mw.servePublicFile('static', 'sitemap.xsl', 'text/xsl', config.get('caching:sitemapXSL:maxAge')));
-
-    // Serve stylesheets for default templates
-    siteApp.use(mw.servePublicFile('static', 'public/ghost.css', 'text/css', config.get('caching:publicAssets:maxAge')));
-    siteApp.use(mw.servePublicFile('static', 'public/ghost.min.css', 'text/css', config.get('caching:publicAssets:maxAge')));
-
-    // Traffic analytics tracking script
-    siteApp.use(mw.servePublicFile('static', 'public/ghost-stats.min.js', 'application/javascript', config.get('caching:publicAssets:maxAge')));
-
-    // Card assets
-    siteApp.use(cardAssets.serveMiddleware(), mw.servePublicFile('built', 'public/cards.min.css', 'text/css', config.get('caching:publicAssets:maxAge')));
-    siteApp.use(cardAssets.serveMiddleware(), mw.servePublicFile('built', 'public/cards.min.js', 'application/javascript', config.get('caching:publicAssets:maxAge')));
-
-    // Comment counts
-    siteApp.use(mw.servePublicFile('static', 'public/comment-counts.min.js', 'application/javascript', config.get('caching:publicAssets:maxAge')));
-
-    // Member attribution
-    siteApp.use(mw.servePublicFile('static', 'public/member-attribution.min.js', 'application/javascript', config.get('caching:publicAssets:maxAge')));
+    // Public files (sitemap.xsl, stylesheets, scripts, etc.)
+    servePublicFiles(siteApp);
 
     // Serve site images using the storage adapter
     siteApp.use(STATIC_IMAGE_URL_PREFIX, mw.handleImageSizes, storage.getStorage('images').serve());
@@ -101,9 +84,6 @@ module.exports = function setupSiteApp(routerConfig) {
         }
     );
 
-    // Recommendations well-known
-    siteApp.use(mw.servePublicFile('built', '.well-known/recommendations.json', 'application/json', config.get('caching:publicAssets:maxAge'), {disableServerCache: true}));
-
     // setup middleware for internal apps
     // @TODO: refactor this to be a proper app middleware hook for internal apps
     config.get('apps:internal').forEach((appName) => {
@@ -116,9 +96,6 @@ module.exports = function setupSiteApp(routerConfig) {
 
     // Theme static assets/files
     siteApp.use(mw.staticTheme());
-
-    // Serve robots.txt if not found in theme
-    siteApp.use(mw.servePublicFile('static', 'robots.txt', 'text/plain', config.get('caching:robotstxt:maxAge')));
 
     debug('Static content done');
 

--- a/ghost/core/test/unit/frontend/web/middleware/serve-public-file.test.js
+++ b/ghost/core/test/unit/frontend/web/middleware/serve-public-file.test.js
@@ -1,7 +1,7 @@
 const should = require('should');
 const sinon = require('sinon');
 const fs = require('fs-extra');
-const servePublicFile = require('../../../../../core/frontend/web/middleware/serve-public-file');
+const {servePublicFile} = require('../../../../../core/frontend/web/routers/serve-public-file');
 
 describe('servePublicFile', function () {
     let res;


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3095

- Extracted the public files code from the middleware to the router. This avoids route comparison on every requests Ghost receives.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors public asset serving from middleware to explicit routes, adds theme/privately-aware robots.txt handling, and updates site wiring and tests.
> 
> - **Routers (public files)**:
>   - Introduce `web/routers/serve-public-file.js` with `servePublicFiles(siteApp)` registering explicit routes for `sitemap.xsl`, `public/*` assets (CSS/JS), `.well-known/recommendations.json`, and card assets via `cardAssets.serveMiddleware()`.
>   - Add conditional `/robots.txt` serving that defers to theme file if present and skips when site is private; otherwise serves default `robots.txt`.
>   - Export `servePublicFile` and `createPublicFileMiddleware` (retained behavior) alongside new router.
> - **Theme Engine**:
>   - In `services/theme-engine/active.js`, detect theme `robots.txt` on init and expose `hasRobotsTxt()`.
> - **Site wiring**:
>   - Replace middleware-based public file serving with router-based `servePublicFiles(siteApp)` in `web/site.js`; remove related middleware wiring.
> - **Middleware index**:
>   - Remove `servePublicFile` export.
> - **Tests**:
>   - Update test imports to use router path for `servePublicFile`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 26de7266e0089498065ddf8c073b6cd2ad355a86. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->