### PR TITLE
Added check for Stripe for displaying paid welcome email option

### DIFF
--- a/apps/admin-x-settings/src/components/settings/membership/member-emails.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import TopLevelGroup from '../../top-level-group';
 import WelcomeEmailModal from './member-emails/welcome-email-modal';
 import {Button, Separator, SettingGroupContent, Toggle, withErrorBoundary} from '@tryghost/admin-x-design-system';
-import {getSettingValues} from '@tryghost/admin-x-framework/api/settings';
+import {checkStripeEnabled, getSettingValues} from '@tryghost/admin-x-framework/api/settings';
 import {useAddAutomatedEmail, useBrowseAutomatedEmails, useEditAutomatedEmail} from '@tryghost/admin-x-framework/api/automated-emails';
 import {useGlobalData} from '../../providers/global-data-provider';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
@@ -63,7 +63,7 @@ const EmailPreview: React.FC<{
 };
 
 const MemberEmails: React.FC<{ keywords: string[] }> = ({keywords}) => {
-    const {settings} = useGlobalData();
+    const {settings, config} = useGlobalData();
     const [siteTitle] = getSettingValues<string>(settings, ['title']);
 
     const {data: automatedEmailsData, isLoading} = useBrowseAutomatedEmails();
@@ -140,25 +140,29 @@ const MemberEmails: React.FC<{ keywords: string[] }> = ({keywords}) => {
                         emailType='free'
                     />
                 }
-                <Separator />
-                <Toggle
-                    key={`paid-${isLoading ? 'loading' : paidWelcomeEmail?.status ?? 'none'}`}
-                    checked={Boolean(paidWelcomeEmailEnabled)}
-                    containerClasses='items-center'
-                    direction='rtl'
-                    disabled={isLoading}
-                    gap='gap-0'
-                    hint='Sent to new paid members as soon as they start their subscription.'
-                    label='Paid members welcome email'
-                    labelClasses='py-4 w-full'
-                    onChange={() => handleToggle('paid')}
-                />
-                {paidWelcomeEmail && paidWelcomeEmailEnabled &&
-                    <EmailPreview
-                        automatedEmail={paidWelcomeEmail}
-                        emailType='paid'
-                    />
-                }
+                {checkStripeEnabled(settings, config) && (
+                    <>
+                        <Separator />
+                        <Toggle
+                            key={`paid-${isLoading ? 'loading' : paidWelcomeEmail?.status ?? 'none'}`}
+                            checked={Boolean(paidWelcomeEmailEnabled)}
+                            containerClasses='items-center'
+                            direction='rtl'
+                            disabled={isLoading}
+                            gap='gap-0'
+                            hint='Sent to new paid members as soon as they start their subscription.'
+                            label='Paid members welcome email'
+                            labelClasses='py-4 w-full'
+                            onChange={() => handleToggle('paid')}
+                        />
+                        {paidWelcomeEmail && paidWelcomeEmailEnabled &&
+                            <EmailPreview
+                                automatedEmail={paidWelcomeEmail}
+                                emailType='paid'
+                            />
+                        }
+                    </>
+                )}
             </SettingGroupContent>
         </TopLevelGroup>
     );

--- a/e2e/helpers/playwright/fixture.ts
+++ b/e2e/helpers/playwright/fixture.ts
@@ -129,14 +129,14 @@ export const test = base.extend<GhostInstanceFixture>({
         const page = pageWithAuthenticatedUser.page;
         const settingsService = new SettingsService(page.request);
 
-        const labsFlagsSpecified = labs && Object.keys(labs).length > 0;
-        if (labsFlagsSpecified) {
-            await setupLabSettings(page, settingsService, labs);
-        }
-
         if (stripeConnected) {
             debug('Setting up Stripe connection for test');
             await settingsService.setStripeConnected();
+        }
+
+        const labsFlagsSpecified = labs && Object.keys(labs).length > 0;
+        if (labsFlagsSpecified) {
+            await setupLabSettings(page, settingsService, labs);
         }
 
         await use(page);

--- a/e2e/helpers/playwright/fixture.ts
+++ b/e2e/helpers/playwright/fixture.ts
@@ -1,5 +1,4 @@
 import baseDebug from '@tryghost/debug';
-import {AnalyticsOverviewPage} from '@/admin-pages';
 import {Browser, BrowserContext, Page, TestInfo, test as base} from '@playwright/test';
 import {EnvironmentManager, GhostInstance} from '@/helpers/environment';
 import {SettingsService} from '@/helpers/services/settings/settings-service';
@@ -131,10 +130,7 @@ export const test = base.extend<GhostInstanceFixture>({
 
         const needsReload = stripeConnected || labsFlagsSpecified;
         if (needsReload) {
-            const analyticsPage = new AnalyticsOverviewPage(page);
-            await analyticsPage.goto();
-            await page.reload();
-            await analyticsPage.header.waitFor({state: 'visible'});
+            await page.reload({waitUntil: 'load'});
             debug('Settings applied and page reloaded');
         }
 

--- a/e2e/helpers/playwright/fixture.ts
+++ b/e2e/helpers/playwright/fixture.ts
@@ -57,14 +57,12 @@ async function setupNewAuthenticatedPage(browser: Browser, baseURL: string, ghos
  * Each instance gets its own database, runs on a unique port, and includes authentication
  *
  * Optionally allows setting labs flags via test.use({labs: {featureName: true}})
- * Ghost config via config settings, and Stripe connection state like:
- *
+ * and Stripe connection via test.use({stripeConnected: true})
+   and Ghost config via config settings: 
  *  test.use({config: {
  *      memberWelcomeEmailSendInstantly: 'true',
  *      memberWelcomeEmailTestInbox: `test+welcome-email@ghost.org`
  *  }})
- * 
- * test.use({stripeConnected: true})
  */
 export const test = base.extend<GhostInstanceFixture>({
     // Define options that can be set per test or describe block

--- a/e2e/helpers/services/settings/settings-service.ts
+++ b/e2e/helpers/services/settings/settings-service.ts
@@ -50,4 +50,23 @@ export class SettingsService {
         const response = await this.request.put(`${this.adminEndpoint}/settings`, {data});
         return await response.json() as SettingsResponse;
     }
+
+    /**
+     * Set Stripe keys to simulate a connected Stripe account
+     * Uses direct Stripe keys (not Connect) as they're not filtered by the API
+     * Uses test keys by default, but can be overridden if needed
+     */
+    async setStripeConnected(
+        secretKey: string = 'sk_test_e2eTestKey',
+        publishableKey: string = 'pk_test_e2eTestKey'
+    ) {
+        const data = {
+            settings: [
+                {key: 'stripe_secret_key', value: secretKey},
+                {key: 'stripe_publishable_key', value: publishableKey}
+            ]
+        };
+        const response = await this.request.put(`${this.adminEndpoint}/settings`, {data});
+        return await response.json() as SettingsResponse;
+    }
 }

--- a/e2e/tests/admin/settings/member-welcome-emails.test.ts
+++ b/e2e/tests/admin/settings/member-welcome-emails.test.ts
@@ -45,14 +45,19 @@ test.describe('Ghost Admin - Member Welcome Emails', () => {
             const response = await route.fetch();
             const json = await response.json();
 
-            json.settings.push(
-                {key: 'stripe_connect_secret_key', value: '••••••••'},
-                {key: 'stripe_connect_publishable_key', value: 'pk_test_fakeKeyForE2eTesting'}
-            );
+            for (const setting of json.settings) {
+                if (setting.key === 'stripe_connect_secret_key') {
+                    setting.value = 'sk_test_fakeKeyForE2eTesting';
+                }
+                if (setting.key === 'stripe_connect_publishable_key') {
+                    setting.value = 'pk_test_fakeKeyForE2eTesting';
+                }
+            }
 
             await route.fulfill({response, json});
         });
 
+        await page.reload();
         await welcomeEmailsSection.goto();
         await welcomeEmailsSection.enablePaidWelcomeEmail();
 

--- a/e2e/tests/admin/settings/member-welcome-emails.test.ts
+++ b/e2e/tests/admin/settings/member-welcome-emails.test.ts
@@ -37,44 +37,6 @@ test.describe('Ghost Admin - Member Welcome Emails', () => {
         expect(freeWelcomeEmail?.status).toBe('active');
     });
 
-    test('can enable paid welcome emails', async ({page}) => {
-        const welcomeEmailsSection = new MemberWelcomeEmailsSection(page);
-
-        // Mocked Stripe as connected so the paid welcome email toggle will render
-        await page.route('**/ghost/api/admin/settings/**', async (route) => {
-            const response = await route.fetch();
-            const json = await response.json();
-
-            for (const setting of json.settings) {
-                if (setting.key === 'stripe_connect_secret_key') {
-                    setting.value = 'sk_test_fakeKeyForE2eTesting';
-                }
-                if (setting.key === 'stripe_connect_publishable_key') {
-                    setting.value = 'pk_test_fakeKeyForE2eTesting';
-                }
-            }
-
-            await route.fulfill({response, json});
-        });
-
-        await page.reload();
-        await welcomeEmailsSection.goto();
-        await welcomeEmailsSection.enablePaidWelcomeEmail();
-
-        await expect(welcomeEmailsSection.paidWelcomeEmailToggle).toHaveAttribute('aria-checked', 'true');
-        await expect(welcomeEmailsSection.paidWelcomeEmailEditButton).toBeVisible();
-
-        // TODO: Update test once full E2E functionality is added for welcome emails
-        // We shouldn't assert via API directly, but for now this verifies the toggle works as expected
-        const response = await page.request.get('/ghost/api/admin/automated_emails/');
-        expect(response.ok()).toBe(true);
-
-        const data = await response.json() as AutomatedEmailsResponse;
-        const paidWelcomeEmail = data.automated_emails.find(email => email.slug === 'member-welcome-email-paid');
-        expect(paidWelcomeEmail).toBeDefined();
-        expect(paidWelcomeEmail?.status).toBe('active');
-    });
-
     test('can disable free welcome emails', async ({page}) => {
         const welcomeEmailsSection = new MemberWelcomeEmailsSection(page);
 
@@ -144,5 +106,29 @@ test.describe('Ghost Admin - Member Welcome Emails', () => {
         // Re-open the modal and verify the subject persisted
         await welcomeEmailsSection.openFreeWelcomeEmailModal();
         await expect(welcomeEmailsSection.modalSubjectInput).toHaveValue('Persisted Subject');
+    });
+});
+
+test.describe('Ghost Admin - Paid Member Welcome Emails', () => {
+    test.use({labs: {welcomeEmails: true}, stripeConnected: true});
+
+    test('can enable paid welcome emails', async ({page}) => {
+        const welcomeEmailsSection = new MemberWelcomeEmailsSection(page);
+
+        await welcomeEmailsSection.goto();
+        await welcomeEmailsSection.enablePaidWelcomeEmail();
+
+        await expect(welcomeEmailsSection.paidWelcomeEmailToggle).toHaveAttribute('aria-checked', 'true');
+        await expect(welcomeEmailsSection.paidWelcomeEmailEditButton).toBeVisible();
+
+        // TODO: Update test once full E2E functionality is added for welcome emails
+        // We shouldn't assert via API directly, but for now this verifies the toggle works as expected
+        const response = await page.request.get('/ghost/api/admin/automated_emails/');
+        expect(response.ok()).toBe(true);
+
+        const data = await response.json() as AutomatedEmailsResponse;
+        const paidWelcomeEmail = data.automated_emails.find(email => email.slug === 'member-welcome-email-paid');
+        expect(paidWelcomeEmail).toBeDefined();
+        expect(paidWelcomeEmail?.status).toBe('active');
     });
 });

--- a/e2e/tests/admin/settings/member-welcome-emails.test.ts
+++ b/e2e/tests/admin/settings/member-welcome-emails.test.ts
@@ -40,6 +40,19 @@ test.describe('Ghost Admin - Member Welcome Emails', () => {
     test('can enable paid welcome emails', async ({page}) => {
         const welcomeEmailsSection = new MemberWelcomeEmailsSection(page);
 
+        // Mocked Stripe as connected so the paid welcome email toggle will render
+        await page.route('**/ghost/api/admin/settings/**', async (route) => {
+            const response = await route.fetch();
+            const json = await response.json();
+
+            json.settings.push(
+                {key: 'stripe_connect_secret_key', value: '••••••••'},
+                {key: 'stripe_connect_publishable_key', value: 'pk_test_fakeKeyForE2eTesting'}
+            );
+
+            await route.fulfill({response, json});
+        });
+
         await welcomeEmailsSection.goto();
         await welcomeEmailsSection.enablePaidWelcomeEmail();
 


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-861

- if the Ghost site doesn't have Stripe connected, we shouldn't show the toggle/editor for paid member welcome emails
- This PR shows the option if Stripe is connected, hides it if it isn't
- We shouldn't need to worry about checking this elsewhere (i.e. in the outbox logic) because a paid member can't sign up if Stripe isn't connected

----
Stripe connected:
<img width="300" height="402" alt="Screenshot 2026-01-06 at 4 37 17 PM" src="https://github.com/user-attachments/assets/c7164fe9-778b-4e2e-9329-9f96558f6acb" />

Stripe not connected (disconnected in "Tiers" section):
<img width="300" height="223" alt="Screenshot 2026-01-06 at 4 36 59 PM" src="https://github.com/user-attachments/assets/7185aa5f-b988-4ab4-8487-3918b4980c39" />

(There might be some spacing tweaks we can make to the box but those are existing, we have other tickets to clean those up)
