### PR TITLE
Updated comment report email with deep link to comment moderation

### DIFF
--- a/ghost/core/core/server/services/comments/comments-service-emails.js
+++ b/ghost/core/core/server/services/comments/comments-service-emails.js
@@ -154,6 +154,8 @@ class CommentsServiceEmails {
 
         const memberName = member.get('name') || 'Anonymous';
 
+        const commentModerationEnabled = this.labs.isSet('commentModeration');
+
         const templateData = {
             siteTitle: this.settingsCache.get('title'),
             siteUrl: this.urlUtils.getSiteUrl(),
@@ -175,7 +177,9 @@ class CommentsServiceEmails {
             accentColor: this.settingsCache.get('accent_color'),
             fromEmail: this.notificationFromAddress,
             toEmail: to,
-            staffUrl: this.urlUtils.urlJoin(this.urlUtils.urlFor('admin', true), '#', `/settings/staff/${owner.get('slug')}/email-notifications`)
+            staffUrl: this.urlUtils.urlJoin(this.urlUtils.urlFor('admin', true), '#', `/settings/staff/${owner.get('slug')}/email-notifications`),
+            commentModerationEnabled,
+            moderationUrl: this.urlUtils.urlJoin(this.urlUtils.urlFor('admin', true), '#', `/comments/?id=is:${comment.get('id')}`)
         };
 
         const {html, text} = await this.commentsServiceEmailRenderer.renderEmailTemplate('report', templateData);

--- a/ghost/core/core/server/services/comments/email-templates/report.hbs
+++ b/ghost/core/core/server/services/comments/email-templates/report.hbs
@@ -116,7 +116,7 @@
                     <tr>
                       <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top;">
                         <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 20px; color: #15212A; font-weight: bold; line-height: 25px; margin: 0; margin-bottom: 15px;">Hey there,</p>
-                          <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; color: #3A464C; font-weight: normal; margin: 0; line-height: 25px; margin-bottom: 32px;">{{reporter}} has reported the comment below on <a href="{{postUrl}}" target="_blank" style="font-weight: bold; text-decoration: underline; color: #15212A;">{{postTitle}}</a>. This comment will remain visible until you choose to remove it, which can be done directly on the post.</p>
+                          <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; color: #3A464C; font-weight: normal; margin: 0; line-height: 25px; margin-bottom: 32px;">{{reporter}} has reported the comment below on <a href="{{postUrl}}" target="_blank" style="font-weight: bold; text-decoration: underline; color: #15212A;">{{postTitle}}</a>.{{#unless commentModerationEnabled}} This comment will remain visible until you choose to remove it, which can be done directly on the post.{{/unless}}</p>
 
                         <table width="100" border="0" cellpadding="0" cellspacing="0" class="btn btn-primary" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; table-layout: fixed; width: 100%; min-width: 100%; box-sizing: border-box; background: #F9F9FA; border-radius: 7px;">
                         <tbody>
@@ -152,7 +152,11 @@
                                 <table border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: auto;">
                                   <tbody>
                                     <tr>
+                                      {{#if commentModerationEnabled}}
+                                      <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; vertical-align: top; background-color: {{accentColor}}; border-radius: 5px; text-align: center;"> <a href="{{moderationUrl}}" target="_blank" style="display: inline-block; color: #ffffff; background-color: {{accentColor}}; border: solid 1px {{accentColor}}; border-radius: 5px; box-sizing: border-box; cursor: pointer; text-decoration: none; font-size: 16px; font-weight: normal; margin: 0; padding: 9px 22px 10px; border-color: {{accentColor}};">Review comment</a> </td>
+                                      {{else}}
                                       <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; vertical-align: top; background-color: {{accentColor}}; border-radius: 5px; text-align: center;"> <a href="{{postUrl}}" target="_blank" style="display: inline-block; color: #ffffff; background-color: {{accentColor}}; border: solid 1px {{accentColor}}; border-radius: 5px; box-sizing: border-box; cursor: pointer; text-decoration: none; font-size: 16px; font-weight: normal; margin: 0; padding: 9px 22px 10px; border-color: {{accentColor}};">View comment</a> </td>
+                                      {{/if}}
                                     </tr>
                                   </tbody>
                                 </table>

--- a/ghost/core/core/server/services/comments/email-templates/report.txt.js
+++ b/ghost/core/core/server/services/comments/email-templates/report.txt.js
@@ -1,13 +1,22 @@
 module.exports = function (data) {
+    let visibilityNote = 'This comment will remain visible until you choose to remove it.';
+    if (!data.commentModerationEnabled) {
+        visibilityNote = 'This comment will remain visible until you choose to remove it, which can be done directly on the post.';
+    }
+
+    let actionLinks = data.postUrl;
+    if (data.commentModerationEnabled) {
+        actionLinks = `View comment: ${data.postUrl}\nModerate comment: ${data.moderationUrl}`;
+    }
+
     // Be careful when you indent the email, because whitespaces are visible in emails!
     return `Hey there,
 
-${data.reporter} has reported the comment below on ${data.postTitle}. This comment will remain visible until you choose to remove it, which can be done directly on the post.
+${data.reporter} has reported the comment below on ${data.postTitle}. ${visibilityNote}
 
 ${data.memberName} (${data.memberEmail}):
 ${data.commentText}
-
-${data.postUrl}
+${actionLinks}
 
 ---
 


### PR DESCRIPTION
requires https://github.com/TryGhost/Ghost/pull/25866

- use `commentModeration` labs flag to provide `commentModerationEnabled` and `moderationUrl` data to the templates
- templates were updated to include both a link to the comment on the front-end (permalink when `commentPermalinks` is enabled) and a deep link to the comments list for moderation actions
