### PR TITLE
Removed unnecessary ESLint suppressions

### DIFF
--- a/apps/comments-ui/src/app.tsx
+++ b/apps/comments-ui/src/app.tsx
@@ -309,7 +309,6 @@ const App: React.FC<AppProps> = ({scriptTag, initialCommentId, pageUrl}) => {
                 commentIdToScrollTo: scrollTargetFound ? initialCommentId : null
             });
         } catch (e) {
-            /* eslint-disable no-console */
             console.error(`[Comments] Failed to initialize:`, e);
             /* eslint-enable no-console */
             setState({

--- a/apps/comments-ui/test/unit/utils/api.test.ts
+++ b/apps/comments-ui/test/unit/utils/api.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-undef */
 import setupGhostApi from '../../../src/utils/api';
 import {vi} from 'vitest';
 

--- a/apps/comments-ui/test/unit/utils/helpers.test.ts
+++ b/apps/comments-ui/test/unit/utils/helpers.test.ts
@@ -3,7 +3,6 @@ import moment, {DurationInputObject} from 'moment';
 import sinon from 'sinon';
 import {buildAnonymousMember, buildComment, buildDeletedMember} from '../../utils/fixtures';
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
 
 describe('COMMENT_HASH_PREFIX', function () {
     it('exports the correct prefix', function () {

--- a/apps/comments-ui/test/utils/mocked-api.ts
+++ b/apps/comments-ui/test/utils/mocked-api.ts
@@ -8,7 +8,6 @@ const htmlToPlaintext = (html) => {
     return html.replace(/<[^>]+>/g, '').replace(/\s+/g, ' ').trim();
 };
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
 
 export class MockedApi {
     comments: any[];

--- a/apps/portal/src/components/common/newsletter-management.js
+++ b/apps/portal/src/components/common/newsletter-management.js
@@ -178,7 +178,6 @@ export default function NewsletterManagement({
                             className="gh-portal-btn-text gh-email-faq-page-button"
                             onClick={() => doAction('switchPage', {page: 'emailReceivingFAQ', pageData: {direct: false}})}
                         >
-                            {/* eslint-disable-next-line i18next/no-literal-string */}
                             {t('Get help')} <span className="right-arrow">&rarr;</span>
                         </button>
                     </div>

--- a/apps/portal/src/components/common/site-title-back-button.js
+++ b/apps/portal/src/components/common/site-title-back-button.js
@@ -17,7 +17,6 @@ export default class SiteTitleBackButton extends React.Component {
                             this.context.doAction('closePopup');
                         }
                     }}>
-                    {/* eslint-disable-next-line i18next/no-literal-string */}
                     <span>&larr; </span> {t('Back')}
                 </button>
             </>

--- a/apps/portal/src/components/pages/account-plan-page.js
+++ b/apps/portal/src/components/pages/account-plan-page.js
@@ -303,7 +303,6 @@ const RetentionOfferSection = ({offer, onAcceptOffer, onDeclineOffer}) => {
     const durationText = formatOfferDuration(offer);
 
     // TODO: Add i18n once copy is finalized
-    /* eslint-disable i18next/no-literal-string */
     return (
         <div className="gh-portal-logged-out-form-container gh-portal-retention-offer">
             <p className="gh-portal-retention-offer-message">

--- a/apps/portal/src/utils/fixtures.js
+++ b/apps/portal/src/utils/fixtures.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-vars*/
 import {getFreeProduct, getMemberData, getOfferData, getPriceData, getProductData, getSiteData, getSubscriptionData, getTestSite} from './fixtures-generator';
 
 export const testSite = getTestSite();

--- a/apps/portal/src/utils/helpers.js
+++ b/apps/portal/src/utils/helpers.js
@@ -903,7 +903,6 @@ export function getUrlHistory() {
         // Failed to access sessionStorage or something related to that.
         // Log a warning, as this shouldn't happen on a modern browser.
 
-        /* eslint-disable no-console */
         console.warn(`[Portal] Failed to load member URL history:`, error);
     }
 }

--- a/apps/portal/test/utils/test-fixtures.js
+++ b/apps/portal/test/utils/test-fixtures.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-vars*/
 import {getFreeProduct, getMemberData, getOfferData, getPriceData, getProductData, getSiteData, getSubscriptionData, getNewsletterData} from '../../src/utils/fixtures-generator';
 
 export const transformTierFixture = [

--- a/apps/posts/test/unit/hooks/use-feature-flag.test.tsx
+++ b/apps/posts/test/unit/hooks/use-feature-flag.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import {beforeEach, describe, expect, it} from 'vitest';
 import {createTestWrapper, mockServer} from '../../utils/msw-helpers';
 import {renderHook} from '@testing-library/react';

--- a/apps/posts/test/unit/hooks/use-post-feedback.test.tsx
+++ b/apps/posts/test/unit/hooks/use-post-feedback.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import {beforeEach, describe, expect, it} from 'vitest';
 import {createTestWrapper, endpoint, mockServer, when} from '../../utils/msw-helpers';
 import {renderHook, waitFor} from '@testing-library/react';

--- a/apps/posts/test/unit/hooks/use-post-newsletter-stats.test.tsx
+++ b/apps/posts/test/unit/hooks/use-post-newsletter-stats.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import {beforeEach, describe, expect, it} from 'vitest';
 import {createTestWrapper, mockData, mockServer} from '../../utils/msw-helpers';
 import {renderHook, waitFor} from '@testing-library/react';

--- a/apps/posts/test/unit/hooks/use-post-referrers.test.tsx
+++ b/apps/posts/test/unit/hooks/use-post-referrers.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import {beforeEach, describe, expect, it} from 'vitest';
 import {createTestWrapper, mockData, mockServer} from '../../utils/msw-helpers';
 import {renderHook, waitFor} from '@testing-library/react';

--- a/apps/posts/test/utils/test-helpers.ts
+++ b/apps/posts/test/utils/test-helpers.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import React from 'react';
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
 import {

--- a/apps/signup-form/src/utils/helpers.tsx
+++ b/apps/signup-form/src/utils/helpers.tsx
@@ -49,7 +49,6 @@ export function getUrlHistory({siteUrl}: {siteUrl: string}): URLHistory {
     } catch (error) {
         // Most likely an invalid siteUrl
 
-        /* eslint-disable no-console */
         console.warn(`[Signup-Form] Failed to load member URL history:`, error);
     }
 

--- a/apps/stats/test/unit/hooks/use-feature-flag.test.tsx
+++ b/apps/stats/test/unit/hooks/use-feature-flag.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import {beforeEach, describe, expect, it, vi} from 'vitest';
 import {renderHook} from '@testing-library/react';
 import {setupStatsAppMocks} from '../../utils/test-helpers';

--- a/apps/stats/test/utils/test-helpers.ts
+++ b/apps/stats/test/utils/test-helpers.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import {
     createErrorMock,
     createLoadingMock,

--- a/ghost/admin/app/models/role.js
+++ b/ghost/admin/app/models/role.js
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 import Model, {attr} from '@ember-data/model';
 import {computed} from '@ember/object';
 

--- a/ghost/admin/app/models/user.js
+++ b/ghost/admin/app/models/user.js
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 import BaseModel from './base';
 import ValidationEngine from 'ghost-admin/mixins/validation-engine';
 import config from 'ghost-admin/config/environment';

--- a/ghost/admin/app/serializers/action.js
+++ b/ghost/admin/app/serializers/action.js
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 import ApplicationSerializer from 'ghost-admin/serializers/application';
 
 export default class ActionSerializer extends ApplicationSerializer {

--- a/ghost/admin/app/serializers/email.js
+++ b/ghost/admin/app/serializers/email.js
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 import ApplicationSerializer from 'ghost-admin/serializers/application';
 
 export default class EmailSerializer extends ApplicationSerializer {

--- a/ghost/admin/app/serializers/label.js
+++ b/ghost/admin/app/serializers/label.js
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 import ApplicationSerializer from './application';
 import {pluralize} from 'ember-inflector';
 

--- a/ghost/admin/app/serializers/member.js
+++ b/ghost/admin/app/serializers/member.js
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 import ApplicationSerializer from './application';
 import {EmbeddedRecordsMixin} from '@ember-data/serializer/rest';
 

--- a/ghost/admin/app/serializers/newsletter.js
+++ b/ghost/admin/app/serializers/newsletter.js
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 import ApplicationSerializer from './application';
 
 export default class MemberSerializer extends ApplicationSerializer {

--- a/ghost/admin/app/serializers/post-revision.js
+++ b/ghost/admin/app/serializers/post-revision.js
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 import ApplicationSerializer from 'ghost-admin/serializers/application';
 import {EmbeddedRecordsMixin} from '@ember-data/serializer/rest';
 

--- a/ghost/admin/app/serializers/post.js
+++ b/ghost/admin/app/serializers/post.js
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 import ApplicationSerializer from 'ghost-admin/serializers/application';
 import {EmbeddedRecordsMixin} from '@ember-data/serializer/rest';
 

--- a/ghost/admin/app/serializers/tag.js
+++ b/ghost/admin/app/serializers/tag.js
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 import ApplicationSerializer from 'ghost-admin/serializers/application';
 import {pluralize} from 'ember-inflector';
 

--- a/ghost/admin/app/validators/nav-item.js
+++ b/ghost/admin/app/validators/nav-item.js
@@ -20,7 +20,6 @@ export default BaseValidator.create({
     url(model) {
         let url = model.url;
         let hasValidated = model.hasValidated;
-        /* eslint-disable camelcase */
         let validatorOptions = {require_protocol: true};
         /* eslint-enable camelcase */
         let urlRegex = new RegExp(/^(\/|#|[a-zA-Z0-9-]+:)/);

--- a/ghost/admin/mirage/config/invites.js
+++ b/ghost/admin/mirage/config/invites.js
@@ -25,7 +25,6 @@ export default function mockInvites(server) {
             oldInvite.destroy();
         }
 
-        /* eslint-disable camelcase */
         attrs.token = `${invites.all().models.length}-token`;
         attrs.expires = moment.utc().add(1, 'day').valueOf();
         attrs.createdAt = moment.utc().format();

--- a/ghost/admin/mirage/factories/member-activity-event.js
+++ b/ghost/admin/mirage/factories/member-activity-event.js
@@ -15,7 +15,6 @@ const EVENT_TYPES = [
     'email_failed_event'
 ];
 
-/* eslint-disable camelcase */
 export default Factory.extend({
     type() { return faker.helpers.arrayElement([EVENT_TYPES]); },
     createdAt() { return moment.utc().format(); },

--- a/ghost/admin/mirage/fixtures/newsletters.js
+++ b/ghost/admin/mirage/fixtures/newsletters.js
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 export default [
     {
         id: 1,

--- a/ghost/admin/mirage/fixtures/roles.js
+++ b/ghost/admin/mirage/fixtures/roles.js
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 export default [
     {
         id: 1,

--- a/ghost/admin/mirage/fixtures/settings.js
+++ b/ghost/admin/mirage/fixtures/settings.js
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 import moment from 'moment-timezone';
 
 let id = 0;

--- a/ghost/admin/mirage/fixtures/tiers.js
+++ b/ghost/admin/mirage/fixtures/tiers.js
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 export default [
     {
         id: '1',

--- a/ghost/admin/mirage/utils.js
+++ b/ghost/admin/mirage/utils.js
@@ -1,4 +1,3 @@
-/* eslint-disable max-statements-per-line */
 import {Response} from 'miragejs';
 import {isArray} from '@ember/array';
 

--- a/ghost/admin/tests/integration/components/tags/tag-form-test.js
+++ b/ghost/admin/tests/integration/components/tags/tag-form-test.js
@@ -19,7 +19,6 @@ describe.skip('Integration: Component: tags/tag-form', function () {
     setupRenderingTest();
 
     beforeEach(function () {
-        /* eslint-disable camelcase */
         let tag = EmberObject.create({
             id: 1,
             name: 'Test',

--- a/ghost/admin/tests/unit/components/gh-post-settings-menu-test.js
+++ b/ghost/admin/tests/unit/components/gh-post-settings-menu-test.js
@@ -1,4 +1,3 @@
-// /* eslint-disable camelcase */
 // import EmberObject from '@ember/object';
 // import RSVP from 'rsvp';
 // import boundOneWay from 'ghost-admin/utils/bound-one-way';

--- a/ghost/core/bin/minify-assets.js
+++ b/ghost/core/bin/minify-assets.js
@@ -11,7 +11,6 @@
  * in the production build and be able to utilize bundler benefits.
  */
 
-/* eslint-disable no-console */
 const esbuild = require('esbuild');
 const path = require('path');
 const fs = require('fs');

--- a/ghost/core/core/cli/generate-data.js
+++ b/ghost/core/core/cli/generate-data.js
@@ -1,4 +1,3 @@
-/* eslint-disable ghost/filenames/match-exported-class */
 const Command = require('./command');
 const DataGenerator = require('../server/data/seeders/data-generator');
 const config = require('../shared/config');

--- a/ghost/core/core/server/data/tinybird/scripts/docker-analytics-manager.js
+++ b/ghost/core/core/server/data/tinybird/scripts/docker-analytics-manager.js
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-/* eslint-disable ghost/filenames/match-exported-class */
 /* eslint-disable no-console */
 /* eslint-disable ghost/ghost-custom/no-native-error */
 /**

--- a/ghost/core/core/server/data/tinybird/scripts/docker-database-utils.js
+++ b/ghost/core/core/server/data/tinybird/scripts/docker-database-utils.js
@@ -1,4 +1,3 @@
-/* eslint-disable ghost/filenames/match-exported-class */
 /* eslint-disable no-console */
 /**
  * Docker Database Utilities for Ghost Analytics Scripts

--- a/ghost/core/core/server/services/email-address/email-address-service.ts
+++ b/ghost/core/core/server/services/email-address/email-address-service.ts
@@ -1,4 +1,3 @@
-/* eslint-disable ghost/filenames/match-exported-class */
 import logging from '@tryghost/logging';
 import EmailAddressParser, {EmailAddress} from './email-address-parser.js';
 

--- a/ghost/core/core/server/services/offers/offers-module.js
+++ b/ghost/core/core/server/services/offers/offers-module.js
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines */
 // @TODO: Reduce file length and remove the line above
 
 const DomainEvents = require('@tryghost/domain-events');

--- a/ghost/core/test/unit/frontend/helpers/content-api-key.test.js
+++ b/ghost/core/test/unit/frontend/helpers/content-api-key.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-regex-spaces */
 const proxy = require('../../../../core/frontend/services/proxy');
 const {getFrontendKey} = proxy;
 const should = require('should');

--- a/ghost/core/test/unit/frontend/helpers/content-api-url.test.js
+++ b/ghost/core/test/unit/frontend/helpers/content-api-url.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-regex-spaces */
 const should = require('should');
 const sinon = require('sinon');
 const configUtils = require('../../../utils/config-utils');

--- a/ghost/core/test/unit/frontend/helpers/ghost-head.test.js
+++ b/ghost/core/test/unit/frontend/helpers/ghost-head.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-regex-spaces */
 const should = require('should');
 
 const sinon = require('sinon');


### PR DESCRIPTION
no ref

This change should have no user impact. It removes `eslint-disable` directives that don't do anything.

I wrote [a script][0] that deletes each `eslint-disable`, runs `yarn lint`, and puts it back if `yarn lint` suddenly starts failing.

[0]: https://gist.github.com/EvanHahn/3978a721a0d4974e7700eeb9e34818ce
