### PR TITLE
Added time-based filters to the mv_session_data pipe

### DIFF
--- a/ghost/core/core/server/data/tinybird/pipes/mv_session_data.pipe
+++ b/ghost/core/core/server/data/tinybird/pipes/mv_session_data.pipe
@@ -18,6 +18,12 @@ SQL >
         argMin(utm_content, timestamp) as utm_content
     FROM _mv_hits
     WHERE site_uuid = {{ String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True) }}
+        {% if defined(date_from) %}
+            AND timestamp >= toDateTime({{ Date(date_from) }}, {{ String(timezone, 'Etc/UTC', description="Site timezone", required=False) }})
+        {% end %}
+        {% if defined(date_to) %}
+            AND timestamp < toDateTime({{ Date(date_to) }}, {{ String(timezone, 'Etc/UTC', description="Site timezone", required=False) }}) + interval 1 day
+        {% end %}
     GROUP BY site_uuid, session_id
 
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/NY-865/analytics-sources-not-populating-for-tangle-due-to-408-timeouts

All of the Tinybird endpoints have date-based filters on them. They also are mostly all based on the mv_session_data pipe, but the date filters aren't passed to the mv_session_data pipe at all. This means that Clickhouse has to run the mv_session_data pipe against all events for a particular site across all time, even if it's only going to return the last 30 days in the finished result.

Adding the time filters to the mv_session_data pipe should reduce the amount of data that Clickhouse has to scan when any of the endpoints that use it are called, thus improving the performance of any endpoint that depends on it.