### PR TITLE
Fixed data-generator creating invalid `parent_id` column values

### DIFF
--- a/ghost/core/core/server/data/seeders/importers/CommentsImporter.js
+++ b/ghost/core/core/server/data/seeders/importers/CommentsImporter.js
@@ -57,7 +57,7 @@ class CommentsImporter extends TableImporter {
             id: this.fastFakeObjectId(),
             post_id: this.model.id,
             member_id: this.possibleMembers[faker.datatype.number(this.possibleMembers.length - 1)].id,
-            parent_id: isReply ? this.commentIds[faker.datatype.number(this.commentIds.length - 1)] : undefined,
+            parent_id: isReply ? this.commentIds[faker.datatype.number(this.commentIds.length - 1)] : null,
             status: 'published',
             created_at: dateToDatabaseString(timestamp),
             updated_at: dateToDatabaseString(timestamp),


### PR DESCRIPTION
no issue

- using `undefined` creates `EMPTY` values instead of `NULL` meaning our API queries to fetch top-level comments fail to find any comments
