### PR TITLE
Added indexnow_api_key setting

### DIFF
--- a/ghost/core/core/server/api/endpoints/utils/serializers/input/settings.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/input/settings.js
@@ -78,7 +78,8 @@ const EDITABLE_SETTINGS = [
     'require_email_mfa',
     'social_web',
     'explore_ping',
-    'explore_ping_growth'
+    'explore_ping_growth',
+    'indexnow_api_key'
 ];
 
 module.exports = {

--- a/ghost/core/core/server/data/exporter/table-lists.js
+++ b/ghost/core/core/server/data/exporter/table-lists.js
@@ -93,7 +93,8 @@ const SETTING_KEYS_BLOCKLIST = [
     'stripe_publishable_key',
     'members_stripe_webhook_id',
     'members_stripe_webhook_secret',
-    'email_verification_required'
+    'email_verification_required',
+    'indexnow_api_key'
 ];
 
 module.exports = {

--- a/ghost/core/core/server/data/migrations/versions/6.12/2026-01-08-11-48-16-add-indexnow-api-key-setting.js
+++ b/ghost/core/core/server/data/migrations/versions/6.12/2026-01-08-11-48-16-add-indexnow-api-key-setting.js
@@ -1,0 +1,9 @@
+const crypto = require('crypto');
+const {addSetting} = require('../../utils');
+
+module.exports = addSetting({
+    key: 'indexnow_api_key',
+    value: crypto.randomBytes(16).toString('hex'),
+    type: 'string',
+    group: 'indexnow'
+});

--- a/ghost/core/core/server/data/schema/default-settings/default-settings.json
+++ b/ghost/core/core/server/data/schema/default-settings/default-settings.json
@@ -637,5 +637,11 @@
             },
             "type": "boolean"
         }
+    },
+    "indexnow": {
+        "indexnow_api_key": {
+            "defaultValue": null,
+            "type": "string"
+        }
     }
 }

--- a/ghost/core/core/server/models/settings.js
+++ b/ghost/core/core/server/models/settings.js
@@ -60,7 +60,8 @@ function parseDefaultSettings() {
         members_otc_secret: () => crypto.randomBytes(64).toString('hex'),
         ghost_public_key: () => getGhostKey('public'),
         ghost_private_key: () => getGhostKey('private'),
-        site_uuid: () => getOrGenerateSiteUuid()
+        site_uuid: () => getOrGenerateSiteUuid(),
+        indexnow_api_key: () => crypto.randomBytes(16).toString('hex')
     };
 
     _.each(defaultSettingsInCategories, function each(settings, categoryName) {

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -37,7 +37,7 @@ describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = '840147221764a9de1b3807e3abb61df2';
     const currentFixturesHash = 'c583f33910bb84a70847303b323be2db';
-    const currentSettingsHash = 'bb8be7d83407f2b4fa2ad68c19610579';
+    const currentSettingsHash = '64007c832bc27eefbe4d0ed3f888eeab';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';
 
     // If this test is failing, then it is likely a change has been made that requires a DB version bump,


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/pull/25773
This setting stores the IndexNow API key for search engine notification

Got some code for us? Awesome 🎊!

Please take a minute to explain the change you're making:
- Why are you making it?
- What does it do?
- Why is this something Ghost users or developers need?

Please check your PR against these items:

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [x] I've written an automated test to prove my change works

We appreciate your contribution! 🙏

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new secret setting for IndexNow integration.
> 
> - Introduces `indexnow_api_key` in default settings under `indexnow`, with dynamic default generation and a migration to create it
> - Allows editing via the settings API by adding to `EDITABLE_SETTINGS`
> - Excludes `indexnow_api_key` from exports via `SETTING_KEYS_BLOCKLIST`
> - Updates settings integrity hash in tests
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 980236bd55fc351393fce413ad38fc3e28a0d144. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->