### PR TITLE
Updated top devices endpoint to default to desktop for unknown values

### DIFF
--- a/ghost/core/core/server/data/tinybird/endpoints/api_top_devices.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_top_devices.pipe
@@ -5,7 +5,7 @@ NODE top_devices
 SQL >
     %
     select
-        device,
+        case when device = 'unknown' then 'desktop' else device end as device,
         count() as visits
     from mv_session_data sd
       inner join filtered_sessions fs

--- a/ghost/core/core/server/data/tinybird/endpoints/api_top_devices_v2.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_top_devices_v2.pipe
@@ -16,7 +16,7 @@ NODE top_devices
 SQL >
     %
     select
-        device,
+        case when device = 'unknown' then 'desktop' else device end as device,
         count() as visits
     from session_data sd
       inner join filtered_sessions_v2 fs


### PR DESCRIPTION
ref https://linear.app/ghost/issue/NY-935/

Currently, 'unknown' is ~0.35% of our traffic. Because this is parsed from the user-agent, it would be awfully uncommon to not encounter, and is generally not helpful to the user. Given that desktop is the biggest value at ~100x the unknown (~40%), we're going to default to Desktop. It should be a very minor increment and in exchange we'll have a cleaner ui.

I've made this change in the pipes so that we don't need to migrate all the data in Tinybird, although that's also a viable option.