### PR TITLE
Added ability to test member welcome emails

### DIFF
--- a/apps/admin-x-framework/src/api/automated-emails.ts
+++ b/apps/admin-x-framework/src/api/automated-emails.ts
@@ -49,8 +49,8 @@ export const useEditAutomatedEmail = createMutation<AutomatedEmailsResponseType,
     }
 });
 
-export const useSendTestWelcomeEmail = createMutation<unknown, {id: string; email: string}>({
+export const useSendTestWelcomeEmail = createMutation<unknown, {id: string; email: string; subject: string; lexical: string}>({
     method: 'POST',
     path: ({id}) => `/automated_emails/${id}/test/`,
-    body: ({email}) => ({email})
+    body: ({email, subject, lexical}) => ({email, subject, lexical})
 });

--- a/apps/admin-x-framework/src/api/automated-emails.ts
+++ b/apps/admin-x-framework/src/api/automated-emails.ts
@@ -48,3 +48,9 @@ export const useEditAutomatedEmail = createMutation<AutomatedEmailsResponseType,
         update: updateQueryCache('automated_emails')
     }
 });
+
+export const useSendTestWelcomeEmail = createMutation<unknown, {id: string; email: string}>({
+    method: 'POST',
+    path: ({id}) => `/automated_emails/${id}/test/`,
+    body: ({email}) => ({email})
+});

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/test-email-dropdown.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/test-email-dropdown.tsx
@@ -1,0 +1,101 @@
+import validator from 'validator';
+import {Button, Hint, TextField} from '@tryghost/admin-x-design-system';
+import {JSONError} from '@tryghost/admin-x-framework/errors';
+import {useCurrentUser} from '@tryghost/admin-x-framework/api/current-user';
+import {useEffect, useRef, useState} from 'react';
+import {useSendTestWelcomeEmail} from '@tryghost/admin-x-framework/api/automated-emails';
+
+export interface TestEmailDropdownProps {
+  automatedEmailId: string
+  subject: string
+  lexical: string
+  validateForm: () => boolean
+}
+
+const TestEmailDropdown: React.FC<TestEmailDropdownProps> = ({
+    automatedEmailId,
+    subject,
+    lexical,
+    validateForm
+
+}) => {
+    const {data: currentUser} = useCurrentUser();
+    const {mutateAsync: sendTestEmail} = useSendTestWelcomeEmail();
+
+    const [testEmail, setTestEmail] = useState(currentUser?.email || '');
+    const [testEmailError, setTestEmailError] = useState('');
+    const [sendState, setSendState] = useState<'idle' | 'sending' | 'sent'>('idle');
+    const sendStateTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    useEffect(() => () => clearTimeout(sendStateTimeoutRef.current ?? undefined), []);
+
+    // Update test email when current user data loads
+    useEffect(() => {
+        if (currentUser?.email) {
+            setTestEmail(currentUser.email);
+        }
+    }, [currentUser?.email]);
+
+    const handleSendTestEmail = async () => {
+        setTestEmailError('');
+
+        if (!validator.isEmail(testEmail)) {
+            setTestEmailError('Please enter a valid email address');
+            return;
+        }
+
+        // check that subject and lexical are valid
+        if (!validateForm()) {
+            setTestEmailError('Please complete the required fields');
+            return;
+        }
+
+        setSendState('sending');
+
+        try {
+            await sendTestEmail({
+                id: automatedEmailId,
+                email: testEmail,
+                subject,
+                lexical
+            });
+            setSendState('sent');
+            clearTimeout(sendStateTimeoutRef.current!);
+            sendStateTimeoutRef.current = setTimeout(() => setSendState('idle'), 2000);
+        } catch (error) {
+            setSendState('idle');
+            let message;
+            if (error instanceof JSONError && error.data && error.data.errors[0]) {
+                message = error.data.errors[0].context || error.data.errors[0].message;
+            } else if (error instanceof Error) {
+                message = error.message;
+            }
+            setTestEmailError(message || 'Failed to send test email');
+        }
+    };
+
+    return (
+        <div className='absolute right-0 top-full z-10 mt-2 w-[260px] rounded border border-grey-200 bg-white p-4 shadow-lg'>
+            <div className='mb-3'>
+                <label className='mb-2 block text-sm font-semibold'>Send test email</label>
+                <TextField
+                    className='!h-[36px]'
+                    placeholder='you@yoursite.com'
+                    value={testEmail}
+                    onChange={(e) => {
+                        setTestEmail(e.target.value);
+                    }}
+                />
+            </div>
+            <Button
+                className='w-full'
+                color={sendState === 'sent' ? 'green' : 'black'}
+                disabled={sendState === 'sending'}
+                label={sendState === 'sent' ? 'Sent' : sendState === 'sending' ? 'Sending...' : 'Send'}
+                onClick={handleSendTestEmail}
+            />
+            {testEmailError && <Hint className='mt-2' color='red'>{testEmailError}</Hint>}
+        </div>
+    );
+};
+
+export default TestEmailDropdown;

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/test-email-dropdown.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/test-email-dropdown.tsx
@@ -26,7 +26,13 @@ const TestEmailDropdown: React.FC<TestEmailDropdownProps> = ({
     const [testEmailError, setTestEmailError] = useState('');
     const [sendState, setSendState] = useState<'idle' | 'sending' | 'sent'>('idle');
     const sendStateTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-    useEffect(() => () => clearTimeout(sendStateTimeoutRef.current ?? undefined), []);
+    useEffect(() => {
+        return () => {
+            if (sendStateTimeoutRef.current) {
+                clearTimeout(sendStateTimeoutRef.current);
+            }
+        };
+    }, []);
 
     // Update test email when current user data loads
     useEffect(() => {
@@ -59,7 +65,9 @@ const TestEmailDropdown: React.FC<TestEmailDropdownProps> = ({
                 lexical
             });
             setSendState('sent');
-            clearTimeout(sendStateTimeoutRef.current!);
+            if (sendStateTimeoutRef.current) {
+                clearTimeout(sendStateTimeoutRef.current);
+            }
             sendStateTimeoutRef.current = setTimeout(() => setSendState('idle'), 2000);
         } catch (error) {
             setSendState('idle');
@@ -76,9 +84,10 @@ const TestEmailDropdown: React.FC<TestEmailDropdownProps> = ({
     return (
         <div className='absolute right-0 top-full z-10 mt-2 w-[260px] rounded border border-grey-200 bg-white p-4 shadow-lg'>
             <div className='mb-3'>
-                <label className='mb-2 block text-sm font-semibold'>Send test email</label>
+                <label className='mb-2 block text-sm font-semibold' htmlFor='test-email-input'>Send test email</label>
                 <TextField
                     className='!h-[36px]'
+                    id='test-email-input'
                     placeholder='you@yoursite.com'
                     value={testEmail}
                     onChange={(e) => {

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/test-email-dropdown.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/test-email-dropdown.tsx
@@ -17,7 +17,6 @@ const TestEmailDropdown: React.FC<TestEmailDropdownProps> = ({
     subject,
     lexical,
     validateForm
-
 }) => {
     const {data: currentUser} = useCurrentUser();
     const {mutateAsync: sendTestEmail} = useSendTestWelcomeEmail();

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-modal.tsx
@@ -126,7 +126,7 @@ const WelcomeEmailModal = NiceModal.create<WelcomeEmailModalProps>(({emailType =
         };
     }, []);
 
-    useEffect(() => () => clearTimeout(sendStateTimeoutRef.current!), []);
+    useEffect(() => () => clearTimeout(sendStateTimeoutRef.current ?? undefined), []);
 
     const handleSendTestEmail = async () => {
         setTestEmailError('');

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-modal.tsx
@@ -64,7 +64,7 @@ const WelcomeEmailModal = NiceModal.create<WelcomeEmailModalProps>(({emailType =
         onValidate: (state) => {
             const newErrors: Record<string, string> = {};
 
-            if (!state.subject) {
+            if (!state.subject?.trim()) {
                 newErrors.subject = 'A subject is required';
             }
 

--- a/ghost/core/core/server/api/endpoints/automated-emails.js
+++ b/ghost/core/core/server/api/endpoints/automated-emails.js
@@ -122,7 +122,9 @@ const controller = {
             'id'
         ],
         data: [
-            'email'
+            'email',
+            'subject',
+            'lexical'
         ],
         validation: {
             options: {
@@ -138,6 +140,8 @@ const controller = {
             memberWelcomeEmailService.init();
             await memberWelcomeEmailService.api.sendTestEmail({
                 email: frame.data.email,
+                subject: frame.data.subject,
+                lexical: frame.data.lexical,
                 automatedEmailId: frame.options.id
             });
         }

--- a/ghost/core/core/server/api/endpoints/automated-emails.js
+++ b/ghost/core/core/server/api/endpoints/automated-emails.js
@@ -1,6 +1,7 @@
 const tpl = require('@tryghost/tpl');
 const errors = require('@tryghost/errors');
 const models = require('../../models');
+const memberWelcomeEmailService = require('../../services/member-welcome-emails/service');
 
 const messages = {
     automatedEmailNotFound: 'Automated email not found.'
@@ -109,6 +110,36 @@ const controller = {
         permissions: true,
         query(frame) {
             return models.AutomatedEmail.destroy({...frame.options, require: true});
+        }
+    },
+
+    sendTestEmail: {
+        statusCode: 204,
+        headers: {
+            cacheInvalidate: false
+        },
+        options: [
+            'id'
+        ],
+        data: [
+            'email'
+        ],
+        validation: {
+            options: {
+                id: {
+                    required: true
+                }
+            }
+        },
+        permissions: {
+            method: 'edit'
+        },
+        async query(frame) {
+            memberWelcomeEmailService.init();
+            await memberWelcomeEmailService.api.sendTestEmail({
+                email: frame.data.email,
+                automatedEmailId: frame.options.id
+            });
         }
     }
 };

--- a/ghost/core/core/server/api/endpoints/utils/validators/input/automated_emails.js
+++ b/ghost/core/core/server/api/endpoints/utils/validators/input/automated_emails.js
@@ -1,7 +1,8 @@
 // Filename must match the docName specified in ../../../automated-emails.js
 /* eslint-disable ghost/filenames/match-regex */
 
-const {ValidationError} = require('@tryghost/errors');
+const validator = require('@tryghost/validator');
+const {ValidationError, BadRequestError} = require('@tryghost/errors');
 const tpl = require('@tryghost/tpl');
 
 const ALLOWED_STATUSES = ['inactive', 'active'];
@@ -12,7 +13,8 @@ const messages = {
     invalidStatus: `Status must be one of: ${ALLOWED_STATUSES.join(', ')}`,
     invalidLexical: 'Lexical must be a valid JSON string',
     invalidSlug: `Slug must be one of: ${ALLOWED_SLUGS.join(', ')}`,
-    invalidName: `Name must be one of: ${ALLOWED_NAMES.join(', ')}`
+    invalidName: `Name must be one of: ${ALLOWED_NAMES.join(', ')}`,
+    invalidEmailReceived: 'The server did not receive a valid email'
 };
 
 const validateAutomatedEmail = async function (frame) {
@@ -63,5 +65,14 @@ module.exports = {
     },
     async edit(apiConfig, frame) {
         await validateAutomatedEmail(frame);
+    },
+    sendTestEmail(apiConfig, frame) {
+        const email = frame.data.email;
+
+        if (typeof email !== 'string' || !validator.isEmail(email)) {
+            throw new BadRequestError({
+                message: tpl(messages.invalidEmailReceived)
+            });
+        }
     }
 };

--- a/ghost/core/core/server/api/endpoints/utils/validators/input/automated_emails.js
+++ b/ghost/core/core/server/api/endpoints/utils/validators/input/automated_emails.js
@@ -14,7 +14,9 @@ const messages = {
     invalidLexical: 'Lexical must be a valid JSON string',
     invalidSlug: `Slug must be one of: ${ALLOWED_SLUGS.join(', ')}`,
     invalidName: `Name must be one of: ${ALLOWED_NAMES.join(', ')}`,
-    invalidEmailReceived: 'The server did not receive a valid email'
+    invalidEmailReceived: 'The server did not receive a valid email',
+    subjectRequired: 'Subject is required',
+    lexicalRequired: 'Email content is required'
 };
 
 const validateAutomatedEmail = async function (frame) {
@@ -68,10 +70,24 @@ module.exports = {
     },
     sendTestEmail(apiConfig, frame) {
         const email = frame.data.email;
+        const subject = frame.data.subject;
+        const lexical = frame.data.lexical;
 
         if (typeof email !== 'string' || !validator.isEmail(email)) {
             throw new BadRequestError({
                 message: tpl(messages.invalidEmailReceived)
+            });
+        }
+
+        if (typeof subject !== 'string' || !subject.trim()) {
+            throw new BadRequestError({
+                message: tpl(messages.subjectRequired)
+            });
+        }
+
+        if (typeof lexical !== 'string' || !lexical.trim()) {
+            throw new BadRequestError({
+                message: tpl(messages.lexicalRequired)
             });
         }
     }

--- a/ghost/core/core/server/api/endpoints/utils/validators/input/automated_emails.js
+++ b/ghost/core/core/server/api/endpoints/utils/validators/input/automated_emails.js
@@ -2,7 +2,7 @@
 /* eslint-disable ghost/filenames/match-regex */
 
 const validator = require('@tryghost/validator');
-const {ValidationError, BadRequestError} = require('@tryghost/errors');
+const {ValidationError} = require('@tryghost/errors');
 const tpl = require('@tryghost/tpl');
 
 const ALLOWED_STATUSES = ['inactive', 'active'];
@@ -74,20 +74,28 @@ module.exports = {
         const lexical = frame.data.lexical;
 
         if (typeof email !== 'string' || !validator.isEmail(email)) {
-            throw new BadRequestError({
+            throw new ValidationError({
                 message: tpl(messages.invalidEmailReceived)
             });
         }
 
         if (typeof subject !== 'string' || !subject.trim()) {
-            throw new BadRequestError({
+            throw new ValidationError({
                 message: tpl(messages.subjectRequired)
             });
         }
 
         if (typeof lexical !== 'string' || !lexical.trim()) {
-            throw new BadRequestError({
+            throw new ValidationError({
                 message: tpl(messages.lexicalRequired)
+            });
+        }
+
+        try {
+            JSON.parse(lexical);
+        } catch (e) {
+            throw new ValidationError({
+                message: tpl(messages.invalidLexical)
             });
         }
     }

--- a/ghost/core/core/server/services/member-welcome-emails/constants.js
+++ b/ghost/core/core/server/services/member-welcome-emails/constants.js
@@ -9,6 +9,8 @@ const MESSAGES = {
     NO_MEMBER_WELCOME_EMAIL: 'No member welcome email found',
     INVALID_LEXICAL_STRUCTURE: 'Member welcome email has invalid content structure',
     MISSING_TEST_INBOX_CONFIG: 'memberWelcomeEmailTestInbox config is required but not defined',
+    MISSING_EMAIL_CONTENT: 'Email content is required to send a test email',
+    MISSING_EMAIL_SUBJECT: 'Email subject is required to send a test email',
     memberWelcomeEmailInactive: memberStatus => `Member welcome email for "${memberStatus}" members is inactive`
 };
 

--- a/ghost/core/core/server/services/member-welcome-emails/service.js
+++ b/ghost/core/core/server/services/member-welcome-emails/service.js
@@ -102,9 +102,10 @@ class MemberWelcomeEmailService {
         return Boolean(row && row.get('lexical') && row.get('status') === 'active');
     }
 
-    async sendTestEmail({email, automatedEmailId}) {
+    async sendTestEmail({email, subject, lexical, automatedEmailId}) {
         logging.info(`${MEMBER_WELCOME_EMAIL_LOG_KEY} Sending test welcome email to ${email}`);
 
+        // Still validate the automated email exists (for permission purposes)
         const automatedEmail = await AutomatedEmail.findOne({id: automatedEmailId});
 
         if (!automatedEmail) {
@@ -112,9 +113,6 @@ class MemberWelcomeEmailService {
                 message: MESSAGES.NO_MEMBER_WELCOME_EMAIL
             });
         }
-
-        const lexical = automatedEmail.get('lexical');
-        const subject = automatedEmail.get('subject');
 
         const siteSettings = {
             title: settingsCache.get('title') || 'Ghost',

--- a/ghost/core/core/server/web/api/endpoints/admin/routes.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/routes.js
@@ -185,6 +185,7 @@ module.exports = function apiRoutes() {
     router.post('/automated_emails', mw.authAdminApi, http(api.automatedEmails.add));
     router.put('/automated_emails/:id', mw.authAdminApi, http(api.automatedEmails.edit));
     router.del('/automated_emails/:id', mw.authAdminApi, http(api.automatedEmails.destroy));
+    router.post('/automated_emails/:id/test', shared.middleware.brute.previewEmailLimiter, mw.authAdminApi, http(api.automatedEmails.sendTestEmail));
 
     // ## Roles
     router.get('/roles/', mw.authAdminApi, http(api.roles.browse));

--- a/ghost/core/test/e2e-api/admin/__snapshots__/automated-emails.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/automated-emails.test.js.snap
@@ -700,3 +700,65 @@ Object {
   "x-powered-by": "Express",
 }
 `;
+
+exports[`Automated Emails API SendTestEmail Cannot send test email without lexical 1: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": null,
+      "context": null,
+      "details": null,
+      "ghostErrorCode": null,
+      "help": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "Email content is required",
+      "property": null,
+      "type": "BadRequestError",
+    },
+  ],
+}
+`;
+
+exports[`Automated Emails API SendTestEmail Cannot send test email without lexical 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "213",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Automated Emails API SendTestEmail Cannot send test email without subject 1: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": null,
+      "context": null,
+      "details": null,
+      "ghostErrorCode": null,
+      "help": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "Subject is required",
+      "property": null,
+      "type": "BadRequestError",
+    },
+  ],
+}
+`;
+
+exports[`Automated Emails API SendTestEmail Cannot send test email without subject 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "207",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;

--- a/ghost/core/test/e2e-api/admin/__snapshots__/automated-emails.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/automated-emails.test.js.snap
@@ -523,3 +523,180 @@ Object {
   "x-powered-by": "Express",
 }
 `;
+
+exports[`Automated Emails API SendTestEmail As Admin Can send test email 1: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Automated Emails API SendTestEmail As Owner Cannot send test email for non-existent automated email 1: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": null,
+      "context": null,
+      "details": null,
+      "ghostErrorCode": null,
+      "help": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "No member welcome email found",
+      "property": null,
+      "type": "NotFoundError",
+    },
+  ],
+}
+`;
+
+exports[`Automated Emails API SendTestEmail As Owner Cannot send test email for non-existent automated email 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "215",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Automated Emails API SendTestEmail As Owner Cannot send test email without email in body 1: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": null,
+      "context": null,
+      "details": null,
+      "ghostErrorCode": null,
+      "help": "Please see https://ghost.org/docs/config/#mail for instructions on configuring email.",
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "Incomplete message data.",
+      "property": null,
+      "type": "EmailError",
+    },
+  ],
+}
+`;
+
+exports[`Automated Emails API SendTestEmail As Owner Cannot send test email without email in body 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "290",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Automated Emails API SendTestEmail Can send test email 1: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Automated Emails API SendTestEmail Cannot send test email for non-existent automated email 1: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": null,
+      "context": null,
+      "details": null,
+      "ghostErrorCode": null,
+      "help": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "No member welcome email found",
+      "property": null,
+      "type": "NotFoundError",
+    },
+  ],
+}
+`;
+
+exports[`Automated Emails API SendTestEmail Cannot send test email for non-existent automated email 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "215",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Automated Emails API SendTestEmail Cannot send test email with invalid email format 1: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": null,
+      "context": null,
+      "details": null,
+      "ghostErrorCode": null,
+      "help": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "The server did not receive a valid email",
+      "property": null,
+      "type": "BadRequestError",
+    },
+  ],
+}
+`;
+
+exports[`Automated Emails API SendTestEmail Cannot send test email with invalid email format 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "228",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Automated Emails API SendTestEmail Cannot send test email without email in body 1: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": null,
+      "context": null,
+      "details": null,
+      "ghostErrorCode": null,
+      "help": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "The server did not receive a valid email",
+      "property": null,
+      "type": "BadRequestError",
+    },
+  ],
+}
+`;
+
+exports[`Automated Emails API SendTestEmail Cannot send test email without email in body 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "228",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;

--- a/ghost/core/test/e2e-api/admin/__snapshots__/automated-emails.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/automated-emails.test.js.snap
@@ -524,79 +524,6 @@ Object {
 }
 `;
 
-exports[`Automated Emails API SendTestEmail As Admin Can send test email 1: [headers] 1`] = `
-Object {
-  "access-control-allow-origin": "http://127.0.0.1:2369",
-  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
-  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
-  "vary": "Accept-Version, Origin",
-  "x-powered-by": "Express",
-}
-`;
-
-exports[`Automated Emails API SendTestEmail As Owner Cannot send test email for non-existent automated email 1: [body] 1`] = `
-Object {
-  "errors": Array [
-    Object {
-      "code": null,
-      "context": null,
-      "details": null,
-      "ghostErrorCode": null,
-      "help": null,
-      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
-      "message": "No member welcome email found",
-      "property": null,
-      "type": "NotFoundError",
-    },
-  ],
-}
-`;
-
-exports[`Automated Emails API SendTestEmail As Owner Cannot send test email for non-existent automated email 2: [headers] 1`] = `
-Object {
-  "access-control-allow-origin": "http://127.0.0.1:2369",
-  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "215",
-  "content-type": "application/json; charset=utf-8",
-  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
-  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
-  "vary": "Accept-Version, Origin, Accept-Encoding",
-  "x-powered-by": "Express",
-}
-`;
-
-exports[`Automated Emails API SendTestEmail As Owner Cannot send test email without email in body 1: [body] 1`] = `
-Object {
-  "errors": Array [
-    Object {
-      "code": null,
-      "context": null,
-      "details": null,
-      "ghostErrorCode": null,
-      "help": "Please see https://ghost.org/docs/config/#mail for instructions on configuring email.",
-      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
-      "message": "Incomplete message data.",
-      "property": null,
-      "type": "EmailError",
-    },
-  ],
-}
-`;
-
-exports[`Automated Emails API SendTestEmail As Owner Cannot send test email without email in body 2: [headers] 1`] = `
-Object {
-  "access-control-allow-origin": "http://127.0.0.1:2369",
-  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "290",
-  "content-type": "application/json; charset=utf-8",
-  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
-  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
-  "vary": "Accept-Version, Origin, Accept-Encoding",
-  "x-powered-by": "Express",
-}
-`;
-
 exports[`Automated Emails API SendTestEmail Can send test email 1: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
@@ -651,7 +578,7 @@ Object {
       "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
       "message": "The server did not receive a valid email",
       "property": null,
-      "type": "BadRequestError",
+      "type": "ValidationError",
     },
   ],
 }
@@ -682,7 +609,7 @@ Object {
       "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
       "message": "The server did not receive a valid email",
       "property": null,
-      "type": "BadRequestError",
+      "type": "ValidationError",
     },
   ],
 }
@@ -713,7 +640,7 @@ Object {
       "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
       "message": "Email content is required",
       "property": null,
-      "type": "BadRequestError",
+      "type": "ValidationError",
     },
   ],
 }
@@ -744,7 +671,7 @@ Object {
       "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
       "message": "Subject is required",
       "property": null,
-      "type": "BadRequestError",
+      "type": "ValidationError",
     },
   ],
 }

--- a/ghost/core/test/e2e-api/admin/automated-emails.test.js
+++ b/ghost/core/test/e2e-api/admin/automated-emails.test.js
@@ -400,7 +400,7 @@ describe('Automated Emails API', function () {
             await agent
                 .post(`automated_emails/${automatedEmailId}/test/`)
                 .body({})
-                .expectStatus(400)
+                .expectStatus(422)
                 .matchBodySnapshot({
                     errors: [{
                         id: anyErrorId
@@ -420,7 +420,7 @@ describe('Automated Emails API', function () {
                     subject: 'Test Subject',
                     lexical: validLexical
                 })
-                .expectStatus(400)
+                .expectStatus(422)
                 .matchBodySnapshot({
                     errors: [{
                         id: anyErrorId
@@ -439,7 +439,7 @@ describe('Automated Emails API', function () {
                     email: 'test@ghost.org',
                     lexical: validLexical
                 })
-                .expectStatus(400)
+                .expectStatus(422)
                 .matchBodySnapshot({
                     errors: [{
                         id: anyErrorId
@@ -458,7 +458,7 @@ describe('Automated Emails API', function () {
                     email: 'test@ghost.org',
                     subject: 'Test Subject'
                 })
-                .expectStatus(400)
+                .expectStatus(422)
                 .matchBodySnapshot({
                     errors: [{
                         id: anyErrorId


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-788

- Adds the ability to send a test of member welcome emails in a similar manner to email previews on posts
- Includes brute protection on the endpoint, same as for posts. It's (currently) also in the same bucket as posts (i.e. if you send 10 test welcome emails and then try to send a post email preview you'd get rate limited)
- Utilizes edit permissions for `sendTestEmail` - where edit and sendTestEmail can be pretty distinct on posts depending the permissions of the staff user, in the case of member welcome emails the concepts are pretty tightly coupled (and only admins have permission anyway)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces test-sending for member welcome emails across API and Admin.
> 
> - Adds `POST /automated_emails/:id/test` endpoint with `edit` permissions, input validation, and brute limiter (shared preview bucket)
> - Extends validators for `sendTestEmail` (valid email, required `subject` and `lexical`, valid JSON) and updates service to render/send test emails; refactors site settings lookup
> - Admin UI: replaces inline test UI with `TestEmailDropdown` component using `useSendTestWelcomeEmail`, validates email/subject/content, and shows send state/errors
> - Tightens modal validation (trimmed subject, empty-lexical check) and wires dropdown into `WelcomeEmailModal`
> - Adds comprehensive e2e tests and snapshots for success and failure cases of test-sending
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 75234952a165fc461e66aa8d0ae9d43c566d3d0f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->