### PR TITLE
Changed comment moderation 'View post' action to use comment permalinks

### DIFF
--- a/apps/posts/src/views/comments/comments.tsx
+++ b/apps/posts/src/views/comments/comments.tsx
@@ -6,11 +6,14 @@ import CommentsList from './components/comments-list';
 import React, {useCallback} from 'react';
 import {Button, EmptyIndicator, LoadingIndicator, LucideIcon, createFilter} from '@tryghost/shade';
 import {useBrowseComments} from '@tryghost/admin-x-framework/api/comments';
+import {useBrowseConfig} from '@tryghost/admin-x-framework/api/config';
 import {useFilterState} from './hooks/use-filter-state';
 import {useKnownFilterValues} from './hooks/use-known-filter-values';
 
 const Comments: React.FC = () => {
     const {filters, nql, setFilters} = useFilterState();
+    const {data: configData} = useBrowseConfig();
+    const commentPermalinksEnabled = configData?.config?.labs?.commentPermalinks === true;
 
     const handleAddFilter = useCallback((field: string, value: string, operator: string = 'is') => {
         setFilters((prevFilters) => {
@@ -72,6 +75,7 @@ const Comments: React.FC = () => {
                     </div>
                 ) : (
                     <CommentsList
+                        commentPermalinksEnabled={commentPermalinksEnabled}
                         fetchNextPage={fetchNextPage}
                         hasNextPage={hasNextPage}
                         isFetchingNextPage={isFetchingNextPage}

--- a/apps/posts/src/views/comments/components/comments-list.tsx
+++ b/apps/posts/src/views/comments/components/comments-list.tsx
@@ -133,7 +133,8 @@ function CommentsList({
     isFetchingNextPage,
     fetchNextPage,
     onAddFilter,
-    isLoading
+    isLoading,
+    commentPermalinksEnabled
 }: {
     items: Comment[];
     totalItems: number;
@@ -142,6 +143,7 @@ function CommentsList({
     fetchNextPage: () => void;
     onAddFilter: (field: string, value: string, operator?: string) => void;
     isLoading?: boolean;
+    commentPermalinksEnabled?: boolean;
 }) {
     const parentRef = useRef<HTMLDivElement>(null);
     
@@ -340,9 +342,16 @@ function CommentsList({
                                                     </Button>
                                                 </DropdownMenuTrigger>
                                                 <DropdownMenuContent align="start">
-                                                    {item.post?.url && (
+                                                    {commentPermalinksEnabled ? (
                                                         <DropdownMenuItem asChild>
-                                                            <a href={item.post.url} rel="noopener noreferrer" target="_blank">
+                                                            <a href={`${item.post!.url}#ghost-comments-${item.id}`} rel="noopener noreferrer" target="_blank">
+                                                                <LucideIcon.ExternalLink className="mr-2 size-4" />
+                                                            View on post
+                                                            </a>
+                                                        </DropdownMenuItem>
+                                                    ) : (
+                                                        <DropdownMenuItem asChild>
+                                                            <a href={item.post!.url} rel="noopener noreferrer" target="_blank">
                                                                 <LucideIcon.ExternalLink className="mr-2 size-4" />
                                                             View post
                                                             </a>

--- a/e2e/helpers/pages/admin/comments/comments-page.ts
+++ b/e2e/helpers/pages/admin/comments/comments-page.ts
@@ -1,0 +1,39 @@
+import {AdminPage} from '@/helpers/pages';
+import {Locator, Page} from '@playwright/test';
+
+export class CommentsPage extends AdminPage {
+    readonly commentsList: Locator;
+    readonly commentRows: Locator;
+
+    constructor(page: Page) {
+        super(page);
+        this.pageUrl = '/ghost/#/comments';
+
+        this.commentsList = page.getByTestId('comments-list');
+        this.commentRows = page.getByTestId('comment-list-row');
+    }
+
+    async waitForComments(): Promise<void> {
+        await this.commentsList.waitFor({state: 'visible'});
+    }
+
+    getCommentRowByText(text: string): Locator {
+        return this.commentRows.filter({hasText: text});
+    }
+
+    getMoreMenuButton(row: Locator): Locator {
+        return row.locator('button').last();
+    }
+
+    getViewPostMenuItem(): Locator {
+        return this.page.getByRole('menuitem', {name: 'View post'});
+    }
+
+    getViewOnPostMenuItem(): Locator {
+        return this.page.getByRole('menuitem', {name: 'View on post'});
+    }
+
+    async openMoreMenu(row: Locator): Promise<void> {
+        await this.getMoreMenuButton(row).click();
+    }
+}

--- a/e2e/helpers/pages/admin/comments/index.ts
+++ b/e2e/helpers/pages/admin/comments/index.ts
@@ -1,0 +1,1 @@
+export * from './comments-page';

--- a/e2e/helpers/pages/admin/index.ts
+++ b/e2e/helpers/pages/admin/index.ts
@@ -10,3 +10,4 @@ export * from './posts';
 export * from './tags';
 export * from './sidebar';
 export * from './billing';
+export * from './comments';

--- a/e2e/tests/admin/comments/comment-moderation.test.ts
+++ b/e2e/tests/admin/comments/comment-moderation.test.ts
@@ -1,0 +1,78 @@
+import {CommentFactory, MemberFactory, PostFactory, createCommentFactory, createMemberFactory, createPostFactory} from '@/data-factory';
+import {CommentsPage} from '@/helpers/pages';
+import {SettingsService} from '@/helpers/services/settings/settings-service';
+import {expect, test} from '@/helpers/playwright';
+
+const useReactShell = process.env.USE_REACT_SHELL === 'true';
+
+test.describe('Ghost Admin - Comment Moderation', () => {
+    test.skip(!useReactShell, 'Skipping: requires USE_REACT_SHELL=true');
+
+    let postFactory: PostFactory;
+    let memberFactory: MemberFactory;
+    let commentFactory: CommentFactory;
+
+    test.beforeEach(async ({page}) => {
+        postFactory = createPostFactory(page.request);
+        memberFactory = createMemberFactory(page.request);
+        commentFactory = createCommentFactory(page.request);
+
+        const settingsService = new SettingsService(page.request);
+        await settingsService.setCommentsEnabled('all');
+    });
+
+    test.describe('with commentPermalinks disabled', () => {
+        test.use({labs: {commentModeration: true, commentPermalinks: false}});
+
+        test('view post action navigates to post', async ({page}) => {
+            const post = await postFactory.create({status: 'published'});
+            const member = await memberFactory.create();
+            await commentFactory.create({
+                post_id: post.id,
+                member_id: member.id,
+                html: '<p>Test comment without permalink</p>'
+            });
+
+            const commentsPage = new CommentsPage(page);
+            await commentsPage.goto();
+            await commentsPage.waitForComments();
+
+            const commentRow = commentsPage.getCommentRowByText('Test comment without permalink');
+            await commentsPage.openMoreMenu(commentRow);
+
+            const popupPromise = page.waitForEvent('popup');
+            await commentsPage.getViewPostMenuItem().click();
+            const postPage = await popupPromise;
+
+            await expect(postPage).toHaveURL(new RegExp(`/${post.slug}/`));
+            expect(postPage.url()).not.toContain('#ghost-comments-');
+        });
+    });
+
+    test.describe('with commentPermalinks enabled', () => {
+        test.use({labs: {commentModeration: true, commentPermalinks: true}});
+
+        test('view on post action navigates to comment permalink', async ({page}) => {
+            const post = await postFactory.create({status: 'published'});
+            const member = await memberFactory.create();
+            const comment = await commentFactory.create({
+                post_id: post.id,
+                member_id: member.id,
+                html: '<p>Test comment with permalink</p>'
+            });
+
+            const commentsPage = new CommentsPage(page);
+            await commentsPage.goto();
+            await commentsPage.waitForComments();
+
+            const commentRow = commentsPage.getCommentRowByText('Test comment with permalink');
+            await commentsPage.openMoreMenu(commentRow);
+
+            const popupPromise = page.waitForEvent('popup');
+            await commentsPage.getViewOnPostMenuItem().click();
+            const postPage = await popupPromise;
+
+            await expect(postPage).toHaveURL(new RegExp(`/${post.slug}/.*#ghost-comments-${comment.id}`));
+        });
+    });
+});


### PR DESCRIPTION
## Summary

- The "View post" action in the comment moderation dropdown now navigates directly to the comment on the post using the comment permalink
- Renamed the action to "View on post" to better describe this behaviour 

ref https://linear.app/ghost/issue/BER-3200