### PR TITLE
Updated paid signup flow to skip redundant email when welcome email is active

### DIFF
--- a/ghost/core/core/server/services/lib/member-signup-contexts.ts
+++ b/ghost/core/core/server/services/lib/member-signup-contexts.ts
@@ -1,0 +1,20 @@
+// Signup context describes the sign-in state when the Stripe checkout session is created.
+// NEEDS_MAGIC_LINK_EMAIL: No guaranteed sign-in path exists yet (custom/direct checkout paths).
+// HAS_PRECHECKOUT_MAGIC_LINK: Ghost generated a signup magic-link before Stripe (standard Portal flow).
+// ALREADY_AUTHENTICATED: Request came from a signed-in member identity (for example, opening a paid signup link directly).
+export const SIGNUP_CONTEXTS = {
+    NEEDS_MAGIC_LINK_EMAIL: 'needs_magic_link_email',
+    HAS_PRECHECKOUT_MAGIC_LINK: 'has_precheckout_magic_link',
+    ALREADY_AUTHENTICATED: 'already_authenticated'
+};
+
+/**
+ * Signup-paid email can be skipped when welcome email is active only if
+ * checkout already has a reliable sign-in path.
+ *
+ * - HAS_PRECHECKOUT_MAGIC_LINK: standard Portal flow generated signup link before Stripe
+ * - ALREADY_AUTHENTICATED: checkout request came from an already signed-in member
+ */
+export function canWelcomeEmailReplaceSignupPaidEmail(signupContext: string) {
+    return signupContext === SIGNUP_CONTEXTS.HAS_PRECHECKOUT_MAGIC_LINK || signupContext === SIGNUP_CONTEXTS.ALREADY_AUTHENTICATED;
+}

--- a/ghost/core/core/server/services/lib/member-signup-contexts.ts
+++ b/ghost/core/core/server/services/lib/member-signup-contexts.ts
@@ -6,7 +6,9 @@ export const SIGNUP_CONTEXTS = {
     NEEDS_MAGIC_LINK_EMAIL: 'needs_magic_link_email',
     HAS_PRECHECKOUT_MAGIC_LINK: 'has_precheckout_magic_link',
     ALREADY_AUTHENTICATED: 'already_authenticated'
-};
+} as const;
+
+export type SignupContext = typeof SIGNUP_CONTEXTS[keyof typeof SIGNUP_CONTEXTS];
 
 /**
  * Signup-paid email can be skipped when welcome email is active only if
@@ -15,6 +17,6 @@ export const SIGNUP_CONTEXTS = {
  * - HAS_PRECHECKOUT_MAGIC_LINK: standard Portal flow generated signup link before Stripe
  * - ALREADY_AUTHENTICATED: checkout request came from an already signed-in member
  */
-export function canWelcomeEmailReplaceSignupPaidEmail(signupContext: string) {
+export function canWelcomeEmailReplaceSignupPaidEmail(signupContext?: SignupContext) {
     return signupContext === SIGNUP_CONTEXTS.HAS_PRECHECKOUT_MAGIC_LINK || signupContext === SIGNUP_CONTEXTS.ALREADY_AUTHENTICATED;
 }

--- a/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
+++ b/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
@@ -8,6 +8,7 @@ const {isEmail} = require('@tryghost/validator');
 const normalizeEmail = require('../utils/normalize-email');
 const {getInboxLinks} = require('../../../../lib/get-inbox-links');
 const {SIGNUP_CONTEXTS} = require('../../../lib/member-signup-contexts');
+/** @typedef {import('../../../lib/member-signup-contexts').SignupContext} SignupContext */
 
 const messages = {
     emailRequired: 'Email is required.',
@@ -476,6 +477,7 @@ module.exports = class RouterController {
         }
 
         const member = options.member;
+        /** @type {SignupContext} */
         let ghostSignupContext = (options.isAuthenticated && member) ? SIGNUP_CONTEXTS.ALREADY_AUTHENTICATED : SIGNUP_CONTEXTS.NEEDS_MAGIC_LINK_EMAIL;
 
         if (!member && options.email) {

--- a/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
+++ b/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
@@ -7,6 +7,7 @@ const errors = require('@tryghost/errors');
 const {isEmail} = require('@tryghost/validator');
 const normalizeEmail = require('../utils/normalize-email');
 const {getInboxLinks} = require('../../../../lib/get-inbox-links');
+const {SIGNUP_CONTEXTS} = require('../../../lib/member-signup-contexts');
 
 const messages = {
     emailRequired: 'Email is required.',
@@ -31,16 +32,6 @@ const messages = {
     otcNotSupported: 'OTC verification not supported.',
     invalidCode: 'Invalid verification code.',
     failedToVerifyCode: 'Failed to verify code, please try again.'
-};
-
-// Signup context describes the sign-in state when the Stripe checkout session is created.
-// NEEDS_MAGIC_LINK_EMAIL: No guaranteed sign-in path exists yet (custom/direct checkout paths).
-// HAS_PRECHECKOUT_MAGIC_LINK: Ghost generated a signup magic-link before Stripe (standard Portal flow).
-// ALREADY_AUTHENTICATED: Request came from a signed-in member identity (for example, opening a paid signup link directly).
-const GHOST_SIGNUP_CONTEXTS = {
-    NEEDS_MAGIC_LINK_EMAIL: 'needs_magic_link_email',
-    HAS_PRECHECKOUT_MAGIC_LINK: 'has_precheckout_magic_link',
-    ALREADY_AUTHENTICATED: 'already_authenticated'
 };
 
 // helper utility for logic shared between sendMagicLink and verifyOTC
@@ -485,7 +476,7 @@ module.exports = class RouterController {
         }
 
         const member = options.member;
-        let ghostSignupContext = (options.isAuthenticated && member) ? GHOST_SIGNUP_CONTEXTS.ALREADY_AUTHENTICATED : GHOST_SIGNUP_CONTEXTS.NEEDS_MAGIC_LINK_EMAIL;
+        let ghostSignupContext = (options.isAuthenticated && member) ? SIGNUP_CONTEXTS.ALREADY_AUTHENTICATED : SIGNUP_CONTEXTS.NEEDS_MAGIC_LINK_EMAIL;
 
         if (!member && options.email) {
             // Create a signup link if there is no member with this email address
@@ -502,7 +493,7 @@ module.exports = class RouterController {
                 // Redirect to the original success url after sign up
                 referrer: options.successUrl
             });
-            ghostSignupContext = GHOST_SIGNUP_CONTEXTS.HAS_PRECHECKOUT_MAGIC_LINK;
+            ghostSignupContext = SIGNUP_CONTEXTS.HAS_PRECHECKOUT_MAGIC_LINK;
         }
 
         if (member) {

--- a/ghost/core/core/server/services/stripe/services/webhook/checkout-session-event-service.js
+++ b/ghost/core/core/server/services/stripe/services/webhook/checkout-session-event-service.js
@@ -2,9 +2,14 @@ const _ = require('lodash');
 const errors = require('@tryghost/errors');
 const logging = require('@tryghost/logging');
 
-const GHOST_SIGNUP_FLOWS = {
-    PRE_CHECKOUT_MAGIC_LINK: 'pre_checkout_magic_link',
-    AUTHENTICATED_MEMBER_CHECKOUT: 'authenticated_member_checkout'
+// Mirrors checkout-session creation context:
+// NEEDS_MAGIC_LINK_EMAIL => direct/custom checkout path.
+// HAS_PRECHECKOUT_MAGIC_LINK => standard Portal flow created a pre-checkout signup link.
+// ALREADY_AUTHENTICATED => checkout request originated from an authenticated member.
+const GHOST_SIGNUP_CONTEXTS = {
+    NEEDS_MAGIC_LINK_EMAIL: 'needs_magic_link_email',
+    HAS_PRECHECKOUT_MAGIC_LINK: 'has_precheckout_magic_link',
+    ALREADY_AUTHENTICATED: 'already_authenticated'
 };
 
 /**
@@ -266,8 +271,8 @@ module.exports = class CheckoutSessionEventService {
         }
 
         if (checkoutType !== 'upgrade') {
-            const ghostSignupFlow = _.get(session, 'metadata.ghostSignupFlow');
-            const shouldSkipSignupEmailWhenWelcomeEmailActive = ghostSignupFlow === GHOST_SIGNUP_FLOWS.PRE_CHECKOUT_MAGIC_LINK || ghostSignupFlow === GHOST_SIGNUP_FLOWS.AUTHENTICATED_MEMBER_CHECKOUT;
+            const ghostSignupContext = _.get(session, 'metadata.ghostSignupContext');
+            const shouldSkipSignupEmailWhenWelcomeEmailActive = ghostSignupContext === GHOST_SIGNUP_CONTEXTS.HAS_PRECHECKOUT_MAGIC_LINK || ghostSignupContext === GHOST_SIGNUP_CONTEXTS.ALREADY_AUTHENTICATED;
 
             if (shouldSkipSignupEmailWhenWelcomeEmailActive) {
                 const isPaidWelcomeEmailActive = await this.deps.isPaidWelcomeEmailActive();

--- a/ghost/core/core/server/services/stripe/services/webhook/checkout-session-event-service.js
+++ b/ghost/core/core/server/services/stripe/services/webhook/checkout-session-event-service.js
@@ -4,6 +4,7 @@ const logging = require('@tryghost/logging');
 const {
     canWelcomeEmailReplaceSignupPaidEmail
 } = require('../../../lib/member-signup-contexts');
+/** @typedef {import('../../../lib/member-signup-contexts').SignupContext} SignupContext */
 
 /**
  * Handles `checkout.session.completed` webhook events
@@ -264,7 +265,7 @@ module.exports = class CheckoutSessionEventService {
         }
 
         if (checkoutType !== 'upgrade') {
-            const ghostSignupContext = _.get(session, 'metadata.ghostSignupContext');
+            const ghostSignupContext = /** @type {SignupContext | undefined} */ (session.metadata?.ghostSignupContext);
             const shouldSkipSignupEmailWhenWelcomeEmailActive = canWelcomeEmailReplaceSignupPaidEmail(ghostSignupContext);
 
             if (shouldSkipSignupEmailWhenWelcomeEmailActive) {

--- a/ghost/core/core/server/services/stripe/stripe-service.js
+++ b/ghost/core/core/server/services/stripe/stripe-service.js
@@ -126,6 +126,7 @@ module.exports = class StripeService {
                 if (!labs.isSet('welcomeEmails')) {
                     return false;
                 }
+                memberWelcomeEmailService.init();
                 return memberWelcomeEmailService.api.isMemberWelcomeEmailActive('paid');
             }
         });

--- a/ghost/core/core/server/services/stripe/stripe-service.js
+++ b/ghost/core/core/server/services/stripe/stripe-service.js
@@ -8,6 +8,7 @@ const {StripeLiveEnabledEvent, StripeLiveDisabledEvent} = require('./events');
 const SubscriptionEventService = require('./services/webhook/subscription-event-service');
 const InvoiceEventService = require('./services/webhook/invoice-event-service');
 const CheckoutSessionEventService = require('./services/webhook/checkout-session-event-service');
+const memberWelcomeEmailService = require('../member-welcome-emails/service');
 
 /**
  * @typedef {object} IStripeServiceConfig
@@ -120,6 +121,12 @@ module.exports = class StripeService {
                     },
                     tokenData: {}
                 });
+            },
+            async isPaidWelcomeEmailActive() {
+                if (!labs.isSet('welcomeEmails')) {
+                    return false;
+                }
+                return memberWelcomeEmailService.api.isMemberWelcomeEmailActive('paid');
             }
         });
 

--- a/ghost/core/test/unit/server/services/members/members-api/controllers/router-controller.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/controllers/router-controller.test.js
@@ -167,7 +167,7 @@ describe('RouterController', function () {
             })), true);
         });
 
-        it('sets ghostSignupFlow to pre_checkout_magic_link when checkout creates a signup magic link', async function () {
+        it('sets ghostSignupContext to has_precheckout_magic_link when checkout creates a signup magic link', async function () {
             const magicLinkService = {
                 getMagicLink: sinon.stub().resolves('https://example.com/members/?token=abc123&action=signup')
             };
@@ -204,12 +204,12 @@ describe('RouterController', function () {
             assert.equal(getPaymentLinkSpy.calledWith(sinon.match({
                 successUrl: 'https://example.com/members/?token=abc123&action=signup',
                 metadata: {
-                    ghostSignupFlow: 'pre_checkout_magic_link'
+                    ghostSignupContext: 'has_precheckout_magic_link'
                 }
             })), true);
         });
 
-        it('sets ghostSignupFlow to authenticated_member_checkout for authenticated members', async function () {
+        it('sets ghostSignupContext to already_authenticated for authenticated members', async function () {
             const member = {
                 get: sinon.stub().withArgs('status').returns('free')
             };
@@ -247,12 +247,12 @@ describe('RouterController', function () {
 
             assert.equal(getPaymentLinkSpy.calledWith(sinon.match({
                 metadata: {
-                    ghostSignupFlow: 'authenticated_member_checkout'
+                    ghostSignupContext: 'already_authenticated'
                 }
             })), true);
         });
 
-        it('sets ghostSignupFlow to direct_checkout when there is no member context or customer email', async function () {
+        it('sets ghostSignupContext to needs_magic_link_email when there is no member context or customer email', async function () {
             const routerController = new RouterController({
                 tiersService,
                 paymentsService,
@@ -278,7 +278,7 @@ describe('RouterController', function () {
 
             assert.equal(getPaymentLinkSpy.calledWith(sinon.match({
                 metadata: {
-                    ghostSignupFlow: 'direct_checkout'
+                    ghostSignupContext: 'needs_magic_link_email'
                 }
             })), true);
         });

--- a/ghost/core/test/unit/server/services/members/members-api/controllers/router-controller.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/controllers/router-controller.test.js
@@ -167,6 +167,122 @@ describe('RouterController', function () {
             })), true);
         });
 
+        it('sets ghostSignupFlow to pre_checkout_magic_link when checkout creates a signup magic link', async function () {
+            const magicLinkService = {
+                getMagicLink: sinon.stub().resolves('https://example.com/members/?token=abc123&action=signup')
+            };
+            const memberRepository = {
+                get: sinon.stub().resolves(null)
+            };
+            const routerController = new RouterController({
+                tiersService,
+                paymentsService,
+                offersAPI,
+                stripeAPIService,
+                labsService,
+                settingsCache,
+                settingsHelpers,
+                magicLinkService,
+                memberRepository
+            });
+
+            await routerController.createCheckoutSession({
+                body: {
+                    tierId: 'tier_123',
+                    cadence: 'month',
+                    customerEmail: 'new-member@example.com',
+                    successUrl: 'https://example.com/paid-success',
+                    cancelUrl: 'https://example.com/cancel',
+                    metadata: {}
+                }
+            }, {
+                writeHead: () => {},
+                end: () => {}
+            });
+
+            assert.equal(magicLinkService.getMagicLink.calledOnce, true);
+            assert.equal(getPaymentLinkSpy.calledWith(sinon.match({
+                successUrl: 'https://example.com/members/?token=abc123&action=signup',
+                metadata: {
+                    ghostSignupFlow: 'pre_checkout_magic_link'
+                }
+            })), true);
+        });
+
+        it('sets ghostSignupFlow to authenticated_member_checkout for authenticated members', async function () {
+            const member = {
+                get: sinon.stub().withArgs('status').returns('free')
+            };
+            const tokenService = {
+                decodeToken: sinon.stub().resolves({sub: 'member@example.com'})
+            };
+            const memberRepository = {
+                get: sinon.stub().resolves(member)
+            };
+            const routerController = new RouterController({
+                tiersService,
+                paymentsService,
+                offersAPI,
+                stripeAPIService,
+                labsService,
+                settingsCache,
+                settingsHelpers,
+                tokenService,
+                memberRepository
+            });
+
+            await routerController.createCheckoutSession({
+                body: {
+                    tierId: 'tier_123',
+                    cadence: 'month',
+                    identity: 'identity-token',
+                    successUrl: 'https://example.com/paid-success',
+                    cancelUrl: 'https://example.com/cancel',
+                    metadata: {}
+                }
+            }, {
+                writeHead: () => {},
+                end: () => {}
+            });
+
+            assert.equal(getPaymentLinkSpy.calledWith(sinon.match({
+                metadata: {
+                    ghostSignupFlow: 'authenticated_member_checkout'
+                }
+            })), true);
+        });
+
+        it('sets ghostSignupFlow to direct_checkout when there is no member context or customer email', async function () {
+            const routerController = new RouterController({
+                tiersService,
+                paymentsService,
+                offersAPI,
+                stripeAPIService,
+                labsService,
+                settingsCache,
+                settingsHelpers
+            });
+
+            await routerController.createCheckoutSession({
+                body: {
+                    tierId: 'tier_123',
+                    cadence: 'month',
+                    successUrl: 'https://example.com/paid-success',
+                    cancelUrl: 'https://example.com/cancel',
+                    metadata: {}
+                }
+            }, {
+                writeHead: () => {},
+                end: () => {}
+            });
+
+            assert.equal(getPaymentLinkSpy.calledWith(sinon.match({
+                metadata: {
+                    ghostSignupFlow: 'direct_checkout'
+                }
+            })), true);
+        });
+
         describe('_getSubscriptionCheckoutData', function () {
             it('returns a BadRequestError if both offerId and tierId are missing', async function () {
                 const routerController = new RouterController({

--- a/ghost/core/test/unit/server/services/stripe/services/webhooks/checkout-session-event-service.test.js
+++ b/ghost/core/test/unit/server/services/stripe/services/webhooks/checkout-session-event-service.test.js
@@ -728,17 +728,6 @@ describe('CheckoutSessionEventService', function () {
                 assert(!sendSignupEmail.called);
             });
 
-            it('should always send signup email for custom membership pages regardless of welcome email status', async function () {
-                api.getCustomer.resolves(customer);
-                memberRepository.get.resolves(null);
-                session.metadata.requestSrc = undefined; // Not portal (custom membership page)
-                isPaidWelcomeEmailActive.resolves(true); // Welcome email IS active
-
-                await service.handleSubscriptionEvent(session);
-
-                assert(sendSignupEmail.calledOnce); // Still sent because user needs magic link
-            });
-
             it('should NOT send signup email on upgrade regardless of requestSrc or welcome email', async function () {
                 api.getCustomer.resolves(customer);
                 memberRepository.get.resolves(member);

--- a/ghost/core/test/unit/server/services/stripe/services/webhooks/checkout-session-event-service.test.js
+++ b/ghost/core/test/unit/server/services/stripe/services/webhooks/checkout-session-event-service.test.js
@@ -696,7 +696,7 @@ describe('CheckoutSessionEventService', function () {
             it('should send signup email for direct checkout flow even when welcome email is active', async function () {
                 api.getCustomer.resolves(customer);
                 memberRepository.get.resolves(null);
-                session.metadata.ghostSignupFlow = 'direct_checkout';
+                session.metadata.ghostSignupContext = 'needs_magic_link_email';
                 isPaidWelcomeEmailActive.resolves(true);
 
                 await service.handleSubscriptionEvent(session);
@@ -706,10 +706,10 @@ describe('CheckoutSessionEventService', function () {
                 assert(!isPaidWelcomeEmailActive.called);
             });
 
-            it('should send signup email when flow is pre_checkout_magic_link and welcome email is not active', async function () {
+            it('should send signup email when flow is has_precheckout_magic_link and welcome email is not active', async function () {
                 api.getCustomer.resolves(customer);
                 memberRepository.get.resolves(null);
-                session.metadata.ghostSignupFlow = 'pre_checkout_magic_link';
+                session.metadata.ghostSignupContext = 'has_precheckout_magic_link';
                 isPaidWelcomeEmailActive.resolves(false);
 
                 await service.handleSubscriptionEvent(session);
@@ -718,10 +718,10 @@ describe('CheckoutSessionEventService', function () {
                 assert(sendSignupEmail.calledWith('customer@example.com'));
             });
 
-            it('should NOT send signup email when flow is pre_checkout_magic_link and welcome email is active', async function () {
+            it('should NOT send signup email when flow is has_precheckout_magic_link and welcome email is active', async function () {
                 api.getCustomer.resolves(customer);
                 memberRepository.get.resolves(null);
-                session.metadata.ghostSignupFlow = 'pre_checkout_magic_link';
+                session.metadata.ghostSignupContext = 'has_precheckout_magic_link';
                 isPaidWelcomeEmailActive.resolves(true);
 
                 await service.handleSubscriptionEvent(session);
@@ -729,10 +729,10 @@ describe('CheckoutSessionEventService', function () {
                 assert(!sendSignupEmail.called);
             });
 
-            it('should send signup email when flow is authenticated_member_checkout and welcome email is not active', async function () {
+            it('should send signup email when flow is already_authenticated and welcome email is not active', async function () {
                 api.getCustomer.resolves(customer);
                 memberRepository.get.resolves(null);
-                session.metadata.ghostSignupFlow = 'authenticated_member_checkout';
+                session.metadata.ghostSignupContext = 'already_authenticated';
                 isPaidWelcomeEmailActive.resolves(false);
 
                 await service.handleSubscriptionEvent(session);
@@ -741,10 +741,10 @@ describe('CheckoutSessionEventService', function () {
                 assert(sendSignupEmail.calledWith('customer@example.com'));
             });
 
-            it('should NOT send signup email when flow is authenticated_member_checkout and welcome email is active', async function () {
+            it('should NOT send signup email when flow is already_authenticated and welcome email is active', async function () {
                 api.getCustomer.resolves(customer);
                 memberRepository.get.resolves(null);
-                session.metadata.ghostSignupFlow = 'authenticated_member_checkout';
+                session.metadata.ghostSignupContext = 'already_authenticated';
                 isPaidWelcomeEmailActive.resolves(true);
 
                 await service.handleSubscriptionEvent(session);
@@ -755,7 +755,7 @@ describe('CheckoutSessionEventService', function () {
             it('should send signup email when flow metadata is missing for backward compatibility', async function () {
                 api.getCustomer.resolves(customer);
                 memberRepository.get.resolves(null);
-                delete session.metadata.ghostSignupFlow;
+                delete session.metadata.ghostSignupContext;
                 isPaidWelcomeEmailActive.resolves(true);
 
                 await service.handleSubscriptionEvent(session);
@@ -769,7 +769,7 @@ describe('CheckoutSessionEventService', function () {
                 api.getCustomer.resolves(customer);
                 memberRepository.get.resolves(member);
                 session.metadata.checkoutType = 'upgrade';
-                session.metadata.ghostSignupFlow = 'pre_checkout_magic_link';
+                session.metadata.ghostSignupContext = 'has_precheckout_magic_link';
                 isPaidWelcomeEmailActive.resolves(false);
 
                 await service.handleSubscriptionEvent(session);


### PR DESCRIPTION
Closes [NY-993: Redundant "Thank you for signing up!" email for new paid memberships](https://linear.app/ghost/issue/NY-993/redundant-thank-you-for-signing-up-email-for-new-paid-memberships)

- Before we added member welcome emails, there was an email that sent a magic link to paid subscribers when they signed up. This exists mostly for the custom membership page use case because if a paid member signs up through portal, then they get signed in immediately. 
- The problem that we want to solve with this PR is that for members that sign up through Portal, if the paid welcome email is enabled and they get the MagicLink email, it's kind of redundant and excessive. But if somebody has a custom membership page, we still want to make sure that we send the magic link email even when welcome emails are enabled. 
- So in this PR, we check if the request for paid signup comes from the portal and if member welcome emails are enabled. If that's the case, then we don't send the email with the magic link, just the welcome email. 

### Behavior Matrix/States to verify

Signup context / flow | Typical entry path | Welcome email disabled | Welcome email enabled | Why
-- | -- | -- | -- | --
needs_magic_link_email | Custom/direct checkout paths (for example data-members-plan, docs-style data-portal="signup/<tier>/monthly") | Signup-paid sent | Signup-paid sent | No guaranteed pre-checkout sign-in path exists yet
has_precheckout_magic_link | Standard Portal paid signup flow (email captured before Stripe) | Signup-paid sent | Signup-paid not sent | Ghost already generated a pre-checkout signup magic link
already_authenticated | Signed-in member starts paid checkout via non-upgrade signup path (identity token present) | Signup-paid sent | Signup-paid not sent | Member is already authenticated at checkout time
checkoutType='upgrade' | Account upgrade flow | Signup-paid not sent | Signup-paid not sent | Upgrade path bypasses signup-paid logic entirely




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes paid membership onboarding emails by conditioning webhook behavior on new Stripe metadata and feature flags; mistakes could suppress required magic-link emails for some checkout flows.
> 
> **Overview**
> Reduces redundant email sends for new paid signups by introducing a `ghostSignupContext` marker on Stripe checkout sessions and using it in the `checkout.session.completed` webhook to decide whether to send the `signup-paid` magic-link email.
> 
> Adds shared signup-context utilities (`SIGNUP_CONTEXTS`, `canWelcomeEmailReplaceSignupPaidEmail`) and sets context during checkout session creation (authenticated member vs pre-checkout magic link vs direct checkout). The Stripe webhook now skips `signup-paid` when context indicates a reliable sign-in path *and* the paid welcome email is active (behind `welcomeEmails` labs), while preserving existing behavior for direct checkouts, upgrades, and backward compatibility when metadata is missing; unit tests cover the new context tagging and email-sending matrix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aaebdbceb044ef5f6933e7938c56b6b25fcfa5e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->