### PR TITLE
🐛 Fixed Analytics > Growth MRR chart starting at zero at beginning of time range

### DIFF
--- a/apps/stats/src/hooks/use-growth-stats.ts
+++ b/apps/stats/src/hooks/use-growth-stats.ts
@@ -296,6 +296,14 @@ export const useGrowthStats = (range: number) => {
                         ...mostRecentBeforeRange,
                         date: dateFromMoment.format('YYYY-MM-DD')
                     });
+                } else if (result.length > 0) {
+                    // No data before range, use the earliest data point in the range
+                    // to fill in the start date (representing MRR at range start)
+                    const earliestInRange = [...result].sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())[0];
+                    result.unshift({
+                        ...earliestInRange,
+                        date: dateFromMoment.format('YYYY-MM-DD')
+                    });
                 }
             }
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/NY-328/investigate-mrr-chart-showing-zero-for-blueshirt-banter

## Problem

In some cases, the MRR chart in Analytics > Growth will incorrectly start at $0 for the very first data point.
<img width="1428" height="496" alt="Screenshot 2025-12-10 at 21 44 47@2x" src="https://github.com/user-attachments/assets/f53a6abc-6f51-4abe-872f-694ca1efa7c7" />


## Cause

The `/stats/mrr` endpoint returns a sparse dataset, only including dates in the response that had changes in MRR, so not every data point in the chart is returned by the API. The frontend logic for calculating the first data point was not accounting for this, and defaulting to $0. 

## Fix

The fix is to check for this condition where there are missing data points between the `dateFrom` parameter passed to the API (the first day of the selected date range) and the first data point returned by the API, and to fill in the earliest MRR value for this range. 