### PR TITLE
Added model URL transformation tests (with and without CDN)

### DIFF
--- a/ghost/core/test/legacy/models/model_newsletters.test.js
+++ b/ghost/core/test/legacy/models/model_newsletters.test.js
@@ -1,0 +1,31 @@
+const should = require('should');
+const sinon = require('sinon');
+const testUtils = require('../../utils');
+const models = require('../../../core/server/models');
+const urlService = require('../../../core/server/services/url');
+
+describe('Newsletter Model', function () {
+    const siteUrl = 'http://127.0.0.1:2369';
+
+    before(testUtils.teardownDb);
+    before(testUtils.stopGhost);
+    after(testUtils.teardownDb);
+
+    before(testUtils.setup('users:roles', 'newsletters'));
+
+    beforeEach(function () {
+        sinon.stub(urlService, 'getUrlByResourceId').returns('/test-url/');
+    });
+
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    describe('URL transformations without CDN config', function () {
+        it('transforms header_image to absolute site URL', async function () {
+            const newsletter = await models.Newsletter.findOne({slug: 'new-newsletter'});
+            should.exist(newsletter, 'New newsletter should exist');
+            newsletter.get('header_image').should.equal(`${siteUrl}/content/images/newsletter-header.jpg`);
+        });
+    });
+});

--- a/ghost/core/test/legacy/models/model_snippets.test.js
+++ b/ghost/core/test/legacy/models/model_snippets.test.js
@@ -1,6 +1,8 @@
 const should = require('should');
 const sinon = require('sinon');
 const testUtils = require('../../utils');
+const configUtils = require('../../utils/configUtils');
+const urlUtilsHelper = require('../../utils/urlUtils');
 const models = require('../../../core/server/models');
 const urlService = require('../../../core/server/services/url');
 
@@ -17,8 +19,9 @@ describe('Snippet Model', function () {
         sinon.stub(urlService, 'getUrlByResourceId').returns('/test-url/');
     });
 
-    afterEach(function () {
+    afterEach(async function () {
         sinon.restore();
+        await configUtils.restore();
     });
 
     describe('URL transformations without CDN config', function () {
@@ -86,6 +89,95 @@ describe('Snippet Model', function () {
 
                 // Verify no __GHOST_URL__ placeholders remain
                 lexicalString.should.not.containEql('__GHOST_URL__');
+            });
+        });
+    });
+
+    describe('URL transformations with CDN config', function () {
+        const cdnUrl = 'https://cdn.example.com/c/site-uuid';
+
+        beforeEach(function () {
+            urlUtilsHelper.stubUrlUtilsWithCdn({
+                assetBaseUrls: {
+                    media: cdnUrl,
+                    files: cdnUrl
+                }
+            }, sinon);
+        });
+
+        describe('Mobiledoc', function () {
+            it('transforms file card src to files CDN URL', async function () {
+                const snippets = await models.Snippet.findAll();
+                const snippet = snippets.models.find(s => s.get('name') === 'Snippet with all media types - Mobiledoc');
+                const mobiledoc = JSON.parse(snippet.get('mobiledoc'));
+
+                const fileCard = mobiledoc.cards.find(card => card[0] === 'file');
+                fileCard[1].src.should.equal(`${cdnUrl}/content/files/snippet-document.pdf`);
+            });
+
+            it('transforms video card src to media CDN URL', async function () {
+                const snippets = await models.Snippet.findAll();
+                const snippet = snippets.models.find(s => s.get('name') === 'Snippet with all media types - Mobiledoc');
+                const mobiledoc = JSON.parse(snippet.get('mobiledoc'));
+
+                const videoCard = mobiledoc.cards.find(card => card[0] === 'video');
+                videoCard[1].src.should.equal(`${cdnUrl}/content/media/snippet-video.mp4`);
+            });
+
+            it('transforms audio card src to media CDN URL', async function () {
+                const snippets = await models.Snippet.findAll();
+                const snippet = snippets.models.find(s => s.get('name') === 'Snippet with all media types - Mobiledoc');
+                const mobiledoc = JSON.parse(snippet.get('mobiledoc'));
+
+                const audioCard = mobiledoc.cards.find(card => card[0] === 'audio');
+                audioCard[1].src.should.equal(`${cdnUrl}/content/media/snippet-audio.mp3`);
+            });
+
+            it('transforms image card src to absolute site URL(NOT CDN)', async function () {
+                const snippets = await models.Snippet.findAll();
+                const snippet = snippets.models.find(s => s.get('name') === 'Snippet with all media types - Mobiledoc');
+                const mobiledoc = JSON.parse(snippet.get('mobiledoc'));
+
+                const imageCard = mobiledoc.cards.find(card => card[0] === 'image');
+                imageCard[1].src.should.equal(`${siteUrl}/content/images/snippet-inline.jpg`);
+            });
+
+            it('transforms video thumbnailSrc to absolute site URL(NOT CDN)', async function () {
+                const snippets = await models.Snippet.findAll();
+                const snippet = snippets.models.find(s => s.get('name') === 'Snippet with all media types - Mobiledoc');
+                const mobiledoc = JSON.parse(snippet.get('mobiledoc'));
+
+                const videoCard = mobiledoc.cards.find(card => card[0] === 'video');
+                videoCard[1].thumbnailSrc.should.equal(`${siteUrl}/content/images/snippet-video-thumb.jpg`);
+            });
+        });
+
+        describe('Lexical', function () {
+            it('transforms file URLs to files CDN URL', async function () {
+                const snippets = await models.Snippet.findAll();
+                const snippet = snippets.models.find(s => s.get('name') === 'Snippet with all media types - Lexical');
+                const lexicalString = snippet.get('lexical');
+
+                lexicalString.should.containEql(`${cdnUrl}/content/files/snippet-document.pdf`);
+            });
+
+            it('transforms video/audio URLs to media CDN URL', async function () {
+                const snippets = await models.Snippet.findAll();
+                const snippet = snippets.models.find(s => s.get('name') === 'Snippet with all media types - Lexical');
+                const lexicalString = snippet.get('lexical');
+
+                lexicalString.should.containEql(`${cdnUrl}/content/media/snippet-video.mp4`);
+                lexicalString.should.containEql(`${cdnUrl}/content/media/snippet-audio.mp3`);
+            });
+
+            it('transforms image URLs to absolute site URL(NOT CDN)', async function () {
+                const snippets = await models.Snippet.findAll();
+                const snippet = snippets.models.find(s => s.get('name') === 'Snippet with all media types - Lexical');
+                const lexicalString = snippet.get('lexical');
+
+                lexicalString.should.containEql(`${siteUrl}/content/images/snippet-inline.jpg`);
+                lexicalString.should.containEql(`${siteUrl}/content/images/snippet-video-thumb.jpg`);
+                lexicalString.should.containEql(`${siteUrl}/content/images/snippet-audio-thumb.jpg`);
             });
         });
     });

--- a/ghost/core/test/legacy/models/model_snippets.test.js
+++ b/ghost/core/test/legacy/models/model_snippets.test.js
@@ -1,0 +1,92 @@
+const should = require('should');
+const sinon = require('sinon');
+const testUtils = require('../../utils');
+const models = require('../../../core/server/models');
+const urlService = require('../../../core/server/services/url');
+
+describe('Snippet Model', function () {
+    const siteUrl = 'http://127.0.0.1:2369';
+
+    before(testUtils.teardownDb);
+    before(testUtils.stopGhost);
+    after(testUtils.teardownDb);
+
+    before(testUtils.setup('users:roles', 'snippets'));
+
+    beforeEach(function () {
+        sinon.stub(urlService, 'getUrlByResourceId').returns('/test-url/');
+    });
+
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    describe('URL transformations without CDN config', function () {
+        describe('Mobiledoc', function () {
+            let snippet, mobiledoc;
+
+            before(async function () {
+                const snippets = await models.Snippet.findAll();
+                snippet = snippets.models.find(s => s.get('name') === 'Snippet with all media types - Mobiledoc');
+                should.exist(snippet, 'Mobiledoc snippet should exist');
+                mobiledoc = JSON.parse(snippet.get('mobiledoc'));
+            });
+
+            it('transforms image card src to absolute site URL', function () {
+                const imageCard = mobiledoc.cards.find(card => card[0] === 'image');
+
+                imageCard[1].src.should.equal(`${siteUrl}/content/images/snippet-inline.jpg`);
+            });
+
+            it('transforms file card src to absolute site URL', function () {
+                const fileCard = mobiledoc.cards.find(card => card[0] === 'file');
+
+                fileCard[1].src.should.equal(`${siteUrl}/content/files/snippet-document.pdf`);
+            });
+
+            it('transforms video card src and thumbnailSrc to absolute site URLs', function () {
+                const videoCard = mobiledoc.cards.find(card => card[0] === 'video');
+
+                videoCard[1].src.should.equal(`${siteUrl}/content/media/snippet-video.mp4`);
+                videoCard[1].thumbnailSrc.should.equal(`${siteUrl}/content/images/snippet-video-thumb.jpg`);
+            });
+
+            it('transforms audio card src and thumbnailSrc to absolute site URLs', function () {
+                const audioCard = mobiledoc.cards.find(card => card[0] === 'audio');
+
+                audioCard[1].src.should.equal(`${siteUrl}/content/media/snippet-audio.mp3`);
+                audioCard[1].thumbnailSrc.should.equal(`${siteUrl}/content/images/snippet-audio-thumb.jpg`);
+            });
+
+            it('transforms link markup href to absolute site URL', function () {
+                const linkMarkup = mobiledoc.markups.find(markup => markup[0] === 'a');
+
+                linkMarkup[1][1].should.equal(`${siteUrl}/snippet-link`);
+            });
+        });
+
+        describe('Lexical', function () {
+            let snippet, lexicalString;
+
+            before(async function () {
+                const snippets = await models.Snippet.findAll();
+                snippet = snippets.models.find(s => s.get('name') === 'Snippet with all media types - Lexical');
+                should.exist(snippet, 'Lexical snippet should exist');
+                lexicalString = snippet.get('lexical');
+            });
+
+            it('transforms all media URLs to absolute site URLs', function () {
+                lexicalString.should.containEql(`${siteUrl}/content/images/snippet-inline.jpg`);
+                lexicalString.should.containEql(`${siteUrl}/content/files/snippet-document.pdf`);
+                lexicalString.should.containEql(`${siteUrl}/content/media/snippet-video.mp4`);
+                lexicalString.should.containEql(`${siteUrl}/content/images/snippet-video-thumb.jpg`);
+                lexicalString.should.containEql(`${siteUrl}/content/media/snippet-audio.mp3`);
+                lexicalString.should.containEql(`${siteUrl}/content/images/snippet-audio-thumb.jpg`);
+                lexicalString.should.containEql(`${siteUrl}/snippet-link`);
+
+                // Verify no __GHOST_URL__ placeholders remain
+                lexicalString.should.not.containEql('__GHOST_URL__');
+            });
+        });
+    });
+});

--- a/ghost/core/test/legacy/models/model_tags.test.js
+++ b/ghost/core/test/legacy/models/model_tags.test.js
@@ -1,0 +1,33 @@
+const should = require('should');
+const sinon = require('sinon');
+const testUtils = require('../../utils');
+const models = require('../../../core/server/models');
+const urlService = require('../../../core/server/services/url');
+
+describe('Tag Model', function () {
+    const siteUrl = 'http://127.0.0.1:2369';
+
+    before(testUtils.teardownDb);
+    before(testUtils.stopGhost);
+    after(testUtils.teardownDb);
+
+    before(testUtils.setup('users:roles', 'posts'));
+
+    beforeEach(function () {
+        sinon.stub(urlService, 'getUrlByResourceId').returns('/test-url/');
+    });
+
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    describe('URL transformations without CDN config', function () {
+        it('transforms feature_image, og_image, and twitter_image to absolute site URLs', async function () {
+            const tag = await models.Tag.findOne({slug: 'tag-with-images'});
+            should.exist(tag, 'Tag with images should exist');
+            tag.get('feature_image').should.equal(`${siteUrl}/content/images/tag-feature.jpg`);
+            tag.get('og_image').should.equal(`${siteUrl}/content/images/tag-og.jpg`);
+            tag.get('twitter_image').should.equal(`${siteUrl}/content/images/tag-twitter.jpg`);
+        });
+    });
+});

--- a/ghost/core/test/legacy/models/model_tags.test.js
+++ b/ghost/core/test/legacy/models/model_tags.test.js
@@ -1,6 +1,8 @@
 const should = require('should');
 const sinon = require('sinon');
 const testUtils = require('../../utils');
+const configUtils = require('../../utils/configUtils');
+const urlUtilsHelper = require('../../utils/urlUtils');
 const models = require('../../../core/server/models');
 const urlService = require('../../../core/server/services/url');
 
@@ -17,12 +19,34 @@ describe('Tag Model', function () {
         sinon.stub(urlService, 'getUrlByResourceId').returns('/test-url/');
     });
 
-    afterEach(function () {
+    afterEach(async function () {
         sinon.restore();
+        await configUtils.restore();
     });
 
     describe('URL transformations without CDN config', function () {
         it('transforms feature_image, og_image, and twitter_image to absolute site URLs', async function () {
+            const tag = await models.Tag.findOne({slug: 'tag-with-images'});
+            should.exist(tag, 'Tag with images should exist');
+            tag.get('feature_image').should.equal(`${siteUrl}/content/images/tag-feature.jpg`);
+            tag.get('og_image').should.equal(`${siteUrl}/content/images/tag-og.jpg`);
+            tag.get('twitter_image').should.equal(`${siteUrl}/content/images/tag-twitter.jpg`);
+        });
+    });
+
+    describe('URL transformations with CDN config', function () {
+        const cdnUrl = 'https://cdn.example.com/c/site-uuid';
+
+        beforeEach(function () {
+            urlUtilsHelper.stubUrlUtilsWithCdn({
+                assetBaseUrls: {
+                    media: cdnUrl,
+                    files: cdnUrl
+                }
+            }, sinon);
+        });
+
+        it('transforms feature_image, og_image, and twitter_image to absolute site URLs(NOT CDN)', async function () {
             const tag = await models.Tag.findOne({slug: 'tag-with-images'});
             should.exist(tag, 'Tag with images should exist');
             tag.get('feature_image').should.equal(`${siteUrl}/content/images/tag-feature.jpg`);

--- a/ghost/core/test/utils/urlUtils.js
+++ b/ghost/core/test/utils/urlUtils.js
@@ -13,7 +13,8 @@ const getInstance = (options) => {
         getAdminUrl: config.getAdminUrl,
         slugs: options.slugs,
         redirectCacheMaxAge: options.redirectCacheMaxAge,
-        baseApiPath: '/ghost/api'
+        baseApiPath: '/ghost/api',
+        assetBaseUrls: options.assetBaseUrls
     };
 
     return new UrlUtils(opts);
@@ -56,6 +57,14 @@ const restore = async () => {
     await configUtils.restore().catch(console.error);
 };
 
+const stubUrlUtilsWithCdn = (options, sandbox = defaultSandbox) => {
+    return stubUrlUtils({
+        assetBaseUrls: options.assetBaseUrls
+    }, sandbox);
+};
+
 module.exports.stubUrlUtilsFromConfig = stubUrlUtilsFromConfig;
+module.exports.stubUrlUtilsWithCdn = stubUrlUtilsWithCdn;
+module.exports.stubUrlUtils = stubUrlUtils;
 module.exports.restore = restore;
 module.exports.getInstance = getInstance;


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PRO-1514/
ref https://linear.app/ghost/issue/PRO-1518/

- Added tests verifying `__GHOST_URL__` transforms to absolute site URLs or CDN URLs based on config
- Added tests to existing `model_posts.test.js`; created new test files for tags, snippets, newsletters as they didn't exist
- When CDN config is present, media/files transform to CDN URLs while images remain site URLs
- Extended `urlUtils` test helper with `stubUrlUtilsWithCdn()` for cleaner CDN stubbing
