### PR TITLE
Fixed missing member count formatting in sidebar

### DIFF
--- a/apps/admin/src/layout/app-sidebar/nav-content.tsx
+++ b/apps/admin/src/layout/app-sidebar/nav-content.tsx
@@ -2,6 +2,7 @@ import React from "react"
 
 import {
     Button,
+    formatNumber,
     LucideIcon,
     SidebarGroup,
     SidebarGroupContent,
@@ -134,7 +135,7 @@ function NavContent({ ...props }: React.ComponentProps<typeof SidebarGroup>) {
                                 <NavMenuItem.Label>Members</NavMenuItem.Label>
                             </NavMenuItem.Link>
                             {memberCount != null && (
-                                <SidebarMenuBadge>{memberCount}</SidebarMenuBadge>
+                                <SidebarMenuBadge>{formatNumber(memberCount)}</SidebarMenuBadge>
                             )}
                         </NavMenuItem>
                     )}

--- a/apps/admin/src/layout/app-sidebar/nav-content.tsx
+++ b/apps/admin/src/layout/app-sidebar/nav-content.tsx
@@ -134,12 +134,9 @@ function NavContent({ ...props }: React.ComponentProps<typeof SidebarGroup>) {
                                 <LucideIcon.Users />
                                 <NavMenuItem.Label>Members</NavMenuItem.Label>
                             </NavMenuItem.Link>
-                            {memberCount != null && !isNaN(memberCount) && (
-                                <SidebarMenuBadge>{formatNumber(memberCount)}</SidebarMenuBadge>
+                            {memberCount != null && (
+                                <SidebarMenuBadge>{formatNumber(Number(memberCount || 0))}</SidebarMenuBadge>
                             )}
-                            <SidebarMenuBadge>
-                                {memberCount != null ? formatNumber(memberCount) : '0'}
-                            </SidebarMenuBadge>
                         </NavMenuItem>
                     )}
 

--- a/apps/admin/src/layout/app-sidebar/nav-content.tsx
+++ b/apps/admin/src/layout/app-sidebar/nav-content.tsx
@@ -134,9 +134,9 @@ function NavContent({ ...props }: React.ComponentProps<typeof SidebarGroup>) {
                                 <LucideIcon.Users />
                                 <NavMenuItem.Label>Members</NavMenuItem.Label>
                             </NavMenuItem.Link>
-                            {typeof memberCount === 'number' && (
-                                <SidebarMenuBadge>{formatNumber(memberCount)}</SidebarMenuBadge>
-                            )}
+                            <SidebarMenuBadge>
+                                {typeof memberCount === 'number' ? formatNumber(memberCount) : '0'}
+                            </SidebarMenuBadge>
                         </NavMenuItem>
                     )}
 

--- a/apps/admin/src/layout/app-sidebar/nav-content.tsx
+++ b/apps/admin/src/layout/app-sidebar/nav-content.tsx
@@ -135,7 +135,7 @@ function NavContent({ ...props }: React.ComponentProps<typeof SidebarGroup>) {
                                 <NavMenuItem.Label>Members</NavMenuItem.Label>
                             </NavMenuItem.Link>
                             <SidebarMenuBadge>
-                                {typeof memberCount === 'number' ? formatNumber(memberCount) : '0'}
+                                {memberCount != null ? formatNumber(memberCount as Number) : '0'}
                             </SidebarMenuBadge>
                         </NavMenuItem>
                     )}

--- a/apps/admin/src/layout/app-sidebar/nav-content.tsx
+++ b/apps/admin/src/layout/app-sidebar/nav-content.tsx
@@ -134,6 +134,9 @@ function NavContent({ ...props }: React.ComponentProps<typeof SidebarGroup>) {
                                 <LucideIcon.Users />
                                 <NavMenuItem.Label>Members</NavMenuItem.Label>
                             </NavMenuItem.Link>
+                            {memberCount != null && !isNaN(memberCount) && (
+                                <SidebarMenuBadge>{formatNumber(memberCount)}</SidebarMenuBadge>
+                            )}
                             <SidebarMenuBadge>
                                 {memberCount != null ? formatNumber(memberCount) : '0'}
                             </SidebarMenuBadge>

--- a/apps/admin/src/layout/app-sidebar/nav-content.tsx
+++ b/apps/admin/src/layout/app-sidebar/nav-content.tsx
@@ -134,7 +134,7 @@ function NavContent({ ...props }: React.ComponentProps<typeof SidebarGroup>) {
                                 <LucideIcon.Users />
                                 <NavMenuItem.Label>Members</NavMenuItem.Label>
                             </NavMenuItem.Link>
-                            {memberCount != null && (
+                            {typeof memberCount === 'number' && (
                                 <SidebarMenuBadge>{formatNumber(memberCount)}</SidebarMenuBadge>
                             )}
                         </NavMenuItem>

--- a/apps/admin/src/layout/app-sidebar/nav-content.tsx
+++ b/apps/admin/src/layout/app-sidebar/nav-content.tsx
@@ -135,7 +135,7 @@ function NavContent({ ...props }: React.ComponentProps<typeof SidebarGroup>) {
                                 <NavMenuItem.Label>Members</NavMenuItem.Label>
                             </NavMenuItem.Link>
                             <SidebarMenuBadge>
-                                {memberCount != null ? formatNumber(memberCount as Number) : '0'}
+                                {memberCount != null ? formatNumber(memberCount) : '0'}
                             </SidebarMenuBadge>
                         </NavMenuItem>
                     )}


### PR DESCRIPTION
no ref.

- The member count was displaying a raw, unformatted number.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves Members count display in the admin sidebar.
> 
> - Imports `formatNumber` from `@tryghost/shade` and applies it to `memberCount` in `nav-content.tsx` (`SidebarMenuBadge`) to show a formatted number.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 559cd6fa63451c13e8f68d9a6b2d8187dd2c779b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->