### PR TITLE
Fixed sidebar user dropdown growing

### DIFF
--- a/apps/admin/src/layout/app-sidebar/user-menu-header.tsx
+++ b/apps/admin/src/layout/app-sidebar/user-menu-header.tsx
@@ -11,11 +11,11 @@ export function UserMenuHeader({ name, email, children }: UserMenuHeaderProps) {
         <div className="p-3">
             <div className="flex items-center gap-3">
                 {children}
-                <div className="flex flex-col">
-                    <span className="text-base font-semibold text-foreground">
+                <div className="flex flex-col w-0">
+                    <span className="text-base font-semibold text-foreground truncate">
                         {name}
                     </span>
-                    <span className="text-xs text-foreground-muted -mt-px">
+                    <span className="text-xs text-foreground-muted -mt-px truncate">
                         {email}
                     </span>
                 </div>

--- a/apps/admin/src/layout/app-sidebar/user-menu-header.tsx
+++ b/apps/admin/src/layout/app-sidebar/user-menu-header.tsx
@@ -11,7 +11,7 @@ export function UserMenuHeader({ name, email, children }: UserMenuHeaderProps) {
         <div className="p-3">
             <div className="flex items-center gap-3">
                 {children}
-                <div className="flex flex-col w-0">
+                <div className="flex flex-col flex-1 min-w-0">
                     <span className="text-base font-semibold text-foreground truncate">
                         {name}
                     </span>

--- a/apps/admin/src/layout/app-sidebar/user-menu.tsx
+++ b/apps/admin/src/layout/app-sidebar/user-menu.tsx
@@ -124,9 +124,9 @@ function UserMenu(props: UserMenuProps) {
                 </SidebarMenuButton>
             </DropdownMenuTrigger>
             <DropdownMenuContent
-                align="end"
+                align="start"
                 sideOffset={10}
-                className={`w-full min-w-[240px] sidebar:min-w-[260px] ${showUpgradeBanner ? 'shadow-[0_18px_80px_0_rgba(0,0,0,0.07),0_7.52px_33.422px_0_rgba(0,0,0,0.05),0_4.021px_17.869px_0_rgba(0,0,0,0.04),0_2.254px_10.017px_0_rgba(0,0,0,0.04),0_1.197px_5.32px_0_rgba(0,0,0,0.03),0_0.498px_2.214px_0_rgba(0,0,0,0.02)]' : ''}`}
+                className={`w-[var(--radix-dropdown-menu-trigger-width)] ${showUpgradeBanner ? 'shadow-[0_18px_80px_0_rgba(0,0,0,0.07),0_7.52px_33.422px_0_rgba(0,0,0,0.05),0_4.021px_17.869px_0_rgba(0,0,0,0.04),0_2.254px_10.017px_0_rgba(0,0,0,0.04),0_1.197px_5.32px_0_rgba(0,0,0,0.03),0_0.498px_2.214px_0_rgba(0,0,0,0.02)]' : ''}`}
             >
                 <UserMenuHeader
                     name={currentUser.data?.name}
@@ -213,7 +213,7 @@ function ContributorUserMenu() {
                 align="start"
                 side="top"
                 sideOffset={10}
-                className="w-full min-w-[240px] mb-2"
+                className="w-[var(--radix-dropdown-menu-trigger-width)] mb-2"
             >
                 <UserMenuHeader
                     name={currentUser.data?.name}


### PR DESCRIPTION
Ref https://linear.app/ghost/issue/BER-3116/long-emails-should-be-truncated-in-user-menu

Added a dynamic max width to the sidebar dropdown and truncated the user name and email address if they're too long.

Uses Radix's (very nice) [CSS variables ](https://www.radix-ui.com/primitives/docs/components/dropdown-menu)

| Before | After |
|--------|--------|
| <img width="339" height="361" alt="Screenshot 2026-01-26 at 10 59 14" src="https://github.com/user-attachments/assets/672a8e95-d551-4345-9652-2d355b88d6b8" /> | <img width="317" height="376" alt="Screenshot 2026-01-26 at 10 58 49" src="https://github.com/user-attachments/assets/6330dd77-7c4c-40b6-a886-3c28fa198d0a" /> | 