### PR TITLE
Skipped retention offers for members in trial period

### DIFF
--- a/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
@@ -31,7 +31,8 @@ const messages = {
     offerCadenceMismatch: 'Offer is not valid for this subscription cadence',
     offerAlreadyRedeemed: 'This offer has already been redeemed on this subscription',
     subscriptionNotActive: 'Cannot apply offer to an inactive subscription',
-    subscriptionHasOffer: 'Subscription already has an offer applied'
+    subscriptionHasOffer: 'Subscription already has an offer applied',
+    subscriptionInTrial: 'Cannot apply offer to a subscription in a trial period'
 };
 
 const SUBSCRIPTION_STATUS_TRIALING = 'trialing';
@@ -1712,6 +1713,14 @@ module.exports = class MemberRepository {
         if (subscriptionModel.get('offer_id')) {
             throw new errors.BadRequestError({
                 message: tpl(messages.subscriptionHasOffer)
+            });
+        }
+
+        // Check subscription is not in a trial period
+        const trialEndAt = subscriptionModel.get('trial_end_at');
+        if (trialEndAt && trialEndAt > new Date()) {
+            throw new errors.BadRequestError({
+                message: tpl(messages.subscriptionInTrial)
             });
         }
 

--- a/ghost/core/test/e2e-api/members/member-offers.test.js
+++ b/ghost/core/test/e2e-api/members/member-offers.test.js
@@ -539,6 +539,50 @@ describe('Members API - Member Offers', function () {
             }
         });
 
+        it('returns 400 when subscription is in a trial period', async function () {
+            const {subscription} = await getMemberSubscription('paid@test.com');
+            const stripePrice = subscription.related('stripePrice');
+            const stripeProduct = stripePrice.related('stripeProduct');
+            const product = stripeProduct.related('product');
+
+            const stripeSubscriptionId = subscription.get('subscription_id');
+            const tierId = product.id;
+            const cadence = stripePrice.get('interval');
+
+            // Temporarily set subscription to have an active trial period
+            const futureDate = new Date();
+            futureDate.setDate(futureDate.getDate() + 7);
+            await subscription.save({trial_end_at: futureDate}, {patch: true});
+
+            // Create a retention offer
+            const retentionOffer = await models.Offer.add({
+                name: 'Test Retention Trial',
+                code: 'test-retention-trial',
+                portal_title: '20% off',
+                portal_description: 'Stay with us!',
+                discount_type: 'percent',
+                discount_amount: 20,
+                duration: 'once',
+                interval: cadence,
+                product_id: tierId,
+                currency: null,
+                active: true,
+                redemption_type: 'retention'
+            });
+
+            try {
+                const token = await getIdentityToken('paid@test.com');
+
+                await membersAgent
+                    .post(`/api/subscriptions/${stripeSubscriptionId}/apply-offer`)
+                    .body({identity: token, offer_id: retentionOffer.id})
+                    .expectStatus(400);
+            } finally {
+                await subscription.save({trial_end_at: null}, {patch: true});
+                await models.Offer.destroy({id: retentionOffer.id});
+            }
+        });
+
         it('successfully applies retention offer to subscription', async function () {
             const {subscription} = await getMemberSubscription('paid@test.com');
             const stripePrice = subscription.related('stripePrice');


### PR DESCRIPTION
ref https://linear.app/ghost/issue/FEA-535

Members on a tier with a trial period were being shown retention offers, which led to a confusing "Free trial - Ends {date}" message after redemption. This change skips retention offers for subscriptions with an active trial period (`trial_end_at` in the future), matching the existing behavior for offer-based trials
