### PR TITLE
Updated offer system to handle `null` tier

### DIFF
--- a/apps/admin-x-framework/src/api/offers.ts
+++ b/apps/admin-x-framework/src/api/offers.ts
@@ -20,7 +20,7 @@ export type Offer = {
     tier: {
         id: string;
         name?: string;
-    },
+    } | null,
     created_at?: string;
     last_redeemed? : string;
 }

--- a/apps/admin-x-framework/src/test/responses/offers.json
+++ b/apps/admin-x-framework/src/test/responses/offers.json
@@ -62,6 +62,24 @@
                 "id": "645453f4d254799990dd0e22",
                 "name": "Supporter"
             }
+        },
+        {
+            "id": "6487f0c364fca78ec2fff601",
+            "name": "Fourth offer",
+            "code": "fourth-offer",
+            "display_title": "Fourth offer",
+            "display_description": "",
+            "type": "percent",
+            "cadence": "month",
+            "amount": 10,
+            "duration": "forever",
+            "duration_in_months": null,
+            "currency_restriction": false,
+            "currency": null,
+            "status": "active",
+            "redemption_count": 0,
+            "redemption_type": "retention",
+            "tier": null
         }
     ]
 }

--- a/apps/admin-x-settings/src/components/settings/growth/offers.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/offers.tsx
@@ -40,7 +40,7 @@ const Offers: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const signupOffers = allOffers.filter(offer => offer.redemption_type === 'signup');
 
     const activeOffers = signupOffers
-        .map(offer => ({...offer, tier: paidActiveTiers.find(tier => tier.id === offer.tier.id)}))
+        .map(offer => ({...offer, tier: paidActiveTiers.find(tier => tier.id === offer.tier?.id)}))
         .filter((offer): offer is Offer & {tier: Tier} => offer.status === 'active' && !!offer.tier);
 
     activeOffers.sort((a, b) => {

--- a/apps/admin-x-settings/src/components/settings/growth/offers/edit-offer-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/offers/edit-offer-modal.tsx
@@ -241,7 +241,7 @@ const EditOfferModal: React.FC<{id: string}> = ({id}) => {
             durationInMonths: formState?.duration_in_months || 0,
             currency: formState?.currency || '',
             status: formState?.status || '',
-            tierId: formState?.tier.id || ''
+            tierId: formState?.tier?.id || ''
         };
 
         const newHref = getOfferPortalPreviewUrl(dataset, siteData.url);

--- a/apps/admin-x-settings/src/components/settings/growth/offers/offers-index.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/offers/offers-index.tsx
@@ -106,11 +106,11 @@ export const OffersIndexModal = () => {
     const {data: {tiers: allTiers} = {}} = useBrowseTiers();
     const signupOffers = allOffers.filter(offer => offer.redemption_type === 'signup');
     const activeOffers = signupOffers.filter((offer) => {
-        const offerTier = allTiers?.find(tier => tier.id === offer?.tier.id);
+        const offerTier = allTiers?.find(tier => tier.id === offer?.tier?.id);
         return (offer.status === 'active' && offerTier && offerTier.active === true);
     });
     const archivedOffers = signupOffers.filter((offer) => {
-        const offerTier = allTiers?.find(tier => tier.id === offer?.tier.id);
+        const offerTier = allTiers?.find(tier => tier.id === offer?.tier?.id);
         return (offer.status === 'archived' || (offerTier && offerTier.active === false));
     });
 
@@ -161,11 +161,11 @@ export const OffersIndexModal = () => {
                 null
             }
             {sortedOffers.filter((offer) => {
-                const offerTier = allTiers?.find(tier => tier.id === offer?.tier.id);
+                const offerTier = allTiers?.find(tier => tier.id === offer?.tier?.id);
                 return (selectedTab === 'active' && (offer.status === 'active' && offerTier && offerTier.active === true)) ||
                 (selectedTab === 'archived' && (offer.status === 'archived' || (offerTier && offerTier.active === false)));
             }).map((offer) => {
-                const offerTier = allTiers?.find(tier => tier.id === offer?.tier.id);
+                const offerTier = allTiers?.find(tier => tier.id === offer?.tier?.id);
 
                 if (!offerTier) {
                     return null;

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.62.1",
+  "version": "2.62.2",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/portal/src/app.js
+++ b/apps/portal/src/app.js
@@ -758,7 +758,7 @@ export default class App extends React.Component {
                 const offerData = await this.GhostApi.site.offer({offerId});
                 const offer = offerData?.offers[0];
 
-                if (!offer) {
+                if (!offer || !offer.tier) {
                     return;
                 }
 

--- a/apps/portal/src/components/pages/account-plan-page.js
+++ b/apps/portal/src/components/pages/account-plan-page.js
@@ -416,7 +416,9 @@ const PlansContainer = ({
 
     // Retention offer flow - shown before cancellation confirmation
     if (confirmationType === 'offerRetention' && pendingOffer) {
-        const offerProduct = getProductFromId({site, productId: pendingOffer.tier.id});
+        const offerProduct = pendingOffer.tier
+            ? getProductFromId({site, productId: pendingOffer.tier.id})
+            : getMemberActiveProduct({member, site});
         const offerPrice = pendingOffer.cadence === 'month' ? offerProduct?.monthlyPrice : offerProduct?.yearlyPrice;
 
         // Skip retention offer if product or price data is invalid

--- a/apps/portal/src/components/pages/offer-page.js
+++ b/apps/portal/src/components/pages/offer-page.js
@@ -276,7 +276,7 @@ export default class OfferPage extends React.Component {
     handleSignup(e) {
         e.preventDefault();
         const {pageData: offer, site} = this.context;
-        if (!offer) {
+        if (!offer || !offer.tier) {
             return null;
         }
         const product = getProductFromId({site, productId: offer.tier.id});
@@ -649,7 +649,7 @@ export default class OfferPage extends React.Component {
 
     render() {
         const {pageData: offer, site} = this.context;
-        if (!offer) {
+        if (!offer || !offer.tier) {
             return null;
         }
         const product = getProductFromId({site, productId: offer.tier.id});

--- a/apps/portal/src/utils/helpers.js
+++ b/apps/portal/src/utils/helpers.js
@@ -823,9 +823,9 @@ export const isActiveOffer = ({site, offer}) => {
         return false;
     }
 
-    // Null-tier offers (retention) are active if their status is active
+    // Null-tier offers are only valid for retention
     if (!offer.tier) {
-        return true;
+        return isRetentionOffer({offer});
     }
 
     // Check if the corresponding tier has been archived

--- a/apps/portal/src/utils/helpers.js
+++ b/apps/portal/src/utils/helpers.js
@@ -823,6 +823,11 @@ export const isActiveOffer = ({site, offer}) => {
         return false;
     }
 
+    // Null-tier offers (retention) are active if their status is active
+    if (!offer.tier) {
+        return true;
+    }
+
     // Check if the corresponding tier has been archived
     const product = getProductFromId({site, productId: offer.tier.id});
     return !!product;

--- a/apps/portal/test/utils/helpers.test.js
+++ b/apps/portal/test/utils/helpers.test.js
@@ -116,6 +116,27 @@ describe('Helpers - ', () => {
             const value = isActiveOffer({offer: FixtureOffer, site: FixturesSite.singleTier.onlyFreePlan});
             expect(value).toBe(false);
         });
+
+        test('returns true for active null-tier offer', () => {
+            const nullTierOffer = {
+                ...FixtureOffer,
+                tier: null,
+                redemption_type: 'retention'
+            };
+            const value = isActiveOffer({offer: nullTierOffer, site: FixturesSite.singleTier.basic});
+            expect(value).toBe(true);
+        });
+
+        test('returns false for archived null-tier offer', () => {
+            const archivedNullTierOffer = {
+                ...FixtureOffer,
+                tier: null,
+                redemption_type: 'retention',
+                status: 'archived'
+            };
+            const value = isActiveOffer({offer: archivedNullTierOffer, site: FixturesSite.singleTier.basic});
+            expect(value).toBe(false);
+        });
     });
 
     describe('isRetentionOffer -', () => {

--- a/apps/portal/test/utils/helpers.test.js
+++ b/apps/portal/test/utils/helpers.test.js
@@ -127,6 +127,16 @@ describe('Helpers - ', () => {
             expect(value).toBe(true);
         });
 
+        test('returns false for active null-tier non-retention offer', () => {
+            const nullTierSignupOffer = {
+                ...FixtureOffer,
+                tier: null,
+                redemption_type: 'signup'
+            };
+            const value = isActiveOffer({offer: nullTierSignupOffer, site: FixturesSite.singleTier.basic});
+            expect(value).toBe(false);
+        });
+
         test('returns false for archived null-tier offer', () => {
             const archivedNullTierOffer = {
                 ...FixtureOffer,

--- a/apps/portal/test/utils/helpers.test.js
+++ b/apps/portal/test/utils/helpers.test.js
@@ -117,7 +117,7 @@ describe('Helpers - ', () => {
             expect(value).toBe(false);
         });
 
-        test('returns true for active null-tier offer', () => {
+        test('returns true for active retention offer', () => {
             const nullTierOffer = {
                 ...FixtureOffer,
                 tier: null,

--- a/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
+++ b/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
@@ -392,6 +392,12 @@ module.exports = class RouterController {
                 });
             }
 
+            if (!offer.tier) {
+                throw new BadRequestError({
+                    message: 'Offer does not have a tier'
+                });
+            }
+
             tier = await this._tiersService.api.read(offer.tier.id);
             cadence = offer.cadence;
         } else if (tierId) {

--- a/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
@@ -1769,7 +1769,7 @@ module.exports = class MemberRepository {
             });
         }
 
-        if (offer.tier.id !== tierId) {
+        if (offer.tier && offer.tier.id !== tierId) {
             throw new errors.BadRequestError({
                 message: tpl(messages.offerTierMismatch)
             });

--- a/ghost/core/core/server/services/members/members-api/services/payments-service.js
+++ b/ghost/core/core/server/services/members/members-api/services/payments-service.js
@@ -72,6 +72,11 @@ class PaymentsService {
         let coupon = null;
         let trialDays = null;
         if (offer) {
+            if (!offer.tier) {
+                throw new BadRequestError({
+                    message: 'Offer does not have a tier'
+                });
+            }
             if (!tier.id.equals(offer.tier.id)) {
                 throw new BadRequestError({
                     message: 'This Offer is not valid for the Tier'

--- a/ghost/core/core/server/services/offers/application/offer-mapper.js
+++ b/ghost/core/core/server/services/offers/application/offer-mapper.js
@@ -26,9 +26,9 @@
  * @prop {number} redemption_count
  * @prop {'signup'|'retention'} redemption_type
  *
- * @prop {object} tier
- * @prop {string} tier.id
- * @prop {string} tier.name
+ * @prop {object|null} tier
+ * @prop {string} [tier.id]
+ * @prop {string} [tier.name]
  * @prop {string} created_at
  * @prop {string|null} last_redeemed
  */
@@ -55,10 +55,9 @@ class OfferMapper {
             status: offer.status.value,
             redemption_count: offer.redemptionCount,
             redemption_type: offer.redemptionType.value,
-            tier: {
-                id: offer.tier.id,
-                name: offer.tier.name
-            },
+            tier: offer.tier
+                ? {id: offer.tier.id, name: offer.tier.name}
+                : null,
             created_at: offer.createdAt,
             last_redeemed: offer.lastRedeemed
         };

--- a/ghost/core/core/server/services/offers/application/offers-api.js
+++ b/ghost/core/core/server/services/offers/application/offers-api.js
@@ -165,12 +165,12 @@ class OffersAPI {
                 return [];
             }
 
-            // Filter by tier and cadence
-            let available = allOffers.filter(offer => offer.tier.id === tierId && offer.cadence.value === cadence);
+            // Filter by tier and cadence - Null-tier offers (retention) match any tier with the correct cadence
+            let available = allOffers.filter(offer => (offer.tier === null || offer.tier.id === tierId) && offer.cadence.value === cadence);
             debug(`listOffersAvailableToSubscription: ${available.length} offers match tier and cadence`);
 
             if (available.length === 0) {
-                const tierIds = [...new Set(allOffers.map(o => o.tier.id))];
+                const tierIds = [...new Set(allOffers.filter(o => o.tier !== null).map(o => o.tier.id))];
                 const cadences = [...new Set(allOffers.map(o => o.cadence.value))];
                 debug(`listOffersAvailableToSubscription: no offers match - available tiers: [${tierIds.join(', ')}], available cadences: [${cadences.join(', ')}]`);
 

--- a/ghost/core/core/server/services/offers/domain/errors/index.js
+++ b/ghost/core/core/server/services/offers/domain/errors/index.js
@@ -18,6 +18,7 @@ class InvalidOfferCode extends InvalidPropError {}
 class InvalidOfferType extends InvalidPropError {}
 class InvalidOfferAmount extends InvalidPropError {}
 class InvalidOfferCurrency extends InvalidPropError {}
+class InvalidOfferTier extends InvalidPropError {}
 class InvalidOfferTierName extends InvalidPropError {}
 class InvalidOfferCadence extends InvalidPropError {}
 class InvalidOfferDuration extends InvalidPropError {}
@@ -36,6 +37,7 @@ module.exports = {
     InvalidOfferCurrency,
     InvalidOfferCadence,
     InvalidOfferDuration,
+    InvalidOfferTier,
     InvalidOfferTierName,
     InvalidOfferCoupon,
     InvalidOfferStatus,

--- a/ghost/core/core/server/services/offers/domain/models/offer.js
+++ b/ghost/core/core/server/services/offers/domain/models/offer.js
@@ -31,7 +31,7 @@ const StripeCoupon = require('./stripe-coupon');
  * @prop {OfferCurrency} [currency]
  * @prop {OfferStatus} status
  * @prop {string|null} [stripeCouponId]
- * @prop {OfferTier} tier
+ * @prop {OfferTier|null} tier
  * @prop {number} redemptionCount
  * @prop {OfferRedemptionType} redemptionType
  * @prop {string} createdAt
@@ -55,7 +55,7 @@ const StripeCoupon = require('./stripe-coupon');
  * @prop {string} [stripe_coupon_id]
  * @prop {number} [redemptionCount]
  * @prop {string} [redemption_type]
- * @prop {TierProps|OfferTier} tier
+ * @prop {TierProps|OfferTier|null} tier
  * @prop {Date} [created_at]
  * @prop {Date} [last_redeemed]
  */
@@ -356,8 +356,20 @@ class Offer {
             }
         }
 
-        const tier = OfferTier.create(data.tier);
         const redemptionType = OfferRedemptionType.create(data.redemption_type || 'signup');
+        const tier = data.tier ? OfferTier.create(data.tier) : null;
+
+        if (redemptionType.value === 'signup' && !tier) {
+            throw new errors.InvalidOfferTier({
+                message: 'Signup offers must be associated with a tier'
+            });
+        }
+
+        if (redemptionType.value === 'retention' && tier) {
+            throw new errors.InvalidOfferTier({
+                message: 'Retention offers cannot be associated with a specific tier'
+            });
+        }
 
         return new Offer({
             id,

--- a/ghost/core/core/server/services/offers/offer-bookshelf-repository.js
+++ b/ghost/core/core/server/services/offers/offer-bookshelf-repository.js
@@ -125,10 +125,9 @@ class OfferBookshelfRepository {
                 redemptionCount: count,
                 redemption_type: json.redemption_type,
                 status: json.active ? 'active' : 'archived',
-                tier: {
-                    id: json.product.id,
-                    name: json.product.name
-                },
+                tier: json.product && json.product.id
+                    ? {id: json.product.id, name: json.product.name}
+                    : null,
                 created_at: json.created_at,
                 last_redeemed: lastRedeemedObject.length > 0 ? lastRedeemedObject[0].created_at : null
             }, null);
@@ -225,7 +224,7 @@ class OfferBookshelfRepository {
             discount_type: offer.type.value === 'fixed' ? 'amount' : offer.type.value,
             discount_amount: offer.amount.value,
             interval: offer.cadence.value,
-            product_id: offer.tier.id,
+            product_id: offer.tier ? offer.tier.id : null,
             duration: offer.duration.value.type,
             duration_in_months: offer.duration.value.type === 'repeating' ? offer.duration.value.months : null,
             currency: offer.currency ? offer.currency.value : null,

--- a/ghost/core/test/e2e-api/admin/__snapshots__/offers.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/offers.test.js.snap
@@ -73,21 +73,6 @@ Object {
 }
 `;
 
-exports[`Offers API Can add a new offer 1: [headers] 1`] = `
-Object {
-  "access-control-allow-origin": "http://127.0.0.1:2369",
-  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "450",
-  "content-type": "application/json; charset=utf-8",
-  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
-  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
-  "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/offers\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
-  "vary": "Accept-Version, Origin, Accept-Encoding",
-  "x-cache-invalidate": "/*",
-  "x-powered-by": "Express",
-}
-`;
-
 exports[`Offers API Can add a new offer 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
@@ -137,6 +122,48 @@ Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
   "content-length": "432",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/offers\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-cache-invalidate": "/*",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Offers API Can add a retention offer without a tier 1: [body] 1`] = `
+Object {
+  "offers": Array [
+    Object {
+      "amount": 10,
+      "cadence": "month",
+      "code": "stay-with-us",
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "currency": null,
+      "currency_restriction": false,
+      "display_description": "10% off if you stay",
+      "display_title": "Stay With Us",
+      "duration": "forever",
+      "duration_in_months": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "last_redeemed": null,
+      "name": "Stay With Us",
+      "redemption_count": 0,
+      "redemption_type": "retention",
+      "status": "active",
+      "tier": null,
+      "type": "percent",
+    },
+  ],
+}
+`;
+
+exports[`Offers API Can add a retention offer without a tier 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "446",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -353,6 +380,26 @@ Object {
       },
       "type": "trial",
     },
+    Object {
+      "amount": 10,
+      "cadence": "month",
+      "code": "stay-with-us",
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "currency": null,
+      "currency_restriction": false,
+      "display_description": "10% off if you stay",
+      "display_title": "Stay With Us",
+      "duration": "forever",
+      "duration_in_months": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "last_redeemed": null,
+      "name": "Stay With Us",
+      "redemption_count": 0,
+      "redemption_type": "retention",
+      "status": "active",
+      "tier": null,
+      "type": "percent",
+    },
   ],
 }
 `;
@@ -361,7 +408,7 @@ exports[`Offers API Can browse 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "2303",
+  "content-length": "2737",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -465,6 +512,26 @@ Object {
       },
       "type": "trial",
     },
+    Object {
+      "amount": 10,
+      "cadence": "month",
+      "code": "stay-with-us",
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "currency": null,
+      "currency_restriction": false,
+      "display_description": "10% off if you stay",
+      "display_title": "Stay With Us",
+      "duration": "forever",
+      "duration_in_months": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "last_redeemed": null,
+      "name": "Stay With Us",
+      "redemption_count": 0,
+      "redemption_type": "retention",
+      "status": "active",
+      "tier": null,
+      "type": "percent",
+    },
   ],
 }
 `;
@@ -473,7 +540,7 @@ exports[`Offers API Can browse active 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "1813",
+  "content-length": "2247",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -647,6 +714,68 @@ Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
   "content-length": "472",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Offers API Cannot create a retention offer with a tier 1: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": null,
+      "context": "Retention offers cannot be associated with a specific tier",
+      "details": null,
+      "ghostErrorCode": null,
+      "help": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "Validation error, cannot save offer.",
+      "property": null,
+      "type": "InvalidOfferTier",
+    },
+  ],
+}
+`;
+
+exports[`Offers API Cannot create a retention offer with a tier 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "281",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Offers API Cannot create a signup offer without a tier 1: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": null,
+      "context": "Signup offers must be associated with a tier",
+      "details": null,
+      "ghostErrorCode": null,
+      "help": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "Validation error, cannot save offer.",
+      "property": null,
+      "type": "InvalidOfferTier",
+    },
+  ],
+}
+`;
+
+exports[`Offers API Cannot create a signup offer without a tier 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "267",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/e2e-api/admin/offers.test.js
+++ b/ghost/core/test/e2e-api/admin/offers.test.js
@@ -224,6 +224,107 @@ describe('Offers API', function () {
         trialOffer = body.offers[0];
     });
 
+    it('Can add a retention offer without a tier', async function () {
+        const newOffer = {
+            name: 'Stay With Us',
+            code: 'stay-with-us',
+            display_title: 'Stay With Us',
+            display_description: '10% off if you stay',
+            type: 'percent',
+            cadence: 'month',
+            amount: 10,
+            duration: 'forever',
+            duration_in_months: null,
+            currency_restriction: false,
+            currency: null,
+            status: 'active',
+            redemption_count: 0,
+            redemption_type: 'retention',
+            tier: null
+        };
+
+        await agent
+            .post(`offers/`)
+            .body({offers: [newOffer]})
+            .expectStatus(200)
+            .matchHeaderSnapshot({
+                'content-version': anyContentVersion,
+                etag: anyEtag,
+                location: anyLocationFor('offers')
+            })
+            .matchBodySnapshot({
+                offers: [{
+                    id: anyObjectId,
+                    tier: null,
+                    created_at: anyISODateTime
+                }]
+            })
+            .expect(({body}) => {
+                body.offers[0].redemption_type.should.eql('retention');
+                should(body.offers[0].tier).be.null();
+            });
+    });
+
+    it('Cannot create a signup offer without a tier', async function () {
+        sinon.stub(logging, 'error');
+
+        const newOffer = {
+            name: 'Bad Signup Offer',
+            code: 'bad-signup',
+            type: 'percent',
+            cadence: 'month',
+            amount: 10,
+            duration: 'once',
+            redemption_type: 'signup',
+            tier: null
+        };
+
+        await agent
+            .post(`offers/`)
+            .body({offers: [newOffer]})
+            .expectStatus(400)
+            .matchHeaderSnapshot({
+                'content-version': anyContentVersion,
+                etag: anyEtag
+            })
+            .matchBodySnapshot({
+                errors: [{
+                    id: anyErrorId
+                }]
+            });
+    });
+
+    it('Cannot create a retention offer with a tier', async function () {
+        sinon.stub(logging, 'error');
+
+        const newOffer = {
+            name: 'Bad Retention Offer',
+            code: 'bad-retention',
+            type: 'percent',
+            cadence: 'month',
+            amount: 10,
+            duration: 'forever',
+            redemption_type: 'retention',
+            tier: {
+                id: defaultTier.id
+            }
+        };
+
+        await agent
+            .post(`offers/`)
+            .body({offers: [newOffer]})
+            .expectStatus(400)
+            .matchHeaderSnapshot({
+                'content-version': anyContentVersion,
+                etag: anyEtag
+            })
+            .matchBodySnapshot({
+                errors: [{
+                    id: anyErrorId
+                }]
+            });
+    });
+
     it('Cannot create offer with same code', async function () {
         sinon.stub(logging, 'error');
 
@@ -326,13 +427,20 @@ describe('Offers API', function () {
                 etag: anyEtag
             })
             .matchBodySnapshot({
-                offers: new Array(5).fill({
-                    id: anyObjectId,
-                    tier: {
-                        id: anyObjectId
-                    },
-                    created_at: anyISODateTime
-                })
+                offers: [
+                    ...new Array(5).fill({
+                        id: anyObjectId,
+                        tier: {
+                            id: anyObjectId
+                        },
+                        created_at: anyISODateTime
+                    }),
+                    {
+                        id: anyObjectId,
+                        tier: null,
+                        created_at: anyISODateTime
+                    }
+                ]
             });
     });
 
@@ -535,13 +643,20 @@ describe('Offers API', function () {
                 etag: anyEtag
             })
             .matchBodySnapshot({
-                offers: new Array(4).fill({
-                    id: anyObjectId,
-                    tier: {
-                        id: anyObjectId
-                    },
-                    created_at: anyISODateTime
-                })
+                offers: [
+                    ...new Array(4).fill({
+                        id: anyObjectId,
+                        tier: {
+                            id: anyObjectId
+                        },
+                        created_at: anyISODateTime
+                    }),
+                    {
+                        id: anyObjectId,
+                        tier: null,
+                        created_at: anyISODateTime
+                    }
+                ]
             });
     });
 

--- a/ghost/core/test/e2e-api/members/member-offers.test.js
+++ b/ghost/core/test/e2e-api/members/member-offers.test.js
@@ -105,13 +105,10 @@ describe('Members API - Member Offers', function () {
 
             const subscription = member.related('stripeSubscriptions').models[0];
             const stripePrice = subscription.related('stripePrice');
-            const stripeProduct = stripePrice.related('stripeProduct');
-            const product = stripeProduct.related('product');
 
-            const tierId = product.id;
             const cadence = stripePrice.get('interval');
 
-            // Create a retention offer for this tier and cadence
+            // Create a retention offer for this cadence (no tier - applies to any tier)
             const offer = await models.Offer.add({
                 name: 'Test Retention Offer',
                 code: 'test-retention',
@@ -122,7 +119,7 @@ describe('Members API - Member Offers', function () {
                 duration: 'repeating',
                 duration_in_months: 3,
                 interval: cadence,
-                product_id: tierId,
+                product_id: null,
                 currency: null,
                 active: true,
                 redemption_type: 'retention'
@@ -150,6 +147,93 @@ describe('Members API - Member Offers', function () {
                 assert.equal(body.offers[0].redemption_type, 'retention');
             } finally {
                 // Clean up
+                await models.Offer.destroy({id: offer.id});
+            }
+        });
+
+        it('returns null-tier retention offers for any paid member', async function () {
+            const member = await models.Member.findOne({email: 'paid@test.com'}, {
+                withRelated: [
+                    'stripeSubscriptions',
+                    'stripeSubscriptions.stripePrice'
+                ]
+            });
+
+            const subscription = member.related('stripeSubscriptions').models[0];
+            const stripePrice = subscription.related('stripePrice');
+            const cadence = stripePrice.get('interval');
+
+            // Create a retention offer with no tier (product_id: null)
+            const offer = await models.Offer.add({
+                name: 'Null Tier Retention',
+                code: 'null-tier-retention',
+                portal_title: '15% off',
+                portal_description: 'Stay with us!',
+                discount_type: 'percent',
+                discount_amount: 15,
+                duration: 'forever',
+                interval: cadence,
+                product_id: null,
+                currency: null,
+                active: true,
+                redemption_type: 'retention'
+            });
+
+            try {
+                const token = await getIdentityToken('paid@test.com');
+
+                const {body} = await membersAgent
+                    .post('/api/member/offers')
+                    .body({identity: token})
+                    .expectStatus(200);
+
+                assert.equal(body.offers.length, 1);
+                assert.equal(body.offers[0].id, offer.id);
+                assert.equal(body.offers[0].tier, null);
+            } finally {
+                await models.Offer.destroy({id: offer.id});
+            }
+        });
+
+        it('does not return null-tier retention offer when cadence does not match', async function () {
+            const member = await models.Member.findOne({email: 'paid@test.com'}, {
+                withRelated: [
+                    'stripeSubscriptions',
+                    'stripeSubscriptions.stripePrice'
+                ]
+            });
+
+            const subscription = member.related('stripeSubscriptions').models[0];
+            const stripePrice = subscription.related('stripePrice');
+            const cadence = stripePrice.get('interval');
+            const wrongCadence = cadence === 'month' ? 'year' : 'month';
+
+            // Create a retention offer with no tier but wrong cadence
+            const offer = await models.Offer.add({
+                name: 'Wrong Cadence Null Tier',
+                code: 'wrong-cadence-null-tier',
+                portal_title: '15% off',
+                portal_description: 'Stay with us!',
+                discount_type: 'percent',
+                discount_amount: 15,
+                duration: 'forever',
+                interval: wrongCadence,
+                product_id: null,
+                currency: null,
+                active: true,
+                redemption_type: 'retention'
+            });
+
+            try {
+                const token = await getIdentityToken('paid@test.com');
+
+                const {body} = await membersAgent
+                    .post('/api/member/offers')
+                    .body({identity: token})
+                    .expectStatus(200);
+
+                assert.deepEqual(body, {offers: []});
+            } finally {
                 await models.Offer.destroy({id: offer.id});
             }
         });
@@ -183,7 +267,7 @@ describe('Members API - Member Offers', function () {
                 discount_amount: 20,
                 duration: 'once',
                 interval: cadence,
-                product_id: tierId,
+                product_id: null,
                 currency: null,
                 active: true,
                 redemption_type: 'retention'
@@ -295,7 +379,7 @@ describe('Members API - Member Offers', function () {
                 discount_amount: 20,
                 duration: 'once',
                 interval: cadence,
-                product_id: tierId,
+                product_id: null,
                 currency: null,
                 active: true,
                 redemption_type: 'retention'
@@ -333,61 +417,11 @@ describe('Members API - Member Offers', function () {
             }
         });
 
-        it('returns 400 when offer tier does not match subscription', async function () {
-            const {subscription} = await getMemberSubscription('paid@test.com');
-            const stripePrice = subscription.related('stripePrice');
-
-            const stripeSubscriptionId = subscription.get('subscription_id');
-            const cadence = stripePrice.get('interval');
-
-            // Create a different tier for testing
-            const differentTier = await models.Product.add({
-                name: 'Different Tier',
-                slug: 'different-tier-test',
-                type: 'paid',
-                currency: 'usd',
-                monthly_price: 1000,
-                yearly_price: 10000,
-                visibility: 'public'
-            });
-
-            // Create a retention offer for a different tier
-            const retentionOffer = await models.Offer.add({
-                name: 'Wrong Tier Retention',
-                code: 'wrong-tier-retention',
-                portal_title: '20% off',
-                portal_description: 'Stay with us!',
-                discount_type: 'percent',
-                discount_amount: 20,
-                duration: 'once',
-                interval: cadence,
-                product_id: differentTier.id,
-                currency: null,
-                active: true,
-                redemption_type: 'retention'
-            });
-
-            try {
-                const token = await getIdentityToken('paid@test.com');
-
-                await membersAgent
-                    .post(`/api/subscriptions/${stripeSubscriptionId}/apply-offer`)
-                    .body({identity: token, offer_id: retentionOffer.id})
-                    .expectStatus(400);
-            } finally {
-                await models.Offer.destroy({id: retentionOffer.id});
-                await models.Product.destroy({id: differentTier.id});
-            }
-        });
-
         it('returns 400 when offer cadence does not match subscription', async function () {
             const {subscription} = await getMemberSubscription('paid@test.com');
             const stripePrice = subscription.related('stripePrice');
-            const stripeProduct = stripePrice.related('stripeProduct');
-            const product = stripeProduct.related('product');
 
             const stripeSubscriptionId = subscription.get('subscription_id');
-            const tierId = product.id;
             const cadence = stripePrice.get('interval');
             // Use opposite cadence
             const wrongCadence = cadence === 'month' ? 'year' : 'month';
@@ -402,7 +436,7 @@ describe('Members API - Member Offers', function () {
                 discount_amount: 20,
                 duration: 'once',
                 interval: wrongCadence,
-                product_id: tierId,
+                product_id: null,
                 currency: null,
                 active: true,
                 redemption_type: 'retention'
@@ -423,11 +457,8 @@ describe('Members API - Member Offers', function () {
         it('returns 400 when offer is inactive', async function () {
             const {subscription} = await getMemberSubscription('paid@test.com');
             const stripePrice = subscription.related('stripePrice');
-            const stripeProduct = stripePrice.related('stripeProduct');
-            const product = stripeProduct.related('product');
 
             const stripeSubscriptionId = subscription.get('subscription_id');
-            const tierId = product.id;
             const cadence = stripePrice.get('interval');
 
             // Create an inactive retention offer
@@ -440,7 +471,7 @@ describe('Members API - Member Offers', function () {
                 discount_amount: 20,
                 duration: 'once',
                 interval: cadence,
-                product_id: tierId,
+                product_id: null,
                 currency: null,
                 active: false,
                 redemption_type: 'retention'
@@ -499,11 +530,8 @@ describe('Members API - Member Offers', function () {
         it('returns 400 when subscription is canceled', async function () {
             const {subscription} = await getMemberSubscription('paid@test.com');
             const stripePrice = subscription.related('stripePrice');
-            const stripeProduct = stripePrice.related('stripeProduct');
-            const product = stripeProduct.related('product');
 
             const stripeSubscriptionId = subscription.get('subscription_id');
-            const tierId = product.id;
             const cadence = stripePrice.get('interval');
 
             // Temporarily set subscription to canceled status
@@ -520,7 +548,7 @@ describe('Members API - Member Offers', function () {
                 discount_amount: 20,
                 duration: 'once',
                 interval: cadence,
-                product_id: tierId,
+                product_id: null,
                 currency: null,
                 active: true,
                 redemption_type: 'retention'
@@ -542,11 +570,8 @@ describe('Members API - Member Offers', function () {
         it('returns 400 when subscription is in a trial period', async function () {
             const {subscription} = await getMemberSubscription('paid@test.com');
             const stripePrice = subscription.related('stripePrice');
-            const stripeProduct = stripePrice.related('stripeProduct');
-            const product = stripeProduct.related('product');
 
             const stripeSubscriptionId = subscription.get('subscription_id');
-            const tierId = product.id;
             const cadence = stripePrice.get('interval');
 
             // Temporarily set subscription to have an active trial period
@@ -564,7 +589,7 @@ describe('Members API - Member Offers', function () {
                 discount_amount: 20,
                 duration: 'once',
                 interval: cadence,
-                product_id: tierId,
+                product_id: null,
                 currency: null,
                 active: true,
                 redemption_type: 'retention'
@@ -587,10 +612,8 @@ describe('Members API - Member Offers', function () {
             const {subscription} = await getMemberSubscription('paid@test.com');
             const stripePrice = subscription.related('stripePrice');
             const stripeProduct = stripePrice.related('stripeProduct');
-            const product = stripeProduct.related('product');
 
             const stripeSubscriptionId = subscription.get('subscription_id');
-            const tierId = product.id;
             const cadence = stripePrice.get('interval');
 
             // Add a mock coupon to the stripe mocker so the subscription update works
@@ -661,7 +684,7 @@ describe('Members API - Member Offers', function () {
                 duration: 'repeating',
                 duration_in_months: 3,
                 interval: cadence,
-                product_id: tierId,
+                product_id: null,
                 currency: null,
                 active: true,
                 redemption_type: 'retention',

--- a/ghost/core/test/unit/server/services/offers/application/offers-api.test.js
+++ b/ghost/core/test/unit/server/services/offers/application/offers-api.test.js
@@ -263,33 +263,6 @@ describe('OffersAPI', function () {
             assert.equal(result.length, 0);
         });
 
-        it('returns both tier-specific and null-tier offers when both match', async function () {
-            const tierId = new ObjectID().toHexString();
-            const offers = [
-                createMockOffer('offer-specific', {tierId, cadence: 'month', redemptionType: 'retention'}),
-                createMockOffer('offer-any', {tierId: null, cadence: 'month', redemptionType: 'retention'})
-            ];
-
-            const repository = createMockRepository({
-                getAll: sinon.stub().resolves(offers),
-                getRedeemedOfferIdsForSubscription: sinon.stub().resolves([])
-            });
-
-            const api = new OffersAPI(/** @type {OfferBookshelfRepository} */ (/** @type {unknown} */ (repository)));
-
-            const result = await api.listOffersAvailableToSubscription({
-                subscriptionId: 'sub_123',
-                tierId,
-                cadence: 'month',
-                redemptionType: 'retention'
-            });
-
-            assert.equal(result.length, 2);
-            const ids = result.map(r => r.id);
-            assert.ok(ids.includes('offer-specific'));
-            assert.ok(ids.includes('offer-any'));
-        });
-
         it('throws error when required parameters are missing', async function () {
             const repository = createMockRepository({});
             const api = new OffersAPI(/** @type {OfferBookshelfRepository} */ (/** @type {unknown} */ (repository)));

--- a/ghost/core/test/unit/server/services/offers/domain/models/offer.test.js
+++ b/ghost/core/test/unit/server/services/offers/domain/models/offer.test.js
@@ -387,7 +387,6 @@ describe('Offer', function () {
                 should.ok(err instanceof errors.InvalidOfferTier);
             }
         });
-
     });
 
     describe('#updateCode', function () {

--- a/ghost/core/test/unit/server/services/offers/domain/models/offer.test.js
+++ b/ghost/core/test/unit/server/services/offers/domain/models/offer.test.js
@@ -303,6 +303,93 @@ describe('Offer', function () {
         });
     });
 
+    describe('Tier and redemption type validation', function () {
+        it('Creates a retention offer with null tier', async function () {
+            const offer = await Offer.create({
+                id: ObjectID(),
+                name: 'Retention Offer',
+                code: 'retention-offer',
+                display_title: 'Stay with us',
+                display_description: 'A discount for staying',
+                cadence: 'month',
+                type: 'percent',
+                amount: 10,
+                duration: 'forever',
+                redemption_type: 'retention',
+                tier: null
+            }, mockUniqueChecker);
+
+            should.ok(offer instanceof Offer);
+            assert.equal(offer.tier, null);
+            assert.equal(offer.redemptionType.value, 'retention');
+        });
+
+        it('Throws when creating a retention offer with a tier', async function () {
+            try {
+                await Offer.create({
+                    id: ObjectID(),
+                    name: 'Bad Retention Offer',
+                    code: 'bad-retention',
+                    display_title: '',
+                    display_description: '',
+                    cadence: 'month',
+                    type: 'percent',
+                    amount: 10,
+                    duration: 'forever',
+                    redemption_type: 'retention',
+                    tier: {
+                        id: ObjectID()
+                    }
+                }, mockUniqueChecker);
+                should.fail('Expected an error');
+            } catch (err) {
+                should.ok(err instanceof errors.InvalidOfferTier);
+            }
+        });
+
+        it('Throws when creating a signup offer without a tier', async function () {
+            try {
+                await Offer.create({
+                    id: ObjectID(),
+                    name: 'Bad Signup Offer',
+                    code: 'bad-signup',
+                    display_title: '',
+                    display_description: '',
+                    cadence: 'month',
+                    type: 'percent',
+                    amount: 10,
+                    duration: 'forever',
+                    redemption_type: 'signup',
+                    tier: null
+                }, mockUniqueChecker);
+                should.fail('Expected an error');
+            } catch (err) {
+                should.ok(err instanceof errors.InvalidOfferTier);
+            }
+        });
+
+        it('Throws when creating an offer without a tier and no redemption_type (defaults to signup)', async function () {
+            try {
+                await Offer.create({
+                    id: ObjectID(),
+                    name: 'No Tier Default',
+                    code: 'no-tier-default',
+                    display_title: '',
+                    display_description: '',
+                    cadence: 'month',
+                    type: 'percent',
+                    amount: 10,
+                    duration: 'forever',
+                    tier: null
+                }, mockUniqueChecker);
+                should.fail('Expected an error');
+            } catch (err) {
+                should.ok(err instanceof errors.InvalidOfferTier);
+            }
+        });
+
+    });
+
     describe('#updateCode', function () {
         it('Requires the code to be unique if it has changed', async function () {
             const data = {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3257
ref https://github.com/TryGhost/Ghost/pull/26215

Updated the offer system to handle `null` tier for offers that are not associated with a specific product (retention offers)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes offer validation, persistence, and subscription filtering across the backend and Portal; incorrect handling could block checkout/offer application or expose invalid offers. Coverage was updated with new unit/e2e tests to reduce regressions.
> 
> **Overview**
> Adds first-class support for **retention offers with `tier: null`** (i.e., not tied to a specific product) while enforcing that **signup offers must still have a tier**.
> 
> Backend now maps/persists `tier` as nullable, validates tier vs `redemption_type` (new `InvalidOfferTier`), and updates offer-availability filtering so null-tier retention offers match any tier with the correct cadence. Members/payment flows add guards that reject tierless offers where a tier is required.
> 
> Admin and Portal UIs are updated to tolerate nullable `tier` via optional chaining, Portal blocks opening offer links without a tier, and retention-cancellation flow falls back to the member’s active product when the offer has no tier. Tests/snapshots are expanded to cover creating null-tier retention offers and invalid tier/redemption combinations, and Portal version bumps to `2.62.2`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ecbe2eb45f588b8e5ff4613b0e28ba6069074bc2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->