### PR TITLE
✨ Released Comment Moderation and Permalinks to GA

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
@@ -44,10 +44,6 @@ const features: Feature[] = [{
     description: 'Enable theme translation using i18next instead of the old translation package.',
     flag: 'themeTranslation'
 }, {
-    title: 'Comment Permalinks',
-    description: 'Enable direct links to individual comments with automatic scrolling and highlighting',
-    flag: 'commentPermalinks'
-}, {
     title: 'IndexNow',
     description: 'Automatically notify search engines when content is published or updated for faster indexing.',
     flag: 'indexnow'

--- a/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
@@ -44,10 +44,6 @@ const features: Feature[] = [{
     description: 'Enable theme translation using i18next instead of the old translation package.',
     flag: 'themeTranslation'
 }, {
-    title: 'Comment Moderation',
-    description: 'Enhanced comment moderation interface with advanced filtering and management. Requires the new admin experience.',
-    flag: 'commentModeration'
-}, {
     title: 'Comment Permalinks',
     description: 'Enable direct links to individual comments with automatic scrolling and highlighting',
     flag: 'commentPermalinks'

--- a/e2e/tests/admin/comments/comment-moderation.test.ts
+++ b/e2e/tests/admin/comments/comment-moderation.test.ts
@@ -26,7 +26,7 @@ test.describe('Ghost Admin - Comment Moderation', () => {
 
     test.describe('with commentPermalinks disabled', () => {
         test.use({
-            labs: {commentModeration: true, commentPermalinks: false}
+            labs: {commentPermalinks: false}
         });
 
         test('view post action navigates to post', async ({page}) => {
@@ -58,7 +58,7 @@ test.describe('Ghost Admin - Comment Moderation', () => {
 
     test.describe('with commentPermalinks enabled', () => {
         test.use({
-            labs: {commentModeration: true, commentPermalinks: true}
+            labs: {commentPermalinks: true}
         });
 
         test('view on post action navigates to comment permalink', async ({
@@ -92,8 +92,6 @@ test.describe('Ghost Admin - Comment Moderation', () => {
     });
 
     test.describe('deep linking', () => {
-        test.use({labs: {commentModeration: true}});
-
         test('can deep link to a specific comment by id', async ({page}) => {
             const post = await postFactory.create({status: 'published'});
             const member = await memberFactory.create();

--- a/e2e/tests/admin/comments/comment-moderation.test.ts
+++ b/e2e/tests/admin/comments/comment-moderation.test.ts
@@ -24,43 +24,7 @@ test.describe('Ghost Admin - Comment Moderation', () => {
         await settingsService.setCommentsEnabled('all');
     });
 
-    test.describe('with commentPermalinks disabled', () => {
-        test.use({
-            labs: {commentPermalinks: false}
-        });
-
-        test('view post action navigates to post', async ({page}) => {
-            const post = await postFactory.create({status: 'published'});
-            const member = await memberFactory.create();
-            await commentFactory.create({
-                post_id: post.id,
-                member_id: member.id,
-                html: '<p>Test comment without permalink</p>'
-            });
-
-            const commentsPage = new CommentsPage(page);
-            await commentsPage.goto();
-            await commentsPage.waitForComments();
-
-            const commentRow = commentsPage.getCommentRowByText(
-                'Test comment without permalink'
-            );
-            await commentsPage.openMoreMenu(commentRow);
-
-            const popupPromise = page.waitForEvent('popup');
-            await commentsPage.viewPostMenuItem.click();
-            const postPage = await popupPromise;
-
-            await expect(postPage).toHaveURL(new RegExp(`/${post.slug}/`));
-            expect(postPage.url()).not.toContain('#ghost-comments-');
-        });
-    });
-
-    test.describe('with commentPermalinks enabled', () => {
-        test.use({
-            labs: {commentPermalinks: true}
-        });
-
+    test.describe('view on post', () => {
         test('view on post action navigates to comment permalink', async ({
             page
         }) => {

--- a/e2e/tests/admin/comments/disable-commenting.test.ts
+++ b/e2e/tests/admin/comments/disable-commenting.test.ts
@@ -7,7 +7,6 @@ const useReactShell = process.env.USE_REACT_SHELL === 'true';
 
 test.describe('Ghost Admin - Disable Commenting', () => {
     test.skip(!useReactShell, 'Skipping: requires USE_REACT_SHELL=true');
-    test.use({labs: {commentModeration: true}});
 
     let postFactory: PostFactory;
     let memberFactory: MemberFactory;

--- a/e2e/tests/admin/members/disable-commenting.test.ts
+++ b/e2e/tests/admin/members/disable-commenting.test.ts
@@ -4,8 +4,6 @@ import {SettingsService} from '@/helpers/services/settings/settings-service';
 import {expect, test} from '@/helpers/playwright';
 
 test.describe('Ghost Admin - Member Detail Disable Commenting', () => {
-    test.use({labs: {commentModeration: true}});
-
     let memberFactory: MemberFactory;
 
     test.beforeEach(async ({page}) => {
@@ -172,8 +170,6 @@ test.describe('Ghost Admin - Member Detail Disable Commenting', () => {
 });
 
 test.describe('Ghost Admin - Disable Commenting Cache Invalidation', () => {
-    test.use({labs: {commentModeration: true}});
-
     let memberFactory: MemberFactory;
     let postFactory: PostFactory;
     let commentFactory: CommentFactory;

--- a/ghost/admin/app/services/feature.js
+++ b/ghost/admin/app/services/feature.js
@@ -72,7 +72,6 @@ export default class FeatureService extends Service {
     @feature('transistor') transistor;
     @feature('tagsX') tagsX;
     @feature('commentModeration') commentModeration;
-
     _user = null;
 
     @computed('settings.labs')

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -25,7 +25,8 @@ const GA_FEATURES = [
     'announcementBar',
     'customFonts',
     'explore',
-    'inboxlinks'
+    'inboxlinks',
+    'commentModeration'
 ];
 
 // These features are considered publicly available and can be enabled/disabled by users
@@ -48,7 +49,6 @@ const PRIVATE_FEATURES = [
     'emailUniqueid',
     'welcomeEmails',
     'themeTranslation',
-    'commentModeration',
     'commentPermalinks',
     'indexnow',
     'featurebaseFeedback',

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -26,7 +26,8 @@ const GA_FEATURES = [
     'customFonts',
     'explore',
     'inboxlinks',
-    'commentModeration'
+    'commentModeration',
+    'commentPermalinks'
 ];
 
 // These features are considered publicly available and can be enabled/disabled by users
@@ -49,7 +50,6 @@ const PRIVATE_FEATURES = [
     'emailUniqueid',
     'welcomeEmails',
     'themeTranslation',
-    'commentPermalinks',
     'indexnow',
     'featurebaseFeedback',
     'transistor'

--- a/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
@@ -1603,7 +1603,7 @@ exports[`Settings API Edit can edit Stripe settings when Stripe Connect limit is
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "4788",
+  "content-length": "4815",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
@@ -1603,7 +1603,7 @@ exports[`Settings API Edit can edit Stripe settings when Stripe Connect limit is
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "4761",
+  "content-length": "4788",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,


### PR DESCRIPTION
Comment Moderation and Comment Permalinks have both been behind private labs flags requiring developer experiments to be enabled. These features are now ready for general availability.

This PR moves both the `commentModeration` and `commentPermalinks` flags from `PRIVATE_FEATURES` to the `GA_FEATURES` list in the labs configuration, making them always enabled for all Ghost instances. Since GA flags are always-on and no longer need user-facing toggles, their entries have been removed from the private features UI in admin-x-settings and the legacy Ember feature service declaration has been cleaned up.

Each flag move is a separate commit so they can be reviewed and reverted independently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Comment Moderation and Comment Permalinks are now generally available (moved out of private labs).
* **Tests**
  * End-to-end tests updated to reflect these features being available without lab toggles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->