### PR TITLE
🐛 Fixed reply form showing parent comment author's details

### DIFF
--- a/apps/comments-ui/src/components/content/forms/form.tsx
+++ b/apps/comments-ui/src/components/content/forms/form.tsx
@@ -241,7 +241,7 @@ const Form: React.FC<FormProps> = ({
     const [progress, setProgress] = useState<Progress>('default');
     const formEl = useRef(null);
 
-    const memberName = member?.name ?? comment?.member?.name;
+    const memberName = member?.name;
 
     if (progress === 'sending' || (memberName && isAskingDetails)) {
         // Force open
@@ -289,7 +289,6 @@ const Form: React.FC<FormProps> = ({
 };
 
 type FormWrapperProps = {
-    comment?: Comment;
     editor: Editor | null;
     isOpen: boolean;
     reduced: boolean;
@@ -298,7 +297,6 @@ type FormWrapperProps = {
 };
 
 const FormWrapper: React.FC<FormWrapperProps> = ({
-    comment,
     editor,
     isOpen,
     reduced,
@@ -307,8 +305,8 @@ const FormWrapper: React.FC<FormWrapperProps> = ({
 }) => {
     const {member, dispatchAction} = useAppContext();
 
-    const memberName = member?.name ?? comment?.member?.name;
-    const memberExpertise = member?.expertise ?? comment?.member?.expertise;
+    const memberName = member?.name;
+    const memberExpertise = member?.expertise;
 
     let openStyles = '';
     if (isOpen) {

--- a/apps/comments-ui/src/components/content/forms/reply-form.tsx
+++ b/apps/comments-ui/src/components/content/forms/reply-form.tsx
@@ -45,7 +45,7 @@ const ReplyForm: React.FC<Props> = ({openForm, parent}) => {
     return (
         <div ref={setForm} data-testid="reply-form">
             <div className='mt-[-16px] pr-2'>
-                <FormWrapper comment={parent} editor={editor} isOpen={true} openForm={openForm} reduced={isMobile()}>
+                <FormWrapper editor={editor} isOpen={true} openForm={openForm} reduced={isMobile()}>
                     <Form
                         close={close}
                         editor={editor}


### PR DESCRIPTION
## Summary

When opening a reply form on a comment, the form header was incorrectly displaying the parent comment author's name and expertise instead of the current user's data. This happened because the code used fallback patterns that pulled values from the comment being replied to when the current member had no name or expertise set.

The fix removes these fallbacks so the reply form only shows the logged-in user's own details (or the appropriate placeholder if they have none).

ref https://linear.app/ghost/issue/BER-3212