### PR TITLE
Fixed flaky Admin X Settings acceptance tests

### DIFF
--- a/apps/admin-x-settings/test/acceptance/advanced/migration-tools.test.ts
+++ b/apps/admin-x-settings/test/acceptance/advanced/migration-tools.test.ts
@@ -7,27 +7,20 @@ test.describe('Migration tools', async () => {
             ...globalDataRequests
         }});
 
-        await page.goto('/');
+        const openMigrator = async (name: string, route: string) => {
+            await page.goto('/');
 
-        const migrationSection = page.getByTestId('migrationtools');
+            const migrationSection = page.getByTestId('migrationtools');
+            await expect(migrationSection).toBeVisible();
 
-        await migrationSection.getByRole('button', {name: 'Substack'}).click();
-        await expectExternalNavigate(page, {route: '/migrate/substack'});
+            await migrationSection.getByRole('button', {name}).click();
+            await expectExternalNavigate(page, {route});
+        };
 
-        await page.goto('/');
-
-        await migrationSection.getByRole('button', {name: 'WordPress'}).click();
-        await expectExternalNavigate(page, {route: '/migrate/wordpress'});
-
-        await page.goto('/');
-
-        await migrationSection.getByRole('button', {name: 'Medium'}).click();
-        await expectExternalNavigate(page, {route: '/migrate/medium'});
-
-        await page.goto('/');
-
-        await migrationSection.getByRole('button', {name: 'Mailchimp'}).click();
-        await expectExternalNavigate(page, {route: '/migrate/mailchimp'});
+        await openMigrator('Substack', '/migrate/substack');
+        await openMigrator('WordPress', '/migrate/wordpress');
+        await openMigrator('Medium', '/migrate/medium');
+        await openMigrator('Mailchimp', '/migrate/mailchimp');
     });
 
     // test('Universal import', async ({page}) => {
@@ -72,6 +65,7 @@ test.describe('Migration tools', async () => {
         await page.goto('/');
 
         const migrationSection = page.getByTestId('migrationtools');
+        await expect(migrationSection).toBeVisible();
 
         await migrationSection.getByRole('tab', {name: 'Export'}).click();
 
@@ -79,6 +73,6 @@ test.describe('Migration tools', async () => {
 
         await expect(page.locator('iframe#iframeDownload')).toHaveAttribute('src', /\/db\/$/);
 
-        expect(lastApiRequests.downloadAllContent).toBeTruthy();
+        await expect.poll(() => lastApiRequests.downloadAllContent).toBeTruthy();
     });
 });

--- a/apps/admin-x-settings/test/acceptance/membership/portal.test.ts
+++ b/apps/admin-x-settings/test/acceptance/membership/portal.test.ts
@@ -111,8 +111,8 @@ test.describe('Portal Settings', async () => {
 
         await modal.getByRole('tab', {name: 'Look & feel'}).click();
 
-        await modal.getByRole('switch').click();
         await modal.getByRole('textbox').fill('become a member of something epic');
+        await modal.getByRole('switch').click();
         await modal.getByRole('button', {name: 'Save'}).click();
 
         await expect.poll(() => lastApiRequests.editSettings?.body).toEqual({

--- a/apps/admin-x-settings/test/acceptance/membership/portal.test.ts
+++ b/apps/admin-x-settings/test/acceptance/membership/portal.test.ts
@@ -15,10 +15,10 @@ test.describe('Portal Settings', async () => {
         });
 
         await page.goto('/');
-        const section = await page.getByTestId('portal');
+        const section = page.getByTestId('portal');
         await section.getByRole('button', {name: 'Customize'}).click();
 
-        await page.waitForSelector('[data-testid="portal-modal"]');
+        await expect(page.getByTestId('portal-modal')).toBeVisible();
     });
 
     test('can set portal signup options', async ({page}) => {
@@ -36,26 +36,25 @@ test.describe('Portal Settings', async () => {
         });
 
         await page.goto('/');
-        const section = await page.getByTestId('portal');
+        const section = page.getByTestId('portal');
         await section.getByRole('button', {name: 'Customize'}).click();
 
-        await page.waitForSelector('[data-testid="portal-modal"]');
+        const modal = page.getByTestId('portal-modal');
+        await expect(modal).toBeVisible();
 
-        const modal = await page.getByTestId('portal-modal');
+        const displayNameToggle = modal.getByLabel('Display name in signup form');
+        await expect(displayNameToggle).toBeVisible();
+        await expect(displayNameToggle).toBeChecked();
 
-        const displayNameToggle = await modal.getByLabel('Display name in signup form');
-        expect(displayNameToggle).toBeVisible();
-        expect(displayNameToggle).toBeChecked();
-
-        const freeTierCheckbox = await modal.getByTestId('free-tier-checkbox');
-        expect(freeTierCheckbox).toBeVisible();
-        expect(freeTierCheckbox).toBeChecked();
+        const freeTierCheckbox = modal.getByTestId('free-tier-checkbox');
+        await expect(freeTierCheckbox).toBeVisible();
+        await expect(freeTierCheckbox).toBeChecked();
 
         await freeTierCheckbox.click();
         await displayNameToggle.click();
         await modal.getByRole('button', {name: 'Save'}).click();
 
-        expect(lastApiRequests.editTiers?.body).toMatchObject({
+        await expect.poll(() => lastApiRequests.editTiers?.body).toMatchObject({
             tiers: [{
                 name: 'Free',
                 visibility: 'none'
@@ -81,14 +80,14 @@ test.describe('Portal Settings', async () => {
         });
 
         await page.goto('/');
-        const section = await page.getByTestId('portal');
+        const section = page.getByTestId('portal');
         await section.getByRole('button', {name: 'Customize'}).click();
-        await page.waitForSelector('[data-testid="portal-modal"]');
-        const modal = await page.getByTestId('portal-modal');
+        const modal = page.getByTestId('portal-modal');
+        await expect(modal).toBeVisible();
 
         // In Portal settings, the free tier is hidden because the site is set to paid-members only, even if available in the tiers list
-        const freeTierCheckbox = await modal.getByTestId('free-tier-checkbox');
-        expect(freeTierCheckbox).not.toBeVisible();
+        const freeTierCheckbox = modal.getByTestId('free-tier-checkbox');
+        await expect(freeTierCheckbox).toBeHidden();
     });
 
     test('can toggle portal Look & Feel options', async ({page}) => {
@@ -104,12 +103,11 @@ test.describe('Portal Settings', async () => {
         });
 
         await page.goto('/');
-        const section = await page.getByTestId('portal');
+        const section = page.getByTestId('portal');
         await section.getByRole('button', {name: 'Customize'}).click();
 
-        await page.waitForSelector('[data-testid="portal-modal"]');
-
-        const modal = await page.getByTestId('portal-modal');
+        const modal = page.getByTestId('portal-modal');
+        await expect(modal).toBeVisible();
 
         await modal.getByRole('tab', {name: 'Look & feel'}).click();
 
@@ -117,7 +115,7 @@ test.describe('Portal Settings', async () => {
         await modal.getByRole('textbox').fill('become a member of something epic');
         await modal.getByRole('button', {name: 'Save'}).click();
 
-        expect(lastApiRequests.editSettings?.body).toEqual({
+        await expect.poll(() => lastApiRequests.editSettings?.body).toEqual({
             settings: [
                 {key: 'portal_button', value: false},
                 {
@@ -141,20 +139,20 @@ test.describe('Portal Settings', async () => {
         });
 
         await page.goto('/');
-        const section = await page.getByTestId('portal');
+        const section = page.getByTestId('portal');
         await section.getByRole('button', {name: 'Customize'}).click();
 
-        await page.waitForSelector('[data-testid="portal-modal"]');
-
         const modal = page.getByTestId('portal-modal');
+        await expect(modal).toBeVisible();
 
         // since account page occurs twice on the page, we need to grab it by ID instead.
-        const accountTab = await page.$('#accountPage');
-        await accountTab?.click();
+        const accountTab = page.locator('#accountPage').first();
+        await expect(accountTab).toBeVisible();
+        await accountTab.click();
         await modal.getByRole('textbox').fill('hello@world.com');
         await modal.getByRole('button', {name: 'Save'}).click();
 
-        expect(lastApiRequests.editSettings?.body).toEqual({
+        await expect.poll(() => lastApiRequests.editSettings?.body).toEqual({
             settings: [
                 {
                     key: 'members_support_address',

--- a/apps/admin-x-settings/test/acceptance/membership/recommendations.test.ts
+++ b/apps/admin-x-settings/test/acceptance/membership/recommendations.test.ts
@@ -32,7 +32,7 @@ test.describe('Recommendations', async () => {
         await page.goto('/');
 
         // Open add recommendation modal
-        const section = await page.getByTestId('recommendations');
+        const section = page.getByTestId('recommendations');
         await section.getByRole('button', {name: 'Add recommendation'}).click();
         const modal = page.getByTestId('add-recommendation-modal');
 
@@ -106,7 +106,7 @@ test.describe('Recommendations', async () => {
         }});
 
         await page.goto('/');
-        const section = await page.getByTestId('recommendations');
+        const section = page.getByTestId('recommendations');
         const activeTab = section.locator('[role=tabpanel]:not(.hidden)');
         await section.getByRole('tab', {name: 'Your Recommendations'}).click();
 


### PR DESCRIPTION
towards https://linear.app/ghost/issue/NY-1000

*This test-only change should have no user impact.*

These tests, which were a little flaky on my machine and on CI, are now more reliable. Basically, I'm just ensuring that things are visible before moving on, or relying on a little polling.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved reliability and consistency across migration tools, membership portal, and recommendations suites.
  * Consolidated navigations with a shared helper to reduce duplication.
  * Replaced ad-hoc waits with explicit visibility assertions for modals and sections.
  * Switched several assertions to polling-based checks to better handle asynchronous updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->