### PR TITLE
Add admin deploy lock/toggle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1564,6 +1564,7 @@ jobs:
       && needs.job_setup.result == 'success'
       && needs.job_setup.outputs.is_main == 'true'
       && needs.job_required_tests.result == 'success'
+      && vars.DEPLOY_ADMIN == 'true'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3160

This should let us disable the automated admin releases if needed. I've gone ahead and created the variable as well. 
