### PR TITLE
Stored subscription discount start/end during Stripe sync

### DIFF
--- a/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
@@ -1108,7 +1108,9 @@ module.exports = class MemberRepository {
                 canceled: stripeSubscriptionData.cancel_at_period_end,
                 discount: stripeSubscriptionData.discount
             }),
-            offer_id: offerId
+            offer_id: offerId,
+            discount_start: stripeSubscriptionData.discount?.start ? new Date(stripeSubscriptionData.discount.start * 1000) : null,
+            discount_end: stripeSubscriptionData.discount?.end ? new Date(stripeSubscriptionData.discount.end * 1000) : null
         };
 
         const getStatus = (modelToCheck) => {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/FEA-537

- As we introduce retention offers that can be applied to existing subscriptions, we need a reliable way to calculate whether the offer applies to the next payment
- instead of computing it ourselves, we retrieve it from Stripe and store it in our database

