### PR TITLE
Passed transistor feature flag through to editor

### DIFF
--- a/ghost/admin/app/components/koenig-lexical-editor.js
+++ b/ghost/admin/app/components/koenig-lexical-editor.js
@@ -441,7 +441,8 @@ export default class KoenigLexicalEditor extends Component {
             renderLabels: !this.session.user.isContributor,
             feature: {
                 contentVisibility: this.feature.contentVisibility,
-                contentVisibilityAlpha: this.feature.contentVisibilityAlpha
+                contentVisibilityAlpha: this.feature.contentVisibilityAlpha,
+                transistor: this.feature.transistor
             },
             deprecated: { // todo fix typo
                 headerV1: true // if false, shows header v1 in the menu

--- a/ghost/admin/app/services/feature.js
+++ b/ghost/admin/app/services/feature.js
@@ -72,6 +72,7 @@ export default class FeatureService extends Service {
     @feature('editorExcerpt') editorExcerpt;
     @feature('contentVisibility') contentVisibility;
     @feature('contentVisibilityAlpha') contentVisibilityAlpha;
+    @feature('transistor') transistor;
     @feature('tagsX') tagsX;
 
     _user = null;


### PR DESCRIPTION
ref https://linear.app/ghost/issue/NY-963/

This is still very limited functionality. It lets you place the card in the editor, however, we need a custom renderer within Ghost before it can be usable in posts/pages/emails.