### PR TITLE
🐛 Fixed email-only posts stuck as "sent" after limit/verification failure

### DIFF
--- a/ghost/core/core/server/services/posts/post-email-handler.js
+++ b/ghost/core/core/server/services/posts/post-email-handler.js
@@ -1,0 +1,140 @@
+const {BadRequestError} = require('@tryghost/errors');
+const tpl = require('@tryghost/tpl');
+
+const messages = {
+    invalidEmailSegment: 'The email segment parameter doesn\'t contain a valid filter'
+};
+
+const EMAIL_SENDING_STATUSES = ['published', 'sent'];
+
+class PostEmailHandler {
+    /**
+     * @param {Object} dependencies
+     * @param {Object} dependencies.models
+     * @param {Object} dependencies.emailService
+     */
+    constructor({models, emailService}) {
+        this.models = models;
+        this.emailService = emailService;
+    }
+
+    /**
+     * Validates email can be sent before saving the post (if an email will be sent)
+     *
+     * @param {import('@tryghost/api-framework').Frame} frame
+     * @returns {Promise<void>}
+     */
+    async validateBeforeSave(frame) {
+        const newStatus = frame.data.posts[0].status;
+
+        if (!EMAIL_SENDING_STATUSES.includes(newStatus)) {
+            return;
+        }
+
+        const existingPost = await this.models.Post.findOne(
+            {id: frame.options.id, status: 'all'},
+            {columns: ['id', 'status', 'newsletter_id', 'email_recipient_filter']}
+        );
+        const previousStatus = existingPost?.get('status');
+
+        const hasNewsletter = frame.options.newsletter || existingPost?.get('newsletter_id');
+        const sendingEmail = hasNewsletter && this.shouldSendEmail(newStatus, previousStatus);
+
+        if (!sendingEmail) {
+            return;
+        }
+
+        const emailRecipientFilter = frame.options.email_segment || existingPost?.get('email_recipient_filter') || 'all';
+
+        await this.validateEmailRecipientFilter(emailRecipientFilter);
+
+        const newsletter = await this.getNewsletter(frame, existingPost);
+
+        await this.emailService.checkCanSendEmail(newsletter, emailRecipientFilter);
+    }
+
+    /**
+     * Validates the email recipient filter is valid
+     *
+     * @param {string} emailRecipientFilter
+     * @returns {Promise<void>}
+     */
+    async validateEmailRecipientFilter(emailRecipientFilter) {
+        if (!emailRecipientFilter || emailRecipientFilter === 'all') {
+            return;
+        }
+
+        try {
+            await this.models.Member.findPage({filter: emailRecipientFilter, limit: 1});
+        } catch (err) {
+            throw new BadRequestError({
+                message: tpl(messages.invalidEmailSegment),
+                context: err.message
+            });
+        }
+    }
+
+    /**
+     * Retrieves the newsletter for the post
+     *
+     * @param {import('@tryghost/api-framework').Frame} frame
+     * @param {Object|null} existingPost
+     * @returns {Promise<Object|null>}
+     */
+    async getNewsletter(frame, existingPost) {
+        if (frame.options.newsletter) {
+            return this.models.Newsletter.findOne({slug: frame.options.newsletter});
+        }
+
+        if (existingPost?.get('newsletter_id')) {
+            return this.models.Newsletter.findOne({id: existingPost.get('newsletter_id')});
+        }
+
+        return null;
+    }
+
+    /**
+     * Handles creating or retrying the newsletter email after post is saved
+     *
+     * @param {Object} model - The post model
+     * @returns {Promise<void>}
+     */
+    async createOrRetryEmail(model) {
+        if (!model.get('newsletter_id')) {
+            return;
+        }
+
+        const sendEmail = model.wasChanged() && this.shouldSendEmail(model.get('status'), model.previous('status'));
+
+        if (!sendEmail) {
+            return;
+        }
+
+        const postEmail = model.relations.email;
+        let email;
+
+        if (!postEmail) {
+            email = await this.emailService.createEmail(model);
+        } else if (postEmail.get('status') === 'failed') {
+            email = await this.emailService.retryEmail(postEmail);
+        }
+
+        if (email) {
+            model.set('email', email);
+        }
+    }
+
+    /**
+     * Calculates if the email should be tried to be sent out
+     *
+     * @param {String} currentStatus current status from the post model
+     * @param {String} previousStatus previous status from the post model
+     * @returns {Boolean}
+     */
+    shouldSendEmail(currentStatus, previousStatus) {
+        return EMAIL_SENDING_STATUSES.includes(currentStatus)
+            && !EMAIL_SENDING_STATUSES.includes(previousStatus);
+    }
+}
+
+module.exports = PostEmailHandler;

--- a/ghost/core/core/server/services/posts/posts-service.js
+++ b/ghost/core/core/server/services/posts/posts-service.js
@@ -5,13 +5,13 @@ const errors = require('@tryghost/errors');
 const ObjectId = require('bson-objectid').default;
 const pick = require('lodash/pick');
 const DomainEvents = require('@tryghost/domain-events');
+const PostEmailHandler = require('./post-email-handler');
 
 const messages = {
     invalidVisibilityFilter: 'Invalid visibility filter.',
     invalidVisibility: 'Invalid visibility value.',
     invalidTiers: 'Invalid tiers value.',
     invalidTags: 'Invalid tags value.',
-    invalidEmailSegment: 'The email segment parameter doesn\'t contain a valid filter',
     unsupportedBulkAction: 'Unsupported bulk action',
     postNotFound: 'Post not found.'
 };
@@ -24,6 +24,7 @@ class PostsService {
         this.stats = stats;
         this.emailService = emailService;
         this.postsExporter = postsExporter;
+        this.postEmailHandler = new PostEmailHandler({models, emailService});
     }
 
     /**
@@ -60,79 +61,11 @@ class PostsService {
      * @returns
      */
     async editPost(frame, options) {
-        let sendingEmail = false;
-        let existingPost = null;
-        let newsletter = null;
-
-        // Determine if we'll be sending an email
-        const newStatus = frame.data.posts[0].status;
-        if (['published', 'sent'].includes(newStatus)) {
-            existingPost = await this.models.Post.findOne(
-                {id: frame.options.id, status: 'all'},
-                {columns: ['id', 'status', 'newsletter_id', 'email_recipient_filter']}
-            );
-            const previousStatus = existingPost?.get('status');
-
-            // Check if we'll be sending an email - either via new newsletter param or existing newsletter on post
-            if (frame.options.newsletter || existingPost?.get('newsletter_id')) {
-                sendingEmail = this.shouldSendEmail(newStatus, previousStatus);
-            }
-        }
-
-        // If we'll be sending an email, pre-check email limits before saving
-        // the post to avoid leaving posts in a stuck "sent" state on failure
-        if (sendingEmail) {
-            const emailRecipientFilter = frame.options.email_segment || existingPost?.get('email_recipient_filter') || 'all';
-
-            if (emailRecipientFilter && emailRecipientFilter !== 'all') {
-                // check filter is valid
-                try {
-                    await this.models.Member.findPage({filter: emailRecipientFilter, limit: 1});
-                } catch (err) {
-                    return Promise.reject(new BadRequestError({
-                        message: tpl(messages.invalidEmailSegment),
-                        context: err.message
-                    }));
-                }
-            }
-
-            // Validate newsletter and check limits before making changes
-            if (frame.options.newsletter) {
-                newsletter = await this.models.Newsletter.findOne(
-                    {slug: frame.options.newsletter},
-                    {filter: 'status:active'}
-                );
-            } else if (existingPost?.get('newsletter_id')) {
-                newsletter = await this.models.Newsletter.findOne(
-                    {id: existingPost.get('newsletter_id')},
-                    {filter: 'status:active'}
-                );
-            }
-
-            // Throws if email cannot be sent
-            await this.emailService.checkCanSendEmail(newsletter, emailRecipientFilter);
-        }
+        await this.postEmailHandler.validateBeforeSave(frame);
 
         const model = await this.models.Post.edit(frame.data.posts[0], frame.options);
 
-        /**Handle newsletter email */
-        if (model.get('newsletter_id')) {
-            const sendEmail = model.wasChanged() && this.shouldSendEmail(model.get('status'), model.previous('status'));
-
-            if (sendEmail) {
-                let postEmail = model.relations.email;
-                let email;
-
-                if (!postEmail) {
-                    email = await this.emailService.createEmail(model);
-                } else if (postEmail && postEmail.get('status') === 'failed') {
-                    email = await this.emailService.retryEmail(postEmail);
-                }
-                if (email) {
-                    model.set('email', email);
-                }
-            }
-        }
+        await this.postEmailHandler.createOrRetryEmail(model);
 
         const dto = model.toJSON(frame.options);
 
@@ -142,6 +75,7 @@ class PostsService {
 
         return dto;
     }
+
     /**
      * @param {any} model
      * @returns {EventString}
@@ -483,18 +417,6 @@ class PostsService {
                 context: err.message
             }));
         }
-    }
-
-    /**
-     * Calculates if the email should be tried to be sent out
-     * @private
-     * @param {String} currentStatus current status from the post model
-     * @param {String} previousStatus previous status from the post model
-     * @returns {Boolean}
-     */
-    shouldSendEmail(currentStatus, previousStatus) {
-        return (['published', 'sent'].includes(currentStatus))
-            && (!['published', 'sent'].includes(previousStatus));
     }
 
     handleCacheInvalidation(model) {

--- a/ghost/core/test/e2e-api/admin/posts-legacy.test.js
+++ b/ghost/core/test/e2e-api/admin/posts-legacy.test.js
@@ -12,6 +12,7 @@ const configUtils = require('../../utils/config-utils');
 const mockManager = require('../../utils/e2e-framework-mock-manager');
 const sinon = require('sinon');
 const logging = require('@tryghost/logging');
+const errors = require('@tryghost/errors');
 
 describe('Posts API', function () {
     let request;
@@ -620,7 +621,6 @@ describe('Posts API', function () {
         const id = res.body.posts[0].id;
 
         const updatedPost = res.body.posts[0];
-
         updatedPost.status = 'published';
 
         const loggingStub = sinon.stub(logging, 'error');
@@ -633,6 +633,90 @@ describe('Posts API', function () {
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(400);
 
+        sinon.assert.calledOnce(loggingStub);
+    });
+
+    it('Does not change post status when email sending fails', async function () {
+        const emailService = require('../../../core/server/services/email-service');
+        const newsletterSlug = testUtils.DataGenerator.Content.newsletters[1].slug;
+
+        // Create a draft post
+        const post = {
+            title: 'My scheduled email-only post',
+            status: 'draft',
+            mobiledoc: testUtils.DataGenerator.markdownToMobiledoc('my post'),
+            created_at: moment().subtract(2, 'days').toDate(),
+            updated_at: moment().subtract(2, 'days').toDate()
+        };
+
+        const res = await request.post(localUtils.API.getApiQuery('posts'))
+            .set('Origin', config.get('url'))
+            .send({posts: [post]})
+            .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect(201);
+
+        const id = res.body.posts[0].id;
+        const createdPost = res.body.posts[0];
+
+        // Schedule the post as email-only with a newsletter
+        createdPost.status = 'scheduled';
+        createdPost.published_at = moment().add(2, 'days').toDate();
+        createdPost.email_only = true;
+
+        const scheduledRes = await request
+            .put(localUtils.API.getApiQuery('posts/' + id + '/?newsletter=' + newsletterSlug))
+            .set('Origin', config.get('url'))
+            .send({posts: [createdPost]})
+            .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect(200);
+
+        const scheduledPost = scheduledRes.body.posts[0];
+        scheduledPost.status.should.eql('scheduled');
+
+        // Verify the post is scheduled in the database
+        let model = await models.Post.findOne({
+            id,
+            status: 'all'
+        }, testUtils.context.internal);
+        should(model.get('status')).eql('scheduled');
+
+        // Now stub checkCanSendEmail to throw a HostLimitError (simulating email limits)
+        const checkCanSendEmailStub = sinon.stub(emailService.service, 'checkCanSendEmail')
+            .rejects(new errors.HostLimitError({
+                message: 'Email sending is temporarily disabled'
+            }));
+        const loggingStub = sinon.stub(logging, 'error');
+
+        // Attempt to publish the scheduled email-only post
+        scheduledPost.status = 'published';
+        scheduledPost.published_at = moment().toDate();
+
+        const failedRes = await request
+            .put(localUtils.API.getApiQuery('posts/' + id + '/'))
+            .set('Origin', config.get('url'))
+            .send({posts: [scheduledPost]})
+            .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect(403);
+
+        failedRes.body.errors[0].type.should.eql('HostLimitError');
+
+        // CRITICAL: Verify the post status was NOT changed - it should still be scheduled
+        model = await models.Post.findOne({
+            id,
+            status: 'all'
+        }, testUtils.context.internal);
+        should(model.get('status')).eql('scheduled', 'Post should remain scheduled when email sending fails');
+
+        // No email should have been created
+        const email = await models.Email.findOne({
+            post_id: id
+        }, testUtils.context.internal);
+        should.not.exist(email);
+
+        checkCanSendEmailStub.restore();
         sinon.assert.calledOnce(loggingStub);
     });
 

--- a/ghost/core/test/unit/server/services/email-service/email-service.test.js
+++ b/ghost/core/test/unit/server/services/email-service/email-service.test.js
@@ -128,6 +128,67 @@ describe('Email Service', function () {
         });
     });
 
+    describe('checkCanSendEmail', function () {
+        it('Throws if newsletter is null', async function () {
+            await assert.rejects(
+                service.checkCanSendEmail(null, 'all'),
+                /The post does not have a newsletter relation/
+            );
+        });
+
+        it('Throws if newsletter is archived', async function () {
+            const newsletter = createModel({
+                status: 'archived'
+            });
+            await assert.rejects(
+                service.checkCanSendEmail(newsletter, 'all'),
+                /Cannot send email to archived newsletters/
+            );
+        });
+
+        it('Throws if over member limit', async function () {
+            limited.members = true;
+            const newsletter = createModel({
+                status: 'active'
+            });
+            await assert.rejects(
+                service.checkCanSendEmail(newsletter, 'all'),
+                /Over limit/
+            );
+        });
+
+        it('Throws if over email limit', async function () {
+            limited.emails = true;
+            const newsletter = createModel({
+                status: 'active'
+            });
+            await assert.rejects(
+                service.checkCanSendEmail(newsletter, 'all'),
+                /Would go over limit/
+            );
+        });
+
+        it('Throws if verification is required', async function () {
+            verificicationRequired = true;
+            const newsletter = createModel({
+                status: 'active'
+            });
+            await assert.rejects(
+                service.checkCanSendEmail(newsletter, 'all'),
+                /Email sending is temporarily disabled/
+            );
+        });
+
+        it('Does not throw for active newsletter within limits', async function () {
+            limited.members = false;
+            limited.emails = false;
+            const newsletter = createModel({
+                status: 'active'
+            });
+            await assert.doesNotReject(service.checkCanSendEmail(newsletter, 'all'));
+        });
+    });
+
     describe('createEmail', function () {
         it('Throws if post does not have a newsletter', async function () {
             const post = createModel({

--- a/ghost/core/test/unit/server/services/posts/post-email-handler.test.js
+++ b/ghost/core/test/unit/server/services/posts/post-email-handler.test.js
@@ -1,0 +1,439 @@
+const PostEmailHandler = require('../../../../../core/server/services/posts/post-email-handler');
+const assert = require('assert/strict');
+const sinon = require('sinon');
+
+describe('PostEmailHandler', function () {
+    let postEmailHandler;
+    let mockModels;
+    let mockEmailService;
+
+    beforeEach(function () {
+        mockModels = {
+            Post: {
+                findOne: sinon.stub()
+            },
+            Member: {
+                findPage: sinon.stub()
+            },
+            Newsletter: {
+                findOne: sinon.stub()
+            }
+        };
+
+        mockEmailService = {
+            checkCanSendEmail: sinon.stub().resolves(),
+            createEmail: sinon.stub(),
+            retryEmail: sinon.stub()
+        };
+
+        postEmailHandler = new PostEmailHandler({
+            models: mockModels,
+            emailService: mockEmailService
+        });
+    });
+
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    describe('constructor', function () {
+        it('can construct class with dependencies', function () {
+            const handler = new PostEmailHandler({
+                models: mockModels,
+                emailService: mockEmailService
+            });
+            assert.ok(handler);
+            assert.equal(handler.models, mockModels);
+            assert.equal(handler.emailService, mockEmailService);
+        });
+    });
+
+    describe('shouldSendEmail', function () {
+        it('returns correct values for status transitions', function () {
+            const testCases = [
+                // [newStatus, previousStatus, expected]
+                // Should send email: transitioning to published/sent from draft/scheduled
+                ['published', 'draft', true],
+                ['published', 'scheduled', true],
+                ['sent', 'draft', true],
+                ['sent', 'scheduled', true],
+                ['published', undefined, true],
+
+                // Should not send email: status unchanged
+                ['published', 'published', false],
+                ['sent', 'sent', false],
+
+                // Should not send email: transitioning between published/sent
+                ['sent', 'published', false],
+                ['published', 'sent', false],
+
+                // Should not send email: transitioning to draft/scheduled
+                ['draft', 'published', false],
+                ['draft', 'draft', false],
+                ['scheduled', 'draft', false],
+
+                // Should not send email: undefined statuses
+                [undefined, undefined, false],
+                [undefined, 'draft', false]
+            ];
+
+            for (const [newStatus, previousStatus, expected] of testCases) {
+                assert.equal(
+                    postEmailHandler.shouldSendEmail(newStatus, previousStatus),
+                    expected,
+                    `shouldSendEmail(${newStatus}, ${previousStatus}) should be ${expected}`
+                );
+            }
+        });
+    });
+
+    describe('validateBeforeSave', function () {
+        function createFrame(status, options = {}) {
+            return {
+                data: {posts: [{status}]},
+                options: {id: 'post-123', ...options}
+            };
+        }
+
+        function createExistingPost({status = 'draft', newsletterId = null, emailRecipientFilter = null} = {}) {
+            const post = {get: sinon.stub()};
+            post.get.withArgs('status').returns(status);
+            post.get.withArgs('newsletter_id').returns(newsletterId);
+            post.get.withArgs('email_recipient_filter').returns(emailRecipientFilter);
+            return post;
+        }
+
+        function setupExistingPost(postOptions) {
+            const post = createExistingPost(postOptions);
+            mockModels.Post.findOne.resolves(post);
+            return post;
+        }
+
+        function setupNewsletter(id = 'newsletter-123') {
+            const newsletter = {id};
+            mockModels.Newsletter.findOne.resolves(newsletter);
+            return newsletter;
+        }
+
+        it('returns early when new status is draft', async function () {
+            await postEmailHandler.validateBeforeSave(createFrame('draft'));
+
+            sinon.assert.notCalled(mockModels.Post.findOne);
+            sinon.assert.notCalled(mockEmailService.checkCanSendEmail);
+        });
+
+        it('returns early when new status is scheduled', async function () {
+            await postEmailHandler.validateBeforeSave(createFrame('scheduled'));
+
+            sinon.assert.notCalled(mockModels.Post.findOne);
+            sinon.assert.notCalled(mockEmailService.checkCanSendEmail);
+        });
+
+        it('validates when publishing post with newsletter option', async function () {
+            setupExistingPost();
+            const newsletter = setupNewsletter();
+
+            await postEmailHandler.validateBeforeSave(createFrame('published', {newsletter: 'default-newsletter'}));
+
+            sinon.assert.calledOnceWithExactly(
+                mockModels.Post.findOne,
+                {id: 'post-123', status: 'all'},
+                {columns: ['id', 'status', 'newsletter_id', 'email_recipient_filter']}
+            );
+            sinon.assert.calledOnceWithExactly(mockEmailService.checkCanSendEmail, newsletter, 'all');
+        });
+
+        it('validates when publishing post with existing newsletter_id', async function () {
+            setupExistingPost({newsletterId: 'newsletter-456'});
+            setupNewsletter('newsletter-456');
+
+            await postEmailHandler.validateBeforeSave(createFrame('published'));
+
+            sinon.assert.calledOnce(mockEmailService.checkCanSendEmail);
+        });
+
+        it('skips validation when post is already published', async function () {
+            setupExistingPost({status: 'published', newsletterId: 'newsletter-456'});
+
+            await postEmailHandler.validateBeforeSave(createFrame('published'));
+
+            sinon.assert.notCalled(mockEmailService.checkCanSendEmail);
+        });
+
+        it('skips validation when no newsletter specified', async function () {
+            setupExistingPost();
+
+            await postEmailHandler.validateBeforeSave(createFrame('published'));
+
+            sinon.assert.notCalled(mockEmailService.checkCanSendEmail);
+        });
+
+        it('validates when status is sent', async function () {
+            setupExistingPost({newsletterId: 'newsletter-456'});
+            setupNewsletter('newsletter-456');
+
+            await postEmailHandler.validateBeforeSave(createFrame('sent'));
+
+            sinon.assert.calledOnce(mockEmailService.checkCanSendEmail);
+        });
+
+        it('validates email recipient filter from frame options', async function () {
+            setupExistingPost({newsletterId: 'newsletter-123'});
+            mockModels.Member.findPage.resolves({data: []});
+            const newsletter = setupNewsletter();
+
+            await postEmailHandler.validateBeforeSave(createFrame('published', {email_segment: 'status:paid'}));
+
+            sinon.assert.calledOnceWithExactly(mockModels.Member.findPage, {filter: 'status:paid', limit: 1});
+            sinon.assert.calledOnceWithExactly(mockEmailService.checkCanSendEmail, newsletter, 'status:paid');
+        });
+
+        it('falls back to existing post email_recipient_filter', async function () {
+            setupExistingPost({newsletterId: 'newsletter-123', emailRecipientFilter: 'status:free'});
+            mockModels.Member.findPage.resolves({data: []});
+            setupNewsletter();
+
+            await postEmailHandler.validateBeforeSave(createFrame('published'));
+
+            sinon.assert.calledOnceWithExactly(mockModels.Member.findPage, {filter: 'status:free', limit: 1});
+        });
+
+        it('defaults to "all" when no filter specified', async function () {
+            setupExistingPost({newsletterId: 'newsletter-123'});
+            const newsletter = setupNewsletter();
+
+            await postEmailHandler.validateBeforeSave(createFrame('published'));
+
+            sinon.assert.notCalled(mockModels.Member.findPage);
+            sinon.assert.calledOnceWithExactly(mockEmailService.checkCanSendEmail, newsletter, 'all');
+        });
+
+        it('propagates filter validation errors', async function () {
+            setupExistingPost({newsletterId: 'newsletter-123'});
+            mockModels.Member.findPage.rejects(new Error('Invalid filter'));
+
+            await assert.rejects(
+                postEmailHandler.validateBeforeSave(createFrame('published', {email_segment: 'invalid:::filter'})),
+                err => err.name === 'BadRequestError'
+            );
+        });
+
+        it('propagates checkCanSendEmail errors', async function () {
+            setupExistingPost({newsletterId: 'newsletter-123'});
+            setupNewsletter();
+            mockEmailService.checkCanSendEmail.rejects(new Error('Email limit exceeded'));
+
+            await assert.rejects(
+                postEmailHandler.validateBeforeSave(createFrame('published')),
+                err => err.message === 'Email limit exceeded'
+            );
+        });
+    });
+
+    describe('validateEmailRecipientFilter', function () {
+        it('skips validation for empty/null/undefined/all filters', async function () {
+            const skipFilters = ['', null, undefined, 'all'];
+
+            for (const filter of skipFilters) {
+                await assert.doesNotReject(
+                    postEmailHandler.validateEmailRecipientFilter(filter)
+                );
+            }
+            sinon.assert.notCalled(mockModels.Member.findPage);
+        });
+
+        it('passes validation for valid custom filter', async function () {
+            mockModels.Member.findPage.resolves({data: []});
+
+            await assert.doesNotReject(
+                postEmailHandler.validateEmailRecipientFilter('status:free')
+            );
+
+            sinon.assert.calledOnceWithExactly(
+                mockModels.Member.findPage,
+                {filter: 'status:free', limit: 1}
+            );
+        });
+
+        it('throws BadRequestError for invalid filter', async function () {
+            mockModels.Member.findPage.rejects(new Error('Invalid filter syntax'));
+
+            await assert.rejects(
+                postEmailHandler.validateEmailRecipientFilter('invalid:::filter'),
+                (err) => {
+                    assert.equal(err.name, 'BadRequestError');
+                    assert.ok(err.message.includes('valid filter'));
+                    assert.equal(err.context, 'Invalid filter syntax');
+                    return true;
+                }
+            );
+        });
+    });
+
+    describe('getNewsletter', function () {
+        function createFrame(newsletterSlug = null) {
+            return {options: newsletterSlug ? {newsletter: newsletterSlug} : {}};
+        }
+
+        function createExistingPost(newsletterId) {
+            return {get: sinon.stub().withArgs('newsletter_id').returns(newsletterId)};
+        }
+
+        it('returns newsletter by slug when specified in frame options', async function () {
+            const newsletter = {id: 'newsletter-123', slug: 'weekly-digest'};
+            mockModels.Newsletter.findOne.resolves(newsletter);
+
+            const result = await postEmailHandler.getNewsletter(createFrame('weekly-digest'), null);
+
+            assert.equal(result, newsletter);
+            sinon.assert.calledOnceWithExactly(mockModels.Newsletter.findOne, {slug: 'weekly-digest'});
+        });
+
+        it('returns newsletter by id from existing post when no slug in options', async function () {
+            const newsletter = {id: 'newsletter-456'};
+            mockModels.Newsletter.findOne.resolves(newsletter);
+
+            const result = await postEmailHandler.getNewsletter(createFrame(), createExistingPost('newsletter-456'));
+
+            assert.equal(result, newsletter);
+            sinon.assert.calledOnceWithExactly(mockModels.Newsletter.findOne, {id: 'newsletter-456'});
+        });
+
+        it('returns null when no newsletter specified and existing post has no newsletter_id', async function () {
+            const result = await postEmailHandler.getNewsletter(createFrame(), createExistingPost(null));
+
+            assert.equal(result, null);
+            sinon.assert.notCalled(mockModels.Newsletter.findOne);
+        });
+
+        it('returns null when no newsletter specified and no existing post', async function () {
+            const result = await postEmailHandler.getNewsletter(createFrame(), null);
+
+            assert.equal(result, null);
+            sinon.assert.notCalled(mockModels.Newsletter.findOne);
+        });
+
+        it('prioritizes frame options newsletter over existing post newsletter_id', async function () {
+            const newsletter = {id: 'newsletter-new', slug: 'new-newsletter'};
+            mockModels.Newsletter.findOne.resolves(newsletter);
+
+            const result = await postEmailHandler.getNewsletter(createFrame('new-newsletter'), createExistingPost('newsletter-old'));
+
+            assert.equal(result, newsletter);
+            sinon.assert.calledOnceWithExactly(mockModels.Newsletter.findOne, {slug: 'new-newsletter'});
+        });
+    });
+
+    describe('createOrRetryEmail', function () {
+        function createMockEmail(status) {
+            return {
+                id: 'email-123',
+                get: sinon.stub().withArgs('status').returns(status)
+            };
+        }
+
+        function createMockModel({
+            newsletterId = 'newsletter-123',
+            currentStatus = 'published',
+            previousStatus = 'draft',
+            wasChanged = true,
+            email = null
+        } = {}) {
+            const get = sinon.stub();
+            get.withArgs('newsletter_id').returns(newsletterId);
+            get.withArgs('status').returns(currentStatus);
+
+            return {
+                wasChanged: sinon.stub().returns(wasChanged),
+                get,
+                previous: sinon.stub().withArgs('status').returns(previousStatus),
+                relations: email ? {email} : {},
+                set: sinon.stub()
+            };
+        }
+
+        it('does nothing when model has no newsletter_id', async function () {
+            const model = createMockModel({newsletterId: null});
+
+            await postEmailHandler.createOrRetryEmail(model);
+
+            sinon.assert.notCalled(mockEmailService.createEmail);
+            sinon.assert.notCalled(mockEmailService.retryEmail);
+        });
+
+        it('does nothing when model was not changed', async function () {
+            const model = createMockModel({wasChanged: false});
+
+            await postEmailHandler.createOrRetryEmail(model);
+
+            sinon.assert.notCalled(mockEmailService.createEmail);
+            sinon.assert.notCalled(mockEmailService.retryEmail);
+        });
+
+        it('does nothing when status transition does not warrant sending email', async function () {
+            const model = createMockModel({previousStatus: 'published'});
+
+            await postEmailHandler.createOrRetryEmail(model);
+
+            sinon.assert.notCalled(mockEmailService.createEmail);
+            sinon.assert.notCalled(mockEmailService.retryEmail);
+        });
+
+        it('creates email when publishing fresh post', async function () {
+            const model = createMockModel();
+            const createdEmail = {id: 'email-123'};
+            mockEmailService.createEmail.resolves(createdEmail);
+
+            await postEmailHandler.createOrRetryEmail(model);
+
+            sinon.assert.calledOnceWithExactly(mockEmailService.createEmail, model);
+            sinon.assert.notCalled(mockEmailService.retryEmail);
+            sinon.assert.calledOnceWithExactly(model.set, 'email', createdEmail);
+        });
+
+        it('retries email when existing email has failed status', async function () {
+            const failedEmail = createMockEmail('failed');
+            const model = createMockModel({email: failedEmail});
+            const retriedEmail = {id: 'email-123', status: 'pending'};
+            mockEmailService.retryEmail.resolves(retriedEmail);
+
+            await postEmailHandler.createOrRetryEmail(model);
+
+            sinon.assert.notCalled(mockEmailService.createEmail);
+            sinon.assert.calledOnceWithExactly(mockEmailService.retryEmail, failedEmail);
+            sinon.assert.calledOnceWithExactly(model.set, 'email', retriedEmail);
+        });
+
+        it('does not set email on model when existing email is not failed', async function () {
+            const existingEmail = createMockEmail('submitted');
+            const model = createMockModel({email: existingEmail});
+
+            await postEmailHandler.createOrRetryEmail(model);
+
+            sinon.assert.notCalled(mockEmailService.createEmail);
+            sinon.assert.notCalled(mockEmailService.retryEmail);
+            sinon.assert.notCalled(model.set);
+        });
+
+        it('handles sent status transition', async function () {
+            const model = createMockModel({currentStatus: 'sent'});
+            const createdEmail = {id: 'email-456'};
+            mockEmailService.createEmail.resolves(createdEmail);
+
+            await postEmailHandler.createOrRetryEmail(model);
+
+            sinon.assert.calledOnceWithExactly(mockEmailService.createEmail, model);
+            sinon.assert.calledOnceWithExactly(model.set, 'email', createdEmail);
+        });
+
+        it('does not set email when createEmail returns null', async function () {
+            const model = createMockModel();
+            mockEmailService.createEmail.resolves(null);
+
+            await postEmailHandler.createOrRetryEmail(model);
+
+            sinon.assert.calledOnceWithExactly(mockEmailService.createEmail, model);
+            sinon.assert.notCalled(model.set);
+        });
+    });
+});


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ONC-1382/

When sending a scheduled email-only post, no rollback occurred if the email creation part failed meaning the post got stuck in a "sent" state.

- added `EmailService.checkCanSendEmail` method
  - performs checks that were previously performed as part of `createEmail` method
  - allows calls from outside of `EmailService` to gate calling `createEmail`
- added pre-email-send checks to `PostsService.editPost`
  - determines if an email would be sent based on query params, existing post state, and new post status
  - uses `EmailService.checkCanSendEmail` to throw early before we get to any post saving or email creation
