### PR TITLE
Fix Accessibility Violation: Incorrect autocomplete token in Setup Form

### DIFF
--- a/ghost/admin/app/templates/setup.hbs
+++ b/ghost/admin/app/templates/setup.hbs
@@ -50,7 +50,7 @@
                         @name="email"
                         @placeholder="jamie@example.com"
                         @autocorrect="off"
-                        @autocomplete="username email"
+                        @autocomplete="email"
                         @value={{readonly this.email}}
                         @input={{action (mut this.email) value="target.value"}}
                         @focus-out={{action "preValidate" "email"}}

--- a/ghost/admin/app/templates/setup.hbs
+++ b/ghost/admin/app/templates/setup.hbs
@@ -50,7 +50,7 @@
                         @name="email"
                         @placeholder="jamie@example.com"
                         @autocorrect="off"
-                        @autocomplete="email"
+                        @autocomplete="username"
                         @value={{readonly this.email}}
                         @input={{action (mut this.email) value="target.value"}}
                         @focus-out={{action "preValidate" "email"}}

--- a/ghost/admin/app/templates/signup.hbs
+++ b/ghost/admin/app/templates/signup.hbs
@@ -39,7 +39,7 @@
                             class="gh-input"
                             placeholder="jamie@example.com"
                             autocorrect="off"
-                            autocomplete="username email"
+                            autocomplete="username"
                             value={{this.signupDetails.email}}
                             {{on "input" (fn this.setSignupProperty "email")}}
                             {{on "blur" (fn this.validate "email")}}


### PR DESCRIPTION
## Description
This PR addresses an accessibility violation (#25974) on the setup page where the email input field used conflicting autocomplete tokens (`username email`).

According to **WCAG Success Criterion 1.3.5 (Identify Input Purpose)**, the autocomplete attribute must clearly and singularly define the purpose of the input field. Using multiple tokens that do not align strictly with the input type can confuse browsers and assistive technologies.

Since the input is explicitly defined as `@type="email"`, the most appropriate and compliant token is `email`.

## Related Issue
Close #25974 

## Changes

Refined the `@autocomplete` attribute in `setup.hbs` from `"username email"` to `"email"`.

## Impact
- Improved Autofill: Browsers will now more reliably suggest the user's saved email addresses.
- Compliance: Resolves a "Violation" flagged by the IBM Equal Access Accessibility Checker.
- Cognitive Accessibility: Reduces friction for users with cognitive disabilities who rely on automated field identification.

## Validation
**Fix Before**
<img width="2560" height="923" alt="image" src="https://github.com/user-attachments/assets/ad65f91a-593d-42e1-a7e8-34f82b282ddd" />

**Fix After**
<img width="2560" height="921" alt="image" src="https://github.com/user-attachments/assets/af01b927-6559-429a-800a-52ae7f99acaa" />

This fix ensures that the metadata matches the visual label and the technical input type, providing a smoother onboarding experience for new Ghost administrators.

## Additional Info
The patch submitted in this PR was generated by [A11YRepair](https://sites.google.com/view/a11yrepair/home), an automated Web Accessibility repair tool that I developed to address common accessibility violations in web applications. The generated fixes were manually reviewed and validated before submission.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-template change to an input attribute; no logic, data handling, or security-sensitive code is affected.
> 
> **Overview**
> Fixes the setup form’s email field metadata by changing `@autocomplete` from `"username email"` to `"email"`, aligning it with the `type="email"` input and improving autofill/accessibility behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c85a9a08183198144b67edd541db593138caa0a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->