### PR TITLE
Fix dev:forward on Windows/WSL

### DIFF
--- a/apps/admin/vite.config.ts
+++ b/apps/admin/vite.config.ts
@@ -47,7 +47,6 @@ export default defineConfig(({ command }) => ({
     },
     server: {
         port: 5174,
-        host: true,
         allowedHosts: true
     },
     resolve: {


### PR DESCRIPTION
closes https://linear.app/ghost/issue/BER-3228/fix-devforward-in-wsl

Only listen on localhost. Trying to listen on all available hosts causes issues under WSL and is no  longer needed since we have the gateway in front.