### PR TITLE
Updated welcome email modal to utilize useForm

### DIFF
--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/member-email-editor.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/member-email-editor.tsx
@@ -22,9 +22,12 @@ const MemberEmailsEditor: React.FC<MemberEmailsEditorProps> = ({
     // but the API expects a JSON string
     const handleChange = useCallback((data: unknown) => {
         if (onChange && data && typeof data === 'object') {
-            onChange(JSON.stringify(data));
+            const stringified = JSON.stringify(data);
+            if (stringified !== value) {
+                onChange(stringified);
+            }
         }
-    }, [onChange]);
+    }, [onChange, value]);
 
     return (
         <KoenigEditorBase

--- a/e2e/helpers/pages/admin/settings/sections/member-welcome-emails-section.ts
+++ b/e2e/helpers/pages/admin/settings/sections/member-welcome-emails-section.ts
@@ -11,10 +11,8 @@ export class MemberWelcomeEmailsSection extends BasePage {
     // Modal locators
     readonly welcomeEmailModal: Locator;
     readonly modalSubjectInput: Locator;
-    readonly modalSenderNameInput: Locator;
-    readonly modalSenderEmailInput: Locator;
-    readonly modalReplyToInput: Locator;
     readonly modalSaveButton: Locator;
+    readonly modalSavedButton: Locator;
     readonly modalLexicalEditor: Locator;
 
     constructor(page: Page) {
@@ -27,11 +25,9 @@ export class MemberWelcomeEmailsSection extends BasePage {
 
         // Modal locators
         this.welcomeEmailModal = page.getByTestId('welcome-email-modal');
-        this.modalSubjectInput = this.welcomeEmailModal.locator('input').nth(3); // Subject is the 4th input
-        this.modalSenderNameInput = this.welcomeEmailModal.locator('input').nth(0); // Sender name is 1st input
-        this.modalSenderEmailInput = this.welcomeEmailModal.locator('input').nth(1); // Sender email is 2nd input
-        this.modalReplyToInput = this.welcomeEmailModal.locator('input').nth(2); // Reply-to is 3rd input
+        this.modalSubjectInput = this.welcomeEmailModal.locator('input').first();
         this.modalSaveButton = this.welcomeEmailModal.getByRole('button', {name: 'Save'});
+        this.modalSavedButton = this.welcomeEmailModal.getByRole('button', {name: 'Saved'});
         this.modalLexicalEditor = this.welcomeEmailModal.locator('[contenteditable="true"]');
     }
 
@@ -95,6 +91,6 @@ export class MemberWelcomeEmailsSection extends BasePage {
 
     async saveWelcomeEmail(): Promise<void> {
         await this.modalSaveButton.click();
-        await this.welcomeEmailModal.waitFor({state: 'hidden'});
+        await this.modalSavedButton.waitFor({state: 'visible'});
     }
 }

--- a/e2e/tests/admin/settings/member-welcome-emails.test.ts
+++ b/e2e/tests/admin/settings/member-welcome-emails.test.ts
@@ -108,34 +108,6 @@ test.describe('Ghost Admin - Member Welcome Emails', () => {
         expect(freeWelcomeEmail?.subject).toBe('Custom Welcome Subject');
     });
 
-    test('can edit free welcome email sender details', async ({page}) => {
-        const welcomeEmailsSection = new MemberWelcomeEmailsSection(page);
-
-        // Enable free welcome email first
-        await welcomeEmailsSection.goto();
-        await welcomeEmailsSection.enableFreeWelcomeEmail();
-
-        // Open the modal and edit sender details
-        await welcomeEmailsSection.openFreeWelcomeEmailModal();
-        await welcomeEmailsSection.modalSenderNameInput.clear();
-        await welcomeEmailsSection.modalSenderNameInput.fill('Test Sender');
-        await welcomeEmailsSection.modalSenderEmailInput.clear();
-        await welcomeEmailsSection.modalSenderEmailInput.fill('sender@example.com');
-        await welcomeEmailsSection.modalReplyToInput.clear();
-        await welcomeEmailsSection.modalReplyToInput.fill('reply@example.com');
-        await welcomeEmailsSection.saveWelcomeEmail();
-
-        // Verify via API that the sender details were saved
-        const response = await page.request.get('/ghost/api/admin/automated_emails/');
-        expect(response.ok()).toBe(true);
-
-        const data = await response.json() as AutomatedEmailsResponse;
-        const freeWelcomeEmail = data.automated_emails.find(email => email.slug === 'member-welcome-email-free');
-        expect(freeWelcomeEmail?.sender_name).toBe('Test Sender');
-        expect(freeWelcomeEmail?.sender_email).toBe('sender@example.com');
-        expect(freeWelcomeEmail?.sender_reply_to).toBe('reply@example.com');
-    });
-
     test('edited welcome email persists after page reload', async ({page}) => {
         const welcomeEmailsSection = new MemberWelcomeEmailsSection(page);
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/NY-856

- Removes placeholder logic and updates form handling in `welcome-email-modal.tsx` to utilize our `useForm` hook and fixes a few related issues in the process
- Save button now shows "Saved" on successful save instead of closing the modal (closes https://linear.app/ghost/issue/NY-854)
- `cmd + S` now saves changes, without closing modal (closes https://linear.app/ghost/issue/NY-853)
- Hides reply-to if it's the same as from, tweaks spacing (ref https://linear.app/ghost/issue/NY-851)
- Makes it so From and Reply-to aren't editable and are the same as the default newsletter values; also updates styles (closes https://linear.app/ghost/issue/NY-846)