### PR TITLE
Removed i18n labs flag; it's been on since 2024

### DIFF
--- a/apps/admin-x-settings/src/components/settings/growth/embed-signup/embed-signup-form-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/embed-signup/embed-signup-form-modal.tsx
@@ -11,8 +11,6 @@ import {useGlobalData} from '../../../providers/global-data-provider';
 import {useRouting} from '@tryghost/admin-x-framework/routing';
 
 const EmbedSignupFormModal = NiceModal.create(() => {
-    let i18nEnabled = false;
-
     const [selectedColor, setSelectedColor] = useState<string>('#08090c');
     const [selectedLabels, setSelectedLabels] = useState<SelectedLabelTypes[]>([]);
     const [selectedLayout, setSelectedLayout] = useState<string>('all-in-one');
@@ -23,12 +21,8 @@ const EmbedSignupFormModal = NiceModal.create(() => {
     const {updateRoute} = useRouting();
     const {config} = useGlobalData();
     const {localSettings, siteData} = useSettingGroup();
-    const [accentColor, title, description, locale, labs, icon] = getSettingValues<string>(localSettings, ['accent_color', 'title', 'description', 'locale', 'labs', 'icon']);
+    const [accentColor, title, description, locale, icon] = getSettingValues<string>(localSettings, ['accent_color', 'title', 'description', 'locale', 'icon']);
     const [customColor, setCustomColor] = useState<{active: boolean}>({active: false});
-
-    if (labs) {
-        i18nEnabled = JSON.parse(labs).i18n;
-    }
 
     useEffect(() => {
         if (!siteData) {
@@ -52,8 +46,7 @@ const EmbedSignupFormModal = NiceModal.create(() => {
             },
             labels: selectedLabels.map(({label}) => ({name: label})),
             backgroundColor: selectedColor || '#08090c',
-            layout: selectedLayout,
-            i18nEnabled
+            layout: selectedLayout
         };
 
         const previewCode = generateCode({
@@ -67,7 +60,7 @@ const EmbedSignupFormModal = NiceModal.create(() => {
             ...defaultConfig
         });
         setGeneratedScript(generatedCode);
-    }, [siteData, accentColor, selectedLabels, config, title, selectedColor, selectedLayout, locale, i18nEnabled, icon, description]);
+    }, [siteData, accentColor, selectedLabels, config, title, selectedColor, selectedLayout, locale, icon, description]);
 
     const handleCopyClick = async () => {
         try {

--- a/apps/admin-x-settings/src/utils/generate-embed-code.ts
+++ b/apps/admin-x-settings/src/utils/generate-embed-code.ts
@@ -14,12 +14,11 @@ export type GenerateCodeOptions = {
         icon?: string;
         title?: string;
         description?: string;
-        locale?: string;
+        locale: string;
     };
     labels: Array<{ name: string }>;
     backgroundColor: string;
     layout: string;
-    i18nEnabled: boolean;
 };
 
 type OptionsType = {
@@ -36,21 +35,17 @@ export const generateCode = ({
     settings,
     labels,
     backgroundColor,
-    layout,
-    i18nEnabled
+    layout
 }: GenerateCodeOptions) => {
     const siteUrl = config.blogUrl;
     const scriptUrl = config.signupForm.url.replace('{version}', config.signupForm.version);
 
     let options: OptionsType = {
         site: siteUrl,
+        locale: settings.locale,
         'button-color': settings.accentColor,
         'button-text-color': textColorForBackgroundColor(settings.accentColor).hex()
     };
-
-    if (i18nEnabled && settings.locale) {
-        options.locale = settings.locale;
-    }
 
     for (const [i, label] of labels.entries()) {
         options[`label-${i + 1}`] = label.name;

--- a/apps/admin-x-settings/test/unit/utils/generate-embed-code.test.ts
+++ b/apps/admin-x-settings/test/unit/utils/generate-embed-code.test.ts
@@ -15,57 +15,51 @@ describe('generateCode', function () {
                 }
             },
             settings: {
-                accentColor: '#000000'
+                accentColor: '#000000',
+                locale: 'af'
             },
             labels: [],
             backgroundColor: '#000000',
-            layout: 'minimal',
-            i18nEnabled: false
+            layout: 'minimal'
         };
     });
 
     it('generates a basic embed script', function () {
-        assert.equal(generateCode(genOptions), '<div style="min-height: 58px;max-width: 440px;margin: 0 auto;width: 100%"><script src="https://example.com" data-button-color="#000000" data-button-text-color="#FFFFFF" data-site="https://example.com" async></script></div>');
-    });
-
-    it('generates a basic embed script with i18n', function () {
-        genOptions.i18nEnabled = true;
-        genOptions.settings.locale = 'af';
         assert.equal(generateCode(genOptions), '<div style="min-height: 58px;max-width: 440px;margin: 0 auto;width: 100%"><script src="https://example.com" data-button-color="#000000" data-button-text-color="#FFFFFF" data-site="https://example.com" data-locale="af" async></script></div>');
     });
 
     it('generates a basic embed script with labels', function () {
         genOptions.labels = [{name: 'label1'}, {name: 'label2'}];
-        assert.equal(generateCode(genOptions), '<div style="min-height: 58px;max-width: 440px;margin: 0 auto;width: 100%"><script src="https://example.com" data-label-1="label1" data-label-2="label2" data-button-color="#000000" data-button-text-color="#FFFFFF" data-site="https://example.com" async></script></div>');
+        assert.equal(generateCode(genOptions), '<div style="min-height: 58px;max-width: 440px;margin: 0 auto;width: 100%"><script src="https://example.com" data-label-1="label1" data-label-2="label2" data-button-color="#000000" data-button-text-color="#FFFFFF" data-site="https://example.com" data-locale="af" async></script></div>');
     });
 
     it('generated an embed with an icon', function () {
         genOptions.settings.icon = 'https://example.com/content/images/size/w256h256/2023/09/snoopy.png';
         genOptions.layout = 'all-in-one';
-        assert.equal(generateCode(genOptions), '<div style="height: 40vmin;min-height: 360px"><script src="https://example.com" data-background-color="#000000" data-text-color="#FFFFFF" data-button-color="#000000" data-button-text-color="#FFFFFF" data-title="" data-description="" data-icon="https://example.com/content/images/size/w192h192/size/w256h256/2023/09/snoopy.png" data-site="https://example.com" async></script></div>');
+        assert.equal(generateCode(genOptions), '<div style="height: 40vmin;min-height: 360px"><script src="https://example.com" data-background-color="#000000" data-text-color="#FFFFFF" data-button-color="#000000" data-button-text-color="#FFFFFF" data-title="" data-description="" data-icon="https://example.com/content/images/size/w192h192/size/w256h256/2023/09/snoopy.png" data-site="https://example.com" data-locale="af" async></script></div>');
     });
 
     it('renders a full preview', function () {
         genOptions.preview = true;
         genOptions.layout = 'all-in-one';
-        assert.equal(generateCode(genOptions), '<div style="height: 100vh"><script src="https://example.com" data-background-color="#000000" data-text-color="#FFFFFF" data-button-color="#000000" data-button-text-color="#FFFFFF" data-title="" data-description="" data-site="https://example.com" async></script></div>');
+        assert.equal(generateCode(genOptions), '<div style="height: 100vh"><script src="https://example.com" data-background-color="#000000" data-text-color="#FFFFFF" data-button-color="#000000" data-button-text-color="#FFFFFF" data-title="" data-description="" data-site="https://example.com" data-locale="af" async></script></div>');
     });
 
     it('renders a preview with a minimal layout', function () {
         genOptions.preview = true;
         genOptions.layout = 'minimal';
-        assert.equal(generateCode(genOptions), '<div style="position: absolute; z-index: -1; top: 0; left: 0; width: 100%; height: 100%; background-image: linear-gradient(45deg, #eee 25%, transparent 25%, transparent 75%, #eee 75%), linear-gradient(45deg, #eee 25%, transparent 25%, transparent 75%, #eee 75%);background-size: 16px 16px;background-position: 0 0, 8px 8px;;"></div><div style="min-height: 58px; max-width: 440px;width: 100%;position: absolute; left: 50%; top:50%; transform: translate(-50%, -50%);"><script src="https://example.com" data-button-color="#000000" data-button-text-color="#FFFFFF" data-site="https://example.com" async></script></div>');
+        assert.equal(generateCode(genOptions), '<div style="position: absolute; z-index: -1; top: 0; left: 0; width: 100%; height: 100%; background-image: linear-gradient(45deg, #eee 25%, transparent 25%, transparent 75%, #eee 75%), linear-gradient(45deg, #eee 25%, transparent 25%, transparent 75%, #eee 75%);background-size: 16px 16px;background-position: 0 0, 8px 8px;;"></div><div style="min-height: 58px; max-width: 440px;width: 100%;position: absolute; left: 50%; top:50%; transform: translate(-50%, -50%);"><script src="https://example.com" data-button-color="#000000" data-button-text-color="#FFFFFF" data-site="https://example.com" data-locale="af" async></script></div>');
     });
 
     it('generates text color based on background color - light background, black text', function () {
         genOptions.backgroundColor = '#ffffff';
         genOptions.layout = 'all-in-one';
-        assert.equal(generateCode(genOptions), '<div style="height: 40vmin;min-height: 360px"><script src="https://example.com" data-background-color="#ffffff" data-text-color="#000000" data-button-color="#000000" data-button-text-color="#FFFFFF" data-title="" data-description="" data-site="https://example.com" async></script></div>');
+        assert.equal(generateCode(genOptions), '<div style="height: 40vmin;min-height: 360px"><script src="https://example.com" data-background-color="#ffffff" data-text-color="#000000" data-button-color="#000000" data-button-text-color="#FFFFFF" data-title="" data-description="" data-site="https://example.com" data-locale="af" async></script></div>');
     });
 
     it('generates text color based on background color - black background, light text', function () {
         genOptions.backgroundColor = '#000000';
         genOptions.layout = 'all-in-one';
-        assert.equal(generateCode(genOptions), '<div style="height: 40vmin;min-height: 360px"><script src="https://example.com" data-background-color="#000000" data-text-color="#FFFFFF" data-button-color="#000000" data-button-text-color="#FFFFFF" data-title="" data-description="" data-site="https://example.com" async></script></div>');
+        assert.equal(generateCode(genOptions), '<div style="height: 40vmin;min-height: 360px"><script src="https://example.com" data-background-color="#000000" data-text-color="#FFFFFF" data-button-color="#000000" data-button-text-color="#FFFFFF" data-title="" data-description="" data-site="https://example.com" data-locale="af" async></script></div>');
     });
 });

--- a/ghost/admin/app/services/feature.js
+++ b/ghost/admin/app/services/feature.js
@@ -65,7 +65,6 @@ export default class FeatureService extends Service {
     @feature('webmentions') webmentions;
     @feature('stripeAutomaticTax') stripeAutomaticTax;
     @feature('emailCustomization') emailCustomization;
-    @feature('i18n') i18n;
     @feature('announcementBar') announcementBar;
     @feature('importMemberTier') importMemberTier;
     @feature('lexicalIndicators') lexicalIndicators;

--- a/ghost/core/core/frontend/helpers/comments.js
+++ b/ghost/core/core/frontend/helpers/comments.js
@@ -1,5 +1,5 @@
 const {SafeString} = require('../services/handlebars');
-const {labs, urlUtils, getFrontendKey, settingsCache} = require('../services/proxy');
+const {urlUtils, getFrontendKey, settingsCache} = require('../services/proxy');
 const {getFrontendAppConfig, getDataAttributes} = require('../utils/frontend-apps');
 
 module.exports = async function comments(options) {
@@ -53,7 +53,7 @@ module.exports = async function comments(options) {
     const {scriptUrl} = getFrontendAppConfig('comments');
 
     const data = {
-        locale: labs.isSet('i18n') ? (settingsCache.get('locale') || 'en') : undefined,
+        locale: settingsCache.get('locale') || 'en',
         'ghost-comments': urlUtils.getSiteUrl(),
         api: urlUtils.urlFor('api', {type: 'content'}, true),
         admin: urlUtils.urlFor('admin', true),

--- a/ghost/core/core/frontend/helpers/ghost_head.js
+++ b/ghost/core/core/frontend/helpers/ghost_head.js
@@ -2,7 +2,7 @@
 // Usage: `{{ghost_head}}`
 //
 // Outputs scripts and other assets at the top of a Ghost theme
-const {labs, metaData, settingsCache, config, blogIcon, urlUtils, getFrontendKey, settingsHelpers} = require('../services/proxy');
+const {metaData, settingsCache, config, blogIcon, urlUtils, getFrontendKey, settingsHelpers} = require('../services/proxy');
 const {escapeExpression, SafeString} = require('../services/handlebars');
 const {generateCustomFontCss, isValidCustomFont, isValidCustomHeadingFont} = require('@tryghost/custom-fonts');
 // BAD REQUIRE
@@ -59,7 +59,7 @@ function getMembersHelper(data, frontendKey, excludeList) {
 
         const colorString = (_.has(data, 'site._preview') && data.site.accent_color) ? data.site.accent_color : '';
         const attributes = {
-            i18n: labs.isSet('i18n'),
+            i18n: true,
             ghost: urlUtils.getSiteUrl(),
             key: frontendKey,
             api: urlUtils.urlFor('api', {type: 'content'}, true),
@@ -95,7 +95,7 @@ function getSearchHelper(frontendKey) {
         key: frontendKey,
         styles: stylesUrl,
         'sodo-search': adminUrl,
-        locale: labs.isSet('i18n') ? (settingsCache.get('locale') || 'en') : undefined
+        locale: settingsCache.get('locale') || 'en'
     };
     const dataAttrs = getDataAttributes(attrs);
     let helper = `<script defer src="${scriptUrl}" ${dataAttrs} crossorigin="anonymous"></script>`;

--- a/ghost/core/core/server/services/email-service/email-renderer.js
+++ b/ghost/core/core/server/services/email-service/email-renderer.js
@@ -232,10 +232,6 @@ class EmailRenderer {
     #getValidLocale() {
         let locale = this.#settingsCache.get('locale') || DEFAULT_LOCALE;
 
-        if (!this.#labs.isSet('i18n')) {
-            locale = DEFAULT_LOCALE;
-        }
-
         // Remove any trailing whitespace
         locale = locale.trim();
 

--- a/ghost/core/core/server/services/i18n.js
+++ b/ghost/core/core/server/services/i18n.js
@@ -7,30 +7,13 @@ module.exports.init = function () {
     const i18n = require('@tryghost/i18n');
     const events = require('../lib/common/events');
     const settingsCache = require('../../shared/settings-cache');
-    const labs = require('../../shared/labs');
 
-    let locale = 'en';
-
-    if (labs.isSet('i18n')) {
-        locale = settingsCache.get('locale');
-    }
+    const locale = settingsCache.get('locale') || 'en';
 
     module.exports = i18nInstance = i18n(locale, 'ghost');
-    /*  TODO: dead code  (i18n is now always on)
-    events.on('settings.labs.edited', () => {
-        if (labs.isSet('i18n')) {
-            debug('labs i18n enabled, updating i18n to', settingsCache.get('locale'));
-            i18nInstance.changeLanguage(settingsCache.get('locale'));
-        } else {
-            debug('labs i18n disabled, updating i18n to en');
-            i18nInstance.changeLanguage('en');
-        }
-    }); */
 
     events.on('settings.locale.edited', (model) => {
-        if (labs.isSet('i18n')) {
-            debug('locale changed, updating i18n to', model.get('value'));
-            i18nInstance.changeLanguage(model.get('value'));
-        }
+        debug('locale changed, updating i18n to', model.get('value'));
+        i18nInstance.changeLanguage(model.get('value'));
     });
 };

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -22,7 +22,6 @@ const messages = {
 // flags in this list always return `true`, allows quick global enable prior to full flag removal
 const GA_FEATURES = [
     'audienceFeedback',
-    'i18n',
     'themeErrorsNotification',
     'announcementBar',
     'customFonts',

--- a/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
@@ -21,7 +21,6 @@ Object {
       "emailUniqueid": true,
       "explore": true,
       "featurebaseFeedback": true,
-      "i18n": true,
       "importMemberTier": true,
       "indexnow": true,
       "lexicalIndicators": true,

--- a/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
@@ -1603,7 +1603,7 @@ exports[`Settings API Edit can edit Stripe settings when Stripe Connect limit is
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "4788",
+  "content-length": "4774",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/unit/frontend/helpers/__snapshots__/ghost-head.test.js.snap
+++ b/ghost/core/test/unit/frontend/helpers/__snapshots__/ghost-head.test.js.snap
@@ -3340,58 +3340,7 @@ Object {
 }
 `;
 
-exports[`{{ghost_head}} helper search scripts does not incldue locale in search when i18n is disabled 1 1`] = `
-Object {
-  "rendered": "<meta name=\\"description\\" content=\\"site description\\">
-    <link rel=\\"canonical\\" href=\\"http://127.0.0.1:2369/\\">
-    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
-    
-    <meta property=\\"og:site_name\\" content=\\"Ghost\\">
-    <meta property=\\"og:type\\" content=\\"website\\">
-    <meta property=\\"og:title\\" content=\\"Ghost\\">
-    <meta property=\\"og:description\\" content=\\"site description\\">
-    <meta property=\\"og:url\\" content=\\"http://127.0.0.1:2369/\\">
-    <meta property=\\"og:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\">
-    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\">
-    <meta name=\\"twitter:title\\" content=\\"Ghost\\">
-    <meta name=\\"twitter:description\\" content=\\"site description\\">
-    <meta name=\\"twitter:url\\" content=\\"http://127.0.0.1:2369/\\">
-    <meta name=\\"twitter:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\">
-    
-    <script type=\\"application/ld+json\\">
-{
-    \\"@context\\": \\"https://schema.org\\",
-    \\"@type\\": \\"WebSite\\",
-    \\"publisher\\": {
-        \\"@type\\": \\"Organization\\",
-        \\"name\\": \\"Ghost\\",
-        \\"url\\": \\"http://127.0.0.1:2369/\\",
-        \\"logo\\": {
-            \\"@type\\": \\"ImageObject\\",
-            \\"url\\": \\"http://127.0.0.1:2369/favicon.ico\\"
-        }
-    },
-    \\"url\\": \\"http://127.0.0.1:2369/\\",
-    \\"name\\": \\"Ghost\\",
-    \\"image\\": {
-        \\"@type\\": \\"ImageObject\\",
-        \\"url\\": \\"http://127.0.0.1:2369/content/images/site-cover.png\\"
-    },
-    \\"mainEntityOfPage\\": \\"http://127.0.0.1:2369/\\",
-    \\"description\\": \\"site description\\"
-}
-    </script>
-
-    <meta name=\\"generator\\" content=\\"Ghost 4.3\\">
-    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
-    
-    <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" crossorigin=\\"anonymous\\"></script>
-    
-    <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">",
-}
-`;
-
-exports[`{{ghost_head}} helper search scripts includes locale in search when i18n is enabled 1 1`] = `
+exports[`{{ghost_head}} helper search scripts includes locale in search 1 1`] = `
 Object {
   "rendered": "<meta name=\\"description\\" content=\\"site description\\">
     <link rel=\\"canonical\\" href=\\"http://127.0.0.1:2369/\\">
@@ -3438,6 +3387,57 @@ Object {
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
+    <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">",
+}
+`;
+
+exports[`{{ghost_head}} helper search scripts includes locale in search when i18n is enabled 1 1`] = `
+Object {
+  "rendered": "<meta name=\\"description\\" content=\\"site description\\">
+    <link rel=\\"canonical\\" href=\\"http://127.0.0.1:2369/\\">
+    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
+
+    <meta property=\\"og:site_name\\" content=\\"Ghost\\">
+    <meta property=\\"og:type\\" content=\\"website\\">
+    <meta property=\\"og:title\\" content=\\"Ghost\\">
+    <meta property=\\"og:description\\" content=\\"site description\\">
+    <meta property=\\"og:url\\" content=\\"http://127.0.0.1:2369/\\">
+    <meta property=\\"og:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\">
+    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\">
+    <meta name=\\"twitter:title\\" content=\\"Ghost\\">
+    <meta name=\\"twitter:description\\" content=\\"site description\\">
+    <meta name=\\"twitter:url\\" content=\\"http://127.0.0.1:2369/\\">
+    <meta name=\\"twitter:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\">
+
+    <script type=\\"application/ld+json\\">
+{
+    \\"@context\\": \\"https://schema.org\\",
+    \\"@type\\": \\"WebSite\\",
+    \\"publisher\\": {
+        \\"@type\\": \\"Organization\\",
+        \\"name\\": \\"Ghost\\",
+        \\"url\\": \\"http://127.0.0.1:2369/\\",
+        \\"logo\\": {
+            \\"@type\\": \\"ImageObject\\",
+            \\"url\\": \\"http://127.0.0.1:2369/favicon.ico\\"
+        }
+    },
+    \\"url\\": \\"http://127.0.0.1:2369/\\",
+    \\"name\\": \\"Ghost\\",
+    \\"image\\": {
+        \\"@type\\": \\"ImageObject\\",
+        \\"url\\": \\"http://127.0.0.1:2369/content/images/site-cover.png\\"
+    },
+    \\"mainEntityOfPage\\": \\"http://127.0.0.1:2369/\\",
+    \\"description\\": \\"site description\\"
+}
+    </script>
+
+    <meta name=\\"generator\\" content=\\"Ghost 4.3\\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
+
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
+
     <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">",
 }
 `;

--- a/ghost/core/test/unit/frontend/helpers/ghost-head.test.js
+++ b/ghost/core/test/unit/frontend/helpers/ghost-head.test.js
@@ -15,7 +15,7 @@ const logging = require('@tryghost/logging');
 
 const ghost_head = require('../../../../core/frontend/helpers/ghost_head');
 const proxy = require('../../../../core/frontend/services/proxy');
-const {settingsCache, labs, settingsHelpers} = proxy;
+const {settingsCache, settingsHelpers} = proxy;
 
 /**
  * This test helper asserts that the helper response matches the stored snapshot. This helps us detect issues where we
@@ -1270,9 +1270,7 @@ describe('{{ghost_head}} helper', function () {
             rendered.should.match(/sodo-search@/);
         });
 
-        it('includes locale in search when i18n is enabled', async function () {
-            sinon.stub(labs, 'isSet').withArgs('i18n').returns(true);
-
+        it('includes locale in search', async function () {
             const rendered = await testGhostHead(testUtils.createHbsResponse({
                 locals: {
                     relativeUrl: '/',
@@ -1282,20 +1280,6 @@ describe('{{ghost_head}} helper', function () {
             }));
 
             rendered.should.match(/sodo-search@[^>]*?data-locale="en"/);
-        });
-
-        it('does not incldue locale in search when i18n is disabled', async function () {
-            sinon.stub(labs, 'isSet').withArgs('i18n').returns(false);
-
-            const rendered = await testGhostHead(testUtils.createHbsResponse({
-                locals: {
-                    relativeUrl: '/',
-                    context: ['home', 'index'],
-                    safeVersion: '4.3'
-                }
-            }));
-
-            rendered.should.not.match(/sodo-search@[^>]*?data-locale="en"/);
         });
     });
 
@@ -1328,7 +1312,6 @@ describe('{{ghost_head}} helper', function () {
     });
 
     describe('includes tinybird tracker script when config is set', function () {
-        let labsStub;
         let settingsHelpersStub;
 
         function setAnalyticsFlags({analytics = false} = {}) {
@@ -1351,9 +1334,6 @@ describe('{{ghost_head}} helper', function () {
                     }
                 }
             });
-            labsStub = sinon.stub(labs, 'isSet');
-            labsStub.withArgs('i18n').returns(true);
-
             settingsHelpersStub = sinon.stub(settingsHelpers, 'isWebAnalyticsEnabled');
             setAnalyticsFlags({analytics: true});
         });

--- a/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
+++ b/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
@@ -492,35 +492,6 @@ describe('Email renderer', function () {
             assert.equal(replacements[0].getValue(member), '13 mars 2023');
         });
 
-        it('handles dates when the locale is fr and labs is disabled', function () {
-            emailRenderer = new EmailRenderer({
-                urlUtils: {
-                    urlFor: () => 'http://example.com/subdirectory/'
-                },
-                labs: {
-                    isSet: () => false
-                },
-                settingsCache: {
-                    get: (key) => {
-                        if (key === 'timezone') {
-                            return 'UTC';
-                        }
-                        if (key === 'locale') {
-                            return 'fr';
-                        }
-                    }
-                },
-                settingsHelpers: {getMembersValidationKey,createUnsubscribeUrl},
-                t: tFr
-            });
-            const html = '%%{created_at}%%';
-            const replacements = emailRenderer.buildReplacementDefinitions({html, newsletterUuid: newsletter.get('uuid')});
-            assert.equal(replacements.length, 2);
-            assert.equal(replacements[0].token.toString(), '/%%\\{created_at\\}%%/g');
-            assert.equal(replacements[0].id, 'created_at');
-            assert.equal(replacements[0].getValue(member), '13 March 2023');
-        });
-
         it('handles dates when the locale is en (US)', function () {
             emailRenderer = new EmailRenderer({
                 urlUtils: {


### PR DESCRIPTION
ref bb9a69edfede00cb30cfcbc9213489ca48101cf6

*This change should have no user impact.*

i18n has been enabled since November 2024. We can remove it from our list of always-on feature flags, remove `labs.isSet('i18n')` calls, and a bit of associated code.
