### PR TITLE
Added rendering output tests for URL transformations

### DIFF
--- a/ghost/core/test/e2e-api/admin/email-previews.test.js
+++ b/ghost/core/test/e2e-api/admin/email-previews.test.js
@@ -1,6 +1,7 @@
 const {agentProvider, fixtureManager, matchers, mockManager} = require('../../utils/e2e-framework');
 const {anyEtag, anyErrorId, anyContentVersion, anyString} = matchers;
 const assert = require('assert/strict');
+const config = require('../../../core/shared/config');
 const sinon = require('sinon');
 const escapeRegExp = require('lodash/escapeRegExp');
 const should = require('should');
@@ -233,6 +234,48 @@ describe('Email Preview API', function () {
                     testCleanedSnapshot(body.email_previews[0].plaintext, {
                         [selectedNewsletter.uuid]: 'requested-newsletter-uuid'
                     });
+                });
+        });
+
+        it('Mobiledoc post email preview renders with all URLs as absolute site URLs', async function () {
+            const siteUrl = config.get('url');
+            const post = await models.Post.findOne({slug: 'post-with-all-media-types-mobiledoc'});
+
+            await agent
+                .get(`email_previews/posts/${post.id}/`)
+                .expectStatus(200)
+                .expect(({body}) => {
+                    const html = body.email_previews[0].html;
+                    html.should.containEql(`${siteUrl}/content/images/feature.jpg`);
+                    html.should.containEql(`${siteUrl}/content/images/inline.jpg`);
+                    html.should.containEql(`${siteUrl}/content/images/gallery-1.jpg`);
+                    html.should.containEql(`${siteUrl}/content/images/video-thumb.jpg`);
+                    html.should.containEql(`${siteUrl}/content/images/audio-thumb.jpg`);
+                    html.should.containEql(`${siteUrl}/content/images/snippet-inline.jpg`);
+                    html.should.containEql(`${siteUrl}/content/images/snippet-video-thumb.jpg`);
+                    html.should.containEql(`${siteUrl}/content/images/snippet-audio-thumb.jpg`);
+                    html.should.not.containEql('__GHOST_URL__');
+                });
+        });
+
+        it('Lexical post email preview renders with all URLs as absolute site URLs', async function () {
+            const siteUrl = config.get('url');
+            const post = await models.Post.findOne({slug: 'post-with-all-media-types-lexical'});
+
+            await agent
+                .get(`email_previews/posts/${post.id}/`)
+                .expectStatus(200)
+                .expect(({body}) => {
+                    const html = body.email_previews[0].html;
+                    html.should.containEql(`${siteUrl}/content/images/feature.jpg`);
+                    html.should.containEql(`${siteUrl}/content/images/inline.jpg`);
+                    html.should.containEql(`${siteUrl}/content/images/gallery-1.jpg`);
+                    html.should.containEql(`${siteUrl}/content/images/video-thumb.jpg`);
+                    html.should.containEql(`${siteUrl}/content/images/audio-thumb.jpg`);
+                    html.should.containEql(`${siteUrl}/content/images/snippet-inline.jpg`);
+                    html.should.containEql(`${siteUrl}/content/images/snippet-video-thumb.jpg`);
+                    html.should.containEql(`${siteUrl}/content/images/snippet-audio-thumb.jpg`);
+                    html.should.not.containEql('__GHOST_URL__');
                 });
         });
     });

--- a/ghost/core/test/e2e-frontend/rendered_content.test.js
+++ b/ghost/core/test/e2e-frontend/rendered_content.test.js
@@ -1,7 +1,9 @@
+const sinon = require('sinon');
 const supertest = require('supertest');
 
 const testUtils = require('../utils');
 const config = require('../../core/shared/config');
+const urlUtilsHelper = require('../utils/urlUtils');
 
 describe('Post Rendering', function () {
     let siteUrl;
@@ -15,6 +17,10 @@ describe('Post Rendering', function () {
         await testUtils.teardownDb();
         await testUtils.initData();
         await testUtils.initFixtures('posts');
+    });
+
+    afterEach(function () {
+        sinon.restore();
     });
 
     describe('HTML', function () {
@@ -53,6 +59,52 @@ describe('Post Rendering', function () {
                     res.text.should.not.containEql('__GHOST_URL__');
                 });
         });
+
+        it('Mobiledoc post renders with CDN URLs for media/files when configured', async function () {
+            const cdnUrl = 'https://cdn.example.com/c/site-uuid';
+            urlUtilsHelper.stubUrlUtilsWithCdn({
+                assetBaseUrls: {media: cdnUrl, files: cdnUrl}
+            }, sinon);
+
+            await request.get('/post-with-all-media-types-mobiledoc/')
+                .expect('Content-Type', /html/)
+                .expect(200)
+                .expect((res) => {
+                    res.text.should.containEql(`${cdnUrl}/content/files/document.pdf`);
+                    res.text.should.containEql(`${cdnUrl}/content/media/video.mp4`);
+                    res.text.should.containEql(`${cdnUrl}/content/media/audio.mp3`);
+                    res.text.should.containEql(`${cdnUrl}/content/files/snippet-document.pdf`);
+                    res.text.should.containEql(`${cdnUrl}/content/media/snippet-video.mp4`);
+                    res.text.should.containEql(`${cdnUrl}/content/media/snippet-audio.mp3`);
+                    res.text.should.containEql(`${siteUrl}/content/images/feature.jpg`);
+                    res.text.should.containEql(`${siteUrl}/content/images/inline.jpg`);
+                    res.text.should.containEql(`${siteUrl}/content/images/snippet-inline.jpg`);
+                    res.text.should.not.containEql('__GHOST_URL__');
+                });
+        });
+
+        it('Lexical post renders with CDN URLs for media/files when configured', async function () {
+            const cdnUrl = 'https://cdn.example.com/c/site-uuid';
+            urlUtilsHelper.stubUrlUtilsWithCdn({
+                assetBaseUrls: {media: cdnUrl, files: cdnUrl}
+            }, sinon);
+
+            await request.get('/post-with-all-media-types-lexical/')
+                .expect('Content-Type', /html/)
+                .expect(200)
+                .expect((res) => {
+                    res.text.should.containEql(`${cdnUrl}/content/files/document.pdf`);
+                    res.text.should.containEql(`${cdnUrl}/content/media/video.mp4`);
+                    res.text.should.containEql(`${cdnUrl}/content/media/audio.mp3`);
+                    res.text.should.containEql(`${cdnUrl}/content/files/snippet-document.pdf`);
+                    res.text.should.containEql(`${cdnUrl}/content/media/snippet-video.mp4`);
+                    res.text.should.containEql(`${cdnUrl}/content/media/snippet-audio.mp3`);
+                    res.text.should.containEql(`${siteUrl}/content/images/feature.jpg`);
+                    res.text.should.containEql(`${siteUrl}/content/images/inline.jpg`);
+                    res.text.should.containEql(`${siteUrl}/content/images/snippet-inline.jpg`);
+                    res.text.should.not.containEql('__GHOST_URL__');
+                });
+        });
     });
 
     describe('RSS', function () {
@@ -70,6 +122,29 @@ describe('Post Rendering', function () {
                     res.text.should.containEql(`${siteUrl}/content/files/snippet-document.pdf`);
                     res.text.should.containEql(`${siteUrl}/content/media/snippet-video.mp4`);
                     res.text.should.containEql(`${siteUrl}/content/media/snippet-audio.mp3`);
+                    res.text.should.not.containEql('__GHOST_URL__');
+                });
+        });
+
+        it('RSS feed renders with CDN URLs for media/files when configured', async function () {
+            const cdnUrl = 'https://cdn.example.com/c/site-uuid';
+            urlUtilsHelper.stubUrlUtilsWithCdn({
+                assetBaseUrls: {media: cdnUrl, files: cdnUrl}
+            }, sinon);
+
+            await request.get('/rss/')
+                .expect(200)
+                .expect('Content-Type', 'application/rss+xml; charset=utf-8')
+                .expect((res) => {
+                    res.text.should.containEql(`${cdnUrl}/content/files/document.pdf`);
+                    res.text.should.containEql(`${cdnUrl}/content/media/video.mp4`);
+                    res.text.should.containEql(`${cdnUrl}/content/media/audio.mp3`);
+                    res.text.should.containEql(`${cdnUrl}/content/files/snippet-document.pdf`);
+                    res.text.should.containEql(`${cdnUrl}/content/media/snippet-video.mp4`);
+                    res.text.should.containEql(`${cdnUrl}/content/media/snippet-audio.mp3`);
+                    res.text.should.containEql(`${siteUrl}/content/images/feature.jpg`);
+                    res.text.should.containEql(`${siteUrl}/content/images/inline.jpg`);
+                    res.text.should.containEql(`${siteUrl}/content/images/snippet-inline.jpg`);
                     res.text.should.not.containEql('__GHOST_URL__');
                 });
         });

--- a/ghost/core/test/e2e-frontend/rendered_content.test.js
+++ b/ghost/core/test/e2e-frontend/rendered_content.test.js
@@ -1,0 +1,77 @@
+const supertest = require('supertest');
+
+const testUtils = require('../utils');
+const config = require('../../core/shared/config');
+
+describe('Post Rendering', function () {
+    let siteUrl;
+    let request;
+
+    before(async function () {
+        await testUtils.startGhost();
+        request = supertest.agent(config.get('url'));
+        siteUrl = config.get('url');
+
+        await testUtils.teardownDb();
+        await testUtils.initData();
+        await testUtils.initFixtures('posts');
+    });
+
+    describe('HTML', function () {
+        it('Mobiledoc post renders with all URLs as absolute site URLs', async function () {
+            await request.get('/post-with-all-media-types-mobiledoc/')
+                .expect('Content-Type', /html/)
+                .expect(200)
+                .expect((res) => {
+                    res.text.should.containEql(`${siteUrl}/content/images/feature.jpg`);
+                    res.text.should.containEql(`${siteUrl}/content/images/inline.jpg`);
+                    res.text.should.containEql(`${siteUrl}/content/files/document.pdf`);
+                    res.text.should.containEql(`${siteUrl}/content/media/video.mp4`);
+                    res.text.should.containEql(`${siteUrl}/content/media/audio.mp3`);
+                    res.text.should.containEql(`${siteUrl}/content/images/snippet-inline.jpg`);
+                    res.text.should.containEql(`${siteUrl}/content/files/snippet-document.pdf`);
+                    res.text.should.containEql(`${siteUrl}/content/media/snippet-video.mp4`);
+                    res.text.should.containEql(`${siteUrl}/content/media/snippet-audio.mp3`);
+                    res.text.should.not.containEql('__GHOST_URL__');
+                });
+        });
+
+        it('Lexical post renders with all URLs as absolute site URLs', async function () {
+            await request.get('/post-with-all-media-types-lexical/')
+                .expect('Content-Type', /html/)
+                .expect(200)
+                .expect((res) => {
+                    res.text.should.containEql(`${siteUrl}/content/images/feature.jpg`);
+                    res.text.should.containEql(`${siteUrl}/content/images/inline.jpg`);
+                    res.text.should.containEql(`${siteUrl}/content/files/document.pdf`);
+                    res.text.should.containEql(`${siteUrl}/content/media/video.mp4`);
+                    res.text.should.containEql(`${siteUrl}/content/media/audio.mp3`);
+                    res.text.should.containEql(`${siteUrl}/content/images/snippet-inline.jpg`);
+                    res.text.should.containEql(`${siteUrl}/content/files/snippet-document.pdf`);
+                    res.text.should.containEql(`${siteUrl}/content/media/snippet-video.mp4`);
+                    res.text.should.containEql(`${siteUrl}/content/media/snippet-audio.mp3`);
+                    res.text.should.not.containEql('__GHOST_URL__');
+                });
+        });
+    });
+
+    describe('RSS', function () {
+        it('RSS feed renders with all URLs as absolute site URLs', async function () {
+            await request.get('/rss/')
+                .expect(200)
+                .expect('Content-Type', 'application/rss+xml; charset=utf-8')
+                .expect((res) => {
+                    res.text.should.containEql(`${siteUrl}/content/images/feature.jpg`);
+                    res.text.should.containEql(`${siteUrl}/content/images/inline.jpg`);
+                    res.text.should.containEql(`${siteUrl}/content/files/document.pdf`);
+                    res.text.should.containEql(`${siteUrl}/content/media/video.mp4`);
+                    res.text.should.containEql(`${siteUrl}/content/media/audio.mp3`);
+                    res.text.should.containEql(`${siteUrl}/content/images/snippet-inline.jpg`);
+                    res.text.should.containEql(`${siteUrl}/content/files/snippet-document.pdf`);
+                    res.text.should.containEql(`${siteUrl}/content/media/snippet-video.mp4`);
+                    res.text.should.containEql(`${siteUrl}/content/media/snippet-audio.mp3`);
+                    res.text.should.not.containEql('__GHOST_URL__');
+                });
+        });
+    });
+});


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PRO-1516/
ref https://linear.app/ghost/issue/PRO-1520/

- Added tests to verify that `__GHOST_URL__` placeholders are transformed to absolute site URLs or CDN url while rendering posts(depending on the config)
- Added `e2e-frontend/rendered_content.test.js` for HTML and RSS rendering
- Added email preview tests in `e2e-api/admin/email-previews.test.js`
- Email preview tests are placed in `e2e-api/admin/email-previews.test.js` because email previews are fetched via the Admin API endpoint, not rendered as frontend routes.
- Email preview tests only check image URLs (feature, inline, gallery, thumbnails) because email rendering doesn't include file/video/audio source URLs directly - these cards link to the post page instead of the actual media files.
