### PR TITLE
Added deep-link by `id` support to comments list

### DIFF
--- a/apps/posts/src/views/comments/comments.tsx
+++ b/apps/posts/src/views/comments/comments.tsx
@@ -11,7 +11,7 @@ import {useFilterState} from './hooks/use-filter-state';
 import {useKnownFilterValues} from './hooks/use-known-filter-values';
 
 const Comments: React.FC = () => {
-    const {filters, nql, setFilters} = useFilterState();
+    const {filters, nql, setFilters, clearFilters, isSingleIdFilter} = useFilterState();
     const {data: configData} = useBrowseConfig();
     const commentPermalinksEnabled = configData?.config?.labs?.commentPermalinks === true;
 
@@ -23,7 +23,7 @@ const Comments: React.FC = () => {
             return [...filtered, createFilter(field, operator, [value])];
         }, {replace: false});
     }, [setFilters]);
-    
+
     const {
         data,
         isError,
@@ -41,12 +41,14 @@ const Comments: React.FC = () => {
     return (
         <CommentsLayout>
             <CommentsHeader>
-                <CommentsFilters 
-                    filters={filters} 
-                    knownMembers={knownMembers}
-                    knownPosts={knownPosts}
-                    onFiltersChange={setFilters}
-                />
+                {!isSingleIdFilter && (
+                    <CommentsFilters
+                        filters={filters}
+                        knownMembers={knownMembers}
+                        knownPosts={knownPosts}
+                        onFiltersChange={setFilters}
+                    />
+                )}
             </CommentsHeader>
             <CommentsContent>
                 {(isFetching && !isFetchingNextPage) ? (
@@ -74,16 +76,25 @@ const Comments: React.FC = () => {
                         </EmptyIndicator>
                     </div>
                 ) : (
-                    <CommentsList
-                        commentPermalinksEnabled={commentPermalinksEnabled}
-                        fetchNextPage={fetchNextPage}
-                        hasNextPage={hasNextPage}
-                        isFetchingNextPage={isFetchingNextPage}
-                        isLoading={isFetching && !isFetchingNextPage}
-                        items={data?.comments ?? []}
-                        totalItems={data?.meta?.pagination?.total ?? 0}
-                        onAddFilter={handleAddFilter}
-                    />
+                    <>
+                        <CommentsList
+                            commentPermalinksEnabled={commentPermalinksEnabled}
+                            fetchNextPage={fetchNextPage}
+                            hasNextPage={hasNextPage}
+                            isFetchingNextPage={isFetchingNextPage}
+                            isLoading={isFetching && !isFetchingNextPage}
+                            items={data?.comments ?? []}
+                            totalItems={data?.meta?.pagination?.total ?? 0}
+                            onAddFilter={handleAddFilter}
+                        />
+                        {isSingleIdFilter && (
+                            <div className="flex justify-center py-8">
+                                <Button variant="outline" onClick={() => clearFilters({replace: false})}>
+                                    Show all comments
+                                </Button>
+                            </div>
+                        )}
+                    </>
                 )}
             </CommentsContent>
         </CommentsLayout>


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3199/

We want to allow linking to a specific comment for moderation from the front-end and in report notifications.

- added URL filtering support for `/comments/?id=is:{comment_id}` to `useFilterState`
  - no UI is added for manually selecting a specific id
  - adds an `isSingleIdFilter` property to the return object, being `true` when a deep-link id filter is present so we can adapt the filtering UI accordingly
  - adds an options param to the returned `clearFilters` function to support URL history behaviour
- modified comments list for deep-link by `id` state
  - hides filtering UI because it doesn't make sense when there's no display of or option to change an `id` filter
  - adds "Show all comments" button underneath the list showing a single comment, uses newly added `{replace: false}` option so it's possible to get back to the single comment using the Back button after showing all
