### PR TITLE
Updated member welcome email content and dark mode styles

### DIFF
--- a/apps/admin-x-design-system/src/global/form/koenig-editor-base.tsx
+++ b/apps/admin-x-design-system/src/global/form/koenig-editor-base.tsx
@@ -16,6 +16,7 @@ export interface KoenigEditorBaseProps {
     darkMode?: boolean
     singleParagraph?: boolean
     className?: string
+    inheritFontStyles?: boolean
 }
 
 declare global {
@@ -165,14 +166,16 @@ const KoenigEditorBase: React.FC<KoenigEditorBaseInternalProps> = ({
     children,
     initialEditorState,
     onChange,
+    inheritFontStyles = true,
     ...props
 }) => {
     const {fetchKoenigLexical, darkMode} = useDesignSystem();
     const editorResource = useMemo(() => loadKoenig(fetchKoenigLexical), [fetchKoenigLexical]);
+    const inheritClasses = inheritFontStyles ? '[&_*]:!font-inherit [&_*]:!text-inherit' : '';
 
     return (
         <div className={className || 'w-full'}>
-            <div className="koenig-react-editor w-full [&_*]:!font-inherit [&_*]:!text-inherit">
+            <div className={`koenig-react-editor w-full ${inheritClasses}`}>
                 <ErrorBoundary name='editor'>
                     <Suspense fallback={<p className="koenig-react-editor-loading">Loading editor...</p>}>
                         <KoenigWrapper

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails.tsx
@@ -30,7 +30,7 @@ const EmailPreview: React.FC<{
     const senderName = automatedEmail.sender_name || siteTitle || 'Your Site';
 
     return (
-        <div className='mb-5 flex items-center justify-between gap-3 rounded-lg border border-grey-100 bg-grey-50 p-5'>
+        <div className='mb-5 flex items-center justify-between gap-3 rounded-lg border border-grey-100 bg-grey-50 p-5 dark:border-grey-925 dark:bg-grey-950'>
             <div className='flex items-start gap-3'>
                 {icon ?
                     <div className='size-10 min-h-10 min-w-10 rounded-sm bg-cover bg-center' style={{

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/member-email-editor.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/member-email-editor.tsx
@@ -33,6 +33,7 @@ const MemberEmailsEditor: React.FC<MemberEmailsEditorProps> = ({
         <KoenigEditorBase
             className={className}
             emojiPicker={false}
+            inheritFontStyles={false}
             initialEditorState={value}
             nodes={nodes}
             placeholder={placeholder}

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/test-email-dropdown.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/test-email-dropdown.tsx
@@ -81,7 +81,7 @@ const TestEmailDropdown: React.FC<TestEmailDropdownProps> = ({
     };
 
     return (
-        <div className='absolute right-0 top-full z-10 mt-2 w-[260px] rounded border border-grey-200 bg-white p-4 shadow-lg'>
+        <div className='absolute right-0 top-full z-10 mt-2 w-[260px] rounded border border-grey-250 bg-white p-4 shadow-lg dark:border-grey-925 dark:bg-grey-975'>
             <div className='mb-3'>
                 <label className='mb-2 block text-sm font-semibold' htmlFor='test-email-input'>Send test email</label>
                 <TextField

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-modal.tsx
@@ -124,14 +124,14 @@ const WelcomeEmailModal = NiceModal.create<WelcomeEmailModalProps>(({emailType =
             header={false}
             testId='welcome-email-modal'
         >
-            <div className='-mx-8 h-[calc(100vh-16vmin)] overflow-y-auto'>
-                <div className='sticky top-0 z-10 flex flex-col gap-2 border-b border-grey-100 bg-white p-5'>
+            <div className='-mx-8 h-[calc(100vh-16vmin)] overflow-y-auto dark:!bg-grey-975'>
+                <div className='sticky top-0 z-10 flex flex-col gap-2 border-b border-grey-100 bg-white p-5 dark:border-grey-900 dark:bg-grey-975'>
                     <div className='mb-2 flex items-center justify-between'>
                         <h3 className='font-semibold'>{emailType === 'paid' ? 'Paid' : 'Free'} members welcome email</h3>
                         <div className='flex items-center gap-2'>
                             <div ref={dropdownRef} className='relative'>
                                 <Button
-                                    className='border border-grey-200 font-semibold hover:border-grey-300 hover:!bg-white'
+                                    className='border border-grey-200 font-semibold hover:border-grey-300 hover:!bg-white dark:border-grey-800 dark:hover:border-grey-700 dark:hover:!bg-grey-950'
                                     color="clear"
                                     icon='send'
                                     label="Test"
@@ -153,13 +153,13 @@ const WelcomeEmailModal = NiceModal.create<WelcomeEmailModalProps>(({emailType =
                         <div className='w-20 font-semibold'>From:</div>
                         <div className='flex grow items-center gap-1'>
                             <span>{automatedEmail?.sender_name || siteTitle}</span>
-                            <span className='text-grey-700'>{`<${senderEmail}>`}</span>
+                            <span className='text-grey-700 dark:text-grey-400'>{`<${senderEmail}>`}</span>
                         </div>
                     </div>
                     {replyToEmail !== senderEmail && (
                         <div className='flex items-center py-0.5'>
                             <div className='w-20 font-semibold'>Reply-to:</div>
-                            <div className='grow text-grey-700'>
+                            <div className='grow text-grey-700 dark:text-grey-400'>
                                 {replyToEmail}
                             </div>
                         </div>
@@ -179,8 +179,8 @@ const WelcomeEmailModal = NiceModal.create<WelcomeEmailModalProps>(({emailType =
                         </div>
                     </div>
                 </div>
-                <div className='bg-grey-50 p-6'>
-                    <div className={`mx-auto max-w-[600px] rounded border bg-white p-8 text-[1.6rem] leading-[1.6] tracking-[-0.01em] shadow-sm [&_a]:text-black [&_a]:underline [&_p]:mb-4 [&_strong]:font-semibold ${errors.lexical ? 'border-red' : 'border-grey-200'}`}>
+                <div className='bg-grey-50 p-6 dark:bg-grey-975'>
+                    <div className={`mx-auto max-w-[600px] rounded border bg-white p-8 text-[1.6rem] leading-[1.6] tracking-[-0.01em] shadow-sm dark:bg-grey-975 dark:text-white dark:shadow-none dark:selection:bg-[rgba(88,101,116,0.99)] [&_:is(h2,h3)]:dark:text-white [&_p]:mb-4 [&_strong]:font-semibold ${errors.lexical ? 'border-red' : 'border-grey-200 dark:border-grey-925'}`}>
                         <MemberEmailEditor
                             key={automatedEmail?.id || 'new'}
                             placeholder='Write your welcome email content...'


### PR DESCRIPTION
ref https://linear.app/ghost/issue/NY-912
closes https://linear.app/ghost/issue/NY-847

- Fixes the hierarchical styling for h2 and h3 headings in the member welcome email editor, while maintaining the inherited font styles for html editors (like the announcements bar)
- Makes various member welcome email elements visible in dark mode that weren't before; may still need some final style tweaks

<img width="350" height="471" alt="Screenshot 2026-01-14 at 1 28 03 PM" src="https://github.com/user-attachments/assets/15f3179f-2a36-4a93-bc83-671123459b54" />