### PR TITLE
Removed `announcementBar` feature flag

### DIFF
--- a/apps/admin-x-framework/src/test/acceptance.ts
+++ b/apps/admin-x-framework/src/test/acceptance.ts
@@ -83,7 +83,6 @@ export const responseFixtures = {
 const defaultLabFlags = {
     collections: false,
     outboundLinkTagging: false,
-    announcementBar: false,
     members: false
 };
 

--- a/ghost/admin/app/services/feature.js
+++ b/ghost/admin/app/services/feature.js
@@ -62,7 +62,6 @@ export default class FeatureService extends Service {
     // labs flags
     @feature('stripeAutomaticTax') stripeAutomaticTax;
     @feature('emailCustomization') emailCustomization;
-    @feature('announcementBar') announcementBar;
     @feature('importMemberTier') importMemberTier;
     @feature('lexicalIndicators') lexicalIndicators;
     @feature('editorExcerpt') editorExcerpt;

--- a/ghost/core/core/server/web/members/app.js
+++ b/ghost/core/core/server/web/members/app.js
@@ -6,7 +6,6 @@ const membersService = require('../../services/members');
 const stripeService = require('../../services/stripe');
 const middleware = membersService.middleware;
 const shared = require('../shared');
-const labs = require('../../../shared/labs');
 const errorHandler = require('@tryghost/mw-error-handler');
 const config = require('../../../shared/config');
 const {http} = require('@tryghost/api-framework');
@@ -132,7 +131,6 @@ module.exports = function setupMembersApp() {
     // Announcement
     membersApp.use(
         '/api/announcement',
-        labs.enabledMiddleware('announcementBar'),
         middleware.loadMemberSession,
         announcementRouter()
     );

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -21,7 +21,6 @@ const messages = {
 
 // flags in this list always return `true`, allows quick global enable prior to full flag removal
 const GA_FEATURES = [
-    'announcementBar',
     'customFonts',
     'explore',
     'commentModeration',

--- a/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
@@ -10,7 +10,6 @@ Object {
     "environment": StringMatching /\\^testing/,
     "labs": Object {
       "additionalPaymentMethods": true,
-      "announcementBar": true,
       "commentModeration": true,
       "customFonts": true,
       "editorExcerpt": true,

--- a/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
@@ -1675,7 +1675,7 @@ exports[`Settings API Edit can edit Stripe settings when Stripe Connect limit is
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "5148",
+  "content-length": "5123",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,


### PR DESCRIPTION
ref f9f5f72752722ae835efbe871e1c9c7a4359a827

*This change should have no user impact.*

The `announcementBar` feature flag has been enabled since 2023. We can remove the flag and assume it's always on.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small flag-removal change that mainly deletes gating and updates tests; risk is limited to unintentionally exposing `/api/announcement` where it was previously blocked by misconfiguration.
> 
> **Overview**
> Removes the `announcementBar` labs feature flag from the admin feature service and from shared labs GA flag handling.
> 
> The members `/api/announcement` route is no longer protected by `labs.enabledMiddleware('announcementBar')`, and related test fixtures/snapshots are updated to stop expecting or setting the flag in config/labs payloads.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f61501548cdab44fdceedac806783dd65fd56eef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->