### PR TITLE
Fixed moving member activity filter button

### DIFF
--- a/ghost/admin/app/styles/layouts/member-activity.css
+++ b/ghost/admin/app/styles/layouts/member-activity.css
@@ -492,6 +492,10 @@
     color: var(--middarkgrey);
 }
 
+.gh-members-activity .gh-canvas-header .view-actions > .ember-basic-dropdown-content-wormhole-origin {
+    position: absolute;
+}
+
 @media (max-width: 800px) {
     .gh-members-activity.gh-canvas {
         padding-left: 0;


### PR DESCRIPTION
no ref

The filter button on the member activity page shifts to the left when you click on it. Solution is from https://github.com/TryGhost/Ghost/pull/25723 (Thanks Sodo!)

| Before | After |
|--------|--------|
| ![Kapture 2026-01-14 at 11 38 22](https://github.com/user-attachments/assets/25fbf2f9-366c-4816-95a0-53114e8a8102) | ![Kapture 2026-01-14 at 11 37 26](https://github.com/user-attachments/assets/4ff1542a-66eb-4502-bd1b-770d4893d795) | 
