### PR TITLE
Added formatting to Analytics percentage values

### DIFF
--- a/apps/shade/src/lib/utils.ts
+++ b/apps/shade/src/lib/utils.ts
@@ -313,7 +313,8 @@ export const formatPercentage = (value: number) => {
     } else if (percentage < 1) {
         return `${percentage.toFixed(1)}%`;
     }
-    return `${Math.round(percentage)}%`;
+    const rounded = Math.round(percentage);
+    return `${new Intl.NumberFormat('en-US').format(rounded)}%`;
 };
 
 // Format cents to Dollars

--- a/apps/shade/test/unit/utils/utils.test.ts
+++ b/apps/shade/test/unit/utils/utils.test.ts
@@ -202,12 +202,44 @@ describe('utils', function () {
         it('formats a decimal as a percentage', function () {
             let formatted = formatPercentage(0.123);
             assert.equal(formatted, '12%');
-            
+
             formatted = formatPercentage(0.789);
             assert.equal(formatted, '79%');
-            
+
             formatted = formatPercentage(1);
             assert.equal(formatted, '100%');
+        });
+
+        it('formats zero percentage', function () {
+            const formatted = formatPercentage(0);
+            assert.equal(formatted, '0%');
+        });
+
+        it('formats very small percentages with 2 decimal places', function () {
+            let formatted = formatPercentage(0.0005);
+            assert.equal(formatted, '0.05%');
+
+            formatted = formatPercentage(0.0009);
+            assert.equal(formatted, '0.09%');
+        });
+
+        it('formats small percentages with 1 decimal place', function () {
+            let formatted = formatPercentage(0.005);
+            assert.equal(formatted, '0.5%');
+
+            formatted = formatPercentage(0.009);
+            assert.equal(formatted, '0.9%');
+        });
+
+        it('formats large percentages with thousand separators', function () {
+            let formatted = formatPercentage(10);
+            assert.equal(formatted, '1,000%');
+
+            formatted = formatPercentage(12.34567);
+            assert.equal(formatted, '1,235%');
+
+            formatted = formatPercentage(100);
+            assert.equal(formatted, '10,000%');
         });
     });
 }); 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/DES-1256/thousands-separator-missing-from-percentage-format-in-analytics

- Thousands separator was missing for percentage values in Analytics charts
