### PR TITLE
Improved welcome email user flow

### DIFF
--- a/apps/admin-x-settings/src/components/settings/membership/member-emails.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails.tsx
@@ -3,7 +3,7 @@ import NiceModal from '@ebay/nice-modal-react';
 import React from 'react';
 import TopLevelGroup from '../../top-level-group';
 import WelcomeEmailModal from './member-emails/welcome-email-modal';
-import {Separator, SettingGroupContent, Toggle, showToast, withErrorBoundary} from '@tryghost/admin-x-design-system';
+import {Icon, Separator, SettingGroupContent, Toggle, showToast, withErrorBoundary} from '@tryghost/admin-x-design-system';
 import {checkStripeEnabled, getSettingValues} from '@tryghost/admin-x-framework/api/settings';
 import {useAddAutomatedEmail, useBrowseAutomatedEmails, useEditAutomatedEmail} from '@tryghost/admin-x-framework/api/automated-emails';
 import {useGlobalData} from '../../providers/global-data-provider';
@@ -39,26 +39,32 @@ const EmailPreview: React.FC<{
 
     return (
         <button
-            className='flex w-full cursor-pointer items-center justify-between gap-3 rounded-lg border border-grey-100 bg-grey-50 p-5 text-left transition-all hover:border-grey-200 hover:shadow-sm dark:border-grey-925 dark:bg-grey-975 dark:hover:border-grey-800'
+            className='flex w-full cursor-pointer items-center justify-between gap-6 rounded-lg border border-grey-100 bg-grey-50 p-5 text-left transition-all hover:border-grey-200 hover:shadow-sm dark:border-grey-925 dark:bg-grey-975 dark:hover:border-grey-800'
             data-testid={`${emailType}-welcome-email-preview`}
             type='button'
             onClick={onEdit}
         >
-            <div className='flex items-start gap-3'>
-                {icon ?
-                    <div className='size-10 min-h-10 min-w-10 rounded-sm bg-cover bg-center' style={{
-                        backgroundImage: `url(${icon})`
-                    }} />
-                    :
-                    <div className='flex aspect-square size-10 items-center justify-center overflow-hidden rounded-full p-1 text-white' style={{
-                        backgroundColor: color
-                    }}>
-                        <img className='h-auto w-8' src={FakeLogo} />
+            <div className='flex w-full items-center justify-between'>
+                <div className='flex items-start gap-3'>
+                    {icon ?
+                        <div className='size-10 min-h-10 min-w-10 rounded-sm bg-cover bg-center' style={{
+                            backgroundImage: `url(${icon})`
+                        }} />
+                        :
+                        <div className='flex aspect-square size-10 items-center justify-center overflow-hidden rounded-full p-1 text-white' style={{
+                            backgroundColor: color
+                        }}>
+                            <img className='h-auto w-8' src={FakeLogo} />
+                        </div>
+                    }
+                    <div>
+                        <div className='font-semibold'>{senderName}</div>
+                        <div className='text-sm'>{automatedEmail.subject}</div>
                     </div>
-                }
-                <div>
-                    <div className='font-semibold'>{senderName}</div>
-                    <div className='text-sm'>{automatedEmail.subject}</div>
+                </div>
+                <div className='text-sm font-semibold opacity-100 transition-all hover:opacity-80'>
+                    Edit
+                    {/* <Icon name='pen' size='sm' /> */}
                 </div>
             </div>
             <div onClick={e => e.stopPropagation()}>

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails.tsx
@@ -3,7 +3,7 @@ import NiceModal from '@ebay/nice-modal-react';
 import React from 'react';
 import TopLevelGroup from '../../top-level-group';
 import WelcomeEmailModal from './member-emails/welcome-email-modal';
-import {Button, Separator, SettingGroupContent, Toggle, withErrorBoundary} from '@tryghost/admin-x-design-system';
+import {Separator, SettingGroupContent, Toggle, withErrorBoundary} from '@tryghost/admin-x-design-system';
 import {checkStripeEnabled, getSettingValues} from '@tryghost/admin-x-framework/api/settings';
 import {useAddAutomatedEmail, useBrowseAutomatedEmails, useEditAutomatedEmail} from '@tryghost/admin-x-framework/api/automated-emails';
 import {useGlobalData} from '../../providers/global-data-provider';
@@ -35,7 +35,7 @@ const EmailPreview: React.FC<{
 
     return (
         <button
-            className='flex w-full items-center justify-between gap-3 rounded-lg border border-grey-200 bg-white p-5 text-left transition-all hover:bg-grey-50 dark:border-grey-925 dark:bg-grey-975'
+            className='flex w-full items-center justify-between gap-3 rounded-lg border border-grey-100 bg-grey-50 p-5 text-left transition-all hover:border-grey-200 dark:border-grey-925 dark:bg-grey-975'
             data-testid={`${emailType}-welcome-email-edit-button`}
             type='button'
             onClick={onEdit}

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails.tsx
@@ -80,24 +80,14 @@ const EmailPreview: React.FC<{
 
 const EmailSettingRow: React.FC<{
     title: string,
-    description: string,
-    onEdit: () => void,
-    testId: string
-}> = ({title, description, onEdit, testId}) => {
+    description: string
+}> = ({title, description}) => {
     return (
         <div className='flex items-center justify-between py-4'>
             <div>
                 <div className='font-medium'>{title}</div>
                 <div className='text-sm text-grey-700 dark:text-grey-600'>{description}</div>
             </div>
-            <button
-                className='hidden font-semibold text-green'
-                data-testid={testId}
-                type='button'
-                onClick={onEdit}
-            >
-                Edit
-            </button>
         </div>
     );
 };
@@ -204,11 +194,10 @@ const MemberEmails: React.FC<{ keywords: string[] }> = ({keywords}) => {
                 <Separator />
                 <EmailSettingRow
                     description='Email new free members receive when they join your site.'
-                    testId='free-welcome-email-edit-button'
                     title='Free members welcome email'
-                    onEdit={() => handleEditClick('free')}
                 />
                 <EmailPreview
+                    key={`free-${freeWelcomeEmailEnabled}`}
                     automatedEmail={freeEmailForDisplay}
                     emailType='free'
                     enabled={freeWelcomeEmailEnabled}
@@ -220,11 +209,10 @@ const MemberEmails: React.FC<{ keywords: string[] }> = ({keywords}) => {
                     <div className='mt-4'>
                         <EmailSettingRow
                             description='Sent to new paid members as soon as they start their subscription.'
-                            testId='paid-welcome-email-edit-button'
                             title='Paid members welcome email'
-                            onEdit={() => handleEditClick('paid')}
                         />
                         <EmailPreview
+                            key={`paid-${paidWelcomeEmailEnabled}`}
                             automatedEmail={paidEmailForDisplay}
                             emailType='paid'
                             enabled={paidWelcomeEmailEnabled}

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails.tsx
@@ -54,7 +54,7 @@ const EmailPreview: React.FC<{
                         <div className='flex aspect-square size-10 items-center justify-center overflow-hidden rounded-full p-1 text-white' style={{
                             backgroundColor: color
                         }}>
-                            <img className='h-auto w-8' src={FakeLogo} />
+                            <img alt="Logo" className='h-auto w-8' src={FakeLogo} />
                         </div>
                     }
                     <div>

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails.tsx
@@ -85,7 +85,7 @@ const EmailSettingRow: React.FC<{
                 <div className='text-sm text-grey-700 dark:text-grey-600'>{description}</div>
             </div>
             <button
-                className='font-semibold text-green'
+                className='hidden font-semibold text-green'
                 data-testid={testId}
                 type='button'
                 onClick={onEdit}

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails.tsx
@@ -3,7 +3,7 @@ import NiceModal from '@ebay/nice-modal-react';
 import React from 'react';
 import TopLevelGroup from '../../top-level-group';
 import WelcomeEmailModal from './member-emails/welcome-email-modal';
-import {Icon, Separator, SettingGroupContent, Toggle, showToast, withErrorBoundary} from '@tryghost/admin-x-design-system';
+import {Separator, SettingGroupContent, Toggle, showToast, withErrorBoundary} from '@tryghost/admin-x-design-system';
 import {checkStripeEnabled, getSettingValues} from '@tryghost/admin-x-framework/api/settings';
 import {useAddAutomatedEmail, useBrowseAutomatedEmails, useEditAutomatedEmail} from '@tryghost/admin-x-framework/api/automated-emails';
 import {useGlobalData} from '../../providers/global-data-provider';

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails.tsx
@@ -34,9 +34,11 @@ const EmailPreview: React.FC<{
     const senderName = automatedEmail.sender_name || siteTitle || 'Your Site';
 
     return (
-        <div
-            className='mb-5 flex items-center justify-between gap-3 rounded-lg border border-grey-100 bg-grey-50 p-5 dark:border-grey-925 dark:bg-grey-975'
-            data-testid={`${emailType}-welcome-email-preview`}
+        <button
+            className='flex w-full items-center justify-between gap-3 rounded-lg border border-grey-200 bg-white p-5 text-left transition-all hover:bg-grey-50 dark:border-grey-925 dark:bg-grey-975'
+            data-testid={`${emailType}-welcome-email-edit-button`}
+            type='button'
+            onClick={onEdit}
         >
             <div className={`flex items-start gap-3 ${!enabled ? 'opacity-60' : ''}`}>
                 {icon ?
@@ -55,15 +57,8 @@ const EmailPreview: React.FC<{
                     <div className='text-sm'>{automatedEmail.subject}</div>
                 </div>
             </div>
-            <Button
-                className='border border-grey-200 font-semibold hover:border-grey-300 dark:border-grey-900 dark:hover:border-grey-800 dark:hover:bg-grey-950'
-                color='white'
-                data-testid={`${emailType}-welcome-email-edit-button`}
-                icon='pen'
-                label='Edit'
-                onClick={onEdit}
-            />
-        </div>
+            <div className='green font-semibold'>Edit</div>
+        </button>
     );
 };
 
@@ -182,8 +177,7 @@ const MemberEmails: React.FC<{ keywords: string[] }> = ({keywords}) => {
                     onEdit={() => handleEditClick('free')}
                 />
                 {checkStripeEnabled(settings, config) && (
-                    <>
-                        <Separator />
+                    <div className='mt-4'>
                         <Toggle
                             key={`paid-${isLoading ? 'loading' : paidWelcomeEmail?.status ?? 'none'}`}
                             checked={Boolean(paidWelcomeEmailEnabled)}
@@ -202,7 +196,7 @@ const MemberEmails: React.FC<{ keywords: string[] }> = ({keywords}) => {
                             enabled={paidWelcomeEmailEnabled}
                             onEdit={() => handleEditClick('paid')}
                         />
-                    </>
+                    </div>
                 )}
             </SettingGroupContent>
         </TopLevelGroup>

--- a/apps/admin-x-settings/test/acceptance/membership/member-welcome-emails.test.ts
+++ b/apps/admin-x-settings/test/acceptance/membership/member-welcome-emails.test.ts
@@ -272,40 +272,6 @@ test.describe('Member emails settings', async () => {
             await expect(editButton).toBeEnabled();
         });
 
-        test('Edit button is NOT dimmed when toggle is OFF', async ({page}) => {
-            const configResponse = {
-                config: {
-                    ...responseFixtures.config.config,
-                    labs: {
-                        welcomeEmails: true
-                    }
-                }
-            };
-
-            const emptyAutomatedEmailsFixture = {
-                automated_emails: []
-            };
-
-            await mockApi({page, requests: {
-                ...globalDataRequests,
-                browseConfig: {method: 'GET', path: '/config/', response: configResponse},
-                browseAutomatedEmails: {method: 'GET', path: '/automated_emails/', response: emptyAutomatedEmailsFixture}
-            }});
-
-            await page.goto('/#/memberemails');
-            await page.waitForLoadState('networkidle');
-
-            const section = page.getByTestId('memberemails');
-            await expect(section).toBeVisible({timeout: 10000});
-
-            // Edit button should be fully visible and NOT have dimmed opacity
-            const editButton = section.getByTestId('free-welcome-email-preview');
-            await expect(editButton).toBeVisible();
-            await expect(editButton).toBeEnabled();
-            // The edit button should NOT have reduced opacity
-            await expect(editButton).not.toHaveClass(/opacity-50/);
-        });
-
         test('Clicking Edit when no row exists creates inactive row then opens modal', async ({page}) => {
             const configResponse = {
                 config: {

--- a/apps/admin-x-settings/test/acceptance/membership/member-welcome-emails.test.ts
+++ b/apps/admin-x-settings/test/acceptance/membership/member-welcome-emails.test.ts
@@ -260,7 +260,7 @@ test.describe('Member emails settings', async () => {
             await expect(section).toBeVisible({timeout: 10000});
 
             // Email preview card should be visible even though no DB row exists
-            const emailPreview = section.getByTestId('free-welcome-email-preview');
+            const emailPreview = section.getByTestId('free-welcome-email-edit-button');
             await expect(emailPreview).toBeVisible();
 
             // Should show default subject based on site title from settings

--- a/apps/admin-x-settings/test/acceptance/membership/member-welcome-emails.test.ts
+++ b/apps/admin-x-settings/test/acceptance/membership/member-welcome-emails.test.ts
@@ -47,7 +47,7 @@ test.describe('Member emails settings', async () => {
             await expect(section).toBeVisible({timeout: 10000});
 
             // Click the Edit button on the welcome email preview to open the modal
-            await section.getByTestId('free-welcome-email-edit-button').click();
+            await section.getByTestId('free-welcome-email-preview').click();
 
             const modal = page.getByTestId('welcome-email-modal');
             await expect(modal).toBeVisible();
@@ -96,7 +96,7 @@ test.describe('Member emails settings', async () => {
             await expect(section).toBeVisible({timeout: 10000});
 
             // Click the Edit button on the welcome email preview to open the modal
-            await section.getByTestId('free-welcome-email-edit-button').click();
+            await section.getByTestId('free-welcome-email-preview').click();
 
             const modal = page.getByTestId('welcome-email-modal');
             await expect(modal).toBeVisible();
@@ -135,7 +135,7 @@ test.describe('Member emails settings', async () => {
             await expect(section).toBeVisible({timeout: 10000});
 
             // Open modal
-            await section.getByTestId('free-welcome-email-edit-button').click();
+            await section.getByTestId('free-welcome-email-preview').click();
             const modal = page.getByTestId('welcome-email-modal');
             await expect(modal).toBeVisible();
 
@@ -145,7 +145,7 @@ test.describe('Member emails settings', async () => {
             await expect(page.getByTestId('confirmation-modal')).not.toBeVisible();
 
             // Re-open modal
-            await section.getByTestId('free-welcome-email-edit-button').click();
+            await section.getByTestId('free-welcome-email-preview').click();
             await expect(modal).toBeVisible();
 
             // Edit subject to mark dirty
@@ -192,7 +192,7 @@ test.describe('Member emails settings', async () => {
             await expect(section).toBeVisible({timeout: 10000});
 
             // Click the Edit button on the welcome email preview to open the modal
-            await section.getByTestId('free-welcome-email-edit-button').click();
+            await section.getByTestId('free-welcome-email-preview').click();
 
             const modal = page.getByTestId('welcome-email-modal');
             await expect(modal).toBeVisible();
@@ -260,14 +260,14 @@ test.describe('Member emails settings', async () => {
             await expect(section).toBeVisible({timeout: 10000});
 
             // Email preview card should be visible even though no DB row exists
-            const emailPreview = section.getByTestId('free-welcome-email-edit-button');
+            const emailPreview = section.getByTestId('free-welcome-email-preview');
             await expect(emailPreview).toBeVisible();
 
             // Should show default subject based on site title from settings
             await expect(emailPreview).toContainText('Welcome to');
 
             // Edit button should be visible and enabled
-            const editButton = section.getByTestId('free-welcome-email-edit-button');
+            const editButton = section.getByTestId('free-welcome-email-preview');
             await expect(editButton).toBeVisible();
             await expect(editButton).toBeEnabled();
         });
@@ -299,7 +299,7 @@ test.describe('Member emails settings', async () => {
             await expect(section).toBeVisible({timeout: 10000});
 
             // Edit button should be fully visible and NOT have dimmed opacity
-            const editButton = section.getByTestId('free-welcome-email-edit-button');
+            const editButton = section.getByTestId('free-welcome-email-preview');
             await expect(editButton).toBeVisible();
             await expect(editButton).toBeEnabled();
             // The edit button should NOT have reduced opacity
@@ -351,7 +351,7 @@ test.describe('Member emails settings', async () => {
             await expect(section).toBeVisible({timeout: 10000});
 
             // Click Edit button when no row exists
-            const editButton = section.getByTestId('free-welcome-email-edit-button');
+            const editButton = section.getByTestId('free-welcome-email-preview');
             await editButton.click();
 
             // Verify API was called to create an INACTIVE row
@@ -407,7 +407,7 @@ test.describe('Member emails settings', async () => {
             await expect(section).toBeVisible({timeout: 10000});
 
             // Click Edit button when row already exists
-            const editButton = section.getByTestId('free-welcome-email-edit-button');
+            const editButton = section.getByTestId('free-welcome-email-preview');
             await editButton.click();
 
             // Verify NO POST API was called (no new row created)

--- a/apps/admin-x-settings/test/acceptance/membership/member-welcome-emails.test.ts
+++ b/apps/admin-x-settings/test/acceptance/membership/member-welcome-emails.test.ts
@@ -228,4 +228,368 @@ test.describe('Member emails settings', async () => {
             });
         });
     });
+
+    // NY-842: Tests for editing/viewing welcome emails before activation
+    test.describe('Email preview visibility and edit-before-activation', async () => {
+        test('Email preview card is visible with default subject when no DB row exists', async ({page}) => {
+            // Config with welcomeEmails feature flag enabled
+            const configResponse = {
+                config: {
+                    ...responseFixtures.config.config,
+                    labs: {
+                        welcomeEmails: true
+                    }
+                }
+            };
+
+            // Empty automated_emails response - no DB rows exist
+            const emptyAutomatedEmailsFixture = {
+                automated_emails: []
+            };
+
+            await mockApi({page, requests: {
+                ...globalDataRequests,
+                browseConfig: {method: 'GET', path: '/config/', response: configResponse},
+                browseAutomatedEmails: {method: 'GET', path: '/automated_emails/', response: emptyAutomatedEmailsFixture}
+            }});
+
+            await page.goto('/#/memberemails');
+            await page.waitForLoadState('networkidle');
+
+            const section = page.getByTestId('memberemails');
+            await expect(section).toBeVisible({timeout: 10000});
+
+            // Email preview card should be visible even though no DB row exists
+            const emailPreview = section.getByTestId('free-welcome-email-preview');
+            await expect(emailPreview).toBeVisible();
+
+            // Should show default subject based on site title from settings
+            await expect(emailPreview).toContainText('Welcome to');
+
+            // Edit button should be visible and enabled
+            const editButton = section.getByTestId('free-welcome-email-edit-button');
+            await expect(editButton).toBeVisible();
+            await expect(editButton).toBeEnabled();
+        });
+
+        test('Edit button is NOT dimmed when toggle is OFF', async ({page}) => {
+            const configResponse = {
+                config: {
+                    ...responseFixtures.config.config,
+                    labs: {
+                        welcomeEmails: true
+                    }
+                }
+            };
+
+            const emptyAutomatedEmailsFixture = {
+                automated_emails: []
+            };
+
+            await mockApi({page, requests: {
+                ...globalDataRequests,
+                browseConfig: {method: 'GET', path: '/config/', response: configResponse},
+                browseAutomatedEmails: {method: 'GET', path: '/automated_emails/', response: emptyAutomatedEmailsFixture}
+            }});
+
+            await page.goto('/#/memberemails');
+            await page.waitForLoadState('networkidle');
+
+            const section = page.getByTestId('memberemails');
+            await expect(section).toBeVisible({timeout: 10000});
+
+            // Edit button should be fully visible and NOT have dimmed opacity
+            const editButton = section.getByTestId('free-welcome-email-edit-button');
+            await expect(editButton).toBeVisible();
+            await expect(editButton).toBeEnabled();
+            // The edit button should NOT have reduced opacity
+            await expect(editButton).not.toHaveClass(/opacity-50/);
+        });
+
+        test('Clicking Edit when no row exists creates inactive row then opens modal', async ({page}) => {
+            const configResponse = {
+                config: {
+                    ...responseFixtures.config.config,
+                    labs: {
+                        welcomeEmails: true
+                    }
+                }
+            };
+
+            const emptyAutomatedEmailsFixture = {
+                automated_emails: []
+            };
+
+            // Response after creating the automated email
+            const createdAutomatedEmailResponse = {
+                automated_emails: [{
+                    id: 'new-free-welcome-email-id',
+                    status: 'inactive',
+                    name: 'Welcome Email (Free)',
+                    slug: 'member-welcome-email-free',
+                    subject: 'Welcome to Test Site',
+                    lexical: '{"root":{"children":[]}}',
+                    sender_name: null,
+                    sender_email: null,
+                    sender_reply_to: null,
+                    created_at: '2024-01-01T00:00:00.000Z',
+                    updated_at: null
+                }]
+            };
+
+            const {lastApiRequests} = await mockApi({page, requests: {
+                ...globalDataRequests,
+                browseConfig: {method: 'GET', path: '/config/', response: configResponse},
+                browseAutomatedEmails: {method: 'GET', path: '/automated_emails/', response: emptyAutomatedEmailsFixture},
+                addAutomatedEmail: {method: 'POST', path: '/automated_emails/', response: createdAutomatedEmailResponse}
+            }});
+
+            await page.goto('/#/memberemails');
+            await page.waitForLoadState('networkidle');
+
+            const section = page.getByTestId('memberemails');
+            await expect(section).toBeVisible({timeout: 10000});
+
+            // Click Edit button when no row exists
+            const editButton = section.getByTestId('free-welcome-email-edit-button');
+            await editButton.click();
+
+            // Verify API was called to create an INACTIVE row
+            expect(lastApiRequests.addAutomatedEmail?.body).toMatchObject({
+                automated_emails: [{
+                    status: 'inactive',
+                    slug: 'member-welcome-email-free'
+                }]
+            });
+
+            // Modal should open
+            const modal = page.getByTestId('welcome-email-modal');
+            await expect(modal).toBeVisible();
+        });
+
+        test('Clicking Edit when row exists does NOT create new row, just opens modal', async ({page}) => {
+            const configResponse = {
+                config: {
+                    ...responseFixtures.config.config,
+                    labs: {
+                        welcomeEmails: true
+                    }
+                }
+            };
+
+            const existingAutomatedEmailsFixture = {
+                automated_emails: [{
+                    id: 'free-welcome-email-id',
+                    status: 'inactive',
+                    name: 'Welcome Email (Free)',
+                    slug: 'member-welcome-email-free',
+                    subject: 'Welcome to Test Site',
+                    lexical: '{"root":{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"Welcome!","type":"extended-text","version":1}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}}',
+                    sender_name: null,
+                    sender_email: null,
+                    sender_reply_to: null,
+                    created_at: '2024-01-01T00:00:00.000Z',
+                    updated_at: null
+                }]
+            };
+
+            const {lastApiRequests} = await mockApi({page, requests: {
+                ...globalDataRequests,
+                browseConfig: {method: 'GET', path: '/config/', response: configResponse},
+                browseAutomatedEmails: {method: 'GET', path: '/automated_emails/', response: existingAutomatedEmailsFixture},
+                addAutomatedEmail: {method: 'POST', path: '/automated_emails/', response: existingAutomatedEmailsFixture}
+            }});
+
+            await page.goto('/#/memberemails');
+            await page.waitForLoadState('networkidle');
+
+            const section = page.getByTestId('memberemails');
+            await expect(section).toBeVisible({timeout: 10000});
+
+            // Click Edit button when row already exists
+            const editButton = section.getByTestId('free-welcome-email-edit-button');
+            await editButton.click();
+
+            // Verify NO POST API was called (no new row created)
+            expect(lastApiRequests.addAutomatedEmail).toBeUndefined();
+
+            // Modal should open
+            const modal = page.getByTestId('welcome-email-modal');
+            await expect(modal).toBeVisible();
+        });
+
+        test('Toggle ON when no row exists creates active row', async ({page}) => {
+            const configResponse = {
+                config: {
+                    ...responseFixtures.config.config,
+                    labs: {
+                        welcomeEmails: true
+                    }
+                }
+            };
+
+            const emptyAutomatedEmailsFixture = {
+                automated_emails: []
+            };
+
+            const createdActiveResponse = {
+                automated_emails: [{
+                    id: 'new-free-welcome-email-id',
+                    status: 'active',
+                    name: 'Welcome Email (Free)',
+                    slug: 'member-welcome-email-free',
+                    subject: 'Welcome to Test Site',
+                    lexical: '{"root":{"children":[]}}',
+                    sender_name: null,
+                    sender_email: null,
+                    sender_reply_to: null,
+                    created_at: '2024-01-01T00:00:00.000Z',
+                    updated_at: null
+                }]
+            };
+
+            const {lastApiRequests} = await mockApi({page, requests: {
+                ...globalDataRequests,
+                browseConfig: {method: 'GET', path: '/config/', response: configResponse},
+                browseAutomatedEmails: {method: 'GET', path: '/automated_emails/', response: emptyAutomatedEmailsFixture},
+                addAutomatedEmail: {method: 'POST', path: '/automated_emails/', response: createdActiveResponse}
+            }});
+
+            await page.goto('/#/memberemails');
+            await page.waitForLoadState('networkidle');
+
+            const section = page.getByTestId('memberemails');
+            await expect(section).toBeVisible({timeout: 10000});
+
+            // Toggle ON when no row exists
+            const toggle = section.getByRole('switch').first();
+            await toggle.click();
+
+            // Verify API was called to create an ACTIVE row
+            expect(lastApiRequests.addAutomatedEmail?.body).toMatchObject({
+                automated_emails: [{
+                    status: 'active',
+                    slug: 'member-welcome-email-free'
+                }]
+            });
+        });
+
+        test('Toggle ON when inactive row exists updates to active', async ({page}) => {
+            const configResponse = {
+                config: {
+                    ...responseFixtures.config.config,
+                    labs: {
+                        welcomeEmails: true
+                    }
+                }
+            };
+
+            const inactiveAutomatedEmailsFixture = {
+                automated_emails: [{
+                    id: 'free-welcome-email-id',
+                    status: 'inactive',
+                    name: 'Welcome Email (Free)',
+                    slug: 'member-welcome-email-free',
+                    subject: 'Welcome to Test Site',
+                    lexical: '{"root":{"children":[]}}',
+                    sender_name: null,
+                    sender_email: null,
+                    sender_reply_to: null,
+                    created_at: '2024-01-01T00:00:00.000Z',
+                    updated_at: null
+                }]
+            };
+
+            const updatedActiveResponse = {
+                automated_emails: [{
+                    ...inactiveAutomatedEmailsFixture.automated_emails[0],
+                    status: 'active'
+                }]
+            };
+
+            const {lastApiRequests} = await mockApi({page, requests: {
+                ...globalDataRequests,
+                browseConfig: {method: 'GET', path: '/config/', response: configResponse},
+                browseAutomatedEmails: {method: 'GET', path: '/automated_emails/', response: inactiveAutomatedEmailsFixture},
+                editAutomatedEmail: {method: 'PUT', path: '/automated_emails/free-welcome-email-id/', response: updatedActiveResponse}
+            }});
+
+            await page.goto('/#/memberemails');
+            await page.waitForLoadState('networkidle');
+
+            const section = page.getByTestId('memberemails');
+            await expect(section).toBeVisible({timeout: 10000});
+
+            // Toggle ON when inactive row exists
+            const toggle = section.getByRole('switch').first();
+            await toggle.click();
+
+            // Verify API was called to UPDATE to active status
+            expect(lastApiRequests.editAutomatedEmail?.body).toMatchObject({
+                automated_emails: [{
+                    id: 'free-welcome-email-id',
+                    status: 'active'
+                }]
+            });
+        });
+
+        test('Toggle OFF when active row exists updates to inactive', async ({page}) => {
+            const configResponse = {
+                config: {
+                    ...responseFixtures.config.config,
+                    labs: {
+                        welcomeEmails: true
+                    }
+                }
+            };
+
+            const activeAutomatedEmailsFixture = {
+                automated_emails: [{
+                    id: 'free-welcome-email-id',
+                    status: 'active',
+                    name: 'Welcome Email (Free)',
+                    slug: 'member-welcome-email-free',
+                    subject: 'Welcome to Test Site',
+                    lexical: '{"root":{"children":[]}}',
+                    sender_name: null,
+                    sender_email: null,
+                    sender_reply_to: null,
+                    created_at: '2024-01-01T00:00:00.000Z',
+                    updated_at: null
+                }]
+            };
+
+            const updatedInactiveResponse = {
+                automated_emails: [{
+                    ...activeAutomatedEmailsFixture.automated_emails[0],
+                    status: 'inactive'
+                }]
+            };
+
+            const {lastApiRequests} = await mockApi({page, requests: {
+                ...globalDataRequests,
+                browseConfig: {method: 'GET', path: '/config/', response: configResponse},
+                browseAutomatedEmails: {method: 'GET', path: '/automated_emails/', response: activeAutomatedEmailsFixture},
+                editAutomatedEmail: {method: 'PUT', path: '/automated_emails/free-welcome-email-id/', response: updatedInactiveResponse}
+            }});
+
+            await page.goto('/#/memberemails');
+            await page.waitForLoadState('networkidle');
+
+            const section = page.getByTestId('memberemails');
+            await expect(section).toBeVisible({timeout: 10000});
+
+            // Toggle OFF when active row exists
+            const toggle = section.getByRole('switch').first();
+            await toggle.click();
+
+            // Verify API was called to UPDATE to inactive status
+            expect(lastApiRequests.editAutomatedEmail?.body).toMatchObject({
+                automated_emails: [{
+                    id: 'free-welcome-email-id',
+                    status: 'inactive'
+                }]
+            });
+        });
+    });
 });

--- a/e2e/helpers/pages/admin/settings/sections/member-welcome-emails-section.ts
+++ b/e2e/helpers/pages/admin/settings/sections/member-welcome-emails-section.ts
@@ -18,10 +18,10 @@ export class MemberWelcomeEmailsSection extends BasePage {
     constructor(page: Page) {
         super(page, '/ghost/#/settings/memberemails');
         this.section = page.getByTestId('memberemails');
-        this.freeWelcomeEmailToggle = this.section.getByLabel('Free members');
-        this.paidWelcomeEmailToggle = this.section.getByLabel('Paid members');
-        this.freeWelcomeEmailEditButton = page.getByTestId('free-welcome-email-edit-button');
-        this.paidWelcomeEmailEditButton = page.getByTestId('paid-welcome-email-edit-button');
+        this.freeWelcomeEmailToggle = this.section.getByTestId('free-welcome-email-preview').getByRole('switch');
+        this.paidWelcomeEmailToggle = this.section.getByTestId('paid-welcome-email-preview').getByRole('switch');
+        this.freeWelcomeEmailEditButton = page.getByTestId('free-welcome-email-preview');
+        this.paidWelcomeEmailEditButton = page.getByTestId('paid-welcome-email-preview');
 
         // Modal locators
         this.welcomeEmailModal = page.getByTestId('welcome-email-modal');
@@ -70,12 +70,12 @@ export class MemberWelcomeEmailsSection extends BasePage {
     }
 
     private async waitForFreeToggle(checked: boolean): Promise<void> {
-        const toggle = this.section.getByLabel('Free members').and(this.page.getByRole('switch', {checked}));
+        const toggle = this.section.getByTestId('free-welcome-email-preview').getByRole('switch', {checked});
         await toggle.waitFor({state: 'visible'});
     }
 
     private async waitForPaidToggle(checked: boolean): Promise<void> {
-        const toggle = this.section.getByLabel('Paid members').and(this.page.getByRole('switch', {checked}));
+        const toggle = this.section.getByTestId('paid-welcome-email-preview').getByRole('switch', {checked});
         await toggle.waitFor({state: 'visible'});
     }
 

--- a/e2e/tests/admin/settings/member-welcome-emails.test.ts
+++ b/e2e/tests/admin/settings/member-welcome-emails.test.ts
@@ -51,7 +51,6 @@ test.describe('Ghost Admin - Member Welcome Emails', () => {
         await welcomeEmailsSection.disableFreeWelcomeEmail();
 
         await expect(welcomeEmailsSection.freeWelcomeEmailToggle).toHaveAttribute('aria-checked', 'false');
-        await expect(welcomeEmailsSection.freeWelcomeEmailEditButton).toBeHidden();
 
         // TODO: Update test once full E2E functionality is added for welcome emails
         // We shouldn't assert via API directly, but for now this verifies the toggle works as expected


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-842/editing-viewing-email-before-setting-to-active

- previously a user needed to toggle a welcome email to active before they could edit it because the button was hidden. this meant there was a scenario where a new member could sign up before the admin was done editing, and get the default welcome email text
- this PR updates the UI so that the welcome email can be edited separately from activating it
- also some improvements for accessibility, markup semantics, and keyboard interactivity


![mwe_edit_toggle](https://github.com/user-attachments/assets/5132c1f0-3a2e-4d16-bdb1-5fc11cf5e6e4)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes automated email creation/update flow (including creating inactive rows on edit) and reworks the settings UI interactions; mistakes could lead to incorrect email status or duplicate records.
> 
> **Overview**
> Improves the welcome email settings UX by always showing a clickable preview card (free/paid) and separating the label/description row from the preview+toggle control.
> 
> Clicking the preview now opens the edit modal; if no `automated_emails` row exists yet, it first creates an *inactive* row so emails can be edited before being enabled. Toggling on/off is refactored to a shared create/update helper, adds busy guards, and shows success toasts on enable/disable.
> 
> Acceptance/E2E tests are updated to use the new `*-welcome-email-preview` test IDs and expanded to cover the “no DB row yet” edit/toggle flows.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b3ecef620319ebec4a26422db790226283a00fa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->