### PR TITLE
Revert "Released @tryghost/comments-ui v1.3.0 (#25761)"

### DIFF
--- a/apps/comments-ui/package.json
+++ b/apps/comments-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/comments-ui",
-  "version": "1.3.0",
+  "version": "1.2.6",
   "license": "MIT",
   "repository": "git@github.com:TryGhost/comments-ui.git",
   "author": "Ghost Foundation",


### PR DESCRIPTION
This reverts commit 15bd6a4e030d62e2c5a762e58bfed9905acf9136.

The automatic publish failed due to an invalid "repository" field in apps/comments-ui/package.json. Reverting to we can fix and then re-release.
