### PR TITLE
Reduced volume of network requests on Web traffic views

### DIFF
--- a/apps/posts/src/views/PostAnalytics/components/stats-filter.tsx
+++ b/apps/posts/src/views/PostAnalytics/components/stats-filter.tsx
@@ -247,14 +247,14 @@ function StatsFilter({filters, utmTrackingEnabled = false, onChange, ...props}: 
     // Fetch options for all Tinybird-backed fields using the generic hook
     // Options are contextual - filtered based on currently applied filters and post_uuid
     // Lazy loading: only fetch when field is active or has applied filter
-    const {options: utmSourceOptions} = useTinybirdFilterOptions('utm_source', filters, postUuid, {enabled: shouldFetchOptions('utm_source')});
-    const {options: utmMediumOptions} = useTinybirdFilterOptions('utm_medium', filters, postUuid, {enabled: shouldFetchOptions('utm_medium')});
-    const {options: utmCampaignOptions} = useTinybirdFilterOptions('utm_campaign', filters, postUuid, {enabled: shouldFetchOptions('utm_campaign')});
-    const {options: utmContentOptions} = useTinybirdFilterOptions('utm_content', filters, postUuid, {enabled: shouldFetchOptions('utm_content')});
-    const {options: utmTermOptions} = useTinybirdFilterOptions('utm_term', filters, postUuid, {enabled: shouldFetchOptions('utm_term')});
-    const {options: sourceOptions} = useTinybirdFilterOptions('source', filters, postUuid, {enabled: shouldFetchOptions('source')});
-    const {options: deviceOptions} = useTinybirdFilterOptions('device', filters, postUuid, {enabled: shouldFetchOptions('device')});
-    const {options: locationOptions} = useTinybirdFilterOptions('location', filters, postUuid, {enabled: shouldFetchOptions('location')});
+    const {options: utmSourceOptions, loading: utmSourceLoading} = useTinybirdFilterOptions('utm_source', filters, postUuid, {enabled: shouldFetchOptions('utm_source')});
+    const {options: utmMediumOptions, loading: utmMediumLoading} = useTinybirdFilterOptions('utm_medium', filters, postUuid, {enabled: shouldFetchOptions('utm_medium')});
+    const {options: utmCampaignOptions, loading: utmCampaignLoading} = useTinybirdFilterOptions('utm_campaign', filters, postUuid, {enabled: shouldFetchOptions('utm_campaign')});
+    const {options: utmContentOptions, loading: utmContentLoading} = useTinybirdFilterOptions('utm_content', filters, postUuid, {enabled: shouldFetchOptions('utm_content')});
+    const {options: utmTermOptions, loading: utmTermLoading} = useTinybirdFilterOptions('utm_term', filters, postUuid, {enabled: shouldFetchOptions('utm_term')});
+    const {options: sourceOptions, loading: sourceLoading} = useTinybirdFilterOptions('source', filters, postUuid, {enabled: shouldFetchOptions('source')});
+    const {options: deviceOptions, loading: deviceLoading} = useTinybirdFilterOptions('device', filters, postUuid, {enabled: shouldFetchOptions('device')});
+    const {options: locationOptions, loading: locationLoading} = useTinybirdFilterOptions('location', filters, postUuid, {enabled: shouldFetchOptions('location')});
 
     // Note: Only 'is' operator supported - Tinybird pipes only support exact match
     const supportedOperators = useMemo(() => [
@@ -275,6 +275,7 @@ function StatsFilter({filters, utmTrackingEnabled = false, onChange, ...props}: 
                 defaultOperator: 'is',
                 hideOperatorSelect: true,
                 options: utmSourceOptions,
+                isLoading: utmSourceLoading,
                 searchable: true,
                 selectedOptionsClassName: 'hidden'
             },
@@ -288,6 +289,7 @@ function StatsFilter({filters, utmTrackingEnabled = false, onChange, ...props}: 
                 defaultOperator: 'is',
                 hideOperatorSelect: true,
                 options: utmMediumOptions,
+                isLoading: utmMediumLoading,
                 className: 'w-60',
                 popoverContentClassName: 'w-60',
                 searchable: true,
@@ -303,6 +305,7 @@ function StatsFilter({filters, utmTrackingEnabled = false, onChange, ...props}: 
                 defaultOperator: 'is',
                 hideOperatorSelect: true,
                 options: utmCampaignOptions,
+                isLoading: utmCampaignLoading,
                 className: 'w-60',
                 popoverContentClassName: 'w-60',
                 searchable: true,
@@ -318,6 +321,7 @@ function StatsFilter({filters, utmTrackingEnabled = false, onChange, ...props}: 
                 defaultOperator: 'is',
                 hideOperatorSelect: true,
                 options: utmContentOptions,
+                isLoading: utmContentLoading,
                 className: 'w-60',
                 popoverContentClassName: 'w-60',
                 searchable: true,
@@ -333,6 +337,7 @@ function StatsFilter({filters, utmTrackingEnabled = false, onChange, ...props}: 
                 defaultOperator: 'is',
                 hideOperatorSelect: true,
                 options: utmTermOptions,
+                isLoading: utmTermLoading,
                 className: 'w-60',
                 popoverContentClassName: 'w-60',
                 searchable: true,
@@ -364,6 +369,7 @@ function StatsFilter({filters, utmTrackingEnabled = false, onChange, ...props}: 
                         defaultOperator: 'is',
                         hideOperatorSelect: true,
                         options: sourceOptions,
+                        isLoading: sourceLoading,
                         className: 'w-60',
                         popoverContentClassName: 'w-60',
                         searchable: true,
@@ -379,6 +385,7 @@ function StatsFilter({filters, utmTrackingEnabled = false, onChange, ...props}: 
                         defaultOperator: 'is',
                         hideOperatorSelect: true,
                         options: deviceOptions,
+                        isLoading: deviceLoading,
                         selectedOptionsClassName: 'hidden'
                     },
                     {
@@ -391,6 +398,7 @@ function StatsFilter({filters, utmTrackingEnabled = false, onChange, ...props}: 
                         defaultOperator: 'is',
                         hideOperatorSelect: true,
                         options: locationOptions,
+                        isLoading: locationLoading,
                         searchable: true,
                         selectedOptionsClassName: 'hidden'
                     }
@@ -401,7 +409,7 @@ function StatsFilter({filters, utmTrackingEnabled = false, onChange, ...props}: 
                 fields: utmFields
             }] : [])
         ];
-    }, [utmTrackingEnabled, utmSourceOptions, utmMediumOptions, utmCampaignOptions, utmContentOptions, utmTermOptions, supportedOperators, audienceOptions, sourceOptions, deviceOptions, locationOptions]);
+    }, [utmTrackingEnabled, utmSourceOptions, utmSourceLoading, utmMediumOptions, utmMediumLoading, utmCampaignOptions, utmCampaignLoading, utmContentOptions, utmContentLoading, utmTermOptions, utmTermLoading, supportedOperators, audienceOptions, sourceOptions, sourceLoading, deviceOptions, deviceLoading, locationOptions, locationLoading]);
 
     // Show clear button when there's at least one filter
     const hasFilters = filters.length > 0;

--- a/apps/shade/src/components/ui/filters.tsx
+++ b/apps/shade/src/components/ui/filters.tsx
@@ -1910,6 +1910,7 @@ interface FiltersProps<T = unknown> {
     popoverContentClassName?: string;
     popoverAlign?: 'start' | 'center' | 'end';
     keyboardShortcut?: string;
+    onActiveFieldChange?: (fieldKey: string | null) => void;
 }
 
 export function Filters<T = unknown>({
@@ -1932,11 +1933,17 @@ export function Filters<T = unknown>({
     allowMultiple = true,
     popoverContentClassName,
     popoverAlign = 'start',
-    keyboardShortcut
+    keyboardShortcut,
+    onActiveFieldChange
 }: FiltersProps<T>) {
     const [addFilterOpen, setAddFilterOpen] = useState(false);
     const [selectedFieldKeyForOptions, setSelectedFieldKeyForOptions] = useState<string | null>(null);
     const [tempSelectedValues, setTempSelectedValues] = useState<unknown[]>([]);
+
+    // Notify parent when active field changes
+    useEffect(() => {
+        onActiveFieldChange?.(selectedFieldKeyForOptions);
+    }, [selectedFieldKeyForOptions, onActiveFieldChange]);
 
     // Keyboard shortcut handler
     useEffect(() => {

--- a/apps/stats/src/views/Stats/components/stats-filter.tsx
+++ b/apps/stats/src/views/Stats/components/stats-filter.tsx
@@ -319,14 +319,14 @@ function StatsFilter({filters, utmTrackingEnabled = false, onChange, ...props}: 
     // Fetch options for all Tinybird-backed fields using the generic hook
     // Options are contextual - filtered based on currently applied filters
     // Lazy loading: only fetch when field is active or has applied filter
-    const {options: utmSourceOptions} = useTinybirdFilterOptions('utm_source', filters, {enabled: shouldFetchOptions('utm_source')});
-    const {options: utmMediumOptions} = useTinybirdFilterOptions('utm_medium', filters, {enabled: shouldFetchOptions('utm_medium')});
-    const {options: utmCampaignOptions} = useTinybirdFilterOptions('utm_campaign', filters, {enabled: shouldFetchOptions('utm_campaign')});
-    const {options: utmContentOptions} = useTinybirdFilterOptions('utm_content', filters, {enabled: shouldFetchOptions('utm_content')});
-    const {options: utmTermOptions} = useTinybirdFilterOptions('utm_term', filters, {enabled: shouldFetchOptions('utm_term')});
-    const {options: sourceOptions} = useTinybirdFilterOptions('source', filters, {enabled: shouldFetchOptions('source')});
-    const {options: deviceOptions} = useTinybirdFilterOptions('device', filters, {enabled: shouldFetchOptions('device')});
-    const {options: locationOptions} = useTinybirdFilterOptions('location', filters, {enabled: shouldFetchOptions('location')});
+    const {options: utmSourceOptions, loading: utmSourceLoading} = useTinybirdFilterOptions('utm_source', filters, {enabled: shouldFetchOptions('utm_source')});
+    const {options: utmMediumOptions, loading: utmMediumLoading} = useTinybirdFilterOptions('utm_medium', filters, {enabled: shouldFetchOptions('utm_medium')});
+    const {options: utmCampaignOptions, loading: utmCampaignLoading} = useTinybirdFilterOptions('utm_campaign', filters, {enabled: shouldFetchOptions('utm_campaign')});
+    const {options: utmContentOptions, loading: utmContentLoading} = useTinybirdFilterOptions('utm_content', filters, {enabled: shouldFetchOptions('utm_content')});
+    const {options: utmTermOptions, loading: utmTermLoading} = useTinybirdFilterOptions('utm_term', filters, {enabled: shouldFetchOptions('utm_term')});
+    const {options: sourceOptions, loading: sourceLoading} = useTinybirdFilterOptions('source', filters, {enabled: shouldFetchOptions('source')});
+    const {options: deviceOptions, loading: deviceLoading} = useTinybirdFilterOptions('device', filters, {enabled: shouldFetchOptions('device')});
+    const {options: locationOptions, loading: locationLoading} = useTinybirdFilterOptions('location', filters, {enabled: shouldFetchOptions('location')});
 
     // Fetch options for posts - data is contextual based on current filters
     const {options: postOptions, loading: postLoading} = usePostOptions(filters, {enabled: shouldFetchOptions('post')});
@@ -349,6 +349,7 @@ function StatsFilter({filters, utmTrackingEnabled = false, onChange, ...props}: 
                 defaultOperator: 'is',
                 hideOperatorSelect: true,
                 options: utmSourceOptions,
+                isLoading: utmSourceLoading,
                 searchable: true,
                 selectedOptionsClassName: 'hidden'
             },
@@ -362,6 +363,7 @@ function StatsFilter({filters, utmTrackingEnabled = false, onChange, ...props}: 
                 defaultOperator: 'is',
                 hideOperatorSelect: true,
                 options: utmMediumOptions,
+                isLoading: utmMediumLoading,
                 className: 'w-60',
                 popoverContentClassName: 'w-60',
                 searchable: true,
@@ -377,6 +379,7 @@ function StatsFilter({filters, utmTrackingEnabled = false, onChange, ...props}: 
                 defaultOperator: 'is',
                 hideOperatorSelect: true,
                 options: utmCampaignOptions,
+                isLoading: utmCampaignLoading,
                 className: 'w-60',
                 popoverContentClassName: 'w-60',
                 searchable: true,
@@ -392,6 +395,7 @@ function StatsFilter({filters, utmTrackingEnabled = false, onChange, ...props}: 
                 defaultOperator: 'is',
                 hideOperatorSelect: true,
                 options: utmContentOptions,
+                isLoading: utmContentLoading,
                 className: 'w-60',
                 popoverContentClassName: 'w-60',
                 searchable: true,
@@ -407,6 +411,7 @@ function StatsFilter({filters, utmTrackingEnabled = false, onChange, ...props}: 
                 defaultOperator: 'is',
                 hideOperatorSelect: true,
                 options: utmTermOptions,
+                isLoading: utmTermLoading,
                 className: 'w-60',
                 popoverContentClassName: 'w-60',
                 searchable: true,
@@ -453,6 +458,7 @@ function StatsFilter({filters, utmTrackingEnabled = false, onChange, ...props}: 
                         defaultOperator: 'is',
                         hideOperatorSelect: true,
                         options: sourceOptions,
+                        isLoading: sourceLoading,
                         className: 'w-60',
                         popoverContentClassName: 'w-60',
                         searchable: true,
@@ -468,6 +474,7 @@ function StatsFilter({filters, utmTrackingEnabled = false, onChange, ...props}: 
                         defaultOperator: 'is',
                         hideOperatorSelect: true,
                         options: deviceOptions,
+                        isLoading: deviceLoading,
                         selectedOptionsClassName: 'hidden'
                     },
                     {
@@ -480,6 +487,7 @@ function StatsFilter({filters, utmTrackingEnabled = false, onChange, ...props}: 
                         defaultOperator: 'is',
                         hideOperatorSelect: true,
                         options: locationOptions,
+                        isLoading: locationLoading,
                         searchable: true,
                         selectedOptionsClassName: 'hidden'
                     }
@@ -490,7 +498,7 @@ function StatsFilter({filters, utmTrackingEnabled = false, onChange, ...props}: 
                 fields: utmFields
             }] : [])
         ];
-    }, [utmTrackingEnabled, utmSourceOptions, utmMediumOptions, utmCampaignOptions, utmContentOptions, utmTermOptions, supportedOperators, postOptions, postLoading, audienceOptions, sourceOptions, deviceOptions, locationOptions]);
+    }, [utmTrackingEnabled, utmSourceOptions, utmSourceLoading, utmMediumOptions, utmMediumLoading, utmCampaignOptions, utmCampaignLoading, utmContentOptions, utmContentLoading, utmTermOptions, utmTermLoading, supportedOperators, postOptions, postLoading, audienceOptions, sourceOptions, sourceLoading, deviceOptions, deviceLoading, locationOptions, locationLoading]);
 
     // Show clear button when there's at least one filter
     const hasFilters = filters.length > 0;

--- a/apps/stats/src/views/Stats/components/stats-filter.tsx
+++ b/apps/stats/src/views/Stats/components/stats-filter.tsx
@@ -129,9 +129,18 @@ const buildFilterParams = (
     return params;
 };
 
+interface UseTinybirdFilterOptionsConfig {
+    enabled?: boolean;
+}
+
 // Generic hook to fetch filter options from Tinybird
 // Handles the common pattern: fetch data, transform to options, ensure selected value is included
-const useTinybirdFilterOptions = (fieldKey: string, currentFilters: Filter[] = []) => {
+const useTinybirdFilterOptions = (
+    fieldKey: string,
+    currentFilters: Filter[] = [],
+    config: UseTinybirdFilterOptionsConfig = {}
+) => {
+    const {enabled = true} = config;
     const {statsConfig, range} = useGlobalData();
     const {startDate, endDate, timezone} = getRangeDates(range);
 
@@ -161,7 +170,7 @@ const useTinybirdFilterOptions = (fieldKey: string, currentFilters: Filter[] = [
         endpoint: definition?.endpoint || '',
         statsConfig,
         params,
-        enabled: !!definition
+        enabled: enabled && !!definition
     });
 
     const options = useMemo(() => {
@@ -192,9 +201,14 @@ const useTinybirdFilterOptions = (fieldKey: string, currentFilters: Filter[] = [
     return {options, loading};
 };
 
+interface UsePostOptionsConfig {
+    enabled?: boolean;
+}
+
 // Hook to fetch posts/pages options from Ghost API (which queries Tinybird and enriches with titles)
 // This uses a different API pattern so it can't use the generic hook
-const usePostOptions = (currentFilters: Filter[] = []) => {
+const usePostOptions = (currentFilters: Filter[] = [], config: UsePostOptionsConfig = {}) => {
+    const {enabled = true} = config;
     const {range} = useGlobalData();
     const {startDate, endDate, timezone} = getRangeDates(range);
 
@@ -221,7 +235,8 @@ const usePostOptions = (currentFilters: Filter[] = []) => {
 
     // Fetch top content data from Ghost API (which queries Tinybird and enriches with titles)
     const {data: topContentData, isLoading} = useTopContent({
-        searchParams: queryParams
+        searchParams: queryParams,
+        enabled
     });
 
     const options = useMemo(() => {
@@ -261,6 +276,9 @@ const usePostOptions = (currentFilters: Filter[] = []) => {
 function StatsFilter({filters, utmTrackingEnabled = false, onChange, ...props}: StatsFilterProps) {
     const {appSettings} = useAppContext();
 
+    // Track which filter field is currently being selected (lazy loading)
+    const [activeFilterField, setActiveFilterField] = useState<string | null>(null);
+
     // Track screen width for responsive popover alignment
     const [isMobile, setIsMobile] = useState(false);
 
@@ -290,19 +308,28 @@ function StatsFilter({filters, utmTrackingEnabled = false, onChange, ...props}: 
         return appSettings?.paidMembersEnabled ? options : options.filter(opt => opt.value !== 'paid');
     }, [appSettings?.paidMembersEnabled]);
 
+    // Helper: determine if a filter field should fetch options
+    // Enable fetching when the field is active OR has an applied filter value (for label display)
+    const shouldFetchOptions = useCallback((fieldKey: string) => {
+        const isActive = activeFilterField === fieldKey;
+        const hasAppliedFilter = filters.some(f => f.field === fieldKey);
+        return isActive || hasAppliedFilter;
+    }, [activeFilterField, filters]);
+
     // Fetch options for all Tinybird-backed fields using the generic hook
     // Options are contextual - filtered based on currently applied filters
-    const {options: utmSourceOptions} = useTinybirdFilterOptions('utm_source', filters);
-    const {options: utmMediumOptions} = useTinybirdFilterOptions('utm_medium', filters);
-    const {options: utmCampaignOptions} = useTinybirdFilterOptions('utm_campaign', filters);
-    const {options: utmContentOptions} = useTinybirdFilterOptions('utm_content', filters);
-    const {options: utmTermOptions} = useTinybirdFilterOptions('utm_term', filters);
-    const {options: sourceOptions} = useTinybirdFilterOptions('source', filters);
-    const {options: deviceOptions} = useTinybirdFilterOptions('device', filters);
-    const {options: locationOptions} = useTinybirdFilterOptions('location', filters);
+    // Lazy loading: only fetch when field is active or has applied filter
+    const {options: utmSourceOptions} = useTinybirdFilterOptions('utm_source', filters, {enabled: shouldFetchOptions('utm_source')});
+    const {options: utmMediumOptions} = useTinybirdFilterOptions('utm_medium', filters, {enabled: shouldFetchOptions('utm_medium')});
+    const {options: utmCampaignOptions} = useTinybirdFilterOptions('utm_campaign', filters, {enabled: shouldFetchOptions('utm_campaign')});
+    const {options: utmContentOptions} = useTinybirdFilterOptions('utm_content', filters, {enabled: shouldFetchOptions('utm_content')});
+    const {options: utmTermOptions} = useTinybirdFilterOptions('utm_term', filters, {enabled: shouldFetchOptions('utm_term')});
+    const {options: sourceOptions} = useTinybirdFilterOptions('source', filters, {enabled: shouldFetchOptions('source')});
+    const {options: deviceOptions} = useTinybirdFilterOptions('device', filters, {enabled: shouldFetchOptions('device')});
+    const {options: locationOptions} = useTinybirdFilterOptions('location', filters, {enabled: shouldFetchOptions('location')});
 
     // Fetch options for posts - data is contextual based on current filters
-    const {options: postOptions, loading: postLoading} = usePostOptions(filters);
+    const {options: postOptions, loading: postLoading} = usePostOptions(filters, {enabled: shouldFetchOptions('post')});
 
     // Note: Only 'is' operator supported - Tinybird pipes only support exact match
     const supportedOperators = useMemo(() => [
@@ -486,6 +513,7 @@ function StatsFilter({filters, utmTrackingEnabled = false, onChange, ...props}: 
                 keyboardShortcut="f"
                 popoverAlign={isMobile ? 'start' : (hasFilters ? 'start' : 'end')}
                 showSearchInput={false}
+                onActiveFieldChange={setActiveFilterField}
                 onChange={onChange || (() => {})}
                 {...props}
             />


### PR DESCRIPTION
ref https://linear.app/ghost/issue/NY-865

- reduced volume of api requests to Tinybird endpoints form posts/stats web views

The frontend apps are querying for all filter results at all times, which is an excessive amount of additional network traffic. We've pared back the handling to only request when filters are being selected by introducing a lazy loading pattern. While verbose, this is ok for now, while we get better definition on what we want the handling to be.

Acknowledged and not done: When we apply a filter, we store the list of values and the counts to that filter dropdown. If someone applies two filters, then goes back to click the first to change it, we have a stale set of results, as the results did _not_ have the second filter applied to them. Patching this up requires additional frequent queries, and we're going to validate whether or not we feel strongly about having the counts at all. We can follow up with a separate change for this.