### PR TITLE
🐛 Fixed admin auth re-fetch overwriting paginated comments

### DIFF
--- a/apps/comments-ui/src/app.tsx
+++ b/apps/comments-ui/src/app.tsx
@@ -140,11 +140,23 @@ const App: React.FC<AppProps> = ({scriptTag, initialCommentId, pageUrl}) => {
                 if (admin) {
                     // this is a bit of a hack, but we need to fetch the comments fully populated if the user is an admin
                     const adminComments = await adminApi.browse({page: 1, postId: options.postId, order: state.order, memberUuid: state.member?.uuid});
-                    setState({
-                        ...state,
-                        adminApi: adminApi,
-                        comments: adminComments.comments,
-                        pagination: adminComments.meta.pagination
+                    setState((currentState) => {
+                        // Don't overwrite paginated comments when initSetup loaded
+                        // multiple pages (e.g., for permalink scrolling)
+                        if (currentState.pagination && currentState.pagination.page > 1) {
+                            return {
+                                adminApi,
+                                admin,
+                                isAdmin: true
+                            };
+                        }
+                        return {
+                            adminApi,
+                            admin,
+                            isAdmin: true,
+                            comments: adminComments.comments,
+                            pagination: adminComments.meta.pagination
+                        };
                     });
                 }
             } catch (e) {

--- a/apps/comments-ui/test/e2e/permalink.test.ts
+++ b/apps/comments-ui/test/e2e/permalink.test.ts
@@ -1,6 +1,6 @@
 import {E2E_PORT} from '../../playwright.config';
 import {FrameLocator, Page} from '@playwright/test';
-import {MOCKED_SITE_URL, MockedApi, initialize} from '../utils/e2e';
+import {MOCKED_SITE_URL, MockedApi, initialize, mockAdminAuthFrame} from '../utils/e2e';
 import {expect, test} from '@playwright/test';
 
 /**
@@ -362,5 +362,82 @@ test.describe('Comment Permalinks', async () => {
         // The element should have the correct ID for highlighting
         const targetElement = commentsFrame.locator(`[id="${targetReplyId}"]`);
         await expect(targetElement).toBeVisible();
+    });
+
+    test('admin auth does not overwrite paginated comments loaded for permalink', async ({page}) => {
+        const mockedApi = new MockedApi({});
+        mockedApi.setMember({id: '1', uuid: '12345'});
+
+        const admin = MOCKED_SITE_URL + '/ghost/';
+        await mockAdminAuthFrame({page, admin});
+
+        // Add 25 comments — member API page size is 5, admin API page size is 20.
+        // The target (comment 25) is on member page 5 and admin page 2.
+        // initSetup paginates member API to find it, then initAdminAuth re-fetches
+        // admin page 1 only (20 comments), which must NOT overwrite the 25.
+        for (let i = 1; i <= 24; i++) {
+            mockedApi.addComment({
+                html: `<p>Filler comment ${i}</p>`
+            });
+        }
+
+        const targetId = 'aaa0000000000000000025';
+        mockedApi.addComment({
+            id: targetId,
+            html: '<p>Target comment beyond admin page 1</p>'
+        });
+
+        // Set up permalink test with admin URL in the script tag options
+        const sitePath = MOCKED_SITE_URL;
+
+        mockedApi.setSettings({
+            settings: {
+                labs: {
+                    commentPermalinks: true
+                }
+            }
+        });
+
+        await page.route(sitePath, async (route) => {
+            await route.fulfill({status: 200, body: '<html><head><meta charset="UTF-8" /></head><body></body></html>'});
+        });
+
+        const url = `http://localhost:${E2E_PORT}/comments-ui.min.js`;
+        await page.setViewportSize({width: 1000, height: 1000});
+        await page.goto(`${sitePath}#ghost-comments-${targetId}`);
+        await mockedApi.listen({page, path: sitePath});
+
+        const options = {
+            publication: 'Publisher Weekly',
+            count: true,
+            title: 'Title',
+            ghostComments: MOCKED_SITE_URL,
+            postId: mockedApi.postId,
+            api: MOCKED_SITE_URL,
+            admin,
+            key: '12345678'
+        };
+
+        await page.evaluate((data) => {
+            const scriptTag = document.createElement('script');
+            scriptTag.src = data.url;
+            for (const option of Object.keys(data.options)) {
+                scriptTag.dataset[option] = data.options[option];
+            }
+            document.body.appendChild(scriptTag);
+        }, {url, options});
+
+        const commentsFrame = page.frameLocator('iframe[title="comments-frame"]');
+
+        // Target comment should be visible after permalink pagination
+        await expect(commentsFrame.getByText('Target comment beyond admin page 1')).toBeVisible();
+
+        // Wait for admin auth to complete — the more button only renders
+        // when isAdmin is true, so its presence proves initAdminAuth has
+        // finished and React has flushed the state update
+        await expect(commentsFrame.locator('[data-testid="more-button"]').first()).toBeVisible();
+
+        // The target comment (beyond admin page 1) must STILL be visible
+        await expect(commentsFrame.getByText('Target comment beyond admin page 1')).toBeVisible();
     });
 });


### PR DESCRIPTION
When a user navigates to a comment permalink that requires loading multiple pages of comments, `initSetup` correctly paginates through all pages to find the target. However, `initAdminAuth` then independently re-fetches only page 1 via the admin API (which has a limit of 20), and overwrites the entire comment list with this truncated result. This causes the permalink target to disappear from the DOM, breaking both scroll-to and highlight behavior.

The root cause is that `initAdminAuth` used a direct `setState({...state, comments, pagination})` call with a stale closure over `state`, rather than the callback form. This meant it always replaced whatever comments were currently loaded with its own page-1 fetch. The fix switches to a callback-form `setState` that checks whether `initSetup` has already loaded beyond page 1 — if so, it preserves the existing comments and only updates admin-related state (`adminApi`, `admin`, `isAdmin`).

An E2E test reproduces the exact scenario: 25 comments with a permalink to the last one, with admin auth enabled. It verifies the target comment remains visible after admin auth completes its re-fetch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized state-update change plus an E2E regression test; low risk aside from potential edge cases around pagination detection.
> 
> **Overview**
> Fixes a permalink regression where `initAdminAuth` re-fetching admin comments (page 1 only) could overwrite comments that `initSetup` had already paginated in to reach a permalink target.
> 
> `initAdminAuth` now uses a functional `setState` and preserves the existing `comments`/`pagination` when the current pagination indicates multiple pages were loaded, updating only admin-related state in that case. Adds an E2E test to reproduce the 25-comment permalink scenario with admin auth enabled and assert the target comment remains visible after admin auth completes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b960d284206c9634efc1703f7b1f0b2c6744311a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented admin authentication from overwriting previously loaded paginated comments, so permalinks and multi-page comment views retain visible comments after admin auth.

* **Tests**
  * Added an end-to-end test validating admin auth does not replace member-paginated comments when following a permalink.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->