### PR TITLE
Added logging for sniper links

### DIFF
--- a/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
+++ b/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
@@ -738,6 +738,9 @@ module.exports = class RouterController {
             });
             if (sniperLinks) {
                 resBody.sniperLinks = sniperLinks;
+                logging.info(`[Sniperlinks] Found sniper links for provider ${sniperLinks.provider}`);
+            } else {
+                logging.info('[Sniperlinks] Found no sniper links');
             }
 
             res.writeHead(201, {'Content-Type': 'application/json'});


### PR DESCRIPTION
This change should have no user impact.

Logs things like "Found sniper links for provider proton" or "Found no sniper links".


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added debug logging to the Signup/Signin flow to capture provider information when available and log when data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->