### PR TITLE
Fixed non-subdir `yarn dev:forward` development

### DIFF
--- a/apps/admin/vite-backend-proxy.ts
+++ b/apps/admin/vite-backend-proxy.ts
@@ -1,17 +1,6 @@
 import type { Plugin, ProxyOptions } from "vite";
 import type { IncomingMessage } from "http";
-
-const GHOST_URL = process.env.GHOST_URL ?? "http://localhost:2368/";
-
-/**
- * Extracts the subdirectory path from GHOST_URL.
- * e.g., "http://localhost:2368/blog/" -> "/blog"
- *       "http://localhost:2368/" -> ""
- */
-function getSubdir(): string {
-    const url = new URL(GHOST_URL);
-    return url.pathname.replace(/\/$/, '');
-}
+import { getSubdir, GHOST_URL } from "./vite.config";
 
 /**
  * Resolves the configured Ghost site URL by calling the admin api site endpoint

--- a/apps/admin/vite-ember-assets.ts
+++ b/apps/admin/vite-ember-assets.ts
@@ -90,11 +90,14 @@ export function emberAssetsPlugin() {
                 dev: true,
                 etag: true
             });
-            
+
+            const base = (server.config.base ?? '/ghost').replace(/\/$/, '');
+            const assetsPrefix = `${base}/assets/`;
+
             server.middlewares.use((req, res, next) => {
-                if (req.url?.startsWith('/ghost/assets/')) {
+                if (req.url?.startsWith(assetsPrefix)) {
                     const originalUrl = req.url;
-                    req.url = req.url.replace('/ghost/assets', '');
+                    req.url = req.url.replace(assetsPrefix, '/');
                     assetsMiddleware(req, res, () => {
                         req.url = originalUrl;
                         next();

--- a/apps/admin/vite.config.ts
+++ b/apps/admin/vite.config.ts
@@ -7,11 +7,40 @@ import { emberAssetsPlugin } from "./vite-ember-assets";
 import { ghostBackendProxyPlugin } from "./vite-backend-proxy";
 import { deepLinksPlugin } from "./vite-deep-links";
 
+export const GHOST_URL = process.env.GHOST_URL ?? "http://localhost:2368/";
 const GHOST_CARDS_PATH = resolve(__dirname, "../../ghost/core/core/frontend/src/cards");
 
+/**
+ * Extracts the subdirectory path from GHOST_URL.
+ * e.g., "http://localhost:2368/blog/" -> "/blog"
+ *       "http://localhost:2368/" -> ""
+ */
+export function getSubdir(): string {
+    const url = new URL(GHOST_URL);
+    return url.pathname.replace(/\/$/, '');
+}
+
+/**
+ * Computes the Vite base path.
+ * - If GHOST_CDN_URL is set, use it (for CDN deployments)
+ * - Otherwise, use the subdir + /ghost (e.g., "/ghost" or "/blog/ghost")
+ * - For builds without CDN, use "./" for relative paths in index-forward.html
+ */
+function getBase(command: 'build' | 'serve'): string {
+    if (process.env.GHOST_CDN_URL) {
+        return process.env.GHOST_CDN_URL;
+    }
+    // During build, use relative paths so index-forward.html works when served from any subdir
+    if (command === 'build') {
+        return './';
+    }
+    // During dev, use absolute path based on GHOST_URL subdir
+    return `${getSubdir()}/ghost`;
+}
+
 // https://vite.dev/config/
-export default defineConfig({
-    base: process.env.GHOST_CDN_URL ?? "./",
+export default defineConfig(({ command }) => ({
+    base: getBase(command),
     plugins: [react(), emberAssetsPlugin(), ghostBackendProxyPlugin(), deepLinksPlugin(), tsconfigPaths()],
     define: {
         "process.env.DEBUG": false, // Shim env var utilized by the @tryghost/nql package
@@ -36,4 +65,4 @@ export default defineConfig({
         setupFiles: ["./test-utils/setup.ts"],
         include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
     },
-});
+}));


### PR DESCRIPTION
no issue

The previous fix for subdir handling (https://github.com/TryGhost/Ghost/pull/25918) changed vite's base from "/ghost" to "./" which broke non-subdir development. The relative base caused the deep-links plugin regex to become "^./(.+)" where the dot matched any character, incorrectly redirecting all requests to hash URLs.

- Changed vite base to be computed dynamically: "./" for builds (so `index-forward.html` works from any subdir) and "${subdir}/ghost" for dev (e.g., "/ghost" or "/blog/ghost")
- Moved `GHOST_URL` and getSubdir() to vite.config.ts as the canonical location for configuration, exported for use by vite-backend-proxy
- Updated ember-assets middleware to use server.config.base instead of hardcoded "/ghost/assets/" path, fixing subdir asset serving