### PR TITLE
Changed react admin app's dev server to use port 5174 to avoid conflicts

### DIFF
--- a/apps/admin/vite.config.ts
+++ b/apps/admin/vite.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
         "process.env.DEBUG": false, // Shim env var utilized by the @tryghost/nql package
     },
     server: {
+        port: 5174,
         host: true,
         allowedHosts: true
     },

--- a/docker/dev-gateway/Dockerfile
+++ b/docker/dev-gateway/Dockerfile
@@ -4,7 +4,7 @@ RUN caddy add-package github.com/caddyserver/transform-encoder
 
 # Default proxy targets (can be overridden via environment variables)
 ENV GHOST_BACKEND=ghost-dev:2368 \
-    ADMIN_DEV_SERVER=host.docker.internal:5173 \
+    ADMIN_DEV_SERVER=host.docker.internal:5174 \
     ADMIN_LIVE_RELOAD_SERVER=host.docker.internal:4200 \
     PORTAL_DEV_SERVER=host.docker.internal:4175 \
     COMMENTS_DEV_SERVER=host.docker.internal:7173 \

--- a/docker/dev-gateway/README.md
+++ b/docker/dev-gateway/README.md
@@ -12,7 +12,7 @@ The Caddy reverse proxy container:
 Caddy uses environment variables (set in `compose.dev.yaml`) to configure proxy targets:
 
 - `GHOST_BACKEND` - Ghost container hostname (e.g., `ghost-dev:2368`)
-- `ADMIN_DEV_SERVER` - React admin dev server (e.g., `host.docker.internal:5173`)
+- `ADMIN_DEV_SERVER` - React admin dev server (e.g., `host.docker.internal:5174`)
 - `ADMIN_LIVE_RELOAD_SERVER` - Ember live reload WebSocket (e.g., `host.docker.internal:4200`)
 - `PORTAL_DEV_SERVER` - Portal dev server (e.g., `host.docker.internal:4175`)
 - `COMMENTS_DEV_SERVER` - Comments UI (e.g., `host.docker.internal:7173`)

--- a/docker/dev-gateway/README.md
+++ b/docker/dev-gateway/README.md
@@ -48,8 +48,8 @@ The Caddyfile defines these routing rules:
 | `/ghost/assets/signup-form/*`        | Signup dev server (port 6174)       | Signup form widget                                                     |
 | `/ghost/assets/sodo-search/*`        | Search dev server (port 4178)       | Search widget (JS + CSS)                                               |
 | `/ghost/assets/announcement-bar/*`   | Announcement dev server (port 4177) | Announcement widget                                                    |
-| `/ghost/assets/*`                    | Admin dev server (port 5173)        | Other admin assets (fallback)                                          |
-| `/ghost/*`                           | Admin dev server (port 5173)        | Admin interface                                                        |
+| `/ghost/assets/*`                    | Admin dev server (port 5174)        | Other admin assets (fallback)                                          |
+| `/ghost/*`                           | Admin dev server (port 5174)        | Admin interface                                                        |
 | Everything else                      | Ghost backend                       | Main Ghost application                                                 |
 
 **Note:** All port numbers listed are the host ports where dev servers run by default.

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "build:clean": "nx reset && rimraf -g 'ghost/*/build' && rimraf -g 'ghost/*/tsconfig.tsbuildinfo'",
     "clean:hard": "node ./.github/scripts/clean.js",
     "dev:forward": "nx run ghost-monorepo:docker:dev",
+    "dev:lexical": "EDITOR_URL=http://localhost:2368/ghost/assets/koenig-lexical/ yarn dev:forward",
     "dev:analytics": "DEV_COMPOSE_FILES='-f compose.dev.analytics.yaml' nx run ghost-monorepo:docker:dev",
     "dev:storage": "DEV_COMPOSE_FILES='-f compose.dev.storage.yaml' nx run ghost-monorepo:docker:dev",
     "dev:all": "DEV_COMPOSE_FILES='-f compose.dev.analytics.yaml -f compose.dev.storage.yaml' nx run ghost-monorepo:docker:dev",


### PR DESCRIPTION
no refs

The react admin app's dev server runs on vite's default port (5173), which conflicts with the Koenig dev server. When running `yarn dev` in Koenig first, then `yarn dev:forward` in Ghost, Koenig grabs the port first and Ghost's `dev-gateway` service will route requests intended for Ghost Admin to the Koenig dev server instead, breaking the development environment.

This changes the react admin app's port to 5174 to avoid this conflict. It also adds a `yarn dev:lexical` command to conveniently run the `dev:forward` environment with your local editor.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates dev environment to avoid port conflicts with Koenig.
> 
> - Changes admin Vite server port to `5174` in `apps/admin/vite.config.ts`
> - Updates `docker/dev-gateway/Dockerfile` and `docker/dev-gateway/README.md` to use `ADMIN_DEV_SERVER=host.docker.internal:5174` and adjust routing docs (`/ghost/*`, `/ghost/assets/*`)
> - Adds `yarn dev:lexical` script in `package.json` to run `dev:forward` with `EDITOR_URL` for local Koenig Lexical
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0394272eeb1cc4115c18c47b6047d6954ed10d79. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->