### PR TITLE
🐛 Fixed sorting in Growth tab Sources table

### DIFF
--- a/ghost/core/core/server/services/stats/referrers-stats-service.js
+++ b/ghost/core/core/server/services/stats/referrers-stats-service.js
@@ -367,7 +367,7 @@ class ReferrersStatsService {
      * @returns {Promise<{data: AttributionCountStatWithMrr[], meta: {}}>}
      */
     async getTopSourcesWithRange(options = {}) {
-        const {order: orderBy = 'signups desc', limit = 50} = options;
+        const {order = 'signups desc', limit = 50} = options;
 
         // Get deduplicated member counts and MRR data in parallel
         const [memberCounts, mrrEntries] = await Promise.all([
@@ -416,7 +416,7 @@ class ReferrersStatsService {
         let results = Array.from(sourceMap.values());
 
         // Apply sorting - only allow descending sorts for sources
-        const [field] = orderBy.split(' ');
+        const [field] = order.split(' ');
 
         results.sort((a, b) => {
             let valueA; let valueB;

--- a/ghost/core/core/server/services/stats/referrers-stats-service.js
+++ b/ghost/core/core/server/services/stats/referrers-stats-service.js
@@ -362,12 +362,12 @@ class ReferrersStatsService {
      * @param {string} [options.date_from] - Start date in YYYY-MM-DD format
      * @param {string} [options.date_to] - End date in YYYY-MM-DD format
      * @param {string} [options.timezone] - Timezone to use for date interpretation
-     * @param {string} [options.orderBy='signups desc'] - Sort order: 'signups desc', 'paid_conversions desc', 'mrr desc', 'source desc'
+     * @param {string} [options.order='signups desc'] - Sort order: 'signups desc', 'paid_conversions desc', 'mrr desc', 'source desc'
      * @param {number} [options.limit=50] - Maximum number of sources to return
      * @returns {Promise<{data: AttributionCountStatWithMrr[], meta: {}}>}
      */
     async getTopSourcesWithRange(options = {}) {
-        const {orderBy = 'signups desc', limit = 50} = options;
+        const {order: orderBy = 'signups desc', limit = 50} = options;
 
         // Get deduplicated member counts and MRR data in parallel
         const [memberCounts, mrrEntries] = await Promise.all([

--- a/ghost/core/core/server/services/stats/stats-service.js
+++ b/ghost/core/core/server/services/stats/stats-service.js
@@ -237,7 +237,7 @@ class StatsService {
      * @param {string} [options.date_from] - Start date in YYYY-MM-DD format
      * @param {string} [options.date_to] - End date in YYYY-MM-DD format
      * @param {string} [options.timezone] - Timezone to use for date interpretation
-     * @param {string} [options.orderBy='signups desc'] - Sort order: 'signups desc', 'paid_conversions desc', 'mrr desc', 'source desc'
+     * @param {string} [options.order='signups desc'] - Sort order: 'signups desc', 'paid_conversions desc', 'mrr desc', 'source desc'
      * @param {number} [options.limit=50] - Maximum number of sources to return
      */
     async getTopSourcesWithRange(options = {}) {

--- a/ghost/core/test/unit/server/services/stats/referrers.test.js
+++ b/ghost/core/test/unit/server/services/stats/referrers.test.js
@@ -319,12 +319,12 @@ describe('ReferrersStatsService', function () {
             ]);
 
             // Test different sort orders
-            const signupsResult = await stats.getTopSourcesWithRange({date_from: '2024-01-01', date_to: '2024-01-31', timezone: 'UTC', orderBy: 'signups desc'});
+            const signupsResult = await stats.getTopSourcesWithRange({date_from: '2024-01-01', date_to: '2024-01-31', timezone: 'UTC', order: 'signups desc'});
             assert.equal(signupsResult.data[0].source, 'Twitter', 'Twitter should be first when sorted by signups');
             assert.equal(signupsResult.data[1].source, 'Facebook', 'Facebook should be second');
             assert.equal(signupsResult.data[2].source, 'Google', 'Google should be third');
 
-            const sourceResult = await stats.getTopSourcesWithRange({date_from: '2024-01-01', date_to: '2024-01-31', timezone: 'UTC', orderBy: 'source desc'});
+            const sourceResult = await stats.getTopSourcesWithRange({date_from: '2024-01-01', date_to: '2024-01-31', timezone: 'UTC', order: 'source desc'});
             assert.equal(sourceResult.data[0].source, 'Twitter', 'Sources should be sorted alphabetically descending');
         });
 
@@ -343,7 +343,7 @@ describe('ReferrersStatsService', function () {
             });
             await db('members_created_events').insert(inserts);
 
-            const result = await stats.getTopSourcesWithRange({date_from: '2024-01-01', date_to: '2024-01-31', timezone: 'UTC', orderBy: 'signups desc', limit: 3});
+            const result = await stats.getTopSourcesWithRange({date_from: '2024-01-01', date_to: '2024-01-31', timezone: 'UTC', order: 'signups desc', limit: 3});
             assert.equal(result.data.length, 3, 'Should return only 3 results when limit is 3');
         });
 


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-696

- Sorting on the Growth tab's Sources table was not working due to a parameter name mismatch. The API was sending `order`, but the backend service was expecting `orderBy`. This meant the sort parameter was never correctly applied, and data always appeared in the default order
- This PR fixes the parameter destructuring in `ghost/core/core/server/services/stats/referrers-stats-service.js` to correctly map the incoming `order` parameter to the internal `orderBy` variable.

-----

![source-sort](https://github.com/user-attachments/assets/352d0c32-6b28-41d1-a99f-ce34f4961a2d)

