### PR TITLE
Added MX record lookup for sniper links

### DIFF
--- a/ghost/core/core/server/lib/get-sniper-links.ts
+++ b/ghost/core/core/server/lib/get-sniper-links.ts
@@ -27,7 +27,10 @@
  * SOFTWARE.
  */
 
+import type {MxRecord} from 'node:dns';
+import * as dns from 'node:dns/promises';
 import {parseEmailAddress} from '@tryghost/parse-email-address';
+import logging from '@tryghost/logging';
 
 type GetLinkFn = (options: Readonly<{recipient: string; sender: string}>) => string;
 
@@ -60,14 +63,106 @@ for (const provider of PROVIDERS) {
     }
 }
 
+const getErrorCode = (err: unknown): undefined | string => (
+    err && typeof err === 'object' && 'code' in err && typeof err.code === 'string'
+        ? err.code
+        : undefined
+);
+
+/**
+ * Grab the MX records for a domain.
+ *
+ * If there are any errors at all, return the empty array. We don't want to
+ * break sniper links if a DNS lookup fails—worst case, the user won't get a
+ * "open in your email app" link.
+ */
+const getMxRecords = async (
+    domain: string,
+    dnsResolver: Pick<dns.Resolver, 'resolveMx'>
+): Promise<MxRecord[]> => {
+    try {
+        return await dnsResolver.resolveMx(domain);
+    } catch (err: unknown) {
+        // This logs a warning, not an error, because most DNS errors could
+        // happen normally. For example, a user could provide a bogus hostname.
+        // There are some errors (like `dns.NOMEM`) which should probably use
+        // `logging.error`, but it's not worth maintaining a long list of which
+        // errors are which.
+        logging.warn('Got error code when looking up MX record', getErrorCode(err));
+        return [];
+    }
+};
+
+/**
+ * Given an MX record exchange, return the provider if found.
+ *
+ * `google.com` and `smtp.google.com` return the Google provider, for example.
+ */
+const getProviderForMxExchange = (exchange: string): undefined | Provider => {
+    const direct = PROVIDER_BY_DOMAIN.get(exchange);
+    if (direct) {
+        return direct;
+    }
+    for (const [providerDomain, provider] of PROVIDER_BY_DOMAIN.entries()) {
+        if (exchange.endsWith(`.${providerDomain}`)) {
+            return provider;
+        }
+    }
+};
+
+/**
+ * Get the first item in an iterable, like a Set.
+ *
+ * Like `_.head()`, but works with any iterable.
+ */
+const first = <T>(iterable: Iterable<T>): undefined | T => {
+    for (const result of iterable) {
+        return result;
+    }
+};
+
 /**
  * Given a domain like `gmail.com`, return a provider object.
  *
- * NOTE: This function will expand once we start doing DNS lookups (see NY-945).
+ * If the domain is in our hard-coded list of providers, return that.
+ *
+ * Otherwise, resolve the domain's MX records. If found, find the exchange with
+ * the best priority that has exactly one unique provider.
  */
-const getProvider = async (domain: string): Promise<undefined | Provider> => (
-    PROVIDER_BY_DOMAIN.get(domain)
-);
+const getProvider = async (
+    domain: string,
+    dnsResolver: Pick<dns.Resolver, 'resolveMx'>
+): Promise<undefined | Provider> => {
+    const hardcoded = PROVIDER_BY_DOMAIN.get(domain);
+    if (hardcoded) {
+        return hardcoded;
+    }
+
+    const mxRecords = await getMxRecords(domain, dnsResolver);
+
+    let bestPriorityThatHasAProvider = Infinity;
+    const providersByPriority = new Map<number, Set<undefined | Provider>>();
+
+    for (const {priority, exchange} of mxRecords) {
+        // We can skip these as an optimization.
+        if (priority > bestPriorityThatHasAProvider) {
+            continue;
+        }
+
+        const provider = getProviderForMxExchange(exchange);
+
+        const providersWithThisPriority = providersByPriority.get(priority) ?? new Set();
+        providersWithThisPriority.add(provider);
+        providersByPriority.set(priority, providersWithThisPriority);
+
+        if (provider) {
+            bestPriorityThatHasAProvider = Math.min(bestPriorityThatHasAProvider, priority);
+        }
+    }
+
+    const candidates = providersByPriority.get(bestPriorityThatHasAProvider);
+    return candidates?.size === 1 ? first(candidates) : undefined;
+};
 
 /**
  * Given an email address, return "sniper links" to open the email app/inbox.
@@ -76,16 +171,20 @@ const getProvider = async (domain: string): Promise<undefined | Provider> => (
  * a link to open Gmail.
  */
 export const getSniperLinks = async (
-    options: Readonly<{recipient: string; sender: string;}>
+    options: Readonly<{
+        recipient: string;
+        sender: string;
+        dnsResolver: Pick<dns.Resolver, 'resolveMx'>
+    }>
 ): Promise<undefined | {android: string; desktop: string}> => {
-    const {recipient} = options;
+    const {recipient, dnsResolver} = options;
 
     const domain = parseEmailAddress(recipient)?.domain;
     if (!domain) {
         return;
     }
 
-    const provider = await getProvider(domain);
+    const provider = await getProvider(domain, dnsResolver);
     if (!provider) {
         return;
     }

--- a/ghost/core/test/unit/server/lib/get-sniper-links.test.ts
+++ b/ghost/core/test/unit/server/lib/get-sniper-links.test.ts
@@ -1,7 +1,15 @@
 import assert from 'node:assert/strict';
+import * as dns from 'node:dns/promises';
+import {shuffle} from 'lodash-es';
 import {getSniperLinks} from '../../../../core/server/lib/get-sniper-links';
 
 describe('getSniperLinks', function () {
+    const resolverThatShouldNeverBeUsed = {
+        resolveMx: () => {
+            assert.fail('This DNS test resolver should never be used');
+        }
+    };
+
     it('returns undefined for invalid recipient emails', async function () {
         const emails = [
             '',
@@ -12,7 +20,8 @@ describe('getSniperLinks', function () {
             assert.equal(
                 await getSniperLinks({
                     recipient: email,
-                    sender: 'ignored@example.com'
+                    sender: 'ignored@example.com',
+                    dnsResolver: resolverThatShouldNeverBeUsed
                 }),
                 undefined
             );
@@ -28,7 +37,8 @@ describe('getSniperLinks', function () {
         await Promise.all(emails.map(async (recipient) => {
             const result = await getSniperLinks({
                 recipient,
-                sender: 'sender@example.com'
+                sender: 'sender@example.com',
+                dnsResolver: resolverThatShouldNeverBeUsed
             });
             assert(result?.desktop.startsWith('https://mail.google.com/'));
             assert(result?.desktop.includes(encodeURIComponent(recipient)));
@@ -37,5 +47,138 @@ describe('getSniperLinks', function () {
             assert(result?.android.includes('com.google.android.gm'));
             assert(result?.android.includes('browser_fallback_url'));
         }));
+    });
+
+    describe('DNS lookups', function () {
+        it('returns undefined if the MX resolution fails for any reason', async function () {
+            const errors = [
+                new Error('Unexpected error'),
+                Object.assign(new Error(), {code: dns.TIMEOUT}),
+                Object.assign(new Error(), {code: dns.NODATA})
+            ];
+            await Promise.all(errors.map(async (error) => {
+                const resolver = {
+                    resolveMx: () => Promise.reject(error)
+                };
+                const result = await getSniperLinks({
+                    recipient: 'recipient@example.com',
+                    sender: 'sender@example.com',
+                    dnsResolver: resolver
+                });
+                assert.equal(result, undefined);
+            }));
+        });
+
+        it('returns undefined if the MX resolution returns a null MX record', async function () {
+            const resolver = {
+                resolveMx: async () => [
+                    {priority: 0, exchange: ''}
+                ]
+            };
+            const result = await getSniperLinks({
+                recipient: 'recipient@example.com',
+                sender: 'sender@example.com',
+                dnsResolver: resolver
+            });
+            assert.equal(result, undefined);
+        });
+
+        it('returns undefined if no MX exchanges are recognized', async function () {
+            const resolver = {
+                resolveMx: async () => shuffle([
+                    {priority: 1, exchange: 'one.example'},
+                    {priority: 2, exchange: 'two.example'},
+                    {priority: 3, exchange: 'three.example'},
+                    {priority: 4, exchange: 'google.com.example'}
+                ])
+            };
+            const result = await getSniperLinks({
+                recipient: 'recipient@example.com',
+                sender: 'sender@example.com',
+                dnsResolver: resolver
+            });
+            assert.equal(result, undefined);
+        });
+
+        it('returns undefined if the first recognized MX exchange has the same priority as one that is not recognized, just in case', async function () {
+            const resolver = {
+                resolveMx: async () => shuffle([
+                    {priority: 1, exchange: 'ignored.example'},
+                    {priority: 2, exchange: 'gmail.com'},
+                    {priority: 2, exchange: 'unknown.example'}
+                ])
+            };
+            const result = await getSniperLinks({
+                recipient: 'recipient@example.com',
+                sender: 'sender@example.com',
+                dnsResolver: resolver
+            });
+            assert.equal(result, undefined);
+        });
+
+        it('returns undefined if two exchanges with the same priority are both recognized, just in case', async function () {
+            const resolver = {
+                resolveMx: async () => shuffle([
+                    {priority: 1, exchange: 'ignored.example'},
+                    {priority: 2, exchange: 'gmail.com'},
+                    {priority: 2, exchange: 'protonmail.ch'}
+                ])
+            };
+            const result = await getSniperLinks({
+                recipient: 'recipient@example.com',
+                sender: 'sender@example.com',
+                dnsResolver: resolver
+            });
+            assert.equal(result, undefined);
+        });
+
+        it('returns the first recognized provider if a top-level domain', async function () {
+            const resolver = {
+                resolveMx: async () => shuffle([
+                    {priority: 1, exchange: 'ignored.example'},
+                    {priority: 2, exchange: 'gmail.com'},
+                    {priority: 3, exchange: 'yahoo.com'}
+                ])
+            };
+            const result = await getSniperLinks({
+                recipient: 'recipient@example.com',
+                sender: 'sender@example.com',
+                dnsResolver: resolver
+            });
+            assert(result?.desktop.includes('mail.google.com'));
+        });
+
+        it('returns the first recognized provider if a subdomain', async function () {
+            const resolver = {
+                resolveMx: async () => shuffle([
+                    {priority: 1, exchange: 'ignored.example'},
+                    {priority: 2, exchange: 'aspmx.l.google.com'},
+                    {priority: 3, exchange: 'mail.protonmail.ch'}
+                ])
+            };
+            const result = await getSniperLinks({
+                recipient: 'recipient@example.com',
+                sender: 'sender@example.com',
+                dnsResolver: resolver
+            });
+            assert(result?.desktop.includes('mail.google.com'));
+        });
+
+        it('handles two exchanges with the same priority but the same provider', async function () {
+            const resolver = {
+                resolveMx: async () => shuffle([
+                    {priority: 1, exchange: 'ignored.example'},
+                    {priority: 2, exchange: 'aspmx.l.google.com'},
+                    {priority: 2, exchange: 'aspmx2.googlemail.com'},
+                    {priority: 3, exchange: 'mail.protonmail.ch'}
+                ])
+            };
+            const result = await getSniperLinks({
+                recipient: 'recipient@example.com',
+                sender: 'sender@example.com',
+                dnsResolver: resolver
+            });
+            assert(result?.desktop.includes('mail.google.com'));
+        });
     });
 });


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-945
ref https://github.com/TryGhost/Ghost/pull/25997

We need the email provider, like Gmail or Proton, to create a sniper link. If we can't get the provider from the email address, we now fall back to looking up the [MX records] for the domain and look there.

For example, though `ghost.org` isn't in our hard-coded list, it includes Gmail domains in the MX records, so we'd show a Gmail sniper link.

[MX records]: https://en.wikipedia.org/wiki/MX_record
