### PR TITLE
Fixed blockquote styles for hidden comments

### DIFF
--- a/apps/posts/src/views/comments/components/comments-list.tsx
+++ b/apps/posts/src/views/comments/components/comments-list.tsx
@@ -116,7 +116,7 @@ function CommentContent({item}: {item: Comment}) {
                             '-mb-1 [&_p]:mb-[0.85em]'
                             :
                             'line-clamp-2 [&_p]:m-0 [&_blockquote+p]:mt-1'),
-                        (item.status === 'hidden' && 'text-muted-foreground')
+                        (item.status === 'hidden' && 'text-muted-foreground [&_blockquote]:border-foreground-muted')
                     )}
                 />
                 {isClamped && (


### PR DESCRIPTION
ref https://linear.app/ghost/issue/FEA-504/fix-quote-styling-in-comment-moderation-ui

- Blockquotes for hidden comments in comment moderation was not dimmed