### PR TITLE
Improved welcome email editor loading state with spinner indicator

### DIFF
--- a/apps/admin-x-design-system/src/global/form/koenig-editor-base.tsx
+++ b/apps/admin-x-design-system/src/global/form/koenig-editor-base.tsx
@@ -17,6 +17,7 @@ export interface KoenigEditorBaseProps {
     singleParagraph?: boolean
     className?: string
     inheritFontStyles?: boolean
+    loadingFallback?: React.ReactNode
 }
 
 declare global {
@@ -167,6 +168,7 @@ const KoenigEditorBase: React.FC<KoenigEditorBaseInternalProps> = ({
     initialEditorState,
     onChange,
     inheritFontStyles = true,
+    loadingFallback,
     ...props
 }) => {
     const {fetchKoenigLexical, darkMode} = useDesignSystem();
@@ -177,7 +179,7 @@ const KoenigEditorBase: React.FC<KoenigEditorBaseInternalProps> = ({
         <div className={className || 'w-full'}>
             <div className={`koenig-react-editor w-full ${inheritClasses}`}>
                 <ErrorBoundary name='editor'>
-                    <Suspense fallback={<p className="koenig-react-editor-loading">Loading editor...</p>}>
+                    <Suspense fallback={loadingFallback || <p className="koenig-react-editor-loading">Loading editor...</p>}>
                         <KoenigWrapper
                             {...props}
                             darkMode={darkMode}

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/member-email-editor.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/member-email-editor.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback} from 'react';
-import {KoenigEditorBase, type KoenigInstance, type NodeType} from '@tryghost/admin-x-design-system';
+import {KoenigEditorBase, type KoenigInstance, LoadingIndicator, type NodeType} from '@tryghost/admin-x-design-system';
 import {cn} from '@tryghost/shade';
 
 export interface MemberEmailsEditorProps {
@@ -63,6 +63,7 @@ const MemberEmailsEditor: React.FC<MemberEmailsEditorProps> = ({
                 emojiPicker={false}
                 inheritFontStyles={false}
                 initialEditorState={value}
+                loadingFallback={<LoadingIndicator delay={200} size="lg" />}
                 nodes={nodes}
                 placeholder={placeholder}
                 singleParagraph={singleParagraph}


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-939/qa-improve-editor-loading-state

## Summary

The welcome emails editor would display a very plain "Loading editor..." loading state while loading the editor & content over the network. This removes the plain text and adds the same loading spinner that's used elsewhere in Admin, like in the main Post editor.

## Changes

- Added a `loadingFallback` prop to `KoenigEditorBase` to allow consumers to customize the loading state
- Used a `LoadingIndicator` spinner with 200ms delay in the welcome email editor instead of plain "Loading editor..." text
- Other uses of `KoenigEditorBase` are unchanged (still show "Loading editor..." text by default)

## Testing

This can be a little tricky to test out locally, since it loads almost instantly without the network latency. Included a short video below to show what it looks like.

To test locally:
- Run the dev server
- Visit Ghost Admin, then Settings
- Open Network Inspector and enable throttling - the slower the better
- Now, click the "Edit" button in the welcome emails section, and you should see the spinner
- Other instances of the Koenig Editor in settings (Portal, announcement bar, etc.) should remain unchanged

https://github.com/user-attachments/assets/126240d1-0904-4fb7-ab17-bc7e234e03f8

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change that adds an optional prop and adjusts a single consumer’s loading state; minimal behavioral impact beyond loading presentation.
> 
> **Overview**
> Improves Koenig editor loading UX by adding an optional `loadingFallback` prop to `KoenigEditorBase`, allowing consumers to override the default "Loading editor..." text used for the `Suspense` fallback.
> 
> Updates the membership welcome email editor (`MemberEmailsEditor`) to pass a delayed `LoadingIndicator` spinner as the fallback, keeping other editor usages unchanged unless they opt in.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6054b5a0f60bc81b7cf6a418ad793eb1c9bfca11. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced loading indicator display in the member email editor with improved visual feedback and timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- BUGBOT_STATUS --><sup><a href="https://cursor.com/dashboard?tab=bugbot">Cursor Bugbot</a> reviewed your changes and found no issues for commit <u>6054b5a</u></sup><!-- /BUGBOT_STATUS -->