### PR TITLE
Removed Should.js from middleware tests

### DIFF
--- a/ghost/core/test/unit/server/web/shared/middleware/api/spam-prevention.test.js
+++ b/ghost/core/test/unit/server/web/shared/middleware/api/spam-prevention.test.js
@@ -1,9 +1,9 @@
-const should = require('should');
+const assert = require('node:assert/strict');
 const spamPrevention = require('../../../../../../../core/server/web/shared/middleware/api/spam-prevention');
 
 describe('Spam Prevention', function () {
     it('exports a contentApiKey method', function () {
-        should.equal(typeof spamPrevention.contentApiKey, 'function');
+        assert.equal(typeof spamPrevention.contentApiKey, 'function');
     });
 
     describe('contentApiKey method', function () {
@@ -11,7 +11,7 @@ describe('Spam Prevention', function () {
             const ExpressBrute = require('express-brute');
             const result = spamPrevention.contentApiKey();
 
-            should.equal(result instanceof ExpressBrute, true);
+            assert(result instanceof ExpressBrute);
         });
     });
 });

--- a/ghost/core/test/unit/server/web/shared/middleware/cache-control.test.js
+++ b/ghost/core/test/unit/server/web/shared/middleware/cache-control.test.js
@@ -1,4 +1,4 @@
-const should = require('should');
+const assert = require('node:assert/strict');
 const sinon = require('sinon');
 
 const cacheControl = require('../../../../../../core/server/web/shared/middleware/cache-control');
@@ -18,55 +18,55 @@ describe('Cache-Control middleware', function () {
 
     it('correctly sets the public profile headers', function (done) {
         cacheControl('public')(null, res, function (a) {
-            should.not.exist(a);
-            res.set.calledOnce.should.be.true();
-            res.set.calledWith({'Cache-Control': 'public, max-age=0'}).should.be.true();
+            assert(!a);
+            sinon.assert.calledOnce(res.set);
+            sinon.assert.calledWith(res.set, {'Cache-Control': 'public, max-age=0'});
             done();
         });
     });
 
     it('correctly sets the public profile headers with custom maxAge', function (done) {
         cacheControl('public', {maxAge: 123456})(null, res, function (a) {
-            should.not.exist(a);
-            res.set.calledOnce.should.be.true();
-            res.set.calledWith({'Cache-Control': 'public, max-age=123456'}).should.be.true();
+            assert(!a);
+            sinon.assert.calledOnce(res.set);
+            sinon.assert.calledWith(res.set, {'Cache-Control': 'public, max-age=123456'});
             done();
         });
     });
 
     it('correctly sets the public profile headers with staleWhileRevalidate', function (done) {
         cacheControl('public', {maxAge: 1, staleWhileRevalidate: 9})(null, res, function (a) {
-            should.not.exist(a);
-            res.set.calledOnce.should.be.true();
-            res.set.calledWith({'Cache-Control': 'public, max-age=1, stale-while-revalidate=9'}).should.be.true();
+            assert(!a);
+            sinon.assert.calledOnce(res.set);
+            sinon.assert.calledWith(res.set, {'Cache-Control': 'public, max-age=1, stale-while-revalidate=9'});
             done();
         });
     });
 
     it('correctly sets the private profile headers', function (done) {
         cacheControl('private')(null, res, function (a) {
-            should.not.exist(a);
-            res.set.calledOnce.should.be.true();
-            res.set.calledWith({
+            assert(!a);
+            sinon.assert.calledOnce(res.set);
+            sinon.assert.calledWith(res.set, {
                 'Cache-Control': 'no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0'
-            }).should.be.true();
+            });
             done();
         });
     });
 
     it('correctly sets the noCache profile headers', function (done) {
         cacheControl('noCache')(null, res, function (a) {
-            should.not.exist(a);
-            res.set.calledOnce.should.be.true();
-            res.set.calledWith({'Cache-Control': 'no-cache, max-age=0, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0'}).should.be.true();
+            assert(!a);
+            sinon.assert.calledOnce(res.set);
+            sinon.assert.calledWith(res.set, {'Cache-Control': 'no-cache, max-age=0, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0'});
             done();
         });
     });
 
     it('will not set headers without a profile', function (done) {
         cacheControl()(null, res, function (a) {
-            should.not.exist(a);
-            res.set.called.should.be.false();
+            assert(!a);
+            sinon.assert.notCalled(res.set);
             done();
         });
     });
@@ -76,23 +76,23 @@ describe('Cache-Control middleware', function () {
         const privateCC = cacheControl('private');
 
         publicCC(null, res, function () {
-            res.set.calledOnce.should.be.true();
-            res.set.calledWith({'Cache-Control': 'public, max-age=0'}).should.be.true();
+            sinon.assert.calledOnce(res.set);
+            sinon.assert.calledWith(res.set, {'Cache-Control': 'public, max-age=0'});
 
             privateCC(null, res, function () {
-                res.set.calledTwice.should.be.true();
-                res.set.calledWith({
+                sinon.assert.calledTwice(res.set);
+                sinon.assert.calledWith(res.set, {
                     'Cache-Control': 'no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0'
-                }).should.be.true();
+                });
 
                 publicCC(null, res, function () {
-                    res.set.calledThrice.should.be.true();
-                    res.set.calledWith({'Cache-Control': 'public, max-age=0'});
+                    sinon.assert.calledThrice(res.set);
+                    sinon.assert.calledWith(res.set, {'Cache-Control': 'public, max-age=0'});
 
                     privateCC(null, res, function () {
-                        res.set.calledWith({
+                        sinon.assert.calledWith(res.set, {
                             'Cache-Control': 'no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0'
-                        }).should.be.true();
+                        });
                         done();
                     });
                 });

--- a/ghost/core/test/unit/server/web/shared/middleware/redirect-amp-urls.test.js
+++ b/ghost/core/test/unit/server/web/shared/middleware/redirect-amp-urls.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const redirectAmpUrls = require('../../../../../../core/server/web/shared/middleware/redirect-amp-urls');
 
@@ -25,8 +26,8 @@ describe('Middleware: redirectAmpUrls', function () {
 
             redirectAmpUrls(req, res, next);
 
-            next.calledOnce.should.be.true();
-            res.redirect.called.should.be.false();
+            sinon.assert.calledOnce(next);
+            sinon.assert.notCalled(res.redirect);
         });
 
         it('should call next() when URL contains amp but not at the end', function () {
@@ -34,8 +35,8 @@ describe('Middleware: redirectAmpUrls', function () {
 
             redirectAmpUrls(req, res, next);
 
-            next.calledOnce.should.be.true();
-            res.redirect.called.should.be.false();
+            sinon.assert.calledOnce(next);
+            sinon.assert.notCalled(res.redirect);
         });
 
         it('should call next() when URL has amp in the middle', function () {
@@ -43,8 +44,8 @@ describe('Middleware: redirectAmpUrls', function () {
 
             redirectAmpUrls(req, res, next);
 
-            next.calledOnce.should.be.true();
-            res.redirect.called.should.be.false();
+            sinon.assert.calledOnce(next);
+            sinon.assert.notCalled(res.redirect);
         });
 
         it('should call next() when URL is root path', function () {
@@ -52,8 +53,8 @@ describe('Middleware: redirectAmpUrls', function () {
 
             redirectAmpUrls(req, res, next);
 
-            next.calledOnce.should.be.true();
-            res.redirect.called.should.be.false();
+            sinon.assert.calledOnce(next);
+            sinon.assert.notCalled(res.redirect);
         });
 
         it('should call next() when URL is empty', function () {
@@ -61,8 +62,8 @@ describe('Middleware: redirectAmpUrls', function () {
 
             redirectAmpUrls(req, res, next);
 
-            next.calledOnce.should.be.true();
-            res.redirect.called.should.be.false();
+            sinon.assert.calledOnce(next);
+            sinon.assert.notCalled(res.redirect);
         });
     });
 
@@ -72,9 +73,9 @@ describe('Middleware: redirectAmpUrls', function () {
 
             redirectAmpUrls(req, res, next);
 
-            next.called.should.be.false();
-            res.redirect.calledOnce.should.be.true();
-            res.redirect.calledWith(301, '/welcome/').should.be.true();
+            sinon.assert.notCalled(next);
+            sinon.assert.calledOnce(res.redirect);
+            sinon.assert.calledWith(res.redirect, 301, '/welcome/');
         });
 
         it('should redirect nested path /blog/post/amp/ to /blog/post/', function () {
@@ -82,9 +83,9 @@ describe('Middleware: redirectAmpUrls', function () {
 
             redirectAmpUrls(req, res, next);
 
-            next.called.should.be.false();
-            res.redirect.calledOnce.should.be.true();
-            res.redirect.calledWith(301, '/blog/post/').should.be.true();
+            sinon.assert.notCalled(next);
+            sinon.assert.calledOnce(res.redirect);
+            sinon.assert.calledWith(res.redirect, 301, '/blog/post/');
         });
 
         it('should redirect root /amp/ to /', function () {
@@ -92,9 +93,9 @@ describe('Middleware: redirectAmpUrls', function () {
 
             redirectAmpUrls(req, res, next);
 
-            next.called.should.be.false();
-            res.redirect.calledOnce.should.be.true();
-            res.redirect.calledWith(301, '/').should.be.true();
+            sinon.assert.notCalled(next);
+            sinon.assert.calledOnce(res.redirect);
+            sinon.assert.calledWith(res.redirect, 301, '/');
         });
     });
 
@@ -104,9 +105,9 @@ describe('Middleware: redirectAmpUrls', function () {
 
             redirectAmpUrls(req, res, next);
 
-            next.called.should.be.false();
-            res.redirect.calledOnce.should.be.true();
-            res.redirect.calledWith(301, '/welcome/').should.be.true();
+            sinon.assert.notCalled(next);
+            sinon.assert.calledOnce(res.redirect);
+            sinon.assert.calledWith(res.redirect, 301, '/welcome/');
         });
 
         it('should redirect nested path /blog/post/amp to /blog/post/', function () {
@@ -114,9 +115,9 @@ describe('Middleware: redirectAmpUrls', function () {
 
             redirectAmpUrls(req, res, next);
 
-            next.called.should.be.false();
-            res.redirect.calledOnce.should.be.true();
-            res.redirect.calledWith(301, '/blog/post/').should.be.true();
+            sinon.assert.notCalled(next);
+            sinon.assert.calledOnce(res.redirect);
+            sinon.assert.calledWith(res.redirect, 301, '/blog/post/');
         });
 
         it('should redirect root /amp to /', function () {
@@ -124,9 +125,9 @@ describe('Middleware: redirectAmpUrls', function () {
 
             redirectAmpUrls(req, res, next);
 
-            next.called.should.be.false();
-            res.redirect.calledOnce.should.be.true();
-            res.redirect.calledWith(301, '/').should.be.true();
+            sinon.assert.notCalled(next);
+            sinon.assert.calledOnce(res.redirect);
+            sinon.assert.calledWith(res.redirect, 301, '/');
         });
     });
 
@@ -136,9 +137,9 @@ describe('Middleware: redirectAmpUrls', function () {
 
             redirectAmpUrls(req, res, next);
 
-            next.called.should.be.false();
-            res.redirect.calledOnce.should.be.true();
-            res.redirect.calledWith(301, '/welcome/').should.be.true();
+            sinon.assert.notCalled(next);
+            sinon.assert.calledOnce(res.redirect);
+            sinon.assert.calledWith(res.redirect, 301, '/welcome/');
         });
 
         it('should redirect /welcome/Amp to /welcome/ (mixed case)', function () {
@@ -146,9 +147,9 @@ describe('Middleware: redirectAmpUrls', function () {
 
             redirectAmpUrls(req, res, next);
 
-            next.called.should.be.false();
-            res.redirect.calledOnce.should.be.true();
-            res.redirect.calledWith(301, '/welcome/').should.be.true();
+            sinon.assert.notCalled(next);
+            sinon.assert.calledOnce(res.redirect);
+            sinon.assert.calledWith(res.redirect, 301, '/welcome/');
         });
 
         it('should redirect /welcome/AmP/ to /welcome/ (mixed case with trailing slash)', function () {
@@ -156,9 +157,9 @@ describe('Middleware: redirectAmpUrls', function () {
 
             redirectAmpUrls(req, res, next);
 
-            next.called.should.be.false();
-            res.redirect.calledOnce.should.be.true();
-            res.redirect.calledWith(301, '/welcome/').should.be.true();
+            sinon.assert.notCalled(next);
+            sinon.assert.calledOnce(res.redirect);
+            sinon.assert.calledWith(res.redirect, 301, '/welcome/');
         });
     });
 
@@ -168,9 +169,9 @@ describe('Middleware: redirectAmpUrls', function () {
 
             redirectAmpUrls(req, res, next);
 
-            next.called.should.be.false();
-            res.redirect.calledOnce.should.be.true();
-            res.redirect.calledWith(301, '/qs-check/?q=1').should.be.true();
+            sinon.assert.notCalled(next);
+            sinon.assert.calledOnce(res.redirect);
+            sinon.assert.calledWith(res.redirect, 301, '/qs-check/?q=1');
         });
 
         it('should preserve query string when redirecting /welcome/amp?q=1&r=2', function () {
@@ -178,9 +179,9 @@ describe('Middleware: redirectAmpUrls', function () {
 
             redirectAmpUrls(req, res, next);
 
-            next.called.should.be.false();
-            res.redirect.calledOnce.should.be.true();
-            res.redirect.calledWith(301, '/welcome/?q=1&r=2').should.be.true();
+            sinon.assert.notCalled(next);
+            sinon.assert.calledOnce(res.redirect);
+            sinon.assert.calledWith(res.redirect, 301, '/welcome/?q=1&r=2');
         });
 
         it('should preserve complex query string when redirecting root /amp/?search=test&page=2', function () {
@@ -188,9 +189,9 @@ describe('Middleware: redirectAmpUrls', function () {
 
             redirectAmpUrls(req, res, next);
 
-            next.called.should.be.false();
-            res.redirect.calledOnce.should.be.true();
-            res.redirect.calledWith(301, '/?search=test&page=2').should.be.true();
+            sinon.assert.notCalled(next);
+            sinon.assert.calledOnce(res.redirect);
+            sinon.assert.calledWith(res.redirect, 301, '/?search=test&page=2');
         });
 
         it('should handle encoded query parameters', function () {
@@ -198,9 +199,9 @@ describe('Middleware: redirectAmpUrls', function () {
 
             redirectAmpUrls(req, res, next);
 
-            next.called.should.be.false();
-            res.redirect.calledOnce.should.be.true();
-            res.redirect.calledWith(301, '/welcome/?q=hello%20world').should.be.true();
+            sinon.assert.notCalled(next);
+            sinon.assert.calledOnce(res.redirect);
+            sinon.assert.calledWith(res.redirect, 301, '/welcome/?q=hello%20world');
         });
     });
 
@@ -210,9 +211,9 @@ describe('Middleware: redirectAmpUrls', function () {
 
             redirectAmpUrls(req, res, next);
 
-            next.called.should.be.false();
-            res.redirect.calledOnce.should.be.true();
-            res.redirect.calledWith(301, '/welcome%20post/').should.be.true();
+            sinon.assert.notCalled(next);
+            sinon.assert.calledOnce(res.redirect);
+            sinon.assert.calledWith(res.redirect, 301, '/welcome%20post/');
         });
     });
 
@@ -222,9 +223,9 @@ describe('Middleware: redirectAmpUrls', function () {
 
             redirectAmpUrls(req, res, next);
 
-            next.called.should.be.false();
-            res.redirect.calledOnce.should.be.true();
-            res.redirect.calledWith(301, '/blog/subdir/welcome/').should.be.true();
+            sinon.assert.notCalled(next);
+            sinon.assert.calledOnce(res.redirect);
+            sinon.assert.calledWith(res.redirect, 301, '/blog/subdir/welcome/');
         });
 
         it('should handle complex subdirectory paths with query strings', function () {
@@ -232,9 +233,9 @@ describe('Middleware: redirectAmpUrls', function () {
 
             redirectAmpUrls(req, res, next);
 
-            next.called.should.be.false();
-            res.redirect.calledOnce.should.be.true();
-            res.redirect.calledWith(301, '/ghost/blog/2023/post-title/?utm_source=test').should.be.true();
+            sinon.assert.notCalled(next);
+            sinon.assert.calledOnce(res.redirect);
+            sinon.assert.calledWith(res.redirect, 301, '/ghost/blog/2023/post-title/?utm_source=test');
         });
     });
 
@@ -245,11 +246,11 @@ describe('Middleware: redirectAmpUrls', function () {
 
             redirectAmpUrls(req, res, next);
 
-            next.called.should.be.false();
-            res.redirect.calledOnce.should.be.true();
+            sinon.assert.notCalled(next);
+            sinon.assert.calledOnce(res.redirect);
             // The exact result depends on removeOpenRedirectFromUrl implementation
             // but we're testing that the middleware calls it
-            res.redirect.firstCall.args[1].should.be.a.String();
+            assert.equal(typeof res.redirect.firstCall.args[1], 'string');
         });
     });
 
@@ -259,8 +260,8 @@ describe('Middleware: redirectAmpUrls', function () {
 
             redirectAmpUrls(req, res, next);
 
-            next.calledOnce.should.be.true();
-            res.redirect.called.should.be.false();
+            sinon.assert.calledOnce(next);
+            sinon.assert.notCalled(res.redirect);
         });
 
         it('should handle multiple consecutive slashes', function () {
@@ -268,10 +269,10 @@ describe('Middleware: redirectAmpUrls', function () {
 
             redirectAmpUrls(req, res, next);
 
-            next.called.should.be.false();
-            res.redirect.calledOnce.should.be.true();
+            sinon.assert.notCalled(next);
+            sinon.assert.calledOnce(res.redirect);
             // The removeOpenRedirectFromUrl should clean up double slashes
-            res.redirect.calledWith(301, '/welcome/').should.be.true();
+            sinon.assert.calledWith(res.redirect, 301, '/welcome/');
         });
     });
 });

--- a/ghost/core/test/unit/server/web/shared/middleware/uncapitalise.test.js
+++ b/ghost/core/test/unit/server/web/shared/middleware/uncapitalise.test.js
@@ -1,4 +1,3 @@
-const should = require('should');
 const sinon = require('sinon');
 const uncapitalise = require('../../../../../../core/server/web/shared/middleware/uncapitalise');
 
@@ -27,7 +26,7 @@ describe('Middleware: uncapitalise', function () {
             req.path = '/ghost/signup/';
             uncapitalise(req, res, next);
 
-            next.calledOnce.should.be.true();
+            sinon.assert.calledOnce(next);
             done();
         });
 
@@ -36,7 +35,7 @@ describe('Middleware: uncapitalise', function () {
             req.path = '';
             uncapitalise(req, res, next);
 
-            next.calledOnce.should.be.true();
+            sinon.assert.calledOnce(next);
             done();
         });
 
@@ -46,7 +45,7 @@ describe('Middleware: uncapitalise', function () {
 
             uncapitalise(req, res, next);
 
-            next.calledOnce.should.be.true();
+            sinon.assert.calledOnce(next);
             done();
         });
 
@@ -55,7 +54,7 @@ describe('Middleware: uncapitalise', function () {
             req.path = '/ghost/reset/NCR3NjY4NzI1ODI1OHzlcmlzZHNAZ51haWwuY29tfEpWeGxRWHUzZ3Y0cEpQRkNYYzQvbUZyc2xFSVozU3lIZHZWeFJLRml6cY54';
             uncapitalise(req, res, next);
 
-            next.calledOnce.should.be.true();
+            sinon.assert.calledOnce(next);
             done();
         });
 
@@ -65,9 +64,9 @@ describe('Middleware: uncapitalise', function () {
 
             uncapitalise(req, res, next);
 
-            next.called.should.be.false();
-            res.redirect.calledOnce.should.be.true();
-            res.redirect.calledWith(301, '/ghost/signup/').should.be.true();
+            sinon.assert.notCalled(next);
+            sinon.assert.calledOnce(res.redirect);
+            sinon.assert.calledWith(res.redirect, 301, '/ghost/signup/');
             done();
         });
 
@@ -79,9 +78,9 @@ describe('Middleware: uncapitalise', function () {
 
             uncapitalise(req, res, next);
 
-            next.called.should.be.false();
-            res.redirect.calledOnce.should.be.true();
-            res.redirect.calledWith(301, '/ghost/signup/').should.be.true();
+            sinon.assert.notCalled(next);
+            sinon.assert.calledOnce(res.redirect);
+            sinon.assert.calledWith(res.redirect, 301, '/ghost/signup/');
             done();
         });
 
@@ -93,9 +92,9 @@ describe('Middleware: uncapitalise', function () {
 
             uncapitalise(req, res, next);
 
-            next.called.should.be.false();
-            res.redirect.calledOnce.should.be.true();
-            res.redirect.calledWith(301, '/blog/ghost/signup/').should.be.true();
+            sinon.assert.notCalled(next);
+            sinon.assert.calledOnce(res.redirect);
+            sinon.assert.calledWith(res.redirect, 301, '/blog/ghost/signup/');
             done();
         });
 
@@ -105,9 +104,9 @@ describe('Middleware: uncapitalise', function () {
 
             uncapitalise(req, res, next);
 
-            next.called.should.be.false();
-            res.redirect.calledOnce.should.be.true();
-            res.redirect.calledWith(301, '/ghost/signup/XEB123').should.be.true();
+            sinon.assert.notCalled(next);
+            sinon.assert.calledOnce(res.redirect);
+            sinon.assert.calledWith(res.redirect, 301, '/ghost/signup/XEB123');
             done();
         });
 
@@ -119,9 +118,9 @@ describe('Middleware: uncapitalise', function () {
 
             uncapitalise(req, res, next);
 
-            next.called.should.be.false();
-            res.redirect.calledOnce.should.be.true();
-            res.redirect.calledWith(301, '/blog/ghost/reset/NCR3NjY4NzI1ODI1OHzlcmlzZHNAZ51haWwuY29tfEpWeGxRWHUzZ3Y0cEpQRkNYYzQvbUZyc2xFSVozU3lIZHZWeFJLRml6cY54').should.be.true();
+            sinon.assert.notCalled(next);
+            sinon.assert.calledOnce(res.redirect);
+            sinon.assert.calledWith(res.redirect, 301, '/blog/ghost/reset/NCR3NjY4NzI1ODI1OHzlcmlzZHNAZ51haWwuY29tfEpWeGxRWHUzZ3Y0cEpQRkNYYzQvbUZyc2xFSVozU3lIZHZWeFJLRml6cY54');
             done();
         });
     });
@@ -137,7 +136,7 @@ describe('Middleware: uncapitalise', function () {
                     req.path = `/ghost/api${getApiPath(apiVersion)}/endpoint/`;
                     uncapitalise(req, res, next);
 
-                    next.calledOnce.should.be.true();
+                    sinon.assert.calledOnce(next);
                     done();
                 });
 
@@ -153,9 +152,9 @@ describe('Middleware: uncapitalise', function () {
 
                     uncapitalise(req, res, next);
 
-                    next.called.should.be.false();
-                    res.redirect.calledOnce.should.be.true();
-                    res.redirect.calledWith(301, `/ghost/api${getApiPath(apiVersion)}/endpoint/`).should.be.true();
+                    sinon.assert.notCalled(next);
+                    sinon.assert.calledOnce(res.redirect);
+                    sinon.assert.calledWith(res.redirect, 301, `/ghost/api${getApiPath(apiVersion)}/endpoint/`);
                     done();
                 });
 
@@ -165,9 +164,9 @@ describe('Middleware: uncapitalise', function () {
 
                     uncapitalise(req, res, next);
 
-                    next.called.should.be.false();
-                    res.redirect.calledOnce.should.be.true();
-                    res.redirect.calledWith(301, `/ghost/api${getApiPath(apiVersion)}/asdfj/`).should.be.true();
+                    sinon.assert.notCalled(next);
+                    sinon.assert.calledOnce(res.redirect);
+                    sinon.assert.calledWith(res.redirect, 301, `/ghost/api${getApiPath(apiVersion)}/asdfj/`);
                     done();
                 });
 
@@ -179,9 +178,9 @@ describe('Middleware: uncapitalise', function () {
 
                     uncapitalise(req, res, next);
 
-                    next.called.should.be.false();
-                    res.redirect.calledOnce.should.be.true();
-                    res.redirect.calledWith(301, `/blog/ghost/api${getApiPath(apiVersion)}/asdfj/`).should.be.true();
+                    sinon.assert.notCalled(next);
+                    sinon.assert.calledOnce(res.redirect);
+                    sinon.assert.calledWith(res.redirect, 301, `/blog/ghost/api${getApiPath(apiVersion)}/asdfj/`);
                     done();
                 });
 
@@ -192,9 +191,9 @@ describe('Middleware: uncapitalise', function () {
 
                     uncapitalise(req, res, next);
 
-                    next.called.should.be.false();
-                    res.redirect.calledOnce.should.be.true();
-                    res.redirect.calledWith(301, `/ghost/api${getApiPath(apiVersion)}/settings/is_private/${query}`).should.be.true();
+                    sinon.assert.notCalled(next);
+                    sinon.assert.calledOnce(res.redirect);
+                    sinon.assert.calledWith(res.redirect, 301, `/ghost/api${getApiPath(apiVersion)}/settings/is_private/${query}`);
                     done();
                 });
 
@@ -207,9 +206,9 @@ describe('Middleware: uncapitalise', function () {
 
                     uncapitalise(req, res, next);
 
-                    next.called.should.be.false();
-                    res.redirect.calledOnce.should.be.true();
-                    res.redirect.calledWith(301, `/blog/ghost/api${getApiPath(apiVersion)}/mail/test@example.COM/${query}`).should.be.true();
+                    sinon.assert.notCalled(next);
+                    sinon.assert.calledOnce(res.redirect);
+                    sinon.assert.calledWith(res.redirect, 301, `/blog/ghost/api${getApiPath(apiVersion)}/mail/test@example.COM/${query}`);
                     done();
                 });
             });
@@ -221,7 +220,7 @@ describe('Middleware: uncapitalise', function () {
             req.path = '/this-is-my-blog-post';
             uncapitalise(req, res, next);
 
-            next.calledOnce.should.be.true();
+            sinon.assert.calledOnce(next);
             done();
         });
 
@@ -231,9 +230,9 @@ describe('Middleware: uncapitalise', function () {
 
             uncapitalise(req, res, next);
 
-            next.called.should.be.false();
-            res.redirect.calledOnce.should.be.true();
-            res.redirect.calledWith(301, '/this-is-my-blog-post').should.be.true();
+            sinon.assert.notCalled(next);
+            sinon.assert.calledOnce(res.redirect);
+            sinon.assert.calledWith(res.redirect, 301, '/this-is-my-blog-post');
             done();
         });
     });


### PR DESCRIPTION
This test-only change should have no user impact.

We want to drop Should.js in favor of Node's assert and Sinon asserts. This does that for all of our middleware specs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Modernizes middleware unit tests by removing `should` and using `node:assert/strict` with `sinon.assert` for expectations.
> 
> - Updates tests for `cache-control`, `redirect-amp-urls`, `uncapitalise`, and `api/spam-prevention` to use `assert` and Sinon spy assertions
> - Swaps patterns like `should.*` and `*.should.be.*()` to `assert(...)`/`assert.equal(...)` and `sinon.assert.*`, keeping test behavior equivalent
> - No application/runtime code changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e7e41248313d77f171eeabeea2f781278ef61c79. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->