### PR TITLE
Optimized top_locations and top_pages endpoints to avoid double-scan

### DIFF
--- a/ghost/core/core/server/data/tinybird/endpoints/api_top_locations.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_top_locations.pipe
@@ -2,17 +2,39 @@ TOKEN "stats_page" READ
 TOKEN "axis" READ
 
 NODE _top_locations_0
+DESCRIPTION >
+    Get top locations by unique session count. When no session-level filters (source, device, utm_*)
+    are provided, queries _mv_hits directly to avoid the double-scan through filtered_sessions.
+
 SQL >
 
     %
         select
             location,
             uniqExact(session_id) as visits
+        {% if defined(source) or defined(device) or defined(utm_source) or defined(utm_medium) or defined(utm_campaign) or defined(utm_term) or defined(utm_content) %}
+        {# Session-level filters require filtered_sessions join #}
         from _mv_hits h
         inner join filtered_sessions fs
             on fs.session_id = h.session_id
         where
             site_uuid = {{String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True)}}
+        {% else %}
+        {# No session-level filters - query _mv_hits directly for better performance #}
+        from _mv_hits h
+        where
+            site_uuid = {{String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True)}}
+            {% if defined(date_from) %}
+                and timestamp >= toDateTime({{ Date(date_from) }}, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})
+            {% else %}
+                and timestamp >= toDateTime(dateAdd(day, -7, today()), {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})
+            {% end %}
+            {% if defined(date_to) %}
+                and timestamp < toDateTime({{ Date(date_to) }}, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}) + interval 1 day
+            {% else %}
+                and timestamp < toDateTime(dateAdd(day, 1, today()), {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})
+            {% end %}
+        {% end %}
             {% if defined(member_status) %}
                 and member_status IN (
                     select arrayJoin(

--- a/ghost/core/core/server/data/tinybird/endpoints/api_top_pages.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_top_pages.pipe
@@ -2,6 +2,10 @@ TOKEN "stats_page" READ
 TOKEN "axis" READ
 
 NODE _top_pages_0
+DESCRIPTION >
+    Get top pages by unique session count. When no session-level filters (source, device, utm_*)
+    are provided, queries _mv_hits directly to avoid the double-scan through filtered_sessions.
+
 SQL >
 
     %
@@ -9,11 +13,29 @@ SQL >
         case when post_uuid = 'undefined' then '' else post_uuid end as post_uuid,
         pathname,
         uniqExact(session_id) as visits
+    {% if defined(source) or defined(device) or defined(utm_source) or defined(utm_medium) or defined(utm_campaign) or defined(utm_term) or defined(utm_content) %}
+    {# Session-level filters require filtered_sessions join #}
     from _mv_hits h
     inner join filtered_sessions fs
         on fs.session_id = h.session_id
     where
         site_uuid = {{String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True)}}
+    {% else %}
+    {# No session-level filters - query _mv_hits directly for better performance #}
+    from _mv_hits h
+    where
+        site_uuid = {{String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True)}}
+        {% if defined(date_from) %}
+            and timestamp >= toDateTime({{ Date(date_from) }}, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})
+        {% else %}
+            and timestamp >= toDateTime(dateAdd(day, -7, today()), {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})
+        {% end %}
+        {% if defined(date_to) %}
+            and timestamp < toDateTime({{ Date(date_to) }}, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}) + interval 1 day
+        {% else %}
+            and timestamp < toDateTime(dateAdd(day, 1, today()), {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})
+        {% end %}
+    {% end %}
         {% if defined(member_status) %}
             and member_status IN (
                 select arrayJoin(


### PR DESCRIPTION
ref https://linear.app/ghost/issue/NY-865/analytics-sources-not-populating-for-tangle-due-to-408-timeouts

These endpoints were scanning `_mv_hits` twice: once through `filtered_sessions` to get qualifying session IDs, then again to aggregate by location/pathname. When no session-level filters (source, device, `utm_*`) are provided, the endpoints now query `_mv_hits` directly in a single pass. This should significantly reduce query time and timeouts for these high-traffic endpoints.
