### PR TITLE
Changed welcome emails to only be gated by labs flag

### DIFF
--- a/e2e/tests/admin/members/member-activity-events.test.ts
+++ b/e2e/tests/admin/members/member-activity-events.test.ts
@@ -9,13 +9,7 @@ import {signupViaPortal} from '@/helpers/playwright/flows/signup';
 test.describe('Ghost Admin - Member Activity Events', () => {
     let emailClient: EmailClient;
 
-    test.use({
-        config: {
-            memberWelcomeEmailSendInstantly: 'true',
-            memberWelcomeEmailTestInbox: 'test+welcome-email@ghost.org'
-        },
-        labs: {welcomeEmails: true}
-    });
+    test.use({labs: {welcomeEmails: true}});
 
     test.beforeEach(async () => {
         emailClient = new MailPit();

--- a/e2e/tests/public/member-signup.test.ts
+++ b/e2e/tests/public/member-signup.test.ts
@@ -8,10 +8,13 @@ import {signupViaPortal} from '@/helpers/playwright/flows/signup';
 test.describe('Ghost Public - Member Signup', () => {
     let emailClient: EmailClient;
 
-    test.use({config: {
-        memberWelcomeEmailSendInstantly: 'true',
-        memberWelcomeEmailTestInbox: `test+welcome-email@ghost.org`
-    }});
+    test.use({
+        config: {
+            memberWelcomeEmailSendInstantly: 'true',
+            memberWelcomeEmailTestInbox: `test+welcome-email@ghost.org`
+        },
+        labs: {welcomeEmails: true}
+    });
 
     test.beforeEach(async () => {
         emailClient = new MailPit();

--- a/e2e/tests/public/member-signup.test.ts
+++ b/e2e/tests/public/member-signup.test.ts
@@ -8,13 +8,7 @@ import {signupViaPortal} from '@/helpers/playwright/flows/signup';
 test.describe('Ghost Public - Member Signup', () => {
     let emailClient: EmailClient;
 
-    test.use({
-        config: {
-            memberWelcomeEmailSendInstantly: 'true',
-            memberWelcomeEmailTestInbox: `test+welcome-email@ghost.org`
-        },
-        labs: {welcomeEmails: true}
-    });
+    test.use({labs: {welcomeEmails: true}});
 
     test.beforeEach(async () => {
         emailClient = new MailPit();
@@ -51,11 +45,10 @@ test.describe('Ghost Public - Member Signup', () => {
         expect(emailTextBody).toContain('complete the signup process');
     });
 
-    test('received welcome email', async ({page, config}) => {
+    test('received welcome email', async ({page}) => {
         const automatedEmailFactory = createAutomatedEmailFactory(page.request);
         await automatedEmailFactory.create();
 
-        const emailInbox = config!.memberWelcomeEmailTestInbox!;
         const homePage = new HomePage(page);
         await homePage.goto();
         const {emailAddress} = await signupViaPortal(page);
@@ -68,7 +61,7 @@ test.describe('Ghost Public - Member Signup', () => {
         await publicPage.goto(magicLink);
         await homePage.waitUntilLoaded();
 
-        latestMessage = await retrieveLatestEmailMessage(emailInbox);
+        latestMessage = await retrieveLatestEmailMessage(emailAddress);
 
         expect(latestMessage.From.Name).toContain('Test Blog');
         expect(latestMessage.From.Address).toContain('test@example.com');

--- a/e2e/tests/public/member-signup.test.ts
+++ b/e2e/tests/public/member-signup.test.ts
@@ -61,7 +61,11 @@ test.describe('Ghost Public - Member Signup', () => {
         await publicPage.goto(magicLink);
         await homePage.waitUntilLoaded();
 
-        latestMessage = await retrieveLatestEmailMessage(emailAddress);
+        const welcomeMessages = await emailClient.search(
+            {to: emailAddress, subject: 'Welcome'},
+            {timeoutMs: 10000}
+        );
+        latestMessage = await emailClient.getMessageDetailed(welcomeMessages[0]);
 
         expect(latestMessage.From.Name).toContain('Test Blog');
         expect(latestMessage.From.Address).toContain('test@example.com');

--- a/ghost/core/core/server/services/member-welcome-emails/constants.js
+++ b/ghost/core/core/server/services/member-welcome-emails/constants.js
@@ -8,7 +8,6 @@ const MEMBER_WELCOME_EMAIL_SLUGS = {
 const MESSAGES = {
     NO_MEMBER_WELCOME_EMAIL: 'No member welcome email found',
     INVALID_LEXICAL_STRUCTURE: 'Member welcome email has invalid content structure',
-    MISSING_TEST_INBOX_CONFIG: 'memberWelcomeEmailTestInbox config is required but not defined',
     MISSING_EMAIL_CONTENT: 'Email content is required to send a test email',
     MISSING_EMAIL_SUBJECT: 'Email subject is required to send a test email',
     memberWelcomeEmailInactive: memberStatus => `Member welcome email for "${memberStatus}" members is inactive`

--- a/ghost/core/core/server/services/member-welcome-emails/constants.js
+++ b/ghost/core/core/server/services/member-welcome-emails/constants.js
@@ -10,6 +10,7 @@ const MESSAGES = {
     INVALID_LEXICAL_STRUCTURE: 'Member welcome email has invalid content structure',
     MISSING_EMAIL_CONTENT: 'Email content is required to send a test email',
     MISSING_EMAIL_SUBJECT: 'Email subject is required to send a test email',
+    MISSING_RECIPIENT_EMAIL: 'Cannot send welcome email: no recipient email address available',
     memberWelcomeEmailInactive: memberStatus => `Member welcome email for "${memberStatus}" members is inactive`
 };
 

--- a/ghost/core/core/server/services/member-welcome-emails/service.js
+++ b/ghost/core/core/server/services/member-welcome-emails/service.js
@@ -80,6 +80,12 @@ class MemberWelcomeEmailService {
         const testInbox = config.get('memberWelcomeEmailTestInbox');
         const toEmail = testInbox || member.email;
 
+        if (!toEmail) {
+            throw new errors.IncorrectUsageError({
+                message: MESSAGES.MISSING_RECIPIENT_EMAIL
+            });
+        }
+
         await this.#mailer.send({
             to: toEmail,
             subject,

--- a/ghost/core/core/server/services/member-welcome-emails/service.js
+++ b/ghost/core/core/server/services/member-welcome-emails/service.js
@@ -77,12 +77,8 @@ class MemberWelcomeEmailService {
             siteSettings: this.#getSiteSettings()
         });
 
-        const toEmail = config.get('memberWelcomeEmailTestInbox');
-        if (!toEmail) {
-            throw new errors.IncorrectUsageError({
-                message: MESSAGES.MISSING_TEST_INBOX_CONFIG
-            });
-        }
+        const testInbox = config.get('memberWelcomeEmailTestInbox');
+        const toEmail = testInbox || member.email;
 
         await this.#mailer.send({
             to: toEmail,

--- a/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
@@ -353,8 +353,8 @@ module.exports = class MemberRepository {
         const memberAddOptions = {...(options || {}), withRelated};
         let member;
 
-        const hasTestInbox = Boolean(config.get('memberWelcomeEmailTestInbox'));
-        if (hasTestInbox && WELCOME_EMAIL_SOURCES.includes(source)) {
+        const welcomeEmailsEnabled = this._labsService.isSet('welcomeEmails');
+        if (welcomeEmailsEnabled && WELCOME_EMAIL_SOURCES.includes(source)) {
             const freeWelcomeEmail = this._AutomatedEmail ? await this._AutomatedEmail.findOne({slug: MEMBER_WELCOME_EMAIL_SLUGS.free}) : null;
             const isFreeWelcomeEmailActive = freeWelcomeEmail && freeWelcomeEmail.get('lexical') && freeWelcomeEmail.get('status') === 'active';
             const isFreeSignup = !stripeCustomer;
@@ -1450,7 +1450,7 @@ module.exports = class MemberRepository {
 
             const context = options?.context || {};
             const source = this._resolveContextSource(context);
-            const shouldSendPaidWelcomeEmail = config.get('memberWelcomeEmailTestInbox') && WELCOME_EMAIL_SOURCES.includes(source);
+            const shouldSendPaidWelcomeEmail = this._labsService.isSet('welcomeEmails') && WELCOME_EMAIL_SOURCES.includes(source);
             let isPaidWelcomeEmailActive = false;
             if (shouldSendPaidWelcomeEmail && this._AutomatedEmail) {
                 const paidWelcomeEmail = await this._AutomatedEmail.findOne({slug: MEMBER_WELCOME_EMAIL_SLUGS.paid}, options);

--- a/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
@@ -8,7 +8,6 @@ const ObjectId = require('bson-objectid').default;
 const {NotFoundError} = require('@tryghost/errors');
 const validator = require('@tryghost/validator');
 const crypto = require('crypto');
-const config = require('../../../../../shared/config');
 const StartOutboxProcessingEvent = require('../../../outbox/events/start-outbox-processing-event');
 const {MEMBER_WELCOME_EMAIL_SLUGS} = require('../../../member-welcome-emails/constants');
 const messages = {

--- a/ghost/core/core/server/services/outbox/jobs/index.js
+++ b/ghost/core/core/server/services/outbox/jobs/index.js
@@ -8,10 +8,7 @@ let hasScheduled = {
 
 module.exports = {
     scheduleOutboxJob() {
-        const testInboxDisabled = !config.get('memberWelcomeEmailTestInbox');
-        const alreadyScheduledProcessing = hasScheduled.processOutbox;
-
-        if (testInboxDisabled || alreadyScheduledProcessing) {
+        if (hasScheduled.processOutbox) {
             return false;
         }
 

--- a/ghost/core/core/server/services/outbox/jobs/lib/process-outbox.js
+++ b/ghost/core/core/server/services/outbox/jobs/lib/process-outbox.js
@@ -1,5 +1,6 @@
 const logging = require('@tryghost/logging');
 const db = require('../../../../data/db');
+const labs = require('../../../../../shared/labs');
 const MemberCreatedEvent = require('../../../../../shared/events/member-created-event');
 const {OUTBOX_STATUSES} = require('../../../../models/outbox');
 const {MESSAGES, MAX_ENTRIES_PER_JOB, BATCH_SIZE, OUTBOX_LOG_KEY} = require('./constants');
@@ -40,6 +41,10 @@ async function fetchPendingEntries({batchSize, jobStartISO}) {
 async function processOutbox() {
     const jobStartMs = Date.now();
     const jobStartISO = new Date(jobStartMs).toISOString().slice(0, 19).replace('T', ' ');
+
+    if (!labs.isSet('welcomeEmails')) {
+        return `${OUTBOX_LOG_KEY} Welcome emails feature is disabled`;
+    }
 
     memberWelcomeEmailService.init();
     try {

--- a/ghost/core/test/integration/jobs/process-outbox.test.js
+++ b/ghost/core/test/integration/jobs/process-outbox.test.js
@@ -21,35 +21,6 @@ describe('Process Outbox Job', function () {
         jobService = require('../../../core/server/services/jobs/job-service');
     });
 
-    beforeEach(async function () {
-        sinon.stub(mailService.GhostMailer.prototype, 'send').resolves('Mail sent');
-        mockManager.mockLabsEnabled('welcomeEmails');
-
-        const lexical = JSON.stringify({
-            root: {
-                children: [{
-                    type: 'paragraph',
-                    children: [{type: 'text', text: 'Welcome to our site!'}]
-                }],
-                direction: null,
-                format: '',
-                indent: 0,
-                type: 'root',
-                version: 1
-            }
-        });
-
-        await db.knex('automated_emails').insert({
-            id: ObjectId().toHexString(),
-            status: 'active',
-            name: 'Free Member Welcome Email',
-            slug: MEMBER_WELCOME_EMAIL_SLUGS.free,
-            subject: 'Welcome to {site_title}',
-            lexical,
-            created_at: new Date()
-        });
-    });
-
     afterEach(async function () {
         sinon.restore();
         mockManager.restore();
@@ -72,198 +43,227 @@ describe('Process Outbox Job', function () {
         await jobService.awaitCompletion(JOB_NAME);
     }
 
-    it('processes pending outbox entries and deletes them after success', async function () {
-        await models.Outbox.add({
-            event_type: 'MemberCreatedEvent',
-            payload: JSON.stringify({
-                memberId: 'member123',
-                email: 'test@example.com',
-                name: 'Test Member',
-                source: 'member',
-                status: 'free'
-            }),
-            status: OUTBOX_STATUSES.PENDING
+    describe('with welcomeEmails enabled', function () {
+        beforeEach(async function () {
+            sinon.stub(mailService.GhostMailer.prototype, 'send').resolves('Mail sent');
+            mockManager.mockLabsEnabled('welcomeEmails');
+
+            const lexical = JSON.stringify({
+                root: {
+                    children: [{
+                        type: 'paragraph',
+                        children: [{type: 'text', text: 'Welcome to our site!'}]
+                    }],
+                    direction: null,
+                    format: '',
+                    indent: 0,
+                    type: 'root',
+                    version: 1
+                }
+            });
+
+            await db.knex('automated_emails').insert({
+                id: ObjectId().toHexString(),
+                status: 'active',
+                name: 'Free Member Welcome Email',
+                slug: MEMBER_WELCOME_EMAIL_SLUGS.free,
+                subject: 'Welcome to {site_title}',
+                lexical,
+                created_at: new Date()
+            });
         });
 
-        const entriesBeforeJob = await models.Outbox.findAll();
-        assert.equal(entriesBeforeJob.length, 1);
+        it('processes pending outbox entries and deletes them after success', async function () {
+            await models.Outbox.add({
+                event_type: 'MemberCreatedEvent',
+                payload: JSON.stringify({
+                    memberId: 'member123',
+                    email: 'test@example.com',
+                    name: 'Test Member',
+                    source: 'member',
+                    status: 'free'
+                }),
+                status: OUTBOX_STATUSES.PENDING
+            });
 
-        await scheduleInlineJob();
+            const entriesBeforeJob = await models.Outbox.findAll();
+            assert.equal(entriesBeforeJob.length, 1);
 
-        const entriesAfterJob = await models.Outbox.findAll();
-        assert.equal(entriesAfterJob.length, 0);
-        assert.equal(mailService.GhostMailer.prototype.send.callCount, 1);
+            await scheduleInlineJob();
+
+            const entriesAfterJob = await models.Outbox.findAll();
+            assert.equal(entriesAfterJob.length, 0);
+            assert.equal(mailService.GhostMailer.prototype.send.callCount, 1);
+        });
+
+        it('does nothing when there are no pending entries', async function () {
+            const entriesBeforeJob = await models.Outbox.findAll();
+            assert.equal(entriesBeforeJob.length, 0);
+
+            await scheduleInlineJob();
+
+            const entriesAfterJob = await models.Outbox.findAll();
+            assert.equal(entriesAfterJob.length, 0);
+            assert.equal(mailService.GhostMailer.prototype.send.callCount, 0);
+        });
+
+        it('processes multiple entries in a batch', async function () {
+            await models.Outbox.add({
+                event_type: 'MemberCreatedEvent',
+                payload: JSON.stringify({
+                    memberId: 'member1',
+                    email: 'test1@example.com',
+                    name: 'Test Member 1',
+                    status: 'free'
+                }),
+                status: OUTBOX_STATUSES.PENDING
+            });
+
+            await models.Outbox.add({
+                event_type: 'MemberCreatedEvent',
+                payload: JSON.stringify({
+                    memberId: 'member2',
+                    email: 'test2@example.com',
+                    name: 'Test Member 2',
+                    status: 'free'
+                }),
+                status: OUTBOX_STATUSES.PENDING
+            });
+
+            await models.Outbox.add({
+                event_type: 'MemberCreatedEvent',
+                payload: JSON.stringify({
+                    memberId: 'member3',
+                    email: 'test3@example.com',
+                    name: 'Test Member 3',
+                    status: 'free'
+                }),
+                status: OUTBOX_STATUSES.PENDING
+            });
+
+            const entriesBeforeJob = await models.Outbox.findAll();
+            assert.equal(entriesBeforeJob.length, 3);
+
+            await scheduleInlineJob();
+
+            const entriesAfterJob = await models.Outbox.findAll();
+            assert.equal(entriesAfterJob.length, 0);
+            assert.equal(mailService.GhostMailer.prototype.send.callCount, 3);
+        });
+
+        it('ignores entries that are not pending', async function () {
+            await models.Outbox.add({
+                event_type: 'MemberCreatedEvent',
+                payload: JSON.stringify({
+                    memberId: 'member1',
+                    email: 'test1@example.com',
+                    name: 'Test Member 1',
+                    status: 'free'
+                }),
+                status: OUTBOX_STATUSES.PROCESSING
+            });
+
+            await models.Outbox.add({
+                event_type: 'MemberCreatedEvent',
+                payload: JSON.stringify({
+                    memberId: 'member2',
+                    email: 'test2@example.com',
+                    name: 'Test Member 2',
+                    status: 'free'
+                }),
+                status: OUTBOX_STATUSES.FAILED
+            });
+
+            const entriesBeforeJob = await models.Outbox.findAll();
+            assert.equal(entriesBeforeJob.length, 2);
+
+            await scheduleInlineJob();
+
+            const entriesAfterJob = await models.Outbox.findAll();
+            assert.equal(entriesAfterJob.length, 2);
+            assert.equal(mailService.GhostMailer.prototype.send.callCount, 0);
+        });
+
+        it('increments retry_count and keeps entry pending when handler fails', async function () {
+            mailService.GhostMailer.prototype.send.rejects(new Error('Mail service unavailable'));
+
+            await models.Outbox.add({
+                event_type: 'MemberCreatedEvent',
+                payload: JSON.stringify({
+                    memberId: 'member1',
+                    email: 'retry@example.com',
+                    name: 'Retry Member',
+                    status: 'free'
+                }),
+                status: OUTBOX_STATUSES.PENDING,
+                retry_count: 0
+            });
+
+            await scheduleInlineJob();
+
+            const entriesAfterJob = await models.Outbox.findAll();
+            assert.equal(entriesAfterJob.length, 1);
+
+            const entry = entriesAfterJob.models[0];
+            assert.equal(entry.get('status'), OUTBOX_STATUSES.PENDING);
+            assert.equal(entry.get('retry_count'), 1);
+            assert.ok(entry.get('message').includes('Mail service unavailable'));
+        });
+
+        it('marks entry as failed when max retries exceeded', async function () {
+            mailService.GhostMailer.prototype.send.rejects(new Error('Persistent failure'));
+
+            await models.Outbox.add({
+                event_type: 'MemberCreatedEvent',
+                payload: JSON.stringify({
+                    memberId: 'member1',
+                    email: 'maxretry@example.com',
+                    name: 'Max Retry Member',
+                    status: 'free'
+                }),
+                status: OUTBOX_STATUSES.PENDING,
+                retry_count: 1
+            });
+
+            await scheduleInlineJob();
+
+            const entriesAfterJob = await models.Outbox.findAll();
+            assert.equal(entriesAfterJob.length, 1);
+
+            const entry = entriesAfterJob.models[0];
+            assert.equal(entry.get('status'), OUTBOX_STATUSES.FAILED);
+            assert.equal(entry.get('retry_count'), 2);
+        });
     });
 
-    it('does nothing when there are no pending entries', async function () {
-        const entriesBeforeJob = await models.Outbox.findAll();
-        assert.equal(entriesBeforeJob.length, 0);
-
-        await scheduleInlineJob();
-
-        const entriesAfterJob = await models.Outbox.findAll();
-        assert.equal(entriesAfterJob.length, 0);
-        assert.equal(mailService.GhostMailer.prototype.send.callCount, 0);
-    });
-
-    it('processes multiple entries in a batch', async function () {
-        await models.Outbox.add({
-            event_type: 'MemberCreatedEvent',
-            payload: JSON.stringify({
-                memberId: 'member1',
-                email: 'test1@example.com',
-                name: 'Test Member 1',
-                status: 'free'
-            }),
-            status: OUTBOX_STATUSES.PENDING
+    describe('with welcomeEmails disabled', function () {
+        beforeEach(async function () {
+            sinon.stub(mailService.GhostMailer.prototype, 'send').resolves('Mail sent');
+            mockManager.mockLabsDisabled('welcomeEmails');
         });
 
-        await models.Outbox.add({
-            event_type: 'MemberCreatedEvent',
-            payload: JSON.stringify({
-                memberId: 'member2',
-                email: 'test2@example.com',
-                name: 'Test Member 2',
-                status: 'free'
-            }),
-            status: OUTBOX_STATUSES.PENDING
+        it('skips processing and leaves entries pending', async function () {
+            await models.Outbox.add({
+                event_type: 'MemberCreatedEvent',
+                payload: JSON.stringify({
+                    memberId: 'member123',
+                    email: 'test@example.com',
+                    name: 'Test Member',
+                    source: 'member',
+                    status: 'free'
+                }),
+                status: OUTBOX_STATUSES.PENDING
+            });
+
+            const entriesBeforeJob = await models.Outbox.findAll();
+            assert.equal(entriesBeforeJob.length, 1);
+
+            await scheduleInlineJob();
+
+            const entriesAfterJob = await models.Outbox.findAll();
+            assert.equal(entriesAfterJob.length, 1);
+            assert.equal(entriesAfterJob.models[0].get('status'), OUTBOX_STATUSES.PENDING);
+            assert.equal(mailService.GhostMailer.prototype.send.callCount, 0);
         });
-
-        await models.Outbox.add({
-            event_type: 'MemberCreatedEvent',
-            payload: JSON.stringify({
-                memberId: 'member3',
-                email: 'test3@example.com',
-                name: 'Test Member 3',
-                status: 'free'
-            }),
-            status: OUTBOX_STATUSES.PENDING
-        });
-
-        const entriesBeforeJob = await models.Outbox.findAll();
-        assert.equal(entriesBeforeJob.length, 3);
-
-        await scheduleInlineJob();
-
-        const entriesAfterJob = await models.Outbox.findAll();
-        assert.equal(entriesAfterJob.length, 0);
-        assert.equal(mailService.GhostMailer.prototype.send.callCount, 3);
-    });
-
-    it('ignores entries that are not pending', async function () {
-        await models.Outbox.add({
-            event_type: 'MemberCreatedEvent',
-            payload: JSON.stringify({
-                memberId: 'member1',
-                email: 'test1@example.com',
-                name: 'Test Member 1',
-                status: 'free'
-            }),
-            status: OUTBOX_STATUSES.PROCESSING
-        });
-
-        await models.Outbox.add({
-            event_type: 'MemberCreatedEvent',
-            payload: JSON.stringify({
-                memberId: 'member2',
-                email: 'test2@example.com',
-                name: 'Test Member 2',
-                status: 'free'
-            }),
-            status: OUTBOX_STATUSES.FAILED
-        });
-
-        const entriesBeforeJob = await models.Outbox.findAll();
-        assert.equal(entriesBeforeJob.length, 2);
-
-        await scheduleInlineJob();
-
-        const entriesAfterJob = await models.Outbox.findAll();
-        assert.equal(entriesAfterJob.length, 2);
-        assert.equal(mailService.GhostMailer.prototype.send.callCount, 0);
-    });
-
-    it('increments retry_count and keeps entry pending when handler fails', async function () {
-        mailService.GhostMailer.prototype.send.rejects(new Error('Mail service unavailable'));
-
-        await models.Outbox.add({
-            event_type: 'MemberCreatedEvent',
-            payload: JSON.stringify({
-                memberId: 'member1',
-                email: 'retry@example.com',
-                name: 'Retry Member',
-                status: 'free'
-            }),
-            status: OUTBOX_STATUSES.PENDING,
-            retry_count: 0
-        });
-
-        await scheduleInlineJob();
-
-        const entriesAfterJob = await models.Outbox.findAll();
-        assert.equal(entriesAfterJob.length, 1);
-
-        const entry = entriesAfterJob.models[0];
-        assert.equal(entry.get('status'), OUTBOX_STATUSES.PENDING);
-        assert.equal(entry.get('retry_count'), 1);
-        assert.ok(entry.get('message').includes('Mail service unavailable'));
-    });
-
-    it('marks entry as failed when max retries exceeded', async function () {
-        mailService.GhostMailer.prototype.send.rejects(new Error('Persistent failure'));
-
-        await models.Outbox.add({
-            event_type: 'MemberCreatedEvent',
-            payload: JSON.stringify({
-                memberId: 'member1',
-                email: 'maxretry@example.com',
-                name: 'Max Retry Member',
-                status: 'free'
-            }),
-            status: OUTBOX_STATUSES.PENDING,
-            retry_count: 1
-        });
-
-        await scheduleInlineJob();
-
-        const entriesAfterJob = await models.Outbox.findAll();
-        assert.equal(entriesAfterJob.length, 1);
-
-        const entry = entriesAfterJob.models[0];
-        assert.equal(entry.get('status'), OUTBOX_STATUSES.FAILED);
-        assert.equal(entry.get('retry_count'), 2);
-    });
-
-    it('skips processing when welcomeEmails labs flag is off', async function () {
-        // Restore previous mocks and re-enable with labs flag off
-        sinon.restore();
-        mockManager.restore();
-
-        // Re-stub the mailer and disable the labs flag
-        const sendStub = sinon.stub(mailService.GhostMailer.prototype, 'send').resolves('Mail sent');
-        mockManager.mockLabsDisabled('welcomeEmails');
-
-        await models.Outbox.add({
-            event_type: 'MemberCreatedEvent',
-            payload: JSON.stringify({
-                memberId: 'member123',
-                email: 'test@example.com',
-                name: 'Test Member',
-                source: 'member',
-                status: 'free'
-            }),
-            status: OUTBOX_STATUSES.PENDING
-        });
-
-        const entriesBeforeJob = await models.Outbox.findAll();
-        assert.equal(entriesBeforeJob.length, 1);
-
-        await scheduleInlineJob();
-
-        // Entry should still be there (not processed)
-        const entriesAfterJob = await models.Outbox.findAll();
-        assert.equal(entriesAfterJob.length, 1);
-        assert.equal(entriesAfterJob.models[0].get('status'), OUTBOX_STATUSES.PENDING);
-        assert.equal(sendStub.callCount, 0);
     });
 });

--- a/ghost/core/test/integration/services/member-welcome-emails.test.js
+++ b/ghost/core/test/integration/services/member-welcome-emails.test.js
@@ -6,8 +6,8 @@ const models = require('../../../core/server/models');
 const {OUTBOX_STATUSES} = require('../../../core/server/models/outbox');
 const db = require('../../../core/server/data/db');
 const configUtils = require('../../utils/config-utils');
+const mockManager = require('../../utils/e2e-framework-mock-manager');
 const mailService = require('../../../core/server/services/mail');
-const config = require('../../../core/shared/config');
 const {MEMBER_WELCOME_EMAIL_SLUGS} = require('../../../core/server/services/member-welcome-emails/constants');
 const processOutbox = require('../../../core/server/services/outbox/jobs/lib/process-outbox');
 
@@ -65,11 +65,12 @@ describe('Member Welcome Emails Integration', function () {
         await db.knex('automated_emails').where('slug', MEMBER_WELCOME_EMAIL_SLUGS.free).del();
         await db.knex('automated_emails').where('slug', MEMBER_WELCOME_EMAIL_SLUGS.paid).del();
         await configUtils.restore();
+        mockManager.restore();
     });
 
     describe('Member creation with welcome emails enabled', function () {
         it('creates outbox entry when member source is "member"', async function () {
-            configUtils.set('memberWelcomeEmailTestInbox', 'test-inbox@example.com');
+            mockManager.mockLabsEnabled('welcomeEmails');
 
             const member = await membersService.api.members.create({
                 email: 'welcome-test@example.com',
@@ -93,8 +94,8 @@ describe('Member Welcome Emails Integration', function () {
             assert.equal(payload.status, 'free');
         });
 
-        it('does NOT create outbox entry when config is not set', async function () {
-            configUtils.set('memberWelcomeEmailTestInbox', '');
+        it('does NOT create outbox entry when welcomeEmails labs flag is off', async function () {
+            mockManager.mockLabsDisabled('welcomeEmails');
 
             await membersService.api.members.create({
                 email: 'no-welcome@example.com',
@@ -109,7 +110,7 @@ describe('Member Welcome Emails Integration', function () {
         });
 
         it('does NOT create outbox entry when member is imported', async function () {
-            configUtils.set('memberWelcomeEmailTestInbox', 'test-inbox@example.com');
+            mockManager.mockLabsEnabled('welcomeEmails');
 
             await membersService.api.members.create({
                 email: 'imported@example.com',
@@ -124,7 +125,7 @@ describe('Member Welcome Emails Integration', function () {
         });
 
         it('does NOT create outbox entry when member is created by admin', async function () {
-            configUtils.set('memberWelcomeEmailTestInbox', 'test-inbox@example.com');
+            mockManager.mockLabsEnabled('welcomeEmails');
 
             await membersService.api.members.create({
                 email: 'admin-created@example.com',
@@ -139,7 +140,7 @@ describe('Member Welcome Emails Integration', function () {
         });
 
         it('creates outbox entry with correct timestamp', async function () {
-            configUtils.set('memberWelcomeEmailTestInbox', 'test-inbox@example.com');
+            mockManager.mockLabsEnabled('welcomeEmails');
 
             const beforeCreation = new Date(Date.now() - 1000);
 
@@ -174,12 +175,7 @@ describe('Member Welcome Emails Integration', function () {
 
         beforeEach(function () {
             sinon.stub(mailService.GhostMailer.prototype, 'send').resolves('Mail sent');
-            sinon.stub(config, 'get').callsFake(function (key) {
-                if (key === 'memberWelcomeEmailTestInbox') {
-                    return 'test-inbox@example.com';
-                }
-                return config.get.wrappedMethod.call(config, key);
-            });
+            mockManager.mockLabsEnabled('welcomeEmails');
         });
 
         afterEach(async function () {
@@ -333,6 +329,53 @@ describe('Member Welcome Emails Integration', function () {
                 .where('slug', MEMBER_WELCOME_EMAIL_SLUGS.free)
                 .first();
             assert.equal(record.automated_email_id, automatedEmail.id);
+        });
+
+        it('sends email to member email when test inbox is not configured', async function () {
+            // Explicitly clear the test inbox config (it's set in config.testing.json)
+            configUtils.set('memberWelcomeEmailTestInbox', '');
+
+            const memberEmail = 'real-member@example.com';
+
+            await models.Outbox.add({
+                event_type: 'MemberCreatedEvent',
+                payload: JSON.stringify({
+                    memberId: ObjectId().toHexString(),
+                    email: memberEmail,
+                    name: 'Real Member',
+                    status: 'free'
+                }),
+                status: OUTBOX_STATUSES.PENDING
+            });
+
+            await scheduleInlineJob();
+
+            assert.equal(mailService.GhostMailer.prototype.send.callCount, 1);
+            const sendCall = mailService.GhostMailer.prototype.send.firstCall;
+            assert.equal(sendCall.args[0].to, memberEmail);
+        });
+
+        it('sends email to test inbox when memberWelcomeEmailTestInbox is configured', async function () {
+            configUtils.set('memberWelcomeEmailTestInbox', 'test-inbox@example.com');
+
+            const memberEmail = 'real-member-2@example.com';
+
+            await models.Outbox.add({
+                event_type: 'MemberCreatedEvent',
+                payload: JSON.stringify({
+                    memberId: ObjectId().toHexString(),
+                    email: memberEmail,
+                    name: 'Real Member 2',
+                    status: 'free'
+                }),
+                status: OUTBOX_STATUSES.PENDING
+            });
+
+            await scheduleInlineJob();
+
+            assert.equal(mailService.GhostMailer.prototype.send.callCount, 1);
+            const sendCall = mailService.GhostMailer.prototype.send.firstCall;
+            assert.equal(sendCall.args[0].to, 'test-inbox@example.com');
         });
     });
 });

--- a/ghost/core/test/unit/server/services/members/members-api/repositories/member-repository.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/repositories/member-repository.test.js
@@ -5,7 +5,6 @@ const errors = require('@tryghost/errors');
 const DomainEvents = require('@tryghost/domain-events');
 const MemberRepository = require('../../../../../../../core/server/services/members/members-api/repositories/member-repository');
 const {SubscriptionCreatedEvent, OfferRedemptionEvent} = require('../../../../../../../core/shared/events');
-const config = require('../../../../../../../core/shared/config');
 
 const mockOfferRedemption = {
     add: sinon.stub(),

--- a/ghost/core/test/unit/server/services/members/members-api/repositories/member-repository.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/repositories/member-repository.test.js
@@ -896,6 +896,7 @@ describe('MemberRepository', function () {
         let MemberSubscribeEvent;
         let newslettersService;
         let AutomatedEmail;
+        let labsService;
         const oldNodeEnv = process.env.NODE_ENV;
 
         beforeEach(function () {
@@ -957,6 +958,15 @@ describe('MemberRepository', function () {
                     })
                 })
             };
+
+            labsService = {
+                isSet: sinon.stub().callsFake((flag) => {
+                    if (flag === 'welcomeEmails') {
+                        return true;
+                    }
+                    return false;
+                })
+            };
         });
 
         afterEach(function () {
@@ -964,8 +974,6 @@ describe('MemberRepository', function () {
         });
 
         it('creates outbox entry for allowed source', async function () {
-            sinon.stub(config, 'get').withArgs('memberWelcomeEmailTestInbox').returns('test-inbox@example.com');
-
             const repo = new MemberRepository({
                 Member,
                 Outbox,
@@ -973,6 +981,7 @@ describe('MemberRepository', function () {
                 MemberSubscribeEventModel: MemberSubscribeEvent,
                 newslettersService,
                 AutomatedEmail,
+                labsService,
                 OfferRedemption: mockOfferRedemption
             });
 
@@ -989,8 +998,8 @@ describe('MemberRepository', function () {
             assert.equal(payload.source, 'member');
         });
 
-        it('does NOT create outbox entry when config is not set', async function () {
-            sinon.stub(config, 'get').withArgs('memberWelcomeEmailTestInbox').returns(undefined);
+        it('does NOT create outbox entry when welcomeEmails labs flag is off', async function () {
+            labsService.isSet.withArgs('welcomeEmails').returns(false);
 
             const repo = new MemberRepository({
                 Member,
@@ -999,6 +1008,7 @@ describe('MemberRepository', function () {
                 MemberSubscribeEventModel: MemberSubscribeEvent,
                 newslettersService,
                 AutomatedEmail,
+                labsService,
                 OfferRedemption: mockOfferRedemption
             });
 
@@ -1008,8 +1018,6 @@ describe('MemberRepository', function () {
         });
 
         it('does not create outbox entry for disallowed sources', async function () {
-            sinon.stub(config, 'get').withArgs('memberWelcomeEmailTestInbox').returns('test-inbox@example.com');
-
             const repo = new MemberRepository({
                 Member,
                 Outbox,
@@ -1017,6 +1025,7 @@ describe('MemberRepository', function () {
                 MemberSubscribeEventModel: MemberSubscribeEvent,
                 newslettersService,
                 AutomatedEmail,
+                labsService,
                 OfferRedemption: mockOfferRedemption
             });
 
@@ -1034,8 +1043,6 @@ describe('MemberRepository', function () {
         });
 
         it('includes timestamp in outbox payload', async function () {
-            sinon.stub(config, 'get').withArgs('memberWelcomeEmailTestInbox').returns('test-inbox@example.com');
-
             const repo = new MemberRepository({
                 Member,
                 Outbox,
@@ -1043,6 +1050,7 @@ describe('MemberRepository', function () {
                 MemberSubscribeEventModel: MemberSubscribeEvent,
                 newslettersService,
                 AutomatedEmail,
+                labsService,
                 OfferRedemption: mockOfferRedemption
             });
 
@@ -1054,8 +1062,6 @@ describe('MemberRepository', function () {
         });
 
         it('passes transaction to outbox entry creation', async function () {
-            sinon.stub(config, 'get').withArgs('memberWelcomeEmailTestInbox').returns('test-inbox@example.com');
-
             const repo = new MemberRepository({
                 Member,
                 Outbox,
@@ -1063,6 +1069,7 @@ describe('MemberRepository', function () {
                 MemberSubscribeEventModel: MemberSubscribeEvent,
                 newslettersService,
                 AutomatedEmail,
+                labsService,
                 OfferRedemption: mockOfferRedemption
             });
 
@@ -1073,8 +1080,6 @@ describe('MemberRepository', function () {
         });
 
         it('does NOT create outbox entry when welcome email is inactive', async function () {
-            sinon.stub(config, 'get').withArgs('memberWelcomeEmailTestInbox').returns('test-inbox@example.com');
-
             AutomatedEmail.findOne.resolves({
                 get: sinon.stub().callsFake((key) => {
                     const data = {lexical: '{"root":{}}', status: 'inactive'};
@@ -1089,6 +1094,7 @@ describe('MemberRepository', function () {
                 MemberSubscribeEventModel: MemberSubscribeEvent,
                 newslettersService,
                 AutomatedEmail,
+                labsService,
                 OfferRedemption: mockOfferRedemption
             });
 
@@ -1097,8 +1103,6 @@ describe('MemberRepository', function () {
             sinon.assert.notCalled(Outbox.add);
         });
         it('does NOT create outbox entry when member is signing up for a paid subscription (stripeCustomer is present)', async function () {
-            sinon.stub(config, 'get').withArgs('memberWelcomeEmailTestInbox').returns('test-inbox@example.com');
-
             const StripeCustomer = {
                 upsert: sinon.stub().resolves()
             };
@@ -1111,6 +1115,7 @@ describe('MemberRepository', function () {
                 newslettersService,
                 AutomatedEmail,
                 StripeCustomer,
+                labsService,
                 OfferRedemption: mockOfferRedemption
             });
 
@@ -1151,6 +1156,7 @@ describe('MemberRepository', function () {
         let stripeAPIService;
         let productRepository;
         let AutomatedEmail;
+        let labsService;
         let subscriptionData;
 
         beforeEach(function () {
@@ -1273,6 +1279,15 @@ describe('MemberRepository', function () {
                     })
                 })
             };
+
+            labsService = {
+                isSet: sinon.stub().callsFake((flag) => {
+                    if (flag === 'welcomeEmails') {
+                        return true;
+                    }
+                    return false;
+                })
+            };
         });
 
         afterEach(function () {
@@ -1280,8 +1295,6 @@ describe('MemberRepository', function () {
         });
 
         it('creates outbox entry when member status changes to paid', async function () {
-            sinon.stub(config, 'get').withArgs('memberWelcomeEmailTestInbox').returns('test-inbox@example.com');
-
             Member.edit.resolves({
                 attributes: {status: 'paid'},
                 _previousAttributes: {status: 'free'},
@@ -1301,6 +1314,7 @@ describe('MemberRepository', function () {
                 stripeAPIService,
                 productRepository,
                 AutomatedEmail,
+                labsService,
                 OfferRedemption: mockOfferRedemption
             });
 
@@ -1326,8 +1340,8 @@ describe('MemberRepository', function () {
             assert.ok(payload.timestamp);
         });
 
-        it('does NOT create outbox entry when config is not set', async function () {
-            sinon.stub(config, 'get').withArgs('memberWelcomeEmailTestInbox').returns(undefined);
+        it('does NOT create outbox entry when welcomeEmails labs flag is off', async function () {
+            labsService.isSet.withArgs('welcomeEmails').returns(false);
 
             Member.edit.resolves({
                 attributes: {status: 'paid'},
@@ -1348,6 +1362,7 @@ describe('MemberRepository', function () {
                 stripeAPIService,
                 productRepository,
                 AutomatedEmail,
+                labsService,
                 OfferRedemption: mockOfferRedemption
             });
 
@@ -1367,8 +1382,6 @@ describe('MemberRepository', function () {
         });
 
         it('does NOT create outbox entry for disallowed sources', async function () {
-            sinon.stub(config, 'get').withArgs('memberWelcomeEmailTestInbox').returns('test-inbox@example.com');
-
             Member.edit.resolves({
                 attributes: {status: 'paid'},
                 _previousAttributes: {status: 'free'},
@@ -1388,6 +1401,7 @@ describe('MemberRepository', function () {
                 stripeAPIService,
                 productRepository,
                 AutomatedEmail,
+                labsService,
                 OfferRedemption: mockOfferRedemption
             });
 
@@ -1415,8 +1429,6 @@ describe('MemberRepository', function () {
         });
 
         it('does NOT create outbox entry when paid welcome email is inactive', async function () {
-            sinon.stub(config, 'get').withArgs('memberWelcomeEmailTestInbox').returns('test-inbox@example.com');
-
             Member.edit.resolves({
                 attributes: {status: 'paid'},
                 _previousAttributes: {status: 'free'},
@@ -1443,6 +1455,7 @@ describe('MemberRepository', function () {
                 stripeAPIService,
                 productRepository,
                 AutomatedEmail,
+                labsService,
                 OfferRedemption: mockOfferRedemption
             });
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/NY-822/remove-the-memberwelcomeemailtestinbox-config-and-send-to-user

## Summary

Currently all welcome emails features are gated behind the presence of a `memberWelcomeEmailTestInbox` configuration parameter. This PR changes the behavior such that `memberWelcomeEmailTestInbox` can still be provided to override the email address welcome emails are sent to, but the lack of a value for this parameter will not disable welcome emails entirely.

Now, as long as the `welcomeEmails` labs flag is set, welcome emails should be enabled. The `memberWelcomeEmailTestInbox` only determines where the welcome emails are sent, rather than enabling/disabling the features entirely.

- Changed welcome email feature to be gated by `labs.welcomeEmails` flag instead of `memberWelcomeEmailTestInbox` config
- Made `memberWelcomeEmailTestInbox` an optional recipient override (falls back to member's email when not set)
- Added tests for recipient behavior (test inbox vs member email)

---

## Testing

Without `memberWelcomeEmailTestInbox` set, with labs flag set to true
- [x] Welcome emails UI should display in Admin
- [x] Free signup test, welcome email should be addressed to the member
- [x] Paid signup test, welcome email should be addressed to the member


With `memberWelcomeEmailTestInbox` set, with labs flag set to true
- [x] Welcome emails UI should display in Admin
- [x] Free signup test, welcome email should be addressed to the config value
- [x] Paid signup test, welcome email should be addressed to the config value

With `memberWelcomeEmailTestInbox` set, with labs flag set to false:
- [x] Welcome emails UI should not display in Admin
- [x] Free signup test, should not send welcome email
- [x] Paid signup test, should not send welcome email


Without `memberWelcomeEmailTestInbox` set, with labs flag set to false:
- [x] Welcome emails UI should not display in Admin
- [x] Free signup test, should not send welcome email
- [x] Paid signup test, should not send welcome email