### PR TITLE
Revert "Disable NX daemon"

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -4,7 +4,6 @@
         "default": ["{projectRoot}/**/*", "{workspaceRoot}/ghost/tsconfig.json"]
     },
     "parallel": 4,
-    "useDaemonProcess": false,
     "targetDefaults": {
         "build": {
             "dependsOn": ["^build"],


### PR DESCRIPTION
Reverts TryGhost/Ghost#25716. Disabling the NX daemon caused the old `yarn dev` workflow to break. 