### PR TITLE
Skipped flaky locations test

### DIFF
--- a/e2e/tests/admin/analytics/post-analytics/web-filters.test.ts
+++ b/e2e/tests/admin/analytics/post-analytics/web-filters.test.ts
@@ -135,7 +135,8 @@ test.describe('Ghost Admin - Post Analytics Web Filters', () => {
             await expect(postAnalyticsPage.getActiveFilter('Source')).toBeHidden();
         });
 
-        test('click on location row adds location filter', async ({page, browser, baseURL}) => {
+        // TODO: This is flaky on CI, so we're skipping it for now.
+        test.skip('click on location row adds location filter', async ({page, browser, baseURL}) => {
             // Generate traffic to the post
             await withIsolatedPage(browser, {baseURL}, async ({page: publicPage}) => {
                 const postPage = new PublicPage(publicPage);


### PR DESCRIPTION
no ref

This test is passing locally and we have redundant other tests checking filters, so it's not critical that this test is sorted out at the moment. We've had some flakiness due to slowness with the Tinybird event ingestion that we can revisit at large vs. extending a timeout on this test.