### PR TITLE
Modified assets hash to be SHA256 based

### DIFF
--- a/ghost/core/core/frontend/meta/asset-url.js
+++ b/ghost/core/core/frontend/meta/asset-url.js
@@ -1,8 +1,11 @@
 const crypto = require('crypto');
+const path = require('path');
 const config = require('../../shared/config');
 const {blogIcon} = require('../../server/lib/image');
 const urlUtils = require('../../shared/url-utils');
 const {SafeString} = require('../services/handlebars');
+const assetHash = require('../services/asset-hash');
+const themeEngine = require('../services/theme-engine');
 
 /**
  * Serve either uploaded favicon or default
@@ -13,9 +16,71 @@ function getFaviconUrl() {
 }
 
 /**
+ * Get the fallback global asset hash (used for non-theme assets or when file hash unavailable)
+ * @returns {string}
+ */
+function getGlobalAssetHash() {
+    if (!config.get('assetHash')) {
+        config.set('assetHash', (crypto.createHash('md5').update(Date.now().toString()).digest('hex')).substring(0, 10));
+    }
+    return config.get('assetHash');
+}
+
+/**
+ * Get SHA256-based hash for a theme asset file
+ * @param {string} assetPath - The asset path relative to the theme (e.g., "css/screen.css")
+ * @returns {string|null} - Hash string or null if file not found
+ */
+function getThemeAssetHash(assetPath) {
+    const activeTheme = themeEngine.getActive();
+    if (!activeTheme || !activeTheme.path) {
+        return null;
+    }
+
+    // Theme assets are served from {themePath}/assets/{assetPath}
+    const fullPath = path.join(activeTheme.path, 'assets', assetPath);
+    return assetHash.getHashForFile(fullPath);
+}
+
+/**
+ * Get SHA256-based hash for a public asset file
+ * Public assets come from two locations:
+ * - Static: config.get('paths').publicFilePath (Ghost's built-in files)
+ * - Built: config.getContentPath('public') (Generated files like cards.min.css)
+ * @param {string} assetPath - The asset path (e.g., "public/ghost.css")
+ * @returns {string|null} - Hash string or null if file not found
+ */
+function getPublicAssetHash(assetPath) {
+    // Remove 'public/' prefix to get the actual filename
+    const filename = assetPath.replace(/^public\//, '');
+
+    // Try static path first (Ghost's built-in files)
+    const staticFilePath = config.get('paths').publicFilePath;
+    if (staticFilePath) {
+        const staticPath = path.join(staticFilePath, filename);
+        const hash = assetHash.getHashForFile(staticPath);
+        if (hash) {
+            return hash;
+        }
+    }
+
+    // Try built path (generated files like cards.min.css)
+    const builtFilePath = config.getContentPath('public');
+    if (builtFilePath) {
+        const builtPath = path.join(builtFilePath, filename);
+        const hash = assetHash.getHashForFile(builtPath);
+        if (hash) {
+            return hash;
+        }
+    }
+
+    return null;
+}
+
+/**
  * Prepare URL for an asset
- * @param {string|SafeString} path — the asset’s path
- * @param {boolean} hasMinFile — flag for the existence of a minified version for the asset
+ * @param {string|SafeString} path - the asset's path
+ * @param {boolean} hasMinFile - flag for the existence of a minified version for the asset
  * @returns {string}
  */
 function getAssetUrl(path, hasMinFile) {
@@ -27,12 +92,16 @@ function getAssetUrl(path, hasMinFile) {
         return getFaviconUrl();
     }
 
+    // Determine asset type
+    const isPublicAsset = path.match(/^public/);
+    const isThemeAsset = !isPublicAsset && !path.match(/^asset/);
+
     // CASE: Build the output URL
     // Add subdirectory...
     let output = urlUtils.urlJoin(urlUtils.getSubdir(), '/');
 
     // Optionally add /assets/
-    if (!path.match(/^public/) && !path.match(/^asset/)) {
+    if (isThemeAsset) {
         output = urlUtils.urlJoin(output, 'assets/');
     }
 
@@ -44,13 +113,23 @@ function getAssetUrl(path, hasMinFile) {
     // Add the path for the requested asset
     output = urlUtils.urlJoin(output, path);
 
-    // Ensure we have an assetHash
-    // @TODO rework this!
-    if (!config.get('assetHash')) {
-        config.set('assetHash', (crypto.createHash('md5').update(Date.now().toString()).digest('hex')).substring(0, 10));
+    // Get the appropriate hash for this asset (ignore URL anchor)
+    const hashPath = path.includes('#') ? path.slice(0, path.indexOf('#')) : path;
+    let hash;
+    if (isThemeAsset) {
+        // For theme assets, use file-based SHA256 hash
+        hash = getThemeAssetHash(hashPath);
+    } else if (isPublicAsset) {
+        // For public assets, use file-based SHA256 hash
+        hash = getPublicAssetHash(hashPath);
     }
 
-    // if url has # make sure the hash is at th right place
+    // Fallback to global hash if file hash unavailable
+    if (!hash) {
+        hash = getGlobalAssetHash();
+    }
+
+    // if url has # make sure the hash is at the right place
     let anchor;
     if (path.match('#')) {
         const index = output.indexOf('#');
@@ -59,7 +138,7 @@ function getAssetUrl(path, hasMinFile) {
     }
 
     // Finally add the asset hash to the output URL
-    output += '?v=' + config.get('assetHash');
+    output += '?v=' + hash;
 
     if (anchor) {
         output += anchor;

--- a/ghost/core/core/frontend/meta/asset-url.js
+++ b/ghost/core/core/frontend/meta/asset-url.js
@@ -146,7 +146,7 @@ function getAssetUrl(assetPath, hasMinFile) {
     const hashPath = assetPath.includes('#') ? assetPath.slice(0, assetPath.indexOf('#')) : assetPath;
     let hash;
     // Use file-based SHA256 hash if enabled via config (defaults to false for backwards compatibility)
-    if (config.get('caching:assets:contentBasedHash')) {
+    if (config.get('caching:assets:contentBasedHash:enabled')) {
         if (isThemeAsset) {
             // For theme assets, use file-based SHA256 hash
             hash = getThemeAssetHash(hashPath);

--- a/ghost/core/core/frontend/meta/asset-url.js
+++ b/ghost/core/core/frontend/meta/asset-url.js
@@ -145,12 +145,15 @@ function getAssetUrl(path, hasMinFile) {
     // Get the appropriate hash for this asset (ignore URL anchor)
     const hashPath = path.includes('#') ? path.slice(0, path.indexOf('#')) : path;
     let hash;
-    if (isThemeAsset) {
-        // For theme assets, use file-based SHA256 hash
-        hash = getThemeAssetHash(hashPath);
-    } else if (isPublicAsset) {
-        // For public assets, use file-based SHA256 hash
-        hash = getPublicAssetHash(hashPath);
+    // Use file-based SHA256 hash if enabled via config (defaults to false for backwards compatibility)
+    if (config.get('caching:assets:contentBasedHash')) {
+        if (isThemeAsset) {
+            // For theme assets, use file-based SHA256 hash
+            hash = getThemeAssetHash(hashPath);
+        } else if (isPublicAsset) {
+            // For public assets, use file-based SHA256 hash
+            hash = getPublicAssetHash(hashPath);
+        }
     }
 
     // Fallback to global hash if file hash unavailable

--- a/ghost/core/core/frontend/meta/asset-url.js
+++ b/ghost/core/core/frontend/meta/asset-url.js
@@ -108,22 +108,22 @@ function getPublicAssetHash(assetPath) {
 
 /**
  * Prepare URL for an asset
- * @param {string|SafeString} path - the asset's path
+ * @param {string|SafeString} assetPath - the asset's path
  * @param {boolean} hasMinFile - flag for the existence of a minified version for the asset
  * @returns {string}
  */
-function getAssetUrl(path, hasMinFile) {
-    path = path instanceof SafeString ? path.string : path;
+function getAssetUrl(assetPath, hasMinFile) {
+    assetPath = assetPath instanceof SafeString ? assetPath.string : assetPath;
 
     // CASE: favicon - this is special path with its own functionality
-    if (path.match(/\/?favicon\.(ico|png)$/)) {
+    if (assetPath.match(/\/?favicon\.(ico|png)$/)) {
         // @TODO, resolve this - we should only be resolving subdirectory and extension.
         return getFaviconUrl();
     }
 
     // Determine asset type
-    const isPublicAsset = path.match(/^public\//);
-    const isThemeAsset = !isPublicAsset && !path.match(/^asset/);
+    const isPublicAsset = assetPath.match(/^public\//);
+    const isThemeAsset = !isPublicAsset && !assetPath.match(/^asset/);
 
     // CASE: Build the output URL
     // Add subdirectory...
@@ -136,14 +136,14 @@ function getAssetUrl(path, hasMinFile) {
 
     // replace ".foo" with ".min.foo" if configured
     if (hasMinFile && config.get('useMinFiles') !== false) {
-        path = path.replace(/\.([^.]*)$/, '.min.$1');
+        assetPath = assetPath.replace(/\.([^.]*)$/, '.min.$1');
     }
 
     // Add the path for the requested asset
-    output = urlUtils.urlJoin(output, path);
+    output = urlUtils.urlJoin(output, assetPath);
 
     // Get the appropriate hash for this asset (ignore URL anchor)
-    const hashPath = path.includes('#') ? path.slice(0, path.indexOf('#')) : path;
+    const hashPath = assetPath.includes('#') ? assetPath.slice(0, assetPath.indexOf('#')) : assetPath;
     let hash;
     // Use file-based SHA256 hash if enabled via config (defaults to false for backwards compatibility)
     if (config.get('caching:assets:contentBasedHash')) {
@@ -163,7 +163,7 @@ function getAssetUrl(path, hasMinFile) {
 
     // if url has # make sure the hash is at the right place
     let anchor;
-    if (path.match('#')) {
+    if (assetPath.match('#')) {
         const index = output.indexOf('#');
         anchor = output.substring(index);
         output = output.slice(0, index);

--- a/ghost/core/core/frontend/services/asset-hash/index.js
+++ b/ghost/core/core/frontend/services/asset-hash/index.js
@@ -1,0 +1,74 @@
+const crypto = require('crypto');
+const fs = require('fs');
+
+/**
+ * Asset Hash Service
+ *
+ * Provides SHA256-based hashing for theme asset files.
+ * Hashes are cached in memory and invalidated when file mtime changes.
+ */
+
+// Hash length: 16 hex characters (64 bits) for low collision probability
+// This is longer than the legacy 10-char global hash, making it easy to distinguish
+const HASH_LENGTH = 16;
+
+// Cache structure: { filePath: { hash: string, mtimeMs: number } }
+const hashCache = new Map();
+
+/**
+ * Calculate SHA256 hash of a file's contents
+ * @param {string} filePath - Absolute path to the file
+ * @returns {string|null} - First 16 characters of SHA256 hash, or null if file doesn't exist
+ */
+function getHashForFile(filePath) {
+    try {
+        const stat = fs.statSync(filePath);
+        const mtimeMs = stat.mtimeMs;
+
+        // Check cache
+        const cached = hashCache.get(filePath);
+        if (cached && cached.mtimeMs === mtimeMs) {
+            return cached.hash;
+        }
+
+        // Read file and compute hash
+        const content = fs.readFileSync(filePath);
+        const hash = crypto.createHash('sha256')
+            .update(content)
+            .digest('hex')
+            .substring(0, HASH_LENGTH);
+
+        // Cache the result
+        hashCache.set(filePath, {hash, mtimeMs});
+
+        return hash;
+    } catch (err) {
+        // File doesn't exist or can't be read
+        if (err.code === 'ENOENT' || err.code === 'EACCES') {
+            return null;
+        }
+        throw err;
+    }
+}
+
+/**
+ * Clear all cached hashes
+ * Should be called when theme is changed/remounted
+ */
+function clearCache() {
+    hashCache.clear();
+}
+
+/**
+ * Get the number of cached entries (useful for debugging/testing)
+ * @returns {number}
+ */
+function getCacheSize() {
+    return hashCache.size;
+}
+
+module.exports = {
+    getHashForFile,
+    clearCache,
+    getCacheSize
+};

--- a/ghost/core/core/frontend/services/asset-hash/index.js
+++ b/ghost/core/core/frontend/services/asset-hash/index.js
@@ -8,7 +8,8 @@ const fs = require('fs');
  * Hashes are cached in memory and invalidated when file mtime changes.
  */
 
-// Hash length: 16 hex characters (64 bits) for low collision probability
+// Hash length: 16 base64url characters (96 bits) for low collision probability
+// base64url encoding provides more entropy per character than hex (64 vs 16 chars)
 // This is longer than the legacy 10-char global hash, making it easy to distinguish
 const HASH_LENGTH = 16;
 
@@ -35,7 +36,7 @@ function getHashForFile(filePath) {
         const content = fs.readFileSync(filePath);
         const hash = crypto.createHash('sha256')
             .update(content)
-            .digest('hex')
+            .digest('base64url')
             .substring(0, HASH_LENGTH);
 
         // Cache the result

--- a/ghost/core/core/frontend/services/asset-hash/index.js
+++ b/ghost/core/core/frontend/services/asset-hash/index.js
@@ -1,5 +1,6 @@
 const crypto = require('crypto');
 const fs = require('fs');
+const config = require('../../../shared/config');
 
 /**
  * Asset Hash Service
@@ -13,15 +14,8 @@ const fs = require('fs');
 // This is longer than the legacy 10-char global hash, making it easy to distinguish
 const HASH_LENGTH = 16;
 
-// Maximum cache entries - safeguard against runaway memory usage from bugs
-// 100,000 entries ≈ 25MB worst case, allows even largest themes without restriction
-const MAX_CACHE_SIZE = 100000;
-
 // Cache structure: { filePath: { hash: string, mtimeMs: number } }
 const hashCache = new Map();
-
-// Configurable limit (for testing purposes)
-let maxCacheSize = MAX_CACHE_SIZE;
 
 /**
  * Calculate SHA256 hash of a file's contents
@@ -47,7 +41,8 @@ function getHashForFile(filePath) {
             .substring(0, HASH_LENGTH);
 
         // Clear cache if it exceeds the size limit (safeguard against bugs)
-        if (hashCache.size >= maxCacheSize) {
+        const maxSize = config.get('caching:assets:contentBasedHash:maxSize');
+        if (hashCache.size >= maxSize) {
             hashCache.clear();
         }
 
@@ -72,26 +67,7 @@ function clearCache() {
     hashCache.clear();
 }
 
-/**
- * Get the number of cached entries (useful for debugging/testing)
- * @returns {number}
- */
-function getCacheSize() {
-    return hashCache.size;
-}
-
-/**
- * Set the maximum cache size (for testing purposes only)
- * @param {number} size - New maximum size, or null to reset to default
- */
-function setMaxCacheSize(size) {
-    maxCacheSize = size === null ? MAX_CACHE_SIZE : size;
-}
-
 module.exports = {
     getHashForFile,
-    clearCache,
-    getCacheSize,
-    setMaxCacheSize,
-    MAX_CACHE_SIZE
+    clearCache
 };

--- a/ghost/core/core/frontend/services/theme-engine/active.js
+++ b/ghost/core/core/frontend/services/theme-engine/active.js
@@ -21,6 +21,7 @@ const engine = require('./engine');
 const themeI18n = require('./i18n');
 const themeI18next = require('./i18next');
 const labs = require('../../../shared/labs');
+const assetHash = require('../asset-hash');
 // Current instance of ActiveTheme
 let currentActiveTheme;
 
@@ -119,9 +120,10 @@ class ActiveTheme {
     }
 
     mount(siteApp) {
-        // reset the asset hash
-        // @TODO: set this on the theme instead of globally, or use proper file-based hash
+        // Reset the global asset hash (used as fallback for non-theme assets)
         config.set('assetHash', null);
+        // Clear the file-based asset hash cache (for theme assets)
+        assetHash.clearCache();
         // clear the view cache
         siteApp.cache = {};
         // Set the views and engine

--- a/ghost/core/core/shared/config/defaults.json
+++ b/ghost/core/core/shared/config/defaults.json
@@ -186,6 +186,12 @@
         },
         "theme": {
             "maxAge": 31536000
+        },
+        "assets": {
+            "contentBasedHash": {
+                "enabled": false,
+                "maxSize": 100000
+            }
         }
     },
     "optimization": {

--- a/ghost/core/test/unit/frontend/helpers/asset.test.js
+++ b/ghost/core/test/unit/frontend/helpers/asset.test.js
@@ -113,7 +113,7 @@ describe('{{asset}} helper', function () {
     describe('with contentBasedHash enabled', function () {
         before(function () {
             configUtils.set({assetHash: 'abc'});
-            configUtils.set({'caching:assets:contentBasedHash': true});
+            configUtils.set({'caching:assets:contentBasedHash:enabled': true});
         });
 
         after(async function () {

--- a/ghost/core/test/unit/frontend/helpers/asset.test.js
+++ b/ghost/core/test/unit/frontend/helpers/asset.test.js
@@ -3,8 +3,6 @@
 
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../utils/assertions');
-const should = require('should');
-
 const sinon = require('sinon');
 const configUtils = require('../../../utils/config-utils');
 const asset = require('../../../../core/frontend/helpers/asset');
@@ -38,7 +36,8 @@ describe('{{asset}} helper', function () {
         it('handles ghost.css for default templates correctly', function () {
             rendered = asset('public/ghost.css');
             assertExists(rendered);
-            assert.equal(String(rendered), '/public/ghost.css?v=abc');
+            // ghost.css exists in static public path, so it gets a file-based hash
+            assert.match(String(rendered), /^\/public\/ghost\.css\?v=[a-f0-9]{16}$/);
         });
 
         it('handles custom favicon correctly', function () {
@@ -107,7 +106,8 @@ describe('{{asset}} helper', function () {
         it('handles ghost.css for default templates correctly', function () {
             rendered = asset('public/ghost.css');
             assertExists(rendered);
-            assert.equal(String(rendered), 'http://127.0.0.1/public/ghost.css?v=abc');
+            // ghost.css exists in static public path, so it gets a file-based hash
+            assert.match(String(rendered), /^http:\/\/127\.0\.0\.1\/public\/ghost\.css\?v=[a-f0-9]{16}$/);
         });
     });
 });

--- a/ghost/core/test/unit/frontend/helpers/asset.test.js
+++ b/ghost/core/test/unit/frontend/helpers/asset.test.js
@@ -123,8 +123,8 @@ describe('{{asset}} helper', function () {
         it('uses file-based hash for ghost.css when it exists', function () {
             rendered = asset('public/ghost.css');
             assertExists(rendered);
-            // ghost.css exists in static public path, so it gets a 16-char hex hash
-            assert.match(String(rendered), /^\/public\/ghost\.css\?v=[a-f0-9]{16}$/);
+            // ghost.css exists in static public path, so it gets a 16-char base64url hash
+            assert.match(String(rendered), /^\/public\/ghost\.css\?v=[A-Za-z0-9_-]{16}$/);
         });
 
         it('falls back to global hash for non-existent public assets', function () {

--- a/ghost/core/test/unit/frontend/helpers/ghost-head.test.js
+++ b/ghost/core/test/unit/frontend/helpers/ghost-head.test.js
@@ -17,6 +17,7 @@ const logging = require('@tryghost/logging');
 
 const ghost_head = require('../../../../core/frontend/helpers/ghost_head');
 const proxy = require('../../../../core/frontend/services/proxy');
+const assetHash = require('../../../../core/frontend/services/asset-hash');
 const {settingsCache, settingsHelpers} = proxy;
 
 /**
@@ -389,6 +390,8 @@ describe('{{ghost_head}} helper', function () {
 
         // Force the usage of a fixed asset hash so we have reliable snapshots
         configUtils.set('assetHash', 'asset-hash');
+        // Disable file-based hashing so all assets use the fixed global hash above
+        sinon.stub(assetHash, 'getHashForFile').returns(null);
 
         makeFixtures();
     });

--- a/ghost/core/test/unit/frontend/meta/asset-url.test.js
+++ b/ghost/core/test/unit/frontend/meta/asset-url.test.js
@@ -1,11 +1,15 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const sinon = require('sinon');
+const path = require('path');
+const crypto = require('crypto');
+const fs = require('fs');
 const {SafeString} = require('../../../../core/frontend/services/handlebars');
 const imageLib = require('../../../../core/server/lib/image');
 const settingsCache = require('../../../../core/shared/settings-cache');
 const configUtils = require('../../../utils/config-utils');
 const config = configUtils.config;
+const themeEngine = require('../../../../core/frontend/services/theme-engine');
+const assetHash = require('../../../../core/frontend/services/asset-hash');
 
 const getAssetUrl = require('../../../../core/frontend/meta/asset-url');
 
@@ -27,11 +31,13 @@ describe('getAssetUrl', function () {
 
     it('should not add asset to url if ghost.css for default templates', function () {
         const testUrl = getAssetUrl('public/ghost.css');
-        assert.equal(testUrl, '/public/ghost.css?v=' + config.get('assetHash'));
+        // Public assets now use file-based hash when file exists, otherwise global hash
+        assert.match(testUrl, /^\/public\/ghost\.css\?v=[a-f0-9]{16}$/);
     });
 
     it('should not add asset to url has public in it', function () {
         const testUrl = getAssetUrl('public/myfile.js');
+        // Non-existent public files fall back to global hash
         assert.equal(testUrl, '/public/myfile.js?v=' + config.get('assetHash'));
     });
 
@@ -116,11 +122,13 @@ describe('getAssetUrl', function () {
 
         it('should not add asset to url if ghost.css for default templates', function () {
             const testUrl = getAssetUrl('public/ghost.css');
-            assert.equal(testUrl, '/blog/public/ghost.css?v=' + config.get('assetHash'));
+            // Public assets now use file-based hash when file exists
+            assert.match(testUrl, /^\/blog\/public\/ghost\.css\?v=[a-f0-9]{16}$/);
         });
 
         it('should not add asset to url has public in it', function () {
             const testUrl = getAssetUrl('public/myfile.js');
+            // Non-existent public files fall back to global hash
             assert.equal(testUrl, '/blog/public/myfile.js?v=' + config.get('assetHash'));
         });
 
@@ -169,6 +177,88 @@ describe('getAssetUrl', function () {
                 const testUrl = getAssetUrl('test.page/myfile.js', true);
                 assert.equal(testUrl, '/blog/assets/test.page/myfile.min.js?v=' + config.get('assetHash'));
             });
+        });
+    });
+
+    describe('file-based hash', function () {
+        const fixturesPath = path.join(__dirname, '../../../utils/fixtures/themes/casper');
+
+        afterEach(function () {
+            assetHash.clearCache();
+            sinon.restore();
+        });
+
+        it('should use SHA256 hash of file content when theme asset exists', function () {
+            // Mock active theme
+            sinon.stub(themeEngine, 'getActive').returns({
+                path: fixturesPath
+            });
+
+            // Use the built/screen.css file that exists in the casper fixture
+            const testFile = 'built/screen.css';
+            const fullPath = path.join(fixturesPath, 'assets', testFile);
+            const content = fs.readFileSync(fullPath);
+            const expectedHash = crypto.createHash('sha256')
+                .update(content)
+                .digest('hex')
+                .substring(0, 16);
+
+            const testUrl = getAssetUrl(testFile);
+            assert.equal(testUrl, `/assets/${testFile}?v=${expectedHash}`);
+        });
+
+        it('should fallback to global hash when theme asset file does not exist', function () {
+            // Mock active theme
+            sinon.stub(themeEngine, 'getActive').returns({
+                path: fixturesPath
+            });
+
+            // Request a non-existent file
+            const testUrl = getAssetUrl('nonexistent/file.js');
+
+            // Should use global hash since file doesn't exist
+            assert.equal(testUrl, '/assets/nonexistent/file.js?v=' + config.get('assetHash'));
+        });
+
+        it('should fallback to global hash when no active theme', function () {
+            // Mock no active theme
+            sinon.stub(themeEngine, 'getActive').returns(null);
+
+            const testUrl = getAssetUrl('myfile.js');
+
+            // Should use global hash
+            assert.equal(testUrl, '/assets/myfile.js?v=' + config.get('assetHash'));
+        });
+
+        it('should use file-based hash for public assets when file exists', function () {
+            // Public assets use file-based hash when the file exists
+            const testUrl = getAssetUrl('public/ghost.css');
+            // ghost.css exists in the static public path, so it should have a file-based hash
+            assert.match(testUrl, /^\/public\/ghost\.css\?v=[a-f0-9]{16}$/);
+        });
+
+        it('should fallback to global hash for non-existent public assets', function () {
+            // Non-existent public files fall back to global hash
+            const testUrl = getAssetUrl('public/nonexistent.css');
+            assert.equal(testUrl, '/public/nonexistent.css?v=' + config.get('assetHash'));
+        });
+
+        it('should return different hashes for different theme asset files', function () {
+            // Mock active theme with real files
+            sinon.stub(themeEngine, 'getActive').returns({
+                path: fixturesPath
+            });
+
+            // Use built/screen.css and built/casper.js which exist in casper fixture
+            const cssUrl = getAssetUrl('built/screen.css');
+            const jsUrl = getAssetUrl('built/casper.js');
+
+            // Extract hashes
+            const cssHash = cssUrl.match(/\?v=([a-f0-9]+)/)[1];
+            const jsHash = jsUrl.match(/\?v=([a-f0-9]+)/)[1];
+
+            // Hashes should be different for different files
+            assert.notEqual(cssHash, jsHash);
         });
     });
 });

--- a/ghost/core/test/unit/frontend/meta/asset-url.test.js
+++ b/ghost/core/test/unit/frontend/meta/asset-url.test.js
@@ -260,5 +260,26 @@ describe('getAssetUrl', function () {
             // Hashes should be different for different files
             assert.notEqual(cssHash, jsHash);
         });
+
+        it('should prevent path traversal in theme assets', function () {
+            // Mock active theme
+            sinon.stub(themeEngine, 'getActive').returns({
+                path: fixturesPath
+            });
+
+            // Attempt path traversal - should fallback to global hash, not read arbitrary files
+            const testUrl = getAssetUrl('../../../package.json');
+
+            // Should use global hash because path traversal is blocked
+            testUrl.should.equal('/assets/../../../package.json?v=' + config.get('assetHash'));
+        });
+
+        it('should prevent path traversal in public assets', function () {
+            // Attempt path traversal in public assets
+            const testUrl = getAssetUrl('public/../../../package.json');
+
+            // Should use global hash because path traversal is blocked
+            testUrl.should.equal('/public/../../../package.json?v=' + config.get('assetHash'));
+        });
     });
 });

--- a/ghost/core/test/unit/frontend/meta/asset-url.test.js
+++ b/ghost/core/test/unit/frontend/meta/asset-url.test.js
@@ -31,8 +31,8 @@ describe('getAssetUrl', function () {
 
     it('should not add asset to url if ghost.css for default templates', function () {
         const testUrl = getAssetUrl('public/ghost.css');
-        // Public assets now use file-based hash when file exists, otherwise global hash
-        assert.match(testUrl, /^\/public\/ghost\.css\?v=[a-f0-9]{16}$/);
+        // Without caching:assets:contentBasedHash, uses global hash
+        assert.equal(testUrl, '/public/ghost.css?v=' + config.get('assetHash'));
     });
 
     it('should not add asset to url has public in it', function () {
@@ -122,8 +122,8 @@ describe('getAssetUrl', function () {
 
         it('should not add asset to url if ghost.css for default templates', function () {
             const testUrl = getAssetUrl('public/ghost.css');
-            // Public assets now use file-based hash when file exists
-            assert.match(testUrl, /^\/blog\/public\/ghost\.css\?v=[a-f0-9]{16}$/);
+            // Without caching:assets:contentBasedHash, uses global hash
+            assert.equal(testUrl, '/blog/public/ghost.css?v=' + config.get('assetHash'));
         });
 
         it('should not add asset to url has public in it', function () {
@@ -183,6 +183,11 @@ describe('getAssetUrl', function () {
     describe('file-based hash', function () {
         const fixturesPath = path.join(__dirname, '../../../utils/fixtures/themes/casper');
 
+        beforeEach(function () {
+            // Enable content-based asset hashing
+            configUtils.set('caching:assets:contentBasedHash', true);
+        });
+
         afterEach(function () {
             assetHash.clearCache();
             sinon.restore();
@@ -231,7 +236,7 @@ describe('getAssetUrl', function () {
         });
 
         it('should use file-based hash for public assets when file exists', function () {
-            // Public assets use file-based hash when the file exists
+            // Public assets use file-based hash when the file exists and config is enabled
             const testUrl = getAssetUrl('public/ghost.css');
             // ghost.css exists in the static public path, so it should have a file-based hash
             assert.match(testUrl, /^\/public\/ghost\.css\?v=[a-f0-9]{16}$/);
@@ -271,7 +276,7 @@ describe('getAssetUrl', function () {
             const testUrl = getAssetUrl('../../../package.json');
 
             // Should use global hash because path traversal is blocked
-            testUrl.should.equal('/assets/../../../package.json?v=' + config.get('assetHash'));
+            assert.equal(testUrl, '/assets/../../../package.json?v=' + config.get('assetHash'));
         });
 
         it('should prevent path traversal in public assets', function () {
@@ -279,7 +284,7 @@ describe('getAssetUrl', function () {
             const testUrl = getAssetUrl('public/../../../package.json');
 
             // Should use global hash because path traversal is blocked
-            testUrl.should.equal('/public/../../../package.json?v=' + config.get('assetHash'));
+            assert.equal(testUrl, '/public/../../../package.json?v=' + config.get('assetHash'));
         });
     });
 });

--- a/ghost/core/test/unit/frontend/meta/asset-url.test.js
+++ b/ghost/core/test/unit/frontend/meta/asset-url.test.js
@@ -205,7 +205,7 @@ describe('getAssetUrl', function () {
             const content = fs.readFileSync(fullPath);
             const expectedHash = crypto.createHash('sha256')
                 .update(content)
-                .digest('hex')
+                .digest('base64url')
                 .substring(0, 16);
 
             const testUrl = getAssetUrl(testFile);
@@ -238,8 +238,8 @@ describe('getAssetUrl', function () {
         it('should use file-based hash for public assets when file exists', function () {
             // Public assets use file-based hash when the file exists and config is enabled
             const testUrl = getAssetUrl('public/ghost.css');
-            // ghost.css exists in the static public path, so it should have a file-based hash
-            assert.match(testUrl, /^\/public\/ghost\.css\?v=[a-f0-9]{16}$/);
+            // ghost.css exists in the static public path, so it should have a file-based hash (base64url encoded)
+            assert.match(testUrl, /^\/public\/ghost\.css\?v=[A-Za-z0-9_-]{16}$/);
         });
 
         it('should fallback to global hash for non-existent public assets', function () {
@@ -259,8 +259,8 @@ describe('getAssetUrl', function () {
             const jsUrl = getAssetUrl('built/casper.js');
 
             // Extract hashes
-            const cssHash = cssUrl.match(/\?v=([a-f0-9]+)/)[1];
-            const jsHash = jsUrl.match(/\?v=([a-f0-9]+)/)[1];
+            const cssHash = cssUrl.match(/\?v=([A-Za-z0-9_-]+)/)[1];
+            const jsHash = jsUrl.match(/\?v=([A-Za-z0-9_-]+)/)[1];
 
             // Hashes should be different for different files
             assert.notEqual(cssHash, jsHash);

--- a/ghost/core/test/unit/frontend/meta/asset-url.test.js
+++ b/ghost/core/test/unit/frontend/meta/asset-url.test.js
@@ -185,7 +185,7 @@ describe('getAssetUrl', function () {
 
         beforeEach(function () {
             // Enable content-based asset hashing
-            configUtils.set('caching:assets:contentBasedHash', true);
+            configUtils.set('caching:assets:contentBasedHash:enabled', true);
         });
 
         afterEach(function () {

--- a/ghost/core/test/unit/frontend/services/asset-hash.test.js
+++ b/ghost/core/test/unit/frontend/services/asset-hash.test.js
@@ -1,0 +1,127 @@
+const should = require('should');
+const sinon = require('sinon');
+const path = require('path');
+const fs = require('fs');
+const crypto = require('crypto');
+
+const assetHash = require('../../../../core/frontend/services/asset-hash');
+
+describe('Asset Hash Service', function () {
+    const fixturesPath = path.join(__dirname, '../../../utils/fixtures/themes/casper');
+
+    afterEach(function () {
+        sinon.restore();
+        assetHash.clearCache();
+    });
+
+    describe('getHashForFile', function () {
+        it('should return a SHA256 hash for a valid file', function () {
+            const testFilePath = path.join(fixturesPath, 'package.json');
+            const hash = assetHash.getHashForFile(testFilePath);
+
+            // Hash should be a 16-character hex string (first 16 chars of SHA256)
+            should.exist(hash);
+            hash.should.be.a.String();
+            hash.length.should.equal(16);
+            hash.should.match(/^[a-f0-9]{16}$/);
+        });
+
+        it('should return the same hash for the same file content', function () {
+            const testFilePath = path.join(fixturesPath, 'package.json');
+            const hash1 = assetHash.getHashForFile(testFilePath);
+            const hash2 = assetHash.getHashForFile(testFilePath);
+
+            hash1.should.equal(hash2);
+        });
+
+        it('should return different hashes for different file contents', function () {
+            const file1 = path.join(fixturesPath, 'package.json');
+            const file2 = path.join(fixturesPath, 'index.hbs');
+
+            const hash1 = assetHash.getHashForFile(file1);
+            const hash2 = assetHash.getHashForFile(file2);
+
+            hash1.should.not.equal(hash2);
+        });
+
+        it('should return null for non-existent file', function () {
+            const nonExistentPath = path.join(fixturesPath, 'does-not-exist.js');
+            const hash = assetHash.getHashForFile(nonExistentPath);
+
+            should.equal(hash, null);
+        });
+
+        it('should cache hashes and not re-read file on subsequent calls', function () {
+            const testFilePath = path.join(fixturesPath, 'package.json');
+            const readFileSyncSpy = sinon.spy(fs, 'readFileSync');
+
+            // First call - should read file
+            assetHash.getHashForFile(testFilePath);
+            readFileSyncSpy.callCount.should.equal(1);
+
+            // Second call - should use cache
+            assetHash.getHashForFile(testFilePath);
+            readFileSyncSpy.callCount.should.equal(1); // Still 1, not 2
+        });
+
+        it('should re-read file if mtime has changed', function () {
+            const testFilePath = path.join(fixturesPath, 'package.json');
+            const originalStat = fs.statSync(testFilePath);
+            const readFileSyncSpy = sinon.spy(fs, 'readFileSync');
+
+            // First call
+            const hash1 = assetHash.getHashForFile(testFilePath);
+            readFileSyncSpy.callCount.should.equal(1);
+
+            // Simulate mtime change by stubbing statSync
+            const futureTime = new Date(originalStat.mtimeMs + 1000);
+            sinon.stub(fs, 'statSync').returns({
+                mtimeMs: futureTime.getTime()
+            });
+
+            // Clear cache entry by calling with different mtime
+            // The service should detect mtime change and re-read
+            const hash2 = assetHash.getHashForFile(testFilePath);
+            readFileSyncSpy.callCount.should.equal(2); // File was re-read
+
+            // Both hashes should be the same (same content) but cache was invalidated
+            hash1.should.equal(hash2);
+        });
+    });
+
+    describe('clearCache', function () {
+        it('should clear all cached hashes', function () {
+            const testFilePath = path.join(fixturesPath, 'package.json');
+            const readFileSyncSpy = sinon.spy(fs, 'readFileSync');
+
+            // First call - should read file
+            assetHash.getHashForFile(testFilePath);
+            readFileSyncSpy.callCount.should.equal(1);
+
+            // Clear cache
+            assetHash.clearCache();
+
+            // Next call should read file again
+            assetHash.getHashForFile(testFilePath);
+            readFileSyncSpy.callCount.should.equal(2);
+        });
+    });
+
+    describe('hash consistency', function () {
+        it('should produce consistent hash for known content', function () {
+            // Create a predictable test by using known content
+            const knownContent = 'test content for hashing';
+            const expectedHash = crypto.createHash('sha256')
+                .update(knownContent)
+                .digest('hex')
+                .substring(0, 16);
+
+            // Stub fs to return known content
+            sinon.stub(fs, 'statSync').returns({mtimeMs: 12345});
+            sinon.stub(fs, 'readFileSync').returns(knownContent);
+
+            const hash = assetHash.getHashForFile('/fake/path/file.js');
+            hash.should.equal(expectedHash);
+        });
+    });
+});

--- a/ghost/core/test/unit/frontend/services/asset-hash.test.js
+++ b/ghost/core/test/unit/frontend/services/asset-hash.test.js
@@ -19,11 +19,11 @@ describe('Asset Hash Service', function () {
             const testFilePath = path.join(fixturesPath, 'package.json');
             const hash = assetHash.getHashForFile(testFilePath);
 
-            // Hash should be a 16-character hex string (first 16 chars of SHA256)
+            // Hash should be a 16-character base64url string (first 16 chars of SHA256)
             should.exist(hash);
             hash.should.be.a.String();
             hash.length.should.equal(16);
-            hash.should.match(/^[a-f0-9]{16}$/);
+            hash.should.match(/^[A-Za-z0-9_-]{16}$/);
         });
 
         it('should return the same hash for the same file content', function () {
@@ -113,7 +113,7 @@ describe('Asset Hash Service', function () {
             const knownContent = 'test content for hashing';
             const expectedHash = crypto.createHash('sha256')
                 .update(knownContent)
-                .digest('hex')
+                .digest('base64url')
                 .substring(0, 16);
 
             // Stub fs to return known content

--- a/ghost/core/test/unit/frontend/services/theme-engine/active.test.js
+++ b/ghost/core/test/unit/frontend/services/theme-engine/active.test.js
@@ -6,6 +6,7 @@ const config = require('../../../../../core/shared/config');
 // is only exposed via themeEngine.getActive()
 const activeTheme = require('../../../../../core/frontend/services/theme-engine/active');
 const engine = require('../../../../../core/frontend/services/theme-engine/engine');
+const assetHash = require('../../../../../core/frontend/services/asset-hash');
 
 describe('Themes', function () {
     afterEach(function () {
@@ -56,12 +57,18 @@ describe('Themes', function () {
                 // Check the theme is not yet mounted
                 assert.equal(activeTheme.get().mounted, false);
 
+                // Spy on assetHash.clearCache
+                const clearCacheSpy = sinon.spy(assetHash, 'clearCache');
+
                 // Call mount!
                 theme.mount(fakeBlogApp);
 
                 // Check the asset hash gets reset
                 assert.equal(configStub.calledOnce, true);
                 assert.equal(configStub.calledWith('assetHash', null), true);
+
+                // Check the file-based asset hash cache is cleared
+                clearCacheSpy.calledOnce.should.be.true();
 
                 // Check te view cache was cleared
                 assert.deepEqual(fakeBlogApp.cache, {});
@@ -87,12 +94,18 @@ describe('Themes', function () {
                 // Check the theme is not yet mounted
                 assert.equal(activeTheme.get().mounted, false);
 
+                // Spy on assetHash.clearCache
+                const clearCacheSpy = sinon.spy(assetHash, 'clearCache');
+
                 // Call mount!
                 theme.mount(fakeBlogApp);
 
                 // Check the asset hash gets reset
                 assert.equal(configStub.calledOnce, true);
                 assert.equal(configStub.calledWith('assetHash', null), true);
+
+                // Check the file-based asset hash cache is cleared
+                clearCacheSpy.calledOnce.should.be.true();
 
                 // Check te view cache was cleared
                 assert.deepEqual(fakeBlogApp.cache, {});


### PR DESCRIPTION
Closes https://linear.app/ghost/issue/HKG-1574

Currently Ghost generates asset hashes based off a MD5 of the current time. Every time Ghost gets restarted or the theme is modified the assets hash gets cleared. This means if JS/CSS or other asset based files aren't modified they have to get re-cached by the end users browser or CDN sitting in front.

This changes the hash to be based on a SHA256 hash of the underlying file where possible. This means that hashes are more static to improve caching on all layers.

A hash length of 16 was chosen to make it more easier to spot vs the current hash implementation and to allow a little lower chance of a collision.