### PR TITLE
Refined dark mode colors in comment moderation

### DIFF
--- a/apps/posts/src/views/comments/components/comment-metrics.tsx
+++ b/apps/posts/src/views/comments/components/comment-metrics.tsx
@@ -1,4 +1,5 @@
 import {
+    Button,
     LucideIcon,
     Tooltip,
     TooltipContent,
@@ -28,14 +29,15 @@ export function CommentMetrics({
     const isClickableReplies = hasReplies && onRepliesClick;
 
     return (
-        <div className={cn('flex items-center gap-6', className)}>
+        <div className={cn('flex items-center gap-1', className)}>
             {isClickableReplies ? (
                 <TooltipProvider>
                     <Tooltip>
                         <TooltipTrigger asChild>
-                            <button
-                                className='flex cursor-pointer items-center gap-1 text-xs text-gray-800 hover:opacity-70'
-                                type="button"
+                            <Button
+                                className='text-foreground/60 [&_svg]:size-4'
+                                size='sm'
+                                variant="ghost"
                                 onClick={(e) => {
                                     e.stopPropagation();
                                     onRepliesClick();
@@ -43,7 +45,7 @@ export function CommentMetrics({
                             >
                                 <LucideIcon.Reply size={16} strokeWidth={1.5} />
                                 <span>{formatNumber(repliesCount)}</span>
-                            </button>
+                            </Button>
                         </TooltipTrigger>
                         <TooltipContent>View replies</TooltipContent>
                     </Tooltip>
@@ -52,7 +54,7 @@ export function CommentMetrics({
                 <TooltipProvider>
                     <Tooltip>
                         <TooltipTrigger asChild>
-                            <div className='flex items-center gap-1 text-xs text-gray-800'>
+                            <div className='inline-flex h-7 items-center justify-center gap-2 whitespace-nowrap rounded-md px-3 text-xs font-medium text-foreground/60'>
                                 <LucideIcon.Reply size={16} strokeWidth={1.5} />
                                 <span>{formatNumber(repliesCount)}</span>
                             </div>
@@ -65,7 +67,7 @@ export function CommentMetrics({
             <TooltipProvider>
                 <Tooltip>
                     <TooltipTrigger asChild>
-                        <div className='flex items-center gap-1 text-xs text-gray-800'>
+                        <div className='inline-flex h-7 items-center justify-center gap-2 whitespace-nowrap rounded-md px-3 text-xs font-medium text-foreground/60'>
                             <LucideIcon.Heart size={16} strokeWidth={1.5} />
                             <span>{formatNumber(likesCount)}</span>
                         </div>
@@ -78,8 +80,8 @@ export function CommentMetrics({
                 <Tooltip>
                     <TooltipTrigger asChild>
                         <div className={cn(
-                            'flex items-center gap-1 text-xs',
-                            reportsCount ? 'font-semibold text-red' : 'text-gray-800'
+                            'inline-flex h-7 items-center justify-center gap-2 whitespace-nowrap rounded-md px-3 text-xs font-medium text-foreground/60',
+                            reportsCount ? 'font-semibold text-red' : 'text-foreground/60'
                         )}>
                             <LucideIcon.Flag size={16} strokeWidth={reportsCount ? 1.75 : 1.5} />
                             <span>{formatNumber(reportsCount)}</span>

--- a/apps/posts/src/views/comments/components/comments-list.tsx
+++ b/apps/posts/src/views/comments/components/comments-list.tsx
@@ -204,13 +204,13 @@ function CommentsList({
 
                                         <div className="mt-4 flex flex-row flex-nowrap items-center gap-3">
                                             {item.status === 'published' && (
-                                                <Button className='text-gray-800' size="sm" variant="outline" onClick={() => hideComment({id: item.id})}>
+                                                <Button className='text-foreground' size="sm" variant="outline" onClick={() => hideComment({id: item.id})}>
                                                     <LucideIcon.EyeOff/>
                                                     Hide
                                                 </Button>
                                             )}
                                             {item.status === 'hidden' && (
-                                                <Button className='text-gray-800' size="sm" variant="outline" onClick={() => showComment({id: item.id})}>
+                                                <Button className='text-foreground' size="sm" variant="outline" onClick={() => showComment({id: item.id})}>
                                                     <LucideIcon.Eye/>
                                                     Show
                                                 </Button>


### PR DESCRIPTION
no ref.

- Some colors were too low contrast in dark mode
- Swapped normal button to using <Button> component from Shade

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely presentational changes (component swap and Tailwind class updates) with minimal behavioral impact beyond the clickable replies control’s styling.
> 
> **Overview**
> Refines comment moderation UI styling for better dark-mode contrast by switching various text colors from `text-gray-800` to theme-aware `text-foreground`/`text-foreground/60`.
> 
> Updates `CommentMetrics` to use the Shade `Button` for clickable reply counts and restyles the replies/likes/reports counters as pill-like inline elements with consistent spacing; also adjusts the list row Hide/Show button text color to match the new theme-aware palette.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 23d5119c506dc848ee4d094866de704b5b2ea08b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Redesigned comment metrics display with pill-style containers for improved visual consistency.
  * Made replies action directly clickable as a button component.
  * Updated button text colors for better visual contrast and consistency across comment actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->