### PR TITLE
Removed unused member permission code from comments API

### DIFF
--- a/ghost/core/core/server/api/endpoints/comments-members.js
+++ b/ghost/core/core/server/api/endpoints/comments-members.js
@@ -1,6 +1,5 @@
 const commentsService = require('../../services/comments');
 const ALLOWED_INCLUDES = ['member', 'replies', 'replies.member', 'replies.count.likes', 'replies.liked', 'count.replies', 'count.likes', 'liked', 'post', 'parent'];
-const UNSAFE_ATTRS = ['status'];
 
 /** @type {import('@tryghost/api-framework').Controller} */
 const controller = {
@@ -25,7 +24,7 @@ const controller = {
                 include: ALLOWED_INCLUDES
             }
         },
-        permissions: true,
+        permissions: false,
         query(frame) {
             return commentsService.controller.browse(frame);
         }
@@ -50,7 +49,7 @@ const controller = {
                 include: ALLOWED_INCLUDES
             }
         },
-        permissions: 'browse',
+        permissions: false,
         query(frame) {
             return commentsService.controller.replies(frame);
         }
@@ -72,7 +71,7 @@ const controller = {
                 include: ALLOWED_INCLUDES
             }
         },
-        permissions: true,
+        permissions: false,
         query(frame) {
             return commentsService.controller.read(frame);
         }
@@ -96,7 +95,7 @@ const controller = {
                 }
             }
         },
-        permissions: true,
+        permissions: false,
         query(frame) {
             return commentsService.controller.edit(frame);
         }
@@ -120,9 +119,7 @@ const controller = {
                 }
             }
         },
-        permissions: {
-            unsafeAttrs: UNSAFE_ATTRS
-        },
+        permissions: false,
         query(frame) {
             return commentsService.controller.add(frame);
         }
@@ -142,7 +139,7 @@ const controller = {
                 include: ALLOWED_INCLUDES
             }
         },
-        permissions: true,
+        permissions: false,
         query() {
             return commentsService.controller.destroy();
         }
@@ -171,7 +168,7 @@ const controller = {
         ],
         validation: {
         },
-        permissions: true,
+        permissions: false,
         async query(frame) {
             return await commentsService.controller.like(frame);
         }
@@ -186,7 +183,7 @@ const controller = {
             'id'
         ],
         validation: {},
-        permissions: true,
+        permissions: false,
         async query(frame) {
             return await commentsService.controller.unlike(frame);
         }
@@ -201,7 +198,7 @@ const controller = {
             'id'
         ],
         validation: {},
-        permissions: true,
+        permissions: false,
         async query(frame) {
             await commentsService.controller.report(frame);
         }

--- a/ghost/core/core/server/api/endpoints/utils/permissions.js
+++ b/ghost/core/core/server/api/endpoints/utils/permissions.js
@@ -90,9 +90,9 @@ module.exports = {
         // @TODO: https://github.com/TryGhost/Ghost/issues/10099
         frame.options.context = permissions.parseContext(frame.options.context);
 
-        // CASE: Content API access
-        if (frame.options.context.public && frame.apiType !== 'comments') {
-            debug('content api permissions pass-through');
+        // CASE: Public API access (Content API and Members API)
+        if (frame.options.context.public) {
+            debug('public api permissions pass-through');
             return Promise.resolve(frame.options);
         }
 

--- a/ghost/core/core/server/services/permissions/can-this.js
+++ b/ghost/core/core/server/services/permissions/can-this.js
@@ -53,11 +53,9 @@ class CanThisResult {
                     // Iterate through the user permissions looking for an affirmation
                     const userPermissions = loadedPermissions.user ? loadedPermissions.user.permissions : null;
                     const apiKeyPermissions = loadedPermissions.apiKey ? loadedPermissions.apiKey.permissions : null;
-                    const memberPermissions = loadedPermissions.member ? loadedPermissions.member.permissions : null;
 
                     let hasUserPermission;
                     let hasApiKeyPermission;
-                    let hasMemberPermission = false;
 
                     const checkPermission = function (perm) {
                         // Look for a matching action type and object type first
@@ -72,10 +70,6 @@ class CanThisResult {
                         hasUserPermission = true;
                     } else if (!_.isEmpty(userPermissions)) {
                         hasUserPermission = _.some(userPermissions, checkPermission);
-                    }
-
-                    if (loadedPermissions.member) {
-                        hasMemberPermission = _.some(memberPermissions, checkPermission);
                     }
 
                     // Check api key permissions if they were passed
@@ -96,7 +90,7 @@ class CanThisResult {
                     // Offer a chance for the TargetModel to override the results
                     if (TargetModel && _.isFunction(TargetModel.permissible)) {
                         return TargetModel.permissible(
-                            modelId, actType, context, unsafeAttrs, loadedPermissions, hasUserPermission, hasApiKeyPermission, hasMemberPermission
+                            modelId, actType, context, unsafeAttrs, loadedPermissions, hasUserPermission, hasApiKeyPermission
                         );
                     }
 
@@ -116,7 +110,6 @@ class CanThisResult {
         const self = this;
         let userPermissionLoad;
         let apiKeyPermissionLoad;
-        let memberPermissionLoad;
         let permissionsLoad;
 
         // Get context.user, context.api_key and context.app
@@ -142,16 +135,11 @@ class CanThisResult {
             apiKeyPermissionLoad = Promise.resolve(null);
         }
 
-        if (context.member) {
-            memberPermissionLoad = providers.member(context.member.id);
-        }
-
-        // Wait for both user and app permissions to load
-        permissionsLoad = Promise.all([userPermissionLoad, apiKeyPermissionLoad, memberPermissionLoad]).then(function (result) {
+        // Wait for both user and api key permissions to load
+        permissionsLoad = Promise.all([userPermissionLoad, apiKeyPermissionLoad]).then(function (result) {
             return {
                 user: result[0],
-                apiKey: result[1],
-                member: result[2]
+                apiKey: result[1]
             };
         });
 

--- a/ghost/core/core/server/services/permissions/providers.js
+++ b/ghost/core/core/server/services/permissions/providers.js
@@ -5,8 +5,7 @@ const tpl = require('@tryghost/tpl');
 
 const messages = {
     userNotFound: 'User not found',
-    apiKeyNotFound: 'API Key not found',
-    memberNotFound: 'Member not found'
+    apiKeyNotFound: 'API Key not found'
 };
 
 module.exports = {
@@ -72,20 +71,5 @@ module.exports = {
 
                 return {permissions, roles};
             });
-    },
-
-    async member(id) {
-        const foundMember = await models.Member.findOne({id});
-        if (!foundMember) {
-            throw new errors.NotFoundError({
-                message: tpl(messages.memberNotFound)
-            });
-        }
-
-        // @TODO: figure out how we want to associate members with permissions
-        // Dirty code to load all comment permissions except moderation for members
-        const permissions = await models.Permission.findAll({filter: 'object_type:comment+action_type:-moderate'});
-
-        return {permissions: permissions.models};
     }
 };

--- a/ghost/core/test/e2e-api/admin/__snapshots__/comments.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/comments.test.js.snap
@@ -1,5 +1,41 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Admin Comments API API Key Permissions API key without comment permissions cannot browse comments 1: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": null,
+      "context": null,
+      "details": null,
+      "ghostErrorCode": null,
+      "help": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "You do not have permission to browse comments",
+      "property": null,
+      "type": "NoPermissionError",
+    },
+  ],
+}
+`;
+
+exports[`Admin Comments API API Key Permissions API key without comment permissions cannot hide comments 1: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": null,
+      "context": "You do not have permission to edit comments",
+      "details": null,
+      "ghostErrorCode": null,
+      "help": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "Permission error, cannot edit comment.",
+      "property": null,
+      "type": "NoPermissionError",
+    },
+  ],
+}
+`;
+
 exports[`Admin Comments API Browse All Always includes member and post relations 1: [body] 1`] = `
 Object {
   "comments": Array [

--- a/ghost/core/test/e2e-api/members-comments/__snapshots__/comments.test.js.snap
+++ b/ghost/core/test/e2e-api/members-comments/__snapshots__/comments.test.js.snap
@@ -747,6 +747,36 @@ Object {
 }
 `;
 
+exports[`Comments API when commenting enabled for all when authenticated Can not delete a comment which does not belong to you 1: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": null,
+      "context": "Unable to find member",
+      "details": null,
+      "ghostErrorCode": null,
+      "help": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "Permission error, cannot edit comment.",
+      "property": null,
+      "type": "NoPermissionError",
+    },
+  ],
+}
+`;
+
+exports[`Comments API when commenting enabled for all when authenticated Can not delete a comment which does not belong to you 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "*",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "247",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
 exports[`Comments API when commenting enabled for all when authenticated Can not edit a comment as a member who is not you 1: [body] 1`] = `
 Object {
   "comments": Array [

--- a/ghost/core/test/e2e-api/members-comments/comments.test.js
+++ b/ghost/core/test/e2e-api/members-comments/comments.test.js
@@ -1207,6 +1207,29 @@ describe('Comments API', function () {
                     });
             });
 
+            it('Can not delete a comment which does not belong to you', async function () {
+                const comment = await dbFns.addComment({
+                    member_id: fixtureManager.get('members', 2).id
+                });
+
+                // Members delete comments by setting status to 'deleted' via PUT
+                await membersAgent2
+                    .put(`/api/comments/${comment.get('id')}`)
+                    .body({comments: [{
+                        status: 'deleted'
+                    }]})
+                    .expectStatus(403)
+                    .matchHeaderSnapshot({
+                        etag: anyEtag
+                    })
+                    .matchBodySnapshot({
+                        errors: [{
+                            type: 'NoPermissionError',
+                            id: anyUuid
+                        }]
+                    });
+            });
+
             it('Can not edit a comment as a member who is not you', async function () {
                 const comment = await dbFns.addComment({
                     member_id: loggedInMember.id

--- a/ghost/core/test/unit/server/models/comment.test.js
+++ b/ghost/core/test/unit/server/models/comment.test.js
@@ -1,6 +1,6 @@
+require('should');
 const sinon = require('sinon');
 const models = require('../../../../core/server/models');
-const testUtils = require('../../../utils');
 
 describe('Unit: models/comment', function () {
     before(function () {
@@ -9,87 +9,5 @@ describe('Unit: models/comment', function () {
 
     afterEach(function () {
         sinon.restore();
-    });
-
-    describe('permissible', function () {
-        function getCommentModel(id, memberId) {
-            const obj = {
-                id: id,
-                member_id: memberId
-            };
-
-            return {
-                id: obj.id,
-                get: sinon.stub().callsFake((prop) => {
-                    return obj[prop];
-                })
-            };
-        }
-
-        it('user can do all', async function () {
-            const comment = getCommentModel(1, 'member_123');
-            const context = {user: 1};
-
-            const response = await models.Comment.permissible(comment, 'destroy', context, {}, testUtils.permissions.owner, true, true, true);
-            response.should.eql(true);
-        });
-
-        it('can only edit own comments', async function () {
-            const comment = getCommentModel(1, 'member_123');
-            const context = {
-                member: {
-                    id: 'other_member'
-                }
-            };
-
-            try {
-                const response = await models.Comment.permissible(comment, 'edit', context, {}, null, false, true, true);
-                response.should.eql(true);
-            } catch (err) {
-                err.message.should.eql('You may only edit your own comments');
-                return;
-            }
-            throw new Error('Should throw');
-        });
-
-        it('can edit own comments', async function () {
-            const comment = getCommentModel(1, 'member_123');
-            const context = {
-                member: {
-                    id: 'member_123'
-                }
-            };
-
-            await models.Comment.permissible(comment, 'edit', context, {}, null, false, true, true);
-        });
-
-        it('can only destroy own comments', async function () {
-            const comment = getCommentModel(1, 'member_123');
-            const context = {
-                member: {
-                    id: 'other_member'
-                }
-            };
-
-            try {
-                const response = await models.Comment.permissible(comment, 'destroy', context, {}, null, false, true, true);
-                response.should.eql(true);
-            } catch (err) {
-                err.message.should.eql('You may only delete your own comments');
-                return;
-            }
-            throw new Error('Should throw');
-        });
-
-        it('can edit destroy comments', async function () {
-            const comment = getCommentModel(1, 'member_123');
-            const context = {
-                member: {
-                    id: 'member_123'
-                }
-            };
-
-            await models.Comment.permissible(comment, 'destroy', context, {}, null, false, true, true);
-        });
     });
 });

--- a/ghost/core/test/unit/server/services/permissions/can-this.test.js
+++ b/ghost/core/test/unit/server/services/permissions/can-this.test.js
@@ -652,16 +652,10 @@ describe('Permissions', function () {
                     done(new Error('was able to edit post without permission'));
                 })
                 .catch(function (err) {
-                    permissibleStub.callCount.should.eql(1);
-                    permissibleStub.firstCall.args.should.have.lengthOf(8);
-
-                    permissibleStub.firstCall.args[0].should.eql(1);
-                    permissibleStub.firstCall.args[1].should.eql('edit');
-                    permissibleStub.firstCall.args[2].should.be.an.Object();
-                    permissibleStub.firstCall.args[3].should.be.an.Object();
-                    permissibleStub.firstCall.args[4].should.be.an.Object();
-                    permissibleStub.firstCall.args[5].should.be.true();
-                    permissibleStub.firstCall.args[6].should.be.true();
+                    sinon.assert.calledOnce(permissibleStub);
+                    sinon.assert.calledWith(permissibleStub,
+                        1, 'edit', sinon.match.object, sinon.match.object, sinon.match.object, true, true
+                    );
 
                     userProviderStub.callCount.should.eql(1);
                     err.message.should.eql('Hello World!');
@@ -687,16 +681,10 @@ describe('Permissions', function () {
                 .edit
                 .post({id: 1}) // tag id in model syntax
                 .then(function (res) {
-                    permissibleStub.callCount.should.eql(1);
-                    permissibleStub.firstCall.args.should.have.lengthOf(8);
-                    permissibleStub.firstCall.args[0].should.eql(1);
-                    permissibleStub.firstCall.args[1].should.eql('edit');
-                    permissibleStub.firstCall.args[2].should.be.an.Object();
-                    permissibleStub.firstCall.args[3].should.be.an.Object();
-                    permissibleStub.firstCall.args[4].should.be.an.Object();
-                    permissibleStub.firstCall.args[5].should.be.true();
-                    permissibleStub.firstCall.args[6].should.be.true();
-                    permissibleStub.firstCall.args[7].should.be.false();
+                    sinon.assert.calledOnce(permissibleStub);
+                    sinon.assert.calledWith(permissibleStub,
+                        1, 'edit', sinon.match.object, sinon.match.object, sinon.match.object, true, true
+                    );
 
                     userProviderStub.callCount.should.eql(1);
                     should.not.exist(res);


### PR DESCRIPTION
## Summary

- Removed dead member permission code that was never enforced
- Simplified the public API bypass condition
- Cleaned up Comment model's `permissible()` function

## Context

The member permission system for comments contained several latent bugs that went undetected until we attempted to implement per-member comment restrictions:

1. **Public bypass was always true**: The condition `apiType !== 'comments'` checked for an API type that doesn't exist (Content API has `apiType: 'content'`, Members API has `apiType: 'members'`). This meant all public requests bypassed permission checks.

2. **providers.member() was a no-op**: It loaded ALL comment permissions for ALL members, so every member effectively had every permission.

3. **Comment.permissible() returned wrong type**: It returned `true` instead of `Promise.resolve()`, which could cause issues in the async permission chain.

Since the entire system was effectively a no-op, we've opted to remove the unused code rather than fix a system that was never enforcing anything.

Admin permission checks remain unchanged and functional.