### PR TITLE
Unsubscribe modal copy logic

### DIFF
--- a/apps/portal/src/components/pages/unsubscribe-page.js
+++ b/apps/portal/src/components/pages/unsubscribe-page.js
@@ -1,7 +1,7 @@
 import AppContext from '../../app-context';
 import ActionButton from '../common/action-button';
 import {useContext, useEffect, useState} from 'react';
-import {getSiteNewsletters,hasNewsletterSendingEnabled} from '../../utils/helpers';
+import {getSiteNewsletters, hasNewsletterSendingEnabled, isPaidMember} from '../../utils/helpers';
 import NewsletterManagement from '../common/newsletter-management';
 import CloseButton from '../common/close-button';
 import {ReactComponent as WarningIcon} from '../../images/icons/warning-fill.svg';
@@ -266,7 +266,7 @@ export default function UnsubscribePage() {
                 await unsubscribeAll();
                 setHasInteracted(true);
             }}
-            isPaidMember={member?.status !== 'free'}
+            isPaidMember={isPaidMember({member})}
             isCommentsEnabled={commentsEnabled !== 'off'}
             enableCommentNotifications={enableCommentNotifications}
         />

--- a/apps/portal/test/unit/components/pages/account-email-page.test.js
+++ b/apps/portal/test/unit/components/pages/account-email-page.test.js
@@ -158,4 +158,26 @@ describe('Account Email Page', () => {
         const unsubscribeBtns = getAllByTestId(`toggle-wrapper`);
         expect(unsubscribeBtns).toHaveLength(3);
     });
+
+    test('paid subscription message is shown for paid members', async () => {
+        const newsletterData = getNewslettersData({numOfNewsletters: 2});
+        const siteData = getSiteData({
+            newsletters: newsletterData,
+            title: 'Test Site'
+        });
+        const paidMember = getMemberData({newsletters: newsletterData, paid: true});
+        const {getByText} = setup({site: siteData, member: paidMember});
+        expect(getByText(`Unsubscribing from emails will not cancel your paid subscription to ${siteData.title}`)).toBeInTheDocument();
+    });
+
+    test('paid subscription message is not shown for free members', async () => {
+        const newsletterData = getNewslettersData({numOfNewsletters: 2});
+        const siteData = getSiteData({
+            newsletters: newsletterData,
+            title: 'Test Site'
+        });
+        const freeMember = getMemberData({newsletters: newsletterData, paid: false});
+        const {queryByText} = setup({site: siteData, member: freeMember});
+        expect(queryByText(`Unsubscribing from emails will not cancel your paid subscription to ${siteData.title}`)).not.toBeInTheDocument();
+    });
 });

--- a/apps/portal/test/unit/components/pages/unsubscribe-page.test.js
+++ b/apps/portal/test/unit/components/pages/unsubscribe-page.test.js
@@ -1,0 +1,88 @@
+import {getSiteData, getNewslettersData, getMemberData} from '../../../../src/utils/fixtures-generator';
+import {render, waitFor} from '../../../utils/test-utils';
+import UnsubscribePage from '../../../../src/components/pages/unsubscribe-page';
+
+const mockApi = {
+    member: {
+        newsletters: vi.fn(),
+        updateNewsletters: vi.fn()
+    }
+};
+
+const setup = (overrides) => {
+    const {mockDoActionFn, context, ...utils} = render(
+        <UnsubscribePage />,
+        {
+            overrideContext: {
+                api: mockApi,
+                pageData: {
+                    uuid: 'test-uuid',
+                    key: 'test-key'
+                },
+                ...overrides
+            }
+        }
+    );
+
+    return {
+        mockDoActionFn,
+        context,
+        ...utils
+    };
+};
+
+describe('Unsubscribe Page', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    test('paid subscription message is shown for paid members', async () => {
+        const newsletterData = getNewslettersData({numOfNewsletters: 2});
+        const siteData = getSiteData({
+            newsletters: newsletterData,
+            title: 'Test Site'
+        });
+        const paidMember = getMemberData({newsletters: newsletterData, paid: true});
+        
+        mockApi.member.newsletters.mockResolvedValue(paidMember);
+
+        const {getByText} = setup({site: siteData});
+
+        await waitFor(() => {
+            expect(getByText(`Unsubscribing from emails will not cancel your paid subscription to ${siteData.title}`)).toBeInTheDocument();
+        });
+    });
+
+    test('paid subscription message is not shown for free members', async () => {
+        const newsletterData = getNewslettersData({numOfNewsletters: 2});
+        const siteData = getSiteData({
+            newsletters: newsletterData,
+            title: 'Test Site'
+        });
+        const freeMember = getMemberData({newsletters: newsletterData, paid: false});
+        
+        mockApi.member.newsletters.mockResolvedValue(freeMember);
+
+        const {queryByText} = setup({site: siteData});
+
+        await waitFor(() => {
+            expect(mockApi.member.newsletters).toHaveBeenCalled();
+        });
+
+        expect(queryByText(`Unsubscribing from emails will not cancel your paid subscription to ${siteData.title}`)).not.toBeInTheDocument();
+    });
+
+    test('handles invalid uuid gracefully', async () => {
+        const siteData = getSiteData({
+            title: 'Test Site'
+        });
+        
+        mockApi.member.newsletters.mockResolvedValue(null);
+
+        const {getByText} = setup({site: siteData});
+
+        await waitFor(() => {
+            expect(getByText('That didn\'t go to plan')).toBeInTheDocument();
+        });
+    });
+});


### PR DESCRIPTION
Got some code for us? Awesome 🎊!

Please take a minute to explain the change you're making:
- Why are you making it?
    The unsubscribe modal incorrectly displayed a disclaimer about not canceling a paid subscription to free members, causing confusion.
- What does it do?
    This PR fixes the logic in `unsubscribe-page.js` to correctly determine if a member is paid using the `isPaidMember` helper function. It also adds comprehensive unit tests for both `account-email-page` and `unsubscribe-page` to ensure the paid subscription disclaimer is shown only to paid members and hidden for free members.
- Why is this something Ghost users or developers need?
    This improves the user experience for members by ensuring they only see relevant information in the Portal. Free members will no longer see confusing messages about paid subscriptions, leading to a clearer and more accurate interface. Developers benefit from consistent logic for determining paid member status and robust test coverage.

Please check your PR against these items:

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [x] I've written an automated test to prove my change works

We appreciate your contribution! 🙏

---
Linear Issue: [DES-1264](https://linear.app/ghost/issue/DES-1264/unsubscribe-modal-still-references-paid-subscription-for-free-users)

<a href="https://cursor.com/background-agent?bcId=bc-8c4bdaf0-8f81-4330-9661-489c4b49b313"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8c4bdaf0-8f81-4330-9661-489c4b49b313"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

