### PR TITLE
🔒 Fixed ability to bypass Staff User 2FA flow

### DIFF
--- a/ghost/admin/app/authenticators/cookie.js
+++ b/ghost/admin/app/authenticators/cookie.js
@@ -19,8 +19,8 @@ export default Authenticator.extend({
         return RSVP.resolve();
     },
 
-    authenticate({identification, password, token, skipEmailVerification}) {
-        if (token) {
+    authenticate({identification, password, token}) {
+        if (token && !identification && !password) {
             const data = {token};
             const options = {
                 data,
@@ -33,9 +33,11 @@ export default Authenticator.extend({
         }
 
         const data = {username: identification, password};
-        if (skipEmailVerification) {
-            data.skipEmailVerification = true;
+
+        if (token) {
+            data.token = token;
         }
+
         const options = {
             data,
             contentType: 'application/json;charset=utf-8',

--- a/ghost/admin/app/controllers/reset.js
+++ b/ghost/admin/app/controllers/reset.js
@@ -57,16 +57,19 @@ export default class ResetController extends Controller.extend(ValidationEngine)
         try {
             yield this.validate();
             try {
-                let resp = yield this.ajax.put(authUrl, {
+                let {password_reset: [{message, emailVerificationToken}]} = yield this.ajax.put(authUrl, {
                     data: {
                         password_reset: [{newPassword, ne2Password, token}]
                     }
                 });
+
                 this.notifications.showNotification(
-                    resp.password_reset[0].message,
+                    message,
                     {type: 'info', delayed: true, key: 'password.reset'}
                 );
-                this.session.authenticate('authenticator:cookie', {identification: email, password: newPassword, skipEmailVerification: true});
+
+                yield this.session.authenticate('authenticator:cookie', {identification: email, password: newPassword, token: emailVerificationToken});
+
                 return true;
             } catch (error) {
                 this.notifications.showAPIError(error, {key: 'password.reset'});

--- a/ghost/admin/tests/unit/authenticators/cookie-test.js
+++ b/ghost/admin/tests/unit/authenticators/cookie-test.js
@@ -98,26 +98,6 @@ describe('Unit: Authenticator: cookie', () => {
                 });
             });
         });
-
-        it('includes skipEmailVerification in request data when provided', function () {
-            let authenticator = this.owner.lookup('authenticator:cookie');
-            let post = authenticator.ajax.post;
-
-            return authenticator.authenticate({
-                identification: 'AzureDiamond', 
-                password: 'hunter2',
-                skipEmailVerification: true
-            }).then(() => {
-                expect(post.args[0][0]).to.equal(`${ghostPaths().apiRoot}/session`);
-                expect(post.args[0][1]).to.deep.include({
-                    data: {
-                        username: 'AzureDiamond',
-                        password: 'hunter2',
-                        skipEmailVerification: true
-                    }
-                });
-            });
-        });
     });
 
     describe('#invalidate', function () {

--- a/ghost/admin/tests/unit/controllers/reset-test.js
+++ b/ghost/admin/tests/unit/controllers/reset-test.js
@@ -15,23 +15,23 @@ describe('Unit: Controller: reset', function () {
             addObjects: sinon.stub()
         };
         controller.validate = sinon.stub().resolves();
-        
+
         controller.ghostPaths = {
             url: {
                 api: sinon.stub().returns('/api/endpoint')
             }
         };
-        
+
         controller.ajax = {
             put: sinon.stub().resolves({
-                password_reset: [{message: 'Password reset successful'}]
+                password_reset: [{message: 'Password reset successful', emailVerificationToken: '123456'}]
             })
         };
-        
+
         controller.notifications = {
             showNotification: sinon.stub()
         };
-        
+
         controller.session = {
             authenticate: sinon.stub().resolves()
         };
@@ -57,21 +57,21 @@ describe('Unit: Controller: reset', function () {
             {
                 identification: 'test@example.com',
                 password: 'newpassword123',
-                skipEmailVerification: true
+                token: '123456'
             }
         )).to.be.true;
     });
 
     it('handles validation errors correctly', async function () {
         const controller = this.owner.lookup('controller:reset');
-        
+
         controller.token = btoa('token|test@example.com|moredata');
         controller.newPassword = 'short';
         controller.ne2Password = 'short';
         controller.hasValidated = {
             addObjects: sinon.stub()
         };
-        
+
         // Simulate validation error
         controller.errors = {
             errorsFor: sinon.stub().returns([{message: 'Password too short'}]),
@@ -87,7 +87,7 @@ describe('Unit: Controller: reset', function () {
 
     it('handles API errors correctly', async function () {
         const controller = this.owner.lookup('controller:reset');
-        
+
         controller.token = btoa('token|test@example.com|moredata');
         controller.newPassword = 'newpassword123';
         controller.ne2Password = 'newpassword123';
@@ -95,18 +95,18 @@ describe('Unit: Controller: reset', function () {
             addObjects: sinon.stub()
         };
         controller.validate = sinon.stub().resolves();
-        
+
         controller.ghostPaths = {
             url: {
                 api: sinon.stub().returns('/api/endpoint')
             }
         };
-        
+
         const apiError = new Error('API Error');
         controller.ajax = {
             put: sinon.stub().rejects(apiError)
         };
-        
+
         controller.notifications = {
             showAPIError: sinon.stub()
         };
@@ -119,14 +119,14 @@ describe('Unit: Controller: reset', function () {
 
     it('handles password mismatch validation error', async function () {
         const controller = this.owner.lookup('controller:reset');
-        
+
         controller.token = btoa('token|test@example.com|moredata');
         controller.newPassword = 'newpassword123';
         controller.ne2Password = 'differentpassword';
         controller.hasValidated = {
             addObjects: sinon.stub()
         };
-        
+
         // Simulate ne2Password validation error
         controller.errors = {
             errorsFor: sinon.stub(),

--- a/ghost/core/core/server/api/endpoints/session.js
+++ b/ghost/core/core/server/api/endpoints/session.js
@@ -24,8 +24,6 @@ const controller = {
         return models.User.getByEmail(object.username).then((user) => {
             if (user && !user.hasLoggedIn()) {
                 skipVerification = true;
-            } else if (frame.data.skipEmailVerification) {
-                skipVerification = true;
             }
 
             return models.User.check({

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/authentication.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/authentication.js
@@ -42,7 +42,8 @@ module.exports = {
     resetPassword(data, apiConfig, frame) {
         frame.response = {
             password_reset: [{
-                message: tpl(messages.passwordChanged)
+                message: tpl(messages.passwordChanged),
+                emailVerificationToken: data.emailVerificationToken
             }]
         };
     },

--- a/ghost/core/core/server/services/auth/otp.js
+++ b/ghost/core/core/server/services/auth/otp.js
@@ -1,0 +1,33 @@
+const {totp} = require('otplib');
+
+totp.options = {
+    digits: 6,
+    step: 60,
+    window: [10, 10]
+};
+
+/**
+ * Generate a TOTP token for a user
+ * @param {string} userId - The user's ID
+ * @param {string} secret - The admin session secret
+ * @returns {string} - The generated 6-digit token
+ */
+function generate(userId, secret) {
+    return totp.generate(secret + userId);
+}
+
+/**
+ * Verify a TOTP token for a user
+ * @param {string} userId - The user's ID
+ * @param {string} token - The token to verify
+ * @param {string} secret - The admin session secret
+ * @returns {boolean} - Whether the token is valid
+ */
+function verify(userId, token, secret) {
+    return totp.check(token, secret + userId);
+}
+
+module.exports = {
+    generate,
+    verify
+};

--- a/ghost/core/core/server/services/auth/passwordreset.js
+++ b/ghost/core/core/server/services/auth/passwordreset.js
@@ -7,6 +7,8 @@ const moment = require('moment');
 const models = require('../../models');
 const urlUtils = require('../../../shared/url-utils');
 const mail = require('../mail');
+const otp = require('./otp');
+const settingsCache = require('../../../shared/settings-cache');
 
 const messages = {
     userNotFound: 'User not found.',
@@ -144,6 +146,12 @@ function doReset(options, tokenParts, settingsAPI) {
         .then((updatedUser) => {
             updatedUser.set('status', 'active');
             return updatedUser.save(options);
+        })
+        .then((savedUser) => {
+            // Generate email verification token for 2FA bypass on login
+            const secret = settingsCache.get('admin_session_secret');
+            const emailVerificationToken = otp.generate(savedUser.id, secret);
+            return {emailVerificationToken};
         })
         .catch((err) => {
             if (errors.utils.isGhostError(err)) {

--- a/ghost/core/test/e2e-api/admin/__snapshots__/authentication.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/authentication.test.js.snap
@@ -17,3 +17,14 @@ Object {
   ],
 }
 `;
+
+exports[`Authentication API resetPassword returns emailVerificationToken that can be used to bypass 2FA on login 1: [body] 1`] = `
+Object {
+  "password_reset": Array [
+    Object {
+      "emailVerificationToken": StringMatching /\\^\\[0-9\\]\\{6\\}\\$/,
+      "message": "Password updated",
+    },
+  ],
+}
+`;

--- a/ghost/core/test/e2e-api/admin/__snapshots__/session.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/session.test.js.snap
@@ -1,5 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Sessions API Staff 2FA can login with 2FA code in session creation request 1: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "7",
+  "content-type": "text/plain; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "set-cookie": Array [
+    StringMatching /\\^ghost-admin-api-session=/,
+  ],
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
 exports[`Sessions API Staff 2FA can verify a session with 2FA code 1: [body] 1`] = `
 Object {
   "errors": Array [

--- a/ghost/core/test/e2e-api/admin/authentication.test.js
+++ b/ghost/core/test/e2e-api/admin/authentication.test.js
@@ -1,5 +1,9 @@
-const {agentProvider, fixtureManager, matchers} = require('../../utils/e2e-framework');
-const {anyErrorId} = matchers;
+const {agentProvider, fixtureManager, matchers, configUtils} = require('../../utils/e2e-framework');
+const models = require('../../../core/server/models');
+const security = require('@tryghost/security');
+const settingsCache = require('../../../core/shared/settings-cache');
+const moment = require('moment');
+const {anyErrorId, stringMatching} = matchers;
 
 describe('Authentication API', function () {
     let agent;
@@ -20,6 +24,70 @@ describe('Authentication API', function () {
                         id: anyErrorId
                     }]
                 });
+        });
+    });
+
+    describe('resetPassword', function () {
+        it('returns emailVerificationToken that can be used to bypass 2FA on login', async function () {
+            // Enable 2FA for this test
+            configUtils.set('security:staffDeviceVerification', true);
+
+            const ownerUser = await fixtureManager.get('users', 0);
+            const newPassword = 'thisissupersafe';
+
+            // Generate a valid reset token manually (simulating the email link)
+            const dbHash = settingsCache.get('db_hash');
+            const user = await models.User.getByEmail(ownerUser.email, {context: {internal: true}});
+            const resetToken = security.tokens.resetToken.generateHash({
+                expires: moment().add(1, 'days').valueOf(),
+                email: ownerUser.email,
+                dbHash: dbHash,
+                password: user.get('password')
+            });
+            const encodedToken = security.url.encodeBase64(resetToken);
+
+            // Reset the password and capture the emailVerificationToken
+            const resetResponse = await agent
+                .put('authentication/password_reset')
+                .body({
+                    password_reset: [{
+                        token: encodedToken,
+                        newPassword: newPassword,
+                        ne2Password: newPassword
+                    }]
+                })
+                .expectStatus(200)
+                .matchBodySnapshot({
+                    password_reset: [{
+                        message: 'Password updated',
+                        emailVerificationToken: stringMatching(/^[0-9]{6}$/)
+                    }]
+                });
+
+            const emailVerificationToken = resetResponse.body.password_reset[0].emailVerificationToken;
+
+            // Clear cookies to simulate a fresh login attempt
+            agent.clearCookies();
+
+            // Now login with the emailVerificationToken - should bypass 2FA
+            await agent
+                .post('session/')
+                .body({
+                    grant_type: 'password',
+                    username: ownerUser.email,
+                    password: newPassword,
+                    token: emailVerificationToken
+                })
+                .expectStatus(201)
+                .expectEmptyBody();
+
+            // Verify we can access protected resources (session is verified)
+            await agent
+                .get('/users/me/')
+                .expectStatus(200);
+
+            // Cleanup: reset the password back to original and disable 2FA
+            configUtils.set('security:staffDeviceVerification', false);
         });
     });
 });

--- a/ghost/core/test/legacy/api/admin/__snapshots__/authentication.test.js.snap
+++ b/ghost/core/test/legacy/api/admin/__snapshots__/authentication.test.js.snap
@@ -781,6 +781,7 @@ exports[`Authentication API Password reset reset password 1: [body] 1`] = `
 Object {
   "password_reset": Array [
     Object {
+      "emailVerificationToken": StringMatching /\\^\\[0-9\\]\\{6\\}\\$/,
       "message": "Password updated",
     },
   ],
@@ -791,7 +792,7 @@ exports[`Authentication API Password reset reset password 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "51",
+  "content-length": "85",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/legacy/api/admin/authentication.test.js
+++ b/ghost/core/test/legacy/api/admin/authentication.test.js
@@ -1,7 +1,7 @@
 const nock = require('nock');
 const assert = require('assert/strict');
 const {agentProvider, mockManager, fixtureManager, matchers} = require('../../../utils/e2e-framework');
-const {anyContentVersion, anyEtag, anyISODateTime, anyErrorId} = matchers;
+const {anyContentVersion, anyEtag, anyISODateTime, anyErrorId, stringMatching} = matchers;
 
 const {tokens} = require('@tryghost/security');
 const models = require('../../../../core/server/models');
@@ -388,7 +388,11 @@ describe('Authentication API', function () {
                     }]
                 })
                 .expectStatus(200)
-                .matchBodySnapshot()
+                .matchBodySnapshot({
+                    password_reset: [{
+                        emailVerificationToken: stringMatching(/^[0-9]{6}$/)
+                    }]
+                })
                 .matchHeaderSnapshot({
                     'content-version': anyContentVersion,
                     etag: anyEtag


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3150/

Previously the session creation endpoint accepted a `skipEmailVerification` property with an intended purpose of allowing the 2FA flow to be bypassed in the login immediately following a password reset, reducing friction in the UX considering a password reset is only possible via email and therefore considered already email-verified. Although Ghost's Admin client followed the expected usage and only used the property on the password reset authentication, the basic nature of the property meant anyone could manually add it to a session creation API request to bypass 2FA.

- removed `skipEmailVerification` implementation
- updated `/authentication/password_reset/` endpoint to generate an OTP after successful reset and return it as an `emailVerificationToken` property in the response
- updated `/session` endpoint to accept a `token` property alongside the username/password, and mark the session as verified if the `token` contains a valid OTP
- updated Admin client's password reset flow to use `emailVerificationToken` and `token` respectively to bypass 2FA when creating a session after password reset

This updated flow removes the blanket 2FA bypass by requiring a valid OTP which can only be obtained via the normal email path after unverified sign-in or a successful password reset.

Credit:

Sho Odagiri
GMO Cybersecurity by Ierae, Inc.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens 2FA by eliminating implicit bypass and requiring a valid OTP.
> 
> - **Auth flow changes**: Removed `skipEmailVerification`; password reset now returns `emailVerificationToken`; session creation accepts `token` with `username/password` to mark session `verified`; `PUT /session/verify` still supports token-only verification.
> - **Server**: Added `services/auth/otp` TOTP helper; `passwordreset.doReset` generates OTP using `admin_session_secret`; serializer includes `emailVerificationToken`; session service verifies `req.body.token`, and centralizes OTP generate/verify.
> - **Admin client**: `cookie.authenticate` includes `token` with login and supports token-only verify; reset controller uses returned `emailVerificationToken` when auto-logging in.
> - **Tests**: Updated unit/e2e tests and snapshots to cover new OTP flow, token-on-login, and reset response shape.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e4793355ebdf4875c3cdb08e509f0e453dc708c7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->