### PR TITLE
Added `DEBUG` env passthrough for `yarn dev:forward`

### DIFF
--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -69,6 +69,7 @@ services:
     environment:
       NODE_ENV: development
       NODE_TLS_REJECT_UNAUTHORIZED: "0"
+      DEBUG: ${DEBUG:-}
       database__client: mysql2
       database__connection__host: mysql
       database__connection__user: root


### PR DESCRIPTION
no issue

- allows for debug logging, e.g. `DEBUG=knex:query,knex:bindings yarn dev:forward`
