### PR TITLE
Fixed flaky welcome emails test

### DIFF
--- a/e2e/helpers/services/members/index.ts
+++ b/e2e/helpers/services/members/index.ts
@@ -1,0 +1,1 @@
+export * from './members-service';

--- a/e2e/helpers/services/members/members-service.ts
+++ b/e2e/helpers/services/members/members-service.ts
@@ -1,0 +1,26 @@
+import {HttpClient as APIRequest, Member} from '@/data-factory';
+
+export interface MembersResponse {
+    members: Member[];
+}
+
+export class MembersService {
+    private readonly request: APIRequest;
+    private readonly adminEndpoint: string;
+
+    constructor(request: APIRequest) {
+        this.request = request;
+        this.adminEndpoint = '/ghost/api/admin';
+    }
+
+    async getByEmail(email: string): Promise<Member> {
+        const response = await this.request.get(
+            `${this.adminEndpoint}/members/?filter=email:'${email}'`
+        );
+        const data = await response.json() as MembersResponse;
+        if (!data.members || data.members.length === 0) {
+            throw new Error(`Member not found with email: ${email}`);
+        }
+        return data.members[0];
+    }
+}

--- a/e2e/helpers/services/members/members-service.ts
+++ b/e2e/helpers/services/members/members-service.ts
@@ -17,6 +17,9 @@ export class MembersService {
         const response = await this.request.get(
             `${this.adminEndpoint}/members/?filter=email:'${email}'`
         );
+        if (!response.ok()) {
+            throw new Error(`Failed to fetch member: ${response.status()}`);
+        }
         const data = await response.json() as MembersResponse;
         if (!data.members || data.members.length === 0) {
             throw new Error(`Member not found with email: ${email}`);

--- a/e2e/tests/admin/members/member-activity-events.test.ts
+++ b/e2e/tests/admin/members/member-activity-events.test.ts
@@ -1,10 +1,22 @@
+import {APIRequestContext} from '@playwright/test';
 import {EmailClient, MailPit} from '@/helpers/services/email/mail-pit';
 import {HomePage, PublicPage} from '@/public-pages';
 import {MemberDetailsPage, MembersPage} from '@/admin-pages';
+import {MembersService} from '@/helpers/services/members';
 import {createAutomatedEmailFactory} from '@/data-factory';
 import {expect, test} from '@/helpers/playwright';
 import {extractMagicLink} from '@/helpers/services/email/utils';
 import {signupViaPortal} from '@/helpers/playwright/flows/signup';
+
+async function waitForWelcomeEmailReceivedEvent(request: APIRequestContext, memberId: string) {
+    await expect.poll(async () => {
+        const now = new Date().toISOString().replace('T', ' ').substring(0, 19);
+        const filter = encodeURIComponent(`data.created_at:<'${now}'+type:automated_email_sent_event+data.member_id:'${memberId}'`);
+        const response = await request.get(`/ghost/api/admin/members/events/?filter=${filter}&limit=5`);
+        const data = await response.json();
+        return data.events?.length > 0;
+    }, {timeout: 10000}).toBe(true);
+}
 
 test.describe('Ghost Admin - Member Activity Events', () => {
     let emailClient: EmailClient;
@@ -30,6 +42,11 @@ test.describe('Ghost Admin - Member Activity Events', () => {
         const publicPage = new PublicPage(page);
         await publicPage.goto(magicLink);
         await homePage.waitUntilLoaded();
+
+        const membersService = new MembersService(page.request);
+        const member = await membersService.getByEmail(emailAddress);
+
+        await waitForWelcomeEmailReceivedEvent(page.request, member.id);
 
         const membersPage = new MembersPage(page);
         await membersPage.goto();


### PR DESCRIPTION
This is a test only change, no changes to Ghost's behavior.


## Problem 

This e2e test was frequently failing, because it was checking for the "Received welcome email" event to appear in the member's activity feed before it existed.

## Fix

This fixes the flaky behavior by polling the API for the "Received welcome email" event to exist, before attempting to make any assertions on the UI in Admin.

## Validation

I've run this test locally with `--repeat-each=50` and it passed all 50 times. It was failing at least 1 in 10 times locally before.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that add API polling and a small helper; low product risk, with minor risk of test brittleness if the events filter/endpoint changes.
> 
> **Overview**
> Deflakes the member activity welcome-email test by **polling the Admin API for the automated email event** before checking the member’s activity feed in Ghost Admin.
> 
> Adds a small `MembersService` helper to fetch a member by email, then uses it in `member-activity-events.test.ts` to look up the new member ID and wait (via `expect.poll`) until `/members/events` returns the expected event before asserting the UI text.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2bbc241bd3e27cab97d12147da687ff40df8a424. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added test infrastructure for welcome email events and integrated member lookup into the member activity test flow.
  * Introduced setup for email client and feature flag initialization within tests.

* **Chores**
  * Added a members service and consolidated its exports to simplify access from test code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->