### PR TITLE
Updated date filtering in Tinybird pipes to improve performance

### DIFF
--- a/ghost/core/core/server/data/tinybird/pipes/filtered_sessions.pipe
+++ b/ghost/core/core/server/data/tinybird/pipes/filtered_sessions.pipe
@@ -12,8 +12,8 @@ SQL >
     from _mv_hits
     where
          site_uuid = {{ String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True) }}
-        {% if defined(date_from) %} and toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})) >= {{ Date(date_from) }} {% else %} and toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})) >= timestampAdd(today(), interval -7 day) {% end %}
-        {% if defined(date_to) %} and toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})) <= {{ Date(date_to) }} {% else %} and toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})) <= today() {% end %}
+        {% if defined(date_from) %} and timestamp >= toDateTime({{ Date(date_from) }}, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}) {% else %} and timestamp >= toDateTime(timestampAdd(today(), interval -7 day), {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}) {% end %}
+        {% if defined(date_to) %} and timestamp < toDateTime({{ Date(date_to) }}, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}) + interval 1 day {% else %} and timestamp < toDateTime(dateAdd(day, 1, today()), {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}) {% end %}
         {% if defined(member_status) %}
             and member_status IN (
                 select arrayJoin(
@@ -41,17 +41,17 @@ SQL >
         site_uuid = {{ String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True) }}
         {% if defined(date_from) %}
             {# Filter from specified start date #}
-            and toDate(toTimezone(first_pageview,{{ String(timezone, 'Etc/UTC', description="Site timezone", required=True) }})) >= {{ Date(date_from) }}
+            and first_pageview >= toDateTime({{ Date(date_from) }}, {{ String(timezone, 'Etc/UTC', description="Site timezone", required=True) }})
         {% else %}
             {# Default to last 7 days if no start date provided #}
-            and toDate(toTimezone(first_pageview,{{ String(timezone, 'Etc/UTC', description="Site timezone", required=True) }})) >= timestampAdd(today(), interval -7 day)
+            and first_pageview >= toDateTime(timestampAdd(today(), interval -7 day), {{ String(timezone, 'Etc/UTC', description="Site timezone", required=True) }})
         {% end %}
         {% if defined(date_to) %}
             {# Filter to specified end date #}
-            and toDate(toTimezone(first_pageview, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})) <= {{ Date(date_to) }}
+            and first_pageview < toDateTime({{ Date(date_to) }}, {{ String(timezone, 'Etc/UTC', description="Site timezone", required=True) }}) + interval 1 day
         {% else %}
             {# Default to today if no end date provided #}
-            and toDate(toTimezone(first_pageview, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})) <= today()
+            and first_pageview < toDateTime(dateAdd(day, 1, today()), {{ String(timezone, 'Etc/UTC', description="Site timezone", required=True) }})
         {% end %}
         {% if defined(source) %} and source = {{ String(source, description="Source to filter on", required=False) }} {% end %}
         {% if defined(device) %} and device = {{ String(device, description="Device type to filter on", required=False) }} {% end %}

--- a/ghost/core/core/server/data/tinybird/pipes/filtered_sessions.pipe
+++ b/ghost/core/core/server/data/tinybird/pipes/filtered_sessions.pipe
@@ -15,7 +15,7 @@ SQL >
         {% if defined(date_from) %} 
             and timestamp >= toDateTime({{ Date(date_from) }}, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}) 
         {% else %} 
-            and timestamp >= toDateTime(timestampAdd(today(), interval -7 day), {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}) 
+            and timestamp >= toDateTime(dateAdd(day, -7, today()), {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}) 
         {% end %}
         {% if defined(date_to) %} 
             and timestamp < toDateTime({{ Date(date_to) }}, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}) + interval 1 day 
@@ -52,7 +52,7 @@ SQL >
             and first_pageview >= toDateTime({{ Date(date_from) }}, {{ String(timezone, 'Etc/UTC', description="Site timezone", required=True) }})
         {% else %}
             {# Default to last 7 days if no start date provided #}
-            and first_pageview >= toDateTime(timestampAdd(today(), interval -7 day), {{ String(timezone, 'Etc/UTC', description="Site timezone", required=True) }})
+            and first_pageview >= toDateTime(dateAdd(day, -7, today()), {{ String(timezone, 'Etc/UTC', description="Site timezone", required=True) }})
         {% end %}
         {% if defined(date_to) %}
             {# Filter to specified end date #}

--- a/ghost/core/core/server/data/tinybird/pipes/filtered_sessions.pipe
+++ b/ghost/core/core/server/data/tinybird/pipes/filtered_sessions.pipe
@@ -12,8 +12,16 @@ SQL >
     from _mv_hits
     where
          site_uuid = {{ String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True) }}
-        {% if defined(date_from) %} and timestamp >= toDateTime({{ Date(date_from) }}, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}) {% else %} and timestamp >= toDateTime(timestampAdd(today(), interval -7 day), {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}) {% end %}
-        {% if defined(date_to) %} and timestamp < toDateTime({{ Date(date_to) }}, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}) + interval 1 day {% else %} and timestamp < toDateTime(dateAdd(day, 1, today()), {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}) {% end %}
+        {% if defined(date_from) %} 
+            and timestamp >= toDateTime({{ Date(date_from) }}, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}) 
+        {% else %} 
+            and timestamp >= toDateTime(timestampAdd(today(), interval -7 day), {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}) 
+        {% end %}
+        {% if defined(date_to) %} 
+            and timestamp < toDateTime({{ Date(date_to) }}, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}) + interval 1 day 
+        {% else %} 
+            and timestamp < toDateTime(dateAdd(day, 1, today()), {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}) 
+        {% end %}
         {% if defined(member_status) %}
             and member_status IN (
                 select arrayJoin(


### PR DESCRIPTION
ref https://linear.app/ghost/issue/NY-865/analytics-sources-not-populating-for-tangle-due-to-408-timeouts

## Problem
The filtered_sessions.pipe date filters wrapped the indexed timestamp column in functions, causing "index blindness":
-- Before (prevents index usage):
```
toDate(toTimezone(timestamp, timezone)) >= date_from
toDate(toTimezone(timestamp, timezone)) <= date_to
```
Since _mv_hits uses ENGINE_SORTING_KEY "site_uuid, timestamp, session_id", wrapping timestamp in functions prevents ClickHouse from using the sparse index, resulting in full scans.

## Solution
Transform the comparison values instead of the column, keeping timestamp bare:
-- After (index-friendly):
```
timestamp >= toDateTime(date_from, timezone)
timestamp < toDateTime(date_to, timezone) + interval 1 day
```

The + interval 1 day syntax (rather than dateAdd()) is required because Tinybird's {{ Date() }} template renders as a string literal, and dateAdd() on strings produces a DateTime with milliseconds that toDateTime() can't parse with a timezone argument.

## Semantic equivalence
Old | New | Meaning
-- | -- | --
toDate(toTimezone(ts, tz)) >= date | ts >= toDateTime(date, tz) | Events on/after midnight of date in user's timezone
toDate(toTimezone(ts, tz)) <= date | ts < toDateTime(date, tz) + 1 day | Events before midnight of date+1 in user's timezone

