### PR TITLE
Moved member email editor styles

### DIFF
--- a/apps/admin-x-settings/src/components/settings/membership/member-emails.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails.tsx
@@ -30,7 +30,7 @@ const EmailPreview: React.FC<{
     const senderName = automatedEmail.sender_name || siteTitle || 'Your Site';
 
     return (
-        <div className='mb-5 flex items-center justify-between gap-3 rounded-lg border border-grey-100 bg-grey-50 p-5 dark:border-grey-925 dark:bg-grey-950'>
+        <div className='mb-5 flex items-center justify-between gap-3 rounded-lg border border-grey-100 bg-grey-50 p-5 dark:border-grey-925 dark:bg-grey-975'>
             <div className='flex items-start gap-3'>
                 {icon ?
                     <div className='size-10 min-h-10 min-w-10 rounded-sm bg-cover bg-center' style={{
@@ -49,7 +49,7 @@ const EmailPreview: React.FC<{
                 </div>
             </div>
             <Button
-                className='rounded-md border border-grey-200 font-semibold hover:shadow-xs'
+                className='border border-grey-200 font-semibold hover:border-grey-300 hover:!bg-white dark:border-grey-900 dark:hover:border-grey-800 dark:hover:!bg-grey-950'
                 color='white'
                 data-testid={`${emailType}-welcome-email-edit-button`}
                 icon='pen'

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/member-email-editor.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/member-email-editor.tsx
@@ -1,5 +1,24 @@
 import React, {useCallback} from 'react';
 import {KoenigEditorBase, type KoenigInstance, type NodeType} from '@tryghost/admin-x-design-system';
+import {cn} from '@tryghost/shade';
+
+const placeholderSelector = '[&_.koenig-lexical-editor-input-placeholder]';
+const contentSelector = '[&_:is(p,blockquote,aside,ul,ol)]';
+
+const baseEditorStyles = cn(
+    // Base typography
+    'text-[1.6rem] leading-[1.6] tracking-[-0.01em]',
+    // Dark mode
+    'dark:text-white dark:selection:bg-[rgba(88,101,116,0.99)]',
+    // Placeholder styling
+    `${placeholderSelector}:font-inter ${placeholderSelector}:text-xl ${placeholderSelector}:tracking-tight`,
+    // Headings dark mode
+    '[&_:is(h2,h3)]:dark:text-white',
+    // Content typography
+    `${contentSelector}:font-inter ${contentSelector}:text-xl ${contentSelector}:tracking-tight`,
+    // Paragraph spacing & bold
+    '[&_p]:mb-4 [&_strong]:font-semibold'
+);
 
 export interface MemberEmailsEditorProps {
     value?: string;
@@ -39,7 +58,7 @@ const MemberEmailsEditor: React.FC<MemberEmailsEditorProps> = ({
     return (
         <div onKeyDown={handleKeyDown}>
             <KoenigEditorBase
-                className={className}
+                className={cn(baseEditorStyles, className)}
                 emojiPicker={false}
                 inheritFontStyles={false}
                 initialEditorState={value}

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-modal.tsx
@@ -132,7 +132,7 @@ const WelcomeEmailModal = NiceModal.create<WelcomeEmailModalProps>(({emailType =
                         <div className='flex items-center gap-2'>
                             <div ref={dropdownRef} className='relative'>
                                 <Button
-                                    className='border border-grey-200 font-semibold hover:border-grey-300 hover:!bg-white dark:border-grey-800 dark:hover:border-grey-700 dark:hover:!bg-grey-950'
+                                    className='border border-grey-200 font-semibold hover:border-grey-300 hover:!bg-white dark:border-grey-900 dark:hover:border-grey-800 dark:hover:!bg-grey-950'
                                     color="clear"
                                     icon='send'
                                     label="Test"
@@ -181,7 +181,7 @@ const WelcomeEmailModal = NiceModal.create<WelcomeEmailModalProps>(({emailType =
                     </div>
                 </div>
                 <div className='flex grow flex-col bg-grey-50 p-8 dark:bg-grey-975'>
-                    <div className={`mx-auto w-full max-w-[600px] grow rounded border bg-white p-8 text-[1.6rem] leading-[1.6] tracking-[-0.01em] shadow-sm dark:bg-grey-975 dark:text-white dark:shadow-none dark:selection:bg-[rgba(88,101,116,0.99)] [&_.koenig-lexical-editor-input-placeholder]:font-inter [&_.koenig-lexical-editor-input-placeholder]:text-xl [&_.koenig-lexical-editor-input-placeholder]:tracking-tight [&_:is(h2,h3)]:dark:text-white [&_:is(p,blockquote,aside,ul,ol)]:font-inter [&_:is(p,blockquote,aside,ul,ol)]:text-xl [&_:is(p,blockquote,aside,ul,ol)]:tracking-tight [&_p]:mb-4 [&_strong]:font-semibold ${errors.lexical ? 'border-red' : 'border-grey-200 dark:border-grey-925'}`}>
+                    <div className={`mx-auto w-full max-w-[600px] grow rounded border bg-white p-8 text-[1.6rem] leading-[1.6] tracking-[-0.01em] shadow-sm dark:bg-grey-950/25 dark:text-white dark:shadow-none dark:selection:bg-[rgba(88,101,116,0.99)] [&_.koenig-lexical-editor-input-placeholder]:font-inter [&_.koenig-lexical-editor-input-placeholder]:text-xl [&_.koenig-lexical-editor-input-placeholder]:tracking-tight [&_:is(h2,h3)]:dark:text-white [&_:is(p,blockquote,aside,ul,ol)]:font-inter [&_:is(p,blockquote,aside,ul,ol)]:text-xl [&_:is(p,blockquote,aside,ul,ol)]:tracking-tight [&_p]:mb-4 [&_strong]:font-semibold ${errors.lexical ? 'border-red' : 'border-grey-200 dark:border-grey-925'}`}>
                         <MemberEmailEditor
                             key={automatedEmail?.id || 'new'}
                             className='welcome-email-editor'

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-modal.tsx
@@ -21,21 +21,21 @@ const isEmptyLexical = (lexical: string | null | undefined): boolean => {
     if (!lexical) {
         return true;
     }
-    
+
     try {
         const parsed = JSON.parse(lexical);
         const children = parsed?.root?.children;
-        
+
         // Empty if no children or only an empty paragraph
         if (!children || children.length === 0) {
             return true;
         }
-        if (children.length === 1 && 
-            children[0].type === 'paragraph' && 
+        if (children.length === 1 &&
+            children[0].type === 'paragraph' &&
             (!children[0].children || children[0].children.length === 0)) {
             return true;
         }
-        
+
         return false;
     } catch {
         return true;
@@ -98,7 +98,7 @@ const WelcomeEmailModal = NiceModal.create<WelcomeEmailModalProps>(({emailType =
         handleSaveRef.current = handleSave;
     }, [handleSave]);
 
-    useEffect(() => {        
+    useEffect(() => {
         const handleCMDS = (e: KeyboardEvent) => {
             if ((e.metaKey || e.ctrlKey) && e.key === 's') {
                 e.preventDefault();
@@ -123,8 +123,9 @@ const WelcomeEmailModal = NiceModal.create<WelcomeEmailModalProps>(({emailType =
             footer={false}
             header={false}
             testId='welcome-email-modal'
+            width={672}
         >
-            <div className='-mx-8 h-[calc(100vh-16vmin)] overflow-y-auto dark:!bg-grey-975'>
+            <div className='-mx-8 flex h-[calc(100vh-16vmin)] flex-col overflow-y-auto dark:!bg-grey-975'>
                 <div className='sticky top-0 z-10 flex flex-col gap-2 border-b border-grey-100 bg-white p-5 dark:border-grey-900 dark:bg-grey-975'>
                     <div className='mb-2 flex items-center justify-between'>
                         <h3 className='font-semibold'>{emailType === 'paid' ? 'Paid' : 'Free'} members welcome email</h3>
@@ -179,10 +180,11 @@ const WelcomeEmailModal = NiceModal.create<WelcomeEmailModalProps>(({emailType =
                         </div>
                     </div>
                 </div>
-                <div className='bg-grey-50 p-6 dark:bg-grey-975'>
-                    <div className={`mx-auto max-w-[600px] rounded border bg-white p-8 text-[1.6rem] leading-[1.6] tracking-[-0.01em] shadow-sm dark:bg-grey-975 dark:text-white dark:shadow-none dark:selection:bg-[rgba(88,101,116,0.99)] [&_:is(h2,h3)]:dark:text-white [&_p]:mb-4 [&_strong]:font-semibold ${errors.lexical ? 'border-red' : 'border-grey-200 dark:border-grey-925'}`}>
+                <div className='flex grow flex-col bg-grey-50 p-8 dark:bg-grey-975'>
+                    <div className={`mx-auto w-full max-w-[600px] grow rounded border bg-white p-8 text-[1.6rem] leading-[1.6] tracking-[-0.01em] shadow-sm dark:bg-grey-975 dark:text-white dark:shadow-none dark:selection:bg-[rgba(88,101,116,0.99)] [&_.koenig-lexical-editor-input-placeholder]:font-inter [&_.koenig-lexical-editor-input-placeholder]:text-xl [&_.koenig-lexical-editor-input-placeholder]:tracking-tight [&_:is(h2,h3)]:dark:text-white [&_:is(p,blockquote,aside,ul,ol)]:font-inter [&_:is(p,blockquote,aside,ul,ol)]:text-xl [&_:is(p,blockquote,aside,ul,ol)]:tracking-tight [&_p]:mb-4 [&_strong]:font-semibold ${errors.lexical ? 'border-red' : 'border-grey-200 dark:border-grey-925'}`}>
                         <MemberEmailEditor
                             key={automatedEmail?.id || 'new'}
+                            className='welcome-email-editor'
                             placeholder='Write your welcome email content...'
                             singleParagraph={false}
                             value={formState.lexical}

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-modal.tsx
@@ -181,7 +181,7 @@ const WelcomeEmailModal = NiceModal.create<WelcomeEmailModalProps>(({emailType =
                     </div>
                 </div>
                 <div className='flex grow flex-col bg-grey-50 p-8 dark:bg-grey-975'>
-                    <div className={`mx-auto w-full max-w-[600px] grow rounded border bg-white p-8 text-[1.6rem] leading-[1.6] tracking-[-0.01em] shadow-sm dark:bg-grey-950/25 dark:text-white dark:shadow-none dark:selection:bg-[rgba(88,101,116,0.99)] [&_.koenig-lexical-editor-input-placeholder]:font-inter [&_.koenig-lexical-editor-input-placeholder]:text-xl [&_.koenig-lexical-editor-input-placeholder]:tracking-tight [&_:is(h2,h3)]:dark:text-white [&_:is(p,blockquote,aside,ul,ol)]:font-inter [&_:is(p,blockquote,aside,ul,ol)]:text-xl [&_:is(p,blockquote,aside,ul,ol)]:tracking-tight [&_p]:mb-4 [&_strong]:font-semibold ${errors.lexical ? 'border-red' : 'border-grey-200 dark:border-grey-925'}`}>
+                    <div className={`mx-auto w-full max-w-[600px] grow rounded border bg-white p-8 shadow-sm dark:bg-grey-950/25 dark:shadow-none ${errors.lexical ? 'border-red' : 'border-grey-200 dark:border-grey-925'}`}>
                         <MemberEmailEditor
                             key={automatedEmail?.id || 'new'}
                             className='welcome-email-editor'


### PR DESCRIPTION
no ref

This moves the classes around so the container-related styles are in `welcome-email-modal.tsx`, and the editor related styles (which are, effectively, koenig overwrites) into `member-email-editor.tsx`. 

Also tries to make things just a bit easier to read, because multiple `[&_.koenig-lexical-editor-input-placeholder]` selectors creates a lot of noise.

I did try moving things out into an external stylesheet, but it required importing it and i found it harder to reason about where the styles were and what was getting applied.

<img width="726" height="923" alt="Screenshot 2026-01-26 at 7 05 43 PM" src="https://github.com/user-attachments/assets/51bb187d-abda-4a46-852b-69d4a7f0b773" />

