### PR TITLE
Removed Should.js from magic link tests

### DIFF
--- a/ghost/core/test/e2e-api/members/send-magic-link.test.js
+++ b/ghost/core/test/e2e-api/members/send-magic-link.test.js
@@ -1,5 +1,4 @@
 const {agentProvider, mockManager, fixtureManager, matchers, configUtils, resetRateLimits, dbUtils} = require('../../utils/e2e-framework');
-const should = require('should');
 const sinon = require('sinon');
 const assert = require('assert/strict');
 const {assertMatchSnapshot} = require('../../utils/assertions');
@@ -154,14 +153,10 @@ describe('sendMagicLink', function () {
         // Get data
         const data = await membersService.api.getTokenDataFromMagicLinkToken(token);
 
-        should(data).match({
-            email,
-            attribution: {
-                id: null,
-                url: null,
-                type: null
-            }
-        });
+        assert.equal(data.email, email);
+        assert.equal(data.attribution.id, null);
+        assert.equal(data.attribution.url, null);
+        assert.equal(data.attribution.type, null);
     });
 
     it('Creates a valid magic link from custom signup with redirection', async function () {
@@ -185,7 +180,7 @@ describe('sendMagicLink', function () {
         const [url] = mail.text.match(/https?:\/\/[^\s]+/);
         const parsed = new URL(url);
         const redirect = parsed.searchParams.get('r');
-        should(redirect).equal(customSignupUrl);
+        assert.equal(redirect, customSignupUrl);
     });
 
     it('Creates a valid magic link from custom signup with redirection disabled', async function () {
@@ -209,7 +204,7 @@ describe('sendMagicLink', function () {
         const [url] = mail.text.match(/https?:\/\/[^\s]+/);
         const parsed = new URL(url);
         const redirect = parsed.searchParams.get('r');
-        should(redirect).equal(null);
+        assert.equal(redirect, null);
     });
 
     it('triggers email alert for free member signup', async function () {
@@ -245,9 +240,7 @@ describe('sendMagicLink', function () {
         });
 
         // Check member data is returned
-        should(data).match({
-            email
-        });
+        assert.equal(data.email, email);
     });
 
     it('Converts the urlHistory to the attribution and stores it in the token', async function () {
@@ -280,14 +273,10 @@ describe('sendMagicLink', function () {
         // Get data
         const data = await membersService.api.getTokenDataFromMagicLinkToken(token);
 
-        should(data).match({
-            email,
-            attribution: {
-                id: null,
-                url: '/test-path',
-                type: 'url'
-            }
-        });
+        assert.equal(data.email, email);
+        assert.equal(data.attribution.id, null);
+        assert.equal(data.attribution.url, '/test-path');
+        assert.equal(data.attribution.type, 'url');
     });
 
     describe('signin email', function () {
@@ -412,7 +401,8 @@ describe('sendMagicLink', function () {
                     })
                     .expectStatus(201)
                     .expect(({body}) => {
-                        body.otc_ref.should.be.a.String().and.match(/^[a-f0-9-]{36}$/);
+                        assert.equal(typeof body.otc_ref, 'string');
+                        assert.match(body.otc_ref, /^[a-f0-9-]{36}$/);
                     });
             });
 
@@ -430,7 +420,8 @@ describe('sendMagicLink', function () {
                     })
                     .expectStatus(201)
                     .expect(({body}) => {
-                        body.otc_ref.should.be.a.String().and.match(/^[a-f0-9-]{36}$/);
+                        assert.equal(typeof body.otc_ref, 'string');
+                        assert.match(body.otc_ref, /^[a-f0-9-]{36}$/);
                     });
             });
         });
@@ -513,7 +504,7 @@ describe('sendMagicLink', function () {
                 to: 'user@xn--tst-jma.com' // Punycode version
             });
 
-            should.exist(mail);
+            assert.ok(mail);
         });
     });
 


### PR DESCRIPTION
This test-only change should have no user impact. We want to drop Should.js in favor of Node's assert. This does that for this test file.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces `should.js` assertions with Node’s `assert` across `test/e2e-api/members/send-magic-link.test.js`.
> 
> - Converts `should(...).match/equal/exist` to `assert.equal`, `assert.ok`, and `assert.match`
> - Adjusts inline expectations for `otc_ref`, redirect param `r`, and token attribution checks
> - No production code changes; test behavior and coverage remain equivalent
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3d9448e28f92eb8f42f94f807b63276dfe344376. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->