### PR TITLE
Switched Tinybird endpoints from uniqExact to uniq for session counting

### DIFF
--- a/ghost/core/core/server/data/tinybird/endpoints/api_active_visitors.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_active_visitors.pipe
@@ -5,7 +5,7 @@ NODE _active_visitors_0
 SQL >
 %
     select
-        uniqExact(session_id) as active_visitors
+        uniq(session_id) as active_visitors
     from _mv_hits
     where
         site_uuid = {{String(site_uuid, 'mock_site_uuid', description="Site UUID", required=True)}}

--- a/ghost/core/core/server/data/tinybird/endpoints/api_post_visitor_counts.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_post_visitor_counts.pipe
@@ -6,7 +6,7 @@ SQL >
 %
     select
         post_uuid,
-        uniqExact(session_id) as visits
+        uniq(session_id) as visits
     from _mv_hits
     where
         site_uuid = {{String(site_uuid, 'mock_site_uuid', description="Site UUID", required=True)}}

--- a/ghost/core/core/server/data/tinybird/endpoints/api_top_locations.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_top_locations.pipe
@@ -7,7 +7,7 @@ SQL >
     %
         select
             location,
-            uniqExact(session_id) as visits
+            uniq(session_id) as visits
         from _mv_hits h
         inner join filtered_sessions fs
             on fs.session_id = h.session_id

--- a/ghost/core/core/server/data/tinybird/endpoints/api_top_pages.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_top_pages.pipe
@@ -8,7 +8,7 @@ SQL >
     select
         case when post_uuid = 'undefined' then '' else post_uuid end as post_uuid,
         pathname,
-        uniqExact(session_id) as visits
+        uniq(session_id) as visits
     from _mv_hits h
     inner join filtered_sessions fs
         on fs.session_id = h.session_id


### PR DESCRIPTION
ref https://linear.app/ghost/issue/NY-865/analytics-sources-not-populating-for-tangle-due-to-408-timeouts

The uniqExact function computes exact unique counts which is more expensive than necessary for analytics dashboards. Using uniq (HyperLogLog) provides approximate counts with ~2-3% error margin, which is acceptable for visitor/session metrics and offers better query performance.