### PR TITLE
Fixed analytics debug screen table layout with long emails

### DIFF
--- a/ghost/admin/app/components/posts/debug.hbs
+++ b/ghost/admin/app/components/posts/debug.hbs
@@ -71,8 +71,8 @@
                             <LinkTo @route="member" @model={{failure.member.id}} class="gh-email-debug-member">
                                 <GhMemberAvatar @member={{failure.member.record}} @containerClass="w9 h9 mr3 flex-shrink-0" />
                                 <div>
-                                    <h3 class="ma0 pa0 gh-members-list-name">{{failure.recipient.name}}</h3>
-                                    <p class="ma0 pa0 middarkgrey f8 gh-members-list-email">{{failure.recipient.email}}</p>
+                                    <h3 class="ma0 pa0 gh-members-list-name" title={{failure.recipient.name}}>{{failure.recipient.name}}</h3>
+                                    <p class="ma0 pa0 middarkgrey f8 gh-members-list-email" title={{failure.recipient.email}}>{{failure.recipient.email}}</p>
                                 </div>
                             </LinkTo>
                         {{else}}
@@ -83,8 +83,8 @@
                                     </div>
                                 </figure>
                                 <div>
-                                    <h3 class="ma0 pa0 gh-members-list-name">{{failure.recipient.name}}</h3>
-                                    <p class="ma0 pa0 middarkgrey f8 gh-members-list-email">{{failure.recipient.email}}</p>
+                                    <h3 class="ma0 pa0 gh-members-list-name" title={{failure.recipient.name}}>{{failure.recipient.name}}</h3>
+                                    <p class="ma0 pa0 middarkgrey f8 gh-members-list-email" title={{failure.recipient.email}}>{{failure.recipient.email}}</p>
                                 </div>
                             </div>
                         {{/if}}
@@ -128,8 +128,8 @@
                             <LinkTo @route="member" @model={{failure.member.id}} class="gh-email-debug-member">
                                 <GhMemberAvatar @member={{failure.member.record}} @containerClass="w9 h9 mr3 flex-shrink-0" />
                                 <div>
-                                    <h3 class="ma0 pa0 gh-members-list-name">{{failure.recipient.name}}</h3>
-                                    <p class="ma0 pa0 middarkgrey f8 gh-members-list-email">{{failure.recipient.email}}</p>
+                                    <h3 class="ma0 pa0 gh-members-list-name" title={{failure.recipient.name}}>{{failure.recipient.name}}</h3>
+                                    <p class="ma0 pa0 middarkgrey f8 gh-members-list-email" title={{failure.recipient.email}}>{{failure.recipient.email}}</p>
                                 </div>
                             </LinkTo>
                         {{else}}
@@ -140,8 +140,8 @@
                                     </div>
                                 </figure>
                                 <div>
-                                    <h3 class="ma0 pa0 gh-members-list-name">{{failure.recipient.name}}</h3>
-                                    <p class="ma0 pa0 middarkgrey f8 gh-members-list-email">{{failure.recipient.email}}</p>
+                                    <h3 class="ma0 pa0 gh-members-list-name" title={{failure.recipient.name}}>{{failure.recipient.name}}</h3>
+                                    <p class="ma0 pa0 middarkgrey f8 gh-members-list-email" title={{failure.recipient.email}}>{{failure.recipient.email}}</p>
                                 </div>
                             </div>
                         {{/if}}

--- a/ghost/admin/app/styles/layouts/posts.css
+++ b/ghost/admin/app/styles/layouts/posts.css
@@ -64,6 +64,10 @@
     border-bottom: none;
 }
 
+.gh-email-debug-permanent-failures {
+    table-layout: fixed;
+}
+
 .gh-email-debug .gh-list thead,
 .gh-email-debug .gh-list tbody {
     width: 100%;
@@ -86,6 +90,18 @@
     display: flex;
     flex-wrap: nowrap;
     align-items: center;
+    min-width: 0;
+}
+
+.gh-email-debug-member > div {
+    min-width: 0;
+}
+
+.gh-email-debug-member .gh-members-list-name,
+.gh-email-debug-member .gh-members-list-email {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .gh-email-debug-failure {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ONC-1434

## Problem

On the Post Analytics > Debug screen, if there are permanent or temporary failures for members with particularly long email addresses or names, the first column would grow and push the actual failure message off the screen entirely.

## Fix

- Added `table-layout: fixed` to the permanent/temporary failures table to constrain column widths
- Added `min-width: 0` to flex containers to allow proper shrinking
- Added text truncation (ellipsis) for long email addresses and names in the member column

Note: these classes are specifically only used on the debug screen, so there's no risk of any unintended side effects elsewhere in Admin.


Before:

<img width="2804" height="2044" alt="Screenshot 2026-02-03 at 17 57 02@2x" src="https://github.com/user-attachments/assets/e905d413-1575-4203-b14f-bd754f9bbd62" />


After:

<img width="2804" height="2040" alt="Screenshot 2026-02-03 at 17 57 59@2x" src="https://github.com/user-attachments/assets/c3237d03-70e8-4fe3-b14b-f782ca1e8e10" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped CSS-only changes to the post analytics debug screen; low chance of side effects outside the targeted tables.
> 
> **Overview**
> Fixes layout breakage on the Post Analytics email debug screen when member names/emails are very long.
> 
> Adds `table-layout: fixed` to the failures tables to prevent the member column from expanding indefinitely, and updates the member cell flex layout (`min-width: 0`) plus ellipsis truncation on name/email text so the failure message column remains visible.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b05b43ee439033885c8bcfa44f5ec41fe11f9620. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->