### PR TITLE
Fixed `@tryghost/parse-email-address` issues in development

### DIFF
--- a/docker/ghost-dev/Dockerfile
+++ b/docker/ghost-dev/Dockerfile
@@ -21,6 +21,7 @@ WORKDIR /home/ghost
 COPY package.json yarn.lock ./
 COPY ghost/core/package.json ghost/core/package.json
 COPY ghost/i18n/package.json ghost/i18n/package.json
+COPY ghost/parse-email-address/package.json ghost/parse-email-address/package.json
 
 # Install dependencies
 # Note: Dependencies are installed at build time, but source code is mounted at runtime

--- a/package.json
+++ b/package.json
@@ -145,7 +145,8 @@
               "@tryghost/comments-ui",
               "@tryghost/signup-form",
               "@tryghost/sodo-search",
-              "@tryghost/announcement-bar"
+              "@tryghost/announcement-bar",
+              "@tryghost/parse-email-address"
             ]
           }
         ]


### PR DESCRIPTION
This package continues to make things a little difficult! `yarn dev` broke because it couldn't find this package. This patch fixes that.
