### PR TITLE
Added support for backporting Portal changes to 5.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1411,7 +1411,7 @@ jobs:
     ]
     name: Publish ${{ matrix.package_name }}
     runs-on: ubuntu-latest
-    if: always() && needs.job_setup.result == 'success' && needs.job_lint.result == 'success' && needs.job_unit-tests.result == 'success' && needs.job_setup.outputs.is_main == 'true'
+    if: always() && needs.job_setup.result == 'success' && needs.job_lint.result == 'success' && needs.job_unit-tests.result == 'success' && (needs.job_setup.outputs.is_main == 'true' || github.ref == 'refs/heads/5.x')
     permissions:
       id-token: write
     strategy:
@@ -1456,9 +1456,7 @@ jobs:
         working-directory: ${{ matrix.package_path }}
         run: |
           CURRENT_VERSION=$(cat package.json | jq -r .version)
-          PUBLISHED_VERSION=$(npm show ${{ matrix.package_name }} version || echo "0.0.0")
           echo "Current version: $CURRENT_VERSION"
-          echo "Published version: $PUBLISHED_VERSION"
 
           CURRENT_MINOR=$(cat package.json | jq -r .version | awk -F. '{print $1"."$2}')
           echo "current_minor=$CURRENT_MINOR" >> $GITHUB_OUTPUT
@@ -1466,12 +1464,27 @@ jobs:
           CURRENT_MAJOR=$(cat package.json | jq -r .version | awk -F. '{print $1}')
           echo "current_major=$CURRENT_MAJOR" >> $GITHUB_OUTPUT
 
-          if [ "$CURRENT_VERSION" = "$PUBLISHED_VERSION" ]; then
-            echo "Version is unchanged."
-            echo "version_changed=false" >> $GITHUB_OUTPUT
+          if [ "${{ github.ref }}" = "refs/heads/5.x" ]; then
+            # For 5.x branch, check if this exact version exists on npm
+            if npm show ${{ matrix.package_name }}@$CURRENT_VERSION version > /dev/null 2>&1; then
+              echo "Version $CURRENT_VERSION already exists on npm."
+              echo "version_changed=false" >> $GITHUB_OUTPUT
+            else
+              echo "Version $CURRENT_VERSION does not exist on npm."
+              echo "version_changed=true" >> $GITHUB_OUTPUT
+            fi
           else
-            echo "Version has changed."
-            echo "version_changed=true" >> $GITHUB_OUTPUT
+            # For main branch, compare against latest
+            PUBLISHED_VERSION=$(npm show ${{ matrix.package_name }} version || echo "0.0.0")
+            echo "Published version (latest): $PUBLISHED_VERSION"
+
+            if [ "$CURRENT_VERSION" = "$PUBLISHED_VERSION" ]; then
+              echo "Version is unchanged."
+              echo "version_changed=false" >> $GITHUB_OUTPUT
+            else
+              echo "Version has changed."
+              echo "version_changed=true" >> $GITHUB_OUTPUT
+            fi
           fi
 
       - name: Build the package
@@ -1491,7 +1504,12 @@ jobs:
       - name: Publish to npm
         if: steps.version_check.outputs.version_changed == 'true'
         working-directory: ${{ matrix.package_path }}
-        run: npm publish --access public
+        run: |
+          if [ "${{ github.ref }}" = "refs/heads/5.x" ]; then
+            npm publish --access public --tag ghost-5x
+          else
+            npm publish --access public
+          fi
 
       - name: Replace version placeholders in cdn-paths
         id: cdn_paths

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
       IS_DEVELOPMENT: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/5.x' || github.ref == 'refs/heads/6.x' }}
       IS_SIX: ${{ github.ref == 'refs/heads/6.x' }}
       IS_SIX_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref == '6.x' }}
+      IS_FIVE: ${{ github.ref == 'refs/heads/5.x' }}
     permissions:
       pull-requests: read
     steps:
@@ -215,6 +216,7 @@ jobs:
       is_development: ${{ env.IS_DEVELOPMENT }}
       is_six: ${{ env.IS_SIX }}
       is_six_pr: ${{ env.IS_SIX_PR }}
+      is_five: ${{ env.IS_FIVE }}
       member_is_in_org: ${{ steps.check_user_org_membership.outputs.is_member }}
       has_browser_tests_label: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'browser-tests') }}
       has_perf_tests_label: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'perf-tests') }}
@@ -1411,7 +1413,7 @@ jobs:
     ]
     name: Publish ${{ matrix.package_name }}
     runs-on: ubuntu-latest
-    if: always() && needs.job_setup.result == 'success' && needs.job_lint.result == 'success' && needs.job_unit-tests.result == 'success' && (needs.job_setup.outputs.is_main == 'true' || github.ref == 'refs/heads/5.x')
+    if: always() && needs.job_setup.result == 'success' && needs.job_lint.result == 'success' && needs.job_unit-tests.result == 'success' && (needs.job_setup.outputs.is_main == 'true' || needs.job_setup.outputs.is_five == 'true')
     permissions:
       id-token: write
     strategy:
@@ -1464,7 +1466,7 @@ jobs:
           CURRENT_MAJOR=$(cat package.json | jq -r .version | awk -F. '{print $1}')
           echo "current_major=$CURRENT_MAJOR" >> $GITHUB_OUTPUT
 
-          if [ "${{ github.ref }}" = "refs/heads/5.x" ]; then
+          if [ "${{ needs.job_setup.outputs.is_five }}" = "true" ]; then
             # For 5.x branch, check if this exact version exists on npm
             if npm show ${{ matrix.package_name }}@$CURRENT_VERSION version > /dev/null 2>&1; then
               echo "Version $CURRENT_VERSION already exists on npm."
@@ -1505,7 +1507,7 @@ jobs:
         if: steps.version_check.outputs.version_changed == 'true'
         working-directory: ${{ matrix.package_path }}
         run: |
-          if [ "${{ github.ref }}" = "refs/heads/5.x" ]; then
+          if [ "${{ needs.job_setup.outputs.is_five }}" = "true" ]; then
             npm publish --access public --tag ghost-5x
           else
             npm publish --access public


### PR DESCRIPTION
ref INC-232

- we currently don't have support for publishing packages such as Portal for 5.x users
- with this change, we check if the current version from the 5.x branch exists on NPM. If not, we publish it under the tag `ghost-5x` - so that it doesn't get tagged as `latest`, which is the default

