### PR TITLE
Stopped reading context file twice in script

### DIFF
--- a/ghost/i18n/generate-context.js
+++ b/ghost/i18n/generate-context.js
@@ -5,7 +5,9 @@ const BASE_PATH = './locales/en';
 const CONTEXT_FILE = './locales/context.json';
 
 (async () => {
-    const context = require(CONTEXT_FILE);
+    const existingContent = await fs.readFile(CONTEXT_FILE, 'utf-8');
+    const context = JSON.parse(existingContent);
+
     const newContext = {};
 
     const files = await fs.readdir(BASE_PATH);
@@ -25,7 +27,6 @@ const CONTEXT_FILE = './locales/context.json';
     }, {});
 
     const newContent = JSON.stringify(orderedContext, null, 4);
-    const existingContent = await fs.readFile(CONTEXT_FILE, 'utf-8');
 
     if (process.env.CI && newContent !== existingContent) {
         // eslint-disable-next-line no-console


### PR DESCRIPTION
ref 91dc97511f53f81a374485f12a1223dd73234fe7

*This change should have no user impact.* Very small change that shouldn't affect much.

This prevents reading the file twice, which (1) should slightly improve performance (2) helps avoid rare race conditions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal data processing flow for better reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->