### PR TITLE
Replaced `should.equal()` with `assert.equal()`

### DIFF
--- a/ghost/core/test/e2e-api/admin/actions.test.js
+++ b/ghost/core/test/e2e-api/admin/actions.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const supertest = require('supertest');
@@ -132,7 +133,7 @@ describe('Actions API', function () {
         res5.body.actions[0].event.should.eql('edited');
         Object.keys(res5.body.actions[0].actor).length.should.eql(4);
         res5.body.actions[0].actor.id.should.eql(testUtils.DataGenerator.Content.integrations[0].id);
-        should.equal(res5.body.actions[0].actor.image, null);
+        assert.equal(res5.body.actions[0].actor.image, null);
         res5.body.actions[0].actor.name.should.eql(testUtils.DataGenerator.Content.integrations[0].name);
         res5.body.actions[0].actor.slug.should.eql(testUtils.DataGenerator.Content.integrations[0].slug);
     });

--- a/ghost/core/test/e2e-api/admin/integrations.test.js
+++ b/ghost/core/test/e2e-api/admin/integrations.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const _ = require('lodash');
 const should = require('should');
 const supertest = require('supertest');
@@ -25,7 +26,7 @@ describe('Integrations API', function () {
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(200);
 
-        should.equal(res.body.integrations.length, 6);
+        assert.equal(res.body.integrations.length, 6);
 
         // there is no enforced order for integrations which makes order different on SQLite and MySQL
         const zapierIntegration = _.find(res.body.integrations, {name: 'Zapier'}); // from migrations
@@ -61,24 +62,24 @@ describe('Integrations API', function () {
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(201);
 
-        should.equal(res.body.integrations.length, 1);
+        assert.equal(res.body.integrations.length, 1);
 
         const [integration] = res.body.integrations;
-        should.equal(integration.name, 'Dis-Integrate!!');
+        assert.equal(integration.name, 'Dis-Integrate!!');
 
-        should.equal(integration.api_keys.length, 2);
+        assert.equal(integration.api_keys.length, 2);
 
         const contentApiKey = integration.api_keys.find(findBy('type', 'content'));
-        should.equal(contentApiKey.integration_id, integration.id);
+        assert.equal(contentApiKey.integration_id, integration.id);
 
         const adminApiKey = integration.api_keys.find(findBy('type', 'admin'));
-        should.equal(adminApiKey.integration_id, integration.id);
+        assert.equal(adminApiKey.integration_id, integration.id);
         should.exist(adminApiKey.secret);
 
         // check Admin API key secret format
         const [id, secret] = adminApiKey.secret.split(':');
         should.exist(id);
-        should.equal(id, adminApiKey.id);
+        assert.equal(id, adminApiKey.id);
         should.exist(secret);
         secret.length.should.equal(64);
 
@@ -102,15 +103,15 @@ describe('Integrations API', function () {
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(201);
 
-        should.equal(res.body.integrations.length, 1);
+        assert.equal(res.body.integrations.length, 1);
 
         const [integration] = res.body.integrations;
-        should.equal(integration.name, 'Integratatron4000');
+        assert.equal(integration.name, 'Integratatron4000');
 
-        should.equal(integration.webhooks.length, 1);
+        assert.equal(integration.webhooks.length, 1);
 
         const webhook = integration.webhooks[0];
-        should.equal(webhook.integration_id, integration.id);
+        assert.equal(webhook.integration_id, integration.id);
 
         should.exist(res.headers.location);
         res.headers.location.should.equal(`http://127.0.0.1:2369${localUtils.API.getApiQuery('integrations/')}${res.body.integrations[0].id}/`);
@@ -134,15 +135,15 @@ describe('Integrations API', function () {
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(200);
 
-        should.equal(res2.body.integrations.length, 1);
+        assert.equal(res2.body.integrations.length, 1);
 
         const [integration] = res2.body.integrations;
 
-        should.equal(integration.id, createdIntegration.id);
-        should.equal(integration.name, createdIntegration.name);
-        should.equal(integration.slug, createdIntegration.slug);
-        should.equal(integration.description, createdIntegration.description);
-        should.equal(integration.icon_image, createdIntegration.icon_image);
+        assert.equal(integration.id, createdIntegration.id);
+        assert.equal(integration.name, createdIntegration.name);
+        assert.equal(integration.slug, createdIntegration.slug);
+        assert.equal(integration.description, createdIntegration.description);
+        assert.equal(integration.icon_image, createdIntegration.icon_image);
     });
 
     it('Can successfully get *all* created integrations with api_keys', async function () {
@@ -172,10 +173,10 @@ describe('Integrations API', function () {
 
         const body = res.body;
         // This is the only page
-        should.equal(body.meta.pagination.page, 1);
-        should.equal(body.meta.pagination.pages, 1);
-        should.equal(body.meta.pagination.next, null);
-        should.equal(body.meta.pagination.prev, null);
+        assert.equal(body.meta.pagination.page, 1);
+        assert.equal(body.meta.pagination.pages, 1);
+        assert.equal(body.meta.pagination.next, null);
+        assert.equal(body.meta.pagination.prev, null);
 
         body.integrations.forEach((integration) => {
             should.exist(integration.api_keys);
@@ -184,9 +185,9 @@ describe('Integrations API', function () {
                     should.exist(apiKey.secret);
 
                     if (apiKey.type === 'content') {
-                        should.equal(apiKey.secret.split(':').length, 1, `${integration.name} api key secret should have correct key format without ":"`);
+                        assert.equal(apiKey.secret.split(':').length, 1, `${integration.name} api key secret should have correct key format without ":"`);
                     } else if (apiKey.type === 'admin') {
-                        should.equal(apiKey.secret.split(':').length, 2, `${integration.name} api key secret should have correct key format with ":"`);
+                        assert.equal(apiKey.secret.split(':').length, 2, `${integration.name} api key secret should have correct key format with ":"`);
                     }
                 });
             }
@@ -223,9 +224,9 @@ describe('Integrations API', function () {
 
         const [updatedIntegration] = res2.body.integrations;
 
-        should.equal(updatedIntegration.id, createdIntegration.id);
-        should.equal(updatedIntegration.name, 'Awesome Integration Name');
-        should.equal(updatedIntegration.description, 'Finally got round to writing this...');
+        assert.equal(updatedIntegration.id, createdIntegration.id);
+        assert.equal(updatedIntegration.name, 'Awesome Integration Name');
+        assert.equal(updatedIntegration.description, 'Finally got round to writing this...');
     });
 
     it('Can successfully refresh an integration api key', async function () {
@@ -259,7 +260,7 @@ describe('Integrations API', function () {
 
         const [updatedIntegration] = res2.body.integrations;
         const updatedAdminApiKey = updatedIntegration.api_keys.find(key => key.type === 'admin');
-        should.equal(updatedIntegration.id, createdIntegration.id);
+        assert.equal(updatedIntegration.id, createdIntegration.id);
         updatedAdminApiKey.secret.should.not.eql(adminApiKey.secret);
 
         const res3 = await request.get(localUtils.API.getApiQuery(`actions/?filter=resource_id:'${adminApiKey.id}'&include=actor`))
@@ -307,10 +308,10 @@ describe('Integrations API', function () {
 
         const [updatedIntegration] = res2.body.integrations;
 
-        should.equal(updatedIntegration.webhooks.length, 1);
+        assert.equal(updatedIntegration.webhooks.length, 1);
 
         const webhook = updatedIntegration.webhooks[0];
-        should.equal(webhook.integration_id, updatedIntegration.id);
+        assert.equal(webhook.integration_id, updatedIntegration.id);
 
         await request.put(localUtils.API.getApiQuery(`integrations/${createdIntegration.id}/`))
             .set('Origin', config.get('url'))
@@ -328,7 +329,7 @@ describe('Integrations API', function () {
             .expect(200);
 
         const [updatedIntegration2] = res3.body.integrations;
-        should.equal(updatedIntegration2.webhooks.length, 0);
+        assert.equal(updatedIntegration2.webhooks.length, 0);
     });
 
     it('Can successfully delete a created integration', async function () {

--- a/ghost/core/test/e2e-api/admin/members-importer.test.js
+++ b/ghost/core/test/e2e-api/admin/members-importer.test.js
@@ -152,7 +152,7 @@ describe('Members Importer API', function () {
     //                     should.exist(jsonResponse.meta);
     //                     should.exist(jsonResponse.meta.stats);
     //                     should.exist(jsonResponse.meta.stats.successful);
-    //                     should.equal(jsonResponse.meta.stats.successful, 8);
+    //                     assert.equal(jsonResponse.meta.stats.successful, 8);
     //                 })
     //                 .then(() => importLabel);
     //         })
@@ -214,7 +214,7 @@ describe('Members Importer API', function () {
         should.exist(bulkUnsubscribeResponse.body.bulk.meta);
         should.exist(bulkUnsubscribeResponse.body.bulk.meta.stats);
         should.exist(bulkUnsubscribeResponse.body.bulk.meta.stats.successful);
-        should.equal(bulkUnsubscribeResponse.body.bulk.meta.stats.successful, 8);
+        assert.equal(bulkUnsubscribeResponse.body.bulk.meta.stats.successful, 8);
 
         const postUnsubscribeBrowseResponse = await request
             .get(localUtils.API.getApiQuery('members/?filter=label:bulk-unsubscribe-test'))
@@ -270,7 +270,7 @@ describe('Members Importer API', function () {
         should.exist(bulkAddLabelResponse.body.bulk.meta);
         should.exist(bulkAddLabelResponse.body.bulk.meta.stats);
         should.exist(bulkAddLabelResponse.body.bulk.meta.stats.successful);
-        should.equal(bulkAddLabelResponse.body.bulk.meta.stats.successful, 8);
+        assert.equal(bulkAddLabelResponse.body.bulk.meta.stats.successful, 8);
 
         const postLabelAddBrowseResponse = await request
             .get(localUtils.API.getApiQuery(`members/?filter=label:${labelToAdd.slug}`))
@@ -302,7 +302,7 @@ describe('Members Importer API', function () {
         should.exist(bulkRemoveLabelResponse.body.bulk.meta);
         should.exist(bulkRemoveLabelResponse.body.bulk.meta.stats);
         should.exist(bulkRemoveLabelResponse.body.bulk.meta.stats.successful);
-        should.equal(bulkRemoveLabelResponse.body.bulk.meta.stats.successful, 8);
+        assert.equal(bulkRemoveLabelResponse.body.bulk.meta.stats.successful, 8);
 
         const postLabelRemoveBrowseResponse = await request
             .get(localUtils.API.getApiQuery(`members/?filter=label:${labelToRemove.slug}`))

--- a/ghost/core/test/e2e-api/admin/pages-legacy.test.js
+++ b/ghost/core/test/e2e-api/admin/pages-legacy.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const supertest = require('supertest');
 const moment = require('moment');
@@ -124,8 +125,8 @@ describe('Pages API', function () {
         const additionalProperties = ['reading_time'];
         localUtils.API.checkResponse(returnedPage, 'page', additionalProperties);
 
-        should.equal(returnedPage.mobiledoc, page.mobiledoc);
-        should.equal(returnedPage.lexical, null);
+        assert.equal(returnedPage.mobiledoc, page.mobiledoc);
+        assert.equal(returnedPage.lexical, null);
     });
 
     it('Can add a page with lexical', async function () {
@@ -175,9 +176,9 @@ describe('Pages API', function () {
         const additionalProperties = ['html', 'reading_time'];
         localUtils.API.checkResponse(returnedPage, 'page', additionalProperties);
 
-        should.equal(returnedPage.mobiledoc, null);
-        should.equal(returnedPage.lexical, page.lexical);
-        should.equal(returnedPage.html, '<p>Testing page creation with lexical</p>');
+        assert.equal(returnedPage.mobiledoc, null);
+        assert.equal(returnedPage.lexical, page.lexical);
+        assert.equal(returnedPage.html, '<p>Testing page creation with lexical</p>');
     });
 
     it('Can\'t add a page with both mobiledoc and lexical', async function () {

--- a/ghost/core/test/e2e-api/admin/posts-legacy.test.js
+++ b/ghost/core/test/e2e-api/admin/posts-legacy.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const nock = require('nock');
 const path = require('path');
@@ -160,7 +161,7 @@ describe('Posts API', function () {
             .expect(200);
 
         const jsonResponse = res.body;
-        should.equal(jsonResponse.meta.pagination.page, 2);
+        assert.equal(jsonResponse.meta.pagination.page, 2);
     });
 
     it('Can request a post by id', async function () {

--- a/ghost/core/test/e2e-api/admin/tags.test.js
+++ b/ghost/core/test/e2e-api/admin/tags.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const supertest = require('supertest');
@@ -60,7 +61,7 @@ describe('Tag API', function () {
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(200);
 
-        should.equal(res.body.meta.pagination.page, 2);
+        assert.equal(res.body.meta.pagination.page, 2);
     });
 
     it('Can read a tag', async function () {

--- a/ghost/core/test/e2e-api/members-comments/comments.test.js
+++ b/ghost/core/test/e2e-api/members-comments/comments.test.js
@@ -870,10 +870,10 @@ describe('Comments API', function () {
 
                 // Check last updated_at is not changed?
                 loggedInMember = await models.Member.findOne({id: loggedInMember.id});
-                should.equal(loggedInMember.get('last_seen_at').getTime(), date.getTime(), 'The member should not update `last_seen_at` if last seen at is same day');
+                assert.equal(loggedInMember.get('last_seen_at').getTime(), date.getTime(), 'The member should not update `last_seen_at` if last seen at is same day');
 
                 // Check last_commented_at changed?
-                should.equal(loggedInMember.get('last_commented_at').getTime(), date.getTime(), 'The member should not update `last_commented_at` f last seen at is same day');
+                assert.equal(loggedInMember.get('last_commented_at').getTime(), date.getTime(), 'The member should not update `last_commented_at` f last seen at is same day');
             });
 
             it('Can reply to a comment', async function () {

--- a/ghost/core/test/e2e-frontend/members.test.js
+++ b/ghost/core/test/e2e-frontend/members.test.js
@@ -282,7 +282,7 @@ describe('Front-end members behavior', function () {
                     'sort_order'
                 ]);
 
-                should.equal(restoreJsonResponse.newsletters[0].name, originalNewsletterName);
+                assert.equal(restoreJsonResponse.newsletters[0].name, originalNewsletterName);
             });
         });
 

--- a/ghost/core/test/integration/exporter/exporter.test.js
+++ b/ghost/core/test/integration/exporter/exporter.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const testUtils = require('../../utils');
@@ -132,7 +133,7 @@ describe('Exporter', function () {
 
             excludedTables.forEach((tableName) => {
                 // NOTE: why is this undefined? The key should probably not even be present
-                should.equal(exportData.data[tableName], undefined);
+                assert.equal(exportData.data[tableName], undefined);
             });
 
             // excludes settings with sensitive data

--- a/ghost/core/test/integration/importer/v2.test.js
+++ b/ghost/core/test/integration/importer/v2.test.js
@@ -787,9 +787,9 @@ describe('Importer', function () {
                     return models.Settings.findOne(_.merge({key: 'labs'}, testUtils.context.internal));
                 })
                 .then(function (result) {
-                    should.equal(result.attributes.key, 'labs');
-                    should.equal(result.attributes.group, 'labs');
-                    should.equal(result.attributes.value, '{"additionalPaymentMethods":true}');
+                    assert.equal(result.attributes.key, 'labs');
+                    assert.equal(result.attributes.group, 'labs');
+                    assert.equal(result.attributes.value, '{"additionalPaymentMethods":true}');
                 });
         });
 
@@ -807,9 +807,9 @@ describe('Importer', function () {
                     return models.Settings.findOne(_.merge({key: 'labs'}, testUtils.context.internal));
                 })
                 .then(function (result) {
-                    should.equal(result.attributes.key, 'labs');
-                    should.equal(result.attributes.group, 'labs');
-                    should.equal(result.attributes.value, '{}');
+                    assert.equal(result.attributes.key, 'labs');
+                    assert.equal(result.attributes.group, 'labs');
+                    assert.equal(result.attributes.value, '{}');
                 });
         });
 

--- a/ghost/core/test/integration/migrations/nullable-utils.test.js
+++ b/ghost/core/test/integration/migrations/nullable-utils.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const testUtils = require('../../utils');
@@ -124,7 +125,7 @@ describe('Migrations - schema utils', function () {
 
             // Verify initial state
             const isNotNullableInitial = await isColumnNotNullable(tableName, 'not_nullable_col');
-            should.equal(isNotNullableInitial, true, 'Column should initially be not nullable');
+            assert.equal(isNotNullableInitial, true, 'Column should initially be not nullable');
 
             // Run up migration
             const transacting = await db.knex.transaction();
@@ -133,7 +134,7 @@ describe('Migrations - schema utils', function () {
 
             // Verify column is now nullable
             const isNullableAfter = await isColumnNullable(tableName, 'not_nullable_col');
-            should.equal(isNullableAfter, true, 'Column should be nullable after up migration');
+            assert.equal(isNullableAfter, true, 'Column should be nullable after up migration');
 
             // Run down migration with foreign key checks disabled
             const transactingDown = await db.knex.transaction();
@@ -142,7 +143,7 @@ describe('Migrations - schema utils', function () {
 
             // Verify column is not nullable again
             const isNotNullableAfterDown = await isColumnNotNullable(tableName, 'not_nullable_col');
-            should.equal(isNotNullableAfterDown, true, 'Column should be not nullable after down migration');
+            assert.equal(isNotNullableAfterDown, true, 'Column should be not nullable after down migration');
         });
 
         it('Skips setting nullable when column is already nullable', async function () {
@@ -151,7 +152,7 @@ describe('Migrations - schema utils', function () {
 
             // Verify initial state
             const isNullableInitial = await isColumnNullable(tableName, 'nullable_col');
-            should.equal(isNullableInitial, true, 'Column should initially be nullable');
+            assert.equal(isNullableInitial, true, 'Column should initially be nullable');
 
             // Run up migration
             const transacting = await db.knex.transaction();
@@ -162,7 +163,7 @@ describe('Migrations - schema utils', function () {
 
             // Column should still be nullable
             const isNullableAfter = await isColumnNullable(tableName, 'nullable_col');
-            should.equal(isNullableAfter, true, 'Column should still be nullable');
+            assert.equal(isNullableAfter, true, 'Column should still be nullable');
         });
 
         it('Handles disableForeignKeyChecks option in down migration', async function () {
@@ -178,7 +179,7 @@ describe('Migrations - schema utils', function () {
 
             // Verify column is nullable
             const isNullableAfter = await isColumnNullable(tableName, 'mixed_col');
-            should.equal(isNullableAfter, true, 'Column should be nullable after up migration');
+            assert.equal(isNullableAfter, true, 'Column should be nullable after up migration');
 
             // Run down migration with foreign key checks disabled
             const transactingDown = await db.knex.transaction();
@@ -187,7 +188,7 @@ describe('Migrations - schema utils', function () {
 
             // Verify column is not nullable again
             const isNotNullableAfterDown = await isColumnNotNullable(tableName, 'mixed_col');
-            should.equal(isNotNullableAfterDown, true, 'Column should be not nullable after down migration');
+            assert.equal(isNotNullableAfterDown, true, 'Column should be not nullable after down migration');
             
             // The test passes if no errors were thrown
             // The disableForeignKeyChecks option is being used internally
@@ -200,7 +201,7 @@ describe('Migrations - schema utils', function () {
 
             // Verify initial state
             const isNullableInitial = await isColumnNullable(tableName, 'nullable_col');
-            should.equal(isNullableInitial, true, 'Column should initially be nullable');
+            assert.equal(isNullableInitial, true, 'Column should initially be nullable');
 
             // Run up migration
             const transacting = await db.knex.transaction();
@@ -209,7 +210,7 @@ describe('Migrations - schema utils', function () {
 
             // Verify column is now not nullable
             const isNotNullableAfter = await isColumnNotNullable(tableName, 'nullable_col');
-            should.equal(isNotNullableAfter, true, 'Column should be not nullable after up migration');
+            assert.equal(isNotNullableAfter, true, 'Column should be not nullable after up migration');
 
             // Run down migration
             const transactingDown = await db.knex.transaction();
@@ -218,7 +219,7 @@ describe('Migrations - schema utils', function () {
 
             // Verify column is nullable again
             const isNullableAfterDown = await isColumnNullable(tableName, 'nullable_col');
-            should.equal(isNullableAfterDown, true, 'Column should be nullable after down migration');
+            assert.equal(isNullableAfterDown, true, 'Column should be nullable after down migration');
         });
 
         it('Skips dropping nullable when column is already not nullable', async function () {
@@ -227,7 +228,7 @@ describe('Migrations - schema utils', function () {
 
             // Verify initial state
             const isNotNullableInitial = await isColumnNotNullable(tableName, 'not_nullable_col');
-            should.equal(isNotNullableInitial, true, 'Column should initially be not nullable');
+            assert.equal(isNotNullableInitial, true, 'Column should initially be not nullable');
 
             // Run up migration
             const transacting = await db.knex.transaction();
@@ -238,7 +239,7 @@ describe('Migrations - schema utils', function () {
 
             // Column should still be not nullable
             const isNotNullableAfter = await isColumnNotNullable(tableName, 'not_nullable_col');
-            should.equal(isNotNullableAfter, true, 'Column should still be not nullable');
+            assert.equal(isNotNullableAfter, true, 'Column should still be not nullable');
         });
 
         it('Handles disableForeignKeyChecks option when dropping nullable', async function () {
@@ -250,7 +251,7 @@ describe('Migrations - schema utils', function () {
 
             // Verify column is initially nullable
             const isNullableInitial = await isColumnNullable(tableName, testColumn);
-            should.equal(isNullableInitial, true, 'Column should be nullable before test');
+            assert.equal(isNullableInitial, true, 'Column should be nullable before test');
 
             // Run up migration with foreign key checks disabled
             const transacting = await db.knex.transaction();
@@ -259,7 +260,7 @@ describe('Migrations - schema utils', function () {
 
             // Verify column is not nullable
             const isNotNullableAfter = await isColumnNotNullable(tableName, testColumn);
-            should.equal(isNotNullableAfter, true, 'Column should be not nullable after up migration');
+            assert.equal(isNotNullableAfter, true, 'Column should be not nullable after up migration');
             
             // The test passes if no errors were thrown
             // The disableForeignKeyChecks option is being used internally
@@ -284,13 +285,13 @@ describe('Migrations - schema utils', function () {
 
             // Verify column is not nullable and still has its default
             const isNotNullable = await isColumnNotNullable(tableName, 'with_default');
-            should.equal(isNotNullable, true, 'Column should be not nullable');
+            assert.equal(isNotNullable, true, 'Column should be not nullable');
             
             // Verify default value is preserved (MySQL-specific check)
             if (dbUtils.isMySQL()) {
                 const response = await db.knex.raw('SHOW COLUMNS FROM ??', [tableName]);
                 const columnInfo = response[0].find(col => col.Field === 'with_default');
-                should.equal(columnInfo.Default, 'default', 'Column should still have its default value');
+                assert.equal(columnInfo.Default, 'default', 'Column should still have its default value');
             }
         });
 

--- a/ghost/core/test/legacy/api/admin/members-importer.test.js
+++ b/ghost/core/test/legacy/api/admin/members-importer.test.js
@@ -68,7 +68,7 @@ describe('Members Importer API', function () {
 
                 should.exist(jsonResponse);
                 should.exist(jsonResponse.members);
-                should.equal(jsonResponse.members.length, 2);
+                assert.equal(jsonResponse.members.length, 2);
 
                 const importedMember1 = jsonResponse.members.find(m => m.email === 'member+labels_1@example.com');
                 should.exist(importedMember1);

--- a/ghost/core/test/legacy/api/admin/posts.test.js
+++ b/ghost/core/test/legacy/api/admin/posts.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const _ = require('lodash');
 const should = require('should');
 const supertest = require('supertest');
@@ -171,7 +172,7 @@ describe('Posts API', function () {
                     localUtils.API.checkResponse(jsonResponse, 'posts');
                     jsonResponse.posts.should.have.length(15);
 
-                    should.equal(jsonResponse.posts[0].meta_description, null);
+                    assert.equal(jsonResponse.posts[0].meta_description, null);
                     jsonResponse.posts[14].slug.should.equal('short-and-sweet');
                     jsonResponse.posts[14].meta_description.should.equal('meta description for short and sweet');
 
@@ -733,8 +734,8 @@ describe('Posts API', function () {
 
                     should.exist(res.body.posts);
                     should.exist(res.body.posts[0].published_at);
-                    should.equal(res.body.posts[0].frontmatter, null);
-                    should.equal(res.body.posts[0].plaintext, testUtils.DataGenerator.Content.posts[0].plaintext);
+                    assert.equal(res.body.posts[0].frontmatter, null);
+                    assert.equal(res.body.posts[0].plaintext, testUtils.DataGenerator.Content.posts[0].plaintext);
                 });
         });
 
@@ -954,7 +955,7 @@ describe('Posts API', function () {
                     should.exist(res.headers['x-cache-invalidate']);
 
                     should.exist(res.body.posts);
-                    should.equal(res.body.posts[0].meta_title, 'changed meta title');
+                    assert.equal(res.body.posts[0].meta_title, 'changed meta title');
                 });
         });
 
@@ -964,7 +965,7 @@ describe('Posts API', function () {
                 .set('Origin', config.get('url'))
                 .expect(200)
                 .then((res) => {
-                    should.equal(res.body.posts[0].email_only, false);
+                    assert.equal(res.body.posts[0].email_only, false);
 
                     return request
                         .put(localUtils.API.getApiQuery('posts/' + testUtils.DataGenerator.Content.posts[3].id + '/'))
@@ -983,8 +984,8 @@ describe('Posts API', function () {
                     should.exist(res.headers['x-cache-invalidate']);
 
                     should.exist(res.body.posts);
-                    should.equal(res.body.posts[0].email_only, true);
-                    should.equal(res.body.posts[0].url, 'http://127.0.0.1:2369/email/d52c42ae-2755-455c-80ec-70b2ec55c903/');
+                    assert.equal(res.body.posts[0].email_only, true);
+                    assert.equal(res.body.posts[0].url, 'http://127.0.0.1:2369/email/d52c42ae-2755-455c-80ec-70b2ec55c903/');
                 });
         });
 
@@ -1005,8 +1006,8 @@ describe('Posts API', function () {
                     should.exist(res.body.posts);
                     should.exist(res.body.posts[0].title);
                     res.body.posts[0].title.should.equal('Has a title by no other content');
-                    should.equal(res.body.posts[0].html, undefined);
-                    should.equal(res.body.posts[0].plaintext, undefined);
+                    assert.equal(res.body.posts[0].html, undefined);
+                    assert.equal(res.body.posts[0].plaintext, undefined);
 
                     return request
                         .put(localUtils.API.getApiQuery(`posts/${res.body.posts[0].id}/`))
@@ -1027,8 +1028,8 @@ describe('Posts API', function () {
 
                     should.exist(res.body.posts);
                     res.body.posts[0].title.should.equal('Has a title by no other content');
-                    should.equal(res.body.posts[0].html, undefined);
-                    should.equal(res.body.posts[0].plaintext, undefined);
+                    assert.equal(res.body.posts[0].html, undefined);
+                    assert.equal(res.body.posts[0].plaintext, undefined);
                 });
         });
 

--- a/ghost/core/test/legacy/api/admin/settings.test.js
+++ b/ghost/core/test/legacy/api/admin/settings.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const supertest = require('supertest');
 const config = require('../../../../core/shared/config');
@@ -127,10 +128,10 @@ describe('Settings API', function () {
             should.exist(putBody);
 
             let setting = putBody.settings.find(s => s.key === 'unsplash');
-            should.equal(setting.value, true);
+            assert.equal(setting.value, true);
 
             setting = putBody.settings.find(s => s.key === 'title');
-            should.equal(setting.value, 'New Value');
+            assert.equal(setting.value, 'New Value');
 
             localUtils.API.checkResponse(putBody, 'settings');
         });

--- a/ghost/core/test/legacy/api/admin/users.test.js
+++ b/ghost/core/test/legacy/api/admin/users.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const supertest = require('supertest');
 const ObjectId = require('bson-objectid').default;
@@ -145,10 +146,10 @@ describe('User API', function () {
                     .expect(200);
 
                 const tags = await otherAuthorPost.related('tags').fetch();
-                should.equal(tags.length, 3);
+                assert.equal(tags.length, 3);
                 // user deletion results in a second tag being added with sort_order of 0, putting it at index 1 instead of at the end (index 2)
-                should.equal(tags.models[1].get('slug'), `hash-${otherAuthor.slug}`);
-                should.equal(tags.models[1].get('name'), `#${otherAuthor.slug}`);
+                assert.equal(tags.models[1].get('slug'), `hash-${otherAuthor.slug}`);
+                assert.equal(tags.models[1].get('name'), `#${otherAuthor.slug}`);
             });
         });
     });

--- a/ghost/core/test/legacy/models/model-member-stripe-customer.test.js
+++ b/ghost/core/test/legacy/models/model-member-stripe-customer.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const {Member} = require('../../../core/server/models/member');
 const {MemberStripeCustomer} = require('../../../core/server/models/member-stripe-customer');
@@ -74,9 +75,9 @@ describe('MemberStripeCustomer Model', function run() {
 
             const subscriptions = customer.related('subscriptions');
 
-            should.equal(subscriptions.length, 1, 'Should  be two subscriptions');
+            assert.equal(subscriptions.length, 1, 'Should  be two subscriptions');
 
-            should.equal(subscriptions.models[0].get('subscription_id'), 'fake_subscription_id');
+            assert.equal(subscriptions.models[0].get('subscription_id'), 'fake_subscription_id');
         });
     });
 
@@ -103,8 +104,8 @@ describe('MemberStripeCustomer Model', function run() {
 
             should.exist(memberFromRelation, 'MemberStripeCustomer should have been fetched with member');
 
-            should.equal(memberFromRelation.get('id'), member.get('id'));
-            should.equal(memberFromRelation.get('email'), 'test@test.member');
+            assert.equal(memberFromRelation.get('id'), member.get('id'));
+            assert.equal(memberFromRelation.get('email'), 'test@test.member');
         });
     });
 

--- a/ghost/core/test/legacy/models/model-member-stripe-customer.test.js
+++ b/ghost/core/test/legacy/models/model-member-stripe-customer.test.js
@@ -75,7 +75,7 @@ describe('MemberStripeCustomer Model', function run() {
 
             const subscriptions = customer.related('subscriptions');
 
-            assert.equal(subscriptions.length, 1, 'Should  be two subscriptions');
+            assert.equal(subscriptions.length, 1, 'Should have one subscription');
 
             assert.equal(subscriptions.models[0].get('subscription_id'), 'fake_subscription_id');
         });

--- a/ghost/core/test/legacy/models/model-members.test.js
+++ b/ghost/core/test/legacy/models/model-members.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const BaseModel = require('../../../core/server/models/base');
 const {Label} = require('../../../core/server/models/label');
@@ -146,10 +147,10 @@ describe('Member Model', function run() {
 
             const stripeCustomers = member.related('stripeCustomers');
 
-            should.equal(stripeCustomers.length, 2, 'Should  be two stripeCustomers');
+            assert.equal(stripeCustomers.length, 2, 'Should  be two stripeCustomers');
 
-            should.equal(stripeCustomers.models[0].get('customer_id'), 'fake_customer_id1');
-            should.equal(stripeCustomers.models[1].get('customer_id'), 'fake_customer_id2');
+            assert.equal(stripeCustomers.models[0].get('customer_id'), 'fake_customer_id1');
+            assert.equal(stripeCustomers.models[1].get('customer_id'), 'fake_customer_id2');
         });
     });
 
@@ -481,7 +482,7 @@ describe('Member Model', function run() {
 
             {
                 const members = await Member.findPage({filter: `subscriptions.status:canceled+subscriptions.status:-active`});
-                should.equal(members.data.length, 0, 'Can search for members with canceled subscription and no active ones');
+                assert.equal(members.data.length, 0, 'Can search for members with canceled subscription and no active ones');
             }
 
             await StripeCustomerSubscription.edit({
@@ -493,12 +494,12 @@ describe('Member Model', function run() {
 
             {
                 const members = await Member.findPage({filter: `subscriptions.status:canceled+subscriptions.status:-active`});
-                should.equal(members.data.length, 1, 'Can search for members with canceled subscription and no active ones');
+                assert.equal(members.data.length, 1, 'Can search for members with canceled subscription and no active ones');
             }
 
             {
                 const members = await Member.findPage({filter: `subscriptions.plan_interval:year`});
-                should.equal(members.data.length, 1, 'Can search for members by plan_interval');
+                assert.equal(members.data.length, 1, 'Can search for members by plan_interval');
             }
 
             await StripeCustomerSubscription.edit({
@@ -510,7 +511,7 @@ describe('Member Model', function run() {
 
             {
                 const members = await Member.findPage({filter: `subscriptions.plan_interval:month+subscriptions.plan_interval:-year`});
-                should.equal(members.data.length, 0, 'Can search for members by plan_interval');
+                assert.equal(members.data.length, 0, 'Can search for members by plan_interval');
             }
         });
 
@@ -582,7 +583,7 @@ describe('Member Model', function run() {
             const members = await Member.findPage({filter: `offer_redemptions:${offerId}`});
             // convert members to json
             const membersJson = members.data.map(model => model.toJSON());
-            should.equal(membersJson[0].email, email, 'Can search for members with offer_redemptions');
+            assert.equal(membersJson[0].email, email, 'Can search for members with offer_redemptions');
         });
     });
 });

--- a/ghost/core/test/legacy/models/model-posts.test.js
+++ b/ghost/core/test/legacy/models/model-posts.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const errors = require('@tryghost/errors');
 const should = require('should');
 const sinon = require('sinon');
@@ -747,8 +748,8 @@ describe('Post Model', function () {
                     (!!createdPost.get('featured')).should.equal(false);
                     (!!createdPost.get('page')).should.equal(false);
 
-                    should.equal(createdPost.get('locale'), null);
-                    should.equal(createdPost.get('visibility'), 'public');
+                    assert.equal(createdPost.get('locale'), null);
+                    assert.equal(createdPost.get('visibility'), 'public');
 
                     // testing for nulls
                     (createdPost.get('feature_image') === null).should.equal(true);
@@ -756,8 +757,8 @@ describe('Post Model', function () {
                     createdPost.get('created_at').should.be.above(new Date(0).getTime());
                     createdPost.relations.authors.models[0].id.should.equal(testUtils.DataGenerator.Content.users[0].id);
                     createdPost.get('updated_at').should.be.above(new Date(0).getTime());
-                    should.equal(createdPost.get('published_at'), null);
-                    should.equal(createdPost.get('published_by'), null);
+                    assert.equal(createdPost.get('published_at'), null);
+                    assert.equal(createdPost.get('published_by'), null);
 
                     createdPostUpdatedDate = createdPost.get('updated_at');
 
@@ -816,8 +817,8 @@ describe('Post Model', function () {
                     (!!createdPost.get('featured')).should.equal(false);
                     (!!createdPost.get('page')).should.equal(false);
 
-                    should.equal(createdPost.get('locale'), null);
-                    should.equal(createdPost.get('visibility'), 'paid');
+                    assert.equal(createdPost.get('locale'), null);
+                    assert.equal(createdPost.get('visibility'), 'paid');
 
                     // testing for nulls
                     (createdPost.get('feature_image') === null).should.equal(true);
@@ -825,8 +826,8 @@ describe('Post Model', function () {
                     createdPost.get('created_at').should.be.above(new Date(0).getTime());
                     createdPost.relations.authors.models[0].id.should.equal(testUtils.DataGenerator.Content.users[0].id);
                     createdPost.get('updated_at').should.be.above(new Date(0).getTime());
-                    should.equal(createdPost.get('published_at'), null);
-                    should.equal(createdPost.get('published_by'), null);
+                    assert.equal(createdPost.get('published_at'), null);
+                    assert.equal(createdPost.get('published_by'), null);
 
                     createdPostUpdatedDate = createdPost.get('updated_at');
 
@@ -1484,7 +1485,7 @@ describe('Post Model', function () {
                 }).then(function (response) {
                     const deleted = response.toJSON();
 
-                    should.equal(deleted.author, undefined);
+                    assert.equal(deleted.author, undefined);
 
                     Object.keys(eventsTriggered).length.should.eql(5);
                     should.exist(eventsTriggered['post.unpublished']);
@@ -1496,7 +1497,7 @@ describe('Post Model', function () {
                     // Double check we can't find the post again
                     return models.Post.findOne(firstItemData);
                 }).then(function (newResults) {
-                    should.equal(newResults, null);
+                    assert.equal(newResults, null);
 
                     // Double check we can't find any related tags
                     return ghostBookshelf.knex.select().table('posts_tags').where('post_id', firstItemData.id);
@@ -1525,7 +1526,7 @@ describe('Post Model', function () {
                 }).then(function (response) {
                     const deleted = response.toJSON();
 
-                    should.equal(deleted.author, undefined);
+                    assert.equal(deleted.author, undefined);
 
                     Object.keys(eventsTriggered).length.should.eql(4);
                     should.exist(eventsTriggered['post.deleted']);
@@ -1536,7 +1537,7 @@ describe('Post Model', function () {
                     // Double check we can't find the post again
                     return models.Post.findOne(firstItemData);
                 }).then(function (newResults) {
-                    should.equal(newResults, null);
+                    assert.equal(newResults, null);
 
                     // Double check we can't find any related tags
                     return ghostBookshelf.knex.select().table('posts_tags').where('post_id', firstItemData.id);
@@ -1565,7 +1566,7 @@ describe('Post Model', function () {
                 }).then(function (response) {
                     const deleted = response.toJSON();
 
-                    should.equal(deleted.author, undefined);
+                    assert.equal(deleted.author, undefined);
 
                     Object.keys(eventsTriggered).length.should.eql(3);
                     should.exist(eventsTriggered['page.unpublished']);
@@ -1575,7 +1576,7 @@ describe('Post Model', function () {
                     // Double check we can't find the post again
                     return models.Post.findOne(firstItemData);
                 }).then(function (newResults) {
-                    should.equal(newResults, null);
+                    assert.equal(newResults, null);
 
                     // Double check we can't find any related tags
                     return ghostBookshelf.knex.select().table('posts_tags').where('post_id', firstItemData.id);
@@ -1602,7 +1603,7 @@ describe('Post Model', function () {
                 }).then(function (response) {
                     const deleted = response.toJSON();
 
-                    should.equal(deleted.author, undefined);
+                    assert.equal(deleted.author, undefined);
 
                     Object.keys(eventsTriggered).length.should.eql(2);
                     should.exist(eventsTriggered['page.deleted']);
@@ -1611,7 +1612,7 @@ describe('Post Model', function () {
                     // Double check we can't find the post again
                     return models.Post.findOne(firstItemData);
                 }).then(function (newResults) {
-                    should.equal(newResults, null);
+                    assert.equal(newResults, null);
 
                     // Double check we can't find any related tags
                     return ghostBookshelf.knex.select().table('posts_tags').where('post_id', firstItemData.id);
@@ -1738,7 +1739,7 @@ describe('Post Model', function () {
                         });
                 })
                 .then((mobiledocRevisions) => {
-                    should.equal(mobiledocRevisions.length, 2);
+                    assert.equal(mobiledocRevisions.length, 2);
 
                     mobiledocRevisions.toJSON()[0].mobiledoc.should.equal(markdownToMobiledoc('b'));
                     mobiledocRevisions.toJSON()[1].mobiledoc.should.equal(markdownToMobiledoc('a'));
@@ -1773,7 +1774,7 @@ describe('Post Model', function () {
                     })
                 )
                 .then((mobiledocRevisions) => {
-                    should.equal(mobiledocRevisions.length, 10);
+                    assert.equal(mobiledocRevisions.length, 10);
 
                     mobiledocRevisions.toJSON()[0].mobiledoc.should.equal(markdownToMobiledoc('revision: 11'));
                     mobiledocRevisions.toJSON()[9].mobiledoc.should.equal(markdownToMobiledoc('revision: 2'));
@@ -1803,7 +1804,7 @@ describe('Post Model', function () {
                         });
                 })
                 .then((mobiledocRevisions) => {
-                    should.equal(mobiledocRevisions.length, 0);
+                    assert.equal(mobiledocRevisions.length, 0);
 
                     return models.Post.edit({
                         mobiledoc: markdownToMobiledoc('b')
@@ -1819,7 +1820,7 @@ describe('Post Model', function () {
                         });
                 })
                 .then((mobiledocRevisions) => {
-                    should.equal(mobiledocRevisions.length, 2);
+                    assert.equal(mobiledocRevisions.length, 2);
 
                     mobiledocRevisions.toJSON()[0].mobiledoc.should.equal(markdownToMobiledoc('b'));
                     mobiledocRevisions.toJSON()[1].mobiledoc.should.equal(markdownToMobiledoc('a'));

--- a/ghost/core/test/legacy/models/model-stripe-customer-subscription.test.js
+++ b/ghost/core/test/legacy/models/model-stripe-customer-subscription.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const {Member} = require('../../../core/server/models/member');
 const {MemberStripeCustomer} = require('../../../core/server/models/member-stripe-customer');
@@ -72,7 +73,7 @@ describe('StripeCustomerSubscription Model', function run() {
 
             should.exist(customer, 'StripeCustomerSubscription should have been fetched with customer');
 
-            should.equal(customer.get('customer_id'), 'fake_customer_id');
+            assert.equal(customer.get('customer_id'), 'fake_customer_id');
         });
     });
 });

--- a/ghost/core/test/legacy/models/model-users.test.js
+++ b/ghost/core/test/legacy/models/model-users.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const errors = require('@tryghost/errors');
 const should = require('should');
 const sinon = require('sinon');
@@ -279,7 +280,7 @@ describe('User Model', function run() {
                 should.exist(results);
                 user = results.toJSON();
                 user.id.should.equal(firstUser);
-                should.equal(user.website, null);
+                assert.equal(user.website, null);
 
                 return UserModel.edit({website: 'http://some.newurl.com'}, {id: firstUser});
             }).then(function (edited) {

--- a/ghost/core/test/unit/api/canary/session.test.js
+++ b/ghost/core/test/unit/api/canary/session.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const {UnauthorizedError} = require('@tryghost/errors');
@@ -17,10 +18,10 @@ describe('Session controller', function () {
     });
 
     it('exports an add method', function () {
-        should.equal(typeof sessionController.add, 'function');
+        assert.equal(typeof sessionController.add, 'function');
     });
     it('exports an delete method', function () {
-        should.equal(typeof sessionController.delete, 'function');
+        assert.equal(typeof sessionController.delete, 'function');
     });
 
     describe('#add', function () {
@@ -28,7 +29,7 @@ describe('Session controller', function () {
             return sessionController.add({}).then(() => {
                 should.fail('session.add did not throw');
             },(err) => {
-                should.equal(err instanceof UnauthorizedError, true);
+                assert.equal(err instanceof UnauthorizedError, true);
             });
         });
 
@@ -42,7 +43,7 @@ describe('Session controller', function () {
             }, {}).then(() => {
                 should.fail('session.add did not throw');
             },(err) => {
-                should.equal(err instanceof UnauthorizedError, true);
+                assert.equal(err instanceof UnauthorizedError, true);
             });
         });
 
@@ -68,13 +69,13 @@ describe('Session controller', function () {
             }}).then((fn) => {
                 fn(fakeReq, fakeRes, fakeNext);
             }).then(function () {
-                should.equal(fakeReq.brute.reset.callCount, 1);
+                assert.equal(fakeReq.brute.reset.callCount, 1);
 
                 const createSessionStubCall = createSessionStub.getCall(0);
-                should.equal(fakeReq.user, fakeUser);
-                should.equal(createSessionStubCall.args[0], fakeReq);
-                should.equal(createSessionStubCall.args[1], fakeRes);
-                should.equal(createSessionStubCall.args[2], fakeNext);
+                assert.equal(fakeReq.user, fakeUser);
+                assert.equal(createSessionStubCall.args[0], fakeReq);
+                assert.equal(createSessionStubCall.args[1], fakeRes);
+                assert.equal(createSessionStubCall.args[2], fakeNext);
             });
         });
 
@@ -101,9 +102,9 @@ describe('Session controller', function () {
             }}).then((fn) => {
                 fn(fakeReq, fakeRes, fakeNext);
             }).then(function () {
-                should.equal(fakeReq.brute.reset.callCount, 1);
-                should.equal(fakeNext.callCount, 1);
-                should.equal(fakeNext.args[0][0], resetError);
+                assert.equal(fakeReq.brute.reset.callCount, 1);
+                assert.equal(fakeNext.callCount, 1);
+                assert.equal(fakeNext.args[0][0], resetError);
             });
         });
 
@@ -129,15 +130,15 @@ describe('Session controller', function () {
             }}).then((fn) => {
                 fn(fakeReq, fakeRes, fakeNext);
             }).then(function () {
-                should.equal(fakeReq.brute.reset.callCount, 1);
+                assert.equal(fakeReq.brute.reset.callCount, 1);
 
                 const createSessionStubCall = createSessionStub.getCall(0);
-                should.equal(fakeReq.user, fakeUser);
-                should.equal(createSessionStubCall.args[0], fakeReq);
-                should.equal(createSessionStubCall.args[1], fakeRes);
-                should.equal(createSessionStubCall.args[2], fakeNext);
+                assert.equal(fakeReq.user, fakeUser);
+                assert.equal(createSessionStubCall.args[0], fakeReq);
+                assert.equal(createSessionStubCall.args[1], fakeRes);
+                assert.equal(createSessionStubCall.args[2], fakeNext);
 
-                should.equal(fakeReq.skipVerification, true);
+                assert.equal(fakeReq.skipVerification, true);
             });
         });
 
@@ -163,15 +164,15 @@ describe('Session controller', function () {
             }}).then((fn) => {
                 fn(fakeReq, fakeRes, fakeNext);
             }).then(function () {
-                should.equal(fakeReq.brute.reset.callCount, 1);
+                assert.equal(fakeReq.brute.reset.callCount, 1);
 
                 const createSessionStubCall = createSessionStub.getCall(0);
-                should.equal(fakeReq.user, fakeUser);
-                should.equal(createSessionStubCall.args[0], fakeReq);
-                should.equal(createSessionStubCall.args[1], fakeRes);
-                should.equal(createSessionStubCall.args[2], fakeNext);
+                assert.equal(fakeReq.user, fakeUser);
+                assert.equal(createSessionStubCall.args[0], fakeReq);
+                assert.equal(createSessionStubCall.args[1], fakeRes);
+                assert.equal(createSessionStubCall.args[2], fakeNext);
 
-                should.equal(fakeReq.skipVerification, false);
+                assert.equal(fakeReq.skipVerification, false);
             });
         });
     });
@@ -187,9 +188,9 @@ describe('Session controller', function () {
                 fn(fakeReq, fakeRes, fakeNext);
             }).then(function () {
                 const destroySessionStubCall = logoutSessionStub.getCall(0);
-                should.equal(destroySessionStubCall.args[0], fakeReq);
-                should.equal(destroySessionStubCall.args[1], fakeRes);
-                should.equal(destroySessionStubCall.args[2], fakeNext);
+                assert.equal(destroySessionStubCall.args[0], fakeReq);
+                assert.equal(destroySessionStubCall.args[1], fakeRes);
+                assert.equal(destroySessionStubCall.args[2], fakeNext);
             });
         });
     });

--- a/ghost/core/test/unit/frontend/helpers/facebook-url.test.js
+++ b/ghost/core/test/unit/frontend/helpers/facebook-url.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 
 // Stuff we are testing
@@ -30,6 +31,6 @@ describe('{{facebook_url}} helper', function () {
     });
 
     it('should return null if there are no facebook usernames', function () {
-        should.equal(facebook_url(options), null);
+        assert.equal(facebook_url(options), null);
     });
 });

--- a/ghost/core/test/unit/frontend/helpers/total-members.test.js
+++ b/ghost/core/test/unit/frontend/helpers/total-members.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 
 const total_members = require('../../../../core/frontend/helpers/total_members');
@@ -5,6 +6,6 @@ const total_members = require('../../../../core/frontend/helpers/total_members')
 describe('{{total_members}} helper', function () {
     it('can render total members', async function () {
         const rendered = await total_members.call({total: 50000});
-        should.equal(rendered.string, '50,000+');
+        assert.equal(rendered.string, '50,000+');
     });
 });

--- a/ghost/core/test/unit/frontend/helpers/total-members.test.js
+++ b/ghost/core/test/unit/frontend/helpers/total-members.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 
 const total_members = require('../../../../core/frontend/helpers/total_members');
 

--- a/ghost/core/test/unit/frontend/helpers/total-paid-members.test.js
+++ b/ghost/core/test/unit/frontend/helpers/total-paid-members.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 
 const total_paid_members = require('../../../../core/frontend/helpers/total_paid_members');
@@ -5,6 +6,6 @@ const total_paid_members = require('../../../../core/frontend/helpers/total_paid
 describe('{{total_paid_members}} helper', function () {
     it('can render total paid members', async function () {
         const rendered = await total_paid_members.call({paid: 3000});
-        should.equal(rendered.string, '3,000+');
+        assert.equal(rendered.string, '3,000+');
     });
 });

--- a/ghost/core/test/unit/frontend/helpers/twitter-url.test.js
+++ b/ghost/core/test/unit/frontend/helpers/twitter-url.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 
 // Stuff we are testing
@@ -30,6 +31,6 @@ describe('{{twitter_url}} helper', function () {
     });
 
     it('should return null if there are no twitter usernames', function () {
-        should.equal(twitter_url(options), null);
+        assert.equal(twitter_url(options), null);
     });
 });

--- a/ghost/core/test/unit/frontend/meta/keywords.test.js
+++ b/ghost/core/test/unit/frontend/meta/keywords.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const models = require('../../../../core/server/models');
@@ -45,20 +46,20 @@ describe('getKeywords', function () {
                 tags: []
             }
         });
-        should.equal(keywords, null);
+        assert.equal(keywords, null);
     });
 
     it('should return null if post has no tags', function () {
         const keywords = getKeywords({
             post: {}
         });
-        should.equal(keywords, null);
+        assert.equal(keywords, null);
     });
 
     it('should return null if not a post', function () {
         const keywords = getKeywords({
             author: {}
         });
-        should.equal(keywords, null);
+        assert.equal(keywords, null);
     });
 });

--- a/ghost/core/test/unit/frontend/meta/modified-date.test.js
+++ b/ghost/core/test/unit/frontend/meta/modified-date.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const getModifiedDate = require('../../../../core/frontend/meta/modified-date');
 
@@ -9,7 +10,7 @@ describe('getModifiedDate', function () {
                 updated_at: new Date('2016-01-01 12:56:45.232Z')
             }
         });
-        should.equal(modDate, '2016-01-01T12:56:45.232Z');
+        assert.equal(modDate, '2016-01-01T12:56:45.232Z');
     });
 
     it('should return null if no update_at date on context', function () {
@@ -17,7 +18,7 @@ describe('getModifiedDate', function () {
             context: ['author'],
             author: {}
         });
-        should.equal(modDate, null);
+        assert.equal(modDate, null);
     });
 
     it('should return null if context and property do not match in name', function () {
@@ -27,6 +28,6 @@ describe('getModifiedDate', function () {
                 updated_at: new Date('2016-01-01 12:56:45.232Z')
             }
         });
-        should.equal(modDate, null);
+        assert.equal(modDate, null);
     });
 });

--- a/ghost/core/test/unit/frontend/meta/og-type.test.js
+++ b/ghost/core/test/unit/frontend/meta/og-type.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const getOgType = require('../../../../core/frontend/meta/og-type');
 
@@ -6,20 +7,20 @@ describe('getOgType', function () {
         const ogType = getOgType({
             context: ['author']
         });
-        should.equal(ogType, 'profile');
+        assert.equal(ogType, 'profile');
     });
 
     it('should return og type article if context is type post', function () {
         const ogType = getOgType({
             context: ['post']
         });
-        should.equal(ogType, 'article');
+        assert.equal(ogType, 'article');
     });
 
     it('should return og type website if context is not author or post', function () {
         const ogType = getOgType({
             context: ['tag']
         });
-        should.equal(ogType, 'website');
+        assert.equal(ogType, 'website');
     });
 });

--- a/ghost/core/test/unit/frontend/meta/published-date.test.js
+++ b/ghost/core/test/unit/frontend/meta/published-date.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const getPublishedDate = require('../../../../core/frontend/meta/published-date');
 
@@ -9,7 +10,7 @@ describe('getPublishedDate', function () {
                 published_at: new Date('2016-01-01 12:56:45.232Z')
             }
         });
-        should.equal(pubDate, '2016-01-01T12:56:45.232Z');
+        assert.equal(pubDate, '2016-01-01T12:56:45.232Z');
     });
 
     it('should return published at over created at date as ISO 8601 if has both', function () {
@@ -20,7 +21,7 @@ describe('getPublishedDate', function () {
                 created_at: new Date('2015-01-01 12:56:45.232Z')
             }
         });
-        should.equal(pubDate, '2016-01-01T12:56:45.232Z');
+        assert.equal(pubDate, '2016-01-01T12:56:45.232Z');
     });
 
     it('should return null if no update_at date on context', function () {
@@ -28,7 +29,7 @@ describe('getPublishedDate', function () {
             context: ['author'],
             author: {}
         });
-        should.equal(pubDate, null);
+        assert.equal(pubDate, null);
     });
 
     it('should return null if context and property do not match in name', function () {
@@ -38,6 +39,6 @@ describe('getPublishedDate', function () {
                 published_at: new Date('2016-01-01 12:56:45.232Z')
             }
         });
-        should.equal(pubDate, null);
+        assert.equal(pubDate, null);
     });
 });

--- a/ghost/core/test/unit/frontend/meta/rss-url.test.js
+++ b/ghost/core/test/unit/frontend/meta/rss-url.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const routing = require('../../../../core/frontend/services/routing');
@@ -17,7 +18,7 @@ describe('getRssUrl', function () {
             secure: false
         });
 
-        should.equal(rssUrl, '/rss/');
+        assert.equal(rssUrl, '/rss/');
     });
 
     it('forwards absolute flags', function () {

--- a/ghost/core/test/unit/frontend/meta/schema.test.js
+++ b/ghost/core/test/unit/frontend/meta/schema.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const {getSchema, SOCIAL_PLATFORMS} = require('../../../../core/frontend/meta/schema');
 const socialUrls = require('@tryghost/social-urls');
@@ -826,7 +827,7 @@ describe('getSchema', function () {
         const schema = getSchema(metadata, data);
 
         should.exist(schema.contributor);
-        should.equal(schema.contributor.length, 2);
+        assert.equal(schema.contributor.length, 2);
         should.deepEqual(schema.contributor[0], {
             '@type': 'Person',
             name: 'Co-Author 1',

--- a/ghost/core/test/unit/frontend/src/privacy.test.js
+++ b/ghost/core/test/unit/frontend/src/privacy.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 
 // Use path relative to test file
@@ -19,10 +20,10 @@ describe('Privacy Utils', function () {
             const result = maskSensitiveData(payload);
             const parsed = JSON.parse(result);
             
-            should.equal(parsed.user, '********');
-            should.equal(parsed.user_id, '********');
-            should.equal(parsed.email, '********');
-            should.equal(parsed.normal, 'data');
+            assert.equal(parsed.user, '********');
+            assert.equal(parsed.user_id, '********');
+            assert.equal(parsed.email, '********');
+            assert.equal(parsed.normal, 'data');
         });
         
         it('should mask custom sensitive attributes', function () {
@@ -35,8 +36,8 @@ describe('Privacy Utils', function () {
             const result = maskSensitiveData(payload, customAttributes);
             const parsed = JSON.parse(result);
             
-            should.equal(parsed.custom_field, '********');
-            should.equal(parsed.normal, 'data');
+            assert.equal(parsed.custom_field, '********');
+            assert.equal(parsed.normal, 'data');
         });
         
         it('should handle nested objects', function () {
@@ -53,9 +54,9 @@ describe('Privacy Utils', function () {
             const result = maskSensitiveData(payload);
             const parsed = JSON.parse(result);
             
-            should.equal(parsed.data.user, '********');
-            should.equal(parsed.data.details.email, '********');
-            should.equal(parsed.normal, 'data');
+            assert.equal(parsed.data.user, '********');
+            assert.equal(parsed.data.details.email, '********');
+            assert.equal(parsed.normal, 'data');
         });
         
         it('should handle empty payloads', function () {
@@ -77,10 +78,10 @@ describe('Privacy Utils', function () {
             
             const result = processPayload(payload);
             
-            should.equal(typeof result, 'string');
+            assert.equal(typeof result, 'string');
             const parsed = JSON.parse(result);
-            should.equal(parsed.email, '********');
-            should.equal(parsed.normal, 'data');
+            assert.equal(parsed.email, '********');
+            assert.equal(parsed.normal, 'data');
         });
         
         it('should add global attributes to payload', function () {
@@ -95,8 +96,8 @@ describe('Privacy Utils', function () {
             const result = processPayload(payload, globalAttributes);
             const parsed = JSON.parse(result);
             
-            should.equal(parsed.data, 'value');
-            should.equal(parsed.global, 'attribute');
+            assert.equal(parsed.data, 'value');
+            assert.equal(parsed.global, 'attribute');
         });
         
         it('should return object when stringify is false', function () {
@@ -107,9 +108,9 @@ describe('Privacy Utils', function () {
             
             const result = processPayload(payload, {}, false);
             
-            should.equal(typeof result, 'object');
-            should.equal(result.email, '********');
-            should.equal(result.normal, 'data');
+            assert.equal(typeof result, 'object');
+            assert.equal(result.email, '********');
+            assert.equal(result.normal, 'data');
         });
         
         it('should mask sensitive data in global attributes', function () {
@@ -123,8 +124,8 @@ describe('Privacy Utils', function () {
             
             const result = processPayload(payload, globalAttributes, false);
             
-            should.equal(result.email, '********');
-            should.equal(result.normal, 'data');
+            assert.equal(result.email, '********');
+            assert.equal(result.normal, 'data');
         });
         
         it('should handle empty payload and attributes', function () {

--- a/ghost/core/test/unit/frontend/src/url-attribution.test.js
+++ b/ghost/core/test/unit/frontend/src/url-attribution.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const {JSDOM} = require('jsdom');
@@ -48,42 +49,42 @@ describe('URL Attribution Utils', function () {
         it('should extract ref parameter correctly', function () {
             const result = parseReferrerData('https://example.com/?ref=newsletter');
             should.exist(result);
-            should.equal(result.source, 'newsletter');
+            assert.equal(result.source, 'newsletter');
         });
         
         it('should extract source parameter correctly', function () {
             const result = parseReferrerData('https://example.com/?source=twitter');
             should.exist(result);
-            should.equal(result.source, 'twitter');
+            assert.equal(result.source, 'twitter');
         });
         
         it('should extract utm_source parameter correctly', function () {
             const result = parseReferrerData('https://example.com/?utm_source=facebook');
             should.exist(result);
-            should.equal(result.source, 'facebook');
+            assert.equal(result.source, 'facebook');
         });
         
         it('should handle portal hash URLs', function () {
             const result = parseReferrerData('https://example.com/#/portal/signup?ref=portal-hash');
             should.exist(result);
-            should.equal(result.source, 'portal-hash');
+            assert.equal(result.source, 'portal-hash');
         });
         
         it('should return document.referrer when no source params are present', function () {
             const result = parseReferrerData('https://example.com/');
             should.exist(result);
-            should.equal(result.url, 'https://external-site.com/');
+            assert.equal(result.url, 'https://external-site.com/');
         });
         
         it('should extract all UTM parameters', function () {
             const result = parseReferrerData('https://example.com/?utm_source=google&utm_medium=cpc&utm_campaign=summer&utm_term=ghost&utm_content=banner');
             should.exist(result);
-            should.equal(result.utmSource, 'google');
-            should.equal(result.utmMedium, 'cpc');
-            should.equal(result.utmCampaign, 'summer');
-            should.equal(result.utmTerm, 'ghost');
-            should.equal(result.utmContent, 'banner');
-            should.equal(result.source, 'google'); // source should be utm_source
+            assert.equal(result.utmSource, 'google');
+            assert.equal(result.utmMedium, 'cpc');
+            assert.equal(result.utmCampaign, 'summer');
+            assert.equal(result.utmTerm, 'ghost');
+            assert.equal(result.utmContent, 'banner');
+            assert.equal(result.source, 'google'); // source should be utm_source
         });
     });
     
@@ -91,25 +92,25 @@ describe('URL Attribution Utils', function () {
         it('should extract parameters from portal hash URL', function () {
             const result = parseReferrerData('https://example.com/#/portal/signup?ref=newsletter');
             should.exist(result);
-            should.equal(result.source, 'newsletter');
+            assert.equal(result.source, 'newsletter');
         });
         
         it('should handle multiple parameters in portal hash', function () {
             const result = parseReferrerData('https://example.com/#/portal/signup?ref=newsletter&utm_medium=email');
             should.exist(result);
-            should.equal(result.source, 'newsletter');
-            should.equal(result.medium, 'email');
+            assert.equal(result.source, 'newsletter');
+            assert.equal(result.medium, 'email');
         });
         
         it('should extract all UTM parameters from portal hash', function () {
             const result = parseReferrerData('https://example.com/#/portal/signup?utm_source=google&utm_medium=cpc&utm_campaign=summer&utm_term=ghost&utm_content=banner');
             should.exist(result);
-            should.equal(result.utmSource, 'google');
-            should.equal(result.utmMedium, 'cpc');
-            should.equal(result.utmCampaign, 'summer');
-            should.equal(result.utmTerm, 'ghost');
-            should.equal(result.utmContent, 'banner');
-            should.equal(result.source, 'google'); // source should be utm_source
+            assert.equal(result.utmSource, 'google');
+            assert.equal(result.utmMedium, 'cpc');
+            assert.equal(result.utmCampaign, 'summer');
+            assert.equal(result.utmTerm, 'ghost');
+            assert.equal(result.utmContent, 'banner');
+            assert.equal(result.source, 'google'); // source should be utm_source
         });
     });
     
@@ -117,49 +118,49 @@ describe('URL Attribution Utils', function () {
         it('should prioritize ref/source over medium and document.referrer', function () {
             // When ref is present along with utm_medium
             const result = getReferrer('https://example.com/?ref=newsletter&utm_medium=email');
-            should.equal(result, 'newsletter');
+            assert.equal(result, 'newsletter');
         });
         
         it('should prioritize utm_source over medium', function () {
             // When utm_source is present along with utm_medium
             const result = getReferrer('https://example.com/?utm_source=twitter&utm_medium=social');
-            should.equal(result, 'twitter');
+            assert.equal(result, 'twitter');
         });
         
         it('should fall back to utm_medium if no ref/source/utm_source', function () {
             // Only utm_medium is present
             const result = getReferrer('https://example.com/?utm_medium=email');
-            should.equal(result, 'email');
+            assert.equal(result, 'email');
         });
         
         it('should fall back to document.referrer if no params are present', function () {
             // No URL params, should use document.referrer (https://external-site.com/ from test setup)
             const result = getReferrer('https://example.com/');
-            should.equal(result, 'https://external-site.com/');
+            assert.equal(result, 'https://external-site.com/');
         });
         
         it('should return null if referrer matches current hostname', function () {
             // Same-domain referrer should be filtered out
             const result = getReferrer('https://example.com/?ref=https://example.com/some-page');
-            should.equal(result, null);
+            assert.equal(result, null);
         });
         
         it('should return non-URL referrers like ghost-newsletter', function () {
             // Non-URL refs should work fine
             const result = getReferrer('https://example.com/?ref=ghost-newsletter');
-            should.equal(result, 'ghost-newsletter');
+            assert.equal(result, 'ghost-newsletter');
         });
     });
     
     describe('getReferrer', function () {
         it('should combine parse and final referrer functions', function () {
             const result = getReferrer('https://example.com/?ref=newsletter');
-            should.equal(result, 'newsletter');
+            assert.equal(result, 'newsletter');
         });
         
         it('should return null for same-domain referrers', function () {
             const result = getReferrer('https://example.com/?ref=https://example.com/page');
-            should.equal(result, null);
+            assert.equal(result, null);
         });
     });
 }); 

--- a/ghost/core/test/unit/frontend/utils/frontend-apps.test.js
+++ b/ghost/core/test/unit/frontend/utils/frontend-apps.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const {getFrontendAppConfig, getDataAttributes} = require('../../../../core/frontend/utils/frontend-apps');
 const configUtils = require('../../../utils/config-utils');
@@ -16,9 +17,9 @@ describe('Frontend apps:', function () {
 
         it('should return app urls and version from config', async function () {
             const {stylesUrl, scriptUrl, appVersion} = getFrontendAppConfig('portal');
-            should.equal(appVersion, '1.0');
-            should.equal(stylesUrl, 'https://cdn.example.com/~1.0/main.css');
-            should.equal(scriptUrl, 'https://cdn.example.com/~1.0/portal.min.js');
+            assert.equal(appVersion, '1.0');
+            assert.equal(stylesUrl, 'https://cdn.example.com/~1.0/main.css');
+            assert.equal(scriptUrl, 'https://cdn.example.com/~1.0/portal.min.js');
         });
     });
 
@@ -29,13 +30,13 @@ describe('Frontend apps:', function () {
                 'example-version': '1.0'
             });
 
-            should.equal(dataAttributes, 'data-admin="test" data-example-version="1.0"');
+            assert.equal(dataAttributes, 'data-admin="test" data-example-version="1.0"');
         });
 
         it('should generate empty string for missing data object', async function () {
             const dataAttributes = getDataAttributes();
 
-            should.equal(dataAttributes, '');
+            assert.equal(dataAttributes, '');
         });
     });
 });

--- a/ghost/core/test/unit/frontend/utils/member-count.test.js
+++ b/ghost/core/test/unit/frontend/utils/member-count.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const {memberCountRounding, getMemberStats} = require('../../../../core/frontend/utils/member-count');
 
@@ -38,13 +39,13 @@ describe('Member Count', function () {
             meta: {totals: {paid: 1000, free: 500, comped: 500}}
         }};
         const members = await getMemberStats.call(meta);
-        should.equal(members.total, 2000);
+        assert.equal(members.total, 2000);
     });
 
     it('should return rounded numbers in correct format', function () {
         getMemberStatsMock.map((mock) => {
             const result = memberCountRounding(mock.members);
-            return should.equal(result, mock.expected);
+            return assert.equal(result, mock.expected);
         });
     });
 });

--- a/ghost/core/test/unit/server/adapters/scheduling/post-scheduling/post-scheduler.test.js
+++ b/ghost/core/test/unit/server/adapters/scheduling/post-scheduling/post-scheduler.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const errors = require('@tryghost/errors');
 const should = require('should');
 const sinon = require('sinon');
@@ -80,7 +81,7 @@ describe('Scheduling: Post Scheduler', function () {
                 adapter.schedule.args[0][0].time.should.equal(moment(post.get('published_at')).valueOf());
                 adapter.schedule.args[0][0].url.should.startWith(urlUtils.urlJoin('http://scheduler.local:1111/', 'schedules', 'posts', post.get('id'), '?token='));
                 adapter.schedule.args[0][0].extra.httpMethod.should.eql('PUT');
-                should.equal(null, adapter.schedule.args[0][0].extra.oldTime);
+                assert.equal(null, adapter.schedule.args[0][0].extra.oldTime);
             });
         });
 

--- a/ghost/core/test/unit/server/adapters/scheduling/utils.test.js
+++ b/ghost/core/test/unit/server/adapters/scheduling/utils.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const fs = require('fs-extra');
 const configUtils = require('../../../../utils/config-utils');
@@ -79,7 +80,7 @@ describe('Scheduling: utils', function () {
             });
             schedulingUtils.createAdapter().catch(function (err) {
                 should.exist(err);
-                should.equal(err.errorType, 'IncorrectUsageError');
+                assert.equal(err.errorType, 'IncorrectUsageError');
                 done();
             });
         });

--- a/ghost/core/test/unit/server/adapters/storage/index.test.js
+++ b/ghost/core/test/unit/server/adapters/storage/index.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const fs = require('fs-extra');
 const StorageBase = require('ghost-storage-base');
@@ -90,7 +91,7 @@ describe('storage: index_spec', function () {
             storage.getStorage();
         } catch (err) {
             should.exist(err);
-            should.equal(err.errorType, 'IncorrectUsageError');
+            assert.equal(err.errorType, 'IncorrectUsageError');
         }
     });
 });

--- a/ghost/core/test/unit/server/data/importer/import-manager.test.js
+++ b/ghost/core/test/unit/server/data/importer/import-manager.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const fs = require('fs-extra');
 const path = require('path');
@@ -15,7 +16,7 @@ describe('Import Manager', function () {
                     const filePath = path.join(extractedPath, file);
                     const stats = fs.statSync(filePath);
                     const fileMode = stats.mode & 0o777;
-                    should.equal(fileMode, 0o644, `File ${file} should have 0644 permissions`);
+                    assert.equal(fileMode, 0o644, `File ${file} should have 0644 permissions`);
                 });
             } finally {
                 await fs.remove(extractedPath);

--- a/ghost/core/test/unit/server/data/importer/importers/data/posts.test.js
+++ b/ghost/core/test/unit/server/data/importer/importers/data/posts.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const find = require('lodash/find');
 const PostsImporter = require('../../../../../../../core/server/data/importer/importers/data/posts-importer');
@@ -134,7 +135,7 @@ describe('PostsImporter', function () {
 
             const post = find(importer.dataToImport, {slug: 'post-with-newsletter'});
             should.exist(post);
-            should.equal(post.mobiledoc, null);
+            assert.equal(post.mobiledoc, null);
         });
     });
 });

--- a/ghost/core/test/unit/server/data/importer/importers/data/posts.test.js
+++ b/ghost/core/test/unit/server/data/importer/importers/data/posts.test.js
@@ -135,7 +135,7 @@ describe('PostsImporter', function () {
 
             const post = find(importer.dataToImport, {slug: 'post-with-newsletter'});
             should.exist(post);
-            assert.equal(post.mobiledoc, null);
+            assert.equal(post.mobiledoc, undefined);
         });
     });
 });

--- a/ghost/core/test/unit/server/data/importer/importers/data/settings.test.js
+++ b/ghost/core/test/unit/server/data/importer/importers/data/settings.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const find = require('lodash/find');
 const should = require('should');
 const SettingsImporter = require('../../../../../../../core/server/data/importer/importers/data/settings-importer');
@@ -19,7 +20,7 @@ describe('SettingsImporter', function () {
 
             const passwordSetting = find(importer.dataToImport, {key: 'password'});
 
-            should.equal(passwordSetting, undefined);
+            assert.equal(passwordSetting, undefined);
         });
 
         it('Removes the is_private setting', function () {
@@ -37,7 +38,7 @@ describe('SettingsImporter', function () {
 
             const passwordSetting = find(importer.dataToImport, {key: 'is_private'});
 
-            should.equal(passwordSetting, undefined);
+            assert.equal(passwordSetting, undefined);
         });
 
         it('Does not overwrite members from address', function () {

--- a/ghost/core/test/unit/server/data/migrations/utils.test.js
+++ b/ghost/core/test/unit/server/data/migrations/utils.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const errors = require('@tryghost/errors');
@@ -393,7 +394,7 @@ describe('migrations/utils/permissions', function () {
                     await runUpMigration(knex, migration);
                     should.fail('addPermissionToRole up migration did not throw');
                 } catch (err) {
-                    should.equal(errors.utils.isGhostError(err), true);
+                    assert.equal(errors.utils.isGhostError(err), true);
                     err.message.should.equal('Cannot add permission(Unimaginable) with role(Not there) - permission does not exist');
                 }
             });
@@ -426,7 +427,7 @@ describe('migrations/utils/permissions', function () {
                     await runUpMigration(knex, migration);
                     should.fail('addPermissionToRole did not throw');
                 } catch (err) {
-                    should.equal(errors.utils.isGhostError(err), true);
+                    assert.equal(errors.utils.isGhostError(err), true);
                     err.message.should.equal('Cannot add permission(Permission Name) with role(Not there) - role does not exist');
                 }
             });
@@ -595,17 +596,17 @@ describe('migrations/utils/settings', function () {
                 return row.key === 'test_key';
             });
 
-            should.equal(addedSettingAfterUp.key, 'test_key', 'The setting was added to the database');
-            should.equal(addedSettingAfterUp.value, 'test_value');
-            should.equal(addedSettingAfterUp.type, 'string');
-            should.equal(addedSettingAfterUp.group, 'test_group');
-            should.equal(addedSettingAfterUp.flags, 'PUBLIC');
+            assert.equal(addedSettingAfterUp.key, 'test_key', 'The setting was added to the database');
+            assert.equal(addedSettingAfterUp.value, 'test_value');
+            assert.equal(addedSettingAfterUp.type, 'string');
+            assert.equal(addedSettingAfterUp.group, 'test_group');
+            assert.equal(addedSettingAfterUp.flags, 'PUBLIC');
 
             await runDownMigration();
 
             const allSettingsAfterDown = await knex('settings').select();
 
-            should.equal(allSettingsAfterDown.length, 0, 'The setting was removed');
+            assert.equal(allSettingsAfterDown.length, 0, 'The setting was removed');
         });
 
         it('Skips adding if setting already exists', async function () {
@@ -638,13 +639,13 @@ describe('migrations/utils/settings', function () {
                 return row.key === 'test_key';
             });
 
-            should.equal(existingSetting.value, 'test_value', 'The original value was preserved');
+            assert.equal(existingSetting.value, 'test_value', 'The original value was preserved');
 
             await runDownMigration();
 
             const allSettingsAfterDown = await knex('settings').select();
 
-            should.equal(allSettingsAfterDown.length, 0, 'The setting was removed');
+            assert.equal(allSettingsAfterDown.length, 0, 'The setting was removed');
         });
     });
 
@@ -676,10 +677,10 @@ describe('migrations/utils/settings', function () {
                 return row.key === 'remove_test_key';
             });
 
-            should.equal(allSettingsAtStart.length, 1, 'Started with one setting');
-            should.equal(allSettingsAfterUp.length, 0, 'Setting was removed');
-            should.equal(allSettingsAfterDown.length, 1, 'Ended with one setting');
-            should.equal(restoredSettingAfterDown.key, 'remove_test_key', 'Setting was restored');
+            assert.equal(allSettingsAtStart.length, 1, 'Started with one setting');
+            assert.equal(allSettingsAfterUp.length, 0, 'Setting was removed');
+            assert.equal(allSettingsAfterDown.length, 1, 'Ended with one setting');
+            assert.equal(restoredSettingAfterDown.key, 'remove_test_key', 'Setting was restored');
         });
 
         it('Skips removal if setting does not exist', async function () {
@@ -697,9 +698,9 @@ describe('migrations/utils/settings', function () {
 
             const allSettingsAfterDown = await knex('settings').select();
 
-            should.equal(allSettingsAtStart.length, 0, 'No settings in place at the start');
-            should.equal(allSettingsAfterUp.length, 0, 'No settings were removed');
-            should.equal(allSettingsAfterDown.length, 0, 'No settings were restored');
+            assert.equal(allSettingsAtStart.length, 0, 'No settings in place at the start');
+            assert.equal(allSettingsAfterUp.length, 0, 'No settings were removed');
+            assert.equal(allSettingsAfterDown.length, 0, 'No settings were restored');
         });
     });
 });
@@ -752,18 +753,18 @@ describe('migrations/utils/schema nullable functions', function () {
 
             // Verify initial state - column should be not nullable
             const isNullableInitial = await checkColumnNullable('test_nullable_migration', 'not_nullable_col', knex);
-            should.equal(isNullableInitial, false, 'Column should initially be not nullable');
+            assert.equal(isNullableInitial, false, 'Column should initially be not nullable');
 
             const runDownMigration = await runUpMigration(knex, migration);
 
             // Verify column is now nullable
             const isNullableAfter = await checkColumnNullable('test_nullable_migration', 'not_nullable_col', knex);
-            should.equal(isNullableAfter, true, 'Column should be nullable after up migration');
+            assert.equal(isNullableAfter, true, 'Column should be nullable after up migration');
 
             // Test down migration
             await runDownMigration();
             const isNullableAfterDown = await checkColumnNullable('test_nullable_migration', 'not_nullable_col', knex);
-            should.equal(isNullableAfterDown, false, 'Column should be not nullable after down migration');
+            assert.equal(isNullableAfterDown, false, 'Column should be not nullable after down migration');
 
             await knex.destroy();
         });
@@ -775,7 +776,7 @@ describe('migrations/utils/schema nullable functions', function () {
 
             // Verify initial state - column should already be nullable
             const isNullableInitial = await checkColumnNullable('test_nullable_migration', 'nullable_col', knex);
-            should.equal(isNullableInitial, true, 'Column should initially be nullable');
+            assert.equal(isNullableInitial, true, 'Column should initially be nullable');
 
             // Spy on logging to verify skip message
             const logSpy = sinon.spy(logging, 'warn');
@@ -787,7 +788,7 @@ describe('migrations/utils/schema nullable functions', function () {
 
                 // Column should still be nullable
                 const isNullableAfter = await checkColumnNullable('test_nullable_migration', 'nullable_col', knex);
-                should.equal(isNullableAfter, true, 'Column should still be nullable');
+                assert.equal(isNullableAfter, true, 'Column should still be nullable');
 
                 await runDownMigration();
             } finally {
@@ -808,18 +809,18 @@ describe('migrations/utils/schema nullable functions', function () {
 
             // Verify initial state - column should be nullable
             const isNullableInitial = await checkColumnNullable('test_nullable_migration', 'nullable_col', knex);
-            should.equal(isNullableInitial, true, 'Column should initially be nullable');
+            assert.equal(isNullableInitial, true, 'Column should initially be nullable');
 
             const runDownMigration = await runUpMigration(knex, migration);
 
             // Verify column is now not nullable
             const isNotNullableAfter = await checkColumnNullable('test_nullable_migration', 'nullable_col', knex);
-            should.equal(isNotNullableAfter, false, 'Column should be not nullable after up migration');
+            assert.equal(isNotNullableAfter, false, 'Column should be not nullable after up migration');
 
             // Test down migration (should set back to nullable)
             await runDownMigration();
             const isNullableAfterDown = await checkColumnNullable('test_nullable_migration', 'nullable_col', knex);
-            should.equal(isNullableAfterDown, true, 'Column should be nullable after down migration');
+            assert.equal(isNullableAfterDown, true, 'Column should be nullable after down migration');
 
             await knex.destroy();
         });
@@ -831,7 +832,7 @@ describe('migrations/utils/schema nullable functions', function () {
 
             // Verify initial state - column should already be not nullable
             const isNotNullableInitial = await checkColumnNullable('test_nullable_migration', 'not_nullable_col', knex);
-            should.equal(isNotNullableInitial, false, 'Column should initially be not nullable');
+            assert.equal(isNotNullableInitial, false, 'Column should initially be not nullable');
 
             // Spy on logging to verify skip message
             const logSpy = sinon.spy(require('@tryghost/logging'), 'warn');
@@ -843,7 +844,7 @@ describe('migrations/utils/schema nullable functions', function () {
 
                 // Column should still be not nullable
                 const isNotNullableAfter = await checkColumnNullable('test_nullable_migration', 'not_nullable_col', knex);
-                should.equal(isNotNullableAfter, false, 'Column should still be not nullable');
+                assert.equal(isNotNullableAfter, false, 'Column should still be not nullable');
 
                 await runDownMigration();
             } finally {
@@ -861,8 +862,8 @@ describe('migrations/utils/schema nullable functions', function () {
             const nullableResult = await checkColumnNullable('test_nullable_migration', 'nullable_col', knex);
             const notNullableResult = await checkColumnNullable('test_nullable_migration', 'not_nullable_col', knex);
 
-            should.equal(nullableResult, true, 'Should identify nullable column correctly');
-            should.equal(notNullableResult, false, 'Should identify not nullable column correctly');
+            assert.equal(nullableResult, true, 'Should identify nullable column correctly');
+            assert.equal(notNullableResult, false, 'Should identify not nullable column correctly');
 
             await knex.destroy();
         });

--- a/ghost/core/test/unit/server/data/schema/commands.test.js
+++ b/ghost/core/test/unit/server/data/schema/commands.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const errors = require('@tryghost/errors');
 
@@ -14,7 +15,7 @@ describe('schema commands', function () {
             await commands._hasForeignSQLite({transaction: knex});
             should.fail('addForeign did not throw');
         } catch (err) {
-            should.equal(errors.utils.isGhostError(err), true);
+            assert.equal(errors.utils.isGhostError(err), true);
             err.message.should.equal('Must use hasForeignSQLite3 on an SQLite3 database');
         }
     });
@@ -29,7 +30,7 @@ describe('schema commands', function () {
             await commands._hasPrimaryKeySQLite(null, knex);
             should.fail('hasPrimaryKeySQLite did not throw');
         } catch (err) {
-            should.equal(errors.utils.isGhostError(err), true);
+            assert.equal(errors.utils.isGhostError(err), true);
             err.message.should.equal('Must use hasPrimaryKeySQLite on an SQLite3 database');
         }
     });

--- a/ghost/core/test/unit/server/data/schema/fixtures/fixture-manager.test.js
+++ b/ghost/core/test/unit/server/data/schema/fixtures/fixture-manager.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 
@@ -318,10 +319,10 @@ describe('Migration Fixture Utils', function () {
             addFixturesForRelationStub.callCount.should.eql(fixtures.relations.length);
 
             // NOTE: users and roles have to be initialized first for the post fixtures to work
-            should.equal(addFixturesForModelStub.firstCall.args[0].name, 'Role');
-            should.equal(addFixturesForModelStub.secondCall.args[0].name, 'User');
+            assert.equal(addFixturesForModelStub.firstCall.args[0].name, 'Role');
+            assert.equal(addFixturesForModelStub.secondCall.args[0].name, 'User');
 
-            should.equal(addFixturesForRelationStub.firstCall.args[0].from.relation, 'roles');
+            assert.equal(addFixturesForRelationStub.firstCall.args[0].from.relation, 'roles');
         });
     });
 

--- a/ghost/core/test/unit/server/lib/image/blog-icon.test.js
+++ b/ghost/core/test/unit/server/lib/image/blog-icon.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const path = require('path');
@@ -83,7 +84,7 @@ describe('lib/image: blog icon', function () {
                     get: () => {}
                 }});
 
-                should.equal(blogIcon.getIconUrl({absolute: true, fallbackToDefault: false}), null);
+                assert.equal(blogIcon.getIconUrl({absolute: true, fallbackToDefault: false}), null);
             });
         });
     });

--- a/ghost/core/test/unit/server/lib/image/cached-image-size-from-url.test.js
+++ b/ghost/core/test/unit/server/lib/image/cached-image-size-from-url.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const errors = require('@tryghost/errors');
 const should = require('should');
 const sinon = require('sinon');
@@ -76,7 +77,7 @@ describe('lib/image: image size cache', function () {
 
         cacheStore.get(url).should.not.be.undefined;
         const image = cacheStore.get(url);
-        should.equal(image.url, 'http://mysite.com/content/image/mypostcoverimage.jpg');
+        assert.equal(image.url, 'http://mysite.com/content/image/mypostcoverimage.jpg');
         should.not.exist(image.width);
         should.not.exist(image.height);
         sinon.assert.calledOnce(loggingStub);
@@ -97,7 +98,7 @@ describe('lib/image: image size cache', function () {
 
         cacheStore.get(url).should.not.be.undefined;
         const image = cacheStore.get(url);
-        should.equal(image.url, 'http://mysite.com/content/image/mypostcoverimage.jpg');
+        assert.equal(image.url, 'http://mysite.com/content/image/mypostcoverimage.jpg');
         should.not.exist(image.width);
         should.not.exist(image.height);
     });

--- a/ghost/core/test/unit/server/models/api-key.test.js
+++ b/ghost/core/test/unit/server/models/api-key.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const models = require('../../../../core/server/models');
 const should = require('should');
 const sinon = require('sinon');
@@ -17,10 +18,10 @@ describe('Unit: models/api_key', function () {
 
             const result = models.ApiKey.refreshSecret(fakeData, fakeOptions);
 
-            should.equal(result, editStub.returnValues[0]);
-            should.equal(editStub.args[0][0].id, 'TREVOR');
-            should.equal(editStub.args[0][0].secret.length, 64);
-            should.equal(editStub.args[0][1], fakeOptions);
+            assert.equal(result, editStub.returnValues[0]);
+            assert.equal(editStub.args[0][0].id, 'TREVOR');
+            assert.equal(editStub.args[0][0].secret.length, 64);
+            assert.equal(editStub.args[0][1], fakeOptions);
 
             sinon.restore();
         });
@@ -36,10 +37,10 @@ describe('Unit: models/api_key', function () {
 
             const result = models.ApiKey.refreshSecret(fakeData, fakeOptions);
 
-            should.equal(result, editStub.returnValues[0]);
-            should.equal(editStub.args[0][0].id, 'TREVOR');
-            should.equal(editStub.args[0][0].secret.length, 26);
-            should.equal(editStub.args[0][1], fakeOptions);
+            assert.equal(result, editStub.returnValues[0]);
+            assert.equal(editStub.args[0][0].id, 'TREVOR');
+            assert.equal(editStub.args[0][0].secret.length, 26);
+            assert.equal(editStub.args[0][1], fakeOptions);
 
             sinon.restore();
         });

--- a/ghost/core/test/unit/server/models/base/crud.test.js
+++ b/ghost/core/test/unit/server/models/base/crud.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const errors = require('@tryghost/errors');
 const should = require('should');
 const sinon = require('sinon');
@@ -28,8 +29,8 @@ describe('Models: crud', function () {
             const destroyStub = sinon.stub(model, 'destroy');
 
             return models.Base.Model.destroy(unfilteredOptions).then(() => {
-                should.equal(filterOptionsSpy.args[0][0], unfilteredOptions);
-                should.equal(filterOptionsSpy.args[0][1], 'destroy');
+                assert.equal(filterOptionsSpy.args[0][0], unfilteredOptions);
+                assert.equal(filterOptionsSpy.args[0][1], 'destroy');
 
                 should.deepEqual(forgeStub.args[0][0], {
                     prop: 'whatever'
@@ -37,8 +38,8 @@ describe('Models: crud', function () {
 
                 const filteredOptions = filterOptionsSpy.returnValues[0];
 
-                should.equal(fetchStub.args[0][0], filteredOptions);
-                should.equal(destroyStub.args[0][0], filteredOptions);
+                assert.equal(fetchStub.args[0][0], filteredOptions);
+                assert.equal(destroyStub.args[0][0], filteredOptions);
             });
         });
 
@@ -55,8 +56,8 @@ describe('Models: crud', function () {
             const destroyStub = sinon.stub(model, 'destroy');
 
             return models.Base.Model.destroy(unfilteredOptions).then(() => {
-                should.equal(filterOptionsSpy.args[0][0], unfilteredOptions);
-                should.equal(filterOptionsSpy.args[0][1], 'destroy');
+                assert.equal(filterOptionsSpy.args[0][0], unfilteredOptions);
+                assert.equal(filterOptionsSpy.args[0][1], 'destroy');
 
                 should.deepEqual(forgeStub.args[0][0], {
                     id: 23
@@ -64,8 +65,8 @@ describe('Models: crud', function () {
 
                 const filteredOptions = filterOptionsSpy.returnValues[0];
 
-                should.equal(fetchStub.args[0][0], filteredOptions);
-                should.equal(destroyStub.args[0][0], filteredOptions);
+                assert.equal(fetchStub.args[0][0], filteredOptions);
+                assert.equal(destroyStub.args[0][0], filteredOptions);
             });
         });
     });
@@ -90,18 +91,18 @@ describe('Models: crud', function () {
             const findOneReturnValue = models.Base.Model.findOne(data, unfilteredOptions);
 
             return findOneReturnValue.then((result) => {
-                should.equal(result, fetchedModel);
+                assert.equal(result, fetchedModel);
 
-                should.equal(filterOptionsSpy.args[0][0], unfilteredOptions);
-                should.equal(filterOptionsSpy.args[0][1], 'findOne');
+                assert.equal(filterOptionsSpy.args[0][0], unfilteredOptions);
+                assert.equal(filterOptionsSpy.args[0][1], 'findOne');
 
-                should.equal(filterDataSpy.args[0][0], data);
+                assert.equal(filterDataSpy.args[0][0], data);
 
                 const filteredData = filterDataSpy.returnValues[0];
                 should.deepEqual(forgeStub.args[0][0], filteredData);
 
                 const filteredOptions = filterOptionsSpy.returnValues[0];
-                should.equal(fetchStub.args[0][0], filteredOptions);
+                assert.equal(fetchStub.args[0][0], filteredOptions);
             });
         });
 
@@ -125,7 +126,7 @@ describe('Models: crud', function () {
 
             await models.Base.Model.findOne(data, unfilteredOptions);
 
-            should.equal(fetchStub.args[0][0].lock, 'forUpdate');
+            assert.equal(fetchStub.args[0][0].lock, 'forUpdate');
         });
     });
 
@@ -149,22 +150,22 @@ describe('Models: crud', function () {
                 .resolves(savedModel);
 
             return models.Base.Model.edit(data, unfilteredOptions).then((result) => {
-                should.equal(result, savedModel);
+                assert.equal(result, savedModel);
 
-                should.equal(filterOptionsSpy.args[0][0], unfilteredOptions);
-                should.equal(filterOptionsSpy.args[0][1], 'edit');
+                assert.equal(filterOptionsSpy.args[0][0], unfilteredOptions);
+                assert.equal(filterOptionsSpy.args[0][1], 'edit');
 
-                should.equal(filterDataSpy.args[0][0], data);
+                assert.equal(filterDataSpy.args[0][0], data);
 
                 const filteredOptions = filterOptionsSpy.returnValues[0];
                 should.deepEqual(forgeStub.args[0][0], {id: filteredOptions.id});
 
-                should.equal(fetchStub.args[0][0], filteredOptions);
-                should.equal(fetchStub.args[0][0].lock, undefined);
+                assert.equal(fetchStub.args[0][0], filteredOptions);
+                assert.equal(fetchStub.args[0][0].lock, undefined);
 
                 const filteredData = filterDataSpy.returnValues[0];
-                should.equal(saveStub.args[0][0], filteredData);
-                should.equal(saveStub.args[0][1].method, 'update');
+                assert.equal(saveStub.args[0][0], filteredData);
+                assert.equal(saveStub.args[0][1].method, 'update');
                 should.deepEqual(saveStub.args[0][1], filteredOptions);
             });
         });
@@ -184,7 +185,7 @@ describe('Models: crud', function () {
                 .resolves();
 
             return models.Base.Model.findOne(data, unfilteredOptions).then(() => {
-                should.equal(fetchStub.args[0][0].lock, undefined);
+                assert.equal(fetchStub.args[0][0].lock, undefined);
             });
         });
 
@@ -200,7 +201,7 @@ describe('Models: crud', function () {
             sinon.stub(model, 'fetch').resolves();
 
             return models.Base.Model.findOne(data, unfilteredOptions).then(() => {
-                should.equal(model.hasTimestamps, true);
+                assert.equal(model.hasTimestamps, true);
             });
         });
 
@@ -242,19 +243,19 @@ describe('Models: crud', function () {
                 .resolves(savedModel);
 
             return models.Base.Model.add(data, unfilteredOptions).then((result) => {
-                should.equal(result, savedModel);
+                assert.equal(result, savedModel);
 
-                should.equal(filterOptionsSpy.args[0][0], unfilteredOptions);
-                should.equal(filterOptionsSpy.args[0][1], 'add');
+                assert.equal(filterOptionsSpy.args[0][0], unfilteredOptions);
+                assert.equal(filterOptionsSpy.args[0][1], 'add');
 
-                should.equal(filterDataSpy.args[0][0], data);
+                assert.equal(filterDataSpy.args[0][0], data);
 
                 const filteredData = filterDataSpy.returnValues[0];
                 should.deepEqual(forgeStub.args[0][0], filteredData);
 
                 const filteredOptions = filterOptionsSpy.returnValues[0];
-                should.equal(saveStub.args[0][0], null);
-                should.equal(saveStub.args[0][1].method, 'insert');
+                assert.equal(saveStub.args[0][0], null);
+                assert.equal(saveStub.args[0][1].method, 'insert');
                 should.deepEqual(saveStub.args[0][1], filteredOptions);
             });
         });
@@ -271,7 +272,7 @@ describe('Models: crud', function () {
             sinon.stub(model, 'save').resolves();
 
             return models.Base.Model.add(data, unfilteredOptions).then(() => {
-                should.equal(model.hasTimestamps, false);
+                assert.equal(model.hasTimestamps, false);
             });
         });
     });

--- a/ghost/core/test/unit/server/models/custom-theme-setting.test.js
+++ b/ghost/core/test/unit/server/models/custom-theme-setting.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const models = require('../../../../core/server/models');
 
@@ -11,28 +12,28 @@ describe('Unit: models/custom-theme-setting', function () {
             const setting = models.CustomThemeSetting.forge();
 
             let returns = setting.parse({theme: 'test', key: 'dark_mode', value: 'false', type: 'boolean'});
-            should.equal(returns.value, false);
+            assert.equal(returns.value, false);
 
             returns = setting.parse({theme: 'test', key: 'dark_mode', value: false, type: 'boolean'});
-            should.equal(returns.value, false);
+            assert.equal(returns.value, false);
 
             returns = setting.parse({theme: 'test', key: 'dark_mode', value: true, type: 'boolean'});
-            should.equal(returns.value, true);
+            assert.equal(returns.value, true);
 
             returns = setting.parse({theme: 'test', key: 'dark_mode', value: 'true', type: 'boolean'});
-            should.equal(returns.value, true);
+            assert.equal(returns.value, true);
 
             returns = setting.parse({theme: 'test', key: 'dark_mode', value: '0', type: 'boolean'});
-            should.equal(returns.value, false);
+            assert.equal(returns.value, false);
 
             returns = setting.parse({theme: 'test', key: 'dark_mode', value: '1', type: 'boolean'});
-            should.equal(returns.value, true);
+            assert.equal(returns.value, true);
 
             returns = setting.parse({theme: 'test', key: 'something', value: 'null', type: 'select'});
-            should.equal(returns.value, 'null');
+            assert.equal(returns.value, 'null');
 
             returns = setting.parse({theme: 'test', key: 'something', value: '__GHOST_URL__/assets/image.jpg', type: 'image'});
-            should.equal(returns.value, 'http://127.0.0.1:2369/assets/image.jpg');
+            assert.equal(returns.value, 'http://127.0.0.1:2369/assets/image.jpg');
         });
     });
 
@@ -41,23 +42,23 @@ describe('Unit: models/custom-theme-setting', function () {
             const setting = models.CustomThemeSetting.forge();
 
             let returns = setting.format({theme: 'test', key: 'dark_mode', value: '0', type: 'boolean'});
-            should.equal(returns.value, 'false');
+            assert.equal(returns.value, 'false');
 
             returns = setting.format({theme: 'test', key: 'dark_mode', value: '1', type: 'boolean'});
-            should.equal(returns.value, 'true');
+            assert.equal(returns.value, 'true');
 
             returns = setting.format({theme: 'test', key: 'dark_mode', value: 'false', type: 'boolean'});
-            should.equal(returns.value, 'false');
+            assert.equal(returns.value, 'false');
 
             returns = setting.format({theme: 'test', key: 'dark_mode', value: 'true', type: 'boolean'});
-            should.equal(returns.value, 'true');
+            assert.equal(returns.value, 'true');
         });
 
         it('transforms urls when persisting to db', function () {
             const setting = models.CustomThemeSetting.forge();
 
             let returns = setting.formatOnWrite({theme: 'test', key: 'something', value: '/assets/image.jpg', type: 'image'});
-            should.equal(returns.value, '__GHOST_URL__/assets/image.jpg');
+            assert.equal(returns.value, '__GHOST_URL__/assets/image.jpg');
         });
     });
 });

--- a/ghost/core/test/unit/server/models/session.test.js
+++ b/ghost/core/test/unit/server/models/session.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const models = require('../../../../core/server/models');
@@ -24,8 +25,8 @@ describe('Unit: models/session', function () {
                 })
             };
             const parsed = parse(attrs);
-            should.equal(typeof parsed.session_data, 'object');
-            should.equal(parsed.session_data.some, 'data');
+            assert.equal(typeof parsed.session_data, 'object');
+            assert.equal(parsed.session_data.some, 'data');
         });
     });
 
@@ -42,8 +43,8 @@ describe('Unit: models/session', function () {
                 }
             };
             const formatted = format(attrs);
-            should.equal(typeof formatted.session_data, 'string');
-            should.equal(formatted.session_data, JSON.stringify({
+            assert.equal(typeof formatted.session_data, 'string');
+            assert.equal(formatted.session_data, JSON.stringify({
                 some: 'data'
             }));
         });
@@ -53,7 +54,7 @@ describe('Unit: models/session', function () {
                 id: 'something'
             };
             const formatted = format(attrs);
-            should.equal(formatted.session_data, undefined);
+            assert.equal(formatted.session_data, undefined);
         });
     });
 
@@ -63,7 +64,7 @@ describe('Unit: models/session', function () {
             const belongsToSpy = sinon.spy(model, 'belongsTo');
             model.user();
 
-            should.equal(belongsToSpy.args[0][0], 'User');
+            assert.equal(belongsToSpy.args[0][0], 'User');
         });
     });
 
@@ -81,8 +82,8 @@ describe('Unit: models/session', function () {
             const methodName = 'methodName';
             models.Session.permittedOptions(methodName);
 
-            should.equal(basePermittedOptionsStub.args[0][0], methodName);
-            should.equal(basePermittedOptionsStub.thisValues[0], models.Session);
+            assert.equal(basePermittedOptionsStub.args[0][0], methodName);
+            assert.equal(basePermittedOptionsStub.thisValues[0], models.Session);
         });
 
         it('returns the base permittedOptions result', function () {
@@ -113,8 +114,8 @@ describe('Unit: models/session', function () {
             const options = {id: 1};
             const returnVal = models.Session.destroy(options);
 
-            should.equal(baseDestroyStub.args[0][0], options);
-            should.equal(returnVal, baseDestroyReturnVal);
+            assert.equal(baseDestroyStub.args[0][0], options);
+            assert.equal(returnVal, baseDestroyReturnVal);
         });
 
         it('calls forge with the session_id, fetchs with the filtered options and then destroys with the options', function (done) {
@@ -133,13 +134,13 @@ describe('Unit: models/session', function () {
                 .resolves();
 
             models.Session.destroy(unfilteredOptions).then(() => {
-                should.equal(filterOptionsStub.args[0][0], unfilteredOptions);
-                should.equal(filterOptionsStub.args[0][1], 'destroy');
+                assert.equal(filterOptionsStub.args[0][0], unfilteredOptions);
+                assert.equal(filterOptionsStub.args[0][1], 'destroy');
 
                 should.deepEqual(forgeStub.args[0][0], {session_id});
 
-                should.equal(fetchStub.args[0][0], filteredOptions);
-                should.equal(destroyStub.args[0][0], filteredOptions);
+                assert.equal(fetchStub.args[0][0], filteredOptions);
+                assert.equal(destroyStub.args[0][0], filteredOptions);
 
                 done();
             });
@@ -166,13 +167,13 @@ describe('Unit: models/session', function () {
             const addStub = sinon.stub(models.Session, 'add');
 
             models.Session.upsert(data, unfilteredOptions).then(() => {
-                should.equal(filterOptionsStub.args[0][0], unfilteredOptions);
-                should.equal(filterOptionsStub.args[0][1], 'upsert');
+                assert.equal(filterOptionsStub.args[0][0], unfilteredOptions);
+                assert.equal(filterOptionsStub.args[0][1], 'upsert');
 
                 should.deepEqual(findOneStub.args[0][0], {
                     session_id
                 });
-                should.equal(findOneStub.args[0][1], filteredOptions);
+                assert.equal(findOneStub.args[0][1], filteredOptions);
 
                 should.deepEqual(addStub.args[0][0], {
                     session_id: filteredOptions.session_id,
@@ -180,7 +181,7 @@ describe('Unit: models/session', function () {
                     user_id: data.session_data.user_id
                 });
 
-                should.equal(addStub.args[0][1], filteredOptions);
+                assert.equal(addStub.args[0][1], filteredOptions);
                 done();
             });
         });
@@ -205,13 +206,13 @@ describe('Unit: models/session', function () {
             const editStub = sinon.stub(models.Session, 'edit');
 
             models.Session.upsert(data, unfilteredOptions).then(() => {
-                should.equal(filterOptionsStub.args[0][0], unfilteredOptions);
-                should.equal(filterOptionsStub.args[0][1], 'upsert');
+                assert.equal(filterOptionsStub.args[0][0], unfilteredOptions);
+                assert.equal(filterOptionsStub.args[0][1], 'upsert');
 
                 should.deepEqual(findOneStub.args[0][0], {
                     session_id
                 });
-                should.equal(findOneStub.args[0][1], filteredOptions);
+                assert.equal(findOneStub.args[0][1], filteredOptions);
 
                 should.deepEqual(editStub.args[0][0], {
                     session_data: data.session_data
@@ -222,7 +223,7 @@ describe('Unit: models/session', function () {
                     id: model.id
                 });
 
-                should.equal(editStub.args[0][1], filteredOptions);
+                assert.equal(editStub.args[0][1], filteredOptions);
                 done();
             });
         });

--- a/ghost/core/test/unit/server/models/settings.test.js
+++ b/ghost/core/test/unit/server/models/settings.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const mockDb = require('mock-knex');
@@ -85,22 +86,22 @@ describe('Unit: models/settings', function () {
             const setting = models.Settings.forge();
 
             let returns = setting.formatOnWrite({key: 'cover_image', value: 'http://127.0.0.1:2369/cover_image.png', type: 'string'});
-            should.equal(returns.value, '__GHOST_URL__/cover_image.png');
+            assert.equal(returns.value, '__GHOST_URL__/cover_image.png');
 
             returns = setting.formatOnWrite({key: 'logo', value: 'http://127.0.0.1:2369/logo.png', type: 'string'});
-            should.equal(returns.value, '__GHOST_URL__/logo.png');
+            assert.equal(returns.value, '__GHOST_URL__/logo.png');
 
             returns = setting.formatOnWrite({key: 'icon', value: 'http://127.0.0.1:2369/icon.png', type: 'string'});
-            should.equal(returns.value, '__GHOST_URL__/icon.png');
+            assert.equal(returns.value, '__GHOST_URL__/icon.png');
 
             returns = setting.formatOnWrite({key: 'portal_button_icon', value: 'http://127.0.0.1:2369/portal_button_icon.png', type: 'string'});
-            should.equal(returns.value, '__GHOST_URL__/portal_button_icon.png');
+            assert.equal(returns.value, '__GHOST_URL__/portal_button_icon.png');
 
             returns = setting.formatOnWrite({key: 'og_image', value: 'http://127.0.0.1:2369/og_image.png', type: 'string'});
-            should.equal(returns.value, '__GHOST_URL__/og_image.png');
+            assert.equal(returns.value, '__GHOST_URL__/og_image.png');
 
             returns = setting.formatOnWrite({key: 'twitter_image', value: 'http://127.0.0.1:2369/twitter_image.png', type: 'string'});
-            should.equal(returns.value, '__GHOST_URL__/twitter_image.png');
+            assert.equal(returns.value, '__GHOST_URL__/twitter_image.png');
         });
     });
 
@@ -109,43 +110,43 @@ describe('Unit: models/settings', function () {
             const setting = models.Settings.forge();
 
             let returns = setting.parse({key: 'is_private', value: 'false', type: 'boolean'});
-            should.equal(returns.value, false);
+            assert.equal(returns.value, false);
 
             returns = setting.parse({key: 'is_private', value: false, type: 'boolean'});
-            should.equal(returns.value, false);
+            assert.equal(returns.value, false);
 
             returns = setting.parse({key: 'is_private', value: true, type: 'boolean'});
-            should.equal(returns.value, true);
+            assert.equal(returns.value, true);
 
             returns = setting.parse({key: 'is_private', value: 'true', type: 'boolean'});
-            should.equal(returns.value, true);
+            assert.equal(returns.value, true);
 
             returns = setting.parse({key: 'is_private', value: '0', type: 'boolean'});
-            should.equal(returns.value, false);
+            assert.equal(returns.value, false);
 
             returns = setting.parse({key: 'is_private', value: '1', type: 'boolean'});
-            should.equal(returns.value, true);
+            assert.equal(returns.value, true);
 
             returns = setting.parse({key: 'something', value: 'null'});
-            should.equal(returns.value, 'null');
+            assert.equal(returns.value, 'null');
 
             returns = setting.parse({key: 'cover_image', value: '__GHOST_URL__/cover_image.png', type: 'string'});
-            should.equal(returns.value, 'http://127.0.0.1:2369/cover_image.png');
+            assert.equal(returns.value, 'http://127.0.0.1:2369/cover_image.png');
 
             returns = setting.parse({key: 'logo', value: '__GHOST_URL__/logo.png', type: 'string'});
-            should.equal(returns.value, 'http://127.0.0.1:2369/logo.png');
+            assert.equal(returns.value, 'http://127.0.0.1:2369/logo.png');
 
             returns = setting.parse({key: 'icon', value: '__GHOST_URL__/icon.png', type: 'string'});
-            should.equal(returns.value, 'http://127.0.0.1:2369/icon.png');
+            assert.equal(returns.value, 'http://127.0.0.1:2369/icon.png');
 
             returns = setting.parse({key: 'portal_button_icon', value: '__GHOST_URL__/portal_button_icon.png', type: 'string'});
-            should.equal(returns.value, 'http://127.0.0.1:2369/portal_button_icon.png');
+            assert.equal(returns.value, 'http://127.0.0.1:2369/portal_button_icon.png');
 
             returns = setting.parse({key: 'og_image', value: '__GHOST_URL__/og_image.png', type: 'string'});
-            should.equal(returns.value, 'http://127.0.0.1:2369/og_image.png');
+            assert.equal(returns.value, 'http://127.0.0.1:2369/og_image.png');
 
             returns = setting.parse({key: 'twitter_image', value: '__GHOST_URL__/twitter_image.png', type: 'string'});
-            should.equal(returns.value, 'http://127.0.0.1:2369/twitter_image.png');
+            assert.equal(returns.value, 'http://127.0.0.1:2369/twitter_image.png');
         });
     });
 

--- a/ghost/core/test/unit/server/models/user.test.js
+++ b/ghost/core/test/unit/server/models/user.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const errors = require('@tryghost/errors');
@@ -18,7 +19,7 @@ describe('Unit: models/user', function () {
 
     describe('updateLastSeen method', function () {
         it('exists', function () {
-            should.equal(typeof models.User.prototype.updateLastSeen, 'function');
+            assert.equal(typeof models.User.prototype.updateLastSeen, 'function');
         });
 
         it('sets the last_seen property to new Date and returns a call to save', function () {
@@ -36,7 +37,7 @@ describe('Unit: models/user', function () {
                 last_seen: now
             });
 
-            should.equal(returnVal, instance.save.returnValues[0]);
+            assert.equal(returnVal, instance.save.returnValues[0]);
 
             clock.restore();
         });
@@ -561,7 +562,7 @@ describe('Unit: models/user', function () {
                 .resolves(userToChangeContext);
 
             models.User.ownerIdCache.set('old-owner-id');
-            should.equal(models.User.ownerIdCache.get(), 'old-owner-id');
+            assert.equal(models.User.ownerIdCache.get(), 'old-owner-id');
 
             const clearSpy = sinon.spy(models.User.ownerIdCache, 'clear');
 
@@ -577,7 +578,7 @@ describe('Unit: models/user', function () {
             return models.User.transferOwnership({id: userToChange.context.user}, loggedInUser)
                 .then(() => {
                     clearSpy.calledOnce.should.be.true();
-                    should.equal(models.User.ownerIdCache.get(), null);
+                    assert.equal(models.User.ownerIdCache.get(), null);
                 })
                 .finally(() => {
                     clearSpy.restore();
@@ -635,20 +636,20 @@ describe('Unit: models/user', function () {
 
     describe('ownerIdCache', function () {
         it('should return null initially', function () {
-            should.equal(models.User.ownerIdCache.get(), null);
+            assert.equal(models.User.ownerIdCache.get(), null);
         });
 
         it('should store and retrieve values', function () {
             models.User.ownerIdCache.set('abc123');
 
-            should.equal(models.User.ownerIdCache.get(), 'abc123');
+            assert.equal(models.User.ownerIdCache.get(), 'abc123');
         });
 
         it('should clear stored values', function () {
             models.User.ownerIdCache.set('abc123');
             models.User.ownerIdCache.clear();
 
-            should.equal(models.User.ownerIdCache.get(), null);
+            assert.equal(models.User.ownerIdCache.get(), null);
         });
     });
 
@@ -668,7 +669,7 @@ describe('Unit: models/user', function () {
 
             return models.User.getOwnerId()
                 .then((ownerId) => {
-                    should.equal(ownerId, 'abc123');
+                    assert.equal(ownerId, 'abc123');
                     models.User.getOwnerUser.called.should.be.false();
                 });
         });
@@ -682,9 +683,9 @@ describe('Unit: models/user', function () {
 
             return models.User.getOwnerId()
                 .then((ownerId) => {
-                    should.equal(ownerId, mockOwner.id);
+                    assert.equal(ownerId, mockOwner.id);
                     models.User.getOwnerUser.calledOnce.should.be.true();
-                    should.equal(models.User.ownerIdCache.get(), mockOwner.id);
+                    assert.equal(models.User.ownerIdCache.get(), mockOwner.id);
                 });
         });
 
@@ -697,13 +698,13 @@ describe('Unit: models/user', function () {
 
             return models.User.getOwnerId()
                 .then((ownerId) => {
-                    should.equal(ownerId, mockOwner.id);
+                    assert.equal(ownerId, mockOwner.id);
                     models.User.getOwnerUser.calledOnce.should.be.true();
 
                     return models.User.getOwnerId();
                 })
                 .then((ownerId) => {
-                    should.equal(ownerId, mockOwner.id);
+                    assert.equal(ownerId, mockOwner.id);
                     models.User.getOwnerUser.calledOnce.should.be.true();
                 });
         });

--- a/ghost/core/test/unit/server/overrides.test.js
+++ b/ghost/core/test/unit/server/overrides.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const luxon = require('luxon');
 
@@ -5,6 +6,6 @@ require('../../../core/server/overrides');
 
 describe('Overrides', function () {
     it('sets global timezone to UTC', function () {
-        should.equal(luxon.DateTime.local().zoneName, 'UTC');
+        assert.equal(luxon.DateTime.local().zoneName, 'UTC');
     });
 });

--- a/ghost/core/test/unit/server/services/adapter-manager/options-resolver.test.js
+++ b/ghost/core/test/unit/server/services/adapter-manager/options-resolver.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 
 const resolveAdapterOptions = require('../../../../../core/server/services/adapter-manager/options-resolver');
@@ -15,7 +16,7 @@ describe('Adapter Manager: options resolver', function () {
         const {adapterClassName, adapterConfig} = resolveAdapterOptions(name, adapterServiceConfig);
 
         adapterClassName.should.equal('Memory');
-        should.equal(adapterConfig, undefined);
+        assert.equal(adapterConfig, undefined);
     });
 
     it('returns default adapter configuration', function () {

--- a/ghost/core/test/unit/server/services/auth/api-key/admin.test.js
+++ b/ghost/core/test/unit/server/services/auth/api-key/admin.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const errors = require('@tryghost/errors');
 const jwt = require('jsonwebtoken');
 const should = require('should');
@@ -127,7 +128,7 @@ describe('Admin API Key Auth', function () {
 
         apiKeyAuth.admin.authenticate(req, res, (err) => {
             should.exist(err);
-            should.equal(err instanceof errors.UnauthorizedError, true);
+            assert.equal(err instanceof errors.UnauthorizedError, true);
             err.code.should.eql('INVALID_JWT');
             should.not.exist(req.api_key);
             done();
@@ -145,7 +146,7 @@ describe('Admin API Key Auth', function () {
 
         apiKeyAuth.admin.authenticate(req, res, function next(err) {
             should.exist(err);
-            should.equal(err instanceof errors.UnauthorizedError, true);
+            assert.equal(err instanceof errors.UnauthorizedError, true);
             err.code.should.eql('INVALID_AUTH_HEADER');
             should.not.exist(req.api_key);
             done();
@@ -163,7 +164,7 @@ describe('Admin API Key Auth', function () {
 
         apiKeyAuth.admin.authenticate(req, res, function next(err) {
             should.exist(err);
-            should.equal(err instanceof errors.BadRequestError, true);
+            assert.equal(err instanceof errors.BadRequestError, true);
             err.code.should.eql('INVALID_JWT');
             should.not.exist(req.api_key);
             done();
@@ -190,7 +191,7 @@ describe('Admin API Key Auth', function () {
 
         apiKeyAuth.admin.authenticate(req, res, function next(err) {
             should.exist(err);
-            should.equal(err instanceof errors.UnauthorizedError, true);
+            assert.equal(err instanceof errors.UnauthorizedError, true);
             err.code.should.eql('UNKNOWN_ADMIN_API_KEY');
             should.not.exist(req.api_key);
             done();
@@ -219,7 +220,7 @@ describe('Admin API Key Auth', function () {
 
         apiKeyAuth.admin.authenticate(req, res, function next(err) {
             should.exist(err);
-            should.equal(err instanceof errors.UnauthorizedError, true);
+            assert.equal(err instanceof errors.UnauthorizedError, true);
             err.code.should.eql('INVALID_JWT');
             err.message.should.match(/jwt expired/);
             should.not.exist(req.api_key);
@@ -249,7 +250,7 @@ describe('Admin API Key Auth', function () {
 
         apiKeyAuth.admin.authenticate(req, res, function next(err) {
             should.exist(err);
-            should.equal(err instanceof errors.UnauthorizedError, true);
+            assert.equal(err instanceof errors.UnauthorizedError, true);
             err.code.should.eql('INVALID_JWT');
             err.message.should.match(/maxAge exceeded/);
             should.not.exist(req.api_key);
@@ -279,7 +280,7 @@ describe('Admin API Key Auth', function () {
 
         apiKeyAuth.admin.authenticate(req, res, function next(err) {
             should.exist(err);
-            should.equal(err instanceof errors.UnauthorizedError, true);
+            assert.equal(err instanceof errors.UnauthorizedError, true);
             err.code.should.eql('INVALID_API_KEY_TYPE');
             should.not.exist(req.api_key);
             done();

--- a/ghost/core/test/unit/server/services/auth/api-key/content.test.js
+++ b/ghost/core/test/unit/server/services/auth/api-key/content.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const errors = require('@tryghost/errors');
 const {authenticateContentApiKey} = require('../../../../../../core/server/services/auth/api-key/content');
 const models = require('../../../../../../core/server/models');
@@ -52,7 +53,7 @@ describe('Content API Key Auth', function () {
 
         authenticateContentApiKey(req, res, function next(err) {
             should.exist(err);
-            should.equal(err instanceof errors.UnauthorizedError, true);
+            assert.equal(err instanceof errors.UnauthorizedError, true);
             err.code.should.eql('UNKNOWN_CONTENT_API_KEY');
             should.not.exist(req.api_key);
             done();
@@ -71,7 +72,7 @@ describe('Content API Key Auth', function () {
 
         authenticateContentApiKey(req, res, function next(err) {
             should.exist(err);
-            should.equal(err instanceof errors.UnauthorizedError, true);
+            assert.equal(err instanceof errors.UnauthorizedError, true);
             err.code.should.eql('INVALID_API_KEY_TYPE');
             should.not.exist(req.api_key);
             done();
@@ -88,7 +89,7 @@ describe('Content API Key Auth', function () {
 
         authenticateContentApiKey(req, res, function next(err) {
             should.exist(err);
-            should.equal(err instanceof errors.BadRequestError, true);
+            assert.equal(err instanceof errors.BadRequestError, true);
             err.code.should.eql('INVALID_REQUEST');
             should.not.exist(req.api_key);
             done();

--- a/ghost/core/test/unit/server/services/auth/members/index.test.js
+++ b/ghost/core/test/unit/server/services/auth/members/index.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const jwt = require('jsonwebtoken');
 const should = require('should');
 const {UnauthorizedError} = require('@tryghost/errors');
@@ -7,7 +8,7 @@ describe('Auth Service - Members', function () {
     it('exports an authenticateMembersToken method', function () {
         const actual = typeof members.authenticateMembersToken;
         const expected = 'function';
-        should.equal(actual, expected);
+        assert.equal(actual, expected);
     });
 
     describe('authenticateMembersToken', function () {
@@ -20,7 +21,7 @@ describe('Auth Service - Members', function () {
                 const actual = err;
                 const expected = undefined;
 
-                should.equal(actual, expected);
+                assert.equal(actual, expected);
             });
         });
 
@@ -33,7 +34,7 @@ describe('Auth Service - Members', function () {
                 const actual = err;
                 const expected = undefined;
 
-                should.equal(actual, expected);
+                assert.equal(actual, expected);
             });
         });
         describe('attempts to verify the credentials as a JWT, not allowing the "NONE" algorithm', function () {
@@ -46,7 +47,7 @@ describe('Auth Service - Members', function () {
                     const actual = err instanceof UnauthorizedError;
                     const expected = true;
 
-                    should.equal(actual, expected);
+                    assert.equal(actual, expected);
                 });
             });
             it('calls next with an error if the token is using the "none" algorithm', function () {
@@ -65,7 +66,7 @@ describe('Auth Service - Members', function () {
                     const actual = err instanceof UnauthorizedError;
                     const expected = true;
 
-                    should.equal(actual, expected);
+                    assert.equal(actual, expected);
                 });
             });
         });

--- a/ghost/core/test/unit/server/services/auth/session/middleware.test.js
+++ b/ghost/core/test/unit/server/services/auth/session/middleware.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const sessionMiddleware = require('../../../../../../core/server/services/auth').session;
 const SessionMiddlware = require('../../../../../../core/server/services/auth/session/middleware');
 const models = require('../../../../../../core/server/models');
@@ -44,7 +45,7 @@ describe('Session Service', function () {
 
             sinon.stub(res, 'sendStatus')
                 .callsFake(function () {
-                    should.equal(req.session.origin, 'http://ghost.org');
+                    assert.equal(req.session.origin, 'http://ghost.org');
                     done();
                 });
 
@@ -64,11 +65,11 @@ describe('Session Service', function () {
 
             sinon.stub(res, 'sendStatus')
                 .callsFake(function (statusCode) {
-                    should.equal(req.session.user_id, 23);
-                    should.equal(req.session.origin, 'http://host.tld');
-                    should.equal(req.session.user_agent, 'bububang');
-                    should.equal(req.session.ip, '127.0.0.1');
-                    should.equal(statusCode, 201);
+                    assert.equal(req.session.user_id, 23);
+                    assert.equal(req.session.origin, 'http://host.tld');
+                    assert.equal(req.session.user_agent, 'bububang');
+                    assert.equal(req.session.ip, '127.0.0.1');
+                    assert.equal(statusCode, 201);
                     done();
                 });
 
@@ -105,9 +106,9 @@ describe('Session Service', function () {
             });
 
             await middleware.createSession(req, res, next);
-            should.equal(next.callCount, 1);
-            should.equal(next.args[0][0].statusCode, 403);
-            should.equal(next.args[0][0].code, '2FA_NEW_DEVICE_DETECTED');
+            assert.equal(next.callCount, 1);
+            assert.equal(next.args[0][0].statusCode, 403);
+            assert.equal(next.args[0][0].code, '2FA_NEW_DEVICE_DETECTED');
         });
 
         it('errors with a 403 when require_email_mfa is true', async function () {
@@ -141,9 +142,9 @@ describe('Session Service', function () {
             });
 
             await middleware.createSession(req, res, next);
-            should.equal(next.callCount, 1);
-            should.equal(next.args[0][0].statusCode, 403);
-            should.equal(next.args[0][0].code, '2FA_TOKEN_REQUIRED');
+            assert.equal(next.callCount, 1);
+            assert.equal(next.args[0][0].statusCode, 403);
+            assert.equal(next.args[0][0].code, '2FA_TOKEN_REQUIRED');
         });
     });
 
@@ -160,7 +161,7 @@ describe('Session Service', function () {
             });
 
             middleware.logout(req, res, function next(err) {
-                should.equal(err.errorType, 'InternalServerError');
+                assert.equal(err.errorType, 'InternalServerError');
                 done();
             });
         });
@@ -170,7 +171,7 @@ describe('Session Service', function () {
             const res = fakeRes();
             sinon.stub(res, 'sendStatus')
                 .callsFake(function (status) {
-                    should.equal(status, 204);
+                    assert.equal(status, 204);
                     done();
                 });
 
@@ -203,10 +204,10 @@ describe('Session Service', function () {
 
             await middleware.sendAuthCode(req, res, nextStub);
 
-            should.equal(sendAuthCodeToUserStub.callCount, 1);
-            should.equal(nextStub.callCount, 0);
-            should.equal(sendStatusStub.callCount, 1);
-            should.equal(sendStatusStub.args[0][0], 200);
+            assert.equal(sendAuthCodeToUserStub.callCount, 1);
+            assert.equal(nextStub.callCount, 0);
+            assert.equal(sendStatusStub.callCount, 1);
+            assert.equal(sendStatusStub.args[0][0], 200);
         });
 
         it('calls next with an error if sendAuthCodeToUser fails', async function () {
@@ -225,9 +226,9 @@ describe('Session Service', function () {
 
             await middleware.sendAuthCode(req, res, nextStub);
 
-            should.equal(sendAuthCodeToUserStub.callCount, 1);
-            should.equal(nextStub.callCount, 1);
-            should.equal(sendStatusStub.callCount, 0);
+            assert.equal(sendAuthCodeToUserStub.callCount, 1);
+            assert.equal(nextStub.callCount, 1);
+            assert.equal(sendStatusStub.callCount, 0);
         });
     });
 
@@ -249,10 +250,10 @@ describe('Session Service', function () {
 
             await middleware.verifyAuthCode(req, res, nextStub);
 
-            should.equal(verifyAuthCodeForUserStub.callCount, 1);
-            should.equal(nextStub.callCount, 0);
-            should.equal(sendStatusStub.callCount, 1);
-            should.equal(sendStatusStub.args[0][0], 200);
+            assert.equal(verifyAuthCodeForUserStub.callCount, 1);
+            assert.equal(nextStub.callCount, 0);
+            assert.equal(sendStatusStub.callCount, 1);
+            assert.equal(sendStatusStub.args[0][0], 200);
         });
 
         it('returns 401 if the auth code is invalid', async function () {
@@ -271,10 +272,10 @@ describe('Session Service', function () {
 
             await middleware.verifyAuthCode(req, res, nextStub);
 
-            should.equal(verifyAuthCodeForUserStub.callCount, 1);
-            should.equal(nextStub.callCount, 0);
-            should.equal(sendStatusStub.callCount, 1);
-            should.equal(sendStatusStub.args[0][0], 401);
+            assert.equal(verifyAuthCodeForUserStub.callCount, 1);
+            assert.equal(nextStub.callCount, 0);
+            assert.equal(sendStatusStub.callCount, 1);
+            assert.equal(sendStatusStub.args[0][0], 401);
         });
 
         it('calls next with an error if sendAuthCodeToUser fails', async function () {
@@ -293,9 +294,9 @@ describe('Session Service', function () {
 
             await middleware.verifyAuthCode(req, res, nextStub);
 
-            should.equal(verifyAuthCodeForUserStub.callCount, 1);
-            should.equal(nextStub.callCount, 1);
-            should.equal(sendStatusStub.callCount, 0);
+            assert.equal(verifyAuthCodeForUserStub.callCount, 1);
+            assert.equal(nextStub.callCount, 1);
+            assert.equal(sendStatusStub.callCount, 0);
         });
     });
 });

--- a/ghost/core/test/unit/server/services/auth/session/session-service.test.js
+++ b/ghost/core/test/unit/server/services/auth/session/session-service.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const express = require('express');
@@ -55,19 +56,19 @@ describe('SessionService', function () {
 
         await sessionService.createSessionForUser(req, res, user);
 
-        should.equal(req.session.user_id, 'egg');
+        assert.equal(req.session.user_id, 'egg');
 
         const actualUser = await sessionService.getUserForSession(req, res);
         should.ok(findUserById.calledWith(sinon.match({id: 'egg'})));
 
         const expectedUser = await findUserById.returnValues[0];
-        should.equal(actualUser, expectedUser);
+        assert.equal(actualUser, expectedUser);
 
         await sessionService.removeUserForSession(req, res);
-        should.equal(req.session.user_id, undefined);
+        assert.equal(req.session.user_id, undefined);
 
         const removedUser = await sessionService.getUserForSession(req, res);
-        should.equal(removedUser, null);
+        assert.equal(removedUser, null);
     });
 
     it('Throws an error when the csrf verification fails', async function () {
@@ -190,19 +191,19 @@ describe('SessionService', function () {
         const user = {id: 'egg'};
 
         await sessionService.createSessionForUser(req, res, user);
-        should.equal(req.session.user_id, 'egg');
-        should.equal(req.session.verified, undefined);
+        assert.equal(req.session.user_id, 'egg');
+        assert.equal(req.session.verified, undefined);
 
         await sessionService.verifySession(req, res);
-        should.equal(req.session.verified, true);
+        assert.equal(req.session.verified, true);
 
         await sessionService.removeUserForSession(req, res);
-        should.equal(req.session.user_id, undefined);
-        should.equal(req.session.verified, true);
+        assert.equal(req.session.user_id, undefined);
+        assert.equal(req.session.verified, true);
 
         await sessionService.createSessionForUser(req, res, user);
-        should.equal(req.session.user_id, 'egg');
-        should.equal(req.session.verified, true);
+        assert.equal(req.session.user_id, 'egg');
+        assert.equal(req.session.verified, true);
     });
 
     it('#createSessionForUser verifies session when valid token is provided on request', async function () {
@@ -254,8 +255,8 @@ describe('SessionService', function () {
         req.body = {token: validToken};
         await sessionService.createSessionForUser(req, res, user);
 
-        should.equal(req.session.user_id, 'egg');
-        should.equal(req.session.verified, true);
+        assert.equal(req.session.user_id, 'egg');
+        assert.equal(req.session.verified, true);
     });
 
     it('#createSessionForUser does not verify session when invalid token is provided on request', async function () {
@@ -302,8 +303,8 @@ describe('SessionService', function () {
         req.body = {token: '000000'};
         await sessionService.createSessionForUser(req, res, user);
 
-        should.equal(req.session.user_id, 'egg');
-        should.equal(req.session.verified, undefined);
+        assert.equal(req.session.user_id, 'egg');
+        assert.equal(req.session.verified, undefined);
     });
 
     it('Generates a valid auth code and verifies it correctly', async function () {
@@ -352,7 +353,7 @@ describe('SessionService', function () {
 
         // Verify the auth code
         const isValid = await sessionService.verifyAuthCodeForUser(req, res);
-        should.equal(isValid, true);
+        assert.equal(isValid, true);
     });
 
     it('Fails to verify an incorrect auth code', async function () {
@@ -401,7 +402,7 @@ describe('SessionService', function () {
 
         // Verify an incorrect auth code
         const isValid = await sessionService.verifyAuthCodeForUser(req, res);
-        should.equal(isValid, false);
+        assert.equal(isValid, false);
     });
 
     it('Generates a different auth code for a different secret', async function () {
@@ -503,7 +504,7 @@ describe('SessionService', function () {
 
         should.ok(mailer.send.calledOnce);
         const emailArgs = mailer.send.firstCall.args[0];
-        should.equal(emailArgs.to, 'test@example.com');
+        assert.equal(emailArgs.to, 'test@example.com');
         emailArgs.subject.should.match(/Ghost sign in verification code/);
     });
 
@@ -595,8 +596,8 @@ describe('SessionService', function () {
 
         await sessionService.createVerifiedSessionForUser(req, res, user);
 
-        should.equal(req.session.user_id, 'egg');
-        should.equal(req.session.verified, true);
+        assert.equal(req.session.user_id, 'egg');
+        assert.equal(req.session.verified, true);
     });
 
     it('Throws if the user id is invalid', async function () {
@@ -686,19 +687,19 @@ describe('SessionService', function () {
         const user = {id: 'egg'};
 
         await sessionService.createSessionForUser(req, res, user);
-        should.equal(req.session.user_id, 'egg');
-        should.equal(req.session.verified, undefined);
+        assert.equal(req.session.user_id, 'egg');
+        assert.equal(req.session.verified, undefined);
 
         await sessionService.verifySession(req, res);
-        should.equal(req.session.verified, true);
+        assert.equal(req.session.verified, true);
 
         await sessionService.removeUserForSession(req, res);
-        should.equal(req.session.user_id, undefined);
-        should.equal(req.session.verified, undefined);
+        assert.equal(req.session.user_id, undefined);
+        assert.equal(req.session.verified, undefined);
 
         await sessionService.createSessionForUser(req, res, user);
-        should.equal(req.session.user_id, 'egg');
-        should.equal(req.session.verified, undefined);
+        assert.equal(req.session.user_id, 'egg');
+        assert.equal(req.session.verified, undefined);
     });
 
     describe('isVerificationRequired', function () {
@@ -710,7 +711,7 @@ describe('SessionService', function () {
             });
 
             const result = sessionService.isVerificationRequired();
-            should.equal(result, true);
+            assert.equal(result, true);
         });
 
         it('returns false when require_email_mfa is false', async function () {
@@ -721,7 +722,7 @@ describe('SessionService', function () {
             });
 
             const result = sessionService.isVerificationRequired();
-            should.equal(result, false);
+            assert.equal(result, false);
         });
 
         it('returns false when require_email_mfa is not set', async function () {
@@ -732,7 +733,7 @@ describe('SessionService', function () {
             });
 
             const result = sessionService.isVerificationRequired();
-            should.equal(result, false);
+            assert.equal(result, false);
         });
     });
 });

--- a/ghost/core/test/unit/server/services/auth/session/store.test.js
+++ b/ghost/core/test/unit/server/services/auth/session/store.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const SessionStore = require('../../../../../../core/server/services/auth/session/session-store');
 const models = require('../../../../../../core/server/models');
 const EventEmitter = require('events');
@@ -16,12 +17,12 @@ describe('Auth Service SessionStore', function () {
     describe('inheritance', function () {
         it('Is an instance of EventEmitter', function () {
             const store = new SessionStore();
-            should.equal(store instanceof EventEmitter, true);
+            assert.equal(store instanceof EventEmitter, true);
         });
 
         it('Is an instance of Store', function () {
             const store = new SessionStore();
-            should.equal(store instanceof Store, true);
+            assert.equal(store instanceof Store, true);
         });
     });
 
@@ -34,7 +35,7 @@ describe('Auth Service SessionStore', function () {
             const sid = 1;
             store.destroy(sid, function () {
                 const destroyStubCall = destroyStub.getCall(0);
-                should.equal(destroyStubCall.args[0].session_id, sid);
+                assert.equal(destroyStubCall.args[0].session_id, sid);
                 done();
             });
         });
@@ -46,7 +47,7 @@ describe('Auth Service SessionStore', function () {
             const store = new SessionStore(models.Session);
             const sid = 1;
             store.destroy(sid, function (err) {
-                should.equal(err, null);
+                assert.equal(err, null);
                 done();
             });
         });
@@ -59,7 +60,7 @@ describe('Auth Service SessionStore', function () {
             const store = new SessionStore(models.Session);
             const sid = 1;
             store.destroy(sid, function (err) {
-                should.equal(err, error);
+                assert.equal(err, error);
                 done();
             });
         });
@@ -74,7 +75,7 @@ describe('Auth Service SessionStore', function () {
             const sid = 1;
             store.get(sid, function () {
                 const findOneStubCall = findOneStub.getCall(0);
-                should.equal(findOneStubCall.args[0].session_id, sid);
+                assert.equal(findOneStubCall.args[0].session_id, sid);
                 done();
             });
         });
@@ -86,8 +87,8 @@ describe('Auth Service SessionStore', function () {
             const store = new SessionStore(models.Session);
             const sid = 1;
             store.get(sid, function (err, session) {
-                should.equal(err, null);
-                should.equal(session, null);
+                assert.equal(err, null);
+                assert.equal(session, null);
                 done();
             });
         });
@@ -104,7 +105,7 @@ describe('Auth Service SessionStore', function () {
             const store = new SessionStore(models.Session);
             const sid = 1;
             store.get(sid, function (err, session) {
-                should.equal(err, null);
+                assert.equal(err, null);
                 should.deepEqual(session, {
                     ice: 'cube'
                 });
@@ -120,7 +121,7 @@ describe('Auth Service SessionStore', function () {
             const store = new SessionStore(models.Session);
             const sid = 1;
             store.get(sid, function (err) {
-                should.equal(err, error);
+                assert.equal(err, error);
                 done();
             });
         });
@@ -136,8 +137,8 @@ describe('Auth Service SessionStore', function () {
             const session_data = {user_id: 100};
             store.set(sid, session_data, function () {
                 const upsertStubCall = upsertStub.getCall(0);
-                should.equal(upsertStubCall.args[0].session_data, session_data);
-                should.equal(upsertStubCall.args[1].session_id, sid);
+                assert.equal(upsertStubCall.args[0].session_data, session_data);
+                assert.equal(upsertStubCall.args[1].session_id, sid);
                 done();
             });
         });
@@ -151,7 +152,7 @@ describe('Auth Service SessionStore', function () {
             const sid = 1;
             const session_data = {user_id: 100};
             store.set(sid, session_data, function (err) {
-                should.equal(err, error);
+                assert.equal(err, error);
                 done();
             });
         });
@@ -164,8 +165,8 @@ describe('Auth Service SessionStore', function () {
             const sid = 1;
             const session_data = {user_id: 100};
             store.set(sid, session_data, function (err, data) {
-                should.equal(err, null);
-                should.equal(data, null);
+                assert.equal(err, null);
+                assert.equal(data, null);
                 done();
             });
         });

--- a/ghost/core/test/unit/server/services/auth/session/store.test.js
+++ b/ghost/core/test/unit/server/services/auth/session/store.test.js
@@ -166,7 +166,7 @@ describe('Auth Service SessionStore', function () {
             const session_data = {user_id: 100};
             store.set(sid, session_data, function (err, data) {
                 assert.equal(err, null);
-                assert.equal(data, null);
+                assert.equal(data, undefined);
                 done();
             });
         });

--- a/ghost/core/test/unit/server/services/lib/dynamic-redirect-manager.test.js
+++ b/ghost/core/test/unit/server/services/lib/dynamic-redirect-manager.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const DynamicRedirectManager = require('../../../../../core/server/services/lib/dynamic-redirect-manager');
 
@@ -56,9 +57,9 @@ describe('DynamicRedirectManager', function () {
                 should.fail(true, false, 'next should NOT have been called');
             });
 
-            should.equal(headers['Cache-Control'], 'public, max-age=100');
-            should.equal(status, 301);
-            should.equal(location, '/result?q=abc&lang=js');
+            assert.equal(headers['Cache-Control'], 'public, max-age=100');
+            assert.equal(status, 301);
+            assert.equal(location, '/result?q=abc&lang=js');
         });
 
         it('Allows redirects to be removed', function () {
@@ -71,9 +72,9 @@ describe('DynamicRedirectManager', function () {
                 should.ok(true, 'next should have been called');
             });
 
-            should.equal(headers, null);
-            should.equal(status, null);
-            should.equal(location, null);
+            assert.equal(headers, null);
+            assert.equal(status, null);
+            assert.equal(location, null);
         });
 
         it('Can add same redirect multiple times and remove it once', function () {
@@ -87,9 +88,9 @@ describe('DynamicRedirectManager', function () {
                 should.ok(true, 'next should have been called');
             });
 
-            should.equal(headers, null);
-            should.equal(status, null);
-            should.equal(location, null);
+            assert.equal(headers, null);
+            assert.equal(status, null);
+            assert.equal(location, null);
         });
 
         it('The routing works when passed an invalid regexp for the from parameter', function () {
@@ -106,9 +107,9 @@ describe('DynamicRedirectManager', function () {
                 should.ok(true, 'next should have been called');
             });
 
-            should.equal(headers, null);
-            should.equal(status, null);
-            should.equal(location, null);
+            assert.equal(headers, null);
+            assert.equal(status, null);
+            assert.equal(location, null);
         });
 
         it('Throws an error if unexpected internal component throws unknown error', function () {
@@ -158,9 +159,9 @@ describe('DynamicRedirectManager', function () {
                 });
 
                 // NOTE: max-age is "0" because it's not a permanent redirect
-                should.equal(headers['Cache-Control'], 'public, max-age=0');
-                should.equal(status, 302);
-                should.equal(location, '/a-nice-blog-post');
+                assert.equal(headers['Cache-Control'], 'public, max-age=0');
+                assert.equal(status, 302);
+                assert.equal(location, '/a-nice-blog-post');
             });
 
             it('Works with substitution redirect case and a trailing slash', function (){
@@ -176,9 +177,9 @@ describe('DynamicRedirectManager', function () {
                 });
 
                 // NOTE: max-age is "0" because it's not a permanent redirect
-                should.equal(headers['Cache-Control'], 'public, max-age=0');
-                should.equal(status, 302);
-                should.equal(location, '/a-nice-blog-post');
+                assert.equal(headers['Cache-Control'], 'public, max-age=0');
+                assert.equal(status, 302);
+                assert.equal(location, '/a-nice-blog-post');
             });
 
             it('Redirects keeping the query params for substitution regexp', function (){
@@ -194,9 +195,9 @@ describe('DynamicRedirectManager', function () {
                 });
 
                 // NOTE: max-age is "0" because it's not a permanent redirect
-                should.equal(headers['Cache-Control'], 'public, max-age=0');
-                should.equal(status, 302);
-                should.equal(location, '/a-nice-blog-post?a=b');
+                assert.equal(headers['Cache-Control'], 'public, max-age=0');
+                assert.equal(status, 302);
+                assert.equal(location, '/a-nice-blog-post?a=b');
             });
 
             it('Redirects keeping the query params', function (){
@@ -212,9 +213,9 @@ describe('DynamicRedirectManager', function () {
                 });
 
                 // NOTE: max-age is "0" because it's not a permanent redirect
-                should.equal(headers['Cache-Control'], 'public, max-age=0');
-                should.equal(status, 302);
-                should.equal(location, '/?something=good');
+                assert.equal(headers['Cache-Control'], 'public, max-age=0');
+                assert.equal(status, 302);
+                assert.equal(location, '/?something=good');
             });
         });
 
@@ -232,9 +233,9 @@ describe('DynamicRedirectManager', function () {
                 });
 
                 // NOTE: max-age is "0" because it's not a permanent redirect
-                should.equal(headers['Cache-Control'], 'public, max-age=0');
-                should.equal(status, 302);
-                should.equal(location, '/redirected-insensitive');
+                assert.equal(headers['Cache-Control'], 'public, max-age=0');
+                assert.equal(status, 302);
+                assert.equal(location, '/redirected-insensitive');
             });
 
             it('with case sensitive', function () {
@@ -250,9 +251,9 @@ describe('DynamicRedirectManager', function () {
                 });
 
                 // NOTE: max-age is "0" because it's not a permanent redirect
-                should.equal(headers['Cache-Control'], 'public, max-age=0');
-                should.equal(status, 302);
-                should.equal(location, '/redirected-sensitive');
+                assert.equal(headers['Cache-Control'], 'public, max-age=0');
+                assert.equal(status, 302);
+                assert.equal(location, '/redirected-sensitive');
             });
 
             it('defaults to case sensitive', function () {
@@ -267,9 +268,9 @@ describe('DynamicRedirectManager', function () {
                     should.fail(true, 'next should NOT have been called');
                 });
 
-                should.equal(headers['Cache-Control'], 'public, max-age=0');
-                should.equal(status, 302);
-                should.equal(location, '/redirected-default');
+                assert.equal(headers['Cache-Control'], 'public, max-age=0');
+                assert.equal(status, 302);
+                assert.equal(location, '/redirected-default');
             });
 
             it('should not redirect with case sensitive', function () {
@@ -284,9 +285,9 @@ describe('DynamicRedirectManager', function () {
                     should.ok(true, 'next should have been called');
                 });
 
-                should.equal(headers, null);
-                should.equal(status, null);
-                should.equal(location, null);
+                assert.equal(headers, null);
+                assert.equal(status, null);
+                assert.equal(location, null);
             });
 
             it('should not redirect with default case sensitive', function () {
@@ -301,9 +302,9 @@ describe('DynamicRedirectManager', function () {
                     should.ok(true, 'next should have been called');
                 });
 
-                should.equal(headers, null);
-                should.equal(status, null);
-                should.equal(location, null);
+                assert.equal(headers, null);
+                assert.equal(status, null);
+                assert.equal(location, null);
             });
         });
 
@@ -321,9 +322,9 @@ describe('DynamicRedirectManager', function () {
                 });
 
                 // NOTE: max-age is "0" because it's not a permanent redirect
-                should.equal(headers['Cache-Control'], 'public, max-age=0');
-                should.equal(status, 302);
-                should.equal(location, 'https://ghost.org/');
+                assert.equal(headers['Cache-Control'], 'public, max-age=0');
+                assert.equal(status, 302);
+                assert.equal(location, 'https://ghost.org/');
             });
 
             it('without trailing slash', function () {
@@ -339,9 +340,9 @@ describe('DynamicRedirectManager', function () {
                 });
 
                 // NOTE: max-age is "0" because it's not a permanent redirect
-                should.equal(headers['Cache-Control'], 'public, max-age=0');
-                should.equal(status, 302);
-                should.equal(location, 'https://ghost.org/');
+                assert.equal(headers['Cache-Control'], 'public, max-age=0');
+                assert.equal(status, 302);
+                assert.equal(location, 'https://ghost.org/');
             });
 
             it('with capturing group', function () {
@@ -357,9 +358,9 @@ describe('DynamicRedirectManager', function () {
                 });
 
                 // NOTE: max-age is "0" because it's not a permanent redirect
-                should.equal(headers['Cache-Control'], 'public, max-age=0');
-                should.equal(status, 302);
-                should.equal(location, 'https://ghost.org/docs');
+                assert.equal(headers['Cache-Control'], 'public, max-age=0');
+                assert.equal(status, 302);
+                assert.equal(location, 'https://ghost.org/docs');
             });
         });
 
@@ -377,9 +378,9 @@ describe('DynamicRedirectManager', function () {
                 });
 
                 // NOTE: max-age is "0" because it's not a permanent redirect
-                should.equal(headers['Cache-Control'], 'public, max-age=0');
-                should.equal(status, 302);
-                should.equal(location, '/joloonii-angilal/а-ангилал');
+                assert.equal(headers['Cache-Control'], 'public, max-age=0');
+                assert.equal(status, 302);
+                assert.equal(location, '/joloonii-angilal/а-ангилал');
             });
         });
     });
@@ -408,9 +409,9 @@ describe('DynamicRedirectManager', function () {
                 should.fail(true, 'next should NOT have been called');
             });
 
-            should.equal(headers['Cache-Control'], 'public, max-age=100');
-            should.equal(status, 301);
-            should.equal(location, '/blog/revamped-url/');
+            assert.equal(headers['Cache-Control'], 'public, max-age=100');
+            assert.equal(status, 301);
+            assert.equal(location, '/blog/revamped-url/');
         });
     });
 });

--- a/ghost/core/test/unit/server/services/members/importer/members-csv-importer.test.js
+++ b/ghost/core/test/unit/server/services/members/importer/members-csv-importer.test.js
@@ -124,7 +124,7 @@ describe('MembersCSVImporter', function () {
             result.meta.stats.imported.should.equal(2);
 
             should.exist(result.meta.stats.invalid);
-            should.equal(result.meta.import_label, null);
+            assert.equal(result.meta.import_label, null);
 
             should.exist(result.meta.originalImportSize);
             result.meta.originalImportSize.should.equal(2);
@@ -183,35 +183,35 @@ describe('MembersCSVImporter', function () {
             // member records get inserted
             membersRepositoryStub.create.calledTwice.should.be.true();
 
-            should.equal(membersRepositoryStub.create.args[0][1].context.import, true, 'inserts are done in the "import" context');
+            assert.equal(membersRepositoryStub.create.args[0][1].context.import, true, 'inserts are done in the "import" context');
 
             should.deepEqual(Object.keys(membersRepositoryStub.create.args[0][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'labels']);
-            should.equal(membersRepositoryStub.create.args[0][0].id, undefined, 'id field should not be taken from the user input');
-            should.equal(membersRepositoryStub.create.args[0][0].email, 'member_complimentary_test@example.com');
-            should.equal(membersRepositoryStub.create.args[0][0].name, 'bobby tables');
-            should.equal(membersRepositoryStub.create.args[0][0].note, 'a note');
-            should.equal(membersRepositoryStub.create.args[0][0].subscribed, true);
-            should.equal(membersRepositoryStub.create.args[0][0].created_at, '2022-10-18T06:34:08.000Z');
-            should.equal(membersRepositoryStub.create.args[0][0].deleted_at, undefined, 'deleted_at field should not be taken from the user input');
+            assert.equal(membersRepositoryStub.create.args[0][0].id, undefined, 'id field should not be taken from the user input');
+            assert.equal(membersRepositoryStub.create.args[0][0].email, 'member_complimentary_test@example.com');
+            assert.equal(membersRepositoryStub.create.args[0][0].name, 'bobby tables');
+            assert.equal(membersRepositoryStub.create.args[0][0].note, 'a note');
+            assert.equal(membersRepositoryStub.create.args[0][0].subscribed, true);
+            assert.equal(membersRepositoryStub.create.args[0][0].created_at, '2022-10-18T06:34:08.000Z');
+            assert.equal(membersRepositoryStub.create.args[0][0].deleted_at, undefined, 'deleted_at field should not be taken from the user input');
             should.deepEqual(membersRepositoryStub.create.args[0][0].labels, [{
                 name: 'user import label'
             }]);
 
             should.deepEqual(Object.keys(membersRepositoryStub.create.args[1][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'labels']);
-            should.equal(membersRepositoryStub.create.args[1][0].id, undefined, 'id field should not be taken from the user input');
-            should.equal(membersRepositoryStub.create.args[1][0].email, 'member_stripe_test@example.com');
-            should.equal(membersRepositoryStub.create.args[1][0].name, 'stirpey beaver');
-            should.equal(membersRepositoryStub.create.args[1][0].note, 'testing notes');
-            should.equal(membersRepositoryStub.create.args[1][0].subscribed, false);
-            should.equal(membersRepositoryStub.create.args[1][0].created_at, '2022-10-18T07:31:57.000Z');
-            should.equal(membersRepositoryStub.create.args[1][0].deleted_at, undefined, 'deleted_at field should not be taken from the user input');
+            assert.equal(membersRepositoryStub.create.args[1][0].id, undefined, 'id field should not be taken from the user input');
+            assert.equal(membersRepositoryStub.create.args[1][0].email, 'member_stripe_test@example.com');
+            assert.equal(membersRepositoryStub.create.args[1][0].name, 'stirpey beaver');
+            assert.equal(membersRepositoryStub.create.args[1][0].note, 'testing notes');
+            assert.equal(membersRepositoryStub.create.args[1][0].subscribed, false);
+            assert.equal(membersRepositoryStub.create.args[1][0].created_at, '2022-10-18T07:31:57.000Z');
+            assert.equal(membersRepositoryStub.create.args[1][0].deleted_at, undefined, 'deleted_at field should not be taken from the user input');
             should.deepEqual(membersRepositoryStub.create.args[1][0].labels, [], 'no labels should be assigned');
 
             // stripe customer import
             membersRepositoryStub.linkStripeCustomer.calledOnce.should.be.true();
-            should.equal(membersRepositoryStub.linkStripeCustomer.args[0][0].customer_id, 'cus_MdR9tqW6bAreiq');
-            should.equal(membersRepositoryStub.linkStripeCustomer.args[0][0].member_id, 'test_member_id');
-            should.equal(membersRepositoryStub.linkStripeCustomer.args[0][1].context.importer, true, 'linkStripeCustomer is called with importer context to prevent welcome emails');
+            assert.equal(membersRepositoryStub.linkStripeCustomer.args[0][0].customer_id, 'cus_MdR9tqW6bAreiq');
+            assert.equal(membersRepositoryStub.linkStripeCustomer.args[0][0].member_id, 'test_member_id');
+            assert.equal(membersRepositoryStub.linkStripeCustomer.args[0][1].context.importer, true, 'linkStripeCustomer is called with importer context to prevent welcome emails');
 
             // complimentary_plan import
             membersRepositoryStub.update.calledOnce.should.be.true();
@@ -327,114 +327,114 @@ describe('MembersCSVImporter', function () {
             fsWriteSpy.calledOnce.should.be.true();
 
             // member records get inserted
-            should.equal(membersRepositoryStub.create.callCount, 5);
+            assert.equal(membersRepositoryStub.create.callCount, 5);
 
-            should.equal(membersRepositoryStub.create.args[0][1].context.import, true, 'inserts are done in the "import" context');
+            assert.equal(membersRepositoryStub.create.args[0][1].context.import, true, 'inserts are done in the "import" context');
 
             // CASE 1: Existing member with at least one newsletter subscription, `subscribed_to_emails` column is true
             // Member's newsletter subscriptions should not change
             should.deepEqual(Object.keys(membersRepositoryStub.update.args[0][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'labels', 'newsletters']);
-            should.equal(membersRepositoryStub.update.args[0][0].email, 'member_subscribed_true@example.com');
-            should.equal(membersRepositoryStub.update.args[0][0].subscribed, true);
+            assert.equal(membersRepositoryStub.update.args[0][0].email, 'member_subscribed_true@example.com');
+            assert.equal(membersRepositoryStub.update.args[0][0].subscribed, true);
             should.deepEqual(membersRepositoryStub.update.args[0][0].newsletters, defaultNewsletters);
 
             // CASE 2: Existing member with at least one newsletter subscription, `subscribed_to_emails` column is false
             // Member's newsletter subscriptions should be removed
             should.deepEqual(Object.keys(membersRepositoryStub.update.args[1][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'labels']);
-            should.equal(membersRepositoryStub.update.args[1][0].email, 'member_subscribed_false@example.com');
-            should.equal(membersRepositoryStub.update.args[1][0].subscribed, false);
-            should.equal(membersRepositoryStub.update.args[1][0].newsletters, undefined);
+            assert.equal(membersRepositoryStub.update.args[1][0].email, 'member_subscribed_false@example.com');
+            assert.equal(membersRepositoryStub.update.args[1][0].subscribed, false);
+            assert.equal(membersRepositoryStub.update.args[1][0].newsletters, undefined);
 
             // CASE 3: Existing member with at least one newsletter subscription, `subscribed_to_emails` column is NULL
             // Member's newsletter subscriptions should not change
             should.deepEqual(Object.keys(membersRepositoryStub.update.args[2][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'labels', 'newsletters']);
-            should.equal(membersRepositoryStub.update.args[2][0].email, 'member_subscribed_null@example.com');
-            should.equal(membersRepositoryStub.update.args[2][0].subscribed, true);
+            assert.equal(membersRepositoryStub.update.args[2][0].email, 'member_subscribed_null@example.com');
+            assert.equal(membersRepositoryStub.update.args[2][0].subscribed, true);
             should.deepEqual(membersRepositoryStub.update.args[2][0].newsletters, defaultNewsletters);
 
             // CASE 4: Existing member with at least one newsletter subscription, `subscribed_to_emails` column is empty
             // Member's newsletter subscriptions should not change
             should.deepEqual(Object.keys(membersRepositoryStub.update.args[3][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'labels', 'newsletters']);
-            should.equal(membersRepositoryStub.update.args[3][0].email, 'member_subscribed_empty@example.com');
-            should.equal(membersRepositoryStub.update.args[3][0].subscribed, true);
+            assert.equal(membersRepositoryStub.update.args[3][0].email, 'member_subscribed_empty@example.com');
+            assert.equal(membersRepositoryStub.update.args[3][0].subscribed, true);
             should.deepEqual(membersRepositoryStub.update.args[3][0].newsletters, defaultNewsletters);
 
             // CASE 5: Existing member with at least one newsletter subscription, `subscribed_to_emails` column is invalid
             // Member's newsletter subscriptions should not change
             should.deepEqual(Object.keys(membersRepositoryStub.update.args[4][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'labels', 'newsletters']);
-            should.equal(membersRepositoryStub.update.args[4][0].email, 'member_subscribed_invalid@example.com');
-            should.equal(membersRepositoryStub.update.args[4][0].subscribed, true);
+            assert.equal(membersRepositoryStub.update.args[4][0].email, 'member_subscribed_invalid@example.com');
+            assert.equal(membersRepositoryStub.update.args[4][0].subscribed, true);
             should.deepEqual(membersRepositoryStub.update.args[4][0].newsletters, defaultNewsletters);
 
             // CASE 6: Existing member with no newsletter subscriptions, `subscribed_to_emails` column is true
             // Member should remain unsubscribed and not added to any newsletters
             should.deepEqual(Object.keys(membersRepositoryStub.update.args[5][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'labels']);
-            should.equal(membersRepositoryStub.update.args[5][0].email, 'member_not_subscribed_true@example.com');
-            should.equal(membersRepositoryStub.update.args[5][0].subscribed, false);
-            should.equal(membersRepositoryStub.update.args[5][0].newsletters, undefined);
+            assert.equal(membersRepositoryStub.update.args[5][0].email, 'member_not_subscribed_true@example.com');
+            assert.equal(membersRepositoryStub.update.args[5][0].subscribed, false);
+            assert.equal(membersRepositoryStub.update.args[5][0].newsletters, undefined);
 
             // CASE 7: Existing member with no newsletter subscriptions, `subscribed_to_emails` column is false
             // Member should remain unsubscribed and not added to any newsletters
             should.deepEqual(Object.keys(membersRepositoryStub.update.args[6][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'labels']);
-            should.equal(membersRepositoryStub.update.args[6][0].email, 'member_not_subscribed_false@example.com');
-            should.equal(membersRepositoryStub.update.args[6][0].subscribed, false);
-            should.equal(membersRepositoryStub.update.args[6][0].newsletters, undefined);
+            assert.equal(membersRepositoryStub.update.args[6][0].email, 'member_not_subscribed_false@example.com');
+            assert.equal(membersRepositoryStub.update.args[6][0].subscribed, false);
+            assert.equal(membersRepositoryStub.update.args[6][0].newsletters, undefined);
 
             // CASE 8: Existing member with no newsletter subscriptions, `subscribed_to_emails` column is NULL
             // Member should remain unsubscribed and not added to any newsletters
             should.deepEqual(Object.keys(membersRepositoryStub.update.args[7][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'labels']);
-            should.equal(membersRepositoryStub.update.args[7][0].email, 'member_not_subscribed_null@example.com');
-            should.equal(membersRepositoryStub.update.args[7][0].subscribed, false);
-            should.equal(membersRepositoryStub.update.args[7][0].newsletters, undefined);
+            assert.equal(membersRepositoryStub.update.args[7][0].email, 'member_not_subscribed_null@example.com');
+            assert.equal(membersRepositoryStub.update.args[7][0].subscribed, false);
+            assert.equal(membersRepositoryStub.update.args[7][0].newsletters, undefined);
 
             // CASE 9: Existing member with no newsletter subscriptions, `subscribed_to_emails` column is empty
             // Member should remain unsubscribed and not added to any newsletters
             should.deepEqual(Object.keys(membersRepositoryStub.update.args[8][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'labels']);
-            should.equal(membersRepositoryStub.update.args[8][0].email, 'member_not_subscribed_empty@example.com');
-            should.equal(membersRepositoryStub.update.args[8][0].subscribed, false);
-            should.equal(membersRepositoryStub.update.args[8][0].newsletters, undefined);
+            assert.equal(membersRepositoryStub.update.args[8][0].email, 'member_not_subscribed_empty@example.com');
+            assert.equal(membersRepositoryStub.update.args[8][0].subscribed, false);
+            assert.equal(membersRepositoryStub.update.args[8][0].newsletters, undefined);
 
             // CASE 10: Existing member with no newsletter subscriptions, `subscribed_to_emails` column is invalid
             // Member should remain unsubscribed and not added to any newsletters
             should.deepEqual(Object.keys(membersRepositoryStub.update.args[9][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'labels']);
-            should.equal(membersRepositoryStub.update.args[9][0].email, 'member_not_subscribed_invalid@example.com');
-            should.equal(membersRepositoryStub.update.args[9][0].subscribed, false);
-            should.equal(membersRepositoryStub.update.args[9][0].newsletters, undefined);
+            assert.equal(membersRepositoryStub.update.args[9][0].email, 'member_not_subscribed_invalid@example.com');
+            assert.equal(membersRepositoryStub.update.args[9][0].subscribed, false);
+            assert.equal(membersRepositoryStub.update.args[9][0].newsletters, undefined);
 
             // CASE 11: New member, `subscribed_to_emails` column is true
             // Member should be created and subscribed
             should.deepEqual(Object.keys(membersRepositoryStub.create.args[0][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'labels']);
-            should.equal(membersRepositoryStub.create.args[0][0].email, 'new_member_true@example.com');
-            should.equal(membersRepositoryStub.create.args[0][0].subscribed, true);
-            should.equal(membersRepositoryStub.create.args[0][0].newsletters, undefined);
+            assert.equal(membersRepositoryStub.create.args[0][0].email, 'new_member_true@example.com');
+            assert.equal(membersRepositoryStub.create.args[0][0].subscribed, true);
+            assert.equal(membersRepositoryStub.create.args[0][0].newsletters, undefined);
 
             // CASE 12: New member, `subscribed_to_emails` column is false
             // Member should be created but not subscribed
             should.deepEqual(Object.keys(membersRepositoryStub.create.args[1][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'labels']);
-            should.equal(membersRepositoryStub.create.args[1][0].email, 'new_member_false@example.com');
-            should.equal(membersRepositoryStub.create.args[1][0].subscribed, false);
-            should.equal(membersRepositoryStub.create.args[1][0].newsletters, undefined);
+            assert.equal(membersRepositoryStub.create.args[1][0].email, 'new_member_false@example.com');
+            assert.equal(membersRepositoryStub.create.args[1][0].subscribed, false);
+            assert.equal(membersRepositoryStub.create.args[1][0].newsletters, undefined);
 
             // CASE 13: New member, `subscribed_to_emails` column is NULL
             // Member should be created but not subscribed
             should.deepEqual(Object.keys(membersRepositoryStub.create.args[2][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'labels']);
-            should.equal(membersRepositoryStub.create.args[2][0].email, 'new_member_null@example.com');
-            should.equal(membersRepositoryStub.create.args[2][0].subscribed, true);
-            should.equal(membersRepositoryStub.create.args[2][0].newsletters, undefined);
+            assert.equal(membersRepositoryStub.create.args[2][0].email, 'new_member_null@example.com');
+            assert.equal(membersRepositoryStub.create.args[2][0].subscribed, true);
+            assert.equal(membersRepositoryStub.create.args[2][0].newsletters, undefined);
 
             // CASE 14: New member, `subscribed_to_emails` column is empty
             // Member should be created but not subscribed
             should.deepEqual(Object.keys(membersRepositoryStub.create.args[3][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'labels']);
-            should.equal(membersRepositoryStub.create.args[3][0].email, 'new_member_empty@example.com');
-            should.equal(membersRepositoryStub.create.args[3][0].subscribed, true);
-            should.equal(membersRepositoryStub.create.args[3][0].newsletters, undefined);
+            assert.equal(membersRepositoryStub.create.args[3][0].email, 'new_member_empty@example.com');
+            assert.equal(membersRepositoryStub.create.args[3][0].subscribed, true);
+            assert.equal(membersRepositoryStub.create.args[3][0].newsletters, undefined);
 
             // CASE 15: New member, `subscribed_to_emails` column is invalid
             // Member should be created but not subscribed
             should.deepEqual(Object.keys(membersRepositoryStub.create.args[4][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'labels']);
-            should.equal(membersRepositoryStub.create.args[4][0].email, 'new_member_invalid@example.com');
-            should.equal(membersRepositoryStub.create.args[4][0].subscribed, true);
-            should.equal(membersRepositoryStub.create.args[4][0].newsletters, undefined);
+            assert.equal(membersRepositoryStub.create.args[4][0].email, 'new_member_invalid@example.com');
+            assert.equal(membersRepositoryStub.create.args[4][0].subscribed, true);
+            assert.equal(membersRepositoryStub.create.args[4][0].newsletters, undefined);
         });
     });
 
@@ -478,7 +478,7 @@ describe('MembersCSVImporter', function () {
 
             result.batches.should.equal(2);
             should.exist(result.metadata);
-            should.equal(result.metadata.hasStripeData, false);
+            assert.equal(result.metadata.hasStripeData, false);
             fsWriteSpy.calledOnce.should.be.true();
         });
 
@@ -508,7 +508,7 @@ describe('MembersCSVImporter', function () {
             const result = await membersImporter.prepare(`${csvPath}/member-csv-export.csv`);
 
             should.exist(result.metadata);
-            should.equal(result.metadata.hasStripeData, true);
+            assert.equal(result.metadata.hasStripeData, true);
         });
     });
 
@@ -571,7 +571,7 @@ describe('MembersCSVImporter', function () {
 
             const result = await importer.perform(`${csvPath}/auto-stripe-customer-id.csv`);
 
-            should.equal(membersRepositoryStub.linkStripeCustomer.args[0][0].customer_id, 'cus_mock_123456');
+            assert.equal(membersRepositoryStub.linkStripeCustomer.args[0][0].customer_id, 'cus_mock_123456');
 
             assert.equal(result.total, 1);
             assert.equal(result.imported, 1);

--- a/ghost/core/test/unit/server/services/members/members-api/services/geolocation-service.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/services/geolocation-service.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const nock = require('nock');
 const should = require('should');
 const GeolocationService = require('../../../../../../../core/server/services/members/members-api/services/geolocation-service');
@@ -57,22 +58,22 @@ describe('lib/geolocation', function () {
             let scope = nock('https://get.geojs.io').get('/v1/ip/geo/.json').reply(200, {test: true});
             let result = await service.getGeolocationFromIP('');
             scope.isDone().should.eql(false);
-            should.equal(undefined, result);
+            assert.equal(undefined, result);
 
             scope = nock('https://get.geojs.io').get('/v1/ip/geo/null.json').reply(200, {test: true});
             result = await service.getGeolocationFromIP(null);
             scope.isDone().should.eql(false);
-            should.equal(undefined, result);
+            assert.equal(undefined, result);
 
             scope = nock('https://get.geojs.io').get('/v1/ip/geo/undefined.json').reply(200, {test: true});
             result = await service.getGeolocationFromIP(undefined);
             scope.isDone().should.eql(false);
-            should.equal(undefined, result);
+            assert.equal(undefined, result);
 
             scope = nock('https://get.geojs.io').get('/v1/ip/geo/test.json').reply(200, {test: true});
             result = await service.getGeolocationFromIP('test');
             scope.isDone().should.eql(false);
-            should.equal(undefined, result);
+            assert.equal(undefined, result);
         });
     });
 });

--- a/ghost/core/test/unit/server/services/members/stripe-connect.test.js
+++ b/ghost/core/test/unit/server/services/members/stripe-connect.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const stripeConnect = require('../../../../../core/server/services/members/stripe-connect');
 
@@ -13,12 +14,12 @@ describe('Members - Stripe Connect', function () {
 
         should.exist(session.get(stripeConnect.STATE_PROP), 'The session should have a state set');
 
-        should.equal(url.origin, 'https://connect.stripe.com');
-        should.equal(url.pathname, '/oauth/authorize');
+        assert.equal(url.origin, 'https://connect.stripe.com');
+        assert.equal(url.pathname, '/oauth/authorize');
 
-        should.equal(url.searchParams.get('response_type'), 'code');
-        should.equal(url.searchParams.get('scope'), 'read_write');
-        should.equal(url.searchParams.get('state'), session.get(stripeConnect.STATE_PROP));
+        assert.equal(url.searchParams.get('response_type'), 'code');
+        assert.equal(url.searchParams.get('scope'), 'read_write');
+        assert.equal(url.searchParams.get('state'), session.get(stripeConnect.STATE_PROP));
     });
 
     it('getStripeConnectTokenData returns token data when the state is correct', async function () {
@@ -35,9 +36,9 @@ describe('Members - Stripe Connect', function () {
 
         const tokenData = await stripeConnect.getStripeConnectTokenData(encodedData, getSessionProp);
 
-        should.equal(tokenData.public_key, data.p);
-        should.equal(tokenData.secret_key, data.a);
-        should.equal(tokenData.livemode, data.l);
+        assert.equal(tokenData.public_key, data.p);
+        assert.equal(tokenData.secret_key, data.a);
+        assert.equal(tokenData.livemode, data.l);
     });
 
     it('getStripeConnectTokenData throws when the state is incorrect', async function () {

--- a/ghost/core/test/unit/server/services/offers/application/unique-checker.test.js
+++ b/ghost/core/test/unit/server/services/offers/application/unique-checker.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const should = require('should');
 const UniqueChecker = require('../../../../../../core/server/services/offers/application/unique-checker');
@@ -14,7 +15,7 @@ describe('UniqueChecker', function () {
 
             const returnVal = await checker.isUniqueCode('code');
 
-            should.equal(returnVal, true);
+            assert.equal(returnVal, true);
         });
 
         it('Returns false if there is an Offer found in the repository', async function () {
@@ -27,7 +28,7 @@ describe('UniqueChecker', function () {
 
             const returnVal = await checker.isUniqueCode('code');
 
-            should.equal(returnVal, false);
+            assert.equal(returnVal, false);
         });
     });
 
@@ -42,7 +43,7 @@ describe('UniqueChecker', function () {
 
             const returnVal = await checker.isUniqueName('name');
 
-            should.equal(returnVal, true);
+            assert.equal(returnVal, true);
         });
 
         it('Returns false if there is an Offer found in the repository', async function () {
@@ -55,7 +56,7 @@ describe('UniqueChecker', function () {
 
             const returnVal = await checker.isUniqueName('name');
 
-            should.equal(returnVal, false);
+            assert.equal(returnVal, false);
         });
     });
 });

--- a/ghost/core/test/unit/server/services/offers/domain/models/offer-code.test.js
+++ b/ghost/core/test/unit/server/services/offers/domain/models/offer-code.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 
 const OfferCode = require('../../../../../../../core/server/services/offers/domain/models/offer-code');
@@ -29,19 +30,19 @@ describe('OfferCode', function () {
 
             const code = OfferCode.create('Hello, world');
 
-            should.equal(code.value, 'hello-world');
+            assert.equal(code.value, 'hello-world');
         });
 
         it('Requires the string to be a maximum of 191 characters', function () {
             const maxLengthInput = Array.from({length: 191}).map(() => 'a').join('');
 
-            should.equal(maxLengthInput.length, 191);
+            assert.equal(maxLengthInput.length, 191);
 
             OfferCode.create(maxLengthInput);
 
             const tooLong = maxLengthInput + 'a';
 
-            should.equal(tooLong.length, 192);
+            assert.equal(tooLong.length, 192);
 
             try {
                 OfferCode.create(tooLong);

--- a/ghost/core/test/unit/server/services/offers/domain/models/offer-currency.test.js
+++ b/ghost/core/test/unit/server/services/offers/domain/models/offer-currency.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 
 const OfferCurrency = require('../../../../../../../core/server/services/offers/domain/models/offer-currency');
@@ -63,7 +64,7 @@ describe('OfferCurrency', function () {
     it('Store the currency as a string on the value property', function () {
         const currency = OfferCurrency.create('usd');
 
-        should.equal(typeof currency.value, 'string');
+        assert.equal(typeof currency.value, 'string');
     });
 
     it('Considers currencies equal if they have the same ISO code', function () {

--- a/ghost/core/test/unit/server/services/offers/domain/models/offer-description.test.js
+++ b/ghost/core/test/unit/server/services/offers/domain/models/offer-description.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 
 const OfferDescription = require('../../../../../../../core/server/services/offers/domain/models/offer-description');
@@ -7,9 +8,9 @@ describe('OfferDescription', function () {
         it('Creates an Offer description containing a string', function () {
             OfferDescription.create('Hello, world');
 
-            should.equal(OfferDescription.create().value, '');
-            should.equal(OfferDescription.create(undefined).value, '');
-            should.equal(OfferDescription.create(null).value, '');
+            assert.equal(OfferDescription.create().value, '');
+            assert.equal(OfferDescription.create(undefined).value, '');
+            assert.equal(OfferDescription.create(null).value, '');
 
             try {
                 OfferDescription.create(12);
@@ -35,13 +36,13 @@ describe('OfferDescription', function () {
         it('Requires the string to be a maximum of 191 characters', function () {
             const maxLengthInput = Array.from({length: 191}).map(() => 'a').join('');
 
-            should.equal(maxLengthInput.length, 191);
+            assert.equal(maxLengthInput.length, 191);
 
             OfferDescription.create(maxLengthInput);
 
             const tooLong = maxLengthInput + 'a';
 
-            should.equal(tooLong.length, 192);
+            assert.equal(tooLong.length, 192);
 
             try {
                 OfferDescription.create(tooLong);
@@ -57,7 +58,7 @@ describe('OfferDescription', function () {
         it('Trims the contents of the OfferDescription', function () {
             const description = OfferDescription.create('    Trim me!    ');
 
-            should.equal(description.value, 'Trim me!');
+            assert.equal(description.value, 'Trim me!');
         });
     });
 });

--- a/ghost/core/test/unit/server/services/offers/domain/models/offer-name.test.js
+++ b/ghost/core/test/unit/server/services/offers/domain/models/offer-name.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 
 const OfferName = require('../../../../../../../core/server/services/offers/domain/models/offer-name');
@@ -51,13 +52,13 @@ describe('OfferName', function () {
         it('Requires the string to be a maximum of 40 characters', function () {
             const maxLengthInput = Array.from({length: 40}).map(() => 'a').join('');
 
-            should.equal(maxLengthInput.length, 40);
+            assert.equal(maxLengthInput.length, 40);
 
             OfferName.create(maxLengthInput);
 
             const tooLong = maxLengthInput + 'a';
 
-            should.equal(tooLong.length, 41);
+            assert.equal(tooLong.length, 41);
 
             try {
                 OfferName.create(tooLong);
@@ -73,7 +74,7 @@ describe('OfferName', function () {
         it('Trims the contents of the OfferName', function () {
             const description = OfferName.create('    Trim me!    ');
 
-            should.equal(description.value, 'Trim me!');
+            assert.equal(description.value, 'Trim me!');
         });
     });
 });

--- a/ghost/core/test/unit/server/services/offers/domain/models/offer-redemption-type.test.js
+++ b/ghost/core/test/unit/server/services/offers/domain/models/offer-redemption-type.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 
 const OfferRedemptionType = require('../../../../../../../core/server/services/offers/domain/models/offer-redemption-type');
@@ -32,14 +33,14 @@ describe('OfferRedemptionType', function () {
 
     describe('OfferRedemptionType.Signup', function () {
         it('Is an OfferRedemptionType with a value of "signup"', function () {
-            should.equal(OfferRedemptionType.Signup.value, 'signup');
+            assert.equal(OfferRedemptionType.Signup.value, 'signup');
             should.ok(OfferRedemptionType.Signup.equals(OfferRedemptionType.create('signup')));
         });
     });
 
     describe('OfferRedemptionType.Retention', function () {
         it('Is an OfferRedemptionType with a value of "retention"', function () {
-            should.equal(OfferRedemptionType.Retention.value, 'retention');
+            assert.equal(OfferRedemptionType.Retention.value, 'retention');
             should.ok(OfferRedemptionType.Retention.equals(OfferRedemptionType.create('retention')));
         });
     });

--- a/ghost/core/test/unit/server/services/offers/domain/models/offer-title.test.js
+++ b/ghost/core/test/unit/server/services/offers/domain/models/offer-title.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 
 const OfferTitle = require('../../../../../../../core/server/services/offers/domain/models/offer-title');
@@ -7,9 +8,9 @@ describe('OfferTitle', function () {
         it('Creates an Offer description containing a string', function () {
             OfferTitle.create('Hello, world');
 
-            should.equal(OfferTitle.create().value, '');
-            should.equal(OfferTitle.create(undefined).value, '');
-            should.equal(OfferTitle.create(null).value, '');
+            assert.equal(OfferTitle.create().value, '');
+            assert.equal(OfferTitle.create(undefined).value, '');
+            assert.equal(OfferTitle.create(null).value, '');
 
             try {
                 OfferTitle.create(12);
@@ -35,13 +36,13 @@ describe('OfferTitle', function () {
         it('Requires the string to be a maximum of 191 characters', function () {
             const maxLengthInput = Array.from({length: 191}).map(() => 'a').join('');
 
-            should.equal(maxLengthInput.length, 191);
+            assert.equal(maxLengthInput.length, 191);
 
             OfferTitle.create(maxLengthInput);
 
             const tooLong = maxLengthInput + 'a';
 
-            should.equal(tooLong.length, 192);
+            assert.equal(tooLong.length, 192);
 
             try {
                 OfferTitle.create(tooLong);
@@ -57,7 +58,7 @@ describe('OfferTitle', function () {
         it('Trims the contents of the OfferTitle', function () {
             const description = OfferTitle.create('    Trim me!    ');
 
-            should.equal(description.value, 'Trim me!');
+            assert.equal(description.value, 'Trim me!');
         });
     });
 });

--- a/ghost/core/test/unit/server/services/offers/domain/models/offer-type.test.js
+++ b/ghost/core/test/unit/server/services/offers/domain/models/offer-type.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 
 const OfferType = require('../../../../../../../core/server/services/offers/domain/models/offer-type');
@@ -33,21 +34,21 @@ describe('OfferType', function () {
 
     describe('OfferType.Percentage', function () {
         it('Is an OfferType with a value of "percent"', function () {
-            should.equal(OfferType.Percentage.value, 'percent');
+            assert.equal(OfferType.Percentage.value, 'percent');
             should.ok(OfferType.Percentage.equals(OfferType.create('percent')));
         });
     });
 
     describe('OfferType.Fixed', function () {
         it('Is an OfferType with a value of "fixed"', function () {
-            should.equal(OfferType.Fixed.value, 'fixed');
+            assert.equal(OfferType.Fixed.value, 'fixed');
             should.ok(OfferType.Fixed.equals(OfferType.create('fixed')));
         });
     });
 
     describe('OfferType.Trial', function () {
         it('Is an OfferType with a value of "trial"', function () {
-            should.equal(OfferType.Trial.value, 'trial');
+            assert.equal(OfferType.Trial.value, 'trial');
             should.ok(OfferType.Trial.equals(OfferType.create('trial')));
         });
     });

--- a/ghost/core/test/unit/server/services/offers/domain/models/offer.test.js
+++ b/ghost/core/test/unit/server/services/offers/domain/models/offer.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const ObjectID = require('bson-objectid').default;
 const errors = require('../../../../../../../core/server/services/offers/domain/errors');
@@ -208,7 +209,7 @@ describe('Offer', function () {
 
             const offer = await Offer.create(data, mockUniqueChecker);
 
-            should.equal(offer.currency, null);
+            assert.equal(offer.currency, null);
         });
 
         it('Has a currency of null if the type is trial', async function () {
@@ -229,7 +230,7 @@ describe('Offer', function () {
 
             const offer = await Offer.create(data, mockUniqueChecker);
 
-            should.equal(offer.currency, null);
+            assert.equal(offer.currency, null);
         });
 
         it('Can handle ObjectID, string and no id', async function () {
@@ -297,7 +298,7 @@ describe('Offer', function () {
 
             const offer = await Offer.create(data, mockUniqueChecker);
 
-            should.equal(typeof offer.createdAt, 'string');
+            assert.equal(typeof offer.createdAt, 'string');
         });
     });
 
@@ -447,14 +448,14 @@ describe('Offer', function () {
             const offer = await Offer.createFromStripeCoupon(stripeCoupon, 'month', tier, mockUniqueChecker);
 
             should.ok(offer instanceof Offer);
-            should.equal(offer.code.value, 'stripe_coupon_abc');
-            should.equal(offer.status.value, 'archived');
-            should.equal(offer.stripeCouponId, 'stripe_coupon_abc');
-            should.equal(offer.type.value, 'percent');
-            should.equal(offer.amount.value, 25);
-            should.equal(offer.name.value, '25% off forever (stripe_coupon_abc)');
-            should.equal(offer.displayTitle.value, '25% off forever (stripe_coupon_abc)');
-            should.equal(offer.displayDescription.value, '');
+            assert.equal(offer.code.value, 'stripe_coupon_abc');
+            assert.equal(offer.status.value, 'archived');
+            assert.equal(offer.stripeCouponId, 'stripe_coupon_abc');
+            assert.equal(offer.type.value, 'percent');
+            assert.equal(offer.amount.value, 25);
+            assert.equal(offer.name.value, '25% off forever (stripe_coupon_abc)');
+            assert.equal(offer.displayTitle.value, '25% off forever (stripe_coupon_abc)');
+            assert.equal(offer.displayDescription.value, '');
         });
 
         it('Creates a valid fixed amount offer from a Stripe coupon', async function () {
@@ -473,13 +474,13 @@ describe('Offer', function () {
             const offer = await Offer.createFromStripeCoupon(stripeCoupon, 'year', tier, mockUniqueChecker);
 
             should.ok(offer instanceof Offer);
-            should.equal(offer.code.value, 'fixed_coupon_xyz');
-            should.equal(offer.status.value, 'archived');
-            should.equal(offer.stripeCouponId, 'fixed_coupon_xyz');
-            should.equal(offer.type.value, 'fixed');
-            should.equal(offer.amount.value, 1000);
-            should.equal(offer.currency.value, 'USD');
-            should.equal(offer.name.value, 'USD 10 off once (fixed_coupon_xyz)');
+            assert.equal(offer.code.value, 'fixed_coupon_xyz');
+            assert.equal(offer.status.value, 'archived');
+            assert.equal(offer.stripeCouponId, 'fixed_coupon_xyz');
+            assert.equal(offer.type.value, 'fixed');
+            assert.equal(offer.amount.value, 1000);
+            assert.equal(offer.currency.value, 'USD');
+            assert.equal(offer.name.value, 'USD 10 off once (fixed_coupon_xyz)');
         });
 
         it('Generates correct name for repeating duration with months', async function () {
@@ -497,9 +498,9 @@ describe('Offer', function () {
 
             const offer = await Offer.createFromStripeCoupon(stripeCoupon, 'month', tier, mockUniqueChecker);
 
-            should.equal(offer.name.value, '15% off for 6 months (SUMMER25)');
-            should.equal(offer.code.value, 'summer25');
-            should.equal(offer.status.value, 'archived');
+            assert.equal(offer.name.value, '15% off for 6 months (SUMMER25)');
+            assert.equal(offer.code.value, 'summer25');
+            assert.equal(offer.status.value, 'archived');
         });
 
         it('Generates correct name for percent off with "once" duration', async function () {
@@ -516,7 +517,7 @@ describe('Offer', function () {
 
             const offer = await Offer.createFromStripeCoupon(stripeCoupon, 'month', tier, mockUniqueChecker);
 
-            should.equal(offer.name.value, '10% off once (WELCOME10)');
+            assert.equal(offer.name.value, '10% off once (WELCOME10)');
         });
 
         it('Generates correct name for fixed amount with "forever" duration', async function () {
@@ -534,7 +535,7 @@ describe('Offer', function () {
 
             const offer = await Offer.createFromStripeCoupon(stripeCoupon, 'year', tier, mockUniqueChecker);
 
-            should.equal(offer.name.value, 'EUR 5 off forever (FLAT5OFF)');
+            assert.equal(offer.name.value, 'EUR 5 off forever (FLAT5OFF)');
         });
 
         it('Generates correct name for fixed amount with repeating duration', async function () {
@@ -553,7 +554,7 @@ describe('Offer', function () {
 
             const offer = await Offer.createFromStripeCoupon(stripeCoupon, 'month', tier, mockUniqueChecker);
 
-            should.equal(offer.name.value, 'GBP 2.5 off for 3 months (SAVE3MONTHS)');
+            assert.equal(offer.name.value, 'GBP 2.5 off for 3 months (SAVE3MONTHS)');
         });
 
         it('Sets cadence correctly from parameter', async function () {
@@ -569,7 +570,7 @@ describe('Offer', function () {
             };
 
             const monthlyOffer = await Offer.createFromStripeCoupon(stripeCoupon, 'month', tier, mockUniqueChecker);
-            should.equal(monthlyOffer.cadence.value, 'month');
+            assert.equal(monthlyOffer.cadence.value, 'month');
 
             const yearlyOffer = await Offer.createFromStripeCoupon(
                 {...stripeCoupon, id: 'yearly_coupon'},
@@ -577,7 +578,7 @@ describe('Offer', function () {
                 tier,
                 mockUniqueChecker
             );
-            should.equal(yearlyOffer.cadence.value, 'year');
+            assert.equal(yearlyOffer.cadence.value, 'year');
         });
 
         it('Associates offer with provided tier', async function () {
@@ -595,8 +596,8 @@ describe('Offer', function () {
 
             const offer = await Offer.createFromStripeCoupon(stripeCoupon, 'month', tier, mockUniqueChecker);
 
-            should.equal(offer.tier.id, tierId.toHexString());
-            should.equal(offer.tier.name, 'Premium');
+            assert.equal(offer.tier.id, tierId.toHexString());
+            assert.equal(offer.tier.name, 'Premium');
         });
 
         it('Is marked as a new offer', async function () {
@@ -613,7 +614,7 @@ describe('Offer', function () {
 
             const offer = await Offer.createFromStripeCoupon(stripeCoupon, 'month', tier, mockUniqueChecker);
 
-            should.equal(offer.isNew, true);
+            assert.equal(offer.isNew, true);
         });
     });
 });

--- a/ghost/core/test/unit/server/services/offers/domain/models/stripe-coupon.test.js
+++ b/ghost/core/test/unit/server/services/offers/domain/models/stripe-coupon.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const StripeCoupon = require('../../../../../../../core/server/services/offers/domain/models/stripe-coupon');
 
@@ -11,10 +12,10 @@ describe('StripeCoupon', function () {
             });
 
             should.ok(coupon instanceof StripeCoupon);
-            should.equal(coupon.id, 'coupon_123');
-            should.equal(coupon.percent_off, 20);
-            should.equal(coupon.duration, 'forever');
-            should.equal(coupon.amount_off, undefined);
+            assert.equal(coupon.id, 'coupon_123');
+            assert.equal(coupon.percent_off, 20);
+            assert.equal(coupon.duration, 'forever');
+            assert.equal(coupon.amount_off, undefined);
         });
 
         it('Creates a valid StripeCoupon with amount_off', function () {
@@ -26,11 +27,11 @@ describe('StripeCoupon', function () {
             });
 
             should.ok(coupon instanceof StripeCoupon);
-            should.equal(coupon.id, 'coupon_456');
-            should.equal(coupon.amount_off, 500);
-            should.equal(coupon.currency, 'usd');
-            should.equal(coupon.duration, 'once');
-            should.equal(coupon.percent_off, undefined);
+            assert.equal(coupon.id, 'coupon_456');
+            assert.equal(coupon.amount_off, 500);
+            assert.equal(coupon.currency, 'usd');
+            assert.equal(coupon.duration, 'once');
+            assert.equal(coupon.percent_off, undefined);
         });
 
         it('Creates a valid StripeCoupon with repeating duration', function () {
@@ -42,8 +43,8 @@ describe('StripeCoupon', function () {
             });
 
             should.ok(coupon instanceof StripeCoupon);
-            should.equal(coupon.duration, 'repeating');
-            should.equal(coupon.duration_in_months, 3);
+            assert.equal(coupon.duration, 'repeating');
+            assert.equal(coupon.duration_in_months, 3);
         });
 
         it('Throws if coupon is null or undefined', function () {

--- a/ghost/core/test/unit/server/services/settings-helpers/settings-helpers.test.js
+++ b/ghost/core/test/unit/server/services/settings-helpers/settings-helpers.test.js
@@ -63,8 +63,8 @@ describe('Settings Helpers', function () {
             const settingsHelpers = new SettingsHelpers({settingsCache: fakeSettings, config: configUtils.config, urlUtils: {}, labs: {}, limitService});
             const keys = settingsHelpers.getActiveStripeKeys();
 
-            should.equal(keys.publicKey, 'direct_publishable');
-            should.equal(keys.secretKey, 'direct_secret');
+            assert.equal(keys.publicKey, 'direct_publishable');
+            assert.equal(keys.secretKey, 'direct_secret');
         });
 
         it('Does not use connect keys if stripeDirect is true, and the direct keys do not exist', function () {
@@ -75,7 +75,7 @@ describe('Settings Helpers', function () {
             const settingsHelpers = new SettingsHelpers({settingsCache: fakeSettings, config: configUtils.config, urlUtils: {}, labs: {}, limitService});
             const keys = settingsHelpers.getActiveStripeKeys();
 
-            should.equal(keys, null);
+            assert.equal(keys, null);
         });
 
         it('Uses connect keys when stripeDirect is false, and the connect keys exist', function () {
@@ -86,8 +86,8 @@ describe('Settings Helpers', function () {
             const settingsHelpers = new SettingsHelpers({settingsCache: fakeSettings, config: configUtils.config, urlUtils: {}, labs: {}, limitService});
             const keys = settingsHelpers.getActiveStripeKeys();
 
-            should.equal(keys.publicKey, 'connect_publishable');
-            should.equal(keys.secretKey, 'connect_secret');
+            assert.equal(keys.publicKey, 'connect_publishable');
+            assert.equal(keys.secretKey, 'connect_secret');
         });
 
         it('Uses direct keys when stripeDirect is false, but the connect keys do not exist', function () {
@@ -98,8 +98,8 @@ describe('Settings Helpers', function () {
             const settingsHelpers = new SettingsHelpers({settingsCache: fakeSettings, config: configUtils.config, urlUtils: {}, labs: {}, limitService});
             const keys = settingsHelpers.getActiveStripeKeys();
 
-            should.equal(keys.publicKey, 'direct_publishable');
-            should.equal(keys.secretKey, 'direct_secret');
+            assert.equal(keys.publicKey, 'direct_publishable');
+            assert.equal(keys.secretKey, 'direct_secret');
         });
     });
 
@@ -108,7 +108,7 @@ describe('Settings Helpers', function () {
             const fakeSettings = createSettingsMock({setDirect: true, setConnect: true});
             const settingsHelpers = new SettingsHelpers({settingsCache: fakeSettings, config: configUtils.config, urlUtils: {}, labs: {}, limitService});
             const key = settingsHelpers.getMembersValidationKey();
-            should.equal(key, 'validation_key');
+            assert.equal(key, 'validation_key');
         });
     });
 
@@ -132,25 +132,25 @@ describe('Settings Helpers', function () {
         it('returns a generic unsubscribe url when no uuid is provided', function () {
             const settingsHelpers = new SettingsHelpers({settingsCache: fakeSettings, config: configUtils.config, urlUtils, labs: {}, limitService});
             const url = settingsHelpers.createUnsubscribeUrl(null);
-            should.equal(url, 'http://domain.com/unsubscribe/?preview=1');
+            assert.equal(url, 'http://domain.com/unsubscribe/?preview=1');
         });
 
         it('returns a url that can be used to unsubscribe a member', function () {
             const settingsHelpers = new SettingsHelpers({settingsCache: fakeSettings, config: configUtils.config, urlUtils, labs: {}, limitService});
             const url = settingsHelpers.createUnsubscribeUrl(memberUuid);
-            should.equal(url, `http://domain.com/unsubscribe/?uuid=memberuuid&key=${memberUuidHash}`);
+            assert.equal(url, `http://domain.com/unsubscribe/?uuid=memberuuid&key=${memberUuidHash}`);
         });
 
         it('returns a url that can be used to unsubscribe a member for a given newsletter', function () {
             const settingsHelpers = new SettingsHelpers({settingsCache: fakeSettings, config: configUtils.config, urlUtils, labs: {}, limitService});
             const url = settingsHelpers.createUnsubscribeUrl(memberUuid, {newsletterUuid});
-            should.equal(url, `http://domain.com/unsubscribe/?uuid=memberuuid&key=${memberUuidHash}&newsletter=newsletteruuid`);
+            assert.equal(url, `http://domain.com/unsubscribe/?uuid=memberuuid&key=${memberUuidHash}&newsletter=newsletteruuid`);
         });
 
         it('returns a url that can be used to unsubscribe a member from comments', function () {
             const settingsHelpers = new SettingsHelpers({settingsCache: fakeSettings, config: configUtils.config, urlUtils, labs: {}, limitService});
             const url = settingsHelpers.createUnsubscribeUrl(memberUuid, {comments: true});
-            should.equal(url, `http://domain.com/unsubscribe/?uuid=memberuuid&key=${memberUuidHash}&comments=1`);
+            assert.equal(url, `http://domain.com/unsubscribe/?uuid=memberuuid&key=${memberUuidHash}&comments=1`);
         });
     });
 

--- a/ghost/core/test/unit/server/services/stats/utils/tinybird.test.js
+++ b/ghost/core/test/unit/server/services/stats/utils/tinybird.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const should = require('should');
 const tinybird = require('../../../../../../core/server/services/stats/utils/tinybird');
@@ -191,7 +192,7 @@ describe('Tinybird Client', function () {
             };
 
             const result = tinybirdClient.parseResponse(mockResponse);
-            should.equal(result, null);
+            assert.equal(result, null);
         });
     });
 
@@ -230,7 +231,7 @@ describe('Tinybird Client', function () {
             
             const result = await tinybirdClient.fetch('test_pipe', {});
             
-            should.equal(result, null);
+            assert.equal(result, null);
             mockRequest.get.calledOnce.should.be.true();
         });
         
@@ -242,7 +243,7 @@ describe('Tinybird Client', function () {
             
             const result = await tinybirdClient.fetch('test_pipe', {});
             
-            should.equal(result, null);
+            assert.equal(result, null);
             mockRequest.get.calledOnce.should.be.true();
         });
     });

--- a/ghost/core/test/unit/server/services/stripe/config.test.js
+++ b/ghost/core/test/unit/server/services/stripe/config.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const UrlUtils = require('@tryghost/url-utils');
@@ -48,7 +49,7 @@ describe('Stripe - config', function () {
         };
         const config = getConfig({settingsHelpers, config: configUtils.config, urlUtils: {}});
 
-        should.equal(config, null);
+        assert.equal(config, null);
     });
 
     it('Includes the subdirectory in the webhookHandlerUrl', function () {
@@ -60,9 +61,9 @@ describe('Stripe - config', function () {
 
         const config = getConfig({settingsHelpers, config: configUtils.config, urlUtils: fakeUrlUtils});
 
-        should.equal(config.secretKey, 'direct_secret');
-        should.equal(config.publicKey, 'direct_publishable');
-        should.equal(config.webhookHandlerUrl, 'http://site.com/subdir/members/webhooks/stripe/');
+        assert.equal(config.secretKey, 'direct_secret');
+        assert.equal(config.publicKey, 'direct_publishable');
+        assert.equal(config.webhookHandlerUrl, 'http://site.com/subdir/members/webhooks/stripe/');
 
         should.exist(config.checkoutSessionSuccessUrl);
         should.exist(config.checkoutSessionCancelUrl);

--- a/ghost/core/test/unit/server/services/stripe/stripe-api.test.js
+++ b/ghost/core/test/unit/server/services/stripe/stripe-api.test.js
@@ -267,7 +267,7 @@ describe('StripeAPI', function () {
             it('returns null if customer exists', async function () {
                 const stripeCustomerId = await api.getCustomerIdByEmail(mockCustomerEmail);
 
-                assert.equal(stripeCustomerId, null);
+                assert.equal(stripeCustomerId, undefined);
             });
         });
 

--- a/ghost/core/test/unit/server/services/stripe/stripe-api.test.js
+++ b/ghost/core/test/unit/server/services/stripe/stripe-api.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const should = require('should');
 const rewire = require('rewire');
@@ -70,14 +71,14 @@ describe('StripeAPI', function () {
 
             should.not.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.subscription_data.trial_from_plan);
             should.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.subscription_data.trial_period_days);
-            should.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.subscription_data.trial_period_days, 12);
+            assert.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.subscription_data.trial_period_days, 12);
         });
 
         it('uses trial_from_plan without trialDays', async function () {
             await api.createCheckoutSession('priceId', null, {});
 
             should.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.subscription_data.trial_from_plan);
-            should.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.subscription_data.trial_from_plan, true);
+            assert.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.subscription_data.trial_from_plan, true);
             should.not.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.subscription_data.trial_period_days);
         });
 
@@ -87,7 +88,7 @@ describe('StripeAPI', function () {
             });
 
             should.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.subscription_data.trial_from_plan);
-            should.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.subscription_data.trial_from_plan, true);
+            assert.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.subscription_data.trial_from_plan, true);
             should.not.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.subscription_data.trial_period_days);
         });
 
@@ -97,7 +98,7 @@ describe('StripeAPI', function () {
             });
 
             should.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.subscription_data.trial_from_plan);
-            should.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.subscription_data.trial_from_plan, true);
+            assert.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.subscription_data.trial_from_plan, true);
             should.not.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.subscription_data.trial_period_days);
         });
 
@@ -113,7 +114,7 @@ describe('StripeAPI', function () {
             });
 
             should.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.customer);
-            should.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.customer, 'cust_mock_123456');
+            assert.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.customer, 'cust_mock_123456');
         });
 
         it('passes email if no customer object provided', async function () {
@@ -123,7 +124,7 @@ describe('StripeAPI', function () {
             });
 
             should.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.customer_email);
-            should.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.customer_email, 'foo@example.com');
+            assert.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.customer_email, 'foo@example.com');
         });
 
         it('passes email if customer object provided w/o ID', async function () {
@@ -137,7 +138,7 @@ describe('StripeAPI', function () {
             });
 
             should.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.customer_email);
-            should.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.customer_email, 'foo@example.com');
+            assert.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.customer_email, 'foo@example.com');
         });
 
         it('passes only one of customer ID and email', async function () {
@@ -153,7 +154,7 @@ describe('StripeAPI', function () {
 
             should.not.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.customer_email);
             should.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.customer);
-            should.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.customer, 'cust_mock_123456');
+            assert.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.customer, 'cust_mock_123456');
         });
 
         it('passes attribution data to the subscription metadata if provided', async function () {
@@ -238,7 +239,7 @@ describe('StripeAPI', function () {
             mockLabsIsSet.withArgs('additionalPaymentMethods').returns(true);
             await api.createCheckoutSetupSession('priceId', {currency: 'usd'});
 
-            should.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.currency, 'usd');
+            assert.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.currency, 'usd');
         });
     });
 
@@ -266,7 +267,7 @@ describe('StripeAPI', function () {
             it('returns null if customer exists', async function () {
                 const stripeCustomerId = await api.getCustomerIdByEmail(mockCustomerEmail);
 
-                should.equal(stripeCustomerId, null);
+                assert.equal(stripeCustomerId, null);
             });
         });
 
@@ -295,7 +296,7 @@ describe('StripeAPI', function () {
             it('returns customer ID if customer exists', async function () {
                 const stripeCustomerId = await api.getCustomerIdByEmail(mockCustomerEmail);
 
-                should.equal(stripeCustomerId, mockCustomerId);
+                assert.equal(stripeCustomerId, mockCustomerId);
             });
         });
 
@@ -345,7 +346,7 @@ describe('StripeAPI', function () {
             it('returns the customer with the most recent subscription', async function () {
                 const stripeCustomerId = await api.getCustomerIdByEmail(mockCustomerEmail);
 
-                should.equal(stripeCustomerId, 'recent_customer_id');
+                assert.equal(stripeCustomerId, 'recent_customer_id');
             });
         });
     });
@@ -374,9 +375,9 @@ describe('StripeAPI', function () {
         it('cancels a subscription trial', async function () {
             const result = await api.cancelSubscriptionTrial(mockSubscription.id);
 
-            should.equal(mockStripe.subscriptions.update.callCount, 1);
+            assert.equal(mockStripe.subscriptions.update.callCount, 1);
 
-            should.equal(mockStripe.subscriptions.update.args[0][0], mockSubscription.id);
+            assert.equal(mockStripe.subscriptions.update.args[0][0], mockSubscription.id);
             should.deepEqual(mockStripe.subscriptions.update.args[0][1], {trial_end: 'now'});
 
             should.deepEqual(result, mockSubscription);
@@ -414,8 +415,8 @@ describe('StripeAPI', function () {
         it('adds a coupon to a subscription', async function () {
             const result = await api.addCouponToSubscription('sub_123', 'coupon_abc');
 
-            should.equal(mockStripe.subscriptions.update.callCount, 1);
-            should.equal(mockStripe.subscriptions.update.args[0][0], 'sub_123');
+            assert.equal(mockStripe.subscriptions.update.callCount, 1);
+            assert.equal(mockStripe.subscriptions.update.args[0][0], 'sub_123');
             should.deepEqual(mockStripe.subscriptions.update.args[0][1], {coupon: 'coupon_abc'});
 
             should.deepEqual(result, mockSubscription);
@@ -549,7 +550,7 @@ describe('StripeAPI', function () {
             });
 
             should.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.customer);
-            should.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.customer, mockCustomerId);
+            assert.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.customer, mockCustomerId);
         });
 
         it('passes customer_email when no customer object is provided', async function () {
@@ -562,7 +563,7 @@ describe('StripeAPI', function () {
             });
 
             should.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.customer_email);
-            should.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.customer_email, mockCustomerEmail);
+            assert.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.customer_email, mockCustomerEmail);
         });
 
         it('uses only customer when both customer and customerEmail are provided', async function () {
@@ -582,7 +583,7 @@ describe('StripeAPI', function () {
             });
 
             should.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.customer);
-            should.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.customer, mockCustomerId);
+            assert.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.customer, mockCustomerId);
             should.not.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.customer_email);
         });
 
@@ -616,7 +617,7 @@ describe('StripeAPI', function () {
 
             should.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.custom_fields);
             const customFields = mockStripe.checkout.sessions.create.firstCall.firstArg.custom_fields;
-            should.equal(customFields.length, 1);
+            assert.equal(customFields.length, 1);
         });
 
         it('has correct data for custom field message', async function () {

--- a/ghost/core/test/unit/server/services/stripe/stripe-api.test.js
+++ b/ghost/core/test/unit/server/services/stripe/stripe-api.test.js
@@ -264,7 +264,7 @@ describe('StripeAPI', function () {
                 sinon.restore();
             });
 
-            it('returns null if customer exists', async function () {
+            it('returns undefined', async function () {
                 const stripeCustomerId = await api.getCustomerIdByEmail(mockCustomerEmail);
 
                 assert.equal(stripeCustomerId, undefined);

--- a/ghost/core/test/unit/server/services/themes/validate.test.js
+++ b/ghost/core/test/unit/server/services/themes/validate.test.js
@@ -53,7 +53,7 @@ describe('Themes', function () {
                     formatStub.calledOnce.should.be.true();
                     checkedTheme.should.be.an.Object();
 
-                    should.equal(validate.canActivate(checkedTheme), true);
+                    assert.equal(validate.canActivate(checkedTheme), true);
                 });
         });
 
@@ -69,7 +69,7 @@ describe('Themes', function () {
                     formatStub.calledOnce.should.be.true();
                     checkedTheme.should.be.an.Object();
 
-                    should.equal(validate.canActivate(checkedTheme), true);
+                    assert.equal(validate.canActivate(checkedTheme), true);
                 });
         });
 
@@ -98,7 +98,7 @@ describe('Themes', function () {
                     checkStub.callCount.should.be.equal(0);
                     formatStub.calledOnce.should.be.true();
 
-                    should.equal(validate.canActivate(checkedTheme), false);
+                    assert.equal(validate.canActivate(checkedTheme), false);
                 });
         });
 
@@ -127,7 +127,7 @@ describe('Themes', function () {
                     checkZipStub.callCount.should.be.equal(0);
                     formatStub.calledOnce.should.be.true();
 
-                    should.equal(validate.canActivate(checkedTheme), false);
+                    assert.equal(validate.canActivate(checkedTheme), false);
                 });
         });
 

--- a/ghost/core/test/unit/server/services/url/local-file-cache.test.js
+++ b/ghost/core/test/unit/server/services/url/local-file-cache.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const fs = require('fs-extra');
@@ -33,7 +34,7 @@ describe('Unit: services/url/LocalFileCache', function () {
 
             const cachedUrls = await localFileCache.read('urls');
 
-            should.equal(cachedUrls, null);
+            assert.equal(cachedUrls, null);
         });
 
         it('returns null when the cache file is malformatted', async function () {
@@ -49,7 +50,7 @@ describe('Unit: services/url/LocalFileCache', function () {
 
             const cachedUrls = await localFileCache.read('urls');
 
-            should.equal(cachedUrls, null);
+            assert.equal(cachedUrls, null);
         });
     });
 
@@ -81,7 +82,7 @@ describe('Unit: services/url/LocalFileCache', function () {
 
             const result = await localFileCache.write('urls', {data: 'test'});
 
-            should.equal(result, null);
+            assert.equal(result, null);
             writeFileStub.called.should.equal(false);
         });
     });

--- a/ghost/core/test/unit/server/web/api/canary/content/middleware.test.js
+++ b/ghost/core/test/unit/server/web/api/canary/content/middleware.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const middleware = require('../../../../../../../core/server/web/api/endpoints/content/middleware');
 
@@ -11,7 +12,7 @@ describe('Content API middleware', function () {
             const firstMiddleware = middleware.authenticatePublic[0];
             const brute = require('../../../../../../../core/server/web/shared/middleware/brute');
 
-            should.equal(firstMiddleware, brute.contentApiKey);
+            assert.equal(firstMiddleware, brute.contentApiKey);
         });
     });
 });

--- a/ghost/core/test/unit/server/web/api/middleware/cors.test.js
+++ b/ghost/core/test/unit/server/web/api/middleware/cors.test.js
@@ -1,4 +1,3 @@
-const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const rewire = require('rewire');
@@ -46,7 +45,7 @@ describe('cors', function () {
 
         cors(req, res, next);
 
-        next.called.should.be.true();
+        sinon.assert.calledOnce(next);
         should.not.exist(res.headers['Access-Control-Allow-Origin']);
 
         done();
@@ -61,7 +60,7 @@ describe('cors', function () {
 
         cors(req, res, next);
 
-        res.end.called.should.be.true();
+        sinon.assert.calledOnce(res.end);
         res.headers['Access-Control-Allow-Origin'].should.equal(origin);
 
         done();
@@ -76,7 +75,7 @@ describe('cors', function () {
 
         cors(req, res, next);
 
-        res.end.called.should.be.true();
+        sinon.assert.calledOnce(res.end);
         res.headers['Access-Control-Allow-Origin'].should.equal(origin);
 
         done();
@@ -91,7 +90,7 @@ describe('cors', function () {
 
         cors(req, res, next);
 
-        next.called.should.be.true();
+        sinon.assert.calledOnce(next);
         should.not.exist(res.headers['Access-Control-Allow-Origin']);
 
         done();
@@ -108,7 +107,7 @@ describe('cors', function () {
 
         cors(req, res, next);
 
-        res.end.called.should.be.true();
+        sinon.assert.calledOnce(res.end);
         res.headers['Access-Control-Allow-Origin'].should.equal(origin);
 
         done();
@@ -130,7 +129,7 @@ describe('cors', function () {
 
         cors(req, res, next);
 
-        res.end.called.should.be.true();
+        sinon.assert.called(res.end);
         res.headers['Access-Control-Allow-Origin'].should.equal(origin);
 
         done();
@@ -138,8 +137,8 @@ describe('cors', function () {
 
     it('should add origin value to the vary header', function (done) {
         corsCaching(req, res, function () {
-            assert.equal(res.vary.called, true);
-            assert.equal(res.vary.args[0], 'Origin');
+            sinon.assert.calledOnce(res.vary);
+            sinon.assert.calledWith(res.vary, 'Origin');
             done();
         });
     });
@@ -147,7 +146,7 @@ describe('cors', function () {
     it('should NOT add origin value to the vary header when not an OPTIONS request', function (done) {
         req.method = 'GET';
         corsCaching(req, res, function () {
-            assert.equal(res.vary.called, false);
+            sinon.assert.notCalled(res.vary);
             done();
         });
     });

--- a/ghost/core/test/unit/server/web/api/middleware/cors.test.js
+++ b/ghost/core/test/unit/server/web/api/middleware/cors.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const rewire = require('rewire');
@@ -137,8 +138,8 @@ describe('cors', function () {
 
     it('should add origin value to the vary header', function (done) {
         corsCaching(req, res, function () {
-            should.equal(res.vary.called, true);
-            should.equal(res.vary.args[0], 'Origin');
+            assert.equal(res.vary.called, true);
+            assert.equal(res.vary.args[0], 'Origin');
             done();
         });
     });
@@ -146,7 +147,7 @@ describe('cors', function () {
     it('should NOT add origin value to the vary header when not an OPTIONS request', function (done) {
         req.method = 'GET';
         corsCaching(req, res, function () {
-            should.equal(res.vary.called, false);
+            assert.equal(res.vary.called, false);
             done();
         });
     });

--- a/ghost/core/test/unit/server/web/api/middleware/update-user-last-seen.test.js
+++ b/ghost/core/test/unit/server/web/api/middleware/update-user-last-seen.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const moment = require('moment');
@@ -10,7 +11,7 @@ describe('updateUserLastSeenMiddleware', function () {
 
     it('calls next with no error if there is no user on the request', function (done) {
         updateUserLastSeenMiddleware({}, {}, function next(err) {
-            should.equal(err, undefined);
+            assert.equal(err, undefined);
             done();
         });
     });
@@ -21,7 +22,7 @@ describe('updateUserLastSeenMiddleware', function () {
             get: sinon.stub().withArgs('last_seen').returns(fakeLastSeen)
         };
         updateUserLastSeenMiddleware({user: fakeUser}, {}, function next(err) {
-            should.equal(err, undefined);
+            assert.equal(err, undefined);
             done();
         });
     });
@@ -34,8 +35,8 @@ describe('updateUserLastSeenMiddleware', function () {
                 updateLastSeen: sinon.stub().resolves()
             };
             updateUserLastSeenMiddleware({user: fakeUser}, {}, function next(err) {
-                should.equal(err, undefined);
-                should.equal(fakeUser.updateLastSeen.callCount, 1);
+                assert.equal(err, undefined);
+                assert.equal(fakeUser.updateLastSeen.callCount, 1);
                 done();
             });
         });
@@ -48,8 +49,8 @@ describe('updateUserLastSeenMiddleware', function () {
                 updateLastSeen: sinon.stub().rejects(fakeError)
             };
             updateUserLastSeenMiddleware({user: fakeUser}, {}, function next(err) {
-                should.equal(err, fakeError);
-                should.equal(fakeUser.updateLastSeen.callCount, 1);
+                assert.equal(err, fakeError);
+                assert.equal(fakeUser.updateLastSeen.callCount, 1);
                 done();
             });
         });


### PR DESCRIPTION
This test-only change should have no user impact.

This change is split into two commits:

- Commit 1: replace `should.equal()` with `assert.equal()` across the codebase. Uses `sed`, and then imports `node:assert/strict` where relevant.
- Commit 2: manual cleanups to fix that change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Tests
  - Standardized the test suite to use Node.js strict assertions for consistency.
  - Tightened a few expectations (e.g., null → undefined) to match stricter checks.
  - No changes to runtime behavior or public APIs; test logic preserved.

- Refactor
  - Modernized test code to improve maintainability without altering functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor with minimal logic impact; risk is limited to potential assertion semantic differences causing flaky or newly-failing tests.
> 
> **Overview**
> Standardizes the test suite to use Node’s strict assertions by importing `node:assert/strict` and replacing many `should.equal()` calls with `assert.equal()` across e2e, integration, legacy, and unit tests.
> 
> Includes minor follow-up fixes to keep tests passing under stricter semantics (notably adjusting an importer test expectation for a lexical post’s `mobiledoc` to be `undefined` rather than `null`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 81fc4a8e06c9b18024f36d4a6b98ad668db20cc7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->