### PR TITLE
Removed `featured` changelog requirement

### DIFF
--- a/apps/admin/src/whats-new/components/whats-new-banner.tsx
+++ b/apps/admin/src/whats-new/components/whats-new-banner.tsx
@@ -9,8 +9,8 @@ function WhatsNewBanner() {
     const { mutate: dismissWhatsNew } = useDismissWhatsNew();
     const [isDismissed, setIsDismissed] = useState(false);
 
-    // Don't show if dismissed or no featured content
-    if (isDismissed || !whatsNewData?.hasNewFeatured) {
+    // Don't show if dismissed or no new content
+    if (isDismissed || !whatsNewData?.hasNew) {
         return null;
     }
 

--- a/apps/admin/src/whats-new/hooks/use-whats-new.test.tsx
+++ b/apps/admin/src/whats-new/hooks/use-whats-new.test.tsx
@@ -49,11 +49,6 @@ const fixtures = {
             createRawChangelogEntry({
                 published_at: dates.past,
             }),
-        featuredEntry: () =>
-            createRawChangelogEntry({
-                published_at: dates.current,
-                featured: "true",
-            }),
     },
     preferences: {
         empty: {},
@@ -321,54 +316,6 @@ describe("useWhatsNew", () => {
         });
     });
 
-    describe("hasNewFeatured", () => {
-        describe("returns true", () => {
-            queryTest("when entry is newer than lastSeenDate and featured", async ({ setup }) => {
-                const result = await setup({
-                    changelog: {
-                        posts: [fixtures.entries.featuredEntry()],
-                    },
-                    accessibility: JSON.stringify(fixtures.preferences.withLastSeen(dates.past)),
-                });
-
-                expect(result.current.data?.hasNewFeatured).toBe(true);
-            });
-        });
-
-        describe("returns false", () => {
-            [
-                {
-                    scenario: "when entry is older than lastSeenDate",
-                    input: {
-                        changelog: {
-                            posts: [fixtures.entries.featuredEntry()],
-                        },
-                        accessibility: JSON.stringify(fixtures.preferences.withLastSeen(dates.future)),
-                    },
-                },
-                {
-                    scenario: "when entry is newer but not featured",
-                    input: {
-                        changelog: {
-                            posts: [fixtures.entries.newEntry()],
-                        },
-                        accessibility: JSON.stringify(fixtures.preferences.withLastSeen(dates.past)),
-                    },
-                },
-                {
-                    scenario: "when no entries exist",
-                    input: {
-                        changelog: { posts: [] },
-                    },
-                },
-            ].forEach(({ scenario, input }) => {
-                queryTest(scenario, async ({ setup }) => {
-                    const result = await setup(input);
-                    expect(result.current.data?.hasNewFeatured).toBe(false);
-                });
-            });
-        });
-    });
 });
 
 describe("useDismissWhatsNew", () => {

--- a/apps/admin/src/whats-new/hooks/use-whats-new.ts
+++ b/apps/admin/src/whats-new/hooks/use-whats-new.ts
@@ -17,7 +17,6 @@ function getDefaultWhatsNewPreferences(): WhatsNewPreferences {
 
 interface WhatsNewData {
     hasNew: boolean;
-    hasNewFeatured: boolean;
 }
 
 const whatsNewQueryKey = (preferences: Preferences | undefined, latestEntry: ChangelogEntry | undefined) =>
@@ -45,7 +44,7 @@ export const useWhatsNew = (): UseQueryResult<WhatsNewData> => {
         queryKey: whatsNewQueryKey(preferences, latestEntry),
         queryFn: () => {
             if (!latestEntry) {
-                return { hasNew: false, hasNewFeatured: false };
+                return { hasNew: false };
             }
 
             // Safe to assert non-null because query is only enabled when hasWhatsNewPreferences is true,
@@ -53,9 +52,8 @@ export const useWhatsNew = (): UseQueryResult<WhatsNewData> => {
             const lastSeenDate = preferences!.whatsNew!.lastSeenDate!;
 
             const hasNew = latestEntry.publishedAt > lastSeenDate;
-            const hasNewFeatured = hasNew && latestEntry.featured === true;
 
-            return { hasNew, hasNewFeatured };
+            return { hasNew };
         },
         enabled: isChangelogLoaded && hasWhatsNewPreferences,
         staleTime: Infinity,

--- a/e2e/tests/admin/whats-new.test.ts
+++ b/e2e/tests/admin/whats-new.test.ts
@@ -60,11 +60,10 @@ async function mockChangelog(page: Page, entries: RawChangelogEntry[]): Promise<
 
 test.describe('Ghost Admin - What\'s New', () => {
     test.describe('banner notification', () => {
-        test('shows banner for new featured entries the user has not seen', async ({page}) => {
+        test('shows banner for new entries the user has not seen', async ({page}) => {
             await mockChangelog(page, [
                 createEntry(daysFromNow(1), {
-                    featured: true,
-                    title: 'New Featured Update',
+                    title: 'New Update',
                     excerpt: 'This is an exciting new feature'
                 })
             ]);
@@ -74,12 +73,12 @@ test.describe('Ghost Admin - What\'s New', () => {
             await banner.waitForBanner();
 
             await expect(banner.container).toBeVisible();
-            await expect(banner.title).toHaveText('New Featured Update');
+            await expect(banner.title).toHaveText('New Update');
             await expect(banner.excerpt).toHaveText('This is an exciting new feature');
         });
 
         test('does not show banner for entries from before user joined', async ({page}) => {
-            await mockChangelog(page, [createEntry(daysAgo(30), {featured: true})]);
+            await mockChangelog(page, [createEntry(daysAgo(30))]);
 
             const banner = new WhatsNewBanner(page);
             await banner.goto();
@@ -96,18 +95,9 @@ test.describe('Ghost Admin - What\'s New', () => {
             await expect(banner.container).toBeHidden();
         });
 
-        test('does not show banner when latest entry is not featured', async ({page}) => {
-            await mockChangelog(page, [createEntry(daysFromNow(1))]);
-
-            const banner = new WhatsNewBanner(page);
-            await banner.goto();
-
-            await expect(banner.container).toBeHidden();
-        });
-
         test.describe('dismissal behavior', () => {
             test('hides banner immediately when close button is clicked', async ({page}) => {
-                await mockChangelog(page, [createEntry(daysFromNow(1), {featured: true})]);
+                await mockChangelog(page, [createEntry(daysFromNow(1))]);
 
                 const banner = new WhatsNewBanner(page);
                 await banner.goto();
@@ -121,7 +111,7 @@ test.describe('Ghost Admin - What\'s New', () => {
             });
 
             test('hides banner immediately when link is clicked', async ({page}) => {
-                await mockChangelog(page, [createEntry(daysFromNow(1), {featured: true})]);
+                await mockChangelog(page, [createEntry(daysFromNow(1))]);
 
                 const banner = new WhatsNewBanner(page);
                 await banner.goto();
@@ -136,7 +126,7 @@ test.describe('Ghost Admin - What\'s New', () => {
 
             test('hides banner immediately when modal is opened', async ({page}) => {
                 await mockChangelog(page, [
-                    createEntry(daysFromNow(1), {featured: true, feature_image: 'https://ghost.org/image1.jpg'}),
+                    createEntry(daysFromNow(1), {feature_image: 'https://ghost.org/image1.jpg'}),
                     createEntry(daysAgo(5))
                 ]);
 
@@ -155,7 +145,7 @@ test.describe('Ghost Admin - What\'s New', () => {
             });
 
             test('banner remains hidden after reload when dismissed', async ({page}) => {
-                await mockChangelog(page, [createEntry(daysFromNow(1), {featured: true})]);
+                await mockChangelog(page, [createEntry(daysFromNow(1))]);
 
                 const banner = new WhatsNewBanner(page);
                 await banner.goto();
@@ -168,7 +158,7 @@ test.describe('Ghost Admin - What\'s New', () => {
             });
 
             test('banner reappears when a new entry is published after dismissal', async ({page}) => {
-                await mockChangelog(page, [createEntry(daysFromNow(1), {featured: true})]);
+                await mockChangelog(page, [createEntry(daysFromNow(1))]);
 
                 const banner = new WhatsNewBanner(page);
 
@@ -181,8 +171,7 @@ test.describe('Ghost Admin - What\'s New', () => {
 
                 await mockChangelog(page, [
                     createEntry(daysFromNow(2), {
-                        featured: true,
-                        title: 'Second Featured Update'
+                        title: 'Second Update'
                     })
                 ]);
 
@@ -190,7 +179,7 @@ test.describe('Ghost Admin - What\'s New', () => {
                 await banner.waitForBanner();
 
                 await expect(banner.container).toBeVisible();
-                await expect(banner.title).toHaveText('Second Featured Update');
+                await expect(banner.title).toHaveText('Second Update');
             });
         });
     });
@@ -199,7 +188,6 @@ test.describe('Ghost Admin - What\'s New', () => {
         test('shows modal with all entries when opened from user menu', async ({page}) => {
             await mockChangelog(page, [
                 createEntry(daysFromNow(1), {
-                    featured: true,
                     title: 'Latest Update',
                     excerpt: 'Latest feature',
                     feature_image: 'https://ghost.org/image1.jpg'


### PR DESCRIPTION
closes https://linear.app/ghost/issue/BER-3075/

- we want to show all changelog as whats-new banners rather than only ones with the `featured` flag
- removed all handling for/usage of `hasNewFeatured` from the `useWhatsNew` hook
