### PR TITLE
Fixed over-eager newsletter redirect, possibly fixing flaky test

### DIFF
--- a/apps/stats/src/views/Stats/Newsletters/newsletters.tsx
+++ b/apps/stats/src/views/Stats/Newsletters/newsletters.tsx
@@ -364,7 +364,7 @@ const Newsletters: React.FC = () => {
     // const hasNewslettersInPeriod = newsletterStatsData?.stats && newsletterStatsData.stats.length > 0;
     // const pageData = isKPIsLoading || isNewsletterStatsLoading ? undefined : (hasNewslettersInPeriod ? ['data exists'] : []);
 
-    if (!appSettings?.newslettersEnabled) {
+    if (appSettings && !appSettings.newslettersEnabled) {
         return (
             <Navigate to='/' />
         );

--- a/apps/stats/src/views/Stats/Newsletters/newsletters.tsx
+++ b/apps/stats/src/views/Stats/Newsletters/newsletters.tsx
@@ -366,7 +366,7 @@ const Newsletters: React.FC = () => {
 
     if (appSettings && !appSettings.newslettersEnabled) {
         return (
-            <Navigate to='/' />
+            <Navigate to='/analytics' />
         );
     }
 


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/actions/runs/21494158108/job/61924761703

One of the newsletter tests is [flaky in CI][0]. I think this is because app settings are loading and we redirect away before they do.

The old logic was, roughly: redirect if newsletters are disabled *or* if app settings are still loading.

The new logic is: redirect if newsletters are disabled. Don't redirect if app settings are still loading.

I'm not certain this will fix CI flakiness--I can't reproduce locally--but I think this is an improvement anyway.

[0]: https://github.com/TryGhost/Ghost/actions/runs/21494158108/job/61924761703
