### PR TITLE
Updated member welcome email token replacement

### DIFF
--- a/e2e/data-factory/factories/automated-email-factory.ts
+++ b/e2e/data-factory/factories/automated-email-factory.ts
@@ -26,7 +26,7 @@ export class AutomatedEmailFactory extends Factory<Partial<AutomatedEmail>, Auto
             status: 'active',
             name: 'Welcome Email (Free)',
             slug: 'member-welcome-email-free',
-            subject: 'Welcome to {{site.title}}!',
+            subject: 'Welcome to {site_title}!',
             lexical: JSON.stringify(this.defaultLexicalContent()),
             sender_name: null,
             sender_email: null,
@@ -45,7 +45,7 @@ export class AutomatedEmailFactory extends Factory<Partial<AutomatedEmail>, Auto
                     type: 'paragraph',
                     children: [{
                         type: 'text',
-                        text: 'Welcome to {{site.title}}!'
+                        text: 'Welcome to {site_title}!'
                     }]
                 }],
                 direction: null,

--- a/ghost/core/core/server/services/member-welcome-emails/constants.js
+++ b/ghost/core/core/server/services/member-welcome-emails/constants.js
@@ -24,7 +24,7 @@ const DEFAULT_PAID_LEXICAL_CONTENT = '{"root":{"children":[{"children":[{"detail
 const DEFAULT_WELCOME_EMAILS = {
     free: {
         lexical: DEFAULT_FREE_LEXICAL_CONTENT,
-        subject: 'Welcome to {{site.title}}',
+        subject: 'Welcome to {site_title}',
         status: 'active'
     },
     paid: {

--- a/ghost/core/core/server/services/member-welcome-emails/member-welcome-email-renderer.js
+++ b/ghost/core/core/server/services/member-welcome-emails/member-welcome-email-renderer.js
@@ -5,6 +5,9 @@ const juice = require('juice');
 const lexicalLib = require('../../lib/lexical');
 const errors = require('@tryghost/errors');
 const {MESSAGES} = require('./constants');
+const {wrapReplacementStrings} = require('../koenig/render-utils/replacement-strings');
+
+const REPLACEMENT_REGEX = /%%\{(\w+?)(?:,? *"(.*?)")?\}%%/g;
 
 class MemberWelcomeEmailRenderer {
     #wrapperTemplate;
@@ -16,6 +19,49 @@ class MemberWelcomeEmailRenderer {
             'utf8'
         );
         this.#wrapperTemplate = this.Handlebars.compile(wrapperSource);
+    }
+
+    /**
+     * Builds replacement token definitions for member and site data
+     * @param {Object} options
+     * @param {Object} options.member - Member data
+     * @param {string} [options.member.name] - Member's full name
+     * @param {string} [options.member.email] - Member's email address
+     * @param {Object} options.siteSettings - Site settings
+     * @param {string} options.siteSettings.title - Site title
+     * @param {string} options.siteSettings.url - Site URL
+     * @returns {{id: string, getValue: () => string|undefined}[]}
+     */
+    #buildReplacementDefinitions({member, siteSettings}) {
+        return [
+            {id: 'first_name', getValue: () => member.name?.split(' ')[0]},
+            {id: 'name', getValue: () => member.name},
+            {id: 'email', getValue: () => member.email},
+            {id: 'site_title', getValue: () => siteSettings.title},
+            {id: 'site_url', getValue: () => siteSettings.url}
+        ];
+    }
+
+    /**
+     * Applies replacement tokens to a string
+     * Supports fallback values: {first_name, "friend"} renders "friend" if name is empty
+     * @param {Object} options
+     * @param {string} options.text - The text to process (content body or subject line)
+     * @param {Object} options.member - Member data
+     * @param {Object} options.siteSettings - Site settings
+     * @returns {string}
+     */
+    #applyReplacements({text, member, siteSettings}) {
+        const definitions = this.#buildReplacementDefinitions({member, siteSettings});
+        let processed = wrapReplacementStrings(text);
+
+        return processed.replace(REPLACEMENT_REGEX, (match, property, fallback) => {
+            const def = definitions.find(d => d.id === property);
+            if (def) {
+                return def.getValue() || fallback || '';
+            }
+            return match;
+        });
     }
 
     /**
@@ -38,31 +84,15 @@ class MemberWelcomeEmailRenderer {
             });
         }
 
-        const memberName = member.name || 'there';
-        const firstName = memberName.split(' ')[0];
+        const contentWithReplacements = this.#applyReplacements({text: content, member, siteSettings});
+        const subjectWithReplacements = this.#applyReplacements({text: subject, member, siteSettings});
 
-        const templateData = {
-            site: {
-                title: siteSettings.title,
-                url: siteSettings.url
-            },
-            member: {
-                name: memberName,
-                email: member.email || '',
-                firstname: firstName
-            },
+        const html = this.#wrapperTemplate({
+            content: contentWithReplacements,
+            subject: subjectWithReplacements,
             siteTitle: siteSettings.title,
             siteUrl: siteSettings.url,
             accentColor: siteSettings.accentColor
-        };
-
-        const contentWithReplacements = this.Handlebars.compile(content)(templateData);
-        const subjectWithReplacements = this.Handlebars.compile(subject)(templateData);
-
-        const html = this.#wrapperTemplate({
-            ...templateData,
-            content: contentWithReplacements,
-            subject: subjectWithReplacements
         });
 
         const inlinedHtml = juice(html, {inlinePseudoElements: true, removeStyleTags: true});

--- a/ghost/core/test/integration/jobs/process-outbox.test.js
+++ b/ghost/core/test/integration/jobs/process-outbox.test.js
@@ -49,7 +49,7 @@ describe('Process Outbox Job', function () {
             status: 'active',
             name: 'Free Member Welcome Email',
             slug: MEMBER_WELCOME_EMAIL_SLUGS.free,
-            subject: 'Welcome to {{site.title}}',
+            subject: 'Welcome to {site_title}',
             lexical,
             created_at: new Date()
         });

--- a/ghost/core/test/integration/services/member-welcome-emails.test.js
+++ b/ghost/core/test/integration/services/member-welcome-emails.test.js
@@ -42,7 +42,7 @@ describe('Member Welcome Emails Integration', function () {
             status: 'active',
             name: 'Free Member Welcome Email',
             slug: MEMBER_WELCOME_EMAIL_SLUGS.free,
-            subject: 'Welcome to {{site.title}}',
+            subject: 'Welcome to {site_title}',
             lexical,
             created_at: new Date()
         });
@@ -52,7 +52,7 @@ describe('Member Welcome Emails Integration', function () {
             status: 'active',
             name: 'Paid Member Welcome Email',
             slug: MEMBER_WELCOME_EMAIL_SLUGS.paid,
-            subject: 'Welcome paid member to {{site.title}}',
+            subject: 'Welcome paid member to {site_title}',
             lexical,
             created_at: new Date()
         });


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-837

- Replaced Handlebars template syntax ({{member.name}}) with simpler brace syntax ({name}, {first_name}, {email}, {site_title}, {site_url})
- Added support for custom fallback values (e.g., {first_name, "friend"} renders "friend" when name is missing)
- Removed hardcoded "there" fallback