### PR TITLE
Added `redemption_type` column to offers table

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/6.13/2026-01-14-12-56-03-add-redemption-type-to-offers.js
+++ b/ghost/core/core/server/data/migrations/versions/6.13/2026-01-14-12-56-03-add-redemption-type-to-offers.js
@@ -1,0 +1,8 @@
+const {createAddColumnMigration} = require('../../utils');
+
+module.exports = createAddColumnMigration('offers', 'redemption_type', {
+    type: 'string',
+    maxlength: 50,
+    nullable: false,
+    defaultTo: 'signup'
+});

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -492,6 +492,7 @@ module.exports = {
         duration_in_months: {type: 'integer', nullable: true},
         portal_title: {type: 'string', maxlength: 191, nullable: true},
         portal_description: {type: 'string', maxlength: 2000, nullable: true},
+        redemption_type: {type: 'string', maxlength: 50, nullable: false, defaultTo: 'signup', validations: {isIn: [['signup', 'retention']]}},
         created_at: {type: 'dateTime', nullable: false},
         updated_at: {type: 'dateTime', nullable: true}
     },

--- a/ghost/core/core/server/models/offer.js
+++ b/ghost/core/core/server/models/offer.js
@@ -6,6 +6,10 @@ const Offer = ghostBookshelf.Model.extend({
     actionsCollectCRUD: true,
     actionsResourceType: 'offer',
 
+    defaults: {
+        redemption_type: 'signup'
+    },
+
     product() {
         return this.belongsTo('Product', 'product_id', 'id');
     }

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '840147221764a9de1b3807e3abb61df2';
+    const currentSchemaHash = '5d8ff12fd51267005bff200abc420bb0';
     const currentFixturesHash = 'c583f33910bb84a70847303b323be2db';
     const currentSettingsHash = '64007c832bc27eefbe4d0ed3f888eeab';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
ref https://linear.app/ghost/issue/FEA-534

Adds a new `redemption_type` column to support applying offers to existing subscriptions

Defaults to 'signup' for backward compatibility

Model default is required because the Bookshelf plugin sets `undefined` schema columns to `null`, bypassing the database default

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a new offer attribute for controlling redemption context.
> 
> - Migration adds `offers.redemption_type` (string, not null, default `'signup'`)
> - Schema updates `offers` with `redemption_type` and validations (`'signup' | `'retention'`)
> - Model (`offer.js`) sets default `redemption_type: 'signup'` to avoid `null` from ORM
> - Test updates integrity `currentSchemaHash` to reflect schema change
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c855e675ba01a56291abec6968b643b0d2dc89bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->