### PR TITLE
🐛 Fixed missing permission checks in paginated query hooks

### DIFF
--- a/apps/admin-x-framework/src/hooks/use-permissions.ts
+++ b/apps/admin-x-framework/src/hooks/use-permissions.ts
@@ -1,11 +1,17 @@
 import {useCurrentUser} from '../api/current-user';
 import {UserRoleType} from '../api/roles';
 
-export const usePermission = (userRoles:string[]) => {
+export const usePermission = (requiredRoles?: UserRoleType[] | null) => {
     const {data: currentUser} = useCurrentUser();
+
+    // No permissions required = allow all
+    if (!requiredRoles || requiredRoles.length === 0) {
+        return true;
+    }
+
     const currentUserRoles = currentUser?.roles.map(role => role.name);
     if (!currentUserRoles) {
         return false;
     }
-    return userRoles.some((role => currentUserRoles.includes(role as UserRoleType)));
+    return requiredRoles.some(role => currentUserRoles.includes(role));
 };

--- a/apps/admin-x-framework/src/utils/api/hooks.ts
+++ b/apps/admin-x-framework/src/utils/api/hooks.ts
@@ -3,6 +3,7 @@ import {usePagination} from '@tryghost/admin-x-design-system';
 import {useCallback, useEffect, useMemo, useState} from 'react';
 import useHandleError from '../../hooks/use-handle-error';
 import {usePermission} from '../../hooks/use-permissions';
+import {UserRoleType} from '../../api/roles';
 import {useFramework} from '../../providers/framework-provider';
 import {RequestOptions, apiUrl, useFetchApi} from './fetch-api';
 
@@ -22,7 +23,7 @@ interface QueryOptions<ResponseData> {
     path: string
     headers?: Record<string, string>;
     defaultSearchParams?: Record<string, string>;
-    permissions?: string[];
+    permissions?: UserRoleType[];
     returnData?: (originalData: unknown) => ResponseData;
     useActivityPub?: boolean;
 }
@@ -36,12 +37,13 @@ export const createQuery = <ResponseData>(options: QueryOptions<ResponseData>) =
     const url = apiUrl(options.path, searchParams || options.defaultSearchParams, options?.useActivityPub);
     const fetchApi = useFetchApi();
     const handleError = useHandleError();
+    const hasPermission = usePermission(options.permissions);
 
     const result = useQuery<ResponseData>({
-        enabled: options.permissions ? usePermission(options.permissions) : true,
+        ...query,
+        enabled: hasPermission && (query.enabled ?? true),
         queryKey: [options.dataType, url],
-        queryFn: () => fetchApi(url, {...options}),
-        ...query
+        queryFn: () => fetchApi(url, {...options})
     });
 
     const data = useMemo(() => (
@@ -70,16 +72,18 @@ export const createPaginatedQuery = <ResponseData extends {meta?: Meta}>(options
     const url = apiUrl(options.path, paginatedSearchParams, options?.useActivityPub);
     const fetchApi = useFetchApi();
     const handleError = useHandleError();
+    const hasPermission = usePermission(options.permissions);
 
     const result = useQuery<ResponseData>({
+        ...query,
+        enabled: hasPermission && (query.enabled ?? true),
         queryKey: [options.dataType, url],
-        queryFn: () => fetchApi(url),
-        ...query
+        queryFn: () => fetchApi(url, {...options})
     });
 
     const data = useMemo(() => (
         (result.data && options.returnData) ? options.returnData(result.data) : result.data)
-    , [result]);
+    , [result.data]);
 
     const pagination = usePagination({
         page,
@@ -116,14 +120,16 @@ type InfiniteQueryHookOptions<ResponseData> = UseInfiniteQueryOptions<ResponseDa
 export const createInfiniteQuery = <ResponseData>(options: InfiniteQueryOptions<ResponseData>) => ({searchParams, getNextPageParams, ...query}: InfiniteQueryHookOptions<ResponseData> = {}) => {
     const fetchApi = useFetchApi();
     const handleError = useHandleError();
+    const hasPermission = usePermission(options.permissions);
 
     const nextPageParams = getNextPageParams || options.defaultNextPageParams || (() => ({}));
 
     const result = useInfiniteQuery<ResponseData>({
+        ...query,
+        enabled: hasPermission && (query.enabled ?? true),
         queryKey: [options.dataType, apiUrl(options.path, searchParams || options.defaultSearchParams, options?.useActivityPub)],
         queryFn: ({pageParam}) => fetchApi(apiUrl(options.path, pageParam || searchParams || options.defaultSearchParams, options?.useActivityPub)),
-        getNextPageParam: data => nextPageParams(data, searchParams || options.defaultSearchParams || {}),
-        ...query
+        getNextPageParam: data => nextPageParams(data, searchParams || options.defaultSearchParams || {})
     });
 
     const data = useMemo(() => result.data && options.returnData(result.data), [result.data]);

--- a/apps/admin-x-framework/test/unit/api/tinybird.test.tsx
+++ b/apps/admin-x-framework/test/unit/api/tinybird.test.tsx
@@ -5,6 +5,17 @@ import {getTinybirdToken} from '../../../src/api/tinybird';
 import {FrameworkProvider} from '../../../src/providers/framework-provider';
 import {withMockFetch} from '../../utils/mock-fetch';
 
+// Mock the currentUser API for permission checks
+vi.mock('../../../src/api/current-user', () => ({
+    useCurrentUser: vi.fn().mockReturnValue({
+        data: {
+            id: '1',
+            name: 'Test User',
+            roles: [{name: 'Administrator', id: '1'}]
+        }
+    })
+}));
+
 const queryClient = new QueryClient({
     defaultOptions: {
         queries: {

--- a/apps/admin-x-framework/test/unit/hooks/use-permissions.test.ts
+++ b/apps/admin-x-framework/test/unit/hooks/use-permissions.test.ts
@@ -1,4 +1,5 @@
 import {renderHook} from '@testing-library/react';
+import {UserRoleType} from '../../../src/api/roles';
 import {usePermission} from '../../../src/hooks/use-permissions';
 
 // Mock the currentUser API
@@ -26,7 +27,7 @@ describe('usePermissions', () => {
             data: undefined
         });
 
-        const {result} = renderHook(() => usePermission(['admin']));
+        const {result} = renderHook(() => usePermission(['Administrator']));
 
         expect(result.current).toBe(false);
     });
@@ -40,7 +41,7 @@ describe('usePermissions', () => {
             }
         });
 
-        const {result} = renderHook(() => usePermission(['admin']));
+        const {result} = renderHook(() => usePermission(['Administrator']));
 
         expect(result.current).toBe(false);
     });
@@ -51,13 +52,13 @@ describe('usePermissions', () => {
                 id: '1',
                 name: 'Test User',
                 roles: [
-                    {name: 'admin', id: '1'},
-                    {name: 'editor', id: '2'}
+                    {name: 'Administrator', id: '1'},
+                    {name: 'Editor', id: '2'}
                 ]
             }
         });
 
-        const {result} = renderHook(() => usePermission(['admin']));
+        const {result} = renderHook(() => usePermission(['Administrator']));
 
         expect(result.current).toBe(true);
     });
@@ -68,13 +69,13 @@ describe('usePermissions', () => {
                 id: '1',
                 name: 'Test User',
                 roles: [
-                    {name: 'editor', id: '2'},
-                    {name: 'author', id: '3'}
+                    {name: 'Editor', id: '2'},
+                    {name: 'Author', id: '3'}
                 ]
             }
         });
 
-        const {result} = renderHook(() => usePermission(['admin', 'editor', 'owner']));
+        const {result} = renderHook(() => usePermission(['Administrator', 'Editor', 'Owner']));
 
         expect(result.current).toBe(true);
     });
@@ -85,31 +86,36 @@ describe('usePermissions', () => {
                 id: '1',
                 name: 'Test User',
                 roles: [
-                    {name: 'contributor', id: '4'},
-                    {name: 'author', id: '3'}
+                    {name: 'Contributor', id: '4'},
+                    {name: 'Author', id: '3'}
                 ]
             }
         });
 
-        const {result} = renderHook(() => usePermission(['admin', 'editor', 'owner']));
+        const {result} = renderHook(() => usePermission(['Administrator', 'Editor', 'Owner']));
 
         expect(result.current).toBe(false);
     });
 
-    it('handles empty required roles array', () => {
+    // eslint-disable-next-line ghost/mocha/no-setup-in-describe
+    it.each([
+        {value: [] as UserRoleType[], description: 'empty array'},
+        {value: undefined, description: 'undefined'},
+        {value: null, description: 'null'}
+    ])('returns true when no permissions are required ($description)', ({value}) => {
         mockUseCurrentUser.mockReturnValue({
             data: {
                 id: '1',
                 name: 'Test User',
                 roles: [
-                    {name: 'admin', id: '1'}
+                    {name: 'Administrator', id: '1'}
                 ]
             }
         });
 
-        const {result} = renderHook(() => usePermission([]));
+        const {result} = renderHook(() => usePermission(value));
 
-        expect(result.current).toBe(false);
+        expect(result.current).toBe(true);
     });
 
     it('handles case sensitivity correctly', () => {
@@ -118,12 +124,12 @@ describe('usePermissions', () => {
                 id: '1',
                 name: 'Test User',
                 roles: [
-                    {name: 'Admin', id: '1'}
+                    {name: 'Editor', id: '1'}
                 ]
             }
         });
 
-        const {result} = renderHook(() => usePermission(['admin']));
+        const {result} = renderHook(() => usePermission(['Administrator']));
 
         expect(result.current).toBe(false); // Case sensitive match
     });
@@ -133,7 +139,7 @@ describe('usePermissions', () => {
             data: undefined
         });
 
-        const {result} = renderHook(() => usePermission(['admin']));
+        const {result} = renderHook(() => usePermission(['Administrator']));
 
         expect(result.current).toBe(false);
     });
@@ -144,13 +150,13 @@ describe('usePermissions', () => {
                 id: '1',
                 name: 'Test User',
                 roles: [
-                    {name: 'owner', id: '1', description: 'Site owner'},
-                    {name: 'administrator', id: '2', description: 'Site admin'}
+                    {name: 'Owner', id: '1', description: 'Site owner'},
+                    {name: 'Administrator', id: '2', description: 'Site admin'}
                 ]
             }
         });
 
-        const {result} = renderHook(() => usePermission(['owner']));
+        const {result} = renderHook(() => usePermission(['Owner']));
 
         expect(result.current).toBe(true);
     });
@@ -161,12 +167,12 @@ describe('usePermissions', () => {
                 id: '1',
                 name: 'Test User',
                 roles: [
-                    {name: 'author', id: '3'}
+                    {name: 'Author', id: '3'}
                 ]
             }
         });
 
-        const {result} = renderHook(() => usePermission(['author']));
+        const {result} = renderHook(() => usePermission(['Author']));
 
         expect(result.current).toBe(true);
     });

--- a/apps/admin-x-framework/test/unit/utils/api/hooks.test.tsx
+++ b/apps/admin-x-framework/test/unit/utils/api/hooks.test.tsx
@@ -5,6 +5,15 @@ import {FrameworkProvider} from '../../../../src/providers/framework-provider';
 import {createInfiniteQuery, createMutation, createPaginatedQuery, createQuery, createQueryWithId} from '../../../../src/utils/api/hooks';
 import {withMockFetch} from '../../../utils/mock-fetch';
 
+// Mock the currentUser API for permission tests
+vi.mock('../../../../src/api/current-user', () => ({
+    useCurrentUser: vi.fn()
+}));
+
+import {useCurrentUser} from '../../../../src/api/current-user';
+
+const mockUseCurrentUser = useCurrentUser as any;
+
 const queryClient = new QueryClient({
     defaultOptions: {
         queries: {
@@ -37,6 +46,21 @@ const wrapper: React.FC<{ children: ReactNode }> = ({children}) => (
 );
 
 describe('API hooks', () => {
+    beforeEach(() => {
+        // Default: user with admin role for most tests
+        mockUseCurrentUser.mockReturnValue({
+            data: {
+                id: '1',
+                name: 'Test User',
+                roles: [{name: 'Administrator', id: '1'}]
+            }
+        });
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
     describe('createQuery', () => {
         afterEach(() => {
             queryClient.clear();
@@ -149,6 +173,61 @@ describe('API hooks', () => {
                 await waitFor(() => expect(result.current.isLoading).toBe(false));
 
                 expect(result.current.data).toEqual(2);
+            });
+        });
+
+        it('does not make a request when user lacks required permissions', async () => {
+            // User is a Contributor, but query requires Administrator
+            mockUseCurrentUser.mockReturnValue({
+                data: {
+                    id: '1',
+                    name: 'Test User',
+                    roles: [{name: 'Contributor', id: '4'}]
+                }
+            });
+
+            await withMockFetch({json: {test: 1}}, async (mock) => {
+                const useTestQuery = createQuery({
+                    dataType: 'test',
+                    path: '/test/',
+                    permissions: ['Owner', 'Administrator']
+                });
+
+                const {result} = renderHook(() => useTestQuery(), {wrapper});
+
+                // Should remain in a non-fetching state since query is disabled
+                await waitFor(() => expect(result.current.fetchStatus).toBe('idle'));
+
+                // No API call should have been made
+                expect(mock.calls.length).toBe(0);
+                expect(result.current.data).toBeUndefined();
+            });
+        });
+
+        it('makes request when user has required permissions', async () => {
+            // User is an Administrator
+            mockUseCurrentUser.mockReturnValue({
+                data: {
+                    id: '1',
+                    name: 'Test User',
+                    roles: [{name: 'Administrator', id: '1'}]
+                }
+            });
+
+            await withMockFetch({json: {test: 1}}, async (mock) => {
+                const useTestQuery = createQuery({
+                    dataType: 'test',
+                    path: '/test/',
+                    permissions: ['Owner', 'Administrator']
+                });
+
+                const {result} = renderHook(() => useTestQuery(), {wrapper});
+
+                await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+                // API call should have been made
+                expect(mock.calls.length).toBe(1);
+                expect(result.current.data).toEqual({test: 1});
             });
         });
     });
@@ -289,6 +368,61 @@ describe('API hooks', () => {
                 expect(mock.calls[3][0]).toEqual('http://localhost:3000/ghost/api/admin/test/?page=5');
             });
         });
+
+        it('does not make a request when user lacks required permissions', async () => {
+            // User is a Contributor, but query requires Administrator
+            mockUseCurrentUser.mockReturnValue({
+                data: {
+                    id: '1',
+                    name: 'Test User',
+                    roles: [{name: 'Contributor', id: '4'}]
+                }
+            });
+
+            await withMockFetch({json: {test: 1}}, async (mock) => {
+                const useTestQuery = createPaginatedQuery({
+                    dataType: 'test',
+                    path: '/test/',
+                    permissions: ['Owner', 'Administrator']
+                });
+
+                const {result} = renderHook(() => useTestQuery(), {wrapper});
+
+                // Should remain in a non-fetching state since query is disabled
+                await waitFor(() => expect(result.current.fetchStatus).toBe('idle'));
+
+                // No API call should have been made
+                expect(mock.calls.length).toBe(0);
+                expect(result.current.data).toBeUndefined();
+            });
+        });
+
+        it('makes request when user has required permissions', async () => {
+            // User is an Administrator
+            mockUseCurrentUser.mockReturnValue({
+                data: {
+                    id: '1',
+                    name: 'Test User',
+                    roles: [{name: 'Administrator', id: '1'}]
+                }
+            });
+
+            await withMockFetch({json: {test: 1}}, async (mock) => {
+                const useTestQuery = createPaginatedQuery({
+                    dataType: 'test',
+                    path: '/test/',
+                    permissions: ['Owner', 'Administrator']
+                });
+
+                const {result} = renderHook(() => useTestQuery(), {wrapper});
+
+                await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+                // API call should have been made
+                expect(mock.calls.length).toBe(1);
+                expect(result.current.data).toEqual({test: 1});
+            });
+        });
     });
 
     describe('createInfiniteQuery', () => {
@@ -338,6 +472,69 @@ describe('API hooks', () => {
                 expect(mock.calls[1][0]).toEqual('http://localhost:3000/ghost/api/admin/test/?page=2');
 
                 await waitFor(() => expect(result.current.data).toEqual([1, 1]));
+            });
+        });
+
+        it('does not make a request when user lacks required permissions', async () => {
+            // User is a Contributor, but query requires Administrator
+            mockUseCurrentUser.mockReturnValue({
+                data: {
+                    id: '1',
+                    name: 'Test User',
+                    roles: [{name: 'Contributor', id: '4'}]
+                }
+            });
+
+            await withMockFetch({json: {test: 1}}, async (mock) => {
+                const useTestQuery = createInfiniteQuery({
+                    dataType: 'test',
+                    path: '/test/',
+                    permissions: ['Owner', 'Administrator'],
+                    returnData: (originalData) => {
+                        const {pages} = originalData as InfiniteData<{test: number}>;
+                        return pages.map(page => page.test);
+                    }
+                });
+
+                const {result} = renderHook(() => useTestQuery(), {wrapper});
+
+                // Should remain in a non-fetching state since query is disabled
+                await waitFor(() => expect(result.current.fetchStatus).toBe('idle'));
+
+                // No API call should have been made
+                expect(mock.calls.length).toBe(0);
+                expect(result.current.data).toBeUndefined();
+            });
+        });
+
+        it('makes request when user has required permissions', async () => {
+            // User is an Administrator
+            mockUseCurrentUser.mockReturnValue({
+                data: {
+                    id: '1',
+                    name: 'Test User',
+                    roles: [{name: 'Administrator', id: '1'}]
+                }
+            });
+
+            await withMockFetch({json: {test: 1, pagination: {next: 2}}}, async (mock) => {
+                const useTestQuery = createInfiniteQuery({
+                    dataType: 'test',
+                    path: '/test/',
+                    permissions: ['Owner', 'Administrator'],
+                    returnData: (originalData) => {
+                        const {pages} = originalData as InfiniteData<{test: number}>;
+                        return pages.map(page => page.test);
+                    }
+                });
+
+                const {result} = renderHook(() => useTestQuery(), {wrapper});
+
+                await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+                // API call should have been made
+                expect(mock.calls.length).toBe(1);
+                expect(result.current.data).toEqual([1]);
             });
         });
     });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3394/

## Summary

Contributors viewing their user profile menu were seeing a permission error toast because `useBrowseInvites()` was making API calls without checking user permissions.

**Root cause:** The `createQuery` hook correctly disabled queries when users lacked permissions via `enabled: hasPermission`, but `createInfiniteQuery` and `createPaginatedQuery` were missing this check.

**Fix:** Added the same permission check pattern to both hooks:
- `createPaginatedQuery` now checks permissions before making requests
- `createInfiniteQuery` now checks permissions before making requests