### PR TITLE
Handled redirects to CDN in S3Storage

### DIFF
--- a/ghost/core/core/server/adapters/storage/S3Storage.ts
+++ b/ghost/core/core/server/adapters/storage/S3Storage.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import type {Request, Response, NextFunction, RequestHandler} from 'express';
 import StorageBase from 'ghost-storage-base';
 import tpl from '@tryghost/tpl';
 import errors from '@tryghost/errors';
@@ -334,9 +335,16 @@ export default class S3Storage extends StorageBase {
         }
     }
 
-    serve() {
-        return function (_req: unknown, _res: unknown, next: (err?: unknown) => void) {
-            next();
+    serve(): RequestHandler {
+        return (req: Request, res: Response, next: NextFunction) => {
+            const relativePath = req.path.replace(/^\/+/, '');
+
+            if (!relativePath) {
+                return next();
+            }
+
+            const key = this.buildKey(relativePath);
+            res.redirect(301, `${this.cdnUrl}/${key}`);
         };
     }
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PRO-1550

After moving to CDN based storage with the S3Storage adapter, there may still be references to the old URLs in the wild. Rather than 404 we want to redirect to the CDN on the assumption that files have been migrated.