### PR TITLE
Added endpoint to apply offers to existing subscriptions

### DIFF
--- a/apps/portal/src/actions.js
+++ b/apps/portal/src/actions.js
@@ -312,6 +312,36 @@ async function continueSubscription({data, state, api}) {
     }
 }
 
+async function applyOffer({data, state, api}) {
+    try {
+        const {offerId, subscriptionId} = data;
+        await api.member.applyOffer({
+            offerId,
+            subscriptionId
+        });
+        const member = await api.member.sessionData();
+        const action = 'applyOffer:success';
+        return {
+            action,
+            page: 'accountHome',
+            member: member,
+            offers: [],
+            popupNotification: createPopupNotification({
+                type: 'applyOffer:success', autoHide: true, closeable: true, state, status: 'success',
+                message: 'Offer applied successfully!'
+            })
+        };
+    } catch (e) {
+        return {
+            action: 'applyOffer:failed',
+            popupNotification: createPopupNotification({
+                type: 'applyOffer:failed', autoHide: false, closeable: true, state, status: 'error',
+                message: 'Failed to apply offer, please try again'
+            })
+        };
+    }
+}
+
 async function editBilling({data, state, api}) {
     try {
         await api.member.editBilling(data);
@@ -629,6 +659,7 @@ const Actions = {
     updateSubscription,
     cancelSubscription,
     continueSubscription,
+    applyOffer,
     updateNewsletter,
     updateProfile,
     refreshMemberData,

--- a/apps/portal/src/components/pages/account-plan-page.js
+++ b/apps/portal/src/components/pages/account-plan-page.js
@@ -464,7 +464,8 @@ export default class AccountPlanPage extends React.Component {
         const selectedPriceId = selectedPrice ? selectedPrice.id : null;
         return {
             selectedPlan: selectedPriceId,
-            pendingOffer: null
+            pendingOffer: null,
+            targetSubscriptionId: null
         };
     }
 
@@ -486,7 +487,8 @@ export default class AccountPlanPage extends React.Component {
             showConfirmation: false,
             confirmationPlan: null,
             confirmationType: null,
-            pendingOffer: null
+            pendingOffer: null,
+            targetSubscriptionId: null
         });
     }
 
@@ -549,7 +551,8 @@ export default class AccountPlanPage extends React.Component {
                 showConfirmation: true,
                 confirmationPlan: subscriptionPlan,
                 confirmationType: 'offerRetention',
-                pendingOffer: retentionOffers[0] // Show first available offer
+                pendingOffer: retentionOffers[0], // Show first available offer
+                targetSubscriptionId: subscriptionId
             });
         } else {
             // No retention offers, go straight to cancellation
@@ -557,22 +560,21 @@ export default class AccountPlanPage extends React.Component {
                 showConfirmation: true,
                 confirmationPlan: subscriptionPlan,
                 confirmationType: 'cancel',
-                pendingOffer: null
+                pendingOffer: null,
+                targetSubscriptionId: subscriptionId
             });
         }
     }
 
     onAcceptRetentionOffer() {
-        const {member} = this.context;
-        const {pendingOffer} = this.state;
-        const subscription = getMemberSubscription({member});
+        const {pendingOffer, targetSubscriptionId} = this.state;
 
-        if (!subscription || !pendingOffer) {
+        if (!targetSubscriptionId || !pendingOffer) {
             return;
         }
 
         this.context.doAction('applyOffer', {
-            subscriptionId: subscription.id,
+            subscriptionId: targetSubscriptionId,
             offerId: pendingOffer.id
         });
     }
@@ -586,13 +588,12 @@ export default class AccountPlanPage extends React.Component {
     }
 
     onCancelSubscriptionConfirmation(reason) {
-        const {member} = this.context;
-        const subscription = getMemberSubscription({member});
-        if (!subscription) {
+        const {targetSubscriptionId} = this.state;
+        if (!targetSubscriptionId) {
             return null;
         }
         this.context.doAction('cancelSubscription', {
-            subscriptionId: subscription.id,
+            subscriptionId: targetSubscriptionId,
             cancelAtPeriodEnd: true,
             cancellationReason: reason
         });

--- a/apps/portal/src/utils/api.js
+++ b/apps/portal/src/utils/api.js
@@ -633,6 +633,30 @@ function setupGhostApi({siteUrl = window.location.origin, apiUrl, apiKey}) {
             }).catch(function () {
                 return {offers: []};
             });
+        },
+
+        async applyOffer({offerId, subscriptionId}) {
+            const identity = await api.member.identity();
+            const url = endpointFor({type: 'members', resource: `subscriptions/${subscriptionId}/apply-offer`});
+
+            const res = await makeRequest({
+                url,
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({
+                    identity,
+                    offer_id: offerId
+                })
+            });
+
+            if (!res.ok) {
+                const errorText = await res.text();
+                throw new Error(errorText || 'Failed to apply offer');
+            }
+
+            return true;
         }
     };
 

--- a/ghost/core/core/server/services/members/members-api/members-api.js
+++ b/ghost/core/core/server/services/members/members-api/members-api.js
@@ -365,6 +365,10 @@ module.exports = function MembersAPI({
             body.json(),
             forwardError((req, res) => memberController.updateSubscription(req, res))
         ),
+        applyOfferToSubscription: Router({mergeParams: true}).use(
+            body.json(),
+            forwardError((req, res) => memberController.applyOfferToSubscription(req, res))
+        ),
         getMemberOffers: Router().use(
             body.json(),
             forwardError((req, res) => routerController.getMemberOffers(req, res))

--- a/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
@@ -1770,17 +1770,10 @@ module.exports = class MemberRepository {
         const stripeSubscriptionId = subscriptionModel.get('subscription_id');
 
         // Apply coupon to Stripe subscription
-        let updatedSubscription = await this._stripeAPIService.addCouponToSubscription(
+        const updatedSubscription = await this._stripeAPIService.addCouponToSubscription(
             stripeSubscriptionId,
             data.couponId
         );
-
-        // If subscription has pending cancellation, reverse it
-        if (subscriptionModel.get('cancel_at_period_end')) {
-            updatedSubscription = await this._stripeAPIService.continueSubscriptionAtPeriodEnd(
-                stripeSubscriptionId
-            );
-        }
 
         // Sync local state with Stripe
         await this.linkSubscription({

--- a/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
@@ -25,6 +25,7 @@ const messages = {
     offerNotFound: 'Could not find Offer {id}',
     offerNotActive: 'Offer is not active',
     offerIsTrialOffer: 'Trial offers cannot be applied to existing subscriptions',
+    offerIsSignupOffer: 'Signup offers cannot be applied to existing subscriptions',
     offerNoCoupon: 'Offer does not have a valid coupon',
     offerTierMismatch: 'Offer is not valid for this subscription tier',
     offerCadenceMismatch: 'Offer is not valid for this subscription cadence',
@@ -1726,6 +1727,12 @@ module.exports = class MemberRepository {
         if (offer.type === 'trial') {
             throw new errors.BadRequestError({
                 message: tpl(messages.offerIsTrialOffer)
+            });
+        }
+
+        if (offer.redemption_type === 'signup') {
+            throw new errors.BadRequestError({
+                message: tpl(messages.offerIsSignupOffer)
             });
         }
 

--- a/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
@@ -21,7 +21,16 @@ const messages = {
     productNotFound: 'Could not find Product {id}',
     bulkActionRequiresFilter: 'Cannot perform {action} without a filter or all=true',
     tierArchived: 'Cannot use archived Tiers',
-    invalidEmail: 'Invalid Email'
+    invalidEmail: 'Invalid Email',
+    offerNotFound: 'Could not find Offer {id}',
+    offerNotActive: 'Offer is not active',
+    offerIsTrialOffer: 'Trial offers cannot be applied to existing subscriptions',
+    offerNoCoupon: 'Offer does not have a valid coupon',
+    offerTierMismatch: 'Offer is not valid for this subscription tier',
+    offerCadenceMismatch: 'Offer is not valid for this subscription cadence',
+    offerAlreadyRedeemed: 'This offer has already been redeemed on this subscription',
+    subscriptionNotActive: 'Cannot apply offer to an inactive subscription',
+    subscriptionHasOffer: 'Subscription already has an offer applied'
 };
 
 const SUBSCRIPTION_STATUS_TRIALING = 'trialing';
@@ -1620,6 +1629,158 @@ module.exports = class MemberRepository {
                 subscription: updatedSubscription
             }, options);
         }
+    }
+
+    /**
+     * @param {Object} data
+     * @param {string} [data.id] - Member ID
+     * @param {string} [data.email] - Member email
+     * @param {Object} data.subscription
+     * @param {string} data.subscription.subscription_id - Stripe subscription ID
+     * @param {string} data.offerId - Offer ID to apply
+     * @param {string} data.couponId - Stripe coupon ID for the offer
+     * @param {Object} [options]
+     */
+    async applyOfferToSubscription(data, options = {}) {
+        if (!this._stripeAPIService.configured) {
+            throw new errors.BadRequestError({
+                message: tpl(messages.noStripeConnection, {action: 'apply offer to Subscription'})
+            });
+        }
+
+        // Find member
+        let findQuery = null;
+        if (data.id) {
+            findQuery = {id: data.id};
+        } else if (data.email) {
+            findQuery = {email: data.email};
+        }
+
+        if (!findQuery) {
+            throw new errors.NotFoundError({
+                message: tpl(messages.memberNotFound, {id: 'unknown'})
+            });
+        }
+
+        const member = await this._Member.findOne(findQuery);
+        if (!member) {
+            throw new errors.NotFoundError({
+                message: tpl(messages.memberNotFound, {id: data.id || data.email})
+            });
+        }
+
+        // Fetch subscription with related data
+        const subscriptionModel = await member.related('stripeSubscriptions').query({
+            where: {
+                subscription_id: data.subscription.subscription_id
+            }
+        }).fetchOne({
+            ...options,
+            withRelated: ['stripePrice', 'stripePrice.stripeProduct', 'stripePrice.stripeProduct.product']
+        });
+
+        if (!subscriptionModel) {
+            throw new errors.NotFoundError({
+                message: tpl(messages.subscriptionNotFound, {id: data.subscription.subscription_id})
+            });
+        }
+
+        // Validate subscription is active
+        const subscriptionStatus = subscriptionModel.get('status');
+        if (!this.isActiveSubscriptionStatus(subscriptionStatus)) {
+            throw new errors.BadRequestError({
+                message: tpl(messages.subscriptionNotActive)
+            });
+        }
+
+        // Check subscription doesn't already have an offer
+        if (subscriptionModel.get('offer_id')) {
+            throw new errors.BadRequestError({
+                message: tpl(messages.subscriptionHasOffer)
+            });
+        }
+
+        // Get tier and cadence from subscription
+        const stripePrice = subscriptionModel.related('stripePrice');
+        const stripeProduct = stripePrice.related('stripeProduct');
+        const product = stripeProduct.related('product');
+
+        const tierId = product.id;
+        const cadence = stripePrice.get('interval');
+
+        // Fetch and validate offer
+        const offer = await this._offersAPI.getOffer({id: data.offerId});
+
+        if (!offer) {
+            throw new errors.NotFoundError({
+                message: tpl(messages.offerNotFound, {id: data.offerId})
+            });
+        }
+
+        if (offer.status !== 'active') {
+            throw new errors.BadRequestError({
+                message: tpl(messages.offerNotActive)
+            });
+        }
+
+        if (offer.type === 'trial') {
+            throw new errors.BadRequestError({
+                message: tpl(messages.offerIsTrialOffer)
+            });
+        }
+
+        if (offer.tier.id !== tierId) {
+            throw new errors.BadRequestError({
+                message: tpl(messages.offerTierMismatch)
+            });
+        }
+
+        if (offer.cadence !== cadence) {
+            throw new errors.BadRequestError({
+                message: tpl(messages.offerCadenceMismatch)
+            });
+        }
+
+        // Check not already redeemed on this subscription
+        const existingRedemption = await this._OfferRedemption.findOne({
+            offer_id: data.offerId,
+            subscription_id: subscriptionModel.id
+        }, options);
+
+        if (existingRedemption) {
+            throw new errors.BadRequestError({
+                message: tpl(messages.offerAlreadyRedeemed)
+            });
+        }
+
+        // Validate coupon was provided (getCouponForOffer returns null for trial offers or if offer has no stripe_coupon_id)
+        if (!data.couponId) {
+            throw new errors.BadRequestError({
+                message: tpl(messages.offerNoCoupon)
+            });
+        }
+
+        const stripeSubscriptionId = subscriptionModel.get('subscription_id');
+
+        // Apply coupon to Stripe subscription
+        let updatedSubscription = await this._stripeAPIService.addCouponToSubscription(
+            stripeSubscriptionId,
+            data.couponId
+        );
+
+        // If subscription has pending cancellation, reverse it
+        if (subscriptionModel.get('cancel_at_period_end')) {
+            updatedSubscription = await this._stripeAPIService.continueSubscriptionAtPeriodEnd(
+                stripeSubscriptionId
+            );
+        }
+
+        // Sync local state with Stripe
+        await this.linkSubscription({
+            id: member.id,
+            subscription: updatedSubscription,
+            offerId: data.offerId
+        }, options);
     }
 
     async createSubscription(data, options) {

--- a/ghost/core/core/server/services/offers/application/offers-api.js
+++ b/ghost/core/core/server/services/offers/application/offers-api.js
@@ -25,14 +25,19 @@ class OffersAPI {
     /**
      * @param {object} data
      * @param {string} data.id
+     * @param {Object} [options]
      *
      * @returns {Promise<OfferMapper.OfferDTO>}
      */
-    async getOffer(data) {
-        return this.repository.createTransaction(async (transaction) => {
-            const options = {transacting: transaction};
-
+    async getOffer(data, options = {}) {
+        if (options.transacting) {
             const offer = await this.repository.getById(data.id, options);
+
+            return offer ? OfferMapper.toDTO(offer) : null;
+        }
+
+        return this.repository.createTransaction(async (transaction) => {
+            const offer = await this.repository.getById(data.id, {transacting: transaction});
 
             if (!offer) {
                 return null;

--- a/ghost/core/core/server/services/stripe/stripe-api.js
+++ b/ghost/core/core/server/services/stripe/stripe-api.js
@@ -816,6 +816,22 @@ module.exports = class StripeAPI {
     }
 
     /**
+     * Add a coupon to the Stripe Subscription by ID.
+     * 
+     * @param {string} id - The ID of the subscription to add coupon to
+     * @param {string} couponId - The ID of the coupon to apply
+     *
+     * @returns {Promise<ISubscription>}
+     */
+    async addCouponToSubscription(id, couponId) {
+        await this._rateLimitBucket.throttle();
+        const subscription = await this._stripe.subscriptions.update(id, {
+            coupon: couponId
+        });
+        return subscription;
+    }
+
+    /**
      * Update the price of the Stripe SubscriptionItem by Subscription ID, 
      * SubscriptionItem ID, and Price ID.
      * 

--- a/ghost/core/core/server/web/members/app.js
+++ b/ghost/core/core/server/web/members/app.js
@@ -110,6 +110,9 @@ module.exports = function setupMembersApp() {
     membersApp.put('/api/subscriptions/:id', function lazyUpdateSubscriptionMw(req, res, next) {
         return membersService.api.middleware.updateSubscription(req, res, next);
     });
+    membersApp.post('/api/subscriptions/:id/apply-offer', function lazyApplyOfferMw(req, res, next) {
+        return membersService.api.middleware.applyOfferToSubscription(req, res, next);
+    });
 
     // Comments
     membersApp.use('/api/comments', commentRouter());

--- a/ghost/core/test/e2e-api/members/member-offers.test.js
+++ b/ghost/core/test/e2e-api/members/member-offers.test.js
@@ -1,6 +1,7 @@
 const {agentProvider, mockManager, fixtureManager} = require('../../utils/e2e-framework');
 const models = require('../../../core/server/models');
 const assert = require('assert/strict');
+const DomainEvents = require('@tryghost/domain-events');
 
 let membersAgent;
 let membersService;
@@ -615,6 +616,9 @@ describe('Members API - Member Offers', function () {
                     .post(`/api/subscriptions/${stripeSubscriptionId}/apply-offer`)
                     .body({identity: token, offer_id: retentionOffer.id})
                     .expectStatus(204);
+
+                // Wait for domain events (offer redemption is created via event)
+                await DomainEvents.allSettled();
 
                 // Verify the subscription was updated with the offer
                 await subscription.refresh();

--- a/ghost/core/test/e2e-api/members/member-offers.test.js
+++ b/ghost/core/test/e2e-api/members/member-offers.test.js
@@ -11,6 +11,22 @@ async function getIdentityToken(email) {
     return membersService.api.getMemberIdentityToken(member.get('transient_id'));
 }
 
+async function getMemberSubscription(email) {
+    const member = await models.Member.findOne({email}, {
+        withRelated: [
+            'stripeSubscriptions',
+            'stripeSubscriptions.stripePrice',
+            'stripeSubscriptions.stripePrice.stripeProduct',
+            'stripeSubscriptions.stripePrice.stripeProduct.product'
+        ]
+    });
+
+    return {
+        member,
+        subscription: member.related('stripeSubscriptions').models[0]
+    };
+}
+
 describe('Members API - Member Offers', function () {
     before(async function () {
         const agents = await agentProvider.getAgentsForMembers();
@@ -206,6 +222,383 @@ describe('Members API - Member Offers', function () {
                 await subscription.save({offer_id: null}, {patch: true});
                 await models.Offer.destroy({id: offer.id});
                 await models.Offer.destroy({id: signupOffer.id});
+            }
+        });
+    });
+
+    describe('POST /members/api/subscriptions/:id/apply-offer', function () {
+        beforeEach(function () {
+            mockManager.mockStripe();
+        });
+
+        it('returns 401 when not authenticated', async function () {
+            await membersAgent
+                .post('/api/subscriptions/sub_123/apply-offer')
+                .body({offer_id: 'offer_123'})
+                .expectStatus(401);
+        });
+
+        it('returns 401 with invalid identity token', async function () {
+            await membersAgent
+                .post('/api/subscriptions/sub_123/apply-offer')
+                .body({identity: 'invalid-token', offer_id: 'offer_123'})
+                .expectStatus(401);
+        });
+
+        it('returns 400 when offer_id is missing', async function () {
+            const token = await getIdentityToken('paid@test.com');
+
+            await membersAgent
+                .post('/api/subscriptions/sub_123/apply-offer')
+                .body({identity: token})
+                .expectStatus(400);
+        });
+
+        it('returns 404 when subscription not found', async function () {
+            const token = await getIdentityToken('paid@test.com');
+
+            await membersAgent
+                .post('/api/subscriptions/sub_nonexistent/apply-offer')
+                .body({identity: token, offer_id: 'offer_123'})
+                .expectStatus(404);
+        });
+
+        it('returns 404 when offer not found', async function () {
+            const {subscription} = await getMemberSubscription('paid@test.com');
+            const stripeSubscriptionId = subscription.get('subscription_id');
+            const token = await getIdentityToken('paid@test.com');
+
+            await membersAgent
+                .post(`/api/subscriptions/${stripeSubscriptionId}/apply-offer`)
+                .body({identity: token, offer_id: 'nonexistent_offer_id'})
+                .expectStatus(404);
+        });
+
+        it('returns 400 when subscription already has an offer', async function () {
+            const {subscription} = await getMemberSubscription('paid@test.com');
+            const stripePrice = subscription.related('stripePrice');
+            const stripeProduct = stripePrice.related('stripeProduct');
+            const product = stripeProduct.related('product');
+
+            const stripeSubscriptionId = subscription.get('subscription_id');
+            const tierId = product.id;
+            const cadence = stripePrice.get('interval');
+
+            // Create a retention offer
+            const retentionOffer = await models.Offer.add({
+                name: 'Test Retention',
+                code: 'test-retention-apply',
+                portal_title: '20% off',
+                portal_description: 'Stay with us!',
+                discount_type: 'percent',
+                discount_amount: 20,
+                duration: 'once',
+                interval: cadence,
+                product_id: tierId,
+                currency: null,
+                active: true,
+                redemption_type: 'retention'
+            });
+
+            // Create another offer and apply it to subscription
+            const existingOffer = await models.Offer.add({
+                name: 'Existing Offer',
+                code: 'existing-offer',
+                portal_title: '5% off',
+                portal_description: 'Already applied',
+                discount_type: 'percent',
+                discount_amount: 5,
+                duration: 'once',
+                interval: cadence,
+                product_id: tierId,
+                currency: null,
+                active: true,
+                redemption_type: 'signup'
+            });
+
+            await subscription.save({offer_id: existingOffer.id}, {patch: true});
+
+            try {
+                const token = await getIdentityToken('paid@test.com');
+
+                await membersAgent
+                    .post(`/api/subscriptions/${stripeSubscriptionId}/apply-offer`)
+                    .body({identity: token, offer_id: retentionOffer.id})
+                    .expectStatus(400);
+            } finally {
+                await subscription.save({offer_id: null}, {patch: true});
+                await models.Offer.destroy({id: retentionOffer.id});
+                await models.Offer.destroy({id: existingOffer.id});
+            }
+        });
+
+        it('returns 400 when offer tier does not match subscription', async function () {
+            const {subscription} = await getMemberSubscription('paid@test.com');
+            const stripePrice = subscription.related('stripePrice');
+
+            const stripeSubscriptionId = subscription.get('subscription_id');
+            const cadence = stripePrice.get('interval');
+
+            // Create a different tier for testing
+            const differentTier = await models.Product.add({
+                name: 'Different Tier',
+                slug: 'different-tier-test',
+                type: 'paid',
+                currency: 'usd',
+                monthly_price: 1000,
+                yearly_price: 10000,
+                visibility: 'public'
+            });
+
+            // Create a retention offer for a different tier
+            const retentionOffer = await models.Offer.add({
+                name: 'Wrong Tier Retention',
+                code: 'wrong-tier-retention',
+                portal_title: '20% off',
+                portal_description: 'Stay with us!',
+                discount_type: 'percent',
+                discount_amount: 20,
+                duration: 'once',
+                interval: cadence,
+                product_id: differentTier.id,
+                currency: null,
+                active: true,
+                redemption_type: 'retention'
+            });
+
+            try {
+                const token = await getIdentityToken('paid@test.com');
+
+                await membersAgent
+                    .post(`/api/subscriptions/${stripeSubscriptionId}/apply-offer`)
+                    .body({identity: token, offer_id: retentionOffer.id})
+                    .expectStatus(400);
+            } finally {
+                await models.Offer.destroy({id: retentionOffer.id});
+                await models.Product.destroy({id: differentTier.id});
+            }
+        });
+
+        it('returns 400 when offer cadence does not match subscription', async function () {
+            const {subscription} = await getMemberSubscription('paid@test.com');
+            const stripePrice = subscription.related('stripePrice');
+            const stripeProduct = stripePrice.related('stripeProduct');
+            const product = stripeProduct.related('product');
+
+            const stripeSubscriptionId = subscription.get('subscription_id');
+            const tierId = product.id;
+            const cadence = stripePrice.get('interval');
+            // Use opposite cadence
+            const wrongCadence = cadence === 'month' ? 'year' : 'month';
+
+            // Create a retention offer with wrong cadence
+            const retentionOffer = await models.Offer.add({
+                name: 'Wrong Cadence Retention',
+                code: 'wrong-cadence-retention',
+                portal_title: '20% off',
+                portal_description: 'Stay with us!',
+                discount_type: 'percent',
+                discount_amount: 20,
+                duration: 'once',
+                interval: wrongCadence,
+                product_id: tierId,
+                currency: null,
+                active: true,
+                redemption_type: 'retention'
+            });
+
+            try {
+                const token = await getIdentityToken('paid@test.com');
+
+                await membersAgent
+                    .post(`/api/subscriptions/${stripeSubscriptionId}/apply-offer`)
+                    .body({identity: token, offer_id: retentionOffer.id})
+                    .expectStatus(400);
+            } finally {
+                await models.Offer.destroy({id: retentionOffer.id});
+            }
+        });
+
+        it('returns 400 when offer is inactive', async function () {
+            const {subscription} = await getMemberSubscription('paid@test.com');
+            const stripePrice = subscription.related('stripePrice');
+            const stripeProduct = stripePrice.related('stripeProduct');
+            const product = stripeProduct.related('product');
+
+            const stripeSubscriptionId = subscription.get('subscription_id');
+            const tierId = product.id;
+            const cadence = stripePrice.get('interval');
+
+            // Create an inactive retention offer
+            const retentionOffer = await models.Offer.add({
+                name: 'Inactive Retention',
+                code: 'inactive-retention',
+                portal_title: '20% off',
+                portal_description: 'Stay with us!',
+                discount_type: 'percent',
+                discount_amount: 20,
+                duration: 'once',
+                interval: cadence,
+                product_id: tierId,
+                currency: null,
+                active: false,
+                redemption_type: 'retention'
+            });
+
+            try {
+                const token = await getIdentityToken('paid@test.com');
+
+                await membersAgent
+                    .post(`/api/subscriptions/${stripeSubscriptionId}/apply-offer`)
+                    .body({identity: token, offer_id: retentionOffer.id})
+                    .expectStatus(400);
+            } finally {
+                await models.Offer.destroy({id: retentionOffer.id});
+            }
+        });
+
+        it('returns 400 when subscription is canceled', async function () {
+            const {subscription} = await getMemberSubscription('paid@test.com');
+            const stripePrice = subscription.related('stripePrice');
+            const stripeProduct = stripePrice.related('stripeProduct');
+            const product = stripeProduct.related('product');
+
+            const stripeSubscriptionId = subscription.get('subscription_id');
+            const tierId = product.id;
+            const cadence = stripePrice.get('interval');
+
+            // Temporarily set subscription to canceled status
+            const originalStatus = subscription.get('status');
+            await subscription.save({status: 'canceled'}, {patch: true});
+
+            // Create a retention offer
+            const retentionOffer = await models.Offer.add({
+                name: 'Test Retention Canceled',
+                code: 'test-retention-canceled',
+                portal_title: '20% off',
+                portal_description: 'Stay with us!',
+                discount_type: 'percent',
+                discount_amount: 20,
+                duration: 'once',
+                interval: cadence,
+                product_id: tierId,
+                currency: null,
+                active: true,
+                redemption_type: 'retention'
+            });
+
+            try {
+                const token = await getIdentityToken('paid@test.com');
+
+                await membersAgent
+                    .post(`/api/subscriptions/${stripeSubscriptionId}/apply-offer`)
+                    .body({identity: token, offer_id: retentionOffer.id})
+                    .expectStatus(400);
+            } finally {
+                await subscription.save({status: originalStatus}, {patch: true});
+                await models.Offer.destroy({id: retentionOffer.id});
+            }
+        });
+
+        it('successfully applies retention offer to subscription', async function () {
+            const {subscription} = await getMemberSubscription('paid@test.com');
+            const stripePrice = subscription.related('stripePrice');
+            const stripeProduct = stripePrice.related('stripeProduct');
+            const product = stripeProduct.related('product');
+
+            const stripeSubscriptionId = subscription.get('subscription_id');
+            const tierId = product.id;
+            const cadence = stripePrice.get('interval');
+
+            // Add a mock coupon to the stripe mocker so the subscription update works
+            const stripeCouponId = 'coupon_test_retention';
+            mockManager.stripeMocker.coupons.push({
+                id: stripeCouponId,
+                object: 'coupon',
+                percent_off: 20,
+                duration: 'repeating',
+                duration_in_months: 3
+            });
+
+            // Create a proper mock price object
+            const mockPrice = {
+                id: stripePrice.get('stripe_price_id'),
+                product: stripeProduct.get('stripe_product_id'),
+                active: true,
+                nickname: cadence,
+                unit_amount: stripePrice.get('amount'),
+                currency: stripePrice.get('currency'),
+                type: 'recurring',
+                recurring: {
+                    interval: cadence
+                }
+            };
+            mockManager.stripeMocker.prices.push(mockPrice);
+
+            // Add the subscription to the stripe mocker so it can be updated
+            mockManager.stripeMocker.subscriptions.push({
+                id: stripeSubscriptionId,
+                object: 'subscription',
+                status: 'active',
+                customer: subscription.get('customer_id'),
+                cancel_at_period_end: false,
+                current_period_end: Math.floor(Date.now() / 1000) + 30 * 24 * 60 * 60,
+                start_date: Math.floor(Date.now() / 1000) - 30 * 24 * 60 * 60,
+                items: {
+                    data: [{
+                        id: 'si_test',
+                        price: mockPrice
+                    }]
+                }
+            });
+
+            // Create a retention offer with stripe_coupon_id to skip Stripe API call
+            const retentionOffer = await models.Offer.add({
+                name: 'Success Retention Offer',
+                code: 'success-retention',
+                portal_title: '20% off for 3 months',
+                portal_description: 'Stay with us!',
+                discount_type: 'percent',
+                discount_amount: 20,
+                duration: 'repeating',
+                duration_in_months: 3,
+                interval: cadence,
+                product_id: tierId,
+                currency: null,
+                active: true,
+                redemption_type: 'retention',
+                stripe_coupon_id: stripeCouponId
+            });
+
+            try {
+                const token = await getIdentityToken('paid@test.com');
+
+                await membersAgent
+                    .post(`/api/subscriptions/${stripeSubscriptionId}/apply-offer`)
+                    .body({identity: token, offer_id: retentionOffer.id})
+                    .expectStatus(204);
+
+                // Verify the subscription was updated with the offer
+                await subscription.refresh();
+                assert.equal(subscription.get('offer_id'), retentionOffer.id);
+
+                // Verify offer redemption was recorded
+                const redemption = await models.OfferRedemption.findOne({
+                    offer_id: retentionOffer.id,
+                    subscription_id: subscription.id
+                });
+                assert.ok(redemption, 'Offer redemption should be recorded');
+            } finally {
+                // Clean up - find the redemption by its criteria and destroy by id
+                const redemption = await models.OfferRedemption.findOne({
+                    offer_id: retentionOffer.id,
+                    subscription_id: subscription.id
+                });
+                if (redemption) {
+                    await models.OfferRedemption.destroy({id: redemption.id});
+                }
+                await subscription.save({offer_id: null}, {patch: true});
+                await models.Offer.destroy({id: retentionOffer.id});
             }
         });
     });

--- a/ghost/core/test/unit/server/services/stripe/stripe-api.test.js
+++ b/ghost/core/test/unit/server/services/stripe/stripe-api.test.js
@@ -380,238 +380,277 @@ describe('StripeAPI', function () {
 
             should.deepEqual(result, mockSubscription);
         });
+    });
 
-        describe('createCheckoutSetupSession automatic tax flag', function () {
-            beforeEach(function () {
-                mockStripe = {
-                    checkout: {
-                        sessions: {
-                            create: sinon.stub().resolves()
-                        }
-                    },
-                    customers: {
-                        create: sinon.stub().resolves()
-                    }
-                };
-                mockLabsIsSet = sinon.stub(mockLabs, 'isSet');
-                mockLabsIsSet.withArgs('stripeAutomaticTax').returns(true);
-                const mockStripeConstructor = sinon.stub().returns(mockStripe);
-                StripeAPI.__set__('Stripe', mockStripeConstructor);
-                api.configure({
-                    checkoutSessionSuccessUrl: '/success',
-                    checkoutSessionCancelUrl: '/cancel',
-                    checkoutSetupSessionSuccessUrl: '/setup-success',
-                    checkoutSetupSessionCancelUrl: '/setup-cancel',
-                    secretKey: '',
-                    enableAutomaticTax: true
-                });
-            });
+    describe('addCouponToSubscription', function () {
+        const mockSubscription = {
+            id: 'sub_123',
+            status: 'active',
+            discount: {
+                coupon: {
+                    id: 'coupon_abc'
+                }
+            }
+        };
 
-            afterEach(function () {
-                sinon.restore();
-            });
-
-            it('createCheckoutSession adds customer_update if automatic tax flag is enabled and customer is not undefined', async function () {
-                const mockCustomer = {
-                    id: mockCustomerId,
-                    customer_email: mockCustomerEmail,
-                    name: 'Example Customer'
-                };
-
-                await api.createCheckoutSession('priceId', mockCustomer, {
-                    trialDays: null
-                });
-                should.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.customer_update);
-            });
-
-            it('createCheckoutSession does not add customer_update if automatic tax flag is enabled and customer is undefined', async function () {
-                await api.createCheckoutSession('priceId', undefined, {
-                    trialDays: null
-                });
-                should.not.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.customer_update);
-            });
-
-            it('createCheckoutSession does not add customer_update if automatic tax flag is disabled', async function () {
-                const mockCustomer = {
-                    id: mockCustomerId,
-                    customer_email: mockCustomerEmail,
-                    name: 'Example Customer'
-                };
-                // set enableAutomaticTax: false
-                api.configure({
-                    checkoutSessionSuccessUrl: '/success',
-                    checkoutSessionCancelUrl: '/cancel',
-                    checkoutSetupSessionSuccessUrl: '/setup-success',
-                    checkoutSetupSessionCancelUrl: '/setup-cancel',
-                    secretKey: '',
-                    enableAutomaticTax: false
-                });
-                await api.createCheckoutSession('priceId', mockCustomer, {
-                    trialDays: null
-                });
-                should.not.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.customer_update);
+        beforeEach(function () {
+            mockStripe = {
+                subscriptions: {
+                    update: sinon.stub().resolves(mockSubscription)
+                }
+            };
+            const mockStripeConstructor = sinon.stub().returns(mockStripe);
+            StripeAPI.__set__('Stripe', mockStripeConstructor);
+            api.configure({
+                secretKey: ''
             });
         });
 
-        describe('createDonationCheckoutSession', function () {
-            beforeEach(function () {
-                mockStripe = {
-                    checkout: {
-                        sessions: {
-                            create: sinon.stub().resolves()
-                        }
+        afterEach(function () {
+            sinon.restore();
+        });
+
+        it('adds a coupon to a subscription', async function () {
+            const result = await api.addCouponToSubscription('sub_123', 'coupon_abc');
+
+            should.equal(mockStripe.subscriptions.update.callCount, 1);
+            should.equal(mockStripe.subscriptions.update.args[0][0], 'sub_123');
+            should.deepEqual(mockStripe.subscriptions.update.args[0][1], {coupon: 'coupon_abc'});
+
+            should.deepEqual(result, mockSubscription);
+        });
+    });
+
+    describe('createCheckoutSetupSession automatic tax flag', function () {
+        beforeEach(function () {
+            mockStripe = {
+                checkout: {
+                    sessions: {
+                        create: sinon.stub().resolves()
                     }
-                };
-                sinon.stub(mockLabs, 'isSet');
-                const mockStripeConstructor = sinon.stub().returns(mockStripe);
-                StripeAPI.__set__('Stripe', mockStripeConstructor);
-                api.configure({
-                    checkoutSessionSuccessUrl: '/success',
-                    checkoutSessionCancelUrl: '/cancel',
-                    checkoutSetupSessionSuccessUrl: '/setup-success',
-                    checkoutSetupSessionCancelUrl: '/setup-cancel',
-                    secretKey: ''
-                });
+                },
+                customers: {
+                    create: sinon.stub().resolves()
+                }
+            };
+            mockLabsIsSet = sinon.stub(mockLabs, 'isSet');
+            mockLabsIsSet.withArgs('stripeAutomaticTax').returns(true);
+            const mockStripeConstructor = sinon.stub().returns(mockStripe);
+            StripeAPI.__set__('Stripe', mockStripeConstructor);
+            api.configure({
+                checkoutSessionSuccessUrl: '/success',
+                checkoutSessionCancelUrl: '/cancel',
+                checkoutSetupSessionSuccessUrl: '/setup-success',
+                checkoutSetupSessionCancelUrl: '/setup-cancel',
+                secretKey: '',
+                enableAutomaticTax: true
+            });
+        });
+
+        afterEach(function () {
+            sinon.restore();
+        });
+
+        it('createCheckoutSession adds customer_update if automatic tax flag is enabled and customer is not undefined', async function () {
+            const mockCustomer = {
+                id: mockCustomerId,
+                customer_email: mockCustomerEmail,
+                name: 'Example Customer'
+            };
+
+            await api.createCheckoutSession('priceId', mockCustomer, {
+                trialDays: null
+            });
+            should.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.customer_update);
+        });
+
+        it('createCheckoutSession does not add customer_update if automatic tax flag is enabled and customer is undefined', async function () {
+            await api.createCheckoutSession('priceId', undefined, {
+                trialDays: null
+            });
+            should.not.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.customer_update);
+        });
+
+        it('createCheckoutSession does not add customer_update if automatic tax flag is disabled', async function () {
+            const mockCustomer = {
+                id: mockCustomerId,
+                customer_email: mockCustomerEmail,
+                name: 'Example Customer'
+            };
+            // set enableAutomaticTax: false
+            api.configure({
+                checkoutSessionSuccessUrl: '/success',
+                checkoutSessionCancelUrl: '/cancel',
+                checkoutSetupSessionSuccessUrl: '/setup-success',
+                checkoutSetupSessionCancelUrl: '/setup-cancel',
+                secretKey: '',
+                enableAutomaticTax: false
+            });
+            await api.createCheckoutSession('priceId', mockCustomer, {
+                trialDays: null
+            });
+            should.not.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.customer_update);
+        });
+    });
+
+    describe('createDonationCheckoutSession', function () {
+        beforeEach(function () {
+            mockStripe = {
+                checkout: {
+                    sessions: {
+                        create: sinon.stub().resolves()
+                    }
+                }
+            };
+            sinon.stub(mockLabs, 'isSet');
+            const mockStripeConstructor = sinon.stub().returns(mockStripe);
+            StripeAPI.__set__('Stripe', mockStripeConstructor);
+            api.configure({
+                checkoutSessionSuccessUrl: '/success',
+                checkoutSessionCancelUrl: '/cancel',
+                checkoutSetupSessionSuccessUrl: '/setup-success',
+                checkoutSetupSessionCancelUrl: '/setup-cancel',
+                secretKey: ''
+            });
+        });
+
+        afterEach(function () {
+            sinon.restore();
+        });
+
+        it('createDonationCheckoutSession sends success_url and cancel_url', async function () {
+            await api.createDonationCheckoutSession('priceId', {});
+
+            should.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.success_url);
+            should.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.cancel_url);
+        });
+
+        it('createDonationCheckoutSession does not send currency if additionalPaymentMethods flag is off', async function () {
+            mockLabsIsSet.withArgs('additionalPaymentMethods').returns(false);
+            await api.createDonationCheckoutSession('priceId', {currency: 'usd'});
+
+            should.not.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.currency);
+        });
+
+        it('passes customer ID when a valid customer object is provided', async function () {
+            const mockCustomer = {
+                id: mockCustomerId,
+                email: mockCustomerEmail,
+                name: mockCustomerName
+            };
+
+            await api.createDonationCheckoutSession({
+                priceId: 'priceId',
+                successUrl: '/success',
+                cancelUrl: '/cancel',
+                metadata: {},
+                customer: mockCustomer
             });
 
-            afterEach(function () {
-                sinon.restore();
+            should.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.customer);
+            should.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.customer, mockCustomerId);
+        });
+
+        it('passes customer_email when no customer object is provided', async function () {
+            await api.createDonationCheckoutSession({
+                priceId: 'priceId',
+                successUrl: '/success',
+                cancelUrl: '/cancel',
+                metadata: {},
+                customerEmail: mockCustomerEmail
             });
 
-            it('createDonationCheckoutSession sends success_url and cancel_url', async function () {
-                await api.createDonationCheckoutSession('priceId', {});
+            should.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.customer_email);
+            should.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.customer_email, mockCustomerEmail);
+        });
 
-                should.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.success_url);
-                should.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.cancel_url);
+        it('uses only customer when both customer and customerEmail are provided', async function () {
+            const mockCustomer = {
+                id: mockCustomerId,
+                email: mockCustomerEmail,
+                name: mockCustomerName
+            };
+
+            await api.createDonationCheckoutSession({
+                priceId: 'priceId',
+                successUrl: '/success',
+                cancelUrl: '/cancel',
+                metadata: {},
+                customer: mockCustomer,
+                customerEmail: 'another_email@example.com'
             });
 
-            it('createDonationCheckoutSession does not send currency if additionalPaymentMethods flag is off', async function () {
-                mockLabsIsSet.withArgs('additionalPaymentMethods').returns(false);
-                await api.createDonationCheckoutSession('priceId', {currency: 'usd'});
+            should.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.customer);
+            should.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.customer, mockCustomerId);
+            should.not.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.customer_email);
+        });
 
-                should.not.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.currency);
+        it('passes metadata correctly', async function () {
+            const metadata = {
+                ghost_donation: true
+            };
+
+            await api.createDonationCheckoutSession({
+                priceId: 'priceId',
+                successUrl: '/success',
+                cancelUrl: '/cancel',
+                metadata,
+                customer: null,
+                customerEmail: mockCustomerEmail
             });
 
-            it('passes customer ID when a valid customer object is provided', async function () {
-                const mockCustomer = {
-                    id: mockCustomerId,
-                    email: mockCustomerEmail,
-                    name: mockCustomerName
-                };
+            should.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.metadata);
+            should.deepEqual(mockStripe.checkout.sessions.create.firstCall.firstArg.metadata, metadata);
+        });
 
-                await api.createDonationCheckoutSession({
-                    priceId: 'priceId',
-                    successUrl: '/success',
-                    cancelUrl: '/cancel',
-                    metadata: {},
-                    customer: mockCustomer
-                });
-
-                should.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.customer);
-                should.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.customer, mockCustomerId);
+        it('passes custom fields correctly', async function () {
+            await api.createDonationCheckoutSession({
+                priceId: 'priceId',
+                successUrl: '/success',
+                cancelUrl: '/cancel',
+                metadata: {},
+                customer: null,
+                customerEmail: mockCustomerEmail
             });
 
-            it('passes customer_email when no customer object is provided', async function () {
-                await api.createDonationCheckoutSession({
-                    priceId: 'priceId',
-                    successUrl: '/success',
-                    cancelUrl: '/cancel',
-                    metadata: {},
-                    customerEmail: mockCustomerEmail
-                });
+            should.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.custom_fields);
+            const customFields = mockStripe.checkout.sessions.create.firstCall.firstArg.custom_fields;
+            should.equal(customFields.length, 1);
+        });
 
-                should.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.customer_email);
-                should.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.customer_email, mockCustomerEmail);
+        it('has correct data for custom field message', async function () {
+            await api.createDonationCheckoutSession({
+                priceId: 'priceId',
+                successUrl: '/success',
+                cancelUrl: '/cancel',
+                metadata: {},
+                customer: null,
+                customerEmail: mockCustomerEmail
             });
 
-            it('uses only customer when both customer and customerEmail are provided', async function () {
-                const mockCustomer = {
-                    id: mockCustomerId,
-                    email: mockCustomerEmail,
-                    name: mockCustomerName
-                };
+            const customFields = mockStripe.checkout.sessions.create.firstCall.firstArg.custom_fields;
+            should.deepEqual(customFields[0], {
+                key: 'donation_message',
+                label: {
+                    type: 'custom',
+                    custom: 'Add a personal note'
+                },
+                type: 'text',
+                optional: true
+            });
+        });
 
-                await api.createDonationCheckoutSession({
-                    priceId: 'priceId',
-                    successUrl: '/success',
-                    cancelUrl: '/cancel',
-                    metadata: {},
-                    customer: mockCustomer,
-                    customerEmail: 'another_email@example.com'
-                });
-
-                should.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.customer);
-                should.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.customer, mockCustomerId);
-                should.not.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.customer_email);
+        it('does not have more than 3 custom fields (stripe limitation)', async function () {
+            await api.createDonationCheckoutSession({
+                priceId: 'priceId',
+                successUrl: '/success',
+                cancelUrl: '/cancel',
+                metadata: {},
+                customer: null,
+                customerEmail: mockCustomerEmail
             });
 
-            it('passes metadata correctly', async function () {
-                const metadata = {
-                    ghost_donation: true
-                };
-
-                await api.createDonationCheckoutSession({
-                    priceId: 'priceId',
-                    successUrl: '/success',
-                    cancelUrl: '/cancel',
-                    metadata,
-                    customer: null,
-                    customerEmail: mockCustomerEmail
-                });
-
-                should.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.metadata);
-                should.deepEqual(mockStripe.checkout.sessions.create.firstCall.firstArg.metadata, metadata);
-            });
-
-            it('passes custom fields correctly', async function () {
-                await api.createDonationCheckoutSession({
-                    priceId: 'priceId',
-                    successUrl: '/success',
-                    cancelUrl: '/cancel',
-                    metadata: {},
-                    customer: null,
-                    customerEmail: mockCustomerEmail
-                });
-
-                should.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.custom_fields);
-                const customFields = mockStripe.checkout.sessions.create.firstCall.firstArg.custom_fields;
-                should.equal(customFields.length, 1);
-            });
-
-            it('has correct data for custom field message', async function () {
-                await api.createDonationCheckoutSession({
-                    priceId: 'priceId',
-                    successUrl: '/success',
-                    cancelUrl: '/cancel',
-                    metadata: {},
-                    customer: null,
-                    customerEmail: mockCustomerEmail
-                });
-
-                const customFields = mockStripe.checkout.sessions.create.firstCall.firstArg.custom_fields;
-                should.deepEqual(customFields[0], {
-                    key: 'donation_message',
-                    label: {
-                        type: 'custom',
-                        custom: 'Add a personal note'
-                    },
-                    type: 'text',
-                    optional: true
-                });
-            });
-
-            it('does not have more than 3 custom fields (stripe limitation)', async function () {
-                await api.createDonationCheckoutSession({
-                    priceId: 'priceId',
-                    successUrl: '/success',
-                    cancelUrl: '/cancel',
-                    metadata: {},
-                    customer: null,
-                    customerEmail: mockCustomerEmail
-                });
-
-                should.ok(mockStripe.checkout.sessions.create.firstCall.firstArg.custom_fields.length <= 3);
-            });
+            should.ok(mockStripe.checkout.sessions.create.firstCall.firstArg.custom_fields.length <= 3);
         });
     });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/FEA-536

Enables retention offers during cancellation flow. When a member initiates cancellation, Portal can now show a retention offer and apply it to their subscription via the new endpoint

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements server and client support for applying retention offers during cancellation.
> 
> - Adds `POST members/api/subscriptions/:id/apply-offer` with identity auth, validation (active subscription, offer status/type/tier/cadence, not already redeemed), applies Stripe coupon via `stripe.addCouponToSubscription`, and links the offer to the subscription
> - Extends `MemberRepository` with `applyOfferToSubscription`; updates `offers-api.getOffer` to support transactions; adds `stripe-api.addCouponToSubscription`
> - Wires Portal: new `api.member.applyOffer`, `applyOffer` action, and retention offer acceptance in `AccountPlanPage` using `targetSubscriptionId` and action state
> - Adds comprehensive tests: e2e coverage for success and error cases, plus unit test for Stripe coupon application
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c2bfebab18f66667355617828b3c8ab4111a6d8e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->