### PR TITLE
Revert "🐛 Fixed attribution for email-only posts (#25800)"

### DIFF
--- a/ghost/core/core/server/services/member-attribution/url-translator.js
+++ b/ghost/core/core/server/services/member-attribution/url-translator.js
@@ -130,16 +130,14 @@ class UrlTranslator {
 
     async getResourceById(id, type) {
         switch (type) {
-        case 'post': {
-            const post = await this.models.Post.findOne({id}, {
-                require: false,
-                filter: 'status:[published,sent]' // Include sent status for email-only posts
-            });
-            return post || null;
-        }
+        case 'post':
         case 'page': {
-            const page = await this.models.Post.findOne({id}, {require: false});
-            return page || null;
+            const post = await this.models.Post.findOne({id}, {require: false});
+            if (!post) {
+                return null;
+            }
+
+            return post;
         }
         case 'author': {
             const user = await this.models.User.findOne({id}, {require: false});

--- a/ghost/core/test/unit/server/services/member-attribution/url-translator.test.js
+++ b/ghost/core/test/unit/server/services/member-attribution/url-translator.test.js
@@ -8,9 +8,7 @@ const models = {
             if (id === 'invalid') {
                 return null;
             }
-            // Return post with appropriate status based on id
-            const postStatus = id === 'sent-post' ? 'sent' : 'published';
-            return {id: 'post_id', get: attr => (attr === 'status' ? postStatus : 'Title')};
+            return {id: 'post_id', get: () => 'Title'};
         }
     },
     User: {
@@ -264,14 +262,6 @@ describe('UrlTranslator', function () {
 
         it('returns null for not found tag', async function () {
             should(await translator.getResourceById('invalid', 'tag')).eql(null);
-        });
-
-        it('returns email-only posts with sent status', async function () {
-            // Email-only posts have status 'sent' instead of 'published'
-            // Attribution should work for both published and sent posts
-            should(await translator.getResourceById('sent-post', 'post')).match({
-                id: 'post_id'
-            });
         });
     });
 


### PR DESCRIPTION
ref d451e8cbb0c06794dbdf51eeb2a544b38f460b72
ref https://linear.app/ghost/issue/NY-878/

I am reverting this change as I discovered the db data was not quite as expected, which wasn't fully caught in tests because we don't have a true e2e test for these pieces (which I was already working on). Even so, I don't think an e2e test would've captured this issue, which is the linkTo for the link in member details, as the text itself is correct. We may need better db/model coverage. See issue for more discussion and details for the full fix, with change in behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reverts the previous email-only post attribution change.
> 
> - Simplifies `getResourceById` to handle `post` and `page` identically via `models.Post.findOne({id}, {require:false})` without status filtering
> - Removes special-case support/tests for `sent` (email-only) posts; updates unit tests and mocks accordingly in `url-translator.test.js`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5e68164d24e9ee8e271a6be1754d0876d369b46b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->