### PR TITLE
Added commenting column to members table

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/6.15/2026-01-26-12-00-00-add-commenting-column-to-members.js
+++ b/ghost/core/core/server/data/migrations/versions/6.15/2026-01-26-12-00-00-add-commenting-column-to-members.js
@@ -1,0 +1,7 @@
+const {createAddColumnMigration} = require('../../utils');
+
+module.exports = createAddColumnMigration('members', 'commenting', {
+    type: 'text',
+    maxlength: 65535,
+    nullable: true
+});

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -435,6 +435,7 @@ module.exports = {
         email_disabled: {type: 'boolean', nullable: false, defaultTo: false},
         last_seen_at: {type: 'dateTime', nullable: true},
         last_commented_at: {type: 'dateTime', nullable: true},
+        commenting: {type: 'text', maxlength: 65535, nullable: true},
         created_at: {type: 'dateTime', nullable: false},
         updated_at: {type: 'dateTime', nullable: true},
         '@@INDEXES@@': [

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '7b3edee6c79a124f6ff53d50558a1949';
+    const currentSchemaHash = 'bbd9a12f190db664b7f00a7f22364472';
     const currentFixturesHash = '4dcbd7b52bc9ce23e6f5f1673118ba73';
     const currentSettingsHash = 'e75a2245c64a4fc82f826676abbc3234';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3184

## Summary

- Adds a nullable `commenting` column to the `members` table
- Stores per-member commenting permissions, allowing admins to disable commenting for specific members with an optional reason

## Why TEXT instead of JSON?

The column stores JSON data but uses `TEXT` type rather than `JSON` because:

1. **SQLite has no native JSON type** - it stores JSON as TEXT anyway, so `type: 'json'` would create inconsistent behavior between MySQL (native JSON with validation) and SQLite (TEXT without validation)

2. **Matches Ghost's established pattern** - all existing JSON-like data uses TEXT columns with manual `JSON.parse`/`JSON.stringify`:
   - `settings.value`
   - `sessions.session_data`  
   - `custom_theme_settings.value`

3. **Cross-database consistency** - TEXT behaves identically on both MySQL and SQLite
