### PR TITLE
Fixed free welcome emails being sent to new paid members

### DIFF
--- a/ghost/core/core/server/services/member-welcome-emails/service.js
+++ b/ghost/core/core/server/services/member-welcome-emails/service.js
@@ -41,7 +41,7 @@ class MemberWelcomeEmailService {
         }
     }
 
-    async send({member, memberStatus = 'free'}) {
+    async send({member, memberStatus}) {
         const name = member?.name ? `${member.name} at ` : '';
         logging.info(`${MEMBER_WELCOME_EMAIL_LOG_KEY} Sending welcome email to ${name}${member?.email}`);
 

--- a/ghost/core/core/server/services/members/members-api/repositories/MemberRepository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/MemberRepository.js
@@ -369,7 +369,8 @@ module.exports = class MemberRepository {
                             email: newMember.get('email'),
                             name: newMember.get('name'),
                             source,
-                            timestamp
+                            timestamp,
+                            memberStatus: 'free'
                         })
                     }, {transacting});
                 }

--- a/ghost/core/core/server/services/members/members-api/repositories/MemberRepository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/MemberRepository.js
@@ -355,7 +355,10 @@ module.exports = class MemberRepository {
                     labels
                 }, {...memberAddOptions, transacting});
                 
-                if (isFreeWelcomeEmailActive) {
+                // Only send the free welcome email if:
+                // 1. The free welcome email is active
+                // 2. The member is not signing up for a paid subscription (no stripeCustomer)
+                if (isFreeWelcomeEmailActive && !stripeCustomer) {
                     const timestamp = eventData.created_at || newMember.get('created_at');
 
                     await this._Outbox.add({
@@ -380,7 +383,7 @@ module.exports = class MemberRepository {
                 member = await this._Member.transaction(runMemberCreation);
             }
 
-            if (isFreeWelcomeEmailActive) {
+            if (isFreeWelcomeEmailActive && !stripeCustomer) {
                 this.dispatchEvent(StartOutboxProcessingEvent.create({memberId: member.id}), memberAddOptions);
             }
         } else {

--- a/ghost/core/core/server/services/members/members-api/repositories/MemberRepository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/MemberRepository.js
@@ -370,7 +370,7 @@ module.exports = class MemberRepository {
                             name: newMember.get('name'),
                             source,
                             timestamp,
-                            memberStatus: 'free'
+                            status: 'free'
                         })
                     }, {transacting});
                 }

--- a/ghost/core/core/server/services/members/members-api/repositories/MemberRepository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/MemberRepository.js
@@ -347,7 +347,8 @@ module.exports = class MemberRepository {
         if (config.get('memberWelcomeEmailTestInbox') && WELCOME_EMAIL_SOURCES.includes(source)) {
             const freeWelcomeEmail = this._AutomatedEmail ? await this._AutomatedEmail.findOne({slug: MEMBER_WELCOME_EMAIL_SLUGS.free}) : null;
             const isFreeWelcomeEmailActive = freeWelcomeEmail && freeWelcomeEmail.get('lexical') && freeWelcomeEmail.get('status') === 'active';
-            
+            const isFreeSignup = !stripeCustomer;
+
             const runMemberCreation = async (transacting) => {
                 const newMember = await this._Member.add({
                     ...memberData,
@@ -358,7 +359,7 @@ module.exports = class MemberRepository {
                 // Only send the free welcome email if:
                 // 1. The free welcome email is active
                 // 2. The member is not signing up for a paid subscription (no stripeCustomer)
-                if (isFreeWelcomeEmailActive && !stripeCustomer) {
+                if (isFreeWelcomeEmailActive && isFreeSignup) {
                     const timestamp = eventData.created_at || newMember.get('created_at');
 
                     await this._Outbox.add({
@@ -384,7 +385,7 @@ module.exports = class MemberRepository {
                 member = await this._Member.transaction(runMemberCreation);
             }
 
-            if (isFreeWelcomeEmailActive && !stripeCustomer) {
+            if (isFreeWelcomeEmailActive && isFreeSignup) {
                 this.dispatchEvent(StartOutboxProcessingEvent.create({memberId: member.id}), memberAddOptions);
             }
         } else {

--- a/ghost/core/core/server/services/outbox/handlers/member-created.js
+++ b/ghost/core/core/server/services/outbox/handlers/member-created.js
@@ -4,9 +4,7 @@ const memberWelcomeEmailService = require('../../member-welcome-emails/service')
 const LOG_KEY = `${OUTBOX_LOG_KEY}[MEMBER-WELCOME-EMAIL]`;
 
 async function handle({payload}) {
-    // TODO: derive memberStatus from payload when paid welcome emails are added
-    const memberStatus = 'free';
-    await memberWelcomeEmailService.api.send({member: payload, memberStatus});
+    await memberWelcomeEmailService.api.send({member: payload, memberStatus: payload.memberStatus});
 }
 
 function getLogInfo(payload) {

--- a/ghost/core/core/server/services/outbox/handlers/member-created.js
+++ b/ghost/core/core/server/services/outbox/handlers/member-created.js
@@ -4,7 +4,7 @@ const memberWelcomeEmailService = require('../../member-welcome-emails/service')
 const LOG_KEY = `${OUTBOX_LOG_KEY}[MEMBER-WELCOME-EMAIL]`;
 
 async function handle({payload}) {
-    await memberWelcomeEmailService.api.send({member: payload, memberStatus: payload.memberStatus});
+    await memberWelcomeEmailService.api.send({member: payload, memberStatus: payload.status});
 }
 
 function getLogInfo(payload) {

--- a/ghost/core/test/integration/jobs/process-outbox.test.js
+++ b/ghost/core/test/integration/jobs/process-outbox.test.js
@@ -84,7 +84,7 @@ describe('Process Outbox Job', function () {
                 email: 'test@example.com',
                 name: 'Test Member',
                 source: 'member',
-                memberStatus: 'free'
+                status: 'free'
             }),
             status: OUTBOX_STATUSES.PENDING
         });
@@ -117,7 +117,7 @@ describe('Process Outbox Job', function () {
                 memberId: 'member1',
                 email: 'test1@example.com',
                 name: 'Test Member 1',
-                memberStatus: 'free'
+                status: 'free'
             }),
             status: OUTBOX_STATUSES.PENDING
         });
@@ -128,7 +128,7 @@ describe('Process Outbox Job', function () {
                 memberId: 'member2',
                 email: 'test2@example.com',
                 name: 'Test Member 2',
-                memberStatus: 'free'
+                status: 'free'
             }),
             status: OUTBOX_STATUSES.PENDING
         });
@@ -139,7 +139,7 @@ describe('Process Outbox Job', function () {
                 memberId: 'member3',
                 email: 'test3@example.com',
                 name: 'Test Member 3',
-                memberStatus: 'free'
+                status: 'free'
             }),
             status: OUTBOX_STATUSES.PENDING
         });
@@ -161,7 +161,7 @@ describe('Process Outbox Job', function () {
                 memberId: 'member1',
                 email: 'test1@example.com',
                 name: 'Test Member 1',
-                memberStatus: 'free'
+                status: 'free'
             }),
             status: OUTBOX_STATUSES.PROCESSING
         });
@@ -172,7 +172,7 @@ describe('Process Outbox Job', function () {
                 memberId: 'member2',
                 email: 'test2@example.com',
                 name: 'Test Member 2',
-                memberStatus: 'free'
+                status: 'free'
             }),
             status: OUTBOX_STATUSES.FAILED
         });
@@ -196,7 +196,7 @@ describe('Process Outbox Job', function () {
                 memberId: 'member1',
                 email: 'retry@example.com',
                 name: 'Retry Member',
-                memberStatus: 'free'
+                status: 'free'
             }),
             status: OUTBOX_STATUSES.PENDING,
             retry_count: 0
@@ -222,7 +222,7 @@ describe('Process Outbox Job', function () {
                 memberId: 'member1',
                 email: 'maxretry@example.com',
                 name: 'Max Retry Member',
-                memberStatus: 'free'
+                status: 'free'
             }),
             status: OUTBOX_STATUSES.PENDING,
             retry_count: 1

--- a/ghost/core/test/integration/jobs/process-outbox.test.js
+++ b/ghost/core/test/integration/jobs/process-outbox.test.js
@@ -83,7 +83,8 @@ describe('Process Outbox Job', function () {
                 memberId: 'member123',
                 email: 'test@example.com',
                 name: 'Test Member',
-                source: 'member'
+                source: 'member',
+                memberStatus: 'free'
             }),
             status: OUTBOX_STATUSES.PENDING
         });
@@ -115,7 +116,8 @@ describe('Process Outbox Job', function () {
             payload: JSON.stringify({
                 memberId: 'member1',
                 email: 'test1@example.com',
-                name: 'Test Member 1'
+                name: 'Test Member 1',
+                memberStatus: 'free'
             }),
             status: OUTBOX_STATUSES.PENDING
         });
@@ -125,7 +127,8 @@ describe('Process Outbox Job', function () {
             payload: JSON.stringify({
                 memberId: 'member2',
                 email: 'test2@example.com',
-                name: 'Test Member 2'
+                name: 'Test Member 2',
+                memberStatus: 'free'
             }),
             status: OUTBOX_STATUSES.PENDING
         });
@@ -135,7 +138,8 @@ describe('Process Outbox Job', function () {
             payload: JSON.stringify({
                 memberId: 'member3',
                 email: 'test3@example.com',
-                name: 'Test Member 3'
+                name: 'Test Member 3',
+                memberStatus: 'free'
             }),
             status: OUTBOX_STATUSES.PENDING
         });
@@ -156,7 +160,8 @@ describe('Process Outbox Job', function () {
             payload: JSON.stringify({
                 memberId: 'member1',
                 email: 'test1@example.com',
-                name: 'Test Member 1'
+                name: 'Test Member 1',
+                memberStatus: 'free'
             }),
             status: OUTBOX_STATUSES.PROCESSING
         });
@@ -166,7 +171,8 @@ describe('Process Outbox Job', function () {
             payload: JSON.stringify({
                 memberId: 'member2',
                 email: 'test2@example.com',
-                name: 'Test Member 2'
+                name: 'Test Member 2',
+                memberStatus: 'free'
             }),
             status: OUTBOX_STATUSES.FAILED
         });
@@ -189,7 +195,8 @@ describe('Process Outbox Job', function () {
             payload: JSON.stringify({
                 memberId: 'member1',
                 email: 'retry@example.com',
-                name: 'Retry Member'
+                name: 'Retry Member',
+                memberStatus: 'free'
             }),
             status: OUTBOX_STATUSES.PENDING,
             retry_count: 0
@@ -214,7 +221,8 @@ describe('Process Outbox Job', function () {
             payload: JSON.stringify({
                 memberId: 'member1',
                 email: 'maxretry@example.com',
-                name: 'Max Retry Member'
+                name: 'Max Retry Member',
+                memberStatus: 'free'
             }),
             status: OUTBOX_STATUSES.PENDING,
             retry_count: 1

--- a/ghost/core/test/integration/services/member-welcome-emails.test.js
+++ b/ghost/core/test/integration/services/member-welcome-emails.test.js
@@ -78,7 +78,7 @@ describe('Member Welcome Emails Integration', function () {
             assert.equal(payload.email, 'welcome-test@example.com');
             assert.equal(payload.name, 'Welcome Test Member');
             assert.equal(payload.source, 'member');
-            assert.equal(payload.memberStatus, 'free');
+            assert.equal(payload.status, 'free');
         });
 
         it('does NOT create outbox entry when config is not set', async function () {
@@ -199,7 +199,7 @@ describe('Member Welcome Emails Integration', function () {
                     memberId: 'member1',
                     email: 'inactive@example.com',
                     name: 'Inactive Template Member',
-                    memberStatus: 'free'
+                    status: 'free'
                 }),
                 status: OUTBOX_STATUSES.PENDING
             });
@@ -222,7 +222,7 @@ describe('Member Welcome Emails Integration', function () {
                     memberId: 'member1',
                     email: 'notemplate@example.com',
                     name: 'No Template Member',
-                    memberStatus: 'free'
+                    status: 'free'
                 }),
                 status: OUTBOX_STATUSES.PENDING
             });

--- a/ghost/core/test/integration/services/member-welcome-emails.test.js
+++ b/ghost/core/test/integration/services/member-welcome-emails.test.js
@@ -78,6 +78,7 @@ describe('Member Welcome Emails Integration', function () {
             assert.equal(payload.email, 'welcome-test@example.com');
             assert.equal(payload.name, 'Welcome Test Member');
             assert.equal(payload.source, 'member');
+            assert.equal(payload.memberStatus, 'free');
         });
 
         it('does NOT create outbox entry when config is not set', async function () {
@@ -197,7 +198,8 @@ describe('Member Welcome Emails Integration', function () {
                 payload: JSON.stringify({
                     memberId: 'member1',
                     email: 'inactive@example.com',
-                    name: 'Inactive Template Member'
+                    name: 'Inactive Template Member',
+                    memberStatus: 'free'
                 }),
                 status: OUTBOX_STATUSES.PENDING
             });
@@ -219,7 +221,8 @@ describe('Member Welcome Emails Integration', function () {
                 payload: JSON.stringify({
                     memberId: 'member1',
                     email: 'notemplate@example.com',
-                    name: 'No Template Member'
+                    name: 'No Template Member',
+                    memberStatus: 'free'
                 }),
                 status: OUTBOX_STATUSES.PENDING
             });


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-857/free-member-welcome-email-is-sent-to-new-paid-members

Currently if free welcome emails are enabled, and a new member signs up for a paid subscription, they will receive the free welcome email in error. This is because new paid members are initially created in the `free` status, until the Stripe subscription is fully processed, at which point they transition to `paid`. 

This fixes the bug by opting to skip sending the welcome email if the member has a `stripeCustomer` attached, which indicates that the member at least _intends_ to become a paid member. 