### PR TITLE
DRYed out signin return in Portal

### DIFF
--- a/apps/portal/src/actions.js
+++ b/apps/portal/src/actions.js
@@ -88,22 +88,11 @@ async function signin({data, api, state}) {
             includeOTC: true
         };
         const response = await api.member.sendMagicLink(payload);
-
-        if (response?.otc_ref) {
-            return {
-                page: 'magiclink',
-                lastPage: 'signin',
-                otcRef: response.otc_ref,
-                pageData: {
-                    ...(state.pageData || {}),
-                    email: (data?.email || '').trim()
-                }
-            };
-        }
-
+        const otcRef = response.otc_ref;
         return {
             page: 'magiclink',
             lastPage: 'signin',
+            ...(otcRef ? {otcRef} : {}),
             pageData: {
                 ...(state.pageData || {}),
                 email: (data?.email || '').trim()


### PR DESCRIPTION
towards https://linear.app/ghost/issue/NY-943/show-sniperlink-for-gmailcom-email-addresses-when-signing-up-for-an

This change should have no user impact.

We can shorten this code a bit. I think this is a useful change on its own, but also makes a future change a little easier.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors `signin` flow in `apps/portal/src/actions.js` to consolidate the post-magic-link return object.
> 
> - Always returns `page: "magiclink"` and `lastPage: "signin"`, conditionally including `otcRef` only when `response.otc_ref` is present
> - Removes duplicated branching and keeps existing `pageData.email` behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3eea9b4a17f13acc9e72e863e6845712a25f2c4c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->