### PR TITLE
Released @tryghost/portal v2.59.0

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.58.1",
+  "version": "2.59.0",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/ghost/core/core/shared/config/defaults.json
+++ b/ghost/core/core/shared/config/defaults.json
@@ -234,7 +234,7 @@
     },
     "portal": {
         "url": "https://cdn.jsdelivr.net/ghost/portal@~{version}/umd/portal.min.js",
-        "version": "2.58"
+        "version": "2.59"
     },
     "sodoSearch": {
         "url": "https://cdn.jsdelivr.net/ghost/sodo-search@~{version}/umd/sodo-search.min.js",


### PR DESCRIPTION
Releasing a new version of Portal for sniper links.

Changelog for v2.58.1 -> 2.59.0:
- Updated i18n translations
- https://github.com/TryGhost/Ghost/commit/70a647af88


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 2.59.0 with updated portal library dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->