### PR TITLE
Fixed subdir handling in admin-forward dev/build

### DIFF
--- a/apps/admin/vite.config.ts
+++ b/apps/admin/vite.config.ts
@@ -11,7 +11,7 @@ const GHOST_CARDS_PATH = resolve(__dirname, "../../ghost/core/core/frontend/src/
 
 // https://vite.dev/config/
 export default defineConfig({
-    base: process.env.GHOST_CDN_URL ?? "/ghost",
+    base: process.env.GHOST_CDN_URL ?? "./",
     plugins: [react(), emberAssetsPlugin(), ghostBackendProxyPlugin(), deepLinksPlugin(), tsconfigPaths()],
     define: {
         "process.env.DEBUG": false, // Shim env var utilized by the @tryghost/nql package


### PR DESCRIPTION
no issue

Ghost can be run on a subdir such as `http://localhost:2368/blog/` which is useful for finding edge cases with path handling in local development. However the new admin-forward dev server was not handling that correctly as it was hardcoded to expect `/ghost/` on the root.

- updated backend proxy to hit and proxy the API on the right path when configured with a subdirectory URL
- updated vite config to generate relative paths for assets in the `index-forward.html` file used for serving `/ghost/` when not building for CDN deployment