### PR TITLE
Renamed post analytics debug "Settings" tab to "Overview"

### DIFF
--- a/ghost/admin/app/components/posts/debug.hbs
+++ b/ghost/admin/app/components/posts/debug.hbs
@@ -250,8 +250,8 @@
         </tabs.tabPanel>
 
         <tabs.tab>
-            <div class="gh-email-debug-settingstab-icon">{{svg-jar "settings"}}</div>
-            <p><span class="analytics-tab-label">Settings</span></p>
+            <div class="gh-email-debug-overviewtab-icon">{{svg-jar "info"}}</div>
+            <p><span class="analytics-tab-label">Overview</span></p>
         </tabs.tab>
 
         <tabs.tabPanel>

--- a/ghost/admin/app/styles/layouts/posts.css
+++ b/ghost/admin/app/styles/layouts/posts.css
@@ -43,17 +43,22 @@
     min-width: 80px;
 }
 
-.gh-email-debug-settingstab-icon {
+.gh-email-debug-overviewtab-icon {
     width: 20px;
     height: 20px;
     margin-bottom: 11px;
     margin-top: 2px;
 }
 
-.gh-email-debug-settingstab-icon svg path,
-.gh-email-debug-settingstab-icon svg circle {
+.gh-email-debug-overviewtab-icon svg {
+    overflow: visible;
+}
+
+.gh-email-debug-overviewtab-icon svg path,
+.gh-email-debug-overviewtab-icon svg circle {
     stroke-width: 2;
 }
+
 
 .gh-email-debug .gh-list {
     border-bottom: none;


### PR DESCRIPTION
ref https://linear.app/ghost/issue/DES-1277

## Summary

- Renamed the "Settings" tab to "Overview" on the analytics debug screen
- Changed the icon from a gear (settings) to an info icon
- Updated CSS class names to match the new naming



The tab shows email send information (status, timestamps, delivery stats) rather than any configurable settings, so "Overview" is a more accurate label.


Before:
<img width="956" height="671" alt="Screenshot 2026-02-03 at 18 23 04" src="https://github.com/user-attachments/assets/bef8d3d3-aedc-41e9-aec7-71e0cd94ece4" />


After:
<img width="958" height="548" alt="Screenshot 2026-02-03 at 18 22 21" src="https://github.com/user-attachments/assets/fe7138df-9992-4521-bd70-3182763c52da" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely UI labeling/icon/CSS selector changes on the debug screen; no business logic, data, or auth paths are affected.
> 
> **Overview**
> Renames the analytics debug screen’s email info tab from **Settings** to **Overview** and swaps the tab icon from `settings` (gear) to `info`.
> 
> Updates the associated CSS by renaming `.gh-email-debug-settingstab-icon` to `.gh-email-debug-overviewtab-icon` and tweaking the SVG styling (adds `overflow: visible` while keeping stroke width rules).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b60a2ff2045d5eb9b50036e972ff9d596f4a988. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the debug tab in the posts section, switching from "Settings" to "Overview" view with a refreshed icon and styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->