### PR TITLE
Removed Should.js from brute middleware tests

### DIFF
--- a/ghost/core/test/unit/server/web/shared/middleware/brute.test.js
+++ b/ghost/core/test/unit/server/web/shared/middleware/brute.test.js
@@ -1,4 +1,4 @@
-const should = require('should');
+const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const brute = require('../../../../../../core/server/web/shared/middleware/brute');
 
@@ -8,7 +8,7 @@ describe('brute middleware', function () {
     });
 
     it('exports a contentApiKey method', function () {
-        should.equal(typeof brute.contentApiKey, 'function');
+        assert.equal(typeof brute.contentApiKey, 'function');
     });
 
     describe('contentApiKey', function () {
@@ -23,7 +23,7 @@ describe('brute middleware', function () {
             } catch (err) {
                 // I don't care
             } finally {
-                should.equal(contentApiKeyStub.called, true);
+                sinon.assert.called(contentApiKeyStub);
             }
         });
     });


### PR DESCRIPTION
This is a test-only change that should have no user impact.

We want to migrate off Should.js. This moves it to `node:assert` and Sinon assertions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Migrates the `brute` middleware unit test off Should.js to modern assertion patterns.
> 
> - Swaps `should` for `node:assert/strict` and uses `sinon.assert.called` in `ghost/core/test/unit/server/web/shared/middleware/brute.test.js`
> - Test-only refactor; no production code changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5837ff030befefbae9521dfbeff3fd9f0623d811. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->