### PR TITLE
Enabled sending welcome emails to black hole when configuration is set

### DIFF
--- a/ghost/core/core/server/services/member-welcome-emails/constants.js
+++ b/ghost/core/core/server/services/member-welcome-emails/constants.js
@@ -14,8 +14,29 @@ const MESSAGES = {
     memberWelcomeEmailInactive: memberStatus => `Member welcome email for "${memberStatus}" members is inactive`
 };
 
+// Default welcome email content in Lexical JSON format
+// Uses __GHOST_URL__ placeholder which Ghost replaces with the actual site URL
+// These match the defaults used in the admin UI (apps/admin-x-settings/src/components/settings/membership/member-emails.tsx)
+const DEFAULT_FREE_LEXICAL_CONTENT = '{"root":{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"Welcome! Thanks for subscribing — it\'s great to have you here.","type":"extended-text","version":1}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1},{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"You\'ll now receive new posts straight to your inbox. You can also log in any time to read the ","type":"extended-text","version":1},{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"full archive","type":"extended-text","version":1}],"direction":"ltr","format":"","indent":0,"type":"link","version":1,"rel":"noreferrer","target":null,"title":null,"url":"__GHOST_URL__/"},{"detail":0,"format":0,"mode":"normal","style":"","text":" or catch up on new posts as they go live.","type":"extended-text","version":1}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1},{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"A little housekeeping: If this email landed in spam or promotions, try moving it to your primary inbox and adding this address to your contacts. Small signals like that help your inbox recognize that these messages matter to you.","type":"extended-text","version":1}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1},{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"Have questions or just want to say hi? Feel free to reply directly to this email or any newsletter in the future.","type":"extended-text","version":1}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1},{"children":[],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}}';
+
+const DEFAULT_PAID_LEXICAL_CONTENT = '{"root":{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"Welcome, and thank you for your support — it means a lot.","type":"extended-text","version":1}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1},{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"As a paid member, you now have full access to everything: the complete archive, and any paid-only content going forward. New posts will land straight to your inbox, and you can log in any time to ","type":"extended-text","version":1},{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"catch up","type":"extended-text","version":1}],"direction":"ltr","format":"","indent":0,"type":"link","version":1,"rel":"noreferrer","target":null,"title":null,"url":"__GHOST_URL__/"},{"detail":0,"format":0,"mode":"normal","style":"","text":" on anything you\'ve missed.","type":"extended-text","version":1}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1},{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"A little housekeeping: If this email landed in spam or promotions, try moving it to your primary inbox and adding this address to your contacts. Small signals like that help your inbox recognize that these messages matter to you.","type":"extended-text","version":1}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1},{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"Have questions or just want to say hi? Feel free to reply directly to this email or any newsletter in the future.","type":"extended-text","version":1}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}}';
+
+const DEFAULT_WELCOME_EMAILS = {
+    free: {
+        lexical: DEFAULT_FREE_LEXICAL_CONTENT,
+        subject: 'Welcome to {{site.title}}',
+        status: 'active'
+    },
+    paid: {
+        lexical: DEFAULT_PAID_LEXICAL_CONTENT,
+        subject: 'Welcome to your paid subscription',
+        status: 'active'
+    }
+};
+
 module.exports = {
     MEMBER_WELCOME_EMAIL_LOG_KEY,
     MEMBER_WELCOME_EMAIL_SLUGS,
-    MESSAGES
+    MESSAGES,
+    DEFAULT_WELCOME_EMAILS
 };

--- a/ghost/core/core/server/services/member-welcome-emails/service.js
+++ b/ghost/core/core/server/services/member-welcome-emails/service.js
@@ -35,8 +35,8 @@ class MemberWelcomeEmailService {
         for (const [memberStatus, slug] of Object.entries(MEMBER_WELCOME_EMAIL_SLUGS)) {
             const row = await AutomatedEmail.findOne({slug});
 
-            if (!row || !row.get('lexical')) {
-                // Use default template when test inbox is configured
+            if (!row) {
+                // No row - use default template when test inbox is configured
                 if (useDefaults) {
                     const defaultEmail = DEFAULT_WELCOME_EMAILS[memberStatus];
                     this.#memberWelcomeEmails[memberStatus] = {
@@ -49,6 +49,13 @@ class MemberWelcomeEmailService {
                 continue;
             }
 
+            // Row exists - check if it has content
+            if (!row.get('lexical')) {
+                this.#memberWelcomeEmails[memberStatus] = null;
+                continue;
+            }
+
+            // Use DB template (status check happens in send())
             this.#memberWelcomeEmails[memberStatus] = {
                 lexical: row.get('lexical'),
                 subject: row.get('subject'),

--- a/ghost/core/core/server/services/member-welcome-emails/service.js
+++ b/ghost/core/core/server/services/member-welcome-emails/service.js
@@ -37,9 +37,15 @@ class MemberWelcomeEmailService {
 
             if (!row || !row.get('lexical')) {
                 // Use default template when test inbox is configured
-                this.#memberWelcomeEmails[memberStatus] = useDefaults
-                    ? DEFAULT_WELCOME_EMAILS[memberStatus]
-                    : null;
+                if (useDefaults) {
+                    const defaultEmail = DEFAULT_WELCOME_EMAILS[memberStatus];
+                    this.#memberWelcomeEmails[memberStatus] = {
+                        ...defaultEmail,
+                        lexical: urlUtils.transformReadyToAbsolute(defaultEmail.lexical)
+                    };
+                } else {
+                    this.#memberWelcomeEmails[memberStatus] = null;
+                }
                 continue;
             }
 

--- a/ghost/core/core/server/services/member-welcome-emails/service.js
+++ b/ghost/core/core/server/services/member-welcome-emails/service.js
@@ -7,8 +7,8 @@ const emailAddressService = require('../email-address');
 const mail = require('../mail');
 // @ts-expect-error type checker has trouble with the dynamic exporting in models
 const {AutomatedEmail} = require('../../models');
-const MemberWelcomeEmailRenderer = require('./member-welcome-email-renderer');
-const {MEMBER_WELCOME_EMAIL_LOG_KEY, MEMBER_WELCOME_EMAIL_SLUGS, MESSAGES} = require('./constants');
+const MemberWelcomeEmailRenderer = require('./MemberWelcomeEmailRenderer');
+const {MEMBER_WELCOME_EMAIL_LOG_KEY, MEMBER_WELCOME_EMAIL_SLUGS, MESSAGES, DEFAULT_WELCOME_EMAILS} = require('./constants');
 
 class MemberWelcomeEmailService {
     #mailer;
@@ -30,11 +30,16 @@ class MemberWelcomeEmailService {
     }
 
     async loadMemberWelcomeEmails() {
+        const useDefaults = Boolean(config.get('memberWelcomeEmailTestInbox'));
+
         for (const [memberStatus, slug] of Object.entries(MEMBER_WELCOME_EMAIL_SLUGS)) {
             const row = await AutomatedEmail.findOne({slug});
 
             if (!row || !row.get('lexical')) {
-                this.#memberWelcomeEmails[memberStatus] = null;
+                // Use default template when test inbox is configured
+                this.#memberWelcomeEmails[memberStatus] = useDefaults
+                    ? DEFAULT_WELCOME_EMAILS[memberStatus]
+                    : null;
                 continue;
             }
 

--- a/ghost/core/core/server/services/member-welcome-emails/service.js
+++ b/ghost/core/core/server/services/member-welcome-emails/service.js
@@ -7,7 +7,7 @@ const emailAddressService = require('../email-address');
 const mail = require('../mail');
 // @ts-expect-error type checker has trouble with the dynamic exporting in models
 const {AutomatedEmail} = require('../../models');
-const MemberWelcomeEmailRenderer = require('./MemberWelcomeEmailRenderer');
+const MemberWelcomeEmailRenderer = require('./member-welcome-email-renderer');
 const {MEMBER_WELCOME_EMAIL_LOG_KEY, MEMBER_WELCOME_EMAIL_SLUGS, MESSAGES, DEFAULT_WELCOME_EMAILS} = require('./constants');
 
 class MemberWelcomeEmailService {

--- a/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
@@ -343,7 +343,8 @@ module.exports = class MemberRepository {
         const memberAddOptions = {...(options || {}), withRelated};
         let member;
 
-        if (config.get('memberWelcomeEmailTestInbox') && WELCOME_EMAIL_SOURCES.includes(source)) {
+        const hasTestInbox = Boolean(config.get('memberWelcomeEmailTestInbox'));
+        if (hasTestInbox && WELCOME_EMAIL_SOURCES.includes(source)) {
             const freeWelcomeEmail = this._AutomatedEmail ? await this._AutomatedEmail.findOne({slug: MEMBER_WELCOME_EMAIL_SLUGS.free}) : null;
             const isFreeWelcomeEmailActive = freeWelcomeEmail && freeWelcomeEmail.get('lexical') && freeWelcomeEmail.get('status') === 'active';
             const isFreeSignup = !stripeCustomer;
@@ -355,10 +356,10 @@ module.exports = class MemberRepository {
                     labels
                 }, {...memberAddOptions, transacting});
 
-                // Only send the free welcome email if:
-                // 1. The free welcome email is active
+                // Send the free welcome email if:
+                // 1. The free welcome email is active OR test inbox is configured (uses default template)
                 // 2. The member is not signing up for a paid subscription (no stripeCustomer)
-                if (isFreeWelcomeEmailActive && isFreeSignup) {
+                if ((isFreeWelcomeEmailActive || hasTestInbox) && isFreeSignup) {
                     const timestamp = eventData.created_at || newMember.get('created_at');
 
                     await this._Outbox.add({
@@ -384,7 +385,7 @@ module.exports = class MemberRepository {
                 member = await this._Member.transaction(runMemberCreation);
             }
 
-            if (isFreeWelcomeEmailActive && isFreeSignup) {
+            if ((isFreeWelcomeEmailActive || hasTestInbox) && isFreeSignup) {
                 this.dispatchEvent(StartOutboxProcessingEvent.create({memberId: member.id}), memberAddOptions);
             }
         } else {
@@ -1429,7 +1430,10 @@ module.exports = class MemberRepository {
                 const paidWelcomeEmail = await this._AutomatedEmail.findOne({slug: MEMBER_WELCOME_EMAIL_SLUGS.paid}, options);
                 isPaidWelcomeEmailActive = paidWelcomeEmail && paidWelcomeEmail.get('lexical') && paidWelcomeEmail.get('status') === 'active';
             }
-            if (updatedMember.get('status') === 'paid' && isPaidWelcomeEmailActive) {
+            // Send paid welcome email if:
+            // 1. The paid welcome email is active OR test inbox is configured (uses default template)
+            // 2. The member status changed to 'paid'
+            if (updatedMember.get('status') === 'paid' && (isPaidWelcomeEmailActive || shouldSendPaidWelcomeEmail)) {
                 await this._Outbox.add({
                     id: ObjectId().toHexString(),
                     event_type: MemberCreatedEvent.name,

--- a/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
@@ -348,6 +348,8 @@ module.exports = class MemberRepository {
             const freeWelcomeEmail = this._AutomatedEmail ? await this._AutomatedEmail.findOne({slug: MEMBER_WELCOME_EMAIL_SLUGS.free}) : null;
             const isFreeWelcomeEmailActive = freeWelcomeEmail && freeWelcomeEmail.get('lexical') && freeWelcomeEmail.get('status') === 'active';
             const isFreeSignup = !stripeCustomer;
+            // Use default template only when no DB row exists (not when inactive - respect explicit user choice)
+            const useDefaultFreeTemplate = !freeWelcomeEmail && hasTestInbox;
 
             const runMemberCreation = async (transacting) => {
                 const newMember = await this._Member.add({
@@ -357,9 +359,9 @@ module.exports = class MemberRepository {
                 }, {...memberAddOptions, transacting});
 
                 // Send the free welcome email if:
-                // 1. The free welcome email is active OR test inbox is configured (uses default template)
+                // 1. The free welcome email is active OR no DB row exists and test inbox is configured (uses default template)
                 // 2. The member is not signing up for a paid subscription (no stripeCustomer)
-                if ((isFreeWelcomeEmailActive || hasTestInbox) && isFreeSignup) {
+                if ((isFreeWelcomeEmailActive || useDefaultFreeTemplate) && isFreeSignup) {
                     const timestamp = eventData.created_at || newMember.get('created_at');
 
                     await this._Outbox.add({
@@ -385,7 +387,7 @@ module.exports = class MemberRepository {
                 member = await this._Member.transaction(runMemberCreation);
             }
 
-            if ((isFreeWelcomeEmailActive || hasTestInbox) && isFreeSignup) {
+            if ((isFreeWelcomeEmailActive || useDefaultFreeTemplate) && isFreeSignup) {
                 this.dispatchEvent(StartOutboxProcessingEvent.create({memberId: member.id}), memberAddOptions);
             }
         } else {
@@ -1426,14 +1428,17 @@ module.exports = class MemberRepository {
             const source = this._resolveContextSource(context);
             const shouldSendPaidWelcomeEmail = config.get('memberWelcomeEmailTestInbox') && WELCOME_EMAIL_SOURCES.includes(source);
             let isPaidWelcomeEmailActive = false;
+            let paidWelcomeEmail = null;
             if (shouldSendPaidWelcomeEmail && this._AutomatedEmail) {
-                const paidWelcomeEmail = await this._AutomatedEmail.findOne({slug: MEMBER_WELCOME_EMAIL_SLUGS.paid}, options);
+                paidWelcomeEmail = await this._AutomatedEmail.findOne({slug: MEMBER_WELCOME_EMAIL_SLUGS.paid}, options);
                 isPaidWelcomeEmailActive = paidWelcomeEmail && paidWelcomeEmail.get('lexical') && paidWelcomeEmail.get('status') === 'active';
             }
+            // Use default template only when no DB row exists (not when inactive - respect explicit user choice)
+            const useDefaultPaidTemplate = !paidWelcomeEmail && shouldSendPaidWelcomeEmail;
             // Send paid welcome email if:
-            // 1. The paid welcome email is active OR test inbox is configured (uses default template)
+            // 1. The paid welcome email is active OR no DB row exists and test inbox is configured (uses default template)
             // 2. The member status changed to 'paid'
-            if (updatedMember.get('status') === 'paid' && (isPaidWelcomeEmailActive || shouldSendPaidWelcomeEmail)) {
+            if (updatedMember.get('status') === 'paid' && (isPaidWelcomeEmailActive || useDefaultPaidTemplate)) {
                 await this._Outbox.add({
                     id: ObjectId().toHexString(),
                     event_type: MemberCreatedEvent.name,

--- a/ghost/core/core/server/services/outbox/jobs/lib/process-outbox.js
+++ b/ghost/core/core/server/services/outbox/jobs/lib/process-outbox.js
@@ -38,7 +38,6 @@ async function fetchPendingEntries({batchSize, jobStartISO}) {
 }
 
 async function processOutbox() {
-    logging.info(`${OUTBOX_LOG_KEY} Starting outbox processing job. Max entries: ${MAX_ENTRIES_PER_JOB}, Batch size: ${BATCH_SIZE}`);
     const jobStartMs = Date.now();
     const jobStartISO = new Date(jobStartMs).toISOString().slice(0, 19).replace('T', ' ');
 

--- a/ghost/core/core/server/services/outbox/jobs/lib/process-outbox.js
+++ b/ghost/core/core/server/services/outbox/jobs/lib/process-outbox.js
@@ -38,6 +38,7 @@ async function fetchPendingEntries({batchSize, jobStartISO}) {
 }
 
 async function processOutbox() {
+    logging.info(`${OUTBOX_LOG_KEY} Starting outbox processing job. Max entries: ${MAX_ENTRIES_PER_JOB}, Batch size: ${BATCH_SIZE}`);
     const jobStartMs = Date.now();
     const jobStartISO = new Date(jobStartMs).toISOString().slice(0, 19).replace('T', ' ');
 

--- a/ghost/core/test/integration/services/member-welcome-emails.test.js
+++ b/ghost/core/test/integration/services/member-welcome-emails.test.js
@@ -224,15 +224,16 @@ describe('Member Welcome Emails Integration', function () {
             assert.ok(entriesAfterJob.models[0].get('message').includes('inactive'));
         });
 
-        it('does not send email when no template exists', async function () {
+        it('sends email using default template when no DB template exists', async function () {
+            // Delete the free welcome email from the database
             await db.knex('automated_emails').where('slug', MEMBER_WELCOME_EMAIL_SLUGS.free).del();
 
             await models.Outbox.add({
                 event_type: 'MemberCreatedEvent',
                 payload: JSON.stringify({
                     memberId: 'member1',
-                    email: 'notemplate@example.com',
-                    name: 'No Template Member',
+                    email: 'default-template@example.com',
+                    name: 'Default Template Member',
                     status: 'free'
                 }),
                 status: OUTBOX_STATUSES.PENDING
@@ -240,11 +241,15 @@ describe('Member Welcome Emails Integration', function () {
 
             await scheduleInlineJob();
 
-            assert.equal(mailService.GhostMailer.prototype.send.callCount, 0);
+            // Email should be sent using default template
+            assert.equal(mailService.GhostMailer.prototype.send.callCount, 1);
+            const sentEmail = mailService.GhostMailer.prototype.send.firstCall.args[0];
+            assert.ok(sentEmail.html.includes('Thanks for subscribing'));
+            assert.equal(sentEmail.to, 'test-inbox@example.com');
 
+            // Outbox entry should be processed (deleted after success)
             const entriesAfterJob = await models.Outbox.findAll();
-            assert.equal(entriesAfterJob.length, 1);
-            assert.ok(entriesAfterJob.models[0].get('message'));
+            assert.equal(entriesAfterJob.length, 0);
         });
 
         it('does not send email when paid template is inactive but entry has status paid', async function () {
@@ -272,15 +277,16 @@ describe('Member Welcome Emails Integration', function () {
             assert.ok(entriesAfterJob.models[0].get('message').includes('inactive'));
         });
 
-        it('does not send email when no paid template exists but entry has status paid', async function () {
+        it('sends email using default paid template when no DB paid template exists', async function () {
+            // Delete the paid welcome email from the database
             await db.knex('automated_emails').where('slug', MEMBER_WELCOME_EMAIL_SLUGS.paid).del();
 
             await models.Outbox.add({
                 event_type: 'MemberCreatedEvent',
                 payload: JSON.stringify({
                     memberId: 'paid_member_2',
-                    email: 'paid-notemplate@example.com',
-                    name: 'Paid No Template Member',
+                    email: 'paid-default-template@example.com',
+                    name: 'Paid Default Template Member',
                     status: 'paid'
                 }),
                 status: OUTBOX_STATUSES.PENDING
@@ -288,11 +294,41 @@ describe('Member Welcome Emails Integration', function () {
 
             await scheduleInlineJob();
 
-            assert.equal(mailService.GhostMailer.prototype.send.callCount, 0);
+            // Email should be sent using default paid template
+            assert.equal(mailService.GhostMailer.prototype.send.callCount, 1);
+            const sentEmail = mailService.GhostMailer.prototype.send.firstCall.args[0];
+            assert.ok(sentEmail.html.includes('thank you for your support'));
+            assert.equal(sentEmail.to, 'test-inbox@example.com');
+
+            // Outbox entry should be processed (deleted after success)
+            const entriesAfterJob = await models.Outbox.findAll();
+            assert.equal(entriesAfterJob.length, 0);
+        });
+
+        it('prefers DB template over default when DB template exists and is active', async function () {
+            // DB template is already set up in beforeEach with custom content
+            await models.Outbox.add({
+                event_type: 'MemberCreatedEvent',
+                payload: JSON.stringify({
+                    memberId: 'member_db_template',
+                    email: 'db-template@example.com',
+                    name: 'DB Template Member',
+                    status: 'free'
+                }),
+                status: OUTBOX_STATUSES.PENDING
+            });
+
+            await scheduleInlineJob();
+
+            // Email should be sent using DB template content
+            assert.equal(mailService.GhostMailer.prototype.send.callCount, 1);
+            const sentEmail = mailService.GhostMailer.prototype.send.firstCall.args[0];
+            // The DB template has "Welcome to our site!" not the default "Thanks for subscribing"
+            assert.ok(sentEmail.html.includes('Welcome to our site!'));
+            assert.ok(!sentEmail.html.includes('Thanks for subscribing'));
 
             const entriesAfterJob = await models.Outbox.findAll();
-            assert.equal(entriesAfterJob.length, 1);
-            assert.ok(entriesAfterJob.models[0].get('message'));
+            assert.equal(entriesAfterJob.length, 0);
         });
     });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/NY-890/test-sending-welcome-emails-to-black-hole-in-production-at-scale

## Summary

Enables testing welcome emails at scale on production sites by allowing the full welcome email flow to execute even when no `automated_emails` rows exist in the database.

## Problem

We want to test the welcome emails functionality on a population of production sites, but simply enabling `memberWelcomeEmailTestInbox` wasn't enough - sites without rows in the `automated_emails` table would never add entries to the outbox, so no emails would actually be sent.

## Solution

When `memberWelcomeEmailTestInbox` is configured and no `automated_emails` row exists, we now use a default template (matching the frontend defaults) to send the welcome email. This allows the full flow to be exercised:

1. Member signs up
2. Outbox entry is created (using default template if no DB row exists)
3. Outbox job processes the entry
4. Email is sent to the configured test inbox

### Behavior Matrix

| DB row state | Test inbox configured | Outbox entry created? | Email sent? |
|--------------|----------------------|----------------------|-------------|
| Active | Yes | Yes | Yes (DB template) |
| Inactive | Yes | No | No (respects user choice) |
| No row | Yes | Yes | Yes (default template) |
| Any | No | No | No |

## Changes

- **constants.js**: Added default lexical content for free/paid welcome emails (matching frontend defaults)
- **service.js**: Modified `loadMemberWelcomeEmails()` to use defaults when no DB row exists and test inbox is configured
- **MemberRepository.js**: Added fallback logic to create outbox entries when no DB row exists but test inbox is configured
- **Tests**: Updated integration tests to verify default template behavior

## Note

These changes would be temporary — once we're satisfied with our testing, I'd plan to revert this change when we remove the `memberWelcomeEmailTestInbox` config and start sending emails to the member themself.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables full welcome email flow for test inboxes even without `automated_emails` rows, matching admin UI defaults and preserving "inactive" behavior.
> 
> - Adds default Lexical templates and subjects in `member-welcome-emails/constants.js` (`DEFAULT_WELCOME_EMAILS`)
> - Updates `member-welcome-emails/service.js` to load default templates when `memberWelcomeEmailTestInbox` is set and DB rows are missing; transforms `__GHOST_URL__` to absolute URLs
> - Updates `members-api/member-repository.js` to create outbox entries using defaults when no DB row exists (free on signup, paid on upgrade), and dispatches processing; still skips when templates are inactive
> - Expands integration tests to cover default fallback sending, DB-template precedence, inactivity handling, and URL placeholder transformation
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 286eac7f76dcd047b585d13a40c7b4f2488c745f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->