### PR TITLE
Linting config file cleanup

### DIFF
--- a/ghost/core/.eslintrc.js
+++ b/ghost/core/.eslintrc.js
@@ -121,7 +121,7 @@ module.exports = {
             // See: core/frontend/services/helpers/registry.js:26
             files: ['core/frontend/helpers/**', 'core/frontend/apps/*/lib/helpers/**'],
             rules: {
-                'ghost/filenames/match-regex': ['off', '^[a-z0-9_.]$', null, false]
+                'ghost/filenames/match-regex': ['error', '^[a-z0-9_.-]+$', false]
             }
         },
         /**

--- a/ghost/core/.eslintrc.js
+++ b/ghost/core/.eslintrc.js
@@ -10,8 +10,6 @@ module.exports = {
         'plugin:ghost/node'
     ],
     rules: {
-        // @TODO: remove this rule once it's turned into "error" in the base plugin
-        'no-shadow': 'error',
         'no-var': 'error',
         'one-var': ['error', 'never']
     },


### PR DESCRIPTION
* removed todo cleanup, since rule was added [to the base plugin](https://github.com/TryGhost/eslint-plugin-ghost/commit/b3075f244f07df7e0f39803138d5a1dc135bd248)
* fixed helper filename regex to properly enforce underscore support instead of being disabled