### PR TITLE
Fixed <GhFullscreenModal> display in Admin-forward

### DIFF
--- a/apps/admin/index.html
+++ b/apps/admin/index.html
@@ -29,6 +29,7 @@
     </div>
     <div id="ember-basic-dropdown-wormhole"></div>
     <div id="ember-modal-wormhole"></div>
+    <div id="ember-liquid-wormhole"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/ghost/admin/app/services/liquid-wormhole.js
+++ b/ghost/admin/app/services/liquid-wormhole.js
@@ -1,0 +1,31 @@
+import LiquidWormholeService from 'liquid-wormhole/services/liquid-wormhole';
+import {action} from '@ember/object';
+import {getOwner} from '@ember/application';
+import {inject as service} from '@ember/service';
+
+export default class CustomLiquidWormholeService extends LiquidWormholeService {
+    @service feature;
+
+    // override of the default destination to account for the new admin forward layout
+    // original method: https://github.com/pzuraq/liquid-wormhole/blob/master/addon/services/liquid-wormhole.js#L59-L74
+    @action
+    addDefaultDestination() {
+        const instance = getOwner(this);
+        const destination = instance.lookup('component:-liquid-destination');
+        destination.set('extraClassesString', 'default-liquid-destination');
+
+        const adminForwardDestination = document.getElementById('ember-liquid-wormhole');
+
+        if (this.feature.inAdminForward && adminForwardDestination) {
+            destination.appendTo(adminForwardDestination);
+        } else if (instance.rootElement) {
+            destination.appendTo(instance.rootElement);
+        } else {
+            destination.appendTo(document);
+        }
+
+        this.defaultDestination = destination;
+
+        return destination;
+    }
+}


### PR DESCRIPTION
closes https://linear.app/ghost/issue/BER-3114/

Some modals in Ember (post history and member-related modals like import) that use an older style of modal implementation were rendering inside of the main content area rather than fullscreen.

- added wormhole element for the liquid-wormhole based modals to the top-level React template
- added override of `liquid-wormhole` service with a replaced `addDefaultDestination()` method that appends to our new wormhole element when in admin-forward
  - the original problem arose because the default `liquid-wormhole` behaviour is to render to the configured `rootElement` rather than the document, we had to set `rootElement` to a nested element for Ember to render alongside the React sidebar which then doesn't work for modals that expect to cover the entire screen
