### PR TITLE
Add modal showing who reported a comment to moderation screens

### DIFF
--- a/apps/admin-x-framework/src/api/comments.ts
+++ b/apps/admin-x-framework/src/api/comments.ts
@@ -5,6 +5,7 @@ import {
     createMutation,
     createQueryWithId
 } from '../utils/api/hooks';
+import {Member} from './members';
 
 export type Comment = {
     id: string;
@@ -17,13 +18,7 @@ export type Comment = {
     parent_id: string | null;
     in_reply_to_id?: string | null;
     in_reply_to_snippet?: string | null;
-    member?: {
-        id: string;
-        name: string;
-        email: string;
-        avatar_image?: string;
-        can_comment?: boolean;
-    };
+    member?: Member;
     post?: {
         id: string;
         title: string;
@@ -39,6 +34,15 @@ export type Comment = {
     };
     // Optional nested replies for tree structures
     replies?: Comment[];
+};
+
+export type CommentReport = {
+    id: string;
+    comment_id: string;
+    member_id: string;
+    created_at: string;
+    updated_at: string;
+    member?: Member;
 };
 
 export interface CommentsResponseType {
@@ -140,3 +144,17 @@ export const useReadComment = createQueryWithId<CommentsResponseType>({
         include: 'member,post,count.replies,count.likes,count.reports,parent'
     }
 });
+
+export interface CommentReportsResponseType {
+    meta?: Meta;
+    comment_reports: CommentReport[];
+}
+
+const useBrowseCommentReportsQuery = createQueryWithId<CommentReportsResponseType>({
+    dataType: 'CommentReportsResponseType',
+    path: id => `/comments/${id}/reports/`
+});
+
+export const useBrowseCommentReports = (commentId: string, options?: {enabled?: boolean}) => {
+    return useBrowseCommentReportsQuery(commentId, {...options});
+};

--- a/apps/admin-x-framework/src/api/members.ts
+++ b/apps/admin-x-framework/src/api/members.ts
@@ -2,15 +2,21 @@ import {Meta, createMutation, createQuery} from '../utils/api/hooks';
 
 export type Member = {
     id: string;
+    transient_id: string;
+    uuid: string;
     name?: string;
     email?: string;
     avatar_image?: string;
+    last_seen_at: string | null;
+    last_commented_at: string | null;
     can_comment?: boolean;
     commenting?: {
         disabled: boolean;
         disabled_reason?: string;
         disabled_until?: string;
     };
+    created_at: string;
+    updated_at: string;
 };
 
 export interface MembersResponseType {

--- a/apps/posts/src/views/comments/components/comment-reports-modal.tsx
+++ b/apps/posts/src/views/comments/components/comment-reports-modal.tsx
@@ -1,0 +1,109 @@
+import {
+    Button,
+    Dialog,
+    DialogContent,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    LoadingIndicator,
+    LucideIcon,
+    formatTimestamp
+} from '@tryghost/shade';
+import {Comment, useBrowseCommentReports} from '@tryghost/admin-x-framework/api/comments';
+import {CommentAvatar} from './comment-avatar';
+
+interface CommentReportsModalProps {
+    comment: Comment;
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+}
+
+function CommentReportsModal({comment, open, onOpenChange}: CommentReportsModalProps) {
+    const {data, isLoading} = useBrowseCommentReports(comment.id, {enabled: open});
+    const reports = data?.comment_reports ?? [];
+    const reportCount = comment.count?.reports ?? reports.length;
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent aria-describedby={undefined}>
+                <DialogHeader>
+                    <DialogTitle>
+                        {reportCount} {reportCount === 1 ? 'report' : 'reports'}
+                    </DialogTitle>
+                </DialogHeader>
+
+                {/* Comment context */}
+                <div className="overflow-hidden rounded-md border p-3 opacity-60">
+                    <div className="flex min-w-0 items-start gap-3">
+                        <CommentAvatar
+                            avatarImage={comment.member?.avatar_image}
+                            className="shrink-0"
+                            memberId={comment.member?.id}
+                        />
+                        <div className="flex min-w-0 flex-col overflow-hidden">
+                            <div className="flex min-w-0 items-center gap-1 text-sm">
+                                <span className="shrink-0 font-semibold">
+                                    {comment.member?.name || 'Unknown'}
+                                </span>
+                                <LucideIcon.Dot className="shrink-0 text-muted-foreground/50" size={16} />
+                                <span className="shrink-0 text-muted-foreground">
+                                    {comment.created_at && formatTimestamp(comment.created_at)}
+                                </span>
+                                <span className="shrink-0 text-muted-foreground">on</span>
+                                <span className="min-w-0 truncate font-medium text-gray-800 dark:text-gray-400">
+                                    {comment.post?.title || 'Unknown post'}
+                                </span>
+                            </div>
+                            <div
+                                dangerouslySetInnerHTML={{__html: comment.html || ''}}
+                                className="prose mt-2 line-clamp-2 text-sm [&_*]:text-sm [&_*]:leading-[1.5em] [&_p]:m-0"
+                            />
+                        </div>
+                    </div>
+                </div>
+
+                {/* Reporters list */}
+                <div className="-mx-1 max-h-64 overflow-y-auto px-1">
+                    {isLoading ? (
+                        <div className="flex justify-center py-4">
+                            <LoadingIndicator size="md" />
+                        </div>
+                    ) : (
+                        <div className="flex flex-col gap-3 pb-1">
+                            {reports.map(report => (
+                                <div key={report.id} className="flex items-center justify-between gap-3">
+                                    <div className="flex items-center gap-3">
+                                        <div className="relative shrink-0">
+                                            <CommentAvatar
+                                                avatarImage={report.member?.avatar_image}
+                                                memberId={report.member?.id}
+                                            />
+                                            {/* Red flag overlay */}
+                                            <div className="absolute -bottom-0.5 -right-0.5 flex size-4 items-center justify-center rounded-full bg-red text-white">
+                                                <LucideIcon.Flag className="size-2.5" fill="currentColor" />
+                                            </div>
+                                        </div>
+                                        <span className="font-medium">
+                                            {report.member?.name || 'Deleted member'}
+                                        </span>
+                                    </div>
+                                    <span className="shrink-0 text-sm text-muted-foreground">
+                                        {formatTimestamp(report.created_at)}
+                                    </span>
+                                </div>
+                            ))}
+                        </div>
+                    )}
+                </div>
+
+                <DialogFooter>
+                    <Button onClick={() => onOpenChange(false)}>
+                        OK
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}
+
+export default CommentReportsModal;

--- a/apps/posts/src/views/comments/components/comment-thread-list.tsx
+++ b/apps/posts/src/views/comments/components/comment-thread-list.tsx
@@ -95,11 +95,8 @@ function CommentRow({comment, isReply = false, onThreadClick, commentPermalinksE
                                 </Button>
                             )}
                             <CommentMetrics
-                                hasReplies={hasReplies}
-                                likesCount={comment.count?.likes}
-                                repliesCount={comment.count?.replies}
-                                reportsCount={comment.count?.reports}
-                                onRepliesClick={hasReplies ? () => onThreadClick(comment.id) : undefined}
+                                comment={comment}
+                                onRepliesClick={() => onThreadClick(comment.id)}
                             />
                             <CommentMenu
                                 comment={comment}

--- a/apps/posts/src/views/comments/components/comments-list.tsx
+++ b/apps/posts/src/views/comments/components/comments-list.tsx
@@ -140,8 +140,6 @@ function CommentsList({
                             return <PlaceholderRow key={key} {...props} />;
                         }
 
-                        const hasReplies = (item.count?.replies ?? 0) > 0;
-
                         return (
                             <div
                                 key={key}
@@ -214,10 +212,7 @@ function CommentsList({
                                             )}
                                             <CommentMetrics
                                                 className="ml-2"
-                                                hasReplies={hasReplies}
-                                                likesCount={item.count?.likes}
-                                                repliesCount={item.count?.replies}
-                                                reportsCount={item.count?.reports}
+                                                comment={item}
                                                 onRepliesClick={() => handleOpenThread(item.id)}
                                             />
                                             <CommentMenu

--- a/ghost/core/core/server/api/endpoints/comment-reports.js
+++ b/ghost/core/core/server/api/endpoints/comment-reports.js
@@ -1,0 +1,34 @@
+// Endpoint for the admin API to return reporters for a comment
+
+const commentsService = require('../../services/comments');
+
+/** @type {import('@tryghost/api-framework').Controller} */
+const controller = {
+    docName: 'comment_reports',
+    browse: {
+        headers: {
+            cacheInvalidate: false
+        },
+        options: [
+            'id',
+            'page',
+            'limit'
+        ],
+        validation: {
+            options: {
+                id: {
+                    required: true
+                }
+            }
+        },
+        // Use comment permissions - browsing reports is part of comment moderation
+        permissions: {
+            docName: 'comments'
+        },
+        query(frame) {
+            return commentsService.controller.getCommentReporters(frame);
+        }
+    }
+};
+
+module.exports = controller;

--- a/ghost/core/core/server/api/endpoints/index.js
+++ b/ghost/core/core/server/api/endpoints/index.js
@@ -213,6 +213,10 @@ module.exports = {
         return apiFramework.pipeline(require('./comment-replies'), localUtils);
     },
 
+    get commentReports() {
+        return apiFramework.pipeline(require('./comment-reports'), localUtils);
+    },
+
     get links() {
         return apiFramework.pipeline(require('./links'), localUtils);
     },

--- a/ghost/core/core/server/services/comments/comments-controller.js
+++ b/ghost/core/core/server/services/comments/comments-controller.js
@@ -349,4 +349,16 @@ module.exports = class CommentsController {
             frame.options?.context?.member
         );
     }
+
+    /**
+     * Get reporters for a specific comment (admin only)
+     * @param {Frame} frame
+     */
+    async getCommentReporters(frame) {
+        const commentId = frame.options.id;
+        return await this.service.getCommentReporters(commentId, {
+            page: frame.options.page,
+            limit: frame.options.limit
+        });
+    }
 };

--- a/ghost/core/core/server/services/comments/comments-service.js
+++ b/ghost/core/core/server/services/comments/comments-service.js
@@ -233,6 +233,22 @@ class CommentsService {
     }
 
     /**
+     * Get reporters for a comment (admin only)
+     * @param {string} commentId - The ID of the Comment to get reporters for
+     * @param {any} options - Query options (page, limit)
+     */
+    async getCommentReporters(commentId, options = {}) {
+        const page = await this.models.CommentReport.findPage({
+            filter: `comment_id:'${commentId}'`,
+            withRelated: ['member'],
+            order: 'created_at desc',
+            ...options
+        });
+
+        return page;
+    }
+
+    /**
      * @param {string} id - The ID of the Comment to get
      * @param {any} options
      */

--- a/ghost/core/core/server/services/comments/comments-service.js
+++ b/ghost/core/core/server/services/comments/comments-service.js
@@ -238,14 +238,23 @@ class CommentsService {
      * @param {any} options - Query options (page, limit)
      */
     async getCommentReporters(commentId, options = {}) {
-        const page = await this.models.CommentReport.findPage({
+        const comment = await this.models.Comment.findOne({id: commentId});
+        if (!comment) {
+            throw new errors.NotFoundError({
+                message: tpl(messages.commentNotFound)
+            });
+        }
+
+        const {page, limit} = options;
+        const result = await this.models.CommentReport.findPage({
             filter: `comment_id:'${commentId}'`,
             withRelated: ['member'],
             order: 'created_at desc',
-            ...options
+            page,
+            limit
         });
 
-        return page;
+        return result;
     }
 
     /**

--- a/ghost/core/core/server/web/api/endpoints/admin/routes.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/routes.js
@@ -46,6 +46,7 @@ module.exports = function apiRoutes() {
     router.get('/comments', mw.authAdminApi, http(api.comments.browseAll));
     router.get('/comments/:id', mw.authAdminApi, http(api.commentReplies.read));
     router.get('/comments/:id/replies', mw.authAdminApi, http(api.commentReplies.browse));
+    router.get('/comments/:id/reports', mw.authAdminApi, http(api.commentReports.browse));
     router.get('/comments/post/:post_id', mw.authAdminApi, http(api.comments.browse));
     router.post('/comments', mw.authAdminApi, http(api.comments.add));
     router.put('/comments/:id', mw.authAdminApi, http(api.comments.edit));

--- a/ghost/core/test/e2e-api/admin/__snapshots__/comments.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/comments.test.js.snap
@@ -874,6 +874,123 @@ Object {
 }
 `;
 
+exports[`Admin Comments API Comment Reports Can browse reporters for a comment 1: [body] 1`] = `
+Object {
+  "comment_reports": Array [
+    Object {
+      "comment_id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "member": Object {
+        "avatar_image": null,
+        "can_comment": true,
+        "commenting": Object {
+          "disabled": false,
+          "disabled_reason": null,
+          "disabled_until": null,
+        },
+        "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+        "email": "member2@test.com",
+        "email_count": 0,
+        "email_disabled": false,
+        "email_open_rate": 50,
+        "email_opened_count": 0,
+        "enable_comment_notifications": true,
+        "expertise": null,
+        "geolocation": null,
+        "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+        "last_commented_at": Nullable<StringMatching>,
+        "last_seen_at": Nullable<StringMatching>,
+        "name": null,
+        "note": null,
+        "status": "free",
+        "transient_id": Any<String>,
+        "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+        "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      },
+      "member_id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+    },
+    Object {
+      "comment_id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "member": Object {
+        "avatar_image": null,
+        "can_comment": true,
+        "commenting": Object {
+          "disabled": false,
+          "disabled_reason": null,
+          "disabled_until": null,
+        },
+        "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+        "email": "paid@test.com",
+        "email_count": 0,
+        "email_disabled": false,
+        "email_open_rate": 80,
+        "email_opened_count": 0,
+        "enable_comment_notifications": true,
+        "expertise": null,
+        "geolocation": null,
+        "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+        "last_commented_at": Nullable<StringMatching>,
+        "last_seen_at": Nullable<StringMatching>,
+        "name": "Egon Spengler",
+        "note": null,
+        "status": "paid",
+        "transient_id": Any<String>,
+        "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+        "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      },
+      "member_id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+    },
+  ],
+  "meta": Object {
+    "pagination": Object {
+      "limit": 15,
+      "next": null,
+      "page": 1,
+      "pages": 1,
+      "prev": null,
+      "total": 2,
+    },
+  },
+}
+`;
+
+exports[`Admin Comments API Comment Reports Returns 404 for non-existent comment 1: [body] 1`] = `
+Object {
+  "comment_reports": Array [],
+  "meta": Object {
+    "pagination": Object {
+      "limit": 15,
+      "next": null,
+      "page": 1,
+      "pages": 1,
+      "prev": null,
+      "total": 0,
+    },
+  },
+}
+`;
+
+exports[`Admin Comments API Comment Reports Returns empty list for comment with no reports 1: [body] 1`] = `
+Object {
+  "comment_reports": Array [],
+  "meta": Object {
+    "pagination": Object {
+      "limit": 15,
+      "next": null,
+      "page": 1,
+      "pages": 1,
+      "prev": null,
+      "total": 0,
+    },
+  },
+}
+`;
+
 exports[`Admin Comments API Hide Can hide comments 1: [body] 1`] = `
 Object {
   "comments": Array [

--- a/ghost/core/test/e2e-api/admin/__snapshots__/comments.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/comments.test.js.snap
@@ -961,17 +961,19 @@ Object {
 
 exports[`Admin Comments API Comment Reports Returns 404 for non-existent comment 1: [body] 1`] = `
 Object {
-  "comment_reports": Array [],
-  "meta": Object {
-    "pagination": Object {
-      "limit": 15,
-      "next": null,
-      "page": 1,
-      "pages": 1,
-      "prev": null,
-      "total": 0,
+  "errors": Array [
+    Object {
+      "code": null,
+      "context": "Comment could not be found",
+      "details": null,
+      "ghostErrorCode": null,
+      "help": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "Resource not found error, cannot list comment_reports.",
+      "property": null,
+      "type": "NotFoundError",
     },
-  },
+  ],
 }
 `;
 

--- a/ghost/core/test/e2e-api/admin/comments.test.js
+++ b/ghost/core/test/e2e-api/admin/comments.test.js
@@ -7,7 +7,7 @@ const {
     dbUtils,
     matchers
 } = require('../../utils/e2e-framework');
-const {anyEtag, anyObjectId, anyISODateTime, anyUuid, anyNumber, anyBoolean, anyString, nullable} = matchers;
+const {anyEtag, anyErrorId, anyObjectId, anyISODateTime, anyUuid, anyNumber, anyBoolean, anyString, nullable} = matchers;
 const models = require('../../../core/server/models');
 const db = require('../../../core/server/data/db');
 const security = require('@tryghost/security');
@@ -1682,9 +1682,11 @@ describe(`Admin Comments API`, function () {
             const fakeCommentId = '507f1f77bcf86cd799439011';
 
             await adminApi.get(`/comments/${fakeCommentId}/reports/`)
-                .expectStatus(200)
+                .expectStatus(404)
                 .matchBodySnapshot({
-                    comment_reports: []
+                    errors: [{
+                        id: anyErrorId
+                    }]
                 });
         });
     });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3196/

- added `useBrowseCommentReports` hook to admin-x-framework
- added `CommentReportsModal` component
- refactored `CommentMetrics`
  - extracted `Metric` sub-component to reduce duplication
  - removed unnecessary `hasReplies` prop, replaced with calculated value inside the component
  - replaced individual `xCount` props with a single `comment` prop
- wired up reports modal inside `CommentMetrics`
  - uses `<Dialog>` underneath so there's no DOM overhead from rendering in every `CommentMetrics` component
  - localizing modal control to the metrics component was preferable to splitting logic across comment and threads list components and requiring callback prop drilling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added comment reports interface to view and browse reports on individual comments with reporter details, avatars, and timestamps
  * Extended member information with additional tracking fields including creation and activity dates

* **Improvements**
  * Enhanced comment metrics component with streamlined API design for improved maintainability
<!-- end of auto-generated comment: release notes by coderabbit.ai -->