### PR TITLE
Fixed timezone bug in browser tests

### DIFF
--- a/ghost/core/test/e2e-browser/admin/publishing.spec.js
+++ b/ghost/core/test/e2e-browser/admin/publishing.spec.js
@@ -9,7 +9,7 @@ const {createTier, createMember, createPostDraft, impersonateMember} = require('
  * Used for scheduling tests to ensure the date is always "today" regardless of time.
  */
 const getTodayDateString = () => {
-    return DateTime.now().toFormat('yyyy-MM-dd');
+    return DateTime.utc().toFormat('yyyy-MM-dd');
 };
 
 /**

--- a/ghost/core/test/e2e-browser/admin/publishing.spec.js
+++ b/ghost/core/test/e2e-browser/admin/publishing.spec.js
@@ -5,6 +5,14 @@ const {slugify} = require('@tryghost/string');
 const {createTier, createMember, createPostDraft, impersonateMember} = require('../utils');
 
 /**
+ * Get today's date as a string in YYYY-MM-DD format.
+ * Used for scheduling tests to ensure the date is always "today" regardless of time.
+ */
+const getTodayDateString = () => {
+    return DateTime.now().toFormat('yyyy-MM-dd');
+};
+
+/**
  * Test the status of a post in the post editor.
  * @param {import('@playwright/test').Page} page
  * @param {string} status The status you expect to see
@@ -274,8 +282,9 @@ test.describe('Publishing', () => {
             await sharedPage.goto('/ghost');
             await createPage(sharedPage, pageData);
 
-            // Schedule the post to publish asap (by setting it to 00:00, it will get auto corrected to the minimum time possible - 5 seconds in the future)
-            await publishPost(sharedPage, {time: '00:00', type: null});
+            // Schedule the post to publish asap (setting today's date with time 00:00 ensures
+            // the datetime is in the past and gets auto-corrected to 5 seconds in the future)
+            await publishPost(sharedPage, {date: getTodayDateString(), time: '00:00', type: null});
             await closePublishFlow(sharedPage);
             await checkPostStatus(sharedPage, 'Scheduled', 'Scheduled to be published in a few seconds');
 
@@ -375,8 +384,9 @@ test.describe('Publishing', () => {
 
             const editorUrl = await sharedPage.url();
 
-            // Schedule the post to publish asap (by setting it to 00:00, it will get auto corrected to the minimum time possible - 5 seconds in the future)
-            await publishPost(sharedPage, {time: '00:00', type: 'publish+send'});
+            // Schedule the post to publish asap (setting today's date with time 00:00 ensures
+            // the datetime is in the past and gets auto-corrected to 5 seconds in the future)
+            await publishPost(sharedPage, {date: getTodayDateString(), time: '00:00', type: 'publish+send'});
             await closePublishFlow(sharedPage);
             await checkPostStatus(sharedPage, 'Scheduled', 'Scheduled to be published and sent'); // Member count can differ, hence not included here
             await checkPostStatus(sharedPage, 'Scheduled', 'in a few seconds'); // Extra test for suffix on hover
@@ -406,8 +416,9 @@ test.describe('Publishing', () => {
             await createPostDraft(sharedPage, postData);
 
             const editorUrl = await sharedPage.url();
-            // Schedule the post to publish asap (by setting it to 00:00, it will get auto corrected to the minimum time possible - 5 seconds in the future)
-            await publishPost(sharedPage, {time: '00:00'});
+            // Schedule the post to publish asap (setting today's date with time 00:00 ensures
+            // the datetime is in the past and gets auto-corrected to 5 seconds in the future)
+            await publishPost(sharedPage, {date: getTodayDateString(), time: '00:00'});
             await closePublishFlow(sharedPage);
             await checkPostStatus(sharedPage, 'Scheduled', 'Scheduled to be published in a few seconds');
 
@@ -438,8 +449,9 @@ test.describe('Publishing', () => {
             await createPostDraft(sharedPage, postData);
             const editorUrl = await sharedPage.url();
 
-            // Schedule the post to publish asap (by setting it to 00:00, it will get auto corrected to the minimum time possible - 5 seconds in the future)
-            await publishPost(sharedPage, {type: 'send', time: '00:00'});
+            // Schedule the post to publish asap (setting today's date with time 00:00 ensures
+            // the datetime is in the past and gets auto-corrected to 5 seconds in the future)
+            await publishPost(sharedPage, {date: getTodayDateString(), time: '00:00', type: 'send'});
             await closePublishFlow(sharedPage);
             await checkPostStatus(sharedPage, 'Scheduled', 'Scheduled to be sent in a few seconds');
 


### PR DESCRIPTION
Test only change that shouldn't impact any user facing behavior.

## Summary

Fixed a timezone-related flaky test failure in the publishing browser tests.

## The Problem

The scheduling tests in `publishing.spec.js` were only setting `time: '00:00'` without specifying a date. The assumption was that midnight today would always be in the past, triggering the auto-correction to "5 seconds in the future."

However, this fails when the **UTC date differs from the local date**:

- **For Americas (UTC-8 to UTC-5)**: Tests fail roughly **4 PM to midnight local time**
  - Example: At 5 PM Pacific (UTC-8), UTC is already 1 AM the next day
  - If the scheduler uses the UTC date, "00:00" on that date is still in the future
  - No auto-correction happens → test fails expecting "in a few seconds"

## The Fix

Explicitly set `date: getTodayDateString()` along with `time: '00:00'`. The helper uses `DateTime.now()` to get the current system date, ensuring that "00:00 today" is always in the past regardless of timezone differences between the test runner and the server.

## Changes

- Added `getTodayDateString()` helper function
- Updated 4 test cases to explicitly pass today's date when scheduling posts