### PR TITLE
✨ Added welcome emails for free and paid members

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
@@ -36,10 +36,6 @@ const features: Feature[] = [{
     description: 'Enables {uniqueid} variable in emails for unique image URLs to bypass ESP image caching',
     flag: 'emailUniqueid'
 }, {
-    title: 'Welcome Emails',
-    description: 'Enables features related to sending welcome emails to new members',
-    flag: 'welcomeEmails'
-}, {
     title: 'Updated theme translation (beta)',
     description: 'Enable theme translation using i18next instead of the old translation package.',
     flag: 'themeTranslation'

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -29,6 +29,7 @@ const GA_FEATURES = [
     'commentModeration',
     'commentPermalinks',
     'featurebaseFeedback'
+    'welcomeEmails'
 ];
 
 // These features are considered publicly available and can be enabled/disabled by users
@@ -49,7 +50,6 @@ const PRIVATE_FEATURES = [
     'emailCustomization',
     'tagsX',
     'emailUniqueid',
-    'welcomeEmails',
     'themeTranslation',
     'indexnow',
     'transistor'

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -28,7 +28,7 @@ const GA_FEATURES = [
     'inboxlinks',
     'commentModeration',
     'commentPermalinks',
-    'featurebaseFeedback'
+    'featurebaseFeedback',
     'welcomeEmails'
 ];
 

--- a/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
@@ -1603,7 +1603,7 @@ exports[`Settings API Edit can edit Stripe settings when Stripe Connect limit is
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "4844",
+  "content-length": "4867",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,


### PR DESCRIPTION
ref https://linear.app/ghost/issue/NY-969/promote-welcomeemails-labs-flag-to-ga-features-in-ghost-backend

We've been iterating on member welcome emails behind a feature flag for a while now, and we're excited to release this in GA for everyone to try out.