### PR TITLE
🎨 Improved member initials to use first and last name and be consistent

### DIFF
--- a/apps/shade/src/lib/utils.ts
+++ b/apps/shade/src/lib/utils.ts
@@ -622,7 +622,7 @@ export const getMemberInitials = (member: {name?: string}) => {
     const name = formatMemberName(member);
     const words = name.split(' ');
     if (words.length >= 2) {
-        return (words[0][0] + words[1][0]).toUpperCase();
+        return (words[0][0] + words[words.length - 1][0]).toUpperCase();
     }
     return name.substring(0, 2).toUpperCase();
 };

--- a/apps/shade/test/unit/utils/utils.test.ts
+++ b/apps/shade/test/unit/utils/utils.test.ts
@@ -2,12 +2,13 @@ import * as assert from 'assert/strict';
 import {
     cn,
     debounce,
-    kebabToPascalCase, 
-    formatQueryDate, 
-    formatDisplayDate, 
+    kebabToPascalCase,
+    formatQueryDate,
+    formatDisplayDate,
     formatNumber,
     formatDuration,
-    formatPercentage
+    formatPercentage,
+    getMemberInitials
 } from '@/lib/utils';
 import moment from 'moment-timezone';
 import {vi} from 'vitest';
@@ -240,6 +241,28 @@ describe('utils', function () {
 
             formatted = formatPercentage(100);
             assert.equal(formatted, '10,000%');
+        });
+    });
+
+    describe('getMemberInitials function', function () {
+        it('returns initials from first and last name', function () {
+            const initials = getMemberInitials({name: 'John Doe'});
+            assert.equal(initials, 'JD');
+        });
+
+        it('returns initials from first and last word for names with middle name', function () {
+            const initials = getMemberInitials({name: 'John Michael Doe'});
+            assert.equal(initials, 'JD');
+        });
+
+        it('returns first two characters for single word names', function () {
+            const initials = getMemberInitials({name: 'John'});
+            assert.equal(initials, 'JO');
+        });
+
+        it('handles empty name by using fallback', function () {
+            const initials = getMemberInitials({name: ''});
+            assert.equal(initials, 'UM'); // "Unknown Member" -> "UM"
         });
     });
 }); 


### PR DESCRIPTION
no_ref

- The getMemberInitials function was using the second word instead of the last word for generating initials. This caused names with middle names like "John Michael Doe" to show "JM" instead of "JD".
- Changed to use the last word to be consistent with other avatar implementations in [Comments UI](https://github.com/TryGhost/Ghost/blob/main/apps/comments-ui/src/utils/helpers.ts#L115), [Admin-X Settings](https://github.com/TryGhost/Ghost/blob/main/apps/admin-x-settings/src/utils/helpers.ts#L28), and [Ghost Admin](https://github.com/TryGhost/Ghost/blob/main/ghost/admin/app/components/gh-member-avatar.js#L39).
