### PR TITLE
Replaced Should.js with Node assert in email normalization tests

### DIFF
--- a/ghost/core/test/unit/server/services/members/members-api/utils/normalize-email.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/utils/normalize-email.test.js
@@ -1,53 +1,53 @@
-const should = require('should');
+const assert = require('node:assert/strict');
 const normalizeEmail = require('../../../../../../../core/server/services/members/members-api/utils/normalize-email');
 
 describe('normalizeEmail', function () {
     it('should normalize unicode domains to punycode', function () {
-        normalizeEmail('test@еxample.com').should.equal('test@xn--xample-2of.com');
-        normalizeEmail('user@tëst.org').should.equal('user@xn--tst-jma.org');
-        normalizeEmail('foo@bär.baz').should.equal('foo@xn--br-via.baz');
+        assert.equal(normalizeEmail('test@еxample.com'), 'test@xn--xample-2of.com');
+        assert.equal(normalizeEmail('user@tëst.org'), 'user@xn--tst-jma.org');
+        assert.equal(normalizeEmail('foo@bär.baz'), 'foo@xn--br-via.baz');
     });
 
     it('should preserve ASCII domains unchanged', function () {
-        normalizeEmail('user@example.com').should.equal('user@example.com');
-        normalizeEmail('admin@test.org').should.equal('admin@test.org');
-        normalizeEmail('foo@bar.baz').should.equal('foo@bar.baz');
+        assert.equal(normalizeEmail('user@example.com'), 'user@example.com');
+        assert.equal(normalizeEmail('admin@test.org'), 'admin@test.org');
+        assert.equal(normalizeEmail('foo@bar.baz'), 'foo@bar.baz');
     });
 
     it('should preserve unicode in the local part of the email', function () {
-        normalizeEmail('üser@example.com').should.equal('üser@example.com');
-        normalizeEmail('tëst@test.org').should.equal('tëst@test.org');
-        normalizeEmail('用户@example.com').should.equal('用户@example.com');
+        assert.equal(normalizeEmail('üser@example.com'), 'üser@example.com');
+        assert.equal(normalizeEmail('tëst@test.org'), 'tëst@test.org');
+        assert.equal(normalizeEmail('用户@example.com'), '用户@example.com');
     });
 
     it('should handle already punycoded domains', function () {
-        normalizeEmail('test@xn--tst-jma.com').should.equal('test@xn--tst-jma.com');
-        normalizeEmail('user@xn--br-via.baz').should.equal('user@xn--br-via.baz');
+        assert.equal(normalizeEmail('test@xn--tst-jma.com'), 'test@xn--tst-jma.com');
+        assert.equal(normalizeEmail('user@xn--br-via.baz'), 'user@xn--br-via.baz');
     });
 
     it('should preserve the case of the email address', function () {
-        normalizeEmail('User@Example.COM').should.equal('User@Example.COM');
-        normalizeEmail('Admin@TEST.org').should.equal('Admin@TEST.org');
+        assert.equal(normalizeEmail('User@Example.COM'), 'User@Example.COM');
+        assert.equal(normalizeEmail('Admin@TEST.org'), 'Admin@TEST.org');
     });
 
     it('should handle edge cases gracefully', function () {
-        should.not.exist(normalizeEmail(null));
-        should.not.exist(normalizeEmail(undefined));
-        should.not.exist(normalizeEmail(''));
-        normalizeEmail('invalid-email').should.equal('invalid-email');
-        normalizeEmail('@example.com').should.equal('@example.com');
-        normalizeEmail('user@').should.equal('user@');
+        assert.equal(normalizeEmail(null), null);
+        assert.equal(normalizeEmail(undefined), null);
+        assert.equal(normalizeEmail(''), null);
+        assert.equal(normalizeEmail('invalid-email'), 'invalid-email');
+        assert.equal(normalizeEmail('@example.com'), '@example.com');
+        assert.equal(normalizeEmail('user@'), 'user@');
     });
 
     it('should handle non-string inputs', function () {
-        should.not.exist(normalizeEmail(123));
-        should.not.exist(normalizeEmail({}));
-        should.not.exist(normalizeEmail([]));
-        should.not.exist(normalizeEmail(true));
+        assert.equal(normalizeEmail(/** @type {any} */ (123)), null);
+        assert.equal(normalizeEmail(/** @type {any} */ ({})), null);
+        assert.equal(normalizeEmail(/** @type {any} */ ([])), null);
+        assert.equal(normalizeEmail(/** @type {any} */ (true)), null);
     });
 
     it('should handle multiple @ symbols by using the last one', function () {
-        normalizeEmail('user@name@example.com').should.equal('user@name@example.com');
-        normalizeEmail('user@name@tëst.com').should.equal('user@name@xn--tst-jma.com');
+        assert.equal(normalizeEmail('user@name@example.com'), 'user@name@example.com');
+        assert.equal(normalizeEmail('user@name@tëst.com'), 'user@name@xn--tst-jma.com');
     });
 });


### PR DESCRIPTION
towards https://linear.app/ghost/issue/NY-942/create-and-use-parse-email-address-package-in-core

This test-only change should have no user impact. We're trying to move off Should.js, and this is a step towards that. It also makes an upcoming change easier.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Modernizes the `normalizeEmail` unit tests by removing Should.js and using Node’s built-in `assert/strict`.
> 
> - Updates `normalize-email.test.js` to replace `.should` assertions with `assert.equal(...)`
> - Makes edge-case expectations explicit: `null`, `undefined`, empty string, and non-string inputs now assert to `null`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fbb301d2b68392f2fcc5e748b4aee7fdffc0ca31. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->