### PR TITLE
Improved keyboard events in member welcome email modal

### DIFF
--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/member-email-editor.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/member-email-editor.tsx
@@ -29,25 +29,34 @@ const MemberEmailsEditor: React.FC<MemberEmailsEditorProps> = ({
         }
     }, [onChange, value]);
 
+    // Stop Cmd+K from bubbling to global search handler
+    const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+        if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+            e.stopPropagation();
+        }
+    }, []);
+
     return (
-        <KoenigEditorBase
-            className={className}
-            emojiPicker={false}
-            inheritFontStyles={false}
-            initialEditorState={value}
-            nodes={nodes}
-            placeholder={placeholder}
-            singleParagraph={singleParagraph}
-            onChange={handleChange}
-        >
-            {(koenig: KoenigInstance) => (
-                <>
-                    <koenig.ReplacementStringsPlugin />
-                    <koenig.ListPlugin />
-                    <koenig.HorizontalRulePlugin />
-                </>
-            )}
-        </KoenigEditorBase>
+        <div onKeyDown={handleKeyDown}>
+            <KoenigEditorBase
+                className={className}
+                emojiPicker={false}
+                inheritFontStyles={false}
+                initialEditorState={value}
+                nodes={nodes}
+                placeholder={placeholder}
+                singleParagraph={singleParagraph}
+                onChange={handleChange}
+            >
+                {(koenig: KoenigInstance) => (
+                    <>
+                        <koenig.ReplacementStringsPlugin />
+                        <koenig.ListPlugin />
+                        <koenig.HorizontalRulePlugin />
+                    </>
+                )}
+            </KoenigEditorBase>
+        </div>
     );
 };
 

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/test-email-dropdown.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/test-email-dropdown.tsx
@@ -10,13 +10,15 @@ export interface TestEmailDropdownProps {
   subject: string
   lexical: string
   validateForm: () => boolean
+  onClose: () => void
 }
 
 const TestEmailDropdown: React.FC<TestEmailDropdownProps> = ({
     automatedEmailId,
     subject,
     lexical,
-    validateForm
+    validateForm,
+    onClose
 }) => {
     const {data: currentUser} = useCurrentUser();
     const {mutateAsync: sendTestEmail} = useSendTestWelcomeEmail();
@@ -39,6 +41,18 @@ const TestEmailDropdown: React.FC<TestEmailDropdownProps> = ({
             setTestEmail(currentUser.email);
         }
     }, [currentUser?.email]);
+
+    // Close dropdown on Escape and stop propagation to prevent modal from *also* closing
+    useEffect(() => {
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') {
+                e.stopPropagation();
+                onClose();
+            }
+        };
+        document.addEventListener('keydown', handleKeyDown, true);
+        return () => document.removeEventListener('keydown', handleKeyDown, true);
+    }, [onClose]);
 
     const handleSendTestEmail = async () => {
         setTestEmailError('');

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/test-email-dropdown.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/test-email-dropdown.tsx
@@ -95,7 +95,7 @@ const TestEmailDropdown: React.FC<TestEmailDropdownProps> = ({
     };
 
     return (
-        <div className='absolute right-0 top-full z-10 mt-2 w-[260px] rounded border border-grey-250 bg-white p-4 shadow-lg dark:border-grey-925 dark:bg-grey-975'>
+        <div className='absolute right-0 top-full z-10 mt-2 w-[260px] rounded border border-grey-250 bg-white p-4 shadow-lg dark:border-grey-925 dark:bg-grey-975' data-testid='test-email-dropdown'>
             <div className='mb-3'>
                 <label className='mb-2 block text-sm font-semibold' htmlFor='test-email-input'>Send test email</label>
                 <TextField

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-modal.tsx
@@ -138,7 +138,7 @@ const WelcomeEmailModal = NiceModal.create<WelcomeEmailModalProps>(({emailType =
                                     onClick={() => setShowTestDropdown(!showTestDropdown)}
                                 />
                                 {showTestDropdown && (
-                                    <TestEmailDropdown automatedEmailId={automatedEmail.id} lexical={formState.lexical} subject={formState.subject} validateForm={validate} />
+                                    <TestEmailDropdown automatedEmailId={automatedEmail.id} lexical={formState.lexical} subject={formState.subject} validateForm={validate} onClose={() => setShowTestDropdown(false)} />
                                 )}
                             </div>
                             <Button

--- a/apps/admin-x-settings/test/acceptance/membership/member-welcome-emails.test.ts
+++ b/apps/admin-x-settings/test/acceptance/membership/member-welcome-emails.test.ts
@@ -1,0 +1,110 @@
+import {expect, test} from '@playwright/test';
+import {globalDataRequests, mockApi, responseFixtures} from '@tryghost/admin-x-framework/test/acceptance';
+
+const automatedEmailsFixture = {
+    automated_emails: [{
+        id: 'free-welcome-email-id',
+        status: 'active',
+        name: 'Welcome Email (Free)',
+        slug: 'member-welcome-email-free',
+        subject: 'Welcome to Test Site',
+        lexical: '{"root":{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"Welcome to our site!","type":"extended-text","version":1}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}}',
+        sender_name: null,
+        sender_email: null,
+        sender_reply_to: null,
+        created_at: '2024-01-01T00:00:00.000Z',
+        updated_at: null
+    }]
+};
+
+test.describe('Member emails settings', async () => {
+    test.describe('Welcome email modal', async () => {
+        test('Escape key closes test email dropdown without closing modal', async ({page}) => {
+            // Config with welcomeEmails feature flag enabled
+            const configResponse = {
+                config: {
+                    ...responseFixtures.config.config,
+                    labs: {
+                        welcomeEmails: true
+                    }
+                }
+            };
+
+            await mockApi({page, requests: {
+                ...globalDataRequests,
+                browseConfig: {method: 'GET', path: '/config/', response: configResponse},
+                browseAutomatedEmails: {method: 'GET', path: '/automated_emails/', response: automatedEmailsFixture}
+            }});
+
+            // Navigate directly to the memberemails section
+            await page.goto('/#/memberemails');
+
+            // Wait for page to load
+            await page.waitForLoadState('networkidle');
+
+            const section = page.getByTestId('memberemails');
+            await expect(section).toBeVisible({timeout: 10000});
+
+            // Click the Edit button on the welcome email preview to open the modal
+            await section.getByTestId('free-welcome-email-edit-button').click();
+
+            const modal = page.getByTestId('welcome-email-modal');
+            await expect(modal).toBeVisible();
+
+            // Click the Test button to open the dropdown
+            await modal.getByRole('button', {name: 'Test'}).click();
+
+            // Verify the dropdown is visible
+            const dropdown = page.getByTestId('test-email-dropdown');
+            await expect(dropdown).toBeVisible();
+
+            // Press Escape - should close dropdown but NOT the modal
+            await page.keyboard.press('Escape');
+
+            // Verify dropdown is closed
+            await expect(dropdown).not.toBeVisible();
+
+            // Verify modal is still open
+            await expect(modal).toBeVisible();
+        });
+
+        test('Escape key closes modal when test email dropdown is not open', async ({page}) => {
+            // Config with welcomeEmails feature flag enabled
+            const configResponse = {
+                config: {
+                    ...responseFixtures.config.config,
+                    labs: {
+                        welcomeEmails: true
+                    }
+                }
+            };
+
+            await mockApi({page, requests: {
+                ...globalDataRequests,
+                browseConfig: {method: 'GET', path: '/config/', response: configResponse},
+                browseAutomatedEmails: {method: 'GET', path: '/automated_emails/', response: automatedEmailsFixture}
+            }});
+
+            // Navigate directly to the memberemails section
+            await page.goto('/#/memberemails');
+
+            // Wait for page to load
+            await page.waitForLoadState('networkidle');
+
+            const section = page.getByTestId('memberemails');
+            await expect(section).toBeVisible({timeout: 10000});
+
+            // Click the Edit button on the welcome email preview to open the modal
+            await section.getByTestId('free-welcome-email-edit-button').click();
+
+            const modal = page.getByTestId('welcome-email-modal');
+            await expect(modal).toBeVisible();
+
+            // Press Escape without opening the dropdown - should close the modal
+            await page.keyboard.press('Escape');
+
+            // Verify modal is closed
+            await expect(modal).not.toBeVisible();
+        });
+    });
+});


### PR DESCRIPTION
ref https://linear.app/ghost/issue/NY-852

- Fixes issue where `Cmd+K` would open both site search and "Enter url" input when focused in the editor and with text selected. Now just opens the url input (note it's an existing Koenig shortcut)
- Makes it so hitting `Escape` with the send test email dropdown open will first close that dropdown if it's open, instead of closing the modal entirely. Hitting `Escape` again will close the modal.