### PR TITLE
Fixed Explore service MRR data

### DIFF
--- a/ghost/core/core/server/services/explore-ping/index.js
+++ b/ghost/core/core/server/services/explore-ping/index.js
@@ -7,6 +7,7 @@ const request = require('@tryghost/request');
 const settingsCache = require('../../../shared/settings-cache');
 const posts = require('../posts/posts-service');
 const members = require('../members');
+const statsService = require('../stats');
 
 // Export the creation function for testing
 module.exports.createService = function createService() {
@@ -18,7 +19,8 @@ module.exports.createService = function createService() {
         ghostVersion,
         request,
         posts: posts(),
-        members
+        members,
+        statsService
     });
 };
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ENG-2555/
- updated to only submit Connect data (real Stripe MRR)
- updated MRR query to use Stats service

The previous implementation had a couple bugs:

The MRR stats query was not actually part of the Members Stats service. This was not caught in unit tests because it was all mocked. This query is actually part of the more generic Stats service.

Additionally, we always submitted MRR data, including Stripe's 'test mode' data. We only want to submit real MRR data.