### PR TITLE
Moved comments-ui unit tests from src/ to test folder

### DIFF
--- a/apps/comments-ui/test/unit/actions.test.js
+++ b/apps/comments-ui/test/unit/actions.test.js
@@ -1,4 +1,4 @@
-import {Actions} from './actions';
+import {Actions} from '../../src/actions';
 
 describe('Actions', function () {
     describe('loadMoreComments', function () {

--- a/apps/comments-ui/test/unit/components/content-box.test.jsx
+++ b/apps/comments-ui/test/unit/components/content-box.test.jsx
@@ -1,16 +1,16 @@
-import ContentBox from './content-box';
+import ContentBox from '../../../src/components/content-box';
 import React from 'react';
-import {AppContext} from '../app-context';
-import {ROOT_DIV_ID} from '../utils/constants';
+import {AppContext} from '../../../src/app-context';
+import {ROOT_DIV_ID} from '../../../src/utils/constants';
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 import {render, screen} from '@testing-library/react';
 
 // Mock the Content and Loading components
-vi.mock('./content/content', () => ({
+vi.mock('../../../src/components/content/content', () => ({
     default: () => <div data-testid="content">${`Content component`}</div>
 }));
 
-vi.mock('./content/loading', () => ({
+vi.mock('../../../src/components/content/loading', () => ({
     default: () => <div data-testid="loading">${`Loading component`}</div>
 }));
 

--- a/apps/comments-ui/test/unit/components/content/avatar.test.tsx
+++ b/apps/comments-ui/test/unit/components/content/avatar.test.tsx
@@ -1,6 +1,6 @@
-import {AppContext} from '../../app-context';
-import {Avatar} from './avatar';
-import {buildDeletedMember, buildMember} from '../../../test/utils/fixtures';
+import {AppContext} from '../../../../src/app-context';
+import {Avatar} from '../../../../src/components/content/avatar';
+import {buildDeletedMember, buildMember} from '../../../utils/fixtures';
 import {render, screen} from '@testing-library/react';
 
 const contextualRender = (ui, {appContext, ...renderOptions}) => {

--- a/apps/comments-ui/test/unit/components/content/comment.test.jsx
+++ b/apps/comments-ui/test/unit/components/content/comment.test.jsx
@@ -1,6 +1,6 @@
-import {AppContext} from '../../app-context';
-import {CommentComponent, RepliedToSnippet} from './comment';
-import {buildComment} from '../../../test/utils/fixtures';
+import {AppContext} from '../../../../src/app-context';
+import {CommentComponent, RepliedToSnippet} from '../../../../src/components/content/comment';
+import {buildComment} from '../../../utils/fixtures';
 import {render, screen} from '@testing-library/react';
 
 const contextualRender = (ui, {appContext, ...renderOptions}) => {

--- a/apps/comments-ui/test/unit/components/content/content.test.jsx
+++ b/apps/comments-ui/test/unit/components/content/content.test.jsx
@@ -1,5 +1,5 @@
-import Content from './content';
-import {AppContext} from '../../app-context';
+import Content from '../../../../src/components/content/content';
+import {AppContext} from '../../../../src/app-context';
 import {render, screen} from '@testing-library/react';
 
 const contextualRender = (ui, {appContext, ...renderOptions}) => {

--- a/apps/comments-ui/test/unit/components/content/context-menus/comment-context-menu.test.jsx
+++ b/apps/comments-ui/test/unit/components/content/context-menus/comment-context-menu.test.jsx
@@ -1,8 +1,8 @@
-import CommentContextMenu from './comment-context-menu';
+import CommentContextMenu from '../../../../../src/components/content/context-menus/comment-context-menu';
 import React from 'react';
 import sinon from 'sinon';
-import {AppContext} from '../../../app-context';
-import {buildComment} from '../../../../test/utils/fixtures';
+import {AppContext} from '../../../../../src/app-context';
+import {buildComment} from '../../../../utils/fixtures';
 import {render, screen} from '@testing-library/react';
 
 const contextualRender = (ui, {appContext, ...renderOptions}) => {

--- a/apps/comments-ui/test/unit/components/content/pagination.test.jsx
+++ b/apps/comments-ui/test/unit/components/content/pagination.test.jsx
@@ -1,6 +1,6 @@
-import Pagination from './pagination';
+import Pagination from '../../../../src/components/content/pagination';
 import i18nLib from '@tryghost/i18n';
-import {AppContext} from '../../app-context';
+import {AppContext} from '../../../../src/app-context';
 import {render, screen} from '@testing-library/react';
 
 const i18n = i18nLib('en', 'comments');

--- a/apps/comments-ui/test/unit/utils/admin-api.test.ts
+++ b/apps/comments-ui/test/unit/utils/admin-api.test.ts
@@ -1,5 +1,5 @@
 import * as vi from 'vitest';
-import {setupAdminAPI} from './admin-api';
+import {setupAdminAPI} from '../../../src/utils/admin-api';
 
 describe('setupAdminAPI', () => {
     let addEventListenerSpy: vi.SpyInstance;

--- a/apps/comments-ui/test/unit/utils/api.test.ts
+++ b/apps/comments-ui/test/unit/utils/api.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-undef */
-import setupGhostApi from './api';
+import setupGhostApi from '../../../src/utils/api';
 import {vi} from 'vitest';
 
 test('should call counts endpoint', () => {

--- a/apps/comments-ui/test/unit/utils/helpers.test.ts
+++ b/apps/comments-ui/test/unit/utils/helpers.test.ts
@@ -1,7 +1,7 @@
-import * as helpers from './helpers';
+import * as helpers from '../../../src/utils/helpers';
 import moment, {DurationInputObject} from 'moment';
 import sinon from 'sinon';
-import {buildAnonymousMember, buildComment, buildDeletedMember} from '../../test/utils/fixtures';
+import {buildAnonymousMember, buildComment, buildDeletedMember} from '../../utils/fixtures';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 

--- a/apps/comments-ui/test/unit/utils/hooks.test.tsx
+++ b/apps/comments-ui/test/unit/utils/hooks.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import sinon from 'sinon';
 import {fireEvent, render, screen} from '@testing-library/react';
-import {useOutOfViewportClasses} from './hooks';
+import {useOutOfViewportClasses} from '../../../src/utils/hooks';
 
 describe('useOutOfViewportClasses', () => {
     const classes = {

--- a/apps/comments-ui/vite.config.mts
+++ b/apps/comments-ui/vite.config.mts
@@ -60,7 +60,7 @@ export default (function viteConfig() {
             globals: true, // required for @testing-library/jest-dom extensions
             environment: 'jsdom',
             setupFiles: './src/setup-tests.ts',
-            include: ['src/**/*.test.jsx', 'src/**/*.test.js', 'src/**/*.test.ts', 'src/**/*.test.tsx'],
+            include: ['test/unit/**/*.test.{js,jsx,ts,tsx}'],
             testTimeout: process.env.TIMEOUT ? parseInt(process.env.TIMEOUT) : 10000,
             ...(process.env.CI && { // https://github.com/vitest-dev/vitest/issues/1674
                 minThreads: 1,


### PR DESCRIPTION
**what**

Moved comments-ui unit tests from src/ to test/unit/

**why**

Aligns comments-ui test organization with other apps in the monorepo (portal, admin-x-settings, posts, stats) which keep unit tests in a separate test/unit/ directory that mirrors the src/ structure. This makes it easier to find tests and maintains consistency across apps.
