### PR TITLE
Replaced Should snapshot matcher with regular assertion function

### DIFF
--- a/ghost/core/test/e2e-api/admin/email-previews.test.js
+++ b/ghost/core/test/e2e-api/admin/email-previews.test.js
@@ -1,10 +1,10 @@
 const {agentProvider, fixtureManager, matchers, mockManager} = require('../../utils/e2e-framework');
 const {anyEtag, anyErrorId, anyContentVersion, anyString} = matchers;
 const assert = require('assert/strict');
+const {assertMatchSnapshot} = require('../../utils/assertions');
 const config = require('../../../core/shared/config');
 const sinon = require('sinon');
 const escapeRegExp = require('lodash/escapeRegExp');
-const should = require('should');
 const settingsHelpers = require('../../../core/server/services/settings-helpers');
 const urlUtilsHelper = require('../../utils/url-utils');
 
@@ -18,7 +18,7 @@ function testCleanedSnapshot(html, cleaned) {
     for (const [key, value] of Object.entries(cleaned)) {
         html = html.replace(new RegExp(escapeRegExp(key), 'g'), value);
     }
-    should({html}).matchSnapshot();
+    assertMatchSnapshot({html});
 }
 
 const matchEmailPreviewBody = {

--- a/ghost/core/test/e2e-api/admin/posts.test.js
+++ b/ghost/core/test/e2e-api/admin/posts.test.js
@@ -1,5 +1,5 @@
-const should = require('should');
 const sinon = require('sinon');
+const {assertMatchSnapshot} = require('../../utils/assertions');
 const {agentProvider, fixtureManager, mockManager, matchers} = require('../../utils/e2e-framework');
 const {anyArray, anyContentVersion, anyEtag, anyErrorId, anyLocationFor, anyObject, anyObjectId, anyISODateTime, anyString, anyStringNumber, anyUuid, stringMatching} = matchers;
 const config = require('../../../core/shared/config');
@@ -37,7 +37,7 @@ function testCleanedSnapshot(text, ignoreReplacements) {
             text = text.replace(new RegExp(escapeRegExp(match), 'g'), replacement);
         }
     }
-    should({text}).matchSnapshot();
+    assertMatchSnapshot({text});
 }
 
 const createLexical = (text) => {

--- a/ghost/core/test/e2e-api/members/send-magic-link.test.js
+++ b/ghost/core/test/e2e-api/members/send-magic-link.test.js
@@ -2,6 +2,7 @@ const {agentProvider, mockManager, fixtureManager, matchers, configUtils, resetR
 const should = require('should');
 const sinon = require('sinon');
 const assert = require('assert/strict');
+const {assertMatchSnapshot} = require('../../utils/assertions');
 const settingsCache = require('../../../core/shared/settings-cache');
 const settingsService = require('../../../core/server/services/settings');
 const DomainEvents = require('@tryghost/domain-events');
@@ -330,13 +331,13 @@ describe('sendMagicLink', function () {
         it('matches snapshot', async function () {
             const mail = await sendSigninRequest();
             const scrubbedEmail = scrubEmailContent(mail);
-            should(scrubbedEmail).matchSnapshot();
+            assertMatchSnapshot(scrubbedEmail);
         });
 
         it('matches OTC snapshot', async function () {
             const mail = await sendSigninRequest({includeOTC: true});
             const scrubbedEmail = scrubEmailContent(mail);
-            should(scrubbedEmail).matchSnapshot();
+            assertMatchSnapshot(scrubbedEmail);
         });
     });
 

--- a/ghost/core/test/unit/frontend/helpers/ghost-head.test.js
+++ b/ghost/core/test/unit/frontend/helpers/ghost-head.test.js
@@ -2,6 +2,7 @@
 const should = require('should');
 
 const sinon = require('sinon');
+const {assertMatchSnapshot} = require('../../../utils/assertions');
 const _ = require('lodash');
 const moment = require('moment');
 const testUtils = require('../../../utils');
@@ -34,7 +35,7 @@ async function testGhostHead(options) {
 
     should.exist(rendered);
     // Note: we need to convert the string to an object in order to use the snapshot feature
-    should({rendered}).matchSnapshot();
+    assertMatchSnapshot({rendered});
     return rendered;
 }
 

--- a/ghost/core/test/utils/assertions.js
+++ b/ghost/core/test/utils/assertions.js
@@ -1,4 +1,11 @@
-const should = require('should');
-const {matchSnapshotAssertion} = require('@tryghost/express-test').snapshot;
+const assert = require('node:assert/strict');
+const {snapshotManager} = require('@tryghost/express-test').snapshot;
 
-should.Assertion.add('matchSnapshot', matchSnapshotAssertion);
+function assertMatchSnapshot(obj, properties) {
+    const result = snapshotManager.match(obj, properties);
+    assert(result.pass, result.message());
+}
+
+module.exports = {
+    assertMatchSnapshot
+};

--- a/ghost/core/test/utils/batch-email-utils.js
+++ b/ghost/core/test/utils/batch-email-utils.js
@@ -4,8 +4,8 @@ const models = require('../../core/server/models');
 const sinon = require('sinon');
 const jobManager = require('../../core/server/services/jobs/job-service');
 const escapeRegExp = require('lodash/escapeRegExp');
-const should = require('should');
 const assert = require('assert/strict');
+const {assertMatchSnapshot} = require('./assertions');
 
 const getDefaultNewsletter = async function () {
     const newsletterSlug = fixtureManager.get('newsletters', 0).slug;
@@ -153,7 +153,7 @@ function testCleanedSnapshot({html, plaintext}, ignoreReplacements) {
             plaintext = plaintext.replace(new RegExp(escapeRegExp(match), 'g'), replacement);
         }
     }
-    should({html, plaintext}).matchSnapshot();
+    assertMatchSnapshot({html, plaintext});
 }
 
 async function matchEmailSnapshot() {


### PR DESCRIPTION
This test-only change should have no user impact.

We want to move away from Should.js and towards `node:assert`. This replaces `should.matchSnapshot()` with a new function, `assertMatchSnapshot()`, which works the same way.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces Should.js-based snapshot assertions with a centralized assertion helper, with no production code changes.
> 
> - Adds `test/utils/assertions.js` exposing `assertMatchSnapshot()` using `snapshotManager` and `node:assert`
> - Updates snapshot checks in `email-previews.test.js`, `posts.test.js`, `send-magic-link.test.js`, `ghost-head.test.js`, and `batch-email-utils.js` to use `assertMatchSnapshot()`
> - Removes usage of `should(...).matchSnapshot()` and related Should.js snapshot assertion wiring
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d249be70ebc85f9f69f4edbc1149952c6ced02a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->