### PR TITLE
Refined comment moderation filters

### DIFF
--- a/apps/posts/src/views/comments/components/comments-filters.tsx
+++ b/apps/posts/src/views/comments/components/comments-filters.tsx
@@ -107,7 +107,11 @@ const CommentsFilters: React.FC<CommentsFiltersProps> = ({
                     {value: 'published', label: 'Published'},
                     {value: 'hidden', label: 'Hidden'}
                 ],
-                searchable: false
+                operators: [
+                    {value: 'is', label: 'is'}
+                ],
+                searchable: false,
+                hideOperatorSelect: true
             },
             {
                 key: 'reported',

--- a/apps/shade/src/components/ui/filters.tsx
+++ b/apps/shade/src/components/ui/filters.tsx
@@ -1222,7 +1222,7 @@ function SelectOptionsPopover<T = unknown>({
                         field.customValueRenderer(values, field.options || [])
                     ) : (
                         <>
-                            {selectedOptions.length > 0 && (
+                            {selectedOptions.length > 0 && selectedOptions.some(option => option.icon) && (
                                 <div className={cn('-space-x-0.5 flex shrink-0 items-center', field.selectedOptionsClassName)}>
                                     {selectedOptions.slice(0, 3).map(option => (
                                         <div key={String(option.value)}>{option.icon}</div>


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3264/filter-refinements

- There was an unwanted space for dropdown options without icons
- Some operators didn't make sense for status filtering