### PR TITLE
Added retention offer flow

### DIFF
--- a/apps/portal/src/app-context.js
+++ b/apps/portal/src/app-context.js
@@ -4,6 +4,7 @@ import React from 'react';
 const AppContext = React.createContext({
     site: {},
     member: {},
+    offers: [],
     action: '',
     actionErrorMessage: null,
     lastPage: '',

--- a/apps/portal/src/app.js
+++ b/apps/portal/src/app.js
@@ -51,6 +51,7 @@ export default class App extends React.Component {
         this.state = {
             site: null,
             member: null,
+            offers: [],
             page: 'loading',
             showPopup: false,
             action: 'init:running',
@@ -197,13 +198,14 @@ export default class App extends React.Component {
     async initSetup() {
         try {
             // Fetch data from API, links, preview, dev sources
-            const {site, member, page, showPopup, popupNotification, lastPage, pageQuery, pageData} = await this.fetchData();
+            const {site, member, offers, page, showPopup, popupNotification, lastPage, pageQuery, pageData} = await this.fetchData();
             const i18nLanguage = this.props.siteI18nEnabled ? this.props.locale || site.locale || 'en' : 'en';
             i18n.changeLanguage(i18nLanguage);
 
             const state = {
                 site,
                 member,
+                offers,
                 page,
                 lastPage,
                 pageQuery,
@@ -254,7 +256,7 @@ export default class App extends React.Component {
 
     /** Fetch state data from all available sources */
     async fetchData() {
-        const {site: apiSiteData, member} = await this.fetchApiData();
+        const {site: apiSiteData, member, offers} = await this.fetchApiData();
         const {site: devSiteData, ...restDevData} = this.fetchDevData();
         const {site: linkSiteData, ...restLinkData} = this.fetchLinkData(apiSiteData, member);
         const {site: previewSiteData, ...restPreviewData} = this.fetchPreviewData();
@@ -262,6 +264,7 @@ export default class App extends React.Component {
         let page = '';
         return {
             member,
+            offers,
             page,
             site: {
                 ...apiSiteData,
@@ -585,12 +588,12 @@ export default class App extends React.Component {
         return false;
     }
 
-    /** Fetch site and member session data with Ghost Apis  */
+    /** Fetch site, member session data and member offers with Ghost Apis  */
     async fetchApiData() {
         const {siteUrl, customSiteUrl, apiUrl, apiKey} = this.props;
         try {
             this.GhostApi = this.props.api || setupGhostApi({siteUrl, apiUrl, apiKey});
-            const {site, member} = await this.GhostApi.init();
+            const {site, member, offers} = await this.GhostApi.init();
 
             const colorOverride = this.getColorOverride();
             if (colorOverride) {
@@ -599,7 +602,7 @@ export default class App extends React.Component {
 
             this.setupFirstPromoter({site, member});
             this.setupSentry({site});
-            return {site, member};
+            return {site, member, offers};
         } catch (e) {
             if (hasMode(['dev', 'test'], {customSiteUrl})) {
                 return {};
@@ -964,12 +967,13 @@ export default class App extends React.Component {
 
     /**Get final App level context from App state*/
     getContextFromState() {
-        const {site, member, action, actionErrorMessage, page, lastPage, showPopup, pageQuery, pageData, popupNotification, customSiteUrl, dir, scrollbarWidth, labs, otcRef} = this.state;
+        const {site, member, offers, action, actionErrorMessage, page, lastPage, showPopup, pageQuery, pageData, popupNotification, customSiteUrl, dir, scrollbarWidth, labs, otcRef} = this.state;
         const contextPage = this.getContextPage({site, page, member});
         const contextMember = this.getContextMember({page: contextPage, member, customSiteUrl});
         return {
             api: this.GhostApi,
             site,
+            offers,
             action,
             actionErrorMessage,
             brandColor: this.getAccentColor(),

--- a/apps/portal/src/components/pages/account-plan-page.js
+++ b/apps/portal/src/components/pages/account-plan-page.js
@@ -298,7 +298,7 @@ function formatOfferDiscount(offer) {
 
 function formatOfferDuration(offer) {
     if (offer.duration === 'once') {
-        return t('your next renewal');
+        return t('your next payment');
     } else if (offer.duration === 'forever') {
         return t('forever');
     } else if (offer.duration === 'repeating' && offer.duration_in_months) {

--- a/apps/portal/src/components/pages/account-plan-page.js
+++ b/apps/portal/src/components/pages/account-plan-page.js
@@ -5,7 +5,7 @@ import CloseButton from '../common/close-button';
 import BackButton from '../common/back-button';
 import {MultipleProductsPlansSection} from '../common/plans-section';
 import {getDateString} from '../../utils/date-time';
-import {allowCompMemberUpgrade, formatNumber, getAvailablePrices, getFilteredPrices, getMemberActivePrice, getMemberActiveProduct, getMemberSubscription, getPriceFromSubscription, getProductFromPrice, getSubscriptionFromId, getUpgradeProducts, hasMultipleProductsFeature, isComplimentaryMember, isPaidMember} from '../../utils/helpers';
+import {allowCompMemberUpgrade, formatNumber, getAvailablePrices, getCurrencySymbol, getFilteredPrices, getMemberActivePrice, getMemberActiveProduct, getMemberSubscription, getPriceFromSubscription, getProductFromPrice, getSubscriptionFromId, getUpgradeProducts, hasMultipleProductsFeature, isComplimentaryMember, isPaidMember} from '../../utils/helpers';
 import Interpolate from '@doist/react-interpolate';
 import {t} from '../../utils/i18n';
 
@@ -38,6 +38,53 @@ export const AccountPlanPageStyles = `
         height: 62px;
         padding: 6px 12px;
     }
+
+    .gh-portal-retention-offer {
+        text-align: center;
+    }
+
+    .gh-portal-retention-offer-message {
+        font-size: 1.5rem;
+        color: var(--grey4);
+        margin: 0 0 24px;
+        line-height: 1.5;
+    }
+
+    .gh-portal-retention-offer-card {
+        background: var(--grey14);
+        border-radius: 8px;
+        padding: 32px 24px;
+        margin-bottom: 24px;
+    }
+
+    .gh-portal-retention-offer-discount {
+        font-size: 2.4rem;
+        font-weight: 700;
+        color: var(--grey1);
+        line-height: 1.1;
+    }
+
+    .gh-portal-retention-offer-duration {
+        font-size: 1.5rem;
+        color: var(--grey5);
+        margin-top: 4px;
+    }
+
+    .gh-portal-btn-link {
+        background: none;
+        border: none;
+        color: var(--grey5);
+        cursor: pointer;
+        font-size: 1.45rem;
+        padding: 12px 8px;
+        margin-top: 12px;
+        display: block;
+        width: 100%;
+    }
+
+    .gh-portal-btn-link:hover {
+        color: var(--grey3);
+    }
 `;
 
 function getConfirmationPageTitle({confirmationType}) {
@@ -47,6 +94,8 @@ function getConfirmationPageTitle({confirmationType}) {
         return t('Cancel subscription');
     } else if (confirmationType === 'subscribe') {
         return t('Subscribe');
+    } else if (confirmationType === 'offerRetention') {
+        return t('Before you go');
     }
 }
 
@@ -237,6 +286,69 @@ function PlansOrProductSection({selectedPlan, onPlanSelect, onPlanCheckout, chan
     );
 }
 
+function formatOfferDiscount(offer) {
+    if (offer.type === 'percent') {
+        return t('{amount}% off', {amount: offer.amount});
+    } else if (offer.type === 'fixed') {
+        const symbol = offer.currency ? getCurrencySymbol(offer.currency) : '';
+        return t('{symbol}{amount} off', {symbol, amount: offer.amount / 100});
+    }
+    return '';
+}
+
+function formatOfferDuration(offer) {
+    if (offer.duration === 'once') {
+        return t('your next renewal');
+    } else if (offer.duration === 'forever') {
+        return t('forever');
+    } else if (offer.duration === 'repeating' && offer.duration_in_months) {
+        const months = offer.duration_in_months;
+        if (months === 1) {
+            return t('the next month');
+        }
+        return t('the next {months} months', {months});
+    }
+    return '';
+}
+
+const RetentionOfferSection = ({offer, onAcceptOffer, onDeclineOffer, isAcceptingOffer}) => {
+    const {brandColor} = useContext(AppContext);
+
+    const discountText = formatOfferDiscount(offer);
+    const durationText = formatOfferDuration(offer);
+
+    return (
+        <div className="gh-portal-logged-out-form-container gh-portal-retention-offer">
+            <p className="gh-portal-retention-offer-message">
+                {t('We\'d hate to see you go! How about a special offer to stay?')}
+            </p>
+            <div className="gh-portal-retention-offer-card">
+                <div className="gh-portal-retention-offer-discount">{discountText}</div>
+                <div className="gh-portal-retention-offer-duration">{t('for')} {durationText}</div>
+            </div>
+            <ActionButton
+                dataTestId={'accept-retention-offer'}
+                onClick={onAcceptOffer}
+                isRunning={isAcceptingOffer}
+                disabled={isAcceptingOffer}
+                isPrimary={true}
+                brandColor={brandColor}
+                label={t('Accept offer')}
+                style={{
+                    width: '100%',
+                    height: '40px'
+                }}
+            />
+            <button
+                className="gh-portal-btn gh-portal-btn-link"
+                onClick={onDeclineOffer}
+            >
+                {t('Continue to cancellation')}
+            </button>
+        </div>
+    );
+};
+
 // For free members
 const UpgradePlanSection = ({
     plans, selectedPlan, onPlanSelect, onPlanCheckout
@@ -272,7 +384,8 @@ const UpgradePlanSection = ({
 
 const PlansContainer = ({
     plans, selectedPlan, confirmationPlan, confirmationType, showConfirmation = false,
-    onPlanSelect, onPlanCheckout, onConfirm, onCancelSubscription
+    pendingOffer, isAcceptingOffer, onPlanSelect, onPlanCheckout, onConfirm, onCancelSubscription,
+    onAcceptRetentionOffer, onDeclineRetentionOffer
 }) => {
     const {member} = useContext(AppContext);
     // Plan upgrade flow for free member
@@ -291,6 +404,18 @@ const PlansContainer = ({
             <ChangePlanSection
                 {...{plans, selectedPlan,
                     onCancelSubscription, onPlanSelect}}
+            />
+        );
+    }
+
+    // Retention offer flow - shown before cancellation confirmation
+    if (confirmationType === 'offerRetention' && pendingOffer) {
+        return (
+            <RetentionOfferSection
+                offer={pendingOffer}
+                onAcceptOffer={onAcceptRetentionOffer}
+                onDeclineOffer={onDeclineRetentionOffer}
+                isAcceptingOffer={isAcceptingOffer}
             />
         );
     }
@@ -344,7 +469,9 @@ export default class AccountPlanPage extends React.Component {
         }
         const selectedPriceId = selectedPrice ? selectedPrice.id : null;
         return {
-            selectedPlan: selectedPriceId
+            selectedPlan: selectedPriceId,
+            pendingOffer: null,
+            isAcceptingOffer: false
         };
     }
 
@@ -365,7 +492,9 @@ export default class AccountPlanPage extends React.Component {
         this.setState({
             showConfirmation: false,
             confirmationPlan: null,
-            confirmationType: null
+            confirmationType: null,
+            pendingOffer: null,
+            isAcceptingOffer: false
         });
     }
 
@@ -419,13 +548,47 @@ export default class AccountPlanPage extends React.Component {
     };
 
     onCancelSubscription({subscriptionId}) {
-        const {member} = this.context;
+        const {member, offers} = this.context;
         const subscription = getSubscriptionFromId({subscriptionId, member});
         const subscriptionPlan = getPriceFromSubscription({subscription});
+        const retentionOffers = (offers || []).filter(o => o.redemption_type === 'retention');
+
+        if (retentionOffers.length > 0) {
+            // Show retention offer instead of going straight to cancellation
+            this.setState({
+                showConfirmation: true,
+                confirmationPlan: subscriptionPlan,
+                confirmationType: 'offerRetention',
+                pendingOffer: retentionOffers[0] // Show first available offer
+            });
+        } else {
+            // No retention offers, go straight to cancellation
+            this.setState({
+                showConfirmation: true,
+                confirmationPlan: subscriptionPlan,
+                confirmationType: 'cancel',
+                pendingOffer: null
+            });
+        }
+    }
+
+    async onAcceptRetentionOffer() {
+        this.setState({isAcceptingOffer: true});
+
+        // TODO: Implement apply offer endpoint call
+        await new Promise((resolve) => {
+            setTimeout(resolve, 2000);
+        });
+
+        this.setState({isAcceptingOffer: false});
+        this.context.doAction('switchPage', {page: 'accountHome'});
+    }
+
+    onDeclineRetentionOffer() {
+        // User declined the offer, proceed to cancellation confirmation
         this.setState({
-            showConfirmation: true,
-            confirmationPlan: subscriptionPlan,
-            confirmationType: 'cancel'
+            confirmationType: 'cancel',
+            pendingOffer: null
         });
     }
 
@@ -461,7 +624,7 @@ export default class AccountPlanPage extends React.Component {
 
     render() {
         const plans = this.prices;
-        const {selectedPlan, showConfirmation, confirmationPlan, confirmationType} = this.state;
+        const {selectedPlan, showConfirmation, confirmationPlan, confirmationType, pendingOffer, isAcceptingOffer} = this.state;
         const {lastPage} = this.context;
         return (
             <>
@@ -474,9 +637,11 @@ export default class AccountPlanPage extends React.Component {
                         showConfirmation={showConfirmation}
                     />
                     <PlansContainer
-                        {...{plans, selectedPlan, showConfirmation, confirmationPlan, confirmationType}}
+                        {...{plans, selectedPlan, showConfirmation, confirmationPlan, confirmationType, pendingOffer, isAcceptingOffer}}
                         onConfirm={(...args) => this.onConfirm(...args)}
                         onCancelSubscription = {data => this.onCancelSubscription(data)}
+                        onAcceptRetentionOffer = {() => this.onAcceptRetentionOffer()}
+                        onDeclineRetentionOffer = {() => this.onDeclineRetentionOffer()}
                         onPlanSelect = {this.onPlanSelect}
                         onPlanCheckout = {(e, name) => this.onPlanCheckout(e, name)}
                     />

--- a/apps/portal/src/components/pages/account-plan-page.js
+++ b/apps/portal/src/components/pages/account-plan-page.js
@@ -79,7 +79,7 @@ function getConfirmationPageTitle({confirmationType}) {
     } else if (confirmationType === 'subscribe') {
         return t('Subscribe');
     } else if (confirmationType === 'offerRetention') {
-        return t('Before you go');
+        return 'Before you go';
     }
 }
 
@@ -272,25 +272,25 @@ function PlansOrProductSection({selectedPlan, onPlanSelect, onPlanCheckout, chan
 
 function formatOfferDiscount(offer) {
     if (offer.type === 'percent') {
-        return t('{amount}% off', {amount: offer.amount});
+        return `${offer.amount}% off`;
     } else if (offer.type === 'fixed') {
         const symbol = offer.currency ? getCurrencySymbol(offer.currency) : '';
-        return t('{symbol}{amount} off', {symbol, amount: offer.amount / 100});
+        return `${symbol}${offer.amount / 100} off`;
     }
     return '';
 }
 
 function formatOfferDuration(offer) {
     if (offer.duration === 'once') {
-        return t('your next payment');
+        return 'your next payment';
     } else if (offer.duration === 'forever') {
-        return t('forever');
+        return 'forever';
     } else if (offer.duration === 'repeating' && offer.duration_in_months) {
         const months = offer.duration_in_months;
         if (months === 1) {
-            return t('the next month');
+            return 'for the next month';
         }
-        return t('the next {months} months', {months});
+        return `for the next ${months} months`;
     }
     return '';
 }
@@ -301,14 +301,16 @@ const RetentionOfferSection = ({offer, onAcceptOffer, onDeclineOffer, isAcceptin
     const discountText = formatOfferDiscount(offer);
     const durationText = formatOfferDuration(offer);
 
+    // TODO: Add i18n once copy is finalized
+    /* eslint-disable i18next/no-literal-string */
     return (
         <div className="gh-portal-logged-out-form-container gh-portal-retention-offer">
             <p className="gh-portal-retention-offer-message">
-                {t('We\'d hate to see you go! How about a special offer to stay?')}
+                {'We\'d hate to see you go! How about a special offer to stay?'}
             </p>
             <div className="gh-portal-retention-offer-card">
                 <div className="gh-portal-retention-offer-discount">{discountText}</div>
-                <div className="gh-portal-retention-offer-duration">{t('for')} {durationText}</div>
+                <div className="gh-portal-retention-offer-duration">{durationText}</div>
             </div>
             <ActionButton
                 dataTestId={'accept-retention-offer'}
@@ -317,7 +319,7 @@ const RetentionOfferSection = ({offer, onAcceptOffer, onDeclineOffer, isAcceptin
                 disabled={isAcceptingOffer}
                 isPrimary={true}
                 brandColor={brandColor}
-                label={t('Accept offer')}
+                label="Accept offer"
                 style={{
                     width: '100%',
                     height: '40px'
@@ -330,7 +332,7 @@ const RetentionOfferSection = ({offer, onAcceptOffer, onDeclineOffer, isAcceptin
                 isDestructive={true}
                 classes={'gh-portal-btn-text'}
                 brandColor={brandColor}
-                label={t('Continue to cancellation')}
+                label="Continue to cancellation"
                 style={{
                     width: '100%',
                     marginTop: '24px',
@@ -339,6 +341,7 @@ const RetentionOfferSection = ({offer, onAcceptOffer, onDeclineOffer, isAcceptin
             />
         </div>
     );
+    /* eslint-enable i18next/no-literal-string */
 };
 
 // For free members

--- a/apps/portal/src/components/pages/account-plan-page.js
+++ b/apps/portal/src/components/pages/account-plan-page.js
@@ -69,22 +69,6 @@ export const AccountPlanPageStyles = `
         color: var(--grey5);
         margin-top: 4px;
     }
-
-    .gh-portal-btn-link {
-        background: none;
-        border: none;
-        color: var(--grey5);
-        cursor: pointer;
-        font-size: 1.45rem;
-        padding: 12px 8px;
-        margin-top: 12px;
-        display: block;
-        width: 100%;
-    }
-
-    .gh-portal-btn-link:hover {
-        color: var(--grey3);
-    }
 `;
 
 function getConfirmationPageTitle({confirmationType}) {
@@ -339,12 +323,20 @@ const RetentionOfferSection = ({offer, onAcceptOffer, onDeclineOffer, isAcceptin
                     height: '40px'
                 }}
             />
-            <button
-                className="gh-portal-btn gh-portal-btn-link"
+            <ActionButton
+                dataTestId={'decline-retention-offer'}
                 onClick={onDeclineOffer}
-            >
-                {t('Continue to cancellation')}
-            </button>
+                isPrimary={false}
+                isDestructive={true}
+                classes={'gh-portal-btn-text'}
+                brandColor={brandColor}
+                label={t('Continue to cancellation')}
+                style={{
+                    width: '100%',
+                    marginTop: '24px',
+                    marginBottom: '24px'
+                }}
+            />
         </div>
     );
 };

--- a/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
+++ b/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
@@ -853,6 +853,106 @@ module.exports = class RouterController {
             .filter(newsletter => newsletter.status === 'active')
             .map(newsletter => ({id: newsletter.id}));
     }
+
+    /**
+     * @param {import('express').Request} req
+     * @param {import('express').Response} res
+     */
+    async getMemberOffers(req, res) {
+        const identity = req.body.identity;
+
+        if (!identity) {
+            res.writeHead(401);
+            return res.end('Unauthorized');
+        }
+
+        let email;
+        try {
+            const claims = await this._tokenService.decodeToken(identity);
+            email = claims && claims.sub;
+        } catch (err) {
+            logging.error(err);
+            res.writeHead(401);
+            return res.end('Unauthorized');
+        }
+
+        if (!email) {
+            res.writeHead(401);
+            return res.end('Unauthorized');
+        }
+
+        // Get member with subscriptions
+        const member = await this._memberRepository.get({email}, {
+            withRelated: [
+                'stripeSubscriptions',
+                'stripeSubscriptions.stripePrice',
+                'stripeSubscriptions.stripePrice.stripeProduct',
+                'stripeSubscriptions.stripePrice.stripeProduct.product'
+            ]
+        });
+
+        if (!member) {
+            res.writeHead(404);
+            return res.end(tpl(messages.memberNotFound));
+        }
+
+        // Find the primary active subscription
+        const subscriptions = member.related('stripeSubscriptions');
+        const activeSubscription = subscriptions.models.find((sub) => {
+            const status = sub.get('status');
+            return ['active', 'trialing', 'past_due', 'unpaid'].includes(status);
+        });
+
+        if (!activeSubscription) {
+            // No active subscription - return empty offers
+            res.writeHead(200, {'Content-Type': 'application/json'});
+            return res.end(JSON.stringify({offers: []}));
+        }
+
+        // If subscription already has an offer applied (e.g. signup offer), don't show retention offers
+        if (activeSubscription.get('offer_id')) {
+            res.writeHead(200, {'Content-Type': 'application/json'});
+            return res.end(JSON.stringify({offers: []}));
+        }
+
+        // Get tier and cadence from the subscription
+        const stripePrice = activeSubscription.related('stripePrice');
+        if (!stripePrice || !stripePrice.id) {
+            res.writeHead(200, {'Content-Type': 'application/json'});
+            return res.end(JSON.stringify({offers: []}));
+        }
+
+        const stripeProduct = stripePrice.related('stripeProduct');
+        if (!stripeProduct || !stripeProduct.id) {
+            res.writeHead(200, {'Content-Type': 'application/json'});
+            return res.end(JSON.stringify({offers: []}));
+        }
+
+        const product = stripeProduct.related('product');
+        if (!product || !product.id) {
+            res.writeHead(200, {'Content-Type': 'application/json'});
+            return res.end(JSON.stringify({offers: []}));
+        }
+
+        const tierId = product.id;
+        const cadence = stripePrice.get('interval');
+        const subscriptionId = activeSubscription.id; // Ghost's internal ID, not Stripe's
+
+        let offers = [];
+        try {
+            offers = await this._offersAPI.listOffersAvailableToSubscription({
+                subscriptionId,
+                tierId,
+                cadence,
+                redemptionType: 'retention'
+            });
+        } catch (err) {
+            logging.error('Failed to fetch retention offers:', err);
+        }
+
+        res.writeHead(200, {'Content-Type': 'application/json'});
+        return res.end(JSON.stringify({offers}));
+    }
 };
 
 function parsePersonalNote(rawText) {

--- a/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
+++ b/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
@@ -860,10 +860,16 @@ module.exports = class RouterController {
      */
     async getMemberOffers(req, res) {
         const identity = req.body.identity;
+        const redemptionType = req.body.redemption_type || 'retention';
 
         if (!identity) {
             res.writeHead(401);
             return res.end('Unauthorized');
+        }
+
+        if (redemptionType !== 'retention') {
+            res.writeHead(400);
+            return res.end('Invalid redemption_type');
         }
 
         let email;
@@ -952,10 +958,10 @@ module.exports = class RouterController {
                 subscriptionId,
                 tierId,
                 cadence,
-                redemptionType: 'retention'
+                redemptionType
             });
         } catch (err) {
-            logging.error('Failed to fetch retention offers:', err);
+            logging.error('Failed to fetch offers:', err);
         }
 
         res.writeHead(200, {'Content-Type': 'application/json'});

--- a/ghost/core/core/server/services/members/members-api/members-api.js
+++ b/ghost/core/core/server/services/members/members-api/members-api.js
@@ -365,6 +365,10 @@ module.exports = function MembersAPI({
             body.json(),
             forwardError((req, res) => memberController.updateSubscription(req, res))
         ),
+        getMemberOffers: Router().use(
+            body.json(),
+            forwardError((req, res) => routerController.getMemberOffers(req, res))
+        ),
         wellKnown: Router()
             .get('/jwks.json',
                 (req, res) => wellKnownController.getPublicKeys(req, res)

--- a/ghost/core/core/server/services/offers/application/offer-mapper.js
+++ b/ghost/core/core/server/services/offers/application/offer-mapper.js
@@ -24,6 +24,7 @@
  *
  * @prop {'active'|'archived'} status
  * @prop {number} redemption_count
+ * @prop {'signup'|'retention'} redemption_type
  *
  * @prop {object} tier
  * @prop {string} tier.id
@@ -53,6 +54,7 @@ class OfferMapper {
             currency: offer.type.value === 'fixed' ? offer.currency.value : null,
             status: offer.status.value,
             redemption_count: offer.redemptionCount,
+            redemption_type: offer.redemptionType.value,
             tier: {
                 id: offer.tier.id,
                 name: offer.tier.name

--- a/ghost/core/core/server/services/offers/application/offers-api.js
+++ b/ghost/core/core/server/services/offers/application/offers-api.js
@@ -138,6 +138,12 @@ class OffersAPI {
      * @returns {Promise<OfferMapper.OfferDTO[]>}
      */
     async listOffersAvailableToSubscription({subscriptionId, tierId, cadence, redemptionType}) {
+        if (!subscriptionId || !tierId || !cadence) {
+            throw new errors.IncorrectUsageError({
+                message: 'subscriptionId, tierId, and cadence are required'
+            });
+        }
+
         return await this.repository.createTransaction(async (transaction) => {
             const allOffers = await this.repository.getAll({
                 transacting: transaction,

--- a/ghost/core/core/server/services/offers/domain/errors/index.js
+++ b/ghost/core/core/server/services/offers/domain/errors/index.js
@@ -23,6 +23,7 @@ class InvalidOfferCadence extends InvalidPropError {}
 class InvalidOfferDuration extends InvalidPropError {}
 class InvalidOfferCoupon extends InvalidPropError {}
 class InvalidOfferStatus extends InvalidPropError {}
+class InvalidOfferRedemptionType extends InvalidPropError {}
 class InvalidStripeCoupon extends InvalidPropError {}
 
 module.exports = {
@@ -38,5 +39,6 @@ module.exports = {
     InvalidOfferTierName,
     InvalidOfferCoupon,
     InvalidOfferStatus,
+    InvalidOfferRedemptionType,
     InvalidStripeCoupon
 };

--- a/ghost/core/core/server/services/offers/domain/models/offer-redemption-type.js
+++ b/ghost/core/core/server/services/offers/domain/models/offer-redemption-type.js
@@ -1,0 +1,32 @@
+const ValueObject = require('./shared/value-object');
+const InvalidOfferRedemptionType = require('../errors').InvalidOfferRedemptionType;
+
+/**
+ * @extends ValueObject<'signup'|'retention'>
+ */
+class OfferRedemptionType extends ValueObject {
+    /** @param {unknown} redemptionType */
+    static create(redemptionType) {
+        if (typeof redemptionType !== 'string') {
+            throw new InvalidOfferRedemptionType({
+                message: 'Offer `redemption_type` must be a string.'
+            });
+        }
+
+        if (redemptionType !== 'signup' && redemptionType !== 'retention') {
+            throw new InvalidOfferRedemptionType({
+                message: 'Offer `redemption_type` must be either "signup" or "retention".'
+            });
+        }
+
+        return new OfferRedemptionType(redemptionType);
+    }
+
+    static InvalidOfferRedemptionType = InvalidOfferRedemptionType;
+
+    static Signup = new OfferRedemptionType('signup');
+
+    static Retention = new OfferRedemptionType('retention');
+}
+
+module.exports = OfferRedemptionType;

--- a/ghost/core/core/server/services/offers/domain/models/offer.js
+++ b/ghost/core/core/server/services/offers/domain/models/offer.js
@@ -11,6 +11,7 @@ const OfferType = require('./offer-type');
 const OfferDuration = require('./offer-duration');
 const OfferCurrency = require('./offer-currency');
 const OfferStatus = require('./offer-status');
+const OfferRedemptionType = require('./offer-redemption-type');
 const OfferCreatedEvent = require('../events/offer-created-event');
 const OfferCodeChangeEvent = require('../events/offer-code-change-event');
 const OfferCreatedAt = require('./offer-created-at');
@@ -32,6 +33,7 @@ const StripeCoupon = require('./stripe-coupon');
  * @prop {string|null} [stripeCouponId]
  * @prop {OfferTier} tier
  * @prop {number} redemptionCount
+ * @prop {OfferRedemptionType} redemptionType
  * @prop {string} createdAt
  * @prop {string|null} lastRedeemed
  */
@@ -52,6 +54,7 @@ const StripeCoupon = require('./stripe-coupon');
  * @prop {string} [status]
  * @prop {string} [stripe_coupon_id]
  * @prop {number} [redemptionCount]
+ * @prop {string} [redemption_type]
  * @prop {TierProps|OfferTier} tier
  * @prop {Date} [created_at]
  * @prop {Date} [last_redeemed]
@@ -135,12 +138,16 @@ class Offer {
         return this.props.status;
     }
 
+    set status(value) {
+        this.props.status = value;
+    }
+
     get redemptionCount() {
         return this.props.redemptionCount;
     }
 
-    set status(value) {
-        this.props.status = value;
+    get redemptionType() {
+        return this.props.redemptionType;
     }
 
     get oldCode() {
@@ -350,6 +357,7 @@ class Offer {
         }
 
         const tier = OfferTier.create(data.tier);
+        const redemptionType = OfferRedemptionType.create(data.redemption_type || 'signup');
 
         return new Offer({
             id,
@@ -365,6 +373,7 @@ class Offer {
             tier,
             stripeCouponId,
             redemptionCount,
+            redemptionType,
             status,
             createdAt,
             lastRedeemed
@@ -426,7 +435,8 @@ class Offer {
                 id: tier.id,
                 name: tier.name
             },
-            stripe_coupon_id: coupon.id
+            stripe_coupon_id: coupon.id,
+            redemption_type: 'signup'
         };
 
         return this.create(data, uniqueChecker);

--- a/ghost/core/core/server/web/members/app.js
+++ b/ghost/core/core/server/web/members/app.js
@@ -63,6 +63,11 @@ module.exports = function setupMembersApp() {
     membersApp.put('/api/member', bodyParser.json({limit: '50mb'}), middleware.updateMemberData);
     membersApp.post('/api/member/email', bodyParser.json({limit: '50mb'}), (req, res, next) => membersService.api.middleware.updateEmailAddress(req, res, next));
 
+    // Member offers (retention etc.)
+    membersApp.post('/api/member/offers', bodyParser.json(), function lazyGetMemberOffersMw(req, res, next) {
+        return membersService.api.middleware.getMemberOffers(req, res, next);
+    });
+
     // Remove email from suppression list
     membersApp.delete('/api/member/suppression', middleware.deleteSuppression);
 

--- a/ghost/core/test/e2e-api/admin/__snapshots__/offers.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/offers.test.js.snap
@@ -18,6 +18,7 @@ Object {
       "last_redeemed": null,
       "name": "Fourth of July Sales",
       "redemption_count": 0,
+      "redemption_type": "signup",
       "status": "active",
       "tier": Object {
         "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -32,7 +33,7 @@ exports[`Offers API Can add a fixed offer 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "408",
+  "content-length": "435",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -61,6 +62,7 @@ Object {
       "last_redeemed": null,
       "name": "Black Friday",
       "redemption_count": 0,
+      "redemption_type": "signup",
       "status": "active",
       "tier": Object {
         "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -90,7 +92,7 @@ exports[`Offers API Can add a new offer 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "450",
+  "content-length": "477",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -119,6 +121,7 @@ Object {
       "last_redeemed": null,
       "name": "Easter Sales",
       "redemption_count": 0,
+      "redemption_type": "signup",
       "status": "active",
       "tier": Object {
         "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -133,7 +136,7 @@ exports[`Offers API Can add a new offer with minimal fields 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "405",
+  "content-length": "432",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -162,6 +165,7 @@ Object {
       "last_redeemed": null,
       "name": "Fourth of July Sales trial",
       "redemption_count": 0,
+      "redemption_type": "signup",
       "status": "active",
       "tier": Object {
         "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -176,7 +180,7 @@ exports[`Offers API Can add a trial offer 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "420",
+  "content-length": "447",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -205,6 +209,7 @@ Object {
       "last_redeemed": null,
       "name": "Cyber Monday",
       "redemption_count": 0,
+      "redemption_type": "signup",
       "status": "archived",
       "tier": Object {
         "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -220,7 +225,7 @@ exports[`Offers API Can archive an offer 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "489",
+  "content-length": "516",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -248,6 +253,7 @@ Object {
       "last_redeemed": null,
       "name": "Black Friday",
       "redemption_count": 0,
+      "redemption_type": "signup",
       "status": "active",
       "tier": Object {
         "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -270,6 +276,7 @@ Object {
       "last_redeemed": null,
       "name": "Easter Sales",
       "redemption_count": 0,
+      "redemption_type": "signup",
       "status": "active",
       "tier": Object {
         "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -292,6 +299,7 @@ Object {
       "last_redeemed": null,
       "name": "Summer Sale",
       "redemption_count": 0,
+      "redemption_type": "signup",
       "status": "active",
       "tier": Object {
         "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -314,6 +322,7 @@ Object {
       "last_redeemed": null,
       "name": "Fourth of July Sales",
       "redemption_count": 0,
+      "redemption_type": "signup",
       "status": "active",
       "tier": Object {
         "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -336,6 +345,7 @@ Object {
       "last_redeemed": null,
       "name": "Fourth of July Sales trial",
       "redemption_count": 0,
+      "redemption_type": "signup",
       "status": "active",
       "tier": Object {
         "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -351,7 +361,7 @@ exports[`Offers API Can browse 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "2168",
+  "content-length": "2303",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -378,6 +388,7 @@ Object {
       "last_redeemed": null,
       "name": "Easter Sales",
       "redemption_count": 0,
+      "redemption_type": "signup",
       "status": "active",
       "tier": Object {
         "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -400,6 +411,7 @@ Object {
       "last_redeemed": null,
       "name": "Summer Sale",
       "redemption_count": 0,
+      "redemption_type": "signup",
       "status": "active",
       "tier": Object {
         "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -422,6 +434,7 @@ Object {
       "last_redeemed": null,
       "name": "Fourth of July Sales",
       "redemption_count": 0,
+      "redemption_type": "signup",
       "status": "active",
       "tier": Object {
         "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -444,6 +457,7 @@ Object {
       "last_redeemed": null,
       "name": "Fourth of July Sales trial",
       "redemption_count": 0,
+      "redemption_type": "signup",
       "status": "active",
       "tier": Object {
         "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -459,7 +473,7 @@ exports[`Offers API Can browse active 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "1705",
+  "content-length": "1813",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -486,6 +500,7 @@ Object {
       "last_redeemed": null,
       "name": "Cyber Monday",
       "redemption_count": 0,
+      "redemption_type": "signup",
       "status": "archived",
       "tier": Object {
         "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -501,7 +516,7 @@ exports[`Offers API Can browse archived 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "489",
+  "content-length": "516",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -528,6 +543,7 @@ Object {
       "last_redeemed": null,
       "name": "Cyber Monday",
       "redemption_count": 0,
+      "redemption_type": "signup",
       "status": "active",
       "tier": Object {
         "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -543,7 +559,7 @@ exports[`Offers API Can edit an offer 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "487",
+  "content-length": "514",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -571,6 +587,7 @@ Object {
       "last_redeemed": null,
       "name": "Black Friday",
       "redemption_count": 0,
+      "redemption_type": "signup",
       "status": "active",
       "tier": Object {
         "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -586,7 +603,7 @@ exports[`Offers API Can get a single offer 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "475",
+  "content-length": "502",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -613,6 +630,7 @@ Object {
       "last_redeemed": null,
       "name": "Fourth of July Sales trial",
       "redemption_count": 0,
+      "redemption_type": "signup",
       "status": "active",
       "tier": Object {
         "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -628,7 +646,7 @@ exports[`Offers API Can get a trial offer 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "445",
+  "content-length": "472",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -748,6 +766,7 @@ Object {
       "last_redeemed": null,
       "name": "Cyber Monday",
       "redemption_count": 0,
+      "redemption_type": "signup",
       "status": "archived",
       "tier": Object {
         "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -763,7 +782,7 @@ exports[`Offers API Cannot update offer amount 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "489",
+  "content-length": "516",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -791,6 +810,7 @@ Object {
       "last_redeemed": null,
       "name": "Cyber Monday",
       "redemption_count": 0,
+      "redemption_type": "signup",
       "status": "archived",
       "tier": Object {
         "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -806,7 +826,7 @@ exports[`Offers API Cannot update offer cadence 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "489",
+  "content-length": "516",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -927,6 +947,7 @@ Object {
       "last_redeemed": null,
       "name": "Cyber Monday",
       "redemption_count": 0,
+      "redemption_type": "signup",
       "status": "archived",
       "tier": Object {
         "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -942,7 +963,7 @@ exports[`Offers API Cannot update offer tier 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "489",
+  "content-length": "516",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -989,6 +1010,7 @@ Object {
       "last_redeemed": null,
       "name": "Summer Sale",
       "redemption_count": 0,
+      "redemption_type": "signup",
       "status": "active",
       "tier": Object {
         "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -1003,7 +1025,7 @@ exports[`Offers API Slugifies offer codes 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "408",
+  "content-length": "435",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/e2e-api/admin/offers.test.js
+++ b/ghost/core/test/e2e-api/admin/offers.test.js
@@ -57,6 +57,7 @@ describe('Offers API', function () {
             currency: null,
             status: 'active',
             redemption_count: 0,
+            redemption_type: 'signup',
             tier: {
                 id: defaultTier.id
             }

--- a/ghost/core/test/e2e-api/members/member-offers.test.js
+++ b/ghost/core/test/e2e-api/members/member-offers.test.js
@@ -1,0 +1,203 @@
+const {agentProvider, mockManager, fixtureManager} = require('../../utils/e2e-framework');
+const models = require('../../../core/server/models');
+const assert = require('assert/strict');
+
+let membersAgent;
+let membersService;
+
+async function getIdentityToken(email) {
+    const member = await models.Member.findOne({email});
+
+    return membersService.api.getMemberIdentityToken(member.get('transient_id'));
+}
+
+describe('Members API - Member Offers', function () {
+    before(async function () {
+        const agents = await agentProvider.getAgentsForMembers();
+
+        membersAgent = agents.membersAgent;
+        membersService = require('../../../core/server/services/members');
+
+        await fixtureManager.init('members');
+    });
+
+    beforeEach(function () {
+        mockManager.mockMail();
+    });
+
+    afterEach(function () {
+        mockManager.restore();
+    });
+
+    describe('POST /members/api/member/offers', function () {
+        it('returns 401 when not authenticated', async function () {
+            await membersAgent
+                .post('/api/member/offers')
+                .body({})
+                .expectStatus(401);
+        });
+
+        it('returns 401 with invalid identity token', async function () {
+            await membersAgent
+                .post('/api/member/offers')
+                .body({identity: 'invalid-token'})
+                .expectStatus(401);
+        });
+
+        it('returns empty offers array for free member', async function () {
+            const token = await getIdentityToken('member1@test.com');
+
+            const {body} = await membersAgent
+                .post('/api/member/offers')
+                .body({identity: token})
+                .expectStatus(200);
+
+            assert.deepEqual(body, {offers: []});
+        });
+
+        it('returns empty offers array when no retention offers exist', async function () {
+            const token = await getIdentityToken('paid@test.com');
+
+            const {body} = await membersAgent
+                .post('/api/member/offers')
+                .body({identity: token})
+                .expectStatus(200);
+
+            assert.deepEqual(body, {offers: []});
+        });
+
+        it('returns retention offers for paid member when available', async function () {
+            // Get the paid member's subscription tier and cadence
+            const member = await models.Member.findOne({email: 'paid@test.com'}, {
+                withRelated: [
+                    'stripeSubscriptions',
+                    'stripeSubscriptions.stripePrice',
+                    'stripeSubscriptions.stripePrice.stripeProduct',
+                    'stripeSubscriptions.stripePrice.stripeProduct.product'
+                ]
+            });
+
+            const subscription = member.related('stripeSubscriptions').models[0];
+            const stripePrice = subscription.related('stripePrice');
+            const stripeProduct = stripePrice.related('stripeProduct');
+            const product = stripeProduct.related('product');
+
+            const tierId = product.id;
+            const cadence = stripePrice.get('interval');
+
+            // Create a retention offer for this tier and cadence
+            const offer = await models.Offer.add({
+                name: 'Test Retention Offer',
+                code: 'test-retention',
+                portal_title: '20% off for 3 months',
+                portal_description: 'Stay with us!',
+                discount_type: 'percent',
+                discount_amount: 20,
+                duration: 'repeating',
+                duration_in_months: 3,
+                interval: cadence,
+                product_id: tierId,
+                currency: null,
+                active: true,
+                redemption_type: 'retention'
+            });
+
+            try {
+                const token = await getIdentityToken('paid@test.com');
+
+                const {body} = await membersAgent
+                    .post('/api/member/offers')
+                    .body({identity: token})
+                    .expectStatus(200);
+
+                assert.equal(body.offers.length, 1);
+                assert.equal(body.offers[0].id, offer.id);
+                assert.equal(body.offers[0].name, 'Test Retention Offer');
+                assert.equal(body.offers[0].code, 'test-retention');
+                assert.equal(body.offers[0].display_title, '20% off for 3 months');
+                assert.equal(body.offers[0].display_description, 'Stay with us!');
+                assert.equal(body.offers[0].type, 'percent');
+                assert.equal(body.offers[0].amount, 20);
+                assert.equal(body.offers[0].duration, 'repeating');
+                assert.equal(body.offers[0].duration_in_months, 3);
+                assert.equal(body.offers[0].cadence, cadence);
+                assert.equal(body.offers[0].redemption_type, 'retention');
+            } finally {
+                // Clean up
+                await models.Offer.destroy({id: offer.id});
+            }
+        });
+
+        it('returns empty offers if subscription already has an offer applied', async function () {
+            // Get the paid member's subscription
+            const member = await models.Member.findOne({email: 'paid@test.com'}, {
+                withRelated: [
+                    'stripeSubscriptions',
+                    'stripeSubscriptions.stripePrice',
+                    'stripeSubscriptions.stripePrice.stripeProduct',
+                    'stripeSubscriptions.stripePrice.stripeProduct.product'
+                ]
+            });
+
+            const subscription = member.related('stripeSubscriptions').models[0];
+            const stripePrice = subscription.related('stripePrice');
+            const stripeProduct = stripePrice.related('stripeProduct');
+            const product = stripeProduct.related('product');
+
+            const tierId = product.id;
+            const cadence = stripePrice.get('interval');
+
+            // Create a retention offer
+            const offer = await models.Offer.add({
+                name: 'Test Retention Offer 2',
+                code: 'test-retention-2',
+                portal_title: '20% off',
+                portal_description: 'Stay with us!',
+                discount_type: 'percent',
+                discount_amount: 20,
+                duration: 'once',
+                interval: cadence,
+                product_id: tierId,
+                currency: null,
+                active: true,
+                redemption_type: 'retention'
+            });
+
+            // Create a signup offer and apply it to the subscription
+            const signupOffer = await models.Offer.add({
+                name: 'Signup Offer',
+                code: 'signup-offer',
+                portal_title: '10% off',
+                portal_description: 'Welcome!',
+                discount_type: 'percent',
+                discount_amount: 10,
+                duration: 'once',
+                interval: cadence,
+                product_id: tierId,
+                currency: null,
+                active: true,
+                redemption_type: 'signup'
+            });
+
+            // Set the offer_id on the subscription
+            await subscription.save({offer_id: signupOffer.id}, {patch: true});
+
+            try {
+                const token = await getIdentityToken('paid@test.com');
+
+                const {body} = await membersAgent
+                    .post('/api/member/offers')
+                    .body({identity: token})
+                    .expectStatus(200);
+
+                // Should not return retention offers if subscription already has an offer
+                assert.deepEqual(body, {offers: []});
+            } finally {
+                // Clean up
+                await subscription.save({offer_id: null}, {patch: true});
+                await models.Offer.destroy({id: offer.id});
+                await models.Offer.destroy({id: signupOffer.id});
+            }
+        });
+    });
+});

--- a/ghost/core/test/e2e-api/members/member-offers.test.js
+++ b/ghost/core/test/e2e-api/members/member-offers.test.js
@@ -44,6 +44,15 @@ describe('Members API - Member Offers', function () {
                 .expectStatus(401);
         });
 
+        it('returns 400 with invalid redemption_type', async function () {
+            const token = await getIdentityToken('paid@test.com');
+
+            await membersAgent
+                .post('/api/member/offers')
+                .body({identity: token, redemption_type: 'invalid'})
+                .expectStatus(400);
+        });
+
         it('returns empty offers array for free member', async function () {
             const token = await getIdentityToken('member1@test.com');
 

--- a/ghost/core/test/unit/server/services/offers/application/offers-api.test.js
+++ b/ghost/core/test/unit/server/services/offers/application/offers-api.test.js
@@ -215,6 +215,38 @@ describe('OffersAPI', function () {
 
             assert.equal(result.length, 2);
         });
+
+        it('throws error when required parameters are missing', async function () {
+            const repository = createMockRepository({});
+            const api = new OffersAPI(/** @type {OfferBookshelfRepository} */ (/** @type {unknown} */ (repository)));
+
+            await assert.rejects(
+                api.listOffersAvailableToSubscription({
+                    subscriptionId: 'sub_123',
+                    tierId: 'tier_123'
+                    // missing cadence
+                }),
+                /subscriptionId, tierId, and cadence are required/
+            );
+
+            await assert.rejects(
+                api.listOffersAvailableToSubscription({
+                    subscriptionId: 'sub_123',
+                    cadence: 'month'
+                    // missing tierId
+                }),
+                /subscriptionId, tierId, and cadence are required/
+            );
+
+            await assert.rejects(
+                api.listOffersAvailableToSubscription({
+                    tierId: 'tier_123',
+                    cadence: 'month'
+                    // missing subscriptionId
+                }),
+                /subscriptionId, tierId, and cadence are required/
+            );
+        });
     });
 
     describe('#ensureOfferForStripeCoupon', function () {

--- a/ghost/core/test/unit/server/services/offers/application/offers-api.test.js
+++ b/ghost/core/test/unit/server/services/offers/application/offers-api.test.js
@@ -22,21 +22,29 @@ function createMockRepository(overrides = {}) {
     };
 }
 
-function createMockOffer(id) {
+function createMockOffer(id, {
+    tierId,
+    tierName = 'Test Tier',
+    cadence = 'month',
+    type = 'percent',
+    status = 'active',
+    redemptionType = 'signup'
+} = {}) {
     return {
         id,
         name: {value: 'Test Offer'},
         code: {value: 'test-code'},
         displayTitle: {value: 'Test Title'},
         displayDescription: {value: 'Test Description'},
-        type: {value: 'percent'},
-        cadence: {value: 'month'},
+        type: {value: type},
+        cadence: {value: cadence},
         amount: {value: 10},
         duration: {value: {type: 'once', months: null}},
         currency: {value: null},
-        status: {value: 'active'},
+        status: {value: status},
+        redemptionType: {value: redemptionType},
         redemptionCount: 0,
-        tier: {id, name: 'Test Tier'},
+        tier: {id: tierId || id, name: tierName},
         createdAt: new Date().toISOString(),
         lastRedeemed: null
     };
@@ -53,6 +61,160 @@ function createMockCoupon(id) {
 describe('OffersAPI', function () {
     afterEach(function () {
         sinon.restore();
+    });
+
+    describe('#listOffersAvailableToSubscription', function () {
+        it('returns offers matching tier, cadence, and redemption type', async function () {
+            const tierId = new ObjectID().toHexString();
+            const offers = [
+                createMockOffer('offer-1', {tierId, cadence: 'month', redemptionType: 'retention'}),
+                createMockOffer('offer-2', {tierId, cadence: 'month', redemptionType: 'signup'}),
+                createMockOffer('offer-3', {tierId, cadence: 'year', redemptionType: 'retention'})
+            ];
+
+            const repository = createMockRepository({
+                getAll: sinon.stub().resolves(offers),
+                getRedeemedOfferIdsForSubscription: sinon.stub().resolves([])
+            });
+
+            const api = new OffersAPI(/** @type {OfferBookshelfRepository} */ (/** @type {unknown} */ (repository)));
+
+            const result = await api.listOffersAvailableToSubscription({
+                subscriptionId: 'sub_123',
+                tierId,
+                cadence: 'month',
+                redemptionType: 'retention'
+            });
+
+            assert.equal(result.length, 1);
+            assert.equal(result[0].id, 'offer-1');
+        });
+
+        it('excludes trial offers', async function () {
+            const tierId = new ObjectID().toHexString();
+            const offers = [
+                createMockOffer('offer-1', {tierId, cadence: 'month', type: 'percent', redemptionType: 'retention'}),
+                createMockOffer('offer-2', {tierId, cadence: 'month', type: 'trial', redemptionType: 'retention'})
+            ];
+
+            const repository = createMockRepository({
+                getAll: sinon.stub().resolves(offers),
+                getRedeemedOfferIdsForSubscription: sinon.stub().resolves([])
+            });
+
+            const api = new OffersAPI(/** @type {OfferBookshelfRepository} */ (/** @type {unknown} */ (repository)));
+
+            const result = await api.listOffersAvailableToSubscription({
+                subscriptionId: 'sub_123',
+                tierId,
+                cadence: 'month',
+                redemptionType: 'retention'
+            });
+
+            assert.equal(result.length, 1);
+            assert.equal(result[0].id, 'offer-1');
+        });
+
+        it('excludes already redeemed offers', async function () {
+            const tierId = new ObjectID().toHexString();
+            const offers = [
+                createMockOffer('offer-1', {tierId, cadence: 'month', redemptionType: 'retention'}),
+                createMockOffer('offer-2', {tierId, cadence: 'month', redemptionType: 'retention'})
+            ];
+
+            const repository = createMockRepository({
+                getAll: sinon.stub().resolves(offers),
+                getRedeemedOfferIdsForSubscription: sinon.stub().resolves(['offer-1'])
+            });
+
+            const api = new OffersAPI(/** @type {OfferBookshelfRepository} */ (/** @type {unknown} */ (repository)));
+
+            const result = await api.listOffersAvailableToSubscription({
+                subscriptionId: 'sub_123',
+                tierId,
+                cadence: 'month',
+                redemptionType: 'retention'
+            });
+
+            assert.equal(result.length, 1);
+            assert.equal(result[0].id, 'offer-2');
+        });
+
+        it('excludes inactive offers', async function () {
+            const tierId = new ObjectID().toHexString();
+            const activeOffer = createMockOffer('offer-1', {tierId, cadence: 'month', status: 'active', redemptionType: 'retention'});
+
+            const repository = createMockRepository({
+                // Emulate real repository behavior: getAll with filter 'status:active' returns only active offers
+                getAll: sinon.stub().resolves([activeOffer]),
+                getRedeemedOfferIdsForSubscription: sinon.stub().resolves([])
+            });
+
+            const api = new OffersAPI(/** @type {OfferBookshelfRepository} */ (/** @type {unknown} */ (repository)));
+
+            const result = await api.listOffersAvailableToSubscription({
+                subscriptionId: 'sub_123',
+                tierId,
+                cadence: 'month',
+                redemptionType: 'retention'
+            });
+
+            // Verify getAll was called with status:active filter
+            assert(repository.getAll.calledOnce);
+            assert.equal(repository.getAll.firstCall.args[0].filter, 'status:active');
+
+            // Only active offer returned
+            assert.equal(result.length, 1);
+            assert.equal(result[0].id, 'offer-1');
+        });
+
+        it('returns empty array when no offers match', async function () {
+            const tierId = new ObjectID().toHexString();
+            const differentTierId = new ObjectID().toHexString();
+            const offers = [
+                createMockOffer('offer-1', {tierId: differentTierId, cadence: 'month', redemptionType: 'retention'})
+            ];
+
+            const repository = createMockRepository({
+                getAll: sinon.stub().resolves(offers),
+                getRedeemedOfferIdsForSubscription: sinon.stub().resolves([])
+            });
+
+            const api = new OffersAPI(/** @type {OfferBookshelfRepository} */ (/** @type {unknown} */ (repository)));
+
+            const result = await api.listOffersAvailableToSubscription({
+                subscriptionId: 'sub_123',
+                tierId,
+                cadence: 'month',
+                redemptionType: 'retention'
+            });
+
+            assert.equal(result.length, 0);
+        });
+
+        it('returns all redemption types when redemptionType is not specified', async function () {
+            const tierId = new ObjectID().toHexString();
+            const offers = [
+                createMockOffer('offer-1', {tierId, cadence: 'month', redemptionType: 'signup'}),
+                createMockOffer('offer-2', {tierId, cadence: 'month', redemptionType: 'retention'})
+            ];
+
+            const repository = createMockRepository({
+                getAll: sinon.stub().resolves(offers),
+                getRedeemedOfferIdsForSubscription: sinon.stub().resolves([])
+            });
+
+            const api = new OffersAPI(/** @type {OfferBookshelfRepository} */ (/** @type {unknown} */ (repository)));
+
+            const result = await api.listOffersAvailableToSubscription({
+                subscriptionId: 'sub_123',
+                tierId,
+                cadence: 'month'
+                // no redemptionType specified
+            });
+
+            assert.equal(result.length, 2);
+        });
     });
 
     describe('#ensureOfferForStripeCoupon', function () {

--- a/ghost/core/test/unit/server/services/offers/domain/models/offer-redemption-type.test.js
+++ b/ghost/core/test/unit/server/services/offers/domain/models/offer-redemption-type.test.js
@@ -1,0 +1,46 @@
+const should = require('should');
+
+const OfferRedemptionType = require('../../../../../../../core/server/services/offers/domain/models/offer-redemption-type');
+
+describe('OfferRedemptionType', function () {
+    describe('OfferRedemptionType.create factory', function () {
+        it('Creates an Offer redemption type containing either "signup" or "retention"', function () {
+            OfferRedemptionType.create('signup');
+            OfferRedemptionType.create('retention');
+
+            try {
+                OfferRedemptionType.create('other');
+                should.fail();
+            } catch (err) {
+                should.ok(
+                    err instanceof OfferRedemptionType.InvalidOfferRedemptionType,
+                    'expected an InvalidOfferRedemptionType error'
+                );
+            }
+
+            try {
+                OfferRedemptionType.create();
+                should.fail();
+            } catch (err) {
+                should.ok(
+                    err instanceof OfferRedemptionType.InvalidOfferRedemptionType,
+                    'expected an InvalidOfferRedemptionType error'
+                );
+            }
+        });
+    });
+
+    describe('OfferRedemptionType.Signup', function () {
+        it('Is an OfferRedemptionType with a value of "signup"', function () {
+            should.equal(OfferRedemptionType.Signup.value, 'signup');
+            should.ok(OfferRedemptionType.Signup.equals(OfferRedemptionType.create('signup')));
+        });
+    });
+
+    describe('OfferRedemptionType.Retention', function () {
+        it('Is an OfferRedemptionType with a value of "retention"', function () {
+            should.equal(OfferRedemptionType.Retention.value, 'retention');
+            should.ok(OfferRedemptionType.Retention.equals(OfferRedemptionType.create('retention')));
+        });
+    });
+});


### PR DESCRIPTION
ref https://linear.app/ghost/issue/FEA-535

This PR adds the retention offer flow to portal

A new API endpoint has been added to support the retrieval of offers and the offer domain model(s) has been updated to include the newly added `redemption_type` field

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds retention offers end-to-end and surfaces them during cancellation.
> 
> - Portal: store `offers` in `AppContext`/state; fetch via `POST /members/api/member/offers`; display a new retention offer screen on `account-plan` before cancellation; minor UI/styles and helper usage updates
> - Members API: new `getMemberOffers` controller and route to return eligible offers for a member’s active subscription (auth required, retention-only), with early exits for edge cases
> - Offers domain: add `redemption_type` (signup|retention); new `OfferRedemptionType` value object; include field in mapper and persistence; repository method to get redeemed offer IDs
> - Offers application API: `listOffersAvailableToSubscription` to filter active, tier/cadence-matching, non-trial, non-redeemed offers (optional redemption type)
> - Tests: new unit/e2e tests and snapshot updates (including `redemption_type`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c241c4016b8164624c716f511425936edbe53c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->