### PR TITLE
Added retries to /e2e/ tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1169,7 +1169,7 @@ jobs:
         env:
           GHOST_IMAGE_TAG: ${{ steps.load.outputs.image-tag }}
           TEST_WORKERS_COUNT: 1
-        run: yarn test:e2e:all --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
+        run: yarn test:e2e:all --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }} --retries=2
 
       - name: Upload blob report to GitHub Actions Artifacts
         if: failure()


### PR DESCRIPTION
no ref

We're chasing down some flakiness in the E2E test suite that is causing significant noise in the CI pipeline. Afaict, these are all flaky failures, not real failures, and they're causing quite a bit of disruption.

While we generally do not want to enable flakiness in our tests on principle, I'm enabling 2 retries while running on CI for now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD test execution with automatic retry capability for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->