### PR TITLE
Added UI to disable member commenting from comment list

### DIFF
--- a/apps/admin-x-framework/src/api/comments.ts
+++ b/apps/admin-x-framework/src/api/comments.ts
@@ -19,6 +19,7 @@ export type Comment = {
         name: string;
         email: string;
         avatar_image?: string;
+        can_comment?: boolean;
     };
     post?: {
         id: string;

--- a/apps/admin-x-framework/src/api/members.ts
+++ b/apps/admin-x-framework/src/api/members.ts
@@ -1,9 +1,11 @@
-import {Meta, createQuery} from '../utils/api/hooks';
+import {Meta, createMutation, createQuery} from '../utils/api/hooks';
 
 export type Member = {
     id: string;
     name?: string;
     email?: string;
+    avatar_image?: string;
+    can_comment?: boolean;
 };
 
 export interface MembersResponseType {
@@ -16,4 +18,30 @@ const dataType = 'MembersResponseType';
 export const useBrowseMembers = createQuery<MembersResponseType>({
     dataType,
     path: '/members/'
+});
+
+export const useDisableMemberCommenting = createMutation<
+    MembersResponseType,
+    {id: string; reason: string}
+>({
+    method: 'POST',
+    path: ({id}) => `/members/${id}/commenting/disable`,
+    body: ({reason}) => ({
+        reason
+    }),
+    invalidateQueries: {
+        dataType: 'CommentsResponseType'
+    }
+});
+
+export const useEnableMemberCommenting = createMutation<
+    MembersResponseType,
+    {id: string}
+>({
+    method: 'POST',
+    path: ({id}) => `/members/${id}/commenting/enable`,
+    body: () => ({}),
+    invalidateQueries: {
+        dataType: 'CommentsResponseType'
+    }
 });

--- a/apps/posts/src/views/comments/comments.tsx
+++ b/apps/posts/src/views/comments/comments.tsx
@@ -14,6 +14,7 @@ const Comments: React.FC = () => {
     const {filters, nql, setFilters, clearFilters, isSingleIdFilter} = useFilterState();
     const {data: configData} = useBrowseConfig();
     const commentPermalinksEnabled = configData?.config?.labs?.commentPermalinks === true;
+    const disableMemberCommentingEnabled = configData?.config?.labs?.disableMemberCommenting === true;
 
     const handleAddFilter = useCallback((field: string, value: string, operator: string = 'is') => {
         setFilters((prevFilters) => {
@@ -83,6 +84,7 @@ const Comments: React.FC = () => {
                     <>
                         <CommentsList
                             commentPermalinksEnabled={commentPermalinksEnabled}
+                            disableMemberCommentingEnabled={disableMemberCommentingEnabled}
                             fetchNextPage={fetchNextPage}
                             hasNextPage={hasNextPage}
                             isFetchingNextPage={isFetchingNextPage}

--- a/apps/posts/src/views/comments/components/comments-filters.tsx
+++ b/apps/posts/src/views/comments/components/comments-filters.tsx
@@ -15,7 +15,7 @@ interface CommentsFiltersProps {
     filters: Filter[];
     onFiltersChange: (filters: Filter[]) => void;
     knownPosts: Array<{ id: string; title: string }>;
-    knownMembers: Array<{ id: string; name: string; email: string }>;
+    knownMembers: Array<{ id: string; name?: string; email?: string }>;
 }
 
 const CommentsFilters: React.FC<CommentsFiltersProps> = ({

--- a/apps/posts/src/views/comments/components/comments-list.tsx
+++ b/apps/posts/src/views/comments/components/comments-list.tsx
@@ -9,6 +9,12 @@ import {
     AlertDialogTitle,
     Badge,
     Button,
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
     DropdownMenu,
     DropdownMenuContent,
     DropdownMenuItem,
@@ -24,6 +30,7 @@ import {
 } from '@tryghost/shade';
 import {Comment, useDeleteComment, useHideComment, useShowComment} from '@tryghost/admin-x-framework/api/comments';
 import {forwardRef, useEffect, useRef, useState} from 'react';
+import {useDisableMemberCommenting, useEnableMemberCommenting} from '@tryghost/admin-x-framework/api/members';
 import {useInfiniteVirtualScroll} from '@components/virtual-table/use-infinite-virtual-scroll';
 import {useScrollRestoration} from '@components/virtual-table/use-scroll-restoration';
 
@@ -127,7 +134,8 @@ function CommentsList({
     fetchNextPage,
     onAddFilter,
     isLoading,
-    commentPermalinksEnabled
+    commentPermalinksEnabled,
+    disableMemberCommentingEnabled
 }: {
     items: Comment[];
     totalItems: number;
@@ -137,6 +145,7 @@ function CommentsList({
     onAddFilter: (field: string, value: string, operator?: string) => void;
     isLoading?: boolean;
     commentPermalinksEnabled?: boolean;
+    disableMemberCommentingEnabled?: boolean;
 }) {
     const parentRef = useRef<HTMLDivElement>(null);
 
@@ -155,12 +164,31 @@ function CommentsList({
     const {mutate: hideComment} = useHideComment();
     const {mutate: showComment} = useShowComment();
     const {mutate: deleteComment} = useDeleteComment();
+    const {mutate: disableCommenting} = useDisableMemberCommenting();
+    const {mutate: enableCommenting} = useEnableMemberCommenting();
     const [commentToDelete, setCommentToDelete] = useState<Comment | null>(null);
+    const [memberToDisable, setMemberToDisable] = useState<{member: Comment['member']; commentId: string} | null>(null);
 
     const confirmDelete = () => {
         if (commentToDelete) {
             deleteComment({id: commentToDelete.id});
             setCommentToDelete(null);
+        }
+    };
+
+    const confirmDisableCommenting = () => {
+        if (memberToDisable?.member?.id) {
+            disableCommenting({
+                id: memberToDisable.member.id,
+                reason: `Disabled from comment ${memberToDisable.commentId}`
+            });
+            setMemberToDisable(null);
+        }
+    };
+
+    const handleEnableCommenting = (member: Comment['member']) => {
+        if (member?.id) {
+            enableCommenting({id: member.id});
         }
     };
 
@@ -202,23 +230,35 @@ function CommentsList({
                                             <div className={`mb-1 flex min-w-0 items-center gap-x-1 text-sm ${item.status === 'hidden' && 'opacity-50'}`}>
                                                 <div className='whitespace-nowrap'>
                                                     {item.member?.id ? (
-                                                        <>
-                                                            <Button
-                                                                className={`flex h-auto items-center gap-1.5 truncate p-0 font-semibold text-primary hover:opacity-70`}
-                                                                variant='link'
-                                                                onClick={() => {
-                                                                    onAddFilter('author', item.member!.id);
-                                                                }}
-                                                            >
-                                                                {item.member.name || 'Unknown'}
-                                                            </Button>
-                                                        </>
+                                                        <Button
+                                                            className={`flex h-auto items-center gap-1.5 truncate p-0 font-semibold text-primary hover:opacity-70`}
+                                                            variant='link'
+                                                            onClick={() => {
+                                                                onAddFilter('author', item.member!.id);
+                                                            }}
+                                                        >
+                                                            {item.member.name || 'Unknown'}
+                                                        </Button>
                                                     ) : (
                                                         <span className="block truncate font-semibold">
                                                             {item.member?.name || 'Unknown'}
                                                         </span>
                                                     )}
                                                 </div>
+                                                {disableMemberCommentingEnabled && item.member?.can_comment === false && (
+                                                    <TooltipProvider>
+                                                        <Tooltip>
+                                                            <TooltipTrigger asChild>
+                                                                <span data-testid="commenting-disabled-indicator">
+                                                                    <LucideIcon.MessageCircleOff
+                                                                        className="size-3.5 text-muted-foreground"
+                                                                    />
+                                                                </span>
+                                                            </TooltipTrigger>
+                                                            <TooltipContent>Comments disabled</TooltipContent>
+                                                        </Tooltip>
+                                                    </TooltipProvider>
+                                                )}
                                                 <LucideIcon.Dot className='shrink-0 text-muted-foreground/50' size={16} />
                                                 <div className='shrink-0 whitespace-nowrap'>
                                                     {item.created_at && (
@@ -350,6 +390,24 @@ function CommentsList({
                                                             </a>
                                                         </DropdownMenuItem>
                                                     )}
+                                                    {disableMemberCommentingEnabled && item.member?.id && (
+                                                        item.member.can_comment !== false ? (
+                                                            <DropdownMenuItem onClick={() => {
+                                                                // Workaround for Radix UI bug where opening Dialog from DropdownMenu
+                                                                // leaves pointer-events: none on body, freezing the UI
+                                                                // https://github.com/radix-ui/primitives/issues/3317
+                                                                queueMicrotask(() => setMemberToDisable({member: item.member, commentId: item.id}));
+                                                            }}>
+                                                                <LucideIcon.MessageCircleOff className="mr-2 size-4" />
+                                                                Disable commenting
+                                                            </DropdownMenuItem>
+                                                        ) : (
+                                                            <DropdownMenuItem onClick={() => handleEnableCommenting(item.member)}>
+                                                                <LucideIcon.MessageCircle className="mr-2 size-4" />
+                                                                Enable commenting
+                                                            </DropdownMenuItem>
+                                                        )
+                                                    )}
                                                 </DropdownMenuContent>
                                             </DropdownMenu>
                                         </div>
@@ -391,6 +449,31 @@ function CommentsList({
                     </AlertDialogFooter>
                 </AlertDialogContent>
             </AlertDialog>
+
+            <Dialog open={!!memberToDisable} onOpenChange={(open) => {
+                if (!open) {
+                    setMemberToDisable(null);
+                }
+            }}>
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>Disable comments</DialogTitle>
+                        <DialogDescription>
+                            {memberToDisable?.member?.name || 'This member'} won&apos;t be able to comment
+                            in the future. You can re-enable commenting anytime.
+                        </DialogDescription>
+                    </DialogHeader>
+
+                    <DialogFooter>
+                        <Button variant="outline" onClick={() => setMemberToDisable(null)}>
+                            Cancel
+                        </Button>
+                        <Button onClick={confirmDisableCommenting}>
+                            Disable comments
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
         </div>
     );
 }

--- a/apps/posts/src/views/comments/hooks/use-known-filter-values.ts
+++ b/apps/posts/src/views/comments/hooks/use-known-filter-values.ts
@@ -6,7 +6,7 @@ export function useKnownFilterValues({comments}: { comments: Comment[] }) {
         const posts = new Map<string, { id: string; title: string }>();
         const members = new Map<
             string,
-            { id: string; name: string; email: string }
+            { id: string; name?: string; email?: string }
         >();
         for (const comment of comments) {
             if (comment.post?.id && comment.post?.title) {

--- a/e2e/helpers/pages/admin/comments/comments-page.ts
+++ b/e2e/helpers/pages/admin/comments/comments-page.ts
@@ -4,6 +4,15 @@ import {Locator, Page} from '@playwright/test';
 export class CommentsPage extends AdminPage {
     readonly commentsList: Locator;
     readonly commentRows: Locator;
+    readonly viewPostMenuItem: Locator;
+    readonly viewOnPostMenuItem: Locator;
+    readonly disableCommentingMenuItem: Locator;
+    readonly enableCommentingMenuItem: Locator;
+    readonly disableCommentsModal: Locator;
+    readonly disableCommentsModalTitle: Locator;
+    readonly disableCommentsButton: Locator;
+    readonly cancelButton: Locator;
+    readonly commentingDisabledIndicator = (row: Locator) => row.getByTestId('commenting-disabled-indicator');
 
     constructor(page: Page) {
         super(page);
@@ -11,6 +20,14 @@ export class CommentsPage extends AdminPage {
 
         this.commentsList = page.getByTestId('comments-list');
         this.commentRows = page.getByTestId('comment-list-row');
+        this.viewPostMenuItem = page.getByRole('menuitem', {name: 'View post'});
+        this.viewOnPostMenuItem = page.getByRole('menuitem', {name: 'View on post'});
+        this.disableCommentingMenuItem = page.getByRole('menuitem', {name: 'Disable commenting'});
+        this.enableCommentingMenuItem = page.getByRole('menuitem', {name: 'Enable commenting'});
+        this.disableCommentsModal = page.getByRole('dialog');
+        this.disableCommentsModalTitle = this.disableCommentsModal.getByRole('heading', {name: 'Disable comments'});
+        this.disableCommentsButton = page.getByRole('button', {name: 'Disable comments'});
+        this.cancelButton = this.disableCommentsModal.getByRole('button', {name: 'Cancel'});
     }
 
     async waitForComments(): Promise<void> {
@@ -25,15 +42,19 @@ export class CommentsPage extends AdminPage {
         return row.locator('button').last();
     }
 
-    getViewPostMenuItem(): Locator {
-        return this.page.getByRole('menuitem', {name: 'View post'});
-    }
-
-    getViewOnPostMenuItem(): Locator {
-        return this.page.getByRole('menuitem', {name: 'View on post'});
-    }
-
     async openMoreMenu(row: Locator): Promise<void> {
         await this.getMoreMenuButton(row).click();
+    }
+
+    async clickDisableCommenting(): Promise<void> {
+        await this.disableCommentingMenuItem.click();
+    }
+
+    async clickEnableCommenting(): Promise<void> {
+        await this.enableCommentingMenuItem.click();
+    }
+
+    async confirmDisableCommenting(): Promise<void> {
+        await this.disableCommentsButton.click();
     }
 }

--- a/e2e/tests/admin/comments/comment-moderation.test.ts
+++ b/e2e/tests/admin/comments/comment-moderation.test.ts
@@ -48,7 +48,7 @@ test.describe('Ghost Admin - Comment Moderation', () => {
             await commentsPage.openMoreMenu(commentRow);
 
             const popupPromise = page.waitForEvent('popup');
-            await commentsPage.getViewPostMenuItem().click();
+            await commentsPage.viewPostMenuItem.click();
             const postPage = await popupPromise;
 
             await expect(postPage).toHaveURL(new RegExp(`/${post.slug}/`));
@@ -82,7 +82,7 @@ test.describe('Ghost Admin - Comment Moderation', () => {
             await commentsPage.openMoreMenu(commentRow);
 
             const popupPromise = page.waitForEvent('popup');
-            await commentsPage.getViewOnPostMenuItem().click();
+            await commentsPage.viewOnPostMenuItem.click();
             const postPage = await popupPromise;
 
             await expect(postPage).toHaveURL(

--- a/e2e/tests/admin/comments/disable-commenting.test.ts
+++ b/e2e/tests/admin/comments/disable-commenting.test.ts
@@ -1,0 +1,175 @@
+import {CommentFactory, MemberFactory, PostFactory, createCommentFactory, createMemberFactory, createPostFactory} from '@/data-factory';
+import {CommentsPage} from '@/helpers/pages';
+import {SettingsService} from '@/helpers/services/settings/settings-service';
+import {expect, test} from '@/helpers/playwright';
+
+const useReactShell = process.env.USE_REACT_SHELL === 'true';
+
+test.describe('Ghost Admin - Disable Commenting', () => {
+    test.skip(!useReactShell, 'Skipping: requires USE_REACT_SHELL=true');
+    test.use({labs: {disableMemberCommenting: true}});
+
+    let postFactory: PostFactory;
+    let memberFactory: MemberFactory;
+    let commentFactory: CommentFactory;
+
+    test.beforeEach(async ({page}) => {
+        postFactory = createPostFactory(page.request);
+        memberFactory = createMemberFactory(page.request);
+        commentFactory = createCommentFactory(page.request);
+
+        const settingsService = new SettingsService(page.request);
+        await settingsService.setCommentsEnabled('all');
+    });
+
+    test('disable commenting menu item appears in comment menu', async ({page}) => {
+        const post = await postFactory.create({status: 'published'});
+        const member = await memberFactory.create();
+        await commentFactory.create({
+            post_id: post.id,
+            member_id: member.id,
+            html: '<p>Test comment for disable menu</p>'
+        });
+
+        const commentsPage = new CommentsPage(page);
+        await commentsPage.goto();
+        await commentsPage.waitForComments();
+
+        const commentRow = commentsPage.getCommentRowByText('Test comment for disable menu');
+        await commentsPage.openMoreMenu(commentRow);
+
+        await expect(commentsPage.disableCommentingMenuItem).toBeVisible();
+    });
+
+    test('clicking disable commenting opens confirmation modal', async ({page}) => {
+        const post = await postFactory.create({status: 'published'});
+        const member = await memberFactory.create({name: 'Test Member'});
+        await commentFactory.create({
+            post_id: post.id,
+            member_id: member.id,
+            html: '<p>Test comment for modal</p>'
+        });
+
+        const commentsPage = new CommentsPage(page);
+        await commentsPage.goto();
+        await commentsPage.waitForComments();
+
+        const commentRow = commentsPage.getCommentRowByText('Test comment for modal');
+        await commentsPage.openMoreMenu(commentRow);
+        await commentsPage.clickDisableCommenting();
+
+        await expect(commentsPage.disableCommentsModalTitle).toBeVisible();
+        await expect(commentsPage.disableCommentsModal).toContainText('Test Member');
+        await expect(commentsPage.disableCommentsModal).toContainText('won\'t be able to comment');
+        await expect(commentsPage.disableCommentsButton).toBeVisible();
+        await expect(commentsPage.cancelButton).toBeVisible();
+    });
+
+    test('cancel button closes the modal and restores UI interactivity', async ({page}) => {
+        const post = await postFactory.create({status: 'published'});
+        const member = await memberFactory.create();
+        await commentFactory.create({
+            post_id: post.id,
+            member_id: member.id,
+            html: '<p>Test comment for cancel</p>'
+        });
+
+        const commentsPage = new CommentsPage(page);
+        await commentsPage.goto();
+        await commentsPage.waitForComments();
+
+        const commentRow = commentsPage.getCommentRowByText('Test comment for cancel');
+        await commentsPage.openMoreMenu(commentRow);
+        await commentsPage.clickDisableCommenting();
+
+        await expect(commentsPage.disableCommentsModal).toBeVisible();
+        await commentsPage.cancelButton.click();
+
+        await expect(commentsPage.disableCommentsModal).toBeHidden();
+
+        // Verify UI is still interactive by opening menu again
+        await commentsPage.openMoreMenu(commentRow);
+        await expect(commentsPage.disableCommentingMenuItem).toBeVisible();
+    });
+
+    test.describe('disable/enable commenting flow', () => {
+        test('members can comment by default - no disabled indicator shown', async ({page}) => {
+            const post = await postFactory.create({status: 'published'});
+            const member = await memberFactory.create();
+            await commentFactory.create({
+                post_id: post.id,
+                member_id: member.id,
+                html: '<p>Comment from enabled member</p>'
+            });
+
+            const commentsPage = new CommentsPage(page);
+            await commentsPage.goto();
+            await commentsPage.waitForComments();
+
+            const commentRow = commentsPage.getCommentRowByText('Comment from enabled member');
+            await expect(commentsPage.commentingDisabledIndicator(commentRow)).toBeHidden();
+
+            await commentsPage.openMoreMenu(commentRow);
+            await expect(commentsPage.disableCommentingMenuItem).toBeVisible();
+            await expect(commentsPage.enableCommentingMenuItem).toBeHidden();
+        });
+
+        test('disabling commenting shows disabled indicator and changes menu', async ({page}) => {
+            const post = await postFactory.create({status: 'published'});
+            const member = await memberFactory.create();
+            await commentFactory.create({
+                post_id: post.id,
+                member_id: member.id,
+                html: '<p>Test comment for disable flow</p>'
+            });
+
+            const commentsPage = new CommentsPage(page);
+            await commentsPage.goto();
+            await commentsPage.waitForComments();
+
+            const commentRow = commentsPage.getCommentRowByText('Test comment for disable flow');
+            await commentsPage.openMoreMenu(commentRow);
+            await commentsPage.clickDisableCommenting();
+            await commentsPage.confirmDisableCommenting();
+
+            await expect(commentsPage.disableCommentsModal).toBeHidden();
+            await expect(commentsPage.commentingDisabledIndicator(commentRow)).toBeVisible();
+
+            await commentsPage.openMoreMenu(commentRow);
+            await expect(commentsPage.enableCommentingMenuItem).toBeVisible();
+            await expect(commentsPage.disableCommentingMenuItem).toBeHidden();
+        });
+
+        test('re-enabling commenting removes indicator and restores menu', async ({page}) => {
+            const post = await postFactory.create({status: 'published'});
+            const member = await memberFactory.create();
+            await commentFactory.create({
+                post_id: post.id,
+                member_id: member.id,
+                html: '<p>Comment for enable flow</p>'
+            });
+
+            const commentsPage = new CommentsPage(page);
+            await commentsPage.goto();
+            await commentsPage.waitForComments();
+
+            const commentRow = commentsPage.getCommentRowByText('Comment for enable flow');
+
+            // First disable commenting
+            await commentsPage.openMoreMenu(commentRow);
+            await commentsPage.clickDisableCommenting();
+            await commentsPage.confirmDisableCommenting();
+            await expect(commentsPage.commentingDisabledIndicator(commentRow)).toBeVisible();
+
+            // Then re-enable commenting
+            await commentsPage.openMoreMenu(commentRow);
+            await commentsPage.clickEnableCommenting();
+
+            await expect(commentsPage.commentingDisabledIndicator(commentRow)).toBeHidden();
+
+            await commentsPage.openMoreMenu(commentRow);
+            await expect(commentsPage.disableCommentingMenuItem).toBeVisible();
+            await expect(commentsPage.enableCommentingMenuItem).toBeHidden();
+        });
+    });
+});

--- a/e2e/tests/admin/tags/list.test.ts
+++ b/e2e/tests/admin/tags/list.test.ts
@@ -5,6 +5,7 @@ import {expect, test} from '@/helpers/playwright';
 
 test.describe('Ghost Admin - Tags', () => {
     let tagFactory: TagFactory;
+
     test.beforeEach(async ({page}) => {
         tagFactory = createTagFactory(page.request);
     });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3184

## What does this PR do?

This adds the ability for staff to disable a member's commenting privileges directly from the comment moderation screen in Ghost Admin. When reviewing comments, staff can now click the menu on any comment and choose "Disable commenting" to prevent that member from commenting in the future. A confirmation dialog explains the action and the member's comments will show a visual indicator once they've been banned.

The feature includes:
- "Disable commenting" / "Enable commenting" menu items in the comment row dropdown
- A confirmation dialog when disabling
- A visual indicator (crossed-out message icon) next to banned members' names
- API mutation hooks for the disable/enable endpoints

## Why is this needed?

Comment moderation currently allows hiding or deleting individual comments, but there's no way to prevent a problematic member from continuing to post. This gives staff a quick way to ban repeat offenders without leaving the comments screen.

## How is this gated?

The UI is behind the `disableMemberCommenting` labs flag. The flag doesn't exist yet - it will be added to `GA_FEATURES` when the backend API is deployed, which will automatically enable this UI for all users.

## Testing

E2E tests are included and will run once the labs flag is enabled. Manual testing requires the backend API to be available.