### PR TITLE
Changed portal button styles to be conditional

### DIFF
--- a/apps/admin-x-settings/src/components/settings/membership/portal/look-and-feel.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/portal/look-and-feel.tsx
@@ -75,49 +75,54 @@ const LookAndFeel: React.FC<{
             label='Show portal button'
             onChange={e => updateSetting('portal_button', e.target.checked)}
         />
-        <Select
-            options={portalButtonOptions}
-            selectedOption={portalButtonOptions.find(option => option.value === portalButtonStyle)}
-            title='Button style'
-            onSelect={option => updateSetting('portal_button_style', option?.value || null)}
-        />
-        {portalButtonStyle?.toString()?.includes('icon') &&
-            <div className='flex flex-col gap-2'>
-                <Heading level={6} grey>Icon</Heading>
-                <div className='flex justify-between'>
+        
+        {portalButton && (
+            <>
+                <Select
+                    options={portalButtonOptions}
+                    selectedOption={portalButtonOptions.find(option => option.value === portalButtonStyle)}
+                    title='Button style'
+                    onSelect={option => updateSetting('portal_button_style', option?.value || null)}
+                />
+                {portalButtonStyle?.toString()?.includes('icon') &&
+                    <div className='flex flex-col gap-2'>
+                        <Heading level={6} grey>Icon</Heading>
+                        <div className='flex justify-between'>
 
-                    {defaultButtonIcons.map(iconConfig => (
-                        <button key={iconConfig.value} className={clsx('border p-3', currentIcon === iconConfig.value ? 'border-green' : 'border-transparent')} type="button" onClick={() => updateSetting('portal_button_icon', iconConfig.value)}>
-                            <Icon className={`size-5 ${currentIcon === iconConfig.value ? 'text-green' : 'text-black opacity-70 transition-all hover:opacity-100 dark:text-white'}`} name={iconConfig.icon} />
-                        </button>
-                    ))}
-                    <div className={clsx('relative w-[46px] border', currentIcon === uploadedIcon ? 'border-green' : 'border-transparent')}>
-                        <ImageUpload
-                            deleteButtonClassName='invisible absolute -right-2 -top-2 flex h-8 w-8 cursor-pointer items-center justify-center rounded-full bg-[rgba(0,0,0,0.75)] text-white hover:bg-black group-hover:!visible'
-                            deleteButtonContent={<Icon colorClass='text-white' name='trash' size='sm' />}
-                            height='46px'
-                            id='test'
-                            imageClassName='cursor-pointer'
-                            imageURL={uploadedIcon}
-                            width='46px'
-                            deleteButtonUnstyled
-                            onDelete={handleImageDelete}
-                            onImageClick={() => uploadedIcon && updateSetting('portal_button_icon', uploadedIcon)}
-                            onUpload={handleImageUpload}
-                        >
-                            <Icon className='dark:text-white' name='upload' size='md' />
-                        </ImageUpload>
+                            {defaultButtonIcons.map(iconConfig => (
+                                <button key={iconConfig.value} className={clsx('border p-3', currentIcon === iconConfig.value ? 'border-green' : 'border-transparent')} type="button" onClick={() => updateSetting('portal_button_icon', iconConfig.value)}>
+                                    <Icon className={`size-5 ${currentIcon === iconConfig.value ? 'text-green' : 'text-black opacity-70 transition-all hover:opacity-100 dark:text-white'}`} name={iconConfig.icon} />
+                                </button>
+                            ))}
+                            <div className={clsx('relative w-[46px] border', currentIcon === uploadedIcon ? 'border-green' : 'border-transparent')}>
+                                <ImageUpload
+                                    deleteButtonClassName='invisible absolute -right-2 -top-2 flex h-8 w-8 cursor-pointer items-center justify-center rounded-full bg-[rgba(0,0,0,0.75)] text-white hover:bg-black group-hover:!visible'
+                                    deleteButtonContent={<Icon colorClass='text-white' name='trash' size='sm' />}
+                                    height='46px'
+                                    id='test'
+                                    imageClassName='cursor-pointer'
+                                    imageURL={uploadedIcon}
+                                    width='46px'
+                                    deleteButtonUnstyled
+                                    onDelete={handleImageDelete}
+                                    onImageClick={() => uploadedIcon && updateSetting('portal_button_icon', uploadedIcon)}
+                                    onUpload={handleImageUpload}
+                                >
+                                    <Icon className='dark:text-white' name='upload' size='md' />
+                                </ImageUpload>
+                            </div>
+                        </div>
                     </div>
-                </div>
-            </div>
-        }
-        {portalButtonStyle?.toString()?.includes('text') &&
-            <TextField
-                title='Signup button text'
-                value={portalButtonSignupText as string}
-                onChange={e => updateSetting('portal_button_signup_text', e.target.value)}
-            />
-        }
+                }
+                {portalButtonStyle?.toString()?.includes('text') &&
+                    <TextField
+                        title='Signup button text'
+                        value={portalButtonSignupText as string}
+                        onChange={e => updateSetting('portal_button_signup_text', e.target.value)}
+                    />
+                }
+            </>
+        )}
     </Form></div>;
 };
 


### PR DESCRIPTION
no ref

We now use the portal button toggle to determine whether the styles for the portal button should be shown. This avoids a situation where the styles are being edited while the button isn't visible.

| Before | After |
|--------|--------|
| <img width="444" height="518" alt="Screenshot 2026-01-13 at 09 26 04" src="https://github.com/user-attachments/assets/e1e65985-6afc-4adb-9dba-a3d8194c7fda" /> | <img width="457" height="247" alt="Screenshot 2026-01-13 at 09 25 29" src="https://github.com/user-attachments/assets/31066dce-a835-43dc-8ce5-3d5e737712fc" /> | 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures style controls are only visible when the portal button is enabled.
> 
> - Wraps `Select` for `portal_button_style`, icon picker/upload (`portal_button_icon`), and `TextField` for `portal_button_signup_text` in a conditional block tied to `portal_button`
> - Prevents editing portal button styles while the button is hidden
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 905c9934c8a3c4f3123a02ffdf4cda3b5de175b2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->