### PR TITLE
Fixed signup-form dev server treating i18n as ESM

### DIFF
--- a/apps/signup-form/vite.config.mts
+++ b/apps/signup-form/vite.config.mts
@@ -24,6 +24,9 @@ export default (function viteConfig() {
             allowedHosts: true, // allows domain-name proxies to the preview server
             port: 6174
         },
+        optimizeDeps: {
+            include: ['@tryghost/i18n']
+        },
         build: {
             outDir: resolve(__dirname, 'umd'),
             reportCompressedSize: false,


### PR DESCRIPTION
no issue

- when running `yarn dev` in the `signup-form` app, all instances of the form failed to render with the error:
  - `Uncaught SyntaxError: The requested module '/@fs/Users/kevin/code/Ghost/ghost/i18n/index.js' does not provide an export named 'default' (at app.tsx:2:8)`
- the problem was that vite loads the monorepo `i18n` package using `/@fs/` and loads it as an ESM package despite being a CommonJS package
- adding `@tryghost/i18n` to vite's `optimizeDeps` config forces the module to be transpiled so the import works correctly
