### PR TITLE
Normalized npm-published apps' package.json `repository` field

### DIFF
--- a/apps/announcement-bar/package.json
+++ b/apps/announcement-bar/package.json
@@ -2,10 +2,7 @@
   "name": "@tryghost/announcement-bar",
   "version": "1.1.12",
   "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "git://github.com/TryGhost/Ghost.git"
-  },
+  "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",
   "files": [
     "umd/",

--- a/apps/comments-ui/package.json
+++ b/apps/comments-ui/package.json
@@ -2,7 +2,7 @@
   "name": "@tryghost/comments-ui",
   "version": "1.2.6",
   "license": "MIT",
-  "repository": "git@github.com:TryGhost/comments-ui.git",
+  "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",
   "unpkg": "umd/comments-ui.umd.js",
   "files": [

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -2,10 +2,7 @@
   "name": "@tryghost/portal",
   "version": "2.56.3",
   "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "git://github.com/TryGhost/Ghost.git"
-  },
+  "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",
   "files": [
     "umd/",

--- a/apps/signup-form/package.json
+++ b/apps/signup-form/package.json
@@ -2,10 +2,7 @@
   "name": "@tryghost/signup-form",
   "version": "0.3.4",
   "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/TryGhost/Ghost/tree/main/packages/signup-form"
-  },
+  "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",
   "files": [
     "LICENSE",

--- a/apps/sodo-search/package.json
+++ b/apps/sodo-search/package.json
@@ -2,10 +2,7 @@
   "name": "@tryghost/sodo-search",
   "version": "1.8.3",
   "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "git://github.com/TryGhost/Ghost.git"
-  },
+  "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",
   "files": [
     "umd/",


### PR DESCRIPTION
no issue

npm with trusted publisher setup requires the `repository` field to match provenance, when set to a git/ssh URL publishing results in an error such as:

```
 Failed to validate repository information: package.json: "repository.url" is "git+ssh://git@github.com/TryGhost/comments-ui.git", expected to match "https://github.com/TryGhost/Ghost" from provenance
```
