### PR TITLE
Re-introduce offer section filtering for signup offers only

### DIFF
--- a/apps/admin-x-framework/src/api/offers.ts
+++ b/apps/admin-x-framework/src/api/offers.ts
@@ -16,6 +16,7 @@ export type Offer = {
     currency: string | null;
     status: string;
     redemption_count: number;
+    redemption_type: 'signup' | 'retention';
     tier: {
         id: string;
         name?: string;

--- a/apps/admin-x-framework/src/test/responses/offers.json
+++ b/apps/admin-x-framework/src/test/responses/offers.json
@@ -15,6 +15,7 @@
             "currency": null,
             "status": "active",
             "redemption_count": 0,
+            "redemption_type": "signup",
             "tier": {
                 "id": "645453f4d254799990dd0e22",
                 "name": "Supporter"
@@ -35,6 +36,7 @@
             "currency": null,
             "status": "active",
             "redemption_count": 0,
+            "redemption_type": "signup",
             "tier": {
                 "id": "645453f4d254799990dd0e22",
                 "name": "Supporter"
@@ -55,6 +57,7 @@
             "currency": null,
             "status": "archived",
             "redemption_count": 0,
+            "redemption_type": "signup",
             "tier": {
                 "id": "645453f4d254799990dd0e22",
                 "name": "Supporter"

--- a/apps/admin-x-settings/src/components/settings/growth/offers.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/offers.tsx
@@ -37,7 +37,9 @@ const Offers: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const {data: {tiers: allTiers} = {}} = useBrowseTiers();
     const paidActiveTiers = getPaidActiveTiers(allTiers || []);
 
-    const activeOffers = allOffers
+    const signupOffers = allOffers.filter(offer => offer.redemption_type === 'signup');
+
+    const activeOffers = signupOffers
         .map(offer => ({...offer, tier: paidActiveTiers.find(tier => tier.id === offer.tier.id)}))
         .filter((offer): offer is Offer & {tier: Tier} => offer.status === 'active' && !!offer.tier);
 
@@ -69,14 +71,14 @@ const Offers: React.FC<{ keywords: string[] }> = ({keywords}) => {
     let offerButtonText = 'Manage offers';
     let offerButtonLink = openOfferListModal;
     let descriptionButtonText = 'Learn more';
-    if (allOffers.length > 0) {
+    if (signupOffers.length > 0) {
         offerButtonText = 'Manage offers';
         offerButtonLink = openOfferListModal;
-    } else if (paidActiveTiers.length === 0 && allOffers.length === 0) {
+    } else if (paidActiveTiers.length === 0 && signupOffers.length === 0) {
         offerButtonText = '';
         offerButtonLink = openTiers;
         descriptionButtonText = '';
-    } else if (paidActiveTiers.length > 0 && allOffers.length === 0) {
+    } else if (paidActiveTiers.length > 0 && signupOffers.length === 0) {
         offerButtonText = 'Add offer';
         offerButtonLink = openAddModal;
     }
@@ -84,7 +86,7 @@ const Offers: React.FC<{ keywords: string[] }> = ({keywords}) => {
     return (
         <TopLevelGroup
             customButtons={<Button className='mt-[-5px]' color='clear' disabled={!checkStripeEnabled(settings, config)} label={offerButtonText} size='sm' onClick={offerButtonLink}/>}
-            description={<>Create discounts & coupons to boost new subscriptions. {allOffers.length === 0 && <><a className='text-green' href="https://ghost.org/help/offers" rel="noopener noreferrer" target="_blank">{descriptionButtonText}</a></>}</>}
+            description={<>Create discounts & coupons to boost new subscriptions. {signupOffers.length === 0 && <><a className='text-green' href="https://ghost.org/help/offers" rel="noopener noreferrer" target="_blank">{descriptionButtonText}</a></>}</>}
             keywords={keywords}
             navid='offers'
             testId='offers'
@@ -107,13 +109,13 @@ const Offers: React.FC<{ keywords: string[] }> = ({keywords}) => {
                             type={offer.type}
                         />))}
                     </div>
-                    {allOffers.length > 3 && <div className='mt-4 border-t border-t-grey-200 pt-2'>
-                        <span className='text-xs text-grey-700 dark:text-grey-600'>{allOffers.length} offers in total</span>
+                    {signupOffers.length > 3 && <div className='mt-4 border-t border-t-grey-200 pt-2'>
+                        <span className='text-xs text-grey-700 dark:text-grey-600'>{signupOffers.length} offers in total</span>
                     </div>}
                 </div> :
                 null
             }
-            {paidActiveTiers.length === 0 && allOffers.length === 0 ?
+            {paidActiveTiers.length === 0 && signupOffers.length === 0 ?
                 (<div>
                     <span>You must have an active tier to create an offer.</span>
                     {` `}

--- a/apps/admin-x-settings/src/components/settings/growth/offers/add-offer-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/offers/add-offer-modal.tsx
@@ -372,6 +372,7 @@ const AddOfferModal = () => {
                 duration_in_months: Number(formState.durationInMonths),
                 currency: formState.currency,
                 status: formState.status,
+                redemption_type: 'signup' as const,
                 tier: {
                     id: formState.tierId
                 },

--- a/apps/admin-x-settings/src/components/settings/growth/offers/offers-index.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/offers/offers-index.tsx
@@ -104,11 +104,12 @@ export const OffersIndexModal = () => {
     const {updateRoute} = useRouting();
     const {data: {offers: allOffers = []} = {}, isFetching: isFetchingOffers} = useBrowseOffers();
     const {data: {tiers: allTiers} = {}} = useBrowseTiers();
-    const activeOffers = allOffers.filter((offer) => {
+    const signupOffers = allOffers.filter(offer => offer.redemption_type === 'signup');
+    const activeOffers = signupOffers.filter((offer) => {
         const offerTier = allTiers?.find(tier => tier.id === offer?.tier.id);
         return (offer.status === 'active' && offerTier && offerTier.active === true);
     });
-    const archivedOffers = allOffers.filter((offer) => {
+    const archivedOffers = signupOffers.filter((offer) => {
         const offerTier = allTiers?.find(tier => tier.id === offer?.tier.id);
         return (offer.status === 'archived' || (offerTier && offerTier.active === false));
     });
@@ -132,7 +133,7 @@ export const OffersIndexModal = () => {
         updateRoute(`offers/edit/${id}`);
     };
 
-    const sortedOffers = allOffers
+    const sortedOffers = signupOffers
         .sort((offer1, offer2) => {
             const multiplier = sortDirection === 'desc' ? -1 : 1;
             switch (sortOption) {


### PR DESCRIPTION
The changes introduced in https://github.com/TryGhost/Ghost/pull/25958 were previously reverted due to a deployment mis-match (frontend being ahead of the backend). The backend changes needed to support this have now been deployed so it should be safe to re-introduce this change.

Reverts TryGhost/Ghost#25998