### PR TITLE
Changed link redirects from middleware to router

### DIFF
--- a/ghost/core/core/frontend/web/routers/link-redirects.js
+++ b/ghost/core/core/frontend/web/routers/link-redirects.js
@@ -1,0 +1,5 @@
+const linkRedirects = require('../../../server/services/link-redirection');
+
+module.exports = function handleRedirects(siteApp) {
+    siteApp.get(linkRedirects.service.relativeRedirectPrefix() + '*', linkRedirects.service.handleRequest);
+};

--- a/ghost/core/core/frontend/web/site.js
+++ b/ghost/core/core/frontend/web/site.js
@@ -16,7 +16,7 @@ const themeMiddleware = themeEngine.middleware;
 const membersService = require('../../server/services/members');
 const offersService = require('../../server/services/offers');
 const customRedirects = require('../../server/services/custom-redirects');
-const linkRedirects = require('../../server/services/link-redirection');
+const linkRedirectsHandler = require('./routers/link-redirects');
 const siteRoutes = require('./routes');
 const shared = require('../../server/web/shared');
 const errorHandler = require('@tryghost/mw-error-handler');
@@ -51,7 +51,7 @@ module.exports = function setupSiteApp(routerConfig) {
 
     siteApp.use(offersService.middleware);
 
-    siteApp.use(linkRedirects.service.handleRequest);
+    linkRedirectsHandler(siteApp);
 
     // you can extend Ghost with a custom redirects file
     // see https://github.com/TryGhost/Ghost/issues/7707

--- a/ghost/core/core/server/services/link-redirection/link-redirects-service.js
+++ b/ghost/core/core/server/services/link-redirection/link-redirects-service.js
@@ -78,6 +78,15 @@ class LinkRedirectsService {
     }
 
     /**
+     * Returns the relative path prefix without subdirectory (e.g., /r/)
+     * Used for Express route matching where subdirectory is already stripped
+     * @return {string}
+     **/
+    relativeRedirectPrefix() {
+        return '/' + this.#redirectURLPrefix;
+    }
+
+    /**
      * @param {import('express').Request} req
      * @param {import('express').Response} res
      * @param {import('express').NextFunction} next
@@ -86,18 +95,6 @@ class LinkRedirectsService {
      */
     async handleRequest(req, res, next) {
         try {
-            // skip handling if original url doesn't match the prefix
-            const fullURLWithRedirectPrefix = `${this.#baseURL.pathname}${this.#redirectURLPrefix}`;
-            // @NOTE: below is equivalent to doing:
-            //          router.get('/r/'), (req, res) ...
-            //        To make it cleaner we should rework it to:
-            //          linkRedirects.service.handleRequest(router);
-            //        and mount routes on top like for example sitemapHandler does
-            //        Cleanup issue: https://github.com/TryGhost/Toolbox/issues/516
-            if (!req.originalUrl.startsWith(fullURLWithRedirectPrefix)) {
-                return next();
-            }
-
             const url = new URL(req.originalUrl, this.#baseURL);
             const link = await this.#linkRedirectRepository.getByURL(url);
 

--- a/ghost/core/test/unit/server/services/link-redirection/link-redirects-service.test.js
+++ b/ghost/core/test/unit/server/services/link-redirection/link-redirects-service.test.js
@@ -137,38 +137,5 @@ describe('LinkRedirectsService', function () {
             assert.equal(next.callCount, 1);
         });
 
-        it('does not redirect if url does not contain a redirect prefix on site with no subdir', async function () {
-            const instance = new LinkRedirectsService({
-                config: {
-                    baseURL: new URL('https://localhost:2368/')
-                }
-            });
-            const req = {
-                originalUrl: 'no_r/prefix'
-            };
-            const res = {};
-            const next = sinon.fake();
-
-            await instance.handleRequest(req, res, next);
-
-            assert.equal(next.callCount, 1);
-        });
-
-        it('does not redirect if url does not contain a redirect prefix on site with subdir', async function () {
-            const instance = new LinkRedirectsService({
-                config: {
-                    baseURL: new URL('https://localhost:2368/blog')
-                }
-            });
-            const req = {
-                originalUrl: 'blog/no_r/prefix'
-            };
-            const res = {};
-            const next = sinon.fake();
-
-            await instance.handleRequest(req, res, next);
-
-            assert.equal(next.callCount, 1);
-        });
     });
 });

--- a/ghost/core/test/unit/server/services/link-redirection/link-redirects-service.test.js
+++ b/ghost/core/test/unit/server/services/link-redirection/link-redirects-service.test.js
@@ -136,6 +136,5 @@ describe('LinkRedirectsService', function () {
             await instance.handleRequest(req, res, next);
             assert.equal(next.callCount, 1);
         });
-
     });
 });

--- a/ghost/core/test/unit/server/services/link-redirection/link-redirects-service.test.js
+++ b/ghost/core/test/unit/server/services/link-redirection/link-redirects-service.test.js
@@ -65,6 +65,28 @@ describe('LinkRedirectsService', function () {
         });
     });
 
+    describe('relativeRedirectPrefix', function () {
+        it('returns relative path without subdirectory for Express routing', function () {
+            const instance = new LinkRedirectsService({
+                linkRedirectRepository: {},
+                config: {
+                    baseURL: new URL('https://localhost:2368/blog/')
+                }
+            });
+            assert.equal(instance.relativeRedirectPrefix(), '/r/');
+        });
+
+        it('returns same value as redirectPrefix when no subdirectory configured', function () {
+            const instance = new LinkRedirectsService({
+                linkRedirectRepository: {},
+                config: {
+                    baseURL: new URL('https://localhost:2368/')
+                }
+            });
+            assert.equal(instance.relativeRedirectPrefix(), '/r/');
+        });
+    });
+
     describe('handleRequest', function () {
         it('redirects if found', async function () {
             const linkRedirectRepository = {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3095

Extracted the link redirects code from the middleware to the router. This avoids route comparison on every requests Ghost receives.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves link redirect handling out of global middleware and into a dedicated router for clearer routing and fewer per-request checks.
> 
> - New `routers/link-redirects.js` registers `GET` handler at `linkRedirects.service.relativeRedirectPrefix() + '*'`; `site.js` mounts this router
> - `LinkRedirectsService`: adds `relativeRedirectPrefix()` and removes in-method prefix checks; `handleRequest` now assumes routing filtered paths
> - Tests: add coverage for `relativeRedirectPrefix`, update redirect behavior tests, and drop non-matching-prefix cases
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 93fa62fbb0e9b7b7110a2d648ecf418988e3aa55. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->