### PR TITLE
🐛 Fixed editor scrolling in legacy browsers

### DIFF
--- a/ghost/admin/app/styles/components/koenig.css
+++ b/ghost/admin/app/styles/components/koenig.css
@@ -8,6 +8,7 @@
 /* Scroll container for the editor canvas */
 .gh-koenig-editor {
     width: 100%;
+    height: 100vh; /* fallback for browsers that don't support dvh */
     height: 100dvh;
     overflow-x: hidden;
     overflow-y: auto;


### PR DESCRIPTION
refs https://linear.app/ghost/issue/ONC-1450/scrolling-issues-with-the-editor

Added a 100vh fallback for browsers that don't support dvh units, which broke scrolling in older Safari versions like those on macOS Catalina.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a viewport-height fallback to improve editor container sizing and maintain correct height behavior on browsers that don’t support modern dvh units.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->