### PR TITLE
Added commentPermalinks labs flag for comment permalink feature

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
@@ -63,6 +63,10 @@ const features: Feature[] = [{
     title: 'Email Size Warnings',
     description: 'Enable warnings in editor when content exceeds email cut-off size',
     flag: 'emailSizeWarnings'
+}, {
+    title: 'Comment Permalinks',
+    description: 'Enable direct links to individual comments with automatic scrolling and highlighting',
+    flag: 'commentPermalinks'
 }];
 
 const AlphaFeatures: React.FC = () => {

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -55,7 +55,8 @@ const PRIVATE_FEATURES = [
     'domainWarmup',
     'themeTranslation',
     'commentModeration',
-    'emailSizeWarnings'
+    'emailSizeWarnings',
+    'commentPermalinks'
 ];
 
 module.exports.GA_KEYS = [...GA_FEATURES];

--- a/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
@@ -14,6 +14,7 @@ Object {
       "announcementBar": true,
       "audienceFeedback": true,
       "commentModeration": true,
+      "commentPermalinks": true,
       "contentVisibility": true,
       "contentVisibilityAlpha": true,
       "customFonts": true,


### PR DESCRIPTION
## Summary

This PR adds a new labs flag `commentPermalinks` to support the comment permalink feature being developed in FEA-486. The flag is added as a private feature, meaning it will only be visible in the Labs settings when developer experiments are enabled.

The comment permalink feature allows users to share direct links to specific comments on posts. When someone opens a permalink, the page automatically scrolls to that comment and highlights it briefly to draw attention. This is particularly useful for moderation workflows where admins need to share links to specific comments that require review.

By gating this behind a labs flag, we can test the feature internally and with select users before making it generally available. The flag infrastructure is being added now so that the main permalink implementation (on the `comment-permalinks` branch) can check for it when merged.

ref https://linear.app/ghost/issue/FEA-500