### PR TITLE
🐛 Fixed race condition in publishing browser test helper

### DIFF
--- a/ghost/core/test/e2e-browser/admin/publishing.spec.js
+++ b/ghost/core/test/e2e-browser/admin/publishing.spec.js
@@ -140,20 +140,29 @@ const publishPost = async (page, {type = 'publish', time, date} = {}) => {
         await page.locator(`[data-test-publish-type="${type}"] + label`).click({timeout: 1000}); // If this times out, it is likely that there are no members (running a single test).
     }
 
+    const scheduleSummary = page.locator('[data-test-setting="publish-at"] [data-test-setting-title]');
+
     // Schedule the post
     if (date || time) {
         await page.locator('[data-test-setting="publish-at"] > button').click();
         await page.locator('[data-test-radio="schedule"] + label').click();
+        // Wait for Ember to process the schedule toggle and update the summary
+        await expect(scheduleSummary).not.toContainText('Right now');
     }
 
     if (date) {
+        const textBefore = await scheduleSummary.textContent();
         await page.locator('[data-test-date-time-picker-date-input]').fill(date);
         await page.locator('[data-test-date-time-picker-date-input]').blur();
+        // Wait for Ember to process the date change before continuing
+        await expect(scheduleSummary).not.toContainText(textBefore.trim());
     }
 
     if (time) {
         await page.locator('[data-test-date-time-picker-time-input]').fill(time);
         await page.locator('[data-test-date-time-picker-time-input]').blur();
+        // Allow Ember's run loop to process the time change
+        await page.waitForTimeout(500);
     }
 
     // TODO: set other publish options


### PR DESCRIPTION
ref https://linear.app/ghost/issue/NY-1000

The `publishPost` test helper clicks "Continue" immediately after filling date/time inputs, before Ember finishes processing the change. This causes the post to be scheduled with the stale default (10 min) instead of the intended time, producing intermittent CI failures.

Fixed by waiting for the schedule summary text to update after each date/time input before proceeding.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of publishing/scheduling tests by adding synchronization points for UI state updates.
  * Enhanced test flow to properly wait for scheduling summary updates when setting dates and times, ensuring deterministic test behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->