### PR TITLE
Disable NX daemon

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -4,6 +4,7 @@
         "default": ["{projectRoot}/**/*", "{workspaceRoot}/ghost/tsconfig.json"]
     },
     "parallel": 4,
+    "useDaemonProcess": false,
     "targetDefaults": {
         "build": {
             "dependsOn": ["^build"],


### PR DESCRIPTION
no ref 

The NX TUI will sometimes hang, requiring you to kill the shell in order to  exit and running `yarn nx reset` to fully recover. This commit removes the  daemon, which should hopefully make it easier to come back if the TUI hangs. If  we're lucky it won't hang at all.

The main motivation for having a background daemon to begin with is to make repeat NX calls faster, but that doesn't really matter to us since we only have long running tasks.