### PR TITLE
Added conditional await for pageHitPromise to base public-page POM

### DIFF
--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -44,6 +44,7 @@ services:
     ports:
       - "1025:1025"  # SMTP server
       - "8025:8025"  # Web interface
+      - "8026:8025"  # Web interface (for e2e tests)
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://localhost:8025"]
       interval: 1s

--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -22,6 +22,18 @@ yarn test --debug                               # See browser during execution, 
 PRESERVE_ENV=true yarn test                     # Debug failed tests (keeps containers)
 ```
 
+## Dev Environment Mode (Recommended)
+
+When `yarn dev` is running, e2e tests automatically use a more efficient execution mode:
+
+```bash
+# Terminal 1: Start dev environment
+yarn dev
+
+# Terminal 2: Run e2e tests (automatically uses dev environment)
+cd e2e && yarn test
+```
+
 ## Test Structure
 
 ### Naming Conventions

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -19,6 +19,19 @@ yarn
 yarn test
 ```
 
+### Dev Environment Mode (Recommended for Development)
+
+When `yarn dev` is running from the repository root, e2e tests automatically detect it and use a more efficient execution mode:
+
+```bash
+# Terminal 1: Start dev environment (from repository root)
+yarn dev
+
+# Terminal 2: Run e2e tests (from e2e folder)
+yarn test
+```
+
+
 ### Running Specific Tests
 
 ```bash
@@ -134,7 +147,11 @@ For example, a `ghostInstance` fixture creates a new Ghost instance with its own
 
 ### Test Isolation 
 
-Test isolation is extremely important to avoid flaky tests that are hard to debug. For the most part, you shouldn't have to worry about this when writing tests, because each test gets a fresh Ghost instance with its own database:
+Test isolation is extremely important to avoid flaky tests that are hard to debug. For the most part, you shouldn't have to worry about this when writing tests, because each test gets a fresh Ghost instance with its own database.
+
+#### Standalone Mode (Default)
+
+When dev environment is not running, tests use full container isolation:
 
 - Global setup (`tests/global.setup.ts`):
     - Starts shared services (MySQL, Tinybird, etc.)
@@ -148,6 +165,27 @@ Test isolation is extremely important to avoid flaky tests that are hard to debu
     - Drops the test database
 - Global teardown (`tests/global.teardown.ts`):
     - Stops and removes shared services
+
+#### Dev Environment Mode (When `yarn dev` is running)
+
+When dev environment is detected, tests use a more efficient approach:
+
+- Global setup:
+    - Creates a database snapshot in the existing `ghost-dev-mysql`
+- Worker setup (once per Playwright worker):
+    - Creates a Ghost container for the worker
+    - Creates a Caddy gateway container for routing
+- Before each test:
+    - Clones database from snapshot
+    - Restarts Ghost container with new database
+- After each test:
+    - Drops the test database
+- Worker teardown:
+    - Removes worker's Ghost and gateway containers
+- Global teardown:
+    - Cleans up all e2e containers (namespace: `ghost-dev-e2e`)
+
+All e2e containers use the `ghost-dev-e2e` project namespace for easy identification and cleanup.
 
 ### Best Practices
 

--- a/e2e/helpers/environment/constants.ts
+++ b/e2e/helpers/environment/constants.ts
@@ -40,3 +40,54 @@ export const MAILPIT = {
     PORT: 1025
 };
 
+/**
+ * Configuration for dev environment mode.
+ * Used when yarn dev infrastructure is detected.
+ */
+export const DEV_ENVIRONMENT = {
+    projectNamespace: 'ghost-dev',
+    networkName: 'ghost_dev'
+} as const;
+
+export const TEST_ENVIRONMENT = {
+    projectNamespace: 'ghost-dev-e2e',
+    gateway: {
+        image: 'ghost-dev-ghost-dev-gateway'
+    },
+    ghost: {
+        image: 'ghost-dev-ghost-dev',
+        workdir: '/home/ghost/ghost/core',
+        port: 2368,
+        env: [
+            // Environment configuration
+            'NODE_ENV=development',
+            'server__host=0.0.0.0',
+            `server__port=2368`,
+
+            // Database configuration (database name is set per container)
+            'database__client=mysql2',
+            `database__connection__host=ghost-dev-mysql`,
+            `database__connection__port=3306`,
+            `database__connection__user=root`,
+            `database__connection__password=root`,
+
+            // Redis configuration
+            'adapters__cache__Redis__host=ghost-dev-redis',
+            'adapters__cache__Redis__port=6379',
+
+            // Email configuration
+            'mail__transport=SMTP',
+            'mail__options__host=ghost-dev-mailpit',
+            'mail__options__port=1025',
+
+            // Public assets via gateway (same as compose.dev.yaml)
+            'portal__url=/ghost/assets/portal/portal.min.js',
+            'comments__url=/ghost/assets/comments-ui/comments-ui.min.js',
+            'sodoSearch__url=/ghost/assets/sodo-search/sodo-search.min.js',
+            'sodoSearch__styles=/ghost/assets/sodo-search/main.css',
+            'signupForm__url=/ghost/assets/signup-form/signup-form.min.js',
+            'announcementBar__url=/ghost/assets/announcement-bar/announcement-bar.min.js'
+        ]   
+    }
+} as const;
+

--- a/e2e/helpers/environment/dev-environment-manager.ts
+++ b/e2e/helpers/environment/dev-environment-manager.ts
@@ -1,0 +1,126 @@
+import Docker from 'dockerode';
+import baseDebug from '@tryghost/debug';
+import logging from '@tryghost/logging';
+import {DevGhostManager} from './service-managers/dev-ghost-manager';
+import {DockerCompose} from './docker-compose';
+import {GhostInstance, MySQLManager} from './service-managers';
+import {randomUUID} from 'crypto';
+
+const debug = baseDebug('e2e:DevEnvironmentManager');
+
+/**
+ * Orchestrates e2e test environment when dev infrastructure is available.
+ * 
+ * Uses:
+ * - MySQLManager with DockerCompose pointing to ghost-dev project
+ * - DevGhostManager for Ghost/Gateway container lifecycle
+ * 
+ * All e2e containers use the 'ghost-dev-e2e' project namespace for easy cleanup.
+ */
+export class DevEnvironmentManager {
+    private readonly workerIndex: number;
+    private readonly dockerCompose: DockerCompose;
+    private readonly mysql: MySQLManager;
+    private readonly ghost: DevGhostManager;
+    private initialized = false;
+
+    constructor() {
+        this.workerIndex = parseInt(process.env.TEST_PARALLEL_INDEX || '0', 10);
+        
+        // Use DockerCompose pointing to ghost-dev project to find MySQL container
+        this.dockerCompose = new DockerCompose({
+            composeFilePath: '', // Not needed for container lookup
+            projectName: 'ghost-dev',
+            docker: new Docker()
+        });
+        this.mysql = new MySQLManager(this.dockerCompose);
+        this.ghost = new DevGhostManager({
+            workerIndex: this.workerIndex
+        });
+    }
+
+    /**
+     * Global setup - creates database snapshot for test isolation.
+     * Mirrors the standalone environment: run migrations, then snapshot.
+     */
+    async globalSetup(): Promise<void> {
+        logging.info('Starting dev environment global setup...');
+
+        await this.cleanupResources();
+        
+        // Create base database, run migrations, then snapshot
+        // This mirrors what docker-compose does with ghost-migrations service
+        await this.mysql.recreateBaseDatabase('ghost_e2e_base');
+        await this.ghost.runMigrations('ghost_e2e_base');
+        await this.mysql.createSnapshot('ghost_e2e_base');
+
+        logging.info('Dev environment global setup complete');
+    }
+
+    /**
+     * Global teardown - cleanup resources.
+     */
+    async globalTeardown(): Promise<void> {
+        if (this.shouldPreserveEnvironment()) {
+            logging.info('PRESERVE_ENV is set - skipping teardown');
+            return;
+        }
+
+        logging.info('Starting dev environment global teardown...');
+        await this.cleanupResources();
+        logging.info('Dev environment global teardown complete');
+    }
+
+    /**
+     * Per-test setup - creates containers on first call, then clones database and restarts Ghost.
+     */
+    async perTestSetup(options: {config?: unknown} = {}): Promise<GhostInstance> {
+        // Lazy initialization of Ghost containers (once per worker)
+        if (!this.initialized) {
+            debug('Initializing Ghost containers for worker', this.workerIndex);
+            await this.ghost.setup();
+            this.initialized = true;
+        }
+
+        const siteUuid = randomUUID();
+        const instanceId = `ghost_e2e_${siteUuid.replace(/-/g, '_')}`;
+
+        // Setup database
+        await this.mysql.setupTestDatabase(instanceId, siteUuid);
+
+        // Restart Ghost with new database
+        const extraConfig = options.config as Record<string, string> | undefined;
+        await this.ghost.restartWithDatabase(instanceId, extraConfig);
+        await this.ghost.waitForReady();
+
+        const port = this.ghost.getGatewayPort();
+
+        return {
+            containerId: this.ghost.ghostContainerId!,
+            instanceId,
+            database: instanceId,
+            port,
+            baseUrl: `http://localhost:${port}`,
+            siteUuid
+        };
+    }
+
+    /**
+     * Per-test teardown - drops test database.
+     */
+    async perTestTeardown(instance: GhostInstance): Promise<void> {
+        await this.mysql.cleanupTestDatabase(instance.database);
+    }
+
+    private async cleanupResources(): Promise<void> {
+        logging.info('Cleaning up e2e resources...');
+        await this.ghost.cleanupAllContainers();
+        await this.mysql.dropAllTestDatabases();
+        await this.mysql.deleteSnapshot();
+        logging.info('E2E resources cleaned up');
+    }
+
+    private shouldPreserveEnvironment(): boolean {
+        return process.env.PRESERVE_ENV === 'true';
+    }
+}

--- a/e2e/helpers/environment/environment-factory.ts
+++ b/e2e/helpers/environment/environment-factory.ts
@@ -1,0 +1,48 @@
+import Docker from 'dockerode';
+import baseDebug from '@tryghost/debug';
+import {DEV_ENVIRONMENT} from './constants';
+import {DevEnvironmentManager} from './dev-environment-manager';
+import {EnvironmentManager} from './environment-manager';
+
+const debug = baseDebug('e2e:EnvironmentFactory');
+
+// Cached manager instance (one per worker process)
+let cachedManager: EnvironmentManager | DevEnvironmentManager | null = null;
+
+/**
+ * Check if the dev environment (yarn dev) is running.
+ * Detects by checking for the ghost_dev network and running MySQL container.
+ */
+export async function isDevEnvironmentAvailable(): Promise<boolean> {
+    const docker = new Docker();
+
+    try {
+        const networks = await docker.listNetworks({
+            filters: {name: [DEV_ENVIRONMENT.networkName]}
+        });
+
+        if (networks.length === 0) {
+            debug('Dev environment not available: network not found');
+            return false;
+        }
+
+        debug('Dev environment is available');
+        return true;
+    } catch (error) {
+        debug('Error checking dev environment:', error);
+        return false;
+    }
+}
+
+/**
+ * Get the environment manager for this worker.
+ * Creates and caches a manager on first call, returns cached instance thereafter.
+ */
+export async function getEnvironmentManager(): Promise<EnvironmentManager | DevEnvironmentManager> {
+    if (!cachedManager) {
+        const useDevEnv = await isDevEnvironmentAvailable();
+        cachedManager = useDevEnv ? new DevEnvironmentManager() : new EnvironmentManager();
+    }
+    return cachedManager;
+}
+

--- a/e2e/helpers/environment/index.ts
+++ b/e2e/helpers/environment/index.ts
@@ -1,3 +1,6 @@
 export * from './service-managers';
 export * from './environment-manager';
+export * from './dev-environment-manager';
+export * from './environment-factory';
+export * from './service-availability';
 

--- a/e2e/helpers/environment/service-availability.ts
+++ b/e2e/helpers/environment/service-availability.ts
@@ -1,0 +1,56 @@
+import Docker from 'dockerode';
+import baseDebug from '@tryghost/debug';
+import {DEV_ENVIRONMENT, DOCKER_COMPOSE_CONFIG, TINYBIRD} from './constants';
+
+const debug = baseDebug('e2e:ServiceAvailability');
+
+// Cache availability checks per process
+let tinybirdAvailable: boolean | null = null;
+
+/**
+ * Find running Tinybird containers for a specific Docker Compose project.
+ */
+async function findTinybirdContainers(docker: Docker, projectName: string) {
+    return docker.listContainers({
+        filters: {
+            label: [
+                `com.docker.compose.service=${TINYBIRD.LOCAL_HOST}`,
+                `com.docker.compose.project=${projectName}`
+            ],
+            status: ['running']
+        }
+    });
+}
+
+/**
+ * Check if Tinybird is running.
+ * Checks for tinybird-local service in either ghost-e2e or ghost-dev compose project.
+ */
+export async function isTinybirdAvailable(): Promise<boolean> {
+    if (tinybirdAvailable !== null) {
+        return tinybirdAvailable;
+    }
+
+    const docker = new Docker();
+
+    try {
+        // TODO: Remove DOCKER_COMPOSE_CONFIG.PROJECT fallback when no longer needed
+        const containers = (await Promise.all([
+            findTinybirdContainers(docker, DEV_ENVIRONMENT.projectNamespace),
+            findTinybirdContainers(docker, DOCKER_COMPOSE_CONFIG.PROJECT)
+        ])).flat();
+
+        tinybirdAvailable = containers.length > 0;
+        if (tinybirdAvailable) {
+            debug('Tinybird is available');
+        } else {
+            debug('Tinybird not available: container not running');
+        }
+
+        return tinybirdAvailable;
+    } catch (error) {
+        debug('Error checking Tinybird availability:', error);
+        tinybirdAvailable = false;
+        return false;
+    }
+}

--- a/e2e/helpers/environment/service-managers/dev-ghost-manager.ts
+++ b/e2e/helpers/environment/service-managers/dev-ghost-manager.ts
@@ -1,0 +1,318 @@
+import Docker from 'dockerode';
+import baseDebug from '@tryghost/debug';
+import path from 'path';
+import {DEV_ENVIRONMENT, TEST_ENVIRONMENT, TINYBIRD} from '@/helpers/environment/constants';
+import {fileURLToPath} from 'url';
+import {isTinybirdAvailable} from '@/helpers/environment/service-availability';
+import type {Container, ContainerCreateOptions} from 'dockerode';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const debug = baseDebug('e2e:DevGhostManager');
+
+export interface DevGhostManagerConfig {
+    workerIndex: number;
+}
+
+/**
+ * Manages Ghost and Gateway containers for dev environment mode.
+ * Creates worker-scoped containers that persist across tests.
+ */
+export class DevGhostManager {
+    private readonly docker: Docker;
+    private readonly config: DevGhostManagerConfig;
+    private ghostContainer: Container | null = null;
+    private gatewayContainer: Container | null = null;
+
+    constructor(config: DevGhostManagerConfig) {
+        this.docker = new Docker();
+        this.config = config;
+    }
+
+    get ghostContainerId(): string | null {
+        return this.ghostContainer?.id ?? null;
+    }
+
+    get gatewayContainerId(): string | null {
+        return this.gatewayContainer?.id ?? null;
+    }
+
+    getGatewayPort(): number {
+        return 30000 + this.config.workerIndex;
+    }
+
+    async setup(): Promise<void> {
+        debug(`Setting up containers for worker ${this.config.workerIndex}...`);
+
+        const ghostName = `ghost-e2e-worker-${this.config.workerIndex}`;
+        const gatewayName = `ghost-e2e-gateway-${this.config.workerIndex}`;
+
+        // Try to reuse existing containers (handles process restarts after test failures)
+        this.ghostContainer = await this.getOrCreateContainer(ghostName, () => this.createGhostContainer(ghostName));
+        this.gatewayContainer = await this.getOrCreateContainer(gatewayName, () => this.createGatewayContainer(gatewayName, ghostName));
+
+        debug(`Worker ${this.config.workerIndex} containers ready`);
+    }
+
+    /**
+     * Get existing container if running, otherwise create new one.
+     * This handles Playwright respawning processes after test failures.
+     */
+    private async getOrCreateContainer(name: string, create: () => Promise<Container>): Promise<Container> {
+        try {
+            const existing = this.docker.getContainer(name);
+            const info = await existing.inspect();
+            
+            if (info.State.Running) {
+                debug(`Reusing running container: ${name}`);
+                return existing;
+            }
+            
+            // Exists but stopped - start it
+            debug(`Starting stopped container: ${name}`);
+            await existing.start();
+            return existing;
+        } catch {
+            // Doesn't exist - create new
+            debug(`Creating new container: ${name}`);
+            const container = await create();
+            await container.start();
+            return container;
+        }
+    }
+
+    async teardown(): Promise<void> {
+        debug(`Tearing down worker ${this.config.workerIndex} containers...`);
+
+        if (this.gatewayContainer) {
+            await this.removeContainer(this.gatewayContainer);
+            this.gatewayContainer = null;
+        }
+        if (this.ghostContainer) {
+            await this.removeContainer(this.ghostContainer);
+            this.ghostContainer = null;
+        }
+
+        debug(`Worker ${this.config.workerIndex} containers removed`);
+    }
+
+    async restartWithDatabase(databaseName: string, extraConfig?: Record<string, string>): Promise<void> {
+        if (!this.ghostContainer) {
+            throw new Error('Ghost container not initialized');
+        }
+
+        debug('Restarting Ghost with database:', databaseName);
+
+        const info = await this.ghostContainer.inspect();
+        const containerName = info.Name.replace(/^\//, '');
+
+        // Remove old and create new with updated database
+        await this.removeContainer(this.ghostContainer);
+        this.ghostContainer = await this.createGhostContainer(containerName, databaseName, extraConfig);
+        await this.ghostContainer.start();
+
+        debug('Ghost restarted with database:', databaseName);
+    }
+
+    async waitForReady(timeoutMs: number = 60000): Promise<void> {
+        const port = this.getGatewayPort();
+        const healthUrl = `http://localhost:${port}/ghost/api/admin/site/`;
+        const startTime = Date.now();
+
+        while (Date.now() - startTime < timeoutMs) {
+            try {
+                const response = await fetch(healthUrl, {
+                    method: 'GET',
+                    signal: AbortSignal.timeout(5000)
+                });
+                if (response.status < 500) {
+                    debug('Ghost is ready');
+                    return;
+                }
+            } catch {
+                // Keep trying
+            }
+            await new Promise((r) => {
+                setTimeout(r, 500);
+            });
+        }
+
+        throw new Error(`Timeout waiting for Ghost on port ${port}`);
+    }
+
+    private async buildEnv(database: string = 'ghost_testing', extraConfig?: Record<string, string>): Promise<string[]> {
+        const env = [
+            ...TEST_ENVIRONMENT.ghost.env,
+            `database__connection__database=${database}`,
+            `url=http://localhost:${this.getGatewayPort()}`
+        ];
+
+        // Add Tinybird config if available
+        // Static endpoints are set here; workspaceId and adminToken are sourced from
+        // /mnt/shared-config/.env.tinybird by development.entrypoint.sh
+        if (await isTinybirdAvailable()) {
+            env.push(
+                `TB_HOST=http://${TINYBIRD.LOCAL_HOST}:${TINYBIRD.PORT}`,
+                `TB_LOCAL_HOST=${TINYBIRD.LOCAL_HOST}`,
+                `tinybird__stats__endpoint=http://${TINYBIRD.LOCAL_HOST}:${TINYBIRD.PORT}`,
+                `tinybird__stats__endpointBrowser=http://localhost:${TINYBIRD.PORT}`,
+                `tinybird__tracker__endpoint=http://localhost:${this.getGatewayPort()}/.ghost/analytics/api/v1/page_hit`,
+                'tinybird__tracker__datasource=analytics_events'
+            );
+        }
+
+        if (extraConfig) {
+            for (const [key, value] of Object.entries(extraConfig)) {
+                env.push(`${key}=${value}`);
+            }
+        }
+
+        return env;
+    }
+
+    private async createGhostContainer(
+        name: string,
+        database: string = 'ghost_testing',
+        extraConfig?: Record<string, string>
+    ): Promise<Container> {
+        const repoRoot = path.resolve(__dirname, '../../../..');
+
+        // Mount only the ghost subdirectory, matching compose.dev.yaml
+        // The image has node_modules and package.json at /home/ghost/ (installed at build time)
+        // We mount source code at /home/ghost/ghost/ for hot-reload
+        // Also mount shared-config volume to access Tinybird tokens (created by tb-cli)
+        const config: ContainerCreateOptions = {
+            name,
+            Image: TEST_ENVIRONMENT.ghost.image,
+            Env: await this.buildEnv(database, extraConfig),
+            ExposedPorts: {[`${TEST_ENVIRONMENT.ghost.port}/tcp`]: {}},
+            HostConfig: {
+                Binds: [
+                    `${repoRoot}/ghost:/home/ghost/ghost`,
+                    // Mount shared-config volume from the ghost-dev project (not ghost-dev-e2e)
+                    // This gives e2e tests access to Tinybird credentials created by yarn dev
+                    'ghost-dev_shared-config:/mnt/shared-config:ro'
+                ],
+                ExtraHosts: ['host.docker.internal:host-gateway']
+            },
+            NetworkingConfig: {
+                EndpointsConfig: {
+                    [DEV_ENVIRONMENT.networkName]: {Aliases: [name]}
+                }
+            },
+            Labels: {
+                'com.docker.compose.project': DEV_ENVIRONMENT.projectNamespace,
+                'tryghost/e2e': 'ghost-dev'
+            }
+        };
+
+        return this.docker.createContainer(config);
+    }
+
+    private async createGatewayContainer(name: string, ghostBackend: string): Promise<Container> {
+        // Gateway just needs to know where Ghost is - everything else uses defaults from the image
+        const config: ContainerCreateOptions = {
+            name,
+            Image: TEST_ENVIRONMENT.gateway.image,
+            Env: [`GHOST_BACKEND=${ghostBackend}:${TEST_ENVIRONMENT.ghost.port}`],
+            ExposedPorts: {'80/tcp': {}},
+            HostConfig: {
+                PortBindings: {'80/tcp': [{HostPort: String(this.getGatewayPort())}]},
+                ExtraHosts: ['host.docker.internal:host-gateway']
+            },
+            NetworkingConfig: {
+                EndpointsConfig: {
+                    [DEV_ENVIRONMENT.networkName]: {Aliases: [name]}
+                }
+            },
+            Labels: {
+                'com.docker.compose.project': TEST_ENVIRONMENT.projectNamespace,
+                'tryghost/e2e': 'gateway-dev'
+            }
+        };
+
+        return this.docker.createContainer(config);
+    }
+
+    private async removeContainer(container: Container): Promise<void> {
+        try {
+            await container.remove({force: true});
+        } catch {
+            debug('Failed to remove container:', container.id);
+        }
+    }
+
+    /**
+     * Remove all e2e containers by project label.
+     */
+    async cleanupAllContainers(): Promise<void> {
+        try {
+            const containers = await this.docker.listContainers({
+                all: true,
+                filters: {
+                    label: [`com.docker.compose.project=${TEST_ENVIRONMENT.projectNamespace}`]
+                }
+            });
+
+            await Promise.all(
+                containers.map(c => this.docker.getContainer(c.Id).remove({force: true}))
+            );
+        } catch {
+            // Ignore - no containers to remove or removal failed
+        }
+    }
+
+    /**
+     * Run knex-migrator init on a database.
+     * Creates a temporary container to run migrations, matching how compose.yml does it.
+     */
+    async runMigrations(database: string): Promise<void> {
+        debug('Running migrations for database:', database);
+
+        const repoRoot = path.resolve(__dirname, '../../../..');
+        const containerName = `ghost-e2e-migrations-${Date.now()}`;
+        const container = await this.docker.createContainer({
+            name: containerName,
+            Image: TEST_ENVIRONMENT.ghost.image,
+            Cmd: ['yarn', 'knex-migrator', 'init'],
+            WorkingDir: '/home/ghost',
+            Env: [
+                ...TEST_ENVIRONMENT.ghost.env,
+                `database__connection__database=${database}`
+            ],
+            HostConfig: {
+                Binds: [`${repoRoot}/ghost:/home/ghost/ghost`],
+                AutoRemove: false
+            },
+            NetworkingConfig: {
+                EndpointsConfig: {
+                    [DEV_ENVIRONMENT.networkName]: {}
+                }
+            },
+            Labels: {
+                'com.docker.compose.project': TEST_ENVIRONMENT.projectNamespace,
+                'tryghost/e2e': 'migrations'
+            }
+        });
+
+        await container.start();
+
+        // Wait for container to finish
+        const result = await container.wait();
+        
+        if (result.StatusCode !== 0) {
+            try {
+                const logs = await container.logs({stdout: true, stderr: true});
+                debug('Migration logs:', logs.toString());
+            } catch {
+                debug('Could not retrieve migration logs');
+            }
+            await this.removeContainer(container);
+            throw new Error(`Migrations failed with exit code ${result.StatusCode}`);
+        }
+
+        await this.removeContainer(container);
+        debug('Migrations completed successfully');
+    }
+}

--- a/e2e/helpers/environment/service-managers/index.ts
+++ b/e2e/helpers/environment/service-managers/index.ts
@@ -1,3 +1,4 @@
+export * from './dev-ghost-manager';
 export * from './ghost-manager';
 export * from './mysql-manager';
 export * from './portal-manager';

--- a/e2e/helpers/environment/service-managers/mysql-manager.ts
+++ b/e2e/helpers/environment/service-managers/mysql-manager.ts
@@ -76,13 +76,13 @@ export class MySQLManager {
 
     /**
      * Used for cleanup of leftover databases from interrupted tests.
-     * This removes all databases matching the pattern 'ghost_%' except 'ghost_testing' (the base database).
+     * This removes all databases matching the pattern 'ghost_%' except base databases.
      */
     async dropAllTestDatabases(): Promise<void> {
         try {
             debug('Finding all test databases to clean up...');
 
-            const query = 'SELECT schema_name FROM information_schema.schemata WHERE schema_name LIKE \'ghost_%\' AND schema_name != \'ghost_testing\'';
+            const query = 'SELECT schema_name FROM information_schema.schemata WHERE schema_name LIKE \'ghost_%\' AND schema_name NOT IN (\'ghost_testing\', \'ghost_e2e_base\', \'ghost_dev\')';
             const output = await this.exec(`mysql -uroot -proot -N -e "${query}"`);
 
             const databaseNames = this.parseDatabaseNames(output);

--- a/e2e/helpers/pages/public/public-page.ts
+++ b/e2e/helpers/pages/public/public-page.ts
@@ -1,5 +1,5 @@
 import {BasePage, pageGotoOptions} from '@/helpers/pages';
-import {Locator, Page, Response} from '@playwright/test';
+import {Locator, Page} from '@playwright/test';
 
 declare global {
     interface Window {
@@ -86,13 +86,11 @@ export class PublicPage extends BasePage {
 
     async goto(url?: string, options?: pageGotoOptions): Promise<void> {
         await this.enableAnalyticsRequests();
-        const pageHitPromise = this.pageHitRequestPromise();
         await super.goto(url, options);
-        await pageHitPromise;
     }
-
-    pageHitRequestPromise(): Promise<Response> {
-        return this.page.waitForResponse((response) => {
+    
+    async waitForPageHitRequest() {
+        return await this.page.waitForResponse((response) => {
             return response
                 .url()
                 .includes('/.ghost/analytics/api/v1/page_hit') && response.request().method() === 'POST';

--- a/e2e/playwright.config.mjs
+++ b/e2e/playwright.config.mjs
@@ -43,8 +43,17 @@ const config = {
         },
         {
             name: 'main',
-            testIgnore: ['**/*.setup.ts', '**/*.teardown.ts'],
+            testIgnore: ['**/*.setup.ts', '**/*.teardown.ts', 'analytics/**/*.test.ts'],
             testDir: './tests',
+            use: {
+                viewport: {width: 1920, height: 1080}
+            },
+            dependencies: ['global-setup']
+        },
+        {
+            name: 'analytics',
+            testDir: './tests',
+            testMatch: ['analytics/**/*.test.ts'],
             use: {
                 viewport: {width: 1920, height: 1080}
             },

--- a/e2e/tests/global.setup.ts
+++ b/e2e/tests/global.setup.ts
@@ -1,10 +1,10 @@
-import {EnvironmentManager} from '@/helpers/environment';
+import {getEnvironmentManager} from '@/helpers/environment';
 import {test as setup} from '@playwright/test';
 
 const TIMEOUT = 2 * 60 * 1000; // 2 minutes
 
 setup('global environment setup', async () => {
     setup.setTimeout(TIMEOUT);
-    const environmentManager = new EnvironmentManager();
-    await environmentManager.globalSetup();
+    const manager = await getEnvironmentManager();
+    await manager.globalSetup();
 });

--- a/e2e/tests/global.teardown.ts
+++ b/e2e/tests/global.teardown.ts
@@ -1,7 +1,7 @@
-import {EnvironmentManager} from '@/helpers/environment';
+import {getEnvironmentManager} from '@/helpers/environment';
 import {test as teardown} from '@playwright/test';
 
 teardown('global environment cleanup', async () => {
-    const environmentManager = new EnvironmentManager();
-    await environmentManager.globalTeardown();
+    const manager = await getEnvironmentManager();
+    await manager.globalTeardown();
 });

--- a/e2e/tests/public/homepage.test.ts
+++ b/e2e/tests/public/homepage.test.ts
@@ -9,15 +9,4 @@ test.describe('Ghost Public - Homepage', () => {
         await expect(homePage.title).toBeVisible();
         await expect(homePage.mainSubscribeButton).toBeVisible();
     });
-
-    test('sends page hit request', async ({page}) => {
-        const homePage = new HomePage(page);
-
-        // Set up request expectation before navigation
-        const response = homePage.waitForPageHitRequest();
-        await homePage.goto();
-
-        // Wait for the request to be fulfilled
-        await expect(response).resolves.toBeDefined();
-    });
 });

--- a/e2e/tests/public/homepage.test.ts
+++ b/e2e/tests/public/homepage.test.ts
@@ -9,4 +9,15 @@ test.describe('Ghost Public - Homepage', () => {
         await expect(homePage.title).toBeVisible();
         await expect(homePage.mainSubscribeButton).toBeVisible();
     });
+
+    test('sends page hit request', async ({page}) => {
+        const homePage = new HomePage(page);
+
+        // Set up request expectation before navigation
+        const response = homePage.waitForPageHitRequest();
+        await homePage.goto();
+
+        // Wait for the request to be fulfilled
+        await expect(response).resolves.toBeDefined();
+    });
 });


### PR DESCRIPTION
This automatically waits for a page hit request on any page on Ghost's frontend if it's running in the `analytics` project, but skips this step if running in any other project.