### PR TITLE
Increased shards for E2E tests from 4 to 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1115,8 +1115,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shardIndex: [1, 2, 3, 4]
-        shardTotal: [4]
+        shardIndex: [1, 2, 3, 4, 5, 6, 7, 8]
+        shardTotal: [8]
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-974

- increases shards for running the E2E test from 4 to 8