### PR TITLE
Hid the upgrade required banner in admin forward

### DIFF
--- a/ghost/admin/app/services/ajax.js
+++ b/ghost/admin/app/services/ajax.js
@@ -353,7 +353,7 @@ class ajaxService extends AjaxService {
             const contentVersion = semverCoerce(headers['content-version']);
             const appVersion = semverCoerce(config.APP.version);
 
-            if (semverLt(appVersion, contentVersion)) {
+            if (semverLt(appVersion, contentVersion) && !this.feature.inAdminForward) {
                 this.upgradeStatus.refreshRequired = true;
             }
         }


### PR DESCRIPTION
no ref 

The "Ghost has been updated! To get access to the latest features, refresh or click here" banner doesn't really make sense in it's current format while in the continuously delivered version of the admin and it's confusing when it shows up on staging.
