### PR TITLE
Added date filters to mv_session_data to improve Tinybird query performance

### DIFF
--- a/ghost/core/core/server/data/tinybird/pipes/mv_session_data.pipe
+++ b/ghost/core/core/server/data/tinybird/pipes/mv_session_data.pipe
@@ -17,7 +17,18 @@ SQL >
         argMin(utm_term, timestamp) as utm_term,
         argMin(utm_content, timestamp) as utm_content
     FROM _mv_hits
-    WHERE site_uuid = {{ String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True) }}
+    WHERE
+        site_uuid = {{ String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True) }}
+        {% if defined(date_from) %}
+            AND toDate(toTimezone(timestamp, {{ String(timezone, 'Etc/UTC', description="Site timezone", required=False) }})) >= {{ Date(date_from, description="Start date for filtering", required=False) }}
+        {% else %}
+            AND toDate(toTimezone(timestamp, {{ String(timezone, 'Etc/UTC', description="Site timezone", required=False) }})) >= timestampAdd(today(), interval -7 day)
+        {% end %}
+        {% if defined(date_to) %}
+            AND toDate(toTimezone(timestamp, {{ String(timezone, 'Etc/UTC', description="Site timezone", required=False) }})) <= {{ Date(date_to, description="End date for filtering", required=False) }}
+        {% else %}
+            AND toDate(toTimezone(timestamp, {{ String(timezone, 'Etc/UTC', description="Site timezone", required=False) }})) <= today()
+        {% end %}
     GROUP BY site_uuid, session_id
 
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/NY-865/analytics-sources-not-populating-for-tangle-due-to-408-timeouts

All of our Tinybird endpoints have date filters on them, and they are all backed by the mv_session_data pipe. The mv_session_data pipe doesn't have date filters itself though, so whenever we call an endpoint, the `mv_session_data` pipe is querying over all dates, thus increasing the response time for all endpoints. 

This adds date filters to the mv_session_data pipe to improve the performance of all our endpoints.

