### PR TITLE
Removed z-index for posts empty state

### DIFF
--- a/ghost/admin/app/styles/layouts/content.css
+++ b/ghost/admin/app/styles/layouts/content.css
@@ -827,7 +827,6 @@
 
 .no-posts-box {
     position: relative;
-    z-index: 600;
     display: flex;
     justify-content: center;
     align-items: center;


### PR DESCRIPTION
Ref https://linear.app/ghost/issue/BER-3115/empty-post-screen-z-index-issue-in-new-admin

The empty state for posts (And, consequently, a few others) was using a z-index value higher than the sidebar. Because of this, the content would show above the sidebar. Be gone!

| Before | After |
|--------|--------|
| <img width="648" height="562" alt="Screenshot 2026-01-26 at 11 25 05" src="https://github.com/user-attachments/assets/e4c74cf0-8d9a-43dc-9b32-4adbf9b9452e" /> | <img width="712" height="506" alt="Screenshot 2026-01-26 at 11 24 30" src="https://github.com/user-attachments/assets/0fa45823-1cde-4e38-ae77-70ee43b4153e" /> | 
