### PR TITLE
Fixed member activity list hover styles

### DIFF
--- a/ghost/admin/app/styles/layouts/member-activity.css
+++ b/ghost/admin/app/styles/layouts/member-activity.css
@@ -136,6 +136,10 @@
     padding-bottom: 12px;
 }
 
+.gh-members-activity .gh-list-scrolling tbody tr:hover > .gh-list-data {
+    background: var(--whitegrey-l2);
+}
+
 .gh-members-activity .gh-list h3 {
     margin-bottom: 4px;
 }


### PR DESCRIPTION
ref https://linear.app/ghost/issue/DES-1270/member-activity-item-hover-state-issues

The background colour wasn't working. The transparency for the borders would work and the list would look broken.

| Before | After |
|--------|--------|
| <img width="777" height="236" alt="Screenshot 2026-01-19 at 14 08 47" src="https://github.com/user-attachments/assets/081a4f88-5373-4f93-999d-6f435e8854f1" /> |<img width="856" height="232" alt="Screenshot 2026-01-19 at 14 08 11" src="https://github.com/user-attachments/assets/f79adb92-d99b-4422-92f7-39563248a03d" /> | 
