### PR TITLE
Renamed query params as analytics filters instead of utm filters

### DIFF
--- a/apps/posts/src/views/PostAnalytics/Web/web.tsx
+++ b/apps/posts/src/views/PostAnalytics/Web/web.tsx
@@ -30,16 +30,16 @@ const Web: React.FC<postAnalyticsProps> = () => {
     const {statsConfig, isLoading: isConfigLoading, range, data: globalData, post, isPostLoading} = useGlobalData();
 
     // Use URL-synced filter state for bookmarking and sharing
-    const {filters: utmFilters, setFilters: setUtmFilters} = useFilterParams();
+    const {filters: analyticsFilters, setFilters: setAnalyticsFilters} = useFilterParams();
 
     // Check if UTM tracking is enabled in labs (defaults to true / GA)
     const utmTrackingEnabled = globalData?.labs?.utmTracking ?? true;
 
     // Derive audience from filters - URL is the single source of truth
     const audience = useMemo(() => {
-        const audienceFilter = utmFilters.find(f => f.field === 'audience');
+        const audienceFilter = analyticsFilters.find(f => f.field === 'audience');
         return getAudienceFromFilterValues(audienceFilter?.values as string[] | undefined);
-    }, [utmFilters]);
+    }, [analyticsFilters]);
 
     // Redirect to Overview if this is an email-only post
     useEffect(() => {
@@ -75,7 +75,7 @@ const Web: React.FC<postAnalyticsProps> = () => {
     const filterParams = useMemo(() => {
         const params: Record<string, string> = {};
 
-        utmFilters.forEach((filter) => {
+        analyticsFilters.forEach((filter) => {
             const fieldKey = filter.field;
             const values = filter.values;
 
@@ -96,11 +96,11 @@ const Web: React.FC<postAnalyticsProps> = () => {
         });
 
         return params;
-    }, [utmFilters]);
+    }, [analyticsFilters]);
 
     // Generic handler for click-to-filter on any field (source, location, etc.)
     const handleFilterClick = useCallback((field: string, value: string) => {
-        setUtmFilters((prevFilters) => {
+        setAnalyticsFilters((prevFilters) => {
             const existingFilter = prevFilters.find(f => f.field === field);
             if (existingFilter) {
                 // Update the existing filter
@@ -112,7 +112,7 @@ const Web: React.FC<postAnalyticsProps> = () => {
             return [...prevFilters, createFilter(field, 'is', [value])];
         });
         scrollToTop();
-    }, [setUtmFilters, scrollToTop]);
+    }, [setAnalyticsFilters, scrollToTop]);
 
     const handleLocationClick = useCallback((location: string) => handleFilterClick('location', location), [handleFilterClick]);
     const handleSourceClick = useCallback((source: string) => handleFilterClick('source', source), [handleFilterClick]);
@@ -206,7 +206,7 @@ const Web: React.FC<postAnalyticsProps> = () => {
     const kpiValues = getWebKpiValues(kpiData as unknown as KpiDataItem[] | null);
 
     // Check if filters are applied
-    const hasFilters = utmFilters.length > 0;
+    const hasFilters = analyticsFilters.length > 0;
 
     return (
         <>
@@ -218,9 +218,9 @@ const Web: React.FC<postAnalyticsProps> = () => {
                 }
                 <NavbarActions className={`${hasFilters ? '!mt-0 [grid-area:subactions] lg:!mt-[25px]' : '[grid-area:actions]'}`}>
                     <StatsFilter
-                        filters={utmFilters}
+                        filters={analyticsFilters}
                         utmTrackingEnabled={utmTrackingEnabled}
-                        onChange={setUtmFilters}
+                        onChange={setAnalyticsFilters}
                     />
                     {!hasFilters && <DateRangeSelect />}
                 </NavbarActions>

--- a/apps/posts/src/views/PostAnalytics/Web/web.tsx
+++ b/apps/posts/src/views/PostAnalytics/Web/web.tsx
@@ -215,8 +215,8 @@ const Web: React.FC<postAnalyticsProps> = () => {
                 }
                 <NavbarActions className={`${hasFilters ? '!mt-0 [grid-area:subactions] lg:!mt-[25px]' : '[grid-area:actions]'}`}>
                     <StatsFilter
-                        filters={utmFilters}
-                        onChange={setUtmFilters}
+                        filters={analyticsFilters}
+                        onChange={setAnalyticsFilters}
                     />
                     {!hasFilters && <DateRangeSelect />}
                 </NavbarActions>

--- a/apps/stats/src/views/Stats/Web/components/top-content.tsx
+++ b/apps/stats/src/views/Stats/Web/components/top-content.tsx
@@ -88,10 +88,10 @@ interface TopContentProps {
     range: number;
     totalVisitors: number;
     audience: number;
-    utmFilterParams?: Record<string, string>;
+    filterParams?: Record<string, string>;
 }
 
-const TopContent: React.FC<TopContentProps> = ({range, totalVisitors, audience, utmFilterParams = {}}) => {
+const TopContent: React.FC<TopContentProps> = ({range, totalVisitors, audience, filterParams = {}}) => {
     const {startDate, endDate, timezone} = getRangeDates(range);
     const [selectedContentType, setSelectedContentType] = useState<ContentType>(CONTENT_TYPES.POSTS_AND_PAGES);
 
@@ -101,7 +101,7 @@ const TopContent: React.FC<TopContentProps> = ({range, totalVisitors, audience, 
             date_from: formatQueryDate(startDate),
             date_to: formatQueryDate(endDate),
             member_status: getAudienceQueryParam(audience),
-            ...utmFilterParams
+            ...filterParams
         };
 
         if (timezone) {
@@ -117,7 +117,7 @@ const TopContent: React.FC<TopContentProps> = ({range, totalVisitors, audience, 
         // For POSTS_AND_PAGES, don't add post_type filter to get both
 
         return params;
-    }, [startDate, endDate, timezone, audience, selectedContentType, utmFilterParams]);
+    }, [startDate, endDate, timezone, audience, selectedContentType, filterParams]);
 
     // Get filtered content data
     const {data: topContentData, isLoading: isLoading} = useTopContent({

--- a/apps/stats/src/views/Stats/Web/web.tsx
+++ b/apps/stats/src/views/Stats/Web/web.tsx
@@ -192,8 +192,8 @@ const Web: React.FC = () => {
                 }
                 <NavbarActions className={`${hasFilters ? '!mt-0 [grid-area:subactions] lg:!mt-[25px]' : '[grid-area:actions]'}`}>
                     <StatsFilter
-                        filters={utmFilters}
-                        onChange={setUtmFilters}
+                        filters={analyticsFilters}
+                        onChange={setAnalyticsFilters}
                     />
                     {!hasFilters && <DateRangeSelect />}
                 </NavbarActions>

--- a/apps/stats/src/views/Stats/Web/web.tsx
+++ b/apps/stats/src/views/Stats/Web/web.tsx
@@ -56,16 +56,16 @@ const Web: React.FC = () => {
     const {appSettings} = useAppContext();
 
     // Use URL-synced filter state for bookmarking and sharing
-    const {filters: utmFilters, setFilters: setUtmFilters} = useFilterParams();
+    const {filters: analyticsFilters, setFilters: setAnalyticsFilters} = useFilterParams();
 
     // Check if UTM tracking is enabled in labs (defaults to true / GA)
     const utmTrackingEnabled = data?.labs?.utmTracking ?? true;
 
     // Derive audience from filters - URL is the single source of truth
     const audience = useMemo(() => {
-        const audienceFilter = utmFilters.find(f => f.field === 'audience');
+        const audienceFilter = analyticsFilters.find(f => f.field === 'audience');
         return getAudienceFromFilterValues(audienceFilter?.values as string[] | undefined);
-    }, [utmFilters]);
+    }, [analyticsFilters]);
 
     // Get site URL and icon for domain comparison and Direct traffic favicon
     const siteUrl = data?.url as string | undefined;
@@ -84,7 +84,7 @@ const Web: React.FC = () => {
     const filterParams = useMemo(() => {
         const params: Record<string, string> = {};
 
-        utmFilters.forEach((filter) => {
+        analyticsFilters.forEach((filter) => {
             const fieldKey = filter.field;
             const values = filter.values;
 
@@ -118,11 +118,11 @@ const Web: React.FC = () => {
         });
 
         return params;
-    }, [utmFilters]);
+    }, [analyticsFilters]);
 
     // Generic handler for click-to-filter on any field (source, location, etc.)
     const handleFilterClick = useCallback((field: string, value: string) => {
-        setUtmFilters((prevFilters) => {
+        setAnalyticsFilters((prevFilters) => {
             const existingFilter = prevFilters.find(f => f.field === field);
             if (existingFilter) {
                 // Update the existing filter
@@ -134,7 +134,7 @@ const Web: React.FC = () => {
             return [...prevFilters, createFilter(field, 'is', [value])];
         });
         scrollToTop();
-    }, [setUtmFilters, scrollToTop]);
+    }, [setAnalyticsFilters, scrollToTop]);
 
     const handleLocationClick = useCallback((location: string) => handleFilterClick('location', location), [handleFilterClick]);
     const handleSourceClick = useCallback((source: string) => handleFilterClick('source', source), [handleFilterClick]);
@@ -183,7 +183,7 @@ const Web: React.FC = () => {
     }
 
     // Check if filters are applied
-    const hasFilters = utmFilters.length > 0;
+    const hasFilters = analyticsFilters.length > 0;
 
     return (
         <StatsLayout>
@@ -195,9 +195,9 @@ const Web: React.FC = () => {
                 }
                 <NavbarActions className={`${hasFilters ? '!mt-0 [grid-area:subactions] lg:!mt-[25px]' : '[grid-area:actions]'}`}>
                     <StatsFilter
-                        filters={utmFilters}
+                        filters={analyticsFilters}
                         utmTrackingEnabled={utmTrackingEnabled}
-                        onChange={setUtmFilters}
+                        onChange={setAnalyticsFilters}
                     />
                     {!hasFilters && <DateRangeSelect />}
                 </NavbarActions>
@@ -215,9 +215,9 @@ const Web: React.FC = () => {
                 <div className='flex grid-cols-2 flex-col gap-6 lg:grid'>
                     <TopContent
                         audience={audience}
+                        filterParams={filterParams}
                         range={range}
                         totalVisitors={totalVisitors}
-                        utmFilterParams={filterParams}
                     />
                     <SourcesCard
                         data={sourcesData as SourcesData[] | null}


### PR DESCRIPTION
no ref

This change in naming more clearly defines the purpose, as the query params have expanded beyond the use of strictly utms.