### PR TITLE
    Prevented offer links to trigger for retention offers

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.59.0",
+  "version": "2.60.0",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/portal/src/app.js
+++ b/apps/portal/src/app.js
@@ -14,7 +14,7 @@ import {transformPortalAnchorToRelative} from './utils/transform-portal-anchor-t
 import {getActivePage, isAccountPage, isOfferPage} from './pages';
 import ActionHandler from './actions';
 import './app.css';
-import {hasRecommendations, createPopupNotification, hasAvailablePrices, getCurrencySymbol, getFirstpromoterId, getPriceIdFromPageQuery, getProductCadenceFromPrice, getProductFromId, getQueryPrice, getSiteDomain, isActiveOffer, isComplimentaryMember, isInviteOnly, isPaidMember, isRecentMember, isSentryEventAllowed, removePortalLinkFromUrl} from './utils/helpers';
+import {hasRecommendations, createPopupNotification, hasAvailablePrices, getCurrencySymbol, getFirstpromoterId, getPriceIdFromPageQuery, getProductCadenceFromPrice, getProductFromId, getQueryPrice, getSiteDomain, isActiveOffer, isRetentionOffer, isComplimentaryMember, isInviteOnly, isPaidMember, isRecentMember, isSentryEventAllowed, removePortalLinkFromUrl} from './utils/helpers';
 import {validateHexColor} from './utils/sanitize-html';
 import {handleDataAttributes} from './data-attributes';
 
@@ -752,30 +752,43 @@ export default class App extends React.Component {
     async handleOfferQuery({site, offerId, member = this.state.member}) {
         const {portal_button: portalButton} = site;
         removePortalLinkFromUrl();
+
         if (!isPaidMember({member}) || isComplimentaryMember({member})) {
             try {
                 const offerData = await this.GhostApi.site.offer({offerId});
                 const offer = offerData?.offers[0];
-                if (isActiveOffer({site, offer})) {
-                    if (!portalButton) {
-                        const product = getProductFromId({site, productId: offer.tier.id});
-                        const price = offer.cadence === 'month' ? product.monthlyPrice : product.yearlyPrice;
-                        this.dispatchAction('openPopup', {
-                            page: 'loading'
-                        });
-                        if (member) {
-                            const {tierId, cadence} = getProductCadenceFromPrice({site, priceId: price.id});
-                            this.dispatchAction('checkoutPlan', {plan: price.id, offerId, tierId, cadence});
-                        } else {
-                            const {tierId, cadence} = getProductCadenceFromPrice({site, priceId: price.id});
-                            this.dispatchAction('signup', {plan: price.id, offerId, tierId, cadence});
-                        }
+
+                if (!offer) {
+                    return;
+                }
+
+                // Retention offers are only triggered during a member cancellation flow - they cannot be accessed via an offer link
+                if (isRetentionOffer({offer})) {
+                    return;
+                }
+
+                if (!isActiveOffer({site, offer})) {
+                    return;
+                }
+
+                if (!portalButton) {
+                    const product = getProductFromId({site, productId: offer.tier.id});
+                    const price = offer.cadence === 'month' ? product.monthlyPrice : product.yearlyPrice;
+                    this.dispatchAction('openPopup', {
+                        page: 'loading'
+                    });
+                    if (member) {
+                        const {tierId, cadence} = getProductCadenceFromPrice({site, priceId: price.id});
+                        this.dispatchAction('checkoutPlan', {plan: price.id, offerId, tierId, cadence});
                     } else {
-                        this.dispatchAction('openPopup', {
-                            page: 'offer',
-                            pageData: offerData?.offers[0]
-                        });
+                        const {tierId, cadence} = getProductCadenceFromPrice({site, priceId: price.id});
+                        this.dispatchAction('signup', {plan: price.id, offerId, tierId, cadence});
                     }
+                } else {
+                    this.dispatchAction('openPopup', {
+                        page: 'offer',
+                        pageData: offerData?.offers[0]
+                    });
                 }
             } catch (e) {
                 // ignore invalid portal url

--- a/apps/portal/src/utils/fixtures-generator.js
+++ b/apps/portal/src/utils/fixtures-generator.js
@@ -89,7 +89,8 @@ export function getOfferData({
     currency = null,
     status = 'active',
     tierId = '',
-    tierName = 'Basic'
+    tierName = 'Basic',
+    redemptionType = 'signup'
 } = {}) {
     return {
         id: `offer_${objectId()}`,
@@ -108,7 +109,8 @@ export function getOfferData({
         tier: {
             id: `${tierId}`,
             name: tierName
-        }
+        },
+        redemption_type: redemptionType
     };
 }
 

--- a/apps/portal/src/utils/helpers.js
+++ b/apps/portal/src/utils/helpers.js
@@ -814,6 +814,10 @@ export const getUpdatedOfferPrice = ({offer, price, useFormatted = false}) => {
     return updatedAmount;
 };
 
+export const isRetentionOffer = ({offer}) => {
+    return offer.redemption_type === 'retention';
+};
+
 export const isActiveOffer = ({site, offer}) => {
     if (offer?.status !== 'active') {
         return false;

--- a/apps/portal/test/utils/helpers.test.js
+++ b/apps/portal/test/utils/helpers.test.js
@@ -1,4 +1,4 @@
-import {hasAvailablePrices, getAllProductsForSite, getAvailableProducts, getCurrencySymbol, getFreeProduct, getMemberName, getMemberSubscription, getPriceFromSubscription, getPriceIdFromPageQuery, getSupportAddress, getDefaultNewsletterSender, getUrlHistory, hasMultipleProducts, isActiveOffer, isInviteOnly, isPaidMember, isPaidMembersOnly, isSameCurrency, transformApiTiersData, isSigninAllowed, isSignupAllowed, getCompExpiry, isInThePast, hasNewsletterSendingEnabled} from '../../src/utils/helpers';
+import {hasAvailablePrices, getAllProductsForSite, getAvailableProducts, getCurrencySymbol, getFreeProduct, getMemberName, getMemberSubscription, getPriceFromSubscription, getPriceIdFromPageQuery, getSupportAddress, getDefaultNewsletterSender, getUrlHistory, hasMultipleProducts, isActiveOffer, isRetentionOffer, isInviteOnly, isPaidMember, isPaidMembersOnly, isSameCurrency, transformApiTiersData, isSigninAllowed, isSignupAllowed, getCompExpiry, isInThePast, hasNewsletterSendingEnabled} from '../../src/utils/helpers';
 import * as Fixtures from '../../src/utils/fixtures-generator';
 import {site as FixturesSite, member as FixtureMember, offer as FixtureOffer, transformTierFixture as TransformFixtureTiers} from './test-fixtures';
 import {isComplimentaryMember} from '../../src/utils/helpers';
@@ -115,6 +115,18 @@ describe('Helpers - ', () => {
         test('returns false for active offer with archived or disabled tier', () => {
             const value = isActiveOffer({offer: FixtureOffer, site: FixturesSite.singleTier.onlyFreePlan});
             expect(value).toBe(false);
+        });
+    });
+
+    describe('isRetentionOffer -', () => {
+        test('returns false for signup offers', () => {
+            const result = isRetentionOffer({offer: {...FixtureOffer, redemption_type: 'signup'}});
+            expect(result).toBe(false);
+        });
+
+        test('returns true for retention offers', () => {
+            const result = isRetentionOffer({offer: {...FixtureOffer, redemption_type: 'retention'}});
+            expect(result).toBe(true);
         });
     });
 

--- a/ghost/core/core/shared/config/defaults.json
+++ b/ghost/core/core/shared/config/defaults.json
@@ -234,7 +234,7 @@
     },
     "portal": {
         "url": "https://cdn.jsdelivr.net/ghost/portal@~{version}/umd/portal.min.js",
-        "version": "2.59"
+        "version": "2.60"
     },
     "sodoSearch": {
         "url": "https://cdn.jsdelivr.net/ghost/sodo-search@~{version}/umd/sodo-search.min.js",

--- a/ghost/core/test/e2e-browser/portal/offers.spec.js
+++ b/ghost/core/test/e2e-browser/portal/offers.spec.js
@@ -1,6 +1,9 @@
 const {expect} = require('@playwright/test');
 const test = require('../fixtures/ghost-test');
 const {deleteAllMembers, createTier, createOffer, completeStripeSubscription} = require('../utils');
+const models = require('../../../core/server/models');
+const offersService = require('../../../core/server/services/offers');
+const ObjectID = require('bson-objectid').default;
 
 test.describe('Portal', () => {
     test.setTimeout(90000); // override the default 60s in the config as these retries can run close to 60s
@@ -336,6 +339,47 @@ test.describe('Portal', () => {
             await sharedPage.goto(offerLink);
             const portalPopup = await sharedPage.locator('[data-testid="portal-popup-frame"]').isVisible();
             await expect(portalPopup).toBeFalsy();
+        });
+
+        test('Retention offers do not trigger the offer redemption popup when visiting the offer URL', async ({sharedPage}) => {
+            await sharedPage.goto('/ghost');
+            await deleteAllMembers(sharedPage);
+
+            const tierName = `Retention Tier ${new ObjectID().toHexString().slice(0, 8)}`;
+            await createTier(sharedPage, {
+                name: tierName,
+                monthlyPrice: 6,
+                yearlyPrice: 60
+            });
+
+            const product = await models.Product.findOne({name: tierName}, {require: true});
+            const suffix = new ObjectID().toHexString().slice(0, 8);
+            const offerCode = `retention-${suffix}`;
+
+            await offersService.api.createOffer({
+                name: `Retention Offer ${suffix}`,
+                code: offerCode,
+                display_title: 'Stay with us',
+                display_description: 'Retention offer',
+                type: 'percent',
+                cadence: 'month',
+                amount: 10,
+                duration: 'once',
+                duration_in_months: null,
+                status: 'active',
+                tier: {
+                    id: product.id,
+                    name: product.get('name')
+                },
+                redemption_type: 'retention'
+            });
+
+            const siteUrl = new URL(sharedPage.url()).origin;
+            await sharedPage.goto(`${siteUrl}/${offerCode}`);
+            await sharedPage.waitForLoadState('load');
+
+            await expect(sharedPage.locator('[data-testid="portal-popup-frame"]')).not.toBeVisible();
+            await expect(sharedPage).not.toHaveURL(/#\/portal\/offers/);
         });
     });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3258

- Retention offers cannot be accessed via an offer link of type https://<mysite.com>/offer-code, as they're meant to be triggered during a member cancellation flow
- Bumped Portal to new minor, given that this relies on a new backend change: https://github.com/TryGhost/Ghost/pull/26214



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes - Version 2.60.0

* **New Features**
  * Added support for retention offers with distinct handling from standard offers.
  * Retention offers no longer trigger the offer redemption popup when accessing offer URLs.

* **Improvements**
  * Enhanced offer flow logic with improved detection and early return handling for missing or inactive offers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->