### PR TITLE
Updated Vietnamese translation

### DIFF
--- a/ghost/i18n/locales/vi/portal.json
+++ b/ghost/i18n/locales/vi/portal.json
@@ -66,7 +66,7 @@
     "Emails": "Email",
     "Emails disabled": "Vô hiệu hóa email",
     "Ends {offerEndDate}": "Kết thúc {offerEndDate}",
-    "Enter code above": "",
+    "Enter code above": "Nhập mã ở trên",
     "Enter your email address": "Nhập địa chỉ email của bạn",
     "Enter your name": "Nhập tên của bạn",
     "Error": "Lỗi",


### PR DESCRIPTION
In portal.json, a string translation is missing: `Enter code above`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Completes a missing Vietnamese locale string.
> 
> - Translates `"Enter code above"` to `"Nhập mã ở trên"` in `ghost/i18n/locales/vi/portal.json`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d07e1d6c59e0508c8543b5ab5adae7a4379b9b3e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->