### PR TITLE
Decreased E2E shards from 8 to 4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1115,8 +1115,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        shardIndex: [1, 2, 3, 4, 5, 6, 7, 8]
-        shardTotal: [8]
+        shardIndex: [1, 2, 3, 4]
+        shardTotal: [4]
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
ref [NY-974: Increase shard count on E2E tests](https://linear.app/ghost/issue/NY-974/increase-shard-count-on-e2e-tests)

- 8 shards made the E2E tests run faster, but flaky tests seem to be more common, which makes running CI slower overall
- Decreasing shards to 4 for now while we fix up the flaky tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that affects CI runtime/parallelism but not production code; main risk is longer E2E cycle time or different flake behavior.
> 
> **Overview**
> Reduces CI `job_e2e_tests` parallelization by changing the shard matrix from **8 shards to 4**, updating both `shardIndex` and `shardTotal` in `.github/workflows/ci.yml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d62d5b47bce4b5488a2073a2ac016a1a23d92105. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD test infrastructure for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->