### PR TITLE
Removed old referrer stats endpoint

### DIFF
--- a/ghost/core/core/server/api/endpoints/stats.js
+++ b/ghost/core/core/server/api/endpoints/stats.js
@@ -70,31 +70,6 @@ const controller = {
             return await statsService.api.getSubscriptionCountHistory();
         }
     },
-    postReferrers: {
-        headers: {
-            cacheInvalidate: false
-        },
-        data: [
-            'id'
-        ],
-        permissions: {
-            docName: 'posts',
-            method: 'browse'
-        },
-        cache: statsService.cache,
-        generateCacheKeyData(frame) {
-            return {
-                method: 'postReferrers',
-                data: {
-                    id: frame.data.id
-                }
-
-            };
-        },
-        async query(frame) {
-            return await statsService.api.getPostReferrers(frame.data.id);
-        }
-    },
     referrersHistory: {
         headers: {
             cacheInvalidate: false
@@ -340,7 +315,7 @@ const controller = {
             return await statsService.api.getNewsletterSubscriberStats(frame.options);
         }
     },
-    postReferrersAlpha: {
+    postReferrers: {
         headers: {
             cacheInvalidate: false
         },
@@ -369,7 +344,7 @@ const controller = {
         cache: statsService.cache,
         generateCacheKeyData(frame) {
             return {
-                method: 'getReferrersForPost',
+                method: 'postReferrers',
                 data: {
                     id: frame.data.id
                 }

--- a/ghost/core/core/server/services/stats/stats-service.js
+++ b/ghost/core/core/server/services/stats/stats-service.js
@@ -54,16 +54,6 @@ class StatsService {
     /**
      * @param {string} postId
      */
-    async getPostReferrers(postId) {
-        return {
-            data: await this.referrers.getForPost(postId),
-            meta: {}
-        };
-    }
-
-    /**
-     * @param {string} postId
-     */
     async getReferrersForPost(postId, options) {
         const result = await this.posts.getReferrersForPost(postId, options);
         return result;

--- a/ghost/core/core/server/web/api/endpoints/admin/routes.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/routes.js
@@ -155,7 +155,6 @@ module.exports = function apiRoutes() {
     router.get('/stats/member_count', mw.authAdminApi, http(api.stats.memberCountHistory));
     router.get('/stats/mrr', mw.authAdminApi, http(api.stats.mrr));
     router.get('/stats/subscriptions', mw.authAdminApi, http(api.stats.subscriptions));
-    router.get('/stats/referrers/posts/:id', mw.authAdminApi, http(api.stats.postReferrers));
     router.get('/stats/referrers', mw.authAdminApi, http(api.stats.referrersHistory));
     router.get('/stats/posts/:id/stats', mw.authAdminApi, http(api.stats.postStats));
     router.get('/stats/top-posts', mw.authAdminApi, http(api.stats.topPosts));
@@ -165,7 +164,7 @@ module.exports = function apiRoutes() {
     router.get('/stats/newsletter-basic-stats', mw.authAdminApi, http(api.stats.newsletterBasicStats));
     router.get('/stats/newsletter-click-stats', mw.authAdminApi, http(api.stats.newsletterClickStats));
     router.get('/stats/subscriber-count', mw.authAdminApi, http(api.stats.subscriberCount));
-    router.get('/stats/posts/:id/top-referrers', mw.authAdminApi, http(api.stats.postReferrersAlpha));
+    router.get('/stats/posts/:id/top-referrers', mw.authAdminApi, http(api.stats.postReferrers));
     router.get('/stats/posts/:id/growth', mw.authAdminApi, http(api.stats.postGrowthStats));
     router.get('/stats/top-sources-growth', mw.authAdminApi, http(api.stats.topSourcesGrowth));
     router.post('/stats/posts-visitor-counts', mw.authAdminApi, http(api.stats.postsVisitorCounts));

--- a/ghost/core/test/e2e-api/admin/stats.test.js
+++ b/ghost/core/test/e2e-api/admin/stats.test.js
@@ -175,29 +175,6 @@ describe('Stats API', function () {
         });
     });
 
-    describe('Post attribution stats', function () {
-        it('Can fetch attribution stats', async function () {
-            await agent
-                .get(`/stats/referrers/posts/${fixtureManager.get('posts', 1).id}/`)
-                .expectStatus(200)
-                .matchBodySnapshot({
-                    stats: [
-                        {
-                            source: 'Direct',
-                            signups: 2,
-                            paid_conversions: 1
-                        },
-                        {
-                            source: 'Twitter',
-                            signups: 1,
-                            paid_conversions: 0
-                        }
-                    ],
-                    meta: {}
-                });
-        });
-    });
-
     describe('Referrer source history stats', function () {
         it('Can fetch attribution stats', async function () {
             await agent


### PR DESCRIPTION
ref https://linear.app/ghost/issue/NY-892/
- removed deprecated referrer stats endpoints (`stats/referrers/posts/:id`)
- cleaned up 'alpha' label on newer referrers endpoint (`/stats/posts/:id/top-referrers`)

When we moved to the new Analytics apps in 6.0, we created new stats endpoints that were consistent with the new design, while the old ones were often consistent with the old design (Dashboard activity). We likely should've cleaned this up with 6.0 to be a bit, well, cleaner, as we deprecated the Dashboard activity at that time.