### PR TITLE
Updated e2e tests to use official Playwright image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1180,14 +1180,49 @@ jobs:
         env:
           DEPENDENCY_CACHE_KEY: ${{ needs.job_setup.outputs.dependency_cache_key }}
 
-      - name: Setup Playwright
-        uses: ./.github/actions/setup-playwright
+      - name: Get Playwright version
+        id: playwright
+        run: echo "version=$(jq -r '.devDependencies["@playwright/test"]' e2e/package.json)" >> $GITHUB_OUTPUT
 
-      - name: Run e2e tests
+      - name: Pull Playwright image
+        run: docker pull mcr.microsoft.com/playwright:v${{ steps.playwright.outputs.version }}-noble
+
+      - name: Start compose services
         env:
           GHOST_IMAGE_TAG: ${{ steps.load.outputs.image-tag }}
-          TEST_WORKERS_COUNT: 1
-        run: yarn test:e2e:all --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }} --retries=2
+        run: |
+          # Start compose on host where volume paths resolve correctly
+          # --wait may exit non-zero when one-shot services (ghost-migrations) exit with code 0
+          docker compose -f e2e/compose.yml -p ghost-e2e up -d --wait || true
+
+      - name: Fetch Tinybird config
+        run: |
+          mkdir -p e2e/data/state
+          raw_env=$(docker compose -f e2e/compose.yml -p ghost-e2e run --rm -T tb-cli \
+            cat /mnt/shared-config/.env.tinybird 2>/dev/null || true)
+          if [ -n "$raw_env" ]; then
+            workspace_id=$(echo "$raw_env" | grep TINYBIRD_WORKSPACE_ID | cut -d'=' -f2 | tr -d '\r')
+            admin_token=$(echo "$raw_env" | grep TINYBIRD_ADMIN_TOKEN | cut -d'=' -f2 | tr -d '\r')
+            tracker_token=$(echo "$raw_env" | grep TINYBIRD_TRACKER_TOKEN | cut -d'=' -f2 | tr -d '\r')
+            jq -n \
+              --arg wid "$workspace_id" \
+              --arg admin "$admin_token" \
+              --arg tracker "$tracker_token" \
+              '{workspaceId: $wid, adminToken: $admin, trackerToken: $tracker}' > e2e/data/state/tinybird.json
+          fi
+
+      - name: Run tests in Playwright container
+        run: |
+          docker run --rm --network host \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            -v ${{ github.workspace }}:/workspace \
+            -w /workspace/e2e \
+            -e CI=true \
+            -e TEST_WORKERS_COUNT=1 \
+            -e GHOST_E2E_COMPOSE_RUNNING=true \
+            -e GHOST_IMAGE_TAG=${{ steps.load.outputs.image-tag }} \
+            mcr.microsoft.com/playwright:v${{ steps.playwright.outputs.version }}-noble \
+            yarn test:all --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }} --retries=2
 
       - name: Upload blob report to GitHub Actions Artifacts
         if: failure()


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-973

## Summary
Run E2E tests inside a prebuilt Playwright container instead of installing Playwright browsers on the CI host. This simplifies CI setup and ensures consistent browser versions.

## Changes
### CI Workflow:
- Pull mcr.microsoft.com/playwright:v{version}-noble image (version from e2e/package.json)
- Start Docker Compose services on the host before running tests
- Fetch Tinybird config on the host (required because compose CLI cannot run inside container)
- Run tests in the Playwright container with --network host for service access

### E2E Framework:
- Add "external compose mode" (`GHOST_E2E_COMPOSE_RUNNING=true`) for when tests run inside a container
- Skip Docker Compose CLI commands in this mode (volume paths don't resolve inside container)
- Use dockerode API directly for container operations (works via mounted socket)

### Why this approach?
Docker Compose volume mounts use host paths. When running docker compose up from inside a container, the paths in compose.yml (like ../docker/caddy/Caddyfile.e2e) don't exist. By starting compose on the host and running tests in a container with --network host, we get the best of both worlds.

### Results
This change consistently shows a ~15-20 second improvement in CI run time. 

[This workflow run](https://github.com/TryGhost/Ghost/actions/runs/21442394182/job/61749015378) was on this branch when the PR was first opened, with no changes. It's worth nothing that we were making other improvements to the E2E tests while this PR was in flight, such as switching to 8 shards instead of 4 - but the important piece to look at in this case is the Setup Playwright step, which takes 42 seconds.
<img width="800" height="90" alt="Screenshot 2026-02-01 at 6 39 02 PM" src="https://github.com/user-attachments/assets/b6a71145-a114-48b2-9591-f53dfaa8d2a5" />

We can see the improvements from this PR in [this workflow run](https://github.com/TryGhost/Ghost/actions/runs/21502460653/job/61951592214). At first it may seem like there's more steps and they take longer than Setup Playwright from above, but "Start compose services" and "Fetch Tinybird config" were actually happening in roughly the same amount of time at the beginning of "Run e2e tests", and we just couldn't see those steps broken down. They have to happen outside of "Run tests in Playwright container" now because docker compose uses host paths for volume mounts, which don't resolve correctly when running docker compose from inside a container. The services must be started on the host where those paths exist.

Anyway, the real comparison is "Setup Playwright" from before to "Pull Playwright image" now. As you can see, 17 second improvement.
<img width="800" height="202" alt="Screenshot 2026-02-01 at 6 41 33 PM" src="https://github.com/user-attachments/assets/7f47868b-fb8c-4eba-82d4-02b5c40d2c3b" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CI orchestration and E2E environment lifecycle, so failures could block builds or leave stale containers/DB state; production runtime code is unaffected.
> 
> **Overview**
> Switches CI E2E execution to run inside the official Playwright Docker image (version pinned from `e2e/package.json`) instead of using the repo’s Playwright setup action.
> 
> CI now starts `docker compose` services on the host, extracts Tinybird tokens into `e2e/data/state/tinybird.json`, then runs `yarn test:all` inside the Playwright container with the Docker socket mounted and `--network host`.
> 
> The E2E `EnvironmentManager` adds an *external compose mode* (`GHOST_E2E_COMPOSE_RUNNING=true`) that skips compose CLI usage during setup/teardown and uses a reduced cleanup path so containerized test runners can operate against host-started services.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 350e1ab21a55b20d8d094ca1012c754cfbf8122b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->