### PR TITLE
🎨 Changed `signup-form` email input to use 'email' type

### DIFF
--- a/apps/signup-form/src/components/pages/form-view.tsx
+++ b/apps/signup-form/src/components/pages/form-view.tsx
@@ -59,13 +59,14 @@ const Form: React.FC<FormProps> = ({isMinimal, loading, success, error, buttonCo
     // The complicated transitions are here so that we animate visibility: hidden (step-start/step-end), which is required for screen readers to know what is visible (they ignore opacity: 0)
     return (
         <>
-            <form className={`relative flex w-full rounded-[.5rem] border bg-white p-[3px] text-grey-900 transition hover:border-grey-400 focus-visible:border-grey-500 ${error ? '!border-red-500' : 'border-grey-300'}`} onSubmit={submitHandler}>
+            <form className={`relative flex w-full rounded-[.5rem] border bg-white p-[3px] text-grey-900 transition hover:border-grey-400 focus-visible:border-grey-500 ${error ? '!border-red-500' : 'border-grey-300'}`} noValidate={true} onSubmit={submitHandler}>
                 <input
+                    autoComplete="email"
                     className={`w-full px-2 py-1 focus-visible:outline-none disabled:bg-white xs:p-2`}
                     data-testid="input"
                     disabled={loading || success}
                     placeholder={t('Your email address')}
-                    type="text"
+                    type="email"
                     value={email}
                     onChange={e => setEmail(e.target.value)}
                 />

--- a/apps/signup-form/src/components/pages/form-view.tsx
+++ b/apps/signup-form/src/components/pages/form-view.tsx
@@ -10,11 +10,13 @@ export const FormView: React.FC<FormProps & {
     backgroundColor?: string
     textColor?: string
 }> = ({isMinimal, title, description, icon, backgroundColor, textColor, error, ...formProps}) => {
+    const errorMessageId = React.useId();
+
     if (isMinimal) {
         return (
             <>
-                <Form error={error} isMinimal={isMinimal} {...formProps} />
-                {error && <p className='text-red-500' data-testid="error-message">{error}</p>}
+                <Form error={error} errorMessageId={errorMessageId} isMinimal={isMinimal} {...formProps} />
+                {error && <p className='text-red-500' data-testid="error-message" id={errorMessageId}>{error}</p>}
             </>
         );
     }
@@ -29,8 +31,8 @@ export const FormView: React.FC<FormProps & {
             {title && <h1 className="text-center text-lg font-bold sm:text-xl md:text-2xl lg:text-3xl">{title}</h1>}
             {description && <p className='mb-4 text-center font-medium md:mb-5'>{description}</p>}
             <div className='relative w-full max-w-[440px]'>
-                <Form error={error} {...formProps} />
-                <p className={`h-5 w-full text-left text-red-500 ${error ? 'visible' : 'invisible'}`} data-testid="error-message">{error}</p>
+                <Form error={error} errorMessageId={errorMessageId} {...formProps} />
+                <p className={`h-5 w-full text-left text-red-500 ${error ? 'visible' : 'invisible'}`} data-testid="error-message" id={errorMessageId}>{error}</p>
             </div>
 
         </div>
@@ -44,10 +46,11 @@ type FormProps = {
     loading: boolean
     success: boolean
     error?: string
+    errorMessageId?: string
     onSubmit: (values: { email: string }) => void
 }
 
-const Form: React.FC<FormProps> = ({isMinimal, loading, success, error, buttonColor, buttonTextColor, onSubmit}) => {
+const Form: React.FC<FormProps> = ({isMinimal, loading, success, error, errorMessageId, buttonColor, buttonTextColor, onSubmit}) => {
     const [email, setEmail] = React.useState('');
     const {t} = useAppContext();
 
@@ -61,6 +64,8 @@ const Form: React.FC<FormProps> = ({isMinimal, loading, success, error, buttonCo
         <>
             <form className={`relative flex w-full rounded-[.5rem] border bg-white p-[3px] text-grey-900 transition hover:border-grey-400 focus-visible:border-grey-500 ${error ? '!border-red-500' : 'border-grey-300'}`} noValidate={true} onSubmit={submitHandler}>
                 <input
+                    aria-describedby={error && errorMessageId ? errorMessageId : undefined}
+                    aria-invalid={!!error}
                     autoComplete="email"
                     className={`w-full px-2 py-1 focus-visible:outline-none disabled:bg-white xs:p-2`}
                     data-testid="input"

--- a/apps/signup-form/test/e2e/form.test.ts
+++ b/apps/signup-form/test/e2e/form.test.ts
@@ -167,7 +167,7 @@ test.describe('Form', async () => {
             // Check error message is visible on the page
             const errorMessage = frame.getByTestId('error-message');
             await expect(errorMessage).toHaveCount(1);
-            expect(await errorMessage.innerText()).toBe('Please enter a valid email address');
+            await expect(errorMessage).toHaveText('Please enter a valid email address');
 
             expect(lastApiRequest.body).toBeNull();
 
@@ -204,7 +204,7 @@ test.describe('Form', async () => {
             // Check error message is visible on the page
             const errorMessage = frame.getByTestId('error-message');
             await expect(errorMessage).toHaveCount(1);
-            expect(await errorMessage.innerText()).toBe('Something went wrong, please try again.');
+            await expect(errorMessage).toHaveText('Something went wrong, please try again.');
         });
 
         test('Shows error message on 4xx status codes', async ({page}) => {
@@ -228,7 +228,7 @@ test.describe('Form', async () => {
             // Check error message is visible on the page
             const errorMessage = frame.getByTestId('error-message');
             await expect(errorMessage).toHaveCount(1);
-            expect(await errorMessage.innerText()).toBe('Something went wrong, please try again.');
+            await expect(errorMessage).toHaveText('Something went wrong, please try again.');
         });
     });
 });


### PR DESCRIPTION
closes https://linear.app/ghost/issue/BER-3092/

- using `type="email"` improves usability by allowing browsers to auto-fill and display an email-focused keyboard on mobile
- added `noValidate={true}` to disable browsers built-in validation as we already have custom validation handling
