### PR TITLE
Fixed flaky post publish browser tests

### DIFF
--- a/ghost/core/test/e2e-browser/admin/publishing.spec.js
+++ b/ghost/core/test/e2e-browser/admin/publishing.spec.js
@@ -166,7 +166,8 @@ const publishPost = async (page, {type = 'publish', time, date} = {}) => {
     // (we need force because the button is animating)
     await page.locator('[data-test-modal="publish-flow"] [data-test-button="confirm-publish"]').click({force: true});
 
-    // TODO: assert publish flow has expected completion details
+    // Wait for the publish flow to complete by checking the confirm button is no longer visible
+    await page.locator('[data-test-modal="publish-flow"] [data-test-button="confirm-publish"]').waitFor({state: 'hidden'});
 };
 
 /**


### PR DESCRIPTION
no issue

- we're seeing flaky browser tests when publishing posts where we can navigate away from the admin area to check for a published post before the publishing PUT request completes, causing an aborted request and a 404 for the post that never got published
- added a wait for the "success" state of the save, indicated by the publish button no longer being visible so we're not navigating away to the frontend before the save request has completed
