### PR TITLE
Added size warning to email preview

### DIFF
--- a/ghost/admin/app/components/editor/email-size-warning.hbs
+++ b/ghost/admin/app/components/editor/email-size-warning.hbs
@@ -7,16 +7,14 @@
         <span {{did-update this.checkEmailSize @post.updatedAtUTC}} class="gh-editor-email-size-warning-container">
             <span class="gh-editor-email-size-warning gh-editor-email-size-warning--{{this.warningLevel}}" data-warning-active={{if this.warningLevel "true" "false"}}>
                 {{#if this.warningLevel}}
-                    <span class="{{concat "gh-editor-email-warning-icon-" this.warningLevel}}">
-                        {{svg-jar "email-warning"}}
-                    </span>
+                    {{svg-jar "email-warning"}}
                 {{/if}}
             </span>
             {{#if this.warningLevel}}
                 <div class="gh-editor-email-size-popup">
                     <div class="gh-editor-email-size-popup-title">Looks like this is a long post</div>
-                    <div class="gh-editor-email-size-popup-text">Email newsletters may get cut off in the inbox behind a "View entire message" link when they're over 100kB.</div>
-                    <div class="gh-editor-email-size-popup-used">You've used: <span class={{this.warningLevel}}>{{this.emailSizeKb}}kB</span></div>
+                    <div class="gh-editor-email-size-popup-text">Email newsletters may get clipped in the inbox behind a "View entire message" link when they're over 100kB.</div>
+                    <div class="gh-editor-email-size-popup-used">You've used: <span class="yellow">{{this.emailSizeKb}}kB</span></div>
                 </div>
             {{/if}}
         </span>

--- a/ghost/admin/app/components/editor/email-size-warning.hbs
+++ b/ghost/admin/app/components/editor/email-size-warning.hbs
@@ -13,7 +13,7 @@
             {{#if this.overLimit}}
                 <div class="gh-editor-email-size-popup">
                     <div class="gh-editor-email-size-popup-title">Looks like this is a long post</div>
-                    <div class="gh-editor-email-size-popup-text">Email newsletters may get clipped in the inbox behind a "View entire message" link when they're over 100kB.</div>
+                    <div class="gh-editor-email-size-popup-text">Emails may get clipped in the inbox behind a "View entire message" link when they're over 100kB.</div>
                     <div class="gh-editor-email-size-popup-used">You've used: <span class="yellow">{{this.emailSizeKb}}kB</span></div>
                 </div>
             {{/if}}

--- a/ghost/admin/app/components/editor/email-size-warning.hbs
+++ b/ghost/admin/app/components/editor/email-size-warning.hbs
@@ -1,19 +1,24 @@
 {{#if this.isEnabled}}
-    {{! Watch for post.updatedAt changes to trigger recalculation after saves }}
-    <span {{did-update this.checkEmailSize @post.updatedAtUTC}} class="gh-editor-email-size-warning-container">
-        <span class="gh-editor-email-size-warning gh-editor-email-size-warning--{{this.warningLevel}}" data-warning-active={{if this.warningLevel "true" "false"}}>
+    {{#if (has-block)}}
+        <div {{did-update this.checkEmailSize @post.updatedAtUTC}}>
+            {{yield this.warningLevel this.emailSizeKb}}
+        </div>
+    {{else}}
+        <span {{did-update this.checkEmailSize @post.updatedAtUTC}} class="gh-editor-email-size-warning-container">
+            <span class="gh-editor-email-size-warning gh-editor-email-size-warning--{{this.warningLevel}}" data-warning-active={{if this.warningLevel "true" "false"}}>
+                {{#if this.warningLevel}}
+                    <span class="{{concat "gh-editor-email-warning-icon-" this.warningLevel}}">
+                        {{svg-jar "email-warning"}}
+                    </span>
+                {{/if}}
+            </span>
             {{#if this.warningLevel}}
-                <span class="{{concat "gh-editor-email-warning-icon-" this.warningLevel}}">
-                    {{svg-jar "email-warning"}}
-                </span>
+                <div class="gh-editor-email-size-popup">
+                    <div class="gh-editor-email-size-popup-title">Looks like this is a long post</div>
+                    <div class="gh-editor-email-size-popup-text">Email newsletters may get cut off in the inbox behind a "View entire message" link when they're over 100kB.</div>
+                    <div class="gh-editor-email-size-popup-used">You've used: <span class={{this.warningLevel}}>{{this.emailSizeKb}}kB</span></div>
+                </div>
             {{/if}}
         </span>
-        {{#if this.warningLevel}}
-            <div class="gh-editor-email-size-popup">
-                <div class="gh-editor-email-size-popup-title">Looks like this is a long post</div>
-                <div class="gh-editor-email-size-popup-text">Email newsletters may get cut off in the inbox behind a "View entire message" link when they're over 100kB.</div>
-                <div class="gh-editor-email-size-popup-used">You've used: <span class={{this.warningLevel}}>{{this.emailSizeKb}}kB</span></div>
-            </div>
-        {{/if}}
-    </span>
+    {{/if}}
 {{/if}}

--- a/ghost/admin/app/components/editor/email-size-warning.hbs
+++ b/ghost/admin/app/components/editor/email-size-warning.hbs
@@ -1,16 +1,16 @@
 {{#if this.isEnabled}}
     {{#if (has-block)}}
         <div {{did-update this.checkEmailSize @post.updatedAtUTC}}>
-            {{yield this.warningLevel this.emailSizeKb}}
+            {{yield this.overLimit this.emailSizeKb}}
         </div>
     {{else}}
         <span {{did-update this.checkEmailSize @post.updatedAtUTC}} class="gh-editor-email-size-warning-container">
-            <span class="gh-editor-email-size-warning gh-editor-email-size-warning--{{this.warningLevel}}" data-warning-active={{if this.warningLevel "true" "false"}}>
-                {{#if this.warningLevel}}
+            <span class="gh-editor-email-size-warning gh-editor-email-size-warning--{{this.overLimit}}" data-warning-active={{if this.overLimit "true" "false"}}>
+                {{#if this.overLimit}}
                     {{svg-jar "email-warning"}}
                 {{/if}}
             </span>
-            {{#if this.warningLevel}}
+            {{#if this.overLimit}}
                 <div class="gh-editor-email-size-popup">
                     <div class="gh-editor-email-size-popup-title">Looks like this is a long post</div>
                     <div class="gh-editor-email-size-popup-text">Email newsletters may get clipped in the inbox behind a "View entire message" link when they're over 100kB.</div>

--- a/ghost/admin/app/components/editor/email-size-warning.js
+++ b/ghost/admin/app/components/editor/email-size-warning.js
@@ -9,19 +9,15 @@ export default class EmailSizeWarningComponent extends Component {
     @service feature;
     @service settings;
 
-    @tracked warningLevel = null;
+    @tracked overLimit = false;
     @tracked emailSizeKb = null;
 
     get isEnabled() {
         return this.feature.emailSizeWarnings
             && this.settings.editorDefaultEmailRecipients !== 'disabled'
-            && this.post
-            && !this.post.email
-            && !this.post.isNew;
-    }
-
-    get post() {
-        return this.args.post;
+            && this.args.post
+            && !this.args.post.email
+            && !this.args.post.isNew;
     }
 
     constructor() {
@@ -40,8 +36,8 @@ export default class EmailSizeWarningComponent extends Component {
 
     @task({restartable: true})
     *checkEmailSizeTask() {
-        const result = yield this.emailSizeWarning.fetchEmailSize(this.post);
-        this.warningLevel = result.warningLevel;
+        const result = yield this.emailSizeWarning.fetchEmailSize(this.args.post);
+        this.overLimit = result.overLimit;
         this.emailSizeKb = result.emailSizeKb;
     }
 }

--- a/ghost/admin/app/components/editor/modals/preview/email.hbs
+++ b/ghost/admin/app/components/editor/modals/preview/email.hbs
@@ -88,14 +88,18 @@
                     />
                 </form>
             </div>
-            <div class="gh-email-preview-clip-container">
-                {{svg-jar "email"}}
-                <div>
-                    <div class="gh-email-preview-clip-title">Looks like this is a long post</div>
-                    <div class="gh-email-preview-clip-description">Email newsletters may get cut off in the inbox behind a “View entire message” link when they’re over 100kB. </div>
-                    <div class="gh-email-preview-clip-used">You’ve used: <span class="yellow-d1">92kB</span></div>
-                </div>
-            </div>
+            <Editor::EmailSizeWarning @post={{@post}} as |warningLevel emailSizeKb| >
+                {{#if warningLevel}}
+                    <div class="gh-email-preview-clip-container">
+                        {{svg-jar "email-warning"}}
+                        <div>
+                            <div class="gh-email-preview-clip-title">Looks like this is a long post</div>
+                            <div class="gh-email-preview-clip-description">Email newsletters may get cut off in the inbox behind a “View entire message” link when they’re over 100kB. </div>
+                            <div class="gh-email-preview-clip-used">You’ve used: <span class="yellow-d1">{{emailSizeKb}}kB</span></div>
+                        </div>
+                    </div>
+                {{/if}}
+            </Editor::EmailSizeWarning>
             <iframe
                 class="gh-pe-iframe"
                 title="Email preview"

--- a/ghost/admin/app/components/editor/modals/preview/email.hbs
+++ b/ghost/admin/app/components/editor/modals/preview/email.hbs
@@ -88,6 +88,14 @@
                     />
                 </form>
             </div>
+            <div class="gh-email-preview-clip-container">
+                {{svg-jar "email"}}
+                <div>
+                    <div class="gh-email-preview-clip-title">Looks like this is a long post</div>
+                    <div class="gh-email-preview-clip-description">Email newsletters may get cut off in the inbox behind a “View entire message” link when they’re over 100kB. </div>
+                    <div class="gh-email-preview-clip-used">You’ve used: <span class="yellow-d1">92kB</span></div>
+                </div>
+            </div>
             <iframe
                 class="gh-pe-iframe"
                 title="Email preview"

--- a/ghost/admin/app/components/editor/modals/preview/email.hbs
+++ b/ghost/admin/app/components/editor/modals/preview/email.hbs
@@ -93,9 +93,8 @@
                     <div class="gh-email-preview-clip-container">
                         {{svg-jar "email-warning"}}
                         <div>
-                            <div class="gh-email-preview-clip-title">Looks like this is a long post</div>
+                            <div class="gh-email-preview-clip-title">This email is <span class="yellow-d1">{{emailSizeKb}}kB</span></div>
                             <div class="gh-email-preview-clip-description">Emails may get clipped in the inbox behind a “View entire message” link when they’re over 100kB.</div>
-                            <div class="gh-email-preview-clip-used">You’ve used: <span class="yellow-d1">{{emailSizeKb}}kB</span></div>
                         </div>
                     </div>
                 {{/if}}

--- a/ghost/admin/app/components/editor/modals/preview/email.hbs
+++ b/ghost/admin/app/components/editor/modals/preview/email.hbs
@@ -94,8 +94,7 @@
                         {{svg-jar "email-warning"}}
                         <div>
                             <div class="gh-email-preview-clip-title">Looks like this is a long post</div>
-                            <div class="gh-email-preview-clip-description">Email newsletters may get cut off in the inbox behind a “View entire message” link when they’re over 100kB. </div>
-                            <div class="gh-email-preview-clip-used">You’ve used: <span class="yellow-d1">{{emailSizeKb}}kB</span></div>
+                            <div class="gh-email-preview-clip-description">Email newsletters may get clipped in the inbox behind a “View entire message” link when they’re over 100kB. <span class="gh-email-preview-clip-used">You’ve used: <span class="yellow-d1">{{emailSizeKb}}kB</span></span></div>
                         </div>
                     </div>
                 {{/if}}

--- a/ghost/admin/app/components/editor/modals/preview/email.hbs
+++ b/ghost/admin/app/components/editor/modals/preview/email.hbs
@@ -88,8 +88,8 @@
                     />
                 </form>
             </div>
-            <Editor::EmailSizeWarning @post={{@post}} as |warningLevel emailSizeKb| >
-                {{#if warningLevel}}
+            <Editor::EmailSizeWarning @post={{@post}} as |overLimit emailSizeKb| >
+                {{#if overLimit}}
                     <div class="gh-email-preview-clip-container">
                         {{svg-jar "email-warning"}}
                         <div>

--- a/ghost/admin/app/components/editor/modals/preview/email.hbs
+++ b/ghost/admin/app/components/editor/modals/preview/email.hbs
@@ -94,7 +94,8 @@
                         {{svg-jar "email-warning"}}
                         <div>
                             <div class="gh-email-preview-clip-title">Looks like this is a long post</div>
-                            <div class="gh-email-preview-clip-description">Email newsletters may get clipped in the inbox behind a “View entire message” link when they’re over 100kB. <span class="gh-email-preview-clip-used">You’ve used: <span class="yellow-d1">{{emailSizeKb}}kB</span></span></div>
+                            <div class="gh-email-preview-clip-description">Emails may get clipped in the inbox behind a “View entire message” link when they’re over 100kB.</div>
+                            <div class="gh-email-preview-clip-used">You’ve used: <span class="yellow-d1">{{emailSizeKb}}kB</span></div>
                         </div>
                     </div>
                 {{/if}}

--- a/ghost/admin/app/components/editor/modals/publish-flow/options.hbs
+++ b/ghost/admin/app/components/editor/modals/publish-flow/options.hbs
@@ -37,6 +37,13 @@
                 />
             </div>
         {{/liquid-if}}
+
+        {{#if @publishOptions.willEmail}}
+            <p class="gh-box gh-content-box pa gh-publish-setting-email-warning {{if (eq this.openSection "publishType") "open"}}">
+                <div class="gh-email-preview-clip-title">Looks like this is a long post</div>
+                <div class="gh-email-preview-clip-description">Email newsletters may get clipped in the inbox behind a “View entire message” link when they’re over 100kB. <span class="gh-email-preview-clip-used">You’ve used: <span class="yellow-d1">101kB</span></span></div>
+            </p>
+        {{/if}}
     </div>
 
     {{#unless @publishOptions.emailUnavailable}}

--- a/ghost/admin/app/components/editor/modals/publish-flow/options.hbs
+++ b/ghost/admin/app/components/editor/modals/publish-flow/options.hbs
@@ -39,10 +39,14 @@
         {{/liquid-if}}
 
         {{#if @publishOptions.willEmail}}
-            <p class="gh-box gh-content-box pa gh-publish-setting-email-warning {{if (eq this.openSection "publishType") "open"}}">
-                <div class="gh-email-preview-clip-title">Looks like this is a long post</div>
-                <div class="gh-email-preview-clip-description">Email newsletters may get clipped in the inbox behind a “View entire message” link when they’re over 100kB. <span class="gh-email-preview-clip-used">You’ve used: <span class="yellow-d1">101kB</span></span></div>
-            </p>
+            <Editor::EmailSizeWarning @post={{@publishOptions.post}} as |overLimit emailSizeKb| >
+                {{#if overLimit}}
+                    <p class="gh-box gh-content-box pa gh-publish-setting-email-warning {{if (eq this.openSection "publishType") "open"}}">
+                        <div class="gh-email-preview-clip-title">Looks like this is a long post</div>
+                        <div class="gh-email-preview-clip-description">Email newsletters may get clipped in the inbox behind a “View entire message” link when they’re over 100kB. <span class="gh-email-preview-clip-used">You’ve used: <span class="yellow-d1">{{emailSizeKb}}kB</span></span></div>
+                    </p>
+                {{/if}}
+            </Editor::EmailSizeWarning>
         {{/if}}
     </div>
 

--- a/ghost/admin/app/components/editor/modals/publish-flow/options.hbs
+++ b/ghost/admin/app/components/editor/modals/publish-flow/options.hbs
@@ -42,8 +42,8 @@
             <Editor::EmailSizeWarning @post={{@publishOptions.post}} as |overLimit emailSizeKb| >
                 {{#if overLimit}}
                     <p class="gh-box gh-content-box pa gh-publish-setting-email-warning {{if (eq this.openSection "publishType") "open"}}">
-                        <div class="gh-email-preview-clip-title">Looks like this is a long post</div>
-                        <div class="gh-email-preview-clip-description">Email newsletters may get clipped in the inbox behind a “View entire message” link when they’re over 100kB. <span class="gh-email-preview-clip-used">You’ve used: <span class="yellow-d1">{{emailSizeKb}}kB</span></span></div>
+                        <div class="gh-email-preview-clip-title">This email is <span class="yellow-d1">{{emailSizeKb}}kB</span></div>
+                        <div class="gh-email-preview-clip-description">Email newsletters may get clipped in the inbox behind a “View entire message” link when they’re over 100kB.</div>
                     </p>
                 {{/if}}
             </Editor::EmailSizeWarning>

--- a/ghost/admin/app/components/editor/modals/publish-flow/options.hbs
+++ b/ghost/admin/app/components/editor/modals/publish-flow/options.hbs
@@ -42,7 +42,7 @@
             <Editor::EmailSizeWarning @post={{@publishOptions.post}} as |overLimit emailSizeKb| >
                 {{#if overLimit}}
                     <p class="gh-box gh-content-box pa gh-publish-setting-email-warning {{if (eq this.openSection "publishType") "open"}}">
-                        <div class="gh-email-preview-clip-title">This email is <span class="yellow-d1">{{emailSizeKb}}kB</span></div>
+                        <div class="gh-email-preview-clip-title mb">This email is <span class="yellow-d1">{{emailSizeKb}}kB</span></div>
                         <div class="gh-email-preview-clip-description">Email newsletters may get clipped in the inbox behind a “View entire message” link when they’re over 100kB.</div>
                     </p>
                 {{/if}}

--- a/ghost/admin/app/styles/components/publishmenu.css
+++ b/ghost/admin/app/styles/components/publishmenu.css
@@ -448,6 +448,15 @@
     line-height: 1.35em;
 }
 
+.gh-publish-setting-email-warning {
+    transition: all 0.3s ease;
+}
+
+.gh-publish-setting-email-warning.open {
+    transform: translateY(-12px);
+    margin-bottom: 12px;
+}
+
 @media (max-width: 560px) {
     .gh-publish-setting-trigger {
         font-size: 1.7rem;

--- a/ghost/admin/app/styles/layouts/editor.css
+++ b/ghost/admin/app/styles/layouts/editor.css
@@ -459,7 +459,7 @@
 }
 
 .gh-editor-email-size-warning svg path {
-    stroke: currentColor !important;
+    stroke: var(--yellow) !important;
 }
 
 .gh-editor-email-size-popup {

--- a/ghost/admin/app/styles/layouts/preview-email.css
+++ b/ghost/admin/app/styles/layouts/preview-email.css
@@ -284,3 +284,38 @@ p .gh-preview-email-address {
         display: none
     }
 }
+
+.gh-email-preview-clip-container {
+    display: flex;
+    background-color: var(--whitegrey-l2);
+    border-bottom: 1px solid var(--whitegrey);
+    padding: 20px;
+    gap: 12px;
+    align-items: flex-start;
+}
+
+.gh-email-preview-clip-container svg {
+    margin-top: 2px;
+    width: 16px;
+    min-width: 16px;
+    height: auto;
+}
+
+.gh-email-preview-clip-container svg path {
+    fill: var(--yellow-d1);
+}
+
+.gh-email-preview-clip-title {
+    font-weight: 600;
+    font-size: 1.3rem;
+}
+
+.gh-email-preview-clip-description {
+    font-size: 1.3rem;
+    text-wrap: pretty;
+}
+
+.gh-email-preview-clip-used {
+    font-size: 1.3rem;
+    font-weight: 600;
+}

--- a/ghost/admin/app/styles/layouts/preview-email.css
+++ b/ghost/admin/app/styles/layouts/preview-email.css
@@ -295,7 +295,7 @@ p .gh-preview-email-address {
 }
 
 .gh-email-preview-clip-container svg {
-    margin-top: 2px;
+    margin-top: 3px;
     width: 16px;
     min-width: 16px;
     height: auto;
@@ -307,7 +307,8 @@ p .gh-preview-email-address {
 
 .gh-email-preview-clip-title {
     font-weight: 600;
-    font-size: 1.3rem;
+    font-size: 1.4rem;
+    margin-bottom: 4px;
 }
 
 .gh-email-preview-clip-description {

--- a/ghost/admin/app/styles/layouts/preview-email.css
+++ b/ghost/admin/app/styles/layouts/preview-email.css
@@ -308,12 +308,17 @@ p .gh-preview-email-address {
 .gh-email-preview-clip-title {
     font-weight: 600;
     font-size: 1.4rem;
+    color: var(--black);
+}
+
+.gh-email-preview-clip-title.mb {
     margin-bottom: 4px;
 }
 
 .gh-email-preview-clip-description {
     font-size: 1.3rem;
     text-wrap: pretty;
+    color: var(--middarkgrey)
 }
 
 .gh-email-preview-clip-used {

--- a/ghost/admin/app/styles/layouts/preview-email.css
+++ b/ghost/admin/app/styles/layouts/preview-email.css
@@ -302,7 +302,7 @@ p .gh-preview-email-address {
 }
 
 .gh-email-preview-clip-container svg path {
-    fill: var(--yellow-d1);
+    stroke: var(--yellow-d1);
 }
 
 .gh-email-preview-clip-title {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/FEA-479/clipping-meter-that-alerts-you-when-html-is-getting-too-large

- The email clipping warning indicator is cool but a little bit easy to dismiss in the editor. To make it more discoverable for large posts we show a similar warning in the email preview.