### PR TITLE
Removed fallback member welcome email content related to performance testing

### DIFF
--- a/ghost/core/core/server/services/member-welcome-emails/constants.js
+++ b/ghost/core/core/server/services/member-welcome-emails/constants.js
@@ -14,29 +14,8 @@ const MESSAGES = {
     memberWelcomeEmailInactive: memberStatus => `Member welcome email for "${memberStatus}" members is inactive`
 };
 
-// Default welcome email content in Lexical JSON format
-// Uses __GHOST_URL__ placeholder which Ghost replaces with the actual site URL
-// These match the defaults used in the admin UI (apps/admin-x-settings/src/components/settings/membership/member-emails.tsx)
-const DEFAULT_FREE_LEXICAL_CONTENT = '{"root":{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"Welcome! Thanks for subscribing — it\'s great to have you here.","type":"extended-text","version":1}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1},{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"You\'ll now receive new posts straight to your inbox. You can also log in any time to read the ","type":"extended-text","version":1},{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"full archive","type":"extended-text","version":1}],"direction":"ltr","format":"","indent":0,"type":"link","version":1,"rel":"noreferrer","target":null,"title":null,"url":"__GHOST_URL__/"},{"detail":0,"format":0,"mode":"normal","style":"","text":" or catch up on new posts as they go live.","type":"extended-text","version":1}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1},{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"A little housekeeping: If this email landed in spam or promotions, try moving it to your primary inbox and adding this address to your contacts. Small signals like that help your inbox recognize that these messages matter to you.","type":"extended-text","version":1}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1},{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"Have questions or just want to say hi? Feel free to reply directly to this email or any newsletter in the future.","type":"extended-text","version":1}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1},{"children":[],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}}';
-
-const DEFAULT_PAID_LEXICAL_CONTENT = '{"root":{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"Welcome, and thank you for your support — it means a lot.","type":"extended-text","version":1}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1},{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"As a paid member, you now have full access to everything: the complete archive, and any paid-only content going forward. New posts will land straight to your inbox, and you can log in any time to ","type":"extended-text","version":1},{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"catch up","type":"extended-text","version":1}],"direction":"ltr","format":"","indent":0,"type":"link","version":1,"rel":"noreferrer","target":null,"title":null,"url":"__GHOST_URL__/"},{"detail":0,"format":0,"mode":"normal","style":"","text":" on anything you\'ve missed.","type":"extended-text","version":1}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1},{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"A little housekeeping: If this email landed in spam or promotions, try moving it to your primary inbox and adding this address to your contacts. Small signals like that help your inbox recognize that these messages matter to you.","type":"extended-text","version":1}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1},{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"Have questions or just want to say hi? Feel free to reply directly to this email or any newsletter in the future.","type":"extended-text","version":1}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}}';
-
-const DEFAULT_WELCOME_EMAILS = {
-    free: {
-        lexical: DEFAULT_FREE_LEXICAL_CONTENT,
-        subject: 'Welcome to {site_title}',
-        status: 'active'
-    },
-    paid: {
-        lexical: DEFAULT_PAID_LEXICAL_CONTENT,
-        subject: 'Welcome to your paid subscription',
-        status: 'active'
-    }
-};
-
 module.exports = {
     MEMBER_WELCOME_EMAIL_LOG_KEY,
     MEMBER_WELCOME_EMAIL_SLUGS,
-    MESSAGES,
-    DEFAULT_WELCOME_EMAILS
+    MESSAGES
 };

--- a/ghost/core/core/server/services/member-welcome-emails/service.js
+++ b/ghost/core/core/server/services/member-welcome-emails/service.js
@@ -8,7 +8,7 @@ const mail = require('../mail');
 // @ts-expect-error type checker has trouble with the dynamic exporting in models
 const {AutomatedEmail} = require('../../models');
 const MemberWelcomeEmailRenderer = require('./member-welcome-email-renderer');
-const {MEMBER_WELCOME_EMAIL_LOG_KEY, MEMBER_WELCOME_EMAIL_SLUGS, MESSAGES, DEFAULT_WELCOME_EMAILS} = require('./constants');
+const {MEMBER_WELCOME_EMAIL_LOG_KEY, MEMBER_WELCOME_EMAIL_SLUGS, MESSAGES} = require('./constants');
 
 class MemberWelcomeEmailService {
     #mailer;
@@ -30,32 +30,14 @@ class MemberWelcomeEmailService {
     }
 
     async loadMemberWelcomeEmails() {
-        const useDefaults = Boolean(config.get('memberWelcomeEmailTestInbox'));
-
         for (const [memberStatus, slug] of Object.entries(MEMBER_WELCOME_EMAIL_SLUGS)) {
             const row = await AutomatedEmail.findOne({slug});
 
-            if (!row) {
-                // No row - use default template when test inbox is configured
-                if (useDefaults) {
-                    const defaultEmail = DEFAULT_WELCOME_EMAILS[memberStatus];
-                    this.#memberWelcomeEmails[memberStatus] = {
-                        ...defaultEmail,
-                        lexical: urlUtils.transformReadyToAbsolute(defaultEmail.lexical)
-                    };
-                } else {
-                    this.#memberWelcomeEmails[memberStatus] = null;
-                }
-                continue;
-            }
-
-            // Row exists - check if it has content
-            if (!row.get('lexical')) {
+            if (!row || !row.get('lexical')) {
                 this.#memberWelcomeEmails[memberStatus] = null;
                 continue;
             }
 
-            // Use DB template (status check happens in send())
             this.#memberWelcomeEmails[memberStatus] = {
                 lexical: row.get('lexical'),
                 subject: row.get('subject'),

--- a/ghost/core/test/integration/services/member-welcome-emails.test.js
+++ b/ghost/core/test/integration/services/member-welcome-emails.test.js
@@ -224,16 +224,15 @@ describe('Member Welcome Emails Integration', function () {
             assert.ok(entriesAfterJob.models[0].get('message').includes('inactive'));
         });
 
-        it('sends email using default template when no DB template exists', async function () {
-            // Delete the free welcome email from the database
+        it('does not send email when no template exists', async function () {
             await db.knex('automated_emails').where('slug', MEMBER_WELCOME_EMAIL_SLUGS.free).del();
 
             await models.Outbox.add({
                 event_type: 'MemberCreatedEvent',
                 payload: JSON.stringify({
                     memberId: 'member1',
-                    email: 'default-template@example.com',
-                    name: 'Default Template Member',
+                    email: 'notemplate@example.com',
+                    name: 'No Template Member',
                     status: 'free'
                 }),
                 status: OUTBOX_STATUSES.PENDING
@@ -241,15 +240,11 @@ describe('Member Welcome Emails Integration', function () {
 
             await scheduleInlineJob();
 
-            // Email should be sent using default template
-            assert.equal(mailService.GhostMailer.prototype.send.callCount, 1);
-            const sentEmail = mailService.GhostMailer.prototype.send.firstCall.args[0];
-            assert.ok(sentEmail.html.includes('Thanks for subscribing'));
-            assert.equal(sentEmail.to, 'test-inbox@example.com');
+            assert.equal(mailService.GhostMailer.prototype.send.callCount, 0);
 
-            // Outbox entry should be processed (deleted after success)
             const entriesAfterJob = await models.Outbox.findAll();
-            assert.equal(entriesAfterJob.length, 0);
+            assert.equal(entriesAfterJob.length, 1);
+            assert.ok(entriesAfterJob.models[0].get('message'));
         });
 
         it('does not send email when paid template is inactive but entry has status paid', async function () {
@@ -277,16 +272,15 @@ describe('Member Welcome Emails Integration', function () {
             assert.ok(entriesAfterJob.models[0].get('message').includes('inactive'));
         });
 
-        it('sends email using default paid template when no DB paid template exists', async function () {
-            // Delete the paid welcome email from the database
+        it('does not send email when no paid template exists but entry has status paid', async function () {
             await db.knex('automated_emails').where('slug', MEMBER_WELCOME_EMAIL_SLUGS.paid).del();
 
             await models.Outbox.add({
                 event_type: 'MemberCreatedEvent',
                 payload: JSON.stringify({
                     memberId: 'paid_member_2',
-                    email: 'paid-default-template@example.com',
-                    name: 'Paid Default Template Member',
+                    email: 'paid-notemplate@example.com',
+                    name: 'Paid No Template Member',
                     status: 'paid'
                 }),
                 status: OUTBOX_STATUSES.PENDING
@@ -294,63 +288,11 @@ describe('Member Welcome Emails Integration', function () {
 
             await scheduleInlineJob();
 
-            // Email should be sent using default paid template
-            assert.equal(mailService.GhostMailer.prototype.send.callCount, 1);
-            const sentEmail = mailService.GhostMailer.prototype.send.firstCall.args[0];
-            assert.ok(sentEmail.html.includes('thank you for your support'));
-            assert.equal(sentEmail.to, 'test-inbox@example.com');
-
-            // Outbox entry should be processed (deleted after success)
-            const entriesAfterJob = await models.Outbox.findAll();
-            assert.equal(entriesAfterJob.length, 0);
-        });
-
-        it('prefers DB template over default when DB template exists and is active', async function () {
-            // DB template is already set up in beforeEach with custom content
-            await models.Outbox.add({
-                event_type: 'MemberCreatedEvent',
-                payload: JSON.stringify({
-                    memberId: 'member_db_template',
-                    email: 'db-template@example.com',
-                    name: 'DB Template Member',
-                    status: 'free'
-                }),
-                status: OUTBOX_STATUSES.PENDING
-            });
-
-            await scheduleInlineJob();
-
-            // Email should be sent using DB template content
-            assert.equal(mailService.GhostMailer.prototype.send.callCount, 1);
-            const sentEmail = mailService.GhostMailer.prototype.send.firstCall.args[0];
-            // The DB template has "Welcome to our site!" not the default "Thanks for subscribing"
-            assert.ok(sentEmail.html.includes('Welcome to our site!'));
-            assert.ok(!sentEmail.html.includes('Thanks for subscribing'));
+            assert.equal(mailService.GhostMailer.prototype.send.callCount, 0);
 
             const entriesAfterJob = await models.Outbox.findAll();
-            assert.equal(entriesAfterJob.length, 0);
-        });
-
-        it('transforms __GHOST_URL__ placeholders to actual site URL in default templates', async function () {
-            await db.knex('automated_emails').where('slug', MEMBER_WELCOME_EMAIL_SLUGS.free).del();
-
-            await models.Outbox.add({
-                event_type: 'MemberCreatedEvent',
-                payload: JSON.stringify({
-                    memberId: 'member_url_test',
-                    email: 'url-test@example.com',
-                    name: 'URL Test Member',
-                    status: 'free'
-                }),
-                status: OUTBOX_STATUSES.PENDING
-            });
-
-            await scheduleInlineJob();
-
-            assert.equal(mailService.GhostMailer.prototype.send.callCount, 1);
-            const sentEmail = mailService.GhostMailer.prototype.send.firstCall.args[0];
-            assert.ok(!sentEmail.html.includes('__GHOST_URL__'), 'Email should not contain __GHOST_URL__ placeholder');
-            assert.ok(sentEmail.html.includes('http://'), 'Email should contain actual URL');
+            assert.equal(entriesAfterJob.length, 1);
+            assert.ok(entriesAfterJob.models[0].get('message'));
         });
     });
 });


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-921

- To test performance we made it so member welcome emails would go to a fake inbox, even if the labs flag wasn't set and the content wasn't set up. This PR removes that code. (effectively reverts https://github.com/TryGhost/Ghost/pull/25802)
- Now, to add to outbox and send an email the following must be true: 1) `memberWelcomeEmailTestInbox` exists in config, because we haven't toggled on real email sending just yet, and 2) particular welcome email (free or paid) exists, and has lexical content, and status is active. 