### PR TITLE
Fixed styling issues with ActivityPub in new admin shell

### DIFF
--- a/apps/activitypub/src/index.tsx
+++ b/apps/activitypub/src/index.tsx
@@ -1,6 +1,7 @@
 import './styles/index.css';
-import App from './app';
 
-export {
-    App as AdminXApp
-};
+export {default as AdminXApp} from './app';
+
+export {routes} from './routes';
+export {FeatureFlagsProvider} from './lib/feature-flags';
+export {useNotificationsCountForUser} from './hooks/use-activity-pub-queries';

--- a/apps/activitypub/tailwind.config.cjs
+++ b/apps/activitypub/tailwind.config.cjs
@@ -1,5 +1,10 @@
 const adminXPreset = require('@tryghost/shade/tailwind.cjs');
 
+/**
+ * Important: Any changes made to this file need to be mirrored to the tailwind
+ * config in the admin package. 
+ */
+
 module.exports = {
     presets: [adminXPreset('.shade-activitypub')],
     content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}', '../../node_modules/@tryghost/shade/es/**/*.{js,ts,jsx,tsx}'],

--- a/apps/admin/src/layout/app-sidebar/nav-main.tsx
+++ b/apps/admin/src/layout/app-sidebar/nav-main.tsx
@@ -12,7 +12,7 @@ import { useCurrentUser } from "@tryghost/admin-x-framework/api/current-user";
 import { useBrowseSettings } from "@tryghost/admin-x-framework/api/settings";
 import { getSettingValue } from "@tryghost/admin-x-framework/api/settings";
 import { hasAdminAccess } from "@tryghost/admin-x-framework/api/users";
-import { useNotificationsCountForUser } from "@tryghost/activitypub/src/hooks/use-activity-pub-queries";
+import { useNotificationsCountForUser } from "@tryghost/activitypub/src/index";
 import NetworkIcon from "./icons/network-icon";
 import { NavMenuItem } from "./nav-menu-item";
 import { useIsActiveLink } from "./use-is-active-link";

--- a/apps/admin/src/routes.tsx
+++ b/apps/admin/src/routes.tsx
@@ -1,8 +1,7 @@
 import {type RouteObject, Outlet, lazyComponent, redirect} from "@tryghost/admin-x-framework";
 
 // ActivityPub
-import { FeatureFlagsProvider } from "@tryghost/activitypub/src/lib/feature-flags";
-import { routes as activityPubRoutes } from "@tryghost/activitypub/src/routes";
+import { FeatureFlagsProvider, routes as activityPubRoutes } from "@tryghost/activitypub/src/index";
 
 // Posts (aka tags and post analytics)
 import PostsAppContextProvider from "@tryghost/posts/src/providers/posts-app-context";

--- a/apps/admin/tailwind.config.js
+++ b/apps/admin/tailwind.config.js
@@ -1,4 +1,5 @@
 import shadePreset from "@tryghost/shade/tailwind.cjs";
+import plugin from "tailwindcss/plugin";
 
 export default {
     presets: [shadePreset(".shade-admin")],
@@ -11,5 +12,56 @@ export default {
         "../activitypub/src/**/*.{js,ts,jsx,tsx}",
         "../admin-x-settings/src/**/*.{js,ts,jsx,tsx}",
         "../admin-x-design-system/src/**/*.{js,ts,jsx,tsx}",
+    ],
+    theme: {
+        extend: {
+            // ActivityPub custom keyframes. Changes here need to be mirrored
+            // to the separate ActivityPub config. 
+            keyframes: {
+                lineExpand: {
+                    "0%": {
+                        transform: "scaleX(0)",
+                        transformOrigin: "right",
+                    },
+                    "100%": {
+                        transform: "scaleX(1)",
+                        transformOrigin: "right",
+                    },
+                },
+                scale: {
+                    "0%": {
+                        transform: "scale(0.8)",
+                    },
+                    "70%": {
+                        transform: "scale(1.1)",
+                    },
+                    "100%": {
+                        transform: "scale(1)",
+                    },
+                },
+            },
+            // ActivityPub custom animations. Changes here need to be mirrored
+            // to the separate ActivityPub config. 
+            animation: {
+                "onboarding-handle-bg": "fadeIn 0.2s ease-in 0.5s forwards",
+                "onboarding-handle-line":
+                    "lineExpand 0.2s ease-in-out 0.7s forwards",
+                "onboarding-handle-label": "fadeIn 0.2s ease-in 1.2s forwards",
+                "onboarding-next-button": "fadeIn 0.2s ease-in 2s forwards",
+                "onboarding-followers":
+                    "fadeIn 0.2s ease-in 0.5s forwards, scale 0.3s ease-in 0.5s forwards",
+            },
+        },
+    },
+    plugins: [
+        // ActivityPub break-anywhere utility. Changes here need to be mirrored
+        // to the separate ActivityPub config. 
+        plugin(function ({ addUtilities }) {
+            addUtilities({
+                ".break-anywhere": {
+                    "overflow-wrap": "anywhere",
+                },
+            });
+        }),
     ],
 };


### PR DESCRIPTION
Fixes https://linear.app/ghost/issue/BER-3211/long-urls-break-activitypub-reply-dialog-styling

**Added missing Tailwind configuration for ActivityPub**
  When embedding the ActivityPub app within the admin shell, we need to mirror the Tailwind configuration from the standalone version. This should resolve the issues with line wrapping. 

**Fixed issue with ActivityPub style overrides not loading**
  Rejigging the imports so that we ensure to include the `index.css` stylesheet when the ActivityPub app is embedded within the new admin shell. This should resolve the issues with hidden content and link styling. 