### PR TITLE
Simplified usage of Playwright dependencies caching by removing not needed OS dependencies installation step

### DIFF
--- a/.github/actions/setup-playwright/action.yml
+++ b/.github/actions/setup-playwright/action.yml
@@ -26,8 +26,3 @@ runs:
       if: steps.playwright-cache.outputs.cache-hit != 'true'
       shell: bash
       run: npx playwright install --with-deps
-
-    - name: Install OS dependencies of Playwright if cache hit
-      if: steps.playwright-cache.outputs.cache-hit == 'true'
-      shell: bash
-      run: npx playwright install-deps


### PR DESCRIPTION
**what**

* removed the need for installation of OS dependencies from `setup playwright` custom action in CI workflow

**why**

In last 6 months, we have experienced two times a significant slowdown in CI, that was caused by slow `setup playwright` action runs. It's a frequent call, since we use it on multiple jobs, and usual time this action takes is `1 minute` in each job (5 min or more on bad day).

While experimenting with using containers instead of installation (that seems to be a bit cumbersome to do with our current setup - docker in docker) I realized that we are partially using caching in our current setup, and it could be source of the issue. We don't really need to install dependencies for OS every time on our Ubuntu boxes, we could just use cached playwright and browsers.

This setup shaves off almost a minute from playwright setup since it only uses cache now ( 5-6s instead of 1 minute on each job). Jobs seem `10-30%` faster.

--
playwright dependencies [doc details ](https://playwright.dev/docs/browsers)
browsers are installed in default cache locations (or in CI the one we chose)

What are your thoughts on this one?