### PR TITLE
✨ Added warning when a post's size exceeds email clients clipping length

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
@@ -60,10 +60,6 @@ const features: Feature[] = [{
     description: 'Enhanced comment moderation interface with advanced filtering and management. Requires the new admin experience.',
     flag: 'commentModeration'
 }, {
-    title: 'Email Size Warnings',
-    description: 'Enable warnings in editor when content exceeds email cut-off size',
-    flag: 'emailSizeWarnings'
-}, {
     title: 'Comment Permalinks',
     description: 'Enable direct links to individual comments with automatic scrolling and highlighting',
     flag: 'commentPermalinks'

--- a/ghost/admin/app/components/editor/email-size-warning.js
+++ b/ghost/admin/app/components/editor/email-size-warning.js
@@ -6,15 +6,13 @@ import {tracked} from '@glimmer/tracking';
 
 export default class EmailSizeWarningComponent extends Component {
     @service emailSizeWarning;
-    @service feature;
     @service settings;
 
     @tracked overLimit = false;
     @tracked emailSizeKb = null;
 
     get isEnabled() {
-        return this.feature.emailSizeWarnings
-            && this.settings.editorDefaultEmailRecipients !== 'disabled'
+        return this.settings.editorDefaultEmailRecipients !== 'disabled'
             && this.args.post
             && !this.args.post.email
             && !this.args.post.isNew;

--- a/ghost/admin/app/services/feature.js
+++ b/ghost/admin/app/services/feature.js
@@ -94,7 +94,6 @@ export default class FeatureService extends Service {
     @feature('contentVisibilityAlpha') contentVisibilityAlpha;
     @feature('tagsX') tagsX;
     @feature('utmTracking') utmTracking;
-    @feature('emailSizeWarnings') emailSizeWarnings;
 
     _user = null;
 

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -55,7 +55,6 @@ const PRIVATE_FEATURES = [
     'domainWarmup',
     'themeTranslation',
     'commentModeration',
-    'emailSizeWarnings',
     'commentPermalinks'
 ];
 

--- a/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
@@ -21,7 +21,6 @@ Object {
       "domainWarmup": true,
       "editorExcerpt": true,
       "emailCustomization": true,
-      "emailSizeWarnings": true,
       "emailUniqueid": true,
       "explore": true,
       "i18n": true,


### PR DESCRIPTION
ref https://linear.app/ghost/issue/FEA-479/

Gmail and other email clients will clip an email when it exceeds a certain size (typically ~100KB), hiding content and potentially breaking layouts. To help avoid this we've added warnings to indicate your email is close to the clipping limit.

When a post's email reaches 100kb or more, a warning will be shown in the following areas:
- bottom right corner of the editor
- email preview screen
- publishing flow

This is a warning only and has no impact on the email or ability to publish.
