### PR TITLE
Fixed zip import storing files at wrong paths with cloud storage

### DIFF
--- a/ghost/core/core/server/data/importer/handlers/importer-content-file-handler.js
+++ b/ghost/core/core/server/data/importer/handlers/importer-content-file-handler.js
@@ -15,11 +15,6 @@ class ImporterContentFileHandler {
     contentTypes;
 
     /**
-     * Holds path to the destination content directory
-     * @property {string} */
-    #contentPath;
-
-    /**
      *
      * @param {Object} deps dependencies
      * @param {'media' | 'files' | 'images'} deps.type type of content file
@@ -27,7 +22,6 @@ class ImporterContentFileHandler {
      * @param {boolean} [deps.ignoreRootFolderFiles] whether to ignore files in the root folder
      * @param {string[]} deps.contentTypes content types to search for
      * @param {string[]} deps.directories directories to search for content files
-     * @param {string} deps.contentPath path to the destination content directory
      * @param {Object} deps.storage storage adapter instance
      * @param {object} deps.urlUtils urlUtils instance
      */
@@ -38,7 +32,6 @@ class ImporterContentFileHandler {
         this.contentTypes = deps.contentTypes;
         this.ignoreRootFolderFiles = deps.ignoreRootFolderFiles;
         this.storage = deps.storage;
-        this.#contentPath = deps.contentPath;
         this.urlUtils = deps.urlUtils;
     }
 
@@ -56,7 +49,6 @@ class ImporterContentFileHandler {
         }
 
         // normalize the directory structure
-        const filesContentPath = this.#contentPath;
         files = _.map(files, function (file) {
             const noBaseDir = file.name.replace(baseDirRegex, '');
             let noGhostDirs = noBaseDir;
@@ -67,7 +59,7 @@ class ImporterContentFileHandler {
 
             file.originalPath = noBaseDir;
             file.name = noGhostDirs;
-            file.targetDir = path.join(filesContentPath, path.dirname(noGhostDirs));
+            file.targetDir = path.dirname(noGhostDirs);
             return file;
         });
 
@@ -78,7 +70,7 @@ class ImporterContentFileHandler {
                     '/',
                     self.urlUtils.getSubdir(),
                     self.storage.staticFileURLPrefix,
-                    path.relative(filesContentPath, targetFilename)
+                    targetFilename
                 );
 
                 return contentFile;

--- a/ghost/core/core/server/data/importer/import-manager.js
+++ b/ghost/core/core/server/data/importer/import-manager.js
@@ -64,7 +64,6 @@ class ImportManager {
             ignoreRootFolderFiles: true,
             extensions: config.get('uploads').media.extensions,
             contentTypes: config.get('uploads').media.contentTypes,
-            contentPath: config.getContentPath('media'),
             urlUtils: urlUtils,
             storage: mediaStorage
         });
@@ -78,7 +77,6 @@ class ImportManager {
             ignoreRootFolderFiles: true,
             extensions: config.get('uploads').files.extensions,
             contentTypes: config.get('uploads').files.contentTypes,
-            contentPath: config.getContentPath('files'),
             urlUtils: urlUtils,
             storage: fileStorage
         });

--- a/ghost/core/test/unit/server/adapters/storage/local-base-storage.test.js
+++ b/ghost/core/test/unit/server/adapters/storage/local-base-storage.test.js
@@ -3,6 +3,8 @@ const path = require('path');
 const http = require('http');
 const express = require('express');
 const should = require('should');
+const sinon = require('sinon');
+const fs = require('fs-extra');
 const LocalStorageBase = require('../../../../../core/server/adapters/storage/LocalStorageBase');
 
 describe('Local Storage Base', function () {
@@ -34,15 +36,17 @@ describe('Local Storage Base', function () {
     });
 
     describe('urlToPath', function () {
-        it('returns path from url', function () {
+        it('returns relative path from url (matches S3Storage behavior)', function () {
             let localStorageBase = new LocalStorageBase({
                 storagePath: '/media-storage/path/',
                 staticFileURLPrefix: 'content/media',
                 siteUrl: 'http://example.com/blog/'
             });
 
+            // urlToPath now returns relative path, not absolute path
+            // This matches S3Storage behavior and allows callers to pass result to save/exists/delete
             localStorageBase.urlToPath('http://example.com/blog/content/media/2021/11/media.mp4')
-                .should.eql('/media-storage/path/2021/11/media.mp4');
+                .should.eql('2021/11/media.mp4');
         });
 
         it('throws if the url does not match current site', function () {
@@ -58,6 +62,96 @@ describe('Local Storage Base', function () {
             } catch (error) {
                 error.message.should.eql('The URL "http://anothersite.com/blog/content/media/2021/11/media.mp4" is not a valid URL for this site.');
             }
+        });
+    });
+
+    describe('relative path handling', function () {
+        afterEach(function () {
+            sinon.restore();
+        });
+
+        describe('save', function () {
+            it('prepends storagePath when targetDir is relative', async function () {
+                const localStorageBase = new LocalStorageBase({
+                    storagePath: '/var/www/ghost/content/media',
+                    staticFileURLPrefix: 'content/media',
+                    siteUrl: 'http://example.com/'
+                });
+
+                sinon.stub(localStorageBase, 'getUniqueFileName').resolves('/var/www/ghost/content/media/2026/01/video.mp4');
+                sinon.stub(fs, 'mkdirs').resolves();
+                sinon.stub(fs, 'copy').resolves();
+
+                const url = await localStorageBase.save({
+                    path: '/tmp/video.mp4',
+                    name: 'video.mp4'
+                }, '2026/01');
+
+                // Verify getUniqueFileName was called with the absolute path
+                assert.ok(localStorageBase.getUniqueFileName.calledOnce);
+                const [, targetDir] = localStorageBase.getUniqueFileName.firstCall.args;
+                assert.equal(targetDir, '/var/www/ghost/content/media/2026/01');
+
+                // Verify the URL is correct
+                assert.equal(url, '/content/media/2026/01/video.mp4');
+            });
+
+            it('does not double-prepend when targetDir already includes storagePath', async function () {
+                const localStorageBase = new LocalStorageBase({
+                    storagePath: '/var/www/ghost/content/media',
+                    staticFileURLPrefix: 'content/media',
+                    siteUrl: 'http://example.com/'
+                });
+
+                sinon.stub(localStorageBase, 'getUniqueFileName').resolves('/var/www/ghost/content/media/2026/01/video.mp4');
+                sinon.stub(fs, 'mkdirs').resolves();
+                sinon.stub(fs, 'copy').resolves();
+
+                await localStorageBase.save({
+                    path: '/tmp/video.mp4',
+                    name: 'video.mp4'
+                }, '/var/www/ghost/content/media/2026/01');
+
+                // Verify getUniqueFileName was called with the original path (unchanged)
+                const [, targetDir] = localStorageBase.getUniqueFileName.firstCall.args;
+                assert.equal(targetDir, '/var/www/ghost/content/media/2026/01');
+            });
+        });
+
+        describe('exists', function () {
+            it('prepends storagePath when targetDir is relative', async function () {
+                const localStorageBase = new LocalStorageBase({
+                    storagePath: '/var/www/ghost/content/media',
+                    staticFileURLPrefix: 'content/media',
+                    siteUrl: 'http://example.com/'
+                });
+
+                const statStub = sinon.stub(fs, 'stat').resolves({});
+
+                await localStorageBase.exists('video.mp4', '2026/01');
+
+                // Verify fs.stat was called with the correct absolute path
+                assert.ok(statStub.calledOnce);
+                assert.equal(statStub.firstCall.args[0], '/var/www/ghost/content/media/2026/01/video.mp4');
+            });
+        });
+
+        describe('delete', function () {
+            it('prepends storagePath when targetDir is relative', async function () {
+                const localStorageBase = new LocalStorageBase({
+                    storagePath: '/var/www/ghost/content/media',
+                    staticFileURLPrefix: 'content/media',
+                    siteUrl: 'http://example.com/'
+                });
+
+                const removeStub = sinon.stub(fs, 'remove').resolves();
+
+                await localStorageBase.delete('video.mp4', '2026/01');
+
+                // Verify fs.remove was called with the correct absolute path
+                assert.ok(removeStub.calledOnce);
+                assert.equal(removeStub.firstCall.args[0], '/var/www/ghost/content/media/2026/01/video.mp4');
+            });
         });
     });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/HKG-1571

## Summary

When importing a zip containing media/files, the importer was passing absolute local filesystem paths (like `/var/www/ghost/content/media/2026/01`) to storage adapters. This worked for local storage but broke cloud storage adapters like S3, which would store files at nonsensical nested paths like `s3://bucket/var/www/ghost/content/media/2026/01/video.mp4`.

This PR:
- Adds relative path support to `LocalStorageBase` so it can accept paths like `2026/01` (preparatory refactor)
- Updates the importer to pass relative paths instead of absolute paths (the actual fix)

The change maintains backwards compatibility - existing code passing absolute paths still works, but the long-term direction is to remove absolute path support entirely.

## Test plan

- [ ] Import a zip file containing media/files and verify they're stored at correct paths
- [ ] Verify existing image/media uploads still work
- [ ] Unit tests pass for storage adapters and importer

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes incorrect cloud storage paths by switching importer and local storage to use relative paths.
> 
> - **LocalStorageBase**: accepts relative `targetDir` in `save/exists/delete` (keeps legacy absolute support); `urlToPath` now returns a relative path; URL generation uses relative paths
> - **ImporterContentFileHandler**: stops using absolute `contentPath`; sets relative `targetDir` (preserves date subdirs) and uses returned unique filename directly for URL building
> - **ImportManager**: removes passing `contentPath` to handlers
> - **Tests**: new/updated unit tests covering relative path handling and `urlToPath` behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e4c23c012357b8d740f58fcd957ddffc24afa83. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->