### PR TITLE
Updated gscan to version 5.2.4

### DIFF
--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -158,7 +158,7 @@
     "ghost-storage-base": "1.0.0",
     "glob": "8.1.0",
     "got": "11.8.6",
-    "gscan": "5.2.2",
+    "gscan": "5.2.4",
     "handlebars": "4.7.8",
     "heic-convert": "2.1.0",
     "html-to-text": "5.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -20879,10 +20879,10 @@ growly@^1.3.0:
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha512-+xGQY0YyAWCnqy7Cd++hc2JqMYzlm0dG30Jd0beaA64sROr8C4nt8Yc9V5Ro3avlSUDTN0ulqP/VBKi1/lLygw==
 
-gscan@5.2.2:
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/gscan/-/gscan-5.2.2.tgz#ab05f237fe6800b8fde803d0c6ae0e5b5a9812ed"
-  integrity sha512-EVWZJ/XzFtyh0NX5TZW+wHVf79HynTY7NeEXgSIee3N0wKDBqPZ7jdtNkI+5Xz31eSvvQ37OojRBXl8qKaMYZQ==
+gscan@5.2.4:
+  version "5.2.4"
+  resolved "https://registry.yarnpkg.com/gscan/-/gscan-5.2.4.tgz#2ce3fa8d0fbd23efba38c3511f95d429d909e179"
+  integrity sha512-pA8o9exAyBDjojkWENzrV5wO2XwXu/pMkxcw/rYP31JjGupxqvs3FPlAN4UI+GvoOB9L/CeFLzX8huFEy79EMQ==
   dependencies:
     "@sentry/node" "^9.0.0"
     "@tryghost/config" "^0.2.18"


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3137

resolved check that was incorrectly flagging external script tags with absolute URLs (e.g. https://example.com/assets/script.js) as needing the `{{asset}}` helper. 

The `{{asset}}` helper is only meant for relative theme assets - using it with an absolute URL would produce an incorrect path like /assets/https://example.com/...
