### PR TITLE
Updated E2E tests to exit more quickly on failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1113,7 +1113,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [job_docker_build, job_setup]
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         shardIndex: [1, 2, 3, 4, 5, 6, 7, 8]
         shardTotal: [8]

--- a/e2e/playwright.config.mjs
+++ b/e2e/playwright.config.mjs
@@ -22,6 +22,7 @@ const config = {
         timeout: process.env.CI ? 30 * 1000 : 10 * 1000
     },
     retries: 0, // Retries open the door to flaky tests. If the test needs retries, it's not a good test or the app is broken.
+    maxFailures: 1,
     workers: parseInt(process.env.TEST_WORKERS_COUNT, 10) || getWorkerCount(),
     fullyParallel: true,
     reporter: process.env.CI ? [['list', {printSteps: true}], ['blob']] : [['list', {printSteps: true}], ['html']],


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-976

- If a test fails in our E2E tests, there's not really a reason to continue running all of them - we know we'll need to fix the failing test to get to green
- With this change we set maxFailures to 1 in the Playwright config, but I think that will only apply per shard. For example, if a test fails in shard 2 it won't run the rest of them, but shards 1, 3, and 4 will continue. To solve that we set `fail-fast: true` on the e2e workflow, and now we'll get the benefit of this both locally and in CI