### PR TITLE
Restored previous CodeRabbit config

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,3 +1,11 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 reviews:
+  high_level_summary: false
+  collapse_walkthrough: false
+  changed_files_summary: false
+  sequence_diagrams: false
   estimate_code_review_effort: false
+  poem: false
+  auto_review:
+    base_branches:
+      - 6.x


### PR DESCRIPTION
ref 0939cd943ed808c9f46378d833a5620d7e29153a

I added a CodeRabbit config file in 0939cd943ed808c9f46378d833a5620d7e29153a. This overwrote the config in the CodeRabbit web UI.

This updates the config file to match what we had in the web UI.
