### PR TITLE
Skipped creating offers for invalid Stripe coupons during migrations

### DIFF
--- a/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
@@ -1054,14 +1054,11 @@ module.exports = class MemberRepository {
                 );
                 offerId = offer.id;
             } catch (e) {
-                if (e instanceof errors.ValidationError) {
-                    // During migrations, some Stripe coupons from other platforms may not compatible with Ghost offers.
+                if (e.code === 'INVALID_YEARLY_DURATION') {
+                    // During migrations, some Stripe coupons from other platforms may not be compatible with Ghost offers.
                     // For example, a `yearly` coupon set to `repeating` (Ghost only accepts `once` or `forever` for `yearly` coupons).
                     //
-                    // When we attempt to create a Ghost offer based on an invalid Stripe coupon, we can either:
-                    //     1. Surface the offer validation errors during migrations, so that they can be resolved case-by-case, until all invalid Stripe coupons have been removed from paid members
-                    //     2. Skip creating the offer but still create the paid member
-                    // The migration team has opted for solution 2, in particular in the context of self-migrations where resolving those errors may be difficult
+                    // In this case, we skip creating the offer, but still create the paid member
                     logging.error(`Failed to create offer for Stripe coupon - ${stripeCouponId}`);
                     logging.error(e);
                 } else {

--- a/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
@@ -1045,13 +1045,29 @@ module.exports = class MemberRepository {
             const cadence = _.get(subscriptionPriceData, 'recurring.interval');
             const tier = {id: ghostProduct.get('id'), name: ghostProduct.get('name')};
 
-            const offer = await this._offersAPI.ensureOfferForStripeCoupon(
-                coupon,
-                cadence,
-                tier,
-                options
-            );
-            offerId = offer.id;
+            try {
+                const offer = await this._offersAPI.ensureOfferForStripeCoupon(
+                    coupon,
+                    cadence,
+                    tier,
+                    options
+                );
+                offerId = offer.id;
+            } catch (e) {
+                if (e instanceof errors.ValidationError) {
+                    // During migrations, some Stripe coupons from other platforms may not compatible with Ghost offers.
+                    // For example, a `yearly` coupon set to `repeating` (Ghost only accepts `once` or `forever` for `yearly` coupons).
+                    //
+                    // When we attempt to create a Ghost offer based on an invalid Stripe coupon, we can either:
+                    //     1. Surface the offer validation errors during migrations, so that they can be resolved case-by-case, until all invalid Stripe coupons have been removed from paid members
+                    //     2. Skip creating the offer but still create the paid member
+                    // The migration team has opted for solution 2, in particular in the context of self-migrations where resolving those errors may be difficult
+                    logging.error(`Failed to create offer for Stripe coupon - ${stripeCouponId}`);
+                    logging.error(e);
+                } else {
+                    throw e;
+                }
+            }
         }
 
         const subscriptionData = {

--- a/ghost/core/core/server/services/offers/domain/models/offer.js
+++ b/ghost/core/core/server/services/offers/domain/models/offer.js
@@ -310,7 +310,8 @@ class Offer {
 
         if (cadence.value === 'year' && duration.value.type === 'repeating') {
             throw new errors.InvalidOfferDuration({
-                message: 'Offer `duration` must be "once" or "forever" for the "yearly" cadence.'
+                message: 'Offer `duration` must be "once" or "forever" for the "yearly" cadence.',
+                code: 'INVALID_YEARLY_DURATION'
             });
         }
 

--- a/ghost/core/test/unit/server/services/members/members-api/repositories/member-repository.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/repositories/member-repository.test.js
@@ -1,6 +1,7 @@
 require('should');
 const assert = require('assert/strict');
 const sinon = require('sinon');
+const errors = require('@tryghost/errors');
 const DomainEvents = require('@tryghost/domain-events');
 const MemberRepository = require('../../../../../../../core/server/services/members/members-api/repositories/member-repository');
 const {SubscriptionCreatedEvent, OfferRedemptionEvent} = require('../../../../../../../core/shared/events');
@@ -528,6 +529,81 @@ describe('MemberRepository', function () {
             offersAPI.ensureOfferForStripeCoupon.firstCall.args[2].should.deepEqual({id: 'tier_1', name: 'Tier One'});
             offersAPI.ensureOfferForStripeCoupon.firstCall.args[3].transacting.should.equal(transacting);
             StripeCustomerSubscription.add.firstCall.args[0].offer_id.should.equal('offer_new');
+        });
+
+        it('sets offer_id to null if unable to create an offer from an invalid Stripe coupon', async function () {
+            const invalidCouponError = new errors.ValidationError({
+                message: 'Offer `duration` must be "once" or "forever" for the "yearly" cadence.'
+            });
+
+            offersAPI = {
+                ensureOfferForStripeCoupon: sinon.stub().rejects(invalidCouponError)
+            };
+
+            const productRepositoryWithTier = {
+                get: sinon.stub().resolves({
+                    get: sinon.stub().callsFake((key) => {
+                        if (key === 'id') {
+                            return 'tier_1';
+                        }
+                        if (key === 'name') {
+                            return 'Tier One';
+                        }
+                        return null;
+                    }),
+                    toJSON: sinon.stub().returns({})
+                }),
+                update: sinon.stub().resolves({})
+            };
+
+            const stripeCoupon = {
+                id: 'coupon_invalid',
+                percent_off: 20,
+                duration: 'repeating',
+                duration_in_months: 3
+            };
+
+            const repo = new MemberRepository({
+                stripeAPIService: {
+                    ...stripeAPIService,
+                    getSubscription: sinon.stub().resolves({
+                        ...subscriptionData,
+                        discount: {
+                            coupon: stripeCoupon
+                        }
+                    })
+                },
+                StripeCustomerSubscription,
+                MemberPaidSubscriptionEvent,
+                MemberProductEvent,
+                productRepository: productRepositoryWithTier,
+                offersAPI,
+                labsService,
+                Member,
+                OfferRedemption: mockOfferRedemption
+            });
+
+            sinon.stub(repo, 'getSubscriptionByStripeID').resolves(null);
+
+            const transacting = {
+                executionPromise: Promise.resolve()
+            };
+
+            // Should not throw despite the offer validation failure
+            await repo.linkSubscription({
+                id: 'member_id_123',
+                subscription: {...subscriptionData, discount: {coupon: {id: 'coupon_invalid'}}}
+            }, {
+                transacting,
+                context: {}
+            });
+
+            // Verify ensureOfferForStripeCoupon was called
+            offersAPI.ensureOfferForStripeCoupon.calledOnce.should.be.true();
+
+            // Verify subscription was still created, but without an offer_id
+            StripeCustomerSubscription.add.calledOnce.should.be.true();
+            assert.equal(StripeCustomerSubscription.add.firstCall.args[0].offer_id, null);
         });
     });
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3162

During migrations, some Stripe coupons from other platforms may not compatible with Ghost offers. For example, a `yearly` coupon set to `repeating` (Ghost only accepts `once` or `forever` for `yearly` coupons).

When we attempt to create a Ghost offer based on an incompatible Stripe coupon, we can either:
    1. Surface the offer validation errors during migrations, so that they can be resolved case-by-case, until all invalid Stripe coupons have been removed from paid members
    2. Skip creating the offer but still create the paid member

The migration team has opted for solution 2, in particular in the context of self-migrations where resolving those errors may be difficult.

As we discover more incompatibilities with Stripe coupons from other platforms, we can expand the list of error codes here: https://github.com/TryGhost/Ghost/blob/43c984792b5a03830a131fc8ba27947ffa2cdd67/ghost/core/core/server/services/members/members-api/repositories/member-repository.js#L1057

