### PR TITLE
Fixed React development mode warnings in admin-x-design-system

### DIFF
--- a/apps/admin-x-design-system/src/global/button-group.tsx
+++ b/apps/admin-x-design-system/src/global/button-group.tsx
@@ -39,13 +39,14 @@ const ButtonGroup: React.FC<ButtonGroupProps> = ({size = 'md', buttons, link, li
 
     return (
         <div className={groupColorClasses}>
-            {buttons.map(({key, ...props}) => {
+            {buttons.map(({key, ...props}, index) => {
+                const buttonKey = key ?? `button-${index}`;
                 const buttonProps = {...props};
 
                 if (!link && !clearBg) {
                     buttonProps.className = clsx(props.className, 'w-8 rounded-lg border px-0!');
 
-                    if (key === activeKey) {
+                    if (buttonKey === activeKey) {
                         buttonProps.color = 'white';
                         buttonProps.className = clsx(buttonProps.className, 'border-grey-300 shadow-xs dark:border-grey-800');
                     } else {
@@ -55,10 +56,10 @@ const ButtonGroup: React.FC<ButtonGroupProps> = ({size = 'md', buttons, link, li
 
                 return (
                     (props.tooltip ?
-                        <Tooltip key={key} content={props.tooltip}>
-                            <Button key={`btn-${key}`} link={link} linkWithPadding={linkWithPadding} size={size} {...buttonProps} />
+                        <Tooltip key={buttonKey} content={props.tooltip}>
+                            <Button link={link} linkWithPadding={linkWithPadding} size={size} {...buttonProps} />
                         </Tooltip> :
-                        <Button key={key} link={link} linkWithPadding={linkWithPadding} size={size} {...buttonProps} />
+                        <Button key={buttonKey} link={link} linkWithPadding={linkWithPadding} size={size} {...buttonProps} />
                     )
                 );
             })}

--- a/apps/admin-x-design-system/src/global/form/checkbox-group.tsx
+++ b/apps/admin-x-design-system/src/global/form/checkbox-group.tsx
@@ -20,8 +20,8 @@ const CheckboxGroup: React.FC<CheckboxGroupProps> = ({
         <div>
             {title && <Heading grey={true} level={6}>{title}</Heading>}
             <div className='mt-2 flex flex-col gap-1'>
-                {checkboxes?.map(({key, ...props}) => (
-                    <Checkbox key={key} {...props} />
+                {checkboxes?.map(({key, ...props}, index) => (
+                    <Checkbox key={key ?? `checkbox-${index}`} {...props} />
                 ))}
             </div>
             <div className={`flex flex-col ${hint && 'mb-2'}`}>

--- a/apps/admin-x-design-system/src/global/tooltip.tsx
+++ b/apps/admin-x-design-system/src/global/tooltip.tsx
@@ -25,7 +25,7 @@ const Tooltip: React.FC<TooltipProps> = ({content, size = 'sm', children, contai
     return (
         <TooltipPrimitive.Provider delayDuration={0}>
             <TooltipPrimitive.Root>
-                <TooltipPrimitive.Trigger className={containerClassName} onClick={event => event.preventDefault()}>
+                <TooltipPrimitive.Trigger className={containerClassName} asChild onClick={event => event.preventDefault()}>
                     {children}
                 </TooltipPrimitive.Trigger>
                 <TooltipPrimitive.Content align={origin} className={tooltipClassName} sideOffset={4} onPointerDownOutside={event => event.preventDefault()}>

--- a/apps/admin-x-settings/src/components/settings/email/newsletters/newsletters-list.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/newsletters/newsletters-list.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {Button, DragIndicator, NoValueLabel, type SortableItemContainerProps, SortableList, Table, TableCell, TableRow} from '@tryghost/admin-x-design-system';
 import {type Newsletter} from '@tryghost/admin-x-framework/api/newsletters';
-import {numberWithCommas} from '../../../../utils/helpers';
+import {formatNumber} from '@tryghost/shade/utils';
 import {useRouting} from '@tryghost/admin-x-framework/routing';
 
 interface NewslettersListProps {
@@ -17,8 +17,11 @@ const NewsletterItemContainer: React.FC<Partial<SortableItemContainerProps>> = (
     isDragging,
     style,
     children,
+    separator,
     ...props
 }) => {
+    void separator; // we don't use the separator prop and it will error if it gets passed to the DragIndicator component
+
     const {updateRoute} = useRouting();
 
     const showDetails = () => {
@@ -64,13 +67,13 @@ const NewsletterItem: React.FC<{newsletter: Newsletter}> = ({newsletter}) => {
             </TableCell>
             <TableCell className='hidden md:visible! md:table-cell! md:min-w-[11rem]' onClick={showDetails}>
                 <div className={`flex grow flex-col`}>
-                    <span>{numberWithCommas(newsletter.count?.active_members || 0) }</span>
+                    <span>{formatNumber(newsletter.count?.active_members || 0) }</span>
                     <span className='mt-0.5 text-sm leading-tight whitespace-nowrap text-grey-700'>Subscribers</span>
                 </div>
             </TableCell>
             <TableCell className='hidden md:visible! md:table-cell! md:min-w-[11rem]' onClick={showDetails}>
                 <div className={`flex grow flex-col`}>
-                    <span>{numberWithCommas(newsletter.count?.posts || 0)}</span>
+                    <span>{formatNumber(newsletter.count?.posts || 0)}</span>
                     <span className='mt-0.5 text-sm leading-tight whitespace-nowrap text-grey-700'>Delivered</span>
                 </div>
             </TableCell>


### PR DESCRIPTION
no issue

Some aspects of `admin-x-design-system` and its usage within `admin-x-settings` caused a lot of errors to be output in the console in development mode making it difficult to find real problems.

- Added missing `key` props to list items in `TabView`, `ButtonGroup`, `CheckboxGroup`, and `TiersList` to fix "unique key" warnings
- Added `asChild` to `Tooltip`'s `TooltipPrimitive.Trigger` to fix nested button warning when Button components are wrapped in Tooltip
- Destructured unused `separator` prop in NewsletterItemContainer to prevent it being passed to `DragIndicator` causing errors
