### PR TITLE
Fixed generate-data script creating uncommentable posts

### DIFF
--- a/ghost/core/core/server/data/seeders/importers/PostsImporter.js
+++ b/ghost/core/core/server/data/seeders/importers/PostsImporter.js
@@ -48,14 +48,16 @@ class PostsImporter extends TableImporter {
             status = 'published';
         }
 
+        const id = this.fastFakeObjectId();
         const visibility = luck(85) ? 'paid' : luck(10) ? 'members' : 'public';
 
         return {
-            id: this.fastFakeObjectId(),
+            id,
             created_at: dateToDatabaseString(timestamp),
             updated_at: dateToDatabaseString(timestamp),
             published_at: status === 'published' ? dateToDatabaseString(timestamp) : status === 'scheduled' ? dateToDatabaseString(faker.date.soon(5, timestamp)) : null,
             uuid: faker.datatype.uuid(),
+            comment_id: this.type === 'post' ? id : null,
             title: title,
             type: this.type,
             slug: `${slugify(title)}-${faker.random.numeric(3)}`,


### PR DESCRIPTION
no issue

- our `{{comments}}` helper exits early and renders nothing if `posts.comment_id` is not filled
- the `PostsImporter` for our data generator never set `posts.comment_id` meaning the comments area never appeared for generated posts
