### PR TITLE
🐛 Fixed upgrade button in trial banner not navigating to checkout

### DIFF
--- a/apps/admin/src/layout/app-sidebar/UpgradeBanner.tsx
+++ b/apps/admin/src/layout/app-sidebar/UpgradeBanner.tsx
@@ -15,7 +15,7 @@ function UpgradeBanner({ trialDaysRemaining }: { trialDaysRemaining: number }) {
             <div className="mt-2 text-gray-700 text-sm mb-4">
                 Choose a plan to access the full power of Ghost right away, you have <span className="font-semibold text-black">{trialDaysRemaining} days</span> free trial remaining.
             </div>
-            <Button>Upgrade now</Button>
+            <Button asChild><a href="#/pro/billing/plans">Upgrade now</a></Button>
         </Banner>
     )
 }

--- a/e2e/helpers/pages/admin/sidebar/sidebar-page.ts
+++ b/e2e/helpers/pages/admin/sidebar/sidebar-page.ts
@@ -18,6 +18,8 @@ export class SidebarPage extends AdminPage {
     public readonly userProfileLink: Locator;
     public readonly signOutLink: Locator;
     public readonly networkNotificationBadge: Locator;
+    public readonly ghostProLink: Locator;
+    public readonly upgradeNowLink: Locator;
 
     constructor(page: Page) {
         super(page);
@@ -33,6 +35,10 @@ export class SidebarPage extends AdminPage {
         this.networkNotificationBadge = this.sidebar
             .getByRole('listitem').filter({hasText: /network/i})
             .locator('[data-sidebar="menu-badge"], .gh-nav-member-count').first();
+        this.ghostProLink = this.sidebar.getByRole('link', {name: 'Ghost(Pro)'});
+        // Matches both React's link and Ember's button for the upgrade action
+        this.upgradeNowLink = this.sidebar.getByRole('link', {name: /upgrade/i})
+            .or(this.sidebar.getByRole('button', {name: /upgrade/i}));
     }
 
     getNavLink(name: string): Locator {

--- a/e2e/helpers/playwright/fixture.ts
+++ b/e2e/helpers/playwright/fixture.ts
@@ -15,8 +15,10 @@ export interface User {
 }
 
 export interface GhostConfig {
-    memberWelcomeEmailSendInstantly: string;
-    memberWelcomeEmailTestInbox: string;
+    memberWelcomeEmailSendInstantly?: string;
+    memberWelcomeEmailTestInbox?: string;
+    hostSettings__billing__enabled?: string;
+    hostSettings__billing__url?: string;
 }
 
 export interface GhostInstanceFixture {

--- a/e2e/tests/admin/sidebar/upgrade-banner.test.ts
+++ b/e2e/tests/admin/sidebar/upgrade-banner.test.ts
@@ -1,0 +1,53 @@
+import {SidebarPage} from '@/helpers/pages';
+import {expect, test} from '@/helpers/playwright';
+
+const MOCK_BILLING_URL = 'https://billing.mock.test';
+const BILLING_HTML = `
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+    window.parent.postMessage({
+        subscription: {
+            isActiveTrial: true,
+            trial_end: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+            status: 'trialing'
+        }
+    }, '*');
+</script>
+</body>
+</html>
+`;
+
+test.describe('Ghost Admin - Upgrade Banner', () => {
+    // Enable billing in the Ghost config with a mock billing URL
+    test.use({
+        config: {
+            hostSettings__billing__enabled: 'true',
+            hostSettings__billing__url: MOCK_BILLING_URL
+        }
+    });
+
+    test('upgrade now button navigates to pro checkout route', async ({page}) => {
+        // Arrange
+
+        // Mock the billing iframe to send trial subscription data
+        // This simulates what the real billing management app does on load
+        await page.route(`${MOCK_BILLING_URL}/**`, async (route) => {
+            await route.fulfill({
+                status: 200,
+                contentType: 'text/html',
+                body: BILLING_HTML
+            });
+        });
+
+        const sidebarPage = new SidebarPage(page);
+        await sidebarPage.goto();
+
+        // Act - Click the upgrade link
+        await sidebarPage.upgradeNowLink.click();
+
+        // Assert - URL should navigate to the billing plans route
+        await expect(page).toHaveURL(/#\/pro\/billing\/plans/);
+    });
+});

--- a/e2e/tests/public/member-signup.test.ts
+++ b/e2e/tests/public/member-signup.test.ts
@@ -52,7 +52,7 @@ test.describe('Ghost Public - Member Signup', () => {
         const automatedEmailFactory = createAutomatedEmailFactory(page.request);
         await automatedEmailFactory.create();
 
-        const emailInbox = config!.memberWelcomeEmailTestInbox;
+        const emailInbox = config!.memberWelcomeEmailTestInbox!;
         const homePage = new HomePage(page);
         await homePage.goto();
         const {emailAddress} = await signupViaPortal(page);


### PR DESCRIPTION
fixes https://linear.app/ghost/issue/BER-3122

The "Upgrade now" button in the React admin sidebar's trial upgrade banner had no click handler. Added navigation to `#/pro?action=checkout` to align with the Ember implementation.