### PR TITLE
Fixed flaky member impersonation e2e test

### DIFF
--- a/e2e/helpers/pages/public/home-page.ts
+++ b/e2e/helpers/pages/public/home-page.ts
@@ -20,6 +20,10 @@ export class HomePage extends PublicPage {
         await this.portalRoot.waitFor({state: 'attached'});
     }
 
+    async openAccountPortal(): Promise<void> {
+        await this.portal.clickLinkAndWaitForPopup(this.accountButton);
+    }
+
     async gotoWithQueryParams(params: Record<string, string>): Promise<void> {
         const queryString = new URLSearchParams(params).toString();
         const url = `/?${queryString}`;

--- a/e2e/tests/admin/members/impersonation.test.ts
+++ b/e2e/tests/admin/members/impersonation.test.ts
@@ -27,10 +27,9 @@ test.describe('Ghost Admin - Member Impersonation', () => {
 
         const homePage = new HomePage(page);
         await homePage.waitUntilLoaded();
-        await homePage.accountButton.click();
+        await homePage.openAccountPortal();
 
         const portal = new PortalPage(page);
-        await portal.waitForPortalToOpen();
 
         await expect(portal.portalFrameBody).toContainText('Your account');
         await expect(portal.portalFrameBody).toContainText('impersonate@ghost.org');


### PR DESCRIPTION
The member impersonation e2e test was intermittently failing because it clicked the Account link on the public site and immediately waited for the Portal popup to appear. Portal's hashchange listener is set up asynchronously after its init completes, so if the click fires before Portal is ready, the hash change goes unhandled and the popup never opens.

The fix adds an `openAccountPortal()` method to `HomePage` that delegates to the existing `clickLinkAndWaitForPopup` helper on `PortalSection`. This helper uses Playwright's `expect.toPass()` to retry the click until the Portal iframe actually becomes visible, which is the same pattern already used by `openPortalViaSubscribeButton()` and `openPortalViaSignInLink()` on `PublicPage`. The test now calls `homePage.openAccountPortal()` instead of the raw click-then-wait sequence.

Verified stable with `--repeat-each=3` (3/3 passes).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test infrastructure for account portal interactions through better abstraction of portal-opening workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->