### PR TITLE
Added route lazy loading

### DIFF
--- a/apps/activitypub/src/routes.tsx
+++ b/apps/activitypub/src/routes.tsx
@@ -1,18 +1,6 @@
 import AppError from '@components/layout/error';
-import BlueskySharing from '@views/preferences/components/bluesky-sharing';
-import Explore from '@views/explore';
-import Feed from './views/feed/feed';
-import Inbox from '@views/inbox';
-import Moderation from '@views/preferences/components/moderation';
-import Note from './views/feed/note';
-import Notifications from '@views/notifications';
-import Onboarding from '@components/layout/onboarding';
-import OnboardingStep1 from '@components/layout/onboarding/step-1';
-import OnboardingStep2 from '@components/layout/onboarding/step-2';
-import OnboardingStep3 from '@components/layout/onboarding/step-3';
-import Preferences from '@views/preferences';
-import Profile from '@views/profile';
-import {Navigate, Outlet, RouteObject} from '@tryghost/admin-x-framework';
+
+import {Navigate, Outlet, RouteObject, lazyComponent} from '@tryghost/admin-x-framework';
 
 const basePath = import.meta.env.VITE_TEST ? '' : 'activitypub';
 
@@ -44,83 +32,83 @@ export const routes: CustomRouteObject[] = [
             },
             {
                 path: 'reader',
-                element: <Inbox />,
+                lazy: lazyComponent(() => import('./views/inbox')),
                 pageTitle: 'Reader'
             },
             {
                 path: 'reader/:postId',
-                element: <Inbox />,
+                lazy: lazyComponent(() => import('./views/inbox')),
                 pageTitle: 'Reader'
             },
             {
                 path: 'notes',
-                element: <Feed />,
+                lazy: lazyComponent(() => import('./views/feed/feed')),
                 pageTitle: 'Notes'
             },
             {
                 path: 'notes/:postId',
-                element: <Note />,
+                lazy: lazyComponent(() => import('./views/feed/note')),
                 pageTitle: 'Note'
             },
             {
                 path: 'notifications',
-                element: <Notifications />,
+                lazy: lazyComponent(() => import('./views/notifications')),
                 pageTitle: 'Notifications'
             },
             {
                 path: 'explore',
-                element: <Explore />,
+                lazy: lazyComponent(() => import('./views/explore')),
                 pageTitle: 'Explore'
             },
             {
                 path: 'explore/:topic',
-                element: <Explore />,
+                lazy: lazyComponent(() => import('./views/explore')),
                 pageTitle: 'Explore'
             },
             {
                 path: 'profile',
-                element: <Profile />,
+                lazy: lazyComponent(() => import('./views/profile')),
                 pageTitle: 'Profile'
             },
             {
                 path: 'profile/likes',
-                element: <Profile />,
+                lazy: lazyComponent(() => import('./views/profile')),
                 pageTitle: 'Profile'
             },
             {
                 path: 'profile/following',
-                element: <Profile />,
+                lazy: lazyComponent(() => import('./views/profile')),
                 pageTitle: 'Profile'
             },
             {
                 path: 'profile/followers',
-                element: <Profile />,
+                lazy: lazyComponent(() => import('./views/profile')),
                 pageTitle: 'Profile'
             },
             {
                 path: 'profile/:handle/:tab?',
-                element: <Profile />,
+                lazy: lazyComponent(() => import('./views/profile')),
                 pageTitle: 'Profile'
             },
             {
                 path: 'preferences',
-                element: <Preferences />,
+                lazy: lazyComponent(() => import('./views/preferences')),
                 pageTitle: 'Preferences'
             },
             {
                 path: 'preferences/moderation',
-                element: <Moderation />,
+                lazy: lazyComponent(() => import('./views/preferences/components/moderation')),
                 pageTitle: 'Moderation',
                 showBackButton: true
             },
             {
                 path: 'preferences/bluesky-sharing',
-                element: <BlueskySharing />,
+                lazy: lazyComponent(() => import('./views/preferences/components/bluesky-sharing')),
                 showBackButton: true
             },
             {
                 path: 'welcome',
-                element: <Onboarding />,
+                lazy: lazyComponent(() => import('./components/layout/onboarding')),
                 pageTitle: 'Welcome',
                 children: [
                     {
@@ -129,15 +117,15 @@ export const routes: CustomRouteObject[] = [
                     },
                     {
                         path: '1',
-                        element: <OnboardingStep1 />
+                        lazy: lazyComponent(() => import('./components/layout/onboarding/step-1'))
                     },
                     {
                         path: '2',
-                        element: <OnboardingStep2 />
+                        lazy: lazyComponent(() => import('./components/layout/onboarding/step-2'))
                     },
                     {
                         path: '3',
-                        element: <OnboardingStep3 />
+                        lazy: lazyComponent(() => import('./components/layout/onboarding/step-3'))
                     },
                     {
                         path: '*',
@@ -147,7 +135,7 @@ export const routes: CustomRouteObject[] = [
             },
             {
                 path: '*',
-                element: <AppError />
+                lazy: lazyComponent(() => import('./components/layout/error'))
             }
         ]
     }

--- a/apps/admin-x-framework/src/index.ts
+++ b/apps/admin-x-framework/src/index.ts
@@ -39,6 +39,9 @@ export {RouterProvider, useNavigate, useBaseRoute, useRouteHasParams, resetScrol
 export {useNavigationStack} from './providers/navigation-stack-provider';
 export {Link, NavLink, Outlet, useLocation, useParams, useSearchParams, redirect, matchRoutes, matchPath, useMatch, useMatches} from 'react-router';
 
+// Lazy component loader
+export {lazyComponent} from './utils/lazy-component';
+
 // Data fetching
 export type {InfiniteData} from '@tanstack/react-query';
 export {useQueryClient} from '@tanstack/react-query';

--- a/apps/admin-x-framework/src/utils/lazy-component.ts
+++ b/apps/admin-x-framework/src/utils/lazy-component.ts
@@ -1,0 +1,7 @@
+export function lazyComponent<T extends React.ComponentType>(
+    fn: () => Promise<{ default: T }>
+) {
+    return () => fn().then(({default: Component}) => ({
+        Component
+    }));
+}

--- a/apps/admin/src/routes.tsx
+++ b/apps/admin/src/routes.tsx
@@ -1,4 +1,4 @@
-import { type RouteObject, Outlet, redirect } from "@tryghost/admin-x-framework";
+import {type RouteObject, Outlet, lazyComponent, redirect} from "@tryghost/admin-x-framework";
 
 // ActivityPub
 import { FeatureFlagsProvider } from "@tryghost/activitypub/src/lib/feature-flags";
@@ -11,9 +11,6 @@ import { routes as postRoutes } from "@tryghost/posts/src/routes";
 // Stats (aka analytics)
 import GlobalDataProvider from "@tryghost/stats/src/providers/global-data-provider";
 import { routes as statsRoutes } from "@tryghost/stats/src/routes";
-
-// Settings
-import { Settings } from "./settings/settings";
 
 // Ember
 import { EmberFallback } from "./ember-bridge";
@@ -59,7 +56,7 @@ export const routes: RouteObject[] = [
     },
     {
         path: `settings/*`,
-        element: <Settings />,
+        lazy: lazyComponent(() => import("./settings/settings")),
     },
     {
         path: "*",

--- a/apps/admin/src/settings/settings.tsx
+++ b/apps/admin/src/settings/settings.tsx
@@ -1,7 +1,7 @@
 import { App } from "@tryghost/admin-x-settings/src/app";
 import { createPortal } from "react-dom";
 
-export function Settings() {
+export default function Settings() {
     return createPortal(
         <div
             className="shade shade-admin"

--- a/apps/posts/src/routes.tsx
+++ b/apps/posts/src/routes.tsx
@@ -1,12 +1,5 @@
-import Growth from '@views/PostAnalytics/Growth/growth';
-import Newsletter from '@views/PostAnalytics/Newsletter/newsletter';
-import Overview from '@views/PostAnalytics/Overview/overview';
-import PostAnalytics from '@views/PostAnalytics/post-analytics';
-import PostAnalyticsProvider from './providers/post-analytics-context';
-import Tags from '@views/Tags/tags';
-import Web from '@views/PostAnalytics/Web/web';
 import {ErrorPage} from '@tryghost/shade';
-import {RouteObject} from '@tryghost/admin-x-framework';
+import {RouteObject, lazyComponent} from '@tryghost/admin-x-framework';
 // import {withFeatureFlag} from '@src/hooks/with-feature-flag';
 
 export const APP_ROUTE_PREFIX = '/';
@@ -22,30 +15,40 @@ export const routes: RouteObject[] = [
         errorElement: <ErrorPage onBackToDashboard={() => {}} />, // @TODO: add back to dashboard click handle
         children: [
             {
-
                 // Post Analytics
                 path: 'posts/analytics/:postId',
-                element: (
-                    <PostAnalyticsProvider>
-                        <PostAnalytics />
-                    </PostAnalyticsProvider>
-                ),
+                lazy: async () => {
+                    const [
+                        {default: PostAnalyticsProvider},
+                        {default: PostAnalytics}
+                    ] = await Promise.all([
+                        import('./providers/post-analytics-context'),
+                        import('./views/PostAnalytics/post-analytics')
+                    ]);
+                    return {
+                        element: (
+                            <PostAnalyticsProvider>
+                                <PostAnalytics />
+                            </PostAnalyticsProvider>
+                        )
+                    };
+                },
                 children: [
                     {
                         path: '',
-                        element: <Overview />
+                        lazy: lazyComponent(() => import('@views/PostAnalytics/Overview/overview'))
                     },
                     {
                         path: 'web',
-                        element: <Web />
+                        lazy: lazyComponent(() => import('@views/PostAnalytics/Web/web'))
                     },
                     {
                         path: 'growth',
-                        element: <Growth />
+                        lazy: lazyComponent(() => import('@views/PostAnalytics/Growth/growth'))
                     },
                     {
                         path: 'newsletter',
-                        element: <Newsletter />
+                        lazy: lazyComponent(() => import('@views/PostAnalytics/Newsletter/newsletter'))
                     }
                 ]
             },
@@ -54,7 +57,7 @@ export const routes: RouteObject[] = [
                 children: [
                     {
                         index: true,
-                        element: <Tags />
+                        lazy: lazyComponent(() => import('@views/Tags/tags'))
                     },
                     {
                         path: ':tagSlug',

--- a/apps/stats/src/routes.tsx
+++ b/apps/stats/src/routes.tsx
@@ -1,8 +1,4 @@
-import Growth from './views/Stats/Growth';
-import Newsletters from './views/Stats/Newsletters';
-import Overview from './views/Stats/Overview';
-import Web from './views/Stats/Web';
-import {RouteObject} from '@tryghost/admin-x-framework';
+import {RouteObject, lazyComponent} from '@tryghost/admin-x-framework';
 // import {withFeatureFlag} from './hooks/withFeatureFlag';
 
 export const APP_ROUTE_PREFIX = '/';
@@ -17,19 +13,19 @@ export const routes: RouteObject[] = [
         children: [
             {
                 index: true,
-                element: <Overview />
+                lazy: lazyComponent(() => import('./views/Stats/Overview'))
             },
             {
                 path: 'web',
-                element: <Web />
+                lazy: lazyComponent(() => import('./views/Stats/Web'))
             },
             {
                 path: 'growth',
-                element: <Growth />
+                lazy: lazyComponent(() => import('./views/Stats/Growth'))
             },
             {
                 path: 'newsletters',
-                element: <Newsletters />
+                lazy: lazyComponent(() => import('./views/Stats/Newsletters'))
             }
         ]
     }

--- a/apps/stats/test/unit/app.test.tsx
+++ b/apps/stats/test/unit/app.test.tsx
@@ -18,7 +18,8 @@ vi.mock('@tryghost/admin-x-framework', () => ({
     FrameworkProvider: ({children}: {children: React.ReactNode}) => <div data-testid="framework-provider">{children}</div>,
     RouterProvider: ({children}: {children: React.ReactNode}) => <div data-testid="router-provider">{children}</div>,
     AppProvider: ({children}: {children: React.ReactNode}) => <div data-testid="app-provider">{children}</div>,
-    Outlet: () => <div data-testid="outlet">Outlet content</div>
+    Outlet: () => <div data-testid="outlet">Outlet content</div>,
+    lazyComponent: (fn: () => Promise<{default: React.ComponentType}>) => fn().then(({default: Component}) => ({Component}))
 }));
 
 vi.mock('@tryghost/shade', () => ({

--- a/ghost/admin/app/routes/application.js
+++ b/ghost/admin/app/routes/application.js
@@ -234,9 +234,12 @@ export default Route.extend(ShortcutsRoute, {
         }
 
         // Preload settings to avoid a delay when opening
-        setTimeout(() => {
-            importComponent(AdminXSettings.packageName);
-        }, 1000);
+        // Skip preloading when running in AdminForward mode (React handles its own loading)
+        if (!this.feature.inAdminForward) {
+            setTimeout(() => {
+                importComponent(AdminXSettings.packageName);
+            }, 1000);
+        }
     }
 
 });


### PR DESCRIPTION
refs https://linear.app/ghost/issue/BER-3126/generated-bundle-is-huge

- Added a simple helper to enable code splitting and lazy loading at the route level. 
- Disabled the redundant preloading of settings in Ember

This reduces the amount of JS we are serving to just render the shell from ~12mb to ~5.4mb pre compression. The minified pre-zip size is in many ways a more relevant metric than the gzip size since the former correlates better with actual JS parse and execution time.

Before:
<img width="619" height="26" alt="Screenshot 2025-12-10 at 15 45 05" src="https://github.com/user-attachments/assets/88cc536c-3d96-46d6-8ea3-cc0bee3fc6dc" />

After: 
<img width="605" height="24" alt="Screenshot 2025-12-10 at 15 39 46" src="https://github.com/user-attachments/assets/fa8eee00-ae5d-4b5f-8751-d7c15fc6437d" />

There is plenty of room to iterate on this further by pulling out some of our larger dependencies in favor of smaller ones.