### PR TITLE
Fixed overflowing titles in the sidebar

### DIFF
--- a/apps/admin/src/layout/app-sidebar/app-sidebar-header.tsx
+++ b/apps/admin/src/layout/app-sidebar/app-sidebar-header.tsx
@@ -35,7 +35,7 @@ function AppSidebarHeader({ ...props }: React.ComponentProps<typeof SidebarHeade
         <SidebarHeader {...props}>
             <div className="flex flex-col items-stretch gap-6">
                 <div className="flex items-center justify-between">
-                    <div className="flex items-center gap-3">
+                    <div className="flex items-center gap-3 min-w-0">
                         <div className="w-8 h-8 rounded-md bg-transparent border-0 flex-shrink-0">
                             <img
                                 src={siteIcon}
@@ -43,7 +43,7 @@ function AppSidebarHeader({ ...props }: React.ComponentProps<typeof SidebarHeade
                                 className="w-full h-full rounded-md object-cover"
                                 />
                         </div>
-                        <div className="font-semibold text-[15px] text-foreground overflow-hidden text-ellipsis whitespace-nowrap">
+                        <div className="font-semibold text-[15px] text-foreground overflow-hidden text-ellipsis whitespace-nowrap flex-1">
                             {title}
                         </div>
                     </div>


### PR DESCRIPTION
Ref https://ghost.slack.com/archives/C09D3RD4M88/p1769410419316989

Added some classes so that the title no longer overflows out of the parent container. While looking at this I did wonder if we should make a recommendation for site title length in settings.

| Before | After |
|--------|--------|
| <img width="404" height="277" alt="Screenshot 2026-01-26 at 09 09 53" src="https://github.com/user-attachments/assets/456dbf90-dac7-49f5-b670-c653ed7f3250" /> | <img width="354" height="277" alt="Screenshot 2026-01-26 at 09 09 30" src="https://github.com/user-attachments/assets/ee2a207b-f667-4506-84e1-669c7ae365fa" /> | 

Obligatory works on mobile as well

<img width="428" height="436" alt="Screenshot 2026-01-26 at 09 12 16" src="https://github.com/user-attachments/assets/d346ebd1-5ccb-4a73-baf7-ba52c72c8a74" />
