### PR TITLE
Hid growth tab on posts when member sources disabled

### DIFF
--- a/apps/posts/src/views/PostAnalytics/Growth/growth.tsx
+++ b/apps/posts/src/views/PostAnalytics/Growth/growth.tsx
@@ -2,7 +2,7 @@ import GrowthSources from './components/growth-sources';
 import KpiCard, {KpiCardContent, KpiCardLabel, KpiCardMoreButton, KpiCardValue} from '../components/kpi-card';
 import PostAnalyticsContent from '../components/post-analytics-content';
 import PostAnalyticsHeader from '../components/post-analytics-header';
-import React, {useEffect} from 'react';
+import React from 'react';
 import {Card, CardContent, CardDescription, CardHeader, CardTitle, LucideIcon, Separator, Skeleton, SkeletonTable, formatNumber} from '@tryghost/shade';
 import {useAppContext} from '@src/providers/posts-app-context';
 import {useGlobalData} from '@src/providers/post-analytics-context';
@@ -22,13 +22,6 @@ const Growth: React.FC<postAnalyticsProps> = () => {
     const {stats: postReferrers, totals, isLoading, currencySymbol} = usePostReferrers(postId || '');
     const {appSettings} = useAppContext();
     const navigate = useNavigate();
-
-    // Redirect to Overview if member source tracking is disabled
-    useEffect(() => {
-        if (!appSettings?.analytics.membersTrackSources) {
-            navigate(`/posts/analytics/${postId}`);
-        }
-    }, [appSettings?.analytics.membersTrackSources, navigate, postId]);
 
     // Get site URL and icon from global data
     const siteUrl = globalData?.url as string | undefined;

--- a/apps/posts/src/views/PostAnalytics/Growth/growth.tsx
+++ b/apps/posts/src/views/PostAnalytics/Growth/growth.tsx
@@ -2,7 +2,7 @@ import GrowthSources from './components/growth-sources';
 import KpiCard, {KpiCardContent, KpiCardLabel, KpiCardMoreButton, KpiCardValue} from '../components/kpi-card';
 import PostAnalyticsContent from '../components/post-analytics-content';
 import PostAnalyticsHeader from '../components/post-analytics-header';
-import React from 'react';
+import React, {useEffect} from 'react';
 import {Card, CardContent, CardDescription, CardHeader, CardTitle, LucideIcon, Separator, Skeleton, SkeletonTable, formatNumber} from '@tryghost/shade';
 import {useAppContext} from '@src/providers/posts-app-context';
 import {useGlobalData} from '@src/providers/post-analytics-context';
@@ -22,6 +22,13 @@ const Growth: React.FC<postAnalyticsProps> = () => {
     const {stats: postReferrers, totals, isLoading, currencySymbol} = usePostReferrers(postId || '');
     const {appSettings} = useAppContext();
     const navigate = useNavigate();
+
+    // Redirect to Overview if member source tracking is disabled
+    useEffect(() => {
+        if (!appSettings?.analytics.membersTrackSources) {
+            navigate(`/posts/analytics/${postId}`);
+        }
+    }, [appSettings?.analytics.membersTrackSources, navigate, postId]);
 
     // Get site URL and icon from global data
     const siteUrl = globalData?.url as string | undefined;

--- a/apps/posts/src/views/PostAnalytics/Overview/overview.tsx
+++ b/apps/posts/src/views/PostAnalytics/Overview/overview.tsx
@@ -94,13 +94,15 @@ const Overview: React.FC = () => {
     // Use the utility function from admin-x-framework
     const showNewsletterSection = hasBeenEmailed(post as Post) && emailTrackOpensEnabled && emailTrackClicksEnabled;
     const showWebSection = !post?.email_only && appSettings?.analytics.webAnalytics;
+    const showGrowthSection = appSettings?.analytics.membersTrackSources;
 
     // Redirect to Growth tab if this is a published-only post with web analytics disabled
+    // Only redirect if Growth section is available
     useEffect(() => {
-        if (!isPostLoading && post && isPublishedOnly(post as Post) && !appSettings?.analytics.webAnalytics) {
+        if (!isPostLoading && post && isPublishedOnly(post as Post) && !appSettings?.analytics.webAnalytics && showGrowthSection) {
             navigate(`/posts/analytics/${postId}/growth`);
         }
-    }, [isPostLoading, post, appSettings?.analytics.webAnalytics, navigate, postId]);
+    }, [isPostLoading, post, appSettings?.analytics.webAnalytics, navigate, postId, showGrowthSection]);
 
     // First we have to wait for the post to be loaded to determine what sections (web, newsletter etc.) should be displayed
     if (isPostLoading) {
@@ -131,37 +133,38 @@ const Overview: React.FC = () => {
                             post={post as Post}
                         />
                     )}
-                    <Card className='group col-span-2 overflow-hidden p-0' data-testid='growth'>
-                        <div className='relative flex items-center justify-between gap-6'>
-                            <CardHeader>
-                                <CardTitle className='flex items-center gap-1.5 text-lg'>
-                                    <LucideIcon.Sprout size={16} strokeWidth={1.5} />
+                    {showGrowthSection && (
+                        <Card className='group col-span-2 overflow-hidden p-0' data-testid='growth'>
+                            <div className='relative flex items-center justify-between gap-6'>
+                                <CardHeader>
+                                    <CardTitle className='flex items-center gap-1.5 text-lg'>
+                                        <LucideIcon.Sprout size={16} strokeWidth={1.5} />
                                 Growth
-                                </CardTitle>
-                            </CardHeader>
-                            <Button className='absolute right-6 translate-x-10 opacity-0 transition-all duration-200 group-hover:translate-x-0 group-hover:opacity-100' size='sm' variant='outline' onClick={() => {
-                                navigate(`/posts/analytics/${postId}/growth`);
-                            }}>View more</Button>
-                        </div>
-                        <CardContent className='flex flex-col gap-6 px-0 md:grid md:grid-cols-3 md:items-stretch md:gap-0'>
-                            {kpiIsLoading ?
-                                Array.from({length: 3}, (_, i) => (
-                                    <div key={i} className='h-[98px] gap-1 border-r px-6 py-5 last:border-r-0'>
-                                        <Skeleton className='w-2/3' />
-                                        <Skeleton className='h-7 w-12' />
-                                    </div>
-                                ))
-                                :
-                                <>
-                                    <KpiCard className='grow gap-1 py-0'>
-                                        <KpiCardLabel>
+                                    </CardTitle>
+                                </CardHeader>
+                                <Button className='absolute right-6 translate-x-10 opacity-0 transition-all duration-200 group-hover:translate-x-0 group-hover:opacity-100' size='sm' variant='outline' onClick={() => {
+                                    navigate(`/posts/analytics/${postId}/growth`);
+                                }}>View more</Button>
+                            </div>
+                            <CardContent className='flex flex-col gap-6 px-0 md:grid md:grid-cols-3 md:items-stretch md:gap-0'>
+                                {kpiIsLoading ?
+                                    Array.from({length: 3}, (_, i) => (
+                                        <div key={i} className='h-[98px] gap-1 border-r px-6 py-5 last:border-r-0'>
+                                            <Skeleton className='w-2/3' />
+                                            <Skeleton className='h-7 w-12' />
+                                        </div>
+                                    ))
+                                    :
+                                    <>
+                                        <KpiCard className='grow gap-1 py-0'>
+                                            <KpiCardLabel>
                                         Free members
-                                        </KpiCardLabel>
-                                        <KpiCardContent>
-                                            <KpiCardValue className='text-[2.2rem]'>{formatNumber((totals?.free_members || 0))}</KpiCardValue>
-                                        </KpiCardContent>
-                                    </KpiCard>
-                                    {appSettings?.paidMembersEnabled &&
+                                            </KpiCardLabel>
+                                            <KpiCardContent>
+                                                <KpiCardValue className='text-[2.2rem]'>{formatNumber((totals?.free_members || 0))}</KpiCardValue>
+                                            </KpiCardContent>
+                                        </KpiCard>
+                                        {appSettings?.paidMembersEnabled &&
                                 <>
                                     <KpiCard className='grow gap-1 py-0'>
                                         <KpiCardLabel>
@@ -180,11 +183,12 @@ const Overview: React.FC = () => {
                                         </KpiCardContent>
                                     </KpiCard>
                                 </>
-                                    }
-                                </>
-                            }
-                        </CardContent>
-                    </Card>
+                                        }
+                                    </>
+                                }
+                            </CardContent>
+                        </Card>
+                    )}
                 </div>
             </PostAnalyticsContent>
         </>

--- a/apps/posts/src/views/PostAnalytics/Overview/overview.tsx
+++ b/apps/posts/src/views/PostAnalytics/Overview/overview.tsx
@@ -1,3 +1,4 @@
+import DisabledSourcesIndicator from '../components/disabled-sources-indicator';
 import KpiCard, {KpiCardContent, KpiCardLabel, KpiCardValue} from '../components/kpi-card';
 import NewsletterOverview from './components/newsletter-overview';
 import PostAnalyticsContent from '../components/post-analytics-content';
@@ -100,7 +101,7 @@ const Overview: React.FC = () => {
     // Only redirect if Growth section is available
     useEffect(() => {
         if (!isPostLoading && post && isPublishedOnly(post as Post) && !appSettings?.analytics.webAnalytics && showGrowthSection) {
-            navigate(`/posts/analytics/${postId}/growth`);
+            navigate(`/posts/analytics/${postId}/growth`, {replace: true});
         }
     }, [isPostLoading, post, appSettings?.analytics.webAnalytics, navigate, postId, showGrowthSection]);
 
@@ -188,6 +189,9 @@ const Overview: React.FC = () => {
                                 }
                             </CardContent>
                         </Card>
+                    )}
+                    {!showWebSection && !showNewsletterSection && !showGrowthSection && (
+                        <DisabledSourcesIndicator className='col-span-2 py-20' />
                     )}
                 </div>
             </PostAnalyticsContent>

--- a/apps/posts/src/views/PostAnalytics/components/post-analytics-header.tsx
+++ b/apps/posts/src/views/PostAnalytics/components/post-analytics-header.tsx
@@ -82,10 +82,13 @@ const PostAnalyticsHeader:React.FC<PostAnalyticsHeaderProps> = ({
         if (hasBeenEmailed(post as Post)) {
             tabs.push('Newsletter');
         }
-        tabs.push('Growth');
+        // Only show Growth tab if member source tracking is enabled
+        if (appSettings?.analytics.membersTrackSources) {
+            tabs.push('Growth');
+        }
 
         return tabs;
-    }, [post, appSettings?.analytics.webAnalytics]);
+    }, [post, appSettings?.analytics.webAnalytics, appSettings?.analytics.membersTrackSources]);
 
     const handleDeletePost = () => {
         if (!post) {

--- a/apps/stats/src/utils/url-helpers.ts
+++ b/apps/stats/src/utils/url-helpers.ts
@@ -113,3 +113,18 @@ export function getClickHandler(
         }
     };
 }
+
+type AnalyticsSettings = {
+    webAnalytics?: boolean;
+    membersTrackSources?: boolean;
+}
+
+export const getPostDestination = (postId: string, hasEmailData: boolean, analyticsSettings?: AnalyticsSettings) => {
+    const analyticsDisabled = !analyticsSettings?.webAnalytics && !analyticsSettings?.membersTrackSources;
+
+    if (analyticsDisabled && !hasEmailData) {
+        return `/editor/post/${postId}`;
+    }
+
+    return `/posts/analytics/${postId}`;
+};

--- a/apps/stats/src/utils/url-helpers.ts
+++ b/apps/stats/src/utils/url-helpers.ts
@@ -1,3 +1,5 @@
+import {AppSettings} from '@tryghost/admin-x-framework';
+
 /**
  * Generate a frontend URL from an attribution path and site URL
  * @param attributionUrl - The path from attribution data (e.g., '/', '/tag/slug/', '/author/slug/')
@@ -114,13 +116,18 @@ export function getClickHandler(
     };
 }
 
-type AnalyticsSettings = {
-    webAnalytics?: boolean;
-    membersTrackSources?: boolean;
-}
+type GetPostDestinationParams = {
+    postId?: string;
+    hasEmailData: boolean;
+    analytics?: Pick<AppSettings['analytics'], 'webAnalytics' | 'membersTrackSources'>;
+};
 
-export const getPostDestination = (postId: string, hasEmailData: boolean, analyticsSettings?: AnalyticsSettings) => {
-    const analyticsDisabled = !analyticsSettings?.webAnalytics && !analyticsSettings?.membersTrackSources;
+export const getPostDestination = ({postId, hasEmailData, analytics}: GetPostDestinationParams) => {
+    if (!postId) {
+        return `/posts/analytics`;
+    }
+
+    const analyticsDisabled = !analytics?.webAnalytics && !analytics?.membersTrackSources;
 
     if (analyticsDisabled && !hasEmailData) {
         return `/editor/post/${postId}`;

--- a/apps/stats/src/views/Stats/Overview/components/latest-post.tsx
+++ b/apps/stats/src/views/Stats/Overview/components/latest-post.tsx
@@ -32,7 +32,12 @@ const LatestPost: React.FC<LatestPostProps> = ({
     const [isShareOpen, setIsShareOpen] = useState(false);
     const {site, settings} = useGlobalData();
     const {appSettings} = useAppContext();
-    const {emailTrackClicks: emailTrackClicksEnabled, emailTrackOpens: emailTrackOpensEnabled} = appSettings?.analytics || {};
+    const {
+        emailTrackClicks: emailTrackClicksEnabled,
+        emailTrackOpens: emailTrackOpensEnabled,
+        webAnalytics = false,
+        membersTrackSources = false
+    } = appSettings?.analytics || {};
 
     // Get site title from settings or site data
     const siteTitle = site.title || String(settings.find(setting => setting.key === 'title')?.value || 'Ghost Site');
@@ -42,15 +47,13 @@ const LatestPost: React.FC<LatestPostProps> = ({
 
     // Calculate metrics to show outside of JSX
     const metricsToShow = latestPostStats ? getPostMetricsToDisplay(latestPostStats as Post, {
-        membersTrackSources: appSettings?.analytics.membersTrackSources
+        membersTrackSources
     }) : null;
 
     const metricClassName = 'group mr-2 flex flex-col gap-1.5 hover:cursor-pointer';
 
     const hasEmailData = Boolean(latestPostStats?.email);
-    const postDestination = latestPostStats
-        ? getPostDestination(latestPostStats.id, hasEmailData, appSettings?.analytics)
-        : '';
+    const postDestination = getPostDestination({postId: latestPostStats?.id, hasEmailData, analytics: {webAnalytics, membersTrackSources}});
     const shouldGoToEditor = postDestination.startsWith('/editor/');
 
     return (
@@ -167,7 +170,7 @@ const LatestPost: React.FC<LatestPostProps> = ({
                         <div className='-ml-4 flex w-full flex-col items-stretch gap-2 pr-6 text-sm xl:h-full xl:max-w-none'>
                             <div className='grid grid-cols-2 gap-6 pl-10 lg:border-l xl:h-full'>
                                 {/* Web metrics - only for published posts */}
-                                {metricsToShow.showWebMetrics && appSettings?.analytics.webAnalytics &&
+                                {metricsToShow.showWebMetrics && webAnalytics &&
                                     <div className={metricClassName} data-testid='latest-post-visitors' onClick={() => {
                                         navigate(`/posts/analytics/${latestPostStats.id}/web`, {crossApp: true});
                                     }}>
@@ -190,7 +193,7 @@ const LatestPost: React.FC<LatestPostProps> = ({
                                             metricClassName,
 
                                             // Member metric is moved to the 2nd row in the grid if the post is email only or if web analytics is turned off, otherwise leave as is
-                                            (metricsToShow.showEmailMetrics && (!metricsToShow.showWebMetrics || !appSettings?.analytics.webAnalytics)) && 'row-[2/3] col-[1/2]'
+                                            (metricsToShow.showEmailMetrics && (!metricsToShow.showWebMetrics || !webAnalytics)) && 'row-[2/3] col-[1/2]'
                                         )
                                     } data-testid='latest-post-members' onClick={() => {
                                         navigate(`/posts/analytics/${latestPostStats.id}/growth`, {crossApp: true});

--- a/apps/stats/src/views/Stats/Overview/components/latest-post.tsx
+++ b/apps/stats/src/views/Stats/Overview/components/latest-post.tsx
@@ -2,6 +2,7 @@ import React, {useState} from 'react';
 import {Button, Card, CardContent, CardDescription, CardHeader, CardTitle, EmptyIndicator, LucideIcon, PostShareModal, Skeleton, cn, formatDisplayDate, formatNumber, formatPercentage} from '@tryghost/shade';
 
 import {Post, getPostMetricsToDisplay} from '@tryghost/admin-x-framework';
+import {getPostDestination} from '@src/utils/url-helpers';
 import {useAppContext, useNavigate} from '@tryghost/admin-x-framework';
 import {useGlobalData} from '@src/providers/global-data-provider';
 
@@ -45,6 +46,12 @@ const LatestPost: React.FC<LatestPostProps> = ({
     }) : null;
 
     const metricClassName = 'group mr-2 flex flex-col gap-1.5 hover:cursor-pointer';
+
+    const hasEmailData = Boolean(latestPostStats?.email);
+    const postDestination = latestPostStats
+        ? getPostDestination(latestPostStats.id, hasEmailData, appSettings?.analytics)
+        : '';
+    const shouldGoToEditor = postDestination.startsWith('/editor/');
 
     return (
         <Card className='group/card bg-gradient-to-tr from-muted/40 to-muted/0 to-50%' data-testid='latest-post'>
@@ -136,13 +143,22 @@ const LatestPost: React.FC<LatestPostProps> = ({
                                         className={latestPostStats.email_only ? 'w-full' : ''}
                                         variant='outline'
                                         onClick={() => {
-                                            navigate(`/posts/analytics/${latestPostStats.id}`, {crossApp: true});
+                                            navigate(postDestination, {crossApp: true});
                                         }}
                                     >
-                                        <LucideIcon.ChartNoAxesColumn />
-                                        <span className='hidden md:!visible md:!block'>
-                                            {!latestPostStats.email_only ? 'Analytics' : 'Post analytics' }
-                                        </span>
+                                        {shouldGoToEditor ? (
+                                            <>
+                                                <LucideIcon.Pen />
+                                                <span className='hidden md:!visible md:!block'>Edit post</span>
+                                            </>
+                                        ) : (
+                                            <>
+                                                <LucideIcon.ChartNoAxesColumn />
+                                                <span className='hidden md:!visible md:!block'>
+                                                    {!latestPostStats.email_only ? 'Analytics' : 'Post analytics'}
+                                                </span>
+                                            </>
+                                        )}
                                     </Button>
                                 </div>
                             </div>

--- a/apps/stats/src/views/Stats/Overview/components/latest-post.tsx
+++ b/apps/stats/src/views/Stats/Overview/components/latest-post.tsx
@@ -106,7 +106,7 @@ const LatestPost: React.FC<LatestPostProps> = ({
                             <div className='flex grow flex-col items-start justify-center self-stretch'>
                                 <div className='text-lg font-semibold leading-tighter tracking-tight hover:cursor-pointer hover:opacity-75' onClick={() => {
                                     if (!isLoading && latestPostStats) {
-                                        navigate(`/posts/analytics/${latestPostStats.id}`, {crossApp: true});
+                                        navigate(postDestination, {crossApp: true});
                                     }
                                 }}>
                                     {latestPostStats.title}

--- a/apps/stats/src/views/Stats/Overview/components/top-posts.tsx
+++ b/apps/stats/src/views/Stats/Overview/components/top-posts.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import {Card, CardContent, CardDescription, CardHeader, CardTitle, EmptyIndicator, LucideIcon, SkeletonTable, abbreviateNumber, cn, formatDisplayDate, formatNumber} from '@tryghost/shade';
 import {TopPostViewsStats} from '@tryghost/admin-x-framework/api/stats';
 import {getPeriodText} from '@src/utils/chart-helpers';
+import {getPostDestination} from '@src/utils/url-helpers';
 import {getPostStatusText} from '@tryghost/admin-x-framework/utils/post-utils';
 import {useAppContext, useNavigate} from '@tryghost/admin-x-framework';
 import {useGlobalData} from '@src/providers/global-data-provider';
@@ -89,7 +90,7 @@ const TopPosts: React.FC<TopPostsProps> = ({
                                 return (
                                     <div key={post.post_id} className='group relative flex w-full items-start justify-between gap-5 border-t border-border/50 py-4 before:absolute before:-inset-x-4 before:inset-y-0 before:z-0 before:hidden before:rounded-md before:bg-accent before:opacity-80 before:content-[""] first:!border-border hover:cursor-pointer hover:border-transparent hover:before:block md:items-center dark:before:bg-accent/50 [&+div]:hover:border-transparent'>
                                         <div className='z-10 flex min-w-[160px] grow items-start gap-4 md:items-center lg:min-w-[320px]' onClick={() => {
-                                            navigate(`/posts/analytics/${post.post_id}`, {crossApp: true});
+                                            navigate(getPostDestination(post.post_id, post.sent_count !== null, appSettings?.analytics), {crossApp: true});
                                         }}>
                                             {post.feature_image ?
                                                 <div className='hidden aspect-[16/10] w-[80px] shrink-0 rounded-sm bg-cover bg-center sm:!visible sm:!block lg:w-[100px]' style={{

--- a/apps/stats/src/views/Stats/Overview/components/top-posts.tsx
+++ b/apps/stats/src/views/Stats/Overview/components/top-posts.tsx
@@ -66,9 +66,12 @@ const TopPosts: React.FC<TopPostsProps> = ({
     const siteTimezone = String(settings.find(setting => setting.key === 'timezone')?.value || 'Etc/UTC');
 
     // Show open rate if newsletters are enabled and email tracking is enabled
-    const showWebAnalytics = appSettings?.analytics.webAnalytics;
-    const showClickTracking = appSettings?.analytics.emailTrackClicks;
-    const showOpenTracking = appSettings?.analytics.emailTrackOpens;
+    const {
+        webAnalytics: showWebAnalytics = false,
+        membersTrackSources = false,
+        emailTrackClicks: showClickTracking = false,
+        emailTrackOpens: showOpenTracking = false
+    } = appSettings?.analytics || {};
 
     const metricClass = 'flex items-center justify-end gap-1 rounded-md px-2 py-1 font-mono text-gray-800 hover:bg-muted-foreground/10 group-hover:text-foreground';
 
@@ -90,7 +93,14 @@ const TopPosts: React.FC<TopPostsProps> = ({
                                 return (
                                     <div key={post.post_id} className='group relative flex w-full items-start justify-between gap-5 border-t border-border/50 py-4 before:absolute before:-inset-x-4 before:inset-y-0 before:z-0 before:hidden before:rounded-md before:bg-accent before:opacity-80 before:content-[""] first:!border-border hover:cursor-pointer hover:border-transparent hover:before:block md:items-center dark:before:bg-accent/50 [&+div]:hover:border-transparent'>
                                         <div className='z-10 flex min-w-[160px] grow items-start gap-4 md:items-center lg:min-w-[320px]' onClick={() => {
-                                            navigate(getPostDestination(post.post_id, post.sent_count !== null, appSettings?.analytics), {crossApp: true});
+                                            navigate(getPostDestination({
+                                                postId: post.post_id,
+                                                hasEmailData: post.sent_count !== null,
+                                                analytics: {
+                                                    webAnalytics: showWebAnalytics,
+                                                    membersTrackSources
+                                                }
+                                            }), {crossApp: true});
                                         }}>
                                             {post.feature_image ?
                                                 <div className='hidden aspect-[16/10] w-[80px] shrink-0 rounded-sm bg-cover bg-center sm:!visible sm:!block lg:w-[100px]' style={{
@@ -137,7 +147,7 @@ const TopPosts: React.FC<TopPostsProps> = ({
                                                     navigate(`/posts/analytics/${post.post_id}/newsletter`, {crossApp: true});
                                                 }}>
                                                     <PostListTooltip
-                                                        className={`${!appSettings?.analytics.membersTrackSources ? 'left-auto right-0 translate-x-0' : ''}`}
+                                                        className={`${!membersTrackSources ? 'left-auto right-0 translate-x-0' : ''}`}
                                                         metrics={[
                                                             // Always show sent
                                                             {
@@ -192,7 +202,7 @@ const TopPosts: React.FC<TopPostsProps> = ({
                                                     </div>
                                                 </div>
                                             }
-                                            {appSettings?.analytics.membersTrackSources &&
+                                            {membersTrackSources &&
                                                 <div className='group/tooltip relative flex w-[66px] lg:w-[92px]' data-testid='statistics-members' onClick={(e) => {
                                                     e.stopPropagation();
                                                     navigate(`/posts/analytics/${post.post_id}/growth`, {crossApp: true});

--- a/apps/stats/test/unit/utils/url-helpers.test.ts
+++ b/apps/stats/test/unit/utils/url-helpers.test.ts
@@ -3,6 +3,7 @@ import {
     generateTitleFromPath,
     getClickHandler,
     getFrontendUrl,
+    getPostDestination,
     shouldMakeClickable
 } from '@src/utils/url-helpers';
 
@@ -324,6 +325,50 @@ describe('url-helpers', () => {
         });
     });
 
+    describe('getPostDestination', () => {
+        it('returns editor route when analytics are disabled and the post has no email data', () => {
+            const destination = getPostDestination('post-1', false, {
+                webAnalytics: false,
+                membersTrackSources: false
+            });
+    
+            expect(destination).toBe('/editor/post/post-1');
+        });
+    
+        it('returns post analytics route when analytics are disabled but the post has email data', () => {
+            const destination = getPostDestination('post-1', true, {
+                webAnalytics: false,
+                membersTrackSources: false
+            });
+    
+            expect(destination).toBe('/posts/analytics/post-1');
+        });
+    
+        it('returns post analytics route when web analytics are enabled', () => {
+            const destination = getPostDestination('post-1', false, {
+                webAnalytics: true,
+                membersTrackSources: false
+            });
+    
+            expect(destination).toBe('/posts/analytics/post-1');
+        });
+    
+        it('returns post analytics route when member source tracking is enabled', () => {
+            const destination = getPostDestination('post-1', false, {
+                webAnalytics: false,
+                membersTrackSources: true
+            });
+    
+            expect(destination).toBe('/posts/analytics/post-1');
+        });
+    
+        it('returns editor route when analytics settings are unavailable and the post has no email data', () => {
+            const destination = getPostDestination('post-1', false, undefined);
+    
+            expect(destination).toBe('/editor/post/post-1');
+        });
+    });
+    
     describe('integration tests', () => {
         it('getClickHandler integrates with getFrontendUrl correctly', () => {
             const mockNavigate = vi.fn();

--- a/apps/stats/test/unit/utils/url-helpers.test.ts
+++ b/apps/stats/test/unit/utils/url-helpers.test.ts
@@ -327,44 +327,64 @@ describe('url-helpers', () => {
 
     describe('getPostDestination', () => {
         it('returns editor route when analytics are disabled and the post has no email data', () => {
-            const destination = getPostDestination('post-1', false, {
-                webAnalytics: false,
-                membersTrackSources: false
+            const destination = getPostDestination({
+                postId: 'post-1',
+                hasEmailData: false,
+                analytics: {
+                    webAnalytics: false,
+                    membersTrackSources: false
+                }
             });
-    
+
             expect(destination).toBe('/editor/post/post-1');
         });
-    
+
         it('returns post analytics route when analytics are disabled but the post has email data', () => {
-            const destination = getPostDestination('post-1', true, {
-                webAnalytics: false,
-                membersTrackSources: false
+            const destination = getPostDestination({
+                postId: 'post-1',
+                hasEmailData: true,
+                analytics: {
+                    webAnalytics: false,
+                    membersTrackSources: false
+                }
             });
-    
+
             expect(destination).toBe('/posts/analytics/post-1');
         });
-    
+
         it('returns post analytics route when web analytics are enabled', () => {
-            const destination = getPostDestination('post-1', false, {
-                webAnalytics: true,
-                membersTrackSources: false
+            const destination = getPostDestination({
+                postId: 'post-1',
+                hasEmailData: false,
+                analytics: {
+                    webAnalytics: true,
+                    membersTrackSources: false
+                }
             });
-    
+
             expect(destination).toBe('/posts/analytics/post-1');
         });
-    
+
         it('returns post analytics route when member source tracking is enabled', () => {
-            const destination = getPostDestination('post-1', false, {
-                webAnalytics: false,
-                membersTrackSources: true
+            const destination = getPostDestination({
+                postId: 'post-1',
+                hasEmailData: false,
+                analytics: {
+                    webAnalytics: false,
+                    membersTrackSources: true
+                }
             });
-    
+
             expect(destination).toBe('/posts/analytics/post-1');
         });
-    
+
         it('returns editor route when analytics settings are unavailable and the post has no email data', () => {
-            const destination = getPostDestination('post-1', false, undefined);
-    
+            const destination = getPostDestination({
+                postId: 'post-1',
+                hasEmailData: false,
+                analytics: undefined
+            });
+
             expect(destination).toBe('/editor/post/post-1');
         });
     });

--- a/e2e/helpers/services/settings/settings-service.ts
+++ b/e2e/helpers/services/settings/settings-service.ts
@@ -69,4 +69,14 @@ export class SettingsService {
         const response = await this.request.put(`${this.adminEndpoint}/settings`, {data});
         return await response.json() as SettingsResponse;
     }
+
+    /**
+     * Set member source tracking enabled/disabled
+     * @param enabled - true to enable member source tracking, false to disable
+     */
+    async setMembersTrackSources(enabled: boolean) {
+        const data = {settings: [{key: 'members_track_sources', value: enabled}]};
+        const response = await this.request.put(`${this.adminEndpoint}/settings`, {data});
+        return await response.json() as SettingsResponse;
+    }
 }

--- a/e2e/tests/admin/analytics/post-analytics/overview.test.ts
+++ b/e2e/tests/admin/analytics/post-analytics/overview.test.ts
@@ -4,6 +4,7 @@ import {
     PostAnalyticsPage,
     PostAnalyticsWebTrafficPage
 } from '@/admin-pages';
+import {SettingsService} from '@/helpers/services/settings/settings-service';
 import {expect, test} from '@/helpers/playwright';
 
 test.describe('Ghost Admin - Post Analytics - Overview', () => {
@@ -43,6 +44,36 @@ test.describe('Ghost Admin - Post Analytics - Overview', () => {
 
         const postAnalyticsGrowthPage = new PostAnalyticsGrowthPage(page);
         await expect(postAnalyticsGrowthPage.topSourcesCard).toContainText('No sources data available');
+    });
+
+    test('Growth tab is hidden when member sources tracking is disabled', async ({page}) => {
+        const settingsService = new SettingsService(page.request);
+        const postAnalyticsPage = new PostAnalyticsPage(page);
+
+        // Initially, Growth tab should be visible (member sources enabled by default)
+        await expect(postAnalyticsPage.growthButton).toBeVisible();
+
+        // Disable member source tracking
+        await settingsService.setMembersTrackSources(false);
+
+        // Reload the page to apply the setting
+        await page.reload();
+
+        // Growth tab should now be hidden
+        await expect(postAnalyticsPage.growthButton).toBeHidden();
+
+        // Overview and Web traffic tabs should still be visible
+        await expect(postAnalyticsPage.overviewButton).toBeVisible();
+        await expect(postAnalyticsPage.webTrafficButton).toBeVisible();
+
+        // Re-enable member source tracking
+        await settingsService.setMembersTrackSources(true);
+
+        // Reload the page to apply the setting
+        await page.reload();
+
+        // Growth tab should be visible again
+        await expect(postAnalyticsPage.growthButton).toBeVisible();
     });
 });
 

--- a/e2e/tests/admin/analytics/post-analytics/overview.test.ts
+++ b/e2e/tests/admin/analytics/post-analytics/overview.test.ts
@@ -80,5 +80,29 @@ test.describe('Ghost Admin - Post Analytics - Overview', () => {
         await expect(postAnalyticsPage.growthButton).toBeVisible();
         await expect(postAnalyticsPage.growthSection.card).toBeVisible();
     });
+
+    test('Growth page redirects to Overview when navigated to directly with member sources tracking disabled', async ({page}) => {
+        const settingsService = new SettingsService(page.request);
+        const postAnalyticsPage = new PostAnalyticsPage(page);
+
+        // Disable member source tracking
+        await settingsService.setMembersTrackSources(false);
+
+        // Navigate directly to the growth page by modifying the current URL
+        const growthUrl = page.url().replace(/\/posts\/analytics\/([^/]+).*/, '/posts/analytics/$1/growth');
+        await page.goto(growthUrl);
+
+        // Should redirect back to overview - URL should not contain /growth
+        await expect(page).toHaveURL(/\/posts\/analytics\/[^/]+$/);
+
+        // Growth tab should not be visible
+        await expect(postAnalyticsPage.growthButton).toBeHidden();
+
+        // Overview tab should be visible and we should be on the overview page
+        await expect(postAnalyticsPage.overviewButton).toBeVisible();
+
+        // Re-enable member source tracking
+        await settingsService.setMembersTrackSources(true);
+    });
 });
 

--- a/e2e/tests/admin/analytics/post-analytics/overview.test.ts
+++ b/e2e/tests/admin/analytics/post-analytics/overview.test.ts
@@ -46,12 +46,13 @@ test.describe('Ghost Admin - Post Analytics - Overview', () => {
         await expect(postAnalyticsGrowthPage.topSourcesCard).toContainText('No sources data available');
     });
 
-    test('Growth tab is hidden when member sources tracking is disabled', async ({page}) => {
+    test('Growth tab and section are hidden when member sources tracking is disabled', async ({page}) => {
         const settingsService = new SettingsService(page.request);
         const postAnalyticsPage = new PostAnalyticsPage(page);
 
         // Initially, Growth tab should be visible (member sources enabled by default)
         await expect(postAnalyticsPage.growthButton).toBeVisible();
+        await expect(postAnalyticsPage.growthSection.card).toBeVisible();
 
         // Disable member source tracking
         await settingsService.setMembersTrackSources(false);
@@ -61,6 +62,9 @@ test.describe('Ghost Admin - Post Analytics - Overview', () => {
 
         // Growth tab should now be hidden
         await expect(postAnalyticsPage.growthButton).toBeHidden();
+
+        // Growth section on overview page should also be hidden
+        await expect(postAnalyticsPage.growthSection.card).toBeHidden();
 
         // Overview and Web traffic tabs should still be visible
         await expect(postAnalyticsPage.overviewButton).toBeVisible();
@@ -74,6 +78,7 @@ test.describe('Ghost Admin - Post Analytics - Overview', () => {
 
         // Growth tab should be visible again
         await expect(postAnalyticsPage.growthButton).toBeVisible();
+        await expect(postAnalyticsPage.growthSection.card).toBeVisible();
     });
 });
 

--- a/e2e/tests/admin/analytics/post-analytics/overview.test.ts
+++ b/e2e/tests/admin/analytics/post-analytics/overview.test.ts
@@ -80,29 +80,5 @@ test.describe('Ghost Admin - Post Analytics - Overview', () => {
         await expect(postAnalyticsPage.growthButton).toBeVisible();
         await expect(postAnalyticsPage.growthSection.card).toBeVisible();
     });
-
-    test('Growth page redirects to Overview when navigated to directly with member sources tracking disabled', async ({page}) => {
-        const settingsService = new SettingsService(page.request);
-        const postAnalyticsPage = new PostAnalyticsPage(page);
-
-        // Disable member source tracking
-        await settingsService.setMembersTrackSources(false);
-
-        // Navigate directly to the growth page by modifying the current URL
-        const growthUrl = page.url().replace(/\/posts\/analytics\/([^/]+).*/, '/posts/analytics/$1/growth');
-        await page.goto(growthUrl);
-
-        // Should redirect back to overview - URL should not contain /growth
-        await expect(page).toHaveURL(/\/posts\/analytics\/[^/]+$/);
-
-        // Growth tab should not be visible
-        await expect(postAnalyticsPage.growthButton).toBeHidden();
-
-        // Overview tab should be visible and we should be on the overview page
-        await expect(postAnalyticsPage.overviewButton).toBeVisible();
-
-        // Re-enable member source tracking
-        await settingsService.setMembersTrackSources(true);
-    });
 });
 

--- a/e2e/tests/admin/analytics/post-analytics/overview.test.ts
+++ b/e2e/tests/admin/analytics/post-analytics/overview.test.ts
@@ -46,40 +46,24 @@ test.describe('Ghost Admin - Post Analytics - Overview', () => {
         await expect(postAnalyticsGrowthPage.topSourcesCard).toContainText('No sources data available');
     });
 
-    test('Growth tab and section are hidden when member sources tracking is disabled', async ({page}) => {
+    test('growth tab and section - hidden when member sources tracking disabled', async ({page}) => {
         const settingsService = new SettingsService(page.request);
         const postAnalyticsPage = new PostAnalyticsPage(page);
 
-        // Initially, Growth tab should be visible (member sources enabled by default)
         await expect(postAnalyticsPage.growthButton).toBeVisible();
         await expect(postAnalyticsPage.growthSection.card).toBeVisible();
 
         try {
-            // Disable member source tracking
             await settingsService.setMembersTrackSources(false);
-
-            // Reload the page to apply the setting
             await page.reload();
 
-            // Growth tab should now be hidden
             await expect(postAnalyticsPage.growthButton).toBeHidden();
-
-            // Growth section on overview page should also be hidden
             await expect(postAnalyticsPage.growthSection.card).toBeHidden();
-
-            // Overview and Web traffic tabs should still be visible
             await expect(postAnalyticsPage.overviewButton).toBeVisible();
             await expect(postAnalyticsPage.webTrafficButton).toBeVisible();
         } finally {
-            // Re-enable member source tracking
             await settingsService.setMembersTrackSources(true);
-
-            // Reload the page to apply the setting
             await page.reload();
         }
-
-        // Growth tab should be visible again
-        await expect(postAnalyticsPage.growthButton).toBeVisible();
-        await expect(postAnalyticsPage.growthSection.card).toBeVisible();
     });
 });

--- a/e2e/tests/admin/analytics/post-analytics/overview.test.ts
+++ b/e2e/tests/admin/analytics/post-analytics/overview.test.ts
@@ -54,31 +54,32 @@ test.describe('Ghost Admin - Post Analytics - Overview', () => {
         await expect(postAnalyticsPage.growthButton).toBeVisible();
         await expect(postAnalyticsPage.growthSection.card).toBeVisible();
 
-        // Disable member source tracking
-        await settingsService.setMembersTrackSources(false);
+        try {
+            // Disable member source tracking
+            await settingsService.setMembersTrackSources(false);
 
-        // Reload the page to apply the setting
-        await page.reload();
+            // Reload the page to apply the setting
+            await page.reload();
 
-        // Growth tab should now be hidden
-        await expect(postAnalyticsPage.growthButton).toBeHidden();
+            // Growth tab should now be hidden
+            await expect(postAnalyticsPage.growthButton).toBeHidden();
 
-        // Growth section on overview page should also be hidden
-        await expect(postAnalyticsPage.growthSection.card).toBeHidden();
+            // Growth section on overview page should also be hidden
+            await expect(postAnalyticsPage.growthSection.card).toBeHidden();
 
-        // Overview and Web traffic tabs should still be visible
-        await expect(postAnalyticsPage.overviewButton).toBeVisible();
-        await expect(postAnalyticsPage.webTrafficButton).toBeVisible();
+            // Overview and Web traffic tabs should still be visible
+            await expect(postAnalyticsPage.overviewButton).toBeVisible();
+            await expect(postAnalyticsPage.webTrafficButton).toBeVisible();
+        } finally {
+            // Re-enable member source tracking
+            await settingsService.setMembersTrackSources(true);
 
-        // Re-enable member source tracking
-        await settingsService.setMembersTrackSources(true);
-
-        // Reload the page to apply the setting
-        await page.reload();
+            // Reload the page to apply the setting
+            await page.reload();
+        }
 
         // Growth tab should be visible again
         await expect(postAnalyticsPage.growthButton).toBeVisible();
         await expect(postAnalyticsPage.growthSection.card).toBeVisible();
     });
 });
-


### PR DESCRIPTION
Closes https://linear.app/ghost/issue/NY-382

- The "Growth" tab in post analytics was incorrectly displayed even when the "Member Sources" setting was disabled, leading to inconsistent UI and user confusion
- This PR conditionally hides the "Growth" tab in the post analytics header. The tab will now only be visible if the `members_track_sources` setting is enabled. An e2e test has been added to verify this behavior.
- Also adds a reusable `getPostDestination` helper so we can link posts to the correct location based on analytics settings. For example, if there is no analytics data to display because everything is turned off and the post wasn't emailed, clicking the post should go straight to the editor.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - **Conditionally render Growth**: `Growth` tab in header and `Growth` section on `Overview` now only appear when `appSettings.analytics.membersTrackSources` is true.
> - **Redirect safeguard**: Overview auto-redirect to `growth` for published-only posts occurs only if Growth is available; uses `replace: true`.
> - **Empty state**: Show `DisabledSourcesIndicator` when Web, Newsletter, and Growth are all unavailable.
> - **E2E support**: Adds `SettingsService.setMembersTrackSources` and an e2e test verifying Growth visibility toggles when the setting is disabled/enabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 91182d15a82615e98378cc0197035f1d9f2586f6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->