### PR TITLE
Converted `should.not.exist(v)` to `assert.equal(v, undefined)`

### DIFF
--- a/ghost/core/test/e2e-api/admin/invites.test.js
+++ b/ghost/core/test/e2e-api/admin/invites.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const supertest = require('supertest');
 const sinon = require('sinon');
@@ -31,7 +32,7 @@ describe('Invites API', function () {
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(200);
 
-            should.not.exist(res.headers['x-cache-invalidate']);
+            assert.equal(res.headers['x-cache-invalidate'], undefined);
             const jsonResponse = res.body;
             should.exist(jsonResponse);
             should.exist(jsonResponse.invites);
@@ -58,7 +59,7 @@ describe('Invites API', function () {
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(200);
 
-            should.not.exist(res.headers['x-cache-invalidate']);
+            assert.equal(res.headers['x-cache-invalidate'], undefined);
             const jsonResponse = res.body;
             should.exist(jsonResponse);
             should.exist(jsonResponse.invites);
@@ -80,7 +81,7 @@ describe('Invites API', function () {
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(201);
 
-            should.not.exist(res.headers['x-cache-invalidate']);
+            assert.equal(res.headers['x-cache-invalidate'], undefined);
             const jsonResponse = res.body;
             should.exist(jsonResponse);
             should.exist(jsonResponse.invites);
@@ -144,7 +145,7 @@ describe('Invites API', function () {
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(201);
 
-            should.not.exist(res.headers['x-cache-invalidate']);
+            assert.equal(res.headers['x-cache-invalidate'], undefined);
             const jsonResponse = res.body;
             should.exist(jsonResponse);
             should.exist(jsonResponse.invites);
@@ -171,7 +172,7 @@ describe('Invites API', function () {
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(201);
 
-            should.not.exist(res.headers['x-cache-invalidate']);
+            assert.equal(res.headers['x-cache-invalidate'], undefined);
             const jsonResponse = res.body;
             should.exist(jsonResponse);
             should.exist(jsonResponse.invites);
@@ -198,7 +199,7 @@ describe('Invites API', function () {
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(201);
 
-            should.not.exist(res.headers['x-cache-invalidate']);
+            assert.equal(res.headers['x-cache-invalidate'], undefined);
             const jsonResponse = res.body;
             should.exist(jsonResponse);
             should.exist(jsonResponse.invites);
@@ -225,7 +226,7 @@ describe('Invites API', function () {
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(201);
 
-            should.not.exist(res.headers['x-cache-invalidate']);
+            assert.equal(res.headers['x-cache-invalidate'], undefined);
             const jsonResponse = res.body;
             should.exist(jsonResponse);
             should.exist(jsonResponse.invites);

--- a/ghost/core/test/e2e-api/admin/members-importer.test.js
+++ b/ghost/core/test/e2e-api/admin/members-importer.test.js
@@ -42,7 +42,7 @@ describe('Members Importer API', function () {
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(201);
 
-        should.not.exist(res.headers['x-cache-invalidate']);
+        assert.equal(res.headers['x-cache-invalidate'], undefined);
         const jsonResponse = res.body;
 
         should.exist(jsonResponse);

--- a/ghost/core/test/e2e-api/admin/members.test.js
+++ b/ghost/core/test/e2e-api/admin/members.test.js
@@ -2604,9 +2604,9 @@ describe('Members API', function () {
 
         const csv = Papa.parse(res.text, {header: true});
         should.exist(csv.data.find(row => row.name === 'Mr Egg'));
-        should.not.exist(csv.data.find(row => row.name === 'Egon Spengler'));
-        should.not.exist(csv.data.find(row => row.name === 'Ray Stantz'));
-        should.not.exist(csv.data.find(row => row.email === 'member2@test.com'));
+        assert.equal(csv.data.find(row => row.name === 'Egon Spengler'), undefined);
+        assert.equal(csv.data.find(row => row.name === 'Ray Stantz'), undefined);
+        assert.equal(csv.data.find(row => row.email === 'member2@test.com'), undefined);
         // note that this member doesn't have tiers
         should.exist(csv.data.find(row => row.labels.length > 0));
     });

--- a/ghost/core/test/e2e-api/admin/oembed.test.js
+++ b/ghost/core/test/e2e-api/admin/oembed.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const nock = require('nock');
 const sinon = require('sinon');
 const should = require('should');
@@ -567,7 +568,7 @@ describe('Oembed API', function () {
                 width: 200,
                 height: 100
             });
-            should.not.exist(res.body.unknown);
+            assert.equal(res.body.unknown, undefined);
         });
 
         it('skips fetching IPv4 addresses', async function () {

--- a/ghost/core/test/e2e-api/admin/pages-legacy.test.js
+++ b/ghost/core/test/e2e-api/admin/pages-legacy.test.js
@@ -24,7 +24,7 @@ describe('Pages API', function () {
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(200);
 
-        should.not.exist(res.headers['x-cache-invalidate']);
+        assert.equal(res.headers['x-cache-invalidate'], undefined);
         const jsonResponse = res.body;
         should.exist(jsonResponse.pages);
         localUtils.API.checkResponse(jsonResponse, 'pages');
@@ -46,7 +46,7 @@ describe('Pages API', function () {
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(200);
 
-        should.not.exist(res.headers['x-cache-invalidate']);
+        assert.equal(res.headers['x-cache-invalidate'], undefined);
         const jsonResponse = res.body;
         should.exist(jsonResponse.pages);
         localUtils.API.checkResponse(jsonResponse, 'pages');

--- a/ghost/core/test/e2e-api/admin/posts-legacy.test.js
+++ b/ghost/core/test/e2e-api/admin/posts-legacy.test.js
@@ -50,7 +50,7 @@ describe('Posts API', function () {
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(200);
 
-        should.not.exist(res.headers['x-cache-invalidate']);
+        assert.equal(res.headers['x-cache-invalidate'], undefined);
         const jsonResponse = res.body;
         should.exist(jsonResponse.posts);
         localUtils.API.checkResponse(jsonResponse, 'posts');
@@ -79,10 +79,10 @@ describe('Posts API', function () {
         // Check if the newsletter relation is loaded by default and newsletter_id is not returned
         jsonResponse.posts[14].id.should.eql(testUtils.DataGenerator.Content.posts[0].id);
         jsonResponse.posts[14].newsletter.id.should.eql(testUtils.DataGenerator.Content.newsletters[0].id);
-        should.not.exist(jsonResponse.posts[14].newsletter_id);
+        assert.equal(jsonResponse.posts[14].newsletter_id, undefined);
 
         should(jsonResponse.posts[0].newsletter).be.null();
-        should.not.exist(jsonResponse.posts[0].newsletter_id);
+        assert.equal(jsonResponse.posts[0].newsletter_id, undefined);
     });
 
     it('Can retrieve multiple post formats', async function () {
@@ -92,7 +92,7 @@ describe('Posts API', function () {
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(200);
 
-        should.not.exist(res.headers['x-cache-invalidate']);
+        assert.equal(res.headers['x-cache-invalidate'], undefined);
         const jsonResponse = res.body;
         should.exist(jsonResponse.posts);
         localUtils.API.checkResponse(jsonResponse, 'posts');
@@ -112,7 +112,7 @@ describe('Posts API', function () {
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(200);
 
-        should.not.exist(res.headers['x-cache-invalidate']);
+        assert.equal(res.headers['x-cache-invalidate'], undefined);
         const jsonResponse = res.body;
         should.exist(jsonResponse.posts);
         localUtils.API.checkResponse(jsonResponse, 'posts');
@@ -134,7 +134,7 @@ describe('Posts API', function () {
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(200);
 
-        should.not.exist(res.headers['x-cache-invalidate']);
+        assert.equal(res.headers['x-cache-invalidate'], undefined);
         const jsonResponse = res.body;
         should.exist(jsonResponse.posts);
         localUtils.API.checkResponse(jsonResponse, 'posts');
@@ -171,7 +171,7 @@ describe('Posts API', function () {
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(200);
 
-        should.not.exist(res.headers['x-cache-invalidate']);
+        assert.equal(res.headers['x-cache-invalidate'], undefined);
         const jsonResponse = res.body;
         should.exist(jsonResponse);
         should.exist(jsonResponse.posts);
@@ -184,7 +184,7 @@ describe('Posts API', function () {
 
         // Check if the newsletter relation is loaded by default and newsletter_id is not returned
         jsonResponse.posts[0].newsletter.id.should.eql(testUtils.DataGenerator.Content.newsletters[0].id);
-        should.not.exist(jsonResponse.posts[0].newsletter_id);
+        assert.equal(jsonResponse.posts[0].newsletter_id, undefined);
     });
 
     it('Can request a post by id without newsletter', async function () {
@@ -194,7 +194,7 @@ describe('Posts API', function () {
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(200);
 
-        should.not.exist(res.headers['x-cache-invalidate']);
+        assert.equal(res.headers['x-cache-invalidate'], undefined);
         const jsonResponse = res.body;
         should.exist(jsonResponse);
         should.exist(jsonResponse.posts);
@@ -207,7 +207,7 @@ describe('Posts API', function () {
 
         // Newsletter should be returned as null
         should(jsonResponse.posts[0].newsletter).be.null();
-        should.not.exist(jsonResponse.posts[0].newsletter_id);
+        assert.equal(jsonResponse.posts[0].newsletter_id, undefined);
     });
 
     it('Can retrieve a post by slug', async function () {
@@ -217,7 +217,7 @@ describe('Posts API', function () {
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(200);
 
-        should.not.exist(res.headers['x-cache-invalidate']);
+        assert.equal(res.headers['x-cache-invalidate'], undefined);
         const jsonResponse = res.body;
         should.exist(jsonResponse);
         should.exist(jsonResponse.posts);
@@ -228,7 +228,7 @@ describe('Posts API', function () {
 
         // Newsletter should be returned as null
         should(jsonResponse.posts[0].newsletter).be.null();
-        should.not.exist(jsonResponse.posts[0].newsletter_id);
+        assert.equal(jsonResponse.posts[0].newsletter_id, undefined);
     });
 
     it('Can include relations for a single post', async function () {
@@ -239,7 +239,7 @@ describe('Posts API', function () {
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(200);
 
-        should.not.exist(res.headers['x-cache-invalidate']);
+        assert.equal(res.headers['x-cache-invalidate'], undefined);
         const jsonResponse = res.body;
         should.exist(jsonResponse);
         should.exist(jsonResponse.posts);
@@ -256,7 +256,7 @@ describe('Posts API', function () {
         localUtils.API.checkResponse(jsonResponse.posts[0].email, 'email');
 
         jsonResponse.posts[0].newsletter.id.should.eql(testUtils.DataGenerator.Content.newsletters[0].id);
-        should.not.exist(jsonResponse.posts[0].newsletter_id);
+        assert.equal(jsonResponse.posts[0].newsletter_id, undefined);
     });
 
     it('Can add a post', async function () {
@@ -281,14 +281,14 @@ describe('Posts API', function () {
         res.body.posts.length.should.eql(1);
         localUtils.API.checkResponse(res.body.posts[0], 'post');
         res.body.posts[0].url.should.match(new RegExp(`${config.get('url')}/p/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}`));
-        should.not.exist(res.headers['x-cache-invalidate']);
+        assert.equal(res.headers['x-cache-invalidate'], undefined);
 
         should.exist(res.headers.location);
         res.headers.location.should.equal(`http://127.0.0.1:2369${localUtils.API.getApiQuery('posts/')}${res.body.posts[0].id}/`);
 
         // Newsletter should be returned as null
         should(res.body.posts[0].newsletter).be.null();
-        should.not.exist(res.body.posts[0].newsletter_id);
+        assert.equal(res.body.posts[0].newsletter_id, undefined);
 
         const model = await models.Post.findOne({
             id: res.body.posts[0].id,
@@ -410,7 +410,7 @@ describe('Posts API', function () {
 
         // Newsletter should be returned as null
         should(res2.body.posts[0].newsletter).be.null();
-        should.not.exist(res2.body.posts[0].newsletter_id);
+        assert.equal(res2.body.posts[0].newsletter_id, undefined);
     });
 
     it('Can update and force re-render', async function () {
@@ -580,7 +580,7 @@ describe('Posts API', function () {
         // Check that the default newsletter is used instead of the one in body (not allowed)
         should(res.body.posts[0].status).eql('draft');
         should(res.body.posts[0].newsletter).eql(null);
-        should.not.exist(res.body.posts[0].newsletter_id);
+        assert.equal(res.body.posts[0].newsletter_id, undefined);
 
         const id = res.body.posts[0].id;
 
@@ -617,7 +617,7 @@ describe('Posts API', function () {
         // Check newsletter relation is loaded, but null in response.
         should(res.body.posts[0].newsletter).eql(null);
         should(res.body.posts[0].email_segment).eql('all');
-        should.not.exist(res.body.posts[0].newsletter_id);
+        assert.equal(res.body.posts[0].newsletter_id, undefined);
 
         const id = res.body.posts[0].id;
 
@@ -715,7 +715,7 @@ describe('Posts API', function () {
         const email = await models.Email.findOne({
             post_id: id
         }, testUtils.context.internal);
-        should.not.exist(email);
+        assert.equal(email, null);
 
         checkCanSendEmailStub.restore();
         sinon.assert.calledOnce(loggingStub);
@@ -741,7 +741,7 @@ describe('Posts API', function () {
 
         // Check newsletter relation is loaded, but null in response.
         should(res.body.posts[0].newsletter).eql(null);
-        should.not.exist(res.body.posts[0].newsletter_id);
+        assert.equal(res.body.posts[0].newsletter_id, undefined);
 
         const id = res.body.posts[0].id;
 
@@ -760,7 +760,7 @@ describe('Posts API', function () {
         // Check newsletter relation is loaded in response
         should(finalPost.body.posts[0].newsletter).eql(null);
         should(finalPost.body.posts[0].email_segment).eql('all');
-        should.not.exist(finalPost.body.posts[0].newsletter_id);
+        assert.equal(finalPost.body.posts[0].newsletter_id, undefined);
 
         const model = await models.Post.findOne({
             id
@@ -774,7 +774,7 @@ describe('Posts API', function () {
             post_id: id
         }, testUtils.context.internal);
 
-        should.not.exist(email);
+        assert.equal(email, null);
     });
 
     it('Interprets sent status as published for not email only posts', async function () {
@@ -797,7 +797,7 @@ describe('Posts API', function () {
 
         // Check newsletter relation is loaded, but null in response.
         should(res.body.posts[0].newsletter).eql(null);
-        should.not.exist(res.body.posts[0].newsletter_id);
+        assert.equal(res.body.posts[0].newsletter_id, undefined);
 
         const id = res.body.posts[0].id;
 
@@ -809,7 +809,7 @@ describe('Posts API', function () {
             id,
             status: 'all'
         }, testUtils.context.internal);
-        should.not.exist(initialModel.get('published_by'));
+        assert.equal(initialModel.get('published_by'), null);
 
         const finalPost = await request
             .put(localUtils.API.getApiQuery('posts/' + id + '/'))
@@ -822,7 +822,7 @@ describe('Posts API', function () {
         // Check newsletter relation is loaded in response
         should(finalPost.body.posts[0].newsletter).eql(null);
         should(finalPost.body.posts[0].email_segment).eql('all');
-        should.not.exist(finalPost.body.posts[0].newsletter_id);
+        assert.equal(finalPost.body.posts[0].newsletter_id, undefined);
 
         // Check status is set to published
         finalPost.body.posts[0].status.should.eql('published');
@@ -840,7 +840,7 @@ describe('Posts API', function () {
             post_id: id
         }, testUtils.context.internal);
 
-        should.not.exist(email);
+        assert.equal(email, null);
     });
 
     it('Can publish a post and send as email', async function () {
@@ -866,7 +866,7 @@ describe('Posts API', function () {
 
         // Check newsletter relation is loaded, but null in response.
         should(res.body.posts[0].newsletter).eql(null);
-        should.not.exist(res.body.posts[0].newsletter_id);
+        assert.equal(res.body.posts[0].newsletter_id, undefined);
 
         const id = res.body.posts[0].id;
 
@@ -878,7 +878,7 @@ describe('Posts API', function () {
             id,
             status: 'all'
         }, testUtils.context.internal);
-        should.not.exist(initialModel.get('published_by'));
+        assert.equal(initialModel.get('published_by'), null);
 
         const finalPost = await request
             .put(localUtils.API.getApiQuery('posts/' + id + '/?newsletter=' + newsletterSlug))
@@ -891,7 +891,7 @@ describe('Posts API', function () {
         // Check newsletter relation is loaded in response
         should(finalPost.body.posts[0].newsletter.id).eql(newsletterId);
         should(finalPost.body.posts[0].email_segment).eql('all');
-        should.not.exist(finalPost.body.posts[0].newsletter_id);
+        assert.equal(finalPost.body.posts[0].newsletter_id, undefined);
 
         const model = await models.Post.findOne({
             id
@@ -934,7 +934,7 @@ describe('Posts API', function () {
 
         // Check newsletter relation is loaded, but null in response.
         should(res.body.posts[0].newsletter).eql(null);
-        should.not.exist(res.body.posts[0].newsletter_id);
+        assert.equal(res.body.posts[0].newsletter_id, undefined);
 
         const id = res.body.posts[0].id;
 
@@ -946,7 +946,7 @@ describe('Posts API', function () {
             id,
             status: 'all'
         }, testUtils.context.internal);
-        should.not.exist(initialModel.get('published_by'));
+        assert.equal(initialModel.get('published_by'), null);
 
         const finalPost = await request
             .put(localUtils.API.getApiQuery('posts/' + id + '/?newsletter=' + newsletterSlug))
@@ -959,7 +959,7 @@ describe('Posts API', function () {
         // Check newsletter relation is loaded in response
         should(finalPost.body.posts[0].newsletter.id).eql(newsletterId);
         should(finalPost.body.posts[0].email_segment).eql('all');
-        should.not.exist(finalPost.body.posts[0].newsletter_id);
+        assert.equal(finalPost.body.posts[0].newsletter_id, undefined);
 
         // Check status
         should(finalPost.body.posts[0].status).eql('published');
@@ -1015,7 +1015,7 @@ describe('Posts API', function () {
             id,
             status: 'all'
         }, testUtils.context.internal);
-        should.not.exist(initialModel.get('published_by'));
+        assert.equal(initialModel.get('published_by'), null);
 
         const publishedRes = await request
             .put(localUtils.API.getApiQuery('posts/' + id + '/?newsletter=' + newsletterSlug))
@@ -1030,7 +1030,7 @@ describe('Posts API', function () {
         publishedPost.newsletter.id.should.eql(newsletterId);
         publishedPost.email_segment.should.eql('all');
         publishedPost.status.should.eql('sent');
-        should.not.exist(publishedPost.newsletter_id);
+        assert.equal(publishedPost.newsletter_id, undefined);
 
         let model = await models.Post.findOne({
             id,
@@ -1084,7 +1084,7 @@ describe('Posts API', function () {
             id,
             status: 'all'
         }, testUtils.context.internal);
-        should.not.exist(initialModel.get('published_by'));
+        assert.equal(initialModel.get('published_by'), null);
 
         const publishedRes = await request
             .put(localUtils.API.getApiQuery('posts/' + id + '/?newsletter=' + newsletterSlug + '&email_segment=status%3Afree'))
@@ -1099,7 +1099,7 @@ describe('Posts API', function () {
         publishedPost.newsletter.id.should.eql(newsletterId);
         publishedPost.email_segment.should.eql('status:free');
         publishedPost.status.should.eql('sent');
-        should.not.exist(publishedPost.newsletter_id);
+        assert.equal(publishedPost.newsletter_id, undefined);
 
         let model = await models.Post.findOne({
             id,
@@ -1153,7 +1153,7 @@ describe('Posts API', function () {
             id,
             status: 'all'
         }, testUtils.context.internal);
-        should.not.exist(initialModel.get('published_by'));
+        assert.equal(initialModel.get('published_by'), null);
 
         const publishedRes = await request
             .put(localUtils.API.getApiQuery('posts/' + id + '/?newsletter=' + newsletterSlug + '&email_segment=status%3Afree'))
@@ -1168,7 +1168,7 @@ describe('Posts API', function () {
         publishedPost.newsletter.id.should.eql(newsletterId);
         publishedPost.email_segment.should.eql('status:free');
         publishedPost.status.should.eql('sent');
-        should.not.exist(publishedPost.newsletter_id);
+        assert.equal(publishedPost.newsletter_id, undefined);
 
         let model = await models.Post.findOne({
             id,
@@ -1230,7 +1230,7 @@ describe('Posts API', function () {
 
         scheduledPost.newsletter.id.should.eql(newsletterId);
         scheduledPost.email_segment.should.eql('all');
-        should.not.exist(scheduledPost.newsletter_id);
+        assert.equal(scheduledPost.newsletter_id, undefined);
 
         let model = await models.Post.findOne({
             id,
@@ -1239,14 +1239,14 @@ describe('Posts API', function () {
 
         should(model.get('newsletter_id')).eql(newsletterId);
         should(model.get('email_recipient_filter')).eql('all');
-        should.not.exist(model.get('published_by'));
+        assert.equal(model.get('published_by'), null);
 
         // We should not have an email
         let email = await models.Email.findOne({
             post_id: id
         }, testUtils.context.internal);
 
-        should.not.exist(email);
+        assert.equal(email, null);
 
         // Publish now, without passing the newsletter_id or other options again!
         scheduledPost.status = 'published';
@@ -1271,7 +1271,7 @@ describe('Posts API', function () {
         should.exist(model.get('published_by'));
 
         publishedPost.newsletter.id.should.eql(newsletterId);
-        should.not.exist(publishedPost.newsletter_id);
+        assert.equal(publishedPost.newsletter_id, undefined);
 
         // Check email is sent to the correct newsletter
         email = await models.Email.findOne({
@@ -1323,7 +1323,7 @@ describe('Posts API', function () {
 
         scheduledPost.newsletter.id.should.eql(newsletterId);
         scheduledPost.email_segment.should.eql('status:free');
-        should.not.exist(scheduledPost.newsletter_id);
+        assert.equal(scheduledPost.newsletter_id, undefined);
 
         let model = await models.Post.findOne({
             id,
@@ -1338,7 +1338,7 @@ describe('Posts API', function () {
             post_id: id
         }, testUtils.context.internal);
 
-        should.not.exist(email);
+        assert.equal(email, null);
 
         // Publish now, without passing the newsletter_id or other options again!
         scheduledPost.status = 'published';
@@ -1362,7 +1362,7 @@ describe('Posts API', function () {
         should(model.get('email_recipient_filter')).eql('status:free');
 
         publishedPost.newsletter.id.should.eql(newsletterId);
-        should.not.exist(publishedPost.newsletter_id);
+        assert.equal(publishedPost.newsletter_id, undefined);
 
         // Check email is sent to the correct newsletter
         email = await models.Email.findOne({
@@ -1412,7 +1412,7 @@ describe('Posts API', function () {
 
         should(scheduledPost.newsletter).eql(null);
         scheduledPost.email_segment.should.eql('all'); // should be igored
-        should.not.exist(scheduledPost.newsletter_id);
+        assert.equal(scheduledPost.newsletter_id, undefined);
 
         let model = await models.Post.findOne({
             id,
@@ -1427,7 +1427,7 @@ describe('Posts API', function () {
             post_id: id
         }, testUtils.context.internal);
 
-        should.not.exist(email);
+        assert.equal(email, null);
 
         // Publish now, without passing the newsletter_id or other options again!
         scheduledPost.status = 'published';
@@ -1451,14 +1451,14 @@ describe('Posts API', function () {
         should(model.get('email_recipient_filter')).eql('all');
 
         should(publishedPost.newsletter).eql(null);
-        should.not.exist(publishedPost.newsletter_id);
+        assert.equal(publishedPost.newsletter_id, undefined);
 
         // Check email is sent to the correct newsletter
         email = await models.Email.findOne({
             post_id: id
         }, testUtils.context.internal);
 
-        should.not.exist(email);
+        assert.equal(email, null);
     });
 
     it('Can publish a scheduled email only post', async function () {
@@ -1504,7 +1504,7 @@ describe('Posts API', function () {
         scheduledPost.email_segment.should.eql('all');
         scheduledPost.status.should.eql('scheduled');
         scheduledPost.email_only.should.eql(true);
-        should.not.exist(scheduledPost.newsletter_id);
+        assert.equal(scheduledPost.newsletter_id, undefined);
 
         let model = await models.Post.findOne({
             id,
@@ -1520,7 +1520,7 @@ describe('Posts API', function () {
             post_id: id
         }, testUtils.context.internal);
 
-        should.not.exist(email);
+        assert.equal(email, null);
 
         // Publish now, without passing the newsletter_id or other options again!
         scheduledPost.status = 'published';
@@ -1545,7 +1545,7 @@ describe('Posts API', function () {
         should(model.get('email_recipient_filter')).eql('all');
 
         publishedPost.newsletter.id.should.eql(newsletterId);
-        should.not.exist(publishedPost.newsletter_id);
+        assert.equal(publishedPost.newsletter_id, undefined);
 
         // Check email is sent to the correct newsletter
         email = await models.Email.findOne({
@@ -1601,7 +1601,7 @@ describe('Posts API', function () {
         should(res2.body.posts[0].newsletter.id).eql(newsletterId);
         should(res2.body.posts[0].email_segment).eql('status:-free');
 
-        should.not.exist(res2.body.posts[0].newsletter_id);
+        assert.equal(res2.body.posts[0].newsletter_id, undefined);
 
         model = await models.Post.findOne({
             id: id,
@@ -1636,7 +1636,7 @@ describe('Posts API', function () {
         // We should keep it, because we already sent an email
         should(res3.body.posts[0].newsletter.id).eql(newsletterId);
         should(res2.body.posts[0].email_segment).eql('status:-free');
-        should.not.exist(res3.body.posts[0].newsletter_id);
+        assert.equal(res3.body.posts[0].newsletter_id, undefined);
 
         model = await models.Post.findOne({
             id: id,
@@ -1671,7 +1671,7 @@ describe('Posts API', function () {
         // + did update the newsletter id
         should(res4.body.posts[0].newsletter.id).eql(newsletterId);
         should(res4.body.posts[0].email_segment).eql('status:-free');
-        should.not.exist(res4.body.posts[0].newsletter_id);
+        assert.equal(res4.body.posts[0].newsletter_id, undefined);
 
         model = await models.Post.findOne({
             id: id,
@@ -1692,7 +1692,7 @@ describe('Posts API', function () {
         // + did not update the newsletter id
         should(res5.body.posts[0].newsletter.id).eql(newsletterId);
         should(res5.body.posts[0].email_segment).eql('status:-free');
-        should.not.exist(res5.body.posts[0].newsletter_id);
+        assert.equal(res5.body.posts[0].newsletter_id, undefined);
 
         model = await models.Post.findOne({
             id: id,
@@ -1762,7 +1762,7 @@ describe('Posts API', function () {
 
             // Check newsletter relation is loaded, but null in response.
             should(res.body.posts[0].newsletter).eql(null);
-            should.not.exist(res.body.posts[0].newsletter_id);
+            assert.equal(res.body.posts[0].newsletter_id, undefined);
 
             const id = res.body.posts[0].id;
 
@@ -1781,7 +1781,7 @@ describe('Posts API', function () {
             // Check newsletter relation is loaded in response
             should(finalPost.body.posts[0].newsletter.id).eql(newsletterId);
             should(finalPost.body.posts[0].email_segment).eql('all');
-            should.not.exist(finalPost.body.posts[0].newsletter_id);
+            assert.equal(finalPost.body.posts[0].newsletter_id, undefined);
 
             const model = await models.Post.findOne({
                 id
@@ -1843,7 +1843,7 @@ describe('Posts API', function () {
             publishedPost.newsletter.id.should.eql(newsletterId);
             publishedPost.email_segment.should.eql('all');
             publishedPost.status.should.eql('sent');
-            should.not.exist(publishedPost.newsletter_id);
+            assert.equal(publishedPost.newsletter_id, undefined);
 
             let model = await models.Post.findOne({
                 id,

--- a/ghost/core/test/e2e-api/admin/tags.test.js
+++ b/ghost/core/test/e2e-api/admin/tags.test.js
@@ -24,7 +24,7 @@ describe('Tag API', function () {
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(200);
 
-        should.not.exist(res.headers['x-cache-invalidate']);
+        assert.equal(res.headers['x-cache-invalidate'], undefined);
         const jsonResponse = res.body;
         should.exist(jsonResponse);
         should.exist(jsonResponse.tags);
@@ -72,7 +72,7 @@ describe('Tag API', function () {
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(200);
 
-        should.not.exist(res.headers['x-cache-invalidate']);
+        assert.equal(res.headers['x-cache-invalidate'], undefined);
         const jsonResponse = res.body;
         should.exist(jsonResponse);
         should.exist(jsonResponse.tags);

--- a/ghost/core/test/e2e-api/admin/themes.test.js
+++ b/ghost/core/test/e2e-api/admin/themes.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const path = require('path');
@@ -108,7 +109,7 @@ describe('Themes API', function () {
         const res = await uploadTheme({themePath: path.join(__dirname, '..', '..', 'utils', 'fixtures', 'themes', 'valid.zip')});
         const jsonResponse = res.body;
 
-        should.not.exist(res.headers['x-cache-invalidate']);
+        assert.equal(res.headers['x-cache-invalidate'], undefined);
 
         should.exist(jsonResponse.themes);
         localUtils.API.checkResponse(jsonResponse, 'themes');
@@ -219,7 +220,7 @@ describe('Themes API', function () {
 
         // The deleted theme should not be here
         const deletedTheme = _.find(jsonResponse2.themes, {name: 'valid'});
-        should.not.exist(deletedTheme);
+        assert.equal(deletedTheme, undefined);
     });
 
     it('Can upload a theme, which has warnings', async function () {
@@ -277,7 +278,7 @@ describe('Themes API', function () {
         jsonResponse2.themes.length.should.eql(1);
 
         const sourceTheme2 = _.find(jsonResponse2.themes, {name: 'source'});
-        should.not.exist(sourceTheme2);
+        assert.equal(sourceTheme2, undefined);
 
         const testTheme2 = _.find(jsonResponse2.themes, {name: 'test-theme'});
         should.exist(testTheme2);

--- a/ghost/core/test/e2e-api/content/tags.test.js
+++ b/ghost/core/test/e2e-api/content/tags.test.js
@@ -31,7 +31,7 @@ describe('Tags Content API', function () {
             .expect('Cache-Control', testUtils.cacheRules.public)
             .expect(200);
 
-        should.not.exist(res.headers['x-cache-invalidate']);
+        assert.equal(res.headers['x-cache-invalidate'], undefined);
         const jsonResponse = res.body;
         should.exist(jsonResponse.tags);
         localUtils.API.checkResponse(jsonResponse, 'tags');
@@ -62,7 +62,7 @@ describe('Tags Content API', function () {
             .expect('Cache-Control', testUtils.cacheRules.public)
             .expect(200);
 
-        should.not.exist(res.headers['x-cache-invalidate']);
+        assert.equal(res.headers['x-cache-invalidate'], undefined);
         const jsonResponse = res.body;
         should.exist(jsonResponse.tags);
         localUtils.API.checkResponse(jsonResponse, 'tags');
@@ -78,7 +78,7 @@ describe('Tags Content API', function () {
             .expect('Cache-Control', testUtils.cacheRules.public)
             .expect(200);
 
-        should.not.exist(res.headers['x-cache-invalidate']);
+        assert.equal(res.headers['x-cache-invalidate'], undefined);
         const jsonResponse = res.body;
         should.exist(jsonResponse.tags);
         localUtils.API.checkResponse(jsonResponse, 'tags');

--- a/ghost/core/test/e2e-api/members-comments/comments.test.js
+++ b/ghost/core/test/e2e-api/members-comments/comments.test.js
@@ -639,7 +639,7 @@ describe('Comments API', function () {
                     commentMatcher,
                     commentMatcherWithReplies({replies: 1})
                 ]);
-                should.not.exist(response.body.comments[0].unsubscribe_url);
+                assert.equal(response.body.comments[0].unsubscribe_url, undefined);
             });
 
             describe('browse by post', function () {
@@ -1435,8 +1435,8 @@ describe('Comments API', function () {
                         });
 
                         // in_reply_to is not set
-                        should.not.exist(newComment.in_reply_to_id);
-                        should.not.exist(newComment.in_reply_to_snippet);
+                        assert.equal(newComment.in_reply_to_id, null);
+                        assert.equal(newComment.in_reply_to_snippet, null);
 
                         // only author and parent email sent
                         emailMockReceiver.assertSentEmailCount(2);
@@ -1458,10 +1458,10 @@ describe('Comments API', function () {
                     });
 
                     // in_reply_to is not set
-                    should.not.exist(newComment.in_reply_to_id);
-                    should.not.exist(newComment.in_reply_to_snippet);
+                    assert.equal(newComment.in_reply_to_id, null);
+                    assert.equal(newComment.in_reply_to_snippet, null);
 
-                    should.not.exist(newComment.parent_id);
+                    assert.equal(newComment.parent_id, null);
 
                     // only author email sent
                     emailMockReceiver.assertSentEmailCount(1);
@@ -1491,8 +1491,8 @@ describe('Comments API', function () {
                     });
 
                     // in_reply_to is not set
-                    should.not.exist(newComment.in_reply_to_id);
-                    should.not.exist(newComment.in_reply_to_snippet);
+                    assert.equal(newComment.in_reply_to_id, null);
+                    assert.equal(newComment.in_reply_to_snippet, null);
                 });
 
                 it('includes in_reply_to_snippet in response', async function () {

--- a/ghost/core/test/e2e-api/members/middleware.test.js
+++ b/ghost/core/test/e2e-api/members/middleware.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const crypto = require('crypto');
 const {agentProvider, mockManager, fixtureManager, matchers, configUtils} = require('../../utils/e2e-framework');
 const {anyEtag, anyObjectId, anyUuid, anyISODateTime, stringMatching} = matchers;
@@ -269,7 +270,7 @@ describe('Comments API', function () {
                 .expectStatus(204)
                 .expectEmptyBody()
                 .expect(({headers}) => {
-                    should.not.exist(headers['set-cookie']);
+                    assert.equal(headers['set-cookie'], undefined);
                 });
         });
 

--- a/ghost/core/test/e2e-frontend/custom-routes.test.js
+++ b/ghost/core/test/e2e-frontend/custom-routes.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const supertest = require('supertest');
 const path = require('path');
@@ -6,9 +7,9 @@ const testUtils = require('../utils');
 const configUtils = require('../utils/config-utils');
 
 function assertCorrectFrontendHeaders(res) {
-    should.not.exist(res.headers['x-cache-invalidate']);
-    should.not.exist(res.headers['X-CSRF-Token']);
-    should.not.exist(res.headers['set-cookie']);
+    assert.equal(res.headers['x-cache-invalidate'], undefined);
+    assert.equal(res.headers['X-CSRF-Token'], undefined);
+    assert.equal(res.headers['set-cookie'], undefined);
     should.exist(res.headers.date);
 }
 

--- a/ghost/core/test/e2e-frontend/default-routes.test.js
+++ b/ghost/core/test/e2e-frontend/default-routes.test.js
@@ -5,6 +5,7 @@
 // As it stands, these tests depend on the database, and as such are integration tests.
 // Mocking out the models to not touch the DB would turn these into unit tests, and should probably be done in future,
 // But then again testing real code, rather than mock code, might be more useful...
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const supertest = require('supertest');
@@ -17,9 +18,9 @@ const settingsCache = require('../../core/shared/settings-cache');
 const origCache = _.cloneDeep(settingsCache);
 
 function assertCorrectFrontendHeaders(res) {
-    should.not.exist(res.headers['x-cache-invalidate']);
-    should.not.exist(res.headers['X-CSRF-Token']);
-    should.not.exist(res.headers['set-cookie']);
+    assert.equal(res.headers['x-cache-invalidate'], undefined);
+    assert.equal(res.headers['X-CSRF-Token'], undefined);
+    assert.equal(res.headers['set-cookie'], undefined);
     should.exist(res.headers.date);
 }
 

--- a/ghost/core/test/e2e-frontend/email-routes.test.js
+++ b/ghost/core/test/e2e-frontend/email-routes.test.js
@@ -2,6 +2,7 @@
 // As it stands, these tests depend on the database, and as such are integration tests.
 // Mocking out the models to not touch the DB would turn these into unit tests, and should probably be done in future,
 // But then again testing real code, rather than mock code, might be more useful...
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const supertest = require('supertest');
@@ -47,9 +48,9 @@ describe('Frontend Routing: Email Routes', function () {
 
         $('title').text().should.equal('I am visible through email route!');
 
-        should.not.exist(res.headers['x-cache-invalidate']);
-        should.not.exist(res.headers['X-CSRF-Token']);
-        should.not.exist(res.headers['set-cookie']);
+        assert.equal(res.headers['x-cache-invalidate'], undefined);
+        assert.equal(res.headers['X-CSRF-Token'], undefined);
+        assert.equal(res.headers['set-cookie'], undefined);
         should.exist(res.headers.date);
     });
 

--- a/ghost/core/test/e2e-frontend/preview-routes.test.js
+++ b/ghost/core/test/e2e-frontend/preview-routes.test.js
@@ -2,6 +2,7 @@
 // As it stands, these tests depend on the database, and as such are integration tests.
 // Mocking out the models to not touch the DB would turn these into unit tests, and should probably be done in future,
 // But then again testing real code, rather than mock code, might be more useful...
+const assert = require('node:assert/strict');
 const should = require('should');
 
 const sinon = require('sinon');
@@ -13,9 +14,9 @@ const {DateTime} = require('luxon');
 let request;
 
 function assertCorrectFrontendHeaders(res) {
-    should.not.exist(res.headers['x-cache-invalidate']);
-    should.not.exist(res.headers['X-CSRF-Token']);
-    should.not.exist(res.headers['set-cookie']);
+    assert.equal(res.headers['x-cache-invalidate'], undefined);
+    assert.equal(res.headers['X-CSRF-Token'], undefined);
+    assert.equal(res.headers['set-cookie'], undefined);
     should.exist(res.headers.date);
 }
 
@@ -63,9 +64,9 @@ describe('Frontend Routing: Preview Routes', function () {
             .expect((res) => {
                 const $ = cheerio.load(res.text);
 
-                should.not.exist(res.headers['x-cache-invalidate']);
-                should.not.exist(res.headers['X-CSRF-Token']);
-                should.not.exist(res.headers['set-cookie']);
+                assert.equal(res.headers['x-cache-invalidate'], undefined);
+                assert.equal(res.headers['X-CSRF-Token'], undefined);
+                assert.equal(res.headers['set-cookie'], undefined);
                 should.exist(res.headers.date);
 
                 $('title').text().should.equal('Not finished yet');

--- a/ghost/core/test/e2e-server/admin.test.js
+++ b/ghost/core/test/e2e-server/admin.test.js
@@ -3,6 +3,7 @@
 // Mocking out the models to not touch the DB would turn these into unit tests, and should probably be done in future,
 // But then again testing real code, rather than mock code, might be more useful...
 
+const assert = require('node:assert/strict');
 const should = require('should');
 const path = require('path');
 const fs = require('fs');
@@ -16,7 +17,7 @@ const config = require('../../core/shared/config');
 let request;
 
 function assertCorrectHeaders(res) {
-    should.not.exist(res.headers['x-cache-invalidate']);
+    assert.equal(res.headers['x-cache-invalidate'], undefined);
     should.exist(res.headers.date);
 }
 

--- a/ghost/core/test/integration/exporter/exporter.test.js
+++ b/ghost/core/test/integration/exporter/exporter.test.js
@@ -148,13 +148,13 @@ describe('Exporter', function () {
             ];
 
             excludedSettings.forEach((settingKey) => {
-                should.not.exist(_.find(exportData.data.settings, {key: settingKey}));
+                assert.equal(_.find(exportData.data.settings, {key: settingKey}), undefined);
             });
 
-            should.not.exist(_.find(exportData.data.settings, {key: 'permalinks'}));
+            assert.equal(_.find(exportData.data.settings, {key: 'permalinks'}), undefined);
 
             // should not export sqlite data
-            should.not.exist(exportData.data.sqlite_sequence);
+            assert.equal(exportData.data.sqlite_sequence, undefined);
             done();
         }).catch(done);
     });

--- a/ghost/core/test/integration/url-service.test.js
+++ b/ghost/core/test/integration/url-service.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const testUtils = require('../utils');
@@ -109,7 +110,7 @@ describe('Integration: services/url/UrlService', function () {
             resource.data.id.should.eql(testUtils.DataGenerator.forKnex.posts[0].id);
 
             resource = urlService.getResource('/does-not-exist/');
-            should.not.exist(resource);
+            assert.equal(resource, null);
         });
     });
 

--- a/ghost/core/test/legacy/api/admin/db.test.js
+++ b/ghost/core/test/legacy/api/admin/db.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const path = require('path');
 const os = require('os');
 const fs = require('fs-extra');
@@ -436,7 +437,7 @@ describe('DB API (cleaned)', function () {
 
         // Check if we ignored the import of the product
         const productDuplicate = await models.Product.findOne({slug: 'ghost-inc-2'});
-        should.not.exist(productDuplicate);
+        assert.equal(productDuplicate, null);
 
         // Check if we have a product
         const product = await models.Product.findOne({slug: 'ghost-inc'});

--- a/ghost/core/test/legacy/api/admin/identities.test.js
+++ b/ghost/core/test/legacy/api/admin/identities.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const supertest = require('supertest');
 const jwt = require('jsonwebtoken');
@@ -48,7 +49,7 @@ describe('Identities API', function () {
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(200)
                 .then((res) => {
-                    should.not.exist(res.headers['x-cache-invalidate']);
+                    assert.equal(res.headers['x-cache-invalidate'], undefined);
                     const jsonResponse = res.body;
                     should.exist(jsonResponse);
                     should.exist(jsonResponse.identities);
@@ -94,7 +95,7 @@ describe('Identities API', function () {
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(200)
                 .then((res) => {
-                    should.not.exist(res.headers['x-cache-invalidate']);
+                    assert.equal(res.headers['x-cache-invalidate'], undefined);
                     const jsonResponse = res.body;
                     should.exist(jsonResponse);
                     should.exist(jsonResponse.identities);

--- a/ghost/core/test/legacy/api/admin/members-importer.test.js
+++ b/ghost/core/test/legacy/api/admin/members-importer.test.js
@@ -42,7 +42,7 @@ describe('Members Importer API', function () {
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(201)
             .then((res) => {
-                should.not.exist(res.headers['x-cache-invalidate']);
+                assert.equal(res.headers['x-cache-invalidate'], undefined);
                 const jsonResponse = res.body;
 
                 should.exist(jsonResponse);
@@ -63,7 +63,7 @@ describe('Members Importer API', function () {
                     .expect(200);
             })
             .then((res) => {
-                should.not.exist(res.headers['x-cache-invalidate']);
+                assert.equal(res.headers['x-cache-invalidate'], undefined);
                 const jsonResponse = res.body;
 
                 should.exist(jsonResponse);
@@ -109,7 +109,7 @@ describe('Members Importer API', function () {
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(201)
             .then((res) => {
-                should.not.exist(res.headers['x-cache-invalidate']);
+                assert.equal(res.headers['x-cache-invalidate'], undefined);
                 const jsonResponse = res.body;
 
                 should.exist(jsonResponse);
@@ -131,7 +131,7 @@ describe('Members Importer API', function () {
                     .expect(200);
             })
             .then((res) => {
-                should.not.exist(res.headers['x-cache-invalidate']);
+                assert.equal(res.headers['x-cache-invalidate'], undefined);
                 const jsonResponse = res.body;
 
                 should.exist(jsonResponse);
@@ -159,7 +159,7 @@ describe('Members Importer API', function () {
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(201)
             .then((res) => {
-                should.not.exist(res.headers['x-cache-invalidate']);
+                assert.equal(res.headers['x-cache-invalidate'], undefined);
                 const jsonResponse = res.body;
 
                 should.exist(jsonResponse);
@@ -178,7 +178,7 @@ describe('Members Importer API', function () {
                     .expect(200);
             })
             .then((res) => {
-                should.not.exist(res.headers['x-cache-invalidate']);
+                assert.equal(res.headers['x-cache-invalidate'], undefined);
                 const jsonResponse = res.body;
 
                 should.exist(jsonResponse);
@@ -207,12 +207,12 @@ describe('Members Importer API', function () {
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(202)
             .then((res) => {
-                should.not.exist(res.headers['x-cache-invalidate']);
+                assert.equal(res.headers['x-cache-invalidate'], undefined);
                 const jsonResponse = res.body;
 
                 should.exist(jsonResponse);
                 should.exist(jsonResponse.meta);
-                should.not.exist(jsonResponse.meta.stats);
+                assert.equal(jsonResponse.meta.stats, undefined);
             });
     });
 
@@ -226,7 +226,7 @@ describe('Members Importer API', function () {
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(201)
             .then((res) => {
-                should.not.exist(res.headers['x-cache-invalidate']);
+                assert.equal(res.headers['x-cache-invalidate'], undefined);
                 const jsonResponse = res.body;
 
                 should.exist(jsonResponse);
@@ -262,7 +262,7 @@ describe('Members Importer API', function () {
             .expect('Content-Type', /json/)
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(201);
-        should.not.exist(res.headers['x-cache-invalidate']);
+        assert.equal(res.headers['x-cache-invalidate'], undefined);
         const jsonResponse = res.body;
 
         should.exist(jsonResponse);
@@ -288,7 +288,7 @@ describe('Members Importer API', function () {
             .expect('Content-Type', /json/)
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(201);
-        should.not.exist(res.headers['x-cache-invalidate']);
+        assert.equal(res.headers['x-cache-invalidate'], undefined);
         const jsonResponse = res.body;
 
         should.exist(jsonResponse);
@@ -331,7 +331,7 @@ describe('Members Importer API', function () {
             .expect('Content-Type', /json/)
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(202);
-        should.not.exist(res.headers['x-cache-invalidate']);
+        assert.equal(res.headers['x-cache-invalidate'], undefined);
         const jsonResponse = res.body;
 
         should.exist(jsonResponse);

--- a/ghost/core/test/legacy/api/admin/members-signin-url.test.js
+++ b/ghost/core/test/legacy/api/admin/members-signin-url.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const supertest = require('supertest');
 const testUtils = require('../../../utils');
@@ -28,7 +29,7 @@ describe('Members Sigin URL API', function () {
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(200)
                 .then((res) => {
-                    should.not.exist(res.headers['x-cache-invalidate']);
+                    assert.equal(res.headers['x-cache-invalidate'], undefined);
                     const jsonResponse = res.body;
                     should.exist(jsonResponse);
                     should.exist(jsonResponse.member_signin_urls);
@@ -59,7 +60,7 @@ describe('Members Sigin URL API', function () {
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(200)
                 .then((res) => {
-                    should.not.exist(res.headers['x-cache-invalidate']);
+                    assert.equal(res.headers['x-cache-invalidate'], undefined);
                     const jsonResponse = res.body;
                     should.exist(jsonResponse);
                     should.exist(jsonResponse.member_signin_urls);
@@ -126,7 +127,7 @@ describe('Members Sigin URL API', function () {
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(200)
                 .then((res) => {
-                    should.not.exist(res.headers['x-cache-invalidate']);
+                    assert.equal(res.headers['x-cache-invalidate'], undefined);
                     const jsonResponse = res.body;
                     should.exist(jsonResponse);
                     should.exist(jsonResponse.member_signin_urls);

--- a/ghost/core/test/legacy/api/admin/posts.test.js
+++ b/ghost/core/test/legacy/api/admin/posts.test.js
@@ -43,7 +43,7 @@ describe('Posts API', function () {
                         return done(err);
                     }
 
-                    should.not.exist(res.headers['x-cache-invalidate']);
+                    assert.equal(res.headers['x-cache-invalidate'], undefined);
                     const jsonResponse = res.body;
                     should.exist(jsonResponse.posts);
                     localUtils.API.checkResponse(jsonResponse, 'posts');
@@ -74,7 +74,7 @@ describe('Posts API', function () {
                         return done(err);
                     }
 
-                    should.not.exist(res.headers['x-cache-invalidate']);
+                    assert.equal(res.headers['x-cache-invalidate'], undefined);
                     const jsonResponse = res.body;
                     should.exist(jsonResponse.posts);
                     localUtils.API.checkResponse(jsonResponse, 'posts');
@@ -105,7 +105,7 @@ describe('Posts API', function () {
                         return done(err);
                     }
 
-                    should.not.exist(res.headers['x-cache-invalidate']);
+                    assert.equal(res.headers['x-cache-invalidate'], undefined);
                     const jsonResponse = res.body;
                     should.exist(jsonResponse.posts);
                     localUtils.API.checkResponse(jsonResponse, 'posts');
@@ -136,7 +136,7 @@ describe('Posts API', function () {
                         return done(err);
                     }
 
-                    should.not.exist(res.headers['x-cache-invalidate']);
+                    assert.equal(res.headers['x-cache-invalidate'], undefined);
                     const jsonResponse = res.body;
                     should.exist(jsonResponse.posts);
                     localUtils.API.checkResponse(jsonResponse, 'posts');
@@ -166,7 +166,7 @@ describe('Posts API', function () {
                         return done(err);
                     }
 
-                    should.not.exist(res.headers['x-cache-invalidate']);
+                    assert.equal(res.headers['x-cache-invalidate'], undefined);
                     const jsonResponse = res.body;
                     should.exist(jsonResponse.posts);
                     localUtils.API.checkResponse(jsonResponse, 'posts');
@@ -231,7 +231,7 @@ describe('Posts API', function () {
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(200)
                 .then((res) => {
-                    should.not.exist(res.headers['x-cache-invalidate']);
+                    assert.equal(res.headers['x-cache-invalidate'], undefined);
                     const jsonResponse = res.body;
                     should.exist(jsonResponse.posts);
                     localUtils.API.checkResponse(jsonResponse, 'posts');
@@ -269,7 +269,7 @@ describe('Posts API', function () {
                         return done(err);
                     }
 
-                    should.not.exist(res.headers['x-cache-invalidate']);
+                    assert.equal(res.headers['x-cache-invalidate'], undefined);
                     const jsonResponse = res.body;
                     should.exist(jsonResponse);
                     should.exist(jsonResponse.errors);
@@ -730,7 +730,7 @@ describe('Posts API', function () {
                 })
                 .then((res) => {
                     // NOTE: when ONLY ignored fields are posted they should not change a thing, thus cache stays untouched
-                    should.not.exist(res.headers['x-cache-invalidate']);
+                    assert.equal(res.headers['x-cache-invalidate'], undefined);
 
                     should.exist(res.body.posts);
                     should.exist(res.body.posts[0].published_at);
@@ -809,7 +809,7 @@ describe('Posts API', function () {
                 .expect(200)
                 .then((res) => {
                     // @NOTE: you cannot modify these fields above manually, that's why the resource won't change.
-                    should.not.exist(res.headers['x-cache-invalidate']);
+                    assert.equal(res.headers['x-cache-invalidate'], undefined);
 
                     return models.Post.findOne({
                         id: res.body.posts[0].id
@@ -1024,7 +1024,7 @@ describe('Posts API', function () {
                         .expect(200);
                 })
                 .then((res) => {
-                    should.not.exist(res.headers['x-cache-invalidate']);
+                    assert.equal(res.headers['x-cache-invalidate'], undefined);
 
                     should.exist(res.body.posts);
                     res.body.posts[0].title.should.equal('Has a title by no other content');
@@ -1078,7 +1078,7 @@ describe('Posts API', function () {
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(404)
                 .then((res) => {
-                    should.not.exist(res.headers['x-cache-invalidate']);
+                    assert.equal(res.headers['x-cache-invalidate'], undefined);
                     should.exist(res.body);
                     should.exist(res.body.errors);
                     testUtils.API.checkResponseValue(res.body.errors[0], [

--- a/ghost/core/test/legacy/api/admin/settings.test.js
+++ b/ghost/core/test/legacy/api/admin/settings.test.js
@@ -54,7 +54,7 @@ describe('Settings API', function () {
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(200)
             .expect((response) => {
-                should.not.exist(response.headers['x-cache-invalidate']);
+                assert.equal(response.headers['x-cache-invalidate'], undefined);
             });
 
         // Check if not changed (also check internal ones)
@@ -297,7 +297,7 @@ describe('Settings API', function () {
                         .expect(403)
                         .then(function ({body, headers}) {
                             jsonResponse = body;
-                            should.not.exist(headers['x-cache-invalidate']);
+                            assert.equal(headers['x-cache-invalidate'], undefined);
                             should.exist(jsonResponse.errors);
                             testUtils.API.checkResponseValue(jsonResponse.errors[0], [
                                 'message',
@@ -350,7 +350,7 @@ describe('Settings API', function () {
                         .expect(403)
                         .then(function ({body, headers}) {
                             jsonResponse = body;
-                            should.not.exist(headers['x-cache-invalidate']);
+                            assert.equal(headers['x-cache-invalidate'], undefined);
                             should.exist(jsonResponse.errors);
                             testUtils.API.checkResponseValue(jsonResponse.errors[0], [
                                 'message',

--- a/ghost/core/test/legacy/api/admin/users.test.js
+++ b/ghost/core/test/legacy/api/admin/users.test.js
@@ -39,7 +39,7 @@ describe('User API', function () {
                             return done(err);
                         }
 
-                        should.not.exist(res.headers['x-cache-invalidate']);
+                        assert.equal(res.headers['x-cache-invalidate'], undefined);
                         const jsonResponse = res.body;
                         should.exist(jsonResponse);
                         should.exist(jsonResponse.errors);
@@ -70,7 +70,7 @@ describe('User API', function () {
                             return done(err);
                         }
 
-                        should.not.exist(res.headers['x-cache-invalidate']);
+                        assert.equal(res.headers['x-cache-invalidate'], undefined);
                         const jsonResponse = res.body;
                         should.exist(jsonResponse);
                         should.exist(jsonResponse.errors);

--- a/ghost/core/test/legacy/api/admin/webhooks.test.js
+++ b/ghost/core/test/legacy/api/admin/webhooks.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const supertest = require('supertest');
 const testUtils = require('../../../utils');
@@ -33,7 +34,7 @@ describe('Webhooks API', function () {
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(201)
             .then((res) => {
-                should.not.exist(res.headers['x-cache-invalidate']);
+                assert.equal(res.headers['x-cache-invalidate'], undefined);
                 const jsonResponse = res.body;
 
                 should.exist(jsonResponse);

--- a/ghost/core/test/legacy/api/content/authors.test.js
+++ b/ghost/core/test/legacy/api/content/authors.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const supertest = require('supertest');
 const localUtils = require('./utils');
@@ -104,7 +105,7 @@ describe('Authors Content API', function () {
             .expect('Cache-Control', testUtils.cacheRules.public)
             .expect(200)
             .then((res) => {
-                should.not.exist(res.headers['x-cache-invalidate']);
+                assert.equal(res.headers['x-cache-invalidate'], undefined);
 
                 // We don't expose any other attrs.
                 localUtils.API.checkResponse(res.body.authors[0], 'author', null, null, ['id', 'name']);

--- a/ghost/core/test/legacy/api/content/posts.test.js
+++ b/ghost/core/test/legacy/api/content/posts.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const supertest = require('supertest');
 const _ = require('lodash');
@@ -113,7 +114,7 @@ describe('api/endpoints/content/posts', function () {
 
                 res.headers.vary.should.eql('Accept-Version, Accept-Encoding');
                 should.exist(res.headers['access-control-allow-origin']);
-                should.not.exist(res.headers['x-cache-invalidate']);
+                assert.equal(res.headers['x-cache-invalidate'], undefined);
 
                 const jsonResponse = res.body;
                 should.exist(jsonResponse.posts);
@@ -134,8 +135,8 @@ describe('api/endpoints/content/posts', function () {
                 jsonResponse.meta.pagination.total.should.eql(13);
                 jsonResponse.meta.pagination.hasOwnProperty('next').should.be.true();
                 jsonResponse.meta.pagination.hasOwnProperty('prev').should.be.true();
-                should.not.exist(jsonResponse.meta.pagination.next);
-                should.not.exist(jsonResponse.meta.pagination.prev);
+                assert.equal(jsonResponse.meta.pagination.next, null);
+                assert.equal(jsonResponse.meta.pagination.prev, null);
 
                 done();
             });
@@ -154,7 +155,7 @@ describe('api/endpoints/content/posts', function () {
 
                 res.headers.vary.should.eql('Accept-Version, Accept-Encoding');
                 should.exist(res.headers['access-control-allow-origin']);
-                should.not.exist(res.headers['x-cache-invalidate']);
+                assert.equal(res.headers['x-cache-invalidate'], undefined);
 
                 const jsonResponse = res.body;
                 should.exist(jsonResponse.posts);
@@ -181,8 +182,8 @@ describe('api/endpoints/content/posts', function () {
                 jsonResponse.meta.pagination.total.should.eql(13);
                 jsonResponse.meta.pagination.hasOwnProperty('next').should.be.true();
                 jsonResponse.meta.pagination.hasOwnProperty('prev').should.be.true();
-                should.not.exist(jsonResponse.meta.pagination.next);
-                should.not.exist(jsonResponse.meta.pagination.prev);
+                assert.equal(jsonResponse.meta.pagination.next, null);
+                assert.equal(jsonResponse.meta.pagination.prev, null);
 
                 done();
             });
@@ -260,7 +261,7 @@ describe('api/endpoints/content/posts', function () {
                 res.headers.vary.should.eql('Accept-Version, Accept, Accept-Encoding');
                 res.headers.location.should.eql(`http://localhost:9999/ghost/api/content/posts/?key=${validKey}`);
                 should.exist(res.headers['access-control-allow-origin']);
-                should.not.exist(res.headers['x-cache-invalidate']);
+                assert.equal(res.headers['x-cache-invalidate'], undefined);
                 done();
             });
     });
@@ -435,7 +436,7 @@ describe('api/endpoints/content/posts', function () {
                 .then((res) => {
                     res.headers.vary.should.eql('Accept-Version, Accept-Encoding');
                     should.exist(res.headers['access-control-allow-origin']);
-                    should.not.exist(res.headers['x-cache-invalidate']);
+                    assert.equal(res.headers['x-cache-invalidate'], undefined);
 
                     const jsonResponse = res.body;
                     should.exist(jsonResponse.posts);
@@ -480,7 +481,7 @@ describe('api/endpoints/content/posts', function () {
                     jsonResponse.meta.pagination.hasOwnProperty('next').should.be.true();
                     jsonResponse.meta.pagination.hasOwnProperty('prev').should.be.true();
                     jsonResponse.meta.pagination.next.should.eql(2);
-                    should.not.exist(jsonResponse.meta.pagination.prev);
+                    assert.equal(jsonResponse.meta.pagination.prev, null);
                 });
         });
     });

--- a/ghost/core/test/legacy/api/content/tags.test.js
+++ b/ghost/core/test/legacy/api/content/tags.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const supertest = require('supertest');
 const _ = require('lodash');
@@ -42,7 +43,7 @@ describe('api/endpoints/content/tags', function () {
             .expect('Cache-Control', testUtils.cacheRules.public)
             .expect(200)
             .then((res) => {
-                should.not.exist(res.headers['x-cache-invalidate']);
+                assert.equal(res.headers['x-cache-invalidate'], undefined);
                 const jsonResponse = res.body;
                 should.exist(jsonResponse);
                 should.exist(jsonResponse.tags);

--- a/ghost/core/test/legacy/models/model-posts.test.js
+++ b/ghost/core/test/legacy/models/model-posts.test.js
@@ -879,7 +879,7 @@ describe('Post Model', function () {
                     mobiledoc: markdownToMobiledoc('This is some content')
                 }, context).then(function (newPost) {
                     should.exist(newPost);
-                    should.not.exist(newPost.get('published_at'));
+                    assert.equal(newPost.get('published_at'), null);
 
                     Object.keys(eventsTriggered).length.should.eql(2);
                     should.exist(eventsTriggered['post.added']);

--- a/ghost/core/test/legacy/models/model-users.test.js
+++ b/ghost/core/test/legacy/models/model-users.test.js
@@ -114,7 +114,7 @@ describe('User Model', function run() {
 
             UserModel.add(userData, context).then(function (createdUser) {
                 should.exist(createdUser);
-                should.not.exist(createdUser.image);
+                assert.equal(createdUser.image, undefined);
                 done();
             }).catch(done);
         });

--- a/ghost/core/test/legacy/site/dynamic-routing.test.js
+++ b/ghost/core/test/legacy/site/dynamic-routing.test.js
@@ -2,6 +2,7 @@
 // As it stands, these tests depend on the database, and as such are integration tests.
 // These tests are here to cover the headers sent with requests and high-level redirects that can't be
 // tested with the unit tests
+const assert = require('node:assert/strict');
 const should = require('should');
 const supertest = require('supertest');
 const sinon = require('sinon');
@@ -21,9 +22,9 @@ describe('Dynamic Routing', function () {
                 return done(err);
             }
 
-            should.not.exist(res.headers['x-cache-invalidate']);
-            should.not.exist(res.headers['X-CSRF-Token']);
-            should.not.exist(res.headers['set-cookie']);
+            assert.equal(res.headers['x-cache-invalidate'], undefined);
+            assert.equal(res.headers['X-CSRF-Token'], undefined);
+            assert.equal(res.headers['set-cookie'], undefined);
             should.exist(res.headers.date);
 
             done();
@@ -58,9 +59,9 @@ describe('Dynamic Routing', function () {
 
                     const $ = cheerio.load(res.text);
 
-                    should.not.exist(res.headers['x-cache-invalidate']);
-                    should.not.exist(res.headers['X-CSRF-Token']);
-                    should.not.exist(res.headers['set-cookie']);
+                    assert.equal(res.headers['x-cache-invalidate'], undefined);
+                    assert.equal(res.headers['X-CSRF-Token'], undefined);
+                    assert.equal(res.headers['set-cookie'], undefined);
                     should.exist(res.headers.date);
 
                     $('title').text().should.equal('Ghost');
@@ -131,9 +132,9 @@ describe('Dynamic Routing', function () {
 
                     const $ = cheerio.load(res.text);
 
-                    should.not.exist(res.headers['x-cache-invalidate']);
-                    should.not.exist(res.headers['X-CSRF-Token']);
-                    should.not.exist(res.headers['set-cookie']);
+                    assert.equal(res.headers['x-cache-invalidate'], undefined);
+                    assert.equal(res.headers['X-CSRF-Token'], undefined);
+                    assert.equal(res.headers['set-cookie'], undefined);
                     should.exist(res.headers.date);
 
                     $('body').attr('class').should.eql('tag-template tag-getting-started has-sans-title has-sans-body');

--- a/ghost/core/test/legacy/site/frontend.test.js
+++ b/ghost/core/test/legacy/site/frontend.test.js
@@ -2,6 +2,7 @@
 // As it stands, these tests depend on the database, and as such are integration tests.
 // Mocking out the models to not touch the DB would turn these into unit tests, and should probably be done in future,
 // But then again testing real code, rather than mock code, might be more useful...
+const assert = require('node:assert/strict');
 const should = require('should');
 
 const sinon = require('sinon');
@@ -19,9 +20,9 @@ describe('Frontend Routing', function () {
                 return done(err);
             }
 
-            should.not.exist(res.headers['x-cache-invalidate']);
-            should.not.exist(res.headers['X-CSRF-Token']);
-            should.not.exist(res.headers['set-cookie']);
+            assert.equal(res.headers['x-cache-invalidate'], undefined);
+            assert.equal(res.headers['X-CSRF-Token'], undefined);
+            assert.equal(res.headers['set-cookie'], undefined);
             should.exist(res.headers.date);
 
             done();
@@ -29,9 +30,9 @@ describe('Frontend Routing', function () {
     }
 
     function assertCorrectFrontendHeaders(res) {
-        should.not.exist(res.headers['x-cache-invalidate']);
-        should.not.exist(res.headers['X-CSRF-Token']);
-        should.not.exist(res.headers['set-cookie']);
+        assert.equal(res.headers['x-cache-invalidate'], undefined);
+        assert.equal(res.headers['X-CSRF-Token'], undefined);
+        assert.equal(res.headers['set-cookie'], undefined);
         should.exist(res.headers.date);
     }
 
@@ -122,9 +123,9 @@ describe('Frontend Routing', function () {
                     .end(function (err, res) {
                         const $ = cheerio.load(res.text);
 
-                        should.not.exist(res.headers['x-cache-invalidate']);
-                        should.not.exist(res.headers['X-CSRF-Token']);
-                        should.not.exist(res.headers['set-cookie']);
+                        assert.equal(res.headers['x-cache-invalidate'], undefined);
+                        assert.equal(res.headers['X-CSRF-Token'], undefined);
+                        assert.equal(res.headers['set-cookie'], undefined);
                         should.exist(res.headers.date);
 
                         $('title').text().should.equal('This is a static page');

--- a/ghost/core/test/unit/api/canary/utils/serializers/output/all.test.js
+++ b/ghost/core/test/unit/api/canary/utils/serializers/output/all.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const serializers = require('../../../../../../../core/server/api/endpoints/utils/serializers');
 
@@ -18,7 +19,7 @@ describe('Unit: endpoints/utils/serializers/output/all', function () {
                 response: response
             });
 
-            should.not.exist(response.posts[0].published_by);
+            assert.equal(response.posts[0].published_by, undefined);
             should.exist(response.posts[0].title);
 
             response = {
@@ -33,7 +34,7 @@ describe('Unit: endpoints/utils/serializers/output/all', function () {
                 response: response
             });
 
-            should.not.exist(response.post.published_by);
+            assert.equal(response.post.published_by, undefined);
             should.exist(response.post.title);
 
             response = {
@@ -56,8 +57,8 @@ describe('Unit: endpoints/utils/serializers/output/all', function () {
                 response: response
             });
 
-            should.not.exist(response.pages[0].published_by);
-            should.not.exist(response.pages[1].published_by);
+            assert.equal(response.pages[0].published_by, undefined);
+            assert.equal(response.pages[1].published_by, undefined);
             should.exist(response.pages[0].authors);
             should.exist(response.pages[0].authors[0].slug);
         });

--- a/ghost/core/test/unit/api/canary/utils/serializers/output/mapper.test.js
+++ b/ghost/core/test/unit/api/canary/utils/serializers/output/mapper.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const testUtils = require('../../../../../../utils');
@@ -155,7 +156,7 @@ describe('Unit: utils/serializers/output/mappers', function () {
                 } else {
                     const [id, secret] = key.secret.split(':');
                     should.exist(id);
-                    should.not.exist(secret);
+                    assert.equal(secret, undefined);
                 }
             });
         });

--- a/ghost/core/test/unit/frontend/helpers/comments.test.js
+++ b/ghost/core/test/unit/frontend/helpers/comments.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const configUtils = require('../../../utils/config-utils');
@@ -36,7 +37,7 @@ describe('{{comments}} helper', function () {
         settingsCacheGetStub.withArgs('comments_enabled').returns('all');
 
         comments({}).then(function (rendered) {
-            should.not.exist(rendered);
+            assert.equal(rendered, undefined);
             done();
         }).catch(done);
     });
@@ -113,7 +114,7 @@ describe('{{comments}} helper', function () {
                 site: {}
             }
         });
-        should.not.exist(rendered);
+        assert.equal(rendered, undefined);
     });
 
     it('returns undefined when no access to post', async function () {
@@ -130,6 +131,6 @@ describe('{{comments}} helper', function () {
                 site: {}
             }
         });
-        should.not.exist(rendered);
+        assert.equal(rendered, undefined);
     });
 });

--- a/ghost/core/test/unit/frontend/helpers/img-url.test.js
+++ b/ghost/core/test/unit/frontend/helpers/img-url.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const configUtils = require('../../../utils/config-utils');
@@ -63,19 +64,19 @@ describe('{{img_url}} helper', function () {
 
         it('should have no output if the image attribute is not provided (with warning)', function () {
             const rendered = img_url({hash: {absolute: 'true'}});
-            should.not.exist(rendered);
+            assert.equal(rendered, undefined);
             logWarnStub.calledOnce.should.be.true();
         });
 
         it('should have no output if the image attribute evaluates to undefined (with warning)', function () {
             const rendered = img_url(undefined, {hash: {absolute: 'true'}});
-            should.not.exist(rendered);
+            assert.equal(rendered, undefined);
             logWarnStub.calledOnce.should.be.true();
         });
 
         it('should have no output if the image attribute evaluates to null (no waring)', function () {
             const rendered = img_url(null, {hash: {absolute: 'true'}});
-            should.not.exist(rendered);
+            assert.equal(rendered, undefined);
             logWarnStub.calledOnce.should.be.false();
         });
     });

--- a/ghost/core/test/unit/frontend/helpers/reading-time.test.js
+++ b/ghost/core/test/unit/frontend/helpers/reading-time.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 
 // Stuff we are testing
@@ -112,6 +113,6 @@ describe('{{reading_time}} helper', function () {
 
         const result = reading_time.call(data);
 
-        should.not.exist(result);
+        assert.equal(result, null);
     });
 });

--- a/ghost/core/test/unit/frontend/meta/author-url.test.js
+++ b/ghost/core/test/unit/frontend/meta/author-url.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const ObjectId = require('bson-objectid').default;
@@ -65,6 +66,6 @@ describe('getAuthorUrl', function () {
     });
 
     it('should return null if no author on data or context', function () {
-        should.not.exist(getAuthorUrl({}, true));
+        assert.equal(getAuthorUrl({}, true), null);
     });
 });

--- a/ghost/core/test/unit/frontend/meta/schema.test.js
+++ b/ghost/core/test/unit/frontend/meta/schema.test.js
@@ -734,7 +734,7 @@ describe('getSchema', function () {
 
         const schema = getSchema(metadata, data);
 
-        should.not.exist(schema.contributor);
+        assert.equal(schema.contributor, undefined);
     });
 
     it('should include contributors when post has multiple authors', function () {

--- a/ghost/core/test/unit/frontend/services/routing/collection-router.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/collection-router.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const express = require('../../../../../core/shared/express')._express;
@@ -41,7 +42,7 @@ describe('UNIT - services/routing/CollectionRouter', function () {
 
             should.exist(collectionRouter.router);
 
-            should.not.exist(collectionRouter.filter);
+            assert.equal(collectionRouter.filter, undefined);
             collectionRouter.getResourceType().should.eql('posts');
             collectionRouter.templates.should.eql([]);
             collectionRouter.getPermalinks().getValue().should.eql('/:slug/');
@@ -88,7 +89,7 @@ describe('UNIT - services/routing/CollectionRouter', function () {
 
             should.exist(collectionRouter.router);
 
-            should.not.exist(collectionRouter.filter);
+            assert.equal(collectionRouter.filter, undefined);
             collectionRouter.getResourceType().should.eql('posts');
             collectionRouter.templates.should.eql([]);
             collectionRouter.getPermalinks().getValue().should.eql('/blog/:year/:slug/');

--- a/ghost/core/test/unit/frontend/services/routing/controllers/entry.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/controllers/entry.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const testUtils = require('../../../../../utils');
@@ -65,7 +66,7 @@ describe('Unit - services/routing/controllers/entry', function () {
             .resolves(null);
 
         controllers.entry(req, res, function (err) {
-            should.not.exist(err);
+            assert.equal(err, undefined);
             done();
         });
     });
@@ -103,7 +104,7 @@ describe('Unit - services/routing/controllers/entry', function () {
                 });
 
             controllers.entry(req, res, function (err) {
-                should.not.exist(err);
+                assert.equal(err, undefined);
                 done();
             });
         });
@@ -147,7 +148,7 @@ describe('Unit - services/routing/controllers/entry', function () {
             controllers.entry(req, res, async (err) => {
                 await configUtils.restore();
                 urlUtilsRedirectToAdminStub.called.should.eql(false);
-                should.not.exist(err);
+                assert.equal(err, undefined);
                 done(err);
             });
         });
@@ -168,7 +169,7 @@ describe('Unit - services/routing/controllers/entry', function () {
                 });
 
             controllers.entry(req, res, function (err) {
-                should.not.exist(err);
+                assert.equal(err, undefined);
                 done();
             });
         });

--- a/ghost/core/test/unit/frontend/services/routing/parent-router.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/parent-router.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const configUtils = require('../../../../utils/config-utils');
@@ -290,7 +291,7 @@ describe('UNIT - services/routing/ParentRouter', function () {
         it('data keys are undefined', function () {
             const parentRouter = new ParentRouter();
             parentRouter.data = {query: {}, router: {}};
-            should.not.exist(parentRouter.isRedirectEnabled('tags', 'bacon'));
+            assert.equal(parentRouter.isRedirectEnabled('tags', 'bacon'), undefined);
         });
 
         it('no redirect when unspecified slug', function () {
@@ -303,7 +304,7 @@ describe('UNIT - services/routing/ParentRouter', function () {
                 }
             };
 
-            should.not.exist(parentRouter.isRedirectEnabled('tags', 'bacon'));
+            assert.equal(parentRouter.isRedirectEnabled('tags', 'bacon'), undefined);
         });
 
         it('no redirect when wrong slug', function () {
@@ -316,7 +317,7 @@ describe('UNIT - services/routing/ParentRouter', function () {
                 }
             };
 
-            should.not.exist(parentRouter.isRedirectEnabled('tags', 'bacon'));
+            assert.equal(parentRouter.isRedirectEnabled('tags', 'bacon'), undefined);
         });
 
         it('no redirect when tag redirect=false', function () {
@@ -329,7 +330,7 @@ describe('UNIT - services/routing/ParentRouter', function () {
                 }
             };
 
-            should.not.exist(parentRouter.isRedirectEnabled('tags', 'bacon'));
+            assert.equal(parentRouter.isRedirectEnabled('tags', 'bacon'), undefined);
         });
 
         it('redirect (tags)', function () {

--- a/ghost/core/test/unit/frontend/services/routing/registry.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/registry.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const registry = require('../../../../../core/frontend/services/routing/registry');
@@ -16,7 +17,7 @@ describe('UNIT: services/routing/registry', function () {
 
     describe('fn: getRssUrl', function () {
         it('no url available', function () {
-            should.not.exist(registry.getRssUrl());
+            assert.equal(registry.getRssUrl(), null);
         });
 
         it('single collection, no index collection', function () {
@@ -36,7 +37,7 @@ describe('UNIT: services/routing/registry', function () {
                 getRssUrl: sinon.stub().returns(null)
             });
 
-            should.not.exist(registry.getRssUrl());
+            assert.equal(registry.getRssUrl(), null);
         });
 
         it('index collection', function () {
@@ -100,7 +101,7 @@ describe('UNIT: services/routing/registry', function () {
                 getRssUrl: sinon.stub().returns(null)
             });
 
-            should.not.exist(registry.getRssUrl());
+            assert.equal(registry.getRssUrl(), null);
         });
     });
 });

--- a/ghost/core/test/unit/frontend/services/routing/static-routes-router.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/static-routes-router.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const controllers = require('../../../../../core/frontend/services/routing/controllers');
@@ -37,8 +38,8 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
             const staticRoutesRouter = new StaticRoutesRouter('/about/', {templates: ['test']}, routerCreatedSpy);
             should.exist(staticRoutesRouter.router);
 
-            should.not.exist(staticRoutesRouter.filter);
-            should.not.exist(staticRoutesRouter.getPermalinks());
+            assert.equal(staticRoutesRouter.filter, undefined);
+            assert.equal(staticRoutesRouter.getPermalinks(), undefined);
 
             staticRoutesRouter.templates.should.eql(['test']);
 
@@ -60,8 +61,8 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
 
             should.exist(staticRoutesRouter.router);
 
-            should.not.exist(staticRoutesRouter.getPermalinks());
-            should.not.exist(staticRoutesRouter.filter);
+            assert.equal(staticRoutesRouter.getPermalinks(), undefined);
+            assert.equal(staticRoutesRouter.filter, undefined);
             staticRoutesRouter.templates.should.eql([]);
 
             routerCreatedSpy.calledOnce.should.be.true();
@@ -88,7 +89,7 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
             res.routerOptions.data.should.eql({});
 
             should(res.routerOptions.contentType).be.undefined();
-            should.not.exist(res.locals.slug);
+            assert.equal(res.locals.slug, undefined);
         });
 
         it('fn: _prepareStaticRouteContext (mainRoute=root)', function () {
@@ -104,7 +105,7 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
             res.routerOptions.context.should.eql(['index']);
             res.routerOptions.data.should.eql({});
 
-            should.not.exist(res.locals.slug);
+            assert.equal(res.locals.slug, undefined);
         });
     });
 
@@ -119,7 +120,7 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
 
                 should.exist(staticRoutesRouter.router);
 
-                should.not.exist(staticRoutesRouter.getPermalinks());
+                assert.equal(staticRoutesRouter.getPermalinks(), undefined);
                 staticRoutesRouter.filter.should.eql('tag:test');
                 staticRoutesRouter.templates.should.eql([]);
                 should.exist(staticRoutesRouter.data);
@@ -146,7 +147,7 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
 
                 should.exist(staticRoutesRouter.router);
 
-                should.not.exist(staticRoutesRouter.getPermalinks());
+                assert.equal(staticRoutesRouter.getPermalinks(), undefined);
                 staticRoutesRouter.filter.should.eql('tag:test');
 
                 staticRoutesRouter.templates.should.eql([]);
@@ -171,7 +172,7 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
                     data: {query: {}, router: {}}
                 }, routerCreatedSpy);
 
-                should.not.exist(staticRoutesRouter.filter);
+                assert.equal(staticRoutesRouter.filter, undefined);
             });
 
             it('initialize on subdirectory with controller+data+filter', function () {

--- a/ghost/core/test/unit/frontend/services/theme-engine/middleware.test.js
+++ b/ghost/core/test/unit/frontend/services/theme-engine/middleware.test.js
@@ -93,7 +93,7 @@ describe('Themes middleware', function () {
 
         executeMiddleware(middleware, req, res, function next(err) {
             try {
-                should.not.exist(err);
+                assert.equal(err, undefined);
 
                 fakeActiveTheme.mount.called.should.be.true();
                 fakeActiveTheme.mount.calledWith(req.app).should.be.true();
@@ -110,7 +110,7 @@ describe('Themes middleware', function () {
 
         executeMiddleware(middleware, req, res, function next(err) {
             try {
-                should.not.exist(err);
+                assert.equal(err, undefined);
 
                 fakeActiveTheme.mount.called.should.be.false();
 
@@ -148,7 +148,7 @@ describe('Themes middleware', function () {
 
             executeMiddleware(middleware, req, res, function next(err) {
                 try {
-                    should.not.exist(err);
+                    assert.equal(err, undefined);
 
                     hbsUpdateTemplateOptionsStub.calledOnce.should.be.true();
                     const templateOptions = hbsUpdateTemplateOptionsStub.firstCall.args[0];
@@ -214,7 +214,7 @@ describe('Themes middleware', function () {
 
             executeMiddleware(middleware, req, res, function next(err) {
                 try {
-                    should.not.exist(err);
+                    assert.equal(err, undefined);
 
                     hbsUpdateLocalTemplateOptionsStub.calledOnce.should.be.true();
                     const templateOptions = hbsUpdateLocalTemplateOptionsStub.firstCall.args[1];
@@ -241,7 +241,7 @@ describe('Themes middleware', function () {
 
             executeMiddleware(middleware, req, res, function next(err) {
                 try {
-                    should.not.exist(err);
+                    assert.equal(err, undefined);
 
                     hbsUpdateLocalTemplateOptionsStub.calledOnce.should.be.true();
                     const templateOptions = hbsUpdateLocalTemplateOptionsStub.firstCall.args[1];
@@ -270,7 +270,7 @@ describe('Themes middleware', function () {
 
             executeMiddleware(middleware, req, res, function next(err) {
                 try {
-                    should.not.exist(err);
+                    assert.equal(err, undefined);
 
                     hbsUpdateLocalTemplateOptionsStub.calledOnce.should.be.true();
                     const templateOptions = hbsUpdateLocalTemplateOptionsStub.firstCall.args[1];
@@ -297,7 +297,7 @@ describe('Themes middleware', function () {
 
             executeMiddleware(middleware, req, res, function next(err) {
                 try {
-                    should.not.exist(err);
+                    assert.equal(err, undefined);
 
                     hbsUpdateLocalTemplateOptionsStub.calledOnce.should.be.true();
                     const templateOptions = hbsUpdateLocalTemplateOptionsStub.firstCall.args[1];
@@ -325,7 +325,7 @@ describe('Themes middleware', function () {
 
             executeMiddleware(middleware, req, res, function next(err) {
                 try {
-                    should.not.exist(err);
+                    assert.equal(err, undefined);
 
                     hbsUpdateLocalTemplateOptionsStub.calledOnce.should.be.true();
                     const templateOptions = hbsUpdateLocalTemplateOptionsStub.firstCall.args[1];
@@ -351,7 +351,7 @@ describe('Themes middleware', function () {
 
             executeMiddleware(middleware, req, res, function next(err) {
                 try {
-                    should.not.exist(err);
+                    assert.equal(err, undefined);
 
                     hbsUpdateLocalTemplateOptionsStub.calledOnce.should.be.true();
                     const templateOptions = hbsUpdateLocalTemplateOptionsStub.firstCall.args[1];

--- a/ghost/core/test/unit/server/adapters/scheduling/scheduling-default.test.js
+++ b/ghost/core/test/unit/server/adapters/scheduling/scheduling-default.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const moment = require('moment');
@@ -47,8 +48,8 @@ describe('Scheduling Default Adapter', function () {
             });
 
             // 2 jobs get immediately executed
-            should.not.exist(scope.adapter.allJobs[moment(dates[1]).valueOf()]);
-            should.not.exist(scope.adapter.allJobs[moment(dates[7]).valueOf()]);
+            assert.equal(scope.adapter.allJobs[moment(dates[1]).valueOf()], undefined);
+            assert.equal(scope.adapter.allJobs[moment(dates[7]).valueOf()], undefined);
             scope.adapter._execute.calledTwice.should.eql(true);
 
             Object.keys(scope.adapter.allJobs).length.should.eql(dates.length - 2);

--- a/ghost/core/test/unit/server/data/importer/importers/data/newsletters.test.js
+++ b/ghost/core/test/unit/server/data/importer/importers/data/newsletters.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const NewslettersImporter = require('../../../../../../../core/server/data/importer/importers/data/newsletters-importer');
 
@@ -47,10 +48,10 @@ describe('NewslettersImporter', function () {
             const newsletter2 = importer.dataToImport[1];
 
             newsletter1.name.should.be.eql('Daily newsletter');
-            should.not.exist(newsletter1.sender_email);
+            assert.equal(newsletter1.sender_email, undefined);
 
             newsletter2.name.should.be.eql('Weekly roundup');
-            should.not.exist(newsletter2.sender_email);
+            assert.equal(newsletter2.sender_email, undefined);
         });
     });
 });

--- a/ghost/core/test/unit/server/data/importer/importers/data/posts.test.js
+++ b/ghost/core/test/unit/server/data/importer/importers/data/posts.test.js
@@ -117,7 +117,7 @@ describe('PostsImporter', function () {
             const post = find(importer.dataToImport, {slug: 'post-with-newsletter'});
             should.exist(post);
             post.email_recipient_filter.should.eql('all');
-            should.not.exist(post.send_email_when_published);
+            assert.equal(post.send_email_when_published, undefined);
             // @TODO: need to check this mapping
             //post.newsletter_id.should.eql();
         });

--- a/ghost/core/test/unit/server/data/importer/importers/data/settings.test.js
+++ b/ghost/core/test/unit/server/data/importer/importers/data/settings.test.js
@@ -53,7 +53,7 @@ describe('SettingsImporter', function () {
 
             const membersFromAddress = find(importer.dataToImport, {key: 'members_from_address'});
 
-            should.not.exist(membersFromAddress);
+            assert.equal(membersFromAddress, undefined);
         });
 
         it('Does not overwrite members support address', function () {
@@ -68,7 +68,7 @@ describe('SettingsImporter', function () {
 
             const membersSupportAddress = find(importer.dataToImport, {key: 'members_support_address'});
 
-            should.not.exist(membersSupportAddress);
+            assert.equal(membersSupportAddress, undefined);
         });
 
         it('Does not overwrite email_verification_required setting', function () {
@@ -84,7 +84,7 @@ describe('SettingsImporter', function () {
 
             const emailVerificationRequired = find(importer.dataToImport, {key: 'email_verification_required'});
 
-            should.not.exist(emailVerificationRequired);
+            assert.equal(emailVerificationRequired, undefined);
         });
 
         it('Does not overwrite site_uuid setting', function () {
@@ -100,7 +100,7 @@ describe('SettingsImporter', function () {
 
             const siteUuid = find(importer.dataToImport, {key: 'site_uuid'});
 
-            should.not.exist(siteUuid);
+            assert.equal(siteUuid, undefined);
         });
 
         it('Adds a problem if the existing data is_private is false, and new data is_private is true', function () {

--- a/ghost/core/test/unit/server/data/importer/index.test.js
+++ b/ghost/core/test/unit/server/data/importer/index.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const errors = require('@tryghost/errors');
 const should = require('should');
 const sinon = require('sinon');
@@ -391,13 +392,13 @@ describe('Importer', function () {
                 it('returns empty for no base directory', function () {
                     const testDir = path.resolve('test/utils/fixtures/import/zips/zip-without-base-dir');
 
-                    should.not.exist(ImportManager.getBaseDirectory(testDir));
+                    assert.equal(ImportManager.getBaseDirectory(testDir), undefined);
                 });
 
                 it('returns empty for content handler directories', function () {
                     const testDir = path.resolve('test/utils/fixtures/import/zips/zip-image-dir');
 
-                    should.not.exist(ImportManager.getBaseDirectory(testDir));
+                    assert.equal(ImportManager.getBaseDirectory(testDir), undefined);
                 });
 
                 it('throws invalidZipFileBaseDirectory', function () {

--- a/ghost/core/test/unit/server/lib/image/cached-image-size-from-url.test.js
+++ b/ghost/core/test/unit/server/lib/image/cached-image-size-from-url.test.js
@@ -78,8 +78,8 @@ describe('lib/image: image size cache', function () {
         cacheStore.get(url).should.not.be.undefined;
         const image = cacheStore.get(url);
         assert.equal(image.url, 'http://mysite.com/content/image/mypostcoverimage.jpg');
-        should.not.exist(image.width);
-        should.not.exist(image.height);
+        assert.equal(image.width, undefined);
+        assert.equal(image.height, undefined);
         sinon.assert.calledOnce(loggingStub);
     });
 
@@ -99,8 +99,8 @@ describe('lib/image: image size cache', function () {
         cacheStore.get(url).should.not.be.undefined;
         const image = cacheStore.get(url);
         assert.equal(image.url, 'http://mysite.com/content/image/mypostcoverimage.jpg');
-        should.not.exist(image.width);
-        should.not.exist(image.height);
+        assert.equal(image.width, undefined);
+        assert.equal(image.height, undefined);
     });
 
     it('should return null if url is null', async function () {
@@ -113,6 +113,6 @@ describe('lib/image: image size cache', function () {
 
         result = await cachedImageSizeFromUrl.getCachedImageSizeFromUrl(url);
 
-        should.not.exist(result);
+        assert.equal(result, undefined);
     });
 });

--- a/ghost/core/test/unit/server/lib/image/gravatar.test.js
+++ b/ghost/core/test/unit/server/lib/image/gravatar.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const Gravatar = require('../../../../../core/server/lib/image/gravatar');
 
@@ -53,7 +54,7 @@ describe('lib/image: gravatar', function () {
 
         gravatar.lookup({email: 'invalid@example.com'}).then(function (result) {
             should.exist(result);
-            should.not.exist(result.image);
+            assert.equal(result.image, undefined);
 
             done();
         }).catch(done);

--- a/ghost/core/test/unit/server/models/base/index.test.js
+++ b/ghost/core/test/unit/server/models/base/index.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const security = require('@tryghost/security');
@@ -212,7 +213,7 @@ describe('Models: base', function () {
             base.get('a').should.eql('');
             base.get('b').should.eql('');
             base.setEmptyValuesToNull();
-            should.not.exist(base.get('a'));
+            assert.equal(base.get('a'), null);
             base.get('b').should.eql('');
         });
     });

--- a/ghost/core/test/unit/server/models/base/relations.test.js
+++ b/ghost/core/test/unit/server/models/base/relations.test.js
@@ -102,7 +102,7 @@ describe('Models: getLazyRelation', function () {
         });
 
         const modelA = TestModel.forge({id: '1'});
-        should.not.exist(await modelA.getLazyRelation('other'));
+        assert.equal(await modelA.getLazyRelation('other'), undefined);
     });
 
     it('throws for model without id for optional relations with require', async function () {
@@ -134,7 +134,7 @@ describe('Models: getLazyRelation', function () {
             tableName: 'test_models'
         });
         const modelA = TestModel.forge({id: '1'});
-        should.not.exist(await modelA.getLazyRelation('other'));
+        assert.equal(await modelA.getLazyRelation('other'), undefined);
     });
 
     it('throws for nonexistent relations with require', async function () {

--- a/ghost/core/test/unit/server/models/post.test.js
+++ b/ghost/core/test/unit/server/models/post.test.js
@@ -1,4 +1,5 @@
 /* eslint no-invalid-this:0 */
+const assert = require('node:assert/strict');
 const errors = require('@tryghost/errors');
 const should = require('should');
 const sinon = require('sinon');
@@ -247,7 +248,7 @@ describe('Unit: models/post', function () {
 
             const json = toJSON(post, {formats: ['mobiledoc']});
 
-            should.not.exist(json.mobiledoc_revisions);
+            assert.equal(json.mobiledoc_revisions, undefined);
             should.exist(json.mobiledoc);
         });
 

--- a/ghost/core/test/unit/server/services/auth/api-key/admin.test.js
+++ b/ghost/core/test/unit/server/services/auth/api-key/admin.test.js
@@ -52,7 +52,7 @@ describe('Admin API Key Auth', function () {
         const res = {};
 
         apiKeyAuth.admin.authenticate(req, res, (err) => {
-            should.not.exist(err);
+            assert.equal(err, undefined);
             req.api_key.should.eql(this.fakeApiKey);
             done();
         });
@@ -77,7 +77,7 @@ describe('Admin API Key Auth', function () {
         const res = {};
 
         apiKeyAuth.admin.authenticate(req, res, (err) => {
-            should.not.exist(err);
+            assert.equal(err, undefined);
             req.api_key.should.eql(this.fakeApiKey);
             done();
         });
@@ -102,7 +102,7 @@ describe('Admin API Key Auth', function () {
         const res = {};
 
         apiKeyAuth.admin.authenticate(req, res, (err) => {
-            should.not.exist(err);
+            assert.equal(err, undefined);
             req.api_key.should.eql(this.fakeApiKey);
             done();
         });
@@ -130,7 +130,7 @@ describe('Admin API Key Auth', function () {
             should.exist(err);
             assert.equal(err instanceof errors.UnauthorizedError, true);
             err.code.should.eql('INVALID_JWT');
-            should.not.exist(req.api_key);
+            assert.equal(req.api_key, undefined);
             done();
         });
     });
@@ -148,7 +148,7 @@ describe('Admin API Key Auth', function () {
             should.exist(err);
             assert.equal(err instanceof errors.UnauthorizedError, true);
             err.code.should.eql('INVALID_AUTH_HEADER');
-            should.not.exist(req.api_key);
+            assert.equal(req.api_key, undefined);
             done();
         });
     });
@@ -166,7 +166,7 @@ describe('Admin API Key Auth', function () {
             should.exist(err);
             assert.equal(err instanceof errors.BadRequestError, true);
             err.code.should.eql('INVALID_JWT');
-            should.not.exist(req.api_key);
+            assert.equal(req.api_key, undefined);
             done();
         });
     });
@@ -193,7 +193,7 @@ describe('Admin API Key Auth', function () {
             should.exist(err);
             assert.equal(err instanceof errors.UnauthorizedError, true);
             err.code.should.eql('UNKNOWN_ADMIN_API_KEY');
-            should.not.exist(req.api_key);
+            assert.equal(req.api_key, undefined);
             done();
         });
     });
@@ -223,7 +223,7 @@ describe('Admin API Key Auth', function () {
             assert.equal(err instanceof errors.UnauthorizedError, true);
             err.code.should.eql('INVALID_JWT');
             err.message.should.match(/jwt expired/);
-            should.not.exist(req.api_key);
+            assert.equal(req.api_key, undefined);
             done();
         });
     });
@@ -253,7 +253,7 @@ describe('Admin API Key Auth', function () {
             assert.equal(err instanceof errors.UnauthorizedError, true);
             err.code.should.eql('INVALID_JWT');
             err.message.should.match(/maxAge exceeded/);
-            should.not.exist(req.api_key);
+            assert.equal(req.api_key, undefined);
             done();
         });
     });
@@ -282,7 +282,7 @@ describe('Admin API Key Auth', function () {
             should.exist(err);
             assert.equal(err instanceof errors.UnauthorizedError, true);
             err.code.should.eql('INVALID_API_KEY_TYPE');
-            should.not.exist(req.api_key);
+            assert.equal(req.api_key, undefined);
             done();
         });
     });

--- a/ghost/core/test/unit/server/services/auth/api-key/content.test.js
+++ b/ghost/core/test/unit/server/services/auth/api-key/content.test.js
@@ -37,7 +37,7 @@ describe('Content API Key Auth', function () {
         const res = {};
 
         authenticateContentApiKey(req, res, (arg) => {
-            should.not.exist(arg);
+            assert.equal(arg, undefined);
             req.api_key.should.eql(this.fakeApiKey);
             done();
         });
@@ -55,7 +55,7 @@ describe('Content API Key Auth', function () {
             should.exist(err);
             assert.equal(err instanceof errors.UnauthorizedError, true);
             err.code.should.eql('UNKNOWN_CONTENT_API_KEY');
-            should.not.exist(req.api_key);
+            assert.equal(req.api_key, undefined);
             done();
         });
     });
@@ -74,7 +74,7 @@ describe('Content API Key Auth', function () {
             should.exist(err);
             assert.equal(err instanceof errors.UnauthorizedError, true);
             err.code.should.eql('INVALID_API_KEY_TYPE');
-            should.not.exist(req.api_key);
+            assert.equal(req.api_key, undefined);
             done();
         });
     });
@@ -91,7 +91,7 @@ describe('Content API Key Auth', function () {
             should.exist(err);
             assert.equal(err instanceof errors.BadRequestError, true);
             err.code.should.eql('INVALID_REQUEST');
-            should.not.exist(req.api_key);
+            assert.equal(req.api_key, undefined);
             done();
         });
     });

--- a/ghost/core/test/unit/server/services/mail/ghost-mailer.test.js
+++ b/ghost/core/test/unit/server/services/mail/ghost-mailer.test.js
@@ -376,7 +376,7 @@ describe('Mail: Ghostmailer', function () {
             sentMessage['o:tag'].should.be.an.Array();
             sentMessage['o:tag'].should.containEql('transactional-email');
             sentMessage['o:tag'].should.containEql('blog-123123');
-            should.not.exist(sentMessage['o:tracking-opens']);
+            assert.equal(sentMessage['o:tracking-opens'], undefined);
         });
 
         it('should not add site ID tag when site ID is missing', async function () {
@@ -416,7 +416,7 @@ describe('Mail: Ghostmailer', function () {
             });
 
             const sentMessage = sendMailSpy.firstCall.args[0];
-            should.not.exist(sentMessage['o:tag']);
+            assert.equal(sentMessage['o:tag'], undefined);
         });
     });
 });

--- a/ghost/core/test/unit/server/services/permissions/can-this.test.js
+++ b/ghost/core/test/unit/server/services/permissions/can-this.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const testUtils = require('../../../../utils');
@@ -281,7 +282,7 @@ describe('Permissions', function () {
                     .tag({id: 1}) // tag id in model syntax
                     .then(function (res) {
                         userProviderStub.callCount.should.eql(1);
-                        should.not.exist(res);
+                        assert.equal(res, undefined);
                         done();
                     })
                     .catch(done);
@@ -302,7 +303,7 @@ describe('Permissions', function () {
                     .tag() // tag id in model syntax
                     .then(function (res) {
                         userProviderStub.callCount.should.eql(1);
-                        should.not.exist(res);
+                        assert.equal(res, undefined);
                         done();
                     })
                     .catch(done);
@@ -324,7 +325,7 @@ describe('Permissions', function () {
                     .tag({id: 1}) // tag id in model syntax
                     .then(function (res) {
                         userProviderStub.callCount.should.eql(1);
-                        should.not.exist(res);
+                        assert.equal(res, undefined);
                         done();
                     })
                     .catch(done);
@@ -352,7 +353,7 @@ describe('Permissions', function () {
                     .tag({id: 1}) // tag id in model syntax
                     .then(function (res) {
                         apiKeyProviderStub.callCount.should.eql(1);
-                        should.not.exist(res);
+                        assert.equal(res, undefined);
                         done();
                     })
                     .catch(done);
@@ -388,7 +389,7 @@ describe('Permissions', function () {
                     .then(function (res) {
                         userProviderStub.callCount.should.eql(1);
                         apiKeyProviderStub.callCount.should.eql(1);
-                        should.not.exist(res);
+                        assert.equal(res, undefined);
                         done();
                     })
                     .catch(done);
@@ -419,7 +420,7 @@ describe('Permissions', function () {
                     .then(function (res) {
                         userProviderStub.callCount.should.eql(1);
                         apiKeyProviderStub.callCount.should.eql(1);
-                        should.not.exist(res);
+                        assert.equal(res, undefined);
                         // Fixed: Now uses USER permission instead of API key logic
                         done();
                     })
@@ -520,7 +521,7 @@ describe('Permissions', function () {
                     .then(function (res) {
                         userProviderStub.callCount.should.eql(1);
                         apiKeyProviderStub.callCount.should.eql(1);
-                        should.not.exist(res);
+                        assert.equal(res, undefined);
                         done();
                     })
                     .catch(done);
@@ -553,7 +554,7 @@ describe('Permissions', function () {
                         .then(function (res) {
                             userProviderStub.callCount.should.eql(1);
                             apiKeyProviderStub.callCount.should.eql(1);
-                            should.not.exist(res);
+                            assert.equal(res, undefined);
                             done();
                         })
                         .catch(function (err) {
@@ -619,7 +620,7 @@ describe('Permissions', function () {
                         .then(function (res) {
                             userProviderStub.callCount.should.eql(1);
                             apiKeyProviderStub.callCount.should.eql(1);
-                            should.not.exist(res);
+                            assert.equal(res, undefined);
                             done();
                         })
                         .catch(function (err) {
@@ -687,7 +688,7 @@ describe('Permissions', function () {
                     );
 
                     userProviderStub.callCount.should.eql(1);
-                    should.not.exist(res);
+                    assert.equal(res, undefined);
                     done();
                 })
                 .catch(done);

--- a/ghost/core/test/unit/server/services/route-settings/yaml-parser.test.js
+++ b/ghost/core/test/unit/server/services/route-settings/yaml-parser.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const should = require('should');
 const fs = require('fs-extra');
@@ -31,7 +32,7 @@ describe('UNIT > Settings Service yaml parser:', function () {
 
             try {
                 const result = yamlParser(file);
-                should.not.exist(result);
+                assert.equal(result, undefined);
             } catch (error) {
                 should.exist(error);
                 error.message.should.eql('Could not parse provided YAML file: bad indentation of a mapping entry.');

--- a/ghost/core/test/unit/server/services/stats/content.test.js
+++ b/ghost/core/test/unit/server/services/stats/content.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const should = require('should');
 const ContentStatsService = require('../../../../../core/server/services/stats/content-stats-service');
@@ -166,7 +167,7 @@ describe('ContentStatsService', function () {
             });
 
             const result = serviceNoUrl.getResourceTitle('/about/');
-            should.not.exist(result);
+            assert.equal(result, null);
         });
 
         it('returns title from resource with title property', function () {
@@ -203,14 +204,14 @@ describe('ContentStatsService', function () {
             mockUrlService.getResource.withArgs('/not-found/').throws(new Error('Resource not found'));
 
             const result = service.getResourceTitle('/not-found/');
-            should.not.exist(result);
+            assert.equal(result, null);
         });
 
         it('returns null if resource has no data or title/name', function () {
             mockUrlService.getResource.withArgs('/empty/').returns({});
 
             const result = service.getResourceTitle('/empty/');
-            should.not.exist(result);
+            assert.equal(result, null);
         });
     });
 
@@ -356,7 +357,7 @@ describe('ContentStatsService', function () {
 
             const result = await service.fetchRawTopContentData(options);
 
-            should.not.exist(result);
+            assert.equal(result, null);
 
             // Verify that camelCase conversion happened
             const calledWith = mockTinybirdClient.fetch.firstCall.args;

--- a/ghost/core/test/unit/server/services/stripe/stripe-api.test.js
+++ b/ghost/core/test/unit/server/services/stripe/stripe-api.test.js
@@ -69,7 +69,7 @@ describe('StripeAPI', function () {
                 trialDays: 12
             });
 
-            should.not.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.subscription_data.trial_from_plan);
+            assert.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.subscription_data.trial_from_plan, undefined);
             should.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.subscription_data.trial_period_days);
             assert.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.subscription_data.trial_period_days, 12);
         });
@@ -79,7 +79,7 @@ describe('StripeAPI', function () {
 
             should.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.subscription_data.trial_from_plan);
             assert.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.subscription_data.trial_from_plan, true);
-            should.not.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.subscription_data.trial_period_days);
+            assert.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.subscription_data.trial_period_days, undefined);
         });
 
         it('ignores 0 trialDays', async function () {
@@ -89,7 +89,7 @@ describe('StripeAPI', function () {
 
             should.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.subscription_data.trial_from_plan);
             assert.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.subscription_data.trial_from_plan, true);
-            should.not.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.subscription_data.trial_period_days);
+            assert.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.subscription_data.trial_period_days, undefined);
         });
 
         it('ignores null trialDays', async function () {
@@ -99,7 +99,7 @@ describe('StripeAPI', function () {
 
             should.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.subscription_data.trial_from_plan);
             assert.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.subscription_data.trial_from_plan, true);
-            should.not.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.subscription_data.trial_period_days);
+            assert.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.subscription_data.trial_period_days, undefined);
         });
 
         it('passes customer ID successfully to Stripe', async function () {
@@ -152,7 +152,7 @@ describe('StripeAPI', function () {
                 trialDays: null
             });
 
-            should.not.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.customer_email);
+            assert.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.customer_email, undefined);
             should.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.customer);
             assert.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.customer, 'cust_mock_123456');
         });
@@ -232,7 +232,7 @@ describe('StripeAPI', function () {
             mockLabsIsSet.withArgs('additionalPaymentMethods').returns(false);
             await api.createCheckoutSetupSession('priceId', {currency: 'usd'});
 
-            should.not.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.currency);
+            assert.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.currency, undefined);
         });
 
         it('createCheckoutSetupSession sends currency if additionalPaymentMethods flag is on', async function () {
@@ -470,7 +470,7 @@ describe('StripeAPI', function () {
             await api.createCheckoutSession('priceId', undefined, {
                 trialDays: null
             });
-            should.not.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.customer_update);
+            assert.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.customer_update, undefined);
         });
 
         it('createCheckoutSession does not add customer_update if automatic tax flag is disabled', async function () {
@@ -491,7 +491,7 @@ describe('StripeAPI', function () {
             await api.createCheckoutSession('priceId', mockCustomer, {
                 trialDays: null
             });
-            should.not.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.customer_update);
+            assert.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.customer_update, undefined);
         });
     });
 
@@ -531,7 +531,7 @@ describe('StripeAPI', function () {
             mockLabsIsSet.withArgs('additionalPaymentMethods').returns(false);
             await api.createDonationCheckoutSession('priceId', {currency: 'usd'});
 
-            should.not.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.currency);
+            assert.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.currency, undefined);
         });
 
         it('passes customer ID when a valid customer object is provided', async function () {
@@ -584,7 +584,7 @@ describe('StripeAPI', function () {
 
             should.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.customer);
             assert.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.customer, mockCustomerId);
-            should.not.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.customer_email);
+            assert.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.customer_email, undefined);
         });
 
         it('passes metadata correctly', async function () {

--- a/ghost/core/test/unit/server/services/themes/list.test.js
+++ b/ghost/core/test/unit/server/services/themes/list.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const _ = require('lodash');
@@ -21,7 +22,7 @@ describe('Themes', function () {
         });
 
         it('get() with no args should do nothing', function () {
-            should.not.exist(themeList.get());
+            assert.equal(themeList.get(), undefined);
         });
 
         it('getAll() returns all themes', function () {
@@ -46,7 +47,7 @@ describe('Themes', function () {
             should.exist(themeList.get('casper'));
             should.exist(themeList.get('not-casper'));
             themeList.del('casper');
-            should.not.exist(themeList.get('casper'));
+            assert.equal(themeList.get('casper'), undefined);
             should.exist(themeList.get('not-casper'));
         });
 

--- a/ghost/core/test/unit/server/services/themes/loader.test.js
+++ b/ghost/core/test/unit/server/services/themes/loader.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const fs = require('fs-extra');
@@ -41,7 +42,7 @@ describe('Themes', function () {
                         const themeResult = themeList.getAll();
 
                         // Loader doesn't return anything
-                        should.not.exist(result);
+                        assert.equal(result, undefined);
 
                         themeResult.should.eql({
                             casper: {
@@ -74,7 +75,7 @@ describe('Themes', function () {
                         const themeResult = themeList.getAll();
 
                         // Loader doesn't return anything
-                        should.not.exist(result);
+                        assert.equal(result, undefined);
 
                         themeResult.should.eql({
                             casper: {

--- a/ghost/core/test/unit/server/services/url/url-generator.test.js
+++ b/ghost/core/test/unit/server/services/url/url-generator.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const urlUtils = require('../../../../../core/shared/url-utils');
@@ -60,7 +61,7 @@ describe('Unit: services/url/UrlGenerator', function () {
         const urlGenerator = new UrlGenerator({router, queue});
 
         queue.register.calledTwice.should.be.true();
-        should.not.exist(urlGenerator.filter);
+        assert.equal(urlGenerator.filter, undefined);
     });
 
     it('routing type has filter', function () {
@@ -181,7 +182,7 @@ describe('Unit: services/url/UrlGenerator', function () {
                     resources,
                     urls
                 });
-                should.not.exist(urlGenerator.nql);
+                assert.equal(urlGenerator.nql, undefined);
 
                 sinon.stub(urlGenerator, '_generateUrl').returns('something');
                 sinon.stub(urlGenerator, '_resourceListeners');
@@ -205,7 +206,7 @@ describe('Unit: services/url/UrlGenerator', function () {
                     resources,
                     urls
                 });
-                should.not.exist(urlGenerator.nql);
+                assert.equal(urlGenerator.nql, undefined);
 
                 sinon.stub(urlGenerator, '_generateUrl').returns('something');
                 sinon.stub(urlGenerator, '_resourceListeners');

--- a/ghost/core/test/unit/server/services/url/url-service.test.js
+++ b/ghost/core/test/unit/server/services/url/url-service.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const errors = require('@tryghost/errors');
 const rewire = require('rewire');
 const should = require('should');
@@ -101,7 +102,7 @@ describe('Unit: services/url/UrlService', function () {
         it('no resource for url found', function () {
             urlService.finished = true;
             urlService.urls.getByUrl.withArgs('/blog-post/').returns([]);
-            should.not.exist(urlService.getResource('/blog-post/'));
+            assert.equal(urlService.getResource('/blog-post/'), null);
         });
 
         it('one resource for url found', function () {

--- a/ghost/core/test/unit/server/services/url/urls.test.js
+++ b/ghost/core/test/unit/server/services/url/urls.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const events = require('../../../../../core/server/lib/common/events');
@@ -105,7 +106,7 @@ describe('Unit: services/url/Urls', function () {
 
     it('fn: removeResourceId', function () {
         urls.removeResourceId('object-id-2');
-        should.not.exist(urls.getByResourceId('object-id-2'));
+        assert.equal(urls.getByResourceId('object-id-2'), undefined);
 
         urls.removeResourceId('does not exist');
     });

--- a/ghost/core/test/unit/server/web/api/middleware/cors.test.js
+++ b/ghost/core/test/unit/server/web/api/middleware/cors.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const rewire = require('rewire');
@@ -46,7 +47,7 @@ describe('cors', function () {
         cors(req, res, next);
 
         sinon.assert.calledOnce(next);
-        should.not.exist(res.headers['Access-Control-Allow-Origin']);
+        assert.equal(res.headers['Access-Control-Allow-Origin'], undefined);
 
         done();
     });
@@ -91,7 +92,7 @@ describe('cors', function () {
         cors(req, res, next);
 
         sinon.assert.calledOnce(next);
-        should.not.exist(res.headers['Access-Control-Allow-Origin']);
+        assert.equal(res.headers['Access-Control-Allow-Origin'], undefined);
 
         done();
     });

--- a/ghost/core/test/unit/server/web/parent/middleware/request-id.test.js
+++ b/ghost/core/test/unit/server/web/parent/middleware/request-id.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const validator = require('@tryghost/validator');
@@ -26,7 +27,7 @@ describe('Request ID middleware', function () {
     });
 
     it('generates a new request ID if X-Request-ID not present', function () {
-        should.not.exist(req.requestId);
+        assert.equal(req.requestId, undefined);
 
         requestId(req, res, next);
 
@@ -36,7 +37,7 @@ describe('Request ID middleware', function () {
     });
 
     it('keeps the request ID if X-Request-ID is present', function () {
-        should.not.exist(req.requestId);
+        assert.equal(req.requestId, undefined);
         req.get.withArgs('X-Request-ID').returns('abcd');
 
         requestId(req, res, next);

--- a/ghost/core/test/unit/shared/config/loader.test.js
+++ b/ghost/core/test/unit/shared/config/loader.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const path = require('path');
 const rewire = require('rewire');
@@ -95,7 +96,7 @@ describe('Config Loader', function () {
             });
 
             customConfig.get('site_uuid').should.eql('a58fe20c-0af0-4fc6-9b1a-20873d5b7d03');
-            should.not.exist(customConfig.get('commented'));
+            assert.equal(customConfig.get('commented'), undefined);
         });
     });
 

--- a/ghost/core/test/unit/shared/custom-theme-settings-cache/cache.test.js
+++ b/ghost/core/test/unit/shared/custom-theme-settings-cache/cache.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 
 const Cache = require('../../../../core/shared/custom-theme-settings-cache/custom-theme-settings-cache');
@@ -127,7 +128,7 @@ describe('Cache', function () {
 
             returned.new = 'exists';
 
-            should.not.exist(cache.get('new'));
+            assert.equal(cache.get('new'), undefined);
         });
     });
 
@@ -144,7 +145,7 @@ describe('Cache', function () {
             cache.clear();
 
             cache.getAll().should.deepEqual({});
-            should.not.exist(cache.get('one'));
+            assert.equal(cache.get('one'), undefined);
         });
     });
 });


### PR DESCRIPTION
This change should have no user impact.

I ran the following:

```sh
ast-grep \
  -p 'should.not.exist($PROP)' \
  --rewrite 'assert.equal($PROP, undefined)'
```

And then changed a few of them that needed to check against `null` instead of `undefined`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated many tests to use Node's strict assertion style, converting negative existence checks to explicit undefined/null equality assertions for clearer expectations.

* **Chores**
  * Standardized assertion patterns across the test suite and added the strict assert import where needed for consistency and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->