### PR TITLE
Fixed `yarn dev:forward` with Docker Desktop on MacOS

### DIFF
--- a/apps/admin/vite.config.ts
+++ b/apps/admin/vite.config.ts
@@ -46,6 +46,7 @@ export default defineConfig(({ command }) => ({
         "process.env.DEBUG": false, // Shim env var utilized by the @tryghost/nql package
     },
     server: {
+        host: '0.0.0.0',
         port: 5174,
         allowedHosts: true
     },


### PR DESCRIPTION
closes https://linear.app/ghost/issue/BER-3234/fix-local-dev-issue-with-docker-desktop-on-macos

Running the dev server with `host: true` fails on Windows/WSL. Running without an explicit host works fine on WSL, Linux and with OrbStack on MacOS, but  fails with Docker Desktop on MacOS. Setting the host to 0.0.0.0 seems to work on all platforms.

This fixes a regression introduced in https://github.com/TryGhost/Ghost/pull/25949.