### PR TITLE
Fixed `@tryghost/parse-email-address` error in CI

### DIFF
--- a/ghost/admin/package.json
+++ b/ghost/admin/package.json
@@ -188,6 +188,7 @@
             "projects": [
               "@tryghost/admin-x-settings",
               "@tryghost/activitypub",
+              "@tryghost/parse-email-address",
               "@tryghost/posts",
               "@tryghost/stats"
             ],
@@ -206,6 +207,7 @@
             "projects": [
               "@tryghost/admin-x-settings",
               "@tryghost/activitypub",
+              "@tryghost/parse-email-address",
               "@tryghost/posts",
               "@tryghost/stats"
             ],

--- a/ghost/parse-email-address/package.json
+++ b/ghost/parse-email-address/package.json
@@ -9,8 +9,8 @@
   "types": "build/index.d.ts",
   "scripts": {
     "dev": "tsc --watch --preserveWatchOutput --sourceMap",
-    "build": "yarn build:ts",
-    "build:ts": "tsc",
+    "build": "yarn build:tsc",
+    "build:tsc": "tsc",
     "prepare": "tsc",
     "test:unit": "NODE_ENV=testing c8 --src src --all --check-coverage --100 --reporter text --reporter cobertura mocha -r ts-node/register './test/**/*.test.ts'",
     "test": "yarn test:types && yarn test:unit",


### PR DESCRIPTION
This should fix [recent CI failures][0] caused by 586ec1aea4c34048ae6a7b80e47b4ce89bcdc3c3.

[0]: https://github.com/TryGhost/Ghost/actions/runs/21368464606
