### PR TITLE
Added migration for Stripe billing portal configuration

### DIFF
--- a/ghost/core/core/server/data/exporter/table-lists.js
+++ b/ghost/core/core/server/data/exporter/table-lists.js
@@ -92,6 +92,7 @@ const SETTING_KEYS_BLOCKLIST = [
     'stripe_connect_account_id',
     'stripe_secret_key',
     'stripe_publishable_key',
+    'stripe_billing_portal_configuration_id',
     'members_stripe_webhook_id',
     'members_stripe_webhook_secret',
     'email_verification_required',

--- a/ghost/core/core/server/data/migrations/versions/6.15/2026-01-26-18-06-00-add-billing-portal-setting.js
+++ b/ghost/core/core/server/data/migrations/versions/6.15/2026-01-26-18-06-00-add-billing-portal-setting.js
@@ -1,0 +1,8 @@
+const {addSetting} = require('../../utils');
+
+module.exports = addSetting({
+    key: 'stripe_billing_portal_configuration_id',
+    value: null,
+    type: 'string',
+    group: 'members'
+});

--- a/ghost/core/core/server/data/schema/default-settings/default-settings.json
+++ b/ghost/core/core/server/data/schema/default-settings/default-settings.json
@@ -277,6 +277,10 @@
             "flags": "PUBLIC,RO",
             "type": "string"
         },
+        "stripe_billing_portal_configuration_id": {
+            "defaultValue": null,
+            "type": "string"
+        },
         "stripe_secret_key": {
             "defaultValue": null,
             "type": "string"

--- a/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
@@ -129,6 +129,10 @@ Object {
       "value": "noreply",
     },
     Object {
+      "key": "stripe_billing_portal_configuration_id",
+      "value": null,
+    },
+    Object {
       "key": "stripe_secret_key",
       "value": null,
     },
@@ -936,6 +940,10 @@ Object {
       "value": "noreply",
     },
     Object {
+      "key": "stripe_billing_portal_configuration_id",
+      "value": null,
+    },
+    Object {
       "key": "stripe_secret_key",
       "value": null,
     },
@@ -1326,6 +1334,10 @@ Object {
       "value": "support@example.com",
     },
     Object {
+      "key": "stripe_billing_portal_configuration_id",
+      "value": null,
+    },
+    Object {
       "key": "stripe_secret_key",
       "value": null,
     },
@@ -1591,7 +1603,7 @@ exports[`Settings API Edit can edit Stripe settings when Stripe Connect limit is
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "4753",
+  "content-length": "4815",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -1759,6 +1771,10 @@ Object {
     Object {
       "key": "members_support_address",
       "value": "noreply",
+    },
+    Object {
+      "key": "stripe_billing_portal_configuration_id",
+      "value": null,
     },
     Object {
       "key": "stripe_secret_key",
@@ -2148,6 +2164,10 @@ Object {
     Object {
       "key": "members_support_address",
       "value": "support@example.com",
+    },
+    Object {
+      "key": "stripe_billing_portal_configuration_id",
+      "value": null,
     },
     Object {
       "key": "stripe_secret_key",
@@ -2994,6 +3014,10 @@ Object {
       "value": "noreply",
     },
     Object {
+      "key": "stripe_billing_portal_configuration_id",
+      "value": null,
+    },
+    Object {
       "key": "stripe_secret_key",
       "value": null,
     },
@@ -3384,6 +3408,10 @@ Object {
       "value": "default@email.com",
     },
     Object {
+      "key": "stripe_billing_portal_configuration_id",
+      "value": null,
+    },
+    Object {
       "key": "stripe_secret_key",
       "value": null,
     },
@@ -3772,6 +3800,10 @@ Object {
     Object {
       "key": "members_support_address",
       "value": "support@sendingdomain.com",
+    },
+    Object {
+      "key": "stripe_billing_portal_configuration_id",
+      "value": null,
     },
     Object {
       "key": "stripe_secret_key",
@@ -4168,6 +4200,10 @@ Object {
       "value": "default@email.com",
     },
     Object {
+      "key": "stripe_billing_portal_configuration_id",
+      "value": null,
+    },
+    Object {
       "key": "stripe_secret_key",
       "value": null,
     },
@@ -4555,6 +4591,10 @@ Object {
     Object {
       "key": "members_support_address",
       "value": "default@email.com",
+    },
+    Object {
+      "key": "stripe_billing_portal_configuration_id",
+      "value": null,
     },
     Object {
       "key": "stripe_secret_key",
@@ -4949,6 +4989,10 @@ Object {
     Object {
       "key": "members_support_address",
       "value": "support@example.com",
+    },
+    Object {
+      "key": "stripe_billing_portal_configuration_id",
+      "value": null,
     },
     Object {
       "key": "stripe_secret_key",
@@ -5701,6 +5745,10 @@ Object {
       "value": "support@customdomain.com",
     },
     Object {
+      "key": "stripe_billing_portal_configuration_id",
+      "value": null,
+    },
+    Object {
       "key": "stripe_secret_key",
       "value": null,
     },
@@ -6089,6 +6137,10 @@ Object {
     Object {
       "key": "members_support_address",
       "value": "default@email.com",
+    },
+    Object {
+      "key": "stripe_billing_portal_configuration_id",
+      "value": null,
     },
     Object {
       "key": "stripe_secret_key",
@@ -6481,6 +6533,10 @@ Object {
       "value": "default@email.com",
     },
     Object {
+      "key": "stripe_billing_portal_configuration_id",
+      "value": null,
+    },
+    Object {
       "key": "stripe_secret_key",
       "value": null,
     },
@@ -6870,6 +6926,10 @@ Object {
     Object {
       "key": "members_support_address",
       "value": "default@email.com",
+    },
+    Object {
+      "key": "stripe_billing_portal_configuration_id",
+      "value": null,
     },
     Object {
       "key": "stripe_secret_key",
@@ -7324,6 +7384,10 @@ Object {
     Object {
       "key": "members_support_address",
       "value": "support@example.com",
+    },
+    Object {
+      "key": "stripe_billing_portal_configuration_id",
+      "value": null,
     },
     Object {
       "key": "stripe_secret_key",

--- a/ghost/core/test/e2e-api/admin/settings.test.js
+++ b/ghost/core/test/e2e-api/admin/settings.test.js
@@ -10,7 +10,7 @@ const membersService = require('../../../core/server/services/members');
 const {anyErrorId} = matchers;
 
 // Updated to reflect current total based on test output
-const CURRENT_SETTINGS_COUNT = 92;
+const CURRENT_SETTINGS_COUNT = 93;
 
 const settingsMatcher = {};
 
@@ -33,10 +33,10 @@ const matchSettingsArray = (length) => {
         settingsArray[26] = publicHashSettingMatcher;
     }
 
-    if (length > 59) {
+    if (length > 60) {
         // Added a setting that is alphabetically before 'labs'? then you need to increment this counter.
         // Item at index x is the lab settings, which changes as we add and remove features
-        settingsArray[59] = labsSettingMatcher;
+        settingsArray[60] = labsSettingMatcher;
     }
 
     return settingsArray;

--- a/ghost/core/test/legacy/models/model-settings.test.js
+++ b/ghost/core/test/legacy/models/model-settings.test.js
@@ -5,7 +5,7 @@ const db = require('../../../core/server/data/db');
 // Stuff we are testing
 const models = require('../../../core/server/models');
 
-const SETTINGS_LENGTH = 97;
+const SETTINGS_LENGTH = 98;
 
 describe('Settings Model', function () {
     before(models.init);

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -37,7 +37,7 @@ describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = 'bbd9a12f190db664b7f00a7f22364472';
     const currentFixturesHash = '4dcbd7b52bc9ce23e6f5f1673118ba73';
-    const currentSettingsHash = 'e75a2245c64a4fc82f826676abbc3234';
+    const currentSettingsHash = 'd18778216289f79a502d75234320b8d3';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';
 
     // If this test is failing, then it is likely a change has been made that requires a DB version bump,

--- a/ghost/core/test/utils/fixtures/default-settings-browser.json
+++ b/ghost/core/test/utils/fixtures/default-settings-browser.json
@@ -265,6 +265,10 @@
             "flags": "PUBLIC,RO",
             "type": "string"
         },
+        "stripe_billing_portal_configuration_id": {
+            "defaultValue": null,
+            "type": "string"
+        },
         "stripe_secret_key": {
             "defaultValue": null,
             "type": "string"

--- a/ghost/core/test/utils/fixtures/default-settings.json
+++ b/ghost/core/test/utils/fixtures/default-settings.json
@@ -277,6 +277,10 @@
             "flags": "PUBLIC,RO",
             "type": "string"
         },
+        "stripe_billing_portal_configuration_id": {
+            "defaultValue": null,
+            "type": "string"
+        },
         "stripe_secret_key": {
             "defaultValue": null,
             "type": "string"


### PR DESCRIPTION
ref [FEA-502](https://linear.app/ghost/issue/FEA-502/portal-billing-management-converted-to-project)

Migration as originally implemented in PR: https://github.com/TryGhost/Ghost/pull/25862/

This will hold the id of the billing portal configuration object defined in Stripe. This way we can create our own billing portal configuration with any of the features we need, and override the default headline.