### PR TITLE
Improved newsletter preview dropdown to only be available if there are multiple options

### DIFF
--- a/ghost/admin/app/components/editor/modals/preview.hbs
+++ b/ghost/admin/app/components/editor/modals/preview.hbs
@@ -17,22 +17,24 @@
                 <button type="button" class="gh-btn {{if (eq this.previewSize "desktop") "gh-btn-group-selected"}} gh-post-preview-mode" {{on "click" (fn this.changePreviewSize "desktop")}}><span>{{svg-jar "laptop"}}</span></button>
                 <button type="button" class="gh-btn {{if (eq this.previewSize "mobile") "gh-btn-group-selected"}} gh-post-preview-mode" {{on "click" (fn this.changePreviewSize "mobile")}}><span>{{svg-jar "mobile-phone"}}</span></button>
             </div>
-            <div class="gh-contentfilter-divider"></div>
-            <span class="gh-select gh-web-preview-segment" data-test-select="preview-segment">
-                <PowerSelect
-                    @selected={{this.selectedPreviewAsOption}}
-                    @options={{this.previewAsOptions}}
-                    @onChange={{this.changePreviewAsOption}}
-                    @triggerComponent={{component "gh-power-select/trigger"}}
-                    @triggerClass="gh-preview-segment-trigger"
-                    @dropdownClass="gh-preview-segment-dropdown"
-                    @matchTriggerWidth={{false}}
-                    @onOpen={{this.dropdown.closeDropdowns}}
-                    as |option|
-                >
-                    {{option.label}}
-                </PowerSelect>
-            </span>
+            {{#if this.showMemberSegmentDropdown}}
+                <div class="gh-contentfilter-divider"></div>
+                <span class="gh-select gh-web-preview-segment" data-test-select="preview-segment">
+                    <PowerSelect
+                        @selected={{this.selectedPreviewAsOption}}
+                        @options={{this.previewAsOptions}}
+                        @onChange={{this.changePreviewAsOption}}
+                        @triggerComponent={{component "gh-power-select/trigger"}}
+                        @triggerClass="gh-preview-segment-trigger"
+                        @dropdownClass="gh-preview-segment-dropdown"
+                        @matchTriggerWidth={{false}}
+                        @onOpen={{this.dropdown.closeDropdowns}}
+                        as |option|
+                    >
+                        {{option.label}}
+                    </PowerSelect>
+                </span>
+            {{/if}}
         </div>
         <div class="right">
             <div class="gh-post-test-email-group">

--- a/ghost/admin/app/components/editor/modals/preview.js
+++ b/ghost/admin/app/components/editor/modals/preview.js
@@ -39,6 +39,15 @@ export default class EditorPostPreviewModal extends Component {
         return this.previewAsOptions.find(option => option.value === this.previewAsSegment);
     }
 
+    get showMemberSegmentDropdown() {
+        // Always show dropdown on browser/web tab (has multiple options)
+        if (this.previewFormat === 'browser') {
+            return true;
+        }
+        // On email tab, only show if there's more than one option
+        return this.previewAsOptions.length > 1;
+    }
+
     get skipAnimation() {
         return this.args.data.skipAnimation || this.isChangingTab;
     }

--- a/ghost/admin/tests/acceptance/editor/post-email-preview-test.js
+++ b/ghost/admin/tests/acceptance/editor/post-email-preview-test.js
@@ -104,15 +104,12 @@ describe('Acceptance: Post email preview', function () {
         expect(requestBody.memberSegment).to.equal('status:-free');
     });
 
-    it('hides paid member option when paid members is disabled', async function () {
+    it('hides segment dropdown when only one option is available', async function () {
         disablePaidMembers(this.server);
 
         await openEmailPreviewModal.call(this);
 
-        await clickTrigger('[data-test-select="preview-segment"]');
-
-        const options = findAll('.ember-power-select-option');
-        expect(options.length).to.equal(1);
-        expect(options[0].textContent.trim()).to.equal('Free member');
+        // segment dropdown should be hidden when there's only one option
+        expect(find('[data-test-select="preview-segment"]'), 'segment select').not.to.exist;
     });
 });


### PR DESCRIPTION
Got some code for us? Awesome 🎊!

Please take a minute to explain the change you're making:
- Why are you making it?
To improve the user experience in the newsletter email preview. Currently, when there's only one member segment option (e.g., no paid members or Stripe not connected), the dropdown is still visible and clickable, which is redundant and can be confusing.
- What does it do?
This change introduces a new computed property `showMemberSegmentDropdown` that controls the visibility of the member segment dropdown and its divider. The dropdown will now be hidden entirely in the email preview when only one member segment option is available, while remaining visible in the web preview or when multiple options exist.
- Why is this something Ghost users or developers need?
Ghost users will benefit from a cleaner and less confusing interface when composing newsletters, as redundant UI elements are removed. Developers will appreciate the more intuitive behavior of the preview modal.

Please check your PR against these items:

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [ ] I've written an automated test to prove my change works

We appreciate your contribution! 🙏

---
Linear Issue: [DES-1274](https://linear.app/ghost/issue/DES-1274/hide-single-choice-newsletter-preview-member-dropdown)

<a href="https://cursor.com/background-agent?bcId=bc-f3376611-649b-465b-9531-9e2926184c4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f3376611-649b-465b-9531-9e2926184c4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

