### PR TITLE
Nx daemon dependency

### DIFF
--- a/.github/scripts/dev.js
+++ b/.github/scripts/dev.js
@@ -1,10 +1,12 @@
 const path = require('path');
 const util = require('util');
 const exec = util.promisify(require('child_process').exec);
+const {spawn} = require('child_process');
 const debug = require('debug')('ghost:dev');
 
 const chalk = require('chalk');
 const concurrently = require('concurrently');
+const chokidar = require('chokidar');
 
 
 debug('loading config');
@@ -109,11 +111,101 @@ const COMMAND_BROWSERTESTS = {
     env: {}
 };
 
+function createFileWatcherCommand(projects) {
+    const projectList = projects.split(',');
+    const workspaceRoot = path.join(__dirname, '../..');
+    
+    const watchPaths = projectList.map(project => {
+        const projectPath = project.startsWith('apps/') ? project : `apps/${project}`;
+        return path.join(workspaceRoot, projectPath);
+    });
+
+    return {
+        command: async () => {
+            const buildQueue = new Set();
+            let isBuilding = false;
+
+            async function processBuildQueue() {
+                if (isBuilding || buildQueue.size === 0) {
+                    return;
+                }
+
+                isBuilding = true;
+                const projectsToBuild = Array.from(buildQueue);
+                buildQueue.clear();
+
+                debug(`Building projects: ${projectsToBuild.join(', ')}`);
+
+                for (const project of projectsToBuild) {
+                    try {
+                        const buildCommand = `nx run ${project}:build`;
+                        debug(`Running: ${buildCommand}`);
+                        await exec(buildCommand, {cwd: workspaceRoot});
+                        debug(`Built: ${project}`);
+                    } catch (err) {
+                        console.error(chalk.red(`Error building ${project}:`), err.message);
+                    }
+                }
+
+                isBuilding = false;
+                if (buildQueue.size > 0) {
+                    setTimeout(processBuildQueue, 100);
+                }
+            }
+
+            const watcher = chokidar.watch(watchPaths, {
+                ignored: [
+                    '**/node_modules/**',
+                    '**/dist/**',
+                    '**/build/**',
+                    '**/.turbo/**',
+                    '**/.nx/**'
+                ],
+                persistent: true,
+                ignoreInitial: true,
+                awaitWriteFinish: {
+                    stabilityThreshold: 100,
+                    pollInterval: 100
+                }
+            });
+
+            watcher.on('change', (filePath) => {
+                const relativePath = path.relative(workspaceRoot, filePath);
+                debug(`File changed: ${relativePath}`);
+
+                for (const project of projectList) {
+                    const projectPath = project.startsWith('apps/') ? project : `apps/${project}`;
+                    if (relativePath.startsWith(projectPath)) {
+                        debug(`Queueing build for: ${project}`);
+                        buildQueue.add(project);
+                        setTimeout(processBuildQueue, 300);
+                        break;
+                    }
+                }
+            });
+
+            watcher.on('ready', () => {
+                console.log(chalk.magenta(`Watching for changes in: ${projectList.join(', ')}`));
+                
+                debug('Running initial builds');
+                projectList.forEach(project => buildQueue.add(project));
+                processBuildQueue();
+            });
+
+            watcher.on('error', error => {
+                console.error(chalk.red('Watcher error:'), error);
+            });
+
+            return new Promise(() => {});
+        }
+    };
+}
+
 const adminXApps = '@tryghost/admin-x-settings,@tryghost/activitypub,@tryghost/posts,@tryghost/stats';
 
 const COMMANDS_ADMINX = [{
     name: 'adminXDeps',
-    command: 'while [ 1 ]; do nx watch --projects=apps/admin-x-design-system,apps/admin-x-framework,apps/shade,apps/stats -- nx run \\$NX_PROJECT_NAME:build; done',
+    command: createFileWatcherCommand('admin-x-design-system,admin-x-framework,shade,stats').command,
     prefixColor: '#C72AF7',
     env: {}
 }, {
@@ -279,12 +371,6 @@ async function handleStripe() {
         process.exit(0);
     }
     debug('at least one command provided');
-
-    debug('resetting nx');
-    await exec("yarn nx reset --onlyDaemon");
-    debug('nx reset');
-    await exec("yarn nx daemon --start");
-    debug('nx daemon started');
 
     console.log(`Running projects: ${commands.map(c => chalk.green(c.name)).join(', ')}`);
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,7 +246,7 @@ jobs:
           path: ghost/**/.eslintcache
           key: eslint-cache
 
-      - run: yarn nx affected -t lint --base=${{ needs.job_setup.outputs.BASE_COMMIT }}
+      - run: yarn nx affected -t lint --base=${{ needs.job_setup.outputs.base_commit }}
 
       - uses: tryghost/actions/actions/slack-build@main
         if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -477,7 +477,7 @@ jobs:
       - name: Build remaining assets
         run: yarn nx run-many -t build --exclude=ghost-admin
 
-      - run: yarn nx affected -t test:unit --base=${{ needs.job_setup.outputs.BASE_COMMIT }}
+      - run: yarn nx affected -t test:unit --base=${{ needs.job_setup.outputs.base_commit }}
 
       - uses: actions/upload-artifact@v4
         if: matrix.node == env.NODE_VERSION

--- a/compose.yml
+++ b/compose.yml
@@ -31,7 +31,7 @@ x-service-template: &service-template
   environment:
     - DEBUG=${DEBUG:-}
     - SSH_AUTH_SOCK=/ssh-agent
-    - NX_DAEMON=${NX_DAEMON:-true}
+    - NX_DAEMON=${NX_DAEMON:-false}
     - GHOST_DEV_IS_DOCKER=true
     - GHOST_DEV_APP_FLAGS=${GHOST_DEV_APP_FLAGS:-}
     - GHOST_UPSTREAM=${GHOST_UPSTREAM:-}

--- a/nx.json
+++ b/nx.json
@@ -1,5 +1,6 @@
 {
     "$schema": "./node_modules/nx/schemas/nx-schema.json",
+    "useDaemonProcess": false,
     "namedInputs": {
         "default": ["{projectRoot}/**/*", "{workspaceRoot}/ghost/tsconfig.json"]
     },


### PR DESCRIPTION
Got some code for us? Awesome 🎊!

Please take a minute to explain the change you're making:
- **Why are you making it?**
  The NX Daemon frequently causes friction and flakiness in our development setup, leading to errors when it's not running or when it needs to be restarted. This change aims to eliminate these recurring annoyances.
- **What does it do?**
  This PR removes the dependency on the NX Daemon by:
  1.  Replacing `nx watch` in `.github/scripts/dev.js` with a custom file watcher using `chokidar` for AdminX projects.
  2.  Removing NX daemon startup commands from `.github/scripts/dev.js`.
  3.  Globally disabling the NX daemon in `nx.json` (`"useDaemonProcess": false`).
  4.  Updating `compose.yml` to set `NX_DAEMON` to `false` by default.
- **Why is this something Ghost users or developers need?**
  This change resolves a whole category of bugs and annoyances in the Ghost development setup, providing a more stable and predictable local development experience by removing the problematic NX Daemon dependency.

Please check your PR against these items:

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [ ] I've written an automated test to prove my change works

---
Linear Issue: [NY-920](https://linear.app/ghost/issue/NY-920/remove-dependency-on-nx-daemon)

<a href="https://cursor.com/background-agent?bcId=bc-9388e7c8-1950-4046-8cea-3fb67b2b0a08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9388e7c8-1950-4046-8cea-3fb67b2b0a08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

