### PR TITLE
Disabled email size warning in unnecessary scenarios

### DIFF
--- a/ghost/admin/app/components/editor/email-size-warning.js
+++ b/ghost/admin/app/components/editor/email-size-warning.js
@@ -14,8 +14,10 @@ export default class EmailSizeWarningComponent extends Component {
     get isEnabled() {
         return this.settings.editorDefaultEmailRecipients !== 'disabled'
             && this.args.post
-            && !this.args.post.email
-            && !this.args.post.isNew;
+            && !this.args.post.isNew
+            && !this.args.post.hasEmail
+            && !this.args.post.isPublished
+            && !this.args.post.isPage;
     }
 
     constructor() {


### PR DESCRIPTION
no issue

- the email size warning was appearing unnecessarily on pages and old published posts
- added additional conditions to the warning being enabled:
  - pages - these can't be emailed
  - published posts - must be unpublished in order to email, at which point warning will show in the publish flow
