### PR TITLE
Simplified bulkEdit/bulkDestroy return type and removed throwErrors

### DIFF
--- a/ghost/core/core/server/api/endpoints/members.js
+++ b/ghost/core/core/server/api/endpoints/members.js
@@ -323,15 +323,12 @@ const controller = {
         async query(frame) {
             const bulkDestroyResult = await membersService.api.members.bulkDestroy(frame.options);
 
-            // shaped to match the importer response
             return {
                 meta: {
                     stats: {
                         successful: bulkDestroyResult.successful,
                         unsuccessful: bulkDestroyResult.unsuccessful
-                    },
-                    unsuccessfulIds: bulkDestroyResult.unsuccessfulIds,
-                    errors: bulkDestroyResult.errors
+                    }
                 }
             };
         }

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/members.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/members.js
@@ -125,9 +125,7 @@ function bulkAction(bulkActionResult, _apiConfig, frame) {
                 stats: {
                     successful: bulkActionResult.successful,
                     unsuccessful: bulkActionResult.unsuccessful
-                },
-                errors: bulkActionResult.errors,
-                unsuccessfulData: bulkActionResult.unsuccessfulData
+                }
             }
         }
     };
@@ -355,8 +353,6 @@ function createSerializer(debugString, serialize) {
  * @prop {string} action
  *
  * @prop {object} meta
- * @prop {object[]} meta.unsuccessfulData
- * @prop {Error[]} meta.errors
  * @prop {object} meta.stats
  *
  * @prop {number} meta.stats.successful

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/pages.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/pages.js
@@ -61,9 +61,7 @@ module.exports = {
                     stats: {
                         successful: bulkActionResult.successful,
                         unsuccessful: bulkActionResult.unsuccessful
-                    },
-                    errors: bulkActionResult.errors,
-                    unsuccessfulData: bulkActionResult.unsuccessfulData
+                    }
                 }
             }
         };
@@ -76,8 +74,7 @@ module.exports = {
                     stats: {
                         successful: bulkActionResult.successful,
                         unsuccessful: bulkActionResult.unsuccessful
-                    },
-                    errors: bulkActionResult.errors
+                    }
                 }
             }
         };

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/posts.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/posts.js
@@ -65,9 +65,7 @@ module.exports = {
                     stats: {
                         successful: bulkActionResult.successful,
                         unsuccessful: bulkActionResult.unsuccessful
-                    },
-                    errors: bulkActionResult.errors,
-                    unsuccessfulData: bulkActionResult.unsuccessfulData
+                    }
                 }
             }
         };
@@ -80,8 +78,7 @@ module.exports = {
                     stats: {
                         successful: bulkActionResult.successful,
                         unsuccessful: bulkActionResult.unsuccessful
-                    },
-                    errors: bulkActionResult.errors
+                    }
                 }
             }
         };

--- a/ghost/core/core/server/models/base/plugins/bulk-operations.js
+++ b/ghost/core/core/server/models/base/plugins/bulk-operations.js
@@ -140,39 +140,23 @@ module.exports = function (Bookshelf) {
          * @param {object} [options]
          * @param {object} [options.data] - Column values to set
          * @param {string} [options.column] - Column to match against (defaults to 'id')
-         * @returns {Promise<{successful: number, unsuccessful: number, errors: Array, unsuccessfulData: Array}>}
+         * @returns {Promise<{successful: number, unsuccessful: number}>}
          */
         bulkEdit: async function bulkEdit(ids, tableName, options = {}) {
             tableName = tableName || this.prototype.tableName;
 
-            try {
-                const affectedRows = await this.bulkEditWhere({
-                    data: options.data,
-                    where: byColumnValues(options.column ?? 'id', ids),
-                    transacting: options.transacting,
-                    tableName
-                });
+            const affectedRows = await this.bulkEditWhere({
+                data: options.data,
+                where: byColumnValues(options.column ?? 'id', ids),
+                transacting: options.transacting,
+                tableName
+            });
 
-                if (affectedRows > 0 && tableName === this.prototype.tableName) {
-                    await this.addActions('edited', ids, options);
-                }
-
-                return {successful: ids.length, unsuccessful: 0, errors: [], unsuccessfulData: []};
-            } catch (err) {
-                if (options.throwErrors) {
-                    throw err;
-                }
-                return {
-                    successful: 0,
-                    unsuccessful: ids.length,
-                    errors: ids.map((id) => {
-                        const e = Object.create(err);
-                        e.errorDetails = id;
-                        return e;
-                    }),
-                    unsuccessfulData: ids
-                };
+            if (affectedRows > 0 && tableName === this.prototype.tableName) {
+                await this.addActions('edited', ids, options);
             }
+
+            return {successful: ids.length, unsuccessful: 0};
         },
 
         /**
@@ -182,7 +166,7 @@ module.exports = function (Bookshelf) {
          * @param {string} tableName - Table to delete from (defaults to model's table)
          * @param {object} [options]
          * @param {string} [options.column] - Column to match against (defaults to 'id')
-         * @returns {Promise<{successful: number, unsuccessful: number, errors: Array, unsuccessfulData: Array}>}
+         * @returns {Promise<{successful: number, unsuccessful: number}>}
          */
         bulkDestroy: async function bulkDestroy(ids, tableName, options = {}) {
             tableName = tableName || this.prototype.tableName;
@@ -192,29 +176,13 @@ module.exports = function (Bookshelf) {
                 await this.addActions('deleted', ids, options);
             }
 
-            try {
-                await this.bulkDestroyWhere({
-                    where: byColumnValues(options.column ?? 'id', ids),
-                    transacting: options.transacting,
-                    tableName
-                });
+            await this.bulkDestroyWhere({
+                where: byColumnValues(options.column ?? 'id', ids),
+                transacting: options.transacting,
+                tableName
+            });
 
-                return {successful: ids.length, unsuccessful: 0, errors: [], unsuccessfulData: []};
-            } catch (err) {
-                if (options.throwErrors) {
-                    throw err;
-                }
-                return {
-                    successful: 0,
-                    unsuccessful: ids.length,
-                    errors: ids.map((id) => {
-                        const e = Object.create(err);
-                        e.errorDetails = id;
-                        return e;
-                    }),
-                    unsuccessfulData: ids
-                };
-            }
+            return {successful: ids.length, unsuccessful: 0};
         }
     });
 };

--- a/ghost/core/core/server/services/link-tracking/post-link-repository.js
+++ b/ghost/core/core/server/services/link-tracking/post-link-repository.js
@@ -78,9 +78,7 @@ module.exports = class PostLinkRepository {
                     stats: {
                         successful: bulkActionResult.successful,
                         unsuccessful: bulkActionResult.unsuccessful
-                    },
-                    errors: bulkActionResult.errors,
-                    unsuccessfulData: bulkActionResult.unsuccessfulData
+                    }
                 }
             }
         };

--- a/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
@@ -833,13 +833,7 @@ module.exports = class MemberRepository {
 
         const memberIds = memberRows.map(row => row.id);
 
-        const bulkDestroyResult = await this._Member.bulkDestroy(memberIds);
-
-        bulkDestroyResult.unsuccessfulIds = bulkDestroyResult.unsuccessfulData;
-
-        delete bulkDestroyResult.unsuccessfulData;
-
-        return bulkDestroyResult;
+        return await this._Member.bulkDestroy(memberIds);
     }
 
     async bulkEdit(data, options) {

--- a/ghost/core/core/server/services/posts/posts-service.js
+++ b/ghost/core/core/server/services/posts/posts-service.js
@@ -123,8 +123,7 @@ class PostsService {
             await this.models.Post.bulkEdit(updateResult.editIds, 'posts_meta', {
                 data: {email_only: false},
                 column: 'post_id',
-                transacting: options.transacting,
-                throwErrors: true
+                transacting: options.transacting
             });
             DomainEvents.dispatch(PostsBulkUnscheduledEvent.create(updateResult.editIds));
 
@@ -290,16 +289,14 @@ class PostsService {
         for (const table of postTablesToDelete) {
             await this.models.Post.bulkDestroy(deleteIds, table, {
                 column: 'post_id',
-                transacting: options.transacting,
-                throwErrors: true
+                transacting: options.transacting
             });
         }
 
         for (const table of emailTablesToDelete) {
             await this.models.Post.bulkDestroy(deleteEmailIds, table, {
                 column: 'email_id',
-                transacting: options.transacting,
-                throwErrors: true
+                transacting: options.transacting
             });
         }
 
@@ -307,14 +304,13 @@ class PostsService {
             await this.models.Post.bulkEdit(deleteEmailIds, table, {
                 data: {email_id: null},
                 column: 'email_id',
-                transacting: options.transacting,
-                throwErrors: true
+                transacting: options.transacting
             });
         }
 
         // Posts and emails
-        await this.models.Post.bulkDestroy(deleteEmailIds, 'emails', {transacting: options.transacting, throwErrors: true});
-        const result = await this.models.Post.bulkDestroy(deleteIds, 'posts', {...options, throwErrors: true});
+        await this.models.Post.bulkDestroy(deleteEmailIds, 'emails', {transacting: options.transacting});
+        const result = await this.models.Post.bulkDestroy(deleteIds, 'posts', options);
 
         result.deleteIds = deleteIds;
 
@@ -359,8 +355,7 @@ class PostsService {
 
         const result = await this.models.Post.bulkEdit(editIds, 'posts', {
             ...options,
-            data,
-            throwErrors: true
+            data
         });
 
         // Update tiers
@@ -368,8 +363,7 @@ class PostsService {
             // First delete all
             await this.models.Post.bulkDestroy(editIds, 'posts_products', {
                 column: 'post_id',
-                transacting: options.transacting,
-                throwErrors: true
+                transacting: options.transacting
             });
 
             // Then add again
@@ -387,8 +381,7 @@ class PostsService {
                 }
             }
             await this.models.Post.bulkAdd(toInsert, 'posts_products', {
-                transacting: options.transacting,
-                throwErrors: true
+                transacting: options.transacting
             });
         }
 

--- a/ghost/core/test/e2e-api/admin/__snapshots__/links.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/links.test.js.snap
@@ -50,53 +50,6 @@ Object {
 }
 `;
 
-exports[`Links API Can browse all links 2: [body] 1`] = `
-Object {
-  "links": Array [
-    Object {
-      "count": Object {
-        "clicks": Any<Number>,
-      },
-      "link": Object {
-        "from": Any<String>,
-        "link_id": Any<String>,
-        "to": Any<String>,
-      },
-      "post_id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-    },
-    Object {
-      "count": Object {
-        "clicks": Any<Number>,
-      },
-      "link": Object {
-        "from": Any<String>,
-        "link_id": Any<String>,
-        "to": Any<String>,
-      },
-      "post_id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-    },
-    Object {
-      "count": Object {
-        "clicks": Any<Number>,
-      },
-      "link": Object {
-        "from": Any<String>,
-        "link_id": Any<String>,
-        "to": Any<String>,
-      },
-      "post_id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-    },
-  ],
-  "meta": Object {
-    "pagination": Object {
-      "page": 1,
-      "pages": 1,
-      "total": 3,
-    },
-  },
-}
-`;
-
 exports[`Links API Can browse all links 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
@@ -110,29 +63,15 @@ Object {
 }
 `;
 
-exports[`Links API Can browse all links 3: [headers] 1`] = `
-Object {
-  "access-control-allow-origin": "http://127.0.0.1:2369",
-  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "885",
-  "content-type": "application/json; charset=utf-8",
-  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
-  "vary": "Accept-Version, Origin, Accept-Encoding",
-  "x-powered-by": "Express",
-}
-`;
-
 exports[`Links API Can bulk update links with external redirect 1: [body] 1`] = `
 Object {
   "bulk": Object {
     "action": "updateLink",
     "meta": Object {
-      "errors": Array [],
       "stats": Object {
         "successful": 1,
         "unsuccessful": 0,
       },
-      "unsuccessfulData": Array [],
     },
   },
 }
@@ -142,7 +81,7 @@ exports[`Links API Can bulk update links with external redirect 2: [headers] 1`]
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "117",
+  "content-length": "83",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -202,53 +141,6 @@ Object {
 }
 `;
 
-exports[`Links API Can bulk update links with external redirect 4: [body] 1`] = `
-Object {
-  "links": Array [
-    Object {
-      "count": Object {
-        "clicks": Any<Number>,
-      },
-      "link": Object {
-        "from": Any<String>,
-        "link_id": Any<String>,
-        "to": "https://example.com/subscribe?ref=Test-newsletter",
-      },
-      "post_id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-    },
-    Object {
-      "count": Object {
-        "clicks": Any<Number>,
-      },
-      "link": Object {
-        "from": Any<String>,
-        "link_id": Any<String>,
-        "to": Any<String>,
-      },
-      "post_id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-    },
-    Object {
-      "count": Object {
-        "clicks": Any<Number>,
-      },
-      "link": Object {
-        "from": Any<String>,
-        "link_id": Any<String>,
-        "to": Any<String>,
-      },
-      "post_id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-    },
-  ],
-  "meta": Object {
-    "pagination": Object {
-      "page": 1,
-      "pages": 1,
-      "total": 3,
-    },
-  },
-}
-`;
-
 exports[`Links API Can bulk update links with external redirect 4: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
@@ -262,29 +154,15 @@ Object {
 }
 `;
 
-exports[`Links API Can bulk update links with external redirect 5: [headers] 1`] = `
-Object {
-  "access-control-allow-origin": "http://127.0.0.1:2369",
-  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "885",
-  "content-type": "application/json; charset=utf-8",
-  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
-  "vary": "Accept-Version, Origin, Accept-Encoding",
-  "x-powered-by": "Express",
-}
-`;
-
 exports[`Links API Can bulk update multiple links with same site redirect 1: [body] 1`] = `
 Object {
   "bulk": Object {
     "action": "updateLink",
     "meta": Object {
-      "errors": Array [],
       "stats": Object {
         "successful": 2,
         "unsuccessful": 0,
       },
-      "unsuccessfulData": Array [],
     },
   },
 }
@@ -294,7 +172,7 @@ exports[`Links API Can bulk update multiple links with same site redirect 2: [he
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "117",
+  "content-length": "83",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -354,53 +232,6 @@ Object {
 }
 `;
 
-exports[`Links API Can bulk update multiple links with same site redirect 4: [body] 1`] = `
-Object {
-  "links": Array [
-    Object {
-      "count": Object {
-        "clicks": Any<Number>,
-      },
-      "link": Object {
-        "from": Any<String>,
-        "link_id": Any<String>,
-        "to": Any<String>,
-      },
-      "post_id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-    },
-    Object {
-      "count": Object {
-        "clicks": Any<Number>,
-      },
-      "link": Object {
-        "from": Any<String>,
-        "link_id": Any<String>,
-        "to": "http://127.0.0.1:2369/blog/emails/test?example=1&ref=Test-newsletter&attribution_type=post&attribution_id=618ba1ffbe2896088840a6df",
-      },
-      "post_id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-    },
-    Object {
-      "count": Object {
-        "clicks": Any<Number>,
-      },
-      "link": Object {
-        "from": Any<String>,
-        "link_id": Any<String>,
-        "to": "http://127.0.0.1:2369/blog/emails/test?example=1&ref=Test-newsletter&attribution_type=post&attribution_id=618ba1ffbe2896088840a6df",
-      },
-      "post_id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-    },
-  ],
-  "meta": Object {
-    "pagination": Object {
-      "page": 1,
-      "pages": 1,
-      "total": 3,
-    },
-  },
-}
-`;
-
 exports[`Links API Can bulk update multiple links with same site redirect 4: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
@@ -414,29 +245,15 @@ Object {
 }
 `;
 
-exports[`Links API Can bulk update multiple links with same site redirect 5: [headers] 1`] = `
-Object {
-  "access-control-allow-origin": "http://127.0.0.1:2369",
-  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "841",
-  "content-type": "application/json; charset=utf-8",
-  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
-  "vary": "Accept-Version, Origin, Accept-Encoding",
-  "x-powered-by": "Express",
-}
-`;
-
 exports[`Links API Can call bulk update link with 0 matches 1: [body] 1`] = `
 Object {
   "bulk": Object {
     "action": "updateLink",
     "meta": Object {
-      "errors": Array [],
       "stats": Object {
         "successful": 0,
         "unsuccessful": 0,
       },
-      "unsuccessfulData": Array [],
     },
   },
 }
@@ -446,7 +263,7 @@ exports[`Links API Can call bulk update link with 0 matches 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "117",
+  "content-length": "83",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -506,53 +323,6 @@ Object {
 }
 `;
 
-exports[`Links API Can call bulk update link with 0 matches 4: [body] 1`] = `
-Object {
-  "links": Array [
-    Object {
-      "count": Object {
-        "clicks": Any<Number>,
-      },
-      "link": Object {
-        "from": Any<String>,
-        "link_id": Any<String>,
-        "to": "https://example.com/subscripe?ref=Test-newsletter",
-      },
-      "post_id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-    },
-    Object {
-      "count": Object {
-        "clicks": Any<Number>,
-      },
-      "link": Object {
-        "from": Any<String>,
-        "link_id": Any<String>,
-        "to": Any<String>,
-      },
-      "post_id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-    },
-    Object {
-      "count": Object {
-        "clicks": Any<Number>,
-      },
-      "link": Object {
-        "from": Any<String>,
-        "link_id": Any<String>,
-        "to": Any<String>,
-      },
-      "post_id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-    },
-  ],
-  "meta": Object {
-    "pagination": Object {
-      "page": 1,
-      "pages": 1,
-      "total": 3,
-    },
-  },
-}
-`;
-
 exports[`Links API Can call bulk update link with 0 matches 4: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
@@ -560,18 +330,6 @@ Object {
   "content-length": "930",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
-  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
-  "vary": "Accept-Version, Origin, Accept-Encoding",
-  "x-powered-by": "Express",
-}
-`;
-
-exports[`Links API Can call bulk update link with 0 matches 5: [headers] 1`] = `
-Object {
-  "access-control-allow-origin": "http://127.0.0.1:2369",
-  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "885",
-  "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Version, Origin, Accept-Encoding",
   "x-powered-by": "Express",

--- a/ghost/core/test/e2e-api/admin/__snapshots__/members.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/members.test.js.snap
@@ -592,12 +592,10 @@ exports[`Members API Bulk operations Can bulk add a label to members 1: [body] 1
 Object {
   "bulk": Object {
     "meta": Object {
-      "errors": Array [],
       "stats": Object {
         "successful": 8,
         "unsuccessful": 0,
       },
-      "unsuccessfulData": Array [],
     },
   },
 }
@@ -607,7 +605,7 @@ exports[`Members API Bulk operations Can bulk add a label to members 2: [headers
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "95",
+  "content-length": "61",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -620,12 +618,10 @@ exports[`Members API Bulk operations Can bulk add a label to members with filter
 Object {
   "bulk": Object {
     "meta": Object {
-      "errors": Array [],
       "stats": Object {
         "successful": 1,
         "unsuccessful": 0,
       },
-      "unsuccessfulData": Array [],
     },
   },
 }
@@ -635,7 +631,7 @@ exports[`Members API Bulk operations Can bulk add a label to members with filter
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "95",
+  "content-length": "61",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -648,12 +644,10 @@ exports[`Members API Bulk operations Can bulk delete a label from members 1: [bo
 Object {
   "bulk": Object {
     "meta": Object {
-      "errors": Array [],
       "stats": Object {
         "successful": 2,
         "unsuccessful": 0,
       },
-      "unsuccessfulData": Array [],
     },
   },
 }
@@ -663,7 +657,7 @@ exports[`Members API Bulk operations Can bulk delete a label from members 2: [he
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "95",
+  "content-length": "61",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -676,12 +670,10 @@ exports[`Members API Bulk operations Can bulk delete a label from members 3: [bo
 Object {
   "bulk": Object {
     "meta": Object {
-      "errors": Array [],
       "stats": Object {
         "successful": 1,
         "unsuccessful": 0,
       },
-      "unsuccessfulData": Array [],
     },
   },
 }
@@ -691,7 +683,7 @@ exports[`Members API Bulk operations Can bulk delete a label from members 4: [he
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "95",
+  "content-length": "61",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -704,12 +696,10 @@ exports[`Members API Bulk operations Can bulk delete a label from members with f
 Object {
   "bulk": Object {
     "meta": Object {
-      "errors": Array [],
       "stats": Object {
         "successful": 1,
         "unsuccessful": 0,
       },
-      "unsuccessfulData": Array [],
     },
   },
 }
@@ -719,7 +709,7 @@ exports[`Members API Bulk operations Can bulk delete a label from members with f
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "95",
+  "content-length": "61",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -731,12 +721,10 @@ Object {
 exports[`Members API Bulk operations Can bulk delete members 1: [body] 1`] = `
 Object {
   "meta": Object {
-    "errors": Array [],
     "stats": Object {
       "successful": 8,
       "unsuccessful": 0,
     },
-    "unsuccessfulIds": Array [],
   },
 }
 `;
@@ -745,12 +733,10 @@ exports[`Members API Bulk operations Can bulk unsubscribe members from specific 
 Object {
   "bulk": Object {
     "meta": Object {
-      "errors": Array [],
       "stats": Object {
         "successful": 4,
         "unsuccessful": 0,
       },
-      "unsuccessfulData": Array [],
     },
   },
 }
@@ -760,12 +746,10 @@ exports[`Members API Bulk operations Can bulk unsubscribe members with deprecate
 Object {
   "bulk": Object {
     "meta": Object {
-      "errors": Array [],
       "stats": Object {
         "successful": 6,
         "unsuccessful": 0,
       },
-      "unsuccessfulData": Array [],
     },
   },
 }
@@ -775,7 +759,7 @@ exports[`Members API Bulk operations Can bulk unsubscribe members with deprecate
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "95",
+  "content-length": "61",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -788,12 +772,10 @@ exports[`Members API Bulk operations Can bulk unsubscribe members with deprecate
 Object {
   "bulk": Object {
     "meta": Object {
-      "errors": Array [],
       "stats": Object {
         "successful": 2,
         "unsuccessful": 0,
       },
-      "unsuccessfulData": Array [],
     },
   },
 }
@@ -803,7 +785,7 @@ exports[`Members API Bulk operations Can bulk unsubscribe members with deprecate
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "95",
+  "content-length": "61",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -816,12 +798,10 @@ exports[`Members API Bulk operations Can bulk unsubscribe members with filter 1:
 Object {
   "bulk": Object {
     "meta": Object {
-      "errors": Array [],
       "stats": Object {
         "successful": 1,
         "unsuccessful": 0,
       },
-      "unsuccessfulData": Array [],
     },
   },
 }
@@ -831,7 +811,7 @@ exports[`Members API Bulk operations Can bulk unsubscribe members with filter 2:
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "95",
+  "content-length": "61",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -844,12 +824,10 @@ exports[`Members API Bulk operations Can bulk unsubscribe members with filter 3:
 Object {
   "bulk": Object {
     "meta": Object {
-      "errors": Array [],
       "stats": Object {
         "successful": 1,
         "unsuccessful": 0,
       },
-      "unsuccessfulData": Array [],
     },
   },
 }
@@ -859,7 +837,7 @@ exports[`Members API Bulk operations Can bulk unsubscribe members with filter 4:
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "95",
+  "content-length": "61",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -872,12 +850,10 @@ exports[`Members API Bulk operations Doesn't delete labels apart from the passed
 Object {
   "bulk": Object {
     "meta": Object {
-      "errors": Array [],
       "stats": Object {
         "successful": 1,
         "unsuccessful": 0,
       },
-      "unsuccessfulData": Array [],
     },
   },
 }
@@ -887,7 +863,7 @@ exports[`Members API Bulk operations Doesn't delete labels apart from the passed
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "95",
+  "content-length": "61",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -900,12 +876,10 @@ exports[`Members API Bulk operations Handles duplicate labels gracefully when bu
 Object {
   "bulk": Object {
     "meta": Object {
-      "errors": Array [],
       "stats": Object {
         "successful": 1,
         "unsuccessful": 0,
       },
-      "unsuccessfulData": Array [],
     },
   },
 }
@@ -915,7 +889,7 @@ exports[`Members API Bulk operations Handles duplicate labels gracefully when bu
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "95",
+  "content-length": "61",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/e2e-api/admin/__snapshots__/pages-bulk.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/pages-bulk.test.js.snap
@@ -4,7 +4,6 @@ exports[`Pages Bulk API Delete Can delete all pages 1: [body] 1`] = `
 Object {
   "bulk": Object {
     "meta": Object {
-      "errors": Array [],
       "stats": Object {
         "successful": 1,
         "unsuccessful": 0,
@@ -18,7 +17,6 @@ exports[`Pages Bulk API Delete Can delete pages that match a tag 1: [body] 1`] =
 Object {
   "bulk": Object {
     "meta": Object {
-      "errors": Array [],
       "stats": Object {
         "successful": 5,
         "unsuccessful": 0,
@@ -58,12 +56,10 @@ exports[`Pages Bulk API Edit Can change access of pages 1: [body] 1`] = `
 Object {
   "bulk": Object {
     "meta": Object {
-      "errors": Array [],
       "stats": Object {
         "successful": 6,
         "unsuccessful": 0,
       },
-      "unsuccessfulData": Array [],
     },
   },
 }
@@ -73,12 +69,10 @@ exports[`Pages Bulk API Edit Can change access of pages to tiers 1: [body] 1`] =
 Object {
   "bulk": Object {
     "meta": Object {
-      "errors": Array [],
       "stats": Object {
         "successful": 6,
         "unsuccessful": 0,
       },
-      "unsuccessfulData": Array [],
     },
   },
 }
@@ -88,12 +82,10 @@ exports[`Pages Bulk API Edit Can feature multiple pages 1: [body] 1`] = `
 Object {
   "bulk": Object {
     "meta": Object {
-      "errors": Array [],
       "stats": Object {
         "successful": 6,
         "unsuccessful": 0,
       },
-      "unsuccessfulData": Array [],
     },
   },
 }
@@ -103,12 +95,10 @@ exports[`Pages Bulk API Edit Can unfeature multiple pages 1: [body] 1`] = `
 Object {
   "bulk": Object {
     "meta": Object {
-      "errors": Array [],
       "stats": Object {
         "successful": 6,
         "unsuccessful": 0,
       },
-      "unsuccessfulData": Array [],
     },
   },
 }
@@ -118,12 +108,10 @@ exports[`Pages Bulk API Edit Can unpublish pages 1: [body] 1`] = `
 Object {
   "bulk": Object {
     "meta": Object {
-      "errors": Array [],
       "stats": Object {
         "successful": 5,
         "unsuccessful": 0,
       },
-      "unsuccessfulData": Array [],
     },
   },
 }

--- a/ghost/core/test/e2e-api/admin/__snapshots__/posts-bulk.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/posts-bulk.test.js.snap
@@ -4,7 +4,6 @@ exports[`Posts Bulk API Delete Can delete all posts 1: [body] 1`] = `
 Object {
   "bulk": Object {
     "meta": Object {
-      "errors": Array [],
       "stats": Object {
         "successful": 2,
         "unsuccessful": 0,
@@ -18,7 +17,6 @@ exports[`Posts Bulk API Delete Can delete posts that match a tag 1: [body] 1`] =
 Object {
   "bulk": Object {
     "meta": Object {
-      "errors": Array [],
       "stats": Object {
         "successful": 13,
         "unsuccessful": 0,
@@ -58,12 +56,10 @@ exports[`Posts Bulk API Edit Can change access of posts 1: [body] 1`] = `
 Object {
   "bulk": Object {
     "meta": Object {
-      "errors": Array [],
       "stats": Object {
         "successful": 15,
         "unsuccessful": 0,
       },
-      "unsuccessfulData": Array [],
     },
   },
 }
@@ -73,12 +69,10 @@ exports[`Posts Bulk API Edit Can change access of posts to tiers 1: [body] 1`] =
 Object {
   "bulk": Object {
     "meta": Object {
-      "errors": Array [],
       "stats": Object {
         "successful": 15,
         "unsuccessful": 0,
       },
-      "unsuccessfulData": Array [],
     },
   },
 }
@@ -88,12 +82,10 @@ exports[`Posts Bulk API Edit Can feature multiple posts 1: [body] 1`] = `
 Object {
   "bulk": Object {
     "meta": Object {
-      "errors": Array [],
       "stats": Object {
         "successful": 15,
         "unsuccessful": 0,
       },
-      "unsuccessfulData": Array [],
     },
   },
 }
@@ -103,12 +95,10 @@ exports[`Posts Bulk API Edit Can unfeature multiple posts 1: [body] 1`] = `
 Object {
   "bulk": Object {
     "meta": Object {
-      "errors": Array [],
       "stats": Object {
         "successful": 15,
         "unsuccessful": 0,
       },
-      "unsuccessfulData": Array [],
     },
   },
 }
@@ -118,12 +108,10 @@ exports[`Posts Bulk API Edit Can unpublish posts 1: [body] 1`] = `
 Object {
   "bulk": Object {
     "meta": Object {
-      "errors": Array [],
       "stats": Object {
         "successful": 13,
         "unsuccessful": 0,
       },
-      "unsuccessfulData": Array [],
     },
   },
 }

--- a/ghost/core/test/e2e-api/admin/links.test.js
+++ b/ghost/core/test/e2e-api/admin/links.test.js
@@ -75,9 +75,7 @@ describe('Links API', function () {
                         stats: {
                             successful: 2,
                             unsuccessful: 0
-                        },
-                        errors: [],
-                        unsuccessfulData: []
+                        }
                     }
                 }
             })
@@ -147,9 +145,7 @@ describe('Links API', function () {
                         stats: {
                             successful: 1,
                             unsuccessful: 0
-                        },
-                        errors: [],
-                        unsuccessfulData: []
+                        }
                     }
                 }
             })
@@ -208,9 +204,7 @@ describe('Links API', function () {
                         stats: {
                             successful: 0,
                             unsuccessful: 0
-                        },
-                        errors: [],
-                        unsuccessfulData: []
+                        }
                     }
                 }
             })

--- a/ghost/core/test/e2e-api/admin/members.test.js
+++ b/ghost/core/test/e2e-api/admin/members.test.js
@@ -3291,9 +3291,7 @@ describe('Members API Bulk operations', function () {
                             // Should contain the count of members, not the newsletter count!
                             successful: 1,
                             unsuccessful: 0
-                        },
-                        unsuccessfulData: [],
-                        errors: []
+                        }
                     }
                 }
             })
@@ -3319,9 +3317,7 @@ describe('Members API Bulk operations', function () {
                             // Should contain the count of members, not the newsletter count!
                             successful: 1,
                             unsuccessful: 0
-                        },
-                        unsuccessfulData: [],
-                        errors: []
+                        }
                     }
                 }
             })
@@ -3352,9 +3348,7 @@ describe('Members API Bulk operations', function () {
                         stats: {
                             successful: 4,
                             unsuccessful: 0
-                        },
-                        unsuccessfulData: [],
-                        errors: []
+                        }
                     }
                 }
             });
@@ -3376,9 +3370,7 @@ describe('Members API Bulk operations', function () {
                         stats: {
                             successful: 2, // We have two members who are subscribed to an inactive newsletter
                             unsuccessful: 0
-                        },
-                        unsuccessfulData: [],
-                        errors: []
+                        }
                     }
                 }
             })
@@ -3404,9 +3396,7 @@ describe('Members API Bulk operations', function () {
                         stats: {
                             successful: 6, // not 7 because members subscribed to an inactive newsletter aren't subscribed (newsletter fixture[2])
                             unsuccessful: 0
-                        },
-                        unsuccessfulData: [],
-                        errors: []
+                        }
                     }
                 }
             })
@@ -3444,9 +3434,7 @@ describe('Members API Bulk operations', function () {
                         stats: {
                             successful: 2,
                             unsuccessful: 0
-                        },
-                        unsuccessfulData: [],
-                        errors: []
+                        }
                     }
                 }
             })
@@ -3472,9 +3460,7 @@ describe('Members API Bulk operations', function () {
                         stats: {
                             successful: 1,
                             unsuccessful: 0
-                        },
-                        unsuccessfulData: [],
-                        errors: []
+                        }
                     }
                 }
             })
@@ -3513,9 +3499,7 @@ describe('Members API Bulk operations', function () {
                         stats: {
                             successful: 1,
                             unsuccessful: 0
-                        },
-                        unsuccessfulData: [],
-                        errors: []
+                        }
                     }
                 }
             })
@@ -3563,9 +3547,7 @@ describe('Members API Bulk operations', function () {
                         stats: {
                             successful: 1,
                             unsuccessful: 0
-                        },
-                        unsuccessfulData: [],
-                        errors: []
+                        }
                     }
                 }
             })
@@ -3602,9 +3584,7 @@ describe('Members API Bulk operations', function () {
                         stats: {
                             successful: 8,
                             unsuccessful: 0
-                        },
-                        unsuccessfulData: [],
-                        errors: []
+                        }
                     }
                 }
             })
@@ -3645,9 +3625,7 @@ describe('Members API Bulk operations', function () {
                         stats: {
                             successful: 1,
                             unsuccessful: 0
-                        },
-                        unsuccessfulData: [],
-                        errors: []
+                        }
                     }
                 }
             })
@@ -3694,9 +3672,7 @@ describe('Members API Bulk operations', function () {
                         stats: {
                             successful: 1,
                             unsuccessful: 0
-                        },
-                        unsuccessfulData: [],
-                        errors: []
+                        }
                     }
                 }
             })
@@ -3720,9 +3696,7 @@ describe('Members API Bulk operations', function () {
                     stats: {
                         successful: 8,
                         unsuccessful: 0
-                    },
-                    unsuccessfulIds: [],
-                    errors: []
+                    }
                 }
             });
     });

--- a/ghost/core/test/unit/server/services/link-tracking/link-click-tracking-service.test.js
+++ b/ghost/core/test/unit/server/services/link-tracking/link-click-tracking-service.test.js
@@ -183,9 +183,7 @@ describe('LinkClickTrackingService', function () {
                 postLinkRepository: {
                     updateLinks: sinon.stub().resolves({
                         successful: 0,
-                        unsuccessful: 0,
-                        errors: [],
-                        unsuccessfulData: []
+                        unsuccessful: 0
                     })
                 },
                 linkRedirectService: {
@@ -204,9 +202,7 @@ describe('LinkClickTrackingService', function () {
             }, options);
             should(result).eql({
                 successful: 0,
-                unsuccessful: 0,
-                errors: [],
-                unsuccessfulData: []
+                unsuccessful: 0
             });
         });
 
@@ -219,9 +215,7 @@ describe('LinkClickTrackingService', function () {
             const postLinkRepositoryStub = {
                 updateLinks: sinon.stub().resolves({
                     successful: 0,
-                    unsuccessful: 0,
-                    errors: [],
-                    unsuccessfulData: []
+                    unsuccessful: 0
                 })
             };
             const linkRedirectServiceStub = {
@@ -250,9 +244,7 @@ describe('LinkClickTrackingService', function () {
             should(postLinkRepositoryStub.updateLinks.calledOnce).be.true();
             should(result).eql({
                 successful: 0,
-                unsuccessful: 0,
-                errors: [],
-                unsuccessfulData: []
+                unsuccessful: 0
             });
 
             const [filterOptions] = linkRedirectServiceStub.getFilteredIds.firstCall.args;
@@ -268,9 +260,7 @@ describe('LinkClickTrackingService', function () {
             const postLinkRepositoryStub = {
                 updateLinks: sinon.stub().resolves({
                     successful: 0,
-                    unsuccessful: 0,
-                    errors: [],
-                    unsuccessfulData: []
+                    unsuccessful: 0
                 })
             };
             const linkRedirectServiceStub = {
@@ -299,9 +289,7 @@ describe('LinkClickTrackingService', function () {
             should(postLinkRepositoryStub.updateLinks.calledOnce).be.true();
             should(result).eql({
                 successful: 0,
-                unsuccessful: 0,
-                errors: [],
-                unsuccessfulData: []
+                unsuccessful: 0
             });
 
             const [filterOptions] = linkRedirectServiceStub.getFilteredIds.firstCall.args;
@@ -317,9 +305,7 @@ describe('LinkClickTrackingService', function () {
             const postLinkRepositoryStub = {
                 updateLinks: sinon.stub().resolves({
                     successful: 0,
-                    unsuccessful: 0,
-                    errors: [],
-                    unsuccessfulData: []
+                    unsuccessful: 0
                 })
             };
             const linkRedirectServiceStub = {

--- a/ghost/core/test/unit/server/services/link-tracking/post-link-repository.test.js
+++ b/ghost/core/test/unit/server/services/link-tracking/post-link-repository.test.js
@@ -16,9 +16,7 @@ describe('UNIT: PostLinkRepository class', function () {
                 }),
                 bulkEdit: sinon.stub().returns({
                     successful: 0,
-                    unsuccessful: 0,
-                    errors: [],
-                    unsuccessfulData: []
+                    unsuccessful: 0
                 })
             },
             linkRedirectRepository: {}
@@ -45,9 +43,7 @@ describe('UNIT: PostLinkRepository class', function () {
                         stats: {
                             successful: 0,
                             unsuccessful: 0
-                        },
-                        errors: [],
-                        unsuccessfulData: []
+                        }
                     }
                 }
             });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3184

## Why

The `bulkEdit` and `bulkDestroy` methods in the base model carry unnecessary complexity inherited from `createBulkOperation`, where error handling per-record makes sense. For bulk UPDATE/DELETE though, the operation either fully succeeds or throws — there's no partial failure. Despite this, the methods wrapped calls in a try/catch, checked a `throwErrors` flag, and returned `errors` and `unsuccessfulData` arrays that were always empty. Every serializer and API response dutifully passed along these empty arrays, and no frontend code ever read them.

This means the bulk operation surface area is larger than it needs to be, making it harder to understand and extend. By removing the dead code paths, the contract becomes honest: bulk edit/destroy succeeds or throws, and the response tells you how many items were affected.

## What

Removed the `throwErrors` flag and try/catch from `bulkEdit`/`bulkDestroy` in `bulk-operations.js`. These methods now call through to `bulkEditWhere`/`bulkDestroyWhere` directly and return `{successful: ids.length, unsuccessful: 0}`. The `successful` count uses `ids.length` (the caller's stated intent) rather than `affectedRows` from the database, which can be misleading for junction table operations where one logical member deletion might affect multiple newsletter subscription rows.

Cleaned up the serializers (`members.js`, `posts.js`, `pages.js`), the members API endpoint, `member-repository.js`, and `post-link-repository.js` to stop referencing the removed `errors`, `unsuccessfulData`, and `unsuccessfulIds` fields. Updated all affected E2E snapshots and unit tests.

`bulkAdd`/`createBulkOperation` are intentionally left unchanged — `throwErrors` has a real purpose there (skip per-record retry on failure).
