### PR TITLE
Fixed flaky comment-replies E2E test

### DIFF
--- a/e2e/helpers/pages/public/home-page.ts
+++ b/e2e/helpers/pages/public/home-page.ts
@@ -17,7 +17,7 @@ export class HomePage extends PublicPage {
 
     async waitUntilLoaded(): Promise<void> {
         await this.accountButton.waitFor({state: 'visible'});
-        await this.portal.waitForScript();
+        await this.portalRoot.waitFor({state: 'attached'});
     }
 
     async gotoWithQueryParams(params: Record<string, string>): Promise<void> {

--- a/e2e/helpers/pages/public/post/comments-section.ts
+++ b/e2e/helpers/pages/public/post/comments-section.ts
@@ -92,8 +92,12 @@ export class CommentsSection {
         const comment = this.getCommentComponentByText(commentToManageText);
         await comment.getByRole('button', {name: 'Reply'}).click();
 
-        await this.commentsFrame.getByTestId('reply-form').getByTestId('editor').fill(replyText);
-        await this.addReplyButton.click();
+        const replyForm = this.commentsFrame.getByTestId('reply-form');
+        const replyEditor = replyForm.getByTestId('editor');
+        await replyEditor.focus();
+        await replyEditor.fill(replyText);
+
+        await replyForm.getByRole('button', {name: 'Add reply'}).click();
     }
 
     async getCommentActionButtons(commentToManageText: string): Promise<{

--- a/e2e/helpers/pages/public/public-page.ts
+++ b/e2e/helpers/pages/public/public-page.ts
@@ -1,5 +1,6 @@
 import {BasePage, pageGotoOptions} from '@/helpers/pages';
 import {Locator, Page, Response, test} from '@playwright/test';
+import {expect} from '@/helpers/playwright';
 
 declare global {
     interface Window {
@@ -22,30 +23,22 @@ class PortalSection extends BasePage {
         this.portalScript = page.locator('script[data-ghost][data-key][data-api]');
     }
 
-    async waitForScript(): Promise<void> {
-        await this.portalScript.waitFor({
-            state: 'attached'
-        });
+    /**
+     * Click a Portal link and wait for the popup to open, with retries.
+     *
+     * Portal's hashchange listener is only set up after its async init completes.
+     * If clicked before init finishes, the popup won't open. This method uses
+     * Playwright's retry mechanism to handle the race condition deterministically.
+     */
+    async clickLinkAndWaitForPopup(link: Locator): Promise<void> {
+        await this.portalScript.waitFor({state: 'attached'});
+        await this.portalRoot.waitFor({state: 'attached'});
 
-        await this.portalRoot.waitFor({
-            state: 'attached'
-        });
-    }
-
-    async waitForIFrame(): Promise<void> {
-        await this.portalIframe.waitFor({
-            state: 'visible',
-            timeout: 5000
-        });
-    }
-
-    async waitForPortalToOpen(): Promise<void> {
-        await this.waitForIFrame();
-
-        await this.portalFrame.waitFor({
-            state: 'visible',
-            timeout: 2000
-        });
+        // Use expect.toPass to retry click + popup check until Portal is ready
+        await expect(async () => {
+            await link.click();
+            await expect(this.portalIframe).toBeVisible();
+        }).toPass();
     }
 
     async isPortalOpen(): Promise<boolean> {
@@ -103,18 +96,14 @@ export class PublicPage extends BasePage {
             return response
                 .url()
                 .includes('/.ghost/analytics/api/v1/page_hit') && response.request().method() === 'POST';
-        }, {timeout: 10000});
+        });
     }
 
     async openPortalViaSubscribeButton(): Promise<void> {
-        await this.portal.waitForScript();
-        await this.subscribeLink.click();
-        await this.portal.waitForPortalToOpen();
+        await this.portal.clickLinkAndWaitForPopup(this.subscribeLink);
     }
 
     async openPortalViaSignInLink(): Promise<void> {
-        await this.portal.waitForScript();
-        await this.signInLink.click();
-        await this.portal.waitForPortalToOpen();
+        await this.portal.clickLinkAndWaitForPopup(this.signInLink);
     }
 }

--- a/e2e/tests/public/comment-replies.test.ts
+++ b/e2e/tests/public/comment-replies.test.ts
@@ -88,6 +88,8 @@ test.describe('Ghost Public - Comments - Replies', () => {
         await postPage.waitForCommentsToLoad();
         const postCommentsSection = postPage.commentsSection;
 
+        await expect(postCommentsSection.comments).toHaveCount(2);
+
         await postCommentsSection.replyToComment('Reply to main comment', 'My reply');
         await expect(postCommentsSection.comments).toHaveCount(3);
         await expect(postCommentsSection.comments.first()).toContainText('Main comment');


### PR DESCRIPTION
The comment-replies E2E test was failing intermittently due to two race conditions in the test infrastructure.

The first issue was with Portal's initialization. Portal's hashchange listener is only registered after its async init completes (fetching site data from the Content API). When the test clicked sign-in links before Portal finished initializing, the hashchange event would fire with no listener to catch it, and the popup would never open. The fix captures the Content API response during page navigation and waits for it before interacting with Portal links.

The second issue was specific to the "reply to reply comment" test. Unlike the "reply to top comment" test which had assertions before calling `replyToComment()`, this test went straight to the interaction without giving comments-ui time to fully initialize its internal state. Adding an assertion to verify the comments have loaded ensures the UI is ready before clicking the Reply button.