### PR TITLE
Updated magic links endpoint to return sniper links

### DIFF
--- a/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
+++ b/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
@@ -1,3 +1,4 @@
+const dns = require('node:dns/promises');
 const tpl = require('@tryghost/tpl');
 const logging = require('@tryghost/logging');
 const sanitizeHtml = require('sanitize-html');
@@ -5,6 +6,7 @@ const {BadRequestError, NoPermissionError, UnauthorizedError, DisabledFeatureErr
 const errors = require('@tryghost/errors');
 const {isEmail} = require('@tryghost/validator');
 const normalizeEmail = require('../utils/normalize-email');
+const {getSniperLinks} = require('../../../../lib/get-sniper-links');
 
 const messages = {
     emailRequired: 'Email is required.',
@@ -51,6 +53,8 @@ function extractRefererOrRedirect(req) {
 }
 
 module.exports = class RouterController {
+    #sniperLinksDnsResolver = new dns.Resolver({maxTimeout: 1000});
+
     /**
      * RouterController
      *
@@ -69,6 +73,7 @@ module.exports = class RouterController {
      * @param {any} deps.newslettersService
      * @param {any} deps.sentry
      * @param {any} deps.settingsCache
+     * @param {any} deps.settingsHelpers
      * @param {any} deps.urlUtils
      */
     constructor({
@@ -87,6 +92,7 @@ module.exports = class RouterController {
         newslettersService,
         sentry,
         settingsCache,
+        settingsHelpers,
         urlUtils
     }) {
         this._offersAPI = offersAPI;
@@ -104,6 +110,7 @@ module.exports = class RouterController {
         this._newslettersService = newslettersService;
         this._sentry = sentry || undefined;
         this._settingsCache = settingsCache;
+        this._settingsHelpers = settingsHelpers;
         this._urlUtils = urlUtils;
     }
 
@@ -698,7 +705,7 @@ module.exports = class RouterController {
             // Honeypot field is filled, this is a bot.
             // Pretend that the email was sent successfully.
             res.writeHead(201);
-            return res.end('Created.');
+            return res.end('{}');
         }
 
         if (!emailType) {
@@ -712,19 +719,29 @@ module.exports = class RouterController {
         }
 
         try {
+            /** @type {{sniperLinks?: {desktop: string; android: string}; otc_ref?: string}} */
+            const resBody = {};
+
             if (emailType === 'signup' || emailType === 'subscribe') {
                 await this._handleSignup(req, normalizedEmail, referrer);
             } else {
                 const signIn = await this._handleSignin(req, normalizedEmail, referrer);
-
                 if (signIn.otcRef) {
-                    res.writeHead(201, {'Content-Type': 'application/json'});
-                    return res.end(JSON.stringify({otc_ref: signIn.otcRef}));
+                    resBody.otc_ref = signIn.otcRef;
                 }
             }
 
-            res.writeHead(201);
-            return res.end('Created.');
+            const sniperLinks = await getSniperLinks({
+                recipient: normalizedEmail,
+                sender: this._settingsHelpers.getMembersSupportAddress(),
+                dnsResolver: this.#sniperLinksDnsResolver
+            });
+            if (sniperLinks) {
+                resBody.sniperLinks = sniperLinks;
+            }
+
+            res.writeHead(201, {'Content-Type': 'application/json'});
+            return res.end(JSON.stringify(resBody));
         } catch (err) {
             if (err.code === 'EENVELOPE') {
                 logging.error(err);

--- a/ghost/core/core/server/services/members/members-api/members-api.js
+++ b/ghost/core/core/server/services/members/members-api/members-api.js
@@ -205,6 +205,7 @@ module.exports = function MembersAPI({
         labsService,
         newslettersService,
         settingsCache,
+        settingsHelpers,
         sentry,
         urlUtils
     });

--- a/ghost/core/test/e2e-api/members/send-magic-link.test.js
+++ b/ghost/core/test/e2e-api/members/send-magic-link.test.js
@@ -131,13 +131,14 @@ describe('sendMagicLink', function () {
 
     it('Creates a valid magic link with tokenData, and without urlHistory', async function () {
         const email = 'newly-created-user-magic-link-test@test.com';
-        await membersAgent.post('/api/send-magic-link')
+        const res = await membersAgent.post('/api/send-magic-link')
             .body({
                 email,
                 emailType: 'signup'
             })
-            .expectEmptyBody()
             .expectStatus(201);
+
+        assert.deepEqual(res.body, {});
 
         // Check email is sent
         const mail = mockManager.assert.sentEmail({
@@ -159,10 +160,23 @@ describe('sendMagicLink', function () {
         assert.equal(data.attribution.type, null);
     });
 
+    it('Creates a valid magic link with sniper links for Gmail', async function () {
+        const email = 'test@gmail.com';
+        const res = await membersAgent.post('/api/send-magic-link')
+            .body({
+                email,
+                emailType: 'signup'
+            })
+            .expectStatus(201);
+
+        assert(res.body.sniperLinks.desktop.startsWith('https://mail.google.com/'));
+        assert(res.body.sniperLinks.android.startsWith('intent://'));
+    });
+
     it('Creates a valid magic link from custom signup with redirection', async function () {
         const customSignupUrl = 'http://localhost:2368/custom-signup-form-page';
         const email = 'newly-created-user-magic-link-test@test.com';
-        await membersAgent
+        const res = await membersAgent
             .post('/api/send-magic-link')
             .header('Referer', customSignupUrl)
             .body({
@@ -170,8 +184,9 @@ describe('sendMagicLink', function () {
                 emailType: 'signup',
                 autoRedirect: true
             })
-            .expectEmptyBody()
             .expectStatus(201);
+
+        assert.deepEqual(res.body, {});
 
         const mail = await mockManager.assert.sentEmail({
             to: email,
@@ -186,7 +201,7 @@ describe('sendMagicLink', function () {
     it('Creates a valid magic link from custom signup with redirection disabled', async function () {
         const customSignupUrl = 'http://localhost:2368/custom-signup-form-page';
         const email = 'newly-created-user-magic-link-test@test.com';
-        await membersAgent
+        const res = await membersAgent
             .post('/api/send-magic-link')
             .header('Referer', customSignupUrl)
             .body({
@@ -194,8 +209,9 @@ describe('sendMagicLink', function () {
                 emailType: 'signup',
                 autoRedirect: false
             })
-            .expectEmptyBody()
             .expectStatus(201);
+
+        assert.deepEqual(res.body, {});
 
         const mail = await mockManager.assert.sentEmail({
             to: email,
@@ -209,13 +225,14 @@ describe('sendMagicLink', function () {
 
     it('triggers email alert for free member signup', async function () {
         const email = 'newly-created-user-magic-link-test@test.com';
-        await membersAgent.post('/api/send-magic-link')
+        const res = await membersAgent.post('/api/send-magic-link')
             .body({
                 email,
                 emailType: 'signup'
             })
-            .expectEmptyBody()
             .expectStatus(201);
+
+        assert.deepEqual(res.body, {});
 
         // Check email is sent
         const mail = mockManager.assert.sentEmail({

--- a/ghost/core/test/unit/server/services/members/members-api/controllers/router-controller.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/controllers/router-controller.test.js
@@ -15,6 +15,7 @@ describe('RouterController', function () {
     let getPaymentLinkSpy;
     let getDonationLinkSpy;
     let settingsCache;
+    let settingsHelpers;
 
     beforeEach(async function () {
         getPaymentLinkSpy = sinon.spy();
@@ -71,6 +72,9 @@ describe('RouterController', function () {
         settingsCache = {
             get: sinon.stub().withArgs('all_blocked_email_domains').returns(['spam.xyz'])
         };
+        settingsHelpers = {
+            getMembersSupportAddress: sinon.stub().returns('noreply@example.com')
+        };
     });
 
     afterEach(function () {
@@ -85,7 +89,8 @@ describe('RouterController', function () {
                 offersAPI,
                 stripeAPIService,
                 labsService,
-                settingsCache
+                settingsCache,
+                settingsHelpers
             });
 
             await routerController.createCheckoutSession({
@@ -120,6 +125,7 @@ describe('RouterController', function () {
                 stripeAPIService,
                 labsService,
                 settingsCache,
+                settingsHelpers,
                 newslettersService: newslettersServiceStub
             });
             const newsletters = [
@@ -161,7 +167,8 @@ describe('RouterController', function () {
                     offersAPI,
                     stripeAPIService,
                     labsService,
-                    settingsCache
+                    settingsCache,
+                    settingsHelpers
                 });
 
                 try {
@@ -180,7 +187,8 @@ describe('RouterController', function () {
                     offersAPI,
                     stripeAPIService,
                     labsService,
-                    settingsCache
+                    settingsCache,
+                    settingsHelpers
                 });
 
                 try {
@@ -199,7 +207,8 @@ describe('RouterController', function () {
                     offersAPI,
                     stripeAPIService,
                     labsService,
-                    settingsCache
+                    settingsCache,
+                    settingsHelpers
                 });
 
                 try {
@@ -218,7 +227,8 @@ describe('RouterController', function () {
                     offersAPI,
                     stripeAPIService,
                     labsService,
-                    settingsCache
+                    settingsCache,
+                    settingsHelpers
                 });
 
                 try {
@@ -241,7 +251,8 @@ describe('RouterController', function () {
                     offersAPI,
                     stripeAPIService,
                     labsService,
-                    settingsCache
+                    settingsCache,
+                    settingsHelpers
                 });
 
                 try {
@@ -267,7 +278,8 @@ describe('RouterController', function () {
                     offersAPI,
                     stripeAPIService,
                     labsService,
-                    settingsCache
+                    settingsCache,
+                    settingsHelpers
                 });
 
                 try {
@@ -293,7 +305,8 @@ describe('RouterController', function () {
                     offersAPI,
                     stripeAPIService,
                     labsService,
-                    settingsCache
+                    settingsCache,
+                    settingsHelpers
                 });
 
                 try {
@@ -315,6 +328,7 @@ describe('RouterController', function () {
                     stripeAPIService,
                     labsService,
                     settingsCache,
+                    settingsHelpers,
                     memberAttributionService: {
                         getAttribution: sinon.stub().resolves({})
                     }
@@ -362,6 +376,7 @@ describe('RouterController', function () {
                     stripeAPIService,
                     labsService,
                     settingsCache,
+                    settingsHelpers,
                     memberAttributionService: {
                         getAttribution: sinon.stub().resolves({})
                     }
@@ -408,6 +423,7 @@ describe('RouterController', function () {
                     stripeAPIService,
                     labsService,
                     settingsCache,
+                    settingsHelpers,
                     memberAttributionService: {
                         getAttribution: sinon.stub().resolves({})
                     }
@@ -454,6 +470,7 @@ describe('RouterController', function () {
                     stripeAPIService,
                     labsService,
                     settingsCache,
+                    settingsHelpers,
                     memberAttributionService: {
                         getAttribution: sinon.stub().resolves({})
                     }
@@ -500,6 +517,7 @@ describe('RouterController', function () {
                     stripeAPIService,
                     labsService,
                     settingsCache,
+                    settingsHelpers,
                     memberAttributionService: {
                         getAttribution: sinon.stub().resolves({})
                     }
@@ -572,7 +590,8 @@ describe('RouterController', function () {
                 },
                 memberAttributionService: {
                     getAttribution: sinon.stub().resolves({})
-                }
+                },
+                settingsHelpers
             });
 
             const req = {
@@ -673,6 +692,7 @@ describe('RouterController', function () {
                     },
                     sendEmailWithMagicLink: sendEmailWithMagicLinkStub,
                     settingsCache,
+                    settingsHelpers,
                     ...deps
                 });
             };
@@ -734,7 +754,7 @@ describe('RouterController', function () {
                 await controller.sendMagicLink(req, res);
 
                 res.writeHead.calledOnceWith(201).should.be.true();
-                res.end.calledOnceWith('Created.').should.be.true();
+                res.end.calledOnceWith('{}').should.be.true();
 
                 sendEmailWithMagicLinkStub.calledOnce.should.be.true();
                 sendEmailWithMagicLinkStub.args[0][0].tokenData.newsletters.should.eql([
@@ -821,6 +841,7 @@ describe('RouterController', function () {
                     },
                     sendEmailWithMagicLink: sendEmailWithMagicLinkStub,
                     settingsCache,
+                    settingsHelpers,
                     ...deps
                 });
             };
@@ -893,6 +914,7 @@ describe('RouterController', function () {
                     stripeAPIService: {},
                     tokenService: {},
                     sendEmailWithMagicLink: sinon.stub(),
+                    settingsHelpers,
                     newslettersService: {},
                     sentry: {},
                     urlUtils: {}
@@ -916,7 +938,7 @@ describe('RouterController', function () {
                 await routerController.sendMagicLink(req, res);
 
                 res.writeHead.calledWith(201).should.be.true();
-                res.end.calledWith('Created.').should.be.true();
+                res.end.calledWith('{}').should.be.true();
             });
 
             it('should not return otc_ref when otcRef is undefined', async function () {
@@ -925,7 +947,7 @@ describe('RouterController', function () {
                 await routerController.sendMagicLink(req, res);
 
                 res.writeHead.calledWith(201).should.be.true();
-                res.end.calledWith('Created.').should.be.true();
+                res.end.calledWith('{}').should.be.true();
             });
         });
     });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/NY-943
ref https://github.com/TryGhost/Ghost/pull/25968

This updates the `send-magic-links` endpoint to return sniper links.

This change should have no user impact yet, but will soon once the frontend supports it.
