### PR TITLE
Removed sniperlink TODOs that have already been completed

### DIFF
--- a/apps/portal/src/actions.js
+++ b/apps/portal/src/actions.js
@@ -92,7 +92,6 @@ async function signin({data, api, state}) {
             page: 'magiclink',
             lastPage: 'signin',
             ...(otcRef ? {otcRef} : {}),
-            // TODO: Display these sniperlinks in the UI. See NY-946.
             sniperLinks,
             pageData: {
                 ...(state.pageData || {}),
@@ -124,7 +123,6 @@ function startSigninOTCFromCustomForm({data, state}) {
         page: 'magiclink',
         lastPage: 'signin',
         otcRef,
-        // TODO: Display these sniperlinks in the UI. See NY-946.
         sniperLinks,
         pageData: {
             ...(state.pageData || {}),


### PR DESCRIPTION
ref NY-946

This change should have no user impact. Just changing comments.

I forgot to remove these comments when I finished this ticket. This removes them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed internal comments from code to improve maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->