### PR TITLE
Removed Should.js from several API Canary unit tests

### DIFF
--- a/ghost/core/test/unit/api/canary/utils/serializers/input/integrations.test.js
+++ b/ghost/core/test/unit/api/canary/utils/serializers/input/integrations.test.js
@@ -1,4 +1,4 @@
-const should = require('should');
+const assert = require('node:assert/strict');
 const serializers = require('../../../../../../../core/server/api/endpoints/utils/serializers');
 
 describe('Unit: endpoints/utils/serializers/input/pages', function () {
@@ -12,7 +12,7 @@ describe('Unit: endpoints/utils/serializers/input/pages', function () {
             };
 
             serializers.input.integrations.browse(apiConfig, frame);
-            frame.options.filter.should.eql('type:[custom,builtin,core]');
+            assert.equal(frame.options.filter, 'type:[custom,builtin,core]');
         });
 
         it('combines filters', function () {
@@ -25,7 +25,7 @@ describe('Unit: endpoints/utils/serializers/input/pages', function () {
             };
 
             serializers.input.integrations.browse(apiConfig, frame);
-            frame.options.filter.should.eql('(type:internal)+type:[custom,builtin,core]');
+            assert.equal(frame.options.filter, '(type:internal)+type:[custom,builtin,core]');
         });
     });
 
@@ -39,7 +39,7 @@ describe('Unit: endpoints/utils/serializers/input/pages', function () {
             };
 
             serializers.input.integrations.read(apiConfig, frame);
-            frame.options.filter.should.eql('type:[custom,builtin,core]');
+            assert.equal(frame.options.filter, 'type:[custom,builtin,core]');
         });
 
         it('combines filters', function () {
@@ -52,7 +52,7 @@ describe('Unit: endpoints/utils/serializers/input/pages', function () {
             };
 
             serializers.input.integrations.read(apiConfig, frame);
-            frame.options.filter.should.eql('(type:internal)+type:[custom,builtin,core]');
+            assert.equal(frame.options.filter, '(type:internal)+type:[custom,builtin,core]');
         });
     });
 });

--- a/ghost/core/test/unit/api/canary/utils/serializers/input/pages.test.js
+++ b/ghost/core/test/unit/api/canary/utils/serializers/input/pages.test.js
@@ -1,4 +1,4 @@
-const should = require('should');
+const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const serializers = require('../../../../../../../core/server/api/endpoints/utils/serializers');
 const postsSchema = require('../../../../../../../core/server/data/schema').tables.posts;
@@ -21,7 +21,7 @@ describe('Unit: endpoints/utils/serializers/input/pages', function () {
             };
 
             serializers.input.pages.browse(apiConfig, frame);
-            frame.options.filter.should.eql('type:page');
+            assert.equal(frame.options.filter, 'type:page');
         });
 
         it('combine status+tag filters', function () {
@@ -35,7 +35,7 @@ describe('Unit: endpoints/utils/serializers/input/pages', function () {
             };
 
             serializers.input.pages.browse(apiConfig, frame);
-            frame.options.filter.should.eql('(status:published+tag:eins)+type:page');
+            assert.equal(frame.options.filter, '(status:published+tag:eins)+type:page');
         });
 
         it('only tag filters', function () {
@@ -49,7 +49,7 @@ describe('Unit: endpoints/utils/serializers/input/pages', function () {
             };
 
             serializers.input.pages.browse(apiConfig, frame);
-            frame.options.filter.should.eql('(tag:eins)+type:page');
+            assert.equal(frame.options.filter, '(tag:eins)+type:page');
         });
 
         it('remove mobiledoc and lexical option from formats', function () {
@@ -63,10 +63,10 @@ describe('Unit: endpoints/utils/serializers/input/pages', function () {
             };
 
             serializers.input.pages.browse(apiConfig, frame);
-            frame.options.formats.should.not.containEql('mobiledoc');
-            frame.options.formats.should.not.containEql('lexical');
-            frame.options.formats.should.containEql('html');
-            frame.options.formats.should.containEql('plaintext');
+            assert(!frame.options.formats.includes('mobiledoc'));
+            assert(!frame.options.formats.includes('lexical'));
+            assert(frame.options.formats.includes('html'));
+            assert(frame.options.formats.includes('plaintext'));
         });
 
         describe('Content API', function () {
@@ -82,7 +82,7 @@ describe('Unit: endpoints/utils/serializers/input/pages', function () {
                 serializers.input.pages.browse(apiConfig, frame);
                 const columns = Object.keys(postsSchema);
                 const parsedSelectRaw = frame.options.selectRaw.split(',').map(column => column.trim());
-                parsedSelectRaw.should.eql(columns.filter(column => !['mobiledoc', 'lexical','@@UNIQUE_CONSTRAINTS@@','@@INDEXES@@'].includes(column)));
+                assert.deepEqual(parsedSelectRaw, columns.filter(column => !['mobiledoc', 'lexical','@@UNIQUE_CONSTRAINTS@@','@@INDEXES@@'].includes(column)));
             });
 
             it('strips mobiledoc and lexical columns from a specified columns option', function () {
@@ -96,7 +96,7 @@ describe('Unit: endpoints/utils/serializers/input/pages', function () {
                 };
 
                 serializers.input.pages.browse(apiConfig, frame);
-                frame.options.columns.should.eql(['id', 'visibility']);
+                assert.deepEqual(frame.options.columns, ['id', 'visibility']);
             });
 
             it('forces visibility column if columns are specified', function () {
@@ -108,11 +108,11 @@ describe('Unit: endpoints/utils/serializers/input/pages', function () {
                         columns: ['id']
                     }
                 };
-                
+
                 serializers.input.pages.browse(apiConfig, frame);
-                frame.options.columns.should.eql(['id', 'visibility']);
+                assert.deepEqual(frame.options.columns, ['id', 'visibility']);
             });
-                
+
             it('strips mobiledoc and lexical columns from a specified selectRaw option', function () {
                 const apiConfig = {};
                 const frame = {
@@ -124,7 +124,7 @@ describe('Unit: endpoints/utils/serializers/input/pages', function () {
                 };
 
                 serializers.input.posts.browse(apiConfig, frame);
-                frame.options.selectRaw.should.eql('id');
+                assert.equal(frame.options.selectRaw, 'id');
             });
         });
     });
@@ -141,7 +141,7 @@ describe('Unit: endpoints/utils/serializers/input/pages', function () {
             };
 
             serializers.input.pages.read(apiConfig, frame);
-            frame.options.filter.should.eql('type:page');
+            assert.equal(frame.options.filter, 'type:page');
         });
 
         it('content api default (with context)', function () {
@@ -161,7 +161,7 @@ describe('Unit: endpoints/utils/serializers/input/pages', function () {
             };
 
             serializers.input.pages.read(apiConfig, frame);
-            frame.options.filter.should.eql('type:page');
+            assert.equal(frame.options.filter, 'type:page');
         });
 
         it('admin api default', function () {
@@ -181,7 +181,7 @@ describe('Unit: endpoints/utils/serializers/input/pages', function () {
             };
 
             serializers.input.pages.read(apiConfig, frame);
-            frame.options.filter.should.eql('(type:page)+status:[draft,published,scheduled]');
+            assert.equal(frame.options.filter, '(type:page)+status:[draft,published,scheduled]');
         });
 
         it('custom status filter', function () {
@@ -202,7 +202,7 @@ describe('Unit: endpoints/utils/serializers/input/pages', function () {
             };
 
             serializers.input.pages.read(apiConfig, frame);
-            frame.options.filter.should.eql('(status:draft)+type:page');
+            assert.equal(frame.options.filter, '(status:draft)+type:page');
         });
 
         it('remove mobiledoc option from formats', function () {
@@ -220,10 +220,10 @@ describe('Unit: endpoints/utils/serializers/input/pages', function () {
             };
 
             serializers.input.pages.read(apiConfig, frame);
-            frame.options.formats.should.not.containEql('mobiledoc');
-            frame.options.formats.should.not.containEql('lexical');
-            frame.options.formats.should.containEql('html');
-            frame.options.formats.should.containEql('plaintext');
+            assert(!frame.options.formats.includes('mobiledoc'));
+            assert(!frame.options.formats.includes('lexical'));
+            assert(frame.options.formats.includes('html'));
+            assert(frame.options.formats.includes('plaintext'));
         });
     });
 
@@ -243,7 +243,7 @@ describe('Unit: endpoints/utils/serializers/input/pages', function () {
         };
 
         serializers.input.pages.edit(apiConfig, frame);
-        frame.data.pages[0].tags.should.eql([{slug: 'slug1', name: 'hey'}, {slug: 'slug2'}]);
+        assert.deepEqual(frame.data.pages[0].tags, [{slug: 'slug1', name: 'hey'}, {slug: 'slug2'}]);
     });
 
     it('throws error if HTML conversion fails', function () {
@@ -266,12 +266,9 @@ describe('Unit: endpoints/utils/serializers/input/pages', function () {
 
         sinon.stub(mobiledocLib, 'toMobiledoc').throws(new Error('Some error'));
 
-        try {
+        assert.throws(() => {
             serializers.input.posts.edit({}, frame);
-            should.fail('Error expected');
-        } catch (err) {
-            err.message.should.eql('Failed to convert HTML to Mobiledoc');
-        }
+        }, /Failed to convert HTML to Mobiledoc/);
     });
 
     describe('Ensure relations format', function () {
@@ -294,8 +291,8 @@ describe('Unit: endpoints/utils/serializers/input/pages', function () {
 
             serializers.input.pages.edit(apiConfig, frame);
 
-            frame.data.pages[0].authors.should.eql([{id: 'id'}]);
-            frame.data.pages[0].tags.should.eql([{slug: 'slug1', name: 'hey'}, {slug: 'slug2'}]);
+            assert.deepEqual(frame.data.pages[0].authors, [{id: 'id'}]);
+            assert.deepEqual(frame.data.pages[0].tags, [{slug: 'slug1', name: 'hey'}, {slug: 'slug2'}]);
         });
 
         it('authors is array of strings', function () {
@@ -317,8 +314,8 @@ describe('Unit: endpoints/utils/serializers/input/pages', function () {
 
             serializers.input.pages.edit(apiConfig, frame);
 
-            frame.data.pages[0].authors.should.eql([{email: 'email1'}, {email: 'email2'}]);
-            frame.data.pages[0].tags.should.eql([{name: 'name1'}, {name: 'name2'}]);
+            assert.deepEqual(frame.data.pages[0].authors, [{email: 'email1'}, {email: 'email2'}]);
+            assert.deepEqual(frame.data.pages[0].tags, [{name: 'name1'}, {name: 'name2'}]);
         });
     });
 
@@ -330,7 +327,7 @@ describe('Unit: endpoints/utils/serializers/input/pages', function () {
 
             serializers.input.pages.copy({}, frame);
 
-            frame.options.formats.should.eql('mobiledoc,lexical');
+            assert.equal(frame.options.formats, 'mobiledoc,lexical');
         });
 
         it('adds default relations if no relations are specified', function () {
@@ -340,7 +337,7 @@ describe('Unit: endpoints/utils/serializers/input/pages', function () {
 
             serializers.input.pages.copy({}, frame);
 
-            frame.options.withRelated.should.eql(['tags', 'authors', 'authors.roles', 'tiers', 'count.signups', 'count.paid_conversions']);
+            assert.deepEqual(frame.options.withRelated, ['tags', 'authors', 'authors.roles', 'tiers', 'count.signups', 'count.paid_conversions']);
         });
     });
 });

--- a/ghost/core/test/unit/api/canary/utils/serializers/input/posts.test.js
+++ b/ghost/core/test/unit/api/canary/utils/serializers/input/posts.test.js
@@ -1,4 +1,4 @@
-const should = require('should');
+const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const serializers = require('../../../../../../../core/server/api/endpoints/utils/serializers');
 const postsSchema = require('../../../../../../../core/server/data/schema').tables.posts;
@@ -27,7 +27,7 @@ describe('Unit: endpoints/utils/serializers/input/posts', function () {
             };
 
             serializers.input.posts.browse(apiConfig, frame);
-            frame.options.filter.should.eql('type:post');
+            assert.equal(frame.options.filter, 'type:post');
         });
 
         it('should not work for non public context', function () {
@@ -42,7 +42,7 @@ describe('Unit: endpoints/utils/serializers/input/posts', function () {
             };
 
             serializers.input.posts.browse(apiConfig, frame);
-            should.equal(frame.options.filter, '(type:post)+status:[draft,published,scheduled,sent]');
+            assert.equal(frame.options.filter, '(type:post)+status:[draft,published,scheduled,sent]');
         });
 
         it('combine status+tag filters', function () {
@@ -62,7 +62,7 @@ describe('Unit: endpoints/utils/serializers/input/posts', function () {
             };
 
             serializers.input.posts.browse(apiConfig, frame);
-            frame.options.filter.should.eql('(status:published+tag:eins)+type:post');
+            assert.equal(frame.options.filter, '(status:published+tag:eins)+type:post');
         });
 
         it('only tag filters', function () {
@@ -82,7 +82,7 @@ describe('Unit: endpoints/utils/serializers/input/posts', function () {
             };
 
             serializers.input.posts.browse(apiConfig, frame);
-            frame.options.filter.should.eql('(tag:eins)+type:post');
+            assert.equal(frame.options.filter, '(tag:eins)+type:post');
         });
 
         it('remove mobiledoc and lexical options from formats', function () {
@@ -96,10 +96,10 @@ describe('Unit: endpoints/utils/serializers/input/posts', function () {
             };
 
             serializers.input.posts.browse(apiConfig, frame);
-            frame.options.formats.should.not.containEql('mobiledoc');
-            frame.options.formats.should.not.containEql('lexical');
-            frame.options.formats.should.containEql('html');
-            frame.options.formats.should.containEql('plaintext');
+            assert(!frame.options.formats.includes('mobiledoc'));
+            assert(!frame.options.formats.includes('lexical'));
+            assert(frame.options.formats.includes('html'));
+            assert(frame.options.formats.includes('plaintext'));
         });
 
         it('adds default order when no order is specified', function () {
@@ -112,7 +112,7 @@ describe('Unit: endpoints/utils/serializers/input/posts', function () {
             };
 
             serializers.input.posts.browse(apiConfig, frame);
-            frame.options.order.should.eql('published_at desc, id desc');
+            assert.equal(frame.options.order, 'published_at desc, id desc');
         });
 
         it('keeps order when it is specified', function () {
@@ -126,7 +126,7 @@ describe('Unit: endpoints/utils/serializers/input/posts', function () {
             };
 
             serializers.input.posts.browse(apiConfig, frame);
-            frame.options.order.should.eql('updated_at desc');
+            assert.equal(frame.options.order, 'updated_at desc');
         });
 
         describe('Content API', function () {
@@ -142,7 +142,7 @@ describe('Unit: endpoints/utils/serializers/input/posts', function () {
                 serializers.input.posts.browse(apiConfig, frame);
                 const columns = Object.keys(postsSchema);
                 const parsedSelectRaw = frame.options.selectRaw.split(',').map(column => column.trim());
-                parsedSelectRaw.should.eql(columns.filter(column => !['mobiledoc', 'lexical','@@UNIQUE_CONSTRAINTS@@','@@INDEXES@@'].includes(column)));
+                assert.deepEqual(parsedSelectRaw, columns.filter(column => !['mobiledoc', 'lexical','@@UNIQUE_CONSTRAINTS@@','@@INDEXES@@'].includes(column)));
             });
 
             it('strips mobiledoc and lexical columns from a specified columns option', function () {
@@ -156,7 +156,7 @@ describe('Unit: endpoints/utils/serializers/input/posts', function () {
                 };
 
                 serializers.input.posts.browse(apiConfig, frame);
-                frame.options.columns.should.eql(['id', 'visibility']);
+                assert.deepEqual(frame.options.columns, ['id', 'visibility']);
             });
 
             it('forces visibility column if columns are specified', function () {
@@ -170,7 +170,7 @@ describe('Unit: endpoints/utils/serializers/input/posts', function () {
                 };
 
                 serializers.input.posts.browse(apiConfig, frame);
-                frame.options.columns.should.eql(['id', 'visibility']);
+                assert.deepEqual(frame.options.columns, ['id', 'visibility']);
             });
 
             it('strips mobiledoc and lexical columns from a specified selectRaw option', function () {
@@ -184,7 +184,7 @@ describe('Unit: endpoints/utils/serializers/input/posts', function () {
                 };
 
                 serializers.input.posts.browse(apiConfig, frame);
-                frame.options.selectRaw.should.eql('id');
+                assert.equal(frame.options.selectRaw, 'id');
             });
         });
     });
@@ -199,7 +199,7 @@ describe('Unit: endpoints/utils/serializers/input/posts', function () {
             };
 
             serializers.input.posts.read(apiConfig, frame);
-            frame.options.filter.should.eql('type:post');
+            assert.equal(frame.options.filter, 'type:post');
         });
 
         it('with apiType of "content" it forces type:post filter', function () {
@@ -213,7 +213,7 @@ describe('Unit: endpoints/utils/serializers/input/posts', function () {
             };
 
             serializers.input.posts.read(apiConfig, frame);
-            frame.options.filter.should.eql('(type:page)+type:post');
+            assert.equal(frame.options.filter, '(type:page)+type:post');
         });
 
         it('with apiType of "admin" it forces type & status false filter', function () {
@@ -232,7 +232,7 @@ describe('Unit: endpoints/utils/serializers/input/posts', function () {
             };
 
             serializers.input.posts.read(apiConfig, frame);
-            frame.options.filter.should.eql('(type:post)+status:[draft,published,scheduled,sent]');
+            assert.equal(frame.options.filter, '(type:post)+status:[draft,published,scheduled,sent]');
         });
 
         it('with apiType of "admin" it forces type:post filter & respects custom status filter', function () {
@@ -252,7 +252,7 @@ describe('Unit: endpoints/utils/serializers/input/posts', function () {
             };
 
             serializers.input.posts.read(apiConfig, frame);
-            frame.options.filter.should.eql('(status:draft)+type:post');
+            assert.equal(frame.options.filter, '(status:draft)+type:post');
         });
 
         it('remove mobiledoc and lexical options from formats', function () {
@@ -267,10 +267,10 @@ describe('Unit: endpoints/utils/serializers/input/posts', function () {
             };
 
             serializers.input.posts.read(apiConfig, frame);
-            frame.options.formats.should.not.containEql('mobiledoc');
-            frame.options.formats.should.not.containEql('lexical');
-            frame.options.formats.should.containEql('html');
-            frame.options.formats.should.containEql('plaintext');
+            assert(!frame.options.formats.includes('mobiledoc'));
+            assert(!frame.options.formats.includes('lexical'));
+            assert(frame.options.formats.includes('html'));
+            assert(frame.options.formats.includes('plaintext'));
         });
     });
 
@@ -296,8 +296,8 @@ describe('Unit: endpoints/utils/serializers/input/posts', function () {
                 serializers.input.posts.edit(apiConfig, frame);
 
                 let postData = frame.data.posts[0];
-                postData.lexical.should.equal(lexical);
-                should.equal(null, postData.mobiledoc);
+                assert.equal(postData.lexical, lexical);
+                assert.equal(postData.mobiledoc, null);
             });
 
             it('no transformation when html data is empty', function () {
@@ -322,8 +322,8 @@ describe('Unit: endpoints/utils/serializers/input/posts', function () {
                 serializers.input.posts.edit(apiConfig, frame);
 
                 let postData = frame.data.posts[0];
-                postData.lexical.should.equal(lexical);
-                should.equal(null, postData.mobiledoc);
+                assert.equal(postData.lexical, lexical);
+                assert.equal(postData.mobiledoc, null);
             });
 
             it('transforms html when html is present in data and source options', function () {
@@ -350,12 +350,12 @@ describe('Unit: endpoints/utils/serializers/input/posts', function () {
                 serializers.input.posts.edit(apiConfig, frame);
 
                 let postData = frame.data.posts[0];
-                postData.lexical.should.not.equal(lexical);
-                postData.lexical.should.equal('{"root":{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"this is great feature","type":"extended-text","version":1}],"direction":null,"format":"","indent":0,"type":"paragraph","version":1}],"direction":null,"format":"","indent":0,"type":"root","version":1}}');
+                assert.notEqual(postData.lexical, lexical);
+                assert.equal(postData.lexical, '{"root":{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"this is great feature","type":"extended-text","version":1}],"direction":null,"format":"","indent":0,"type":"paragraph","version":1}],"direction":null,"format":"","indent":0,"type":"root","version":1}}');
                 // we convert to both mobiledoc and lexical to avoid changing formats
                 // for existing content when updating with `?source=html,
                 // the unused data is cleared in the Post model when saving
-                postData.mobiledoc.should.equal('{"version":"0.3.1","atoms":[],"cards":[],"markups":[],"sections":[[1,"p",[[0,[],0,"this is great feature"]]]]}');
+                assert.equal(postData.mobiledoc, '{"version":"0.3.1","atoms":[],"cards":[],"markups":[],"sections":[[1,"p",[[0,[],0,"this is great feature"]]]]}');
             });
 
             it('preserves html cards in transformed html', function () {
@@ -380,7 +380,7 @@ describe('Unit: endpoints/utils/serializers/input/posts', function () {
                 serializers.input.posts.edit(apiConfig, frame);
 
                 let postData = frame.data.posts[0];
-                postData.lexical.should.equal('{"root":{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"this is great feature","type":"extended-text","version":1}],"direction":null,"format":"","indent":0,"type":"paragraph","version":1},{"type":"html","version":1,"html":"<div class=\\"custom\\">My Custom HTML</div>","visibility":{"web":{"nonMember":true,"memberSegment":"status:free,status:-free"},"email":{"memberSegment":"status:free,status:-free"}}},{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"custom html preserved!","type":"extended-text","version":1}],"direction":null,"format":"","indent":0,"type":"paragraph","version":1}],"direction":null,"format":"","indent":0,"type":"root","version":1}}');
+                assert.equal(postData.lexical, '{"root":{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"this is great feature","type":"extended-text","version":1}],"direction":null,"format":"","indent":0,"type":"paragraph","version":1},{"type":"html","version":1,"html":"<div class=\\"custom\\">My Custom HTML</div>","visibility":{"web":{"nonMember":true,"memberSegment":"status:free,status:-free"},"email":{"memberSegment":"status:free,status:-free"}}},{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"custom html preserved!","type":"extended-text","version":1}],"direction":null,"format":"","indent":0,"type":"paragraph","version":1}],"direction":null,"format":"","indent":0,"type":"root","version":1}}');
             });
 
             it('throws error when HTML conversion fails', function () {
@@ -403,12 +403,9 @@ describe('Unit: endpoints/utils/serializers/input/posts', function () {
 
                 sinon.stub(mobiledocLib, 'toMobiledoc').throws(new Error('Some error'));
 
-                try {
+                assert.throws(() => {
                     serializers.input.posts.edit({}, frame);
-                    should.fail('Error expected');
-                } catch (err) {
-                    err.message.should.eql('Failed to convert HTML to Mobiledoc');
-                }
+                }, /Failed to convert HTML to Mobiledoc/);
             });
         });
 
@@ -428,7 +425,7 @@ describe('Unit: endpoints/utils/serializers/input/posts', function () {
             };
 
             serializers.input.posts.edit(apiConfig, frame);
-            frame.data.posts[0].tags.should.eql([{slug: 'slug1', name: 'hey'}, {slug: 'slug2'}]);
+            assert.deepEqual(frame.data.posts[0].tags, [{slug: 'slug1', name: 'hey'}, {slug: 'slug2'}]);
         });
 
         describe('Ensure relations format', function () {
@@ -450,8 +447,8 @@ describe('Unit: endpoints/utils/serializers/input/posts', function () {
 
                 serializers.input.posts.edit(apiConfig, frame);
 
-                frame.data.posts[0].authors.should.eql([{id: 'id'}]);
-                frame.data.posts[0].tags.should.eql([{slug: 'slug1', name: 'hey'}, {slug: 'slug2'}]);
+                assert.deepEqual(frame.data.posts[0].authors, [{id: 'id'}]);
+                assert.deepEqual(frame.data.posts[0].tags, [{slug: 'slug1', name: 'hey'}, {slug: 'slug2'}]);
             });
 
             it('authors is array of strings', function () {
@@ -472,8 +469,8 @@ describe('Unit: endpoints/utils/serializers/input/posts', function () {
 
                 serializers.input.posts.edit(apiConfig, frame);
 
-                frame.data.posts[0].authors.should.eql([{email: 'email1'}, {email: 'email2'}]);
-                frame.data.posts[0].tags.should.eql([{name: 'name1'}, {name: 'name2'}]);
+                assert.deepEqual(frame.data.posts[0].authors, [{email: 'email1'}, {email: 'email2'}]);
+                assert.deepEqual(frame.data.posts[0].tags, [{name: 'name1'}, {name: 'name2'}]);
             });
         });
     });
@@ -486,7 +483,7 @@ describe('Unit: endpoints/utils/serializers/input/posts', function () {
 
             serializers.input.posts.copy({}, frame);
 
-            frame.options.formats.should.eql('mobiledoc,lexical');
+            assert.equal(frame.options.formats, 'mobiledoc,lexical');
         });
 
         it('adds default relations if no relations are specified', function () {
@@ -496,7 +493,7 @@ describe('Unit: endpoints/utils/serializers/input/posts', function () {
 
             serializers.input.posts.copy({}, frame);
 
-            frame.options.withRelated.should.eql(['tags', 'authors', 'authors.roles', 'email', 'tiers', 'newsletter', 'count.clicks']);
+            assert.deepEqual(frame.options.withRelated, ['tags', 'authors', 'authors.roles', 'email', 'tiers', 'newsletter', 'count.clicks']);
         });
     });
 });

--- a/ghost/core/test/unit/api/canary/utils/serializers/input/utils/settings-filter-type-group-mapper.test.js
+++ b/ghost/core/test/unit/api/canary/utils/serializers/input/utils/settings-filter-type-group-mapper.test.js
@@ -1,26 +1,26 @@
-const should = require('should');
+const assert = require('node:assert/strict');
 const mapper = require('../../../../../../../../core/server/api/endpoints/utils/serializers/input/utils/settings-filter-type-group-mapper');
 
 describe('Unit: endpoints/utils/serializers/input/utils/settings-type-group-mapper', function () {
     describe('browse', function () {
         it('maps type to group 1:1', function () {
-            mapper('theme').should.eql('theme');
+            assert.equal(mapper('theme'), 'theme');
         });
 
         it('maps type to multiple groups', function () {
-            mapper('blog').should.eql('site,labs,slack,unsplash,views');
+            assert.equal(mapper('blog'), 'site,labs,slack,unsplash,views');
         });
 
         it('maps multiple types to multiple groups', function () {
-            mapper('bulk_email,portal').should.eql('email,portal');
+            assert.equal(mapper('bulk_email,portal'), 'email,portal');
         });
 
         it('skips unknown options for "bulk_email,unknown,portal" type to "bulk_email,portal', function () {
-            mapper('bulk_email,unknown,portal').should.eql('email,portal');
+            assert.equal(mapper('bulk_email,unknown,portal'), 'email,portal');
         });
 
         it('handles unexpected spacing', function () {
-            mapper(' bulk_email, portal ').should.eql('email,portal');
+            assert.equal(mapper(' bulk_email, portal '), 'email,portal');
         });
     });
 });

--- a/ghost/core/test/unit/api/canary/utils/serializers/output/default.test.js
+++ b/ghost/core/test/unit/api/canary/utils/serializers/output/default.test.js
@@ -1,4 +1,4 @@
-const should = require('should');
+const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const serializers = require('../../../../../../../core/server/api/endpoints/utils/serializers');
 const mappers = require('../../../../../../../core/server/api/endpoints/utils/serializers/output/mappers');
@@ -27,7 +27,7 @@ describe('Unit: endpoints/utils/serializers/output/default', function () {
 
         serializers.output.default.all(response, apiConfig, frame);
 
-        frame.response.should.eql({
+        assert.deepEqual(frame.response, {
             stuffs: [response]
         });
     });
@@ -54,7 +54,7 @@ describe('Unit: endpoints/utils/serializers/output/default', function () {
 
         serializers.output.default.all(response, apiConfig, frame);
 
-        frame.response.should.eql({
+        assert.deepEqual(frame.response, {
             stuffs: response.data,
             meta: response.meta
         });
@@ -73,7 +73,7 @@ describe('Unit: endpoints/utils/serializers/output/default', function () {
 
         serializers.output.default.all(response, apiConfig, frame);
 
-        frame.response.should.eql({
+        assert.deepEqual(frame.response, {
             stuffs: [
                 {title: 'foo', hello: 'world'}
             ]
@@ -106,7 +106,7 @@ describe('Unit: endpoints/utils/serializers/output/default', function () {
 
         serializers.output.default.all(response, apiConfig, frame);
 
-        frame.response.should.eql({
+        assert.deepEqual(frame.response, {
             stuffs: [
                 {title: 'foo', hello: 'world'},
                 {title: 'bar', hello: 'world'}
@@ -137,7 +137,7 @@ describe('Unit: endpoints/utils/serializers/output/default', function () {
 
         serializers.output.default.all(response, apiConfig, frame);
 
-        frame.response.should.eql({
+        assert.deepEqual(frame.response, {
             stuffs: [
                 {title: 'foo', custom: 'thing'}
             ]
@@ -178,7 +178,7 @@ describe('Unit: endpoints/utils/serializers/output/default', function () {
 
         serializers.output.default.all(response, apiConfig, frame);
 
-        frame.response.should.eql({
+        assert.deepEqual(frame.response, {
             stuffs: [
                 {title: 'foo', custom: 'thing'},
                 {title: 'bar', custom: 'thing'}

--- a/ghost/core/test/unit/api/canary/utils/serializers/output/pages.test.js
+++ b/ghost/core/test/unit/api/canary/utils/serializers/output/pages.test.js
@@ -1,4 +1,3 @@
-const should = require('should');
 const sinon = require('sinon');
 const testUtils = require('../../../../../../utils');
 const mappers = require('../../../../../../../core/server/api/endpoints/utils/serializers/output/mappers');
@@ -54,7 +53,7 @@ describe('Unit: endpoints/utils/serializers/output/pages', function () {
 
         await serializers.output.pages.all(ctrlResponse, apiConfig, frame);
 
-        mappers.pages.callCount.should.equal(2);
-        mappers.pages.getCall(0).args.should.eql([ctrlResponse.data[0], frame, {tiers: []}]);
+        sinon.assert.callCount(mappers.pages, 2);
+        sinon.assert.calledWithExactly(mappers.pages.firstCall, ctrlResponse.data[0], frame, {tiers: []});
     });
 });

--- a/ghost/core/test/unit/api/canary/utils/serializers/output/posts.test.js
+++ b/ghost/core/test/unit/api/canary/utils/serializers/output/posts.test.js
@@ -1,4 +1,3 @@
-const should = require('should');
 const sinon = require('sinon');
 const testUtils = require('../../../../../../utils');
 const mappers = require('../../../../../../../core/server/api/endpoints/utils/serializers/output/mappers');
@@ -48,7 +47,7 @@ describe('Unit: endpoints/utils/serializers/output/posts', function () {
 
         await serializers.output.posts.all(ctrlResponse, apiConfig, frame);
 
-        mappers.posts.callCount.should.equal(2);
-        mappers.posts.getCall(0).args.should.eql([ctrlResponse.data[0], frame, {tiers: []}]);
+        sinon.assert.callCount(mappers.posts, 2);
+        sinon.assert.calledWithExactly(mappers.posts.firstCall, ctrlResponse.data[0], frame, {tiers: []});
     });
 });

--- a/ghost/core/test/unit/api/canary/utils/serializers/output/previews.test.js
+++ b/ghost/core/test/unit/api/canary/utils/serializers/output/previews.test.js
@@ -1,4 +1,4 @@
-const should = require('should');
+const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const testUtils = require('../../../../../../utils');
 const mappers = require('../../../../../../../core/server/api/endpoints/utils/serializers/output/mappers');
@@ -45,9 +45,9 @@ describe('Unit: endpoints/utils/serializers/output/previews', function () {
 
         await serializers.output.previews.all(ctrlResponse, apiConfig, frame);
 
-        mappers.posts.callCount.should.equal(1);
-        mappers.posts.getCall(0).args.should.eql([ctrlResponse, frame, {tiers: []}]);
+        sinon.assert.callCount(mappers.posts, 1);
+        sinon.assert.calledWithExactly(mappers.posts.firstCall, ctrlResponse, frame, {tiers: []});
 
-        frame.response.previews[0].type.should.equal('page');
+        assert.equal(frame.response.previews[0].type, 'page');
     });
 });

--- a/ghost/core/test/unit/api/canary/utils/serializers/output/tags.test.js
+++ b/ghost/core/test/unit/api/canary/utils/serializers/output/tags.test.js
@@ -1,4 +1,3 @@
-const should = require('should');
 const sinon = require('sinon');
 const testUtils = require('../../../../../../utils');
 const mappers = require('../../../../../../../core/server/api/endpoints/utils/serializers/output/mappers');
@@ -31,8 +30,7 @@ describe('Unit: endpoints/utils/serializers/output/tags', function () {
 
         serializers.output.default.all(ctrlResponse, apiConfig, frame);
 
-        mappers.tags.callCount.should.equal(1);
-        mappers.tags.getCall(0).args.should.eql([ctrlResponse, frame]);
+        sinon.assert.calledOnceWithExactly(mappers.tags, ctrlResponse, frame);
     });
 
     it('calls the mapper with multiple tags', function () {
@@ -53,7 +51,7 @@ describe('Unit: endpoints/utils/serializers/output/tags', function () {
 
         serializers.output.default.all(ctrlResponse, apiConfig, frame);
 
-        mappers.tags.callCount.should.equal(2);
-        mappers.tags.getCall(0).args.should.eql([ctrlResponse.data[0], frame]);
+        sinon.assert.callCount(mappers.tags, 2);
+        sinon.assert.calledWithExactly(mappers.tags.getCall(0), ctrlResponse.data[0], frame);
     });
 });

--- a/ghost/core/test/unit/api/canary/utils/serializers/output/utils/date.test.js
+++ b/ghost/core/test/unit/api/canary/utils/serializers/output/utils/date.test.js
@@ -1,4 +1,4 @@
-const should = require('should');
+const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const settingsCache = require('../../../../../../../../core/shared/settings-cache');
 const dateUtil = require('../../../../../../../../core/server/api/endpoints/utils/serializers/output/utils/date');
@@ -18,7 +18,7 @@ describe('Unit: endpoints/utils/serializers/output/utils/date', function () {
         sinon.stub(settingsCache, 'get').returns(timezone);
 
         testDates.forEach((date) => {
-            dateUtil.format(date.in).should.equal(date.out);
+            assert.equal(dateUtil.format(date.in), date.out);
         });
     });
 });

--- a/ghost/core/test/unit/api/canary/utils/serializers/output/utils/url.test.js
+++ b/ghost/core/test/unit/api/canary/utils/serializers/output/utils/url.test.js
@@ -1,4 +1,4 @@
-const should = require('should');
+const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const testUtils = require('../../../../../../../utils');
 const urlService = require('../../../../../../../../core/server/services/url');
@@ -42,10 +42,10 @@ describe('Unit: endpoints/utils/serializers/output/utils/url', function () {
 
             urlUtil.forPost(post.id, post, {options: {}});
 
-            post.hasOwnProperty('url').should.be.true();
+            assert(Object.hasOwn(post, 'url'));
 
-            urlService.getUrlByResourceId.callCount.should.eql(1);
-            urlService.getUrlByResourceId.getCall(0).args.should.eql(['id1', {absolute: true}]);
+            sinon.assert.callCount(urlService.getUrlByResourceId, 1);
+            sinon.assert.calledWithExactly(urlService.getUrlByResourceId, 'id1', {absolute: true});
         });
     });
 });

--- a/ghost/core/test/unit/api/canary/utils/validators/input/pages.test.js
+++ b/ghost/core/test/unit/api/canary/utils/validators/input/pages.test.js
@@ -1,5 +1,5 @@
 const _ = require('lodash');
-const should = require('should');
+const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const validators = require('../../../../../../../core/server/api/endpoints/utils/validators');
 const models = require('../../../../../../../core/server/models');
@@ -34,7 +34,7 @@ describe('Unit: endpoints/utils/validators/input/pages', function () {
                 return validators.input.pages.add(apiConfig, frame)
                     .then(Promise.reject)
                     .catch((err) => {
-                        err.errorType.should.equal('ValidationError');
+                        assert.equal(err.errorType, 'ValidationError');
                     });
             });
 
@@ -49,7 +49,7 @@ describe('Unit: endpoints/utils/validators/input/pages', function () {
                 return validators.input.pages.add(apiConfig, frame)
                     .then(Promise.reject)
                     .catch((err) => {
-                        err.errorType.should.equal('ValidationError');
+                        assert.equal(err.errorType, 'ValidationError');
                     });
             });
 
@@ -64,7 +64,7 @@ describe('Unit: endpoints/utils/validators/input/pages', function () {
                 return validators.input.pages.add(apiConfig, frame)
                     .then(Promise.reject)
                     .catch((err) => {
-                        err.errorType.should.equal('ValidationError');
+                        assert.equal(err.errorType, 'ValidationError');
                     });
             });
 
@@ -80,7 +80,7 @@ describe('Unit: endpoints/utils/validators/input/pages', function () {
                 return validators.input.pages.add(apiConfig, frame)
                     .then(Promise.reject)
                     .catch((err) => {
-                        err.errorType.should.equal('ValidationError');
+                        assert.equal(err.errorType, 'ValidationError');
                     });
             });
 
@@ -97,7 +97,7 @@ describe('Unit: endpoints/utils/validators/input/pages', function () {
                 return validators.input.pages.add(apiConfig, frame)
                     .then(Promise.reject)
                     .catch((err) => {
-                        err.errorType.should.equal('ValidationError');
+                        assert.equal(err.errorType, 'ValidationError');
                     });
             });
 
@@ -131,11 +131,11 @@ describe('Unit: endpoints/utils/validators/input/pages', function () {
 
                 let result = validators.input.pages.add(apiConfig, frame);
 
-                should.exist(frame.data.pages[0].title);
-                should.exist(frame.data.pages[0].authors);
-                should.not.exist(frame.data.pages[0].id);
-                should.not.exist(frame.data.pages[0].created_at);
-                should.not.exist(frame.data.pages[0].published_by);
+                assert(frame.data.pages[0].title);
+                assert(frame.data.pages[0].authors);
+                assert.equal(frame.data.pages[0].id, undefined);
+                assert.equal(frame.data.pages[0].created_at, undefined);
+                assert.equal(frame.data.pages[0].published_by, undefined);
 
                 return result;
             });
@@ -177,7 +177,7 @@ describe('Unit: endpoints/utils/validators/input/pages', function () {
                         return validators.input.pages.add(apiConfig, frame)
                             .then(Promise.reject)
                             .catch((err) => {
-                                err.errorType.should.equal('ValidationError');
+                                assert.equal(err.errorType, 'ValidationError');
                             });
                     });
 
@@ -219,7 +219,7 @@ describe('Unit: endpoints/utils/validators/input/pages', function () {
                 return validators.input.pages.add(apiConfig, frame)
                     .then(Promise.reject)
                     .catch((err) => {
-                        err.errorType.should.equal('ValidationError');
+                        assert.equal(err.errorType, 'ValidationError');
                     });
             });
 
@@ -241,7 +241,7 @@ describe('Unit: endpoints/utils/validators/input/pages', function () {
                 return validators.input.pages.add(apiConfig, frame)
                     .then(Promise.reject)
                     .catch((err) => {
-                        err.errorType.should.equal('ValidationError');
+                        assert.equal(err.errorType, 'ValidationError');
                     });
             });
 
@@ -282,7 +282,7 @@ describe('Unit: endpoints/utils/validators/input/pages', function () {
                 return validators.input.pages.edit(apiConfig, frame)
                     .then(Promise.reject)
                     .catch((err) => {
-                        err.errorType.should.equal('ValidationError');
+                        assert.equal(err.errorType, 'ValidationError');
                     });
             });
 
@@ -297,7 +297,7 @@ describe('Unit: endpoints/utils/validators/input/pages', function () {
                 return validators.input.pages.edit(apiConfig, frame)
                     .then(Promise.reject)
                     .catch((err) => {
-                        err.errorType.should.equal('ValidationError');
+                        assert.equal(err.errorType, 'ValidationError');
                     });
             });
 
@@ -313,7 +313,7 @@ describe('Unit: endpoints/utils/validators/input/pages', function () {
                 return validators.input.pages.edit(apiConfig, frame)
                     .then(Promise.reject)
                     .catch((err) => {
-                        err.errorType.should.equal('ValidationError');
+                        assert.equal(err.errorType, 'ValidationError');
                     });
             });
 
@@ -349,7 +349,7 @@ describe('Unit: endpoints/utils/validators/input/pages', function () {
                 return validators.input.pages.edit(apiConfig, frame)
                     .then(Promise.reject)
                     .catch((err) => {
-                        err.errorType.should.equal('ValidationError');
+                        assert.equal(err.errorType, 'ValidationError');
                     });
             });
 
@@ -371,7 +371,7 @@ describe('Unit: endpoints/utils/validators/input/pages', function () {
                 return validators.input.pages.edit(apiConfig, frame)
                     .then(Promise.reject)
                     .catch((err) => {
-                        err.errorType.should.equal('ValidationError');
+                        assert.equal(err.errorType, 'ValidationError');
                     });
             });
 

--- a/ghost/core/test/unit/api/canary/utils/validators/input/posts.test.js
+++ b/ghost/core/test/unit/api/canary/utils/validators/input/posts.test.js
@@ -1,5 +1,5 @@
 const _ = require('lodash');
-const should = require('should');
+const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const validators = require('../../../../../../../core/server/api/endpoints/utils/validators');
 const models = require('../../../../../../../core/server/models');
@@ -34,7 +34,7 @@ describe('Unit: endpoints/utils/validators/input/posts', function () {
                 return validators.input.posts.add(apiConfig, frame)
                     .then(Promise.reject)
                     .catch((err) => {
-                        err.errorType.should.equal('ValidationError');
+                        assert.equal(err.errorType, 'ValidationError');
                     });
             });
 
@@ -49,7 +49,7 @@ describe('Unit: endpoints/utils/validators/input/posts', function () {
                 return validators.input.posts.add(apiConfig, frame)
                     .then(Promise.reject)
                     .catch((err) => {
-                        err.errorType.should.equal('ValidationError');
+                        assert.equal(err.errorType, 'ValidationError');
                     });
             });
 
@@ -64,7 +64,7 @@ describe('Unit: endpoints/utils/validators/input/posts', function () {
                 return validators.input.posts.add(apiConfig, frame)
                     .then(Promise.reject)
                     .catch((err) => {
-                        err.errorType.should.equal('ValidationError');
+                        assert.equal(err.errorType, 'ValidationError');
                     });
             });
 
@@ -80,7 +80,7 @@ describe('Unit: endpoints/utils/validators/input/posts', function () {
                 return validators.input.posts.add(apiConfig, frame)
                     .then(Promise.reject)
                     .catch((err) => {
-                        err.errorType.should.equal('ValidationError');
+                        assert.equal(err.errorType, 'ValidationError');
                     });
             });
 
@@ -97,7 +97,7 @@ describe('Unit: endpoints/utils/validators/input/posts', function () {
                 return validators.input.posts.add(apiConfig, frame)
                     .then(Promise.reject)
                     .catch((err) => {
-                        err.errorType.should.equal('ValidationError');
+                        assert.equal(err.errorType, 'ValidationError');
                     });
             });
 
@@ -131,11 +131,11 @@ describe('Unit: endpoints/utils/validators/input/posts', function () {
 
                 let result = validators.input.posts.add(apiConfig, frame);
 
-                should.exist(frame.data.posts[0].title);
-                should.exist(frame.data.posts[0].authors);
-                should.not.exist(frame.data.posts[0].id);
-                should.not.exist(frame.data.posts[0].created_at);
-                should.not.exist(frame.data.posts[0].published_by);
+                assert(frame.data.posts[0].title);
+                assert(frame.data.posts[0].authors);
+                assert.equal(frame.data.posts[0].id, undefined);
+                assert.equal(frame.data.posts[0].created_at, undefined);
+                assert.equal(frame.data.posts[0].published_by, undefined);
 
                 return result;
             });
@@ -177,7 +177,7 @@ describe('Unit: endpoints/utils/validators/input/posts', function () {
                         return validators.input.posts.add(apiConfig, frame)
                             .then(Promise.reject)
                             .catch((err) => {
-                                err.errorType.should.equal('ValidationError');
+                                assert.equal(err.errorType, 'ValidationError');
                             });
                     });
 
@@ -219,7 +219,7 @@ describe('Unit: endpoints/utils/validators/input/posts', function () {
                 return validators.input.posts.add(apiConfig, frame)
                     .then(Promise.reject)
                     .catch((err) => {
-                        err.errorType.should.equal('ValidationError');
+                        assert.equal(err.errorType, 'ValidationError');
                     });
             });
 
@@ -241,7 +241,7 @@ describe('Unit: endpoints/utils/validators/input/posts', function () {
                 return validators.input.posts.add(apiConfig, frame)
                     .then(Promise.reject)
                     .catch((err) => {
-                        err.errorType.should.equal('ValidationError');
+                        assert.equal(err.errorType, 'ValidationError');
                     });
             });
 
@@ -282,7 +282,7 @@ describe('Unit: endpoints/utils/validators/input/posts', function () {
                 return validators.input.posts.edit(apiConfig, frame)
                     .then(Promise.reject)
                     .catch((err) => {
-                        err.errorType.should.equal('ValidationError');
+                        assert.equal(err.errorType, 'ValidationError');
                     });
             });
 
@@ -297,7 +297,7 @@ describe('Unit: endpoints/utils/validators/input/posts', function () {
                 return validators.input.posts.edit(apiConfig, frame)
                     .then(Promise.reject)
                     .catch((err) => {
-                        err.errorType.should.equal('ValidationError');
+                        assert.equal(err.errorType, 'ValidationError');
                     });
             });
 
@@ -313,7 +313,7 @@ describe('Unit: endpoints/utils/validators/input/posts', function () {
                 return validators.input.posts.edit(apiConfig, frame)
                     .then(Promise.reject)
                     .catch((err) => {
-                        err.errorType.should.equal('ValidationError');
+                        assert.equal(err.errorType, 'ValidationError');
                     });
             });
 
@@ -349,7 +349,7 @@ describe('Unit: endpoints/utils/validators/input/posts', function () {
                 return validators.input.posts.edit(apiConfig, frame)
                     .then(Promise.reject)
                     .catch((err) => {
-                        err.errorType.should.equal('ValidationError');
+                        assert.equal(err.errorType, 'ValidationError');
                     });
             });
 
@@ -371,7 +371,7 @@ describe('Unit: endpoints/utils/validators/input/posts', function () {
                 return validators.input.posts.edit(apiConfig, frame)
                     .then(Promise.reject)
                     .catch((err) => {
-                        err.errorType.should.equal('ValidationError');
+                        assert.equal(err.errorType, 'ValidationError');
                     });
             });
 

--- a/ghost/core/test/unit/api/canary/utils/validators/input/tags.test.js
+++ b/ghost/core/test/unit/api/canary/utils/validators/input/tags.test.js
@@ -1,5 +1,5 @@
 const _ = require('lodash');
-const should = require('should');
+const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const validators = require('../../../../../../../core/server/api/endpoints/utils/validators');
 
@@ -24,7 +24,7 @@ describe('Unit: endpoints/utils/validators/input/tags', function () {
                 return validators.input.tags.add(apiConfig, frame)
                     .then(Promise.reject)
                     .catch((err) => {
-                        err.errorType.should.equal('ValidationError');
+                        assert.equal(err.errorType, 'ValidationError');
                     });
             });
 
@@ -39,7 +39,7 @@ describe('Unit: endpoints/utils/validators/input/tags', function () {
                 return validators.input.tags.add(apiConfig, frame)
                     .then(Promise.reject)
                     .catch((err) => {
-                        err.errorType.should.equal('ValidationError');
+                        assert.equal(err.errorType, 'ValidationError');
                     });
             });
 
@@ -54,7 +54,7 @@ describe('Unit: endpoints/utils/validators/input/tags', function () {
                 return validators.input.tags.add(apiConfig, frame)
                     .then(Promise.reject)
                     .catch((err) => {
-                        err.errorType.should.equal('ValidationError');
+                        assert.equal(err.errorType, 'ValidationError');
                     });
             });
 
@@ -70,7 +70,7 @@ describe('Unit: endpoints/utils/validators/input/tags', function () {
                 return validators.input.tags.add(apiConfig, frame)
                     .then(Promise.reject)
                     .catch((err) => {
-                        err.errorType.should.equal('ValidationError');
+                        assert.equal(err.errorType, 'ValidationError');
                     });
             });
 
@@ -87,7 +87,7 @@ describe('Unit: endpoints/utils/validators/input/tags', function () {
                 return validators.input.tags.add(apiConfig, frame)
                     .then(Promise.reject)
                     .catch((err) => {
-                        err.errorType.should.equal('ValidationError');
+                        assert.equal(err.errorType, 'ValidationError');
                     });
             });
 
@@ -119,10 +119,10 @@ describe('Unit: endpoints/utils/validators/input/tags', function () {
 
                 let result = validators.input.tags.add(apiConfig, frame);
 
-                should.exist(frame.data.tags[0].name);
-                should.not.exist(frame.data.tags[0].parent);
-                should.not.exist(frame.data.tags[0].created_at);
-                should.not.exist(frame.data.tags[0].updated_at);
+                assert(frame.data.tags[0].name);
+                assert.equal(frame.data.tags[0].parent, undefined);
+                assert.equal(frame.data.tags[0].created_at, undefined);
+                assert.equal(frame.data.tags[0].updated_at, undefined);
 
                 return result;
             });
@@ -161,7 +161,7 @@ describe('Unit: endpoints/utils/validators/input/tags', function () {
                         return validators.input.tags.add(apiConfig, frame)
                             .then(Promise.reject)
                             .catch((err) => {
-                                err.errorType.should.equal('ValidationError');
+                                assert.equal(err.errorType, 'ValidationError');
                             });
                     });
 
@@ -187,7 +187,7 @@ describe('Unit: endpoints/utils/validators/input/tags', function () {
                 return validators.input.tags.edit(apiConfig, frame)
                     .then(Promise.reject)
                     .catch((err) => {
-                        err.errorType.should.equal('ValidationError');
+                        assert.equal(err.errorType, 'ValidationError');
                     });
             });
 
@@ -202,7 +202,7 @@ describe('Unit: endpoints/utils/validators/input/tags', function () {
                 return validators.input.tags.edit(apiConfig, frame)
                     .then(Promise.reject)
                     .catch((err) => {
-                        err.errorType.should.equal('ValidationError');
+                        assert.equal(err.errorType, 'ValidationError');
                     });
             });
 
@@ -218,7 +218,7 @@ describe('Unit: endpoints/utils/validators/input/tags', function () {
                 return validators.input.tags.edit(apiConfig, frame)
                     .then(Promise.reject)
                     .catch((err) => {
-                        err.errorType.should.equal('ValidationError');
+                        assert.equal(err.errorType, 'ValidationError');
                     });
             });
 

--- a/ghost/core/test/unit/api/canary/utils/validators/input/webhooks.test.js
+++ b/ghost/core/test/unit/api/canary/utils/validators/input/webhooks.test.js
@@ -1,5 +1,5 @@
 const _ = require('lodash');
-const should = require('should');
+const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const validators = require('../../../../../../../core/server/api/endpoints/utils/validators');
 
@@ -24,7 +24,7 @@ describe('Unit: endpoints/utils/validators/input/webhooks', function () {
                 return validators.input.webhooks.add(apiConfig, frame)
                     .then(Promise.reject)
                     .catch((err) => {
-                        err.errorType.should.equal('ValidationError');
+                        assert.equal(err.errorType, 'ValidationError');
                     });
             });
 
@@ -39,7 +39,7 @@ describe('Unit: endpoints/utils/validators/input/webhooks', function () {
                 return validators.input.webhooks.add(apiConfig, frame)
                     .then(Promise.reject)
                     .catch((err) => {
-                        err.errorType.should.equal('ValidationError');
+                        assert.equal(err.errorType, 'ValidationError');
                     });
             });
 
@@ -54,7 +54,7 @@ describe('Unit: endpoints/utils/validators/input/webhooks', function () {
                 return validators.input.webhooks.add(apiConfig, frame)
                     .then(Promise.reject)
                     .catch((err) => {
-                        err.errorType.should.equal('ValidationError');
+                        assert.equal(err.errorType, 'ValidationError');
                     });
             });
 
@@ -70,7 +70,7 @@ describe('Unit: endpoints/utils/validators/input/webhooks', function () {
                 return validators.input.webhooks.add(apiConfig, frame)
                     .then(Promise.reject)
                     .catch((err) => {
-                        err.errorType.should.equal('ValidationError');
+                        assert.equal(err.errorType, 'ValidationError');
                     });
             });
 
@@ -87,7 +87,7 @@ describe('Unit: endpoints/utils/validators/input/webhooks', function () {
                 return validators.input.webhooks.add(apiConfig, frame)
                     .then(Promise.reject)
                     .catch((err) => {
-                        err.errorType.should.equal('ValidationError');
+                        assert.equal(err.errorType, 'ValidationError');
                     });
             });
 
@@ -128,16 +128,16 @@ describe('Unit: endpoints/utils/validators/input/webhooks', function () {
 
                 validators.input.webhooks.add(apiConfig, frame);
 
-                frame.data.webhooks[0].name.should.equal('pass');
-                frame.data.webhooks[0].target_url.should.equal('https://example.com/target/1');
-                frame.data.webhooks[0].event.should.equal('post.published');
-                frame.data.webhooks[0].integration_id.should.equal('1234');
-                should.not.exist(frame.data.webhooks[0].status);
-                should.not.exist(frame.data.webhooks[0].last_triggered_at);
-                should.not.exist(frame.data.webhooks[0].last_triggered_status);
-                should.not.exist(frame.data.webhooks[0].last_triggered_error);
-                should.not.exist(frame.data.webhooks[0].created_at);
-                should.not.exist(frame.data.webhooks[0].updated_at);
+                assert.equal(frame.data.webhooks[0].name, 'pass');
+                assert.equal(frame.data.webhooks[0].target_url, 'https://example.com/target/1');
+                assert.equal(frame.data.webhooks[0].event, 'post.published');
+                assert.equal(frame.data.webhooks[0].integration_id, '1234');
+                assert.equal(frame.data.webhooks[0].status, undefined);
+                assert.equal(frame.data.webhooks[0].last_triggered_at, undefined);
+                assert.equal(frame.data.webhooks[0].last_triggered_status, undefined);
+                assert.equal(frame.data.webhooks[0].last_triggered_error, undefined);
+                assert.equal(frame.data.webhooks[0].created_at, undefined);
+                assert.equal(frame.data.webhooks[0].updated_at, undefined);
             });
         });
 
@@ -171,7 +171,7 @@ describe('Unit: endpoints/utils/validators/input/webhooks', function () {
                         return validators.input.webhooks.add(apiConfig, frame)
                             .then(Promise.reject)
                             .catch((err) => {
-                                err.errorType.should.equal('ValidationError');
+                                assert.equal(err.errorType, 'ValidationError');
                             });
                     });
 
@@ -197,7 +197,7 @@ describe('Unit: endpoints/utils/validators/input/webhooks', function () {
                 return validators.input.webhooks.edit(apiConfig, frame)
                     .then(Promise.reject)
                     .catch((err) => {
-                        err.errorType.should.equal('ValidationError');
+                        assert.equal(err.errorType, 'ValidationError');
                     });
             });
 
@@ -212,7 +212,7 @@ describe('Unit: endpoints/utils/validators/input/webhooks', function () {
                 return validators.input.webhooks.edit(apiConfig, frame)
                     .then(Promise.reject)
                     .catch((err) => {
-                        err.errorType.should.equal('ValidationError');
+                        assert.equal(err.errorType, 'ValidationError');
                     });
             });
 
@@ -228,7 +228,7 @@ describe('Unit: endpoints/utils/validators/input/webhooks', function () {
                 return validators.input.webhooks.edit(apiConfig, frame)
                     .then(Promise.reject)
                     .catch((err) => {
-                        err.errorType.should.equal('ValidationError');
+                        assert.equal(err.errorType, 'ValidationError');
                     });
             });
 


### PR DESCRIPTION
*This test-only change should have no user impact.*

This changes 15 test files. They no longer use Should.js and instead use `node:assert/strict` and Sinon assertions.
