### PR TITLE
Deferred Featurebase load+initialization until interaction

### DIFF
--- a/apps/admin/src/layout/app-sidebar/hooks/use-featurebase.ts
+++ b/apps/admin/src/layout/app-sidebar/hooks/use-featurebase.ts
@@ -91,11 +91,13 @@ export function useFeaturebase(): Featurebase {
                 defaultBoard: DEFAULT_BOARD,
                 featurebaseJwt: token
             }, (err) => {
-                // Only gate actions on first init - re-inits (e.g. theme/token changes) are
-                // best-effort. Resolving/rejecting an already-settled promise is a no-op.
                 if (err) {
                     console.error('[Featurebase] Failed to initialize widget:', err);
                     deferredInitRef.current.reject(err);
+
+                    // reset so we can retry on next interaction
+                    deferredInitRef.current = deferred();
+                    setShouldLoad(false);
                 } else {
                     deferredInitRef.current.resolve();
                 }

--- a/apps/admin/src/layout/app-sidebar/hooks/use-featurebase.ts
+++ b/apps/admin/src/layout/app-sidebar/hooks/use-featurebase.ts
@@ -32,6 +32,7 @@ function loadFeaturebaseSDK(): Promise<void> {
             script.onload = () => resolve();
             script.onerror = (event) => {
                 script.remove();
+                featurebaseSDKPromise = null; // Allow retry on next interaction
                 const error = new Error(`[Featurebase] Failed to load SDK from ${SDK_URL}`, {cause: event});
                 console.error(error);
                 reject(error);

--- a/apps/admin/src/layout/app-sidebar/hooks/use-featurebase.ts
+++ b/apps/admin/src/layout/app-sidebar/hooks/use-featurebase.ts
@@ -16,6 +16,11 @@ declare global {
 
 const SDK_URL = 'https://do.featurebase.app/js/sdk.js';
 
+/**
+ * Injects the Featurebase SDK script into the page if not already present.
+ * While the script loads, creates a queue function so calls made before
+ * the SDK is ready are buffered and executed once loaded.
+ */
 function loadFeaturebaseSDK(): Promise<void> {
     return new Promise((resolve, reject) => {
         const existingScript = document.querySelector(`script[src="${SDK_URL}"]`);
@@ -49,35 +54,49 @@ interface Featurebase {
     preloadFeedbackWidget: () => void;
 }
 
+/**
+ * Hook for lazy-loading and interacting with the Featurebase feedback widget.
+ *
+ * The SDK and authentication token are NOT fetched on mount. Instead, loading
+ * is deferred until user interaction (hover/focus/click on the Feedback button).
+ * This improves initial page load performance.
+ */
 export function useFeaturebase(): Featurebase {
     const {data: currentUser} = useCurrentUser();
     const {data: config} = useBrowseConfig();
     const {data: preferences} = useUserPreferences();
     const featureFlagEnabled = useFeatureFlag('featurebaseFeedback');
 
+    // Queued open request - set when user clicks before token is available
     const [pendingOpen, setPendingOpen] = useState<{board?: string} | null>(null);
+    // Flipped to true on hover/focus/click to trigger SDK + token loading
     const [shouldLoad, setShouldLoad] = useState(false);
 
+    // Singleton promise for SDK script loading (prevents duplicate loads)
     const loadPromiseRef = useRef<Promise<void> | null>(null);
+    // Tracks widget initialization state to avoid duplicate inits and handle theme/token changes
     const initStateRef = useRef<{
-        ready: {token: string; theme: string} | null;
-        inFlight: {promise: Promise<void>; token: string; theme: string} | null;
+        ready: {token: string; theme: string} | null;      // Successfully initialized config
+        inFlight: {promise: Promise<void>; token: string; theme: string} | null;  // Currently initializing
     }>({ready: null, inFlight: null});
 
     const {organization, enabled} = config?.config.featurebase ?? {};
     const featurebaseEnabled = !!(featureFlagEnabled && enabled);
     const theme = preferences?.nightShift ? 'dark' : 'light';
 
+    // Token is only fetched once shouldLoad becomes true (on user interaction)
     const {data: tokenData} = getFeaturebaseToken({
         enabled: featurebaseEnabled && shouldLoad
     });
     const token = tokenData?.featurebase?.token;
+    // All prerequisites needed before we can initialize the widget
     const hasInitPrereqs = !!(featurebaseEnabled && organization && currentUser && token);
 
+    // Loads SDK script once, returns cached promise on subsequent calls
     const ensureSdkLoaded = useCallback(() => {
         if (!loadPromiseRef.current) {
             loadPromiseRef.current = loadFeaturebaseSDK().catch((error) => {
-                loadPromiseRef.current = null;
+                loadPromiseRef.current = null; // Allow retry on failure
                 throw error;
             });
         }
@@ -85,28 +104,38 @@ export function useFeaturebase(): Featurebase {
         return loadPromiseRef.current;
     }, []);
 
+    /**
+     * Ensures the widget is initialized with current token/theme.
+     * Handles deduplication (won't re-init if already ready with same config)
+     * and concurrent calls (joins existing in-flight init if matching).
+     */
     const ensureInitialized = useCallback(async () => {
         if (!hasInitPrereqs) {
             return false;
         }
 
         const {ready, inFlight} = initStateRef.current;
+
+        // Already initialized with current config - nothing to do
         if (ready?.token === token && ready?.theme === theme) {
             return true;
         }
 
+        // Another init is in progress with same config - wait for it instead of starting a new one
         const matchesCurrent = inFlight?.token === token && inFlight?.theme === theme;
         if (inFlight && matchesCurrent) {
             try {
                 await inFlight.promise;
                 return true;
             } catch {
+                // Clear failed in-flight state (only if it's still the same promise)
                 if (initStateRef.current.inFlight?.promise === inFlight.promise) {
                     initStateRef.current.inFlight = null;
                 }
             }
         }
 
+        // Start fresh initialization: load SDK then initialize widget
         const initPromise = ensureSdkLoaded().then(() => new Promise<void>((resolve, reject) => {
             window.Featurebase?.('initialize_feedback_widget', {
                 organization,
@@ -123,10 +152,12 @@ export function useFeaturebase(): Featurebase {
             });
         }));
 
+        // Track in-flight init so concurrent calls can join it
         initStateRef.current.inFlight = {promise: initPromise, token, theme};
 
         try {
             await initPromise;
+            // Only update state if this is still the current init (guards against races)
             if (initStateRef.current.inFlight?.promise === initPromise) {
                 initStateRef.current.ready = {theme, token};
                 initStateRef.current.inFlight = null;
@@ -140,30 +171,42 @@ export function useFeaturebase(): Featurebase {
         }
     }, [ensureSdkLoaded, organization, hasInitPrereqs, theme, token]);
 
+    /**
+     * Called on hover/focus to start loading SDK + fetching token in advance.
+     * This makes the widget open faster when the user actually clicks.
+     */
     const preloadFeedbackWidget = useCallback(() => {
         if (!featurebaseEnabled || !organization) {
             return;
         }
 
-        setShouldLoad(true);
+        setShouldLoad(true);  // Triggers token fetch via the query above
         void ensureSdkLoaded().catch(() => {
-            // Errors are logged in loadFeaturebaseSDK.
+            // Errors are logged in loadFeaturebaseSDK
         });
     }, [ensureSdkLoaded, featurebaseEnabled, organization]);
 
+    /**
+     * Internal function that actually opens the widget.
+     * Ensures initialization before opening, and triggers background re-init
+     * if theme/token has changed since last init.
+     */
     const doOpenFeedbackWidget = useCallback(async (options?: {board?: string}) => {
         const ready = initStateRef.current.ready;
         const hasPreviousInit = !!ready;
 
         if (!hasPreviousInit) {
+            // First time - must wait for init before opening
             const initialized = await ensureInitialized();
             if (!initialized) {
                 return;
             }
         } else if (ready?.token !== token || ready?.theme !== theme) {
+            // Config changed - re-init in background, but open immediately with old config
             void ensureInitialized();
         }
 
+        // Send message to the Featurebase widget iframe to open
         window.postMessage({
             target: 'FeaturebaseWidget',
             data: {
@@ -173,27 +216,37 @@ export function useFeaturebase(): Featurebase {
         }, '*');
     }, [ensureInitialized, theme, token]);
 
+    /**
+     * Public handler for opening the feedback widget (called on click).
+     * Handles the case where token hasn't arrived yet by queuing the open request.
+     */
     const openFeedbackWidget = useCallback((options?: {board?: string}) => {
         if (!featurebaseEnabled || !organization || !currentUser) {
             return;
         }
 
+        // Ensure loading has started (in case user clicked without hovering first)
         preloadFeedbackWidget();
 
         if (!token) {
+            // Token not yet available
             if (!initStateRef.current.ready) {
+                // Never initialized - queue this open request for when token arrives
                 setPendingOpen(options ?? {});
                 return;
             }
 
+            // Was previously initialized (has cached config) - can open with that
             void doOpenFeedbackWidget(options);
             return;
         }
 
+        // Token available - proceed to open
         void doOpenFeedbackWidget(options);
     }, [currentUser, doOpenFeedbackWidget, featurebaseEnabled, organization, preloadFeedbackWidget, token]);
 
-    // Complete a queued open once the token arrives after a click.
+    // Effect: Complete a queued open request once the token arrives.
+    // This handles the case where user clicked before token was fetched.
     useEffect(() => {
         if (!pendingOpen || !hasInitPrereqs) {
             return;
@@ -203,7 +256,8 @@ export function useFeaturebase(): Featurebase {
         void doOpenFeedbackWidget(pendingOpen);
     }, [doOpenFeedbackWidget, hasInitPrereqs, pendingOpen]);
 
-    // Pre-initialize after hover/click as soon as we have the token + user data.
+    // Effect: Auto-initialize once we have all prerequisites after a preload trigger.
+    // This ensures the widget is ready to open quickly after hover/focus.
     useEffect(() => {
         if (!shouldLoad || !hasInitPrereqs) {
             return;

--- a/apps/admin/src/layout/app-sidebar/hooks/use-featurebase.ts
+++ b/apps/admin/src/layout/app-sidebar/hooks/use-featurebase.ts
@@ -1,28 +1,28 @@
 import {useCallback, useEffect, useRef, useState} from 'react';
 import {getFeaturebaseToken} from '@tryghost/admin-x-framework';
 import {useBrowseConfig} from '@tryghost/admin-x-framework/api/config';
-import {useCurrentUser} from '@tryghost/admin-x-framework/api/current-user';
 import {useFeatureFlag} from '@/hooks/use-feature-flag';
 import {useUserPreferences} from '@/hooks/user-preferences';
+import {deferred} from '@/utils/deferred';
+import type {Deferred} from '@/utils/deferred';
 
 type FeaturebaseCallback = (err: unknown, data?: unknown) => void;
 type FeaturebaseFunction = (action: string, options: Record<string, unknown>, callback?: FeaturebaseCallback) => void;
 
 declare global {
     interface Window {
-        Featurebase?: FeaturebaseFunction & {q?: unknown[]};
+        Featurebase?: FeaturebaseFunction;
     }
 }
 
 const SDK_URL = 'https://do.featurebase.app/js/sdk.js';
 
-/**
- * Injects the Featurebase SDK script into the page if not already present.
- * While the script loads, creates a queue function so calls made before
- * the SDK is ready are buffered and executed once loaded.
- */
+let featurebaseSDKPromise: Promise<void> | null = null;
 function loadFeaturebaseSDK(): Promise<void> {
-    return new Promise((resolve, reject) => {
+    if (featurebaseSDKPromise) {
+        return featurebaseSDKPromise;
+    }
+    featurebaseSDKPromise = new Promise((resolve, reject) => {
         const existingScript = document.querySelector(`script[src="${SDK_URL}"]`);
         if (existingScript) {
             resolve();
@@ -39,14 +39,8 @@ function loadFeaturebaseSDK(): Promise<void> {
             reject(error);
         };
         document.head.appendChild(script);
-
-        // Set up the queue function while script loads
-        if (typeof window.Featurebase !== 'function') {
-            window.Featurebase = function (...args: unknown[]) {
-                (window.Featurebase!.q = window.Featurebase!.q || []).push(args);
-            } as FeaturebaseFunction & {q?: unknown[]};
-        }
     });
+    return featurebaseSDKPromise;
 }
 
 interface Featurebase {
@@ -62,23 +56,10 @@ interface Featurebase {
  * This improves initial page load performance.
  */
 export function useFeaturebase(): Featurebase {
-    const {data: currentUser} = useCurrentUser();
     const {data: config} = useBrowseConfig();
     const {data: preferences} = useUserPreferences();
     const featureFlagEnabled = useFeatureFlag('featurebaseFeedback');
-
-    // Queued open request - set when user clicks before token is available
-    const [pendingOpen, setPendingOpen] = useState<{board?: string} | null>(null);
-    // Flipped to true on hover/focus/click to trigger SDK + token loading
     const [shouldLoad, setShouldLoad] = useState(false);
-
-    // Singleton promise for SDK script loading (prevents duplicate loads)
-    const loadPromiseRef = useRef<Promise<void> | null>(null);
-    // Tracks widget initialization state to avoid duplicate inits and handle theme/token changes
-    const initStateRef = useRef<{
-        ready: {token: string; theme: string} | null;      // Successfully initialized config
-        inFlight: {promise: Promise<void>; token: string; theme: string} | null;  // Currently initializing
-    }>({ready: null, inFlight: null});
 
     const {organization, enabled} = config?.config.featurebase ?? {};
     const featurebaseEnabled = !!(featureFlagEnabled && enabled);
@@ -89,182 +70,65 @@ export function useFeaturebase(): Featurebase {
         enabled: featurebaseEnabled && shouldLoad
     });
     const token = tokenData?.featurebase?.token;
-    // All prerequisites needed before we can initialize the widget
-    const hasInitPrereqs = !!(featurebaseEnabled && organization && currentUser && token);
 
-    // Loads SDK script once, returns cached promise on subsequent calls
-    const ensureSdkLoaded = useCallback(() => {
-        if (!loadPromiseRef.current) {
-            loadPromiseRef.current = loadFeaturebaseSDK().catch((error) => {
-                loadPromiseRef.current = null; // Allow retry on failure
-                throw error;
+    useEffect(() => {
+        if (shouldLoad ) {
+            loadFeaturebaseSDK().catch((err) => {
+                console.error('[Featurebase] Failed to load SDK:', err);
             });
         }
+    }, [shouldLoad]);
 
-        return loadPromiseRef.current;
-    }, []);
-
-    /**
-     * Ensures the widget is initialized with current token/theme.
-     * Handles deduplication (won't re-init if already ready with same config)
-     * and concurrent calls (joins existing in-flight init if matching).
-     */
-    const ensureInitialized = useCallback(async () => {
-        if (!hasInitPrereqs) {
-            return false;
+    const initPromise = useRef<Deferred<void>>(deferred());
+    useEffect(() => {
+        if (!shouldLoad || !organization || !theme || !token) {
+            return;
         }
-
-        const {ready, inFlight} = initStateRef.current;
-
-        // Already initialized with current config - nothing to do
-        if (ready?.token === token && ready?.theme === theme) {
-            return true;
-        }
-
-        // Another init is in progress with same config - wait for it instead of starting a new one
-        const matchesCurrent = inFlight?.token === token && inFlight?.theme === theme;
-        if (inFlight && matchesCurrent) {
-            try {
-                await inFlight.promise;
-                return true;
-            } catch {
-                // Clear failed in-flight state (only if it's still the same promise)
-                if (initStateRef.current.inFlight?.promise === inFlight.promise) {
-                    initStateRef.current.inFlight = null;
-                }
-            }
-        }
-
-        // Start fresh initialization: load SDK then initialize widget
-        const initPromise = ensureSdkLoaded().then(() => new Promise<void>((resolve, reject) => {
+        void featurebaseSDKPromise?.then(() => {
             window.Featurebase?.('initialize_feedback_widget', {
                 organization,
                 theme,
                 defaultBoard: 'Feature Request',
                 featurebaseJwt: token
             }, (err) => {
+                // Only gate actions on first init - re-inits (e.g. theme/token changes) are
+                // best-effort. Resolving/rejecting an already-settled promise is a no-op.
                 if (err) {
                     console.error('[Featurebase] Failed to initialize widget:', err);
-                    reject(err as Error);
+                    initPromise.current.reject(err as Error);
                 } else {
-                    resolve();
+                    initPromise.current.resolve();
                 }
             });
-        }));
-
-        // Track in-flight init so concurrent calls can join it
-        initStateRef.current.inFlight = {promise: initPromise, token, theme};
-
-        try {
-            await initPromise;
-            // Only update state if this is still the current init (guards against races)
-            if (initStateRef.current.inFlight?.promise === initPromise) {
-                initStateRef.current.ready = {theme, token};
-                initStateRef.current.inFlight = null;
-            }
-            return true;
-        } catch {
-            if (initStateRef.current.inFlight?.promise === initPromise) {
-                initStateRef.current.inFlight = null;
-            }
-            return false;
-        }
-    }, [ensureSdkLoaded, organization, hasInitPrereqs, theme, token]);
+        });
+    }
+    , [organization, theme, token, shouldLoad]);
 
     /**
      * Called on hover/focus to start loading SDK + fetching token in advance.
      * This makes the widget open faster when the user actually clicks.
      */
     const preloadFeedbackWidget = useCallback(() => {
-        if (!featurebaseEnabled || !organization) {
+        if (!featurebaseEnabled) {
             return;
         }
+        // Trigger SDK loading and initialization via effects above
+        setShouldLoad(true);
+    }, [featurebaseEnabled]);
 
-        setShouldLoad(true);  // Triggers token fetch via the query above
-        void ensureSdkLoaded().catch(() => {
-            // Errors are logged in loadFeaturebaseSDK
-        });
-    }, [ensureSdkLoaded, featurebaseEnabled, organization]);
-
-    /**
-     * Internal function that actually opens the widget.
-     * Ensures initialization before opening, and triggers background re-init
-     * if theme/token has changed since last init.
-     */
-    const doOpenFeedbackWidget = useCallback(async (options?: {board?: string}) => {
-        const ready = initStateRef.current.ready;
-        const hasPreviousInit = !!ready;
-
-        if (!hasPreviousInit) {
-            // First time - must wait for init before opening
-            const initialized = await ensureInitialized();
-            if (!initialized) {
-                return;
-            }
-        } else if (ready?.token !== token || ready?.theme !== theme) {
-            // Config changed - re-init in background, but open immediately with old config
-            void ensureInitialized();
-        }
-
-        // Send message to the Featurebase widget iframe to open
-        window.postMessage({
-            target: 'FeaturebaseWidget',
-            data: {
-                action: 'openFeedbackWidget',
-                ...(options?.board && {setBoard: options.board})
-            }
-        }, '*');
-    }, [ensureInitialized, theme, token]);
-
-    /**
-     * Public handler for opening the feedback widget (called on click).
-     * Handles the case where token hasn't arrived yet by queuing the open request.
-     */
     const openFeedbackWidget = useCallback((options?: {board?: string}) => {
-        if (!featurebaseEnabled || !organization || !currentUser) {
-            return;
-        }
+        setShouldLoad(true);
 
-        // Ensure loading has started (in case user clicked without hovering first)
-        preloadFeedbackWidget();
-
-        if (!token) {
-            // Token not yet available
-            if (!initStateRef.current.ready) {
-                // Never initialized - queue this open request for when token arrives
-                setPendingOpen(options ?? {});
-                return;
-            }
-
-            // Was previously initialized (has cached config) - can open with that
-            void doOpenFeedbackWidget(options);
-            return;
-        }
-
-        // Token available - proceed to open
-        void doOpenFeedbackWidget(options);
-    }, [currentUser, doOpenFeedbackWidget, featurebaseEnabled, organization, preloadFeedbackWidget, token]);
-
-    // Effect: Complete a queued open request once the token arrives.
-    // This handles the case where user clicked before token was fetched.
-    useEffect(() => {
-        if (!pendingOpen || !hasInitPrereqs) {
-            return;
-        }
-
-        setPendingOpen(null);
-        void doOpenFeedbackWidget(pendingOpen);
-    }, [doOpenFeedbackWidget, hasInitPrereqs, pendingOpen]);
-
-    // Effect: Auto-initialize once we have all prerequisites after a preload trigger.
-    // This ensures the widget is ready to open quickly after hover/focus.
-    useEffect(() => {
-        if (!shouldLoad || !hasInitPrereqs) {
-            return;
-        }
-
-        void ensureInitialized();
-    }, [ensureInitialized, hasInitPrereqs, shouldLoad]);
+        void initPromise.current.promise.then(() => {
+            window.postMessage({
+                target: 'FeaturebaseWidget',
+                data: {
+                    action: 'openFeedbackWidget',
+                    ...(options?.board && {setBoard: options.board})
+                }
+            }, '*');
+        });
+    }, []);
 
     return {openFeedbackWidget, preloadFeedbackWidget};
 }

--- a/apps/admin/src/layout/app-sidebar/nav-ghost-pro.tsx
+++ b/apps/admin/src/layout/app-sidebar/nav-ghost-pro.tsx
@@ -16,7 +16,7 @@ function NavGhostPro({ ...props }: React.ComponentProps<typeof SidebarGroup>) {
     const { data: currentUser } = useCurrentUser();
     const { data: config } = useBrowseConfig();
     const featurebaseFeedbackFlag = useFeatureFlag('featurebaseFeedback');
-    const { openFeedbackWidget } = useFeaturebase();
+    const { openFeedbackWidget, preloadFeedbackWidget } = useFeaturebase();
 
     if (!currentUser) {
         return null;
@@ -44,7 +44,7 @@ function NavGhostPro({ ...props }: React.ComponentProps<typeof SidebarGroup>) {
                     )}
                     {showFeedback && (
                         <NavMenuItem>
-                            <NavMenuItem.Button onClick={openFeedbackWidget}>
+                            <NavMenuItem.Button onClick={openFeedbackWidget} onMouseEnter={preloadFeedbackWidget} onFocus={preloadFeedbackWidget}>
                                 <LucideIcon.MessageCircle />
                                 <NavMenuItem.Label>Feedback</NavMenuItem.Label>
                             </NavMenuItem.Button>

--- a/apps/admin/src/utils/deferred.test.ts
+++ b/apps/admin/src/utils/deferred.test.ts
@@ -1,0 +1,28 @@
+import {describe, expect, it} from 'vitest';
+import {deferred} from './deferred';
+
+describe('deferred', () => {
+    it('returns a promise with externally accessible resolve and reject functions', () => {
+        const d = deferred<string>();
+
+        expect(d.promise).toBeInstanceOf(Promise);
+        expect(typeof d.resolve).toBe('function');
+        expect(typeof d.reject).toBe('function');
+    });
+
+    it('resolve function resolves the promise', async () => {
+        const d = deferred<string>();
+
+        d.resolve('test value');
+
+        await expect(d.promise).resolves.toBe('test value');
+    });
+
+    it('reject function rejects the promise', async () => {
+        const d = deferred<string>();
+
+        d.reject(new Error('test error'));
+
+        await expect(d.promise).rejects.toThrow('test error');
+    });
+});

--- a/apps/admin/src/utils/deferred.ts
+++ b/apps/admin/src/utils/deferred.ts
@@ -1,4 +1,4 @@
-export const deferred = <T>() => {
+export const deferred = function deferred<T>() {
     let resolve!: (value: T) => void;
     let reject!: (reason?: unknown) => void;
     const promise = new Promise<T>((_resolve, _reject) => {

--- a/apps/admin/src/utils/deferred.ts
+++ b/apps/admin/src/utils/deferred.ts
@@ -1,0 +1,10 @@
+export const deferred = <T>() => {
+    let resolve!: (value: T) => void;
+    let reject!: (reason?: unknown) => void;
+    const promise = new Promise<T>((_resolve, _reject) => {
+        resolve = _resolve;
+        reject = _reject;
+    });
+    return {promise, resolve, reject};
+};
+export type Deferred<T> = ReturnType<typeof deferred<T>>;


### PR DESCRIPTION
ref https://linear.app/ghost/issue/FEA-509/

We shouldn't need to pay the network and CPU cost of loading the Featurebase script until we actually need it to display the Feedback widget.

- Delayed Featurebase SDK loading and JWT token fetching until the user interacts with the Feedback button
- Added preloading on hover/focus to hide latency while avoiding unnecessary page load overhead
- Clicks will wait for all preloading to finish (starting if not already started) before opening the feedback modal