### PR TITLE
Added hide comments checkbox to disable commenting dialog

### DIFF
--- a/apps/admin-x-framework/src/api/members.ts
+++ b/apps/admin-x-framework/src/api/members.ts
@@ -6,6 +6,11 @@ export type Member = {
     email?: string;
     avatar_image?: string;
     can_comment?: boolean;
+    commenting?: {
+        disabled: boolean;
+        disabled_reason?: string;
+        disabled_until?: string;
+    };
 };
 
 export interface MembersResponseType {
@@ -22,12 +27,13 @@ export const useBrowseMembers = createQuery<MembersResponseType>({
 
 export const useDisableMemberCommenting = createMutation<
     MembersResponseType,
-    {id: string; reason: string}
+    {id: string; reason: string; hideComments?: boolean}
 >({
     method: 'POST',
     path: ({id}) => `/members/${id}/commenting/disable`,
-    body: ({reason}) => ({
-        reason
+    body: ({reason, hideComments}) => ({
+        reason,
+        hide_comments: hideComments
     }),
     invalidateQueries: {
         dataType: 'CommentsResponseType'

--- a/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
@@ -68,6 +68,10 @@ const features: Feature[] = [{
     description: 'Allow staff to disable commenting for individual members',
     flag: 'disableMemberCommenting'
 }, {
+    title: 'Hide Comments When Disabling',
+    description: 'Show option to hide all previous comments when disabling commenting for a member',
+    flag: 'disableMemberCommentingHideComments'
+}, {
     title: 'Sniper Links',
     description: 'Enable mail app links on signup/signin',
     flag: 'sniperlinks'

--- a/apps/posts/src/views/comments/comments.tsx
+++ b/apps/posts/src/views/comments/comments.tsx
@@ -15,6 +15,7 @@ const Comments: React.FC = () => {
     const {data: configData} = useBrowseConfig();
     const commentPermalinksEnabled = configData?.config?.labs?.commentPermalinks === true;
     const disableMemberCommentingEnabled = configData?.config?.labs?.disableMemberCommenting === true;
+    const hideCommentsEnabled = configData?.config?.labs?.disableMemberCommentingHideComments === true;
 
     const handleAddFilter = useCallback((field: string, value: string, operator: string = 'is') => {
         setFilters((prevFilters) => {
@@ -87,6 +88,7 @@ const Comments: React.FC = () => {
                             disableMemberCommentingEnabled={disableMemberCommentingEnabled}
                             fetchNextPage={fetchNextPage}
                             hasNextPage={hasNextPage}
+                            hideCommentsEnabled={hideCommentsEnabled}
                             isFetchingNextPage={isFetchingNextPage}
                             isLoading={isFetching && !isFetchingNextPage}
                             items={data?.comments ?? []}

--- a/apps/posts/src/views/comments/components/comments-list.tsx
+++ b/apps/posts/src/views/comments/components/comments-list.tsx
@@ -9,6 +9,7 @@ import {
     AlertDialogTitle,
     Badge,
     Button,
+    Checkbox,
     Dialog,
     DialogContent,
     DialogDescription,
@@ -19,6 +20,7 @@ import {
     DropdownMenuContent,
     DropdownMenuItem,
     DropdownMenuTrigger,
+    Label,
     LucideIcon,
     Tooltip,
     TooltipContent,
@@ -135,7 +137,8 @@ function CommentsList({
     onAddFilter,
     isLoading,
     commentPermalinksEnabled,
-    disableMemberCommentingEnabled
+    disableMemberCommentingEnabled,
+    hideCommentsEnabled
 }: {
     items: Comment[];
     totalItems: number;
@@ -146,6 +149,7 @@ function CommentsList({
     isLoading?: boolean;
     commentPermalinksEnabled?: boolean;
     disableMemberCommentingEnabled?: boolean;
+    hideCommentsEnabled?: boolean;
 }) {
     const parentRef = useRef<HTMLDivElement>(null);
 
@@ -168,6 +172,7 @@ function CommentsList({
     const {mutate: enableCommenting} = useEnableMemberCommenting();
     const [commentToDelete, setCommentToDelete] = useState<Comment | null>(null);
     const [memberToDisable, setMemberToDisable] = useState<{member: Comment['member']; commentId: string} | null>(null);
+    const [hideComments, setHideComments] = useState(false);
 
     const confirmDelete = () => {
         if (commentToDelete) {
@@ -180,9 +185,11 @@ function CommentsList({
         if (memberToDisable?.member?.id) {
             disableCommenting({
                 id: memberToDisable.member.id,
-                reason: `Disabled from comment ${memberToDisable.commentId}`
+                reason: `Disabled from comment ${memberToDisable.commentId}`,
+                ...(hideCommentsEnabled && {hideComments})
             });
             setMemberToDisable(null);
+            setHideComments(false);
         }
     };
 
@@ -450,6 +457,7 @@ function CommentsList({
             <Dialog open={!!memberToDisable} onOpenChange={(open) => {
                 if (!open) {
                     setMemberToDisable(null);
+                    setHideComments(false);
                 }
             }}>
                 <DialogContent>
@@ -461,8 +469,24 @@ function CommentsList({
                         </DialogDescription>
                     </DialogHeader>
 
+                    {hideCommentsEnabled && (
+                        <div className="flex items-center gap-2 py-2">
+                            <Checkbox
+                                checked={hideComments}
+                                id="hide-comments"
+                                onCheckedChange={checked => setHideComments(checked === true)}
+                            />
+                            <Label htmlFor="hide-comments">
+                                Hide all previous comments
+                            </Label>
+                        </div>
+                    )}
+
                     <DialogFooter>
-                        <Button variant="outline" onClick={() => setMemberToDisable(null)}>
+                        <Button variant="outline" onClick={() => {
+                            setMemberToDisable(null);
+                            setHideComments(false);
+                        }}>
                             Cancel
                         </Button>
                         <Button onClick={confirmDisableCommenting}>

--- a/e2e/helpers/pages/admin/comments/comments-page.ts
+++ b/e2e/helpers/pages/admin/comments/comments-page.ts
@@ -13,6 +13,7 @@ export class CommentsPage extends AdminPage {
     readonly disableCommentsButton: Locator;
     readonly cancelButton: Locator;
     readonly commentingDisabledIndicator = (row: Locator) => row.getByTestId('commenting-disabled-indicator');
+    readonly hideCommentsCheckbox: Locator;
 
     constructor(page: Page) {
         super(page);
@@ -28,6 +29,7 @@ export class CommentsPage extends AdminPage {
         this.disableCommentsModalTitle = this.disableCommentsModal.getByRole('heading', {name: 'Disable comments'});
         this.disableCommentsButton = page.getByRole('button', {name: 'Disable comments'});
         this.cancelButton = this.disableCommentsModal.getByRole('button', {name: 'Cancel'});
+        this.hideCommentsCheckbox = page.getByRole('checkbox', {name: 'Hide all previous comments'});
     }
 
     async waitForComments(): Promise<void> {

--- a/e2e/tests/admin/comments/disable-commenting.test.ts
+++ b/e2e/tests/admin/comments/disable-commenting.test.ts
@@ -92,6 +92,79 @@ test.describe('Ghost Admin - Disable Commenting', () => {
         await expect(commentsPage.disableCommentingMenuItem).toBeVisible();
     });
 
+    test.describe('with hide comments enabled', () => {
+        test.use({labs: {disableMemberCommenting: true, disableMemberCommentingHideComments: true}});
+
+        test('hide comments checkbox appears in modal', async ({page}) => {
+            const post = await postFactory.create({status: 'published'});
+            const member = await memberFactory.create();
+            await commentFactory.create({
+                post_id: post.id,
+                member_id: member.id,
+                html: '<p>Test comment for hide checkbox</p>'
+            });
+
+            const commentsPage = new CommentsPage(page);
+            await commentsPage.goto();
+            await commentsPage.waitForComments();
+
+            const commentRow = commentsPage.getCommentRowByText('Test comment for hide checkbox');
+            await commentsPage.openMoreMenu(commentRow);
+            await commentsPage.clickDisableCommenting();
+
+            await expect(commentsPage.hideCommentsCheckbox).toBeVisible();
+        });
+
+        test('disabling with hide comments checked marks comments as hidden', async ({page}) => {
+            const post = await postFactory.create({status: 'published'});
+            const member = await memberFactory.create();
+            await commentFactory.create({
+                post_id: post.id,
+                member_id: member.id,
+                html: '<p>Comment that should be hidden</p>'
+            });
+
+            const commentsPage = new CommentsPage(page);
+            await commentsPage.goto();
+            await commentsPage.waitForComments();
+
+            const commentRow = commentsPage.getCommentRowByText('Comment that should be hidden');
+            await expect(commentRow).toBeVisible();
+            await expect(commentRow.getByText('Hidden', {exact: true})).toBeHidden();
+
+            await commentsPage.openMoreMenu(commentRow);
+            await commentsPage.clickDisableCommenting();
+            await commentsPage.hideCommentsCheckbox.check();
+            await commentsPage.confirmDisableCommenting();
+
+            await expect(commentRow.getByText('Hidden', {exact: true})).toBeVisible();
+            await expect(commentsPage.commentingDisabledIndicator(commentRow)).toBeVisible();
+        });
+
+        test('disabling without hide comments checked keeps comments visible', async ({page}) => {
+            const post = await postFactory.create({status: 'published'});
+            const member = await memberFactory.create();
+            await commentFactory.create({
+                post_id: post.id,
+                member_id: member.id,
+                html: '<p>Comment that should stay visible</p>'
+            });
+
+            const commentsPage = new CommentsPage(page);
+            await commentsPage.goto();
+            await commentsPage.waitForComments();
+
+            const commentRow = commentsPage.getCommentRowByText('Comment that should stay visible');
+            await commentsPage.openMoreMenu(commentRow);
+            await commentsPage.clickDisableCommenting();
+            await commentsPage.confirmDisableCommenting();
+
+            await expect(commentsPage.disableCommentsModal).toBeHidden();
+            await expect(commentRow).toBeVisible();
+            await expect(commentsPage.commentingDisabledIndicator(commentRow)).toBeVisible();
+        });
+    });
+
     test.describe('disable/enable commenting flow', () => {
         test('members can comment by default - no disabled indicator shown', async ({page}) => {
             const post = await postFactory.create({status: 'published'});


### PR DESCRIPTION
## Summary

When disabling a member from commenting, staff may also want to hide all the member's previous comments. This adds an optional "Hide all previous comments" checkbox to the disable commenting confirmation dialog.

The checkbox is gated behind a separate `disableMemberCommentingHideComments` labs flag since the backend support for the `hide_comments` API parameter will be deployed separately from the frontend.

ref https://linear.app/ghost/issue/BER-3184

Requires https://github.com/TryGhost/Ghost/pull/25906

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes comment-moderation behavior and request payloads (new `hide_comments` parameter) behind a feature flag; failures could incorrectly hide or not hide comments when disabling members.
> 
> **Overview**
> Adds a **labs-gated** “Hide all previous comments” checkbox to the disable-commenting confirmation dialog in Comments; when enabled it passes a new `hide_comments` parameter when calling `POST /members/:id/commenting/disable`.
> 
> Introduces the new `disableMemberCommentingHideComments` labs flag (surfaced in Labs settings), threads `hideCommentsEnabled` through the comments UI, and extends the members API hook/types to support the optional `hideComments` field. Updates Playwright page objects and adds e2e coverage for checkbox visibility and hide-vs-keep behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b091c8bca4fbd08d56e7e1e177c5b4a4afb15594. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added member commenting management—disable or enable commenting for individual members.
  * Added optional "Hide all previous comments" feature when disabling member commenting.
  * New private lab feature "Hide Comments When Disabling" to control the hide comments option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->