### PR TITLE
Updated comments data-generator to include replies-to-replies

### DIFF
--- a/ghost/core/core/server/data/seeders/importers/comments-importer.js
+++ b/ghost/core/core/server/data/seeders/importers/comments-importer.js
@@ -25,23 +25,22 @@ class CommentsImporter extends TableImporter {
     setReferencedModel(model) {
         this.model = model;
 
-        this.commentIds = [];
+        this.commentIds = []; // Store [id, parent_id, timestamp] tuples for reply-to-reply
 
         this.timestamps = generateEvents({
             shape: 'ease-out',
             trend: 'negative',
-            // Steady readers login more, readers who lose interest read less overall.
-            // ceil because members will all have logged in at least once
-            total: faker.datatype.number({min: 0, max: this.commentsPerPost}),
+            // Use commentsPerPost as a baseline with some variance (+/- 20%)
+            total: Math.round(this.commentsPerPost * faker.datatype.float({min: 0.8, max: 1.2})),
             startTime: new Date(model.published_at),
             endTime: new Date()
-        });
+        }).sort((a, b) => a.getTime() - b.getTime()); // Sort chronologically so replies always come after their targets
 
         this.possibleMembers = this.members.filter(member => new Date(member.created_at) < new Date(model.published_at));
     }
 
     generate() {
-        const timestamp = this.timestamps.pop();
+        const timestamp = this.timestamps.shift();
         if (!timestamp) {
             // Out of events for this post
             return null;
@@ -51,20 +50,58 @@ class CommentsImporter extends TableImporter {
             return null;
         }
 
-        const isReply = luck(30) && this.commentIds.length > 0; // 30% of comments are replies
+        const isReply = luck(55) && this.commentIds.length > 0; // 55% of comments are replies
+
+        let parentId = null;
+        let inReplyToId = null;
+
+        if (isReply) {
+            // Filter to only include comments created before the current timestamp
+            const eligibleComments = this.commentIds.filter(([, , ts]) => ts < timestamp);
+            if (eligibleComments.length > 0) {
+                // Bias toward picking existing replies to increase reply-to-reply frequency
+                // 60% chance to prefer replying to a reply (if any exist)
+                const existingReplies = eligibleComments.filter(([, pId]) => pId !== null);
+                const preferReplyToReply = luck(60) && existingReplies.length > 0;
+
+                let replyTarget;
+                if (preferReplyToReply) {
+                    // Pick from existing replies to create a reply-to-reply
+                    const replyToIndex = faker.datatype.number(existingReplies.length - 1);
+                    replyTarget = existingReplies[replyToIndex];
+                } else {
+                    // Pick any random eligible comment
+                    const replyToIndex = faker.datatype.number(eligibleComments.length - 1);
+                    replyTarget = eligibleComments[replyToIndex];
+                }
+                const [replyToId, replyToParentId] = replyTarget;
+
+                if (replyToParentId === null) {
+                    // Replying to a top-level comment - this becomes a direct reply
+                    parentId = replyToId;
+                } else {
+                    // Replying to a reply
+                    // parent_id stays the thread root, in_reply_to_id points to the specific reply
+                    parentId = replyToParentId;
+                    inReplyToId = replyToId;
+                }
+            }
+            // If no eligible comments, parentId/inReplyToId stay null (top-level comment)
+        }
 
         const event = {
             id: this.fastFakeObjectId(),
             post_id: this.model.id,
             member_id: this.possibleMembers[faker.datatype.number(this.possibleMembers.length - 1)].id,
-            parent_id: isReply ? this.commentIds[faker.datatype.number(this.commentIds.length - 1)] : null,
+            parent_id: parentId,
+            in_reply_to_id: inReplyToId,
             status: 'published',
             created_at: dateToDatabaseString(timestamp),
             updated_at: dateToDatabaseString(timestamp),
             html: `<p>${faker.lorem.sentence().replace(/[&<>"']/g, c => `&#${c.charCodeAt(0)};`)}</p>`
         };
 
-        this.commentIds.push(event.id);
+        this.commentIds.push([event.id, parentId, timestamp]);
 
         return event;
     }


### PR DESCRIPTION
no issue

- our seed data for dev and manual testing should include replies-to-replies so we can work with the full spectrum of comment states
- reduced randomness for # of comments per post and increased bias towards replies for a better spread
- fixed replies sometimes having an earlier timestamp than the parent comment

---

With these changes, for the default of 10 comments per post (used unless total number of comments specified) you should now expect approximately:

~8-12 comments per post (instead of 0-10)
~4-5 top-level comments (first comment + ~45% of remainder)
~3-4 direct replies
~2-3 replies-to-replies
