### PR TITLE
Improved search UX by eliminating content flashing in ActivityPub

### DIFF
--- a/apps/activitypub/package.json
+++ b/apps/activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/activitypub",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3081/slice-1-the-search-result-shouldnt-be-cleared-on-keystroke

Previously, when typing search queries, there were jarring flashes where content would briefly disappear or show incorrect states (suggested accounts, "no results found") before displaying the actual results. This happened because display logic relied on delayed state updates rather than the actual query data.

The fix ensures smooth transitions by:
  - Checking actual query data (`data?.accounts`) for display conditions instead of delayed display state
  - Keeping previous results visible while new searches are loading
  - Only clearing results when definitively needed (query too short or confirmed empty results)
  - Preventing "no results" state from flashing before results appear