### PR TITLE
Refactored bulk operations to use composable where strategies

### DIFF
--- a/ghost/core/core/server/lib/post-revisions.ts
+++ b/ghost/core/core/server/lib/post-revisions.ts
@@ -1,3 +1,5 @@
+import {byIds} from '../models/base/plugins/bulk-filters';
+
 type PostLike = {
     id: string;
     lexical: string;
@@ -143,13 +145,12 @@ export class PostRevisions {
             return;
         }
 
-        await this.model.bulkEdit(revisionIds, 'post_revisions', {
+        await this.model.bulkUpdate('post_revisions', {
             data: {
                 author_id: null
             },
-            column: 'id',
-            transacting: options.transacting,
-            throwErrors: true
+            where: byIds(revisionIds),
+            transacting: options.transacting
         });
     }
 }

--- a/ghost/core/core/server/models/base/plugins/bulk-filters.ts
+++ b/ghost/core/core/server/models/base/plugins/bulk-filters.ts
@@ -1,0 +1,34 @@
+import chunk from 'lodash/chunk';
+import nql from '@tryghost/nql';
+
+export const CHUNK_SIZE = 100;
+
+export type WhereStrategy = Iterable<(qb: import('knex').Knex.QueryBuilder) => void>;
+
+/**
+ * Creates a where strategy that applies an NQL filter to the query builder.
+ * Yields a single query modifier — no chunking.
+ */
+export function* byNQL(filter: string): WhereStrategy {
+    yield (qb) => {
+        nql(filter).querySQL(qb);
+    };
+}
+
+/**
+ * Creates a where strategy that applies whereIn for the given column and values.
+ * Automatically chunks values to avoid SQL parameter limits.
+ */
+export function* byColumnValues(column: string, values: string[], chunkSize: number = CHUNK_SIZE): WhereStrategy {
+    for (const c of chunk(values, chunkSize)) {
+        yield qb => qb.whereIn(column, c);
+    }
+}
+
+/**
+ * Creates a where strategy for matching by id column.
+ * Convenience wrapper around byColumnValues.
+ */
+export function* byIds(ids: string[], chunkSize: number = CHUNK_SIZE): WhereStrategy {
+    yield* byColumnValues('id', ids, chunkSize);
+}

--- a/ghost/core/core/server/services/comments/comments-service.js
+++ b/ghost/core/core/server/services/comments/comments-service.js
@@ -2,7 +2,7 @@ const tpl = require('@tryghost/tpl');
 const errors = require('@tryghost/errors');
 const {MemberCommentEvent} = require('../../../shared/events');
 const DomainEvents = require('@tryghost/domain-events');
-const {byNQL} = require('../../models/base/plugins/bulk-operations');
+const {byNQL} = require('../../models/base/plugins/bulk-filters');
 
 const messages = {
     commentNotFound: 'Comment could not be found',
@@ -462,7 +462,7 @@ class CommentsService {
         await this.models.Comment.bulkUpdate('comments', {
             data: {status},
             where: byNQL(filter)
-        });
+        }, {});
     }
 
     async getMemberIdByUUID(uuid, options) {

--- a/ghost/core/core/server/services/link-tracking/post-link-repository.js
+++ b/ghost/core/core/server/services/link-tracking/post-link-repository.js
@@ -1,5 +1,5 @@
 const FullPostLink = require('./full-post-link');
-const _ = require('lodash');
+const {byIds} = require('../../models/base/plugins/bulk-filters');
 
 /**
  * @typedef {import('bson-objectid').default} ObjectID
@@ -64,11 +64,10 @@ module.exports = class PostLinkRepository {
     }
 
     async updateLinks(linkIds, updateData, options) {
-        const bulkUpdateOptions = _.pick(options, ['transacting']);
-
-        const bulkActionResult = await this.#LinkRedirect.bulkEdit(linkIds, 'redirects', {
-            ...bulkUpdateOptions,
-            data: updateData
+        const affectedRows = await this.#LinkRedirect.bulkUpdate('redirects', {
+            data: updateData,
+            where: byIds(linkIds),
+            transacting: options.transacting
         });
 
         return {
@@ -76,11 +75,11 @@ module.exports = class PostLinkRepository {
                 action: 'updateLink',
                 meta: {
                     stats: {
-                        successful: bulkActionResult.successful,
-                        unsuccessful: bulkActionResult.unsuccessful
+                        successful: affectedRows,
+                        unsuccessful: 0
                     },
-                    errors: bulkActionResult.errors,
-                    unsuccessfulData: bulkActionResult.unsuccessfulData
+                    errors: [],
+                    unsuccessfulData: []
                 }
             }
         };

--- a/ghost/core/test/e2e-api/admin/__snapshots__/members.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/members.test.js.snap
@@ -588,6 +588,62 @@ Object {
 }
 `;
 
+exports[`Members API Bulk operations Can bulk add a label to members 1: [body] 1`] = `
+Object {
+  "bulk": Object {
+    "meta": Object {
+      "errors": Array [],
+      "stats": Object {
+        "successful": 8,
+        "unsuccessful": 0,
+      },
+      "unsuccessfulData": Array [],
+    },
+  },
+}
+`;
+
+exports[`Members API Bulk operations Can bulk add a label to members 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "95",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Members API Bulk operations Can bulk add a label to members with filter 1: [body] 1`] = `
+Object {
+  "bulk": Object {
+    "meta": Object {
+      "errors": Array [],
+      "stats": Object {
+        "successful": 1,
+        "unsuccessful": 0,
+      },
+      "unsuccessfulData": Array [],
+    },
+  },
+}
+`;
+
+exports[`Members API Bulk operations Can bulk add a label to members with filter 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "95",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
 exports[`Members API Bulk operations Can bulk delete a label from members 1: [body] 1`] = `
 Object {
   "bulk": Object {
@@ -828,6 +884,34 @@ Object {
 `;
 
 exports[`Members API Bulk operations Doesn't delete labels apart from the passed label id 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "95",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Members API Bulk operations Handles duplicate labels gracefully when bulk adding 1: [body] 1`] = `
+Object {
+  "bulk": Object {
+    "meta": Object {
+      "errors": Array [],
+      "stats": Object {
+        "successful": 1,
+        "unsuccessful": 0,
+      },
+      "unsuccessfulData": Array [],
+    },
+  },
+}
+`;
+
+exports[`Members API Bulk operations Handles duplicate labels gracefully when bulk adding 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",

--- a/ghost/core/test/unit/server/models/base/plugins/bulk-operations.test.js
+++ b/ghost/core/test/unit/server/models/base/plugins/bulk-operations.test.js
@@ -1,0 +1,112 @@
+const should = require('should');
+const sinon = require('sinon');
+
+// Import the module under test
+const bulkFilters = require('../../../../../../core/server/models/base/plugins/bulk-filters');
+const {byNQL} = bulkFilters;
+
+describe('Models: bulk-operations plugin', function () {
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    describe('byNQL', function () {
+        it('yields a single query modifier function', function () {
+            const strategy = byNQL('status:published');
+            const results = [...strategy];
+
+            results.length.should.equal(1);
+            results[0].should.be.a.Function();
+        });
+
+        it('returns a function that calls nql().querySQL(qb)', function () {
+            const strategy = byNQL('status:published');
+            const [applyWhere] = [...strategy];
+
+            // Verify it's a function - actual NQL integration is tested by E2E tests
+            applyWhere.should.be.a.Function();
+        });
+    });
+
+    describe('byColumnValues', function () {
+        // These tests will fail until Phase 2 implementation
+        it('chunks values into groups of 100 by default', function () {
+            const {byColumnValues} = bulkFilters;
+
+            // Create 150 IDs
+            const ids = Array.from({length: 150}, (_, i) => `id-${i}`);
+            const strategy = byColumnValues('id', ids);
+            const results = [...strategy];
+
+            // Should produce 2 chunks: 100 + 50
+            results.length.should.equal(2);
+        });
+
+        it('yields single chunk for values less than chunk size', function () {
+            const {byColumnValues} = bulkFilters;
+
+            const ids = Array.from({length: 50}, (_, i) => `id-${i}`);
+            const strategy = byColumnValues('id', ids);
+            const results = [...strategy];
+
+            results.length.should.equal(1);
+        });
+
+        it('yields no chunks for empty array', function () {
+            const {byColumnValues} = bulkFilters;
+
+            const strategy = byColumnValues('id', []);
+            const results = [...strategy];
+
+            results.length.should.equal(0);
+        });
+
+        it('applies whereIn to query builder for each chunk', function () {
+            const {byColumnValues} = bulkFilters;
+
+            const ids = ['id-1', 'id-2', 'id-3'];
+            const strategy = byColumnValues('member_id', ids);
+            const [applyWhere] = [...strategy];
+
+            const mockQb = {
+                whereIn: sinon.stub().returnsThis()
+            };
+
+            applyWhere(mockQb);
+
+            mockQb.whereIn.calledOnce.should.be.true();
+            mockQb.whereIn.calledWith('member_id', ids).should.be.true();
+        });
+
+        it('allows custom chunk size', function () {
+            const {byColumnValues} = bulkFilters;
+
+            const ids = Array.from({length: 25}, (_, i) => `id-${i}`);
+            const strategy = byColumnValues('id', ids, 10);
+            const results = [...strategy];
+
+            // Should produce 3 chunks: 10 + 10 + 5
+            results.length.should.equal(3);
+        });
+    });
+
+    describe('byIds', function () {
+        // These tests will fail until Phase 2 implementation
+        it('delegates to byColumnValues with id column', function () {
+            const {byIds} = bulkFilters;
+
+            const ids = ['id-1', 'id-2', 'id-3'];
+            const strategy = byIds(ids);
+            const [applyWhere] = [...strategy];
+
+            const mockQb = {
+                whereIn: sinon.stub().returnsThis()
+            };
+
+            applyWhere(mockQb);
+
+            mockQb.whereIn.calledOnce.should.be.true();
+            mockQb.whereIn.calledWith('id', ids).should.be.true();
+        });
+    });
+});

--- a/ghost/core/test/unit/server/services/link-tracking/post-link-repository.test.js
+++ b/ghost/core/test/unit/server/services/link-tracking/post-link-repository.test.js
@@ -14,12 +14,7 @@ describe('UNIT: PostLinkRepository class', function () {
                         distinct: sinon.stub().returns([])
                     })
                 }),
-                bulkEdit: sinon.stub().returns({
-                    successful: 0,
-                    unsuccessful: 0,
-                    errors: [],
-                    unsuccessfulData: []
-                })
+                bulkUpdate: sinon.stub().resolves(0)
             },
             linkRedirectRepository: {}
         });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3184

## Summary

Ghost's bulk operations (`bulkEdit`, `bulkDestroy`) coupled query construction with execution — callers fetched ID arrays, then passed them into methods that iterated those arrays with chunked `whereIn` clauses. This worked, but every bulk operation followed the same two-step pattern regardless of whether the ID fetch was necessary.

This PR replaces `bulkEdit` and `bulkDestroy` with `bulkUpdate` and `bulkDelete` that accept composable *where strategies* — generator functions (`byNQL`, `byIds`, `byColumnValues`) that yield query modifier callbacks. The strategies handle their own chunking internally, and the bulk methods simply iterate whatever the strategy yields.

The practical benefit is that direct-table operations (comment status updates, link redirect updates) can now pass an NQL filter straight through via `byNQL`, skipping the fetch-all-IDs round trip entirely. Junction-table operations (members_newsletters, members_labels, posts_products) still need to fetch parent IDs first because the API filter targets the parent table, not the junction — so those use `byIds` or `byColumnValues` with the same two-step flow, just through the cleaner strategy interface.

Action logging (`addActions` for the audit trail) is preserved via an explicit `actionOptions` parameter separated from query parameters, making the contract clearer than the previous approach where logging options were mixed into the same object as query data.

The first commit adds missing E2E test coverage for the `addLabel` bulk member operation (which previously had none, unlike `removeLabel`). These tests pass against the original implementation and establish baseline coverage before the refactor.
