### PR TITLE
Updated Stripe verified partner logo

### DIFF
--- a/apps/admin-x-settings/src/components/settings/membership/stripe/stripe-connect-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/stripe/stripe-connect-modal.tsx
@@ -26,7 +26,7 @@ const Start: React.FC<{onNext?: () => void}> = ({onNext}) => {
         <div>
             <div className='flex items-center justify-between'>
                 <Heading level={3}>Getting paid</Heading>
-                <StripeVerifiedBadge />
+                <img alt='Stripe Verified Partner Badge' src={StripeVerifiedBadge} />
             </div>
             <div className='mb-7 mt-6'>
                 Stripe is our exclusive direct payments partner. Ghost collects <strong>no fees</strong> on any payments! If you don’t have a Stripe account yet, you can <a className='underline' href="https://stripe.com" rel="noopener noreferrer" target="_blank">sign up here</a>.

--- a/apps/admin-x-settings/src/components/settings/membership/stripe/stripe-connect-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/stripe/stripe-connect-modal.tsx
@@ -4,8 +4,9 @@ import GhostLogoPink from '../../../../assets/images/orb-pink.png';
 import NiceModal, {useModal} from '@ebay/nice-modal-react';
 import React, {useEffect, useState} from 'react';
 import StripeLogo from '../../../../assets/images/stripe-emblem.svg';
+import StripeVerifiedBadge from '../../../../assets/images/stripe-verified.svg';
 import useSettingGroup from '../../../../hooks/use-setting-group';
-import {Button, ConfirmationModal, Form, Heading, Icon, LimitModal, Modal, StripeButton, TextArea, TextField, Toggle, showToast} from '@tryghost/admin-x-design-system';
+import {Button, ConfirmationModal, Form, Heading, LimitModal, Modal, StripeButton, TextArea, TextField, Toggle, showToast} from '@tryghost/admin-x-design-system';
 import {HostLimitError, useLimiter} from '../../../../hooks/use-limiter';
 import {JSONError} from '@tryghost/admin-x-framework/errors';
 import {checkStripeEnabled, getSettingValue, getSettingValues, useDeleteStripeSettings, useEditSettings} from '@tryghost/admin-x-framework/api/settings';
@@ -25,7 +26,7 @@ const Start: React.FC<{onNext?: () => void}> = ({onNext}) => {
         <div>
             <div className='flex items-center justify-between'>
                 <Heading level={3}>Getting paid</Heading>
-                <Icon name='stripe-verified' />
+                <StripeVerifiedBadge />
             </div>
             <div className='mb-7 mt-6'>
                 Stripe is our exclusive direct payments partner. Ghost collects <strong>no fees</strong> on any payments! If you don’t have a Stripe account yet, you can <a className='underline' href="https://stripe.com" rel="noopener noreferrer" target="_blank">sign up here</a>.


### PR DESCRIPTION
ref https://linear.app/ghost/issue/DES-1261/tiny-stripe-verified-partner-logo-when-connecting-stripe

The Icon component was constraining the dimensions of the logo because it's not square.

| Before | After |
|--------|--------|
| <img width="562" height="281" alt="Screenshot 2026-01-12 at 11 36 53" src="https://github.com/user-attachments/assets/7923ac6a-b528-4a79-9d94-e1e399c4fc37" /> | <img width="563" height="275" alt="Screenshot 2026-01-12 at 11 33 34" src="https://github.com/user-attachments/assets/333a6ef5-ca65-4841-8a2b-f61dc4ff29bc" /> | 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates Stripe Connect modal to correctly display the Stripe Verified Partner badge.
> 
> - Replaces `Icon` usage with an image-based badge using `stripe-verified.svg` in `stripe-connect-modal.tsx` to fix sizing
> - Removes `Icon` from `@tryghost/admin-x-design-system` imports
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 97804d7712ecbb8e9d678a077b380664ac1adc6f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->