### PR TITLE
Grouped NQL packages separately in Renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -58,6 +58,15 @@
         "ghost/admin/lib/koenig-editor/package.json"
     ],
     "packageRules": [
+        // Group NQL packages separately from other TryGhost packages
+        {
+            "groupName": "NQL packages",
+            "matchPackageNames": [
+                "@tryghost/nql",
+                "@tryghost/nql-lang"
+            ]
+        },
+
         // Always automerge these packages:
         {
             "matchPackageNames": [


### PR DESCRIPTION
## Summary

- Adds a dedicated package rule to group `@tryghost/nql` and `@tryghost/nql-lang` under "NQL packages"
- These packages will now receive their own Renovate PR instead of being bundled with other TryGhost package updates

## Why

Previously, NQL package updates were grouped with all other `@tryghost/*` packages under the shared `tryghost/renovate-config`. This made it difficult to manage NQL updates separately since they have different ownership and release cycles.

## Testing

- ✅ Renovate config validation passed (`npx --package renovate -- renovate-config-validator .github/renovate.json5`)
- Real validation will occur on the next NQL package release when Renovate creates a separate "NQL packages" PR