### PR TITLE
Allowed GHOST_URL to be customised in yarn dev:forward x Stripe

### DIFF
--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -136,7 +136,7 @@ services:
       - ./docker/stripe/entrypoint.sh:/entrypoint.sh:ro
       - shared-config:/mnt/shared-config
     environment:
-      - GHOST_URL=http://ghost-dev:2368
+      - GHOST_URL=${GHOST_URL:-http://ghost-dev:2368}
       - STRIPE_SECRET_KEY=${STRIPE_SECRET_KEY:-}
     healthcheck:
       test: ["CMD", "test", "-f", "/mnt/shared-config/.env.stripe"]


### PR DESCRIPTION
no issue

- When running ActivityPub alongside Ghost, we use a public-facing url for local development - so that it can interact with other actors from the Fediverse. We typically use Tailscale funnel to proxy our localhost to a public-facing url
- This change allows us to pass the public-facing url in the `yarn dev:forward` dev setup with Stripe profile, so that Stripe webhooks are forwarded to the correct url

How to use:
- Add `GHOST_URL=<YOUR_LOCAL_SITE_URL>` to the .env file at the root of the monorepo
- If left empty, it will fallback to the default value of `http://ghost-dev:2368`
