### PR TITLE
Cleaned up login page loading in E2E tests

### DIFF
--- a/e2e/helpers/pages/admin/login-page.ts
+++ b/e2e/helpers/pages/admin/login-page.ts
@@ -8,8 +8,6 @@ export class LoginPage extends AdminPage {
     readonly forgotButton: Locator;
     readonly passwordResetSuccessMessage: Locator;
 
-    private setupNewUserUrl = 'setup';
-
     constructor(page: Page) {
         super(page);
         this.pageUrl = '/ghost/#/signin';
@@ -22,8 +20,6 @@ export class LoginPage extends AdminPage {
     };
 
     async signIn(email: string, password: string) {
-        await this.emailAddressField.waitFor({state: 'visible'});
-
         await this.emailAddressField.fill(email);
         await this.passwordField.fill(password);
         await this.signInButton.click();
@@ -40,24 +36,12 @@ export class LoginPage extends AdminPage {
     }
 
     async waitForLoginPageAfterUserCreated(): Promise<void> {
-        let counter = 0;
-
-        while (counter < 5) {
-            await this.goto();
-
-            try {
-                await this.page.waitForURL(
-                    url => !url.href.includes(this.setupNewUserUrl),
-                    {timeout: 1000}
-                );
-
-                break;
-            } catch (error) {
-                counter += 1;
-                if (counter >= 5) {
-                    throw error;
-                }
-            }
+        const response = await this.goto();
+        if (!response) {
+            throw new Error('Error going to signin page (no response)');
+        }
+        if (!response.ok) {
+            throw new Error(`Error going to signin page (${response.status})`);
         }
     }
 }

--- a/e2e/helpers/pages/admin/settings/settings-page.ts
+++ b/e2e/helpers/pages/admin/settings/settings-page.ts
@@ -37,7 +37,8 @@ export class SettingsPage extends BasePage {
     }
 
     async goto() {
-        await super.goto();
+        const result = await super.goto();
         await this.sidebar.waitFor({state: 'visible'});
+        return result;
     }
 }

--- a/e2e/helpers/pages/base-page.ts
+++ b/e2e/helpers/pages/base-page.ts
@@ -1,6 +1,6 @@
-import {Locator, Page} from '@playwright/test';
 import {PageHttpLogger} from './page-http-logger';
 import {appConfig} from '@/helpers/utils/app-config';
+import type {Locator, Page, Response} from '@playwright/test';
 
 export interface pageGotoOptions {
     referer?: string;
@@ -31,9 +31,9 @@ export class BasePage {
         await this.page.reload();
     }
 
-    async goto(url?: string, options?: pageGotoOptions) {
+    async goto(url?: string, options?: pageGotoOptions): Promise<null | Response> {
         const urlToVisit = url || this.pageUrl;
-        await this.page.goto(urlToVisit, options);
+        return await this.page.goto(urlToVisit, options);
     }
 
     async pressKey(key: string) {

--- a/e2e/helpers/pages/public/public-page.ts
+++ b/e2e/helpers/pages/public/public-page.ts
@@ -77,7 +77,7 @@ export class PublicPage extends BasePage {
         });
     }
 
-    async goto(url?: string, options?: pageGotoOptions): Promise<void> {
+    async goto(url?: string, options?: pageGotoOptions): Promise<null | Response> {
         const testInfo = test.info();
         let pageHitPromise = null;
         if (testInfo.project.name === 'analytics') {
@@ -85,10 +85,11 @@ export class PublicPage extends BasePage {
             pageHitPromise = this.pageHitRequestPromise();
         }
         await this.enableAnalyticsRequests();
-        await super.goto(url, options);
+        const result = await super.goto(url, options);
         if (pageHitPromise) {
             await pageHitPromise;
         }
+        return result;
     }
 
     pageHitRequestPromise(): Promise<Response> {


### PR DESCRIPTION
towards https://linear.app/ghost/issue/NY-1000

*This test-only change should have no user impact.*

This change:

- Logs a more helpful error when visiting the signup page. This seems to be failing in CI a lot, and it'd be useful to know more about the error.

- Removes an unnecessary `waitFor` on the email address field. `locator.fill()` [automatically waits for this][0].

- Stops an unnecessary check when going to the sign-in page. A user should already be available, and the extra wait will probably never happen--we visit a URL and then check that we're not at a different URL, which it will never be. (And if it *did* redirect, we wouldn't catch it this way.)

[0]: https://playwright.dev/docs/actionability
