### PR TITLE
Replaced `should.deepEqual()` with `assert.deepEqual()`

### DIFF
--- a/ghost/core/test/e2e-api/admin/members.test.js
+++ b/ghost/core/test/e2e-api/admin/members.test.js
@@ -1768,8 +1768,8 @@ describe('Members API', function () {
         }
 
         // Check for this member with a paid subscription that the body results for the patch, get and browse endpoints are 100% identical
-        should.deepEqual(browseMember, readMember, 'Browsing a member returns a different format than reading a member');
-        should.deepEqual(memberWithPaidSubscription, readMember, 'Editing a member returns a different format than reading a member');
+        assert.deepEqual(browseMember, readMember, 'Browsing a member returns a different format than reading a member');
+        assert.deepEqual(memberWithPaidSubscription, readMember, 'Editing a member returns a different format than reading a member');
     });
 
     it('Cannot add unknown tiers to a member', async function () {

--- a/ghost/core/test/legacy/api/admin/settings.test.js
+++ b/ghost/core/test/legacy/api/admin/settings.test.js
@@ -32,7 +32,7 @@ describe('Settings API', function () {
 
         // Check if not changed (also check internal ones)
         const afterValue = settingsCache.get(key);
-        should.deepEqual(afterValue, expectedValue);
+        assert.deepEqual(afterValue, expectedValue);
     }
 
     async function checkCantEdit(key, value) {
@@ -59,7 +59,7 @@ describe('Settings API', function () {
 
         // Check if not changed (also check internal ones)
         const afterValue = settingsCache.get(key);
-        should.deepEqual(afterValue, currentValue);
+        assert.deepEqual(afterValue, currentValue);
     }
 
     describe('As Owner', function () {

--- a/ghost/core/test/unit/frontend/meta/keywords.test.js
+++ b/ghost/core/test/unit/frontend/meta/keywords.test.js
@@ -23,7 +23,7 @@ describe('getKeywords', function () {
                 ]
             }
         });
-        should.deepEqual(keywords, ['one', 'two', 'three']);
+        assert.deepEqual(keywords, ['one', 'two', 'three']);
     });
 
     it('should only return visible tags', function () {
@@ -37,7 +37,7 @@ describe('getKeywords', function () {
                 ]
             }
         });
-        should.deepEqual(keywords, ['one', 'three']);
+        assert.deepEqual(keywords, ['one', 'three']);
     });
 
     it('should return null if post has tags is empty array', function () {

--- a/ghost/core/test/unit/frontend/meta/schema.test.js
+++ b/ghost/core/test/unit/frontend/meta/schema.test.js
@@ -94,7 +94,7 @@ describe('getSchema', function () {
 
         const schema = getSchema(metadata, data);
 
-        should.deepEqual(schema, {
+        assert.deepEqual(schema, {
             '@context': 'https://schema.org',
             '@type': 'Article',
             author: {
@@ -195,7 +195,7 @@ describe('getSchema', function () {
 
         const schema = getSchema(metadata, data);
 
-        should.deepEqual(schema, {
+        assert.deepEqual(schema, {
             '@context': 'https://schema.org',
             '@type': 'Article',
             author: {
@@ -276,7 +276,7 @@ describe('getSchema', function () {
 
         const schema = getSchema(metadata, data);
 
-        should.deepEqual(schema, {
+        assert.deepEqual(schema, {
             '@context': 'https://schema.org',
             '@type': 'Article',
             author: {
@@ -344,7 +344,7 @@ describe('getSchema', function () {
 
         const schema = getSchema(metadata, data);
 
-        should.deepEqual(schema, {
+        assert.deepEqual(schema, {
             '@context': 'https://schema.org',
             '@type': 'Article',
             author: {
@@ -408,7 +408,7 @@ describe('getSchema', function () {
 
         const schema = getSchema(metadata, data);
 
-        should.deepEqual(schema, {
+        assert.deepEqual(schema, {
             '@context': 'https://schema.org',
             '@type': 'WebSite',
             description: 'This is the theme description',
@@ -455,7 +455,7 @@ describe('getSchema', function () {
 
         const schema = getSchema(metadata, data);
 
-        should.deepEqual(schema, {
+        assert.deepEqual(schema, {
             '@context': 'https://schema.org',
             '@type': 'Series',
             description: 'This is the tag description!',
@@ -505,7 +505,7 @@ describe('getSchema', function () {
 
         const schema = getSchema(metadata, data);
 
-        should.deepEqual(schema, {
+        assert.deepEqual(schema, {
             '@context': 'https://schema.org',
             '@type': 'Person',
             description: 'This is the author description!',
@@ -560,7 +560,7 @@ describe('getSchema', function () {
 
         const schema = getSchema(metadata, data);
 
-        should.deepEqual(schema, {
+        assert.deepEqual(schema, {
             '@context': 'https://schema.org',
             '@type': 'Person',
             description: 'This is the author description!',
@@ -608,7 +608,7 @@ describe('getSchema', function () {
 
         const schema = getSchema(metadata, data);
 
-        should.deepEqual(schema, {
+        assert.deepEqual(schema, {
             '@context': 'https://schema.org',
             '@type': 'Person',
             description: 'This is the author description!',
@@ -647,7 +647,7 @@ describe('getSchema', function () {
         const expectedSameAs = buildExpectedSameAs('http://myblogsite.com/', USERNAMES);
 
         const schema = getSchema(metadata, data);
-        should.deepEqual(schema.author.sameAs, expectedSameAs);
+        assert.deepEqual(schema.author.sameAs, expectedSameAs);
     });
 
     it('should include all supported social links in sameAs for author context', function () {
@@ -672,7 +672,7 @@ describe('getSchema', function () {
         const expectedSameAs = buildExpectedSameAs('http://myblogsite.com/', USERNAMES);
 
         const schema = getSchema(metadata, data);
-        should.deepEqual(schema.sameAs, expectedSameAs);
+        assert.deepEqual(schema.sameAs, expectedSameAs);
     });
 
     it('should escape special characters in social platform urls', function () {
@@ -697,7 +697,7 @@ describe('getSchema', function () {
         const expectedSameAs = buildExpectedSameAs('http://myblogsite.com/', {facebook: 'user&#x3D;name&#x3D;'});
 
         const schema = getSchema(metadata, data);
-        should.deepEqual(schema.sameAs, expectedSameAs);
+        assert.deepEqual(schema.sameAs, expectedSameAs);
     });
 
     it('should return null if not a supported type', function () {
@@ -705,7 +705,7 @@ describe('getSchema', function () {
         const data = {};
         const schema = getSchema(metadata, data);
 
-        should.deepEqual(schema, null);
+        assert.deepEqual(schema, null);
     });
 
     // Contributors tests
@@ -772,7 +772,7 @@ describe('getSchema', function () {
         const schema = getSchema(metadata, data);
 
         should.exist(schema.contributor);
-        should.deepEqual(schema.contributor, [
+        assert.deepEqual(schema.contributor, [
             {
                 '@type': 'Person',
                 name: 'Co-Author',
@@ -828,7 +828,7 @@ describe('getSchema', function () {
 
         should.exist(schema.contributor);
         assert.equal(schema.contributor.length, 2);
-        should.deepEqual(schema.contributor[0], {
+        assert.deepEqual(schema.contributor[0], {
             '@type': 'Person',
             name: 'Co-Author 1',
             url: 'http://mysite.com/author/co-author-1/',
@@ -837,7 +837,7 @@ describe('getSchema', function () {
                 'https://x.com/coauthor1'
             ]
         });
-        should.deepEqual(schema.contributor[1], {
+        assert.deepEqual(schema.contributor[1], {
             '@type': 'Person',
             name: 'Co-Author 2',
             url: 'http://mysite.com/author/co-author-2/',
@@ -877,7 +877,7 @@ describe('getSchema', function () {
         const schema = getSchema(metadata, data);
 
         should.exist(schema.contributor);
-        should.deepEqual(schema.contributor[0].sameAs, expectedSameAs);
+        assert.deepEqual(schema.contributor[0].sameAs, expectedSameAs);
     });
 
     it('should handle contributors with missing or null data', function () {
@@ -912,7 +912,7 @@ describe('getSchema', function () {
         const schema = getSchema(metadata, data);
 
         should.exist(schema.contributor);
-        should.deepEqual(schema.contributor[0], {
+        assert.deepEqual(schema.contributor[0], {
             '@type': 'Person',
             name: 'Co-Author',
             url: 'http://mysite.com/author/co-author/',
@@ -953,7 +953,7 @@ describe('getSchema', function () {
         const schema = getSchema(metadata, data);
 
         should.exist(schema.contributor);
-        should.deepEqual(schema.contributor[0], {
+        assert.deepEqual(schema.contributor[0], {
             '@type': 'Person',
             name: 'Co-Author',
             url: 'http://mysite.com/author/co-author/',
@@ -991,7 +991,7 @@ describe('getSchema', function () {
         const schema = getSchema(metadata, data);
 
         should.exist(schema.contributor);
-        should.deepEqual(schema.contributor[0].sameAs, [
+        assert.deepEqual(schema.contributor[0].sameAs, [
             'http://coauthorsite.com/?user&#x3D;name&amp;param&#x3D;&lt;script&gt;alert(&quot;test&quot;)&lt;/script&gt;',
             'https://www.facebook.com/user&#x3D;name&#x3D;'
         ]);

--- a/ghost/core/test/unit/frontend/meta/structured-data.test.js
+++ b/ghost/core/test/unit/frontend/meta/structured-data.test.js
@@ -1,4 +1,4 @@
-const should = require('should');
+const assert = require('node:assert/strict');
 const getStructuredData = require('../../../../core/frontend/meta/structured-data');
 
 describe('getStructuredData', function () {
@@ -38,7 +38,7 @@ describe('getStructuredData', function () {
 
         const structuredData = getStructuredData(metadata);
 
-        should.deepEqual(structuredData, {
+        assert.deepEqual(structuredData, {
             'article:modified_time': '2016-01-21T22:13:05.412Z',
             'article:published_time': '2015-12-25T05:35:01.234Z',
             'article:tag': ['one', 'two', 'tag'],
@@ -100,7 +100,7 @@ describe('getStructuredData', function () {
 
         const structuredData = getStructuredData(metadata);
 
-        should.deepEqual(structuredData, {
+        assert.deepEqual(structuredData, {
             'article:modified_time': '2016-01-21T22:13:05.412Z',
             'article:published_time': '2015-12-25T05:35:01.234Z',
             'article:tag': ['one', 'two', 'tag'],
@@ -160,7 +160,7 @@ describe('getStructuredData', function () {
 
         const structuredData = getStructuredData(metadata);
 
-        should.deepEqual(structuredData, {
+        assert.deepEqual(structuredData, {
             'article:modified_time': '2016-01-21T22:13:05.412Z',
             'og:site_name': 'Site Title',
             'og:title': 'Post Title',

--- a/ghost/core/test/unit/frontend/services/theme-engine/middleware.test.js
+++ b/ghost/core/test/unit/frontend/services/theme-engine/middleware.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const hbs = require('../../../../../core/frontend/services/theme-engine/engine');
@@ -163,9 +164,9 @@ describe('Themes middleware', function () {
                     data.config.posts_per_page.should.eql(2);
 
                     // Check labs config
-                    should.deepEqual(data.labs, fakeLabsData);
+                    assert.deepEqual(data.labs, fakeLabsData);
 
-                    should.deepEqual(data.site, {
+                    assert.deepEqual(data.site, {
                         ...fakeSiteData,
 
                         // signup_url should get added
@@ -176,7 +177,7 @@ describe('Themes middleware', function () {
                         comments_access: 'all'
                     });
 
-                    should.deepEqual(data.custom, fakeCustomThemeSettingsData);
+                    assert.deepEqual(data.custom, fakeCustomThemeSettingsData);
 
                     done();
                 } catch (error) {

--- a/ghost/core/test/unit/frontend/src/privacy.test.js
+++ b/ghost/core/test/unit/frontend/src/privacy.test.js
@@ -65,7 +65,7 @@ describe('Privacy Utils', function () {
             const result = maskSensitiveData(payload);
             const parsed = JSON.parse(result);
             
-            should.deepEqual(parsed, {});
+            assert.deepEqual(parsed, {});
         });
     });
 
@@ -135,7 +135,7 @@ describe('Privacy Utils', function () {
             const result = processPayload(payload, globalAttributes);
             const parsed = JSON.parse(result);
             
-            should.deepEqual(parsed, {});
+            assert.deepEqual(parsed, {});
         });
     });
 }); 

--- a/ghost/core/test/unit/server/data/exporter/index.test.js
+++ b/ghost/core/test/unit/server/data/exporter/index.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const errors = require('@tryghost/errors');
@@ -221,7 +222,7 @@ describe('Exporter', function () {
 
             // NOTE: this test is serving a role of a reminder to have a look into exported tables allowlists
             //       if it failed you probably need to add or remove a table entry from table-lists module
-            should.deepEqual(actualTables, expectedTables);
+            assert.deepEqual(actualTables, expectedTables);
         });
 
         it('should be fixed when default settings is changed', function () {

--- a/ghost/core/test/unit/server/models/base/crud.test.js
+++ b/ghost/core/test/unit/server/models/base/crud.test.js
@@ -32,7 +32,7 @@ describe('Models: crud', function () {
                 assert.equal(filterOptionsSpy.args[0][0], unfilteredOptions);
                 assert.equal(filterOptionsSpy.args[0][1], 'destroy');
 
-                should.deepEqual(forgeStub.args[0][0], {
+                assert.deepEqual(forgeStub.args[0][0], {
                     prop: 'whatever'
                 });
 
@@ -59,7 +59,7 @@ describe('Models: crud', function () {
                 assert.equal(filterOptionsSpy.args[0][0], unfilteredOptions);
                 assert.equal(filterOptionsSpy.args[0][1], 'destroy');
 
-                should.deepEqual(forgeStub.args[0][0], {
+                assert.deepEqual(forgeStub.args[0][0], {
                     id: 23
                 });
 
@@ -99,7 +99,7 @@ describe('Models: crud', function () {
                 assert.equal(filterDataSpy.args[0][0], data);
 
                 const filteredData = filterDataSpy.returnValues[0];
-                should.deepEqual(forgeStub.args[0][0], filteredData);
+                assert.deepEqual(forgeStub.args[0][0], filteredData);
 
                 const filteredOptions = filterOptionsSpy.returnValues[0];
                 assert.equal(fetchStub.args[0][0], filteredOptions);
@@ -158,7 +158,7 @@ describe('Models: crud', function () {
                 assert.equal(filterDataSpy.args[0][0], data);
 
                 const filteredOptions = filterOptionsSpy.returnValues[0];
-                should.deepEqual(forgeStub.args[0][0], {id: filteredOptions.id});
+                assert.deepEqual(forgeStub.args[0][0], {id: filteredOptions.id});
 
                 assert.equal(fetchStub.args[0][0], filteredOptions);
                 assert.equal(fetchStub.args[0][0].lock, undefined);
@@ -166,7 +166,7 @@ describe('Models: crud', function () {
                 const filteredData = filterDataSpy.returnValues[0];
                 assert.equal(saveStub.args[0][0], filteredData);
                 assert.equal(saveStub.args[0][1].method, 'update');
-                should.deepEqual(saveStub.args[0][1], filteredOptions);
+                assert.deepEqual(saveStub.args[0][1], filteredOptions);
             });
         });
 
@@ -251,12 +251,12 @@ describe('Models: crud', function () {
                 assert.equal(filterDataSpy.args[0][0], data);
 
                 const filteredData = filterDataSpy.returnValues[0];
-                should.deepEqual(forgeStub.args[0][0], filteredData);
+                assert.deepEqual(forgeStub.args[0][0], filteredData);
 
                 const filteredOptions = filterOptionsSpy.returnValues[0];
                 assert.equal(saveStub.args[0][0], null);
                 assert.equal(saveStub.args[0][1].method, 'insert');
-                should.deepEqual(saveStub.args[0][1], filteredOptions);
+                assert.deepEqual(saveStub.args[0][1], filteredOptions);
             });
         });
 

--- a/ghost/core/test/unit/server/models/integration.test.js
+++ b/ghost/core/test/unit/server/models/integration.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const models = require('../../../../core/server/models');
@@ -23,12 +24,12 @@ describe('Unit: models/integration', function () {
 
         it('returns the base permittedOptions result', function () {
             const returnedOptions = models.Integration.permittedOptions();
-            should.deepEqual(returnedOptions, basePermittedOptionsReturnVal);
+            assert.deepEqual(returnedOptions, basePermittedOptionsReturnVal);
         });
 
         it('returns the base permittedOptions result plus "filter" when methodName is findOne', function () {
             const returnedOptions = models.Integration.permittedOptions('findOne');
-            should.deepEqual(returnedOptions, basePermittedOptionsReturnVal.concat('filter'));
+            assert.deepEqual(returnedOptions, basePermittedOptionsReturnVal.concat('filter'));
         });
     });
 

--- a/ghost/core/test/unit/server/models/session.test.js
+++ b/ghost/core/test/unit/server/models/session.test.js
@@ -89,19 +89,19 @@ describe('Unit: models/session', function () {
         it('returns the base permittedOptions result', function () {
             const returnedOptions = models.Session.permittedOptions();
 
-            should.deepEqual(returnedOptions, basePermittedOptionsReturnVal);
+            assert.deepEqual(returnedOptions, basePermittedOptionsReturnVal);
         });
 
         it('returns the base permittedOptions result plus "session_id" when methodName is upsert', function () {
             const returnedOptions = models.Session.permittedOptions('upsert');
 
-            should.deepEqual(returnedOptions, basePermittedOptionsReturnVal.concat('session_id'));
+            assert.deepEqual(returnedOptions, basePermittedOptionsReturnVal.concat('session_id'));
         });
 
         it('returns the base permittedOptions result plus "session_id" when methodName is destroy', function () {
             const returnedOptions = models.Session.permittedOptions('destroy');
 
-            should.deepEqual(returnedOptions, basePermittedOptionsReturnVal.concat('session_id'));
+            assert.deepEqual(returnedOptions, basePermittedOptionsReturnVal.concat('session_id'));
         });
     });
 
@@ -137,7 +137,7 @@ describe('Unit: models/session', function () {
                 assert.equal(filterOptionsStub.args[0][0], unfilteredOptions);
                 assert.equal(filterOptionsStub.args[0][1], 'destroy');
 
-                should.deepEqual(forgeStub.args[0][0], {session_id});
+                assert.deepEqual(forgeStub.args[0][0], {session_id});
 
                 assert.equal(fetchStub.args[0][0], filteredOptions);
                 assert.equal(destroyStub.args[0][0], filteredOptions);
@@ -170,12 +170,12 @@ describe('Unit: models/session', function () {
                 assert.equal(filterOptionsStub.args[0][0], unfilteredOptions);
                 assert.equal(filterOptionsStub.args[0][1], 'upsert');
 
-                should.deepEqual(findOneStub.args[0][0], {
+                assert.deepEqual(findOneStub.args[0][0], {
                     session_id
                 });
                 assert.equal(findOneStub.args[0][1], filteredOptions);
 
-                should.deepEqual(addStub.args[0][0], {
+                assert.deepEqual(addStub.args[0][0], {
                     session_id: filteredOptions.session_id,
                     session_data: data.session_data,
                     user_id: data.session_data.user_id
@@ -209,16 +209,16 @@ describe('Unit: models/session', function () {
                 assert.equal(filterOptionsStub.args[0][0], unfilteredOptions);
                 assert.equal(filterOptionsStub.args[0][1], 'upsert');
 
-                should.deepEqual(findOneStub.args[0][0], {
+                assert.deepEqual(findOneStub.args[0][0], {
                     session_id
                 });
                 assert.equal(findOneStub.args[0][1], filteredOptions);
 
-                should.deepEqual(editStub.args[0][0], {
+                assert.deepEqual(editStub.args[0][0], {
                     session_data: data.session_data
                 });
 
-                should.deepEqual(editStub.args[0][1], {
+                assert.deepEqual(editStub.args[0][1], {
                     session_id,
                     id: model.id
                 });

--- a/ghost/core/test/unit/server/models/user.test.js
+++ b/ghost/core/test/unit/server/models/user.test.js
@@ -33,7 +33,7 @@ describe('Unit: models/user', function () {
 
             const returnVal = models.User.prototype.updateLastSeen.call(instance);
 
-            should.deepEqual(instance.set.args[0][0], {
+            assert.deepEqual(instance.set.args[0][0], {
                 last_seen: now
             });
 

--- a/ghost/core/test/unit/server/services/auth/session/store.test.js
+++ b/ghost/core/test/unit/server/services/auth/session/store.test.js
@@ -106,7 +106,7 @@ describe('Auth Service SessionStore', function () {
             const sid = 1;
             store.get(sid, function (err, session) {
                 assert.equal(err, null);
-                should.deepEqual(session, {
+                assert.deepEqual(session, {
                     ice: 'cube'
                 });
                 done();

--- a/ghost/core/test/unit/server/services/members/importer/members-csv-importer.test.js
+++ b/ghost/core/test/unit/server/services/members/importer/members-csv-importer.test.js
@@ -173,7 +173,7 @@ describe('MembersCSVImporter', function () {
             result.meta.stats.imported.should.equal(2);
 
             should.exist(result.meta.stats.invalid);
-            should.deepEqual(result.meta.import_label, internalLabel);
+            assert.deepEqual(result.meta.import_label, internalLabel);
 
             should.exist(result.meta.originalImportSize);
             result.meta.originalImportSize.should.equal(2);
@@ -185,7 +185,7 @@ describe('MembersCSVImporter', function () {
 
             assert.equal(membersRepositoryStub.create.args[0][1].context.import, true, 'inserts are done in the "import" context');
 
-            should.deepEqual(Object.keys(membersRepositoryStub.create.args[0][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'labels']);
+            assert.deepEqual(Object.keys(membersRepositoryStub.create.args[0][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'labels']);
             assert.equal(membersRepositoryStub.create.args[0][0].id, undefined, 'id field should not be taken from the user input');
             assert.equal(membersRepositoryStub.create.args[0][0].email, 'member_complimentary_test@example.com');
             assert.equal(membersRepositoryStub.create.args[0][0].name, 'bobby tables');
@@ -193,11 +193,11 @@ describe('MembersCSVImporter', function () {
             assert.equal(membersRepositoryStub.create.args[0][0].subscribed, true);
             assert.equal(membersRepositoryStub.create.args[0][0].created_at, '2022-10-18T06:34:08.000Z');
             assert.equal(membersRepositoryStub.create.args[0][0].deleted_at, undefined, 'deleted_at field should not be taken from the user input');
-            should.deepEqual(membersRepositoryStub.create.args[0][0].labels, [{
+            assert.deepEqual(membersRepositoryStub.create.args[0][0].labels, [{
                 name: 'user import label'
             }]);
 
-            should.deepEqual(Object.keys(membersRepositoryStub.create.args[1][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'labels']);
+            assert.deepEqual(Object.keys(membersRepositoryStub.create.args[1][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'labels']);
             assert.equal(membersRepositoryStub.create.args[1][0].id, undefined, 'id field should not be taken from the user input');
             assert.equal(membersRepositoryStub.create.args[1][0].email, 'member_stripe_test@example.com');
             assert.equal(membersRepositoryStub.create.args[1][0].name, 'stirpey beaver');
@@ -205,7 +205,7 @@ describe('MembersCSVImporter', function () {
             assert.equal(membersRepositoryStub.create.args[1][0].subscribed, false);
             assert.equal(membersRepositoryStub.create.args[1][0].created_at, '2022-10-18T07:31:57.000Z');
             assert.equal(membersRepositoryStub.create.args[1][0].deleted_at, undefined, 'deleted_at field should not be taken from the user input');
-            should.deepEqual(membersRepositoryStub.create.args[1][0].labels, [], 'no labels should be assigned');
+            assert.deepEqual(membersRepositoryStub.create.args[1][0].labels, [], 'no labels should be assigned');
 
             // stripe customer import
             membersRepositoryStub.linkStripeCustomer.calledOnce.should.be.true();
@@ -215,10 +215,10 @@ describe('MembersCSVImporter', function () {
 
             // complimentary_plan import
             membersRepositoryStub.update.calledOnce.should.be.true();
-            should.deepEqual(membersRepositoryStub.update.args[0][0].products, [{
+            assert.deepEqual(membersRepositoryStub.update.args[0][0].products, [{
                 id: defaultTierId.toString()
             }]);
-            should.deepEqual(membersRepositoryStub.update.args[0][1].id, 'test_member_id');
+            assert.deepEqual(membersRepositoryStub.update.args[0][1].id, 'test_member_id');
         });
 
         it('should subscribe or unsubscribe members as per the `subscribe_to_emails` column', async function () {
@@ -319,7 +319,7 @@ describe('MembersCSVImporter', function () {
             result.meta.stats.imported.should.equal(5);
 
             should.exist(result.meta.stats.invalid);
-            should.deepEqual(result.meta.import_label, internalLabel);
+            assert.deepEqual(result.meta.import_label, internalLabel);
 
             should.exist(result.meta.originalImportSize);
             result.meta.originalImportSize.should.equal(15);
@@ -333,105 +333,105 @@ describe('MembersCSVImporter', function () {
 
             // CASE 1: Existing member with at least one newsletter subscription, `subscribed_to_emails` column is true
             // Member's newsletter subscriptions should not change
-            should.deepEqual(Object.keys(membersRepositoryStub.update.args[0][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'labels', 'newsletters']);
+            assert.deepEqual(Object.keys(membersRepositoryStub.update.args[0][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'labels', 'newsletters']);
             assert.equal(membersRepositoryStub.update.args[0][0].email, 'member_subscribed_true@example.com');
             assert.equal(membersRepositoryStub.update.args[0][0].subscribed, true);
-            should.deepEqual(membersRepositoryStub.update.args[0][0].newsletters, defaultNewsletters);
+            assert.deepEqual(membersRepositoryStub.update.args[0][0].newsletters, defaultNewsletters);
 
             // CASE 2: Existing member with at least one newsletter subscription, `subscribed_to_emails` column is false
             // Member's newsletter subscriptions should be removed
-            should.deepEqual(Object.keys(membersRepositoryStub.update.args[1][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'labels']);
+            assert.deepEqual(Object.keys(membersRepositoryStub.update.args[1][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'labels']);
             assert.equal(membersRepositoryStub.update.args[1][0].email, 'member_subscribed_false@example.com');
             assert.equal(membersRepositoryStub.update.args[1][0].subscribed, false);
             assert.equal(membersRepositoryStub.update.args[1][0].newsletters, undefined);
 
             // CASE 3: Existing member with at least one newsletter subscription, `subscribed_to_emails` column is NULL
             // Member's newsletter subscriptions should not change
-            should.deepEqual(Object.keys(membersRepositoryStub.update.args[2][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'labels', 'newsletters']);
+            assert.deepEqual(Object.keys(membersRepositoryStub.update.args[2][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'labels', 'newsletters']);
             assert.equal(membersRepositoryStub.update.args[2][0].email, 'member_subscribed_null@example.com');
             assert.equal(membersRepositoryStub.update.args[2][0].subscribed, true);
-            should.deepEqual(membersRepositoryStub.update.args[2][0].newsletters, defaultNewsletters);
+            assert.deepEqual(membersRepositoryStub.update.args[2][0].newsletters, defaultNewsletters);
 
             // CASE 4: Existing member with at least one newsletter subscription, `subscribed_to_emails` column is empty
             // Member's newsletter subscriptions should not change
-            should.deepEqual(Object.keys(membersRepositoryStub.update.args[3][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'labels', 'newsletters']);
+            assert.deepEqual(Object.keys(membersRepositoryStub.update.args[3][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'labels', 'newsletters']);
             assert.equal(membersRepositoryStub.update.args[3][0].email, 'member_subscribed_empty@example.com');
             assert.equal(membersRepositoryStub.update.args[3][0].subscribed, true);
-            should.deepEqual(membersRepositoryStub.update.args[3][0].newsletters, defaultNewsletters);
+            assert.deepEqual(membersRepositoryStub.update.args[3][0].newsletters, defaultNewsletters);
 
             // CASE 5: Existing member with at least one newsletter subscription, `subscribed_to_emails` column is invalid
             // Member's newsletter subscriptions should not change
-            should.deepEqual(Object.keys(membersRepositoryStub.update.args[4][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'labels', 'newsletters']);
+            assert.deepEqual(Object.keys(membersRepositoryStub.update.args[4][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'labels', 'newsletters']);
             assert.equal(membersRepositoryStub.update.args[4][0].email, 'member_subscribed_invalid@example.com');
             assert.equal(membersRepositoryStub.update.args[4][0].subscribed, true);
-            should.deepEqual(membersRepositoryStub.update.args[4][0].newsletters, defaultNewsletters);
+            assert.deepEqual(membersRepositoryStub.update.args[4][0].newsletters, defaultNewsletters);
 
             // CASE 6: Existing member with no newsletter subscriptions, `subscribed_to_emails` column is true
             // Member should remain unsubscribed and not added to any newsletters
-            should.deepEqual(Object.keys(membersRepositoryStub.update.args[5][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'labels']);
+            assert.deepEqual(Object.keys(membersRepositoryStub.update.args[5][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'labels']);
             assert.equal(membersRepositoryStub.update.args[5][0].email, 'member_not_subscribed_true@example.com');
             assert.equal(membersRepositoryStub.update.args[5][0].subscribed, false);
             assert.equal(membersRepositoryStub.update.args[5][0].newsletters, undefined);
 
             // CASE 7: Existing member with no newsletter subscriptions, `subscribed_to_emails` column is false
             // Member should remain unsubscribed and not added to any newsletters
-            should.deepEqual(Object.keys(membersRepositoryStub.update.args[6][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'labels']);
+            assert.deepEqual(Object.keys(membersRepositoryStub.update.args[6][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'labels']);
             assert.equal(membersRepositoryStub.update.args[6][0].email, 'member_not_subscribed_false@example.com');
             assert.equal(membersRepositoryStub.update.args[6][0].subscribed, false);
             assert.equal(membersRepositoryStub.update.args[6][0].newsletters, undefined);
 
             // CASE 8: Existing member with no newsletter subscriptions, `subscribed_to_emails` column is NULL
             // Member should remain unsubscribed and not added to any newsletters
-            should.deepEqual(Object.keys(membersRepositoryStub.update.args[7][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'labels']);
+            assert.deepEqual(Object.keys(membersRepositoryStub.update.args[7][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'labels']);
             assert.equal(membersRepositoryStub.update.args[7][0].email, 'member_not_subscribed_null@example.com');
             assert.equal(membersRepositoryStub.update.args[7][0].subscribed, false);
             assert.equal(membersRepositoryStub.update.args[7][0].newsletters, undefined);
 
             // CASE 9: Existing member with no newsletter subscriptions, `subscribed_to_emails` column is empty
             // Member should remain unsubscribed and not added to any newsletters
-            should.deepEqual(Object.keys(membersRepositoryStub.update.args[8][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'labels']);
+            assert.deepEqual(Object.keys(membersRepositoryStub.update.args[8][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'labels']);
             assert.equal(membersRepositoryStub.update.args[8][0].email, 'member_not_subscribed_empty@example.com');
             assert.equal(membersRepositoryStub.update.args[8][0].subscribed, false);
             assert.equal(membersRepositoryStub.update.args[8][0].newsletters, undefined);
 
             // CASE 10: Existing member with no newsletter subscriptions, `subscribed_to_emails` column is invalid
             // Member should remain unsubscribed and not added to any newsletters
-            should.deepEqual(Object.keys(membersRepositoryStub.update.args[9][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'labels']);
+            assert.deepEqual(Object.keys(membersRepositoryStub.update.args[9][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'labels']);
             assert.equal(membersRepositoryStub.update.args[9][0].email, 'member_not_subscribed_invalid@example.com');
             assert.equal(membersRepositoryStub.update.args[9][0].subscribed, false);
             assert.equal(membersRepositoryStub.update.args[9][0].newsletters, undefined);
 
             // CASE 11: New member, `subscribed_to_emails` column is true
             // Member should be created and subscribed
-            should.deepEqual(Object.keys(membersRepositoryStub.create.args[0][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'labels']);
+            assert.deepEqual(Object.keys(membersRepositoryStub.create.args[0][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'labels']);
             assert.equal(membersRepositoryStub.create.args[0][0].email, 'new_member_true@example.com');
             assert.equal(membersRepositoryStub.create.args[0][0].subscribed, true);
             assert.equal(membersRepositoryStub.create.args[0][0].newsletters, undefined);
 
             // CASE 12: New member, `subscribed_to_emails` column is false
             // Member should be created but not subscribed
-            should.deepEqual(Object.keys(membersRepositoryStub.create.args[1][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'labels']);
+            assert.deepEqual(Object.keys(membersRepositoryStub.create.args[1][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'labels']);
             assert.equal(membersRepositoryStub.create.args[1][0].email, 'new_member_false@example.com');
             assert.equal(membersRepositoryStub.create.args[1][0].subscribed, false);
             assert.equal(membersRepositoryStub.create.args[1][0].newsletters, undefined);
 
             // CASE 13: New member, `subscribed_to_emails` column is NULL
             // Member should be created but not subscribed
-            should.deepEqual(Object.keys(membersRepositoryStub.create.args[2][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'labels']);
+            assert.deepEqual(Object.keys(membersRepositoryStub.create.args[2][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'labels']);
             assert.equal(membersRepositoryStub.create.args[2][0].email, 'new_member_null@example.com');
             assert.equal(membersRepositoryStub.create.args[2][0].subscribed, true);
             assert.equal(membersRepositoryStub.create.args[2][0].newsletters, undefined);
 
             // CASE 14: New member, `subscribed_to_emails` column is empty
             // Member should be created but not subscribed
-            should.deepEqual(Object.keys(membersRepositoryStub.create.args[3][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'labels']);
+            assert.deepEqual(Object.keys(membersRepositoryStub.create.args[3][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'labels']);
             assert.equal(membersRepositoryStub.create.args[3][0].email, 'new_member_empty@example.com');
             assert.equal(membersRepositoryStub.create.args[3][0].subscribed, true);
             assert.equal(membersRepositoryStub.create.args[3][0].newsletters, undefined);
 
             // CASE 15: New member, `subscribed_to_emails` column is invalid
             // Member should be created but not subscribed
-            should.deepEqual(Object.keys(membersRepositoryStub.create.args[4][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'labels']);
+            assert.deepEqual(Object.keys(membersRepositoryStub.create.args[4][0]), ['email', 'name', 'note', 'subscribed', 'created_at', 'labels']);
             assert.equal(membersRepositoryStub.create.args[4][0].email, 'new_member_invalid@example.com');
             assert.equal(membersRepositoryStub.create.args[4][0].subscribed, true);
             assert.equal(membersRepositoryStub.create.args[4][0].newsletters, undefined);

--- a/ghost/core/test/unit/server/services/stripe/stripe-api.test.js
+++ b/ghost/core/test/unit/server/services/stripe/stripe-api.test.js
@@ -47,14 +47,14 @@ describe('StripeAPI', function () {
         it('Sends card as payment method if labs flag not enabled', async function () {
             await api.createCheckoutSession('priceId', null, {});
 
-            should.deepEqual(mockStripe.checkout.sessions.create.firstCall.firstArg.payment_method_types, ['card']);
+            assert.deepEqual(mockStripe.checkout.sessions.create.firstCall.firstArg.payment_method_types, ['card']);
         });
 
         it('Sends no payment methods if labs flag is enabled', async function () {
             mockLabsIsSet.withArgs('additionalPaymentMethods').returns(true);
             await api.createCheckoutSession('priceId', null, {});
 
-            should.deepEqual(mockStripe.checkout.sessions.create.firstCall.firstArg.payment_method_types, undefined);
+            assert.deepEqual(mockStripe.checkout.sessions.create.firstCall.firstArg.payment_method_types, undefined);
         });
 
         it('sends success_url and cancel_url', async function () {
@@ -378,9 +378,9 @@ describe('StripeAPI', function () {
             assert.equal(mockStripe.subscriptions.update.callCount, 1);
 
             assert.equal(mockStripe.subscriptions.update.args[0][0], mockSubscription.id);
-            should.deepEqual(mockStripe.subscriptions.update.args[0][1], {trial_end: 'now'});
+            assert.deepEqual(mockStripe.subscriptions.update.args[0][1], {trial_end: 'now'});
 
-            should.deepEqual(result, mockSubscription);
+            assert.deepEqual(result, mockSubscription);
         });
     });
 
@@ -417,9 +417,9 @@ describe('StripeAPI', function () {
 
             assert.equal(mockStripe.subscriptions.update.callCount, 1);
             assert.equal(mockStripe.subscriptions.update.args[0][0], 'sub_123');
-            should.deepEqual(mockStripe.subscriptions.update.args[0][1], {coupon: 'coupon_abc'});
+            assert.deepEqual(mockStripe.subscriptions.update.args[0][1], {coupon: 'coupon_abc'});
 
-            should.deepEqual(result, mockSubscription);
+            assert.deepEqual(result, mockSubscription);
         });
     });
 
@@ -602,7 +602,7 @@ describe('StripeAPI', function () {
             });
 
             should.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.metadata);
-            should.deepEqual(mockStripe.checkout.sessions.create.firstCall.firstArg.metadata, metadata);
+            assert.deepEqual(mockStripe.checkout.sessions.create.firstCall.firstArg.metadata, metadata);
         });
 
         it('passes custom fields correctly', async function () {
@@ -631,7 +631,7 @@ describe('StripeAPI', function () {
             });
 
             const customFields = mockStripe.checkout.sessions.create.firstCall.firstArg.custom_fields;
-            should.deepEqual(customFields[0], {
+            assert.deepEqual(customFields[0], {
                 key: 'donation_message',
                 label: {
                     type: 'custom',


### PR DESCRIPTION
This test-only change should have no user impact.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
* Standardized test assertions across the codebase for consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->