### PR TITLE
Added keyboard navigation to ActivityPub search

### DIFF
--- a/apps/activitypub/package.json
+++ b/apps/activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/activitypub",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/activitypub/src/components/activities/activity-item.tsx
+++ b/apps/activitypub/src/components/activities/activity-item.tsx
@@ -5,13 +5,14 @@ interface ActivityItemProps {
     url?: string | null;
     onClick?: () => void;
     'data-testid'?: string;
+    isSelected?: boolean;
 }
 
-const ActivityItem: React.FC<ActivityItemProps> = ({children, url = null, onClick, 'data-testid': testId}) => {
+const ActivityItem: React.FC<ActivityItemProps> = ({children, url = null, onClick, 'data-testid': testId, isSelected = false}) => {
     const childrenArray = React.Children.toArray(children);
 
     const Item = (
-        <div className='relative flex w-full max-w-[620px] cursor-pointer flex-col before:absolute before:inset-x-[-16px] before:inset-y-[-1px] before:rounded-md before:bg-gray-50 before:opacity-0 before:transition-opacity hover:z-10 hover:cursor-pointer hover:border-b-transparent hover:before:opacity-100 dark:before:bg-gray-950' data-testid={testId} onClick={() => {
+        <div className={`relative flex w-full max-w-[620px] cursor-pointer flex-col before:absolute before:inset-x-[-16px] before:inset-y-[-1px] before:rounded-md before:bg-gray-50 before:transition-opacity hover:z-10 hover:cursor-pointer hover:border-b-transparent hover:before:opacity-100 dark:before:bg-gray-950 ${isSelected ? 'z-10 before:opacity-100' : 'before:opacity-0'}`} data-testid={testId} onClick={() => {
             if (!url && onClick) {
                 onClick();
             }

--- a/apps/activitypub/src/components/modals/search.tsx
+++ b/apps/activitypub/src/components/modals/search.tsx
@@ -232,6 +232,8 @@ const Search: React.FC<SearchProps> = ({onOpenChange, query, setQuery}) => {
     // Total number of navigable items (topics + accounts)
     const totalItems = matchingTopics.length + displayResults.length;
 
+    const lastKeyPressRef = useRef(0);
+
     useEffect(() => {
         if (!shouldSearch) {
             setDisplayResults([]);
@@ -268,9 +270,24 @@ const Search: React.FC<SearchProps> = ({onOpenChange, query, setQuery}) => {
 
     useEffect(() => {
         const handleKeyDown = (e: KeyboardEvent) => {
+            if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp' && e.key !== 'Enter') {
+                return;
+            }
+
             if (!showSearchResults || totalItems === 0) {
                 return;
             }
+
+            // Throttle rapid key presses to prevent race conditions
+            const now = Date.now();
+
+            if (e.key !== 'Enter' && now - lastKeyPressRef.current < 50) {
+                e.preventDefault();
+
+                return;
+            }
+
+            lastKeyPressRef.current = now;
 
             switch (e.key) {
             case 'ArrowDown':

--- a/apps/activitypub/src/components/modals/search.tsx
+++ b/apps/activitypub/src/components/modals/search.tsx
@@ -20,168 +20,14 @@ interface AccountSearchResult {
     domainBlockedByMe: boolean;
 }
 
-interface AccountSearchResultItemProps {
-    account: AccountSearchResult;
-    update: (id: string, updated: Partial<AccountSearchResult>) => void;
+interface TopicSearchResult {
+    slug: string;
+    name: string;
 }
 
-const AccountSearchResultItem: React.FC<AccountSearchResultItemProps & {
-    onOpenChange?: (open: boolean) => void;
-    isSelected?: boolean;
-    onRefSet?: (ref: HTMLDivElement | null) => void;
-}> = ({account, update, onOpenChange, isSelected = false, onRefSet}) => {
-    const currentAccountQuery = useAccountForUser('index', 'me');
-    const {data: currentUser} = currentAccountQuery;
-    const isCurrentUser = account.handle === currentUser?.handle;
-
-    const onFollow = () => {
-        update(account.id, {
-            followedByMe: true
-        });
-    };
-
-    const onUnfollow = () => {
-        update(account.id, {
-            followedByMe: false
-        });
-    };
-
-    const navigate = useNavigateWithBasePath();
-
-    return (
-        <ProfilePreviewHoverCard actor={account as unknown as ActorProperties} align='center' isCurrentUser={isCurrentUser} side='left'>
-            <div ref={onRefSet}>
-                <ActivityItem
-                    key={account.id}
-                    isSelected={isSelected}
-                    onClick={() => {
-                        onOpenChange?.(false);
-                        navigate(`/profile/${account.handle}`);
-                    }}
-                >
-                    <APAvatar author={{
-                        icon: {
-                            url: account.avatarUrl
-                        },
-                        name: account.name,
-                        handle: account.handle
-                    }}/>
-                    <div className='flex flex-col break-anywhere'>
-                        <span className='line-clamp-1 font-semibold text-black dark:text-white'>{account.name}</span>
-                        <span className='line-clamp-1 text-sm text-gray-700 dark:text-gray-600'>{account.handle}</span>
-                    </div>
-                    {account.blockedByMe || account.domainBlockedByMe ?
-                        <Button className='pointer-events-none ml-auto min-w-[90px]' variant='destructive'>Blocked</Button> :
-                        !isCurrentUser ? (
-                            <FollowButton
-                                className='ml-auto'
-                                following={account.followedByMe}
-                                handle={account.handle}
-                                type='secondary'
-                                onFollow={onFollow}
-                                onUnfollow={onUnfollow}
-                            />
-                        ) : null
-                    }
-                </ActivityItem>
-            </div>
-        </ProfilePreviewHoverCard>
-    );
-};
-
-interface TopicSearchResultItemProps {
-    topic: {slug: string; name: string};
-    onOpenChange?: (open: boolean) => void;
-    isSelected?: boolean;
-    onRefSet?: (ref: HTMLDivElement | null) => void;
-}
-
-const TopicSearchResultItem: React.FC<TopicSearchResultItemProps> = ({topic, onOpenChange, isSelected = false, onRefSet}) => {
-    const navigate = useNavigateWithBasePath();
-
-    return (
-        <div ref={onRefSet}>
-            <ActivityItem
-                isSelected={isSelected}
-                onClick={() => {
-                    onOpenChange?.(false);
-                    navigate(`/explore/${topic.slug}`);
-                }}
-            >
-                <div className='flex size-10 shrink-0 items-center justify-center rounded-full bg-gray-100 dark:bg-gray-900'>
-                    <LucideIcon.Globe className='text-gray-700 dark:text-gray-500' size={18} strokeWidth={1.5} />
-                </div>
-                <div className='flex flex-col'>
-                    <span className='font-semibold text-black dark:text-white'>{topic.name}</span>
-                    <span className='text-sm text-gray-700 dark:text-gray-600'>Topic</span>
-                </div>
-            </ActivityItem>
-        </div>
-    );
-};
-
-interface TopicSearchResultsProps {
-    topics: {slug: string; name: string}[];
-    onOpenChange?: (open: boolean) => void;
-    selectedIndex: number;
-    itemRefs: React.MutableRefObject<(HTMLDivElement | null)[]>;
-    startIndex: number;
-}
-
-const TopicSearchResults: React.FC<TopicSearchResultsProps> = ({topics, onOpenChange, selectedIndex, itemRefs, startIndex}) => {
-    if (!topics.length) {
-        return null;
-    }
-
-    return (
-        <div>
-            {topics.map((topic, index) => (
-                <TopicSearchResultItem
-                    key={topic.slug}
-                    isSelected={selectedIndex === startIndex + index}
-                    topic={topic}
-                    onOpenChange={onOpenChange}
-                    onRefSet={(ref) => {
-                        itemRefs.current[startIndex + index] = ref;
-                    }}
-                />
-            ))}
-        </div>
-    );
-};
-
-interface SearchResultsProps {
-    results: AccountSearchResult[];
-    onUpdate: (id: string, updated: Partial<AccountSearchResult>) => void;
-    selectedIndex: number;
-    itemRefs: React.MutableRefObject<(HTMLDivElement | null)[]>;
-    startIndex: number;
-}
-
-const SearchResults: React.FC<SearchResultsProps & {
-    onOpenChange?: (open: boolean) => void;
-}> = ({results, onUpdate, onOpenChange, selectedIndex, itemRefs, startIndex}) => {
-    if (!results.length) {
-        return null;
-    }
-
-    return (
-        <div>
-            {results.map((account, index) => (
-                <AccountSearchResultItem
-                    key={account.id}
-                    account={account}
-                    isSelected={selectedIndex === startIndex + index}
-                    update={onUpdate}
-                    onOpenChange={onOpenChange}
-                    onRefSet={(ref) => {
-                        itemRefs.current[startIndex + index] = ref;
-                    }}
-                />
-            ))}
-        </div>
-    );
-};
+type SearchResult =
+    | {type: 'topic'; data: TopicSearchResult}
+    | {type: 'account'; data: AccountSearchResult};
 
 interface SearchProps {
     onOpenChange?: (open: boolean) => void;
@@ -189,26 +35,37 @@ interface SearchProps {
     setQuery: (query: string) => void;
 }
 
+const STICKY_HEADER_HEIGHT = 80;
+
 const Search: React.FC<SearchProps> = ({onOpenChange, query, setQuery}) => {
     const queryInputRef = useRef<HTMLInputElement>(null);
-    const itemRefs = useRef<(HTMLDivElement | null)[]>([]);
+    const selectedItemRef = useRef<HTMLDivElement>(null);
+    const lastKeyPressRef = useRef(0);
+
     const navigate = useNavigateWithBasePath();
     const [debouncedQuery] = useDebounce(query, 300);
+
     const shouldSearch = query.length >= 2;
+
     const {searchQuery, updateAccountSearchResult: updateResult} = useSearchForUser('index', shouldSearch ? debouncedQuery : '');
     const {data, isFetching, isFetched} = searchQuery;
+
     const {suggestedProfilesQuery} = useSuggestedProfilesForUser('index', 5);
     const {data: suggestedProfilesData, isLoading: isLoadingSuggestedProfiles} = suggestedProfilesQuery;
+
     const hasSuggestedProfiles = isLoadingSuggestedProfiles || (suggestedProfilesData && suggestedProfilesData.length > 0);
 
     const {topicsQuery} = useTopicsForUser();
     const {data: topicsData} = topicsQuery;
 
+    const currentAccountQuery = useAccountForUser('index', 'me');
+    const {data: currentUser} = currentAccountQuery;
+
     const [displayResults, setDisplayResults] = useState<AccountSearchResult[]>([]);
     const [lastResultState, setLastResultState] = useState<'results' | 'none' | null>(null);
-    const [selectedIndex, setSelectedIndex] = useState<number>(0);
+    const [selectedIndex, setSelectedIndex] = useState(0);
 
-    // Filter topics client-side (no additional API call needed)
+    // Filter topics client-side
     const matchingTopics = useMemo(() => {
         const topics = topicsData?.topics || [];
 
@@ -219,7 +76,6 @@ const Search: React.FC<SearchProps> = ({onOpenChange, query, setQuery}) => {
         const normalizedQuery = query.toLowerCase();
 
         return topics.filter((topic) => {
-            // Exclude "following" meta-topic from search results
             if (topic.slug === 'following') {
                 return false;
             }
@@ -229,10 +85,11 @@ const Search: React.FC<SearchProps> = ({onOpenChange, query, setQuery}) => {
         });
     }, [query, shouldSearch, topicsData?.topics]);
 
-    // Total number of navigable items (topics + accounts)
-    const totalItems = matchingTopics.length + displayResults.length;
-
-    const lastKeyPressRef = useRef(0);
+    // Merge topics and accounts into a single list
+    const searchResults: SearchResult[] = useMemo(() => [
+        ...matchingTopics.map(topic => ({type: 'topic' as const, data: topic})),
+        ...displayResults.map(account => ({type: 'account' as const, data: account}))
+    ], [matchingTopics, displayResults]);
 
     useEffect(() => {
         if (!shouldSearch) {
@@ -261,112 +118,75 @@ const Search: React.FC<SearchProps> = ({onOpenChange, query, setQuery}) => {
     const showNoResults = !showSuggested && lastResultState === 'none' && matchingTopics.length === 0;
     const showSearchResults = !showSuggested && (displayResults.length > 0 || matchingTopics.length > 0);
 
-    // Focus the query input on initial render
+    // Focus input on mount
     useEffect(() => {
-        if (queryInputRef.current) {
-            queryInputRef.current.focus();
-        }
+        queryInputRef.current?.focus();
     }, []);
-
-    useEffect(() => {
-        const handleKeyDown = (e: KeyboardEvent) => {
-            if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp' && e.key !== 'Enter') {
-                return;
-            }
-
-            if (!showSearchResults || totalItems === 0) {
-                return;
-            }
-
-            // Throttle rapid key presses to prevent race conditions
-            const now = Date.now();
-
-            if (e.key !== 'Enter' && now - lastKeyPressRef.current < 50) {
-                e.preventDefault();
-
-                return;
-            }
-
-            lastKeyPressRef.current = now;
-
-            switch (e.key) {
-            case 'ArrowDown':
-                e.preventDefault();
-                setSelectedIndex(prev => (prev + 1) % totalItems);
-                break;
-            case 'ArrowUp':
-                e.preventDefault();
-                setSelectedIndex(prev => (prev - 1 + totalItems) % totalItems);
-                break;
-            case 'Enter':
-                e.preventDefault();
-                // Check if selected item is a topic or an account
-                if (selectedIndex < matchingTopics.length) {
-                    // It's a topic
-                    const topic = matchingTopics[selectedIndex];
-                    onOpenChange?.(false);
-                    navigate(`/explore/${topic.slug}`);
-                } else {
-                    // It's an account
-                    const accountIndex = selectedIndex - matchingTopics.length;
-                    const account = displayResults[accountIndex];
-                    if (account) {
-                        onOpenChange?.(false);
-                        navigate(`/profile/${account.handle}`);
-                    }
-                }
-                break;
-            }
-        };
-
-        window.addEventListener('keydown', handleKeyDown);
-        return () => window.removeEventListener('keydown', handleKeyDown);
-    }, [showSearchResults, totalItems, selectedIndex, matchingTopics, displayResults, onOpenChange, navigate]);
 
     // Scroll selected item into view
     useEffect(() => {
-        const selectedElement = itemRefs.current[selectedIndex];
-        if (!selectedElement) {
+        const element = selectedItemRef.current;
+        if (!element) {
             return;
         }
 
-        const scrollContainer = selectedElement.closest('[class*="overflow"]') ||
-                                selectedElement.parentElement?.parentElement?.parentElement;
+        const container = element.closest('[data-radix-scroll-area-viewport]') || element.closest('.overflow-y-auto');
+        if (!container) {
+            element.scrollIntoView({block: 'nearest'});
 
-        if (!scrollContainer || !('scrollTop' in scrollContainer)) {
             return;
         }
 
-        if (selectedIndex === 0) {
-            scrollContainer.scrollTo({
-                top: 0,
+        const containerRect = container.getBoundingClientRect();
+        const elementRect = element.getBoundingClientRect();
+
+        if (elementRect.top < containerRect.top + STICKY_HEADER_HEIGHT) {
+            container.scrollTo({
+                top: container.scrollTop - (containerRect.top + STICKY_HEADER_HEIGHT - elementRect.top),
                 behavior: 'smooth'
             });
-        } else {
-            const containerRect = scrollContainer.getBoundingClientRect();
-            const elementRect = selectedElement.getBoundingClientRect();
-            const stickyHeaderHeight = 72;
-            const topSpacing = 18;
-            const bottomSpacing = 18;
-
-            const isAboveViewport = elementRect.top < containerRect.top + stickyHeaderHeight + topSpacing;
-            const isBelowViewport = elementRect.bottom > containerRect.bottom - bottomSpacing;
-
-            if (isAboveViewport) {
-                const scrollOffset = scrollContainer.scrollTop - (containerRect.top + stickyHeaderHeight + topSpacing - elementRect.top);
-                scrollContainer.scrollTo({
-                    top: scrollOffset,
-                    behavior: 'smooth'
-                });
-            } else if (isBelowViewport) {
-                const scrollOffset = scrollContainer.scrollTop + (elementRect.bottom - containerRect.bottom + bottomSpacing);
-                scrollContainer.scrollTo({
-                    top: scrollOffset,
-                    behavior: 'smooth'
-                });
-            }
+        } else if (elementRect.bottom > containerRect.bottom) {
+            container.scrollTo({
+                top: container.scrollTop + (elementRect.bottom - containerRect.bottom),
+                behavior: 'smooth'
+            });
         }
     }, [selectedIndex]);
+
+    const handleKeyDown = (e: React.KeyboardEvent) => {
+        if (!showSearchResults) {
+            return;
+        }
+
+        if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+            e.preventDefault();
+
+            // Throttle rapid key presses
+            const now = Date.now();
+            if (now - lastKeyPressRef.current < 50) {
+                return;
+            }
+            lastKeyPressRef.current = now;
+
+            if (e.key === 'ArrowDown') {
+                setSelectedIndex(prev => (prev + 1) % searchResults.length);
+            } else {
+                setSelectedIndex(prev => (prev - 1 + searchResults.length) % searchResults.length);
+            }
+        } else if (e.key === 'Enter') {
+            e.preventDefault();
+
+            const item = searchResults[selectedIndex];
+
+            onOpenChange?.(false);
+
+            if (item.type === 'topic') {
+                navigate(`/explore/${item.data.slug}`);
+            } else {
+                navigate(`/profile/${item.data.handle}`);
+            }
+        }
+    };
 
     return (
         <>
@@ -380,7 +200,8 @@ const Search: React.FC<SearchProps> = ({onOpenChange, query, setQuery}) => {
                     title="Search"
                     type='text'
                     value={query}
-                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => setQuery(e.target.value)}
+                    onChange={e => setQuery(e.target.value)}
+                    onKeyDown={handleKeyDown}
                 />
                 {showLoading && (
                     <LoadingIndicator className='!absolute right-0 mr-0.5 shrink-0' size='sm' />
@@ -397,21 +218,79 @@ const Search: React.FC<SearchProps> = ({onOpenChange, query, setQuery}) => {
                 )}
                 {showSearchResults && (
                     <div className='mt-[-14px] pb-2'>
-                        <TopicSearchResults
-                            itemRefs={itemRefs}
-                            selectedIndex={selectedIndex}
-                            startIndex={0}
-                            topics={matchingTopics}
-                            onOpenChange={onOpenChange}
-                        />
-                        <SearchResults
-                            itemRefs={itemRefs}
-                            results={displayResults}
-                            selectedIndex={selectedIndex}
-                            startIndex={matchingTopics.length}
-                            onOpenChange={onOpenChange}
-                            onUpdate={updateResult}
-                        />
+                        {searchResults.map((item, index) => {
+                            const isSelected = index === selectedIndex;
+
+                            if (item.type === 'topic') {
+                                return (
+                                    <div
+                                        key={item.data.slug}
+                                        ref={isSelected ? selectedItemRef : undefined}
+                                    >
+                                        <ActivityItem
+                                            isSelected={isSelected}
+                                            onClick={() => {
+                                                onOpenChange?.(false);
+                                                navigate(`/explore/${item.data.slug}`);
+                                            }}
+                                        >
+                                            <div className='flex size-10 shrink-0 items-center justify-center rounded-full bg-gray-100 dark:bg-gray-900'>
+                                                <LucideIcon.Globe className='text-gray-700 dark:text-gray-500' size={18} strokeWidth={1.5} />
+                                            </div>
+                                            <div className='flex flex-col'>
+                                                <span className='font-semibold text-black dark:text-white'>{item.data.name}</span>
+                                                <span className='text-sm text-gray-700 dark:text-gray-600'>Topic</span>
+                                            </div>
+                                        </ActivityItem>
+                                    </div>
+                                );
+                            }
+
+                            const account = item.data;
+                            const isCurrentUser = account.handle === currentUser?.handle;
+
+                            return (
+                                <ProfilePreviewHoverCard
+                                    key={account.id}
+                                    actor={account as unknown as ActorProperties}
+                                    align='center'
+                                    isCurrentUser={isCurrentUser}
+                                    side='left'
+                                >
+                                    <div ref={isSelected ? selectedItemRef : undefined}>
+                                        <ActivityItem
+                                            isSelected={isSelected}
+                                            onClick={() => {
+                                                onOpenChange?.(false);
+                                                navigate(`/profile/${account.handle}`);
+                                            }}
+                                        >
+                                            <APAvatar author={{
+                                                icon: {url: account.avatarUrl},
+                                                name: account.name,
+                                                handle: account.handle
+                                            }}/>
+                                            <div className='flex flex-col break-anywhere'>
+                                                <span className='line-clamp-1 font-semibold text-black dark:text-white'>{account.name}</span>
+                                                <span className='line-clamp-1 text-sm text-gray-700 dark:text-gray-600'>{account.handle}</span>
+                                            </div>
+                                            {account.blockedByMe || account.domainBlockedByMe ? (
+                                                <Button className='pointer-events-none ml-auto min-w-[90px]' variant='destructive'>Blocked</Button>
+                                            ) : !isCurrentUser ? (
+                                                <FollowButton
+                                                    className='ml-auto'
+                                                    following={account.followedByMe}
+                                                    handle={account.handle}
+                                                    type='secondary'
+                                                    onFollow={() => updateResult(account.id, {followedByMe: true})}
+                                                    onUnfollow={() => updateResult(account.id, {followedByMe: false})}
+                                                />
+                                            ) : null}
+                                        </ActivityItem>
+                                    </div>
+                                </ProfilePreviewHoverCard>
+                            );
+                        })}
                     </div>
                 )}
                 {showSuggested && hasSuggestedProfiles && (

--- a/apps/activitypub/src/components/modals/search.tsx
+++ b/apps/activitypub/src/components/modals/search.tsx
@@ -145,9 +145,9 @@ const Search: React.FC<SearchProps> = ({onOpenChange, query, setQuery}) => {
                 top: container.scrollTop - (containerRect.top + STICKY_HEADER_HEIGHT - elementRect.top),
                 behavior: 'smooth'
             });
-        } else if (elementRect.bottom > containerRect.bottom) {
+        } else if (elementRect.bottom > containerRect.bottom - STICKY_HEADER_HEIGHT) {
             container.scrollTo({
-                top: container.scrollTop + (elementRect.bottom - containerRect.bottom),
+                top: container.scrollTop + (elementRect.bottom - containerRect.bottom + STICKY_HEADER_HEIGHT),
                 behavior: 'smooth'
             });
         }

--- a/apps/activitypub/src/components/modals/search.tsx
+++ b/apps/activitypub/src/components/modals/search.tsx
@@ -39,7 +39,7 @@ const STICKY_HEADER_HEIGHT = 80;
 
 const Search: React.FC<SearchProps> = ({onOpenChange, query, setQuery}) => {
     const queryInputRef = useRef<HTMLInputElement>(null);
-    const selectedItemRef = useRef<HTMLDivElement>(null);
+    const itemRefs = useRef<(HTMLDivElement | null)[]>([]);
     const lastKeyPressRef = useRef(0);
 
     const navigate = useNavigateWithBasePath();
@@ -125,7 +125,7 @@ const Search: React.FC<SearchProps> = ({onOpenChange, query, setQuery}) => {
 
     // Scroll selected item into view
     useEffect(() => {
-        const element = selectedItemRef.current;
+        const element = itemRefs.current[selectedIndex];
         if (!element) {
             return;
         }
@@ -154,7 +154,7 @@ const Search: React.FC<SearchProps> = ({onOpenChange, query, setQuery}) => {
     }, [selectedIndex]);
 
     const handleKeyDown = (e: React.KeyboardEvent) => {
-        if (!showSearchResults) {
+        if (!showSearchResults || searchResults.length === 0) {
             return;
         }
 
@@ -174,10 +174,12 @@ const Search: React.FC<SearchProps> = ({onOpenChange, query, setQuery}) => {
                 setSelectedIndex(prev => (prev - 1 + searchResults.length) % searchResults.length);
             }
         } else if (e.key === 'Enter') {
-            e.preventDefault();
-
             const item = searchResults[selectedIndex];
+            if (!item) {
+                return;
+            }
 
+            e.preventDefault();
             onOpenChange?.(false);
 
             if (item.type === 'topic') {
@@ -225,7 +227,7 @@ const Search: React.FC<SearchProps> = ({onOpenChange, query, setQuery}) => {
                                 return (
                                     <div
                                         key={item.data.slug}
-                                        ref={isSelected ? selectedItemRef : undefined}
+                                        ref={el => itemRefs.current[index] = el}
                                     >
                                         <ActivityItem
                                             isSelected={isSelected}
@@ -257,7 +259,7 @@ const Search: React.FC<SearchProps> = ({onOpenChange, query, setQuery}) => {
                                     isCurrentUser={isCurrentUser}
                                     side='left'
                                 >
-                                    <div ref={isSelected ? selectedItemRef : undefined}>
+                                    <div ref={el => itemRefs.current[index] = el}>
                                         <ActivityItem
                                             isSelected={isSelected}
                                             onClick={() => {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3119/add-keyboard-navigation-for-search-results-list

Users can now navigate search results using arrow keys and Enter:

- ArrowUp/ArrowDown to move between results with visual highlight
- Enter to navigate to selected profile
- Selection wraps around from last to first result and vice versa