### PR TITLE
🐛 Fixed admin posts list loading every page on access

### DIFF
--- a/ghost/admin/app/components/gh-canvas-header.hbs
+++ b/ghost/admin/app/components/gh-canvas-header.hbs
@@ -1,5 +1,5 @@
 <div
-    {{on-scroll this.onScroll scrollContainer=".gh-main"}}
+    {{on-scroll this.onScroll scrollContainer=".shade-admin main:not(main main)"}}
     ...attributes
 >
     <header class="gh-canvas-header-content">

--- a/ghost/admin/app/templates/mentions.hbs
+++ b/ghost/admin/app/templates/mentions.hbs
@@ -104,7 +104,7 @@
             {{/if}}
             <GhInfinityLoader
             @infinityModel={{this.mentionsInfinityModel}}
-            @scrollable=".gh-main"
+            @scrollable=".shade-admin main"
             @triggerOffset={{1000}} />
         </div>
         {{#if this.mentionsInfinityModel}}

--- a/ghost/admin/app/templates/pages.hbs
+++ b/ghost/admin/app/templates/pages.hbs
@@ -56,19 +56,19 @@
     {{#if @model.scheduledInfinityModel}}
         <GhInfinityLoader
             @infinityModel={{@model.scheduledInfinityModel}}
-            @scrollable=".gh-main"
+            @scrollable=".shade-admin main"
             @triggerOffset={{1000}} />
     {{/if}}
     {{#if (and @model.draftInfinityModel (or (not @model.scheduledInfinityModel) (and @model.scheduledInfinityModel @model.scheduledInfinityModel.reachedInfinity)))}}
         <GhInfinityLoader
             @infinityModel={{@model.draftInfinityModel}}
-            @scrollable=".gh-main"
+            @scrollable=".shade-admin main"
             @triggerOffset={{1000}} />
     {{/if}}
     {{#if (and @model.publishedAndSentInfinityModel (and (or (not @model.scheduledInfinityModel) @model.scheduledInfinityModel.reachedInfinity) (or (not @model.draftInfinityModel) @model.draftInfinityModel.reachedInfinity)))}}
         <GhInfinityLoader
             @infinityModel={{@model.publishedAndSentInfinityModel}}
-            @scrollable=".gh-main"
+            @scrollable=".shade-admin main"
             @triggerOffset={{1000}} />
     {{/if}}
 

--- a/ghost/admin/app/templates/posts.hbs
+++ b/ghost/admin/app/templates/posts.hbs
@@ -58,19 +58,19 @@
     {{#if @model.scheduledInfinityModel}}
         <GhInfinityLoader
             @infinityModel={{@model.scheduledInfinityModel}}
-            @scrollable=".gh-main"
+            @scrollable=".shade-admin main"
             @triggerOffset={{1000}} />
     {{/if}}
     {{#if (and @model.draftInfinityModel (or (not @model.scheduledInfinityModel) (and @model.scheduledInfinityModel @model.scheduledInfinityModel.reachedInfinity)))}}
         <GhInfinityLoader
             @infinityModel={{@model.draftInfinityModel}}
-            @scrollable=".gh-main"
+            @scrollable=".shade-admin main"
             @triggerOffset={{1000}} />
     {{/if}}
     {{#if (and @model.publishedAndSentInfinityModel (and (or (not @model.scheduledInfinityModel) @model.scheduledInfinityModel.reachedInfinity) (or (not @model.draftInfinityModel) @model.draftInfinityModel.reachedInfinity)))}}
         <GhInfinityLoader
             @infinityModel={{@model.publishedAndSentInfinityModel}}
-            @scrollable=".gh-main"
+            @scrollable=".shade-admin main"
             @triggerOffset={{1000}} />
     {{/if}}
 


### PR DESCRIPTION
closes https://linear.app/ghost/issue/BER-3245/

- with the new React Admin shell the scrollable element for the main content area has changed from `.gh-main` to `.shade-admin main` meaning our infinite scroll and other scroll-detect handlers inside Ember Admin were not firing correctly
- the React shell is now the default for the admin app so these changes aren't behind the `adminForward` labs flag
