### PR TITLE
Fixed hidden publish footer on mobile

### DIFF
--- a/apps/admin/src/layout/app-sidebar/mobile-nav-bar.tsx
+++ b/apps/admin/src/layout/app-sidebar/mobile-nav-bar.tsx
@@ -6,6 +6,7 @@ import {
     useSidebar,
 } from "@tryghost/shade";
 import { useIsActiveLink } from "./use-is-active-link";
+import { useSidebarVisibility } from "@/ember-bridge/ember-bridge";
 
 const ICON_STROKE_WIDTH = 1.5;
 
@@ -34,8 +35,10 @@ function MobileNavBarButton({ to, activeOnSubpath = false, children, ...props }:
 
 export function MobileNavBar() {
     const { isMobile } = useSidebar();
+    const sidebarVisible = useSidebarVisibility();
 
-    if (!isMobile) {
+
+    if (!isMobile || !sidebarVisible) {
         return <></>
     }
 

--- a/ghost/admin/app/styles/layouts/editor.css
+++ b/ghost/admin/app/styles/layouts/editor.css
@@ -293,6 +293,14 @@
     }
 }
 
+.gh-editor-fullscreen-container {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+}
+
 .gh-editor-header {
     position: absolute;
     top: 0;

--- a/ghost/admin/app/templates/lexical-editor.hbs
+++ b/ghost/admin/app/templates/lexical-editor.hbs
@@ -1,4 +1,5 @@
 {{#if this.post}}
+<div class="gh-editor-fullscreen-container">
     <div class="flex flex-row">
         <GhEditor
             @tagName="section"
@@ -161,6 +162,8 @@
             @close={{this.closePostHistory}}
             @modifier="total-overlay post-history" />
     {{/if}}
+
+</div>
 {{/if}}
 
 {{outlet}}


### PR DESCRIPTION
Closes https://linear.app/ghost/issue/BER-3247/mobile-publish-option-hard-to-find-or-missing

Updated so that the mobile nav doesn't show in the editor. Also gave the editor a new container to respect sticky header and footer.
