### PR TITLE
Improve pure black accent color bug in member emails

### DIFF
--- a/ghost/core/core/server/services/members/emails/signin.js
+++ b/ghost/core/core/server/services/members/emails/signin.js
@@ -1,5 +1,9 @@
 /* eslint-disable indent */
-module.exports = ({t, siteTitle, email, url, otc, accentColor = '#15212A', siteDomain, siteUrl}) => `
+module.exports = ({t, siteTitle, email, url, otc, accentColor = '#15212A', siteDomain, siteUrl}) => {
+    // Using the closest gray to pure black to fix bug caused by Apple mail's automatic color conversion in dark mode
+    const safeAccentColor = (accentColor === '#000000' || accentColor === '#000') ? '#010101' : accentColor;
+
+    return `
 <!doctype html>
 <html>
   <head>
@@ -144,7 +148,7 @@ module.exports = ({t, siteTitle, email, url, otc, accentColor = '#15212A', siteD
                                 <table border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; min-width: 100%;">
                                   <tbody>
                                     <tr>
-                                      <td align="center" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; vertical-align: top; background-color: ${accentColor}; border-radius: 5px; text-align: center;"> <a href="${url}" target="_blank" style="display: inline-block; color: #ffffff; background-color: ${accentColor}; border: solid 1px ${accentColor}; border-radius: 5px; box-sizing: border-box; cursor: pointer; text-decoration: none; font-size: 16px; font-weight: normal; margin: 0; padding: 9px 22px 10px; border-color: ${accentColor};">${t('Sign in now')}</a> </td>
+                                      <td align="center" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; vertical-align: top; background-color: ${safeAccentColor}; border-radius: 5px; text-align: center;"> <a href="${url}" target="_blank" style="display: inline-block; color: #ffffff; background-color: ${safeAccentColor}; border: solid 1px ${safeAccentColor}; border-radius: 5px; box-sizing: border-box; cursor: pointer; text-decoration: none; font-size: 16px; font-weight: normal; margin: 0; padding: 9px 22px 10px; border-color: ${safeAccentColor};">${t('Sign in now')}</a> </td>
                                     </tr>
                                   </tbody>
                                 </table>
@@ -162,7 +166,7 @@ module.exports = ({t, siteTitle, email, url, otc, accentColor = '#15212A', siteD
                                 <table border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: auto;">
                                   <tbody>
                                     <tr>
-                                      <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; vertical-align: top; background-color: ${accentColor}; border-radius: 5px; text-align: center;"> <a href="${url}" target="_blank" style="display: inline-block; color: #ffffff; background-color: ${accentColor}; border: solid 1px ${accentColor}; border-radius: 5px; box-sizing: border-box; cursor: pointer; text-decoration: none; font-size: 16px; font-weight: normal; margin: 0; padding: 9px 22px 10px; border-color: ${accentColor};">${t('Sign in to {siteTitle}', {siteTitle, interpolation: {escapeValue: false}})}</a> </td>
+                                      <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; vertical-align: top; background-color: ${safeAccentColor}; border-radius: 5px; text-align: center;"> <a href="${url}" target="_blank" style="display: inline-block; color: #ffffff; background-color: ${safeAccentColor}; border: solid 1px ${safeAccentColor}; border-radius: 5px; box-sizing: border-box; cursor: pointer; text-decoration: none; font-size: 16px; font-weight: normal; margin: 0; padding: 9px 22px 10px; border-color: ${safeAccentColor};">${t('Sign in to {siteTitle}', {siteTitle, interpolation: {escapeValue: false}})}</a> </td>
                                     </tr>
                                   </tbody>
                                 </table>
@@ -210,3 +214,4 @@ module.exports = ({t, siteTitle, email, url, otc, accentColor = '#15212A', siteD
   </body>
 </html>
 `;
+};

--- a/ghost/core/core/server/services/members/emails/signup-paid.js
+++ b/ghost/core/core/server/services/members/emails/signup-paid.js
@@ -1,4 +1,8 @@
-module.exports = ({t, siteTitle, email, url, accentColor = '#15212A', siteDomain, siteUrl}) => `
+module.exports = ({t, siteTitle, email, url, accentColor = '#15212A', siteDomain, siteUrl}) => {
+    // Using the closest gray to pure black to fix bug caused by Apple mail's automatic color conversion in dark mode
+    const safeAccentColor = (accentColor === '#000000' || accentColor === '#000') ? '#010101' : accentColor;
+
+    return `
 <!doctype html>
    <html>
   <head>
@@ -125,7 +129,7 @@ module.exports = ({t, siteTitle, email, url, accentColor = '#15212A', siteDomain
                                 <table border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: auto;">
                                   <tbody>
                                     <tr>
-                                      <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; vertical-align: top; background-color: ${accentColor}; border-radius: 5px; text-align: center;"> <a href="${url}" target="_blank" style="display: inline-block; color: #ffffff; background-color: ${accentColor}; border: solid 1px ${accentColor}; border-radius: 5px; box-sizing: border-box; cursor: pointer; text-decoration: none; font-size: 16px; font-weight: normal; margin: 0; padding: 9px 22px 10px; border-color: ${accentColor};">${t('Sign in')}</a> </td>
+                                      <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; vertical-align: top; background-color: ${safeAccentColor}; border-radius: 5px; text-align: center;"> <a href="${url}" target="_blank" style="display: inline-block; color: #ffffff; background-color: ${safeAccentColor}; border: solid 1px ${safeAccentColor}; border-radius: 5px; box-sizing: border-box; cursor: pointer; text-decoration: none; font-size: 16px; font-weight: normal; margin: 0; padding: 9px 22px 10px; border-color: ${safeAccentColor};">${t('Sign in')}</a> </td>
                                     </tr>
                                   </tbody>
                                 </table>
@@ -165,3 +169,4 @@ module.exports = ({t, siteTitle, email, url, accentColor = '#15212A', siteDomain
   </body>
 </html>
 `;
+};

--- a/ghost/core/core/server/services/members/emails/signup.js
+++ b/ghost/core/core/server/services/members/emails/signup.js
@@ -1,4 +1,8 @@
-module.exports = ({t, siteTitle, email, url, accentColor = '#15212A', siteDomain, siteUrl}) => `
+module.exports = ({t, siteTitle, email, url, accentColor = '#15212A', siteDomain, siteUrl}) => {
+    // Using the closest gray to pure black to fix bug caused by Apple mail's automatic color conversion in dark mode
+    const safeAccentColor = (accentColor === '#000000' || accentColor === '#000') ? '#010101' : accentColor;
+
+    return `
 <!doctype html>
 <html>
   <head>
@@ -125,7 +129,7 @@ module.exports = ({t, siteTitle, email, url, accentColor = '#15212A', siteDomain
                                 <table border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: auto;">
                                   <tbody>
                                     <tr>
-                                      <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; vertical-align: top; background-color: ${accentColor}; border-radius: 5px; text-align: center;"> <a href="${url}" target="_blank" style="display: inline-block; color: #ffffff; background-color: ${accentColor}; border: solid 1px ${accentColor}; border-radius: 5px; box-sizing: border-box; cursor: pointer; text-decoration: none; font-size: 16px; font-weight: normal; margin: 0; padding: 9px 22px 10px; border-color: ${accentColor};">${t('Confirm signup')}</a> </td>
+                                      <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; vertical-align: top; background-color: ${safeAccentColor}; border-radius: 5px; text-align: center;"> <a href="${url}" target="_blank" style="display: inline-block; color: #ffffff; background-color: ${safeAccentColor}; border: solid 1px ${safeAccentColor}; border-radius: 5px; box-sizing: border-box; cursor: pointer; text-decoration: none; font-size: 16px; font-weight: normal; margin: 0; padding: 9px 22px 10px; border-color: ${safeAccentColor};">${t('Confirm signup')}</a> </td>
                                     </tr>
                                   </tbody>
                                 </table>
@@ -171,3 +175,4 @@ module.exports = ({t, siteTitle, email, url, accentColor = '#15212A', siteDomain
   </body>
 </html>
 `;
+};

--- a/ghost/core/core/server/services/members/emails/subscribe.js
+++ b/ghost/core/core/server/services/members/emails/subscribe.js
@@ -1,4 +1,8 @@
-module.exports = ({t, siteTitle, email, url, accentColor = '#15212A', siteDomain, siteUrl}) => `
+module.exports = ({t, siteTitle, email, url, accentColor = '#15212A', siteDomain, siteUrl}) => {
+    // Using the closest gray to pure black to fix bug caused by Apple mail's automatic color conversion in dark mode
+    const safeAccentColor = (accentColor === '#000000' || accentColor === '#000') ? '#010101' : accentColor;
+
+    return `
 <!doctype html>
 <html>
   <head>
@@ -125,7 +129,7 @@ module.exports = ({t, siteTitle, email, url, accentColor = '#15212A', siteDomain
                                 <table border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: auto;">
                                   <tbody>
                                     <tr>
-                                      <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; vertical-align: top; background-color: ${accentColor}; border-radius: 5px; text-align: center;"> <a href="${url}" target="_blank" style="display: inline-block; color: #ffffff; background-color: ${accentColor}; border: solid 1px ${accentColor}; border-radius: 5px; box-sizing: border-box; cursor: pointer; text-decoration: none; font-size: 16px; font-weight: normal; margin: 0; padding: 9px 22px 10px; border-color: ${accentColor};">${t('Confirm email address')}</a> </td>
+                                      <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; vertical-align: top; background-color: ${safeAccentColor}; border-radius: 5px; text-align: center;"> <a href="${url}" target="_blank" style="display: inline-block; color: #ffffff; background-color: ${safeAccentColor}; border: solid 1px ${safeAccentColor}; border-radius: 5px; box-sizing: border-box; cursor: pointer; text-decoration: none; font-size: 16px; font-weight: normal; margin: 0; padding: 9px 22px 10px; border-color: ${safeAccentColor};">${t('Confirm email address')}</a> </td>
                                     </tr>
                                   </tbody>
                                 </table>
@@ -171,3 +175,4 @@ module.exports = ({t, siteTitle, email, url, accentColor = '#15212A', siteDomain
   </body>
 </html>
 `;
+};

--- a/ghost/core/core/server/services/members/emails/update-email.js
+++ b/ghost/core/core/server/services/members/emails/update-email.js
@@ -1,4 +1,8 @@
-module.exports = ({t, email, url, accentColor = '#15212A', siteDomain, siteUrl}) => `
+module.exports = ({t, email, url, accentColor = '#15212A', siteDomain, siteUrl}) => {
+    // Using the closest gray to pure black to fix bug caused by Apple mail's automatic color conversion in dark mode
+    const safeAccentColor = (accentColor === '#000000' || accentColor === '#000') ? '#010101' : accentColor;
+
+    return `
 <!doctype html>
 <html>
   <head>
@@ -125,7 +129,7 @@ module.exports = ({t, email, url, accentColor = '#15212A', siteDomain, siteUrl})
                                 <table border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: auto;">
                                   <tbody>
                                     <tr>
-                                      <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; vertical-align: top; background-color: ${accentColor}; border-radius: 5px; text-align: center;"> <a href="${url}" target="_blank" style="display: inline-block; color: #ffffff; background-color: ${accentColor}; border: solid 1px ${accentColor}; border-radius: 5px; box-sizing: border-box; cursor: pointer; text-decoration: none; font-size: 16px; font-weight: normal; margin: 0; padding: 9px 22px 10px; border-color: ${accentColor};">${t('Confirm email address')}</a> </td>
+                                      <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; vertical-align: top; background-color: ${safeAccentColor}; border-radius: 5px; text-align: center;"> <a href="${url}" target="_blank" style="display: inline-block; color: #ffffff; background-color: ${safeAccentColor}; border: solid 1px ${safeAccentColor}; border-radius: 5px; box-sizing: border-box; cursor: pointer; text-decoration: none; font-size: 16px; font-weight: normal; margin: 0; padding: 9px 22px 10px; border-color: ${safeAccentColor};">${t('Confirm email address')}</a> </td>
                                     </tr>
                                   </tbody>
                                 </table>
@@ -171,3 +175,4 @@ module.exports = ({t, email, url, accentColor = '#15212A', siteDomain, siteUrl})
   </body>
 </html>
 `;
+};


### PR DESCRIPTION
ref https://linear.app/ghost/issue/DES-1169/email-cta-for-signups-lacks-contrast-when-received-in-dark-mode

- Transactional member emails had a bug on Apple Mail which caused low contrast buttons when the accent color was set to pure black (`#000000`). This change updates the accent color to its closest gray variant (`#010101`) when set to `#000000` so that the automatic color application is not causing a bug in Apple Mail.