### PR TITLE
Cleaned up custom redirects validation unit tests

### DIFF
--- a/ghost/core/test/unit/server/services/custom-redirects/validation.test.js
+++ b/ghost/core/test/unit/server/services/custom-redirects/validation.test.js
@@ -1,4 +1,4 @@
-const should = require('should');
+const assert = require('node:assert/strict');
 
 const {validate} = require('../../../../../core/server/services/custom-redirects/validation');
 
@@ -19,12 +19,9 @@ describe('UNIT: custom redirects validation', function () {
             to: '/'
         }];
 
-        try {
-            validate(config);
-            should.fail('should have thrown');
-        } catch (err) {
-            err.message.should.equal('Incorrect redirects file format.');
-        }
+        assert.throws(() => {
+            validate(/** @type {any} */ (config));
+        }, {message: 'Incorrect redirects file format.'});
     });
 
     it('throws for an invalid redirects config having invalid RegExp in from field', function () {
@@ -34,12 +31,9 @@ describe('UNIT: custom redirects validation', function () {
             to: '/'
         }];
 
-        try {
+        assert.throws(() => {
             validate(config);
-            should.fail('should have thrown');
-        } catch (err) {
-            err.message.should.equal('Incorrect RegEx in redirects file.');
-        }
+        }, {message: 'Incorrect RegEx in redirects file.'});
     });
 
     it('throws when setting a file with wrong format: no array', function () {
@@ -48,11 +42,8 @@ describe('UNIT: custom redirects validation', function () {
             to: 'd'
         };
 
-        try {
-            validate(config);
-            should.fail('should have thrown');
-        } catch (err) {
-            err.message.should.equal('Incorrect redirects file format.');
-        }
+        assert.throws(() => {
+            validate(/** @type {any} */ (config));
+        }, {message: 'Incorrect redirects file format.'});
     });
 });


### PR DESCRIPTION
_This test-only change should have no user impact._

This makes three changes to the custom redirect validation unit tests:

1. Instead of using `try`, use `assert.throws()`.
2. Switch from Should.js to `node:assert/strict`.
3. Fix type errors in the file.
