### PR TITLE
Removed accent color override logic from Portal

### DIFF
--- a/apps/portal/src/app.js
+++ b/apps/portal/src/app.js
@@ -580,27 +580,12 @@ export default class App extends React.Component {
         return {};
     }
 
-    /* Get the accent color from data attributes */
-    getColorOverride() {
-        const scriptTag = document.querySelector('script[data-ghost]');
-        if (scriptTag && scriptTag.dataset.accentColor) {
-            return scriptTag.dataset.accentColor;
-        }
-        return false;
-    }
-
     /** Fetch site, member session data and member offers with Ghost Apis  */
     async fetchApiData() {
         const {siteUrl, customSiteUrl, apiUrl, apiKey} = this.props;
         try {
             this.GhostApi = this.props.api || setupGhostApi({siteUrl, apiUrl, apiKey});
             const {site, member, offers} = await this.GhostApi.init();
-
-            const colorOverride = this.getColorOverride();
-            if (colorOverride) {
-                site.accent_color = colorOverride;
-            }
-
             this.setupFirstPromoter({site, member});
             this.setupSentry({site});
             return {site, member, offers};


### PR DESCRIPTION
towards https://linear.app/ghost/issue/NY-943
ref #26030
ref #26043

_This change should have no user impact._

When Portal fetches the site data, it overrides the accent color with the `data-accent-color` attribute on the Portal `<script>` tag. But [that property is set to the same value][0], so it's unnecessary.

As a followup, I removed the code that sets this in the HTML. See #26043.

Tested this manually by changing my accent color and making sure it's correct in Portal:

<p align="center"><img alt="Screenshot" src="https://github.com/user-attachments/assets/852c82ce-e98e-469b-900c-8c0d30cdc1d3"></p>

[0]: https://github.com/TryGhost/Ghost/blob/0a94c3df12ac30359541c48a322dfff5639a6bd9/ghost/core/core/frontend/helpers/ghost_head.js#L60
