### PR TITLE
Fixed MRR Impact values missing number formatting

### DIFF
--- a/apps/posts/src/views/PostAnalytics/Growth/components/growth-sources.tsx
+++ b/apps/posts/src/views/PostAnalytics/Growth/components/growth-sources.tsx
@@ -67,7 +67,7 @@ const SourcesTable: React.FC<SourcesTableProps> = ({headerStyle = 'table', child
                                 {appSettings?.paidMembersEnabled &&
                                 <>
                                     <TableCell className='text-right font-mono text-sm'>+{formatNumber(row.paid_members || 0)}</TableCell>
-                                    <TableCell className='text-right font-mono text-sm'>+${centsToDollars(row.mrr || 0)}</TableCell>
+                                    <TableCell className='text-right font-mono text-sm'>+${formatNumber(centsToDollars(row.mrr || 0))}</TableCell>
                                 </>
                                 }
                             </TableRow>

--- a/apps/posts/src/views/PostAnalytics/Overview/overview.tsx
+++ b/apps/posts/src/views/PostAnalytics/Overview/overview.tsx
@@ -176,7 +176,7 @@ const Overview: React.FC = () => {
                                         MRR impact
                                         </KpiCardLabel>
                                         <KpiCardContent>
-                                            <KpiCardValue className='text-[2.2rem]'>{currencySymbol}{centsToDollars(totals?.mrr || 0)}</KpiCardValue>
+                                            <KpiCardValue className='text-[2.2rem]'>{currencySymbol}{formatNumber(centsToDollars(totals?.mrr || 0))}</KpiCardValue>
                                         </KpiCardContent>
                                     </KpiCard>
                                 </>

--- a/apps/stats/src/views/Stats/Growth/components/growth-sources.tsx
+++ b/apps/stats/src/views/Stats/Growth/components/growth-sources.tsx
@@ -67,7 +67,7 @@ const GrowthSourcesTableBody: React.FC<GrowthSourcesTableProps> = ({data, curren
                             +{formatNumber(row.paid_members)}
                         </TableCell>
                         <TableCell className='text-right font-mono text-sm'>
-                            +{currencySymbol}{formatNumber(Math.round(centsToDollars(row.mrr)))}
+                            +{currencySymbol}{formatNumber(centsToDollars(row.mrr))}
                         </TableCell>
                     </>
                     }

--- a/apps/stats/src/views/Stats/Growth/components/growth-sources.tsx
+++ b/apps/stats/src/views/Stats/Growth/components/growth-sources.tsx
@@ -67,7 +67,7 @@ const GrowthSourcesTableBody: React.FC<GrowthSourcesTableProps> = ({data, curren
                             +{formatNumber(row.paid_members)}
                         </TableCell>
                         <TableCell className='text-right font-mono text-sm'>
-                            +{currencySymbol}{centsToDollars(row.mrr)}
+                            +{currencySymbol}{formatNumber(Math.round(centsToDollars(row.mrr)))}
                         </TableCell>
                     </>
                     }

--- a/apps/stats/src/views/Stats/Growth/growth.tsx
+++ b/apps/stats/src/views/Stats/Growth/growth.tsx
@@ -245,7 +245,7 @@ const Growth: React.FC = () => {
                                                                 {(post.paid_members > 0 && '+')}{formatNumber(post.paid_members)}
                                                             </TableCell>
                                                             <TableCell className='text-right font-mono text-sm'>
-                                                                {(post.mrr > 0 && '+')}{currencySymbol}{centsToDollars(post.mrr).toFixed(0)}
+                                                                {(post.mrr > 0 && '+')}{currencySymbol}{formatNumber(Math.round(centsToDollars(post.mrr)))}
                                                             </TableCell>
                                                         </>
                                                     }

--- a/apps/stats/src/views/Stats/Growth/growth.tsx
+++ b/apps/stats/src/views/Stats/Growth/growth.tsx
@@ -245,7 +245,7 @@ const Growth: React.FC = () => {
                                                                 {(post.paid_members > 0 && '+')}{formatNumber(post.paid_members)}
                                                             </TableCell>
                                                             <TableCell className='text-right font-mono text-sm'>
-                                                                {(post.mrr > 0 && '+')}{currencySymbol}{formatNumber(Math.round(centsToDollars(post.mrr)))}
+                                                                {(post.mrr > 0 && '+')}{currencySymbol}{formatNumber(centsToDollars(post.mrr))}
                                                             </TableCell>
                                                         </>
                                                     }


### PR DESCRIPTION
MRR values were displaying without thousand separators (e.g., $12345 instead of $12,345). Added formatNumber() wrapper to all MRR display locations in stats and posts apps.