### PR TITLE
Fixed button background missing in setup form

### DIFF
--- a/apps/shade/preflight.css
+++ b/apps/shade/preflight.css
@@ -234,12 +234,15 @@
     /*
     1. Correct the inability to style clickable types in iOS and Safari.
     2. Remove default button styles.
+    Note: Attribute selectors are wrapped rapped in :where() to give zero 
+    specificity so any class can override.
     */
 
     button,
+    :where(
         /* [type='button'], */
         [type='reset'],
-        [type='submit'] {
+        [type='submit']) {
         -webkit-appearance: button; /* 1 */
         background-color: transparent; /* 2 */
         background-image: none; /* 2 */


### PR DESCRIPTION
fixes https://linear.app/ghost/issue/BER-3074/fix-css-conflict-in-setup

Shade's CSS reset for submit buttons (`[type='submit']`) had the same specificity as `.gh-btn-*` classes, so CSS load order determined the winner. In the React admin shell where Ember is wrapped inside `.shade`, the reset was overriding button backgrounds certain contexts (e.g setup.) 

Wrapping the button reset selectors in `:where()` gives them zero specificity, ensuring any button class always wins. 

Compared to the previous attempt at fixing this: https://github.com/TryGhost/Ghost/pull/25630 (reverted in https://github.com/TryGhost/Ghost/pull/25659) this approach should not introduce more specificity conflicts. 