### PR TITLE
Added `automated_email_recipients` database table

### DIFF
--- a/ghost/core/core/server/data/exporter/table-lists.js
+++ b/ghost/core/core/server/data/exporter/table-lists.js
@@ -2,6 +2,7 @@
 const BACKUP_TABLES = [
     'actions',
     'api_keys',
+    'automated_email_recipients',
     'automated_emails',
     'brute',
     'donation_payment_events',

--- a/ghost/core/core/server/data/migrations/versions/6.14/2026-01-19-23-55-51-add-automated-email-recipients-table.js
+++ b/ghost/core/core/server/data/migrations/versions/6.14/2026-01-19-23-55-51-add-automated-email-recipients-table.js
@@ -3,9 +3,9 @@ const {addTable} = require('../../utils');
 module.exports = addTable('automated_email_recipients', {
     id: {type: 'string', maxlength: 24, nullable: false, primary: true},
     automated_email_id: {type: 'string', maxlength: 24, nullable: false, references: 'automated_emails.id'},
-    member_id: {type: 'string', maxlength: 24, nullable: false},
+    member_id: {type: 'string', maxlength: 24, nullable: false, index: true},
     processed_at: {type: 'dateTime', nullable: false},
-    member_uuid: {type: 'string', maxlength: 36, nullable: true},
-    member_email: {type: 'string', maxlength: 191, nullable: true},
+    member_uuid: {type: 'string', maxlength: 36, nullable: false},
+    member_email: {type: 'string', maxlength: 191, nullable: false},
     member_name: {type: 'string', maxlength: 191, nullable: true}
 });

--- a/ghost/core/core/server/data/migrations/versions/6.14/2026-01-19-23-55-51-add-automated-email-recipients-table.js
+++ b/ghost/core/core/server/data/migrations/versions/6.14/2026-01-19-23-55-51-add-automated-email-recipients-table.js
@@ -1,0 +1,11 @@
+const {addTable} = require('../../utils');
+
+module.exports = addTable('automated_email_recipients', {
+    id: {type: 'string', maxlength: 24, nullable: false, primary: true},
+    automated_email_id: {type: 'string', maxlength: 24, nullable: false, references: 'automated_emails.id'},
+    member_id: {type: 'string', maxlength: 24, nullable: false},
+    processed_at: {type: 'dateTime', nullable: false},
+    member_uuid: {type: 'string', maxlength: 36, nullable: true},
+    member_email: {type: 'string', maxlength: 191, nullable: true},
+    member_name: {type: 'string', maxlength: 191, nullable: true}
+});

--- a/ghost/core/core/server/data/migrations/versions/6.14/2026-01-22-12-00-49-add-automated-email-recipients-table.js
+++ b/ghost/core/core/server/data/migrations/versions/6.14/2026-01-22-12-00-49-add-automated-email-recipients-table.js
@@ -4,8 +4,9 @@ module.exports = addTable('automated_email_recipients', {
     id: {type: 'string', maxlength: 24, nullable: false, primary: true},
     automated_email_id: {type: 'string', maxlength: 24, nullable: false, references: 'automated_emails.id'},
     member_id: {type: 'string', maxlength: 24, nullable: false, index: true},
-    processed_at: {type: 'dateTime', nullable: false},
     member_uuid: {type: 'string', maxlength: 36, nullable: false},
     member_email: {type: 'string', maxlength: 191, nullable: false},
-    member_name: {type: 'string', maxlength: 191, nullable: true}
+    member_name: {type: 'string', maxlength: 191, nullable: true},
+    created_at: {type: 'dateTime', nullable: false},
+    updated_at: {type: 'dateTime', nullable: true}
 });

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -1153,10 +1153,10 @@ module.exports = {
     automated_email_recipients: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
         automated_email_id: {type: 'string', maxlength: 24, nullable: false, references: 'automated_emails.id'},
-        member_id: {type: 'string', maxlength: 24, nullable: false},
+        member_id: {type: 'string', maxlength: 24, nullable: false, index: true},
         processed_at: {type: 'dateTime', nullable: false},
-        member_uuid: {type: 'string', maxlength: 36, nullable: true},
-        member_email: {type: 'string', maxlength: 191, nullable: true},
+        member_uuid: {type: 'string', maxlength: 36, nullable: false},
+        member_email: {type: 'string', maxlength: 191, nullable: false},
         member_name: {type: 'string', maxlength: 191, nullable: true}
     }
 };

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -1149,5 +1149,14 @@ module.exports = {
             ['slug'],
             ['status']
         ]
+    },
+    automated_email_recipients: {
+        id: {type: 'string', maxlength: 24, nullable: false, primary: true},
+        automated_email_id: {type: 'string', maxlength: 24, nullable: false, references: 'automated_emails.id'},
+        member_id: {type: 'string', maxlength: 24, nullable: false},
+        processed_at: {type: 'dateTime', nullable: false},
+        member_uuid: {type: 'string', maxlength: 36, nullable: true},
+        member_email: {type: 'string', maxlength: 191, nullable: true},
+        member_name: {type: 'string', maxlength: 191, nullable: true}
     }
 };

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -1154,9 +1154,10 @@ module.exports = {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
         automated_email_id: {type: 'string', maxlength: 24, nullable: false, references: 'automated_emails.id'},
         member_id: {type: 'string', maxlength: 24, nullable: false, index: true},
-        processed_at: {type: 'dateTime', nullable: false},
         member_uuid: {type: 'string', maxlength: 36, nullable: false},
         member_email: {type: 'string', maxlength: 191, nullable: false},
-        member_name: {type: 'string', maxlength: 191, nullable: true}
+        member_name: {type: 'string', maxlength: 191, nullable: true},
+        created_at: {type: 'dateTime', nullable: false},
+        updated_at: {type: 'dateTime', nullable: true}
     }
 };

--- a/ghost/core/test/integration/exporter/exporter.test.js
+++ b/ghost/core/test/integration/exporter/exporter.test.js
@@ -24,6 +24,7 @@ describe('Exporter', function () {
             const tables = [
                 'actions',
                 'api_keys',
+                'automated_email_recipients',
                 'automated_emails',
                 'benefits',
                 'brute',

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '24119fc016ca002eb790e4f7bfb9d854';
+    const currentSchemaHash = '7b3edee6c79a124f6ff53d50558a1949';
     const currentFixturesHash = '4dcbd7b52bc9ce23e6f5f1673118ba73';
     const currentSettingsHash = 'e75a2245c64a4fc82f826676abbc3234';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '59d2badf67858999658474ca88e46737';
+    const currentSchemaHash = '24119fc016ca002eb790e4f7bfb9d854';
     const currentFixturesHash = '4dcbd7b52bc9ce23e6f5f1673118ba73';
     const currentSettingsHash = 'e75a2245c64a4fc82f826676abbc3234';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '5d8ff12fd51267005bff200abc420bb0';
+    const currentSchemaHash = '59d2badf67858999658474ca88e46737';
     const currentFixturesHash = '4dcbd7b52bc9ce23e6f5f1673118ba73';
     const currentSettingsHash = 'e75a2245c64a4fc82f826676abbc3234';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
ref https://linear.app/ghost/issue/NY-936

## Summary

- Adds `automated_email_recipients` table to track automated emails sent to members
- First step in implementing welcome emails in the member activity feed
- Follows the `email_recipients` pattern: no FK on `member_id` to preserve audit history when members are deleted