### PR TITLE
Added manage preferences link to member welcome email

### DIFF
--- a/ghost/core/core/server/services/member-welcome-emails/email-templates/wrapper.hbs
+++ b/ghost/core/core/server/services/member-welcome-emails/email-templates/wrapper.hbs
@@ -332,6 +332,16 @@
                 </td>
               </tr>
             </table>
+            <table border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;">
+              <tr>
+                <td style="border-top: 1px solid #EEF5F8; padding-top: 24px;"></td>
+              </tr>
+              <tr>
+                <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 11px; color: #738A94; font-weight: normal; line-height: 16px; vertical-align: top; padding-top: 12px; text-align: center;">
+                  {{siteTitle}} &copy; {{year}} &mdash; <a class="small" href="{{managePreferencesUrl}}" style="text-decoration: underline; text-underline-offset: 2px; color: #738A94; font-size: 11px;">Manage your preferences</a>
+                </td>
+              </tr>
+            </table>
           </div>
         </td>
         <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top;">&nbsp;</td>

--- a/ghost/core/core/server/services/member-welcome-emails/member-welcome-email-renderer.js
+++ b/ghost/core/core/server/services/member-welcome-emails/member-welcome-email-renderer.js
@@ -99,12 +99,17 @@ class MemberWelcomeEmailRenderer {
         const contentWithReplacements = this.#applyReplacements({text: content, member, siteSettings, escapeHtml: true});
         const subjectWithReplacements = this.#applyReplacements({text: subject, member, siteSettings, escapeHtml: false});
 
+        const managePreferencesUrl = new URL('#/portal/account', siteSettings.url).href;
+        const year = new Date().getFullYear();
+
         const html = this.#wrapperTemplate({
             content: contentWithReplacements,
             subject: subjectWithReplacements,
             siteTitle: siteSettings.title,
             siteUrl: siteSettings.url,
-            accentColor: siteSettings.accentColor
+            accentColor: siteSettings.accentColor,
+            managePreferencesUrl,
+            year
         });
 
         const inlinedHtml = juice(html, {inlinePseudoElements: true, removeStyleTags: true});

--- a/ghost/core/core/server/services/member-welcome-emails/member-welcome-email-renderer.js
+++ b/ghost/core/core/server/services/member-welcome-emails/member-welcome-email-renderer.js
@@ -99,7 +99,7 @@ class MemberWelcomeEmailRenderer {
         const contentWithReplacements = this.#applyReplacements({text: content, member, siteSettings, escapeHtml: true});
         const subjectWithReplacements = this.#applyReplacements({text: subject, member, siteSettings, escapeHtml: false});
 
-        const managePreferencesUrl = new URL('#/portal/account', siteSettings.url).href;
+        const managePreferencesUrl = new URL('#/portal/account/newsletters', siteSettings.url).href;
         const year = new Date().getFullYear();
 
         const html = this.#wrapperTemplate({

--- a/ghost/core/test/unit/server/services/member-welcome-emails/member-welcome-email-renderer.test.js
+++ b/ghost/core/test/unit/server/services/member-welcome-emails/member-welcome-email-renderer.test.js
@@ -210,6 +210,7 @@ describe('MemberWelcomeEmailRenderer', function () {
         it('wraps content in wrapper.hbs template', async function () {
             lexicalRenderStub.resolves('<p>Content</p>');
             const renderer = new MemberWelcomeEmailRenderer();
+            const year = new Date().getFullYear();
 
             const result = await renderer.render({
                 lexical: '{}',
@@ -221,6 +222,10 @@ describe('MemberWelcomeEmailRenderer', function () {
             result.html.should.containEql('<!doctype html>');
             result.html.should.containEql('<title>Test Subject</title>');
             result.html.should.containEql('>Content</p>');
+            result.html.should.containEql('Test Site');
+            result.html.should.containEql(`&copy; ${year}`);
+            result.html.should.containEql('Manage your preferences');
+            result.html.should.containEql('https://example.com/#/portal/account');
         });
 
         it('generates plain text from HTML', async function () {


### PR DESCRIPTION
closes [NY-988: Add footer to welcome emails](https://linear.app/ghost/issue/NY-988/add-footer-to-welcome-emails)

- Adds a "Manage Preferences" link to the bottom of welcome emails
- This is a transactional email so there's not really anything for users to unsubscribe from, but they can at least have a familiar path to updating their preferences for newsletters
<img width="562" height="576" alt="Screenshot 2026-02-03 at 2 34 07 PM" src="https://github.com/user-attachments/assets/029e4195-9780-4dee-a9c2-2f35670f4325" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely presentational email-template changes plus a deterministic URL/year addition, with limited blast radius outside welcome email rendering.
> 
> **Overview**
> Member welcome emails now include a small footer under the content with a divider, `{{siteTitle}} © {{year}}`, and a **Manage your preferences** link.
> 
> The renderer now injects `managePreferencesUrl` (built from `siteSettings.url` to `#/portal/account/newsletters`) and the current year into the wrapper template, and unit tests assert the footer content and link are present.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 363ab7f0e7e38505ecadb41d0801a635df190544. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Member welcome emails now include a footer with site branding, current year, and a "Manage your preferences" link for controlling email preferences.

* **Tests**
  * Added tests to verify the footer renders correctly, including site name, copyright year, and the preferences link.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->