### PR TITLE
Updated Portal to read next payment amount from API

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.57.1",
+  "version": "2.58.0",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/portal/src/utils/fixtures-generator.js
+++ b/apps/portal/src/utils/fixtures-generator.js
@@ -112,6 +112,40 @@ export function getOfferData({
     };
 }
 
+export function getNextPaymentData({
+    originalAmount = 500,
+    amount = 500,
+    interval = 'month',
+    currency = 'USD',
+    discount = null
+} = {}) {
+    return {
+        original_amount: originalAmount,
+        amount,
+        interval,
+        currency,
+        discount
+    };
+}
+
+export function getDiscountData({
+    offerId = `offer_${objectId()}`,
+    start = '2025-01-01T00:00:00.000Z',
+    end = null,
+    duration = 'forever',
+    type = 'percent',
+    amount = 20
+} = {}) {
+    return {
+        offer_id: offerId,
+        start,
+        end,
+        duration,
+        type,
+        amount
+    };
+}
+
 export function getMemberData({
     name = 'Jamie Larson',
     email = 'jamie@example.com',
@@ -347,7 +381,10 @@ export function getSubscriptionData({
     priceId: price_id = `price_${objectId()}`,
     startDate: start_date = '2021-10-05T03:18:30.000Z',
     currentPeriodEnd: current_period_end = '2022-10-05T03:18:30.000Z',
-    cancelAtPeriodEnd: cancel_at_period_end = false
+    cancelAtPeriodEnd: cancel_at_period_end = false,
+    trialEndAt: trial_end_at = null,
+    nextPayment: next_payment = null,
+    tier = null
 } = {}) {
     return {
         id,
@@ -370,6 +407,9 @@ export function getSubscriptionData({
         cancel_at_period_end,
         cancellation_reason: null,
         current_period_end,
+        trial_end_at,
+        next_payment,
+        tier,
         price: {
             id: `stripe_price_${objectId()}`,
             price_id,

--- a/apps/portal/test/unit/components/pages/AccountHomePage/paid-account-actions.test.js
+++ b/apps/portal/test/unit/components/pages/AccountHomePage/paid-account-actions.test.js
@@ -1,0 +1,381 @@
+import {render} from '../../../../utils/test-utils';
+import PaidAccountActions from '../../../../../src/components/pages/AccountHomePage/components/paid-account-actions';
+import {getDiscountData, getMemberData, getNextPaymentData, getSubscriptionData, getSiteData, getProductsData} from '../../../../../src/utils/fixtures-generator';
+
+const setup = (overrides) => {
+    const {mockDoActionFn, ...utils} = render(
+        <PaidAccountActions />,
+        {
+            overrideContext: {
+                ...overrides
+            }
+        }
+    );
+    return {
+        mockDoActionFn,
+        ...utils
+    };
+};
+
+describe('PaidAccountActions', () => {
+    describe('Next payment display', () => {
+        test('displays regular price when no discount on next payment', () => {
+            const products = getProductsData({numOfProducts: 1});
+            const site = getSiteData({products, portalProducts: products.map(p => p.id)});
+            const member = getMemberData({
+                paid: true,
+                subscriptions: [
+                    getSubscriptionData({
+                        status: 'active',
+                        amount: 500,
+                        currency: 'USD',
+                        interval: 'month',
+                        offer: null,
+                        nextPayment: getNextPaymentData({
+                            originalAmount: 500,
+                            amount: 500,
+                            interval: 'month',
+                            currency: 'USD',
+                            discount: null
+                        })
+                    })
+                ]
+            });
+
+            const {queryByText, queryByTestId} = setup({site, member});
+
+            // Should show the regular price
+            expect(queryByText('$5.00/month')).toBeInTheDocument();
+            // Should not show any offer label
+            expect(queryByTestId('offer-label')).not.toBeInTheDocument();
+        });
+
+        test('displays "Free Trial" for trial subscriptions', () => {
+            const products = getProductsData({numOfProducts: 1});
+            const site = getSiteData({products, portalProducts: products.map(p => p.id)});
+
+            const trialEndAt = new Date('2099-01-01T12:00:00.000Z');
+
+            const member = getMemberData({
+                paid: true,
+                subscriptions: [
+                    getSubscriptionData({
+                        status: 'trialing',
+                        amount: 500,
+                        currency: 'USD',
+                        interval: 'month',
+                        offer: null,
+                        trialEndAt: trialEndAt,
+                        nextPayment: getNextPaymentData({
+                            originalAmount: 500,
+                            amount: 500,
+                            interval: 'month',
+                            currency: 'USD',
+                            discount: null
+                        })
+                    })
+                ]
+            });
+
+            const {queryByText} = setup({site, member});
+
+            // Should show the regular price with strikethrough class
+            expect(queryByText('$5.00/month')).toBeInTheDocument();
+            // Should show "Free trial - Ends {date}"
+            expect(queryByText(/Free Trial/)).toBeInTheDocument();
+            expect(queryByText(/Ends/)).toBeInTheDocument();
+            expect(queryByText(/1 Jan 2099/)).toBeInTheDocument();
+        });
+
+        test('displays "Complimentary" with expiry date', () => {
+            const products = getProductsData({numOfProducts: 1});
+            const site = getSiteData({products, portalProducts: products.map(p => p.id)});
+
+            const expiryAt = new Date('2099-01-01T12:00:00.000Z');
+
+            const member = getMemberData({
+                paid: true,
+                subscriptions: [
+                    getSubscriptionData({
+                        status: 'active',
+                        amount: 0,
+                        currency: 'USD',
+                        interval: 'month',
+                        offer: null,
+                        tier: {
+                            expiry_at: expiryAt
+                        },
+                        nextPayment: getNextPaymentData({
+                            originalAmount: 0,
+                            amount: 0,
+                            interval: 'month',
+                            currency: 'USD',
+                            discount: null
+                        })
+                    })
+                ]
+            });
+
+            const {queryByText} = setup({site, member});
+
+            // Should show "Complimentary - Expires {date}"
+            expect(queryByText(/Complimentary/)).toBeInTheDocument();
+            expect(queryByText(/Expires/)).toBeInTheDocument();
+            expect(queryByText(/1 Jan 2099/)).toBeInTheDocument();
+        });
+
+        test('displays "Complimentary" without expiry for permanent comp', () => {
+            const products = getProductsData({numOfProducts: 1});
+            const site = getSiteData({products, portalProducts: products.map(p => p.id)});
+
+            const member = getMemberData({
+                paid: true,
+                subscriptions: [
+                    getSubscriptionData({
+                        status: 'active',
+                        amount: 0,
+                        currency: 'USD',
+                        interval: 'month',
+                        offer: null,
+                        tier: null,
+                        nextPayment: getNextPaymentData({
+                            originalAmount: 0,
+                            amount: 0,
+                            interval: 'month',
+                            currency: 'USD',
+                            discount: null
+                        })
+                    })
+                ]
+            });
+
+            const {queryByText} = setup({site, member});
+
+            // Should show "Complimentary" without expiry
+            expect(queryByText(/Complimentary/)).toBeInTheDocument();
+            expect(queryByText(/Expires/)).not.toBeInTheDocument();
+        });
+
+        test('displays discounted price with "Forever" for forever offers', () => {
+            const products = getProductsData({numOfProducts: 1});
+            const site = getSiteData({products, portalProducts: products.map(p => p.id)});
+
+            const member = getMemberData({
+                paid: true,
+                subscriptions: [
+                    getSubscriptionData({
+                        status: 'active',
+                        amount: 500,
+                        currency: 'USD',
+                        interval: 'month',
+                        offer: {
+                            type: 'percent',
+                            amount: 20,
+                            duration: 'forever'
+                        },
+                        nextPayment: getNextPaymentData({
+                            originalAmount: 500,
+                            amount: 400,
+                            interval: 'month',
+                            currency: 'USD',
+                            discount: getDiscountData({
+                                duration: 'forever',
+                                type: 'percent',
+                                amount: 20,
+                                end: null
+                            })
+                        })
+                    })
+                ]
+            });
+
+            const {queryByText, queryByTestId} = setup({site, member});
+
+            // Should show the original price with strikethrough
+            expect(queryByText('$5.00/month')).toBeInTheDocument();
+            // Should have the offer label
+            expect(queryByTestId('offer-label')).toBeInTheDocument();
+            // Should show the discounted price with Forever label
+            expect(queryByText('$4.00/month — Forever')).toBeInTheDocument();
+        });
+
+        test('displays discounted price with "Ends {date}" for repeating offers', () => {
+            const products = getProductsData({numOfProducts: 1});
+            const site = getSiteData({products, portalProducts: products.map(p => p.id)});
+
+            const endDate = new Date('2099-01-01T12:00:00.000Z');
+
+            const member = getMemberData({
+                paid: true,
+                subscriptions: [
+                    getSubscriptionData({
+                        status: 'active',
+                        amount: 500,
+                        currency: 'USD',
+                        interval: 'month',
+                        offer: {
+                            type: 'percent',
+                            amount: 20,
+                            duration: 'repeating',
+                            duration_in_months: 6
+                        },
+                        nextPayment: getNextPaymentData({
+                            originalAmount: 500,
+                            amount: 400,
+                            interval: 'month',
+                            currency: 'USD',
+                            discount: getDiscountData({
+                                duration: 'repeating',
+                                type: 'percent',
+                                amount: 20,
+                                end: endDate.toISOString()
+                            })
+                        })
+                    })
+                ]
+            });
+
+            const {queryByText, queryByTestId} = setup({site, member});
+
+            // Should show the original price (with strikethrough)
+            expect(queryByText('$5.00/month')).toBeInTheDocument();
+            // Should have the offer label
+            expect(queryByTestId('offer-label')).toBeInTheDocument();
+            // Should show the discounted price with end date
+            expect(queryByText(/\$4\.00\/month/)).toBeInTheDocument();
+            expect(queryByText(/Ends/)).toBeInTheDocument();
+            expect(queryByText(/1 Jan 2099/)).toBeInTheDocument();
+        });
+
+        test('displays "Next payment" for once duration offers', () => {
+            const products = getProductsData({numOfProducts: 1});
+            const site = getSiteData({products, portalProducts: products.map(p => p.id)});
+
+            const member = getMemberData({
+                paid: true,
+                subscriptions: [
+                    getSubscriptionData({
+                        status: 'active',
+                        amount: 500,
+                        currency: 'USD',
+                        interval: 'month',
+                        offer: {
+                            type: 'percent',
+                            amount: 20,
+                            duration: 'once'
+                        },
+
+                        nextPayment: getNextPaymentData({
+                            originalAmount: 500,
+                            amount: 500,
+                            interval: 'month',
+                            currency: 'USD',
+                            discount: getDiscountData({
+                                duration: 'once',
+                                type: 'percent',
+                                amount: 20,
+                                end: null
+                            })
+                        })
+                    })
+                ]
+            });
+
+            const {queryByText, queryByTestId} = setup({site, member});
+
+            // Should show the original price (with strikethrough)
+            expect(queryByText('$5.00/month')).toBeInTheDocument();
+            // Should have the offer label
+            expect(queryByTestId('offer-label')).toBeInTheDocument();
+            // Should show the discounted price with "Next payment"
+            expect(queryByText('$5.00/month — Next payment')).toBeInTheDocument();
+        });
+
+        test('displays fixed amount discount correctly', () => {
+            const products = getProductsData({numOfProducts: 1});
+            const site = getSiteData({products, portalProducts: products.map(p => p.id)});
+
+            const member = getMemberData({
+                paid: true,
+                subscriptions: [
+                    getSubscriptionData({
+                        status: 'active',
+                        amount: 1000,
+                        currency: 'USD',
+                        interval: 'month',
+                        offer: {
+                            type: 'fixed',
+                            amount: 300,
+                            duration: 'forever',
+                            currency: 'USD'
+                        },
+                        nextPayment: getNextPaymentData({
+                            originalAmount: 1000,
+                            amount: 700,
+                            interval: 'month',
+                            currency: 'USD',
+                            discount: getDiscountData({
+                                duration: 'forever',
+                                type: 'fixed',
+                                amount: 300,
+                                end: null
+                            })
+                        })
+                    })
+                ]
+            });
+
+            const {queryByText, queryByTestId} = setup({site, member});
+
+            // Should show the original price
+            expect(queryByText('$10.00/month')).toBeInTheDocument();
+            // Should have the offer label
+            expect(queryByTestId('offer-label')).toBeInTheDocument();
+            // Should show the discounted price
+            expect(queryByText('$7.00/month — Forever')).toBeInTheDocument();
+        });
+
+        test('displays yearly subscription with discount correctly', () => {
+            const products = getProductsData({numOfProducts: 1});
+            const site = getSiteData({products, portalProducts: products.map(p => p.id)});
+
+            const member = getMemberData({
+                paid: true,
+                subscriptions: [
+                    getSubscriptionData({
+                        status: 'active',
+                        amount: 5000,
+                        currency: 'USD',
+                        interval: 'year',
+                        offer: {
+                            type: 'percent',
+                            amount: 10,
+                            duration: 'forever'
+                        },
+                        nextPayment: getNextPaymentData({
+                            originalAmount: 5000,
+                            amount: 4500,
+                            interval: 'year',
+                            currency: 'USD',
+                            discount: getDiscountData({
+                                duration: 'forever',
+                                type: 'percent',
+                                amount: 10,
+                                end: null
+                            })
+                        })
+                    })
+                ]
+            });
+
+            const {queryByText, queryByTestId} = setup({site, member});
+
+            // Should show the original yearly price
+            expect(queryByText('$50.00/year')).toBeInTheDocument();
+            // Should have the offer label
+            expect(queryByTestId('offer-label')).toBeInTheDocument();
+            // Should show the discounted yearly price
+            expect(queryByText('$45.00/year — Forever')).toBeInTheDocument();
+        });
+    });
+});

--- a/ghost/core/core/shared/config/defaults.json
+++ b/ghost/core/core/shared/config/defaults.json
@@ -234,7 +234,7 @@
     },
     "portal": {
         "url": "https://cdn.jsdelivr.net/ghost/portal@~{version}/umd/portal.min.js",
-        "version": "2.57"
+        "version": "2.58"
     },
     "sodoSearch": {
         "url": "https://cdn.jsdelivr.net/ghost/sodo-search@~{version}/umd/sodo-search.min.js",


### PR DESCRIPTION
ref https://linear.app/ghost/issue/FEA-537

- The API now returns the next payment amount for a subscription, taking into account active offers for both signup and retention type of offers
- Thus, we can now remove the next amount calculation logic from Portal