### PR TITLE
Added support for activitypub with improved dev workflow

### DIFF
--- a/apps/admin/vite-deep-links.ts
+++ b/apps/admin/vite-deep-links.ts
@@ -16,19 +16,6 @@ export function deepLinksPlugin(): Plugin {
 
         return () => {
             server.middlewares.use((req, res, next) => {
-                // Skip WebSocket upgrade requests (used for HMR)
-                if (req.headers.upgrade?.toLowerCase() === 'websocket') {
-                    next();
-                    return;
-                }
-
-                // Skip root path with query string only (e.g. /ghost/?token=xxx for Vite HMR)
-                const urlPath = req.originalUrl?.split('?')[0];
-                if (urlPath === `${base}/` || urlPath === base) {
-                    next();
-                    return;
-                }
-
                 const match = req.originalUrl?.match(pathRegex);
 
                 if (match) {

--- a/apps/admin/vite-deep-links.ts
+++ b/apps/admin/vite-deep-links.ts
@@ -16,6 +16,19 @@ export function deepLinksPlugin(): Plugin {
 
         return () => {
             server.middlewares.use((req, res, next) => {
+                // Skip WebSocket upgrade requests (used for HMR)
+                if (req.headers.upgrade?.toLowerCase() === 'websocket') {
+                    next();
+                    return;
+                }
+
+                // Skip root path with query string only (e.g. /ghost/?token=xxx for Vite HMR)
+                const urlPath = req.originalUrl?.split('?')[0];
+                if (urlPath === `${base}/` || urlPath === base) {
+                    next();
+                    return;
+                }
+
                 const match = req.originalUrl?.match(pathRegex);
 
                 if (match) {

--- a/apps/admin/vite.config.ts
+++ b/apps/admin/vite.config.ts
@@ -18,12 +18,7 @@ export default defineConfig({
     },
     server: {
         host: true,
-        allowedHosts: [
-            "localhost",
-            "127.0.0.1",
-            "::1",
-            "host.docker.internal",
-        ]
+        allowedHosts: true
     },
     resolve: {
         alias: {

--- a/docker/dev-gateway/Caddyfile
+++ b/docker/dev-gateway/Caddyfile
@@ -1,6 +1,6 @@
 {
     admin off
-} 
+}
 
 :80 {
     # Compact log format for development
@@ -43,6 +43,37 @@
             header_up X-Forwarded-Host {host}
             header_up X-Real-IP {remote_host}
             header_up X-Forwarded-For {remote_host}
+        }
+    }
+
+    # ActivityPub API - proxy activityPub requests to activityPub service (running in separate project)
+    # Requires activityPub containers to be running via the ActivityPub project's docker-compose
+    handle /.ghost/activitypub/* {
+        reverse_proxy {env.ACTIVITYPUB_PROXY_TARGET} {
+            header_up Host {host}
+            header_up X-Real-IP {remote_host}
+            header_up X-Forwarded-For {remote_host}
+            header_up X-Forwarded-Proto https
+        }
+    }
+
+    # WebFinger - required for ActivityPub federation
+    handle /.well-known/webfinger {
+        reverse_proxy {env.ACTIVITYPUB_PROXY_TARGET} {
+            header_up Host {host}
+            header_up X-Real-IP {remote_host}
+            header_up X-Forwarded-For {remote_host}
+            header_up X-Forwarded-Proto https
+        }
+    }
+
+    # NodeInfo - required for ActivityPub federation
+    handle /.well-known/nodeinfo {
+        reverse_proxy {env.ACTIVITYPUB_PROXY_TARGET} {
+            header_up Host {host}
+            header_up X-Real-IP {remote_host}
+            header_up X-Forwarded-For {remote_host}
+            header_up X-Forwarded-Proto https
         }
     }
 
@@ -138,16 +169,22 @@
         }
     }
 
+    # JWKS endpoint - must go to Ghost backend for JWT verification
+    handle /ghost/.well-known/* {
+        reverse_proxy {env.GHOST_BACKEND} {
+            header_up Host {host}
+            header_up X-Real-IP {remote_host}
+            header_up X-Forwarded-For {remote_host}
+            header_up X-Forwarded-Proto https
+        }
+    }
+
     # Admin interface - served from admin dev server
     # This includes /ghost/, etc. (but /ghost/assets/* is handled above)
-    # Also handles WebSocket upgrade requests for live reload
-    handle /ghost/* {
+    # Also handles WebSocket upgrade requests for HMR
+    handle /ghost* {
         reverse_proxy {env.ADMIN_DEV_SERVER} {
-            header_up Host {http.reverse_proxy.upstream.hostport}
             header_up X-Forwarded-Host {host}
-            # Enable WebSocket support
-            header_up Connection {>Connection}
-            header_up Upgrade {>Upgrade}
         }
     }
 

--- a/docker/dev-gateway/Caddyfile
+++ b/docker/dev-gateway/Caddyfile
@@ -47,7 +47,7 @@
     }
 
     # ActivityPub API - proxy activityPub requests to activityPub service (running in separate project)
-    # Requires activityPub containers to be running via the ActivityPub project's docker-compose
+    # Requires activitypub containers to be running via the ActivityPub project's docker-compose
     handle /.ghost/activitypub/* {
         reverse_proxy {env.ACTIVITYPUB_PROXY_TARGET} {
             header_up Host {host}

--- a/docker/dev-gateway/Dockerfile
+++ b/docker/dev-gateway/Dockerfile
@@ -12,7 +12,8 @@ ENV GHOST_BACKEND=ghost-dev:2368 \
     SEARCH_DEV_SERVER=host.docker.internal:4178 \
     ANNOUNCEMENT_DEV_SERVER=host.docker.internal:4177 \
     LEXICAL_DEV_SERVER=host.docker.internal:4173 \
-    ANALYTICS_PROXY_TARGET=analytics:3000
+    ANALYTICS_PROXY_TARGET=analytics:3000 \
+    ACTIVITYPUB_PROXY_TARGET=host.docker.internal:8080
 
 COPY Caddyfile /etc/caddy/Caddyfile
 EXPOSE 80 2368

--- a/docker/dev-gateway/README.md
+++ b/docker/dev-gateway/README.md
@@ -23,6 +23,9 @@ Caddy uses environment variables (set in `compose.dev.yaml`) to configure proxy 
   - For developing Lexical in the separate [Koenig repository](https://github.com/TryGhost/Koenig)
   - Requires `EDITOR_URL=/ghost/assets/koenig-lexical/` when starting admin dev server
   - Automatically falls back to Ghost backend (built package) if dev server is not running
+- `ACTIVITYPUB_PROXY_TARGET` - *Optional:* ActivityPub service (e.g., `host.docker.internal:8080`)
+  - For developing with the [ActivityPub project](https://github.com/TryGhost/ActivityPub) running locally
+  - Requires the ActivityPub docker-compose services to be running
 
 **Note:** AdminX React apps (admin-x-settings, activitypub, posts, stats) are served through the admin dev server so they don't need separate proxy entries.
 
@@ -36,6 +39,9 @@ The Caddyfile defines these routing rules:
 |--------------------------------------|-------------------------------------|------------------------------------------------------------------------|
 | `/ember-cli-live-reload.js`          | Admin live reload (port 4200)       | Ember hot-reload script and WebSocket                                  |
 | `/ghost/api/*`                       | Ghost backend                       | Ghost API (bypasses admin dev server)                                  |
+| `/.ghost/activitypub/*`              | ActivityPub server (port 8080)      | *Optional:* ActivityPub API (requires AP project running)              |
+| `/.well-known/webfinger`             | ActivityPub server (port 8080)      | *Optional:* WebFinger for federation                                   |
+| `/.well-known/nodeinfo`              | ActivityPub server (port 8080)      | *Optional:* NodeInfo for federation                                    |
 | `/ghost/assets/koenig-lexical/*`     | Lexical dev server (port 4173)      | *Optional:* Koenig Lexical editor (falls back to Ghost if not running) |
 | `/ghost/assets/portal/*`             | Portal dev server (port 4175)       | Membership UI                                                          |
 | `/ghost/assets/comments-ui/*`        | Comments dev server (port 7173)     | Comments widget                                                        |


### PR DESCRIPTION
ref https://github.com/TryGhost/ActivityPub/pull/1487

Added ActivityPub routing and HMR support for external domains
- Added `dev-gateway` routing for ActivityPub API (`/.ghost/activitypub/*`) and federation endpoints (`/.well-known/webfinger`, `/.well-known/nodeinfo`)
- Fixed HMR WebSocket connections through reverse proxies by updating `vite-deep-links.ts` to skip WebSocket upgrades and root path requests
- Changed `allowedHosts` to `true` to support external domains (Tailscale, etc.)
- Added `/ghost/.well-known/*` route to Ghost backend for JWKS endpoint
- Simplified admin reverse proxy config (Caddy handles WebSocket automatically)
