### PR TITLE
🐛 Fixed comp subscription not being cancelled on upgrade to paid

### DIFF
--- a/ghost/core/test/e2e-api/admin/__snapshots__/members-edit-subscriptions.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/members-edit-subscriptions.test.js.snap
@@ -936,3 +936,111 @@ Object {
   "x-powered-by": "Express",
 }
 `;
+
+exports[`Members API: edit subscriptions Comp product is removed when a comped member upgrades to a paid subscription 1: [body] 1`] = `
+Object {
+  "members": Array [
+    Object {
+      "attribution": null,
+      "avatar_image": null,
+      "can_comment": true,
+      "commenting": Object {
+        "disabled": false,
+        "disabled_reason": null,
+        "disabled_until": null,
+      },
+      "comped": false,
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "email": "comped-paid-combination@example.com",
+      "email_count": 0,
+      "email_open_rate": null,
+      "email_opened_count": 0,
+      "email_suppression": Object {
+        "info": null,
+        "suppressed": false,
+      },
+      "geolocation": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "labels": Any<Array>,
+      "last_seen_at": null,
+      "name": null,
+      "newsletters": Any<Array>,
+      "note": null,
+      "status": "paid",
+      "subscribed": false,
+      "subscriptions": Any<Array>,
+      "tiers": Any<Array>,
+      "unsubscribe_url": "http://domain.com/unsubscribe/?uuid=memberuuid&key=abc123dontstealme",
+      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+    },
+  ],
+}
+`;
+
+exports[`Members API: edit subscriptions Comp product is removed when a comped member upgrades to a paid subscription 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "2665",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Members API: edit subscriptions Comp product is removed when a comped member upgrades to a paid subscription 3: [body] 1`] = `
+Object {
+  "members": Array [
+    Object {
+      "attribution": null,
+      "avatar_image": null,
+      "can_comment": true,
+      "commenting": Object {
+        "disabled": false,
+        "disabled_reason": null,
+        "disabled_until": null,
+      },
+      "comped": false,
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "email": "comped-paid-combination@example.com",
+      "email_count": 0,
+      "email_open_rate": null,
+      "email_opened_count": 0,
+      "email_suppression": Object {
+        "info": null,
+        "suppressed": false,
+      },
+      "geolocation": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "labels": Any<Array>,
+      "last_seen_at": null,
+      "name": null,
+      "newsletters": Any<Array>,
+      "note": null,
+      "status": "free",
+      "subscribed": false,
+      "subscriptions": Any<Array>,
+      "tiers": Any<Array>,
+      "unsubscribe_url": "http://domain.com/unsubscribe/?uuid=memberuuid&key=abc123dontstealme",
+      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+    },
+  ],
+}
+`;
+
+exports[`Members API: edit subscriptions Comp product is removed when a comped member upgrades to a paid subscription 4: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "1681",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;

--- a/ghost/core/test/e2e-api/members/webhooks.test.js
+++ b/ghost/core/test/e2e-api/members/webhooks.test.js
@@ -60,7 +60,6 @@ function set(object, newValues) {
 
 describe('Members API', function () {
     // @todo: Test what happens when a complimentary subscription ends (should create comped -> free event)
-    // @todo: Test what happens when a complimentary subscription starts a paid subscription
 
     // We create some shared stripe resources, so we don't have to have nocks in every test case
     const subscription = {};
@@ -68,6 +67,9 @@ describe('Members API', function () {
     const paymentMethod = {};
     const setupIntent = {};
     const coupon = {};
+
+    // Additional subscriptions that tests can register for multi-subscription scenarios
+    const subscriptionOverrides = {};
 
     beforeEach(function () {
         nock('https://api.stripe.com')
@@ -92,6 +94,9 @@ describe('Members API', function () {
                 }
 
                 if (resource === 'subscriptions') {
+                    if (subscriptionOverrides[id]) {
+                        return [200, subscriptionOverrides[id]];
+                    }
                     if (subscription.id !== id) {
                         return [404];
                     }
@@ -150,11 +155,39 @@ describe('Members API', function () {
                 return [500];
             });
 
+        nock('https://api.stripe.com')
+            .persist()
+            .delete(/v1\/.*/)
+            .reply((uri) => {
+                const [match, resource, id] = uri.match(/\/?v1\/(\w+)\/?(\w+)/) || [null];
+
+                if (!match) {
+                    return [500];
+                }
+
+                if (resource === 'subscriptions') {
+                    const sub = subscriptionOverrides[id] || (subscription.id === id ? subscription : null);
+                    if (!sub) {
+                        return [404];
+                    }
+                    const canceled = {...sub, status: 'canceled'};
+                    // Update the override so subsequent GETs return the canceled version
+                    subscriptionOverrides[id] = canceled;
+                    return [200, canceled];
+                }
+
+                return [500];
+            });
+
         sinon.stub(settingsHelpers, 'createUnsubscribeUrl').returns('http://domain.com/unsubscribe/?uuid=memberuuid&key=abc123dontstealme');
     });
 
     afterEach(function () {
         mockManager.restore();
+        // Clear subscription overrides between tests
+        for (const key of Object.keys(subscriptionOverrides)) {
+            delete subscriptionOverrides[key];
+        }
     });
 
     describe('/webhooks/stripe/', function () {
@@ -1058,6 +1091,428 @@ describe('Members API', function () {
                 .header('content-type', 'application/json')
                 .header('stripe-signature', webhookSignature)
                 .expectStatus(200);
+        });
+
+        it('Cancels Stripe-backed complimentary subscription when comped member completes a paid checkout', async function () {
+            const compCustomerId = createStripeID('cust');
+            const compSubscriptionId = createStripeID('sub');
+            const paidSubscriptionId = createStripeID('sub');
+
+            const compPrice = {
+                id: 'price_comp',
+                product: 'product_123',
+                active: true,
+                nickname: 'Complimentary',
+                currency: 'usd',
+                recurring: {
+                    interval: 'month'
+                },
+                unit_amount: 0,
+                type: 'recurring'
+            };
+
+            // Set up the complimentary subscription
+            set(subscription, {
+                id: compSubscriptionId,
+                customer: compCustomerId,
+                status: 'active',
+                items: {
+                    type: 'list',
+                    data: [{
+                        id: 'item_comp',
+                        price: compPrice
+                    }]
+                },
+                plan: compPrice,
+                start_date: Date.now() / 1000,
+                current_period_end: Date.now() / 1000 + (60 * 60 * 24 * 31),
+                cancel_at_period_end: false
+            });
+
+            set(customer, {
+                id: compCustomerId,
+                name: 'Test Stripe Comp Member',
+                email: 'stripe-comp-test@email.com',
+                subscriptions: {
+                    type: 'list',
+                    data: [subscription]
+                }
+            });
+
+            // Create a comped member with a Stripe subscription
+            const {body: createBody} = await adminAgent
+                .post('/members/')
+                .body({members: [{
+                    name: customer.name,
+                    email: customer.email,
+                    subscribed: true,
+                    stripe_customer_id: customer.id
+                }]})
+                .expectStatus(201);
+
+            const initialMember = createBody.members[0];
+            assert.equal(initialMember.status, 'comped', 'The member initial status should be comped');
+            assert.equal(initialMember.tiers.length, 1, 'The member should have one tier');
+            assert.equal(initialMember.subscriptions.length, 1, 'The member should have one Stripe subscription');
+
+            // Define the paid subscription
+            const paidPrice = {
+                id: 'price_123',
+                product: 'product_123',
+                active: true,
+                nickname: 'Monthly',
+                currency: 'usd',
+                recurring: {
+                    interval: 'month'
+                },
+                unit_amount: 500,
+                type: 'recurring'
+            };
+
+            const paidSubscription = {
+                id: paidSubscriptionId,
+                customer: compCustomerId,
+                status: 'active',
+                items: {
+                    type: 'list',
+                    data: [{
+                        id: 'item_paid',
+                        price: paidPrice
+                    }]
+                },
+                start_date: beforeNow / 1000,
+                current_period_end: Math.floor(beforeNow / 1000) + (60 * 60 * 24 * 31),
+                cancel_at_period_end: false
+            };
+
+            // Register the comp subscription in overrides so the DELETE and GET handlers can find it
+            subscriptionOverrides[compSubscriptionId] = {
+                id: compSubscriptionId,
+                customer: compCustomerId,
+                status: 'active',
+                items: {
+                    type: 'list',
+                    data: [{
+                        id: 'item_comp',
+                        price: compPrice
+                    }]
+                },
+                plan: compPrice,
+                start_date: Date.now() / 1000,
+                current_period_end: Date.now() / 1000 + (60 * 60 * 24 * 31),
+                cancel_at_period_end: false
+            };
+
+            // Update shared objects for the paid subscription
+            set(subscription, paidSubscription);
+
+            set(customer, {
+                id: compCustomerId,
+                name: 'Test Stripe Comp Member',
+                email: 'stripe-comp-test@email.com',
+                subscriptions: {
+                    type: 'list',
+                    data: [paidSubscription]
+                }
+            });
+
+            // Send checkout.session.completed webhook
+            const webhookPayload = JSON.stringify({
+                type: 'checkout.session.completed',
+                data: {
+                    object: {
+                        mode: 'subscription',
+                        customer: compCustomerId,
+                        subscription: paidSubscriptionId,
+                        metadata: {}
+                    }
+                }
+            });
+
+            const webhookSignature = stripe.webhooks.generateTestHeaderString({
+                payload: webhookPayload,
+                secret: process.env.WEBHOOK_SECRET
+            });
+
+            await membersAgent.post('/webhooks/stripe/')
+                .body(webhookPayload)
+                .header('content-type', 'application/json')
+                .header('stripe-signature', webhookSignature)
+                .expectStatus(200);
+
+            await DomainEvents.allSettled();
+
+            // Verify member state
+            const {body} = await adminAgent.get('/members/' + initialMember.id + '/');
+            const updatedMember = body.members[0];
+
+            assert.equal(updatedMember.status, 'paid', 'The member should now be paid');
+            assert.equal(updatedMember.tiers.length, 1, 'The member should have one tier');
+            assert.equal(updatedMember.subscriptions.length, 2, 'The member should have two subscriptions');
+
+            const compSub = updatedMember.subscriptions.find(s => s.id === compSubscriptionId);
+            const paidSub = updatedMember.subscriptions.find(s => s.id === paidSubscriptionId);
+
+            assert.equal(compSub.status, 'canceled', 'The complimentary subscription should be canceled');
+            assert.equal(paidSub.status, 'active', 'The paid subscription should be active');
+        });
+
+        it('Removes Ghost-only comp tier when comped member completes a paid checkout', async function () {
+            // Create a separate product for the comp tier (different from the paid subscription product)
+            const compProduct = await Product.add({
+                name: 'Comp Tier',
+                slug: 'comp-tier-test',
+                type: 'paid'
+            });
+
+            const compCustomerId = createStripeID('cust');
+            const paidSubscriptionId = createStripeID('sub');
+
+            // Create a free member
+            const {body: createBody} = await adminAgent
+                .post('/members/')
+                .body({members: [{
+                    name: 'Ghost Comp Test Member',
+                    email: 'ghost-comp-test@email.com',
+                    subscribed: true
+                }]})
+                .expectStatus(201);
+
+            const memberId = createBody.members[0].id;
+            assert.equal(createBody.members[0].status, 'free', 'The member should start as free');
+
+            // Comp the member by assigning a different tier than the paid subscription product
+            const {body: compBody} = await adminAgent
+                .put(`/members/${memberId}/`)
+                .body({members: [{
+                    id: memberId,
+                    tiers: [{id: compProduct.id}]
+                }]})
+                .expectStatus(200);
+
+            assert.equal(compBody.members[0].status, 'comped', 'The member should be comped');
+            assert.equal(compBody.members[0].tiers.length, 1, 'The member should have one tier');
+
+            // Set up Stripe customer and paid subscription
+            const paidPrice = {
+                id: 'price_123',
+                product: 'product_123',
+                active: true,
+                nickname: 'Monthly',
+                currency: 'usd',
+                recurring: {
+                    interval: 'month'
+                },
+                unit_amount: 500,
+                type: 'recurring'
+            };
+
+            const paidSubscription = {
+                id: paidSubscriptionId,
+                customer: compCustomerId,
+                status: 'active',
+                items: {
+                    type: 'list',
+                    data: [{
+                        id: 'item_paid',
+                        price: paidPrice
+                    }]
+                },
+                start_date: beforeNow / 1000,
+                current_period_end: Math.floor(beforeNow / 1000) + (60 * 60 * 24 * 31),
+                cancel_at_period_end: false
+            };
+
+            set(subscription, paidSubscription);
+
+            set(customer, {
+                id: compCustomerId,
+                name: 'Ghost Comp Test Member',
+                email: 'ghost-comp-test@email.com',
+                subscriptions: {
+                    type: 'list',
+                    data: [paidSubscription]
+                }
+            });
+
+            // Send checkout.session.completed webhook
+            const webhookPayload = JSON.stringify({
+                type: 'checkout.session.completed',
+                data: {
+                    object: {
+                        mode: 'subscription',
+                        customer: compCustomerId,
+                        subscription: paidSubscriptionId,
+                        metadata: {}
+                    }
+                }
+            });
+
+            const webhookSignature = stripe.webhooks.generateTestHeaderString({
+                payload: webhookPayload,
+                secret: process.env.WEBHOOK_SECRET
+            });
+
+            await membersAgent.post('/webhooks/stripe/')
+                .body(webhookPayload)
+                .header('content-type', 'application/json')
+                .header('stripe-signature', webhookSignature)
+                .expectStatus(200);
+
+            await DomainEvents.allSettled();
+
+            // Verify member state - comp tier should be removed
+            const {body} = await adminAgent.get('/members/' + memberId + '/');
+            const updatedMember = body.members[0];
+
+            assert.equal(updatedMember.status, 'paid', 'The member should now be paid');
+            assert.equal(updatedMember.tiers.length, 1, 'The member should have one tier (the paid one)');
+            assert.equal(updatedMember.subscriptions.length, 1, 'The member should have one subscription');
+            assert.equal(updatedMember.subscriptions[0].status, 'active', 'The paid subscription should be active');
+        });
+
+        it('Member becomes free (not comped) when paid subscription is cancelled after upgrading from comp', async function () {
+            // Create a separate product for the comp tier (different from the paid subscription product)
+            const compProduct = await Product.add({
+                name: 'Comp Tier Cancel',
+                slug: 'comp-tier-cancel-test',
+                type: 'paid'
+            });
+
+            const compCustomerId = createStripeID('cust');
+            const paidSubscriptionId = createStripeID('sub');
+
+            // Create a free member
+            const {body: createBody} = await adminAgent
+                .post('/members/')
+                .body({members: [{
+                    name: 'Comp Cancel Test Member',
+                    email: 'comp-cancel-test@email.com',
+                    subscribed: true
+                }]})
+                .expectStatus(201);
+
+            const memberId = createBody.members[0].id;
+
+            // Comp the member by assigning a different tier than the paid subscription product
+            await adminAgent
+                .put(`/members/${memberId}/`)
+                .body({members: [{
+                    id: memberId,
+                    tiers: [{id: compProduct.id}]
+                }]})
+                .expectStatus(200);
+
+            // Set up Stripe customer and paid subscription
+            const paidPrice = {
+                id: 'price_123',
+                product: 'product_123',
+                active: true,
+                nickname: 'Monthly',
+                currency: 'usd',
+                recurring: {
+                    interval: 'month'
+                },
+                unit_amount: 500,
+                type: 'recurring'
+            };
+
+            const paidSubscription = {
+                id: paidSubscriptionId,
+                customer: compCustomerId,
+                status: 'active',
+                items: {
+                    type: 'list',
+                    data: [{
+                        id: 'item_paid',
+                        price: paidPrice
+                    }]
+                },
+                start_date: beforeNow / 1000,
+                current_period_end: Math.floor(beforeNow / 1000) + (60 * 60 * 24 * 31),
+                cancel_at_period_end: false
+            };
+
+            set(subscription, paidSubscription);
+
+            set(customer, {
+                id: compCustomerId,
+                name: 'Comp Cancel Test Member',
+                email: 'comp-cancel-test@email.com',
+                subscriptions: {
+                    type: 'list',
+                    data: [paidSubscription]
+                }
+            });
+
+            // Send checkout.session.completed webhook to upgrade to paid
+            let webhookPayload = JSON.stringify({
+                type: 'checkout.session.completed',
+                data: {
+                    object: {
+                        mode: 'subscription',
+                        customer: compCustomerId,
+                        subscription: paidSubscriptionId,
+                        metadata: {}
+                    }
+                }
+            });
+
+            let webhookSignature = stripe.webhooks.generateTestHeaderString({
+                payload: webhookPayload,
+                secret: process.env.WEBHOOK_SECRET
+            });
+
+            await membersAgent.post('/webhooks/stripe/')
+                .body(webhookPayload)
+                .header('content-type', 'application/json')
+                .header('stripe-signature', webhookSignature)
+                .expectStatus(200);
+
+            await DomainEvents.allSettled();
+
+            // Verify the member is now paid
+            const {body: paidBody} = await adminAgent.get('/members/' + memberId + '/');
+            assert.equal(paidBody.members[0].status, 'paid', 'The member should be paid after checkout');
+
+            // Now cancel the paid subscription
+            set(subscription, {
+                ...paidSubscription,
+                status: 'canceled',
+                canceled_at: Date.now() / 1000,
+                cancellation_details: {
+                    reason: 'cancellation_requested'
+                }
+            });
+
+            webhookPayload = JSON.stringify({
+                type: 'customer.subscription.deleted',
+                data: {
+                    object: subscription
+                }
+            });
+
+            webhookSignature = stripe.webhooks.generateTestHeaderString({
+                payload: webhookPayload,
+                secret: process.env.WEBHOOK_SECRET
+            });
+
+            await membersAgent.post('/webhooks/stripe/')
+                .body(webhookPayload)
+                .header('content-type', 'application/json')
+                .header('stripe-signature', webhookSignature)
+                .expectStatus(200);
+
+            await DomainEvents.allSettled();
+
+            // Verify the member is now free, not comped
+            const {body: cancelBody} = await adminAgent.get('/members/' + memberId + '/');
+            const cancelledMember = cancelBody.members[0];
+
+            assert.equal(cancelledMember.status, 'free', 'The member should be free after cancellation, not comped');
+            assert.equal(cancelledMember.tiers.length, 0, 'The member should have no tiers');
+            assert.equal(cancelledMember.subscriptions.length, 1, 'The member should have one subscription');
+            assert.equal(cancelledMember.subscriptions[0].status, 'canceled', 'The subscription should be canceled');
         });
     });
 

--- a/ghost/core/test/unit/server/services/members/members-api/repositories/member-repository.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/repositories/member-repository.test.js
@@ -284,7 +284,8 @@ describe('MemberRepository', function () {
                     related: (relation) => {
                         return {
                             query: sinon.stub().returns({
-                                fetchOne: sinon.stub().resolves({})
+                                fetchOne: sinon.stub().resolves({}),
+                                fetch: sinon.stub().resolves({models: []})
                             }),
                             toJSON: sinon.stub().returns(relation === 'products' ? [] : {}),
                             fetch: sinon.stub().resolves({
@@ -1199,7 +1200,8 @@ describe('MemberRepository', function () {
                     related: (relation) => {
                         return {
                             query: sinon.stub().returns({
-                                fetchOne: sinon.stub().resolves({})
+                                fetchOne: sinon.stub().resolves({}),
+                                fetch: sinon.stub().resolves({models: []})
                             }),
                             toJSON: sinon.stub().returns(relation === 'products' ? [] : {}),
                             fetch: sinon.stub().resolves({

--- a/ghost/core/test/unit/server/services/stripe/services/webhooks/checkout-session-event-service.test.js
+++ b/ghost/core/test/unit/server/services/stripe/services/webhooks/checkout-session-event-service.test.js
@@ -18,7 +18,9 @@ describe('CheckoutSessionEventService', function () {
 
         memberRepository = {
             get: sinon.stub(),
-            create: sinon.stub(),
+            create: sinon.stub().resolves({
+                id: 'created_member'
+            }),
             update: sinon.stub(),
             linkSubscription: sinon.stub(),
             upsertCustomer: sinon.stub()


### PR DESCRIPTION
## What

ref https://linear.app/ghost/issue/BER-3243

When a comped member upgrades to a paid plan via Stripe Checkout, the existing complimentary access is not removed. The member ends up with both paid and complimentary access. If the paid subscription is later cancelled, the member reverts to `comped` instead of `free`.

There are two types of comp: Stripe-backed (legacy, created via the `comped` flag which creates a real $0 Stripe subscription) and Ghost-only (current Admin UI, created via the tiers array which only adds a `members_products` row with no Stripe subscription). Neither type was being removed on upgrade to paid.

## Why

`linkSubscription()` in `member-repository.js` reconciles member products when a subscription changes, but only removes the *previous* product for the subscription being updated. It had no concept of complimentary access that should be revoked when a paid subscription is linked — whether that's a Stripe-backed comp subscription or a Ghost-only comp product.

## How

Added a `removeComplimentaryAccess()` method on `MemberRepository` that handles both comp types. It is called from `linkSubscription()` when a paid subscription is linked (`status === 'paid'`):

1. **Stripe-backed comps:** Fetches the member's Stripe subscriptions, identifies any active complimentary ones (using existing `isComplimentarySubscription()` and `isActiveSubscriptionStatus()` helpers), cancels them via the Stripe API, and re-links via `linkSubscription()` to update database state and dispatch events.

2. **Ghost-only comps:** Queries active Stripe subscriptions with their associated products, builds a set of product IDs backed by an active subscription, and filters `memberProducts` to only include those. Ghost-only comp products have no backing subscription, so they get removed.

By living inside `linkSubscription`, this runs for all subscription changes — checkout, webhooks, imports — rather than only the checkout path.