### PR TITLE
🐛 Fixed force upgrade mode not blocking React shell routes

### DIFF
--- a/apps/admin-x-framework/src/api/config.ts
+++ b/apps/admin-x-framework/src/api/config.ts
@@ -34,6 +34,7 @@ export type Config = {
     };
     hostSettings?: {
         siteId?: string;
+        forceUpgrade?: boolean;
         limits?: {
             // Partially typed, see https://github.com/TryGhost/SDK/tree/main/packages/limit-service
             customIntegrations?: {

--- a/apps/admin/src/ember-bridge/force-upgrade-guard.tsx
+++ b/apps/admin/src/ember-bridge/force-upgrade-guard.tsx
@@ -1,0 +1,44 @@
+import { Navigate, Outlet, useMatches } from "@tryghost/admin-x-framework";
+import { useForceUpgrade } from "./ember-bridge";
+
+export interface RouteHandle {
+    allowInForceUpgrade?: boolean;
+}
+
+/**
+ * Guard component that redirects to /pro when site is in force upgrade mode.
+ *
+ * Routes can opt-out of being blocked by setting `handle: { allowInForceUpgrade: true }`
+ * in their route definition. This is used for routes that should remain accessible
+ * during force upgrade (e.g., /pro itself, /settings, /signout).
+ *
+ * When forceUpgrade is active:
+ * - Routes with allowInForceUpgrade: true render normally
+ * - All other routes redirect to /pro (billing page)
+ *
+ * @example
+ * ```tsx
+ * // In routes.tsx
+ * {
+ *     path: "settings/*",
+ *     element: <Settings />,
+ *     handle: { allowInForceUpgrade: true }
+ * }
+ * ```
+ */
+export function ForceUpgradeGuard() {
+    const forceUpgrade = useForceUpgrade();
+    const matches = useMatches();
+
+    // Check if any matched route allows access in force upgrade mode
+    const isAllowed = matches.some((match) => {
+        const handle = match.handle as RouteHandle | undefined;
+        return handle?.allowInForceUpgrade === true;
+    });
+
+    if (forceUpgrade && !isAllowed) {
+        return <Navigate to="/pro" replace />;
+    }
+
+    return <Outlet />;
+}

--- a/apps/admin/src/ember-bridge/index.ts
+++ b/apps/admin/src/ember-bridge/index.ts
@@ -2,5 +2,7 @@ export { EmberRoot } from "./ember-root";
 export { EmberProvider } from "./ember-provider";
 export { useEmberContext } from "./ember-context";
 export { EmberFallback } from "./ember-fallback";
-export { useEmberAuthSync, useEmberDataSync, useSidebarVisibility, useSubscriptionStatus, useEmberRouting } from "./ember-bridge";
+export { ForceUpgradeGuard } from "./force-upgrade-guard";
+export { useEmberAuthSync, useEmberDataSync, useSidebarVisibility, useSubscriptionStatus, useEmberRouting, useForceUpgrade } from "./ember-bridge";
 export type { EmberDataChangeEvent, EmberRouting } from "./ember-bridge";
+export type { RouteHandle } from "./force-upgrade-guard";

--- a/apps/admin/src/layout/app-sidebar/hooks/use-upgrade-status.ts
+++ b/apps/admin/src/layout/app-sidebar/hooks/use-upgrade-status.ts
@@ -7,8 +7,8 @@ export interface UpgradeStatus {
 
 export function useUpgradeStatus(): UpgradeStatus {
     const subscriptionStatus = useSubscriptionStatus();
-    const showUpgradeBanner = !!subscriptionStatus?.subscription.isActiveTrial;
-    const trialDaysRemaining = subscriptionStatus?.subscription.trial_end ? Math.ceil((new Date(subscriptionStatus.subscription.trial_end).getTime() - Date.now()) / (1000 * 60 * 60 * 24)) : 0;
+    const showUpgradeBanner = !!subscriptionStatus?.subscription?.isActiveTrial;
+    const trialDaysRemaining = subscriptionStatus?.subscription?.trial_end ? Math.ceil((new Date(subscriptionStatus.subscription.trial_end).getTime() - Date.now()) / (1000 * 60 * 60 * 24)) : 0;
 
     return {
         showUpgradeBanner,

--- a/apps/admin/src/routes.tsx
+++ b/apps/admin/src/routes.tsx
@@ -13,53 +13,66 @@ import GlobalDataProvider from "@tryghost/stats/src/providers/global-data-provid
 import { routes as statsRoutes } from "@tryghost/stats/src/routes";
 
 // Ember
-import { EmberFallback } from "./ember-bridge";
+import { EmberFallback, ForceUpgradeGuard } from "./ember-bridge";
+import type { RouteHandle } from "./ember-bridge";
 
 export const routes: RouteObject[] = [
     {
-        // Override the tag detail route from the posts app to ensure we
-        // correctly delegate to Ember since we can't remove the blank screen in
-        // the posts app. The blank screen needs to be there to prevent the
-        // router error fallback from triggering when navigating from the tag
-        // list to a tag detail page.
-        path: "/tags/:tagSlug",
-        Component: EmberFallback,
-    },
-    {
-        element: (
-            <PostsAppContextProvider value={{ fromAnalytics: true }}>
-                <Outlet />
-            </PostsAppContextProvider>
-        ),
-        children: postRoutes[0].children!.filter((route) => route.path !== "*"),
-    },
-    {
-        element: (
-            <GlobalDataProvider>
-                <Outlet />
-            </GlobalDataProvider>
-        ),
-        children: statsRoutes,
-    },
-    {
-        path: `network`,
-        loader: () => redirect("/activitypub"),
-    },
-    {
-        path: "",
-        element: (
-            <FeatureFlagsProvider>
-                <Outlet />
-            </FeatureFlagsProvider>
-        ),
-        children: activityPubRoutes,
-    },
-    {
-        path: `settings/*`,
-        lazy: lazyComponent(() => import("./settings/settings")),
-    },
-    {
-        path: "*",
-        Component: EmberFallback,
+        // ForceUpgradeGuard wraps all routes to redirect to /pro when in force upgrade mode.
+        // Routes with handle.allowInForceUpgrade: true bypass this protection.
+        element: <ForceUpgradeGuard />,
+        children: [
+            {
+                // Override the tag detail route from the posts app to ensure we
+                // correctly delegate to Ember since we can't remove the blank screen in
+                // the posts app. The blank screen needs to be there to prevent the
+                // router error fallback from triggering when navigating from the tag
+                // list to a tag detail page.
+                path: "/tags/:tagSlug",
+                Component: EmberFallback,
+                handle: { allowInForceUpgrade: true } satisfies RouteHandle,
+            },
+            {
+                element: (
+                    <PostsAppContextProvider value={{ fromAnalytics: true }}>
+                        <Outlet />
+                    </PostsAppContextProvider>
+                ),
+                children: postRoutes[0].children!.filter((route) => route.path !== "*"),
+            },
+            {
+                element: (
+                    <GlobalDataProvider>
+                        <Outlet />
+                    </GlobalDataProvider>
+                ),
+                children: statsRoutes,
+            },
+            {
+                path: `network`,
+                loader: () => redirect("/activitypub"),
+            },
+            {
+                path: "",
+                element: (
+                    <FeatureFlagsProvider>
+                        <Outlet />
+                    </FeatureFlagsProvider>
+                ),
+                children: activityPubRoutes,
+            },
+            {
+                path: `settings/*`,
+                lazy: lazyComponent(() => import("./settings/settings")),
+                handle: { allowInForceUpgrade: true } satisfies RouteHandle,
+            },
+            {
+                // Catch-all route for Ember-handled routes (including /pro, /signout, etc.)
+                // These must be allowed in force upgrade mode since Ember handles the actual protection
+                path: "*",
+                Component: EmberFallback,
+                handle: { allowInForceUpgrade: true } satisfies RouteHandle,
+            },
+        ],
     },
 ];

--- a/e2e/helpers/pages/admin/billing/billing-page.ts
+++ b/e2e/helpers/pages/admin/billing/billing-page.ts
@@ -1,0 +1,16 @@
+import {AdminPage} from '@/admin-pages';
+import {Locator, Page} from '@playwright/test';
+
+export class BillingPage extends AdminPage {
+    public readonly billingIframe: Locator;
+
+    constructor(page: Page) {
+        super(page);
+        this.billingIframe = page.getByTitle('Billing');
+    }
+
+    async waitForBillingIframe(): Promise<Locator> {
+        await this.billingIframe.waitFor({state: 'visible', timeout: 10000});
+        return this.billingIframe;
+    }
+}

--- a/e2e/helpers/pages/admin/billing/index.ts
+++ b/e2e/helpers/pages/admin/billing/index.ts
@@ -1,0 +1,1 @@
+export * from './billing-page';

--- a/e2e/helpers/pages/admin/index.ts
+++ b/e2e/helpers/pages/admin/index.ts
@@ -9,3 +9,4 @@ export * from './analytics';
 export * from './posts';
 export * from './tags';
 export * from './sidebar';
+export * from './billing';

--- a/e2e/helpers/pages/admin/sidebar/sidebar-page.ts
+++ b/e2e/helpers/pages/admin/sidebar/sidebar-page.ts
@@ -1,6 +1,29 @@
 import {AdminPage} from '@/admin-pages';
 import {Locator, Page} from '@playwright/test';
 
+export type UserRole = 'Administrator' | 'Editor' | 'Author' | 'Contributor';
+
+export interface NavItem {
+    name: string;
+    path: RegExp;
+    directUrl: string;
+    roles: UserRole[];
+}
+
+/**
+ * Navigation items in the sidebar with their expected paths and role visibility.
+ * Used for navigation tests and force upgrade redirect validation.
+ */
+export const NAV_ITEMS: NavItem[] = [
+    {name: 'Analytics', path: /\/ghost\/#\/analytics\/?$/, directUrl: '/ghost/#/analytics', roles: ['Administrator']},
+    {name: 'Network', path: /\/ghost\/#\/(network|activitypub)\/?/, directUrl: '/ghost/#/activitypub', roles: ['Administrator']},
+    {name: 'View site', path: /\/ghost\/#\/site\/?$/, directUrl: '/ghost/#/site', roles: ['Administrator', 'Editor']},
+    {name: 'Posts', path: /\/ghost\/#\/posts\/?$/, directUrl: '/ghost/#/posts', roles: ['Administrator', 'Editor', 'Author', 'Contributor']},
+    {name: 'Pages', path: /\/ghost\/#\/pages\/?$/, directUrl: '/ghost/#/pages', roles: ['Administrator', 'Editor']},
+    {name: 'Tags', path: /\/ghost\/#\/tags\/?$/, directUrl: '/ghost/#/tags', roles: ['Administrator', 'Editor']},
+    {name: 'Members', path: /\/ghost\/#\/members\/?$/, directUrl: '/ghost/#/members', roles: ['Administrator', 'Editor']}
+];
+
 /**
  * SidebarPage uses semantic, accessibility-first locators.
  * This approach tests the UI as users interact with it, not implementation details.

--- a/e2e/helpers/playwright/fixture.ts
+++ b/e2e/helpers/playwright/fixture.ts
@@ -19,6 +19,7 @@ export interface GhostConfig {
     memberWelcomeEmailTestInbox?: string;
     hostSettings__billing__enabled?: string;
     hostSettings__billing__url?: string;
+    hostSettings__forceUpgrade?: string;
 }
 
 export interface GhostInstanceFixture {

--- a/e2e/helpers/playwright/flows/sign-in.ts
+++ b/e2e/helpers/playwright/flows/sign-in.ts
@@ -12,7 +12,12 @@ export async function loginToGetAuthenticatedSession(page: Page, email: string, 
     await loginPage.waitForLoginPageAfterUserCreated();
     await loginPage.signIn(email, password);
     const analyticsPage = new AnalyticsOverviewPage(page);
-    await analyticsPage.header.waitFor({state: 'visible'});
+    // Wait for either Analytics header (normal mode) or billing iframe (force upgrade mode)
+    const billingIframe = page.getByTitle('Billing');
+    await Promise.race([
+        analyticsPage.header.waitFor({state: 'visible'}),
+        billingIframe.waitFor({state: 'visible'})
+    ]);
 }
 
 /**

--- a/e2e/tests/admin/billing/force-upgrade.test.ts
+++ b/e2e/tests/admin/billing/force-upgrade.test.ts
@@ -1,0 +1,127 @@
+import {BillingPage, NAV_ITEMS, SidebarPage} from '@/helpers/pages';
+import {expect, test} from '@/helpers/playwright';
+
+const MOCK_BILLING_URL = 'https://billing.mock.test';
+
+const FORCE_UPGRADE_BMA_HTML = `
+<!DOCTYPE html>
+<html>
+<head><title>Upgrade Required</title></head>
+<body>
+<h1 data-testid="force-upgrade-prompt">Upgrade Required</h1>
+<script>
+    window.addEventListener('message', (event) => {
+        if (event.data?.request === 'forceUpgradeInfo') {
+            console.log('Force upgrade info requested');
+        }
+        if (event.data?.request === 'token') {
+            console.log('Token requested');
+        }
+    });
+
+    window.parent.postMessage({
+        subscription: {
+            isActiveTrial: false,
+            status: 'past_due'
+        }
+    }, '*');
+</script>
+</body>
+</html>
+`;
+
+test.describe('Ghost Admin - Force Upgrade Mode', () => {
+    test.use({
+        config: {
+            hostSettings__forceUpgrade: 'true',
+            hostSettings__billing__enabled: 'true',
+            hostSettings__billing__url: MOCK_BILLING_URL
+        }
+    });
+
+    test.beforeEach(async ({page}) => {
+        await page.route(`${MOCK_BILLING_URL}/**`, async (route) => {
+            await route.fulfill({
+                status: 200,
+                contentType: 'text/html',
+                body: FORCE_UPGRADE_BMA_HTML
+            });
+        });
+    });
+
+    test.describe('navigation blocked in force upgrade mode', () => {
+        NAV_ITEMS.forEach(({name}) => {
+            test(`${name} link - billing iframe blocks access`, async ({page}) => {
+                const sidebarPage = new SidebarPage(page);
+                const billingPage = new BillingPage(page);
+                await sidebarPage.goto();
+
+                const billingIframe = await billingPage.waitForBillingIframe();
+                await expect(billingIframe).toBeVisible();
+
+                await sidebarPage.getNavLink(name).click();
+
+                await expect(billingIframe).toBeVisible();
+            });
+        });
+    });
+
+    test.describe('direct URL navigation blocked', () => {
+        NAV_ITEMS.forEach(({name, directUrl}) => {
+            test(`direct navigation to ${name} shows billing iframe`, async ({page}) => {
+                const sidebarPage = new SidebarPage(page);
+                const billingPage = new BillingPage(page);
+                await sidebarPage.goto(directUrl);
+
+                const billingIframe = await billingPage.waitForBillingIframe();
+                await expect(billingIframe).toBeVisible();
+            });
+        });
+    });
+
+    test.describe('allowed routes in force upgrade mode', () => {
+        test('Settings is accessible via sidebar', async ({page}) => {
+            const sidebarPage = new SidebarPage(page);
+            const billingPage = new BillingPage(page);
+            await sidebarPage.goto();
+
+            await billingPage.waitForBillingIframe();
+            await sidebarPage.getNavLink('Settings').click();
+
+            await expect(page).toHaveURL(/#\/settings/);
+            await expect(billingPage.billingIframe).toBeHidden();
+        });
+
+        test('Settings is accessible via direct URL', async ({page}) => {
+            const sidebarPage = new SidebarPage(page);
+            const billingPage = new BillingPage(page);
+            await sidebarPage.goto('/ghost/#/settings');
+
+            await expect(page).toHaveURL(/#\/settings/);
+            await expect(billingPage.billingIframe).toBeHidden();
+        });
+
+        test('Sign out is accessible', async ({page}) => {
+            const sidebarPage = new SidebarPage(page);
+            const billingPage = new BillingPage(page);
+            await sidebarPage.goto();
+
+            await billingPage.waitForBillingIframe();
+            await sidebarPage.userDropdownTrigger.click();
+            await sidebarPage.signOutLink.click();
+
+            await expect(page).toHaveURL(/signin/);
+        });
+    });
+
+    test.describe('Ember-handled routes in force upgrade mode', () => {
+        test('tag detail route shows billing iframe', async ({page}) => {
+            const sidebarPage = new SidebarPage(page);
+            const billingPage = new BillingPage(page);
+            await sidebarPage.goto('/ghost/#/tags/default-tag');
+
+            const billingIframe = await billingPage.waitForBillingIframe();
+            await expect(billingIframe).toBeVisible();
+        });
+    });
+});

--- a/e2e/tests/admin/sidebar/navigation.test.ts
+++ b/e2e/tests/admin/sidebar/navigation.test.ts
@@ -1,8 +1,6 @@
+import {NAV_ITEMS, SidebarPage} from '@/admin-pages';
 import {Page} from '@playwright/test';
-import {SidebarPage} from '@/admin-pages';
 import {expect, test} from '@/helpers/playwright/fixture';
-
-type UserRole = 'Administrator' | 'Editor' | 'Author' | 'Contributor';
 
 // TODO: Remove this when the ActivityPub backend has been integrated with the E2E tests
 async function mockNotificationCount(page: Page, count: number) {
@@ -14,22 +12,6 @@ async function mockNotificationCount(page: Page, count: number) {
         });
     });
 }
-
-interface NavItem {
-    name: string;
-    path: RegExp;
-    roles: UserRole[];
-}
-
-const NAV_ITEMS: NavItem[] = [
-    {name: 'Analytics', path: /\/ghost\/#\/analytics\/?$/, roles: ['Administrator']},
-    {name: 'Network', path: /\/ghost\/#\/(network|activitypub)\/?/, roles: ['Administrator']},
-    {name: 'View site', path: /\/ghost\/#\/site\/?$/, roles: ['Administrator', 'Editor']},
-    {name: 'Posts', path: /\/ghost\/#\/posts\/?$/, roles: ['Administrator', 'Editor', 'Author', 'Contributor']},
-    {name: 'Pages', path: /\/ghost\/#\/pages\/?$/, roles: ['Administrator', 'Editor']},
-    {name: 'Tags', path: /\/ghost\/#\/tags\/?$/, roles: ['Administrator', 'Editor']},
-    {name: 'Members', path: /\/ghost\/#\/members\/?$/, roles: ['Administrator', 'Editor']}
-];
 
 test.describe('Ghost Admin - Sidebar Navigation', () => {
     test.describe('main navigation', () => {

--- a/ghost/admin/app/routes/application.js
+++ b/ghost/admin/app/routes/application.js
@@ -49,6 +49,7 @@ export default Route.extend(ShortcutsRoute, {
     router: service(),
     session: service(),
     settings: service(),
+    stateBridge: service(),
     ui: service(),
     whatsNew: service(),
     billing: service(),
@@ -232,6 +233,12 @@ export default Route.extend(ShortcutsRoute, {
             // enforce opening the BMA in a force upgrade state
             this.billing.openBillingWindow(this.router.currentURL, '/pro');
         }
+
+        // Notify React of the initial subscription state
+        // React uses this to derive forceUpgrade state (config.forceUpgrade && subscription.status !== 'active')
+        this.stateBridge.triggerSubscriptionChange({
+            subscription: this.billing.subscription
+        });
 
         // Preload settings to avoid a delay when opening
         // Skip preloading when running in AdminForward mode (React handles its own loading)

--- a/ghost/admin/app/services/state-bridge.js
+++ b/ghost/admin/app/services/state-bridge.js
@@ -202,9 +202,7 @@ export default class StateBridgeService extends Service.extend(Evented) {
 
     @action
     triggerSubscriptionChange(data) {
-        this.trigger('subscriptionChange', {
-            ...data
-        });
+        this.trigger('subscriptionChange', data);
     }
 
     @action


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3127

## Summary

### What is Force Upgrade mode?

Force Upgrade is a Ghost(Pro) billing feature that locks users out of most of the admin when a subscription action is required (e.g., payment failed, plan expired). In this mode, users are redirected to the `/pro` billing page, with only settings and sign-out remaining accessible.

### The Bug

The force upgrade protection was implemented in Ember's routing layer, which intercepts route transitions and redirects to `/pro`. However, as we've migrated routes to React (Analytics, Network/ActivityPub, Tags), these routes bypassed the Ember protection entirely - React was unaware of the force upgrade state, so these pages would render normally when they should have been blocked.

### The Fix

We chose a declarative approach using React Router's `handle` metadata:

1. **React reads forceUpgrade from the API config** - The `hostSettings.forceUpgrade` flag is set by the server and available via the config endpoint
2. **React derives the effective state** - If config says `forceUpgrade: true` but subscription status is `active`, billing was just completed (server hasn't restarted yet), so we clear the lock locally. This mirrors Ember's logic.
3. **A ForceUpgradeGuard wraps all React routes** - This guard checks the derived forceUpgrade state and route metadata
4. **Routes opt-in to being allowed** - Routes set `handle: { allowInForceUpgrade: true }` to bypass the guard (used for settings and the Ember fallback which handles `/pro`)

This approach mirrors how Ember handles it (checking route transitions) but uses React Router's native patterns.