### PR TITLE
Added generated types from frontend apps to `.dockerignore`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,6 +8,8 @@ node_modules
 build
 dist
 
+apps/*/types
+
 coverage
 
 .eslintcache


### PR DESCRIPTION
No changes to functionality included in this change.

When running `yarn docker:build` locally (which is required to run e2e tests locally), the build was sometimes flaky when building the frontend apps. These generated typescript types were not in the .dockerignore, so stale types from local builds could pollute the docker image and ultimately cause the build to fail.

Adding these generated types directories to the .dockerignore seems to eliminate this flakiness by ensuring it only uses the latest and greatest type definitions.