### PR TITLE
Increased MySQL setup timeout in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -541,7 +541,7 @@ jobs:
 
       - uses: tryghost/mysql-action@main
         if: matrix.env.DB == 'mysql8'
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           authentication plugin: 'caching_sha2_password'
           mysql version: '8.0'
@@ -627,7 +627,7 @@ jobs:
 
       - uses: tryghost/mysql-action@main
         if: matrix.env.DB == 'mysql8'
-        timeout-minutes: 3
+        timeout-minutes: 5
         with:
           authentication plugin: 'caching_sha2_password'
           mysql version: '8.0'


### PR DESCRIPTION
towards https://linear.app/ghost/issue/NY-1000

This allows more time for MySQL to start. [A recent CI failure][0] shows that this timed out after 3 minutes, and at least two images failed to pull in that time.

[0]: https://github.com/TryGhost/Ghost/actions/runs/21683986870/job/62525954605


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Increased timeout for database initialization in CI/CD workflows to improve test execution reliability when using MySQL 8.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->