### PR TITLE
🐛 Allowed complimentary members to upgrade to a paid plan

### DIFF
--- a/apps/portal/src/app.js
+++ b/apps/portal/src/app.js
@@ -14,7 +14,7 @@ import {transformPortalAnchorToRelative} from './utils/transform-portal-anchor-t
 import {getActivePage, isAccountPage, isOfferPage} from './pages';
 import ActionHandler from './actions';
 import './app.css';
-import {hasRecommendations, createPopupNotification, hasAvailablePrices, getCurrencySymbol, getFirstpromoterId, getPriceIdFromPageQuery, getProductCadenceFromPrice, getProductFromId, getQueryPrice, getSiteDomain, isActiveOffer, isComplimentaryMember, isInviteOnly, isPaidMember, isRecentMember, isSentryEventAllowed, removePortalLinkFromUrl} from './utils/helpers';
+import {hasRecommendations, createPopupNotification, hasAvailablePrices, getCurrencySymbol, getFirstpromoterId, getPriceIdFromPageQuery, getProductCadenceFromPrice, getProductFromId, getQueryPrice, getSiteDomain, isActiveOffer, isInviteOnly, isPaidMember, isRecentMember, isSentryEventAllowed, removePortalLinkFromUrl} from './utils/helpers';
 import {handleDataAttributes} from './data-attributes';
 
 const DEV_MODE_DATA = {

--- a/apps/portal/src/app.js
+++ b/apps/portal/src/app.js
@@ -14,7 +14,7 @@ import {transformPortalAnchorToRelative} from './utils/transform-portal-anchor-t
 import {getActivePage, isAccountPage, isOfferPage} from './pages';
 import ActionHandler from './actions';
 import './app.css';
-import {hasRecommendations, allowCompMemberUpgrade, createPopupNotification, hasAvailablePrices, getCurrencySymbol, getFirstpromoterId, getPriceIdFromPageQuery, getProductCadenceFromPrice, getProductFromId, getQueryPrice, getSiteDomain, isActiveOffer, isComplimentaryMember, isInviteOnly, isPaidMember, isRecentMember, isSentryEventAllowed, removePortalLinkFromUrl} from './utils/helpers';
+import {hasRecommendations, createPopupNotification, hasAvailablePrices, getCurrencySymbol, getFirstpromoterId, getPriceIdFromPageQuery, getProductCadenceFromPrice, getProductFromId, getQueryPrice, getSiteDomain, isActiveOffer, isComplimentaryMember, isInviteOnly, isPaidMember, isRecentMember, isSentryEventAllowed, removePortalLinkFromUrl} from './utils/helpers';
 import {handleDataAttributes} from './data-attributes';
 
 const DEV_MODE_DATA = {
@@ -936,10 +936,6 @@ export default class App extends React.Component {
         if (!page || page === 'default') {
             const loggedOutPage = isInviteOnly({site}) || !hasAvailablePrices({site}) ? 'signin' : 'signup';
             page = member ? 'accountHome' : loggedOutPage;
-        }
-
-        if (page === 'accountPlan' && isComplimentaryMember({member}) && !allowCompMemberUpgrade({member})) {
-            page = 'accountHome';
         }
 
         return getActivePage({page});

--- a/apps/portal/src/app.js
+++ b/apps/portal/src/app.js
@@ -14,7 +14,7 @@ import {transformPortalAnchorToRelative} from './utils/transform-portal-anchor-t
 import {getActivePage, isAccountPage, isOfferPage} from './pages';
 import ActionHandler from './actions';
 import './app.css';
-import {hasRecommendations, createPopupNotification, hasAvailablePrices, getCurrencySymbol, getFirstpromoterId, getPriceIdFromPageQuery, getProductCadenceFromPrice, getProductFromId, getQueryPrice, getSiteDomain, isActiveOffer, isInviteOnly, isPaidMember, isRecentMember, isSentryEventAllowed, removePortalLinkFromUrl} from './utils/helpers';
+import {hasRecommendations, createPopupNotification, hasAvailablePrices, getCurrencySymbol, getFirstpromoterId, getPriceIdFromPageQuery, getProductCadenceFromPrice, getProductFromId, getQueryPrice, getSiteDomain, isActiveOffer, isComplimentaryMember, isInviteOnly, isPaidMember, isRecentMember, isSentryEventAllowed, removePortalLinkFromUrl} from './utils/helpers';
 import {handleDataAttributes} from './data-attributes';
 
 const DEV_MODE_DATA = {

--- a/apps/portal/src/components/pages/AccountHomePage/components/paid-account-actions.js
+++ b/apps/portal/src/components/pages/AccountHomePage/components/paid-account-actions.js
@@ -1,5 +1,5 @@
 import AppContext from '../../../../app-context';
-import {allowCompMemberUpgrade, getCompExpiry, getMemberSubscription, getMemberTierName, getUpdatedOfferPrice, hasMultipleProductsFeature, hasOnlyFreePlan, isComplimentaryMember, isPaidMember, isInThePast, subscriptionHasFreeTrial} from '../../../../utils/helpers';
+import {getCompExpiry, getMemberSubscription, getMemberTierName, getUpdatedOfferPrice, hasMultipleProductsFeature, hasOnlyFreePlan, isComplimentaryMember, isPaidMember, isInThePast, subscriptionHasFreeTrial} from '../../../../utils/helpers';
 import {getDateString} from '../../../../utils/date-time';
 import {ReactComponent as LoaderIcon} from '../../../../images/icons/loader.svg';
 import {ReactComponent as OfferTagIcon} from '../../../../images/icons/offer-tag.svg';
@@ -84,9 +84,8 @@ const PaidAccountActions = () => {
         );
     };
 
-    const PlanUpdateButton = ({isComplimentary, isPaid}) => {
-        const hideUpgrade = allowCompMemberUpgrade({member}) ? false : isComplimentary;
-        if (hideUpgrade || (hasOnlyFreePlan({site}) && !isPaid)) {
+    const PlanUpdateButton = ({isPaid}) => {
+        if (hasOnlyFreePlan({site}) && !isPaid) {
             return null;
         }
         return (
@@ -140,7 +139,6 @@ const PaidAccountActions = () => {
     const subscription = getMemberSubscription({member});
     const isComplimentary = isComplimentaryMember({member});
     const isPaid = isPaidMember({member});
-    const isCancelled = subscription?.cancel_at_period_end;
     if (subscription || isComplimentary) {
         const {
             price,
@@ -163,7 +161,7 @@ const PaidAccountActions = () => {
                         <h3>{planLabel}</h3>
                         <PlanLabel price={price} isComplimentary={isComplimentary} subscription={subscription} />
                     </div>
-                    <PlanUpdateButton isComplimentary={isComplimentary} isPaid={isPaid} isCancelled={isCancelled} />
+                    <PlanUpdateButton isPaid={isPaid} />
                 </section>
                 <BillingSection isComplimentary={isComplimentary} defaultCardLast4={defaultCardLast4} />
             </>

--- a/apps/portal/src/components/pages/account-plan-page.js
+++ b/apps/portal/src/components/pages/account-plan-page.js
@@ -5,7 +5,7 @@ import CloseButton from '../common/close-button';
 import BackButton from '../common/back-button';
 import {MultipleProductsPlansSection} from '../common/plans-section';
 import {getDateString} from '../../utils/date-time';
-import {allowCompMemberUpgrade, formatNumber, getAvailablePrices, getCurrencySymbol, getFilteredPrices, getMemberActivePrice, getMemberActiveProduct, getMemberSubscription, getPriceFromSubscription, getProductFromPrice, getSubscriptionFromId, getUpgradeProducts, hasMultipleProductsFeature, isComplimentaryMember, isPaidMember} from '../../utils/helpers';
+import {formatNumber, getAvailablePrices, getCurrencySymbol, getFilteredPrices, getMemberActivePrice, getMemberActiveProduct, getMemberSubscription, getPriceFromSubscription, getProductFromPrice, getSubscriptionFromId, getUpgradeProducts, hasMultipleProductsFeature, isComplimentaryMember, isPaidMember} from '../../utils/helpers';
 import Interpolate from '@doist/react-interpolate';
 import {t} from '../../utils/i18n';
 

--- a/apps/portal/src/components/pages/account-plan-page.js
+++ b/apps/portal/src/components/pages/account-plan-page.js
@@ -383,9 +383,8 @@ const PlansContainer = ({
     onAcceptRetentionOffer, onDeclineRetentionOffer
 }) => {
     const {member} = useContext(AppContext);
-    // Plan upgrade flow for free member
-    const allowUpgrade = allowCompMemberUpgrade({member}) && isComplimentaryMember({member});
-    if (!isPaidMember({member}) || allowUpgrade) {
+    // Plan upgrade flow for free member or complimentary member
+    if (!isPaidMember({member}) || isComplimentaryMember({member})) {
         return (
             <UpgradePlanSection
                 {...{plans, selectedPlan, onPlanSelect, onPlanCheckout}}
@@ -500,8 +499,7 @@ export default class AccountPlanPage extends React.Component {
             selectedPlan = priceId;
         }
 
-        const restrictCheckout = allowCompMemberUpgrade({member}) ? !isComplimentaryMember({member}) : true;
-        if (isPaidMember({member}) && restrictCheckout) {
+        if (isPaidMember({member}) && !isComplimentaryMember({member})) {
             const subscription = getMemberSubscription({member});
             const subscriptionId = subscription ? subscription.id : '';
             if (subscriptionId) {
@@ -517,9 +515,8 @@ export default class AccountPlanPage extends React.Component {
 
         const {member} = this.context;
 
-        const allowCompMember = allowCompMemberUpgrade({member}) ? isComplimentaryMember({member}) : false;
         // Work as checkboxes for free member plan selection and button for paid members
-        if (!isPaidMember({member}) || allowCompMember) {
+        if (!isPaidMember({member}) || isComplimentaryMember({member})) {
             // Hack: React checkbox gets out of sync with dom state with instant update
             this.timeoutId = setTimeout(() => {
                 this.setState(() => {

--- a/apps/portal/src/utils/helpers.js
+++ b/apps/portal/src/utils/helpers.js
@@ -90,10 +90,6 @@ export function hasNewsletterSendingEnabled({site}) {
     return site?.editor_default_email_recipients !== 'disabled';
 }
 
-export function allowCompMemberUpgrade({member}) {
-    return isComplimentaryMember({member});
-}
-
 export function getCompExpiry({member}) {
     const subscription = getMemberSubscription({member});
     if (subscription?.tier?.expiry_at) {

--- a/apps/portal/src/utils/helpers.js
+++ b/apps/portal/src/utils/helpers.js
@@ -91,7 +91,7 @@ export function hasNewsletterSendingEnabled({site}) {
 }
 
 export function allowCompMemberUpgrade({member}) {
-    return member?.subscriptions?.[0]?.tier?.expiry_at !== undefined;
+    return isComplimentaryMember({member});
 }
 
 export function getCompExpiry({member}) {

--- a/apps/portal/test/upgrade-flow.test.js
+++ b/apps/portal/test/upgrade-flow.test.js
@@ -343,9 +343,7 @@ describe('Logged-in free member', () => {
             window.location.hash = '';
         });
     });
-});
 
-describe('Logged-in free member', () => {
     describe('can upgrade on multi tier site', () => {
         test('with default settings', async () => {
             const {
@@ -552,6 +550,88 @@ describe('Logged-in complimentary member', () => {
                 cadence: 'month'
             });
         });
+
+        test('to an offer via link', async () => {
+            window.location.hash = '#/portal/offers/61fa22bd0cbecc7d423d20b3';
+            const {
+                ghostApi, popupFrame, triggerButtonFrame, emailInput, nameInput, signinButton, submitButton,
+                siteTitle,
+                offerName, offerDescription
+            } = await offerSetup({
+                site: FixtureSite.singleTier.basic,
+                member: FixtureMember.altComplimentary,
+                offer: FixtureOffer
+            });
+            let planId = FixtureSite.singleTier.basic.products.find(p => p.type === 'paid').monthlyPrice.id;
+            let singleTierProduct = FixtureSite.singleTier.basic.products.find(p => p.type === 'paid');
+            let offerId = FixtureOffer.id;
+            expect(popupFrame).toBeInTheDocument();
+            expect(triggerButtonFrame).toBeInTheDocument();
+            expect(siteTitle).toBeInTheDocument();
+            expect(emailInput).toBeInTheDocument();
+            expect(nameInput).toBeInTheDocument();
+            expect(signinButton).not.toBeInTheDocument();
+            expect(submitButton).toBeInTheDocument();
+            expect(offerName).toBeInTheDocument();
+            expect(offerDescription).toBeInTheDocument();
+
+            expect(emailInput).toHaveValue('jimmie@example.com');
+            expect(nameInput).toHaveValue('Jimmie Larson');
+            fireEvent.click(submitButton);
+
+            expect(ghostApi.member.checkoutPlan).toHaveBeenLastCalledWith({
+                email: 'jimmie@example.com',
+                name: 'Jimmie Larson',
+                offerId,
+                plan: planId,
+                tierId: singleTierProduct.id,
+                cadence: 'month'
+            });
+
+            window.location.hash = '';
+        });
+
+        test('to an offer via link with portal disabled', async () => {
+            let site = {
+                ...FixtureSite.singleTier.basic,
+                portal_button: false
+            };
+
+            window.location.hash = `#/portal/offers/${FixtureOffer.id}`;
+            const {
+                ghostApi, popupFrame, triggerButtonFrame, emailInput, nameInput, signinButton, submitButton,
+                siteTitle,
+                offerName, offerDescription
+            } = await offerSetup({
+                site: site,
+                member: FixtureMember.altComplimentary,
+                offer: FixtureOffer
+            });
+            let planId = FixtureSite.singleTier.basic.products.find(p => p.type === 'paid').monthlyPrice.id;
+            let singleTierProduct = FixtureSite.singleTier.basic.products.find(p => p.type === 'paid');
+            let offerId = FixtureOffer.id;
+            expect(popupFrame).toBeInTheDocument();
+            expect(triggerButtonFrame).not.toBeInTheDocument();
+            expect(siteTitle).not.toBeInTheDocument();
+            expect(emailInput).not.toBeInTheDocument();
+            expect(nameInput).not.toBeInTheDocument();
+            expect(signinButton).not.toBeInTheDocument();
+            expect(submitButton).not.toBeInTheDocument();
+            expect(offerName).not.toBeInTheDocument();
+            expect(offerDescription).not.toBeInTheDocument();
+
+            expect(ghostApi.member.checkoutPlan).toHaveBeenLastCalledWith({
+                metadata: {
+                    checkoutType: 'upgrade'
+                },
+                offerId: offerId,
+                plan: planId,
+                tierId: singleTierProduct.id,
+                cadence: 'month'
+            });
+
+            window.location.hash = '';
+        });
     });
 
     describe('can upgrade on multi tier site', () => {
@@ -636,97 +716,7 @@ describe('Logged-in complimentary member', () => {
                 cadence: 'year'
             });
         });
-    });
-});
 
-describe('Logged-in complimentary member', () => {
-    describe('can upgrade on single tier site', () => {
-        test('to an offer via link', async () => {
-            window.location.hash = '#/portal/offers/61fa22bd0cbecc7d423d20b3';
-            const {
-                ghostApi, popupFrame, triggerButtonFrame, emailInput, nameInput, signinButton, submitButton,
-                siteTitle,
-                offerName, offerDescription
-            } = await offerSetup({
-                site: FixtureSite.singleTier.basic,
-                member: FixtureMember.altComplimentary,
-                offer: FixtureOffer
-            });
-            let planId = FixtureSite.singleTier.basic.products.find(p => p.type === 'paid').monthlyPrice.id;
-            let singleTierProduct = FixtureSite.singleTier.basic.products.find(p => p.type === 'paid');
-            let offerId = FixtureOffer.id;
-            expect(popupFrame).toBeInTheDocument();
-            expect(triggerButtonFrame).toBeInTheDocument();
-            expect(siteTitle).toBeInTheDocument();
-            expect(emailInput).toBeInTheDocument();
-            expect(nameInput).toBeInTheDocument();
-            expect(signinButton).not.toBeInTheDocument();
-            expect(submitButton).toBeInTheDocument();
-            expect(offerName).toBeInTheDocument();
-            expect(offerDescription).toBeInTheDocument();
-
-            expect(emailInput).toHaveValue('jimmie@example.com');
-            expect(nameInput).toHaveValue('Jimmie Larson');
-            fireEvent.click(submitButton);
-
-            expect(ghostApi.member.checkoutPlan).toHaveBeenLastCalledWith({
-                email: 'jimmie@example.com',
-                name: 'Jimmie Larson',
-                offerId,
-                plan: planId,
-                tierId: singleTierProduct.id,
-                cadence: 'month'
-            });
-
-            window.location.hash = '';
-        });
-
-        test('to an offer via link with portal disabled', async () => {
-            let site = {
-                ...FixtureSite.singleTier.basic,
-                portal_button: false
-            };
-
-            window.location.hash = `#/portal/offers/${FixtureOffer.id}`;
-            const {
-                ghostApi, popupFrame, triggerButtonFrame, emailInput, nameInput, signinButton, submitButton,
-                siteTitle,
-                offerName, offerDescription
-            } = await offerSetup({
-                site: site,
-                member: FixtureMember.altComplimentary,
-                offer: FixtureOffer
-            });
-            let planId = FixtureSite.singleTier.basic.products.find(p => p.type === 'paid').monthlyPrice.id;
-            let singleTierProduct = FixtureSite.singleTier.basic.products.find(p => p.type === 'paid');
-            let offerId = FixtureOffer.id;
-            expect(popupFrame).toBeInTheDocument();
-            expect(triggerButtonFrame).not.toBeInTheDocument();
-            expect(siteTitle).not.toBeInTheDocument();
-            expect(emailInput).not.toBeInTheDocument();
-            expect(nameInput).not.toBeInTheDocument();
-            expect(signinButton).not.toBeInTheDocument();
-            expect(submitButton).not.toBeInTheDocument();
-            expect(offerName).not.toBeInTheDocument();
-            expect(offerDescription).not.toBeInTheDocument();
-
-            expect(ghostApi.member.checkoutPlan).toHaveBeenLastCalledWith({
-                metadata: {
-                    checkoutType: 'upgrade'
-                },
-                offerId: offerId,
-                plan: planId,
-                tierId: singleTierProduct.id,
-                cadence: 'month'
-            });
-
-            window.location.hash = '';
-        });
-    });
-});
-
-describe('Logged-in complimentary member', () => {
-    describe('can upgrade on multi tier site', () => {
         test('to an offer via link', async () => {
             window.location.hash = '#/portal/offers/61fa22bd0cbecc7d423d20b3';
             const {
@@ -768,3 +758,4 @@ describe('Logged-in complimentary member', () => {
         });
     });
 });
+

--- a/apps/portal/test/upgrade-flow.test.js
+++ b/apps/portal/test/upgrade-flow.test.js
@@ -429,6 +429,218 @@ describe('Logged-in free member', () => {
 
 describe('Logged-in complimentary member', () => {
     describe('can upgrade on single tier site', () => {
+        test('with default settings on monthly plan', async () => {
+            const {
+                ghostApi, popupFrame, triggerButtonFrame,
+                popupIframeDocument, accountHomeTitle
+            } = await setup({
+                site: FixtureSite.singleTier.basic,
+                member: FixtureMember.complimentary
+            });
+
+            expect(popupFrame).toBeInTheDocument();
+            expect(triggerButtonFrame).toBeInTheDocument();
+            expect(accountHomeTitle).toBeInTheDocument();
+
+            // Complimentary members see "Change" button instead of "View plans"
+            const changePlanButton = within(popupIframeDocument).queryByRole('button', {name: 'Change'});
+            expect(changePlanButton).toBeInTheDocument();
+
+            const singleTierProduct = FixtureSite.singleTier.basic.products.find(p => p.type === 'paid');
+
+            fireEvent.click(changePlanButton);
+            const monthlyPlanContainer = await within(popupIframeDocument).findByText('Monthly');
+            fireEvent.click(monthlyPlanContainer);
+            // added fake timeout for react state delay in setting plan
+            await new Promise((r) => {
+                setTimeout(r, 10);
+            });
+
+            const submitButton = within(popupIframeDocument).queryByRole('button', {name: 'Continue'});
+
+            fireEvent.click(submitButton);
+            expect(ghostApi.member.checkoutPlan).toHaveBeenLastCalledWith({
+                metadata: {
+                    checkoutType: 'upgrade'
+                },
+                offerId: undefined,
+                plan: singleTierProduct.monthlyPrice.id,
+                tierId: singleTierProduct.id,
+                cadence: 'month'
+            });
+        });
+
+        test('with default settings on yearly plan', async () => {
+            const {
+                ghostApi, popupFrame, triggerButtonFrame,
+                popupIframeDocument, accountHomeTitle
+            } = await setup({
+                site: FixtureSite.singleTier.basic,
+                member: FixtureMember.complimentary
+            });
+
+            expect(popupFrame).toBeInTheDocument();
+            expect(triggerButtonFrame).toBeInTheDocument();
+            expect(accountHomeTitle).toBeInTheDocument();
+
+            // Complimentary members see "Change" button instead of "View plans"
+            const changePlanButton = within(popupIframeDocument).queryByRole('button', {name: 'Change'});
+            expect(changePlanButton).toBeInTheDocument();
+
+            const singleTierProduct = FixtureSite.singleTier.basic.products.find(p => p.type === 'paid');
+
+            fireEvent.click(changePlanButton);
+            await within(popupIframeDocument).findByText('Monthly');
+            const yearlyPlanContainer = await within(popupIframeDocument).findByText('Yearly');
+            fireEvent.click(yearlyPlanContainer);
+            // added fake timeout for react state delay in setting plan
+            await new Promise((r) => {
+                setTimeout(r, 10);
+            });
+
+            const submitButton = within(popupIframeDocument).queryByRole('button', {name: 'Continue'});
+
+            fireEvent.click(submitButton);
+            expect(ghostApi.member.checkoutPlan).toHaveBeenLastCalledWith({
+                metadata: {
+                    checkoutType: 'upgrade'
+                },
+                offerId: undefined,
+                plan: singleTierProduct.yearlyPrice.id,
+                tierId: singleTierProduct.id,
+                cadence: 'year'
+            });
+        });
+
+        test('with cancelled subscription on monthly plan', async () => {
+            const {
+                ghostApi, popupFrame, triggerButtonFrame,
+                popupIframeDocument, accountHomeTitle
+            } = await setup({
+                site: FixtureSite.singleTier.basic,
+                member: FixtureMember.complimentaryWithCancelledSubscription
+            });
+
+            expect(popupFrame).toBeInTheDocument();
+            expect(triggerButtonFrame).toBeInTheDocument();
+            expect(accountHomeTitle).toBeInTheDocument();
+
+            // Complimentary members see "Change" button instead of "View plans"
+            const changePlanButton = within(popupIframeDocument).queryByRole('button', {name: 'Change'});
+            expect(changePlanButton).toBeInTheDocument();
+
+            const singleTierProduct = FixtureSite.singleTier.basic.products.find(p => p.type === 'paid');
+
+            fireEvent.click(changePlanButton);
+            const monthlyPlanContainer = await within(popupIframeDocument).findByText('Monthly');
+            fireEvent.click(monthlyPlanContainer);
+            // added fake timeout for react state delay in setting plan
+            await new Promise((r) => {
+                setTimeout(r, 10);
+            });
+
+            const submitButton = within(popupIframeDocument).queryByRole('button', {name: 'Continue'});
+
+            fireEvent.click(submitButton);
+            expect(ghostApi.member.checkoutPlan).toHaveBeenLastCalledWith({
+                metadata: {
+                    checkoutType: 'upgrade'
+                },
+                offerId: undefined,
+                plan: singleTierProduct.monthlyPrice.id,
+                tierId: singleTierProduct.id,
+                cadence: 'month'
+            });
+        });
+    });
+
+    describe('can upgrade on multi tier site', () => {
+        test('with default settings', async () => {
+            const {
+                ghostApi, popupFrame, triggerButtonFrame,
+                popupIframeDocument, accountHomeTitle
+            } = await multiTierSetup({
+                site: FixtureSite.multipleTiers.basic,
+                member: FixtureMember.complimentary
+            });
+
+            expect(popupFrame).toBeInTheDocument();
+            expect(triggerButtonFrame).toBeInTheDocument();
+            expect(accountHomeTitle).toBeInTheDocument();
+
+            // Complimentary members see "Change" button instead of "View plans"
+            const changePlanButton = within(popupIframeDocument).queryByRole('button', {name: 'Change'});
+            expect(changePlanButton).toBeInTheDocument();
+
+            const singleTierProduct = FixtureSite.multipleTiers.basic.products.find(p => p.type === 'paid');
+
+            fireEvent.click(changePlanButton);
+            await within(popupIframeDocument).findByText('Monthly');
+
+            // allow default checkbox switch to yearly
+            await new Promise((r) => {
+                setTimeout(r, 10);
+            });
+
+            const chooseBtns = within(popupIframeDocument).queryAllByRole('button', {name: 'Choose'});
+
+            fireEvent.click(chooseBtns[0]);
+            expect(ghostApi.member.checkoutPlan).toHaveBeenLastCalledWith({
+                metadata: {
+                    checkoutType: 'upgrade'
+                },
+                offerId: undefined,
+                plan: singleTierProduct.yearlyPrice.id,
+                tierId: singleTierProduct.id,
+                cadence: 'year'
+            });
+        });
+
+        test('with cancelled subscription', async () => {
+            const {
+                ghostApi, popupFrame, triggerButtonFrame,
+                popupIframeDocument, accountHomeTitle
+            } = await multiTierSetup({
+                site: FixtureSite.multipleTiers.basic,
+                member: FixtureMember.complimentaryWithCancelledSubscription
+            });
+
+            expect(popupFrame).toBeInTheDocument();
+            expect(triggerButtonFrame).toBeInTheDocument();
+            expect(accountHomeTitle).toBeInTheDocument();
+
+            // Complimentary members see "Change" button instead of "View plans"
+            const changePlanButton = within(popupIframeDocument).queryByRole('button', {name: 'Change'});
+            expect(changePlanButton).toBeInTheDocument();
+
+            const singleTierProduct = FixtureSite.multipleTiers.basic.products.find(p => p.type === 'paid');
+
+            fireEvent.click(changePlanButton);
+            await within(popupIframeDocument).findByText('Monthly');
+
+            // allow default checkbox switch to yearly
+            await new Promise((r) => {
+                setTimeout(r, 10);
+            });
+
+            const chooseBtns = within(popupIframeDocument).queryAllByRole('button', {name: 'Choose'});
+
+            fireEvent.click(chooseBtns[0]);
+            expect(ghostApi.member.checkoutPlan).toHaveBeenLastCalledWith({
+                metadata: {
+                    checkoutType: 'upgrade'
+                },
+                offerId: undefined,
+                plan: singleTierProduct.yearlyPrice.id,
+                tierId: singleTierProduct.id,
+                cadence: 'year'
+            });
+        });
+    });
+});
+
+describe('Logged-in complimentary member', () => {
+    describe('can upgrade on single tier site', () => {
         test('to an offer via link', async () => {
             window.location.hash = '#/portal/offers/61fa22bd0cbecc7d423d20b3';
             const {

--- a/apps/portal/test/utils/test-fixtures.js
+++ b/apps/portal/test/utils/test-fixtures.js
@@ -318,6 +318,24 @@ export const member = {
             })
         ]
     }),
+    complimentaryWithCancelledSubscription: getMemberData({
+        name: 'Comped Former Paid',
+        email: 'comped-former-paid@example.com',
+        firstname: 'Comped',
+        paid: true,
+        subscriptions: [
+            getSubscriptionData({
+                status: 'canceled',
+                currency: 'USD',
+                interval: 'year',
+                amount: 5000,
+                cardLast4: '4242',
+                startDate: '2021-10-05T03:18:30.000Z',
+                currentPeriodEnd: '2022-10-05T03:18:30.000Z',
+                cancelAtPeriodEnd: false
+            })
+        ]
+    }),
     preview: getMemberData({
         paid: true,
         subscriptions: [


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-2985

Allowing all complimentary members to upgrade to a paid plan. In turn removed `allowCompMemberUpgrade` (because that would now always return true for all comped members) and simplified the places where it was used. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Makes complimentary members eligible to upgrade like free members and removes now-redundant gating logic.
> 
> - Removes `allowCompMemberUpgrade` from `utils/helpers` and all call sites
> - Simplifies upgrade flow: treats complimentary members as upgrade-eligible in `account-plan-page` and `paid-account-actions` (always shows `Change` button unless only free plans)
> - Adjusts checkout/update logic to route complimentary members through `checkoutPlan` instead of subscription update paths
> - Cleans `app.js` page resolution (no longer forces `accountPlan` to `accountHome` for complimentary members)
> - Adds/updates tests to cover complimentary upgrade paths (single/multi-tier, monthly/yearly, cancelled subscriptions, offers) and adds `complimentaryWithCancelledSubscription` fixture
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8090bc937685134423ebe10dd26225532c34aa67. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->