### PR TITLE
Removed unnecessary arguments from Portal method call

### DIFF
--- a/apps/portal/src/app.js
+++ b/apps/portal/src/app.js
@@ -47,7 +47,7 @@ export default class App extends React.Component {
     constructor(props) {
         super(props);
 
-        this.setupCustomTriggerButton(props);
+        this.setupCustomTriggerButton();
 
         this.state = {
             site: null,


### PR DESCRIPTION
*This change should have no user impact.*

This method takes no arguments, but we passed them anyway. Let's remove that.
