### PR TITLE
fix: increased the z-index of the alerts

### DIFF
--- a/apps/admin/src/index.css
+++ b/apps/admin/src/index.css
@@ -13,7 +13,7 @@ body.react-admin {
 body.react-admin #ember-alerts-wormhole {
     grid-row: 1;
     grid-column: 1;
-    z-index: 0; /* Hide alerts when settings app modal is open */
+    z-index: 999; /* Hide alerts when settings app modal is open */
 }
 
 /* Main app container - pass through to children (.shade.shade-admin) */


### PR DESCRIPTION
### Why are you making this change?
In some layouts, Ghost alerts can appear behind page content, headers, or overlays, making them partially or completely invisible to users.

This typically happens due to an insufficient `z-index` value combined with existing stacking contexts in themes or admin UI.

### What does this change do?
This change updates the `z-index` of alert components to ensure they consistently appear above normal page content.

The new value is chosen to be high enough to avoid common stacking conflicts without introducing excessive or arbitrary z-index values.

### Why do Ghost users or developers need this?
Alerts are critical for communicating errors, warnings, and success messages to users. When they are hidden behind other UI elements, important feedback can be missed, leading to confusion and poor user experience.

This change ensures alerts remain visible and reliable across different layouts and themes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CSS stacking change scoped to the alerts container; risk is limited to potential layering conflicts with other modals/overlays.
> 
> **Overview**
> Ensures admin alerts render above overlapping UI by increasing `z-index` on `#ember-alerts-wormhole` from `0` to `999` in `apps/admin/src/index.css`, preventing alerts from being obscured by headers/overlays.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 20f53c7048407c0ded9b3c48a990d7eb334cc2b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Fixed alert display positioning to properly render behind the settings app modal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->