### PR TITLE
Normalized email addresses more reliably

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -544,6 +544,9 @@ jobs:
         env:
           DEPENDENCY_CACHE_KEY: ${{ needs.job_setup.outputs.dependency_cache_key }}
 
+      - name: Build TS packages
+        run: yarn nx run-many -t build --exclude=ghost-admin
+
       - name: Set timezone (non-UTC)
         uses: szenius/set-timezone@v2.0
         with:
@@ -626,6 +629,9 @@ jobs:
         uses: ./.github/actions/restore-cache
         env:
           DEPENDENCY_CACHE_KEY: ${{ needs.job_setup.outputs.dependency_cache_key }}
+
+      - name: Build TS packages
+        run: yarn nx run-many -t build --exclude=ghost-admin
 
       - name: Set env vars (SQLite)
         if: contains(matrix.env.DB, 'sqlite')

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,7 +72,7 @@ COPY apps/shade apps/shade
 RUN cd apps/shade && yarn build
 
 # --------------------
-# Parse Email Address Builder
+# parse-email-address Builder
 # --------------------
 FROM development-base AS parse-email-address-builder
 WORKDIR /home/ghost

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,7 @@ COPY ghost/admin/lib/ember-power-calendar-utils/package.json ghost/admin/lib/emb
 COPY ghost/admin/package.json ghost/admin/package.json
 COPY ghost/core/package.json ghost/core/package.json
 COPY ghost/i18n/package.json ghost/i18n/package.json
+COPY ghost/parse-email-address/package.json ghost/parse-email-address/package.json
 
 COPY .github/scripts/install-deps.sh .github/scripts/install-deps.sh
 RUN --mount=type=cache,target=/usr/local/share/.cache/yarn,id=yarn-cache \

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,6 +72,14 @@ COPY apps/shade apps/shade
 RUN cd apps/shade && yarn build
 
 # --------------------
+# Parse Email Address Builder
+# --------------------
+FROM development-base AS parse-email-address-builder
+WORKDIR /home/ghost
+COPY ghost/parse-email-address ghost/parse-email-address
+RUN cd ghost/parse-email-address && yarn build
+
+# --------------------
 # Admin-x-design-system Builder
 # --------------------
 FROM development-base AS admin-x-design-system-builder
@@ -214,5 +222,6 @@ COPY --from=portal-builder /home/ghost/apps/portal/umd apps/portal/umd
 COPY --from=admin-x-settings-builder /home/ghost/apps/admin-x-settings/dist apps/admin-x-settings/dist
 COPY --from=activitypub-builder /home/ghost/apps/activitypub/dist apps/activitypub/dist
 COPY --from=admin-react-builder /home/ghost/ghost/core/core/built/admin ghost/core/core/built/admin
+COPY --from=parse-email-address-builder /home/ghost/ghost/parse-email-address/build ghost/parse-email-address/build
 
 CMD ["yarn", "dev"]

--- a/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
+++ b/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
@@ -682,20 +682,14 @@ module.exports = class RouterController {
         }
 
         // Normalize email to prevent homograph attacks
-        let normalizedEmail;
-
-        try {
-            normalizedEmail = normalizeEmail(email);
-
-            if (normalizedEmail !== email) {
-                logging.info(`Email normalized from ${email} to ${normalizedEmail} for magic link`);
-            }
-        } catch (err) {
-            logging.error(`Failed to normalize [${email}]: ${err.message}`);
-
+        const normalizedEmail = normalizeEmail(email);
+        if (!normalizedEmail) {
             throw new errors.BadRequestError({
                 message: tpl(messages.invalidEmail)
             });
+        }
+        if (normalizedEmail !== email) {
+            logging.info(`Email normalized from ${email} to ${normalizedEmail} for magic link`);
         }
 
         if (honeypot) {

--- a/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
+++ b/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
@@ -688,9 +688,6 @@ module.exports = class RouterController {
                 message: tpl(messages.invalidEmail)
             });
         }
-        if (normalizedEmail !== email) {
-            logging.info(`Email normalized from ${email} to ${normalizedEmail} for magic link`);
-        }
 
         if (honeypot) {
             logging.warn('Honeypot field filled, this is likely a bot');

--- a/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
+++ b/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
@@ -681,7 +681,7 @@ module.exports = class RouterController {
             });
         }
 
-        // Normalize email to prevent homograph attacks
+        // Normalize email to avoid invalid addresses and mitigate homograph attacks
         const normalizedEmail = normalizeEmail(email);
         if (!normalizedEmail) {
             throw new errors.BadRequestError({

--- a/ghost/core/core/server/services/members/members-api/utils/normalize-email.js
+++ b/ghost/core/core/server/services/members/members-api/utils/normalize-email.js
@@ -6,7 +6,7 @@ const {parseEmailAddress} = require('@tryghost/parse-email-address');
  * domains
  *
  * @param {string} email The email address to normalize
- * @returns {null | string} The normalized email address, nor null if the email can't be normalized
+ * @returns {null | string} The normalized email address, or null if the email can't be normalized
  */
 function normalizeEmail(email) {
     if (typeof email !== 'string') {

--- a/ghost/core/core/server/services/members/members-api/utils/normalize-email.js
+++ b/ghost/core/core/server/services/members/members-api/utils/normalize-email.js
@@ -1,4 +1,4 @@
-const punycode = require('punycode/');
+const {parseEmailAddress} = require('@tryghost/parse-email-address');
 
 /**
  * Normalizes email addresses by converting Unicode domains to ASCII (punycode)
@@ -6,26 +6,20 @@ const punycode = require('punycode/');
  * domains
  *
  * @param {string} email The email address to normalize
- * @returns {string} The normalized email address
- * @throws {Error} When punycode conversion fails
+ * @returns {null | string} The normalized email address, nor null if the email can't be normalized
  */
 function normalizeEmail(email) {
-    if (!email || typeof email !== 'string') {
+    if (typeof email !== 'string') {
         return null;
     }
 
-    const atIndex = email.lastIndexOf('@');
-
-    if (atIndex === -1) {
-        return email;
+    const parsedEmail = parseEmailAddress(email);
+    if (!parsedEmail) {
+        return null;
     }
 
-    const localPart = email.substring(0, atIndex);
-    const domainPart = email.substring(atIndex + 1);
-
-    const asciiDomain = punycode.toASCII(domainPart);
-
-    return `${localPart}@${asciiDomain}`;
+    const {local, domain} = parsedEmail;
+    return `${local}@${domain}`;
 }
 
 module.exports = normalizeEmail;

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -105,6 +105,7 @@
     "@tryghost/mw-vhost": "1.0.1",
     "@tryghost/nodemailer": "0.3.48",
     "@tryghost/nql": "0.12.8",
+    "@tryghost/parse-email-address": "0.0.0",
     "@tryghost/pretty-cli": "1.2.47",
     "@tryghost/prometheus-metrics": "1.0.2",
     "@tryghost/promise": "0.3.15",

--- a/ghost/core/test/unit/server/services/members/members-api/utils/normalize-email.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/utils/normalize-email.test.js
@@ -25,29 +25,25 @@ describe('normalizeEmail', function () {
         assert.equal(normalizeEmail('user@xn--br-via.baz'), 'user@xn--br-via.baz');
     });
 
-    it('should preserve the case of the email address', function () {
-        assert.equal(normalizeEmail('User@Example.COM'), 'User@Example.COM');
-        assert.equal(normalizeEmail('Admin@TEST.org'), 'Admin@TEST.org');
+    it('should preserve the case of the local part, but not the domain', function () {
+        assert.equal(normalizeEmail('User@Example.COM'), 'User@example.com');
     });
 
-    it('should handle edge cases gracefully', function () {
-        assert.equal(normalizeEmail(null), null);
-        assert.equal(normalizeEmail(undefined), null);
+    it('should handle invalid email addresses', function () {
         assert.equal(normalizeEmail(''), null);
-        assert.equal(normalizeEmail('invalid-email'), 'invalid-email');
-        assert.equal(normalizeEmail('@example.com'), '@example.com');
-        assert.equal(normalizeEmail('user@'), 'user@');
+        assert.equal(normalizeEmail('invalid-email'), null);
+        assert.equal(normalizeEmail('@example.com'), null);
+        assert.equal(normalizeEmail('user@'), null);
+        assert.equal(normalizeEmail('user@name@example.com'), null);
+        assert.equal(normalizeEmail('user@name@tëst.com'), null);
     });
 
     it('should handle non-string inputs', function () {
+        assert.equal(normalizeEmail(/** @type {any} */ (null)), null);
+        assert.equal(normalizeEmail(/** @type {any} */ (undefined)), null);
         assert.equal(normalizeEmail(/** @type {any} */ (123)), null);
         assert.equal(normalizeEmail(/** @type {any} */ ({})), null);
         assert.equal(normalizeEmail(/** @type {any} */ ([])), null);
         assert.equal(normalizeEmail(/** @type {any} */ (true)), null);
-    });
-
-    it('should handle multiple @ symbols by using the last one', function () {
-        assert.equal(normalizeEmail('user@name@example.com'), 'user@name@example.com');
-        assert.equal(normalizeEmail('user@name@tëst.com'), 'user@name@xn--tst-jma.com');
     });
 });

--- a/ghost/parse-email-address/.eslintrc.js
+++ b/ghost/parse-email-address/.eslintrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+    parser: '@typescript-eslint/parser',
+    plugins: ['ghost'],
+    extends: [
+        'plugin:ghost/node'
+    ]
+};

--- a/ghost/parse-email-address/LICENSE
+++ b/ghost/parse-email-address/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2013-2026 Ghost Foundation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/ghost/parse-email-address/README.md
+++ b/ghost/parse-email-address/README.md
@@ -1,0 +1,36 @@
+# Parse Email Address
+
+Extract the local and domain parts of email address strings.
+
+## Usage
+
+```javascript
+parseEmailAddress('foo@example.com');
+// => {local: 'foo', domain: 'example.com'}
+
+parseEmailAddress('invalid');
+// => null
+
+parseEmailAddress('foo@中文.example');
+// => {local: 'foo', domain: 'xn--fiq228c.example'}
+```
+
+- Domain names must have at least two labels. `example.com` is okay, `example` is not.
+- The top level domain must have at least two octets. `example.com` is okay, `example.x` is not.
+- There are various length limits:
+    - The whole email is limited to 986 octets, per SMTP.
+    - Domain names are limited to 253 octets, per SMTP.
+    - Domain labels are limited to 63 octets, per DNS.
+
+## Develop
+
+This is a monorepo package.
+
+Follow the instructions for the top-level repo.
+1. `git clone` this repo & `cd` into it as usual
+2. Run `yarn` to install top-level dependencies.
+
+## Test
+
+- `yarn lint` run just eslint
+- `yarn test` run lint and tests

--- a/ghost/parse-email-address/package.json
+++ b/ghost/parse-email-address/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@tryghost/parse-email-address",
+  "version": "0.0.0",
+  "private": true,
+  "repository": "https://github.com/TryGhost/Ghost/tree/main/ghost/parse-email-address",
+  "author": "Ghost Foundation",
+  "license": "MIT",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
+  "scripts": {
+    "dev": "tsc --watch --preserveWatchOutput --sourceMap",
+    "build": "yarn build:ts",
+    "build:ts": "tsc",
+    "prepare": "tsc",
+    "test:unit": "NODE_ENV=testing c8 --src src --all --check-coverage --100 --reporter text --reporter cobertura mocha -r ts-node/register './test/**/*.test.ts'",
+    "test": "yarn test:types && yarn test:unit",
+    "test:types": "tsc --noEmit",
+    "lint:code": "eslint src/ --ext .ts --cache",
+    "lint": "yarn lint:code && yarn lint:test",
+    "lint:test": "eslint -c test/.eslintrc.js test/ --ext .ts --cache"
+  },
+  "files": [
+    "build"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "devDependencies": {
+    "c8": "10.1.3",
+    "mocha": "11.7.5",
+    "sinon": "21.0.1",
+    "ts-node": "10.9.2",
+    "typescript": "5.9.3"
+  },
+  "dependencies": {
+    "parse-email-address": "^0.0.2"
+  }
+}

--- a/ghost/parse-email-address/src/index.ts
+++ b/ghost/parse-email-address/src/index.ts
@@ -1,0 +1,20 @@
+import {parseEmailAddress as upstreamParseEmailAddress} from 'parse-email-address';
+import {domainToASCII} from 'node:url';
+
+export const parseEmailAddress = (
+    emailAddress: string
+): null | { local: string; domain: string } => {
+    const upstreamParsed = upstreamParseEmailAddress(emailAddress);
+    if (!upstreamParsed) {
+        return null;
+    }
+
+    const {user: local, domain: rawDomain} = upstreamParsed;
+
+    const domain = domainToASCII(rawDomain);
+    if (!domain) {
+        return null;
+    }
+
+    return {local, domain};
+};

--- a/ghost/parse-email-address/test/.eslintrc.js
+++ b/ghost/parse-email-address/test/.eslintrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+    parser: '@typescript-eslint/parser',
+    plugins: ['ghost'],
+    extends: [
+        'plugin:ghost/test'
+    ]
+};

--- a/ghost/parse-email-address/test/index.test.ts
+++ b/ghost/parse-email-address/test/index.test.ts
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict';
+import {parseEmailAddress} from '../src';
+
+describe('parseEmailAddress', function () {
+    it('returns null for invalid email addresses', function () {
+        const invalid = [
+            // These aren't email addresses
+            '',
+            'foo',
+            'example.com',
+            '@example.com',
+            // Bad spacing
+            ' foo@example.com',
+            'foo@example.com ',
+            'foo @example.com',
+            'foo@example .com',
+            // Too many @s
+            'foo@bar@example.com',
+            // Invalid user
+            'a"b(c)d,e:f;g<h>i[j\\k]l@example.com',
+            'just"not"right@example.com',
+            'this is"not\\allowed@example.com',
+            'x'.repeat(975) + '@example.com',
+            // Invalid domains
+            'foo@example',
+            'foo@no_underscores.example',
+            'foo@xn--iñvalid.com',
+            'foo@' + 'x'.repeat(253) + '.yz',
+            // IP domains
+            'foo@[127.0.0.1]',
+            'foo@[IPv6:::1]',
+            'foo@[ipv6:::1]',
+            // Tag domains
+            'foo@[bar:Baz]'
+        ];
+        for (const input of invalid) {
+            assert.equal(parseEmailAddress(input), null, input);
+        }
+    });
+
+    it('returns the local and domain part of domains', function () {
+        const testCases: [string, string, string][] = [
+            // Basic cases
+            ['foo@example.com', 'foo', 'example.com'],
+            ['foo.bar@example.com', 'foo.bar', 'example.com'],
+            ['foo.bar+baz@example.com', 'foo.bar+baz', 'example.com'],
+            // Unusual usernames
+            ['" "@example.com', '" "', 'example.com'],
+            ['"foo..bar"@example.com', '"foo..bar"', 'example.com'],
+            ['"<foo>"@example.com', '"<foo>"', 'example.com'],
+            ['"\\<foo\\>"@example.com', '"\\<foo\\>"', 'example.com'],
+            ['"foo@bar.example"@example.com', '"foo@bar.example"', 'example.com'],
+            // Lowercasing
+            ['Foo@Example.COM', 'Foo', 'example.com'],
+            // Non-ASCII
+            ['foo@中文.example', 'foo', 'xn--fiq228c.example'],
+            ['中文@example.com', '中文', 'example.com']
+        ];
+        for (const [input, local, domain] of testCases) {
+            assert.deepEqual(parseEmailAddress(input), {local, domain}, input);
+        }
+    });
+});

--- a/ghost/parse-email-address/tsconfig.json
+++ b/ghost/parse-email-address/tsconfig.json
@@ -99,8 +99,8 @@
     "noUncheckedIndexedAccess": true,                    /* Add 'undefined' to a type when accessed using an index. */
     "noImplicitOverride": true,                          /* Ensure overriding members in derived classes are marked with an override modifier. */
     "noPropertyAccessFromIndexSignature": true,          /* Enforces using indexed accessors for keys declared using an indexed type. */
-    "allowUnusedLabels": true,                           /* Disable error reporting for unused labels. */
-    "allowUnreachableCode": true,                        /* Disable error reporting for unreachable code. */
+    "allowUnusedLabels": false,                          /* Disable error reporting for unused labels. */
+    "allowUnreachableCode": false,                       /* Disable error reporting for unreachable code. */
 
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */

--- a/ghost/parse-email-address/tsconfig.json
+++ b/ghost/parse-email-address/tsconfig.json
@@ -1,0 +1,110 @@
+{
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig to read more about this file */
+
+    /* Projects */
+    "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
+    // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
+    // "tsBuildInfoFile": "./.tsbuildinfo",              /* Specify the path to .tsbuildinfo incremental compilation file. */
+    // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects. */
+    // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
+    // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
+
+    /* Language and Environment */
+    "target": "es2022",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    // "lib": ["es2019"],                                      /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    // "jsx": "preserve",                                /* Specify what JSX code is generated. */
+    // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
+    // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
+    // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */
+    // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
+    // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using 'jsx: react-jsx*'. */
+    // "reactNamespace": "",                             /* Specify the object invoked for 'createElement'. This only applies when targeting 'react' JSX emit. */
+    // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
+    // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
+    // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
+
+    /* Modules */
+    "module": "commonjs",                                /* Specify what module code is generated. */
+    "rootDir": "src",                                    /* Specify the root folder within your source files. */
+    // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
+    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
+    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
+    // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
+    // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
+    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+    // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
+    // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
+    // "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */
+    // "resolvePackageJsonExports": true,                /* Use the package.json 'exports' field when resolving package imports. */
+    // "resolvePackageJsonImports": true,                /* Use the package.json 'imports' field when resolving imports. */
+    // "customConditions": [],                           /* Conditions to set in addition to the resolver-specific defaults when resolving imports. */
+    "resolveJsonModule": true,                           /* Enable importing .json files. */
+    // "allowArbitraryExtensions": true,                 /* Enable importing files with any extension, provided a declaration file is present. */
+    // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
+
+    /* JavaScript Support */
+    // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
+    // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
+    // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
+
+    /* Emit */
+    "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+    // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
+    // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
+    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+    // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
+    // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
+    "outDir": "build",                                   /* Specify an output folder for all emitted files. */
+    // "removeComments": true,                           /* Disable emitting comments. */
+    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
+    // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
+    // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types. */
+    // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
+    // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
+    // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
+    // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
+    // "newLine": "crlf",                                /* Set the newline character for emitting files. */
+    // "stripInternal": true,                            /* Disable emitting declarations that have '@internal' in their JSDoc comments. */
+    // "noEmitHelpers": true,                            /* Disable generating custom helper functions like '__extends' in compiled output. */
+    // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
+    // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
+    // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
+    // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
+
+    /* Interop Constraints */
+    // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
+    // "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
+    // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
+    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
+    // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
+    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
+
+    /* Type Checking */
+    "strict": true,                                      /* Enable all strict type-checking options. */
+    "noImplicitAny": true,                               /* Enable error reporting for expressions and declarations with an implied 'any' type. */
+    "strictNullChecks": true,                            /* When type checking, take into account 'null' and 'undefined'. */
+    "strictFunctionTypes": true,                         /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
+    "strictBindCallApply": true,                         /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
+    "strictPropertyInitialization": true,                /* Check for class properties that are declared but not set in the constructor. */
+    "noImplicitThis": true,                              /* Enable error reporting when 'this' is given the type 'any'. */
+    "useUnknownInCatchVariables": true,                  /* Default catch clause variables as 'unknown' instead of 'any'. */
+    "alwaysStrict": true,                                /* Ensure 'use strict' is always emitted. */
+    "noUnusedLocals": true,                              /* Enable error reporting when local variables aren't read. */
+    "noUnusedParameters": true,                          /* Raise an error when a function parameter isn't read. */
+    "exactOptionalPropertyTypes": true,                  /* Interpret optional property types as written, rather than adding 'undefined'. */
+    "noImplicitReturns": true,                           /* Enable error reporting for codepaths that do not explicitly return in a function. */
+    "noFallthroughCasesInSwitch": true,                  /* Enable error reporting for fallthrough cases in switch statements. */
+    "noUncheckedIndexedAccess": true,                    /* Add 'undefined' to a type when accessed using an index. */
+    "noImplicitOverride": true,                          /* Ensure overriding members in derived classes are marked with an override modifier. */
+    "noPropertyAccessFromIndexSignature": true,          /* Enforces using indexed accessors for keys declared using an indexed type. */
+    "allowUnusedLabels": true,                           /* Disable error reporting for unused labels. */
+    "allowUnreachableCode": true,                        /* Disable error reporting for unreachable code. */
+
+    /* Completeness */
+    // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
+    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
+  },
+  "include": ["src/**/*"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6357,6 +6357,13 @@
   dependencies:
     "@sinonjs/commons" "^3.0.1"
 
+"@sinonjs/fake-timers@^15.1.0":
+  version "15.1.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-15.1.0.tgz#f42e713425d4eb1a7bc88ef5d7f76c4546586c25"
+  integrity sha512-cqfapCxwTGsrR80FEgOoPsTonoefMBY7dnUEbQ+GRcved0jvkJLzvX6F4WtN+HBqbPX/SiFsIRUp+IrCW/2I2w==
+  dependencies:
+    "@sinonjs/commons" "^3.0.1"
+
 "@sinonjs/fake-timers@^6.0.0", "@sinonjs/fake-timers@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz#293674fccb3262ac782c7aadfdeca86b10c75c40"
@@ -6380,6 +6387,14 @@
   dependencies:
     "@sinonjs/commons" "^3.0.1"
     lodash.get "^4.4.2"
+    type-detect "^4.1.0"
+
+"@sinonjs/samsam@^8.0.3":
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-8.0.3.tgz#eb6ffaef421e1e27783cc9b52567de20cb28072d"
+  integrity sha512-hw6HbX+GyVZzmaYNh82Ecj1vdGZrqVIn/keDTg63IgAwiQPO+xCz99uG6Woqgb4tM0mUiFENKZ4cqd7IX94AXQ==
+  dependencies:
+    "@sinonjs/commons" "^3.0.1"
     type-detect "^4.1.0"
 
 "@sinonjs/text-encoding@^0.7.1", "@sinonjs/text-encoding@^0.7.3":
@@ -16317,6 +16332,11 @@ diff@^7.0.0:
   resolved "https://registry.yarnpkg.com/diff/-/diff-7.0.0.tgz#3fb34d387cd76d803f6eebea67b921dab0182a9a"
   integrity sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==
 
+diff@^8.0.2:
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-8.0.3.tgz#c7da3d9e0e8c283bb548681f8d7174653720c2d5"
+  integrity sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==
+
 diffie-hellman@^5.0.0:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/diffie-hellman/-/diffie-hellman-5.0.3.tgz#40e8ee98f55a2149607146921c63e1ae5f3d2875"
@@ -25701,6 +25721,33 @@ mocha@11.7.3:
     yargs-parser "^21.1.1"
     yargs-unparser "^2.0.0"
 
+mocha@11.7.5:
+  version "11.7.5"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-11.7.5.tgz#58f5bbfa5e0211ce7e5ee6128107cefc2515a627"
+  integrity sha512-mTT6RgopEYABzXWFx+GcJ+ZQ32kp4fMf0xvpZIIfSq9Z8lC/++MtcCnQ9t5FP2veYEP95FIYSvW+U9fV4xrlig==
+  dependencies:
+    browser-stdout "^1.3.1"
+    chokidar "^4.0.1"
+    debug "^4.3.5"
+    diff "^7.0.0"
+    escape-string-regexp "^4.0.0"
+    find-up "^5.0.0"
+    glob "^10.4.5"
+    he "^1.2.0"
+    is-path-inside "^3.0.3"
+    js-yaml "^4.1.0"
+    log-symbols "^4.1.0"
+    minimatch "^9.0.5"
+    ms "^2.1.3"
+    picocolors "^1.1.1"
+    serialize-javascript "^6.0.2"
+    strip-json-comments "^3.1.1"
+    supports-color "^8.1.1"
+    workerpool "^9.2.0"
+    yargs "^17.7.2"
+    yargs-parser "^21.1.1"
+    yargs-unparser "^2.0.0"
+
 mocha@^2.5.3:
   version "2.5.3"
   resolved "https://registry.yarnpkg.com/mocha/-/mocha-2.5.3.tgz#161be5bdeb496771eb9b35745050b622b5aefc58"
@@ -27042,6 +27089,11 @@ parse-asn1@^5.0.0, parse-asn1@^5.1.5:
     evp_bytestokey "^1.0.0"
     pbkdf2 "^3.0.3"
     safe-buffer "^5.1.1"
+
+parse-email-address@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/parse-email-address/-/parse-email-address-0.0.2.tgz#1fc9f86cad5e703aeb04554904f5f5a6e4ac0884"
+  integrity sha512-Ul8NS2MQ6PG7xdaa2SCNbkUjKcm0TTySXWquqDT8u+vldPVHZNhhrwfhG0KqN8caA96ul34Ptu6JtX7JYtK8CA==
 
 parse-entities@^1.0.2, parse-entities@^1.1.0:
   version "1.2.2"
@@ -30910,6 +30962,17 @@ sinon@18.0.1:
     nise "^6.0.0"
     supports-color "^7"
 
+sinon@21.0.1:
+  version "21.0.1"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-21.0.1.tgz#36b9126065a44906f7ba4a47b723b99315a8c356"
+  integrity sha512-Z0NVCW45W8Mg5oC/27/+fCqIHFnW8kpkFOq0j9XJIev4Ld0mKmERaZv5DMLAb9fGCevjKwaEeIQz5+MBXfZcDw==
+  dependencies:
+    "@sinonjs/commons" "^3.0.1"
+    "@sinonjs/fake-timers" "^15.1.0"
+    "@sinonjs/samsam" "^8.0.3"
+    diff "^8.0.2"
+    supports-color "^7.2.0"
+
 sinon@^9.0.0:
   version "9.2.4"
   resolved "https://registry.yarnpkg.com/sinon/-/sinon-9.2.4.tgz#e55af4d3b174a4443a8762fa8421c2976683752b"
@@ -31999,7 +32062,7 @@ supports-color@^5.3.0:
   dependencies:
     has-flag "^3.0.0"
 
-supports-color@^7, supports-color@^7.0.0, supports-color@^7.1.0:
+supports-color@^7, supports-color@^7.0.0, supports-color@^7.1.0, supports-color@^7.2.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-942/create-and-use-parse-email-address-package-in-core
ref https://github.com/TryGhost/Ghost/pull/25919
ref https://github.com/TryGhost/framework/pull/342

This creates the `parse-email-address` package (previously reviewed [here][0]--all I did was move it over) and uses it in email normalization, used when sending magic links.

This should not change behavior for "normal", lowercase ASCII email addresses. However, it does make several subtler tweaks to the way emails are normalized:

- Some totally invalid emails weren't normalized.

  Before: if `req.body.email` wasn't a string or lacked an `@`, no normalization would occur. The system would then attempt to send an email that'd almost certainly fail.

  After: these throw a "bad request" error.

- Invalid emails with multiple `@` signs were considered valid.

  Before: `foo@bar@example.com` was accepted.

  After: it is not accepted and throws a "bad request" error.

- Domains are now lowercased.

  Before: `FOO@Example.COM` was normalized to `FOO@Example.COM`.

  After: `FOO@Example.COM` is normalized to `FOO@example.com`.

[0]: https://github.com/TryGhost/framework/pull/340

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Introduce and integrate email parsing utility**
> 
> - New TS package `@tryghost/parse-email-address` (wrapper around `parse-email-address`) with tests and build config
> - Core `normalize-email` now uses `parseEmailAddress` to punycode domains and lowercase them; returns `null` for invalid emails (e.g. multiple `@`)
> - `members` router controller updated to use strict normalization; rejects invalid emails earlier and logs normalization changes
> 
> **Tests and tooling**
> 
> - Updated unit tests reflecting stricter normalization (invalid inputs now `null`, domain lowercased)
> - CI: build TS packages before acceptance/legacy tests; Dockerfile adds builder stage for `ghost/parse-email-address` and includes its build output
> - `ghost/core/package.json` adds dependency on `@tryghost/parse-email-address`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eaad95ab03b0711527e990fe341cd5d029c9a3d8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->