### PR TITLE
Growth chart source description

### DIFF
--- a/apps/stats/src/utils/content-helpers.ts
+++ b/apps/stats/src/utils/content-helpers.ts
@@ -46,7 +46,7 @@ export const getGrowthContentDescription = (selectedContentType: ContentType, ra
     case CONTENT_TYPES.POSTS_AND_PAGES:
         return `Which posts or pages drove the most growth ${getPeriodText(rangeValue)}`;
     case CONTENT_TYPES.SOURCES:
-        return `How readers found your site ${getPeriodText(rangeValue)}`;
+        return `Which sources drove the most growth ${getPeriodText(rangeValue)}`;
     default:
         return `Which posts drove the most growth ${getPeriodText(rangeValue)}`;
     }

--- a/apps/stats/test/unit/utils/content-helpers.test.ts
+++ b/apps/stats/test/unit/utils/content-helpers.test.ts
@@ -143,7 +143,7 @@ describe('content-helpers', () => {
             mockGetPeriodText.mockReturnValue('in the last 90 days');
             const result = getGrowthContentDescription(CONTENT_TYPES.SOURCES, 90, mockGetPeriodText);
             
-            expect(result).toBe('How readers found your site in the last 90 days');
+            expect(result).toBe('Which sources drove the most growth in the last 90 days');
             expect(mockGetPeriodText).toHaveBeenCalledWith(90);
         });
 

--- a/e2e/tests/admin/analytics/growth.test.ts
+++ b/e2e/tests/admin/analytics/growth.test.ts
@@ -31,7 +31,7 @@ test.describe('Ghost Admin - Growth', () => {
     test('empty top content card - sources', async () => {
         await growthPage.topContent.sourcesButton.click();
 
-        await expect(growthPage.topContent.contentCard).toContainText('How readers found your site in the last 30 days');
+        await expect(growthPage.topContent.contentCard).toContainText('Which sources drove the most growth in the last 30 days');
         await expect(growthPage.topContent.contentCard).toContainText('No conversions');
     });
 });


### PR DESCRIPTION
Got some code for us? Awesome 🎊!

Please take a minute to explain the change you're making:
- **Why are you making it?**
  The description for the "sources" tab on the growth analytics page was inconsistent with other growth-related descriptions (e.g., posts, pages) and did not accurately reflect "growth." This change aligns the copy to be more precise within the growth context.
- **What does it do?**
  It updates the description for the "sources" content type in the `getGrowthContentDescription` function from "How readers found your site in the last {period}" to "Which sources drove the most growth in the last {period}". Unit and e2e tests have been updated accordingly.
- **Why is this something Ghost users or developers need?**
  Ghost users will see a clearer and more consistent description on the growth analytics page, ensuring the displayed information accurately reflects the "growth" metric for sources. This improves data interpretation and overall user experience.

Please check your PR against these items:

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [x] I've written an automated test to prove my change works

We appreciate your contribution! 🙏

---
Linear Issue: [NY-692](https://linear.app/ghost/issue/NY-692/description-for-sources-on-the-growth-chart-is-incorrect)

<a href="https://cursor.com/background-agent?bcId=bc-ebeef195-679b-48e1-ace0-ce24105753d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ebeef195-679b-48e1-ace0-ce24105753d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns growth analytics copy for the sources tab with other content types.
> 
> - Updates `getGrowthContentDescription` for `SOURCES` to return `"Which sources drove the most growth ..."`
> - Updates corresponding unit test in `apps/stats/test/unit/utils/content-helpers.test.ts`
> - Updates e2e expectation in `e2e/tests/admin/analytics/growth.test.ts`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dcd1b2cf996e0499a9d1947b56280f66d19c2357. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->