### PR TITLE
Added sniper link button to OTC flow

### DIFF
--- a/apps/portal/src/components/pages/magic-link-page.js
+++ b/apps/portal/src/components/pages/magic-link-page.js
@@ -240,7 +240,8 @@ export default class MagicLinkPage extends React.Component {
     }
 
     renderOTCForm() {
-        const {action, actionErrorMessage, otcRef} = this.context;
+        const {action, actionErrorMessage, otcRef, site, sniperLinks} = this.context;
+        const isSniperLinksEnabled = Boolean(site.labs?.sniperlinks);
         const errors = this.state.errors || {};
 
         if (!otcRef) {
@@ -293,6 +294,13 @@ export default class MagicLinkPage extends React.Component {
                         retry={isError}
                         disabled={isRunning}
                     />
+                    {isSniperLinksEnabled && sniperLinks ? (
+                        <SniperLinkButton
+                            href={isAndroidChrome(navigator) ? sniperLinks.android : sniperLinks.desktop}
+                            label={t('Open email')}
+                            brandColor={this.context.brandColor}
+                        />
+                    ) : null}
                 </footer>
             </form>
         );

--- a/apps/portal/src/components/pages/signup-page.js
+++ b/apps/portal/src/components/pages/signup-page.js
@@ -94,7 +94,7 @@ html[dir="rtl"] .gh-portal-back-sitetitle {
     justify-content: center;
     color: var(--grey4);
     font-size: 1.5rem;
-    margin: 16px 0 0;
+    margin: 4px 0 0;
 }
 
 .gh-portal-signup-message,
@@ -137,6 +137,7 @@ footer.gh-portal-signin-footer {
     position: relative;
     padding-top: 24px;
     height: unset;
+    gap: 12px;
 }
 
 .gh-portal-content.signup,

--- a/apps/portal/test/signin-flow.test.js
+++ b/apps/portal/test/signin-flow.test.js
@@ -15,8 +15,17 @@ const setup = async ({site, member = null, labs = {}}) => {
         });
     });
 
-    ghostApi.member.sendMagicLink = vi.fn(() => {
-        return Promise.resolve('success');
+    ghostApi.member.sendMagicLink = vi.fn(async ({email}) => {
+        if (email.endsWith('@test-sniper-link.example')) {
+            return {
+                sniperLinks: {
+                    android: 'https://test.example/',
+                    desktop: 'https://test.example/'
+                }
+            };
+        } else {
+            return {};
+        }
     });
 
     ghostApi.member.getIntegrityToken = vi.fn(() => {
@@ -222,6 +231,32 @@ describe('Signin', () => {
             expect(magicLink).toBeInTheDocument();
 
             expectOTCEnabledSendMagicLinkAPICall(ghostApi, 'jamie@example.com');
+        });
+
+        test('with sniper link', async () => {
+            const {
+                ghostApi,
+                emailInput,
+                popupIframeDocument,
+                submitButton
+            } = await setup({
+                site: {
+                    ...FixtureSite.singleTier.basic,
+                    labs: {sniperlinks: true}
+                }
+            });
+
+            fireEvent.change(emailInput, {target: {value: 'test@test-sniper-link.example'}});
+
+            expect(emailInput).toHaveValue('test@test-sniper-link.example');
+            fireEvent.click(submitButton);
+
+            const sniperLinkButton = await within(popupIframeDocument).findByText(/open email/i);
+            expect(sniperLinkButton).toBeInTheDocument();
+            expect(sniperLinkButton).toHaveAttribute('href', 'https://test.example/');
+            expect(sniperLinkButton).toHaveAttribute('target', '_blank');
+
+            expectOTCEnabledSendMagicLinkAPICall(ghostApi, 'test@test-sniper-link.example');
         });
     });
 });


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-946

<p align="center"><img src="https://github.com/user-attachments/assets/805202f5-f763-4f97-add0-6b16b4fcc3fb" alt="Screenshot" width="40%"></p>

This adds a sniper link button to the OTC flow, which you can see on signup.

We'll likely change this UI a bit before GA.