### PR TITLE
🎨 Improved child display in thread sidebar

### DIFF
--- a/apps/admin-x-framework/src/api/comments.ts
+++ b/apps/admin-x-framework/src/api/comments.ts
@@ -151,7 +151,7 @@ export const useReadComment = createQueryWithId<CommentsResponseType>({
     dataType,
     path: (id: string) => `/comments/${id}/`,
     defaultSearchParams: {
-        include: 'member,post,count.replies,count.likes,count.reports,parent'
+        include: 'member,post,count.replies,count.direct_replies,count.likes,count.reports,parent,in_reply_to'
     }
 });
 
@@ -186,4 +186,21 @@ const useBrowseCommentLikesQuery = createQueryWithId<CommentLikesResponseType>({
 
 export const useBrowseCommentLikes = (commentId: string, options?: {enabled?: boolean}) => {
     return useBrowseCommentLikesQuery(commentId, {...options});
+};
+
+/**
+ * Fetches direct replies for a thread view.
+ * - For top-level comments: returns comments where parent_id matches AND in_reply_to_id is null
+ * - For nested comments: returns comments where in_reply_to_id matches
+ */
+export const useThreadComments = (commentId: string, options?: {enabled?: boolean}) => {
+    return useBrowseComments({
+        ...options,
+        searchParams: {
+            filter: `(parent_id:${commentId}+in_reply_to_id:null),in_reply_to_id:${commentId}`,
+            order: 'created_at asc',
+            include: 'member,post,count.direct_replies,count.likes,count.reports,parent,in_reply_to',
+            limit: '100'
+        }
+    });
 };

--- a/apps/posts/src/views/comments/components/comment-thread-sidebar.tsx
+++ b/apps/posts/src/views/comments/components/comment-thread-sidebar.tsx
@@ -11,13 +11,12 @@ import {
     SheetHeader,
     SheetTitle
 } from '@tryghost/shade';
-import {useCommentReplies, useReadComment} from '@tryghost/admin-x-framework/api/comments';
+import {useReadComment, useThreadComments} from '@tryghost/admin-x-framework/api/comments';
 
 interface CommentThreadSidebarProps {
     commentId: string | null;
     open: boolean;
     onOpenChange: (open: boolean) => void;
-    onThreadClick: (commentId: string) => void;
     commentPermalinksEnabled?: boolean;
 }
 
@@ -25,28 +24,27 @@ const CommentThreadSidebar: React.FC<CommentThreadSidebarProps> = ({
     commentId,
     open,
     onOpenChange,
-    onThreadClick,
     commentPermalinksEnabled
 }) => {
-    const {data: repliesData, isLoading: isLoadingReplies, isError: isRepliesError} = useCommentReplies(commentId ?? '', {
+    const {data: threadData, isLoading: isLoadingThread, isError: isThreadError} = useThreadComments(commentId ?? '', {
         enabled: open && !!commentId
     });
 
-    // Fetch the parent comment separately using the read endpoint
-    const {data: parentData, isLoading: isLoadingParent, isError: isParentError} = useReadComment(commentId ?? '', {
+    // Fetch the selected comment separately using the read endpoint
+    const {data: selectedData, isLoading: isLoadingSelected, isError: isSelectedError} = useReadComment(commentId ?? '', {
         enabled: open && !!commentId
     });
 
-    const isLoading = isLoadingReplies || isLoadingParent;
-    // Only show error if both queries failed, or if parent failed (we need parent to render)
-    // If only replies failed, we can still show the parent comment
-    const isError = isParentError || (isRepliesError && !parentData);
+    const isLoading = isLoadingThread || isLoadingSelected;
+    // Only show error if both queries failed, or if selected comment failed (we need it to render)
+    // If only thread query failed, we can still show the selected comment
+    const isError = isSelectedError || (isThreadError && !selectedData);
 
-    // Get the parent comment from the read results
-    const parentComment = parentData?.comments?.[0];
+    // Get the selected comment from the read results
+    const selectedComment = selectedData?.comments?.[0];
 
-    // Get all replies (empty array if replies query failed)
-    const replies = repliesData?.comments || [];
+    // Get all thread comments (empty array if thread query failed)
+    const threadReplies = threadData?.comments || [];
 
     return (
         <Sheet open={open} onOpenChange={onOpenChange}>
@@ -54,24 +52,24 @@ const CommentThreadSidebar: React.FC<CommentThreadSidebarProps> = ({
                 <SheetHeader className='sticky top-0 z-40 -mx-6 bg-background/60 p-6 backdrop-blur'>
                     <SheetTitle className='text-md'>Thread</SheetTitle>
                 </SheetHeader>
-                {parentComment?.post && (
+                {selectedComment?.post && (
                     <>
                         <div className="flex items-center gap-4">
                             <div className="min-w-0 flex-1">
                                 <h3 className="line-clamp-1 text-xl font-semibold text-foreground">
-                                    {parentComment.post.title}
+                                    {selectedComment.post.title}
                                 </h3>
-                                {parentComment.post.excerpt && (
+                                {selectedComment.post.excerpt && (
                                     <p className="mt-1 line-clamp-2 text-sm text-muted-foreground">
-                                        {parentComment.post.excerpt}
+                                        {selectedComment.post.excerpt}
                                     </p>
                                 )}
                             </div>
-                            {parentComment.post.feature_image && (
+                            {selectedComment.post.feature_image && (
                                 <img
-                                    alt={parentComment.post.title || 'Post feature image'}
+                                    alt={selectedComment.post.title || 'Post feature image'}
                                     className="hidden aspect-video h-18 shrink-0 rounded object-cover lg:block"
-                                    src={parentComment.post.feature_image}
+                                    src={selectedComment.post.feature_image}
                                 />
                             )}
                         </div>
@@ -83,7 +81,7 @@ const CommentThreadSidebar: React.FC<CommentThreadSidebarProps> = ({
                         <div className="flex h-full items-center justify-center py-8">
                             <LoadingIndicator size="lg" />
                         </div>
-                    ) : isError || !parentComment ? (
+                    ) : isError || !selectedComment ? (
                         <div className="flex h-full items-center justify-center py-8">
                             <EmptyIndicator
                                 actions={
@@ -100,9 +98,9 @@ const CommentThreadSidebar: React.FC<CommentThreadSidebarProps> = ({
                     ) : (
                         <CommentThreadList
                             commentPermalinksEnabled={commentPermalinksEnabled}
-                            parentComment={parentComment}
-                            replies={replies}
-                            onThreadClick={onThreadClick}
+                            replies={threadReplies}
+                            selectedComment={selectedComment}
+                            selectedCommentId={commentId ?? ''}
                         />
                     )}
                 </div>

--- a/apps/posts/src/views/comments/components/comments-list.tsx
+++ b/apps/posts/src/views/comments/components/comments-list.tsx
@@ -5,7 +5,7 @@ import {Comment, useHideComment, useShowComment} from '@tryghost/admin-x-framewo
 import {CommentAvatar} from './comment-avatar';
 import {CommentHeader} from './comment-header';
 import {CommentMenu} from './comment-menu';
-import {CommentMetrics} from './comment-metrics';
+import {CommentMetrics, buildThreadLink} from './comment-metrics';
 import {Link, useSearchParams} from '@tryghost/admin-x-framework';
 import {forwardRef, useEffect, useRef, useState} from 'react';
 import {useInfiniteVirtualScroll} from '@components/virtual-table/use-infinite-virtual-scroll';
@@ -63,29 +63,12 @@ function CommentsList({
     const {mutate: hideComment} = useHideComment();
     const {mutate: showComment} = useShowComment();
 
-    const handleOpenThread = (commentId: string) => {
-        // Update URL to open thread sidebar
-        const newParams = new URLSearchParams(searchParams);
-        newParams.set('thread', `is:${commentId}`);
-        setSearchParams(newParams, {replace: false});
-    };
-
-    const handleThreadClick = (commentId: string) => {
-        // Update URL to show the clicked thread
-        const newParams = new URLSearchParams(searchParams);
-        newParams.set('thread', `is:${commentId}`);
-        // Remove reply_to when navigating to a new thread
-        newParams.delete('reply_to');
-        setSearchParams(newParams, {replace: false});
-    };
-
     const handleCloseSidebar = (open: boolean) => {
         setThreadSidebarOpen(open);
         if (!open) {
-            // Remove thread and reply_to params from URL when sidebar closes
+            // Remove thread param from URL when sidebar closes
             const newParams = new URLSearchParams(searchParams);
             newParams.delete('thread');
-            newParams.delete('reply_to');
             setSearchParams(newParams, {replace: true});
         }
     };
@@ -177,15 +160,7 @@ function CommentsList({
                                                 <span className="text-muted-foreground">Replied to:</span>&nbsp;
                                                 <Link
                                                     className="text-sm font-normal text-muted-foreground hover:text-foreground"
-                                                    to={(() => {
-                                                        // Preserve existing query params and add/update thread params
-                                                        const newParams = new URLSearchParams(searchParams);
-                                                        newParams.set('thread', `is:${item.parent_id}`);
-                                                        if (item.in_reply_to_id) {
-                                                            newParams.set('reply_to', `is:${item.in_reply_to_id}`);
-                                                        }
-                                                        return `?${newParams.toString()}`;
-                                                    })()}
+                                                    to={buildThreadLink(searchParams, item.in_reply_to_id || item.parent_id) || ''}
                                                     onClick={(e) => {
                                                         e.stopPropagation();
                                                     }}
@@ -213,7 +188,6 @@ function CommentsList({
                                             <CommentMetrics
                                                 className="ml-2"
                                                 comment={item}
-                                                onRepliesClick={() => handleOpenThread(item.id)}
                                             />
                                             <CommentMenu
                                                 comment={item}
@@ -244,7 +218,6 @@ function CommentsList({
                 commentPermalinksEnabled={commentPermalinksEnabled}
                 open={threadSidebarOpen}
                 onOpenChange={handleCloseSidebar}
-                onThreadClick={handleThreadClick}
             />
         </div>
     );

--- a/e2e/helpers/pages/admin/comments/comments-page.ts
+++ b/e2e/helpers/pages/admin/comments/comments-page.ts
@@ -16,6 +16,10 @@ export class CommentsPage extends AdminPage {
     readonly commentingDisabledIndicator = (row: Locator) => row.getByTestId('commenting-disabled-indicator');
     readonly hideCommentsCheckbox: Locator;
 
+    readonly threadSidebar: Locator;
+    readonly threadSidebarTitle: Locator;
+    readonly threadCommentRows: Locator;
+
     constructor(page: Page) {
         super(page);
         this.pageUrl = '/ghost/#/comments';
@@ -27,11 +31,15 @@ export class CommentsPage extends AdminPage {
         this.viewMemberMenuItem = page.getByRole('menuitem', {name: 'View member'});
         this.disableCommentingMenuItem = page.getByRole('menuitem', {name: 'Disable commenting'});
         this.enableCommentingMenuItem = page.getByRole('menuitem', {name: 'Enable commenting'});
-        this.disableCommentsModal = page.getByRole('dialog');
+        this.disableCommentsModal = page.getByRole('dialog', {name: 'Disable comments'});
         this.disableCommentsModalTitle = this.disableCommentsModal.getByRole('heading', {name: 'Disable comments'});
-        this.disableCommentsButton = page.getByRole('button', {name: 'Disable comments'});
+        this.disableCommentsButton = this.disableCommentsModal.getByRole('button', {name: 'Disable comments'});
         this.cancelButton = this.disableCommentsModal.getByRole('button', {name: 'Cancel'});
-        this.hideCommentsCheckbox = page.getByRole('checkbox', {name: 'Hide all previous comments'});
+        this.hideCommentsCheckbox = this.disableCommentsModal.getByRole('checkbox', {name: 'Hide all previous comments'});
+
+        this.threadSidebar = page.getByRole('dialog', {name: 'Thread'});
+        this.threadSidebarTitle = this.threadSidebar.getByRole('heading', {name: 'Thread'});
+        this.threadCommentRows = page.getByTestId('comment-thread-row');
     }
 
     async waitForComments(): Promise<void> {
@@ -60,5 +68,35 @@ export class CommentsPage extends AdminPage {
 
     async confirmDisableCommenting(): Promise<void> {
         await this.disableCommentsButton.click();
+    }
+
+    getRepliesButton(row: Locator): Locator {
+        // Use first() because nested replies also have their own replies-metric
+        return row.getByTestId('replies-metric').first();
+    }
+
+    async openThread(row: Locator): Promise<void> {
+        await this.getRepliesButton(row).click();
+        await this.threadSidebar.waitFor({state: 'visible'});
+    }
+
+    async waitForThreadSidebar(): Promise<void> {
+        await this.threadSidebar.waitFor({state: 'visible'});
+    }
+
+    getThreadCommentByText(text: string): Locator {
+        return this.threadCommentRows.filter({hasText: text});
+    }
+
+    getThreadCommentById(commentId: string): Locator {
+        return this.page.locator(`[data-testid="comment-thread-row"][data-comment-id="${commentId}"]`);
+    }
+
+    getRepliedToLink(row: Locator): Locator {
+        return row.getByText('Replied to:').locator('..').locator('a, button');
+    }
+
+    getMainListRepliedToLink(row: Locator): Locator {
+        return row.getByText('Replied to:').locator('..').getByRole('link');
     }
 }

--- a/e2e/tests/admin/comments/thread-sidebar.test.ts
+++ b/e2e/tests/admin/comments/thread-sidebar.test.ts
@@ -1,0 +1,230 @@
+import {
+    CommentFactory,
+    MemberFactory,
+    PostFactory,
+    createCommentFactory,
+    createMemberFactory,
+    createPostFactory
+} from '@/data-factory';
+import {CommentsPage} from '@/helpers/pages';
+import {SettingsService} from '@/helpers/services/settings/settings-service';
+import {expect, test} from '@/helpers/playwright';
+
+test.describe('Ghost Admin - Thread Sidebar', () => {
+    let postFactory: PostFactory;
+    let memberFactory: MemberFactory;
+    let commentFactory: CommentFactory;
+
+    test.beforeEach(async ({page}) => {
+        postFactory = createPostFactory(page.request);
+        memberFactory = createMemberFactory(page.request);
+        commentFactory = createCommentFactory(page.request);
+
+        const settingsService = new SettingsService(page.request);
+        await settingsService.setCommentsEnabled('all');
+    });
+
+    test.describe('thread navigation', () => {
+        test.use({labs: {commentModeration: true}});
+
+        test('opening thread for root comment shows root and direct replies', async ({page}) => {
+            const post = await postFactory.create({status: 'published'});
+            const member = await memberFactory.create();
+
+            const rootComment = await commentFactory.create({
+                post_id: post.id,
+                member_id: member.id,
+                html: '<p>Root comment</p>'
+            });
+            await commentFactory.create({
+                post_id: post.id,
+                member_id: member.id,
+                parent_id: rootComment.id,
+                html: '<p>Direct reply to root</p>'
+            });
+
+            const commentsPage = new CommentsPage(page);
+            await page.goto(`/ghost/#/comments?thread=is:${rootComment.id}`);
+            await commentsPage.waitForThreadSidebar();
+
+            await expect(commentsPage.threadSidebar.getByText('Root comment')).toBeVisible();
+            await expect(commentsPage.threadSidebar.getByText('Direct reply to root')).toBeVisible();
+        });
+
+        test('opening thread for reply comment shows reply and its children', async ({page}) => {
+            const post = await postFactory.create({status: 'published'});
+            const member = await memberFactory.create();
+
+            const rootComment = await commentFactory.create({
+                post_id: post.id,
+                member_id: member.id,
+                html: '<p>Root comment</p>'
+            });
+            const replyComment = await commentFactory.create({
+                post_id: post.id,
+                member_id: member.id,
+                parent_id: rootComment.id,
+                html: '<p>First level reply</p>'
+            });
+            await commentFactory.create({
+                post_id: post.id,
+                member_id: member.id,
+                parent_id: rootComment.id,
+                in_reply_to_id: replyComment.id,
+                html: '<p>Reply to first level reply</p>'
+            });
+
+            const commentsPage = new CommentsPage(page);
+            await page.goto(`/ghost/#/comments?thread=is:${replyComment.id}`);
+            await commentsPage.waitForThreadSidebar();
+
+            await expect(commentsPage.threadSidebar.getByText('First level reply', {exact: true})).toBeVisible();
+            await expect(commentsPage.threadSidebar.getByText('Reply to first level reply')).toBeVisible();
+        });
+
+        test('replied to link in main list opens thread focused on that comment', async ({page}) => {
+            const post = await postFactory.create({status: 'published'});
+            const member = await memberFactory.create();
+
+            const rootComment = await commentFactory.create({
+                post_id: post.id,
+                member_id: member.id,
+                html: '<p>This is the root comment that was replied to</p>'
+            });
+            await commentFactory.create({
+                post_id: post.id,
+                member_id: member.id,
+                parent_id: rootComment.id,
+                in_reply_to_id: rootComment.id,
+                html: '<p>Reply that shows replied to</p>'
+            });
+
+            const commentsPage = new CommentsPage(page);
+            await commentsPage.goto();
+            await commentsPage.waitForComments();
+
+            const replyRow = commentsPage.getCommentRowByText('Reply that shows replied to');
+            const repliedToLink = commentsPage.getMainListRepliedToLink(replyRow);
+            await repliedToLink.click();
+
+            await commentsPage.waitForThreadSidebar();
+            expect(page.url()).toContain(`thread=is%3A${rootComment.id}`);
+        });
+
+        test('clicking replies metric in main list opens thread for that comment', async ({page}) => {
+            const post = await postFactory.create({status: 'published'});
+            const member = await memberFactory.create();
+
+            const rootComment = await commentFactory.create({
+                post_id: post.id,
+                member_id: member.id,
+                html: '<p>Comment with replies</p>'
+            });
+            await commentFactory.create({
+                post_id: post.id,
+                member_id: member.id,
+                parent_id: rootComment.id,
+                html: '<p>A reply to the comment</p>'
+            });
+
+            const commentsPage = new CommentsPage(page);
+            await commentsPage.goto();
+            await commentsPage.waitForComments();
+
+            const commentRow = commentsPage.getCommentRowByText('Comment with replies');
+            await commentsPage.openThread(commentRow);
+
+            expect(page.url()).toContain(`thread=is%3A${rootComment.id}`);
+            await expect(commentsPage.threadSidebar.getByText('Comment with replies')).toBeVisible();
+            await expect(commentsPage.threadSidebar.getByText('A reply to the comment')).toBeVisible();
+        });
+
+        test('clicking replies metric in thread navigates to that reply', async ({page}) => {
+            const post = await postFactory.create({status: 'published'});
+            const member = await memberFactory.create();
+
+            const rootComment = await commentFactory.create({
+                post_id: post.id,
+                member_id: member.id,
+                html: '<p>Root comment</p>'
+            });
+            const firstReply = await commentFactory.create({
+                post_id: post.id,
+                member_id: member.id,
+                parent_id: rootComment.id,
+                html: '<p>First reply with its own replies</p>'
+            });
+            const nestedReply = await commentFactory.create({
+                post_id: post.id,
+                member_id: member.id,
+                parent_id: rootComment.id,
+                in_reply_to_id: firstReply.id,
+                html: '<p>Nested reply to first reply</p>'
+            });
+
+            const commentsPage = new CommentsPage(page);
+            await page.goto(`/ghost/#/comments?thread=is:${rootComment.id}`);
+            await commentsPage.waitForThreadSidebar();
+
+            const firstReplyRow = commentsPage.getThreadCommentById(firstReply.id);
+            const repliesButton = commentsPage.getRepliesButton(firstReplyRow);
+            await repliesButton.click();
+
+            await page.waitForURL(new RegExp(`thread=is%3A${firstReply.id}`));
+            expect(page.url()).toContain(`thread=is%3A${firstReply.id}`);
+            // Children being nested in the parent comment row required explicit targetting by ID
+            await expect(commentsPage.getThreadCommentById(firstReply.id)).toBeVisible();
+            await expect(commentsPage.getThreadCommentById(nestedReply.id)).toBeVisible();
+        });
+
+        test('shows replied to context for selected reply comment in thread', async ({page}) => {
+            const post = await postFactory.create({status: 'published'});
+            const member = await memberFactory.create();
+
+            const rootComment = await commentFactory.create({
+                post_id: post.id,
+                member_id: member.id,
+                html: '<p>Root comment content</p>'
+            });
+            const replyComment = await commentFactory.create({
+                post_id: post.id,
+                member_id: member.id,
+                parent_id: rootComment.id,
+                in_reply_to_id: rootComment.id,
+                html: '<p>Reply with replied-to context</p>'
+            });
+
+            const commentsPage = new CommentsPage(page);
+            await page.goto(`/ghost/#/comments?thread=is:${replyComment.id}`);
+            await commentsPage.waitForThreadSidebar();
+
+            const selectedComment = commentsPage.getThreadCommentByText('Reply with replied-to context');
+            await expect(selectedComment.getByText('Replied to:')).toBeVisible();
+        });
+
+        test('hides replied to context for direct children in thread', async ({page}) => {
+            const post = await postFactory.create({status: 'published'});
+            const member = await memberFactory.create();
+
+            const rootComment = await commentFactory.create({
+                post_id: post.id,
+                member_id: member.id,
+                html: '<p>Thread root</p>'
+            });
+            await commentFactory.create({
+                post_id: post.id,
+                member_id: member.id,
+                parent_id: rootComment.id,
+                in_reply_to_id: rootComment.id,
+                html: '<p>Direct reply to root</p>'
+            });
+
+            const commentsPage = new CommentsPage(page);
+            await page.goto(`/ghost/#/comments?thread=is:${rootComment.id}`);
+            await commentsPage.waitForThreadSidebar();
+
+            const directReply = commentsPage.getThreadCommentByText('Direct reply to root');
+            await expect(directReply.getByText('Replied to:')).toBeHidden();
+        });
+    });
+});

--- a/ghost/core/core/server/api/endpoints/comment-replies.js
+++ b/ghost/core/core/server/api/endpoints/comment-replies.js
@@ -1,7 +1,7 @@
 // This is a new endpoint for the admin API to return replies to a comment with pagination
 
 const commentsService = require('../../services/comments');
-const ALLOWED_INCLUDES = ['member', 'replies', 'replies.member', 'replies.count.likes', 'replies.liked', 'count.replies', 'count.direct_replies', 'count.likes', 'liked', 'post', 'parent'];
+const ALLOWED_INCLUDES = ['member', 'replies', 'replies.member', 'replies.count.likes', 'replies.liked', 'count.replies', 'count.direct_replies', 'count.likes', 'liked', 'post', 'parent', 'in_reply_to'];
 
 /** @type {import('@tryghost/api-framework').Controller} */
 const controller = {

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/mappers/comments.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/mappers/comments.js
@@ -60,8 +60,8 @@ const commentMapper = (model, frame) => {
     const isPublicRequest = utils.isMembersAPI(frame);
 
     // For admin requests, we want to show a snippet for ALL replies
-    // Use inReplyTo if available, otherwise fall back to parent for first-level replies
-    const replyToComment = jsonModel.inReplyTo || (!isPublicRequest && jsonModel.parent_id && jsonModel.parent);
+    // Use in_reply_to if available, otherwise fall back to parent for first-level replies
+    const replyToComment = jsonModel.in_reply_to || (!isPublicRequest && jsonModel.parent_id && jsonModel.parent);
 
     if (replyToComment && (replyToComment.status === 'published' || (!isPublicRequest && replyToComment.status === 'hidden'))) {
         jsonModel.in_reply_to_snippet = htmlToPlaintext.commentSnippet(replyToComment.html);
@@ -71,7 +71,7 @@ const commentMapper = (model, frame) => {
         jsonModel.in_reply_to_snippet = null;
     }
 
-    if (!jsonModel.inReplyTo) {
+    if (!jsonModel.in_reply_to) {
         jsonModel.in_reply_to_id = null;
     }
 

--- a/ghost/core/core/server/models/comment.js
+++ b/ghost/core/core/server/models/comment.js
@@ -42,7 +42,7 @@ const Comment = ghostBookshelf.Model.extend({
         return this.belongsTo('Comment', 'parent_id');
     },
 
-    inReplyTo() {
+    in_reply_to() {
         return this.belongsTo('Comment', 'in_reply_to_id');
     },
 
@@ -199,7 +199,7 @@ const Comment = ghostBookshelf.Model.extend({
                     // Do not include replies for replies
                     options.withRelated = [
                         // Relations
-                        'inReplyTo', 'member', 'count.direct_replies', 'count.likes', 'count.liked'
+                        'in_reply_to', 'member', 'count.direct_replies', 'count.likes', 'count.liked'
                     ];
 
                     // Add count.reports for admin requests only
@@ -209,9 +209,9 @@ const Comment = ghostBookshelf.Model.extend({
                 } else {
                     options.withRelated = [
                         // Relations
-                        'member', 'inReplyTo', 'count.replies', 'count.direct_replies', 'count.likes', 'count.liked',
+                        'member', 'in_reply_to', 'count.replies', 'count.direct_replies', 'count.likes', 'count.liked',
                         // Replies (limited to 3)
-                        'replies', 'replies.member', 'replies.inReplyTo',
+                        'replies', 'replies.member', 'replies.in_reply_to',
                         'replies.count.direct_replies', 'replies.count.likes', 'replies.count.liked'
                     ];
 
@@ -235,7 +235,7 @@ const Comment = ghostBookshelf.Model.extend({
         const relationsToLoadIndividually = [
             'replies',
             'replies.member',
-            'replies.inReplyTo',
+            'replies.in_reply_to',
             'replies.count.direct_replies',
             'replies.count.likes',
             'replies.count.liked'

--- a/ghost/core/core/server/services/comments/comments-service.js
+++ b/ghost/core/core/server/services/comments/comments-service.js
@@ -201,7 +201,7 @@ class CommentsService {
      */
     async getAdminAllComments({includeNested, filter, mongoTransformer, reportCount, order, page, limit}) {
         return await this.models.Comment.findPage({
-            withRelated: ['member', 'post', 'count.replies', 'count.direct_replies', 'count.likes', 'count.reports', 'inReplyTo', 'parent'],
+            withRelated: ['member', 'post', 'count.replies', 'count.direct_replies', 'count.likes', 'count.reports', 'in_reply_to', 'parent'],
             filter,
             mongoTransformer,
             reportCount,

--- a/ghost/core/test/unit/api/canary/utils/serializers/output/mapper.test.js
+++ b/ghost/core/test/unit/api/canary/utils/serializers/output/mapper.test.js
@@ -644,7 +644,7 @@ describe('Unit: utils/serializers/output/mappers', function () {
                     }
                 },
                 in_reply_to_id: 'comment2',
-                inReplyTo: {
+                in_reply_to: {
                     id: 'comment2',
                     parent_id: 'comment1',
                     html: '<p>comment 2</p>',
@@ -693,7 +693,7 @@ describe('Unit: utils/serializers/output/mappers', function () {
             const frame = {};
 
             const model = {
-                inReplyTo: {
+                in_reply_to: {
                     html: '<p>First paragraph <a href="https://example.com">with link</a>,<br> and new line.</p><p>Second paragraph</p>',
                     status: 'published'
                 }
@@ -715,7 +715,7 @@ describe('Unit: utils/serializers/output/mappers', function () {
             const model = {
                 id: 'comment1',
                 html: '<p>comment 1</p>',
-                inReplyTo: undefined
+                in_reply_to: undefined
             };
 
             const mapped = mappers.comments(model, frame);


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3276

Changed the thread sidebar to act as a unified filter view showing the selected comment and its relevant children

- Renamed comments `inReplyTo` relation to `in_reply_to` - removes camelCase/snake_case inconsistency
- Added useThreadComments hook with NQL filter to fetch only direct replies
- Thread sidebar can now open for any comment (not just top-level)
- "Replied to" links use URL navigation to open threads for referenced comments
- Uses count.direct_replies for accurate reply counts in thread view

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Thread sidebar: view a selected comment and its direct replies in a dedicated pane.
  * Thread-focused comment loader and public helper to build/share thread links.

* **Improvements**
  * Clickable reply metrics and replied-to links open focused thread views while preserving search context.
  * Replied-to context displays appropriately for selected replies; reply counts and related member/post info are more complete.

* **Tests**
  * End-to-end tests added to cover thread navigation and sidebar behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->