### PR TITLE
Improved local development experience with lexical editor and `dev:forward`

### DIFF
--- a/apps/admin/src/utils/fetch-koenig-lexical.ts
+++ b/apps/admin/src/utils/fetch-koenig-lexical.ts
@@ -5,9 +5,13 @@
  * This ensures React is properly deduped by Vite's bundler, avoiding the
  * "Invalid hook call" errors that occur when the UMD bundle (which includes
  * its own bundled React) is loaded alongside Vite's React.
+ *
+ * For local Koenig development, set KOENIG_PATH in vite.config.ts to alias
+ * @tryghost/koenig-lexical to your local Koenig source (yarn dev:lexical).
  */
 export async function fetchKoenigLexical(): Promise<unknown> {
     // Import the ESM module directly - Vite will handle React deduplication
+    // When KOENIG_PATH is set, Vite aliases this to the local source
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const koenig = await import('@tryghost/koenig-lexical');
     return koenig;

--- a/apps/admin/vite.config.ts
+++ b/apps/admin/vite.config.ts
@@ -9,9 +9,8 @@ import { deepLinksPlugin } from "./vite-deep-links";
 
 const GHOST_CARDS_PATH = resolve(__dirname, "../../ghost/core/core/frontend/src/cards");
 
-// Local Koenig development: set KOENIG_PATH to the koenig-lexical package source
-// e.g., KOENIG_PATH=../Koenig/packages/koenig-lexical/src/index.js (relative to monorepo root)
-// or KOENIG_PATH=/absolute/path/to/koenig-lexical/src/index.js
+// Local Koenig development: set KOENIG_PATH to the koenig-lexical ESM build
+// Path is relative to Ghost monorepo root, e.g., ../Koenig/packages/koenig-lexical/dist/koenig-lexical.js
 const MONOREPO_ROOT = resolve(__dirname, "../..");
 const KOENIG_PATH = process.env.KOENIG_PATH
     ? resolve(MONOREPO_ROOT, process.env.KOENIG_PATH)
@@ -33,7 +32,7 @@ export default defineConfig({
             "@ghost-cards": GHOST_CARDS_PATH,
             // TODO: Remove this when @tryghost/nql is updated
             mingo: resolve(__dirname, "../../node_modules/mingo/dist/mingo.js"),
-            // Local Koenig development: alias to local source for HMR
+            // Local Koenig development: alias to local build
             ...(KOENIG_PATH ? { "@tryghost/koenig-lexical": KOENIG_PATH } : {}),
         },
         // Shim node modules utilized by the @tryghost/nql package

--- a/apps/admin/vite.config.ts
+++ b/apps/admin/vite.config.ts
@@ -9,6 +9,14 @@ import { deepLinksPlugin } from "./vite-deep-links";
 
 const GHOST_CARDS_PATH = resolve(__dirname, "../../ghost/core/core/frontend/src/cards");
 
+// Local Koenig development: set KOENIG_PATH to the koenig-lexical package source
+// e.g., KOENIG_PATH=../Koenig/packages/koenig-lexical/src/index.js (relative to monorepo root)
+// or KOENIG_PATH=/absolute/path/to/koenig-lexical/src/index.js
+const MONOREPO_ROOT = resolve(__dirname, "../..");
+const KOENIG_PATH = process.env.KOENIG_PATH
+    ? resolve(MONOREPO_ROOT, process.env.KOENIG_PATH)
+    : undefined;
+
 // https://vite.dev/config/
 export default defineConfig({
     base: process.env.GHOST_CDN_URL ?? "/ghost",
@@ -25,10 +33,16 @@ export default defineConfig({
             "@ghost-cards": GHOST_CARDS_PATH,
             // TODO: Remove this when @tryghost/nql is updated
             mingo: resolve(__dirname, "../../node_modules/mingo/dist/mingo.js"),
+            // Local Koenig development: alias to local source for HMR
+            ...(KOENIG_PATH ? { "@tryghost/koenig-lexical": KOENIG_PATH } : {}),
         },
         // Shim node modules utilized by the @tryghost/nql package
         external: ["fs", "path", "util"],
     },
+    // When using local Koenig source, exclude from optimization since it's pre-built
+    optimizeDeps: KOENIG_PATH ? {
+        exclude: ["@tryghost/koenig-lexical"],
+    } : {},
     test: {
         environment: "jsdom",
         globals: true,

--- a/apps/admin/vite.config.ts
+++ b/apps/admin/vite.config.ts
@@ -24,6 +24,8 @@ export default defineConfig({
         "process.env.DEBUG": false, // Shim env var utilized by the @tryghost/nql package
     },
     server: {
+        // Port 5174 to avoid conflict with Koenig's dev server (5173) during local Koenig development
+        port: 5174,
         host: true,
         allowedHosts: true
     },

--- a/apps/admin/vite.config.ts
+++ b/apps/admin/vite.config.ts
@@ -9,11 +9,11 @@ import { deepLinksPlugin } from "./vite-deep-links";
 
 const GHOST_CARDS_PATH = resolve(__dirname, "../../ghost/core/core/frontend/src/cards");
 
-// Local Koenig development: set KOENIG_PATH to the koenig-lexical ESM build
-// Path is relative to Ghost monorepo root, e.g., ../Koenig/packages/koenig-lexical/dist/koenig-lexical.js
+// Local Koenig development: set KOENIG_PATH to the Koenig repo root
+// Path is relative to Ghost monorepo root, e.g., ../Koenig
 const MONOREPO_ROOT = resolve(__dirname, "../..");
 const KOENIG_PATH = process.env.KOENIG_PATH
-    ? resolve(MONOREPO_ROOT, process.env.KOENIG_PATH)
+    ? resolve(MONOREPO_ROOT, process.env.KOENIG_PATH, "packages/koenig-lexical/dist/koenig-lexical.js")
     : undefined;
 
 // https://vite.dev/config/

--- a/docker/dev-gateway/Dockerfile
+++ b/docker/dev-gateway/Dockerfile
@@ -4,7 +4,7 @@ RUN caddy add-package github.com/caddyserver/transform-encoder
 
 # Default proxy targets (can be overridden via environment variables)
 ENV GHOST_BACKEND=ghost-dev:2368 \
-    ADMIN_DEV_SERVER=host.docker.internal:5173 \
+    ADMIN_DEV_SERVER=host.docker.internal:5174 \
     ADMIN_LIVE_RELOAD_SERVER=host.docker.internal:4200 \
     PORTAL_DEV_SERVER=host.docker.internal:4175 \
     COMMENTS_DEV_SERVER=host.docker.internal:7173 \

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "dev:analytics": "DEV_COMPOSE_FILES='-f compose.dev.analytics.yaml' nx run ghost-monorepo:docker:dev",
     "dev:storage": "DEV_COMPOSE_FILES='-f compose.dev.storage.yaml' nx run ghost-monorepo:docker:dev",
     "dev:all": "DEV_COMPOSE_FILES='-f compose.dev.analytics.yaml -f compose.dev.storage.yaml' nx run ghost-monorepo:docker:dev",
-    "dev:lexical": "KOENIG_PATH=../../Koenig/packages/koenig-lexical/dist/koenig-lexical.js nx run ghost-monorepo:docker:dev",
+    "dev:lexical": "KOENIG_PATH=${KOENIG_PATH:-../Koenig/packages/koenig-lexical/dist/koenig-lexical.js} nx run ghost-monorepo:docker:dev",
     "dev:debug": "DEBUG_COLORS=true DEBUG=@tryghost*,ghost:* yarn dev",
     "dev:admin": "node .github/scripts/dev.js --admin",
     "dev:ghost": "node .github/scripts/dev.js --ghost",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "dev:analytics": "DEV_COMPOSE_FILES='-f compose.dev.analytics.yaml' nx run ghost-monorepo:docker:dev",
     "dev:storage": "DEV_COMPOSE_FILES='-f compose.dev.storage.yaml' nx run ghost-monorepo:docker:dev",
     "dev:all": "DEV_COMPOSE_FILES='-f compose.dev.analytics.yaml -f compose.dev.storage.yaml' nx run ghost-monorepo:docker:dev",
-    "dev:lexical": "KOENIG_PATH=${KOENIG_PATH:-../Koenig/packages/koenig-lexical/dist/koenig-lexical.js} nx run ghost-monorepo:docker:dev",
+    "dev:lexical": "KOENIG_PATH=${KOENIG_PATH:-../Koenig} nx run ghost-monorepo:docker:dev",
     "dev:debug": "DEBUG_COLORS=true DEBUG=@tryghost*,ghost:* yarn dev",
     "dev:admin": "node .github/scripts/dev.js --admin",
     "dev:ghost": "node .github/scripts/dev.js --ghost",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "dev:analytics": "DEV_COMPOSE_FILES='-f compose.dev.analytics.yaml' nx run ghost-monorepo:docker:dev",
     "dev:storage": "DEV_COMPOSE_FILES='-f compose.dev.storage.yaml' nx run ghost-monorepo:docker:dev",
     "dev:all": "DEV_COMPOSE_FILES='-f compose.dev.analytics.yaml -f compose.dev.storage.yaml' nx run ghost-monorepo:docker:dev",
+    "dev:lexical": "KOENIG_PATH=../../Koenig/packages/koenig-lexical/dist/koenig-lexical.js nx run ghost-monorepo:docker:dev",
     "dev:debug": "DEBUG_COLORS=true DEBUG=@tryghost*,ghost:* yarn dev",
     "dev:admin": "node .github/scripts/dev.js --admin",
     "dev:ghost": "node .github/scripts/dev.js --ghost",


### PR DESCRIPTION

## Usage

1. In Koenig repo: `yarn dev` (runs dev server on port 4173)
2. In Ghost repo: `yarn dev:lexical`

By default, expects Koenig at `../Koenig`. Override via environment variable or `.env`:

```bash
KOENIG_PATH=/path/to/Koenig/packages/koenig-lexical/dist/koenig-lexical.js yarn dev:lexical
```

Changes to Koenig require `yarn build` in Koenig before they appear in Ghost's settings app.

## How It Works

Ghost loads the Koenig editor in two different ways, depending on the app:

- **Post Editor (Ember)** - Loads koenig-lexical UMD bundle at runtime via URL. Caddy proxies `/ghost/assets/koenig-lexical/*` to the Koenig dev server.

- **Settings App (React)** - Imports koenig-lexical as an ES module. When `KOENIG_PATH` is set, Vite aliases `@tryghost/koenig-lexical` to the local build.

### Why ESM Build Instead of Source?

We alias to the pre-built ESM file (`dist/koenig-lexical.js`) because Koenig has CommonJS and Node.js dependencies that would fail to compile in the browser. The ESM build has these pre-bundled.

### Why Not the UMD Bundle for React?

The UMD bundle includes React inside it - fine for Ember (which has no React), but causes conflicts in the React admin which already has React loaded. The ESM build marks React as external, sharing the host app's instance.

## Files Changed

- `package.json` - Added `dev:lexical` script
- `apps/admin/vite.config.ts` - Added conditional Koenig aliasing
