### PR TITLE
Added database migration to store start/end of a discount

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/6.15/2026-01-26-08-34-21-add-discount-start-end-to-subscriptions.js
+++ b/ghost/core/core/server/data/migrations/versions/6.15/2026-01-26-08-34-21-add-discount-start-end-to-subscriptions.js
@@ -1,0 +1,13 @@
+const {createAddColumnMigration, combineNonTransactionalMigrations} = require('../../utils');
+
+module.exports = combineNonTransactionalMigrations(
+    createAddColumnMigration('members_stripe_customers_subscriptions', 'discount_start', {
+        type: 'dateTime',
+        nullable: true
+    }),
+
+    createAddColumnMigration('members_stripe_customers_subscriptions', 'discount_end', {
+        type: 'dateTime',
+        nullable: true
+    })
+);

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -699,6 +699,8 @@ module.exports = {
         updated_at: {type: 'dateTime', nullable: true},
         mrr: {type: 'integer', unsigned: true, nullable: false, defaultTo: 0},
         offer_id: {type: 'string', maxlength: 24, nullable: true, unique: false, references: 'offers.id'},
+        discount_start: {type: 'dateTime', nullable: true},
+        discount_end: {type: 'dateTime', nullable: true},
         trial_start_at: {type: 'dateTime', nullable: true},
         trial_end_at: {type: 'dateTime', nullable: true},
         /* Below fields are now redundant as we link stripe_price_id to stripe_prices table */

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = 'bbd9a12f190db664b7f00a7f22364472';
+    const currentSchemaHash = '7513361f486eae436e3e2e6d35b4d313';
     const currentFixturesHash = '4dcbd7b52bc9ce23e6f5f1673118ba73';
     const currentSettingsHash = 'e75a2245c64a4fc82f826676abbc3234';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
ref https://linear.app/ghost/issue/FEA-537

- As we introduce retention offers that can be applied to existing subscriptions, we need a reliable way to calculate whether the offer applies to the next payment
- instead of computing it ourselves, we're going to retrieve the discount start / end from Stripe and store it in the database

