### PR TITLE
Added disableMemberCommenting labs flag

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
@@ -67,6 +67,10 @@ const features: Feature[] = [{
     title: 'Transistor',
     description: 'Enable Transistor podcast integration',
     flag: 'transistor'
+}, {
+    title: 'Disable Member Commenting',
+    description: 'Allow staff to disable commenting for individual members',
+    flag: 'disableMemberCommenting'
 }];
 
 const AlphaFeatures: React.FC = () => {

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -56,7 +56,8 @@ const PRIVATE_FEATURES = [
     'commentPermalinks',
     'indexnow',
     'featurebaseFeedback',
-    'transistor'
+    'transistor',
+    'disableMemberCommenting'
 ];
 
 module.exports.GA_KEYS = [...GA_FEATURES];

--- a/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
@@ -18,6 +18,7 @@ Object {
       "contentVisibility": true,
       "contentVisibilityAlpha": true,
       "customFonts": true,
+      "disableMemberCommenting": true,
       "editorExcerpt": true,
       "emailCustomization": true,
       "emailUniqueid": true,


### PR DESCRIPTION
This PR adds the `disableMemberCommenting` private labs flag, which will gate the upcoming feature allowing staff to disable commenting for individual members.

The flag is being merged separately from the feature implementation to provide a clean integration point for testing the various components of this feature independently.

ref https://linear.app/ghost/issue/BER-3184