### PR TITLE
🔒 Fixed potential SSRF via media inliner

### DIFF
--- a/ghost/core/core/server/services/media-inliner/ExternalMediaInliner.js
+++ b/ghost/core/core/server/services/media-inliner/ExternalMediaInliner.js
@@ -1,6 +1,6 @@
 const mime = require('mime-types');
 const FileType = require('file-type');
-const request = require('@tryghost/request');
+const request = require('../../lib/request-external');
 const errors = require('@tryghost/errors');
 const logging = require('@tryghost/logging');
 const string = require('@tryghost/string');


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3159/

- a malicious staff user could craft URLs for media assets in a post that could potentially access/exfiltrate data from internal URLS when run through the media inliner
- switching the request library used by `ExternalMediaInliner` to our restricted `externalRequest` library blocks any requests to servers that resolve to an internal IP block, limiting any SSRF exfiltration to publicly served data

Credit:

Sho Odagiri
GMO Cybersecurity by Ierae, Inc.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens SSRF defenses in media inlining.
> 
> - Replaces `@tryghost/request` with restricted `request-external` in `ExternalMediaInliner` to prevent requests to hosts resolving to private IPs
> - Adds SSRF unit test stubbing `dns.promises.lookup` to ensure `getRemoteMedia` returns `null` and logs an error when a URL resolves to a private address
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d89d85b1aa0aba7bab842c3a9bc646fbf5337cdc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->