### PR TITLE
Added feature flag for sniper links

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
@@ -67,6 +67,10 @@ const features: Feature[] = [{
     title: 'Disable Member Commenting',
     description: 'Allow staff to disable commenting for individual members',
     flag: 'disableMemberCommenting'
+}, {
+    title: 'Sniper Links',
+    description: 'Enable mail app links on signup/signin',
+    flag: 'sniperlinks'
 }];
 
 const AlphaFeatures: React.FC = () => {

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -56,7 +56,8 @@ const PRIVATE_FEATURES = [
     'indexnow',
     'featurebaseFeedback',
     'transistor',
-    'disableMemberCommenting'
+    'disableMemberCommenting',
+    'sniperlinks'
 ];
 
 module.exports.GA_KEYS = [...GA_FEATURES];

--- a/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
@@ -28,6 +28,7 @@ Object {
       "indexnow": true,
       "lexicalIndicators": true,
       "members": true,
+      "sniperlinks": true,
       "stripeAutomaticTax": true,
       "superEditors": true,
       "tagsX": true,


### PR DESCRIPTION
towards https://linear.app/ghost/issue/NY-943

<p align="center"><img alt="Screenshot" src="https://github.com/user-attachments/assets/d260cc86-58e4-4957-badf-6fcfb048a080" width="40%"></p>

This adds the `sniperlinks` feature flag which we'll use in upcoming work.