### PR TITLE
Used comment permalinks in notification emails

### DIFF
--- a/ghost/core/core/server/services/comments/comments-service-emails.js
+++ b/ghost/core/core/server/services/comments/comments-service-emails.js
@@ -5,7 +5,7 @@ const CommentsServiceEmailRenderer = require('./comments-service-email-renderer'
 const {t} = require('../i18n');
 
 class CommentsServiceEmails {
-    constructor({config, logging, models, mailer, settingsCache, settingsHelpers, urlService, urlUtils}) {
+    constructor({config, logging, models, mailer, settingsCache, settingsHelpers, urlService, urlUtils, labs}) {
         this.config = config;
         this.logging = logging;
         this.models = models;
@@ -14,7 +14,22 @@ class CommentsServiceEmails {
         this.settingsHelpers = settingsHelpers;
         this.urlService = urlService;
         this.urlUtils = urlUtils;
+        this.labs = labs;
         this.commentsServiceEmailRenderer = new CommentsServiceEmailRenderer({t});
+    }
+
+    /**
+     * Build the post URL with comment fragment for email links
+     * @param {string} postId - The ID of the post
+     * @param {string} commentId - The ID of the comment to link to
+     * @returns {string} The post URL with appropriate comment fragment
+     */
+    getPostUrl(postId, commentId) {
+        const baseUrl = this.urlService.getUrlByResourceId(postId, {absolute: true});
+        if (this.labs.isSet('commentPermalinks')) {
+            return `${baseUrl}#ghost-comments-${commentId}`;
+        }
+        return `${baseUrl}#ghost-comments-root`;
     }
 
     async notifyPostAuthors(comment) {
@@ -36,7 +51,7 @@ class CommentsServiceEmails {
                 siteUrl: this.urlUtils.getSiteUrl(),
                 siteDomain: this.siteDomain,
                 postTitle: post.get('title'),
-                postUrl: this.urlService.getUrlByResourceId(post.get('id'), {absolute: true}),
+                postUrl: this.getPostUrl(post.get('id'), comment.get('id')),
                 commentHtml: comment.get('html'),
                 commentDate: moment(comment.get('created_at')).tz(this.settingsCache.get('timezone')).format('D MMM YYYY'),
                 memberName: memberName,
@@ -98,7 +113,7 @@ class CommentsServiceEmails {
             siteUrl: this.urlUtils.getSiteUrl(),
             siteDomain: this.siteDomain,
             postTitle: post.get('title'),
-            postUrl: this.urlService.getUrlByResourceId(post.get('id'), {absolute: true}),
+            postUrl: this.getPostUrl(post.get('id'), reply.get('id')),
             replyHtml: reply.get('html'),
             replyDate: moment(reply.get('created_at')).tz(this.settingsCache.get('timezone')).format('D MMM YYYY'),
             memberName: memberName,
@@ -144,7 +159,7 @@ class CommentsServiceEmails {
             siteUrl: this.urlUtils.getSiteUrl(),
             siteDomain: this.siteDomain,
             postTitle: post.get('title'),
-            postUrl: this.urlService.getUrlByResourceId(post.get('id'), {absolute: true}),
+            postUrl: this.getPostUrl(post.get('id'), comment.get('id')),
             commentHtml: comment.get('html'),
             commentText: htmlToPlaintext.comment(comment.get('html')),
             commentDate: moment(comment.get('created_at')).tz(this.settingsCache.get('timezone')).format('D MMM YYYY'),

--- a/ghost/core/core/server/services/comments/comments-service.js
+++ b/ghost/core/core/server/services/comments/comments-service.js
@@ -15,7 +15,7 @@ const messages = {
 };
 
 class CommentsService {
-    constructor({config, logging, models, mailer, settingsCache, settingsHelpers, urlService, urlUtils, contentGating}) {
+    constructor({config, logging, models, mailer, settingsCache, settingsHelpers, urlService, urlUtils, contentGating, labs}) {
         /** @private */
         this.models = models;
 
@@ -35,7 +35,8 @@ class CommentsService {
             settingsCache,
             settingsHelpers,
             urlService,
-            urlUtils
+            urlUtils,
+            labs
         });
     }
 

--- a/ghost/core/core/server/services/comments/email-templates/new-comment-reply.hbs
+++ b/ghost/core/core/server/services/comments/email-templates/new-comment-reply.hbs
@@ -157,7 +157,7 @@
                                 <table border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: auto;">
                                   <tbody>
                                     <tr>
-                                      <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; vertical-align: top; background-color: {{accentColor}}; border-radius: 5px; text-align: center;"> <a href="{{postUrl}}#ghost-comments-root" target="_blank" style="display: inline-block; color: #ffffff; background-color: {{accentColor}}; border: solid 1px {{accentColor}}; border-radius: 5px; box-sizing: border-box; cursor: pointer; text-decoration: none; font-size: 16px; font-weight: normal; margin: 0; padding: 9px 22px 10px; border-color: {{accentColor}};">{{t 'View comments'}}</a> </td>
+                                      <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; vertical-align: top; background-color: {{accentColor}}; border-radius: 5px; text-align: center;"> <a href="{{postUrl}}" target="_blank" style="display: inline-block; color: #ffffff; background-color: {{accentColor}}; border: solid 1px {{accentColor}}; border-radius: 5px; box-sizing: border-box; cursor: pointer; text-decoration: none; font-size: 16px; font-weight: normal; margin: 0; padding: 9px 22px 10px; border-color: {{accentColor}};">{{t 'View comments'}}</a> </td>
                                     </tr>
                                   </tbody>
                                 </table>
@@ -167,7 +167,7 @@
                         </table>
                         <hr/>
                         <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 15px; color: #3A464C; font-weight: normal; margin: 0; line-height: 25px; margin-bottom: 5px;">{{t 'You can also copy & paste this URL into your browser:'}}</p>
-                        <p style="word-break: break-all; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 15px; line-height: 25px; margin-top:0; color: #3A464C;">{{postUrl}}#ghost-comments-root</p>
+                        <p style="word-break: break-all; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 15px; line-height: 25px; margin-top:0; color: #3A464C;">{{postUrl}}</p>
                       </td>
                     </tr>
 

--- a/ghost/core/core/server/services/comments/email-templates/new-comment-reply.txt.js
+++ b/ghost/core/core/server/services/comments/email-templates/new-comment-reply.txt.js
@@ -4,7 +4,7 @@ module.exports = function (data, t) {
 
 ${t('Someone just replied to your comment on {postTitle}.', {postTitle: data.postTitle, interpolation: {escapeValue: false}})}
 
-${data.postUrl}#ghost-comments-root
+${data.postUrl}
 
 ---
 

--- a/ghost/core/core/server/services/comments/email-templates/new-comment.hbs
+++ b/ghost/core/core/server/services/comments/email-templates/new-comment.hbs
@@ -157,7 +157,7 @@
                                 <table border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: auto;">
                                   <tbody>
                                     <tr>
-                                      <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; vertical-align: top; background-color: {{accentColor}}; border-radius: 5px; text-align: center;"> <a href="{{postUrl}}#ghost-comments-root" target="_blank" style="display: inline-block; color: #ffffff; background-color: {{accentColor}}; border: solid 1px {{accentColor}}; border-radius: 5px; box-sizing: border-box; cursor: pointer; text-decoration: none; font-size: 16px; font-weight: normal; margin: 0; padding: 9px 22px 10px; border-color: {{accentColor}};">View comments</a> </td>
+                                      <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; vertical-align: top; background-color: {{accentColor}}; border-radius: 5px; text-align: center;"> <a href="{{postUrl}}" target="_blank" style="display: inline-block; color: #ffffff; background-color: {{accentColor}}; border: solid 1px {{accentColor}}; border-radius: 5px; box-sizing: border-box; cursor: pointer; text-decoration: none; font-size: 16px; font-weight: normal; margin: 0; padding: 9px 22px 10px; border-color: {{accentColor}};">View comments</a> </td>
                                     </tr>
                                   </tbody>
                                 </table>
@@ -167,7 +167,7 @@
                         </table>
                         <hr/>
                         <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 15px; color: #3A464C; font-weight: normal; margin: 0; line-height: 25px; margin-bottom: 5px;">You can also copy & paste this URL into your browser:</p>
-                        <p style="word-break: break-all; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 15px; line-height: 25px; margin-top:0; color: #3A464C;">{{postUrl}}#ghost-comments-root</p>
+                        <p style="word-break: break-all; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 15px; line-height: 25px; margin-top:0; color: #3A464C;">{{postUrl}}</p>
                       </td>
                     </tr>
 

--- a/ghost/core/core/server/services/comments/email-templates/new-comment.txt.js
+++ b/ghost/core/core/server/services/comments/email-templates/new-comment.txt.js
@@ -5,7 +5,7 @@ Hey there,
 
 Someone just posted a comment on your post "${data.postTitle}"
 
-${data.postUrl}#ghost-comments-root
+${data.postUrl}
 
 ---
 

--- a/ghost/core/core/server/services/comments/email-templates/report.hbs
+++ b/ghost/core/core/server/services/comments/email-templates/report.hbs
@@ -152,7 +152,7 @@
                                 <table border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: auto;">
                                   <tbody>
                                     <tr>
-                                      <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; vertical-align: top; background-color: {{accentColor}}; border-radius: 5px; text-align: center;"> <a href="{{postUrl}}#ghost-comments-root" target="_blank" style="display: inline-block; color: #ffffff; background-color: {{accentColor}}; border: solid 1px {{accentColor}}; border-radius: 5px; box-sizing: border-box; cursor: pointer; text-decoration: none; font-size: 16px; font-weight: normal; margin: 0; padding: 9px 22px 10px; border-color: {{accentColor}};">View comment</a> </td>
+                                      <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; vertical-align: top; background-color: {{accentColor}}; border-radius: 5px; text-align: center;"> <a href="{{postUrl}}" target="_blank" style="display: inline-block; color: #ffffff; background-color: {{accentColor}}; border: solid 1px {{accentColor}}; border-radius: 5px; box-sizing: border-box; cursor: pointer; text-decoration: none; font-size: 16px; font-weight: normal; margin: 0; padding: 9px 22px 10px; border-color: {{accentColor}};">View comment</a> </td>
                                     </tr>
                                   </tbody>
                                 </table>
@@ -162,7 +162,7 @@
                         </table>
                         <hr/>
                         <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 15px; color: #3A464C; font-weight: normal; margin: 0; line-height: 25px; margin-bottom: 5px;">You can also copy & paste this URL into your browser:</p>
-                        <p style="word-break: break-all; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 15px; line-height: 25px; margin-top:0; color: #3A464C;">{{postUrl}}#ghost-comments-root</p>
+                        <p style="word-break: break-all; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 15px; line-height: 25px; margin-top:0; color: #3A464C;">{{postUrl}}</p>
                       </td>
                     </tr>
 

--- a/ghost/core/core/server/services/comments/email-templates/report.txt.js
+++ b/ghost/core/core/server/services/comments/email-templates/report.txt.js
@@ -7,7 +7,7 @@ ${data.reporter} has reported the comment below on ${data.postTitle}. This comme
 ${data.memberName} (${data.memberEmail}):
 ${data.commentText}
 
-${data.postUrl}#ghost-comments-root
+${data.postUrl}
 
 ---
 

--- a/ghost/core/core/server/services/comments/index.js
+++ b/ghost/core/core/server/services/comments/index.js
@@ -15,6 +15,7 @@ class CommentsServiceWrapper {
         const membersService = require('../members');
         const db = require('../../data/db');
         const settingsHelpers = require('../settings-helpers');
+        const labs = require('../../../shared/labs');
 
         this.api = new CommentsService({
             config,
@@ -25,7 +26,8 @@ class CommentsServiceWrapper {
             settingsHelpers,
             urlService,
             urlUtils,
-            contentGating: membersService.contentGating
+            contentGating: membersService.contentGating,
+            labs
         });
 
         const stats = new CommentsStats({db});

--- a/ghost/core/test/unit/server/services/comments/comments-service-emails.test.js
+++ b/ghost/core/test/unit/server/services/comments/comments-service-emails.test.js
@@ -1,0 +1,50 @@
+const should = require('should');
+const sinon = require('sinon');
+const CommentsServiceEmails = require('../../../../../core/server/services/comments/comments-service-emails');
+
+describe('Comments Service: CommentsServiceEmails', function () {
+    function createClassInstance({labs = {}}) {
+        const urlService = {
+            getUrlByResourceId: sinon.stub().returns('https://example.com/my-post/')
+        };
+        const labsStub = {
+            isSet: sinon.stub().callsFake(flag => labs[flag] || false)
+        };
+
+        const instance = new CommentsServiceEmails({
+            config: {},
+            logging: {},
+            models: {},
+            mailer: {},
+            settingsCache: {get: sinon.stub()},
+            settingsHelpers: {},
+            urlService,
+            urlUtils: {},
+            labs: labsStub
+        });
+
+        return {instance, urlService};
+    }
+
+    describe('getPostUrl', function () {
+        it('returns post URL with comment permalink when commentPermalinks lab flag is enabled', function () {
+            const {instance} = createClassInstance({
+                labs: {commentPermalinks: true}
+            });
+
+            const result = instance.getPostUrl('123', '456');
+
+            should(result).equal('https://example.com/my-post/#ghost-comments-456');
+        });
+
+        it('returns post URL with ghost-comments-root when commentPermalinks lab flag is disabled', function () {
+            const {instance} = createClassInstance({
+                labs: {commentPermalinks: false}
+            });
+
+            const result = instance.getPostUrl('123', '456');
+
+            should(result).equal('https://example.com/my-post/#ghost-comments-root');
+        });
+    });
+});


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3183/

- removes hardcoded `#ghost-comments-root` from email templates in favor of including that in the `postUrl` data that's passed through
- added conditional `postUrl` generation that uses `#ghost-comments-root` or the specific comment permalink depending on the `commentPermalinks` labs flag
- leaves "View comments" wording in place for now rather than switching to "View comment" to avoid i18n locale churn
