### PR TITLE
🌐 Added missing i18n for Portal field placeholders

### DIFF
--- a/apps/portal/src/components/pages/offer-page.js
+++ b/apps/portal/src/components/pages/offer-page.js
@@ -183,7 +183,7 @@ export default class OfferPage extends React.Component {
             {
                 type: 'email',
                 value: member?.email || state.email,
-                placeholder: 'jamie@example.com',
+                placeholder: t('jamie@example.com'),
                 label: t('Email'),
                 name: 'email',
                 disabled: !!member,

--- a/apps/portal/src/components/pages/signin-page.js
+++ b/apps/portal/src/components/pages/signin-page.js
@@ -69,7 +69,7 @@ export default class SigninPage extends React.Component {
             {
                 type: 'email',
                 value: state.email,
-                placeholder: 'jamie@example.com',
+                placeholder: t('jamie@example.com'),
                 label: t('Email'),
                 name: 'email',
                 required: true,


### PR DESCRIPTION
I found two missing translation entries for Portal field placeholders. I added `t()` around static email placeholders in `offer-page.js` and `signin-page.js`.

<img width="512" height="418" alt="missing-i18n" src="https://github.com/user-attachments/assets/969a254d-d939-4cb9-8c09-3158ffc39fae" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Localizes the email field placeholder by wrapping it with `t()` in `offer-page.js` and `signin-page.js`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b1a7ee2574827f2e9bd871bcf24c53b4451b5384. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->