### PR TITLE
Removed duplicate Ember/React E2E test runs from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1097,7 +1097,7 @@ jobs:
           } >> $GITHUB_STEP_SUMMARY
 
   job_e2e_tests:
-    name: ${{matrix.shell == 'react' && '[Optional] ' || ''}}E2E Tests (${{ matrix.shell == 'react' && 'React' || 'Ember' }} ${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
+    name: E2E Tests (${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
     runs-on: ubuntu-latest
     needs: [job_docker_build, job_setup]
     strategy:
@@ -1105,8 +1105,6 @@ jobs:
       matrix:
         shardIndex: [1, 2, 3, 4]
         shardTotal: [4]
-        shell: [ember, react]
-    continue-on-error: ${{ matrix.shell == 'react' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -1155,7 +1153,6 @@ jobs:
       - name: Run e2e tests
         env:
           GHOST_IMAGE_TAG: ${{ steps.load.outputs.image-tag }}
-          USE_REACT_SHELL: ${{ matrix.shell == 'react' && 'true' || '' }}
           TEST_WORKERS_COUNT: 1
         run: yarn test:e2e --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
 
@@ -1163,7 +1160,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: blob-report-${{ matrix.shell }}-${{ matrix.shardIndex }}
+          name: blob-report-${{ matrix.shardIndex }}
           path: e2e/blob-report
           retention-days: 1
 
@@ -1171,7 +1168,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: test-results-${{ matrix.shell }}-${{ matrix.shardIndex }}
+          name: test-results-${{ matrix.shardIndex }}
           path: e2e/test-results
           retention-days: 7
 
@@ -1183,14 +1180,12 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   job_merge_e2e_reports:
-    name: Merge ${{ matrix.shell == 'react' && 'React' || 'Ember' }} Reports
+    name: Merge Reports
     if: always()
     needs: [job_e2e_tests, job_setup]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        shell: [ember, react]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -1209,7 +1204,7 @@ jobs:
         continue-on-error: true
         with:
           path: e2e/all-blob-reports
-          pattern: blob-report-${{ matrix.shell }}-*
+          pattern: blob-report-*
           merge-multiple: true
 
       - name: Check for blob reports
@@ -1226,7 +1221,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: e2e/all-test-results
-          pattern: test-results-${{ matrix.shell }}-*
+          pattern: test-results-*
           merge-multiple: true
 
       - name: Merge into HTML Report
@@ -1238,7 +1233,7 @@ jobs:
         if: steps.check.outputs.has_reports == 'true'
         uses: actions/upload-artifact@v4
         with:
-          name: playwright-report-${{ matrix.shell }}
+          name: playwright-report
           path: e2e/playwright-report
           retention-days: 14
 
@@ -1246,26 +1241,26 @@ jobs:
         if: steps.check.outputs.has_reports == 'true'
         uses: actions/upload-artifact@v4
         with:
-          name: test-results-${{ matrix.shell }}
+          name: test-results
           path: e2e/all-test-results
           retention-days: 7
 
       - name: View Test Report command
         if: steps.check.outputs.has_reports == 'true'
         run: |
-          echo -e "::notice::To view the ${{ matrix.shell == 'react' && 'React' || 'Ember' }} Playwright report locally, run:\n\nREPORT_DIR=\$(mktemp -d) && gh run download ${{ github.run_id }} -n playwright-report-${{ matrix.shell }} -D \"\$REPORT_DIR\" && npx playwright show-report \"\$REPORT_DIR\""
+          echo -e "::notice::To view the Playwright report locally, run:\n\nREPORT_DIR=\$(mktemp -d) && gh run download ${{ github.run_id }} -n playwright-report -D \"\$REPORT_DIR\" && npx playwright show-report \"\$REPORT_DIR\""
 
       - name: Comment on PR with test report command
         if: github.event_name == 'pull_request' && steps.check.outputs.has_reports == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh pr comment ${{ github.event.pull_request.number }} --body "## ${{ matrix.shell == 'react' && 'React' || 'Ember' }} E2E Tests Failed
+          gh pr comment ${{ github.event.pull_request.number }} --body "## E2E Tests Failed
 
           To view the Playwright test report locally, run:
 
           \`\`\`bash
-          REPORT_DIR=\$(mktemp -d) && gh run download ${{ github.run_id }} -n playwright-report-${{ matrix.shell }} -D \"\$REPORT_DIR\" && npx playwright show-report \"\$REPORT_DIR\"
+          REPORT_DIR=\$(mktemp -d) && gh run download ${{ github.run_id }} -n playwright-report -D \"\$REPORT_DIR\" && npx playwright show-report \"\$REPORT_DIR\"
           \`\`\`"
 
   job_coverage:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,26 +1,29 @@
 {
-  "editor.quickSuggestions": {
-    "strings": true
-  },
-  "eslint.workingDirectories": [
-    {
-      "pattern": "./apps/*/"
+    "editor.quickSuggestions": {
+        "strings": true
     },
-    {
-      "pattern": "./ghost/*/"
+    "eslint.workingDirectories": [
+        {
+            "pattern": "./apps/*/"
+        },
+        {
+            "pattern": "./ghost/*/"
+        }
+    ],
+    "search.exclude": {
+        "**/.git": true,
+        "**/build/*": true,
+        "**/coverage/**": true,
+        "**/dist/**": true,
+        "**/ghost.map": true,
+        "**/node_modules": true,
+        "ghost/core/core/built/**": true
+    },
+    "tailwindCSS.experimental.classRegex": [
+        ["clsx\\(([^)]*)\\)", "(?:'|\"|`)([^']*)(?:'|\"|`)"]
+    ],
+    "git.detectSubmodules": false,
+    "[typescript]": {
+        "editor.defaultFormatter": "dbaeumer.vscode-eslint"
     }
-  ],
-  "search.exclude": {
-    "**/.git": true,
-    "**/build/*": true,
-    "**/coverage/**": true,
-    "**/dist/**": true,
-    "**/ghost.map": true,
-    "**/node_modules": true,
-    "ghost/core/core/built/**": true
-  },
-  "tailwindCSS.experimental.classRegex": [
-    ["clsx\\(([^)]*)\\)", "(?:'|\"|`)([^']*)(?:'|\"|`)"]
-  ],
-  "git.detectSubmodules": false
 }

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -32,18 +32,6 @@ yarn test --grep "homepage"
 yarn test --debug
 ```
 
-### Testing with React Admin Shell
-
-To run e2e tests against the new React admin shell instead of the Ember admin:
-
-From the repository root:
-
-```bash
-USE_REACT_SHELL=true yarn test
-```
-
-This builds the React admin (`apps/admin`) and configures Ghost to serve it at `/ghost/` instead of the Ember admin.
-
 ## Tests Development
 
 The test suite is organized into separate directories for different areas/functions:

--- a/e2e/helpers/pages/admin/sidebar/sidebar-page.ts
+++ b/e2e/helpers/pages/admin/sidebar/sidebar-page.ts
@@ -49,19 +49,16 @@ export class SidebarPage extends AdminPage {
         this.sidebar = page.getByRole('navigation');
         this.postsToggle = this.sidebar.getByRole('button', {name: /toggle post views/i});
         this.userDropdownTrigger = page.locator('[data-test-nav="arrow-down"]');
-        this.nightShiftToggle = page.getByRole('button', {name: /dark mode/i}).or(page.getByRole('menuitem', {name: /dark mode/i}).getByRole('switch'));
+        this.nightShiftToggle = page.getByRole('menuitem', {name: /dark mode/i}).getByRole('switch');
         this.whatsNewButton = page.getByRole('menuitem', {name: /what's new/i});
         this.userProfileLink = page.getByRole('menuitem', {name: /your profile/i});
         this.signOutLink = page.getByRole('menuitem', {name: /sign out/i});
 
-        // TODO: Remove .first() and .gh-nav-member-count after React shell fully replaces Ember admin
         this.networkNotificationBadge = this.sidebar
             .getByRole('listitem').filter({hasText: /network/i})
-            .locator('[data-sidebar="menu-badge"], .gh-nav-member-count').first();
+            .locator('[data-sidebar="menu-badge"]');
         this.ghostProLink = this.sidebar.getByRole('link', {name: 'Ghost(Pro)'});
-        // Matches both React's link and Ember's button for the upgrade action
-        this.upgradeNowLink = this.sidebar.getByRole('link', {name: /upgrade/i})
-            .or(this.sidebar.getByRole('button', {name: /upgrade/i}));
+        this.upgradeNowLink = this.sidebar.getByRole('link', {name: /upgrade/i});
     }
 
     getNavLink(name: string): Locator {
@@ -89,20 +86,14 @@ export class SidebarPage extends AdminPage {
     }
 
     async isNightShiftEnabled(): Promise<boolean> {
-        // React uses a switch with aria-checked attribute
         const isChecked = await this.nightShiftToggle.getAttribute('aria-checked');
-        if (isChecked !== null) {
-            return isChecked === 'true';
-        }
-        // Ember uses a button with 'on' class
-        const classes = await this.nightShiftToggle.getAttribute('class');
-        return classes?.includes('on') ?? false;
+        return isChecked === 'true';
     }
 
     async waitForNightShiftEnabled(enabled: boolean): Promise<void> {
         const locator = enabled
-            ? this.page.locator('[aria-checked="true"], .nightshift-toggle.on')
-            : this.page.locator('[aria-checked="false"], .nightshift-toggle:not(.on)');
-        await locator.first().waitFor();
+            ? this.page.locator('[aria-checked="true"]')
+            : this.page.locator('[aria-checked="false"]');
+        await locator.waitFor();
     }
 }

--- a/e2e/helpers/pages/admin/whats-new/whats-new-menu.ts
+++ b/e2e/helpers/pages/admin/whats-new/whats-new-menu.ts
@@ -11,14 +11,10 @@ export class WhatsNewMenu extends AdminPage {
     constructor(page: Page) {
         super(page);
 
-        // TODO: Remove .first() after React shell fully replaces Ember admin
-        // During migration, both shells render the arrow-down icon
-        this.userMenuTrigger = page.locator('[data-test-nav="arrow-down"]').first();
+        this.userMenuTrigger = page.locator('[data-test-nav="arrow-down"]');
         this.whatsNewMenuItem = page.getByRole('menuitem', {name: /What’s new\?/i});
-        // TODO: Remove .first() after React shell fully replaces Ember admin
-        // During migration, both shells render badges - .first() selects React's
-        this.avatarBadge = page.locator('[data-test-whats-new-avatar-badge]').first();
-        this.menuBadge = page.locator('[data-test-whats-new-menu-badge]').first();
+        this.avatarBadge = page.locator('[data-test-whats-new-avatar-badge]');
+        this.menuBadge = page.locator('[data-test-whats-new-menu-badge]');
     }
 
     async openUserMenu(): Promise<void> {

--- a/e2e/tests/admin/comments/comment-moderation.test.ts
+++ b/e2e/tests/admin/comments/comment-moderation.test.ts
@@ -1,13 +1,16 @@
-import {CommentFactory, MemberFactory, PostFactory, createCommentFactory, createMemberFactory, createPostFactory} from '@/data-factory';
+import {
+    CommentFactory,
+    MemberFactory,
+    PostFactory,
+    createCommentFactory,
+    createMemberFactory,
+    createPostFactory
+} from '@/data-factory';
 import {CommentsPage} from '@/helpers/pages';
 import {SettingsService} from '@/helpers/services/settings/settings-service';
 import {expect, test} from '@/helpers/playwright';
 
-const useReactShell = process.env.USE_REACT_SHELL === 'true';
-
 test.describe('Ghost Admin - Comment Moderation', () => {
-    test.skip(!useReactShell, 'Skipping: requires USE_REACT_SHELL=true');
-
     let postFactory: PostFactory;
     let memberFactory: MemberFactory;
     let commentFactory: CommentFactory;
@@ -22,7 +25,9 @@ test.describe('Ghost Admin - Comment Moderation', () => {
     });
 
     test.describe('with commentPermalinks disabled', () => {
-        test.use({labs: {commentModeration: true, commentPermalinks: false}});
+        test.use({
+            labs: {commentModeration: true, commentPermalinks: false}
+        });
 
         test('view post action navigates to post', async ({page}) => {
             const post = await postFactory.create({status: 'published'});
@@ -37,7 +42,9 @@ test.describe('Ghost Admin - Comment Moderation', () => {
             await commentsPage.goto();
             await commentsPage.waitForComments();
 
-            const commentRow = commentsPage.getCommentRowByText('Test comment without permalink');
+            const commentRow = commentsPage.getCommentRowByText(
+                'Test comment without permalink'
+            );
             await commentsPage.openMoreMenu(commentRow);
 
             const popupPromise = page.waitForEvent('popup');
@@ -50,9 +57,13 @@ test.describe('Ghost Admin - Comment Moderation', () => {
     });
 
     test.describe('with commentPermalinks enabled', () => {
-        test.use({labs: {commentModeration: true, commentPermalinks: true}});
+        test.use({
+            labs: {commentModeration: true, commentPermalinks: true}
+        });
 
-        test('view on post action navigates to comment permalink', async ({page}) => {
+        test('view on post action navigates to comment permalink', async ({
+            page
+        }) => {
             const post = await postFactory.create({status: 'published'});
             const member = await memberFactory.create();
             const comment = await commentFactory.create({
@@ -65,14 +76,18 @@ test.describe('Ghost Admin - Comment Moderation', () => {
             await commentsPage.goto();
             await commentsPage.waitForComments();
 
-            const commentRow = commentsPage.getCommentRowByText('Test comment with permalink');
+            const commentRow = commentsPage.getCommentRowByText(
+                'Test comment with permalink'
+            );
             await commentsPage.openMoreMenu(commentRow);
 
             const popupPromise = page.waitForEvent('popup');
             await commentsPage.getViewOnPostMenuItem().click();
             const postPage = await popupPromise;
 
-            await expect(postPage).toHaveURL(new RegExp(`/${post.slug}/.*#ghost-comments-${comment.id}`));
+            await expect(postPage).toHaveURL(
+                new RegExp(`/${post.slug}/.*#ghost-comments-${comment.id}`)
+            );
         });
     });
 
@@ -99,20 +114,34 @@ test.describe('Ghost Admin - Comment Moderation', () => {
             await page.goto(`/ghost/#/comments?id=is:${targetComment.id}`);
             await commentsPage.waitForComments();
 
-            await expect(commentsPage.getCommentRowByText('This is the target comment')).toBeVisible();
-            await expect(commentsPage.getCommentRowByText('This is another comment')).not.toBeVisible();
+            await expect(
+                commentsPage.getCommentRowByText('This is the target comment')
+            ).toBeVisible();
+            await expect(
+                commentsPage.getCommentRowByText('This is another comment')
+            ).toBeHidden();
 
-            await expect(page.getByRole('button', {name: 'Filter'})).not.toBeVisible();
+            await expect(
+                page.getByRole('button', {name: 'Filter'})
+            ).toBeHidden();
 
-            const showAllButton = page.getByRole('button', {name: 'Show all comments'});
+            const showAllButton = page.getByRole('button', {
+                name: 'Show all comments'
+            });
             await expect(showAllButton).toBeVisible();
 
             await showAllButton.click();
-            await expect(commentsPage.getCommentRowByText('This is the target comment')).toBeVisible();
-            await expect(commentsPage.getCommentRowByText('This is another comment')).toBeVisible();
+            await expect(
+                commentsPage.getCommentRowByText('This is the target comment')
+            ).toBeVisible();
+            await expect(
+                commentsPage.getCommentRowByText('This is another comment')
+            ).toBeVisible();
 
-            await expect(page.getByRole('button', {name: 'Filter'})).toBeVisible();
-            await expect(showAllButton).not.toBeVisible();
+            await expect(
+                page.getByRole('button', {name: 'Filter'})
+            ).toBeVisible();
+            await expect(showAllButton).toBeHidden();
         });
     });
 });


### PR DESCRIPTION
closes https://linear.app/ghost/issue/BER-3233/update-ci-to-remove-duplicate-react-e2e-jobs

The React admin shell is now the default admin, so we no longer need to run E2E tests for both Ember and React shells. I've also removed all related conditionals from tests and page objects.
