### PR TITLE
Merged disableMemberCommenting into commentModeration labs flag

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
@@ -64,10 +64,6 @@ const features: Feature[] = [{
     description: 'Enable Transistor podcast integration',
     flag: 'transistor'
 }, {
-    title: 'Disable Member Commenting',
-    description: 'Allow staff to disable commenting for individual members',
-    flag: 'disableMemberCommenting'
-}, {
     title: 'Sniper Links',
     description: 'Enable mail app links on signup/signin',
     flag: 'sniperlinks'

--- a/apps/posts/src/views/comments/comments.tsx
+++ b/apps/posts/src/views/comments/comments.tsx
@@ -14,7 +14,6 @@ const Comments: React.FC = () => {
     const {filters, nql, setFilters, clearFilters, isSingleIdFilter} = useFilterState();
     const {data: configData} = useBrowseConfig();
     const commentPermalinksEnabled = configData?.config?.labs?.commentPermalinks === true;
-    const disableMemberCommentingEnabled = configData?.config?.labs?.disableMemberCommenting === true;
 
     const handleAddFilter = useCallback((field: string, value: string, operator: string = 'is') => {
         setFilters((prevFilters) => {
@@ -84,7 +83,6 @@ const Comments: React.FC = () => {
                     <>
                         <CommentsList
                             commentPermalinksEnabled={commentPermalinksEnabled}
-                            disableMemberCommentingEnabled={disableMemberCommentingEnabled}
                             fetchNextPage={fetchNextPage}
                             hasNextPage={hasNextPage}
                             isFetchingNextPage={isFetchingNextPage}

--- a/apps/posts/src/views/comments/components/comment-header.tsx
+++ b/apps/posts/src/views/comments/components/comment-header.tsx
@@ -28,7 +28,6 @@ interface CommentHeaderProps {
     createdAt?: string;
     isHidden?: boolean;
     canComment?: boolean | null;
-    disableMemberCommentingEnabled?: boolean;
     onAuthorClick?: () => void;
     postTitle?: string | null;
     onPostClick?: () => void;
@@ -41,7 +40,6 @@ export function CommentHeader({
     createdAt,
     isHidden,
     canComment,
-    disableMemberCommentingEnabled,
     onAuthorClick,
     postTitle,
     onPostClick,
@@ -68,7 +66,7 @@ export function CommentHeader({
                         </span>
                     )}
                 </div>
-                {disableMemberCommentingEnabled && canComment === false && (
+                {canComment === false && (
                     <TooltipProvider>
                         <Tooltip>
                             <TooltipTrigger asChild>

--- a/apps/posts/src/views/comments/components/comment-menu.tsx
+++ b/apps/posts/src/views/comments/components/comment-menu.tsx
@@ -14,13 +14,11 @@ import {useState} from 'react';
 interface CommentMenuProps {
     comment: Comment;
     commentPermalinksEnabled?: boolean;
-    disableMemberCommentingEnabled?: boolean;
 }
 
 export function CommentMenu({
     comment,
-    commentPermalinksEnabled,
-    disableMemberCommentingEnabled
+    commentPermalinksEnabled
 }: CommentMenuProps) {
     const {mutate: disableCommenting} = useDisableMemberCommenting();
     const {mutate: enableCommenting} = useEnableMemberCommenting();
@@ -87,7 +85,7 @@ export function CommentMenu({
                         </DropdownMenuItem>
 
                     )}
-                    {memberId && disableMemberCommentingEnabled && (
+                    {memberId && (
                         canComment !== false ? (
                             <DropdownMenuItem onClick={() => setDisableDialogOpen(true)}>
                                 <LucideIcon.MessageCircleOff className="mr-2 size-4" />

--- a/apps/posts/src/views/comments/components/comment-thread-list.tsx
+++ b/apps/posts/src/views/comments/components/comment-thread-list.tsx
@@ -25,10 +25,9 @@ interface CommentRowProps {
     isReply?: boolean;
     onThreadClick: (commentId: string) => void;
     commentPermalinksEnabled?: boolean;
-    disableMemberCommentingEnabled?: boolean;
 }
 
-function CommentRow({comment, isReply = false, onThreadClick, commentPermalinksEnabled, disableMemberCommentingEnabled}: CommentRowProps) {
+function CommentRow({comment, isReply = false, onThreadClick, commentPermalinksEnabled}: CommentRowProps) {
     const {mutate: hideComment} = useHideComment();
     const {mutate: showComment} = useShowComment();
 
@@ -56,7 +55,6 @@ function CommentRow({comment, isReply = false, onThreadClick, commentPermalinksE
                         <CommentHeader
                             canComment={comment.member?.can_comment}
                             createdAt={comment.created_at}
-                            disableMemberCommentingEnabled={disableMemberCommentingEnabled}
                             isHidden={comment.status === 'hidden'}
                             memberId={comment.member?.id}
                             memberName={comment.member?.name}
@@ -106,7 +104,6 @@ function CommentRow({comment, isReply = false, onThreadClick, commentPermalinksE
                             <CommentMenu
                                 comment={comment}
                                 commentPermalinksEnabled={commentPermalinksEnabled}
-                                disableMemberCommentingEnabled={disableMemberCommentingEnabled}
                             />
                         </div>
                     </div>
@@ -119,7 +116,6 @@ function CommentRow({comment, isReply = false, onThreadClick, commentPermalinksE
                                     key={reply.id}
                                     comment={reply}
                                     commentPermalinksEnabled={commentPermalinksEnabled}
-                                    disableMemberCommentingEnabled={disableMemberCommentingEnabled}
                                     isReply={true}
                                     onThreadClick={onThreadClick}
                                 />
@@ -137,15 +133,13 @@ interface CommentThreadListProps {
     replies: Comment[];
     onThreadClick: (commentId: string) => void;
     commentPermalinksEnabled?: boolean;
-    disableMemberCommentingEnabled?: boolean;
 }
 
 const CommentThreadList: React.FC<CommentThreadListProps> = ({
     parentComment,
     replies,
     onThreadClick,
-    commentPermalinksEnabled,
-    disableMemberCommentingEnabled
+    commentPermalinksEnabled
 }) => {
     // All replies are direct children of the parent comment (flat structure)
     const commentWithReplies: Comment = {...parentComment, replies};
@@ -155,7 +149,6 @@ const CommentThreadList: React.FC<CommentThreadListProps> = ({
             <CommentRow
                 comment={commentWithReplies}
                 commentPermalinksEnabled={commentPermalinksEnabled}
-                disableMemberCommentingEnabled={disableMemberCommentingEnabled}
                 onThreadClick={onThreadClick}
             />
         </div>

--- a/apps/posts/src/views/comments/components/comment-thread-sidebar.tsx
+++ b/apps/posts/src/views/comments/components/comment-thread-sidebar.tsx
@@ -18,7 +18,6 @@ interface CommentThreadSidebarProps {
     onOpenChange: (open: boolean) => void;
     onThreadClick: (commentId: string) => void;
     commentPermalinksEnabled?: boolean;
-    disableMemberCommentingEnabled?: boolean;
 }
 
 const CommentThreadSidebar: React.FC<CommentThreadSidebarProps> = ({
@@ -26,8 +25,7 @@ const CommentThreadSidebar: React.FC<CommentThreadSidebarProps> = ({
     open,
     onOpenChange,
     onThreadClick,
-    commentPermalinksEnabled,
-    disableMemberCommentingEnabled
+    commentPermalinksEnabled
 }) => {
     const {data: repliesData, isLoading: isLoadingReplies, isError: isRepliesError} = useCommentReplies(commentId ?? '', {
         enabled: open && !!commentId
@@ -77,7 +75,6 @@ const CommentThreadSidebar: React.FC<CommentThreadSidebarProps> = ({
                     ) : (
                         <CommentThreadList
                             commentPermalinksEnabled={commentPermalinksEnabled}
-                            disableMemberCommentingEnabled={disableMemberCommentingEnabled}
                             parentComment={parentComment}
                             replies={replies}
                             onThreadClick={onThreadClick}

--- a/apps/posts/src/views/comments/components/comments-list.tsx
+++ b/apps/posts/src/views/comments/components/comments-list.tsx
@@ -44,8 +44,7 @@ function CommentsList({
     fetchNextPage,
     onAddFilter,
     isLoading,
-    commentPermalinksEnabled,
-    disableMemberCommentingEnabled
+    commentPermalinksEnabled
 }: {
     items: Comment[];
     totalItems: number;
@@ -55,7 +54,6 @@ function CommentsList({
     onAddFilter: (field: string, value: string, operator?: string) => void;
     isLoading?: boolean;
     commentPermalinksEnabled?: boolean;
-    disableMemberCommentingEnabled?: boolean;
 }) {
     const parentRef = useRef<HTMLDivElement>(null);
     const [searchParams, setSearchParams] = useSearchParams();
@@ -168,7 +166,6 @@ function CommentsList({
                                         <CommentHeader
                                             canComment={item.member?.can_comment}
                                             createdAt={item.created_at}
-                                            disableMemberCommentingEnabled={disableMemberCommentingEnabled}
                                             isHidden={item.status === 'hidden'}
                                             memberId={item.member?.id}
                                             memberName={item.member?.name}
@@ -226,7 +223,6 @@ function CommentsList({
                                             <CommentMenu
                                                 comment={item}
                                                 commentPermalinksEnabled={commentPermalinksEnabled}
-                                                disableMemberCommentingEnabled={disableMemberCommentingEnabled}
                                             />
                                         </div>
                                     </div>
@@ -251,7 +247,6 @@ function CommentsList({
             <CommentThreadSidebar
                 commentId={selectedThreadCommentId}
                 commentPermalinksEnabled={commentPermalinksEnabled}
-                disableMemberCommentingEnabled={disableMemberCommentingEnabled}
                 open={threadSidebarOpen}
                 onOpenChange={handleCloseSidebar}
                 onThreadClick={handleThreadClick}

--- a/e2e/tests/admin/comments/disable-commenting.test.ts
+++ b/e2e/tests/admin/comments/disable-commenting.test.ts
@@ -7,7 +7,7 @@ const useReactShell = process.env.USE_REACT_SHELL === 'true';
 
 test.describe('Ghost Admin - Disable Commenting', () => {
     test.skip(!useReactShell, 'Skipping: requires USE_REACT_SHELL=true');
-    test.use({labs: {disableMemberCommenting: true}});
+    test.use({labs: {commentModeration: true}});
 
     let postFactory: PostFactory;
     let memberFactory: MemberFactory;

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -52,8 +52,7 @@ const PRIVATE_FEATURES = [
     'commentPermalinks',
     'indexnow',
     'featurebaseFeedback',
-    'transistor',
-    'disableMemberCommenting'
+    'transistor'
 ];
 
 module.exports.GA_KEYS = [...GA_FEATURES];

--- a/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
@@ -15,7 +15,6 @@ Object {
       "commentModeration": true,
       "commentPermalinks": true,
       "customFonts": true,
-      "disableMemberCommenting": true,
       "editorExcerpt": true,
       "emailCustomization": true,
       "emailUniqueid": true,


### PR DESCRIPTION
The `disableMemberCommenting` labs flag allowed staff to disable commenting for individual members. It existed as a separate toggle from `commentModeration`, which gates the entire comment moderation page in the admin sidebar. Since the disable-commenting UI only lives within the comment moderation page — which is already gated by `commentModeration` — having a second flag was redundant. The two features are tightly coupled and should ship together.

This removes the `disableMemberCommenting` flag from the labs definition and its toggle from the labs settings UI. On the frontend, instead of reading a separate flag from config and threading a `disableMemberCommentingEnabled` prop through the entire component tree (comments → comments-list → comment-header / comment-menu / comment-thread-sidebar → comment-thread-list), the prop is removed entirely. The disable/enable commenting menu items and the "comments disabled" indicator now render unconditionally since they're only reachable when `commentModeration` is already enabled. The E2E tests for disable-commenting now activate `commentModeration` instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed "Disable Member Commenting" from the private features list.
  * Simplified internal comment component logic by streamlining prop handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->