### PR TITLE
Updated test welcome emails to send in-progress content

### DIFF
--- a/apps/admin-x-framework/src/api/automated-emails.ts
+++ b/apps/admin-x-framework/src/api/automated-emails.ts
@@ -49,8 +49,8 @@ export const useEditAutomatedEmail = createMutation<AutomatedEmailsResponseType,
     }
 });
 
-export const useSendTestWelcomeEmail = createMutation<unknown, {id: string; email: string}>({
+export const useSendTestWelcomeEmail = createMutation<unknown, {id: string; email: string; subject: string; lexical: string}>({
     method: 'POST',
     path: ({id}) => `/automated_emails/${id}/test/`,
-    body: ({email}) => ({email})
+    body: ({email, subject, lexical}) => ({email, subject, lexical})
 });

--- a/ghost/core/core/server/api/endpoints/automated-emails.js
+++ b/ghost/core/core/server/api/endpoints/automated-emails.js
@@ -122,7 +122,9 @@ const controller = {
             'id'
         ],
         data: [
-            'email'
+            'email',
+            'subject',
+            'lexical'
         ],
         validation: {
             options: {
@@ -138,6 +140,8 @@ const controller = {
             memberWelcomeEmailService.init();
             await memberWelcomeEmailService.api.sendTestEmail({
                 email: frame.data.email,
+                subject: frame.data.subject,
+                lexical: frame.data.lexical,
                 automatedEmailId: frame.options.id
             });
         }

--- a/ghost/core/core/server/api/endpoints/utils/validators/input/automated_emails.js
+++ b/ghost/core/core/server/api/endpoints/utils/validators/input/automated_emails.js
@@ -14,7 +14,9 @@ const messages = {
     invalidLexical: 'Lexical must be a valid JSON string',
     invalidSlug: `Slug must be one of: ${ALLOWED_SLUGS.join(', ')}`,
     invalidName: `Name must be one of: ${ALLOWED_NAMES.join(', ')}`,
-    invalidEmailReceived: 'The server did not receive a valid email'
+    invalidEmailReceived: 'The server did not receive a valid email',
+    subjectRequired: 'Subject is required',
+    lexicalRequired: 'Email content is required'
 };
 
 const validateAutomatedEmail = async function (frame) {
@@ -68,10 +70,24 @@ module.exports = {
     },
     sendTestEmail(apiConfig, frame) {
         const email = frame.data.email;
+        const subject = frame.data.subject;
+        const lexical = frame.data.lexical;
 
         if (typeof email !== 'string' || !validator.isEmail(email)) {
             throw new BadRequestError({
                 message: tpl(messages.invalidEmailReceived)
+            });
+        }
+
+        if (typeof subject !== 'string' || !subject.trim()) {
+            throw new BadRequestError({
+                message: tpl(messages.subjectRequired)
+            });
+        }
+
+        if (typeof lexical !== 'string' || !lexical.trim()) {
+            throw new BadRequestError({
+                message: tpl(messages.lexicalRequired)
             });
         }
     }

--- a/ghost/core/core/server/services/member-welcome-emails/service.js
+++ b/ghost/core/core/server/services/member-welcome-emails/service.js
@@ -102,9 +102,10 @@ class MemberWelcomeEmailService {
         return Boolean(row && row.get('lexical') && row.get('status') === 'active');
     }
 
-    async sendTestEmail({email, automatedEmailId}) {
+    async sendTestEmail({email, subject, lexical, automatedEmailId}) {
         logging.info(`${MEMBER_WELCOME_EMAIL_LOG_KEY} Sending test welcome email to ${email}`);
 
+        // Still validate the automated email exists (for permission purposes)
         const automatedEmail = await AutomatedEmail.findOne({id: automatedEmailId});
 
         if (!automatedEmail) {
@@ -112,9 +113,6 @@ class MemberWelcomeEmailService {
                 message: MESSAGES.NO_MEMBER_WELCOME_EMAIL
             });
         }
-
-        const lexical = automatedEmail.get('lexical');
-        const subject = automatedEmail.get('subject');
 
         const siteSettings = {
             title: settingsCache.get('title') || 'Ghost',

--- a/ghost/core/test/e2e-api/admin/__snapshots__/automated-emails.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/automated-emails.test.js.snap
@@ -700,3 +700,65 @@ Object {
   "x-powered-by": "Express",
 }
 `;
+
+exports[`Automated Emails API SendTestEmail Cannot send test email without lexical 1: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": null,
+      "context": null,
+      "details": null,
+      "ghostErrorCode": null,
+      "help": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "Email content is required",
+      "property": null,
+      "type": "BadRequestError",
+    },
+  ],
+}
+`;
+
+exports[`Automated Emails API SendTestEmail Cannot send test email without lexical 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "213",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Automated Emails API SendTestEmail Cannot send test email without subject 1: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": null,
+      "context": null,
+      "details": null,
+      "ghostErrorCode": null,
+      "help": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "Subject is required",
+      "property": null,
+      "type": "BadRequestError",
+    },
+  ],
+}
+`;
+
+exports[`Automated Emails API SendTestEmail Cannot send test email without subject 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "207",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;


### PR DESCRIPTION
no ref

Original PR first saves the automated email before sending the test email, but that creates a scenario where you'll _also_ have the changes live, which you might not want.

This PR, pointed at that one for comparison, switches the logic around so whatever is currently in the form for subject and lexical is what gets sent. This also happens to make validation and error/loading/success states a lot less jumpy.
