### PR TITLE
Removed non nullable constraint from `offers.product_id`

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/6.17/2026-02-04-10-42-20-offers-nullable-product-id.js
+++ b/ghost/core/core/server/data/migrations/versions/6.17/2026-02-04-10-42-20-offers-nullable-product-id.js
@@ -1,3 +1,4 @@
 const {createSetNullableMigration} = require('../../utils');
 
+// We need to disable foreign key checks because if MySQL is missing the STRICT_TRANS_TABLES mode, we cannot revert the migration
 module.exports = createSetNullableMigration('offers', 'product_id', {disableForeignKeyChecks: true});

--- a/ghost/core/core/server/data/migrations/versions/6.17/2026-02-04-10-42-20-offers-nullable-product-id.js
+++ b/ghost/core/core/server/data/migrations/versions/6.17/2026-02-04-10-42-20-offers-nullable-product-id.js
@@ -1,0 +1,3 @@
+const {createSetNullableMigration} = require('../../utils');
+
+module.exports = createSetNullableMigration('offers', 'product_id', {disableForeignKeyChecks: true});

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -483,7 +483,7 @@ module.exports = {
         active: {type: 'boolean', nullable: false, defaultTo: true},
         name: {type: 'string', maxlength: 191, nullable: false, unique: true},
         code: {type: 'string', maxlength: 191, nullable: false, unique: true},
-        product_id: {type: 'string', maxlength: 24, nullable: false, references: 'products.id'},
+        product_id: {type: 'string', maxlength: 24, nullable: true, references: 'products.id'},
         stripe_coupon_id: {type: 'string', maxlength: 255, nullable: true, unique: true},
         interval: {type: 'string', maxlength: 50, nullable: false, validations: {isIn: [['month', 'year']]}},
         currency: {type: 'string', maxlength: 50, nullable: true},

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '7513361f486eae436e3e2e6d35b4d313';
+    const currentSchemaHash = '0faf1ab8fe5d1582b21e8f828f718c9f';
     const currentFixturesHash = '4dcbd7b52bc9ce23e6f5f1673118ba73';
     const currentSettingsHash = 'd18778216289f79a502d75234320b8d3';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3257

Removed non nullable constraint from `offers.product_id` so that offers can be created that are not assigned to a specific tier. This is required for retention offers where an offer is applicate to the cadence (`monthly`, `yearly`) of any tier, and not the specific tier

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Alters a production DB constraint on a foreign-keyed column; low code surface area, but schema changes can impact existing queries/assumptions and rollback behavior.
> 
> **Overview**
> Allows `offers` to be created without a linked tier by making `offers.product_id` nullable.
> 
> Adds a new `6.17` migration to set the column nullable (with foreign key checks disabled for safe rollback on some MySQL configs), updates the schema definition accordingly, and refreshes the schema integrity test hash.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 92c2c1547b5e25020470294f10655d2ea4b07565. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->