### PR TITLE
🐛 Fixed comp subscription not being cancelled on upgrade to paid

### DIFF
--- a/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
@@ -152,7 +152,11 @@ module.exports = class MemberRepository {
     }
 
     isComplimentarySubscription(subscription) {
-        return subscription.plan && subscription.plan.nickname && subscription.plan.nickname.toLowerCase() === 'complimentary';
+        return this.isComplimentaryPlanNickname(subscription.plan?.nickname);
+    }
+
+    isComplimentaryPlanNickname(nickname) {
+        return nickname && nickname.toLowerCase() === 'complimentary';
     }
 
     /**
@@ -1991,34 +1995,66 @@ module.exports = class MemberRepository {
      * @param {Object} options
      * @param {Object} [options.transacting]
      */
-    async cancelComplimentarySubscription({id}, options) {
+    /**
+     * Removes all complimentary access for a member.
+     * Handles two types:
+     * 1. Stripe-backed: Subscriptions with plan_nickname 'Complimentary' — cancelled via Stripe, then synced via linkSubscription
+     * 2. Ghost-only: Products in members_products not backed by any active Stripe subscription — removed directly
+     *
+     * @param {{id: string}} data - member identifier
+     * @param {Object} options
+     */
+    async removeComplimentarySubscription({id}, options) {
         if (!this._stripeAPIService.configured) {
             throw new errors.BadRequestError({message: tpl(messages.noStripeConnection, {action: 'cancel Complimentary Subscription'})});
         }
 
-        const member = await this._Member.findOne({
-            id: id
-        });
+        const member = await this._Member.findOne({id});
+        const subscriptions = await member.related('stripeSubscriptions').fetch(options);
 
-        const subscriptions = await member.related('stripeSubscriptions').fetch();
-
+        // 1. Cancel Stripe-backed complimentary subscriptions
         for (const subscription of subscriptions.models) {
-            if (subscription.get('status') !== 'canceled') {
+            const isComp = this.isComplimentaryPlanNickname(subscription.get('plan_nickname'));
+            const isActive = this.isActiveSubscriptionStatus(subscription.get('status'));
+
+            if (isActive && isComp) {
                 try {
                     const updatedSubscription = await this._stripeAPIService.cancelSubscription(
                         subscription.get('subscription_id')
                     );
-                    // Only needs to update `status`
                     await this.linkSubscription({
                         id: id,
                         subscription: updatedSubscription
                     }, options);
                 } catch (err) {
-                    logging.error(`There was an error cancelling subscription ${subscription.get('subscription_id')}`);
+                    logging.error(`Error cancelling complimentary subscription ${subscription.get('subscription_id')}`);
                     logging.error(err);
                 }
             }
         }
+
+        // 2. Remove Ghost-only comp products (products not backed by any active Stripe subscription)
+        await member.load([
+            'products',
+            'stripeSubscriptions',
+            'stripeSubscriptions.stripePrice',
+            'stripeSubscriptions.stripePrice.stripeProduct'
+        ], options);
+
+        const activeSubscriptionProductIds = new Set(
+            member.related('stripeSubscriptions').models
+                .filter(sub => this.isActiveSubscriptionStatus(sub.get('status')))
+                .map(sub => sub.related('stripePrice')?.related('stripeProduct')?.get('product_id'))
+                .filter(Boolean)
+        );
+
+        const currentProducts = member.related('products').toJSON();
+        const filteredProducts = currentProducts.filter(product => activeSubscriptionProductIds.has(product.id));
+
+        if (filteredProducts.length !== currentProducts.length) {
+            await this._Member.edit({products: filteredProducts}, {id});
+        }
+
         return true;
     }
 

--- a/ghost/core/core/server/services/members/members-api/services/member-bread-service.js
+++ b/ghost/core/core/server/services/members/members-api/services/member-bread-service.js
@@ -380,7 +380,7 @@ module.exports = class MemberBREADService {
                         transacting: options.transacting
                     });
                 } else if (!(data.comped) && hasCompedSubscription) {
-                    await this.memberRepository.cancelComplimentarySubscription(model, {
+                    await this.memberRepository.removeComplimentarySubscription(model, {
                         context: options.context,
                         transacting: options.transacting
                     });

--- a/ghost/core/core/server/services/stripe/services/webhook/checkout-session-event-service.js
+++ b/ghost/core/core/server/services/stripe/services/webhook/checkout-session-event-service.js
@@ -251,6 +251,12 @@ module.exports = class CheckoutSessionEventService {
                     });
                 }
             }
+
+            // If member is now paid, remove any complimentary access
+            const updatedMember = await memberRepository.get({id: member.id});
+            if (updatedMember && updatedMember.get('status') === 'paid') {
+                await memberRepository.removeComplimentarySubscription({id: member.id});
+            }
         }
 
         if (checkoutType !== 'upgrade') {

--- a/ghost/core/core/server/services/stripe/services/webhook/subscription-event-service.js
+++ b/ghost/core/core/server/services/stripe/services/webhook/subscription-event-service.js
@@ -49,6 +49,12 @@ module.exports = class SubscriptionEventService {
                 }
                 throw new errors.ConflictError({err});
             }
+
+            // If member is now paid, remove any complimentary access
+            const updatedMember = await memberRepository.get({id: member.id});
+            if (updatedMember && updatedMember.get('status') === 'paid') {
+                await memberRepository.removeComplimentarySubscription({id: member.id});
+            }
         }
     }
 };

--- a/ghost/core/test/e2e-api/admin/__snapshots__/members-edit-subscriptions.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/members-edit-subscriptions.test.js.snap
@@ -936,3 +936,111 @@ Object {
   "x-powered-by": "Express",
 }
 `;
+
+exports[`Members API: edit subscriptions Comp product is removed when a comped member upgrades to a paid subscription 1: [body] 1`] = `
+Object {
+  "members": Array [
+    Object {
+      "attribution": null,
+      "avatar_image": null,
+      "can_comment": true,
+      "commenting": Object {
+        "disabled": false,
+        "disabled_reason": null,
+        "disabled_until": null,
+      },
+      "comped": false,
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "email": "comped-paid-combination@example.com",
+      "email_count": 0,
+      "email_open_rate": null,
+      "email_opened_count": 0,
+      "email_suppression": Object {
+        "info": null,
+        "suppressed": false,
+      },
+      "geolocation": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "labels": Any<Array>,
+      "last_seen_at": null,
+      "name": null,
+      "newsletters": Any<Array>,
+      "note": null,
+      "status": "paid",
+      "subscribed": false,
+      "subscriptions": Any<Array>,
+      "tiers": Any<Array>,
+      "unsubscribe_url": "http://domain.com/unsubscribe/?uuid=memberuuid&key=abc123dontstealme",
+      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+    },
+  ],
+}
+`;
+
+exports[`Members API: edit subscriptions Comp product is removed when a comped member upgrades to a paid subscription 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "2665",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Members API: edit subscriptions Comp product is removed when a comped member upgrades to a paid subscription 3: [body] 1`] = `
+Object {
+  "members": Array [
+    Object {
+      "attribution": null,
+      "avatar_image": null,
+      "can_comment": true,
+      "commenting": Object {
+        "disabled": false,
+        "disabled_reason": null,
+        "disabled_until": null,
+      },
+      "comped": false,
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "email": "comped-paid-combination@example.com",
+      "email_count": 0,
+      "email_open_rate": null,
+      "email_opened_count": 0,
+      "email_suppression": Object {
+        "info": null,
+        "suppressed": false,
+      },
+      "geolocation": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "labels": Any<Array>,
+      "last_seen_at": null,
+      "name": null,
+      "newsletters": Any<Array>,
+      "note": null,
+      "status": "free",
+      "subscribed": false,
+      "subscriptions": Any<Array>,
+      "tiers": Any<Array>,
+      "unsubscribe_url": "http://domain.com/unsubscribe/?uuid=memberuuid&key=abc123dontstealme",
+      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+    },
+  ],
+}
+`;
+
+exports[`Members API: edit subscriptions Comp product is removed when a comped member upgrades to a paid subscription 4: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "1681",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;

--- a/ghost/core/test/e2e-api/members/webhooks.test.js
+++ b/ghost/core/test/e2e-api/members/webhooks.test.js
@@ -60,7 +60,6 @@ function set(object, newValues) {
 
 describe('Members API', function () {
     // @todo: Test what happens when a complimentary subscription ends (should create comped -> free event)
-    // @todo: Test what happens when a complimentary subscription starts a paid subscription
 
     // We create some shared stripe resources, so we don't have to have nocks in every test case
     const subscription = {};
@@ -68,6 +67,9 @@ describe('Members API', function () {
     const paymentMethod = {};
     const setupIntent = {};
     const coupon = {};
+
+    // Additional subscriptions that tests can register for multi-subscription scenarios
+    const subscriptionOverrides = {};
 
     beforeEach(function () {
         nock('https://api.stripe.com')
@@ -92,6 +94,9 @@ describe('Members API', function () {
                 }
 
                 if (resource === 'subscriptions') {
+                    if (subscriptionOverrides[id]) {
+                        return [200, subscriptionOverrides[id]];
+                    }
                     if (subscription.id !== id) {
                         return [404];
                     }
@@ -150,11 +155,39 @@ describe('Members API', function () {
                 return [500];
             });
 
+        nock('https://api.stripe.com')
+            .persist()
+            .delete(/v1\/.*/)
+            .reply((uri) => {
+                const [match, resource, id] = uri.match(/\/?v1\/(\w+)\/?(\w+)/) || [null];
+
+                if (!match) {
+                    return [500];
+                }
+
+                if (resource === 'subscriptions') {
+                    const sub = subscriptionOverrides[id] || (subscription.id === id ? subscription : null);
+                    if (!sub) {
+                        return [404];
+                    }
+                    const canceled = {...sub, status: 'canceled'};
+                    // Update the override so subsequent GETs return the canceled version
+                    subscriptionOverrides[id] = canceled;
+                    return [200, canceled];
+                }
+
+                return [500];
+            });
+
         sinon.stub(settingsHelpers, 'createUnsubscribeUrl').returns('http://domain.com/unsubscribe/?uuid=memberuuid&key=abc123dontstealme');
     });
 
     afterEach(function () {
         mockManager.restore();
+        // Clear subscription overrides between tests
+        for (const key of Object.keys(subscriptionOverrides)) {
+            delete subscriptionOverrides[key];
+        }
     });
 
     describe('/webhooks/stripe/', function () {
@@ -1058,6 +1091,716 @@ describe('Members API', function () {
                 .header('content-type', 'application/json')
                 .header('stripe-signature', webhookSignature)
                 .expectStatus(200);
+        });
+
+        it('Cancels Stripe-backed complimentary subscription when comped member completes a paid checkout', async function () {
+            const compCustomerId = createStripeID('cust');
+            const compSubscriptionId = createStripeID('sub');
+            const paidSubscriptionId = createStripeID('sub');
+
+            const compPrice = {
+                id: 'price_comp',
+                product: 'product_123',
+                active: true,
+                nickname: 'Complimentary',
+                currency: 'usd',
+                recurring: {
+                    interval: 'month'
+                },
+                unit_amount: 0,
+                type: 'recurring'
+            };
+
+            // Set up the complimentary subscription
+            set(subscription, {
+                id: compSubscriptionId,
+                customer: compCustomerId,
+                status: 'active',
+                items: {
+                    type: 'list',
+                    data: [{
+                        id: 'item_comp',
+                        price: compPrice
+                    }]
+                },
+                plan: compPrice,
+                start_date: Date.now() / 1000,
+                current_period_end: Date.now() / 1000 + (60 * 60 * 24 * 31),
+                cancel_at_period_end: false
+            });
+
+            set(customer, {
+                id: compCustomerId,
+                name: 'Test Stripe Comp Member',
+                email: 'stripe-comp-test@email.com',
+                subscriptions: {
+                    type: 'list',
+                    data: [subscription]
+                }
+            });
+
+            // Create a comped member with a Stripe subscription
+            const {body: createBody} = await adminAgent
+                .post('/members/')
+                .body({members: [{
+                    name: customer.name,
+                    email: customer.email,
+                    subscribed: true,
+                    stripe_customer_id: customer.id
+                }]})
+                .expectStatus(201);
+
+            const initialMember = createBody.members[0];
+            assert.equal(initialMember.status, 'comped', 'The member initial status should be comped');
+            assert.equal(initialMember.tiers.length, 1, 'The member should have one tier');
+            assert.equal(initialMember.subscriptions.length, 1, 'The member should have one Stripe subscription');
+
+            // Define the paid subscription
+            const paidPrice = {
+                id: 'price_123',
+                product: 'product_123',
+                active: true,
+                nickname: 'Monthly',
+                currency: 'usd',
+                recurring: {
+                    interval: 'month'
+                },
+                unit_amount: 500,
+                type: 'recurring'
+            };
+
+            const paidSubscription = {
+                id: paidSubscriptionId,
+                customer: compCustomerId,
+                status: 'active',
+                items: {
+                    type: 'list',
+                    data: [{
+                        id: 'item_paid',
+                        price: paidPrice
+                    }]
+                },
+                start_date: beforeNow / 1000,
+                current_period_end: Math.floor(beforeNow / 1000) + (60 * 60 * 24 * 31),
+                cancel_at_period_end: false
+            };
+
+            // Register the comp subscription in overrides so the DELETE and GET handlers can find it
+            subscriptionOverrides[compSubscriptionId] = {
+                id: compSubscriptionId,
+                customer: compCustomerId,
+                status: 'active',
+                items: {
+                    type: 'list',
+                    data: [{
+                        id: 'item_comp',
+                        price: compPrice
+                    }]
+                },
+                plan: compPrice,
+                start_date: Date.now() / 1000,
+                current_period_end: Date.now() / 1000 + (60 * 60 * 24 * 31),
+                cancel_at_period_end: false
+            };
+
+            // Update shared objects for the paid subscription
+            set(subscription, paidSubscription);
+
+            set(customer, {
+                id: compCustomerId,
+                name: 'Test Stripe Comp Member',
+                email: 'stripe-comp-test@email.com',
+                subscriptions: {
+                    type: 'list',
+                    data: [paidSubscription]
+                }
+            });
+
+            // Send checkout.session.completed webhook
+            const webhookPayload = JSON.stringify({
+                type: 'checkout.session.completed',
+                data: {
+                    object: {
+                        mode: 'subscription',
+                        customer: compCustomerId,
+                        subscription: paidSubscriptionId,
+                        metadata: {}
+                    }
+                }
+            });
+
+            const webhookSignature = stripe.webhooks.generateTestHeaderString({
+                payload: webhookPayload,
+                secret: process.env.WEBHOOK_SECRET
+            });
+
+            await membersAgent.post('/webhooks/stripe/')
+                .body(webhookPayload)
+                .header('content-type', 'application/json')
+                .header('stripe-signature', webhookSignature)
+                .expectStatus(200);
+
+            await DomainEvents.allSettled();
+
+            // Verify member state
+            const {body} = await adminAgent.get('/members/' + initialMember.id + '/');
+            const updatedMember = body.members[0];
+
+            assert.equal(updatedMember.status, 'paid', 'The member should now be paid');
+            assert.equal(updatedMember.tiers.length, 1, 'The member should have one tier');
+            assert.equal(updatedMember.subscriptions.length, 2, 'The member should have two subscriptions');
+
+            const compSub = updatedMember.subscriptions.find(s => s.id === compSubscriptionId);
+            const paidSub = updatedMember.subscriptions.find(s => s.id === paidSubscriptionId);
+
+            assert.equal(compSub.status, 'canceled', 'The complimentary subscription should be canceled');
+            assert.equal(paidSub.status, 'active', 'The paid subscription should be active');
+        });
+
+        it('Removes Ghost-only comp tier when comped member completes a paid checkout', async function () {
+            // Create a separate product for the comp tier (different from the paid subscription product)
+            const compProduct = await Product.add({
+                name: 'Comp Tier',
+                slug: 'comp-tier-test',
+                type: 'paid'
+            });
+
+            const compCustomerId = createStripeID('cust');
+            const paidSubscriptionId = createStripeID('sub');
+
+            // Create a free member
+            const {body: createBody} = await adminAgent
+                .post('/members/')
+                .body({members: [{
+                    name: 'Ghost Comp Test Member',
+                    email: 'ghost-comp-test@email.com',
+                    subscribed: true
+                }]})
+                .expectStatus(201);
+
+            const memberId = createBody.members[0].id;
+            assert.equal(createBody.members[0].status, 'free', 'The member should start as free');
+
+            // Comp the member by assigning a different tier than the paid subscription product
+            const {body: compBody} = await adminAgent
+                .put(`/members/${memberId}/`)
+                .body({members: [{
+                    id: memberId,
+                    tiers: [{id: compProduct.id}]
+                }]})
+                .expectStatus(200);
+
+            assert.equal(compBody.members[0].status, 'comped', 'The member should be comped');
+            assert.equal(compBody.members[0].tiers.length, 1, 'The member should have one tier');
+
+            // Set up Stripe customer and paid subscription
+            const paidPrice = {
+                id: 'price_123',
+                product: 'product_123',
+                active: true,
+                nickname: 'Monthly',
+                currency: 'usd',
+                recurring: {
+                    interval: 'month'
+                },
+                unit_amount: 500,
+                type: 'recurring'
+            };
+
+            const paidSubscription = {
+                id: paidSubscriptionId,
+                customer: compCustomerId,
+                status: 'active',
+                items: {
+                    type: 'list',
+                    data: [{
+                        id: 'item_paid',
+                        price: paidPrice
+                    }]
+                },
+                start_date: beforeNow / 1000,
+                current_period_end: Math.floor(beforeNow / 1000) + (60 * 60 * 24 * 31),
+                cancel_at_period_end: false
+            };
+
+            set(subscription, paidSubscription);
+
+            set(customer, {
+                id: compCustomerId,
+                name: 'Ghost Comp Test Member',
+                email: 'ghost-comp-test@email.com',
+                subscriptions: {
+                    type: 'list',
+                    data: [paidSubscription]
+                }
+            });
+
+            // Send checkout.session.completed webhook
+            const webhookPayload = JSON.stringify({
+                type: 'checkout.session.completed',
+                data: {
+                    object: {
+                        mode: 'subscription',
+                        customer: compCustomerId,
+                        subscription: paidSubscriptionId,
+                        metadata: {}
+                    }
+                }
+            });
+
+            const webhookSignature = stripe.webhooks.generateTestHeaderString({
+                payload: webhookPayload,
+                secret: process.env.WEBHOOK_SECRET
+            });
+
+            await membersAgent.post('/webhooks/stripe/')
+                .body(webhookPayload)
+                .header('content-type', 'application/json')
+                .header('stripe-signature', webhookSignature)
+                .expectStatus(200);
+
+            await DomainEvents.allSettled();
+
+            // Verify member state - comp tier should be removed
+            const {body} = await adminAgent.get('/members/' + memberId + '/');
+            const updatedMember = body.members[0];
+
+            assert.equal(updatedMember.status, 'paid', 'The member should now be paid');
+            assert.equal(updatedMember.tiers.length, 1, 'The member should have one tier (the paid one)');
+            assert.equal(updatedMember.subscriptions.length, 1, 'The member should have one subscription');
+            assert.equal(updatedMember.subscriptions[0].status, 'active', 'The paid subscription should be active');
+        });
+
+        it('Member becomes free (not comped) when paid subscription is cancelled after upgrading from comp', async function () {
+            // Create a separate product for the comp tier (different from the paid subscription product)
+            const compProduct = await Product.add({
+                name: 'Comp Tier Cancel',
+                slug: 'comp-tier-cancel-test',
+                type: 'paid'
+            });
+
+            const compCustomerId = createStripeID('cust');
+            const paidSubscriptionId = createStripeID('sub');
+
+            // Create a free member
+            const {body: createBody} = await adminAgent
+                .post('/members/')
+                .body({members: [{
+                    name: 'Comp Cancel Test Member',
+                    email: 'comp-cancel-test@email.com',
+                    subscribed: true
+                }]})
+                .expectStatus(201);
+
+            const memberId = createBody.members[0].id;
+
+            // Comp the member by assigning a different tier than the paid subscription product
+            await adminAgent
+                .put(`/members/${memberId}/`)
+                .body({members: [{
+                    id: memberId,
+                    tiers: [{id: compProduct.id}]
+                }]})
+                .expectStatus(200);
+
+            // Set up Stripe customer and paid subscription
+            const paidPrice = {
+                id: 'price_123',
+                product: 'product_123',
+                active: true,
+                nickname: 'Monthly',
+                currency: 'usd',
+                recurring: {
+                    interval: 'month'
+                },
+                unit_amount: 500,
+                type: 'recurring'
+            };
+
+            const paidSubscription = {
+                id: paidSubscriptionId,
+                customer: compCustomerId,
+                status: 'active',
+                items: {
+                    type: 'list',
+                    data: [{
+                        id: 'item_paid',
+                        price: paidPrice
+                    }]
+                },
+                start_date: beforeNow / 1000,
+                current_period_end: Math.floor(beforeNow / 1000) + (60 * 60 * 24 * 31),
+                cancel_at_period_end: false
+            };
+
+            set(subscription, paidSubscription);
+
+            set(customer, {
+                id: compCustomerId,
+                name: 'Comp Cancel Test Member',
+                email: 'comp-cancel-test@email.com',
+                subscriptions: {
+                    type: 'list',
+                    data: [paidSubscription]
+                }
+            });
+
+            // Send checkout.session.completed webhook to upgrade to paid
+            let webhookPayload = JSON.stringify({
+                type: 'checkout.session.completed',
+                data: {
+                    object: {
+                        mode: 'subscription',
+                        customer: compCustomerId,
+                        subscription: paidSubscriptionId,
+                        metadata: {}
+                    }
+                }
+            });
+
+            let webhookSignature = stripe.webhooks.generateTestHeaderString({
+                payload: webhookPayload,
+                secret: process.env.WEBHOOK_SECRET
+            });
+
+            await membersAgent.post('/webhooks/stripe/')
+                .body(webhookPayload)
+                .header('content-type', 'application/json')
+                .header('stripe-signature', webhookSignature)
+                .expectStatus(200);
+
+            await DomainEvents.allSettled();
+
+            // Verify the member is now paid
+            const {body: paidBody} = await adminAgent.get('/members/' + memberId + '/');
+            assert.equal(paidBody.members[0].status, 'paid', 'The member should be paid after checkout');
+
+            // Now cancel the paid subscription
+            set(subscription, {
+                ...paidSubscription,
+                status: 'canceled',
+                canceled_at: Date.now() / 1000,
+                cancellation_details: {
+                    reason: 'cancellation_requested'
+                }
+            });
+
+            webhookPayload = JSON.stringify({
+                type: 'customer.subscription.deleted',
+                data: {
+                    object: subscription
+                }
+            });
+
+            webhookSignature = stripe.webhooks.generateTestHeaderString({
+                payload: webhookPayload,
+                secret: process.env.WEBHOOK_SECRET
+            });
+
+            await membersAgent.post('/webhooks/stripe/')
+                .body(webhookPayload)
+                .header('content-type', 'application/json')
+                .header('stripe-signature', webhookSignature)
+                .expectStatus(200);
+
+            await DomainEvents.allSettled();
+
+            // Verify the member is now free, not comped
+            const {body: cancelBody} = await adminAgent.get('/members/' + memberId + '/');
+            const cancelledMember = cancelBody.members[0];
+
+            assert.equal(cancelledMember.status, 'free', 'The member should be free after cancellation, not comped');
+            assert.equal(cancelledMember.tiers.length, 0, 'The member should have no tiers');
+            assert.equal(cancelledMember.subscriptions.length, 1, 'The member should have one subscription');
+            assert.equal(cancelledMember.subscriptions[0].status, 'canceled', 'The subscription should be canceled');
+        });
+    });
+
+    describe('customer.subscription.created - complimentary removal', function () {
+        before(async function () {
+            const agents = await agentProvider.getAgentsForMembers();
+            membersAgent = agents.membersAgent;
+            adminAgent = agents.adminAgent;
+
+            await fixtureManager.init('members');
+            await adminAgent.loginAsOwner();
+        });
+
+        beforeEach(function () {
+            mockManager.mockMail();
+        });
+
+        afterEach(function () {
+            mockManager.restore();
+        });
+
+        it('Cancels Stripe-backed complimentary subscription when a paid subscription is created', async function () {
+            const compCustomerId = createStripeID('cust');
+            const compSubscriptionId = createStripeID('sub');
+            const paidSubscriptionId = createStripeID('sub');
+
+            const compPrice = {
+                id: 'price_comp',
+                product: 'product_123',
+                active: true,
+                nickname: 'Complimentary',
+                currency: 'usd',
+                recurring: {
+                    interval: 'month'
+                },
+                unit_amount: 0,
+                type: 'recurring'
+            };
+
+            // Set up the complimentary subscription
+            set(subscription, {
+                id: compSubscriptionId,
+                customer: compCustomerId,
+                status: 'active',
+                items: {
+                    type: 'list',
+                    data: [{
+                        id: 'item_comp',
+                        price: compPrice
+                    }]
+                },
+                plan: compPrice,
+                start_date: Date.now() / 1000,
+                current_period_end: Date.now() / 1000 + (60 * 60 * 24 * 31),
+                cancel_at_period_end: false
+            });
+
+            set(customer, {
+                id: compCustomerId,
+                name: 'Comp Sub Event Test',
+                email: 'comp-sub-event-test@email.com',
+                subscriptions: {
+                    type: 'list',
+                    data: [subscription]
+                }
+            });
+
+            // Create a comped member with a Stripe complimentary subscription
+            const {body: createBody} = await adminAgent
+                .post('/members/')
+                .body({members: [{
+                    name: customer.name,
+                    email: customer.email,
+                    subscribed: true,
+                    stripe_customer_id: customer.id
+                }]})
+                .expectStatus(201);
+
+            const memberId = createBody.members[0].id;
+            assert.equal(createBody.members[0].status, 'comped');
+            assert.equal(createBody.members[0].subscriptions.length, 1);
+
+            // Register the comp subscription in overrides so DELETE can find it
+            subscriptionOverrides[compSubscriptionId] = {
+                id: compSubscriptionId,
+                customer: compCustomerId,
+                status: 'active',
+                items: {
+                    type: 'list',
+                    data: [{
+                        id: 'item_comp',
+                        price: compPrice
+                    }]
+                },
+                plan: compPrice,
+                start_date: Date.now() / 1000,
+                current_period_end: Date.now() / 1000 + (60 * 60 * 24 * 31),
+                cancel_at_period_end: false
+            };
+
+            // Define the paid subscription
+            const paidPrice = {
+                id: 'price_123',
+                product: 'product_123',
+                active: true,
+                nickname: 'Monthly',
+                currency: 'usd',
+                recurring: {
+                    interval: 'month'
+                },
+                unit_amount: 500,
+                type: 'recurring'
+            };
+
+            const paidSubscription = {
+                id: paidSubscriptionId,
+                customer: compCustomerId,
+                status: 'active',
+                items: {
+                    type: 'list',
+                    data: [{
+                        id: 'item_paid',
+                        price: paidPrice
+                    }]
+                },
+                start_date: Date.now() / 1000,
+                current_period_end: Date.now() / 1000 + (60 * 60 * 24 * 31),
+                cancel_at_period_end: false
+            };
+
+            // Register it so GET can find it
+            subscriptionOverrides[paidSubscriptionId] = paidSubscription;
+
+            // Send customer.subscription.created webhook for the paid subscription
+            const webhookPayload = JSON.stringify({
+                type: 'customer.subscription.created',
+                data: {
+                    object: paidSubscription
+                }
+            });
+
+            const webhookSignature = stripe.webhooks.generateTestHeaderString({
+                payload: webhookPayload,
+                secret: process.env.WEBHOOK_SECRET
+            });
+
+            await membersAgent.post('/webhooks/stripe/')
+                .body(webhookPayload)
+                .header('content-type', 'application/json')
+                .header('stripe-signature', webhookSignature)
+                .expectStatus(200);
+
+            await DomainEvents.allSettled();
+
+            // Verify: member should be paid, comp subscription cancelled
+            const {body} = await adminAgent.get('/members/' + memberId + '/');
+            const updatedMember = body.members[0];
+
+            assert.equal(updatedMember.status, 'paid');
+            assert.equal(updatedMember.tiers.length, 1);
+            assert.equal(updatedMember.subscriptions.length, 2);
+
+            const compSub = updatedMember.subscriptions.find(s => s.id === compSubscriptionId);
+            const paidSub = updatedMember.subscriptions.find(s => s.id === paidSubscriptionId);
+
+            assert.equal(compSub.status, 'canceled', 'Complimentary subscription should be canceled');
+            assert.equal(paidSub.status, 'active', 'Paid subscription should be active');
+        });
+
+        it('Removes Ghost-only comp tier when a paid subscription is created', async function () {
+            // Create a separate product for the comp tier
+            const compProduct = await Product.add({
+                name: 'Comp Tier Sub Event',
+                slug: 'comp-tier-sub-event',
+                type: 'paid'
+            });
+
+            const paidCustomerId = createStripeID('cust');
+            const paidSubscriptionId = createStripeID('sub');
+
+            // Create a free member
+            const {body: createBody} = await adminAgent
+                .post('/members/')
+                .body({members: [{
+                    name: 'Ghost Comp Sub Event Test',
+                    email: 'ghost-comp-sub-event@email.com',
+                    subscribed: true
+                }]})
+                .expectStatus(201);
+
+            const memberId = createBody.members[0].id;
+            assert.equal(createBody.members[0].status, 'free');
+
+            // Comp the member with the separate product
+            const {body: compBody} = await adminAgent
+                .put(`/members/${memberId}/`)
+                .body({members: [{
+                    id: memberId,
+                    tiers: [{id: compProduct.id}]
+                }]})
+                .expectStatus(200);
+
+            assert.equal(compBody.members[0].status, 'comped');
+            assert.equal(compBody.members[0].tiers.length, 1);
+
+            // Define the paid subscription
+            const paidPrice = {
+                id: 'price_123',
+                product: 'product_123',
+                active: true,
+                nickname: 'Monthly',
+                currency: 'usd',
+                recurring: {
+                    interval: 'month'
+                },
+                unit_amount: 500,
+                type: 'recurring'
+            };
+
+            const paidSubscription = {
+                id: paidSubscriptionId,
+                customer: paidCustomerId,
+                status: 'active',
+                items: {
+                    type: 'list',
+                    data: [{
+                        id: 'item_paid',
+                        price: paidPrice
+                    }]
+                },
+                start_date: Date.now() / 1000,
+                current_period_end: Date.now() / 1000 + (60 * 60 * 24 * 31),
+                cancel_at_period_end: false
+            };
+
+            // Set up shared mocks
+            set(subscription, paidSubscription);
+            set(customer, {
+                id: paidCustomerId,
+                name: 'Ghost Comp Sub Event Test',
+                email: 'ghost-comp-sub-event@email.com',
+                subscriptions: {
+                    type: 'list',
+                    data: [paidSubscription]
+                }
+            });
+
+            // Register the subscription in overrides
+            subscriptionOverrides[paidSubscriptionId] = paidSubscription;
+
+            // First link the customer to the member via a checkout webhook
+            // (subscription events alone don't create the stripe customer link)
+            const checkoutPayload = JSON.stringify({
+                type: 'checkout.session.completed',
+                data: {
+                    object: {
+                        mode: 'subscription',
+                        customer: paidCustomerId,
+                        subscription: paidSubscriptionId,
+                        metadata: {}
+                    }
+                }
+            });
+
+            const checkoutSignature = stripe.webhooks.generateTestHeaderString({
+                payload: checkoutPayload,
+                secret: process.env.WEBHOOK_SECRET
+            });
+
+            await membersAgent.post('/webhooks/stripe/')
+                .body(checkoutPayload)
+                .header('content-type', 'application/json')
+                .header('stripe-signature', checkoutSignature)
+                .expectStatus(200);
+
+            await DomainEvents.allSettled();
+
+            // Verify: member should be paid, Ghost-only comp tier removed
+            const {body} = await adminAgent.get('/members/' + memberId + '/');
+            const updatedMember = body.members[0];
+
+            assert.equal(updatedMember.status, 'paid');
+            assert.equal(updatedMember.tiers.length, 1, 'Only the paid tier should remain');
+            assert.equal(updatedMember.subscriptions.length, 1);
+            assert.equal(updatedMember.subscriptions[0].status, 'active');
+
+            // The remaining tier should be the one from the paid subscription, not the comp tier
+            assert.notEqual(updatedMember.tiers[0].id, compProduct.id, 'Comp tier should be removed');
         });
     });
 

--- a/ghost/core/test/unit/server/services/stripe/services/webhooks/checkout-session-event-service.test.js
+++ b/ghost/core/test/unit/server/services/stripe/services/webhooks/checkout-session-event-service.test.js
@@ -18,10 +18,13 @@ describe('CheckoutSessionEventService', function () {
 
         memberRepository = {
             get: sinon.stub(),
-            create: sinon.stub(),
+            create: sinon.stub().resolves({
+                id: 'created_member'
+            }),
             update: sinon.stub(),
             linkSubscription: sinon.stub(),
-            upsertCustomer: sinon.stub()
+            upsertCustomer: sinon.stub(),
+            removeComplimentarySubscription: sinon.stub()
         };
 
         donationRepository = {

--- a/ghost/core/test/unit/server/services/stripe/services/webhooks/subscription-event-service.test.js
+++ b/ghost/core/test/unit/server/services/stripe/services/webhooks/subscription-event-service.test.js
@@ -8,7 +8,7 @@ describe('SubscriptionEventService', function () {
     let memberRepository;
 
     beforeEach(function () {
-        memberRepository = {get: sinon.stub(), linkSubscription: sinon.stub()};
+        memberRepository = {get: sinon.stub(), linkSubscription: sinon.stub(), removeComplimentarySubscription: sinon.stub()};
 
         service = new SubscriptionEventService({memberRepository});
     });
@@ -104,7 +104,9 @@ describe('SubscriptionEventService', function () {
             customer: 'cust_123'
         };
 
-        memberRepository.get.resolves({id: 'member_123'});
+        memberRepository.get
+            .onFirstCall().resolves({id: 'member_123'})
+            .onSecondCall().resolves({get: sinon.stub().returns('free')});
 
         await service.handleSubscriptionEvent(subscription);
 


### PR DESCRIPTION
When a comped member upgrades to a paid subscription, the complimentary access was not being removed. This meant that when the paid subscription was later cancelled, the member would revert to `comped` status instead of `free` — effectively giving them perpetual access after a single payment cycle. The bug manifests when the comp tier is different from the paid subscription tier, which is why it was tricky to reproduce locally.

This PR consolidates the two flavours of complimentary access removal into a single `removeComplimentarySubscription` method in MemberRepository. Ghost has two types of comp access: Stripe-backed subscriptions (with `plan_nickname: 'Complimentary'` and `unit_amount: 0`) and Ghost-only comps (products added directly via the Admin UI with no backing Stripe subscription). The old `cancelComplimentarySubscription` only handled Stripe-backed comps, and didn't filter specifically for complimentary subscriptions — it would cancel all non-canceled subscriptions. The new method handles both types correctly: it cancels Stripe-backed comp subscriptions via the Stripe API (then syncs via `linkSubscription`), and removes Ghost-only comp products by checking which products are backed by active Stripe subscriptions.

Rather than embedding this logic inside `linkSubscription` (which was the v1 approach and raised recursion concerns), the comp removal is called from the webhook handlers — `SubscriptionEventService` and `CheckoutSessionEventService` — after `linkSubscription` completes. If the member's status is now `paid`, any remaining comp access is cleaned up. This keeps `linkSubscription` focused on its single responsibility of syncing one Stripe subscription to the Ghost database.

Supersedes https://github.com/TryGhost/Ghost/pull/26074.