### PR TITLE
Cleaned up Mailgun email provider tests

### DIFF
--- a/ghost/core/test/unit/server/services/email-service/mailgun-email-provider.test.js
+++ b/ghost/core/test/unit/server/services/email-service/mailgun-email-provider.test.js
@@ -1,6 +1,5 @@
 const MailgunEmailProvider = require('../../../../../core/server/services/email-service/mailgun-email-provider');
 const sinon = require('sinon');
-const should = require('should');
 const assert = require('assert/strict');
 
 describe('Mailgun Email Provider', function () {
@@ -62,9 +61,9 @@ describe('Mailgun Email Provider', function () {
                 openTrackingEnabled: true,
                 deliveryTime
             });
-            should(response.id).eql('provider-123');
-            should(sendStub.calledOnce).be.true();
-            sendStub.calledWith(
+            assert.equal(response.id, 'provider-123');
+            sinon.assert.calledOnce(sendStub);
+            sinon.assert.calledWith(sendStub,
                 {
                     subject: 'Hi',
                     html: '<html><body>Hi %recipient.name%</body></html>',
@@ -79,7 +78,7 @@ describe('Mailgun Email Provider', function () {
                 },
                 {'member@example.com': {name: 'John'}},
                 []
-            ).should.be.true();
+            );
         });
 
         it('handles mailgun client error correctly', async function () {
@@ -99,8 +98,8 @@ describe('Mailgun Email Provider', function () {
                 mailgunClient,
                 errorHandler: () => {}
             });
-            try {
-                const response = await mailgunEmailProvider.send({
+            await assert.rejects(async () => {
+                await mailgunEmailProvider.send({
                     subject: 'Hi',
                     html: '<html><body>Hi {{name}}</body></html>',
                     plaintext: 'Hi',
@@ -127,12 +126,12 @@ describe('Mailgun Email Provider', function () {
                         }
                     ]
                 }, {});
-                should(response).be.undefined();
-            } catch (e) {
-                should(e.message).eql('Bad Request: Invalid domain');
-                should(e.statusCode).eql(400);
-                should(e.errorDetails).eql('{"error":{"details":"Invalid domain","status":400},"messageData":{}}');
-            }
+                assert.fail();
+            }, {
+                message: 'Bad Request: Invalid domain',
+                statusCode: 400,
+                errorDetails: '{"error":{"details":"Invalid domain","status":400},"messageData":{}}'
+            });
         });
 
         it('handles unknown error correctly', async function () {
@@ -147,8 +146,8 @@ describe('Mailgun Email Provider', function () {
                 mailgunClient,
                 errorHandler: () => {}
             });
-            try {
-                const response = await mailgunEmailProvider.send({
+            await assert.rejects(async () => {
+                await mailgunEmailProvider.send({
                     subject: 'Hi',
                     html: '<html><body>Hi {{name}}</body></html>',
                     plaintext: 'Hi',
@@ -175,11 +174,11 @@ describe('Mailgun Email Provider', function () {
                         }
                     ]
                 }, {});
-                should(response).be.undefined();
-            } catch (e) {
-                should(e.message).eql('Unknown Error');
-                should(e.errorDetails).eql(undefined);
-            }
+                assert.fail();
+            }, {
+                message: 'Unknown Error',
+                errorDetails: undefined
+            });
         });
 
         it('handles empty error correctly', async function () {
@@ -194,8 +193,8 @@ describe('Mailgun Email Provider', function () {
                 mailgunClient,
                 errorHandler: () => {}
             });
-            try {
-                const response = await mailgunEmailProvider.send({
+            await assert.rejects(async () => {
+                await mailgunEmailProvider.send({
                     subject: 'Hi',
                     html: '<html><body>Hi {{name}}</body></html>',
                     plaintext: 'Hi',
@@ -222,11 +221,11 @@ describe('Mailgun Email Provider', function () {
                         }
                     ]
                 }, {});
-                should(response).be.undefined();
-            } catch (e) {
-                should(e.message).eql('Mailgun Error');
-                should(e.errorDetails).eql(undefined);
-            }
+                assert.fail();
+            }, {
+                message: 'Mailgun Error',
+                errorDetails: undefined
+            });
         });
     });
 


### PR DESCRIPTION
_This test-only change should have no user impact._

This makes two changes to the Mailgun email provider tests:

1. Instead of using `try`, use `assert.throws()` or just call the function.
2. Switch from Should.js to `node:assert/strict` and Sinon assertions.
