### PR TITLE
🔒 Fixed staff token authorization bypass via trailing slash mismatch

### DIFF
--- a/ghost/core/core/server/web/api/endpoints/admin/middleware.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/middleware.js
@@ -24,8 +24,9 @@ const tokenPermissionCheck = function tokenPermissionCheck(req, res, next) {
     // Staff tokens have a user_id associated with them, integration tokens don't
     if (req.api_key?.get('user_id')) {
         // Check if staff token is trying to access blocked endpoints
-        const isDeleteAllContent = req.method === 'DELETE' && req.path === '/db/';
-        const isTransferOwnership = req.method === 'PUT' && req.path === '/users/owner/';
+        // Match both with and without trailing slash since Express routes accept both
+        const isDeleteAllContent = req.method === 'DELETE' && (req.path === '/db/' || req.path === '/db');
+        const isTransferOwnership = req.method === 'PUT' && (req.path === '/users/owner/' || req.path === '/users/owner');
 
         if (isDeleteAllContent || isTransferOwnership) {
             return next(new errors.NoPermissionError({

--- a/ghost/core/test/unit/server/web/api/admin/middleware.test.js
+++ b/ghost/core/test/unit/server/web/api/admin/middleware.test.js
@@ -117,16 +117,30 @@ describe('Admin API Middleware', function () {
                 assert.equal(next.firstCall.args.length, 0);
             });
 
-            it('should not block staff tokens from DELETE /db (without trailing slash)', function () {
+            it('should block staff tokens from DELETE /db (without trailing slash)', function () {
                 req.path = '/db';
                 req.method = 'DELETE';
 
                 const tokenPermissionCheck = middleware.authAdminApi[middleware.authAdminApi.length - 1];
                 tokenPermissionCheck(req, res, next);
 
-                // Should pass through since we're checking for exact match with trailing slash
                 assert.equal(next.calledOnce, true);
-                assert.equal(next.firstCall.args.length, 0);
+                const error = next.firstCall.args[0];
+                assert.equal(error instanceof errors.NoPermissionError, true);
+                assert.equal(error.message, 'Staff tokens are not allowed to access this endpoint');
+            });
+
+            it('should block staff tokens from PUT /users/owner (without trailing slash)', function () {
+                req.path = '/users/owner';
+                req.method = 'PUT';
+
+                const tokenPermissionCheck = middleware.authAdminApi[middleware.authAdminApi.length - 1];
+                tokenPermissionCheck(req, res, next);
+
+                assert.equal(next.calledOnce, true);
+                const error = next.firstCall.args[0];
+                assert.equal(error instanceof errors.NoPermissionError, true);
+                assert.equal(error.message, 'Staff tokens are not allowed to access this endpoint');
             });
         });
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/pull/23585

The staff token blocklist checked for `/db/` and `/users/owner/` with trailing slashes, but Express routes accept both `/db` and `/db/`. Requests without the trailing slash bypassed the security check entirely, allowing staff tokens to delete all content or transfer site ownership.

Co-authored-by: Fabien O'Carroll <fabien@allou.is>

Credit:

Sho Odagiri
GMO Cybersecurity by Ierae, Inc.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens staff token blocklist to cover route variants accepted by Express.
> 
> - Update `tokenPermissionCheck` to block `DELETE /db` and `PUT /users/owner` for staff tokens with or without a trailing slash
> - Add E2E tests using `rawRequest` to verify blocking for both `/db` and `/db/`, `/users/owner` and `/users/owner/`
> - Update unit tests to assert blocking on no-trailing-slash variants; retain existing allowlist and behavior for integration tokens and other routes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d44cab9b1e534677904f1f8ba188957501a6c4ae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->