### PR TITLE
Changed `require()` on sentry to boot faster

### DIFF
--- a/ghost/core/core/shared/sentry.js
+++ b/ghost/core/core/shared/sentry.js
@@ -1,7 +1,7 @@
 const config = require('./config');
 const SentryKnexTracingIntegration = require('./SentryKnexTracingIntegration');
 const sentryConfig = config.get('sentry');
-const errors = require('@tryghost/errors');
+let _errors;
 
 /**
  * @param {import('@sentry/node').Event} event
@@ -10,6 +10,7 @@ const errors = require('@tryghost/errors');
  */
 const beforeSend = function (event, hint) {
     try {
+        const errors = _errors || (_errors = require('@tryghost/errors'));
         const exception = hint.originalException;
         const code = exception?.code ?? null;
         const context = exception?.context ?? null;


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3132

- The `require('@tryghost/errors')` adds 50-100ms on boot time, this is due to the package's own initialization and `require()`. Since it's not needed at boot, it can be moved inside the `beforeSend` function.
