### PR TITLE
Optimized filtered_sessions pipe to skip unnecessary join

### DIFF
--- a/ghost/core/core/server/data/tinybird/pipes/filtered_sessions.pipe
+++ b/ghost/core/core/server/data/tinybird/pipes/filtered_sessions.pipe
@@ -37,10 +37,11 @@ SQL >
 NODE sessions_filtered_by_session_attributes
 DESCRIPTION >
     Further filter by session-level attributes (source, device, utm_*). These attributes are specific to the first hit in a session,
-    whereas other filters are on hits.
+    whereas other filters are on hits. If no session-level filters are provided, skip the join with mv_session_data entirely.
 
 SQL >
     %
+    {% if defined(source) or defined(device) or defined(utm_source) or defined(utm_medium) or defined(utm_campaign) or defined(utm_term) or defined(utm_content) %}
     select session_id
     from mv_session_data sd
     inner join sessions_filtered_by_hit_attributes sfha
@@ -68,3 +69,8 @@ SQL >
         {% if defined(utm_campaign) %} and utm_campaign = {{ String(utm_campaign, description="UTM campaign to filter on", required=False) }} {% end %}
         {% if defined(utm_term) %} and utm_term = {{ String(utm_term, description="UTM term to filter on", required=False) }} {% end %}
         {% if defined(utm_content) %} and utm_content = {{ String(utm_content, description="UTM content to filter on", required=False) }} {% end %}
+    {% else %}
+    {# No session-level filters, skip the join with mv_session_data #}
+    select session_id
+    from sessions_filtered_by_hit_attributes
+    {% end %}


### PR DESCRIPTION
ref https://linear.app/ghost/issue/NY-865/analytics-sources-not-populating-for-tangle-due-to-408-timeouts

The filtered_sessions pipe always joins with `mv_session_data`, even when no session-level filters (source, device, utm_*) were provided. This added overhead for the majority of analytics queries that only use hit-level filters. The pipe now conditionally skips the join when no session-level filters are present, passing session IDs directly from the first filtering stage.

The vast majority of requests don't include filters on these fields. By skipping the join, we avoid running the `mv_session_data` pipe one additional time. From local testing, this reduces the memory usage in our endpoints by ~15%, cpu time by ~14-25%, and ultimately reduces the amount of rows and bytes read by ~30% across all our Tinybird endpoints.