### PR TITLE
Merged disableMemberCommentingHideComments into disableMemberCommenting

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
@@ -68,10 +68,6 @@ const features: Feature[] = [{
     description: 'Allow staff to disable commenting for individual members',
     flag: 'disableMemberCommenting'
 }, {
-    title: 'Hide Comments When Disabling',
-    description: 'Show option to hide all previous comments when disabling commenting for a member',
-    flag: 'disableMemberCommentingHideComments'
-}, {
     title: 'Sniper Links',
     description: 'Enable mail app links on signup/signin',
     flag: 'sniperlinks'

--- a/apps/posts/src/views/comments/comments.tsx
+++ b/apps/posts/src/views/comments/comments.tsx
@@ -15,7 +15,6 @@ const Comments: React.FC = () => {
     const {data: configData} = useBrowseConfig();
     const commentPermalinksEnabled = configData?.config?.labs?.commentPermalinks === true;
     const disableMemberCommentingEnabled = configData?.config?.labs?.disableMemberCommenting === true;
-    const hideCommentsEnabled = configData?.config?.labs?.disableMemberCommentingHideComments === true;
 
     const handleAddFilter = useCallback((field: string, value: string, operator: string = 'is') => {
         setFilters((prevFilters) => {
@@ -88,7 +87,6 @@ const Comments: React.FC = () => {
                             disableMemberCommentingEnabled={disableMemberCommentingEnabled}
                             fetchNextPage={fetchNextPage}
                             hasNextPage={hasNextPage}
-                            hideCommentsEnabled={hideCommentsEnabled}
                             isFetchingNextPage={isFetchingNextPage}
                             isLoading={isFetching && !isFetchingNextPage}
                             items={data?.comments ?? []}

--- a/apps/posts/src/views/comments/components/comments-list.tsx
+++ b/apps/posts/src/views/comments/components/comments-list.tsx
@@ -137,8 +137,7 @@ function CommentsList({
     onAddFilter,
     isLoading,
     commentPermalinksEnabled,
-    disableMemberCommentingEnabled,
-    hideCommentsEnabled
+    disableMemberCommentingEnabled
 }: {
     items: Comment[];
     totalItems: number;
@@ -149,7 +148,6 @@ function CommentsList({
     isLoading?: boolean;
     commentPermalinksEnabled?: boolean;
     disableMemberCommentingEnabled?: boolean;
-    hideCommentsEnabled?: boolean;
 }) {
     const parentRef = useRef<HTMLDivElement>(null);
 
@@ -186,7 +184,7 @@ function CommentsList({
             disableCommenting({
                 id: memberToDisable.member.id,
                 reason: `Disabled from comment ${memberToDisable.commentId}`,
-                ...(hideCommentsEnabled && {hideComments})
+                hideComments
             });
             setMemberToDisable(null);
             setHideComments(false);
@@ -469,18 +467,16 @@ function CommentsList({
                         </DialogDescription>
                     </DialogHeader>
 
-                    {hideCommentsEnabled && (
-                        <div className="flex items-center gap-2 py-2">
-                            <Checkbox
-                                checked={hideComments}
-                                id="hide-comments"
-                                onCheckedChange={checked => setHideComments(checked === true)}
-                            />
-                            <Label htmlFor="hide-comments">
-                                Hide all previous comments
-                            </Label>
-                        </div>
-                    )}
+                    <div className="flex items-center gap-2 py-2">
+                        <Checkbox
+                            checked={hideComments}
+                            id="hide-comments"
+                            onCheckedChange={checked => setHideComments(checked === true)}
+                        />
+                        <Label htmlFor="hide-comments">
+                            Hide all previous comments
+                        </Label>
+                    </div>
 
                     <DialogFooter>
                         <Button variant="outline" onClick={() => {

--- a/e2e/tests/admin/comments/disable-commenting.test.ts
+++ b/e2e/tests/admin/comments/disable-commenting.test.ts
@@ -92,77 +92,73 @@ test.describe('Ghost Admin - Disable Commenting', () => {
         await expect(commentsPage.disableCommentingMenuItem).toBeVisible();
     });
 
-    test.describe('with hide comments enabled', () => {
-        test.use({labs: {disableMemberCommenting: true, disableMemberCommentingHideComments: true}});
-
-        test('hide comments checkbox appears in modal', async ({page}) => {
-            const post = await postFactory.create({status: 'published'});
-            const member = await memberFactory.create();
-            await commentFactory.create({
-                post_id: post.id,
-                member_id: member.id,
-                html: '<p>Test comment for hide checkbox</p>'
-            });
-
-            const commentsPage = new CommentsPage(page);
-            await commentsPage.goto();
-            await commentsPage.waitForComments();
-
-            const commentRow = commentsPage.getCommentRowByText('Test comment for hide checkbox');
-            await commentsPage.openMoreMenu(commentRow);
-            await commentsPage.clickDisableCommenting();
-
-            await expect(commentsPage.hideCommentsCheckbox).toBeVisible();
+    test('hide comments checkbox appears in modal', async ({page}) => {
+        const post = await postFactory.create({status: 'published'});
+        const member = await memberFactory.create();
+        await commentFactory.create({
+            post_id: post.id,
+            member_id: member.id,
+            html: '<p>Test comment for hide checkbox</p>'
         });
 
-        test('disabling with hide comments checked marks comments as hidden', async ({page}) => {
-            const post = await postFactory.create({status: 'published'});
-            const member = await memberFactory.create();
-            await commentFactory.create({
-                post_id: post.id,
-                member_id: member.id,
-                html: '<p>Comment that should be hidden</p>'
-            });
+        const commentsPage = new CommentsPage(page);
+        await commentsPage.goto();
+        await commentsPage.waitForComments();
 
-            const commentsPage = new CommentsPage(page);
-            await commentsPage.goto();
-            await commentsPage.waitForComments();
+        const commentRow = commentsPage.getCommentRowByText('Test comment for hide checkbox');
+        await commentsPage.openMoreMenu(commentRow);
+        await commentsPage.clickDisableCommenting();
 
-            const commentRow = commentsPage.getCommentRowByText('Comment that should be hidden');
-            await expect(commentRow).toBeVisible();
-            await expect(commentRow.getByText('Hidden', {exact: true})).toBeHidden();
+        await expect(commentsPage.hideCommentsCheckbox).toBeVisible();
+    });
 
-            await commentsPage.openMoreMenu(commentRow);
-            await commentsPage.clickDisableCommenting();
-            await commentsPage.hideCommentsCheckbox.check();
-            await commentsPage.confirmDisableCommenting();
-
-            await expect(commentRow.getByText('Hidden', {exact: true})).toBeVisible();
-            await expect(commentsPage.commentingDisabledIndicator(commentRow)).toBeVisible();
+    test('disabling with hide comments checked marks comments as hidden', async ({page}) => {
+        const post = await postFactory.create({status: 'published'});
+        const member = await memberFactory.create();
+        await commentFactory.create({
+            post_id: post.id,
+            member_id: member.id,
+            html: '<p>Comment that should be hidden</p>'
         });
 
-        test('disabling without hide comments checked keeps comments visible', async ({page}) => {
-            const post = await postFactory.create({status: 'published'});
-            const member = await memberFactory.create();
-            await commentFactory.create({
-                post_id: post.id,
-                member_id: member.id,
-                html: '<p>Comment that should stay visible</p>'
-            });
+        const commentsPage = new CommentsPage(page);
+        await commentsPage.goto();
+        await commentsPage.waitForComments();
 
-            const commentsPage = new CommentsPage(page);
-            await commentsPage.goto();
-            await commentsPage.waitForComments();
+        const commentRow = commentsPage.getCommentRowByText('Comment that should be hidden');
+        await expect(commentRow).toBeVisible();
+        await expect(commentRow.getByText('Hidden', {exact: true})).toBeHidden();
 
-            const commentRow = commentsPage.getCommentRowByText('Comment that should stay visible');
-            await commentsPage.openMoreMenu(commentRow);
-            await commentsPage.clickDisableCommenting();
-            await commentsPage.confirmDisableCommenting();
+        await commentsPage.openMoreMenu(commentRow);
+        await commentsPage.clickDisableCommenting();
+        await commentsPage.hideCommentsCheckbox.check();
+        await commentsPage.confirmDisableCommenting();
 
-            await expect(commentsPage.disableCommentsModal).toBeHidden();
-            await expect(commentRow).toBeVisible();
-            await expect(commentsPage.commentingDisabledIndicator(commentRow)).toBeVisible();
+        await expect(commentRow.getByText('Hidden', {exact: true})).toBeVisible();
+        await expect(commentsPage.commentingDisabledIndicator(commentRow)).toBeVisible();
+    });
+
+    test('disabling without hide comments checked keeps comments visible', async ({page}) => {
+        const post = await postFactory.create({status: 'published'});
+        const member = await memberFactory.create();
+        await commentFactory.create({
+            post_id: post.id,
+            member_id: member.id,
+            html: '<p>Comment that should stay visible</p>'
         });
+
+        const commentsPage = new CommentsPage(page);
+        await commentsPage.goto();
+        await commentsPage.waitForComments();
+
+        const commentRow = commentsPage.getCommentRowByText('Comment that should stay visible');
+        await commentsPage.openMoreMenu(commentRow);
+        await commentsPage.clickDisableCommenting();
+        await commentsPage.confirmDisableCommenting();
+
+        await expect(commentsPage.disableCommentsModal).toBeHidden();
+        await expect(commentRow).toBeVisible();
+        await expect(commentsPage.commentingDisabledIndicator(commentRow)).toBeVisible();
     });
 
     test.describe('disable/enable commenting flow', () => {

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -53,7 +53,6 @@ const PRIVATE_FEATURES = [
     'featurebaseFeedback',
     'transistor',
     'disableMemberCommenting',
-    'disableMemberCommentingHideComments',
     'sniperlinks'
 ];
 

--- a/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
@@ -16,7 +16,6 @@ Object {
       "commentPermalinks": true,
       "customFonts": true,
       "disableMemberCommenting": true,
-      "disableMemberCommentingHideComments": true,
       "editorExcerpt": true,
       "emailCustomization": true,
       "emailUniqueid": true,


### PR DESCRIPTION
The disable member commenting feature previously used two separate labs flags: `disableMemberCommenting` to enable the feature itself, and `disableMemberCommentingHideComments` to control whether the "Hide all previous comments" checkbox appeared in the disable dialog. This split made sense during iterative development but adds unnecessary complexity now that both features are ready to ship together.

This change removes the `disableMemberCommentingHideComments` flag entirely and makes the hide comments checkbox always visible when `disableMemberCommenting` is enabled. The labs settings UI entry, config reads, and conditional rendering have all been cleaned up accordingly. The E2E tests that previously lived in a nested describe block with both flags enabled have been flattened into the parent describe since the checkbox is now always present.

ref https://linear.app/ghost/issue/BER-3184

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removes a labs flag and changes request payload shape/semantics for disabling member commenting, which could affect deployments or clients still expecting the old flag gating or optional parameter behavior.
> 
> **Overview**
> Removes the separate labs flag `disableMemberCommentingHideComments` and folds that behavior into `disableMemberCommenting`, simplifying labs configuration and the private labs UI.
> 
> In the comments UI, the “Hide all previous comments” checkbox is now always shown when member commenting disablement is enabled, and the disable-member API call always includes a `hideComments` boolean. E2E coverage is updated accordingly (tests flattened to assume the checkbox is present) and the config/labs snapshots are adjusted to no longer expect the removed flag.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7cc67e1a217ecc8c07a860a44eabc6b5fbf2a709. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The "Hide comments" option is always shown in the Disable Comments flow (no experimental flag); hide behavior is applied consistently when disabling a member.

* **Tests**
  * E2E tests updated to independently verify the hide-comments checkbox and hide/unhide outcomes across disable/enable scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->