### PR TITLE
Added more providers to sniper link detection

### DIFF
--- a/ghost/core/core/server/lib/get-sniper-links.ts
+++ b/ghost/core/core/server/lib/get-sniper-links.ts
@@ -31,7 +31,6 @@ import type {MxRecord} from 'node:dns';
 import * as dns from 'node:dns/promises';
 import {parseEmailAddress} from '@tryghost/parse-email-address';
 import logging from '@tryghost/logging';
-import {constant} from 'lodash';
 
 type GetLinkFn = (options: Readonly<{recipient: string; sender: string}>) => string;
 
@@ -69,22 +68,22 @@ const PROVIDERS: ReadonlyArray<Provider> = [
                 sender
             )})+in%3Aanywhere+newer_than%3A1h`
         ),
-        getAndroidLink: constant(getAndroidIntentUrl('com.google.android.gm', 'https://mail.google.com/'))
+        getAndroidLink: () => getAndroidIntentUrl('com.google.android.gm', 'https://mail.google.com/')
     },
     {
         domains: ['yahoo.com', 'myyahoo.com', 'yahoo.co.uk', 'yahoo.fr', 'yahoo.it', 'ymail.com', 'rocketmail.com'],
         getDesktopLink: ({sender}) => `https://mail.yahoo.com/d/search/keyword=from:${encodeURIComponent(sender)}`,
-        getAndroidLink: constant(getAndroidIntentUrl('com.yahoo.mobile.client.android.mail', 'https://mail.yahoo.com/'))
+        getAndroidLink: () => getAndroidIntentUrl('com.yahoo.mobile.client.android.mail', 'https://mail.yahoo.com/')
     },
     {
         domains: ['outlook.com', 'live.com', 'live.de', 'hotmail.com', 'hotmail.co.uk', 'hotmail.de', 'msn.com', 'passport.com', 'passport.net'],
         getDesktopLink: ({recipient}) => buildUrl('https://outlook.live.com/mail/', 'login_hint', recipient),
-        getAndroidLink: constant(getAndroidIntentUrl('com.microsoft.office.outlook', 'https://outlook.live.com/'))
+        getAndroidLink: () => getAndroidIntentUrl('com.microsoft.office.outlook', 'https://outlook.live.com/')
     },
     {
         domains: ['proton.me', 'pm.me', 'protonmail.com', 'protonmail.ch'],
         getDesktopLink: ({sender}) => `https://mail.proton.me/u/0/all-mail#from=${encodeURIComponent(sender)}`,
-        getAndroidLink: constant(getAndroidIntentUrl('ch.protonmail.android', 'https://mail.proton.me/'))
+        getAndroidLink: () => getAndroidIntentUrl('ch.protonmail.android', 'https://mail.proton.me/')
     },
     {
         domains: ['icloud.com', 'me.com', 'mac.com'],
@@ -93,18 +92,18 @@ const PROVIDERS: ReadonlyArray<Provider> = [
     },
     {
         domains: ['hey.com'],
-        getDesktopLink: constant('https://app.hey.com/topics/everything'),
-        getAndroidLink: constant(getAndroidIntentUrl('com.basecamp.hey', 'https://app.hey.com/'))
+        getDesktopLink: () => 'https://app.hey.com/topics/everything',
+        getAndroidLink: () => getAndroidIntentUrl('com.basecamp.hey', 'https://app.hey.com/')
     },
     {
         domains: ['aol.com'],
         getDesktopLink: ({sender}) => `https://mail.aol.com/d/search/keyword=from:${encodeURIComponent(sender)}`,
-        getAndroidLink: constant(getAndroidIntentUrl('com.aol.mobile.aolapp', 'https://mail.aol.com/'))
+        getAndroidLink: () => getAndroidIntentUrl('com.aol.mobile.aolapp', 'https://mail.aol.com/')
     },
     {
         domains: ['mail.ru'],
         getDesktopLink: ({sender}) => buildUrl('https://e.mail.ru/search/', 'q_from', sender),
-        getAndroidLink: constant(getAndroidIntentUrl('ru.mail.mailapp', 'https://e.mail.ru/'))
+        getAndroidLink: () => getAndroidIntentUrl('ru.mail.mailapp', 'https://e.mail.ru/')
     }
 ];
 

--- a/ghost/core/test/unit/server/lib/get-sniper-links.test.ts
+++ b/ghost/core/test/unit/server/lib/get-sniper-links.test.ts
@@ -43,10 +43,132 @@ describe('getSniperLinks', function () {
             assert(result?.desktop.startsWith('https://mail.google.com/'));
             assert(result?.desktop.includes(encodeURIComponent(recipient)));
             assert(result?.desktop.includes(encodeURIComponent('sender@example.com')));
-            assert(result?.android.startsWith('intent://'));
+            assert(result?.android.startsWith('intent:'));
             assert(result?.android.includes('com.google.android.gm'));
             assert(result?.android.includes('browser_fallback_url'));
         }));
+    });
+
+    it('handles Yahoo emails', async function () {
+        const emails = [
+            'example@yahoo.com',
+            'example@myyahoo.com',
+            'example@yahoo.co.uk',
+            'example@yahoo.fr',
+            'example@yahoo.it',
+            'example@ymail.com',
+            'example@rocketmail.com'
+        ];
+        await Promise.all(emails.map(async (recipient) => {
+            const result = await getSniperLinks({
+                recipient,
+                sender: 'sender@example.com',
+                dnsResolver: resolverThatShouldNeverBeUsed
+            });
+            assert(result?.desktop.startsWith('https://mail.yahoo.com/d/search/keyword=from:'));
+            assert(result?.desktop.includes(encodeURIComponent('sender@example.com')));
+            assert(result?.android.startsWith('intent:'));
+            assert(result?.android.includes('com.yahoo.mobile.client.android.mail'));
+            assert(result?.android.includes('browser_fallback_url'));
+        }));
+    });
+
+    it('handles Microsoft emails', async function () {
+        const emails = [
+            'example@outlook.com',
+            'example@live.com',
+            'example@live.de',
+            'example@hotmail.com',
+            'example@hotmail.co.uk',
+            'example@hotmail.de',
+            'example@msn.com'
+        ];
+        await Promise.all(emails.map(async (recipient) => {
+            const result = await getSniperLinks({
+                recipient,
+                sender: 'sender@example.com',
+                dnsResolver: resolverThatShouldNeverBeUsed
+            });
+            assert.equal(result?.desktop, `https://outlook.live.com/mail/?login_hint=${encodeURIComponent(recipient)}`);
+            assert(result?.android.startsWith('intent:'));
+            assert(result?.android.includes('com.microsoft.office.outlook'));
+            assert(result?.android.includes('browser_fallback_url'));
+        }));
+    });
+
+    it('handles Proton emails', async function () {
+        const emails = [
+            'example@proton.me',
+            'example@pm.me',
+            'example@protonmail.com'
+        ];
+        await Promise.all(emails.map(async (recipient) => {
+            const result = await getSniperLinks({
+                recipient,
+                sender: 'sender@example.com',
+                dnsResolver: resolverThatShouldNeverBeUsed
+            });
+            assert(result?.desktop.startsWith('https://mail.proton.me/'));
+            assert(result?.desktop.includes(encodeURIComponent('sender@example.com')));
+            assert(result?.android.startsWith('intent:'));
+            assert(result?.android.includes('ch.protonmail.android'));
+            assert(result?.android.includes('browser_fallback_url'));
+        }));
+    });
+
+    it('handles iCloud emails', async function () {
+        const emails = [
+            'example@icloud.com',
+            'example@me.com',
+            'example@mac.com'
+        ];
+        await Promise.all(emails.map(async (recipient) => {
+            const result = await getSniperLinks({
+                recipient,
+                sender: 'sender@example.com',
+                dnsResolver: resolverThatShouldNeverBeUsed
+            });
+            assert.equal(result?.desktop, 'https://www.icloud.com/mail');
+            assert.equal(result?.android, 'https://www.icloud.com/mail');
+        }));
+    });
+
+    it('handles Hey emails', async function () {
+        const result = await getSniperLinks({
+            recipient: 'example@hey.com',
+            sender: 'sender@example.com',
+            dnsResolver: resolverThatShouldNeverBeUsed
+        });
+        assert.equal(result?.desktop, 'https://app.hey.com/topics/everything');
+        assert(result?.android.startsWith('intent:'));
+        assert(result?.android.includes('com.basecamp.hey'));
+        assert(result?.android.includes('browser_fallback_url'));
+    });
+
+    it('handles AOL emails', async function () {
+        const result = await getSniperLinks({
+            recipient: 'example@aol.com',
+            sender: 'sender@example.com',
+            dnsResolver: resolverThatShouldNeverBeUsed
+        });
+        assert(result?.desktop.startsWith('https://mail.aol.com/'));
+        assert(result?.desktop.includes(encodeURIComponent('sender@example.com')));
+        assert(result?.android.startsWith('intent:'));
+        assert(result?.android.includes('com.aol.mobile.aolapp'));
+        assert(result?.android.includes('browser_fallback_url'));
+    });
+
+    it('handles Mail.ru emails', async function () {
+        const result = await getSniperLinks({
+            recipient: 'example@mail.ru',
+            sender: 'sender@example.com',
+            dnsResolver: resolverThatShouldNeverBeUsed
+        });
+        assert(result?.desktop.startsWith('https://e.mail.ru/search/'));
+        assert(result?.desktop.includes(encodeURIComponent('sender@example.com')));
+        assert(result?.android.startsWith('intent:'));
+        assert(result?.android.includes('ru.mail.mailapp'));
+        assert(result?.android.includes('browser_fallback_url'));
     });
 
     describe('DNS lookups', function () {


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-944

Before this change, `getSniperLinks()` only supported Gmail. Now, it supports Yahoo, Outlook, Proton, iCloud, Hey, AOL, and Mail.ru.
