### PR TITLE
Fixed real date dependence in preview tests

### DIFF
--- a/ghost/core/test/e2e-api/admin/email-previews.test.js
+++ b/ghost/core/test/e2e-api/admin/email-previews.test.js
@@ -41,6 +41,8 @@ describe('Email Preview API', function () {
     beforeEach(function () {
         mockManager.mockMailgun();
         sinon.stub(settingsHelpers, 'getMembersValidationKey').returns('test-validation-key');
+        // Stub Date.getFullYear to return a fixed year for consistent snapshots
+        sinon.stub(Date.prototype, 'getFullYear').returns(2025);
     });
 
     before(async function () {

--- a/ghost/core/test/integration/services/email-service/cards.test.js
+++ b/ghost/core/test/integration/services/email-service/cards.test.js
@@ -86,6 +86,7 @@ describe('Can send cards via email', function () {
     beforeEach(function () {
         mockManager.mockMail();
         mockManager.mockMailgun();
+        sinon.stub(Date.prototype, 'getFullYear').returns(2025); // for consistent snapshots
     });
 
     afterEach(async function () {


### PR DESCRIPTION
no ref

We have a couple snapshot tests that are dependent on the real date (e.g. 2026) that are failing on main/branches since the new year. These tests are now stubbed.