### PR TITLE
🐛 Fixed contributor profile editor navigation to posts page

### DIFF
--- a/apps/admin-x-settings/src/components/settings/general/user-detail-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/user-detail-modal.tsx
@@ -210,7 +210,8 @@ const UserDetailModalContent: React.FC<{user: User}> = ({user}) => {
         if (canAccessSettings(currentUser)) {
             updateRoute('staff');
         } else {
-            updateRoute({isExternal: true, route: 'analytics'});
+            // Contributors can't access settings, exit to let the shell handle navigation
+            updateRoute({isExternal: true, route: ''});
         }
     }, [currentUser, updateRoute]);
 

--- a/apps/admin-x-settings/src/main-content.tsx
+++ b/apps/admin-x-settings/src/main-content.tsx
@@ -22,7 +22,7 @@ const Page: React.FC<{children: ReactNode}> = ({children}) => {
 
 const MainContent: React.FC = () => {
     const {currentUser} = useGlobalData();
-    const {route, updateRoute, loadingModal} = useRouting();
+    const {loadingModal} = useRouting();
     const {isDirty} = useGlobalDirtyState();
 
     const navigateAway = (escLocation: string) => {
@@ -50,12 +50,8 @@ const MainContent: React.FC = () => {
         toast.remove();
     }, []);
 
-    useEffect(() => {
-        if (!canAccessSettings(currentUser) && route !== `staff/${currentUser.slug}`) {
-            updateRoute(`staff/${currentUser.slug}`);
-        }
-    }, [currentUser, route, updateRoute]);
-
+    // Contributors/Authors only see their profile modal (rendered via routing)
+    // Don't render the main settings content for them
     if (!canAccessSettings(currentUser)) {
         return null;
     }

--- a/apps/admin-x-settings/test/acceptance/permissions.test.ts
+++ b/apps/admin-x-settings/test/acceptance/permissions.test.ts
@@ -16,20 +16,22 @@ test.describe('User permissions', async () => {
         await expect(page.getByTestId('title-and-description')).toBeHidden();
     });
 
+    // Note: Author/Contributor redirect to profile is handled by the Ember router (settings-x.js),
+    // not by the React app. These tests verify the UI renders correctly when on the profile route.
     test('Authors can only see their own profile', async ({page}) => {
         await mockApi({page, requests: {
             ...globalDataRequests,
             browseMe: {...globalDataRequests.browseMe, response: meWithRole('Author')}
         }});
 
-        await page.goto('/');
+        // Navigate directly to profile route using hash-based routing
+        // (Ember router handles redirect in production)
+        await page.goto('/#/settings/staff/owner');
 
         await expect(page.getByTestId('user-detail-modal')).toBeVisible();
         await expect(page.getByTestId('sidebar')).toBeHidden();
         await expect(page.getByTestId('users')).toBeHidden();
         await expect(page.getByTestId('title-and-description')).toBeHidden();
-
-        expect(page.url()).toMatch(/\/owner$/);
     });
 
     test('Contributors can only see their own profile', async ({page}) => {
@@ -38,13 +40,13 @@ test.describe('User permissions', async () => {
             browseMe: {...globalDataRequests.browseMe, response: meWithRole('Contributor')}
         }});
 
-        await page.goto('/');
+        // Navigate directly to profile route using hash-based routing
+        // (Ember router handles redirect in production)
+        await page.goto('/#/settings/staff/owner');
 
         await expect(page.getByTestId('user-detail-modal')).toBeVisible();
         await expect(page.getByTestId('sidebar')).toBeHidden();
         await expect(page.getByTestId('users')).toBeHidden();
         await expect(page.getByTestId('title-and-description')).toBeHidden();
-
-        expect(page.url()).toMatch(/\/owner$/);
     });
 });

--- a/ghost/admin/app/routes/settings-x.js
+++ b/ghost/admin/app/routes/settings-x.js
@@ -7,6 +7,22 @@ export default class SettingsXRoute extends AuthenticatedRoute {
     @service ui;
     @service modals;
 
+    beforeModel(transition) {
+        super.beforeModel(...arguments);
+
+        // Contributors and Authors can only access their own profile in settings
+        if (this.session.user.isAuthorOrContributor) {
+            // Check if they're trying to access their own profile route
+            const subPath = transition.to?.params?.sub;
+            const ownProfilePath = `staff/${this.session.user.slug}`;
+
+            // Only allow access to their own profile, redirect everything else
+            if (subPath !== ownProfilePath) {
+                return this.transitionTo('settings-x.settings-x', ownProfilePath);
+            }
+        }
+    }
+
     activate() {
         super.activate(...arguments);
 


### PR DESCRIPTION
## Summary

Contributors couldn't close their profile editor modal because a race condition would redirect them back. The modal's external navigation to `/posts` was being overridden by a useEffect that detected the route change and redirected contributors back to their profile.

the issue was AdminXSettings is always mounted and it has a side effect to re-direct to the user profile page if the User isn't permitted to see all the settings. This effect was running all the time (because the settings are always mounted) and it was affecting the navigation away from the profile.

Rather than amend the effect, or conditionally mount the settings (too many changes), I opted to lift the permissions for the settings to the router level (which should be responsible for routes and their permissions) which fixes the issue.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restricts Authors/Contributors to their own profile via Ember routing, removes React-side redirect, updates modal close navigation, and adapts tests.
> 
> - **Routing/Access Control**:
>   - Add Ember `beforeModel` guard in `ghost/admin/app/routes/settings-x.js` to redirect Authors/Contributors to `staff/<slug>` and block other settings paths.
> - **React UI**:
>   - In `main-content.tsx`, stop React-side redirects; hide main settings entirely for non-`canAccessSettings` users so only the profile modal renders via routing.
>   - In `user-detail-modal.tsx`, change close behavior for non-settings users to external `''` route to let the shell handle navigation.
> - **Tests**:
>   - Update acceptance tests to navigate directly to `/#/settings/staff/owner` and verify profile-only view for Author/Contributor; remove URL assertions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0623ad83a83c864cb614868653e826119162fede. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->