### PR TITLE
Don't trigger comment list loading state on refetch

### DIFF
--- a/apps/posts/src/views/comments/comments.tsx
+++ b/apps/posts/src/views/comments/comments.tsx
@@ -26,6 +26,7 @@ const Comments: React.FC = () => {
         isError,
         isFetching,
         isFetchingNextPage,
+        isRefetching,
         fetchNextPage,
         hasNextPage
     } = useBrowseComments({
@@ -34,6 +35,9 @@ const Comments: React.FC = () => {
     });
 
     const {knownPosts, knownMembers} = useKnownFilterValues({comments: data?.comments ?? []});
+
+    // If we are fetching comments, but not fetching the next page and not refetching, we should show the loading indicator
+    const shouldShowLoading = isFetching && !isFetchingNextPage && !isRefetching;
 
     return (
         <CommentsLayout>
@@ -46,7 +50,7 @@ const Comments: React.FC = () => {
                 />
             </CommentsHeader>
             <CommentsContent>
-                {(isFetching && !isFetchingNextPage) ? (
+                {shouldShowLoading ? (
                     <div className="flex h-full items-center justify-center">
                         <LoadingIndicator size="lg" />
                     </div>


### PR DESCRIPTION
fixes https://linear.app/ghost/issue/BER-3215/remove-loading-state-when-toggling-comment-visibility

The comment query gets revalidated when we mutate a comment by toggling the visibility. We shouldn't show a loading state in that scenario.