### PR TITLE
🐛 Fixed wrongly caching admin html

### DIFF
--- a/ghost/core/core/server/web/admin/controller.js
+++ b/ghost/core/core/server/web/admin/controller.js
@@ -31,12 +31,12 @@ module.exports = function adminController(req, res) {
     updateCheck();
 
     const useAdminForward = labs.isSet('adminForward');
-    
+
     // Choose the appropriate index file based on feature flag
     // Default to Ember (index.html), use React (index-forward.html) when flag is enabled
     const indexFilename = useAdminForward ? 'index-forward.html' : 'index.html';
     const templatePath = path.resolve(config.get('paths').adminAssets, indexFilename);
-    
+
     const headers = {};
 
     try {
@@ -53,7 +53,7 @@ module.exports = function adminController(req, res) {
             headers['X-Frame-Options'] = 'sameorigin';
         }
 
-        res.sendFile(templatePath, {headers});
+        res.sendFile(templatePath, {headers, lastModified: false});
     } catch (err) {
         if (err.code === 'ENOENT') {
             throw new errors.IncorrectUsageError({


### PR DESCRIPTION
Express's `sendFile` adds `Last-Modified` header by default with the modified date of the file ([ref](https://expressjs.com/en/5x/api.html#res.sendFile)). Modified date of `index.html` file is not reliable and currently this response header sets a date as `Sat, 26 Oct 1985 08:15:00 GMT`. This causes opening Ghost Admin with HTML file with CSS and JS references of previous version if browser, request with `if-modified-since` header. Since those JS and CSS files are not present anymore, page stuck with loading animation. A hard refresh bypass the issue.

This fix prevents ExpressJS adding Last-Modified header, so there will be no date comparison between browser and server.

Got some code for us? Awesome 🎊!

Please take a minute to explain the change you're making:
- Why are you making it?
- What does it do?
- Why is this something Ghost users or developers need?

Please check your PR against these items:

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [x] I've written an automated test to prove my change works

We appreciate your contribution! 🙏

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents stale admin HTML caching by disabling Express’s default Last-Modified behavior while keeping a stable custom ETag.
> 
> - Serve admin `index*.html` with `res.sendFile(..., {headers, lastModified: false})` to omit `Last-Modified`
> - Continue generating deterministic `ETag` from file contents and honoring `X-Frame-Options` when enabled
> - Still select `index-forward.html` vs `index.html` based on `labs` flag
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 04c427d496dc87d36d6dabdb3e8fac1647d5a88d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->