### PR TITLE
Moved audience filter logic to dedicated utils

### DIFF
--- a/apps/posts/src/utils/audience.ts
+++ b/apps/posts/src/utils/audience.ts
@@ -1,10 +1,4 @@
-import {ALL_AUDIENCES, AUDIENCE_BITS} from '@src/utils/constants';
-
-export const AUDIENCE_TYPES = [
-    {name: 'Public visitors', value: 'undefined', bit: AUDIENCE_BITS.PUBLIC},
-    {name: 'Free members', value: 'free', bit: AUDIENCE_BITS.FREE},
-    {name: 'Paid members', value: 'paid', bit: AUDIENCE_BITS.PAID}
-];
+import {ALL_AUDIENCES, AUDIENCE_BITS, AUDIENCE_TYPES} from './constants';
 
 /**
  * Derive audience bitmask from filter values

--- a/apps/posts/src/utils/constants.ts
+++ b/apps/posts/src/utils/constants.ts
@@ -43,3 +43,9 @@ export const AUDIENCE_BITS = {
 
 // All audiences selected (PUBLIC | FREE | PAID = 7)
 export const ALL_AUDIENCES = AUDIENCE_BITS.PUBLIC | AUDIENCE_BITS.FREE | AUDIENCE_BITS.PAID;
+
+export const AUDIENCE_TYPES = [
+    {name: 'Public visitors', value: 'undefined', bit: AUDIENCE_BITS.PUBLIC},
+    {name: 'Free members', value: 'free', bit: AUDIENCE_BITS.FREE},
+    {name: 'Paid members', value: 'paid', bit: AUDIENCE_BITS.PAID}
+];

--- a/apps/posts/src/views/PostAnalytics/Newsletter/newsletter.tsx
+++ b/apps/posts/src/views/PostAnalytics/Newsletter/newsletter.tsx
@@ -1,4 +1,3 @@
-// import AudienceSelect from './components/audience-select';
 import Feedback from './components/feedback';
 import KpiCard, {KpiCardContent, KpiCardLabel, KpiCardMoreButton, KpiCardValue} from '../components/kpi-card';
 import PostAnalyticsContent from '../components/post-analytics-content';

--- a/apps/posts/src/views/PostAnalytics/Web/web.tsx
+++ b/apps/posts/src/views/PostAnalytics/Web/web.tsx
@@ -9,7 +9,7 @@ import {BarChartLoadingIndicator, Card, CardContent, EmptyIndicator, LucideIcon,
 import {BaseSourceData, useNavigate, useParams, useTinybirdQuery} from '@tryghost/admin-x-framework';
 import {KpiDataItem, getWebKpiValues} from '@src/utils/kpi-helpers';
 import {STATS_RANGES, UNKNOWN_LOCATION_VALUES} from '@src/utils/constants';
-import {getAudienceFromFilterValues, getAudienceQueryParam} from '../components/audience-select';
+import {getAudienceFromFilterValues, getAudienceQueryParam} from '@src/utils/audience';
 import {getPeriodText} from '@src/utils/chart-helpers';
 import {useCallback, useEffect, useMemo} from 'react';
 import {useFilterParams} from '@src/hooks/use-filter-params';

--- a/apps/posts/src/views/PostAnalytics/components/stats-filter.tsx
+++ b/apps/posts/src/views/PostAnalytics/components/stats-filter.tsx
@@ -4,7 +4,7 @@ import enLocale from 'i18n-iso-countries/langs/en.json';
 import {Button, Filter, FilterFieldConfig, Filters, LucideIcon} from '@tryghost/shade';
 import {STATS_LABEL_MAPPINGS, UNKNOWN_LOCATION_VALUES} from '@src/utils/constants';
 import {formatQueryDate, getRangeDates} from '@tryghost/shade';
-import {getAudienceFromFilterValues, getAudienceQueryParam} from './audience-select';
+import {getAudienceFromFilterValues, getAudienceQueryParam} from '@src/utils/audience';
 import {useAppContext} from '@src/providers/posts-app-context';
 import {useGlobalData} from '@src/providers/post-analytics-context';
 import {useTinybirdQuery} from '@tryghost/admin-x-framework';

--- a/apps/stats/src/hooks/use-top-sources-growth.ts
+++ b/apps/stats/src/hooks/use-top-sources-growth.ts
@@ -1,6 +1,6 @@
 import {ALL_AUDIENCES} from '@src/utils/constants';
 import {formatQueryDate, getRangeDates} from '@tryghost/shade';
-import {getAudienceQueryParam} from '@views/Stats/components/audience-select';
+import {getAudienceQueryParam} from '@src/utils/audience';
 import {useTopSourcesGrowth as useTopSourcesGrowthAPI} from '@tryghost/admin-x-framework/api/referrers';
 
 export const useTopSourcesGrowth = (range: number, orderBy: string = 'signups desc', limit: number = 50) => {

--- a/apps/stats/src/utils/audience.ts
+++ b/apps/stats/src/utils/audience.ts
@@ -1,10 +1,4 @@
-import {ALL_AUDIENCES, AUDIENCE_BITS} from '@src/utils/constants';
-
-export const AUDIENCE_TYPES = [
-    {name: 'Public visitors', value: 'undefined', bit: AUDIENCE_BITS.PUBLIC},
-    {name: 'Free members', value: 'free', bit: AUDIENCE_BITS.FREE},
-    {name: 'Paid members', value: 'paid', bit: AUDIENCE_BITS.PAID}
-];
+import {ALL_AUDIENCES, AUDIENCE_BITS, AUDIENCE_TYPES} from './constants';
 
 /**
  * Derive audience bitmask from filter values

--- a/apps/stats/src/utils/constants.ts
+++ b/apps/stats/src/utils/constants.ts
@@ -74,3 +74,9 @@ export const AUDIENCE_BITS = {
 
 // All audiences selected (PUBLIC | FREE | PAID = 7)
 export const ALL_AUDIENCES = AUDIENCE_BITS.PUBLIC | AUDIENCE_BITS.FREE | AUDIENCE_BITS.PAID;
+
+export const AUDIENCE_TYPES = [
+    {name: 'Public visitors', value: 'undefined', bit: AUDIENCE_BITS.PUBLIC},
+    {name: 'Free members', value: 'free', bit: AUDIENCE_BITS.FREE},
+    {name: 'Paid members', value: 'paid', bit: AUDIENCE_BITS.PAID}
+];

--- a/apps/stats/src/views/Stats/Overview/overview.tsx
+++ b/apps/stats/src/views/Stats/Overview/overview.tsx
@@ -8,7 +8,7 @@ import StatsView from '../layout/stats-view';
 import TopPosts from './components/top-posts';
 import {ALL_AUDIENCES} from '@src/utils/constants';
 import {GhAreaChartDataItem, H3, LucideIcon, NavbarActions, centsToDollars, cn, formatNumber, formatQueryDate, getRangeDates, sanitizeChartData} from '@tryghost/shade';
-import {getAudienceQueryParam} from '../components/audience-select';
+import {getAudienceQueryParam} from '@src/utils/audience';
 import {useAppContext} from '@src/app';
 import {useGlobalData} from '@src/providers/global-data-provider';
 import {useGrowthStats} from '@hooks/use-growth-stats';

--- a/apps/stats/src/views/Stats/Web/components/top-content.tsx
+++ b/apps/stats/src/views/Stats/Web/components/top-content.tsx
@@ -1,6 +1,6 @@
 import {Button, Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle, DataList, DataListBar, DataListBody, DataListHead, DataListHeader, DataListItemContent, DataListItemValue, DataListItemValueAbs, DataListItemValuePerc, DataListRow, EmptyIndicator, LucideIcon, Separator, Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle, SheetTrigger, SkeletonTable, Tabs, TabsList, TabsTrigger, formatNumber, formatPercentage, formatQueryDate, getRangeDates} from '@tryghost/shade';
 import {CONTENT_TYPES, ContentType, getContentDescription, getContentTitle} from '@src/utils/content-helpers';
-import {getAudienceQueryParam} from '../../components/audience-select';
+import {getAudienceQueryParam} from '@src/utils/audience';
 import {getClickHandler} from '@src/utils/url-helpers';
 import {getPeriodText} from '@src/utils/chart-helpers';
 import {useGlobalData} from '@src/providers/global-data-provider';

--- a/apps/stats/src/views/Stats/Web/web.tsx
+++ b/apps/stats/src/views/Stats/Web/web.tsx
@@ -12,7 +12,7 @@ import {Card, CardContent, NavbarActions, createFilter, formatDuration, formatNu
 import {KpiMetric} from '@src/types/kpi';
 import {Navigate, useAppContext, useTinybirdQuery} from '@tryghost/admin-x-framework';
 import {STATS_DEFAULT_SOURCE_ICON_URL} from '@src/utils/constants';
-import {getAudienceFromFilterValues, getAudienceQueryParam} from '../components/audience-select';
+import {getAudienceFromFilterValues, getAudienceQueryParam} from '@src/utils/audience';
 import {useFilterParams} from '@hooks/use-filter-params';
 import {useGlobalData} from '@src/providers/global-data-provider';
 

--- a/apps/stats/src/views/Stats/components/stats-filter.tsx
+++ b/apps/stats/src/views/Stats/components/stats-filter.tsx
@@ -4,7 +4,7 @@ import enLocale from 'i18n-iso-countries/langs/en.json';
 import {Button, Filter, FilterFieldConfig, Filters, LucideIcon} from '@tryghost/shade';
 import {STATS_LABEL_MAPPINGS, UNKNOWN_LOCATION_VALUES} from '@src/utils/constants';
 import {formatQueryDate, getRangeDates} from '@tryghost/shade';
-import {getAudienceFromFilterValues, getAudienceQueryParam} from './audience-select';
+import {getAudienceFromFilterValues, getAudienceQueryParam} from '@src/utils/audience';
 import {useAppContext} from '@src/app';
 import {useGlobalData} from '@src/providers/global-data-provider';
 import {useTinybirdQuery} from '@tryghost/admin-x-framework';

--- a/apps/stats/test/unit/hooks/use-top-sources-growth.test.tsx
+++ b/apps/stats/test/unit/hooks/use-top-sources-growth.test.tsx
@@ -13,15 +13,14 @@ vi.mock('@tryghost/admin-x-framework/api/referrers', () => ({
     useTopSourcesGrowth: vi.fn()
 }));
 
-vi.mock('@src/views/Stats/components/audience-select', () => ({
-    getAudienceQueryParam: vi.fn(),
-    ALL_AUDIENCES: 7 // Binary 111 = all audiences
+vi.mock('@src/utils/audience', () => ({
+    getAudienceQueryParam: vi.fn()
 }));
 
 const mockFormatQueryDate = vi.mocked(await import('@tryghost/shade')).formatQueryDate;
 const mockGetRangeDates = vi.mocked(await import('@tryghost/shade')).getRangeDates;
 const mockUseTopSourcesGrowthAPI = vi.mocked(await import('@tryghost/admin-x-framework/api/referrers')).useTopSourcesGrowth;
-const mockGetAudienceQueryParam = vi.mocked(await import('@views/Stats/components/audience-select')).getAudienceQueryParam;
+const mockGetAudienceQueryParam = vi.mocked(await import('@src/utils/audience')).getAudienceQueryParam;
 
 describe('useTopSourcesGrowth', () => {
     const mockStartDate = new Date('2024-01-01');


### PR DESCRIPTION
no ref

This is part of a series of commits to clean up the business logic in the stats/posts apps.

There's still a lot of duplication but rather than push the analytics-specific utils into admin-x-framework, it seems reasonable to continue the duplication until we merge the apps into the React Admin app.