### PR TITLE
Removed unnecessary function from Portal init

### DIFF
--- a/apps/portal/src/index.js
+++ b/apps/portal/src/index.js
@@ -39,16 +39,14 @@ function handleTokenUrl() {
     }
 }
 
-function setup() {
-    addRootDiv();
-    handleTokenUrl();
-}
-
 function init() {
     // const customSiteUrl = getSiteUrl();
     const {siteUrl: customSiteUrl, apiKey, apiUrl, siteI18nEnabled, locale, labs} = getSiteData();
     const siteUrl = customSiteUrl || window.location.origin;
-    setup({siteUrl});
+
+    addRootDiv();
+    handleTokenUrl();
+
     ReactDOM.render(
         <React.StrictMode>
             <App siteUrl={siteUrl} customSiteUrl={customSiteUrl} apiKey={apiKey} apiUrl={apiUrl} siteI18nEnabled={siteI18nEnabled} locale={locale} labs={labs}/>


### PR DESCRIPTION
*This change should have no user impact.*

Previously, `init()` called `setup()` with an unnecessary argument.

Now, it inlines `setup()` and removes it. I think this is clearer, and it also sidesteps the unnecessary argument.
