### PR TITLE
Added redemption_type to Offers Content API

### DIFF
--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/mappers/offers.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/mappers/offers.js
@@ -18,6 +18,7 @@ module.exports = (model, frame) => {
             currency_restriction: jsonModel.currency_restriction,
             currency: jsonModel.currency,
             status: jsonModel.status,
+            redemption_type: jsonModel.redemption_type,
             tier: jsonModel.tier
         };
 

--- a/ghost/core/test/e2e-api/content/__snapshots__/offers.test.js.snap
+++ b/ghost/core/test/e2e-api/content/__snapshots__/offers.test.js.snap
@@ -14,6 +14,7 @@ Object {
       "duration_in_months": null,
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
       "name": "Black Friday",
+      "redemption_type": "signup",
       "status": "active",
       "tier": Object {
         "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -29,7 +30,7 @@ exports[`Offers Content API Can read offer details from id 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "public, max-age=0",
-  "content-length": "331",
+  "content-length": "358",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3258/disable-offer-link-for-retention-offers

- The new field `redemption_type` is set to `signup` for signup offers (default) and to `retention` for retention offers
- With this change, we expose the `redemption_type` in Content API, so that it can be used by Portal to handle offers differently, based on their redemption type. For instance, retention offers are triggered during the cancellation flow and cannot be redeemed via an offer link
