### PR TITLE
Welcome email activity feed

### DIFF
--- a/ghost/admin/app/helpers/parse-member-event.js
+++ b/ghost/admin/app/helpers/parse-member-event.js
@@ -104,6 +104,10 @@ export default class ParseMemberEventHelper extends Helper {
             icon = 'sent-email';
         }
 
+        if (event.type === 'automated_email_sent_event') {
+            icon = 'sent-email';
+        }
+
         if (event.type === 'email_delivered_event') {
             icon = 'received-email';
         }
@@ -195,6 +199,12 @@ export default class ParseMemberEventHelper extends Helper {
 
         if (event.type === 'email_sent_event') {
             return 'sent email';
+        }
+
+        if (event.type === 'automated_email_sent_event') {
+            const slug = event.data.automatedEmail?.slug || '';
+            const emailType = slug.includes('paid') ? 'Paid' : 'Free';
+            return `received welcome email (${emailType})`;
         }
 
         if (event.type === 'email_delivered_event') {

--- a/ghost/admin/app/utils/member-event-types.js
+++ b/ghost/admin/app/utils/member-event-types.js
@@ -8,7 +8,8 @@ export const ALL_EVENT_TYPES = [
     {event: 'email_delivered_event', icon: 'filter-dropdown-email-received', name: 'Email received', group: 'emails'},
     {event: 'email_complaint_event', icon: 'filter-dropdown-email-flagged-as-spam', name: 'Email flagged as spam', group: 'emails'},
     {event: 'email_failed_event', icon: 'filter-dropdown-email-bounced', name: 'Email bounced', group: 'emails'},
-    {event: 'email_change_event', icon: 'filter-dropdown-email-address-changed', name: 'Email address changed', group: 'emails'}
+    {event: 'email_change_event', icon: 'filter-dropdown-email-address-changed', name: 'Email address changed', group: 'emails'},
+    {event: 'automated_email_sent_event', icon: 'filter-dropdown-email-sent', name: 'Welcome email received', group: 'emails'}
 ];
 
 export function getAvailableEventTypes(settings, feature, hiddenEvents = []) {


### PR DESCRIPTION
Got some code for us? Awesome 🎊!

Please take a minute to explain the change you're making:
- Why are you making it?
  This change completes the implementation of welcome email tracking by displaying `automated_email_sent_event` events in the Ghost Admin member activity feed. This allows admins to see when members receive their welcome emails (free or paid).
- What does it do?
  It updates `ghost/admin/app/helpers/parse-member-event.js` to parse `automated_email_sent_event` and display "Received welcome email (Free)" or "Received welcome email (Paid)" with the `sent-email` icon. It also adds "Welcome email received" to the activity feed filter dropdown in `ghost/admin/app/utils/member-event-types.js`.
- Why is this something Ghost users or developers need?
  Ghost admins need this to gain visibility into the welcome email delivery status for their members, providing a clearer picture of member engagement and completing the welcome email feature.

Please check your PR against these items:

- [ ] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [ ] I've written an automated test to prove my change works

We appreciate your contribution! 🙏

---
Linear Issue: [NY-937](https://linear.app/ghost/issue/NY-937/display-welcome-email-events-in-admin-ui)

<a href="https://cursor.com/background-agent?bcId=bc-67687051-b716-458a-8d0c-da2a82c88919"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-67687051-b716-458a-8d0c-da2a82c88919"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

