### PR TITLE
Added materialized view for mv_session_data pipe

### DIFF
--- a/e2e/tests/admin/analytics/overview.test.ts
+++ b/e2e/tests/admin/analytics/overview.test.ts
@@ -20,6 +20,35 @@ test.describe('Ghost Admin - Analytics Overview', () => {
         expect(await analyticsOverviewPage.uniqueVisitors.count()).toBe(1);
     });
 
+    test('records multiple pageviews in single session correctly', async ({page, browser, baseURL}) => {
+        const analyticsWebTrafficPage = new AnalyticsWebTrafficPage(page);
+
+        const context = await browser.newContext({baseURL});
+        const publicBrowserPage = await context.newPage();
+        const homePage = new HomePage(publicBrowserPage);
+
+        await homePage.goto();
+        await page.waitForTimeout(1000);
+        await analyticsWebTrafficPage.goto();
+        await expect(analyticsWebTrafficPage.totalViewsTab).toContainText('1');
+        await expect(analyticsWebTrafficPage.totalUniqueVisitorsTab).toContainText('1');
+
+        await homePage.goto();
+        await page.waitForTimeout(1000);
+        await analyticsWebTrafficPage.refreshData();
+        await expect(analyticsWebTrafficPage.totalViewsTab).toContainText('2');
+        await expect(analyticsWebTrafficPage.totalUniqueVisitorsTab).toContainText('1');
+
+        await homePage.goto();
+        await page.waitForTimeout(1000);
+        await analyticsWebTrafficPage.refreshData();
+        await expect(analyticsWebTrafficPage.totalViewsTab).toContainText('3');
+        await expect(analyticsWebTrafficPage.totalUniqueVisitorsTab).toContainText('1');
+
+        await publicBrowserPage.close();
+        await context.close();
+    });
+
     test('latest post', async ({page}) => {
         const analyticsOverviewPage = new AnalyticsOverviewPage(page);
         await analyticsOverviewPage.goto();

--- a/ghost/core/core/server/data/tinybird/datasources/_mv_session_data.datasource
+++ b/ghost/core/core/server/data/tinybird/datasources/_mv_session_data.datasource
@@ -1,0 +1,16 @@
+SCHEMA >
+    `site_uuid` LowCardinality(String),
+    `session_id` String,
+    `pageviews` AggregateFunction(count, UInt64),
+    `first_pageview` AggregateFunction(min, DateTime),
+    `last_pageview` AggregateFunction(max, DateTime),
+    `source` AggregateFunction(argMin, String, DateTime),
+    `device` AggregateFunction(argMin, String, DateTime),
+    `utm_source` AggregateFunction(argMin, String, DateTime),
+    `utm_medium` AggregateFunction(argMin, String, DateTime),
+    `utm_campaign` AggregateFunction(argMin, String, DateTime),
+    `utm_term` AggregateFunction(argMin, String, DateTime),
+    `utm_content` AggregateFunction(argMin, String, DateTime)
+
+ENGINE "AggregatingMergeTree"
+ENGINE_SORTING_KEY "site_uuid, session_id"

--- a/ghost/core/core/server/data/tinybird/endpoints/README.md
+++ b/ghost/core/core/server/data/tinybird/endpoints/README.md
@@ -7,7 +7,7 @@
 Ghost analytics distinguishes between two types of attributes:
 
 #### Session-Level Attributes
-These are captured from the **first hit** (earliest timestamp) in a session using `argMin(field, timestamp)` in the `mv_session_data` materialized view:
+These are captured from the **first hit** (earliest timestamp) in a session using `argMinState(field, timestamp)` in the `_mv_session_data` materialized view (an `AggregatingMergeTree` table):
 
 - `source` - Referring domain
 - `utm_source` - UTM source parameter
@@ -39,7 +39,7 @@ Finds sessions where **at least one hit** matches the hit-level filter criteria 
 ```sql
 NODE sessions_filtered_by_session_attributes
 ```
-Further filters by session-level attributes (source, utm_*) by joining with `mv_session_data`. These filters check attributes from the **first hit only**.
+Further filters by session-level attributes (source, utm_*) by reading from `_mv_session_data` using `-Merge` combinators (e.g., `argMinMerge(source)`). These filters check attributes from the **first hit only**.
 
 **Stage 3: Final Output**
 ```sql

--- a/ghost/core/core/server/data/tinybird/endpoints/api_kpis.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_kpis.pipe
@@ -56,6 +56,22 @@ SQL >
         {% end %}
 
 
+NODE session_data
+DESCRIPTION >
+    Read session data from AggregatingMergeTree MV using -Merge combinators
+
+SQL >
+    %
+    SELECT
+        site_uuid,
+        session_id,
+        countMerge(pageviews) as pageviews,
+        minMerge(first_pageview) as first_pageview,
+        maxMerge(last_pageview) as last_pageview
+    FROM _mv_session_data
+    WHERE site_uuid = {{ String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True) }}
+    GROUP BY site_uuid, session_id
+
 NODE session_metrics
 DESCRIPTION >
     Calculate session-level metrics (visits, pageviews, bounce rate, avg session duration)
@@ -70,15 +86,13 @@ SQL >
             {% else %}
                 toDate(toTimezone(first_pageview, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})) as date,
             {% end %}
-            session_id,
+            sd.session_id,
             pageviews,
-            is_bounce,
-            duration as session_sec
-        from mv_session_data sd
+            pageviews = 1 as is_bounce,
+            last_pageview - first_pageview as session_sec
+        from session_data sd
             inner join filtered_sessions fs
                 on fs.session_id = sd.session_id
-        where
-            site_uuid = {{ String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True) }}
 
 
 NODE data

--- a/ghost/core/core/server/data/tinybird/endpoints/api_top_devices.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_top_devices.pipe
@@ -1,17 +1,26 @@
 TOKEN "stats_page" READ
 TOKEN "axis" READ
 
+NODE session_data
+SQL >
+    %
+    SELECT
+        site_uuid,
+        session_id,
+        argMinMerge(device) as device
+    FROM _mv_session_data
+    WHERE site_uuid = {{ String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True) }}
+    GROUP BY site_uuid, session_id
+
 NODE top_devices
 SQL >
     %
     select
         device,
         count() as visits
-    from mv_session_data sd
+    from session_data sd
       inner join filtered_sessions fs
          on fs.session_id = sd.session_id
-    where
-        site_uuid = {{ String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True) }}
     group by device
     order by visits desc
     limit {{ Int32(skip, 0) }},{{ Int32(limit, 50) }}

--- a/ghost/core/core/server/data/tinybird/endpoints/api_top_sources.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_top_sources.pipe
@@ -1,17 +1,26 @@
 TOKEN "stats_page" READ
 TOKEN "axis" READ
 
+NODE session_data
+SQL >
+    %
+    SELECT
+        site_uuid,
+        session_id,
+        argMinMerge(source) as source
+    FROM _mv_session_data
+    WHERE site_uuid = {{ String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True) }}
+    GROUP BY site_uuid, session_id
+
 NODE top_sources
 SQL >
     %
     select
         source,
         count() as visits
-    from mv_session_data sd
+    from session_data sd
       inner join filtered_sessions fs
          on fs.session_id = sd.session_id
-    where
-        site_uuid = {{ String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True) }}
     group by source
     order by visits desc
     limit {{ Int32(skip, 0) }},{{ Int32(limit, 50) }}

--- a/ghost/core/core/server/data/tinybird/endpoints/api_top_utm_campaigns.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_top_utm_campaigns.pipe
@@ -1,18 +1,28 @@
 TOKEN "stats_page" READ
 TOKEN "axis" READ
 
+NODE session_data
+SQL >
+    %
+    SELECT
+        site_uuid,
+        session_id,
+        argMinMerge(utm_campaign) as utm_campaign
+    FROM _mv_session_data
+    WHERE site_uuid = {{ String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True) }}
+    GROUP BY site_uuid, session_id
+
 NODE top_utm_campaigns
 SQL >
     %
     select
         utm_campaign,
         count() as visits
-    from mv_session_data sd
+    from session_data sd
       inner join filtered_sessions fs
          on fs.session_id = sd.session_id
     where
-        site_uuid = {{ String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True) }}
-        and utm_campaign != ''
+        utm_campaign != ''
     group by utm_campaign
     order by visits desc
     limit {{ Int32(skip, 0) }},{{ Int32(limit, 50) }}

--- a/ghost/core/core/server/data/tinybird/endpoints/api_top_utm_contents.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_top_utm_contents.pipe
@@ -1,18 +1,28 @@
 TOKEN "stats_page" READ
 TOKEN "axis" READ
 
+NODE session_data
+SQL >
+    %
+    SELECT
+        site_uuid,
+        session_id,
+        argMinMerge(utm_content) as utm_content
+    FROM _mv_session_data
+    WHERE site_uuid = {{ String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True) }}
+    GROUP BY site_uuid, session_id
+
 NODE top_utm_content
 SQL >
     %
     select
         utm_content,
         count() as visits
-    from mv_session_data sd
+    from session_data sd
       inner join filtered_sessions fs
          on fs.session_id = sd.session_id
     where
-        site_uuid = {{ String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True) }}
-        and utm_content != ''
+        utm_content != ''
     group by utm_content
     order by visits desc
     limit {{ Int32(skip, 0) }},{{ Int32(limit, 50) }}

--- a/ghost/core/core/server/data/tinybird/endpoints/api_top_utm_contents.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_top_utm_contents.pipe
@@ -12,7 +12,7 @@ SQL >
     WHERE site_uuid = {{ String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True) }}
     GROUP BY site_uuid, session_id
 
-NODE top_utm_content
+NODE top_utm_contents
 SQL >
     %
     select

--- a/ghost/core/core/server/data/tinybird/endpoints/api_top_utm_mediums.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_top_utm_mediums.pipe
@@ -1,18 +1,28 @@
 TOKEN "stats_page" READ
 TOKEN "axis" READ
 
+NODE session_data
+SQL >
+    %
+    SELECT
+        site_uuid,
+        session_id,
+        argMinMerge(utm_medium) as utm_medium
+    FROM _mv_session_data
+    WHERE site_uuid = {{ String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True) }}
+    GROUP BY site_uuid, session_id
+
 NODE top_utm_mediums
 SQL >
     %
     select
         utm_medium,
         count() as visits
-    from mv_session_data sd
+    from session_data sd
       inner join filtered_sessions fs
          on fs.session_id = sd.session_id
     where
-        site_uuid = {{ String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True) }}
-        and utm_medium != ''
+        utm_medium != ''
     group by utm_medium
     order by visits desc
     limit {{ Int32(skip, 0) }},{{ Int32(limit, 50) }}

--- a/ghost/core/core/server/data/tinybird/endpoints/api_top_utm_sources.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_top_utm_sources.pipe
@@ -1,5 +1,16 @@
-TOKEN "stats_page" READ 
+TOKEN "stats_page" READ
 TOKEN "axis" READ
+
+NODE session_data
+SQL >
+    %
+    SELECT
+        site_uuid,
+        session_id,
+        argMinMerge(utm_source) as utm_source
+    FROM _mv_session_data
+    WHERE site_uuid = {{ String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True) }}
+    GROUP BY site_uuid, session_id
 
 NODE top_utm_sources
 SQL >
@@ -7,12 +18,11 @@ SQL >
     select
         utm_source,
         count() as visits
-    from mv_session_data sd
+    from session_data sd
       inner join filtered_sessions fs
          on fs.session_id = sd.session_id
     where
-        site_uuid = {{ String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True) }}
-        and utm_source != ''
+        utm_source != ''
     group by utm_source
     order by visits desc
     limit {{ Int32(skip, 0) }},{{ Int32(limit, 50) }}

--- a/ghost/core/core/server/data/tinybird/endpoints/api_top_utm_terms.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_top_utm_terms.pipe
@@ -1,18 +1,28 @@
 TOKEN "stats_page" READ
 TOKEN "axis" READ
 
+NODE session_data
+SQL >
+    %
+    SELECT
+        site_uuid,
+        session_id,
+        argMinMerge(utm_term) as utm_term
+    FROM _mv_session_data
+    WHERE site_uuid = {{ String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True) }}
+    GROUP BY site_uuid, session_id
+
 NODE top_utm_terms
 SQL >
     %
     select
         utm_term,
         count() as visits
-    from mv_session_data sd
+    from session_data sd
       inner join filtered_sessions fs
          on fs.session_id = sd.session_id
     where
-        site_uuid = {{ String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True) }}
-        and utm_term != ''
+        utm_term != ''
     group by utm_term
     order by visits desc
     limit {{ Int32(skip, 0) }},{{ Int32(limit, 50) }}

--- a/ghost/core/core/server/data/tinybird/pipes/filtered_sessions.pipe
+++ b/ghost/core/core/server/data/tinybird/pipes/filtered_sessions.pipe
@@ -37,16 +37,31 @@ SQL >
 NODE sessions_filtered_by_session_attributes
 DESCRIPTION >
     Further filter by session-level attributes (source, device, utm_*). These attributes are specific to the first hit in a session,
-    whereas other filters are on hits.
+    whereas other filters are on hits. Reads from AggregatingMergeTree MV using -Merge combinators.
 
 SQL >
     %
     select session_id
-    from mv_session_data sd
+    from (
+        SELECT
+            site_uuid,
+            session_id,
+            minMerge(first_pageview) as first_pageview,
+            argMinMerge(source) as source,
+            argMinMerge(device) as device,
+            argMinMerge(utm_source) as utm_source,
+            argMinMerge(utm_medium) as utm_medium,
+            argMinMerge(utm_campaign) as utm_campaign,
+            argMinMerge(utm_term) as utm_term,
+            argMinMerge(utm_content) as utm_content
+        FROM _mv_session_data
+        WHERE site_uuid = {{ String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True) }}
+        GROUP BY site_uuid, session_id
+    ) sd
     inner join sessions_filtered_by_hit_attributes sfha
       on sfha.session_id = sd.session_id
     where
-        site_uuid = {{ String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True) }}
+        1 = 1
         {% if defined(date_from) %}
             {# Filter from specified start date #}
             and first_pageview >= toDateTime({{ Date(date_from) }}, {{ String(timezone, 'Etc/UTC', description="Site timezone", required=True) }})

--- a/ghost/core/core/server/data/tinybird/pipes/mv_session_data.pipe
+++ b/ghost/core/core/server/data/tinybird/pipes/mv_session_data.pipe
@@ -1,49 +1,22 @@
 TOKEN "axis" READ
 
-NODE mv_hits_0
+NODE mv_session_data_0
 SQL >
-    %
     SELECT
         site_uuid,
         session_id,
-        count() as pageviews,
-        min(timestamp) as first_pageview,
-        max(timestamp) as last_pageview,
-        argMin(source, timestamp) as source,
-        argMin(device, timestamp) as device,
-        argMin(utm_source, timestamp) as utm_source,
-        argMin(utm_medium, timestamp) as utm_medium,
-        argMin(utm_campaign, timestamp) as utm_campaign,
-        argMin(utm_term, timestamp) as utm_term,
-        argMin(utm_content, timestamp) as utm_content
+        countState() as pageviews,
+        minState(timestamp) as first_pageview,
+        maxState(timestamp) as last_pageview,
+        argMinState(source, timestamp) as source,
+        argMinState(device, timestamp) as device,
+        argMinState(utm_source, timestamp) as utm_source,
+        argMinState(utm_medium, timestamp) as utm_medium,
+        argMinState(utm_campaign, timestamp) as utm_campaign,
+        argMinState(utm_term, timestamp) as utm_term,
+        argMinState(utm_content, timestamp) as utm_content
     FROM _mv_hits
-    WHERE site_uuid = {{ String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True) }}
-        {% if defined(date_from) %}
-            AND timestamp >= toDateTime({{ Date(date_from) }}, {{ String(timezone, 'Etc/UTC', description="Site timezone", required=False) }})
-        {% end %}
-        {% if defined(date_to) %}
-            AND timestamp < toDateTime({{ Date(date_to) }}, {{ String(timezone, 'Etc/UTC', description="Site timezone", required=False) }}) + interval 1 day
-        {% end %}
     GROUP BY site_uuid, session_id
 
-
-
-NODE data
-SQL >
-
-    SELECT
-        site_uuid,
-        session_id,
-        pageviews,
-        first_pageview,
-        last_pageview,
-        last_pageview - first_pageview AS duration,
-        pageviews = 1 AS is_bounce,
-        source,
-        device,
-        utm_source,
-        utm_medium,
-        utm_campaign,
-        utm_term,
-        utm_content
-    FROM mv_hits_0
+TYPE materialized
+DATASOURCE _mv_session_data


### PR DESCRIPTION
ref https://linear.app/ghost/issue/NY-865/analytics-sources-not-populating-for-tangle-due-to-408-timeouts

The `mv_session_data` pipe aggregates session data that is then used in almost all our downstream endpoints. Originally we created this as a materialized view (hence the `mv` prefix), but we encountered a bug that caused us to double count pageviews within a session. We've now reached a point where we are encountering performance issues with the current implementation, with requests to Tinybird endpoints timing out after 10 seconds.

This reimplements the materialized view for `mv_session_data`, using the `AggregatingMergeTree` table engine and the appropriate -State and -Merge [aggregate function combinators.](https://clickhouse.com/docs/sql-reference/aggregate-functions/combinators). These combinators were the missing piece in our original implementation which caused the double counting.