### PR TITLE
Changed spam complaint suppressions to automatically delete from Mailgun

### DIFF
--- a/ghost/core/core/server/services/email-service/email-event-storage.js
+++ b/ghost/core/core/server/services/email-service/email-event-storage.js
@@ -195,6 +195,9 @@ class EmailEventStorage {
                 email_id: event.emailId,
                 email_address: event.email
             });
+
+            // Remove from Mailgun's suppression list so it doesn't affect other sites on the same domain
+            await this.#emailSuppressionList.removeComplaint(event.email);
         } catch (err) {
             if (err.code !== 'ER_DUP_ENTRY' && err.code !== 'SQLITE_CONSTRAINT') {
                 logging.error(err);

--- a/ghost/core/core/server/services/email-suppression-list/mailgun-email-suppression-list.js
+++ b/ghost/core/core/server/services/email-suppression-list/mailgun-email-suppression-list.js
@@ -57,6 +57,15 @@ class MailgunEmailSuppressionList extends AbstractEmailSuppressionList {
         }
     }
 
+    async removeComplaint(email) {
+        try {
+            await this.apiClient.removeComplaint(email);
+        } catch (err) {
+            logging.error(err);
+            return false;
+        }
+    }
+
     async getSuppressionData(email) {
         try {
             const model = await this.Suppression.findOne({

--- a/ghost/core/test/unit/server/services/email-service/email-event-storage.test.js
+++ b/ghost/core/test/unit/server/services/email-service/email-event-storage.test.js
@@ -576,13 +576,20 @@ describe('Email Event Storage', function () {
             add: sinon.stub().resolves()
         };
 
+        const emailSuppressionList = {
+            removeComplaint: sinon.stub().resolves()
+        };
+
         const eventHandler = new EmailEventStorage({
             models: {
                 EmailSpamComplaintEvent
-            }
+            },
+            emailSuppressionList
         });
         await eventHandler.handleComplained(event);
         assert(EmailSpamComplaintEvent.add.calledOnce);
+        assert(emailSuppressionList.removeComplaint.calledOnce);
+        assert(emailSuppressionList.removeComplaint.calledWith('example@example.com'));
     });
 
     it('Handles duplicate complaints', async function () {
@@ -597,10 +604,15 @@ describe('Email Event Storage', function () {
             add: sinon.stub().rejects({code: 'ER_DUP_ENTRY'})
         };
 
+        const emailSuppressionList = {
+            removeComplaint: sinon.stub().resolves()
+        };
+
         const eventHandler = new EmailEventStorage({
             models: {
                 EmailSpamComplaintEvent
-            }
+            },
+            emailSuppressionList
         });
         await eventHandler.handleComplained(event);
         assert(EmailSpamComplaintEvent.add.calledOnce);
@@ -619,10 +631,15 @@ describe('Email Event Storage', function () {
             add: sinon.stub().rejects(new Error('Some database error'))
         };
 
+        const emailSuppressionList = {
+            removeComplaint: sinon.stub().resolves()
+        };
+
         const eventHandler = new EmailEventStorage({
             models: {
                 EmailSpamComplaintEvent
-            }
+            },
+            emailSuppressionList
         });
         await eventHandler.handleComplained(event);
         assert(EmailSpamComplaintEvent.add.calledOnce);


### PR DESCRIPTION
ref [GVA-646](https://linear.app/ghost/issue/GVA-646/sync-spam-complaint-suppressions-from-mailgun-to-disable-members)

At the moment, spam complaints persist in Mailgun. This means that for sites that share a domain, a member creating a spam complaint on one site can impact another.

Also, if the spam complaint is made in error, the site admin has no way to fix the issue on behalf of the member.
