### PR TITLE
Fixed invalid nested <p> markup in comment body

### DIFF
--- a/apps/comments-ui/src/components/content/comment.tsx
+++ b/apps/comments-ui/src/components/content/comment.tsx
@@ -393,7 +393,7 @@ const CommentBody: React.FC<CommentBodyProps> = ({html, className = '', isHighli
 
     return (
         <div className={`mt mb-2 flex flex-row items-center gap-4 pr-4 ${className}`}>
-            <p dangerouslySetInnerHTML={dangerouslySetInnerHTML} className="gh-comment-content text-md -mx-1 text-pretty rounded-md px-1 font-sans leading-normal text-neutral-900 [overflow-wrap:anywhere] sm:text-lg dark:text-white/85" data-testid="comment-content"/>
+            <div dangerouslySetInnerHTML={dangerouslySetInnerHTML} className="gh-comment-content text-md -mx-1 text-pretty rounded-md px-1 font-sans leading-normal text-neutral-900 [overflow-wrap:anywhere] sm:text-lg dark:text-white/85" data-testid="comment-content"/>
         </div>
     );
 };

--- a/apps/comments-ui/test/e2e/permalink.test.ts
+++ b/apps/comments-ui/test/e2e/permalink.test.ts
@@ -143,6 +143,26 @@ test.describe('Comment Permalinks', async () => {
         await expect(commentElement).toBeVisible();
     });
 
+    test('shows highlight mark inside comment content when navigating via permalink', async ({page}) => {
+        const mockedApi = new MockedApi({});
+        mockedApi.setMember({});
+
+        const commentId = '64a1b2c3d4e5f6a7b8c9d0e1';
+        mockedApi.addComment({
+            id: commentId,
+            html: '<p>Comment to highlight</p>'
+        });
+
+        const commentsFrame = await setupPermalinkTest(page, mockedApi, `#ghost-comments-${commentId}`);
+
+        // The comment content container should contain a <mark> with the highlight class
+        const commentContent = commentsFrame.getByTestId('comment-content').first();
+        const mark = commentContent.locator('mark');
+        await expect(mark).toBeVisible();
+        await expect(mark).toHaveClass(/bg-yellow-300\/40/);
+        await expect(mark).toContainText('Comment to highlight');
+    });
+
     test('handles invalid comment ID gracefully', async ({page}) => {
         const mockedApi = new MockedApi({});
         mockedApi.setMember({});


### PR DESCRIPTION
The `CommentBody` component in comments-ui uses `dangerouslySetInnerHTML` to render comment HTML. Comment content from the API always contains `<p>` tags (the server-side sanitizer only allows `p`, `br`, `a`, and `blockquote`), but the container element was itself a `<p>`. This produces invalid nested `<p>` elements in the DOM, since the HTML spec does not allow `<p>` to contain other block-level elements.

This changes the container from `<p>` to `<div>`, which can validly contain block elements. The `gh-comment-content` class and its associated CSS rules in `iframe.css` (targeting `.gh-comment-content p`, `.gh-comment-content a`, etc.) are already designed to style descendants — and the same class is already used on a `<div>` in the TipTap editor. All Tailwind utility classes on the element are tag-agnostic, so no styling changes result from this swap.

Also adds an E2E test that verifies the permalink highlight `<mark>` elements render correctly inside the comment content container.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated comment content container structure for improved semantic markup.

* **Tests**
  * Added end-to-end test to verify highlight visibility within comment content when navigating via permalink links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->