### PR TITLE
Refactored filtered_sessions to eliminate redundant scans

### DIFF
--- a/ghost/core/core/server/data/tinybird/endpoints/api_kpis.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_kpis.pipe
@@ -75,10 +75,31 @@ SQL >
             is_bounce,
             duration as session_sec
         from mv_session_data sd
-            inner join filtered_sessions fs
-                on fs.session_id = sd.session_id
         where
             site_uuid = {{ String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True) }}
+            -- Date filters on session start
+            {% if defined(date_from) %}
+                and first_pageview >= toDateTime({{ Date(date_from, description="Starting day for filtering a date range", required=False) }}, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})
+            {% else %}
+                and first_pageview >= toDateTime(dateAdd(day, -7, today()), {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})
+            {% end %}
+            {% if defined(date_to) %}
+                and first_pageview < toDateTime({{ Date(date_to, description="Finishing day for filtering a date range", required=False) }}, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}) + interval 1 day
+            {% else %}
+                and first_pageview < toDateTime(dateAdd(day, 1, today()), {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})
+            {% end %}
+            -- Session-level filters
+            {% if defined(source) %} and source = {{ String(source, description="Source to filter on", required=False) }} {% end %}
+            {% if defined(device) %} and device = {{ String(device, description="Device type to filter on", required=False) }} {% end %}
+            {% if defined(utm_source) %} and utm_source = {{ String(utm_source, description="UTM source to filter on", required=False) }} {% end %}
+            {% if defined(utm_medium) %} and utm_medium = {{ String(utm_medium, description="UTM medium to filter on", required=False) }} {% end %}
+            {% if defined(utm_campaign) %} and utm_campaign = {{ String(utm_campaign, description="UTM campaign to filter on", required=False) }} {% end %}
+            {% if defined(utm_term) %} and utm_term = {{ String(utm_term, description="UTM term to filter on", required=False) }} {% end %}
+            {% if defined(utm_content) %} and utm_content = {{ String(utm_content, description="UTM content to filter on", required=False) }} {% end %}
+            -- Hit-level filters: use filtered_sessions for session lookup
+            {% if defined(member_status) or defined(location) or defined(pathname) or defined(post_uuid) %}
+            and session_id IN (select distinct session_id from filtered_sessions)
+            {% end %}
 
 
 NODE data
@@ -114,20 +135,12 @@ SQL >
                 {% end %}
                 count() pageviews
             from timeseries a
-            inner join _mv_hits h on
+            inner join filtered_sessions h on
                 {% if defined(date_from) and day_diff(date_from, date_to) == 0 %}
                     a.date = toStartOfHour(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}))
                 {% else %}
                     a.date = toDate(toTimezone(timestamp, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}))
                 {% end %}
-            inner join filtered_sessions fs
-                on fs.session_id = h.session_id
-            where
-                site_uuid = {{ String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True) }}
-                {% if defined(member_status) %} and member_status IN {{ Array(member_status, "'undefined', 'free', 'paid'", description="Member status to filter on", required=False) }} {% end %}
-                {% if defined(location) %} and location = {{ String(location, description="Location to filter on", required=False) }} {% end %}
-                {% if defined(pathname) %} and pathname = {{ String(pathname, description="Pathname to filter on", required=False) }} {% end %}
-                {% if defined(post_uuid) %} and post_uuid = {{String(post_uuid, description="Post UUID to filter on", required=False) }} {% end %}
             group by date
             order by date
 

--- a/ghost/core/core/server/data/tinybird/endpoints/api_top_devices.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_top_devices.pipe
@@ -8,10 +8,9 @@ SQL >
         device,
         count() as visits
     from mv_session_data sd
-      inner join filtered_sessions fs
-         on fs.session_id = sd.session_id
     where
         site_uuid = {{ String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True) }}
+        and session_id IN (select distinct session_id from filtered_sessions)
     group by device
     order by visits desc
     limit {{ Int32(skip, 0) }},{{ Int32(limit, 50) }}

--- a/ghost/core/core/server/data/tinybird/endpoints/api_top_locations.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_top_locations.pipe
@@ -8,22 +8,7 @@ SQL >
         select
             location,
             uniqExact(session_id) as visits
-        from _mv_hits h
-        inner join filtered_sessions fs
-            on fs.session_id = h.session_id
-        where
-            site_uuid = {{String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True)}}
-            {% if defined(member_status) %}
-                and member_status IN (
-                    select arrayJoin(
-                        {{ Array(member_status, "'undefined', 'free', 'paid'", description="Member status to filter on", required=False) }}
-                        || if('paid' IN {{ Array(member_status) }}, ['comped'], [])
-                    )
-                )
-            {% end %}
-            {% if defined(location) %} and location = {{ String(location, description="Location to filter on", required=False) }} {% end %}
-            {% if defined(pathname) %} and pathname = {{ String(pathname, description="Pathname to filter on", required=False) }} {% end %}
-            {% if defined(post_uuid) %} and post_uuid = {{ String(post_uuid, description="Post UUID to filter on", required=False) }} {% end %}
+        from filtered_sessions
         group by location
         order by visits desc
         limit {{ Int32(skip, 0) }},{{ Int32(limit, 50) }}

--- a/ghost/core/core/server/data/tinybird/endpoints/api_top_pages.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_top_pages.pipe
@@ -9,29 +9,15 @@ SQL >
         case when post_uuid = 'undefined' then '' else post_uuid end as post_uuid,
         pathname,
         uniqExact(session_id) as visits
-    from _mv_hits h
-    inner join filtered_sessions fs
-        on fs.session_id = h.session_id
+    from filtered_sessions
+    {% if defined(post_type) %}
     where
-        site_uuid = {{String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True)}}
-        {% if defined(member_status) %}
-            and member_status IN (
-                select arrayJoin(
-                    {{ Array(member_status, "'undefined', 'free', 'paid'", description="Member status to filter on", required=False) }}
-                    || if('paid' IN {{ Array(member_status) }}, ['comped'], [])
-                )
-            )
+        {% if post_type == 'post' %}
+            post_type = 'post'
+        {% else %}
+            (post_type != 'post' or post_type is null)
         {% end %}
-        {% if defined(location) %} and location = {{ String(location, description="Location to filter on", required=False) }} {% end %}
-        {% if defined(pathname) %} and pathname = {{ String(pathname, description="Pathname to filter on", required=False) }} {% end %}
-        {% if defined(post_uuid) %} and post_uuid = {{ String(post_uuid, description="Post UUID to filter on", required=False) }} {% end %}
-        {% if defined(post_type) %}
-            {% if post_type == 'post' %}
-                and post_type = 'post'
-            {% else %}
-                and (post_type != 'post' or post_type is null)
-            {% end %}
-        {% end %}
+    {% end %}
     group by post_uuid, pathname
     order by visits desc
     limit {{ Int32(skip, 0) }},{{ Int32(limit, 50) }}

--- a/ghost/core/core/server/data/tinybird/endpoints/api_top_sources.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_top_sources.pipe
@@ -8,10 +8,9 @@ SQL >
         source,
         count() as visits
     from mv_session_data sd
-      inner join filtered_sessions fs
-         on fs.session_id = sd.session_id
     where
         site_uuid = {{ String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True) }}
+        and session_id IN (select distinct session_id from filtered_sessions)
     group by source
     order by visits desc
     limit {{ Int32(skip, 0) }},{{ Int32(limit, 50) }}

--- a/ghost/core/core/server/data/tinybird/endpoints/api_top_utm_campaigns.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_top_utm_campaigns.pipe
@@ -8,10 +8,9 @@ SQL >
         utm_campaign,
         count() as visits
     from mv_session_data sd
-      inner join filtered_sessions fs
-         on fs.session_id = sd.session_id
     where
         site_uuid = {{ String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True) }}
+        and session_id IN (select distinct session_id from filtered_sessions)
         and utm_campaign != ''
     group by utm_campaign
     order by visits desc

--- a/ghost/core/core/server/data/tinybird/endpoints/api_top_utm_contents.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_top_utm_contents.pipe
@@ -8,10 +8,9 @@ SQL >
         utm_content,
         count() as visits
     from mv_session_data sd
-      inner join filtered_sessions fs
-         on fs.session_id = sd.session_id
     where
         site_uuid = {{ String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True) }}
+        and session_id IN (select distinct session_id from filtered_sessions)
         and utm_content != ''
     group by utm_content
     order by visits desc

--- a/ghost/core/core/server/data/tinybird/endpoints/api_top_utm_mediums.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_top_utm_mediums.pipe
@@ -8,10 +8,9 @@ SQL >
         utm_medium,
         count() as visits
     from mv_session_data sd
-      inner join filtered_sessions fs
-         on fs.session_id = sd.session_id
     where
         site_uuid = {{ String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True) }}
+        and session_id IN (select distinct session_id from filtered_sessions)
         and utm_medium != ''
     group by utm_medium
     order by visits desc

--- a/ghost/core/core/server/data/tinybird/endpoints/api_top_utm_sources.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_top_utm_sources.pipe
@@ -1,4 +1,4 @@
-TOKEN "stats_page" READ 
+TOKEN "stats_page" READ
 TOKEN "axis" READ
 
 NODE top_utm_sources
@@ -8,10 +8,9 @@ SQL >
         utm_source,
         count() as visits
     from mv_session_data sd
-      inner join filtered_sessions fs
-         on fs.session_id = sd.session_id
     where
         site_uuid = {{ String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True) }}
+        and session_id IN (select distinct session_id from filtered_sessions)
         and utm_source != ''
     group by utm_source
     order by visits desc

--- a/ghost/core/core/server/data/tinybird/endpoints/api_top_utm_terms.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_top_utm_terms.pipe
@@ -8,10 +8,9 @@ SQL >
         utm_term,
         count() as visits
     from mv_session_data sd
-      inner join filtered_sessions fs
-         on fs.session_id = sd.session_id
     where
         site_uuid = {{ String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True) }}
+        and session_id IN (select distinct session_id from filtered_sessions)
         and utm_term != ''
     group by utm_term
     order by visits desc

--- a/ghost/core/core/server/data/tinybird/pipes/filtered_sessions.pipe
+++ b/ghost/core/core/server/data/tinybird/pipes/filtered_sessions.pipe
@@ -1,27 +1,51 @@
 TOKEN "axis" READ
 
-NODE sessions_filtered_by_hit_attributes
+NODE data
 DESCRIPTION >
-    Get sessions where at least one hit matches the hit-level filter criteria.
-    Hit-level filters (pathname, post_uuid, member_status, location) can vary across pageviews within a session.
-    A session qualifies if ANY of its hits match the specified criteria.
+    Returns filtered hits with all columns needed by endpoints.
+    Centralizes all filtering logic (date, hit-level, and session-level) to avoid
+    redundant table scans and keep filter definitions in one place.
+
+    - Hit-aggregation endpoints (api_top_locations, api_top_pages): query this directly
+    - Session-aggregation endpoints (api_top_sources, etc.): use session_id IN subquery
 
 SQL >
     %
-    select distinct session_id
+    select
+        site_uuid,
+        session_id,
+        timestamp,
+        member_uuid,
+        member_status,
+        post_uuid,
+        post_type,
+        location,
+        source,
+        pathname,
+        href,
+        device,
+        os,
+        browser,
+        utm_source,
+        utm_medium,
+        utm_campaign,
+        utm_term,
+        utm_content
     from _mv_hits
     where
-         site_uuid = {{ String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True) }}
-        {% if defined(date_from) %} 
-            and timestamp >= toDateTime({{ Date(date_from) }}, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}) 
-        {% else %} 
-            and timestamp >= toDateTime(dateAdd(day, -7, today()), {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}) 
+        site_uuid = {{ String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True) }}
+        -- Date filters
+        {% if defined(date_from) %}
+            and timestamp >= toDateTime({{ Date(date_from, description="Starting day for filtering a date range", required=False) }}, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})
+        {% else %}
+            and timestamp >= toDateTime(dateAdd(day, -7, today()), {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})
         {% end %}
-        {% if defined(date_to) %} 
-            and timestamp < toDateTime({{ Date(date_to) }}, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}) + interval 1 day 
-        {% else %} 
-            and timestamp < toDateTime(dateAdd(day, 1, today()), {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}) 
+        {% if defined(date_to) %}
+            and timestamp < toDateTime({{ Date(date_to, description="Finishing day for filtering a date range", required=False) }}, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}) + interval 1 day
+        {% else %}
+            and timestamp < toDateTime(dateAdd(day, 1, today()), {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})
         {% end %}
+        -- Hit-level filters
         {% if defined(member_status) %}
             and member_status IN (
                 select arrayJoin(
@@ -33,44 +57,18 @@ SQL >
         {% if defined(location) %} and location = {{ String(location, description="Location to filter on", required=False) }} {% end %}
         {% if defined(pathname) %} and pathname = {{ String(pathname, description="Pathname to filter on", required=False) }} {% end %}
         {% if defined(post_uuid) %} and post_uuid = {{ String(post_uuid, description="Post UUID to filter on", required=False) }} {% end %}
-
-NODE sessions_filtered_by_session_attributes
-DESCRIPTION >
-    Further filter by session-level attributes (source, device, utm_*). These attributes are specific to the first hit in a session,
-    whereas other filters are on hits. If no session-level filters are provided, skip the join with mv_session_data entirely.
-
-SQL >
-    %
-    {% if defined(source) or defined(device) or defined(utm_source) or defined(utm_medium) or defined(utm_campaign) or defined(utm_term) or defined(utm_content) %}
-    select session_id
-    from mv_session_data sd
-    inner join sessions_filtered_by_hit_attributes sfha
-      on sfha.session_id = sd.session_id
-    where
-        site_uuid = {{ String(site_uuid, 'mock_site_uuid', description="Tenant ID", required=True) }}
-        {% if defined(date_from) %}
-            {# Filter from specified start date #}
-            and first_pageview >= toDateTime({{ Date(date_from) }}, {{ String(timezone, 'Etc/UTC', description="Site timezone", required=True) }})
-        {% else %}
-            {# Default to last 7 days if no start date provided #}
-            and first_pageview >= toDateTime(dateAdd(day, -7, today()), {{ String(timezone, 'Etc/UTC', description="Site timezone", required=True) }})
+        -- Session-level filters (require subquery to mv_session_data)
+        {% if defined(source) or defined(device) or defined(utm_source) or defined(utm_medium) or defined(utm_campaign) or defined(utm_term) or defined(utm_content) %}
+        and session_id IN (
+            select session_id
+            from mv_session_data
+            where site_uuid = {{String(site_uuid, 'mock_site_uuid')}}
+                {% if defined(source) %} and source = {{ String(source, description="Source to filter on", required=False) }} {% end %}
+                {% if defined(device) %} and device = {{ String(device, description="Device type to filter on", required=False) }} {% end %}
+                {% if defined(utm_source) %} and utm_source = {{ String(utm_source, description="UTM source to filter on", required=False) }} {% end %}
+                {% if defined(utm_medium) %} and utm_medium = {{ String(utm_medium, description="UTM medium to filter on", required=False) }} {% end %}
+                {% if defined(utm_campaign) %} and utm_campaign = {{ String(utm_campaign, description="UTM campaign to filter on", required=False) }} {% end %}
+                {% if defined(utm_term) %} and utm_term = {{ String(utm_term, description="UTM term to filter on", required=False) }} {% end %}
+                {% if defined(utm_content) %} and utm_content = {{ String(utm_content, description="UTM content to filter on", required=False) }} {% end %}
+        )
         {% end %}
-        {% if defined(date_to) %}
-            {# Filter to specified end date #}
-            and first_pageview < toDateTime({{ Date(date_to) }}, {{ String(timezone, 'Etc/UTC', description="Site timezone", required=True) }}) + interval 1 day
-        {% else %}
-            {# Default to today if no end date provided #}
-            and first_pageview < toDateTime(dateAdd(day, 1, today()), {{ String(timezone, 'Etc/UTC', description="Site timezone", required=True) }})
-        {% end %}
-        {% if defined(source) %} and source = {{ String(source, description="Source to filter on", required=False) }} {% end %}
-        {% if defined(device) %} and device = {{ String(device, description="Device type to filter on", required=False) }} {% end %}
-        {% if defined(utm_source) %} and utm_source = {{ String(utm_source, description="UTM source to filter on", required=False) }} {% end %}
-        {% if defined(utm_medium) %} and utm_medium = {{ String(utm_medium, description="UTM medium to filter on", required=False) }} {% end %}
-        {% if defined(utm_campaign) %} and utm_campaign = {{ String(utm_campaign, description="UTM campaign to filter on", required=False) }} {% end %}
-        {% if defined(utm_term) %} and utm_term = {{ String(utm_term, description="UTM term to filter on", required=False) }} {% end %}
-        {% if defined(utm_content) %} and utm_content = {{ String(utm_content, description="UTM content to filter on", required=False) }} {% end %}
-    {% else %}
-    {# No session-level filters, skip the join with mv_session_data #}
-    select session_id
-    from sessions_filtered_by_hit_attributes
-    {% end %}


### PR DESCRIPTION
The filtered_sessions pipe previously returned only session IDs, which forced endpoints to JOIN back to _mv_hits to get the data they needed. This caused two full table scans per query, leading to timeouts on high-traffic sites.

Now filtered_sessions returns full hit rows with all filtering logic centralized in one place. Endpoints query it directly (for hit-level aggregations) or use a session_id IN subquery (for session-level aggregations). This eliminates the redundant scan.