### PR TITLE
🐛 Fixed member name not being trimmed in Portal

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.56.3",
+  "version": "2.56.4",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/portal/src/actions.js
+++ b/apps/portal/src/actions.js
@@ -167,10 +167,11 @@ async function verifyOTC({data, api}) {
 async function signup({data, state, api}) {
     try {
         let {plan, tierId, cadence, email, name, newsletters, offerId} = data;
+        name = name?.trim();
 
         if (plan.toLowerCase() === 'free') {
             const integrityToken = await api.member.getIntegrityToken();
-            await api.member.sendMagicLink({emailType: 'signup', integrityToken, ...data});
+            await api.member.sendMagicLink({emailType: 'signup', integrityToken, ...data, name});
         } else {
             if (tierId && cadence) {
                 await api.member.checkoutPlan({plan, tierId, cadence, email, name, newsletters, offerId});
@@ -447,8 +448,9 @@ async function updateMemberEmail({data, state, api}) {
 }
 
 async function updateMemberData({data, state, api}) {
-    const {name} = data;
+    const name = data?.name?.trim();
     const originalName = getMemberName({member: state.member});
+
     if (originalName !== name) {
         try {
             const member = await api.member.update({name});

--- a/apps/portal/src/data-attributes.js
+++ b/apps/portal/src/data-attributes.js
@@ -28,7 +28,7 @@ export async function formSubmitHandler(
     let nameInput = event.target.querySelector('input[data-members-name]');
     let autoRedirect = form?.dataset?.membersAutoredirect || 'true';
     let email = emailInput?.value;
-    let name = (nameInput && nameInput.value) || undefined;
+    let name = (nameInput?.value || '').trim() || undefined;
     let emailType = undefined;
     let labels = [];
     let newsletters = [];

--- a/apps/portal/test/actions.test.js
+++ b/apps/portal/test/actions.test.js
@@ -1,6 +1,51 @@
 import ActionHandler from '../src/actions';
 import {vi} from 'vitest';
 
+describe('updateProfile action', () => {
+    test('trims whitespace from name before saving', async () => {
+        const mockApi = {
+            member: {
+                update: vi.fn(() => Promise.resolve({name: 'John Doe', email: 'john@example.com'}))
+            }
+        };
+        const state = {
+            member: {name: 'Old Name', email: 'john@example.com'}
+        };
+
+        await ActionHandler({
+            action: 'updateProfile',
+            data: {name: '  John Doe  ', email: 'john@example.com'},
+            state,
+            api: mockApi
+        });
+
+        expect(mockApi.member.update).toHaveBeenCalledWith({name: 'John Doe'});
+    });
+});
+
+describe('signup action', () => {
+    test('trims whitespace from name', async () => {
+        const mockApi = {
+            member: {
+                getIntegrityToken: vi.fn(() => Promise.resolve('token-123')),
+                sendMagicLink: vi.fn(() => Promise.resolve())
+            }
+        };
+        const state = {site: {}};
+
+        await ActionHandler({
+            action: 'signup',
+            data: {plan: 'free', email: 'john@example.com', name: '  John Doe  '},
+            state,
+            api: mockApi
+        });
+
+        expect(mockApi.member.sendMagicLink).toHaveBeenCalledWith(
+            expect.objectContaining({name: 'John Doe'})
+        );
+    });
+});
+
 describe('startSigninOTCFromCustomForm action', () => {
     test('opens magic link popup with otcRef', async () => {
         const state = {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ENG-454

**what**

Added trimming to all three entry points when saving user details: signup, profile update, and custom theme forms.

**why**

Member names with leading/trailing whitespace were being saved as-is, causing single-letter avatars and data quality issues. 
