### PR TITLE
Capitalized unknown device filter label

### DIFF
--- a/apps/stats/src/utils/constants.ts
+++ b/apps/stats/src/utils/constants.ts
@@ -53,6 +53,7 @@ export const STATS_LABEL_MAPPINGS = {
     'duckduckgo.com': 'DuckDuckGo',
 
     // Unknown/Other values - normalize to "Unknown"
+    unknown: 'Unknown',
     Others: 'Unknown',
     Other: 'Unknown',
     NULL: 'Unknown',

--- a/apps/stats/src/views/Stats/components/stats-filter.tsx
+++ b/apps/stats/src/views/Stats/components/stats-filter.tsx
@@ -91,7 +91,8 @@ const FILTER_FIELD_DEFINITIONS: Record<string, FilterFieldDefinition> = {
             label: v === 'mobile-ios' ? 'iOS' :
                 v === 'mobile-android' ? 'Android' :
                     v === 'desktop' ? 'Desktop' :
-                        v === 'bot' ? 'Bot' : v
+                        v === 'bot' ? 'Bot' :
+                            v === 'unknown' ? 'Unknown' : v
         })
     }
 };


### PR DESCRIPTION
ref https://linear.app/ghost/issue/NY-935/
- values are 'unknown' and are better displayed capitalized to be consistent with other return values