### PR TITLE
Added stripe to `yarn dev:forward`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,7 @@
 # Docker Compose profiles to enable
 ## Run `docker compose config --profiles` to see all available profiles
 ## See https://docs.docker.com/compose/how-tos/profiles/ for more information
-COMPOSE_PROFILES=ghost
+# COMPOSE_PROFILES=stripe
 
 # Debug level to pass to Ghost
 # DEBUG=

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -98,6 +98,9 @@ services:
         condition: service_healthy
       mailpit:
         condition: service_healthy
+      stripe:
+        condition: service_healthy
+        required: false
     healthcheck:
       test: ["CMD", "node", "-e", "fetch('http://localhost:2368',{redirect:'manual'}).then(r=>process.exit(r.status<500?0:1)).catch(()=>process.exit(1))"]
       timeout: 5s
@@ -133,9 +136,7 @@ services:
       - shared-config:/mnt/shared-config
     environment:
       - GHOST_URL=http://ghost-dev:2368
-      - STRIPE_SECRET_KEY=${STRIPE_SECRET_KEY}
-      - STRIPE_PUBLISHABLE_KEY=${STRIPE_PUBLISHABLE_KEY}
-      - STRIPE_ACCOUNT_ID=${STRIPE_ACCOUNT_ID}
+      - STRIPE_SECRET_KEY=${STRIPE_SECRET_KEY:-}
     healthcheck:
       test: ["CMD", "test", "-f", "/mnt/shared-config/.env.stripe"]
       interval: 1s

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -127,6 +127,7 @@ services:
     image: stripe/stripe-cli:latest
     container_name: ghost-dev-stripe
     entrypoint: ["/entrypoint.sh"]
+    profiles: ["stripe"]
     volumes:
       - ./docker/stripe/entrypoint.sh:/entrypoint.sh:ro
       - shared-config:/mnt/shared-config

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -66,6 +66,7 @@ services:
       - ghost-dev-media:/home/ghost/ghost/core/content/media
       - ghost-dev-files:/home/ghost/ghost/core/content/files
       - ghost-dev-logs:/home/ghost/ghost/core/content/logs
+      - shared-config:/mnt/shared-config:ro
     environment:
       NODE_ENV: development
       NODE_TLS_REJECT_UNAUTHORIZED: "0"
@@ -122,10 +123,27 @@ services:
       ghost-dev:
         condition: service_healthy
 
+  stripe:
+    image: stripe/stripe-cli:latest
+    container_name: ghost-dev-stripe
+    entrypoint: ["/entrypoint.sh"]
+    volumes:
+      - ./docker/stripe/entrypoint.sh:/entrypoint.sh:ro
+      - shared-config:/mnt/shared-config
+    environment:
+      - GHOST_URL=http://ghost-dev:2368
+      - STRIPE_SECRET_KEY=${STRIPE_SECRET_KEY}
+      - STRIPE_PUBLISHABLE_KEY=${STRIPE_PUBLISHABLE_KEY}
+      - STRIPE_ACCOUNT_ID=${STRIPE_ACCOUNT_ID}
+    healthcheck:
+      test: ["CMD", "test", "-f", "/mnt/shared-config/.env.stripe"]
+      interval: 1s
+      retries: 120
 
 volumes:
   mysql-data:
   redis-data:
+  shared-config:
   ghost-dev-data:
   ghost-dev-images:
   ghost-dev-media:

--- a/compose.yml
+++ b/compose.yml
@@ -294,6 +294,7 @@ services:
       - ./docker/stripe/entrypoint.sh:/entrypoint.sh:ro
       - shared-config:/mnt/shared-config
     environment:
+      - GHOST_URL=http://server:2368
       - STRIPE_SECRET_KEY=${STRIPE_SECRET_KEY:-}
       - STRIPE_PUBLISHABLE_KEY=${STRIPE_PUBLISHABLE_KEY:-}
       - STRIPE_ACCOUNT_ID=${STRIPE_ACCOUNT_ID:-}

--- a/docker/ghost-dev/entrypoint.sh
+++ b/docker/ghost-dev/entrypoint.sh
@@ -17,6 +17,18 @@ else
     echo "WARNING: Tinybird not enabled: .env.tinybird file not found at /mnt/shared-config/.env.tinybird" >&2
 fi
 
+
+# Configure Stripe webhook secret
+if [ -f /mnt/shared-config/.env.stripe ]; then
+    source /mnt/shared-config/.env.stripe
+    if [ -n "${STRIPE_WEBHOOK_SECRET:-}" ]; then
+        export WEBHOOK_SECRET="$STRIPE_WEBHOOK_SECRET"
+        echo "Stripe webhook secret configured successfully"
+    else
+        echo "WARNING: Stripe webhook secret not found in shared config"
+    fi
+fi
+
 # Execute the CMD
 exec "$@"
 

--- a/docker/stripe/entrypoint.sh
+++ b/docker/stripe/entrypoint.sh
@@ -87,8 +87,8 @@ else
 fi
 
 # Start stripe listen in the background
-echo "Starting Stripe webhook listener forwarding to http://server:2368/members/webhooks/stripe/"
-stripe listen --forward-to http://server:2368/members/webhooks/stripe/ --api-key "${STRIPE_SECRET_KEY}" &
+echo "Starting Stripe webhook listener forwarding to ${GHOST_URL}/members/webhooks/stripe/"
+stripe listen --forward-to ${GHOST_URL}/members/webhooks/stripe/ --api-key "${STRIPE_SECRET_KEY}" &
 child=$!
 
 # Wait for the child process


### PR DESCRIPTION
no issue

Currently to run Ghost locally with Stripe with the new `yarn dev:forward` setup, you need to install and run the Stripe CLI locally, and pass the webhook secret to Ghost via environment variable. This change makes it easier to run Ghost with Stripe with the `yarn dev:forward` command.

---
To use:
- Add `COMPOSE_PROFILES=stripe` to `.env` file at root of repo
- Add `STRIPE_SECRET_KEY` to `.env` file at root of repo (or export it in your shell)
- Run `yarn dev:forward`

---
How it works
- The stripe CLI runs in docker. The entrypoint file runs to fetch the WEBHOOK_SECRET required by Ghost to verify Stripe webhooks, and saves it to a shared volume
- When `ghost-dev` starts, the entrypoint reads WEBHOOK_SECRET from the shared volume into its environment before booting Ghost

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables local Stripe integration without a host-installed CLI by wiring a Dockerized Stripe CLI to Ghost via a shared config volume.
> 
> - Adds `stripe` service (profile `stripe`) running `stripe/stripe-cli` with an entrypoint that fetches `STRIPE_WEBHOOK_SECRET`, writes it to `shared-config/.env.stripe`, and forwards webhooks to `${GHOST_URL}/members/webhooks/stripe/`
> - Updates `ghost-dev` entrypoint to read `STRIPE_WEBHOOK_SECRET` from shared config and export it as `WEBHOOK_SECRET`
> - Mounts `shared-config` into `ghost-dev` and adds optional `depends_on` for `stripe`; healthcheck waits for `.env.stripe`
> - In `compose.yml`, sets `GHOST_URL` for the `stripe` service; `.env.example` hints enabling the `stripe` profile
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 06adeb123b40a31393a7c9329a78db5d257c619b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->