### PR TITLE
Fixed Content-Type for magic link honeypot response

### DIFF
--- a/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
+++ b/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
@@ -704,7 +704,7 @@ module.exports = class RouterController {
 
             // Honeypot field is filled, this is a bot.
             // Pretend that the email was sent successfully.
-            res.writeHead(201);
+            res.writeHead(201, {'Content-Type': 'application/json'});
             return res.end('{}');
         }
 


### PR DESCRIPTION
ref <https://github.com/TryGhost/Ghost/pull/26022#discussion_r2733556509>

I forgot to set `Content-Type: application/json` in the magic link endpoint's honeypot response. This could let bots know whether they're being detected.

[@coderabbitai pointed this out][0] and I missed it. Taught me not to ignore the automatic review!

[0]: https://github.com/TryGhost/Ghost/pull/26022#discussion_r2733556509
