### PR TITLE
Refined formatting for comments in moderation

### DIFF
--- a/apps/posts/src/views/comments/components/comments-list.tsx
+++ b/apps/posts/src/views/comments/components/comments-list.tsx
@@ -9,7 +9,6 @@ import {
     AlertDialogTitle,
     Avatar,
     AvatarFallback,
-    AvatarImage,
     Button,
     DropdownMenu,
     DropdownMenuContent,
@@ -113,7 +112,7 @@ function CommentContent({item}: {item: Comment}) {
                     ref={contentRef}
                     className={cn(
                         'prose flex-1 text-base leading-[1.45em] [&_*]:text-base [&_*]:font-normal [&_blockquote]:border-l-[3px] [&_blockquote]:border-foreground [&_blockquote]:p-0 [&_blockquote]:pl-3 [&_blockquote_p]:mt-0 [&_a]:underline',
-                        (!isExpanded && 'line-clamp-2 [&_p]:m-0 [&_p]:inline'),
+                        (!isExpanded && 'line-clamp-2 [&_p]:m-0 [&_blockquote+p]:mt-1'),
                         (isExpanded && '-mb-1 [&_p]:mb-[0.85em]'),
                         (item.status === 'hidden' && 'text-muted-foreground')
                     )}
@@ -205,9 +204,9 @@ function CommentsList({
                                                         }}
                                                     >
                                                         <Avatar className={`size-5 ${item.status === 'hidden' && 'opacity-40'}`}>
-                                                            {item.member.avatar_image && (
+                                                            {/* {item.member.avatar_image && (
                                                                 <AvatarImage alt={item.member.name} src={item.member.avatar_image} />
-                                                            )}
+                                                            )} */}
                                                             <AvatarFallback>
                                                                 <LucideIcon.User className='!size-3 text-muted-foreground' size={12} />
                                                             </AvatarFallback>
@@ -311,8 +310,8 @@ function CommentsList({
                                                 <TooltipProvider>
                                                     <Tooltip>
                                                         <TooltipTrigger asChild>
-                                                            <div className={`ml-2 flex items-center gap-1 text-xs ${item.count?.reports ? 'text-yellow-600 dark:text-yellow' : 'text-muted-foreground/70'}`}>
-                                                                <LucideIcon.TriangleAlert size={16} strokeWidth={1.5} />
+                                                            <div className={`ml-2 flex items-center gap-1 text-xs ${item.count?.reports ? 'font-medium text-yellow-600 dark:text-yellow' : 'text-muted-foreground/70'}`}>
+                                                                <LucideIcon.TriangleAlert size={16} strokeWidth={(item.count?.reports ? 1.75 : 1.5)} />
                                                                 <span>{formatNumber(item.count?.reports)}</span>
                                                             </div>
                                                         </TooltipTrigger>

--- a/apps/posts/src/views/comments/components/comments-list.tsx
+++ b/apps/posts/src/views/comments/components/comments-list.tsx
@@ -112,8 +112,10 @@ function CommentContent({item}: {item: Comment}) {
                     ref={contentRef}
                     className={cn(
                         'prose flex-1 text-base leading-[1.45em] [&_*]:text-base [&_*]:font-normal [&_blockquote]:border-l-[3px] [&_blockquote]:border-foreground [&_blockquote]:p-0 [&_blockquote]:pl-3 [&_blockquote_p]:mt-0 [&_a]:underline',
-                        (!isExpanded && 'line-clamp-2 [&_p]:m-0 [&_blockquote+p]:mt-1'),
-                        (isExpanded && '-mb-1 [&_p]:mb-[0.85em]'),
+                        (!isExpanded ?
+                            '-mb-1 [&_p]:mb-[0.85em]'
+                            :
+                            'line-clamp-2 [&_p]:m-0 [&_blockquote+p]:mt-1'),
                         (item.status === 'hidden' && 'text-muted-foreground')
                     )}
                 />

--- a/apps/posts/src/views/comments/components/comments-list.tsx
+++ b/apps/posts/src/views/comments/components/comments-list.tsx
@@ -112,7 +112,7 @@ function CommentContent({item}: {item: Comment}) {
                     ref={contentRef}
                     className={cn(
                         'prose flex-1 text-base leading-[1.45em] [&_*]:text-base [&_*]:font-normal [&_blockquote]:border-l-[3px] [&_blockquote]:border-foreground [&_blockquote]:p-0 [&_blockquote]:pl-3 [&_blockquote_p]:mt-0 [&_a]:underline',
-                        (!isExpanded ?
+                        (isExpanded ?
                             '-mb-1 [&_p]:mb-[0.85em]'
                             :
                             'line-clamp-2 [&_p]:m-0 [&_blockquote+p]:mt-1'),

--- a/apps/posts/src/views/comments/components/comments-list.tsx
+++ b/apps/posts/src/views/comments/components/comments-list.tsx
@@ -9,6 +9,7 @@ import {
     AlertDialogTitle,
     Avatar,
     AvatarFallback,
+    AvatarImage,
     Button,
     DropdownMenu,
     DropdownMenuContent,
@@ -25,6 +26,7 @@ import {
     TooltipContent,
     TooltipProvider,
     TooltipTrigger,
+    cn,
     formatNumber,
     formatTimestamp
 } from '@tryghost/shade';
@@ -109,7 +111,12 @@ function CommentContent({item}: {item: Comment}) {
                 <div
                     dangerouslySetInnerHTML={{__html: item.html || ''}}
                     ref={contentRef}
-                    className={`prose flex-1 text-base leading-[1.45em] ${isExpanded ? '-mb-1 [&_p]:mb-[0.85em]' : 'line-clamp-2 [&_*]:m-0 [&_*]:inline'} ${item.status === 'hidden' && 'text-muted-foreground'}`}
+                    className={cn(
+                        'prose flex-1 text-base leading-[1.45em] [&_*]:text-base [&_*]:font-normal [&_blockquote]:border-l-[3px] [&_blockquote]:border-foreground [&_blockquote]:p-0 [&_blockquote]:pl-3 [&_blockquote_p]:mt-0 [&_a]:underline',
+                        (!isExpanded && 'line-clamp-2 [&_p]:m-0 [&_p]:inline'),
+                        (isExpanded && '-mb-1 [&_p]:mb-[0.85em]'),
+                        (item.status === 'hidden' && 'text-muted-foreground')
+                    )}
                 />
                 {isClamped && (
                     <ExpandButton expanded={isExpanded} onClick={() => setIsExpanded(!isExpanded)} />
@@ -198,9 +205,9 @@ function CommentsList({
                                                         }}
                                                     >
                                                         <Avatar className={`size-5 ${item.status === 'hidden' && 'opacity-40'}`}>
-                                                            {/* {item.member.avatar_image && (
+                                                            {item.member.avatar_image && (
                                                                 <AvatarImage alt={item.member.name} src={item.member.avatar_image} />
-                                                            )} */}
+                                                            )}
                                                             <AvatarFallback>
                                                                 <LucideIcon.User className='!size-3 text-muted-foreground' size={12} />
                                                             </AvatarFallback>
@@ -304,7 +311,7 @@ function CommentsList({
                                                 <TooltipProvider>
                                                     <Tooltip>
                                                         <TooltipTrigger asChild>
-                                                            <div className={`ml-2 flex items-center gap-1 text-xs ${item.count?.reports ? 'text-yellow-600' : 'text-muted-foreground/70'}`}>
+                                                            <div className={`ml-2 flex items-center gap-1 text-xs ${item.count?.reports ? 'text-yellow-600 dark:text-yellow' : 'text-muted-foreground/70'}`}>
                                                                 <LucideIcon.TriangleAlert size={16} strokeWidth={1.5} />
                                                                 <span>{formatNumber(item.count?.reports)}</span>
                                                             </div>


### PR DESCRIPTION
ref. https://linear.app/ghost/issue/FEA-504/fix-quote-styling-in-comment-moderation-ui

Some styles were off in the comment moderation list:

- blockquotes missed styling
- blockquotes carriage return was missing in truncated view
- paragraphs where inline so they weren't breaking properly in truncated view