### PR TITLE
Removed `themeErrorsNotification` lab flag

### DIFF
--- a/apps/admin-x-framework/src/test/acceptance.ts
+++ b/apps/admin-x-framework/src/test/acceptance.ts
@@ -83,7 +83,6 @@ export const responseFixtures = {
 const defaultLabFlags = {
     audienceFeedback: false,
     collections: false,
-    themeErrorsNotification: false,
     outboundLinkTagging: false,
     announcementBar: false,
     members: false

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -22,7 +22,6 @@ const messages = {
 // flags in this list always return `true`, allows quick global enable prior to full flag removal
 const GA_FEATURES = [
     'audienceFeedback',
-    'themeErrorsNotification',
     'announcementBar',
     'customFonts',
     'explore'

--- a/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
@@ -29,7 +29,6 @@ Object {
       "stripeAutomaticTax": true,
       "superEditors": true,
       "tagsX": true,
-      "themeErrorsNotification": true,
       "themeTranslation": true,
       "transistor": true,
       "urlCache": true,

--- a/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
@@ -1603,7 +1603,7 @@ exports[`Settings API Edit can edit Stripe settings when Stripe Connect limit is
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "4774",
+  "content-length": "4741",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,


### PR DESCRIPTION
ref c7230f1858180a7f34c0cd1313c4d4bd97657c04

This flag has been in GA for over 3 years, so we can remove all related code. (There wasn't much left.)
