### PR TITLE
🐛 Fixed ghost-members-ssr cookie not being cleared on invalid signature

### DIFF
--- a/ghost/core/core/server/services/members/members-ssr.js
+++ b/ghost/core/core/server/services/members/members-ssr.js
@@ -145,6 +145,11 @@ class MembersSSR {
         const cookies = this._getCookies(req, res);
         const value = cookies.get(this.sessionCookieName, {signed: true});
         if (!value) {
+            // Clear orphaned cookie (cookies library only clears .sig on invalid signature)
+            const unsignedValue = cookies.get(this.sessionCookieName, {signed: false});
+            if (unsignedValue) {
+                cookies.set(this.sessionCookieName, null, {...this.sessionCookieOptions, signed: false});
+            }
             throw new BadRequestError({
                 message: `Cookie ${this.sessionCookieName} not found`
             });

--- a/ghost/core/test/e2e-frontend/members.test.js
+++ b/ghost/core/test/e2e-frontend/members.test.js
@@ -659,7 +659,7 @@ describe('Front-end members behavior', function () {
 
                 const setCookieHeaders = response.headers['set-cookie'] || [];
 
-                const mainCookieCleared = setCookieHeaders.some(cookie => cookie.includes('ghost-members-ssr=') && !cookie.includes('ghost-members-ssr.sig') && cookie.includes('expires=Thu, 01 Jan 1970 00:00:00 GMT'));
+                const mainCookieCleared = setCookieHeaders.some(cookie => cookie.startsWith('ghost-members-ssr=') && cookie.includes('expires=Thu, 01 Jan 1970 00:00:00 GMT'));
 
                 const sigCookieCleared = setCookieHeaders.some(cookie => cookie.includes('ghost-members-ssr.sig=') && cookie.includes('expires=Thu, 01 Jan 1970 00:00:00 GMT'));
 

--- a/ghost/core/test/e2e-frontend/members.test.js
+++ b/ghost/core/test/e2e-frontend/members.test.js
@@ -664,7 +664,7 @@ describe('Front-end members behavior', function () {
                 const sigCookieCleared = setCookieHeaders.some(cookie => cookie.startsWith('ghost-members-ssr.sig=') && cookie.includes('expires=Thu, 01 Jan 1970 00:00:00 GMT'));
 
                 assert.ok(sigCookieCleared, 'ghost-members-ssr.sig cookie should be cleared with expiry in the past');
-                assert.ok(mainCookieCleared, 'ghost-members-ssr cookie should be cleared with expiry in the past (this is the fix)');
+                assert.ok(mainCookieCleared, 'ghost-members-ssr cookie should be cleared with expiry in the past');
             });
 
             it('an invalid token causes a set-cookie logout when requesting the identity', async function () {

--- a/ghost/core/test/e2e-frontend/members.test.js
+++ b/ghost/core/test/e2e-frontend/members.test.js
@@ -661,7 +661,7 @@ describe('Front-end members behavior', function () {
 
                 const mainCookieCleared = setCookieHeaders.some(cookie => cookie.startsWith('ghost-members-ssr=') && cookie.includes('expires=Thu, 01 Jan 1970 00:00:00 GMT'));
 
-                const sigCookieCleared = setCookieHeaders.some(cookie => cookie.includes('ghost-members-ssr.sig=') && cookie.includes('expires=Thu, 01 Jan 1970 00:00:00 GMT'));
+                const sigCookieCleared = setCookieHeaders.some(cookie => cookie.startsWith('ghost-members-ssr.sig=') && cookie.includes('expires=Thu, 01 Jan 1970 00:00:00 GMT'));
 
                 assert.ok(sigCookieCleared, 'ghost-members-ssr.sig cookie should be cleared with expiry in the past');
                 assert.ok(mainCookieCleared, 'ghost-members-ssr cookie should be cleared with expiry in the past (this is the fix)');

--- a/ghost/core/test/e2e-frontend/members.test.js
+++ b/ghost/core/test/e2e-frontend/members.test.js
@@ -645,6 +645,28 @@ describe('Front-end members behavior', function () {
                 member = await loginAsMember('member1@test.com');
             });
 
+            it('clears both ghost-members-ssr and ghost-members-ssr.sig cookies when signature is invalid', async function () {
+                const newRequest = supertest.agent(configUtils.config.get('url'));
+
+                // Send a request with a valid-looking cookie but an invalid signature
+                // This simulates the scenario where the cookie exists but signature verification fails
+                const response = await newRequest.get('/members/api/member')
+                    .set('Cookie', [
+                        'ghost-members-ssr=fake-transient-id',
+                        'ghost-members-ssr.sig=invalid-signature'
+                    ])
+                    .expect(204);
+
+                const setCookieHeaders = response.headers['set-cookie'] || [];
+
+                const mainCookieCleared = setCookieHeaders.some(cookie => cookie.includes('ghost-members-ssr=') && !cookie.includes('ghost-members-ssr.sig') && cookie.includes('expires=Thu, 01 Jan 1970 00:00:00 GMT'));
+
+                const sigCookieCleared = setCookieHeaders.some(cookie => cookie.includes('ghost-members-ssr.sig=') && cookie.includes('expires=Thu, 01 Jan 1970 00:00:00 GMT'));
+
+                assert.ok(sigCookieCleared, 'ghost-members-ssr.sig cookie should be cleared with expiry in the past');
+                assert.ok(mainCookieCleared, 'ghost-members-ssr cookie should be cleared with expiry in the past (this is the fix)');
+            });
+
             it('an invalid token causes a set-cookie logout when requesting the identity', async function () {
                 // Check logged in
                 await request.get('/members/api/member')


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ENG-1357/

- The `cookies` library only clears the `.sig` cookie when signature verification fails, leaving the main `ghost-members-ssr` cookie orphaned. This orphaned cookie is sent with subsequent requests, preventing them from being served from cache and reducing Cache Hit Rate (CHR).
- Added check in `_getSessionCookies` to detect orphaned cookies
- When signature verification fails, now explicitly clear the main cookie
- Added e2e test to verify both cookies are cleared on invalid signature