### PR TITLE
Fixed closing of link input in member welcome email editor

### DIFF
--- a/apps/admin-x-design-system/src/global/modal/modal.tsx
+++ b/apps/admin-x-design-system/src/global/modal/modal.tsx
@@ -97,6 +97,12 @@ const Modal = forwardRef<HTMLElement, ModalProps>(({
     useEffect(() => {
         const handleEscapeKey = (event: KeyboardEvent) => {
             if (event.key === 'Escape') {
+                // Don't close modal if user is in Koenig's link input (which handles ESC itself)
+                const activeEl = document.activeElement;
+                if (activeEl?.hasAttribute('data-kg-link-input')) {
+                    return;
+                }
+
                 // Fix for Safari - if an element in the modal is focused, closing it will jump to
                 // the bottom of the page because Safari tries to focus the "next" element in the DOM
                 if (document.activeElement && document.activeElement instanceof HTMLElement) {

--- a/apps/admin-x-settings/src/main-content.tsx
+++ b/apps/admin-x-settings/src/main-content.tsx
@@ -32,6 +32,12 @@ const MainContent: React.FC = () => {
     useEffect(() => {
         const handleKeyDown = (event: KeyboardEvent) => {
             if (event.key === 'Escape') {
+                // Don't navigate away if a modal is open - let the modal handle ESC
+                const modalBackdrop = document.getElementById('modal-backdrop');
+                if (modalBackdrop) {
+                    return;
+                }
+
                 confirmIfDirty(isDirty, () => {
                     navigateAway('/');
                 });

--- a/apps/admin-x-settings/test/acceptance/membership/member-welcome-emails.test.ts
+++ b/apps/admin-x-settings/test/acceptance/membership/member-welcome-emails.test.ts
@@ -106,5 +106,68 @@ test.describe('Member emails settings', async () => {
             // Verify modal is closed
             await expect(modal).not.toBeVisible();
         });
+
+        test('Escape key does not close modal or navigate away when pressed from Koenig link input', async ({page}) => {
+            // Config with welcomeEmails feature flag enabled
+            const configResponse = {
+                config: {
+                    ...responseFixtures.config.config,
+                    labs: {
+                        welcomeEmails: true
+                    }
+                }
+            };
+
+            await mockApi({page, requests: {
+                ...globalDataRequests,
+                browseConfig: {method: 'GET', path: '/config/', response: configResponse},
+                browseAutomatedEmails: {method: 'GET', path: '/automated_emails/', response: automatedEmailsFixture}
+            }});
+
+            // Navigate directly to the memberemails section
+            await page.goto('/#/memberemails');
+
+            // Wait for page to load
+            await page.waitForLoadState('networkidle');
+
+            const section = page.getByTestId('memberemails');
+            await expect(section).toBeVisible({timeout: 10000});
+
+            // Click the Edit button on the welcome email preview to open the modal
+            await section.getByTestId('free-welcome-email-edit-button').click();
+
+            const modal = page.getByTestId('welcome-email-modal');
+            await expect(modal).toBeVisible();
+
+            // Inject a mock link input with data-kg-link-input attribute (simulating Koenig's portal-rendered input)
+            // Koenig renders the link input in a portal outside the editor container
+            await page.evaluate(() => {
+                const mockInput = document.createElement('input');
+                mockInput.setAttribute('data-kg-link-input', '');
+                mockInput.setAttribute('type', 'text');
+                document.body.appendChild(mockInput);
+                mockInput.focus();
+            });
+
+            // Verify our mock input is focused
+            const linkInput = page.locator('[data-kg-link-input]');
+            await expect(linkInput).toBeFocused();
+
+            // Press Escape - should NOT close the modal and should NOT navigate away from settings
+            await page.keyboard.press('Escape');
+
+            // Verify modal is still open
+            await expect(modal).toBeVisible();
+
+            // Verify we didn't navigate away from settings
+            expect(page.url()).toContain('/#/memberemails');
+            const settingsContent = page.locator('#admin-x-settings-content');
+            await expect(settingsContent).toBeVisible();
+
+            // Clean up
+            await page.evaluate(() => {
+                document.querySelector('[data-kg-link-input]')?.remove();
+            });
+        });
     });
 });


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-852

When using Cmd+K to add a link in the welcome email editor, pressing ESC would close the entire modal (losing edits) and navigate away from settings, instead of just closing the link input.

### Changes

- `modal.tsx`: Skip closing when Koenig's link input is focused (`data-testid="link-input"`), allowing the ESC event to propagate to Koenig's handler which closes the input
- `main-content.tsx`: Skip navigation to dashboard when a modal is open (`#modal-backdrop` exists), since the modal's ESC handler doesn't stop propagation when it skips closing

### Manual Testing
- Open Settings > Welcome emails > Edit on a welcome email
- Type some text, select it, press Cmd+K to open the link input
- Press ESC
- Link input should close, modal should stay open, settings page should remain visible
- Press ESC again — modal should close normally

Related Koenig PR https://github.com/TryGhost/Koenig/pull/1693