### PR TITLE
Admin email re-enable button

### DIFF
--- a/ghost/admin/app/components/member/newsletter-preference.hbs
+++ b/ghost/admin/app/components/member/newsletter-preference.hbs
@@ -46,6 +46,16 @@
 
                 <a class="midgrey" href="https://ghost.org/help/disabled-emails" target="_blank" rel="noopener noreferrer">Learn more</a>
             </p>
+
+            <button
+                type="button"
+                class="gh-btn gh-btn-primary gh-btn-icon"
+                {{on "click" this.reEnableEmail}}
+                disabled={{this.isReEnabling}}
+                data-test-button="reenable-email"
+            >
+                <span>{{if this.isReEnabling "Re-enabling..." "Re-enable email"}}</span>
+            </button>
         </div>
     {{else}}
         <div class="gh-member-newsletter-footer middarkgrey">

--- a/ghost/admin/app/components/member/newsletter-preference.hbs
+++ b/ghost/admin/app/components/member/newsletter-preference.hbs
@@ -54,7 +54,7 @@
                 disabled={{this.isReEnabling}}
                 data-test-button="reenable-email"
             >
-                <span>{{if this.isReEnabling "Re-enabling..." "Re-enable email"}}</span>
+                <span>Re-enable email</span>
             </button>
         </div>
     {{else}}

--- a/ghost/admin/app/components/member/newsletter-preference.js
+++ b/ghost/admin/app/components/member/newsletter-preference.js
@@ -9,7 +9,7 @@ export default class MembersNewsletterPreference extends Component {
     @service notifications;
     @service ghostPaths;
     @service store;
-    
+
     @tracked filterValue;
     @tracked isReEnabling = false;
 
@@ -71,7 +71,7 @@ export default class MembersNewsletterPreference extends Component {
         this.isReEnabling = true;
 
         try {
-            const url = `${this.ghostPaths.url.api('members', this.args.member.id)}/suppression`;
+            const url = `${this.ghostPaths.url.api('members', this.args.member.id)}suppression`;
             await this.ajax.delete(url);
 
             // Refresh the member data to get updated suppression status

--- a/ghost/admin/app/components/member/newsletter-preference.js
+++ b/ghost/admin/app/components/member/newsletter-preference.js
@@ -1,10 +1,17 @@
 import Component from '@glimmer/component';
 import moment from 'moment-timezone';
 import {action} from '@ember/object';
+import {inject as service} from '@ember/service';
 import {tracked} from '@glimmer/tracking';
 
 export default class MembersNewsletterPreference extends Component {
+    @service ajax;
+    @service notifications;
+    @service ghostPaths;
+    @service store;
+    
     @tracked filterValue;
+    @tracked isReEnabling = false;
 
     constructor(...args) {
         super(...args);
@@ -57,5 +64,31 @@ export default class MembersNewsletterPreference extends Component {
             }).concat(selectedNewsletter);
         }
         this.args.setMemberNewsletters(updatedNewsletters);
+    }
+
+    @action
+    async reEnableEmail() {
+        this.isReEnabling = true;
+
+        try {
+            const url = `${this.ghostPaths.url.api('members', this.args.member.id)}/suppression`;
+            await this.ajax.delete(url);
+
+            // Refresh the member data to get updated suppression status
+            await this.store.findRecord('member', this.args.member.id, {
+                reload: true,
+                include: 'tiers'
+            });
+
+            this.notifications.showNotification('Email re-enabled successfully', {
+                type: 'success'
+            });
+        } catch (error) {
+            this.notifications.showAlert('Failed to re-enable email. Please try again.', {
+                type: 'error'
+            });
+        } finally {
+            this.isReEnabling = false;
+        }
     }
 }

--- a/ghost/admin/app/styles/layouts/members.css
+++ b/ghost/admin/app/styles/layouts/members.css
@@ -1185,6 +1185,10 @@ textarea.gh-member-details-textarea {
     text-decoration: underline;
 }
 
+.gh-member-newsletter-no-data p {
+    margin-bottom: 0.8rem;
+}
+
 .gh-member-newsletter-footer {
     font-size: 1.3rem;
     margin-top: 12px;

--- a/ghost/core/core/server/api/endpoints/members.js
+++ b/ghost/core/core/server/api/endpoints/members.js
@@ -532,10 +532,10 @@ const controller = {
         },
         async query(frame) {
             const emailSuppressionList = require('../../services/email-suppression-list');
-            
+
             // Get the member first to retrieve their email
             const member = await membersService.api.memberBREADService.read({id: frame.options.id}, {});
-            
+
             if (!member) {
                 throw new errors.NotFoundError({
                     message: tpl(messages.memberNotFound)
@@ -543,11 +543,17 @@ const controller = {
             }
 
             // Remove the email from the suppression list
-            await emailSuppressionList.removeEmail(member.email);
-            
+            const didRemoveSuppression = await emailSuppressionList.removeEmail(member.email);
+
+            if (!didRemoveSuppression) {
+                throw new errors.InternalServerError({
+                    message: 'Failed to remove email suppression.'
+                });
+            }
+
             // Update the member to re-enable email
             await membersService.api.memberBREADService.edit({email_disabled: false}, {id: frame.options.id});
-            
+
             return null;
         }
     }

--- a/ghost/core/core/server/api/endpoints/members.js
+++ b/ghost/core/core/server/api/endpoints/members.js
@@ -510,6 +510,46 @@ const controller = {
         async query(frame) {
             return await membersService.api.events.getEventTimeline(frame.options);
         }
+    },
+
+    deleteEmailSuppression: {
+        statusCode: 204,
+        headers: {
+            cacheInvalidate: false
+        },
+        options: [
+            'id'
+        ],
+        validation: {
+            options: {
+                id: {
+                    required: true
+                }
+            }
+        },
+        permissions: {
+            method: 'edit'
+        },
+        async query(frame) {
+            const emailSuppressionList = require('../../services/email-suppression-list');
+            
+            // Get the member first to retrieve their email
+            const member = await membersService.api.memberBREADService.read({id: frame.options.id}, {});
+            
+            if (!member) {
+                throw new errors.NotFoundError({
+                    message: tpl(messages.memberNotFound)
+                });
+            }
+
+            // Remove the email from the suppression list
+            await emailSuppressionList.removeEmail(member.email);
+            
+            // Update the member to re-enable email
+            await membersService.api.memberBREADService.edit({email_disabled: false}, {id: frame.options.id});
+            
+            return null;
+        }
     }
 };
 

--- a/ghost/core/core/server/web/api/endpoints/admin/routes.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/routes.js
@@ -145,6 +145,7 @@ module.exports = function apiRoutes() {
     router.put('/members/:id', mw.authAdminApi, http(api.members.edit));
     router.del('/members/:id', mw.authAdminApi, http(api.members.destroy));
     router.del('/members/:id/sessions', mw.authAdminApi, http(api.members.logout));
+    router.del('/members/:id/suppression', mw.authAdminApi, http(api.members.deleteEmailSuppression));
 
     router.post('/members/:id/subscriptions/', mw.authAdminApi, http(api.members.createSubscription));
     router.put('/members/:id/subscriptions/:subscription_id', mw.authAdminApi, http(api.members.editSubscription));

--- a/ghost/core/test/e2e-api/admin/__snapshots__/members.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/members.test.js.snap
@@ -7911,6 +7911,81 @@ Object {
 }
 `;
 
+exports[`Members API deleteEmailSuppression Can delete email suppression for a member 1: [body] 1`] = `Object {}`;
+
+exports[`Members API deleteEmailSuppression Can delete email suppression for a member 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Members API deleteEmailSuppression Returns 404 for non-existent member 1: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": null,
+      "context": null,
+      "details": null,
+      "ghostErrorCode": null,
+      "help": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "Member not found.",
+      "property": null,
+      "type": "NotFoundError",
+    },
+  ],
+}
+`;
+
+exports[`Members API deleteEmailSuppression Returns 404 for non-existent member 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "203",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Members API deleteEmailSuppression Returns 500 when suppression removal fails 1: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": null,
+      "context": null,
+      "details": null,
+      "ghostErrorCode": null,
+      "help": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "Failed to remove email suppression.",
+      "property": null,
+      "type": "InternalServerError",
+    },
+  ],
+}
+`;
+
+exports[`Members API deleteEmailSuppression Returns 500 when suppression removal fails 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "227",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
 exports[`Members API without Stripe Add should fail when comped flag is passed in but Stripe is not enabled 1: [body] 1`] = `
 Object {
   "errors": Array [

--- a/ghost/core/test/e2e-api/admin/members.test.js
+++ b/ghost/core/test/e2e-api/admin/members.test.js
@@ -2397,6 +2397,60 @@ describe('Members API', function () {
         });
     });
 
+    describe('deleteEmailSuppression', function () {
+        it('Can delete email suppression for a member', async function () {
+            const suppressedMember = await models.Member.add({
+                email: 'suppression-test@email.com',
+                name: 'Suppression Test',
+                email_disabled: true
+            });
+
+            const suppression = await models.Suppression.add({
+                email: 'suppression-test@email.com',
+                reason: 'bounce'
+            });
+
+            try {
+                await agent
+                    .delete(`/members/${suppressedMember.id}/suppression`)
+                    .expectStatus(204)
+                    .matchBodySnapshot()
+                    .matchHeaderSnapshot({
+                        'content-version': anyContentVersion,
+                        etag: anyEtag
+                    });
+
+                await suppressedMember.refresh();
+                should(suppressedMember.get('email_disabled')).be.false();
+
+                const suppressionRecord = await models.Suppression.findOne({email: 'suppression-test@email.com'});
+                should(suppressionRecord).be.null();
+            } finally {
+                await models.Member.destroy({id: suppressedMember.id});
+                try {
+                    await models.Suppression.destroy({id: suppression.id});
+                } catch (e) {
+                    // Suppression was already deleted by the endpoint
+                }
+            }
+        });
+
+        it('Returns 404 for non-existent member', async function () {
+            await agent
+                .delete('/members/abcd1234abcd1234abcd1234/suppression')
+                .expectStatus(404)
+                .matchBodySnapshot({
+                    errors: [{
+                        id: anyUuid
+                    }]
+                })
+                .matchHeaderSnapshot({
+                    'content-version': anyContentVersion,
+                    etag: anyEtag
+                });
+        });
+    });
+
     // Log out
     it('Can log out', async function () {
         const member = await createMember({


### PR DESCRIPTION
Got some code for us? Awesome 🎊!

Please take a minute to explain the change you're making:
- **Why are you making it?**
  This change introduces the ability for publishers to re-enable a member's email directly from Ghost Admin when it has been disabled (e.g., due to bounces or spam complaints). This streamlines the process of managing email suppressions without needing to leave the admin interface, improving workflow efficiency for publishers.
- **What does it do?**
  A "Re-enable email" button is added to the member's newsletter subscription settings in Ghost Admin, appearing when their email is in a disabled state. Clicking this button calls a new API endpoint to remove the email from the suppression list and updates the member's `email_disabled` status to `false`, subsequently refreshing the UI to show active newsletter settings.
- **Why is this something Ghost users or developers need?**
  Publishers gain a direct and convenient tool within Ghost Admin to manage member email deliverability, which is essential for reactivating members whose emails were temporarily disabled. This enhances administrative control over member engagement.

Please check your PR against these items:

- [ ] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [ ] I've explained my change
- [ ] I've written an automated test to prove my change works

We appreciate your contribution! 🙏

---
Linear Issue: [GVA-645](https://linear.app/ghost/issue/GVA-645/add-suppression-re-enable-button-in-ghost-admin)

<a href="https://cursor.com/background-agent?bcId=bc-edf898b1-a4ca-4989-9e52-0ac43ba9148c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-edf898b1-a4ca-4989-9e52-0ac43ba9148c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new authenticated admin write endpoint that alters suppression state and `email_disabled`, so regressions could incorrectly re-enable sending or fail to clear suppressions.
> 
> **Overview**
> Adds a **“Re-enable email”** button to the member newsletter preferences UI when a member is email-suppressed, including loading/disabled state and a small layout tweak.
> 
> Introduces a new Admin API endpoint `DELETE /members/:id/suppression` that removes the member’s email from the suppression list and flips `email_disabled` back to `false`, plus e2e tests/snapshots covering success, missing member (404), and suppression removal failure (500).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 71fc112a7c28223ac6ba8128e7d16839fa5904ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Re-enable email" button to member newsletter preferences, enabling administrators to restore email communications for members with suppressed email addresses.

* **Style**
  * Improved spacing in newsletter no-data state for better visual presentation.

* **Tests**
  * Added comprehensive test coverage for email suppression removal including success and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->