### PR TITLE
Fixed send-magic-link unit test

### DIFF
--- a/ghost/core/test/e2e-api/members/send-magic-link.test.js
+++ b/ghost/core/test/e2e-api/members/send-magic-link.test.js
@@ -170,7 +170,7 @@ describe('sendMagicLink', function () {
             .expectStatus(201);
 
         assert(res.body.sniperLinks.desktop.startsWith('https://mail.google.com/'));
-        assert(res.body.sniperLinks.android.startsWith('intent://'));
+        assert(res.body.sniperLinks.android.startsWith('intent:'));
     });
 
     it('Creates a valid magic link from custom signup with redirection', async function () {


### PR DESCRIPTION
ref b289c4ee69277a8a2d06ed654c8670ee2d72273f
ref #26023

This fixes a trivial unit test failure with the `send-magic-link` endpoint.

I don't understand how [CI was green with this error][0], but this will fix the error.

[0]: https://github.com/TryGhost/Ghost/pull/26023/checks
