### PR TITLE
Fixed font size mismatch on growth chart tooltip

### DIFF
--- a/apps/stats/src/views/Stats/Growth/components/growth-kpis.tsx
+++ b/apps/stats/src/views/Stats/Growth/components/growth-kpis.tsx
@@ -78,13 +78,13 @@ const PaidMembersTooltipContent = ({active, payload, range, color, showBreakdown
                         <div className='flex items-center gap-2'>
                             <div className='flex grow items-center justify-between gap-5'>
                                 <div className="text-sm text-muted-foreground">Paid subscriptions</div>
-                                <div className="font-mono text-sm">{formatNumber(paidSubscriptions)}</div>
+                                <div className="font-mono text-xs">{formatNumber(paidSubscriptions)}</div>
                             </div>
                         </div>
                         <div className='flex items-center gap-2'>
                             <div className='flex grow items-center justify-between gap-5'>
                                 <div className="text-sm text-muted-foreground">Complimentary</div>
-                                <div className="font-mono text-sm">{(comped !== undefined && comped > 0) ? (formatNumber(comped)) : '0'}</div>
+                                <div className="font-mono text-xs">{(comped !== undefined && comped > 0) ? (formatNumber(comped)) : '0'}</div>
                             </div>
                         </div>
                         <Separator />


### PR DESCRIPTION
no ref.

- The font size for breakdown values were one step larger than the rest.