### PR TITLE
Refactored useFeatureFlag hook to use config instead of settings

### DIFF
--- a/apps/posts/src/hooks/use-feature-flag.tsx
+++ b/apps/posts/src/hooks/use-feature-flag.tsx
@@ -1,5 +1,4 @@
 import {Navigate} from '@tryghost/admin-x-framework';
-import {getSettingValue} from '@tryghost/admin-x-framework/api/settings';
 import {useGlobalData} from '@src/providers/post-analytics-context';
 
 /**
@@ -11,14 +10,10 @@ import {useGlobalData} from '@src/providers/post-analytics-context';
  * @returns An object containing the feature flag status and optional component to render
  */
 export const useFeatureFlag = (flagName: string, fallbackPath: string) => {
-    const {isLoading, settings} = useGlobalData();
+    const {isLoading, data} = useGlobalData();
 
-    // Parse labs settings
-    const labsJSON = getSettingValue<string>(settings, 'labs') || '{}';
-    const labs = JSON.parse(labsJSON);
-
-    // Check if the feature flag is enabled
-    const isEnabled = labs[flagName] === true;
+    // Check if the feature flag is enabled from config.labs
+    const isEnabled = data?.labs?.[flagName] === true;
 
     // If loading, don't make a decision yet
     if (isLoading) {

--- a/apps/posts/test/unit/hooks/use-feature-flag.test.tsx
+++ b/apps/posts/test/unit/hooks/use-feature-flag.test.tsx
@@ -1,183 +1,75 @@
-import {beforeEach, describe, expect, it} from 'vitest';
-import {createTestWrapper, mockServer} from '../../utils/msw-helpers';
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import React from 'react';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
 import {renderHook} from '@testing-library/react';
 import {useFeatureFlag} from '@src/hooks/use-feature-flag';
 
-/*
- * TODO: Fix useFeatureFlag tests - currently failing due to React Context dependency
- *
- * PROBLEM: useFeatureFlag depends on useGlobalData from PostAnalyticsContext, but MSW
- * only mocks HTTP requests, not React Context. The PostAnalyticsProvider requires
- * complex setup with multiple API dependencies.
- *
- * SOLUTIONS:
- * 1. Accept vi.mock for context dependencies (MSW for HTTP, vi.mock for React contexts)
- * 2. Refactor useFeatureFlag to use useBrowseSettings directly instead of useGlobalData
- *    This would make it work perfectly with MSW since it only needs HTTP calls
- * 3. Create a minimal PostAnalyticsContext provider wrapper for tests
- *
- * CURRENT STATUS: Tests skipped since this code is not currently in use
- * When this feature is needed, choose solution #2 (refactor) for better architecture
- */
+vi.mock('@tryghost/admin-x-framework', () => ({
+    Navigate: ({to}: {to: string}) => React.createElement('div', {'data-testid': 'navigate', 'data-to': to})
+}));
 
-describe.skip('useFeatureFlag', () => {
-    beforeEach(() => {
-        mockServer.setup(); // Basic setup with defaults
+vi.mock('@src/providers/post-analytics-context');
+
+describe('useFeatureFlag', () => {
+    let mockUseGlobalData: any;
+
+    beforeEach(async () => {
+        vi.clearAllMocks();
+        mockUseGlobalData = vi.mocked(await import('@src/providers/post-analytics-context')).useGlobalData;
     });
 
-    it('returns loading state when data is loading', () => {
-        // Note: The hook uses useGlobalData which gets settings from the context
-        // The mockServer provides default empty settings, and the hook handles loading internally
-        const {result} = renderHook(() => useFeatureFlag('testFlag', '/fallback'), {
-            wrapper: createTestWrapper()
+    it('returns loading state while data is loading', () => {
+        mockUseGlobalData.mockReturnValue({
+            isLoading: true,
+            data: undefined
         });
 
-        // Since mockServer provides default stable data, isLoading will be false
-        // This tests the actual behavior when settings are available
+        const {result} = renderHook(() => useFeatureFlag('testFlag', '/fallback'));
+
         expect(result.current.isEnabled).toBe(false);
-        expect(result.current.isLoading).toBe(false);
-        expect(result.current.redirect).toBeTruthy();
+        expect(result.current.isLoading).toBe(true);
+        expect(result.current.redirect).toBe(null);
     });
 
-    it('returns enabled state when feature flag is true', () => {
-        mockServer.setup({
-            settings: [
-                {key: 'labs', value: '{"testFlag": true}'}
-            ]
+    it('returns enabled when flag is true', () => {
+        mockUseGlobalData.mockReturnValue({
+            isLoading: false,
+            data: {labs: {testFlag: true}}
         });
 
-        const {result} = renderHook(() => useFeatureFlag('testFlag', '/fallback'), {
-            wrapper: createTestWrapper()
-        });
+        const {result} = renderHook(() => useFeatureFlag('testFlag', '/fallback'));
 
         expect(result.current.isEnabled).toBe(true);
         expect(result.current.isLoading).toBe(false);
         expect(result.current.redirect).toBe(null);
     });
 
-    it('returns disabled state with redirect when feature flag is false', () => {
-        mockServer.setup({
-            settings: [
-                {key: 'labs', value: '{"testFlag": false}'}
-            ]
+    it('returns redirect when flag is explicitly false', () => {
+        mockUseGlobalData.mockReturnValue({
+            isLoading: false,
+            data: {labs: {testFlag: false}}
         });
 
-        const {result} = renderHook(() => useFeatureFlag('testFlag', '/fallback'), {
-            wrapper: createTestWrapper()
-        });
+        const {result} = renderHook(() => useFeatureFlag('testFlag', '/fallback'));
 
         expect(result.current.isEnabled).toBe(false);
         expect(result.current.isLoading).toBe(false);
-        expect(result.current.redirect).toBeTruthy();
+        expect(result.current.redirect).toMatchObject({
+            props: {to: '/fallback'}
+        });
     });
 
-    it('returns disabled state when feature flag is not present', () => {
-        mockServer.setup({
-            settings: [
-                {key: 'labs', value: '{"otherFlag": true}'}
-            ]
+    it('returns redirect when flag is absent', () => {
+        mockUseGlobalData.mockReturnValue({
+            isLoading: false,
+            data: {labs: {otherFlag: true}}
         });
 
-        const {result} = renderHook(() => useFeatureFlag('testFlag', '/fallback'), {
-            wrapper: createTestWrapper()
-        });
+        const {result} = renderHook(() => useFeatureFlag('testFlag', '/fallback'));
 
         expect(result.current.isEnabled).toBe(false);
-        expect(result.current.isLoading).toBe(false);
-        expect(result.current.redirect).toBeTruthy();
-    });
-
-    it('handles invalid JSON gracefully', () => {
-        mockServer.setup({
-            settings: [
-                {key: 'labs', value: 'invalid json'}
-            ]
+        expect(result.current.redirect).toMatchObject({
+            props: {to: '/fallback'}
         });
-
-        expect(() => {
-            renderHook(() => useFeatureFlag('testFlag', '/fallback'), {
-                wrapper: createTestWrapper()
-            });
-        }).toThrow();
-    });
-
-    it('handles null labs setting', () => {
-        mockServer.setup({
-            settings: [
-                {key: 'labs', value: null}
-            ]
-        });
-
-        const {result} = renderHook(() => useFeatureFlag('testFlag', '/fallback'), {
-            wrapper: createTestWrapper()
-        });
-
-        expect(result.current.isEnabled).toBe(false);
-        expect(result.current.isLoading).toBe(false);
-        expect(result.current.redirect).toBeTruthy();
-    });
-
-    it('handles undefined labs setting', () => {
-        mockServer.setup({
-            settings: [
-                {key: 'labs', value: undefined}
-            ]
-        });
-
-        const {result} = renderHook(() => useFeatureFlag('testFlag', '/fallback'), {
-            wrapper: createTestWrapper()
-        });
-
-        expect(result.current.isEnabled).toBe(false);
-        expect(result.current.isLoading).toBe(false);
-        expect(result.current.redirect).toBeTruthy();
-    });
-
-    it('handles empty labs setting', () => {
-        mockServer.setup({
-            settings: [
-                {key: 'labs', value: '{}'}
-            ]
-        });
-
-        const {result} = renderHook(() => useFeatureFlag('testFlag', '/fallback'), {
-            wrapper: createTestWrapper()
-        });
-
-        expect(result.current.isEnabled).toBe(false);
-        expect(result.current.isLoading).toBe(false);
-        expect(result.current.redirect).toBeTruthy();
-    });
-
-    it('handles multiple feature flags in labs', () => {
-        mockServer.setup({
-            settings: [
-                {key: 'labs', value: '{"flag1": true, "testFlag": false, "flag3": true}'}
-            ]
-        });
-
-        const {result} = renderHook(() => useFeatureFlag('testFlag', '/fallback'), {
-            wrapper: createTestWrapper()
-        });
-
-        expect(result.current.isEnabled).toBe(false);
-        expect(result.current.isLoading).toBe(false);
-        expect(result.current.redirect).toBeTruthy();
-    });
-
-    it('works with different flag names', () => {
-        mockServer.setup({
-            settings: [
-                {key: 'labs', value: '{"customFlag": true}'}
-            ]
-        });
-
-        const {result} = renderHook(() => useFeatureFlag('customFlag', '/custom-fallback'), {
-            wrapper: createTestWrapper()
-        });
-
-        expect(result.current.isEnabled).toBe(true);
-        expect(result.current.isLoading).toBe(false);
-        expect(result.current.redirect).toBe(null);
     });
 });

--- a/apps/posts/test/unit/hooks/with-feature-flag.test.tsx
+++ b/apps/posts/test/unit/hooks/with-feature-flag.test.tsx
@@ -1,183 +1,69 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React from 'react';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
-import {createTestWrapper, setupUniversalMocks} from '../../utils/test-helpers';
 import {render, screen} from '@testing-library/react';
 import {withFeatureFlag} from '@src/hooks/with-feature-flag';
 
-// Mock the Navigate component
 vi.mock('@tryghost/admin-x-framework', () => ({
     Navigate: ({to}: {to: string}) => React.createElement('div', {'data-testid': 'navigate', 'data-to': to}, `Redirecting to ${to}`)
 }));
 
-// Centralized API mocking
-vi.mock('@tryghost/admin-x-framework/api/posts');
-vi.mock('@tryghost/admin-x-framework/api/stats');
-vi.mock('@tryghost/admin-x-framework/api/links');
 vi.mock('@src/providers/post-analytics-context');
-vi.mock('@tryghost/admin-x-framework/api/settings');
 
 describe('withFeatureFlag', () => {
     const TestComponent = ({message}: {message: string}) => <div data-testid="test-component">{message}</div>;
-    let wrapper: any;
-    let mocks: any;
+    let mockUseGlobalData: any;
 
     beforeEach(async () => {
         vi.clearAllMocks();
-        wrapper = createTestWrapper();
-
-        // Universal setup - mocks ALL API hooks with sensible defaults
-        mocks = await setupUniversalMocks();
+        mockUseGlobalData = vi.mocked(await import('@src/providers/post-analytics-context')).useGlobalData;
     });
 
-    it('renders the wrapped component when feature flag is enabled', () => {
-        mocks.mockGetSettingValue.mockReturnValue('{"testFlag": true}');
-        mocks.mockUseGlobalData.mockReturnValue({
+    it('renders the wrapped component and forwards props when enabled', () => {
+        mockUseGlobalData.mockReturnValue({
             isLoading: false,
-            settings: [
-                {key: 'labs', value: '{"testFlag": true}'}
-            ]
+            data: {labs: {testFlag: true}}
         });
 
         const WrappedComponent = withFeatureFlag(TestComponent, 'testFlag', '/fallback', 'Test Title');
-
-        render(<WrappedComponent message="Hello World" />, {wrapper});
+        render(<WrappedComponent message="Hello World" />);
 
         expect(screen.getByTestId('test-component')).toBeInTheDocument();
         expect(screen.getByText('Hello World')).toBeInTheDocument();
     });
 
-    it('prevents access when feature flag is disabled', () => {
-        mocks.mockUseGlobalData.mockReturnValue({
+    it('renders redirect when disabled', () => {
+        mockUseGlobalData.mockReturnValue({
             isLoading: false,
-            settings: [
-                {key: 'labs', value: '{"testFlag": false}'}
-            ]
+            data: {labs: {testFlag: false}}
         });
 
         const WrappedComponent = withFeatureFlag(TestComponent, 'testFlag', '/fallback', 'Test Title');
+        render(<WrappedComponent message="Hello World" />);
 
-        render(<WrappedComponent message="Hello World" />, {wrapper});
-
-        // Component should not render when feature is disabled
         expect(screen.queryByTestId('test-component')).not.toBeInTheDocument();
-        expect(screen.queryByText('Hello World')).not.toBeInTheDocument();
+        expect(screen.getByTestId('navigate')).toHaveAttribute('data-to', '/fallback');
     });
 
-    it('prevents access when feature flag is missing', () => {
-        mocks.mockUseGlobalData.mockReturnValue({
-            isLoading: false,
-            settings: [
-                {key: 'labs', value: '{"otherFlag": true}'}
-            ]
-        });
-
-        const WrappedComponent = withFeatureFlag(TestComponent, 'testFlag', '/fallback', 'Test Title');
-
-        render(<WrappedComponent message="Hello World" />, {wrapper});
-
-        // Component should not render when feature flag doesn't exist
-        expect(screen.queryByTestId('test-component')).not.toBeInTheDocument();
-        expect(screen.queryByText('Hello World')).not.toBeInTheDocument();
-    });
-
-    it('shows loading state during data loading', () => {
-        mocks.mockUseGlobalData.mockReturnValue({
+    it('renders loading UI with title while loading', () => {
+        mockUseGlobalData.mockReturnValue({
             isLoading: true,
-            settings: []
+            data: undefined
         });
 
         const WrappedComponent = withFeatureFlag(TestComponent, 'testFlag', '/fallback', 'Test Title');
+        render(<WrappedComponent message="Hello World" />);
 
-        render(<WrappedComponent message="Hello World" />, {wrapper});
-
-        // Component should not render during loading, should show title
         expect(screen.queryByTestId('test-component')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('navigate')).not.toBeInTheDocument();
         expect(screen.getByText('Test Title')).toBeInTheDocument();
     });
 
-    it('passes through props to the wrapped component', () => {
-        mocks.mockGetSettingValue.mockReturnValue('{"analytics": true}');
-        mocks.mockUseGlobalData.mockReturnValue({
-            isLoading: false,
-            settings: [
-                {key: 'labs', value: '{"analytics": true}'}
-            ]
-        });
+    it('sets display name from wrapped component', () => {
+        const Named = withFeatureFlag(TestComponent, 'flag', '/', 'Title');
+        expect(Named.displayName).toBe('withFeatureFlag(TestComponent)');
 
-        const WrappedComponent = withFeatureFlag(TestComponent, 'analytics', '/dashboard', 'Analytics');
-
-        render(<WrappedComponent message="Custom Message" />, {wrapper});
-
-        expect(screen.getByText('Custom Message')).toBeInTheDocument();
-    });
-
-    it('sets correct display name for the wrapped component', () => {
-        const WrappedComponent = withFeatureFlag(TestComponent, 'testFlag', '/fallback', 'Test Title');
-
-        expect(WrappedComponent.displayName).toBe('withFeatureFlag(TestComponent)');
-    });
-
-    it('works with different feature flags', () => {
-        mocks.mockGetSettingValue.mockReturnValue('{"customFeature": true, "otherFeature": false}');
-        mocks.mockUseGlobalData.mockReturnValue({
-            isLoading: false,
-            settings: [
-                {key: 'labs', value: '{"customFeature": true, "otherFeature": false}'}
-            ]
-        });
-
-        const CustomWrapped = withFeatureFlag(TestComponent, 'customFeature', '/home', 'Custom Feature');
-        const OtherWrapped = withFeatureFlag(TestComponent, 'otherFeature', '/home', 'Other Feature');
-
-        render(
-            <div>
-                <CustomWrapped message="Custom Feature Active" />
-                <OtherWrapped message="Other Feature Active" />
-            </div>,
-            {wrapper}
-        );
-
-        // Only the enabled feature should render, disabled shows redirect
-        expect(screen.getByText('Custom Feature Active')).toBeInTheDocument();
-        expect(screen.getByText('Redirecting to /home')).toBeInTheDocument();
-        expect(screen.queryByText('Other Feature Active')).not.toBeInTheDocument();
-    });
-
-    it('handles complex feature flag scenarios', () => {
-        mocks.mockGetSettingValue.mockReturnValue('{"analytics": true, "webAnalytics": false, "trafficAnalytics": true}');
-        mocks.mockUseGlobalData.mockReturnValue({
-            isLoading: false,
-            settings: [
-                {key: 'labs', value: '{"analytics": true, "webAnalytics": false, "trafficAnalytics": true}'}
-            ]
-        });
-
-        const AnalyticsComponent = withFeatureFlag(TestComponent, 'analytics', '/dashboard', 'Analytics');
-        const WebAnalyticsComponent = withFeatureFlag(TestComponent, 'webAnalytics', '/dashboard', 'Web Analytics');
-        const TrafficComponent = withFeatureFlag(TestComponent, 'trafficAnalytics', '/dashboard', 'Traffic');
-
-        render(
-            <div>
-                <AnalyticsComponent message="Analytics Enabled" />
-                <WebAnalyticsComponent message="Web Analytics Enabled" />
-                <TrafficComponent message="Traffic Enabled" />
-            </div>,
-            {wrapper}
-        );
-
-        // Only enabled features should render, disabled shows redirect
-        expect(screen.getByText('Analytics Enabled')).toBeInTheDocument();
-        expect(screen.getByText('Traffic Enabled')).toBeInTheDocument();
-        expect(screen.getByText('Redirecting to /dashboard')).toBeInTheDocument();
-        expect(screen.queryByText('Web Analytics Enabled')).not.toBeInTheDocument();
-    });
-
-    it('works with components that have no display name', () => {
-        const AnonymousComponent = ({text}: {text: string}) => <div>{text}</div>;
-
-        const WrappedComponent = withFeatureFlag(AnonymousComponent, 'testFlag', '/fallback', 'Test');
-
-        expect(WrappedComponent.displayName).toBe('withFeatureFlag(AnonymousComponent)');
+        const Anonymous = withFeatureFlag(({text}: {text: string}) => <div>{text}</div>, 'flag', '/', 'Title');
+        expect(Anonymous.displayName).toBe('withFeatureFlag(Component)');
     });
 });

--- a/apps/posts/test/utils/test-helpers.ts
+++ b/apps/posts/test/utils/test-helpers.ts
@@ -146,7 +146,6 @@ export const setupPostsAppMocks = async () => {
     const mockUseMrrHistory = vi.mocked(await import('@tryghost/admin-x-framework/api/stats')).useMrrHistory;
     const mockUseTopLinks = vi.mocked(await import('@tryghost/admin-x-framework/api/links')).useTopLinks;
     const mockUseGlobalData = vi.mocked(await import('@src/providers/post-analytics-context')).useGlobalData;
-    const mockGetSettingValue = vi.mocked(await import('@tryghost/admin-x-framework/api/settings')).getSettingValue;
 
     // Set up ALL mocks with sensible defaults using centralized fixtures
     mockApiHook<PostsResponseType>(mockGetPost, defaultMockData.postsResponse);
@@ -158,7 +157,6 @@ export const setupPostsAppMocks = async () => {
     mockApiHook<MrrHistoryResponseType>(mockUseMrrHistory, responseFixtures.mrrHistory);
     mockApiHook<LinkResponseType>(mockUseTopLinks, responseFixtures.links);
     mockUseGlobalData.mockReturnValue(defaultMockData.globalData);
-    mockGetSettingValue.mockReturnValue('{}');
 
     return {
         mockGetPost,
@@ -169,8 +167,7 @@ export const setupPostsAppMocks = async () => {
         mockUsePostGrowthStats,
         mockUseMrrHistory,
         mockUseTopLinks,
-        mockUseGlobalData,
-        mockGetSettingValue
+        mockUseGlobalData
     };
 };
 


### PR DESCRIPTION
The `useFeatureFlag` hook in the posts app was checking feature flags by parsing a JSON string from the settings API, while everywhere else in the codebase reads flags directly from `config.labs`. This created an inconsistency where toggling a feature flag via the Labs settings page wouldn't immediately reflect in components using this hook, since the `FeatureToggle` component updates the config cache but not the settings cache.

This PR simplifies the hook to read directly from `config.labs`, bringing it in line with how other apps check feature flags and ensuring changes are reflected immediately when flags are toggled.