### PR TITLE
🐛 Fixed Analytics Overview dates to use site timezone instead of UTC

### DIFF
--- a/apps/shade/test/unit/utils/utils.test.ts
+++ b/apps/shade/test/unit/utils/utils.test.ts
@@ -158,6 +158,24 @@ describe('utils', function () {
             const differentYearFormatted = formatDisplayDate('2020-12-31');
             assert.equal(differentYearFormatted, '31 Dec 2020');
         });
+
+        it('converts ISO date to site timezone when timezone is provided', function () {
+            // July 31, 2023 at midnight UTC - in America/New_York (UTC-4 in summer) this is July 30
+            const formatted = formatDisplayDate('2023-07-31T00:00:00Z', 'America/New_York');
+            assert.equal(formatted, '30 Jul 2023');
+        });
+
+        it('converts ISO date to site timezone correctly for positive offset', function () {
+            // July 30, 2023 at 11pm UTC - in Europe/Berlin (UTC+2 in summer) this is July 31
+            const formatted = formatDisplayDate('2023-07-30T23:00:00Z', 'Europe/Berlin');
+            assert.equal(formatted, '31 Jul 2023');
+        });
+
+        it('formats date in UTC when no timezone is provided for ISO dates', function () {
+            // July 31, 2023 at midnight UTC - should show July 31 without timezone conversion
+            const formatted = formatDisplayDate('2023-07-31T00:00:00Z');
+            assert.equal(formatted, '31 Jul 2023');
+        });
     });
 
     describe('formatNumber function', function () {

--- a/apps/stats/src/views/Stats/Growth/growth.tsx
+++ b/apps/stats/src/views/Stats/Growth/growth.tsx
@@ -40,7 +40,10 @@ type SourcesOrder = 'free_members desc' | 'paid_members desc' | 'mrr desc' | 'so
 type UnifiedSortOrder = TopPostsOrder | SourcesOrder;
 
 const Growth: React.FC = () => {
-    const {range, site} = useGlobalData();
+    const {range, site, settings} = useGlobalData();
+
+    // Get site timezone from settings for displaying dates consistently
+    const siteTimezone = String(settings.find(setting => setting.key === 'timezone')?.value || 'Etc/UTC');
     const navigate = useNavigate();
     const [sortBy, setSortBy] = useState<UnifiedSortOrder>('free_members desc');
     const [selectedContentType, setSelectedContentType] = useState<ContentType>(CONTENT_TYPES.POSTS_AND_PAGES);
@@ -232,7 +235,7 @@ const Growth: React.FC = () => {
                                                                 </span>
                                                             }
                                                             {post.published_at && formatDisplayDate && new Date(post.published_at).getTime() > 0 && (
-                                                                <span className='text-muted-foreground'>Published on {formatDisplayDate(post.published_at)}</span>
+                                                                <span className='text-muted-foreground'>Published on {formatDisplayDate(post.published_at, siteTimezone)}</span>
                                                             )}
                                                         </div>
                                                     </TableCell>

--- a/apps/stats/src/views/Stats/Newsletters/newsletters.tsx
+++ b/apps/stats/src/views/Stats/Newsletters/newsletters.tsx
@@ -34,6 +34,10 @@ const NewsletterTableRows: React.FC<{
     sortBy: TopNewslettersOrder;
 }> = React.memo(({range, selectedNewsletterId, shouldFetchStats, sortBy}) => {
     const navigate = useNavigate();
+    const {settings} = useGlobalData();
+
+    // Get site timezone from settings for displaying dates consistently
+    const siteTimezone = String(settings.find(setting => setting.key === 'timezone')?.value || 'Etc/UTC');
 
     // Fetch newsletter stats with reactive sort order - isolated to this component
     const {data: newsletterStatsData, isLoading: isStatsLoading, isClicksLoading} = useNewsletterStatsWithRangeSplit(
@@ -85,7 +89,7 @@ const NewsletterTableRows: React.FC<{
                                 </div>
                             </TableCell>
                             <TableCell className="whitespace-nowrap text-sm">
-                                {formatDisplayDate(post.send_date)}
+                                {formatDisplayDate(post.send_date, siteTimezone)}
                             </TableCell>
                             <TableCell className='text-right font-mono text-sm'>
                                 {formatNumber(post.sent_to)}

--- a/apps/stats/src/views/Stats/Overview/components/latest-post.tsx
+++ b/apps/stats/src/views/Stats/Overview/components/latest-post.tsx
@@ -36,6 +36,9 @@ const LatestPost: React.FC<LatestPostProps> = ({
     // Get site title from settings or site data
     const siteTitle = site.title || String(settings.find(setting => setting.key === 'title')?.value || 'Ghost Site');
 
+    // Get site timezone from settings for displaying dates consistently
+    const siteTimezone = String(settings.find(setting => setting.key === 'timezone')?.value || 'Etc/UTC');
+
     // Calculate metrics to show outside of JSX
     const metricsToShow = latestPostStats ? getPostMetricsToDisplay(latestPostStats as Post, {
         membersTrackSources: appSettings?.analytics.membersTrackSources
@@ -104,7 +107,7 @@ const LatestPost: React.FC<LatestPostProps> = ({
                                 <div className='mt-0.5 text-sm text-muted-foreground'>
                                     {latestPostStats.authors && latestPostStats.authors.length > 0 && (
                                         <div>
-                                            By {latestPostStats.authors.map(author => author.name).join(', ')} &ndash; {formatDisplayDate(latestPostStats.published_at)}
+                                            By {latestPostStats.authors.map(author => author.name).join(', ')} &ndash; {formatDisplayDate(latestPostStats.published_at, siteTimezone)}
                                         </div>
                                     )}
                                     <div className='mt-0.5'>

--- a/apps/stats/src/views/Stats/Overview/components/top-posts.tsx
+++ b/apps/stats/src/views/Stats/Overview/components/top-posts.tsx
@@ -58,8 +58,11 @@ const TopPosts: React.FC<TopPostsProps> = ({
     isLoading
 }) => {
     const navigate = useNavigate();
-    const {range} = useGlobalData();
+    const {range, settings} = useGlobalData();
     const {appSettings} = useAppContext();
+
+    // Get site timezone from settings for displaying dates consistently
+    const siteTimezone = String(settings.find(setting => setting.key === 'timezone')?.value || 'Etc/UTC');
 
     // Show open rate if newsletters are enabled and email tracking is enabled
     const showWebAnalytics = appSettings?.analytics.webAnalytics;
@@ -98,7 +101,7 @@ const TopPosts: React.FC<TopPostsProps> = ({
                                             <div className='flex flex-col'>
                                                 <span className='line-clamp-2 text-lg font-semibold leading-[1.35em]'>{post.title}</span>
                                                 <span className='text-sm text-muted-foreground'>
-                                                    By {post.authors} &ndash; {formatDisplayDate(post.published_at)}
+                                                    By {post.authors} &ndash; {formatDisplayDate(post.published_at, siteTimezone)}
                                                 </span>
                                                 <span className='text-sm text-muted-foreground'>
                                                     {getPostStatusText(post)}


### PR DESCRIPTION
ref https://linear.app/ghost/issue/NY-381/

## Summary
- Fixed Analytics Overview displaying `published_at` dates in UTC instead of site timezone
- Added optional `timezone` parameter to `formatDisplayDate` utility function
- Updated Latest Post and Top Posts components to pass site's configured timezone

## Problem
The Analytics > Overview tab was showing post dates in UTC, causing confusion when dates appeared as "tomorrow" for users in timezones behind UTC. This was inconsistent with the Ember admin's posts list which correctly displays dates in the site's configured timezone.

## Solution
- Extended `formatDisplayDate` in `apps/shade/src/lib/utils.ts` to accept an optional timezone parameter
- When timezone is provided, uses `moment-timezone` to convert ISO dates to the specified timezone
- Updated `latest-post.tsx` and `top-posts.tsx` to read the site timezone from settings and pass it to the formatter

This matches the pattern used in the Ember admin's `gh-format-post-time` helper.