### PR TITLE
Added docs link to universal import

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/migration-tools/universal-import-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/migration-tools/universal-import-modal.tsx
@@ -1,6 +1,6 @@
 import NiceModal, {useModal} from '@ebay/nice-modal-react';
 import React, {useState} from 'react';
-import {ConfirmationModal, FileUpload, Modal} from '@tryghost/admin-x-design-system';
+import {ConfirmationModal, FileUpload, Link, Modal} from '@tryghost/admin-x-design-system';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
 import {useImportContent} from '@tryghost/admin-x-framework/api/db';
 
@@ -18,6 +18,7 @@ const UniversalImportModal: React.FC = () => {
             testId='universal-import-modal'
             title='Universal import'
         >
+            <p className='mt-4'>Need some help? <Link href="https://docs.ghost.org/migration/custom" target="_blank">Learn more</Link> about importing.</p>
             <div className='py-4 leading-9'>
                 <FileUpload
                     accept="application/json, application/zip"

--- a/apps/admin-x-settings/src/components/settings/advanced/migration-tools/universal-import-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/migration-tools/universal-import-modal.tsx
@@ -14,8 +14,8 @@ const UniversalImportModal: React.FC = () => {
         <Modal
             backDropClick={false}
             footer={
-                <div className='p-8 flex w-full items-center justify-between'>
-                    <Link href="https://docs.ghost.org/migration/custom" target="_blank">Learn about importing</Link>
+                <div className='flex w-full items-center justify-between p-8'>
+                    <Link href="https://docs.ghost.org/migration/ghost" target="_blank">Learn about importing</Link>
                     <Button color='outline' label='Cancel' onClick={() => modal.remove()} />
                 </div>
             }

--- a/apps/admin-x-settings/src/components/settings/advanced/migration-tools/universal-import-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/migration-tools/universal-import-modal.tsx
@@ -1,6 +1,6 @@
 import NiceModal, {useModal} from '@ebay/nice-modal-react';
 import React, {useState} from 'react';
-import {ConfirmationModal, FileUpload, Link, Modal} from '@tryghost/admin-x-design-system';
+import {Button, ConfirmationModal, FileUpload, Link, Modal} from '@tryghost/admin-x-design-system';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
 import {useImportContent} from '@tryghost/admin-x-framework/api/db';
 
@@ -13,12 +13,17 @@ const UniversalImportModal: React.FC = () => {
     return (
         <Modal
             backDropClick={false}
+            footer={
+                <div className='p-8 flex w-full items-center justify-between'>
+                    <Link href="https://docs.ghost.org/migration/custom" target="_blank">Learn about importing</Link>
+                    <Button color='outline' label='Cancel' onClick={() => modal.remove()} />
+                </div>
+            }
             okLabel=''
             size='sm'
             testId='universal-import-modal'
             title='Universal import'
         >
-            <p className='mt-4'>Need some help? <Link href="https://docs.ghost.org/migration/custom" target="_blank">Learn more</Link> about importing.</p>
             <div className='py-4 leading-9'>
                 <FileUpload
                     accept="application/json, application/zip"

--- a/apps/admin-x-settings/src/components/settings/advanced/migration-tools/universal-import-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/migration-tools/universal-import-modal.tsx
@@ -16,7 +16,7 @@ const UniversalImportModal: React.FC = () => {
             footer={
                 <div className='flex w-full items-center justify-between p-8'>
                     <Link href="https://docs.ghost.org/migration/ghost" target="_blank">Learn about importing</Link>
-                    <Button color='outline' label='Cancel' onClick={() => modal.remove()} />
+                    <Button color='outline' disabled={uploading} label='Cancel' onClick={() => modal.remove()} />
                 </div>
             }
             okLabel=''


### PR DESCRIPTION
Ref https://linear.app/ghost/issue/DES-1266/add-docs-link-to-universal-import-modal

Previously this modal didn't have a link to any docs. I've added one so that the purpose of universal import can be better understood.

| Before | After |
|--------|--------|
| <img width="522" height="332" alt="Screenshot 2026-01-12 at 13 36 24" src="https://github.com/user-attachments/assets/5c80c5a1-c922-4e6a-88e9-47fa68573a1d" /> | <img width="525" height="377" alt="Screenshot 2026-01-12 at 13 35 19" src="https://github.com/user-attachments/assets/27c813ab-f119-4587-a49f-67ea2ed5dc0f" /> | 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances the Universal Import modal with clearer guidance and controls.
> 
> - Adds `footer` to `Modal` with a `Link` to docs (`https://docs.ghost.org/migration/ghost`) and an outline `Cancel` button (disabled while uploading)
> - Imports `Button` and `Link` to support the new footer UI
> - No changes to import/upload logic
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7815dfb9434c9e70e7df2a8fb7e22c3c7651bb7a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->