### PR TITLE
Skipped flaky reply-to-reply comment E2E test

### DIFF
--- a/e2e/tests/public/comment-replies.test.ts
+++ b/e2e/tests/public/comment-replies.test.ts
@@ -63,6 +63,7 @@ test.describe('Ghost Public - Comments - Replies', () => {
     });
 
     test('reply to reply comment', async ({page}) => {
+        test.skip(true, 'Race condition fix in #26247');
         const post = await postFactory.create({status: 'published'});
         const member = await memberFactory.create({status: 'free'});
         const paidTier = await tiersService.getFirstPaidTier();


### PR DESCRIPTION
The `reply to reply comment` E2E test has a race condition where `openCommentForm` awaits `loadMoreReplies` before showing the reply form, causing intermittent timeouts. The proper fix is in #26247 which splits the action into sync and async parts.

This PR skips the test in the meantime so it stops blocking CI. Once #26247 is merged the skip can be removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Temporarily skipped a test for comment reply functionality due to a race condition being addressed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->