### PR TITLE
Added API URL transformation tests (with and without CDN config)

### DIFF
--- a/ghost/core/test/e2e-api/admin/newsletters.test.js
+++ b/ghost/core/test/e2e-api/admin/newsletters.test.js
@@ -1646,4 +1646,17 @@ describe('Newsletters API', function () {
             await before.save();
         });
     });
+
+    describe('URL transformations', function () {
+        it('Can read newsletter with header_image as absolute site URL', async function () {
+            const res = await agent
+                .get('newsletters/?filter=slug:new-newsletter')
+                .expectStatus(200);
+
+            const newsletter = res.body.newsletters[0];
+            const siteUrl = configUtils.config.getSiteUrl();
+
+            assert.equal(newsletter.header_image, `${siteUrl}content/images/newsletter-header.jpg`);
+        });
+    });
 });

--- a/ghost/core/test/e2e-api/admin/newsletters.test.js
+++ b/ghost/core/test/e2e-api/admin/newsletters.test.js
@@ -6,6 +6,7 @@ const {queryStringToken} = regexes;
 const models = require('../../../core/server/models');
 const logging = require('@tryghost/logging');
 const settingsHelpers = require('../../../core/server/services/settings-helpers');
+const urlUtilsHelper = require('../../utils/urlUtils');
 
 const assertMemberRelationCount = async (newsletterId, expectedCount) => {
     const relations = await dbUtils.knex('members_newsletters').where({newsletter_id: newsletterId}).pluck('id');
@@ -1648,14 +1649,28 @@ describe('Newsletters API', function () {
     });
 
     describe('URL transformations', function () {
+        const siteUrl = configUtils.config.getSiteUrl();
+
         it('Can read newsletter with header_image as absolute site URL', async function () {
             const res = await agent
                 .get('newsletters/?filter=slug:new-newsletter')
                 .expectStatus(200);
 
             const newsletter = res.body.newsletters[0];
-            const siteUrl = configUtils.config.getSiteUrl();
 
+            assert.equal(newsletter.header_image, `${siteUrl}content/images/newsletter-header.jpg`);
+        });
+
+        it('Can read newsletter with header_image as absolute site URL even when CDN is configured', async function () {
+            urlUtilsHelper.stubUrlUtilsWithCdn({
+                assetBaseUrls: {media: 'https://cdn.example.com', files: 'https://cdn.example.com'}
+            }, sinon);
+
+            const res = await agent
+                .get('newsletters/?filter=slug:new-newsletter')
+                .expectStatus(200);
+
+            const newsletter = res.body.newsletters[0];
             assert.equal(newsletter.header_image, `${siteUrl}content/images/newsletter-header.jpg`);
         });
     });

--- a/ghost/core/test/e2e-api/admin/posts.test.js
+++ b/ghost/core/test/e2e-api/admin/posts.test.js
@@ -1,6 +1,7 @@
 const should = require('should');
 const {agentProvider, fixtureManager, mockManager, matchers} = require('../../utils/e2e-framework');
 const {anyArray, anyContentVersion, anyEtag, anyErrorId, anyLocationFor, anyObject, anyObjectId, anyISODateTime, anyString, anyStringNumber, anyUuid, stringMatching} = matchers;
+const config = require('../../../core/shared/config');
 const models = require('../../../core/server/models');
 const escapeRegExp = require('lodash/escapeRegExp');
 const {mobiledocToLexical} = require('@tryghost/kg-converters');
@@ -731,6 +732,51 @@ describe('Posts API', function () {
                         lexical: updatedLexical
                     })]
                 });
+        });
+    });
+
+    describe('URL transformations', function () {
+        const siteUrl = config.get('url');
+
+        it('Can read Mobiledoc post with all URLs as absolute site URLs', async function () {
+            const res = await agent
+                .get('posts/slug/post-with-all-media-types-mobiledoc/?formats=mobiledoc')
+                .expectStatus(200);
+
+            const post = res.body.posts[0];
+            const mobiledoc = JSON.parse(post.mobiledoc);
+
+            post.feature_image.should.equal(`${siteUrl}/content/images/feature.jpg`);
+            mobiledoc.cards.find(c => c[0] === 'image')[1].src.should.equal(`${siteUrl}/content/images/inline.jpg`);
+            mobiledoc.cards.find(c => c[0] === 'file')[1].src.should.equal(`${siteUrl}/content/files/document.pdf`);
+            mobiledoc.cards.find(c => c[0] === 'video')[1].src.should.equal(`${siteUrl}/content/media/video.mp4`);
+            mobiledoc.cards.find(c => c[0] === 'audio')[1].src.should.equal(`${siteUrl}/content/media/audio.mp3`);
+            post.mobiledoc.should.containEql(`${siteUrl}/content/images/snippet-inline.jpg`);
+            post.mobiledoc.should.containEql(`${siteUrl}/content/files/snippet-document.pdf`);
+            post.mobiledoc.should.containEql(`${siteUrl}/content/media/snippet-video.mp4`);
+            post.mobiledoc.should.containEql(`${siteUrl}/content/media/snippet-audio.mp3`);
+
+            post.mobiledoc.should.not.containEql('__GHOST_URL__');
+        });
+
+        it('Can read Lexical post with all URLs as absolute site URLs', async function () {
+            const res = await agent
+                .get('posts/slug/post-with-all-media-types-lexical/?formats=lexical')
+                .expectStatus(200);
+
+            const post = res.body.posts[0];
+
+            post.feature_image.should.equal(`${siteUrl}/content/images/feature.jpg`);
+            post.lexical.should.containEql(`${siteUrl}/content/images/inline.jpg`);
+            post.lexical.should.containEql(`${siteUrl}/content/files/document.pdf`);
+            post.lexical.should.containEql(`${siteUrl}/content/media/video.mp4`);
+            post.lexical.should.containEql(`${siteUrl}/content/media/audio.mp3`);
+            post.lexical.should.containEql(`${siteUrl}/content/images/snippet-inline.jpg`);
+            post.lexical.should.containEql(`${siteUrl}/content/files/snippet-document.pdf`);
+            post.lexical.should.containEql(`${siteUrl}/content/media/snippet-video.mp4`);
+            post.lexical.should.containEql(`${siteUrl}/content/media/snippet-audio.mp3`);
+
+            post.lexical.should.not.containEql('__GHOST_URL__');
         });
     });
 });

--- a/ghost/core/test/e2e-api/admin/posts.test.js
+++ b/ghost/core/test/e2e-api/admin/posts.test.js
@@ -1,8 +1,10 @@
 const should = require('should');
+const sinon = require('sinon');
 const {agentProvider, fixtureManager, mockManager, matchers} = require('../../utils/e2e-framework');
 const {anyArray, anyContentVersion, anyEtag, anyErrorId, anyLocationFor, anyObject, anyObjectId, anyISODateTime, anyString, anyStringNumber, anyUuid, stringMatching} = matchers;
 const config = require('../../../core/shared/config');
 const models = require('../../../core/server/models');
+const urlUtilsHelper = require('../../utils/urlUtils');
 const escapeRegExp = require('lodash/escapeRegExp');
 const {mobiledocToLexical} = require('@tryghost/kg-converters');
 
@@ -737,6 +739,11 @@ describe('Posts API', function () {
 
     describe('URL transformations', function () {
         const siteUrl = config.get('url');
+        const cdnUrl = 'https://cdn.example.com';
+
+        afterEach(function () {
+            sinon.restore();
+        });
 
         it('Can read Mobiledoc post with all URLs as absolute site URLs', async function () {
             const res = await agent
@@ -755,7 +762,6 @@ describe('Posts API', function () {
             post.mobiledoc.should.containEql(`${siteUrl}/content/files/snippet-document.pdf`);
             post.mobiledoc.should.containEql(`${siteUrl}/content/media/snippet-video.mp4`);
             post.mobiledoc.should.containEql(`${siteUrl}/content/media/snippet-audio.mp3`);
-
             post.mobiledoc.should.not.containEql('__GHOST_URL__');
         });
 
@@ -775,7 +781,61 @@ describe('Posts API', function () {
             post.lexical.should.containEql(`${siteUrl}/content/files/snippet-document.pdf`);
             post.lexical.should.containEql(`${siteUrl}/content/media/snippet-video.mp4`);
             post.lexical.should.containEql(`${siteUrl}/content/media/snippet-audio.mp3`);
+            post.lexical.should.not.containEql('__GHOST_URL__');
+        });
 
+        it('Can read Mobiledoc post with CDN URLs for media/files when configured', async function () {
+            urlUtilsHelper.stubUrlUtilsWithCdn({
+                assetBaseUrls: {media: cdnUrl, files: cdnUrl}
+            }, sinon);
+
+            const res = await agent
+                .get('posts/slug/post-with-all-media-types-mobiledoc/?formats=mobiledoc')
+                .expectStatus(200);
+
+            const post = res.body.posts[0];
+            const mobiledoc = JSON.parse(post.mobiledoc);
+
+            // Images stay on site URL
+            post.feature_image.should.equal(`${siteUrl}/content/images/feature.jpg`);
+            mobiledoc.cards.find(c => c[0] === 'image')[1].src.should.equal(`${siteUrl}/content/images/inline.jpg`);
+            // Media/files use CDN URL
+            mobiledoc.cards.find(c => c[0] === 'file')[1].src.should.equal(`${cdnUrl}/content/files/document.pdf`);
+            mobiledoc.cards.find(c => c[0] === 'video')[1].src.should.equal(`${cdnUrl}/content/media/video.mp4`);
+            mobiledoc.cards.find(c => c[0] === 'audio')[1].src.should.equal(`${cdnUrl}/content/media/audio.mp3`);
+            // Inserted snippet images stay on site URL
+            post.mobiledoc.should.containEql(`${siteUrl}/content/images/snippet-inline.jpg`);
+            // Inserted snippet media/files use CDN URL
+            post.mobiledoc.should.containEql(`${cdnUrl}/content/files/snippet-document.pdf`);
+            post.mobiledoc.should.containEql(`${cdnUrl}/content/media/snippet-video.mp4`);
+            post.mobiledoc.should.containEql(`${cdnUrl}/content/media/snippet-audio.mp3`);
+            post.mobiledoc.should.not.containEql('__GHOST_URL__');
+        });
+
+        it('Can read Lexical post with CDN URLs for media/files when configured', async function () {
+            urlUtilsHelper.stubUrlUtilsWithCdn({
+                assetBaseUrls: {media: cdnUrl, files: cdnUrl}
+            }, sinon);
+
+            const res = await agent
+                .get('posts/slug/post-with-all-media-types-lexical/?formats=lexical')
+                .expectStatus(200);
+
+            const post = res.body.posts[0];
+
+            // Images stay on site URL
+            post.feature_image.should.equal(`${siteUrl}/content/images/feature.jpg`);
+            post.lexical.should.containEql(`${siteUrl}/content/images/inline.jpg`);
+            // Media/files use CDN URL
+            post.lexical.should.containEql(`${cdnUrl}/content/files/document.pdf`);
+            post.lexical.should.containEql(`${cdnUrl}/content/media/video.mp4`);
+            post.lexical.should.containEql(`${cdnUrl}/content/media/audio.mp3`);
+            // Inserted snippet images stay on site URL
+            post.lexical.should.containEql(`${siteUrl}/content/images/snippet-inline.jpg`);
+            // Inserted snippet media/files use CDN URL
+            post.lexical.should.containEql(`${cdnUrl}/content/files/snippet-document.pdf`);
+            post.lexical.should.containEql(`${cdnUrl}/content/media/snippet-video.mp4`);
+            post.lexical.should.containEql(`${cdnUrl}/content/media/snippet-audio.mp3`);
             post.lexical.should.not.containEql('__GHOST_URL__');
         });
     });

--- a/ghost/core/test/e2e-api/admin/snippets.test.js
+++ b/ghost/core/test/e2e-api/admin/snippets.test.js
@@ -1,5 +1,7 @@
+require('should');
 const {agentProvider, fixtureManager, matchers} = require('../../utils/e2e-framework');
 const {anyContentVersion, anyEtag, anyLocationFor, anyObjectId, anyISODateTime, anyErrorId} = matchers;
+const config = require('../../../core/shared/config');
 
 const matchSnippet = {
     id: anyObjectId,
@@ -246,5 +248,38 @@ describe('Snippets API', function () {
                 'content-version': anyContentVersion,
                 etag: anyEtag
             });
+    });
+
+    describe('URL transformations', function () {
+        const siteUrl = config.get('url');
+
+        it('Can read Mobiledoc snippet with all URLs as absolute site URLs', async function () {
+            const res = await agent
+                .get('snippets/?formats=mobiledoc&filter=name:\'Snippet with all media types - Mobiledoc\'')
+                .expectStatus(200);
+
+            const snippet = res.body.snippets[0];
+            const mobiledoc = JSON.parse(snippet.mobiledoc);
+
+            mobiledoc.cards.find(c => c[0] === 'image')[1].src.should.equal(`${siteUrl}/content/images/snippet-inline.jpg`);
+            mobiledoc.cards.find(c => c[0] === 'file')[1].src.should.equal(`${siteUrl}/content/files/snippet-document.pdf`);
+            mobiledoc.cards.find(c => c[0] === 'video')[1].src.should.equal(`${siteUrl}/content/media/snippet-video.mp4`);
+            mobiledoc.cards.find(c => c[0] === 'audio')[1].src.should.equal(`${siteUrl}/content/media/snippet-audio.mp3`);
+            snippet.mobiledoc.should.not.containEql('__GHOST_URL__');
+        });
+
+        it('Can read Lexical snippet with all URLs as absolute site URLs', async function () {
+            const res = await agent
+                .get('snippets/?formats=lexical&filter=name:\'Snippet with all media types - Lexical\'')
+                .expectStatus(200);
+
+            const snippet = res.body.snippets[0];
+
+            snippet.lexical.should.containEql(`${siteUrl}/content/images/snippet-inline.jpg`);
+            snippet.lexical.should.containEql(`${siteUrl}/content/files/snippet-document.pdf`);
+            snippet.lexical.should.containEql(`${siteUrl}/content/media/snippet-video.mp4`);
+            snippet.lexical.should.containEql(`${siteUrl}/content/media/snippet-audio.mp3`);
+            snippet.lexical.should.not.containEql('__GHOST_URL__');
+        });
     });
 });

--- a/ghost/core/test/e2e-api/admin/snippets.test.js
+++ b/ghost/core/test/e2e-api/admin/snippets.test.js
@@ -1,7 +1,9 @@
 require('should');
+const sinon = require('sinon');
 const {agentProvider, fixtureManager, matchers} = require('../../utils/e2e-framework');
 const {anyContentVersion, anyEtag, anyLocationFor, anyObjectId, anyISODateTime, anyErrorId} = matchers;
 const config = require('../../../core/shared/config');
+const urlUtilsHelper = require('../../utils/urlUtils');
 
 const matchSnippet = {
     id: anyObjectId,
@@ -252,6 +254,11 @@ describe('Snippets API', function () {
 
     describe('URL transformations', function () {
         const siteUrl = config.get('url');
+        const cdnUrl = 'https://cdn.example.com';
+
+        afterEach(function () {
+            sinon.restore();
+        });
 
         it('Can read Mobiledoc snippet with all URLs as absolute site URLs', async function () {
             const res = await agent
@@ -279,6 +286,47 @@ describe('Snippets API', function () {
             snippet.lexical.should.containEql(`${siteUrl}/content/files/snippet-document.pdf`);
             snippet.lexical.should.containEql(`${siteUrl}/content/media/snippet-video.mp4`);
             snippet.lexical.should.containEql(`${siteUrl}/content/media/snippet-audio.mp3`);
+            snippet.lexical.should.not.containEql('__GHOST_URL__');
+        });
+
+        it('Can read Mobiledoc snippet with CDN URLs for media/files when configured', async function () {
+            urlUtilsHelper.stubUrlUtilsWithCdn({
+                assetBaseUrls: {media: cdnUrl, files: cdnUrl}
+            }, sinon);
+
+            const res = await agent
+                .get('snippets/?formats=mobiledoc&filter=name:\'Snippet with all media types - Mobiledoc\'')
+                .expectStatus(200);
+
+            const snippet = res.body.snippets[0];
+            const mobiledoc = JSON.parse(snippet.mobiledoc);
+
+            // Images stay on site URL
+            mobiledoc.cards.find(c => c[0] === 'image')[1].src.should.equal(`${siteUrl}/content/images/snippet-inline.jpg`);
+            // Media/files use CDN URL
+            mobiledoc.cards.find(c => c[0] === 'file')[1].src.should.equal(`${cdnUrl}/content/files/snippet-document.pdf`);
+            mobiledoc.cards.find(c => c[0] === 'video')[1].src.should.equal(`${cdnUrl}/content/media/snippet-video.mp4`);
+            mobiledoc.cards.find(c => c[0] === 'audio')[1].src.should.equal(`${cdnUrl}/content/media/snippet-audio.mp3`);
+            snippet.mobiledoc.should.not.containEql('__GHOST_URL__');
+        });
+
+        it('Can read Lexical snippet with CDN URLs for media/files when configured', async function () {
+            urlUtilsHelper.stubUrlUtilsWithCdn({
+                assetBaseUrls: {media: cdnUrl, files: cdnUrl}
+            }, sinon);
+
+            const res = await agent
+                .get('snippets/?formats=lexical&filter=name:\'Snippet with all media types - Lexical\'')
+                .expectStatus(200);
+
+            const snippet = res.body.snippets[0];
+
+            // Images stay on site URL
+            snippet.lexical.should.containEql(`${siteUrl}/content/images/snippet-inline.jpg`);
+            // Media/files use CDN URL
+            snippet.lexical.should.containEql(`${cdnUrl}/content/files/snippet-document.pdf`);
+            snippet.lexical.should.containEql(`${cdnUrl}/content/media/snippet-video.mp4`);
+            snippet.lexical.should.containEql(`${cdnUrl}/content/media/snippet-audio.mp3`);
             snippet.lexical.should.not.containEql('__GHOST_URL__');
         });
     });

--- a/ghost/core/test/e2e-api/admin/tags.test.js
+++ b/ghost/core/test/e2e-api/admin/tags.test.js
@@ -174,4 +174,22 @@ describe('Tag API', function () {
 
         res.body.errors[0].message.should.eql('Resource not found error, cannot delete tag.');
     });
+
+    describe('URL transformations', function () {
+        it('Can read tag with all image URLs as absolute site URLs', async function () {
+            const res = await request
+                .get(localUtils.API.getApiQuery('tags/slug/tag-with-images/'))
+                .set('Origin', config.get('url'))
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(200);
+
+            const tag = res.body.tags[0];
+            const siteUrl = config.get('url');
+
+            tag.feature_image.should.equal(`${siteUrl}/content/images/tag-feature.jpg`);
+            tag.og_image.should.equal(`${siteUrl}/content/images/tag-og.jpg`);
+            tag.twitter_image.should.equal(`${siteUrl}/content/images/tag-twitter.jpg`);
+        });
+    });
 });

--- a/ghost/core/test/e2e-api/admin/tags.test.js
+++ b/ghost/core/test/e2e-api/admin/tags.test.js
@@ -1,8 +1,10 @@
 const should = require('should');
+const sinon = require('sinon');
 const supertest = require('supertest');
 const testUtils = require('../../utils');
 const config = require('../../../core/shared/config');
 const localUtils = require('./utils');
+const urlUtilsHelper = require('../../utils/urlUtils');
 
 describe('Tag API', function () {
     let request;
@@ -176,6 +178,12 @@ describe('Tag API', function () {
     });
 
     describe('URL transformations', function () {
+        const siteUrl = config.get('url');
+
+        afterEach(function () {
+            sinon.restore();
+        });
+
         it('Can read tag with all image URLs as absolute site URLs', async function () {
             const res = await request
                 .get(localUtils.API.getApiQuery('tags/slug/tag-with-images/'))
@@ -185,7 +193,25 @@ describe('Tag API', function () {
                 .expect(200);
 
             const tag = res.body.tags[0];
-            const siteUrl = config.get('url');
+
+            tag.feature_image.should.equal(`${siteUrl}/content/images/tag-feature.jpg`);
+            tag.og_image.should.equal(`${siteUrl}/content/images/tag-og.jpg`);
+            tag.twitter_image.should.equal(`${siteUrl}/content/images/tag-twitter.jpg`);
+        });
+
+        it('Transforms image URLs to absolute site URLs even when CDN is configured', async function () {
+            urlUtilsHelper.stubUrlUtilsWithCdn({
+                assetBaseUrls: {media: 'https://cdn.example.com', files: 'https://cdn.example.com'}
+            }, sinon);
+
+            const res = await request
+                .get(localUtils.API.getApiQuery('tags/slug/tag-with-images/'))
+                .set('Origin', config.get('url'))
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(200);
+
+            const tag = res.body.tags[0];
 
             tag.feature_image.should.equal(`${siteUrl}/content/images/tag-feature.jpg`);
             tag.og_image.should.equal(`${siteUrl}/content/images/tag-og.jpg`);

--- a/ghost/core/test/e2e-api/content/posts.test.js
+++ b/ghost/core/test/e2e-api/content/posts.test.js
@@ -1,5 +1,6 @@
 const assert = require('assert/strict');
 const cheerio = require('cheerio');
+const config = require('../../../core/shared/config');
 const moment = require('moment');
 const testUtils = require('../../utils');
 const models = require('../../../core/server/models');
@@ -479,5 +480,49 @@ describe('Posts Content API', function () {
         // published_at desc, id desc. First page should have post 2, second page should have post 1.
         assert.equal(page1Response.body.posts[0].id, post2.id, 'First page should have post 2');
         assert.equal(page2Response.body.posts[0].id, post1.id, 'Second post should have post 1');
+    });
+
+    describe('URL transformations', function () {
+        const siteUrl = config.get('url');
+
+        it('Can read Mobiledoc post with all URLs as absolute site URLs', async function () {
+            const res = await agent
+                .get('posts/?filter=slug:post-with-all-media-types-mobiledoc')
+                .expectStatus(200);
+
+            const post = res.body.posts[0];
+
+            assert.equal(post.feature_image, `${siteUrl}/content/images/feature.jpg`);
+            assert(post.html.includes(`${siteUrl}/content/images/inline.jpg`));
+            assert(post.html.includes(`${siteUrl}/content/files/document.pdf`));
+            assert(post.html.includes(`${siteUrl}/content/media/video.mp4`));
+            assert(post.html.includes(`${siteUrl}/content/media/audio.mp3`));
+            assert(post.html.includes(`${siteUrl}/content/images/snippet-inline.jpg`));
+            assert(post.html.includes(`${siteUrl}/content/files/snippet-document.pdf`));
+            assert(post.html.includes(`${siteUrl}/content/media/snippet-video.mp4`));
+            assert(post.html.includes(`${siteUrl}/content/media/snippet-audio.mp3`));
+
+            assert(!post.html.includes('__GHOST_URL__'));
+        });
+
+        it('Can read Lexical post with all URLs as absolute site URLs', async function () {
+            const res = await agent
+                .get('posts/?filter=slug:post-with-all-media-types-lexical')
+                .expectStatus(200);
+
+            const post = res.body.posts[0];
+
+            assert.equal(post.feature_image, `${siteUrl}/content/images/feature.jpg`);
+            assert(post.html.includes(`${siteUrl}/content/images/inline.jpg`));
+            assert(post.html.includes(`${siteUrl}/content/files/document.pdf`));
+            assert(post.html.includes(`${siteUrl}/content/media/video.mp4`));
+            assert(post.html.includes(`${siteUrl}/content/media/audio.mp3`));
+            assert(post.html.includes(`${siteUrl}/content/images/snippet-inline.jpg`));
+            assert(post.html.includes(`${siteUrl}/content/files/snippet-document.pdf`));
+            assert(post.html.includes(`${siteUrl}/content/media/snippet-video.mp4`));
+            assert(post.html.includes(`${siteUrl}/content/media/snippet-audio.mp3`));
+
+            assert(!post.html.includes('__GHOST_URL__'));
+        });
     });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PRO-1515
ref https://linear.app/ghost/issue/PRO-1519

- Added tests for both with and without CDN config
- Covers posts (Mobiledoc/Lexical), snippets, tags and newsletters
- Verifies media/files use CDN when configured, images stay on site URL