### PR TITLE
Added hide_comments option to commenting/disable API

### DIFF
--- a/ghost/core/core/server/api/endpoints/member-commenting.ts
+++ b/ghost/core/core/server/api/endpoints/member-commenting.ts
@@ -10,6 +10,7 @@ interface DisableFrame {
     data: {
         reason: string;
         expires_at: Date | null;
+        hide_comments: boolean;
     };
 }
 
@@ -33,7 +34,8 @@ const controller = {
         ],
         data: [
             'reason',
-            'expires_at'
+            'expires_at',
+            'hide_comments'
         ],
         validation: {
             options: {
@@ -51,6 +53,7 @@ const controller = {
                 frame.options.id,
                 frame.data.reason,
                 frame.data.expires_at || null,
+                frame.data.hide_comments || false,
                 frame.options.context
             );
         }

--- a/ghost/core/core/server/models/base/plugins/bulk-filters.ts
+++ b/ghost/core/core/server/models/base/plugins/bulk-filters.ts
@@ -1,0 +1,35 @@
+import chunk from 'lodash/chunk';
+import nql from '@tryghost/nql';
+import type {Knex} from 'knex';
+
+export const CHUNK_SIZE = 100;
+
+export type WhereStrategy = Iterable<(qb: Knex.QueryBuilder) => void>;
+
+/**
+ * Creates a where strategy that applies an NQL filter to the query builder.
+ * Yields a single query modifier — no chunking.
+ */
+export function* byNQL(filter: string): WhereStrategy {
+    yield (qb) => {
+        nql(filter).querySQL(qb);
+    };
+}
+
+/**
+ * Creates a where strategy that applies whereIn for the given column and values.
+ * Automatically chunks values to avoid SQL parameter limits.
+ */
+export function* byColumnValues(column: string, values: string[], chunkSize: number = CHUNK_SIZE): WhereStrategy {
+    for (const c of chunk(values, chunkSize)) {
+        yield qb => qb.whereIn(column, c);
+    }
+}
+
+/**
+ * Creates a where strategy for matching by id column.
+ * Convenience wrapper around byColumnValues.
+ */
+export function* byIds(ids: string[], chunkSize: number = CHUNK_SIZE): WhereStrategy {
+    yield* byColumnValues('id', ids, chunkSize);
+}

--- a/ghost/core/core/server/models/base/plugins/bulk-operations.js
+++ b/ghost/core/core/server/models/base/plugins/bulk-operations.js
@@ -1,8 +1,5 @@
 const _ = require('lodash');
-const errors = require('@tryghost/errors');
-const logging = require('@tryghost/logging');
-
-const CHUNK_SIZE = 100;
+const {byColumnValues, CHUNK_SIZE} = require('./bulk-filters');
 
 function createBulkOperation(singular, multiple) {
     return async function (knex, table, data, options) {
@@ -55,51 +52,33 @@ async function insertMultiple(knex, table, chunk, options) {
     await k.insert(chunk);
 }
 
-async function editSingle(knex, table, id, options) {
-    let k = knex(table);
-    if (options.transacting) {
-        k = k.transacting(options.transacting);
-    }
-    await k.where(options.column ?? 'id', id).update(options.data);
-}
-
-async function editMultiple(knex, table, chunk, options) {
-    let k = knex(table);
-    if (options.transacting) {
-        k = k.transacting(options.transacting);
-    }
-    await k.whereIn(options.column ?? 'id', chunk).update(options.data);
-}
-
-async function delSingle(knex, table, id, options) {
-    try {
-        let k = knex(table);
-        if (options.transacting) {
-            k = k.transacting(options.transacting);
-        }
-        await k.where(options.column ?? 'id', id).del();
-    } catch (err) {
-        const importError = new errors.DataImportError({
-            message: `Failed to remove entry from ${table}`,
-            context: `Entry id: ${id}`,
-            err: err
-        });
-        logging.error(importError);
-        throw importError;
-    }
-}
-
-async function delMultiple(knex, table, chunk, options) {
-    let k = knex(table);
-    if (options.transacting) {
-        k = k.transacting(options.transacting);
-    }
-    await k.whereIn(options.column ?? 'id', chunk).del();
-}
-
 const insert = createBulkOperation(insertSingle, insertMultiple);
-const edit = createBulkOperation(editSingle, editMultiple);
-const del = createBulkOperation(delSingle, delMultiple);
+
+/**
+ * Execute a bulk operation (update or delete) with a where strategy.
+ * Iterates over each query modifier yielded by the strategy, applies it to
+ * a fresh query builder, and executes the operation.
+ *
+ * @param {import('knex')} knex - Knex instance
+ * @param {string} tableName - Table to operate on
+ * @param {object} options
+ * @param {Iterable<(qb: import('knex').QueryBuilder) => void>} options.where - Where strategy
+ * @param {object} [options.transacting] - Knex transaction
+ * @param {(qb: import('knex').QueryBuilder) => Promise<number>} operation - The operation to perform (update/delete)
+ * @returns {Promise<number>} Total affected rows
+ */
+async function bulkWhereOperation(knex, tableName, {where, transacting}, operation) {
+    let affectedRows = 0;
+    for (const applyWhere of where) {
+        let qb = knex(tableName);
+        if (transacting) {
+            qb = qb.transacting(transacting);
+        }
+        applyWhere(qb);
+        affectedRows += await operation(qb);
+    }
+    return affectedRows;
+}
 
 /**
  * @param {import('bookshelf')} Bookshelf
@@ -113,33 +92,97 @@ module.exports = function (Bookshelf) {
         },
 
         /**
+         * Edit rows matching a where strategy (e.g. byNQL, byIds, byColumnValues).
+         * Pure data operation — no action logging.
          *
-         * @param {*} ids
-         * @param {*} tableName
          * @param {object} options
-         * @param {object} [options.data] Data change you want to apply to the rows
-         * @param {string} [options.column] Update the rows where this column equals the ids (defaults to 'id')
-         * @returns
+         * @param {object} options.data - Column values to set
+         * @param {Iterable<(qb: import('knex').QueryBuilder) => void>} options.where - Where strategy
+         * @param {object} [options.transacting] - Knex transaction
+         * @param {string} [options.tableName] - Table to update (defaults to model's table)
+         * @returns {Promise<number>} Total affected rows
+         */
+        bulkEditWhere: async function bulkEditWhere({data, where, transacting, tableName}) {
+            tableName = tableName || this.prototype.tableName;
+            return bulkWhereOperation(
+                Bookshelf.knex,
+                tableName,
+                {where, transacting},
+                qb => qb.update(data)
+            );
+        },
+
+        /**
+         * Delete rows matching a where strategy (e.g. byNQL, byIds, byColumnValues).
+         * Pure data operation — no action logging.
+         *
+         * @param {object} options
+         * @param {Iterable<(qb: import('knex').QueryBuilder) => void>} options.where - Where strategy
+         * @param {object} [options.transacting] - Knex transaction
+         * @param {string} [options.tableName] - Table to delete from (defaults to model's table)
+         * @returns {Promise<number>} Total affected rows
+         */
+        bulkDestroyWhere: async function bulkDestroyWhere({where, transacting, tableName}) {
+            tableName = tableName || this.prototype.tableName;
+            return bulkWhereOperation(
+                Bookshelf.knex,
+                tableName,
+                {where, transacting},
+                qb => qb.del()
+            );
+        },
+
+        /**
+         * Edit rows by ID list, with action logging.
+         *
+         * @param {string[]} ids - IDs (or column values) to match
+         * @param {string} tableName - Table to update (defaults to model's table)
+         * @param {object} [options]
+         * @param {object} [options.data] - Column values to set
+         * @param {string} [options.column] - Column to match against (defaults to 'id')
+         * @returns {Promise<{successful: number, unsuccessful: number, errors: Array, unsuccessfulData: Array}>}
          */
         bulkEdit: async function bulkEdit(ids, tableName, options = {}) {
             tableName = tableName || this.prototype.tableName;
 
-            const result = await edit(Bookshelf.knex, tableName, ids, options);
+            try {
+                const affectedRows = await this.bulkEditWhere({
+                    data: options.data,
+                    where: byColumnValues(options.column ?? 'id', ids),
+                    transacting: options.transacting,
+                    tableName
+                });
 
-            if (result.successful > 0 && tableName === this.prototype.tableName) {
-                await this.addActions('edited', ids, options);
+                if (affectedRows > 0 && tableName === this.prototype.tableName) {
+                    await this.addActions('edited', ids, options);
+                }
+
+                return {successful: ids.length, unsuccessful: 0, errors: [], unsuccessfulData: []};
+            } catch (err) {
+                if (options.throwErrors) {
+                    throw err;
+                }
+                return {
+                    successful: 0,
+                    unsuccessful: ids.length,
+                    errors: ids.map((id) => {
+                        const e = Object.create(err);
+                        e.errorDetails = id;
+                        return e;
+                    }),
+                    unsuccessfulData: ids
+                };
             }
-
-            return result;
         },
 
         /**
+         * Delete rows by ID list, with action logging.
          *
-         * @param {string[]} ids List of ids to delete
-         * @param {*} tableName
-         * @param {Object} [options]
-         * @param {string} [options.column] Delete the rows where this column equals the ids in `data` (defaults to 'id')
-         * @returns
+         * @param {string[]} ids - IDs (or column values) to match
+         * @param {string} tableName - Table to delete from (defaults to model's table)
+         * @param {object} [options]
+         * @param {string} [options.column] - Column to match against (defaults to 'id')
+         * @returns {Promise<{successful: number, unsuccessful: number, errors: Array, unsuccessfulData: Array}>}
          */
         bulkDestroy: async function bulkDestroy(ids, tableName, options = {}) {
             tableName = tableName || this.prototype.tableName;
@@ -149,7 +192,29 @@ module.exports = function (Bookshelf) {
                 await this.addActions('deleted', ids, options);
             }
 
-            return await del(Bookshelf.knex, tableName, ids, options);
+            try {
+                await this.bulkDestroyWhere({
+                    where: byColumnValues(options.column ?? 'id', ids),
+                    transacting: options.transacting,
+                    tableName
+                });
+
+                return {successful: ids.length, unsuccessful: 0, errors: [], unsuccessfulData: []};
+            } catch (err) {
+                if (options.throwErrors) {
+                    throw err;
+                }
+                return {
+                    successful: 0,
+                    unsuccessful: ids.length,
+                    errors: ids.map((id) => {
+                        const e = Object.create(err);
+                        e.errorDetails = id;
+                        return e;
+                    }),
+                    unsuccessfulData: ids
+                };
+            }
         }
     });
 };

--- a/ghost/core/core/server/services/comments/comments-service.js
+++ b/ghost/core/core/server/services/comments/comments-service.js
@@ -2,6 +2,7 @@ const tpl = require('@tryghost/tpl');
 const errors = require('@tryghost/errors');
 const {MemberCommentEvent} = require('../../../shared/events');
 const DomainEvents = require('@tryghost/domain-events');
+const {byNQL} = require('../../models/base/plugins/bulk-filters');
 
 const messages = {
     commentNotFound: 'Comment could not be found',
@@ -450,6 +451,18 @@ class CommentsService {
         });
 
         return model;
+    }
+
+    /**
+     * Bulk update comment status based on NQL filter
+     * @param {string} filter - NQL filter string (e.g., "member_id:'abc123'+status:published")
+     * @param {string} status - New status ('hidden', 'published', 'deleted')
+     */
+    async bulkUpdateStatus(filter, status) {
+        await this.models.Comment.bulkEditWhere({
+            data: {status},
+            where: byNQL(filter)
+        });
     }
 
     async getMemberIdByUUID(uuid, options) {

--- a/ghost/core/core/server/services/members/api.js
+++ b/ghost/core/core/server/services/members/api.js
@@ -18,6 +18,7 @@ const tiersService = require('../tiers');
 const newslettersService = require('../newsletters');
 const memberAttributionService = require('../member-attribution');
 const emailSuppressionList = require('../email-suppression-list');
+const commentsService = require('../comments');
 const {t} = require('../i18n');
 const sentry = require('../../../shared/sentry');
 
@@ -252,7 +253,8 @@ function createApiInstance(config) {
         settingsCache,
         sentry,
         settingsHelpers,
-        urlUtils
+        urlUtils,
+        commentsService
     });
 
     return membersApiInstance;

--- a/ghost/core/core/server/services/members/index.d.ts
+++ b/ghost/core/core/server/services/members/index.d.ts
@@ -3,6 +3,7 @@ interface MemberBREADService {
         memberId: string,
         reason: string,
         expiresAt: Date | null,
+        hideComments: boolean,
         context: unknown
     ): Promise<unknown>;
 

--- a/ghost/core/core/server/services/members/members-api/members-api.js
+++ b/ghost/core/core/server/services/members/members-api/members-api.js
@@ -78,7 +78,8 @@ module.exports = function MembersAPI({
     settingsCache,
     sentry,
     settingsHelpers,
-    urlUtils
+    urlUtils,
+    commentsService
 }) {
     const tokenService = new TokenService({
         privateKey,
@@ -157,7 +158,8 @@ module.exports = function MembersAPI({
         memberAttributionService,
         emailSuppressionList,
         settingsHelpers,
-        nextPaymentCalculator
+        nextPaymentCalculator,
+        commentsService
     });
 
     const geolocationService = new GeolocationService();

--- a/ghost/core/core/server/services/members/members-api/services/member-bread-service.js
+++ b/ghost/core/core/server/services/members/members-api/services/member-bread-service.js
@@ -41,7 +41,7 @@ module.exports = class MemberBREADService {
      * @param {import('@tryghost/settings-helpers')} deps.settingsHelpers
      * @param {import('./next-payment-calculator')} deps.nextPaymentCalculator
      */
-    constructor({memberRepository, labsService, emailService, stripeService, offersAPI, memberAttributionService, emailSuppressionList, settingsHelpers, nextPaymentCalculator}) {
+    constructor({memberRepository, labsService, emailService, stripeService, offersAPI, memberAttributionService, emailSuppressionList, settingsHelpers, nextPaymentCalculator, commentsService}) {
         this.offersAPI = offersAPI;
         /** @private */
         this.memberRepository = memberRepository;
@@ -59,6 +59,8 @@ module.exports = class MemberBREADService {
         this.settingsHelpers = settingsHelpers;
         /** @private */
         this.nextPaymentCalculator = nextPaymentCalculator;
+        /** @private */
+        this.commentsService = commentsService;
     }
 
     /**
@@ -393,10 +395,11 @@ module.exports = class MemberBREADService {
      * @param {string} memberId
      * @param {string} reason
      * @param {Date|null} until
+     * @param {boolean} hideComments
      * @param {Object} context
      * @returns {Promise<Object>}
      */
-    async disableCommenting(memberId, reason, until, context) {
+    async disableCommenting(memberId, reason, until, hideComments, context) {
         const model = await this.memberRepository.get({id: memberId});
 
         if (!model) {
@@ -414,6 +417,10 @@ module.exports = class MemberBREADService {
             'commenting_disabled',
             context
         );
+
+        if (hideComments) {
+            await this.commentsService.api.bulkUpdateStatus(`member_id:'${memberId}'+status:published`, 'hidden');
+        }
 
         return this.read({id: memberId});
     }

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -54,6 +54,7 @@ const PRIVATE_FEATURES = [
     'featurebaseFeedback',
     'transistor',
     'disableMemberCommenting',
+    'disableMemberCommentingHideComments',
     'sniperlinks'
 ];
 

--- a/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
@@ -16,6 +16,7 @@ Object {
       "commentPermalinks": true,
       "customFonts": true,
       "disableMemberCommenting": true,
+      "disableMemberCommentingHideComments": true,
       "editorExcerpt": true,
       "emailCustomization": true,
       "emailUniqueid": true,

--- a/ghost/core/test/e2e-api/admin/__snapshots__/member-commenting.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/member-commenting.test.js.snap
@@ -1,5 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Member Commenting API POST /members/:id/commenting/disable Can disable commenting and hide comments with hide_comments: true 1: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "822",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-cache-invalidate": "/members/",
+  "x-powered-by": "Express",
+}
+`;
+
 exports[`Member Commenting API POST /members/:id/commenting/disable Can disable commenting with reason and expiry date (temporary) 1: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
@@ -60,6 +74,20 @@ Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
   "content-length": "831",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-cache-invalidate": "/members/",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Member Commenting API POST /members/:id/commenting/disable Can disable commenting without hiding comments when hide_comments: false 1: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "816",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/e2e-api/admin/__snapshots__/members.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/members.test.js.snap
@@ -588,6 +588,62 @@ Object {
 }
 `;
 
+exports[`Members API Bulk operations Can bulk add a label to members 1: [body] 1`] = `
+Object {
+  "bulk": Object {
+    "meta": Object {
+      "errors": Array [],
+      "stats": Object {
+        "successful": 8,
+        "unsuccessful": 0,
+      },
+      "unsuccessfulData": Array [],
+    },
+  },
+}
+`;
+
+exports[`Members API Bulk operations Can bulk add a label to members 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "95",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Members API Bulk operations Can bulk add a label to members with filter 1: [body] 1`] = `
+Object {
+  "bulk": Object {
+    "meta": Object {
+      "errors": Array [],
+      "stats": Object {
+        "successful": 1,
+        "unsuccessful": 0,
+      },
+      "unsuccessfulData": Array [],
+    },
+  },
+}
+`;
+
+exports[`Members API Bulk operations Can bulk add a label to members with filter 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "95",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
 exports[`Members API Bulk operations Can bulk delete a label from members 1: [body] 1`] = `
 Object {
   "bulk": Object {
@@ -828,6 +884,34 @@ Object {
 `;
 
 exports[`Members API Bulk operations Doesn't delete labels apart from the passed label id 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "95",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Members API Bulk operations Handles duplicate labels gracefully when bulk adding 1: [body] 1`] = `
+Object {
+  "bulk": Object {
+    "meta": Object {
+      "errors": Array [],
+      "stats": Object {
+        "successful": 1,
+        "unsuccessful": 0,
+      },
+      "unsuccessfulData": Array [],
+    },
+  },
+}
+`;
+
+exports[`Members API Bulk operations Handles duplicate labels gracefully when bulk adding 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",

--- a/ghost/core/test/unit/server/models/base/bulk-filters.test.js
+++ b/ghost/core/test/unit/server/models/base/bulk-filters.test.js
@@ -1,0 +1,86 @@
+const sinon = require('sinon');
+const bulkFilters = require('../../../../../core/server/models/base/plugins/bulk-filters');
+const {byNQL, byColumnValues, byIds} = bulkFilters;
+
+describe('Models: bulk-filters', function () {
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    describe('byNQL', function () {
+        it('yields a single query modifier function', function () {
+            const strategy = byNQL('status:published');
+            const results = [...strategy];
+
+            results.length.should.equal(1);
+            results[0].should.be.a.Function();
+        });
+    });
+
+    describe('byColumnValues', function () {
+        it('chunks values into groups of 100 by default', function () {
+            const ids = Array.from({length: 150}, (_, i) => `id-${i}`);
+            const strategy = byColumnValues('id', ids);
+            const results = [...strategy];
+
+            // Should produce 2 chunks: 100 + 50
+            results.length.should.equal(2);
+        });
+
+        it('yields single chunk for values less than chunk size', function () {
+            const ids = Array.from({length: 50}, (_, i) => `id-${i}`);
+            const strategy = byColumnValues('id', ids);
+            const results = [...strategy];
+
+            results.length.should.equal(1);
+        });
+
+        it('yields no chunks for empty array', function () {
+            const strategy = byColumnValues('id', []);
+            const results = [...strategy];
+
+            results.length.should.equal(0);
+        });
+
+        it('applies whereIn to query builder for each chunk', function () {
+            const ids = ['id-1', 'id-2', 'id-3'];
+            const strategy = byColumnValues('member_id', ids);
+            const [applyWhere] = [...strategy];
+
+            const mockQb = {
+                whereIn: sinon.stub().returnsThis()
+            };
+
+            applyWhere(mockQb);
+
+            mockQb.whereIn.calledOnce.should.be.true();
+            mockQb.whereIn.calledWith('member_id', ids).should.be.true();
+        });
+
+        it('allows custom chunk size', function () {
+            const ids = Array.from({length: 25}, (_, i) => `id-${i}`);
+            const strategy = byColumnValues('id', ids, 10);
+            const results = [...strategy];
+
+            // Should produce 3 chunks: 10 + 10 + 5
+            results.length.should.equal(3);
+        });
+    });
+
+    describe('byIds', function () {
+        it('delegates to byColumnValues with id column', function () {
+            const ids = ['id-1', 'id-2', 'id-3'];
+            const strategy = byIds(ids);
+            const [applyWhere] = [...strategy];
+
+            const mockQb = {
+                whereIn: sinon.stub().returnsThis()
+            };
+
+            applyWhere(mockQb);
+
+            mockQb.whereIn.calledOnce.should.be.true();
+            mockQb.whereIn.calledWith('id', ids).should.be.true();
+        });
+    });
+});


### PR DESCRIPTION
When disabling a member's commenting ability, admins can now optionally hide all of the member's existing comments in one operation by passing `hide_comments: true`.

This addresses a common moderation workflow where you want to both prevent future comments from a problematic member and remove visibility of their past comments. Rather than requiring two separate actions (disable commenting + manually hide each comment), this combines them into a single API call.

The implementation introduces `bulkUpdateStatus` to the CommentsService, which uses NQL filters to perform bulk updates. This lays groundwork for a future bulk comments API where admins can hide/delete comments matching arbitrary filters. For now, the `hide_comments` option simply calls this with a filter targeting the member's published comments.

Only published comments are hidden - already hidden or deleted comments are left unchanged.
