### PR TITLE
Fixed padding on editor back button

### DIFF
--- a/ghost/admin/app/styles/layouts/editor.css
+++ b/ghost/admin/app/styles/layouts/editor.css
@@ -977,7 +977,6 @@ body[data-user-is-dragging] .gh-editor-feature-image-dropzone {
     width: 1.2rem;
     height: 1.2rem;
     margin-right: .5em;
-    padding-top: 2px;
     fill: var(--darkgrey);
 }
 


### PR DESCRIPTION
No ref

Removed the unnecessary padding causing the chevron to be misaligned. 

| Before | After |
|--------|--------|
| <img width="214" height="56" alt="Screenshot 2026-01-08 at 12 30 52" src="https://github.com/user-attachments/assets/c3987e1a-a8bd-4f9d-b89a-82f405dcfb52" /> | <img width="215" height="61" alt="Screenshot 2026-01-08 at 12 30 11" src="https://github.com/user-attachments/assets/22c6008e-3f2d-4efb-90b2-4d33cb4ceb4f" /> | 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Minor CSS tweak to correct editor back button icon alignment.
> 
> - Removes `padding-top: 2px` from `.gh-editor-back-button svg` to align the chevron properly
> - No JS/functional changes; stylesheet-only update in `editor.css`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf700f1287388b9c74cf34e1d3bf8b0da041fb9d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->