### PR TITLE
🌐 Updated Bulgarian translations (minor enhancement)

### DIFF
--- a/ghost/i18n/locales/bg/ghost.json
+++ b/ghost/i18n/locales/bg/ghost.json
@@ -14,7 +14,7 @@
     "Confirm your subscription to {siteTitle}": "Потвърдете абонамента си за {siteTitle}",
     "Device:": "Устройство:",
     "Email": "Имейл",
-    "For security verification, enter the code below to sign in to {siteTitle}:": "От съображения за сигурност въведете кода по-долу, за да влезете в {siteTitle}:",
+    "For security verification, enter the code below to sign in to {siteTitle}:": "От съображения за сигурност въведете кода по-долу, за да влезете в сайта {siteTitle}:",
     "For your security, the link will expire in 24 hours time.": "За ваша сигурност линкът ще бъде валиден само 24 часа.",
     "free": "безплатен",
     "Here's your code to login to {siteTitle}": "Ето вашия код за вход в {siteTitle}",


### PR DESCRIPTION
This PR introduces a refinement for an awkward translation that occurs when a site is titled solely with its owner's name.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Minor i18n refinement in Bulgarian locale.
> 
> - Updates translation of `"For security verification, enter the code below to sign in to {siteTitle}:"` in `ghost.json` to say "в сайта {siteTitle}" for clearer phrasing
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 78ff92eaff570259a9319db2ff5c60d1463f87d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->