### PR TITLE
Added auth-frame route to dev gateway and mounted Caddyfile

### DIFF
--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -115,6 +115,9 @@ services:
       - "80:80"
     extra_hosts:
       - "host.docker.internal:host-gateway"
+    volumes:
+      # Mount Caddyfile for live config changes without rebuilding
+      - ./docker/dev-gateway/Caddyfile:/etc/caddy/Caddyfile:ro
     depends_on:
       ghost-dev:
         condition: service_healthy

--- a/docker/dev-gateway/Caddyfile
+++ b/docker/dev-gateway/Caddyfile
@@ -128,6 +128,16 @@
         }
     }
 
+    # Auth frame - must go to Ghost backend for comment admin authentication
+    handle /ghost/auth-frame/* {
+        reverse_proxy {env.GHOST_BACKEND} {
+            header_up Host {host}
+            header_up X-Real-IP {remote_host}
+            header_up X-Forwarded-For {remote_host}
+            header_up X-Forwarded-Proto https
+        }
+    }
+
     # Admin interface - served from admin dev server
     # This includes /ghost/, etc. (but /ghost/assets/* is handled above)
     # Also handles WebSocket upgrade requests for live reload


### PR DESCRIPTION
## Summary

When developing locally with `yarn dev:forward`, the Caddy reverse proxy routes requests to either the Ghost backend or the admin dev server. The `/ghost/auth-frame/*` endpoint was missing a dedicated route, causing these requests to fall through to the admin dev server when they should go to the Ghost backend.

This endpoint serves the authentication frame used by comments-ui to enable admin moderation features on frontend comments. Without the correct routing, developers working on comment moderation couldn't test the auth flow locally.

This PR also mounts the Caddyfile as a volume in the Docker Compose configuration, allowing developers to iterate on proxy rules without rebuilding the gateway container each time.