### PR TITLE
clean(comments-list): no fragment for single-child case

### DIFF
--- a/apps/posts/src/views/comments/components/comments-list.tsx
+++ b/apps/posts/src/views/comments/components/comments-list.tsx
@@ -202,7 +202,6 @@ function CommentsList({
                                     <div className='flex flex-col gap-3'>
                                         <div className="flex flex-wrap items-center">
                                             {item.member?.id ? (
-                                                <>
                                                     <Button
                                                         className={`flex h-auto items-center gap-1.5 truncate p-0 font-semibold text-primary hover:opacity-70 ${item.status === 'hidden' && 'text-muted-foreground'}`}
                                                         variant='link'
@@ -220,8 +219,7 @@ function CommentsList({
                                                             </div>
                                                         </div>
                                                         {item.member.name || 'Unknown'}
-                                                    </Button>
-                                                </>
+                                                    </Button> 
                                             ) : (
                                                 <span className="block truncate font-semibold">
                                                     {item.member?.name || 'Unknown'}


### PR DESCRIPTION
## What

In the `comments-list` component we had used a Fragment that wraps a Button component.

However, the purpose of Fragment is used to _**group multiple elements without adding an extra DOM node.**_

## Tests

These changes are purely semantic and do not introduce any logic modifications that would require automated testing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes a redundant Fragment wrapping the author Button in `comments-list.tsx`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0bcc24eb089da2b9b6b64c62fd023705f5097b23. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->