### PR TITLE
🐛 Fixed paginated sitemaps returning 404 for large sites

### DIFF
--- a/ghost/core/test/unit/frontend/web/middleware/static-theme.test.js
+++ b/ghost/core/test/unit/frontend/web/middleware/static-theme.test.js
@@ -426,6 +426,67 @@ describe('staticTheme', function () {
             });
         });
 
+        it('should set fallthrough to true for paginated sitemaps like /sitemap-posts-2.xml', function (done) {
+            req.path = '/sitemap-posts-2.xml';
+
+            staticTheme()(req, res, function next() {
+                activeThemeStub.calledTwice.should.be.true();
+                expressStaticStub.called.should.be.true();
+
+                should.exist(expressStaticStub.firstCall.args);
+                expressStaticStub.firstCall.args[0].should.eql('my/fake/path');
+
+                const options = expressStaticStub.firstCall.args[1];
+                options.should.be.an.Object();
+                options.should.have.property('maxAge');
+                options.should.have.property('fallthrough', true);
+
+                done();
+            });
+        });
+
+        it('should set fallthrough to true for higher page numbers like /sitemap-posts-99.xml', function (done) {
+            req.path = '/sitemap-posts-99.xml';
+
+            staticTheme()(req, res, function next() {
+                activeThemeStub.calledTwice.should.be.true();
+                expressStaticStub.called.should.be.true();
+
+                const options = expressStaticStub.firstCall.args[1];
+                options.should.have.property('fallthrough', true);
+
+                done();
+            });
+        });
+
+        it('should set fallthrough to true for paginated tag sitemaps like /sitemap-tags-3.xml', function (done) {
+            req.path = '/sitemap-tags-3.xml';
+
+            staticTheme()(req, res, function next() {
+                activeThemeStub.calledTwice.should.be.true();
+                expressStaticStub.called.should.be.true();
+
+                const options = expressStaticStub.firstCall.args[1];
+                options.should.have.property('fallthrough', true);
+
+                done();
+            });
+        });
+
+        it('should set fallthrough to true for paginated author sitemaps like /sitemap-authors-2.xml', function (done) {
+            req.path = '/sitemap-authors-2.xml';
+
+            staticTheme()(req, res, function next() {
+                activeThemeStub.calledTwice.should.be.true();
+                expressStaticStub.called.should.be.true();
+
+                const options = expressStaticStub.firstCall.args[1];
+                options.should.have.property('fallthrough', true);
+
+                done();
+            });
+        });
+
         it('should set fallthrough to false for other static files', function (done) {
             req.path = '/style.css';
 


### PR DESCRIPTION
fixes https://linear.app/ghost/issue/BER-3152

## Summary

- Fixed issue where paginated sitemaps (e.g., `/sitemap-posts-2.xml`) returned 404 for sites with more than 50k posts
- The static-theme middleware now correctly allows all paginated sitemap URLs to fall through to Ghost's sitemap handler

## Problem

Sites with more than 50,000 posts get paginated sitemaps. The sitemap index (`/sitemap.xml`) correctly contains links to paginated files like `/sitemap-posts-2.xml`. However, when browsers or crawlers request these paginated URLs, they receive a 404 error.

**Root Cause:** The `static-theme.js` middleware had a hardcoded list of fallthrough files that only included the first page of each sitemap type (e.g., `/sitemap-posts.xml`). Paginated URLs like `/sitemap-posts-2.xml` were not in this list, so the middleware tried to serve them from the theme folder, failed, and returned 404 instead of passing the request to Ghost's sitemap handler.

## Solution

Replaced the hardcoded sitemap URL list with a regex pattern that matches all paginated sitemap URLs: `/^\/sitemap-(posts|pages|tags|authors|users)(-\d+)?\.xml$/`

## Test plan

- [x] Added unit tests for paginated sitema...[Response truncated]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves sitemap handling in the static theme middleware to ensure Ghost-generated sitemaps are served correctly.
> 
> - Introduces `isFallthroughFile` to centralize fallthrough logic for `robots.txt`, `sitemap.xml`, `sitemap.xsl`, and `sitemap-{posts|pages|tags|authors|users}(-page).xml`
> - Updates `forwardToExpressStatic` to use `isFallthroughFile` instead of a hardcoded list
> - Adds unit tests covering paginated sitemap variants (e.g., `sitemap-posts-2.xml`, `sitemap-posts-99.xml`, `sitemap-tags-3.xml`, `sitemap-authors-2.xml`) and validates fallthrough remains false for other static files
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 266777e09093e87a28ab000999ef81f48a600051. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->