### PR TITLE
Removed `memberWelcomeEmailSendInstantly` configuration parameter

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,8 +8,6 @@ node_modules
 build
 dist
 
-apps/*/types
-
 coverage
 
 .eslintcache

--- a/.dockerignore
+++ b/.dockerignore
@@ -8,6 +8,8 @@ node_modules
 build
 dist
 
+apps/*/types
+
 coverage
 
 .eslintcache

--- a/e2e/helpers/playwright/fixture.ts
+++ b/e2e/helpers/playwright/fixture.ts
@@ -15,7 +15,6 @@ export interface User {
 }
 
 export interface GhostConfig {
-    memberWelcomeEmailSendInstantly?: string;
     memberWelcomeEmailTestInbox?: string;
     hostSettings__billing__enabled?: string;
     hostSettings__billing__url?: string;
@@ -59,11 +58,7 @@ async function setupNewAuthenticatedPage(browser: Browser, baseURL: string, ghos
  *
  * Optionally allows setting labs flags via test.use({labs: {featureName: true}})
  * and Stripe connection via test.use({stripeConnected: true})
-   and Ghost config via config settings: 
- *  test.use({config: {
- *      memberWelcomeEmailSendInstantly: 'true',
- *      memberWelcomeEmailTestInbox: `test+welcome-email@ghost.org`
- *  }})
+ * and Ghost config via test.use({config: {memberWelcomeEmailTestInbox: 'test@ghost.org'}})
  */
 export const test = base.extend<GhostInstanceFixture>({
     // Define options that can be set per test or describe block

--- a/ghost/core/core/server/services/outbox/jobs/index.js
+++ b/ghost/core/core/server/services/outbox/jobs/index.js
@@ -12,15 +12,8 @@ module.exports = {
             return false;
         }
 
-        const configValue = config.get('memberWelcomeEmailSendInstantly');
-        const testEmailSendInstantly = configValue === true || configValue === 'true';
-
-        // use a random seconds value to avoid spikes to the database on the minute
-        const s = Math.floor(Math.random() * 60); // 0-59
-        // run every 5 minutes, on 1,6,11..., 2,7,12..., 3,8,13..., etc
-        const m = Math.floor(Math.random() * 5); // 0-4
-
-        const cronSchedule = testEmailSendInstantly ? '*/3 * * * * *' : `${s} ${m}/5 * * * *`;
+        // Run every 3 seconds for instant welcome email delivery
+        const cronSchedule = '*/3 * * * * *';
 
         jobsService.addJob({
             at: cronSchedule,

--- a/ghost/core/core/server/services/outbox/jobs/index.js
+++ b/ghost/core/core/server/services/outbox/jobs/index.js
@@ -1,6 +1,5 @@
 const path = require('path');
 const jobsService = require('../../jobs');
-const config = require('../../../../shared/config');
 
 let hasScheduled = {
     processOutbox: false

--- a/ghost/core/core/server/services/outbox/jobs/index.js
+++ b/ghost/core/core/server/services/outbox/jobs/index.js
@@ -11,8 +11,12 @@ module.exports = {
             return false;
         }
 
-        // Run every 3 seconds for instant welcome email delivery
-        const cronSchedule = '*/3 * * * * *';
+        // use a random seconds value to avoid spikes to the database on the minute
+        const s = Math.floor(Math.random() * 60); // 0-59
+        // run every 5 minutes, on 1,6,11..., 2,7,12..., 3,8,13..., etc
+        const m = Math.floor(Math.random() * 5); // 0-4
+
+        const cronSchedule = `${s} ${m}/5 * * * *`;
 
         jobsService.addJob({
             at: cronSchedule,


### PR DESCRIPTION
ref https://linear.app/ghost/issue/NY-964/cleanup-remove-welcomeemailsendinstantly-configuration

Initially the process outbox job would run at most every 5 minutes, so we created this `memberWelcomeEmailSendInstantly` configuration parameter to run the job much more frequently for the sake of our e2e tests. We've since updated the implementation so the process-outbox job is triggered immediately when a member signs up anyways, so this configuration parameter is now redundant and unnecessary.