### PR TITLE
Added transistor setting to settings endpoint allowlist

### DIFF
--- a/apps/admin-x-framework/src/api/settings.ts
+++ b/apps/admin-x-framework/src/api/settings.ts
@@ -29,7 +29,10 @@ const dataType = 'SettingsResponseType';
 
 export const useBrowseSettings = createQuery<SettingsResponseType>({
     dataType,
-    path: '/settings/'
+    path: '/settings/',
+    defaultSearchParams: {
+        group: 'site,theme,private,members,portal,newsletter,email,labs,slack,unsplash,views,firstpromoter,editor,comments,analytics,announcement,pintura,donations,security,social_web,explore,transistor'
+    }
 });
 
 export const useEditSettings = createMutation<SettingsResponseType, Setting[]>({

--- a/apps/admin-x-framework/src/api/settings.ts
+++ b/apps/admin-x-framework/src/api/settings.ts
@@ -29,10 +29,7 @@ const dataType = 'SettingsResponseType';
 
 export const useBrowseSettings = createQuery<SettingsResponseType>({
     dataType,
-    path: '/settings/',
-    defaultSearchParams: {
-        group: 'site,theme,private,members,portal,newsletter,email,labs,slack,unsplash,views,firstpromoter,editor,comments,analytics,announcement,pintura,donations,security,social_web,explore'
-    }
+    path: '/settings/'
 });
 
 export const useEditSettings = createMutation<SettingsResponseType, Setting[]>({

--- a/ghost/core/core/server/api/endpoints/utils/serializers/input/settings.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/input/settings.js
@@ -79,7 +79,8 @@ const EDITABLE_SETTINGS = [
     'social_web',
     'explore_ping',
     'explore_ping_growth',
-    'indexnow_api_key'
+    'indexnow_api_key',
+    'transistor'
 ];
 
 module.exports = {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/NY-953/
- updated integration copy
- updated input serializer to include new setting
- removed default search params; this is an annoying piece of additional maintenance any time a setting is added that is easy to miss (much like the serializer...)