### PR TITLE
Removed unnecessary Should.js import from EventStorage test

### DIFF
--- a/ghost/core/test/unit/server/services/members-events/event-storage.test.js
+++ b/ghost/core/test/unit/server/services/members-events/event-storage.test.js
@@ -1,4 +1,3 @@
-require('should');
 const sinon = require('sinon');
 
 const {MemberCreatedEvent, SubscriptionCreatedEvent} = require('../../../../../core/shared/events');


### PR DESCRIPTION
*This change should have no user impact.*

This import was unnecessary and can be removed.
