### PR TITLE
Removed comment tombstone serialization

### DIFF
--- a/apps/comments-ui/src/app-context.ts
+++ b/apps/comments-ui/src/app-context.ts
@@ -27,7 +27,7 @@ export type Comment = {
     member: Member | null,
     edited_at: string,
     created_at: string,
-    html: string
+    html: string | null
 }
 
 export type OpenCommentForm = {

--- a/ghost/core/core/server/services/comments/CommentsService.js
+++ b/ghost/core/core/server/services/comments/CommentsService.js
@@ -202,16 +202,15 @@ class CommentsService {
             order,
             page,
             limit,
-            // If includeNested is false, only return top-level comments
             parentId: includeNested ? undefined : null,
-            // Admin context: see hidden comments with full content, and all statuses including deleted
-            isAdmin: true
+            isAdmin: true,
+            browseAll: true
         });
     }
 
     async getAdminComments(options) {
         this.checkEnabled();
-        const page = await this.models.Comment.findPage({...options, parentId: null});
+        const page = await this.models.Comment.findPage({...options, parentId: null, isAdmin: true});
 
         return page;
     }

--- a/ghost/core/test/e2e-api/admin/__snapshots__/comments.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/comments.test.js.snap
@@ -294,58 +294,32 @@ Object {
 }
 `;
 
-exports[`Admin Comments API Browse All Includes deleted comments for admin 1: [body] 1`] = `
+exports[`Admin Comments API Browse All Excludes deleted comments even when they have published replies 1: [body] 1`] = `
 Object {
   "comments": Array [
     Object {
-      "count": Object {
-        "likes": 0,
-        "replies": 0,
-      },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
       "edited_at": Nullable<StringMatching>,
-      "html": "<p>Published</p>",
+      "html": "<p>Published reply</p>",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
       "in_reply_to_id": null,
       "in_reply_to_snippet": null,
-      "liked": false,
       "member": Object {
         "avatar_image": null,
-        "email": "member1@test.com",
+        "email": "member2@test.com",
         "expertise": null,
         "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-        "name": "Mr Egg",
+        "name": null,
         "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
       },
       "parent_id": Nullable<StringMatching>,
-      "post_id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "replies": Array [],
+      "post": Object {
+        "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+        "title": "Ghostly Kitchen Sink",
+        "url": Any<String>,
+        "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      },
       "status": "published",
-    },
-    Object {
-      "count": Object {
-        "likes": 0,
-        "replies": 0,
-      },
-      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-      "edited_at": Nullable<StringMatching>,
-      "html": "<p>Deleted</p>",
-      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "in_reply_to_id": null,
-      "in_reply_to_snippet": null,
-      "liked": false,
-      "member": Object {
-        "avatar_image": null,
-        "email": "member1@test.com",
-        "expertise": null,
-        "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-        "name": "Mr Egg",
-        "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
-      },
-      "parent_id": Nullable<StringMatching>,
-      "post_id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "replies": Array [],
-      "status": "deleted",
     },
   ],
   "meta": Object {
@@ -355,7 +329,7 @@ Object {
       "page": 1,
       "pages": 1,
       "prev": null,
-      "total": 2,
+      "total": 1,
     },
   },
 }
@@ -387,83 +361,6 @@ Object {
         "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
       },
       "status": "hidden",
-    },
-  ],
-  "meta": Object {
-    "pagination": Object {
-      "limit": 15,
-      "next": null,
-      "page": 1,
-      "pages": 1,
-      "prev": null,
-      "total": 1,
-    },
-  },
-}
-`;
-
-exports[`Admin Comments API Browse All Includes member relation by default 1: [body] 1`] = `
-Object {
-  "comments": Array [
-    Object {
-      "count": Object {
-        "likes": 0,
-        "replies": 0,
-      },
-      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-      "edited_at": Nullable<StringMatching>,
-      "html": "<p>This is a comment</p>",
-      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "in_reply_to_id": null,
-      "in_reply_to_snippet": null,
-      "liked": false,
-      "member": Object {
-        "avatar_image": null,
-        "email": "member1@test.com",
-        "expertise": null,
-        "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-        "name": "Mr Egg",
-        "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
-      },
-      "parent_id": Nullable<StringMatching>,
-      "post_id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "replies": Array [],
-      "status": "published",
-    },
-  ],
-  "meta": Object {
-    "pagination": Object {
-      "limit": 15,
-      "next": null,
-      "page": 1,
-      "pages": 1,
-      "prev": null,
-      "total": 1,
-    },
-  },
-}
-`;
-
-exports[`Admin Comments API Browse All Includes post relation when requested 1: [body] 1`] = `
-Object {
-  "comments": Array [
-    Object {
-      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-      "edited_at": Nullable<StringMatching>,
-      "html": "<p>This is a comment</p>",
-      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "in_reply_to_id": null,
-      "in_reply_to_snippet": null,
-      "member": null,
-      "parent_id": Nullable<StringMatching>,
-      "post": Object {
-        "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-        "title": "HTML Ipsum",
-        "url": Any<String>,
-        "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
-      },
-      "post_id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "status": "published",
     },
   ],
   "meta": Object {
@@ -519,58 +416,6 @@ Object {
         "expertise": null,
         "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
         "name": "Mr Egg",
-        "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
-      },
-      "parent_id": Nullable<StringMatching>,
-      "post": Object {
-        "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-        "title": "Ghostly Kitchen Sink",
-        "url": Any<String>,
-        "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
-      },
-      "status": "published",
-    },
-  ],
-  "meta": Object {
-    "pagination": Object {
-      "limit": 15,
-      "next": null,
-      "page": 1,
-      "pages": 1,
-      "prev": null,
-      "total": 2,
-    },
-  },
-}
-`;
-
-exports[`Admin Comments API Browse All Returns deleted parent as tombstone when it has published replies 1: [body] 1`] = `
-Object {
-  "comments": Array [
-    Object {
-      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "parent_id": null,
-      "post": Object {
-        "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-        "title": "Ghostly Kitchen Sink",
-        "url": Any<String>,
-        "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
-      },
-      "status": "deleted",
-    },
-    Object {
-      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-      "edited_at": Nullable<StringMatching>,
-      "html": "<p>Published reply</p>",
-      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "in_reply_to_id": null,
-      "in_reply_to_snippet": null,
-      "member": Object {
-        "avatar_image": null,
-        "email": "member2@test.com",
-        "expertise": null,
-        "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-        "name": null,
         "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
       },
       "parent_id": Nullable<StringMatching>,
@@ -981,22 +826,6 @@ Object {
 }
 `;
 
-exports[`Admin Comments API browse by post does not return deleted comments with only deleted replies 1: [body] 1`] = `
-Object {
-  "comments": Array [],
-  "meta": Object {
-    "pagination": Object {
-      "limit": 15,
-      "next": null,
-      "page": 1,
-      "pages": 1,
-      "prev": null,
-      "total": 0,
-    },
-  },
-}
-`;
-
 exports[`Admin Comments API browse by post does not return deleted replies 1: [body] 1`] = `
 Object {
   "comments": Array [
@@ -1083,105 +912,9 @@ Object {
 }
 `;
 
-exports[`Admin Comments API browse by post includes all replies in count for admin 1: [body] 1`] = `
+exports[`Admin Comments API browse by post excludes deleted comments when all replies are also deleted 1: [body] 1`] = `
 Object {
-  "comments": Array [
-    Object {
-      "count": Object {
-        "likes": Any<Number>,
-        "replies": 3,
-      },
-      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-      "edited_at": null,
-      "html": "Comment 1",
-      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "in_reply_to_id": null,
-      "in_reply_to_snippet": null,
-      "liked": Any<Boolean>,
-      "member": Object {
-        "avatar_image": null,
-        "email": "member1@test.com",
-        "expertise": null,
-        "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-        "name": "Mr Egg",
-        "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
-      },
-      "parent_id": Nullable<StringMatching>,
-      "post_id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "replies": Array [
-        Object {
-          "count": Object {
-            "likes": 0,
-          },
-          "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-          "edited_at": null,
-          "html": "Reply 1",
-          "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-          "in_reply_to_id": null,
-          "in_reply_to_snippet": null,
-          "liked": false,
-          "member": Object {
-            "avatar_image": null,
-            "email": "member1@test.com",
-            "expertise": null,
-            "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-            "name": "Mr Egg",
-            "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
-          },
-          "parent_id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-          "post_id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-          "status": "hidden",
-        },
-        Object {
-          "count": Object {
-            "likes": 0,
-          },
-          "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-          "edited_at": null,
-          "html": "Reply 2",
-          "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-          "in_reply_to_id": null,
-          "in_reply_to_snippet": null,
-          "liked": false,
-          "member": Object {
-            "avatar_image": null,
-            "email": "member1@test.com",
-            "expertise": null,
-            "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-            "name": "Mr Egg",
-            "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
-          },
-          "parent_id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-          "post_id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-          "status": "deleted",
-        },
-        Object {
-          "count": Object {
-            "likes": 0,
-          },
-          "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-          "edited_at": null,
-          "html": "Reply 3",
-          "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-          "in_reply_to_id": null,
-          "in_reply_to_snippet": null,
-          "liked": false,
-          "member": Object {
-            "avatar_image": null,
-            "email": "member1@test.com",
-            "expertise": null,
-            "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-            "name": "Mr Egg",
-            "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
-          },
-          "parent_id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-          "post_id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-          "status": "published",
-        },
-      ],
-      "status": "published",
-    },
-  ],
+  "comments": Array [],
   "meta": Object {
     "pagination": Object {
       "limit": 15,
@@ -1189,7 +922,7 @@ Object {
       "page": 1,
       "pages": 1,
       "prev": null,
-      "total": 1,
+      "total": 0,
     },
   },
 }
@@ -1281,207 +1014,7 @@ Object {
 }
 `;
 
-exports[`Admin Comments API browse by post returns all replies including deleted for admin 1: [body] 1`] = `
-Object {
-  "comments": Array [
-    Object {
-      "count": Object {
-        "likes": Any<Number>,
-        "replies": 3,
-      },
-      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-      "edited_at": null,
-      "html": "Comment 1",
-      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "in_reply_to_id": null,
-      "in_reply_to_snippet": null,
-      "liked": Any<Boolean>,
-      "member": Object {
-        "avatar_image": null,
-        "email": "member1@test.com",
-        "expertise": null,
-        "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-        "name": "Mr Egg",
-        "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
-      },
-      "parent_id": Nullable<StringMatching>,
-      "post_id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "replies": Array [
-        Object {
-          "count": Object {
-            "likes": 0,
-          },
-          "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-          "edited_at": null,
-          "html": "Reply 1",
-          "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-          "in_reply_to_id": null,
-          "in_reply_to_snippet": null,
-          "liked": false,
-          "member": Object {
-            "avatar_image": null,
-            "email": "member1@test.com",
-            "expertise": null,
-            "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-            "name": "Mr Egg",
-            "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
-          },
-          "parent_id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-          "post_id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-          "status": "deleted",
-        },
-        Object {
-          "count": Object {
-            "likes": 0,
-          },
-          "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-          "edited_at": null,
-          "html": "Reply 2",
-          "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-          "in_reply_to_id": null,
-          "in_reply_to_snippet": null,
-          "liked": false,
-          "member": Object {
-            "avatar_image": null,
-            "email": "member1@test.com",
-            "expertise": null,
-            "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-            "name": "Mr Egg",
-            "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
-          },
-          "parent_id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-          "post_id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-          "status": "hidden",
-        },
-        Object {
-          "count": Object {
-            "likes": 0,
-          },
-          "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-          "edited_at": null,
-          "html": "Reply 3",
-          "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-          "in_reply_to_id": null,
-          "in_reply_to_snippet": null,
-          "liked": false,
-          "member": Object {
-            "avatar_image": null,
-            "email": "member1@test.com",
-            "expertise": null,
-            "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-            "name": "Mr Egg",
-            "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
-          },
-          "parent_id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-          "post_id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-          "status": "published",
-        },
-      ],
-      "status": "published",
-    },
-  ],
-  "meta": Object {
-    "pagination": Object {
-      "limit": 15,
-      "next": null,
-      "page": 1,
-      "pages": 1,
-      "prev": null,
-      "total": 1,
-    },
-  },
-}
-`;
-
-exports[`Admin Comments API browse by post returns deleted comments as tombstones if they have published replies 1: [body] 1`] = `
-Object {
-  "comments": Array [
-    Object {
-      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "parent_id": null,
-      "replies": Array [
-        Object {
-          "count": Object {
-            "likes": 0,
-          },
-          "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-          "edited_at": null,
-          "html": "Reply 1",
-          "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-          "in_reply_to_id": null,
-          "in_reply_to_snippet": null,
-          "liked": false,
-          "member": Object {
-            "avatar_image": null,
-            "email": "member1@test.com",
-            "expertise": null,
-            "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-            "name": "Mr Egg",
-            "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
-          },
-          "parent_id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-          "status": "published",
-        },
-      ],
-      "status": "deleted",
-    },
-  ],
-  "meta": Object {
-    "pagination": Object {
-      "limit": 15,
-      "next": null,
-      "page": 1,
-      "pages": 1,
-      "prev": null,
-      "total": 1,
-    },
-  },
-}
-`;
-
-exports[`Admin Comments API browse by post returns deleted comments for admin 1: [body] 1`] = `
-Object {
-  "comments": Array [
-    Object {
-      "count": Object {
-        "likes": Any<Number>,
-        "replies": 0,
-      },
-      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-      "edited_at": null,
-      "html": "Comment 1",
-      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "in_reply_to_id": null,
-      "in_reply_to_snippet": null,
-      "liked": Any<Boolean>,
-      "member": Object {
-        "avatar_image": null,
-        "email": "member1@test.com",
-        "expertise": null,
-        "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-        "name": "Mr Egg",
-        "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
-      },
-      "parent_id": Nullable<StringMatching>,
-      "post_id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "replies": Array [],
-      "status": "deleted",
-    },
-  ],
-  "meta": Object {
-    "pagination": Object {
-      "limit": 15,
-      "next": null,
-      "page": 1,
-      "pages": 1,
-      "prev": null,
-      "total": 1,
-    },
-  },
-}
-`;
-
-exports[`Admin Comments API browse by post returns deleted comments with deleted replies for admin 1: [body] 1`] = `
+exports[`Admin Comments API browse by post returns deleted comments if they have published replies 1: [body] 1`] = `
 Object {
   "comments": Array [
     Object {
@@ -1491,7 +1024,7 @@ Object {
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
       "edited_at": null,
-      "html": "Comment 1",
+      "html": null,
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
       "in_reply_to_id": null,
       "in_reply_to_snippet": null,
@@ -1505,7 +1038,6 @@ Object {
         "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
       },
       "parent_id": Nullable<StringMatching>,
-      "post_id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
       "replies": Array [
         Object {
           "count": Object {
@@ -1527,8 +1059,7 @@ Object {
             "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
           },
           "parent_id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-          "post_id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-          "status": "deleted",
+          "status": "published",
         },
       ],
       "status": "deleted",
@@ -1573,75 +1104,6 @@ Object {
       "parent_id": Nullable<StringMatching>,
       "replies": Array [],
       "status": "published",
-    },
-  ],
-}
-`;
-
-exports[`Admin Comments API get by id includes deleted replies for admin 1: [body] 1`] = `
-Object {
-  "comments": Array [
-    Object {
-      "count": Object {
-        "likes": Any<Number>,
-        "replies": 1,
-      },
-      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-      "edited_at": null,
-      "html": "<p>This is a comment</p>",
-      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "in_reply_to_id": null,
-      "in_reply_to_snippet": null,
-      "liked": Any<Boolean>,
-      "member": Object {
-        "avatar_image": null,
-        "email": "member1@test.com",
-        "expertise": null,
-        "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-        "name": "Mr Egg",
-        "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
-      },
-      "parent_id": Nullable<StringMatching>,
-      "post_id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "replies": Array [
-        Object {
-          "count": Object {
-            "likes": 0,
-          },
-          "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-          "edited_at": null,
-          "html": "Reply 1",
-          "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-          "in_reply_to_id": null,
-          "in_reply_to_snippet": null,
-          "liked": false,
-          "member": Object {
-            "avatar_image": null,
-            "email": "member2@test.com",
-            "expertise": null,
-            "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-            "name": null,
-            "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
-          },
-          "parent_id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-          "post_id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-          "status": "deleted",
-        },
-      ],
-      "status": "published",
-    },
-  ],
-}
-`;
-
-exports[`Admin Comments API get by id returns deleted comment as tombstone 1: [body] 1`] = `
-Object {
-  "comments": Array [
-    Object {
-      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "parent_id": null,
-      "replies": Array [],
-      "status": "deleted",
     },
   ],
 }

--- a/ghost/core/test/e2e-api/members-comments/__snapshots__/comments.test.js.snap
+++ b/ghost/core/test/e2e-api/members-comments/__snapshots__/comments.test.js.snap
@@ -1491,7 +1491,24 @@ exports[`Comments API when commenting enabled for all when authenticated browse 
 Object {
   "comments": Array [
     Object {
+      "count": Object {
+        "likes": Any<Number>,
+        "replies": Any<Number>,
+      },
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "edited_at": null,
+      "html": null,
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "in_reply_to_id": null,
+      "in_reply_to_snippet": null,
+      "liked": Any<Boolean>,
+      "member": Object {
+        "avatar_image": null,
+        "expertise": null,
+        "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+        "name": "Mr Egg",
+        "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      },
       "parent_id": Nullable<StringMatching>,
       "replies": Array [
         Object {
@@ -1536,7 +1553,7 @@ exports[`Comments API when commenting enabled for all when authenticated browse 
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "588",
+  "content-length": "894",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Encoding",
@@ -1764,7 +1781,24 @@ exports[`Comments API when commenting enabled for all when authenticated browse 
 Object {
   "comments": Array [
     Object {
+      "count": Object {
+        "likes": Any<Number>,
+        "replies": Any<Number>,
+      },
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "edited_at": null,
+      "html": null,
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "in_reply_to_id": null,
+      "in_reply_to_snippet": null,
+      "liked": Any<Boolean>,
+      "member": Object {
+        "avatar_image": null,
+        "expertise": null,
+        "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+        "name": "Mr Egg",
+        "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      },
       "parent_id": Nullable<StringMatching>,
       "replies": Array [
         Object {
@@ -1809,7 +1843,7 @@ exports[`Comments API when commenting enabled for all when authenticated browse 
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "588",
+  "content-length": "894",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Encoding",


### PR DESCRIPTION
## Why?

PR #25700 introduced "tombstones" - a pattern where deleted comments with replies would be returned with minimal data (`id`, `parent_id`, `status` only). This was intended to preserve thread structure while hiding deleted content.

However, tombstones caused issues because they were missing expected attributes like `member` and `replies`, which broke assumptions in consuming code and made the API response inconsistent.

## What does it do?

**Both Admin and Public APIs** now preserve thread structure by including deleted parents when they have published replies. Deleted comments return full attributes with `html: null`, so the UI can show appropriate placeholder text ("This comment has been removed").

**New Browse All endpoint** (`GET /comments/`): Uses `browseAll: true` flag to exclude deleted comments entirely. This provides a flat list without thread preservation, suitable for admin moderation tables.

## Changes

- Removed tombstone serialization from comment mapper
- Deleted comments now return `html: null` (content never exposed)
- Both Admin and Public APIs preserve thread structure for deleted parents with replies
- Added `browseAll` option for the new `/comments` endpoint to exclude deleted comments