### PR TITLE
Removed top-level `labs` property from Portal code

### DIFF
--- a/apps/portal/src/app.js
+++ b/apps/portal/src/app.js
@@ -61,8 +61,7 @@ export default class App extends React.Component {
             lastPage: null,
             customSiteUrl: props.customSiteUrl,
             locale: props.locale,
-            scrollbarWidth: 0,
-            labs: props.labs || {}
+            scrollbarWidth: 0
         };
     }
 
@@ -110,7 +109,6 @@ export default class App extends React.Component {
                 siteUrl,
                 site: contextState.site,
                 member: contextState.member,
-                labs: contextState.labs,
                 doAction: contextState.doAction,
                 captureException: Sentry.captureException
             });
@@ -964,7 +962,7 @@ export default class App extends React.Component {
 
     /**Get final App level context from App state*/
     getContextFromState() {
-        const {site, member, offers, action, actionErrorMessage, page, lastPage, showPopup, pageQuery, pageData, popupNotification, customSiteUrl, dir, scrollbarWidth, labs, otcRef, sniperLinks} = this.state;
+        const {site, member, offers, action, actionErrorMessage, page, lastPage, showPopup, pageQuery, pageData, popupNotification, customSiteUrl, dir, scrollbarWidth, otcRef, sniperLinks} = this.state;
         const contextPage = this.getContextPage({site, page, member});
         const contextMember = this.getContextMember({page: contextPage, member, customSiteUrl});
         return {
@@ -984,7 +982,6 @@ export default class App extends React.Component {
             customSiteUrl,
             dir,
             scrollbarWidth,
-            labs,
             otcRef,
             sniperLinks,
             doAction: (_action, data) => this.dispatchAction(_action, data)

--- a/apps/portal/src/data-attributes.js
+++ b/apps/portal/src/data-attributes.js
@@ -205,7 +205,7 @@ export function planClickHandler({event, el, errorEl, siteUrl, site, member, cli
     });
 }
 
-export function handleDataAttributes({siteUrl, site = {}, member, labs = {}, doAction, captureException} = {}) {
+export function handleDataAttributes({siteUrl, site = {}, member, doAction, captureException} = {}) {
     if (!siteUrl) {
         return;
     }
@@ -214,7 +214,7 @@ export function handleDataAttributes({siteUrl, site = {}, member, labs = {}, doA
     Array.prototype.forEach.call(document.querySelectorAll('form[data-members-form]'), function (form) {
         let errorEl = form.querySelector('[data-members-error]');
         function submitHandler(event) {
-            formSubmitHandler({event, errorEl, form, siteUrl, submitHandler, labs, doAction, captureException});
+            formSubmitHandler({event, errorEl, form, siteUrl, submitHandler, doAction, captureException});
         }
         form.addEventListener('submit', submitHandler);
     });

--- a/apps/portal/src/index.js
+++ b/apps/portal/src/index.js
@@ -23,10 +23,7 @@ function getSiteData() {
         const apiKey = scriptTag.dataset.key;
         const apiUrl = scriptTag.dataset.api;
         const locale = scriptTag.dataset.locale; // not providing a fallback here but will do it within the app.
-
-        const labs = {};
-
-        return {siteUrl, apiKey, apiUrl, siteI18nEnabled, locale, labs};
+        return {siteUrl, apiKey, apiUrl, siteI18nEnabled, locale};
     }
     return {};
 }
@@ -46,12 +43,12 @@ function setup() {
 
 function init() {
     // const customSiteUrl = getSiteUrl();
-    const {siteUrl: customSiteUrl, apiKey, apiUrl, siteI18nEnabled, locale, labs} = getSiteData();
+    const {siteUrl: customSiteUrl, apiKey, apiUrl, siteI18nEnabled, locale} = getSiteData();
     const siteUrl = customSiteUrl || window.location.origin;
     setup({siteUrl});
     ReactDOM.render(
         <React.StrictMode>
-            <App siteUrl={siteUrl} customSiteUrl={customSiteUrl} apiKey={apiKey} apiUrl={apiUrl} siteI18nEnabled={siteI18nEnabled} locale={locale} labs={labs}/>
+            <App siteUrl={siteUrl} customSiteUrl={customSiteUrl} apiKey={apiKey} apiUrl={apiUrl} siteI18nEnabled={siteI18nEnabled} locale={locale} />
         </React.StrictMode>,
         document.getElementById(ROOT_DIV_ID)
     );

--- a/apps/portal/test/data-attributes.test.js
+++ b/apps/portal/test/data-attributes.test.js
@@ -212,7 +212,6 @@ describe('Member Data attributes:', () => {
                 return originalQuerySelector(selector);
             });
 
-            const labs = {};
             const doAction = vi.fn(() => Promise.resolve());
 
             const json = async () => ({otc_ref: 'otc_test_ref'});
@@ -235,7 +234,7 @@ describe('Member Data attributes:', () => {
                 return Promise.resolve({ok: true});
             });
 
-            await formSubmitHandler({event, form, errorEl, siteUrl, submitHandler, labs, doAction});
+            await formSubmitHandler({event, form, errorEl, siteUrl, submitHandler, doAction});
 
             const magicLinkCall = window.fetch.mock.calls.find(([fetchUrl]) => fetchUrl.includes('send-magic-link'));
             const requestBody = JSON.parse(magicLinkCall[1].body);
@@ -260,7 +259,6 @@ describe('Member Data attributes:', () => {
                 return originalQuerySelector(selector);
             });
 
-            const labs = {};
             const actionErrorMessage = new Error('failed to start OTC sign-in');
             const doAction = vi.fn(() => {
                 throw actionErrorMessage;
@@ -288,7 +286,7 @@ describe('Member Data attributes:', () => {
                 return Promise.resolve({ok: true});
             });
 
-            await formSubmitHandler({event, form, errorEl, siteUrl, submitHandler, labs, doAction, captureException});
+            await formSubmitHandler({event, form, errorEl, siteUrl, submitHandler, doAction, captureException});
 
             expect(doAction).toHaveBeenCalledWith('startSigninOTCFromCustomForm', {
                 email: 'jamie@example.com',

--- a/apps/portal/test/signin-flow.test.js
+++ b/apps/portal/test/signin-flow.test.js
@@ -5,7 +5,7 @@ import setupGhostApi from '../src/utils/api.js';
 
 const OTC_LABEL_REGEX = /Code/i;
 
-const setup = async ({site, member = null, labs = {}}) => {
+const setup = async ({site, member = null}) => {
     const ghostApi = setupGhostApi({siteUrl: 'https://example.com'});
 
     ghostApi.init = vi.fn(() => {
@@ -28,7 +28,7 @@ const setup = async ({site, member = null, labs = {}}) => {
     });
 
     const utils = appRender(
-        <App api={ghostApi} labs={labs} />
+        <App api={ghostApi} />
     );
 
     const triggerButtonFrame = await utils.findByTitle(/portal-trigger/i);
@@ -414,7 +414,7 @@ describe('OTC Integration Flow', () => {
         });
 
         const utils = appRender(
-            <App api={ghostApi} labs={{}} />
+            <App api={ghostApi} />
         );
 
         await utils.findByTitle(/portal-trigger/i);

--- a/apps/portal/test/unit/components/pages/magic-link-page.test.js
+++ b/apps/portal/test/unit/components/pages/magic-link-page.test.js
@@ -6,7 +6,6 @@ const OTC_ERROR_REGEX = /Enter code/i;
 
 const setupTest = (options = {}) => {
     const {
-        labs = {},
         otcRef = null,
         action = 'init:success',
         ...contextOverrides
@@ -16,7 +15,6 @@ const setupTest = (options = {}) => {
         <MagicLinkPage />,
         {
             overrideContext: {
-                labs,
                 otcRef,
                 action,
                 ...contextOverrides
@@ -33,7 +31,6 @@ const setupTest = (options = {}) => {
 // Helper for OTC-enabled tests
 const setupOTCTest = (options = {}) => {
     return setupTest({
-        labs: {},
         otcRef: 'test-otc-ref',
         ...options
     });
@@ -85,16 +82,10 @@ describe('MagicLinkPage', () => {
         });
 
         test('does not render OTC form when conditions not met', () => {
-            const scenarios = [
-                {labs: {}, otcRef: null}
-            ];
+            const utils = setupTest({otcRef: null});
 
-            scenarios.forEach(({labs, otcRef}) => {
-                const utils = setupTest({labs, otcRef});
-
-                expect(utils.queryByLabelText(OTC_LABEL_REGEX)).not.toBeInTheDocument();
-                expect(utils.queryByRole('button', {name: 'Continue'})).not.toBeInTheDocument();
-            });
+            expect(utils.queryByLabelText(OTC_LABEL_REGEX)).not.toBeInTheDocument();
+            expect(utils.queryByRole('button', {name: 'Continue'})).not.toBeInTheDocument();
         });
     });
 
@@ -333,10 +324,7 @@ describe('MagicLinkPage', () => {
 
     describe('OTC flow edge cases', () => {
         test('does not render form without otcRef', () => {
-            const utils = setupTest({
-                labs: {},
-                otcRef: null
-            });
+            const utils = setupTest({otcRef: null});
 
             expect(utils.queryByText(/You can also use the one-time code to sign in here/i)).not.toBeInTheDocument();
             expect(utils.queryByRole('button', {name: 'Continue'})).not.toBeInTheDocument();


### PR DESCRIPTION
no ref

*This cleanup change should have no user impact.*

This removes references to a top-level `labs` variable and its usages. Two reasons for doing this:

1. Portal uses `site.labs` to handle feature flags. See 3d4eeff699b71d5a0124cd5242fbd6d1ea2b49b8.
2. The top-level `labs` property was useless because it was always initialized to `{}`.
