### PR TITLE
Replaced some Should.js assertions

### DIFF
--- a/ghost/core/test/e2e-api/admin/members-exporter.test.js
+++ b/ghost/core/test/e2e-api/admin/members-exporter.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const {agentProvider, mockManager, fixtureManager, matchers} = require('../../utils/e2e-framework');
 const {anyContentVersion, anyString} = matchers;
 
@@ -116,7 +117,7 @@ describe('Members API — exportCSV', function () {
 
         await testOutput(member, (row) => {
             basicAsserts(member, row);
-            should(row.subscribed_to_emails).eql('false');
+            assert.equal(row.subscribed_to_emails, 'false');
             should(row.complimentary_plan).eql('');
             should(row.tiers.split(',').sort().join(',')).eql(tiersList);
         }, [`filter=tier:[${tiers[0].get('slug')}]`, 'filter=subscribed:false']);
@@ -131,7 +132,7 @@ describe('Members API — exportCSV', function () {
 
         await testOutput(member, (row) => {
             basicAsserts(member, row);
-            should(row.subscribed_to_emails).eql('false');
+            assert.equal(row.subscribed_to_emails, 'false');
             should(row.complimentary_plan).eql('');
             should(row.tiers).eql('');
         }, ['filter=subscribed:false']);
@@ -153,7 +154,7 @@ describe('Members API — exportCSV', function () {
 
         await testOutput(member, (row) => {
             basicAsserts(member, row);
-            should(row.subscribed_to_emails).eql('false');
+            assert.equal(row.subscribed_to_emails, 'false');
             should(row.complimentary_plan).eql('');
             should(row.labels.split(',').sort().join(',')).eql(labelsList);
             should(row.tiers).eql('');
@@ -170,8 +171,8 @@ describe('Members API — exportCSV', function () {
 
         await testOutput(member, (row) => {
             basicAsserts(member, row);
-            should(row.subscribed_to_emails).eql('false');
-            should(row.complimentary_plan).eql('true');
+            assert.equal(row.subscribed_to_emails, 'false');
+            assert.equal(row.complimentary_plan, 'true');
             should(row.labels).eql('');
             should(row.tiers).eql('');
         }, ['filter=status:comped', 'filter=subscribed:false']);
@@ -189,7 +190,7 @@ describe('Members API — exportCSV', function () {
 
         await testOutput(member, (row) => {
             basicAsserts(member, row);
-            should(row.subscribed_to_emails).eql('true');
+            assert.equal(row.subscribed_to_emails, 'true');
             should(row.complimentary_plan).eql('');
             should(row.labels).eql('');
             should(row.tiers).eql('');
@@ -228,11 +229,11 @@ describe('Members API — exportCSV', function () {
 
         await testOutput(member, (row) => {
             basicAsserts(member, row);
-            should(row.subscribed_to_emails).eql('false');
+            assert.equal(row.subscribed_to_emails, 'false');
             should(row.complimentary_plan).eql('');
             should(row.labels).eql('');
             should(row.tiers).eql('');
-            should(row.stripe_customer_id).eql('cus_12345');
+            assert.equal(row.stripe_customer_id, 'cus_12345');
         }, ['filter=subscribed:false', 'filter=subscriptions.subscription_id:sub_123']);
     });
 });

--- a/ghost/core/test/e2e-api/admin/members-importer.test.js
+++ b/ghost/core/test/e2e-api/admin/members-importer.test.js
@@ -70,7 +70,7 @@ describe('Members Importer API', function () {
         const importedMember1 = jsonResponse2.members.find(m => m.email === 'jbloggs@example.com');
         should.exist(importedMember1);
         importedMember1.name.should.equal('joe');
-        should(importedMember1.note).equal(null);
+        assert.equal(importedMember1.note, null);
         importedMember1.subscribed.should.equal(true);
         importedMember1.newsletters.length.should.equal(filteredNewsletters.length);
         importedMember1.labels.length.should.equal(1);
@@ -82,7 +82,7 @@ describe('Members Importer API', function () {
         const importedMember2 = jsonResponse2.members.find(m => m.email === 'test@example.com');
         should.exist(importedMember2);
         importedMember2.name.should.equal('test');
-        should(importedMember2.note).equal('test note');
+        assert.equal(importedMember2.note, 'test note');
         importedMember2.subscribed.should.equal(false);
         importedMember2.newsletters.length.should.equal(0);
         importedMember2.labels.length.should.equal(2);

--- a/ghost/core/test/e2e-api/admin/members.test.js
+++ b/ghost/core/test/e2e-api/admin/members.test.js
@@ -3447,7 +3447,7 @@ describe('Members API Bulk operations', function () {
             });
         const updatedModel = await models.Member.findOne({id: member.id}, {withRelated: 'newsletters'});
         // ensure they were unsubscribed from the single 'chosen' newsletter
-        should(updatedModel.relations.newsletters.models.length).equal(newsletterCount - 1);
+        assert.equal(updatedModel.relations.newsletters.models.length, newsletterCount - 1);
     });
 
     it('Can bulk unsubscribe members with deprecated subscribed filter', async function () {
@@ -3761,7 +3761,7 @@ describe('Members API Bulk operations', function () {
         // Verify member1 has the label
         const beforeMember = await models.Member.findOne({id: member1.id}, {withRelated: 'labels'});
         const beforeLabelCount = beforeMember.relations.labels.models.filter(m => m.id === label.id).length;
-        should(beforeLabelCount).equal(1);
+        assert.equal(beforeLabelCount, 1);
 
         // Try to add the same label again
         await agent
@@ -3795,7 +3795,7 @@ describe('Members API Bulk operations', function () {
         // Verify member1 still has only one instance of the label (not duplicated)
         const afterMember = await models.Member.findOne({id: member1.id}, {withRelated: 'labels'});
         const afterLabelCount = afterMember.relations.labels.models.filter(m => m.id === label.id).length;
-        should(afterLabelCount).equal(1);
+        assert.equal(afterLabelCount, 1);
     });
 
     it('Can bulk delete members', async function () {

--- a/ghost/core/test/e2e-api/admin/posts-legacy.test.js
+++ b/ghost/core/test/e2e-api/admin/posts-legacy.test.js
@@ -578,7 +578,7 @@ describe('Posts API', function () {
             .expect(201);
 
         // Check that the default newsletter is used instead of the one in body (not allowed)
-        should(res.body.posts[0].status).eql('draft');
+        assert.equal(res.body.posts[0].status, 'draft');
         should(res.body.posts[0].newsletter).eql(null);
         assert.equal(res.body.posts[0].newsletter_id, undefined);
 
@@ -616,7 +616,7 @@ describe('Posts API', function () {
 
         // Check newsletter relation is loaded, but null in response.
         should(res.body.posts[0].newsletter).eql(null);
-        should(res.body.posts[0].email_segment).eql('all');
+        assert.equal(res.body.posts[0].email_segment, 'all');
         assert.equal(res.body.posts[0].newsletter_id, undefined);
 
         const id = res.body.posts[0].id;
@@ -681,7 +681,7 @@ describe('Posts API', function () {
             id,
             status: 'all'
         }, testUtils.context.internal);
-        should(model.get('status')).eql('scheduled');
+        assert.equal(model.get('status'), 'scheduled');
 
         // Now stub checkCanSendEmail to throw a HostLimitError (simulating email limits)
         const checkCanSendEmailStub = sinon.stub(emailService.service, 'checkCanSendEmail')
@@ -759,7 +759,7 @@ describe('Posts API', function () {
 
         // Check newsletter relation is loaded in response
         should(finalPost.body.posts[0].newsletter).eql(null);
-        should(finalPost.body.posts[0].email_segment).eql('all');
+        assert.equal(finalPost.body.posts[0].email_segment, 'all');
         assert.equal(finalPost.body.posts[0].newsletter_id, undefined);
 
         const model = await models.Post.findOne({
@@ -821,7 +821,7 @@ describe('Posts API', function () {
 
         // Check newsletter relation is loaded in response
         should(finalPost.body.posts[0].newsletter).eql(null);
-        should(finalPost.body.posts[0].email_segment).eql('all');
+        assert.equal(finalPost.body.posts[0].email_segment, 'all');
         assert.equal(finalPost.body.posts[0].newsletter_id, undefined);
 
         // Check status is set to published
@@ -890,7 +890,7 @@ describe('Posts API', function () {
 
         // Check newsletter relation is loaded in response
         should(finalPost.body.posts[0].newsletter.id).eql(newsletterId);
-        should(finalPost.body.posts[0].email_segment).eql('all');
+        assert.equal(finalPost.body.posts[0].email_segment, 'all');
         assert.equal(finalPost.body.posts[0].newsletter_id, undefined);
 
         const model = await models.Post.findOne({
@@ -958,11 +958,11 @@ describe('Posts API', function () {
 
         // Check newsletter relation is loaded in response
         should(finalPost.body.posts[0].newsletter.id).eql(newsletterId);
-        should(finalPost.body.posts[0].email_segment).eql('all');
+        assert.equal(finalPost.body.posts[0].email_segment, 'all');
         assert.equal(finalPost.body.posts[0].newsletter_id, undefined);
 
         // Check status
-        should(finalPost.body.posts[0].status).eql('published');
+        assert.equal(finalPost.body.posts[0].status, 'published');
 
         const model = await models.Post.findOne({
             id
@@ -1037,9 +1037,9 @@ describe('Posts API', function () {
             status: 'all'
         }, testUtils.context.internal);
 
-        should(model.get('status')).eql('sent');
+        assert.equal(model.get('status'), 'sent');
         should(model.get('newsletter_id')).eql(newsletterId);
-        should(model.get('email_recipient_filter')).eql('all');
+        assert.equal(model.get('email_recipient_filter'), 'all');
         should.exist(model.get('published_by'));
 
         // We should have an email
@@ -1048,7 +1048,7 @@ describe('Posts API', function () {
         }, testUtils.context.internal);
 
         should(email.get('newsletter_id')).eql(newsletterId);
-        should(email.get('recipient_filter')).eql('all');
+        assert.equal(email.get('recipient_filter'), 'all');
         should(email.get('status')).equalOneOf('pending', 'submitted', 'submitting');
     });
 
@@ -1106,9 +1106,9 @@ describe('Posts API', function () {
             status: 'all'
         }, testUtils.context.internal);
 
-        should(model.get('status')).eql('sent');
+        assert.equal(model.get('status'), 'sent');
         should(model.get('newsletter_id')).eql(newsletterId);
-        should(model.get('email_recipient_filter')).eql('status:free');
+        assert.equal(model.get('email_recipient_filter'), 'status:free');
         should.exist(model.get('published_by'));
 
         // We should have an email
@@ -1117,7 +1117,7 @@ describe('Posts API', function () {
         }, testUtils.context.internal);
 
         should(email.get('newsletter_id')).eql(newsletterId);
-        should(email.get('recipient_filter')).eql('status:free');
+        assert.equal(email.get('recipient_filter'), 'status:free');
         should(email.get('status')).equalOneOf('pending', 'submitted', 'submitting');
     });
 
@@ -1175,9 +1175,9 @@ describe('Posts API', function () {
             status: 'all'
         }, testUtils.context.internal);
 
-        should(model.get('status')).eql('sent');
+        assert.equal(model.get('status'), 'sent');
         should(model.get('newsletter_id')).eql(newsletterId);
-        should(model.get('email_recipient_filter')).eql('status:free');
+        assert.equal(model.get('email_recipient_filter'), 'status:free');
         should.exist(model.get('published_by'));
 
         // We should have an email
@@ -1186,7 +1186,7 @@ describe('Posts API', function () {
         }, testUtils.context.internal);
 
         should(email.get('newsletter_id')).eql(newsletterId);
-        should(email.get('recipient_filter')).eql('status:free');
+        assert.equal(email.get('recipient_filter'), 'status:free');
         should(email.get('status')).equalOneOf('pending', 'submitted', 'submitting');
     });
 
@@ -1238,7 +1238,7 @@ describe('Posts API', function () {
         }, testUtils.context.internal);
 
         should(model.get('newsletter_id')).eql(newsletterId);
-        should(model.get('email_recipient_filter')).eql('all');
+        assert.equal(model.get('email_recipient_filter'), 'all');
         assert.equal(model.get('published_by'), null);
 
         // We should not have an email
@@ -1267,7 +1267,7 @@ describe('Posts API', function () {
         }, testUtils.context.internal);
 
         should(model.get('newsletter_id')).eql(newsletterId);
-        should(model.get('email_recipient_filter')).eql('all');
+        assert.equal(model.get('email_recipient_filter'), 'all');
         should.exist(model.get('published_by'));
 
         publishedPost.newsletter.id.should.eql(newsletterId);
@@ -1279,7 +1279,7 @@ describe('Posts API', function () {
         }, testUtils.context.internal);
 
         should(email.get('newsletter_id')).eql(newsletterId);
-        should(email.get('recipient_filter')).eql('all');
+        assert.equal(email.get('recipient_filter'), 'all');
         should(email.get('status')).equalOneOf('pending', 'submitted', 'submitting');
     });
 
@@ -1331,7 +1331,7 @@ describe('Posts API', function () {
         }, testUtils.context.internal);
 
         should(model.get('newsletter_id')).eql(newsletterId);
-        should(model.get('email_recipient_filter')).eql('status:free');
+        assert.equal(model.get('email_recipient_filter'), 'status:free');
 
         // We should not have an email
         let email = await models.Email.findOne({
@@ -1359,7 +1359,7 @@ describe('Posts API', function () {
         }, testUtils.context.internal);
 
         should(model.get('newsletter_id')).eql(newsletterId);
-        should(model.get('email_recipient_filter')).eql('status:free');
+        assert.equal(model.get('email_recipient_filter'), 'status:free');
 
         publishedPost.newsletter.id.should.eql(newsletterId);
         assert.equal(publishedPost.newsletter_id, undefined);
@@ -1370,7 +1370,7 @@ describe('Posts API', function () {
         }, testUtils.context.internal);
 
         should(email.get('newsletter_id')).eql(newsletterId);
-        should(email.get('recipient_filter')).eql('status:free');
+        assert.equal(email.get('recipient_filter'), 'status:free');
         should(email.get('status')).equalOneOf('pending', 'submitted', 'submitting');
     });
 
@@ -1420,7 +1420,7 @@ describe('Posts API', function () {
         }, testUtils.context.internal);
 
         should(model.get('newsletter_id')).eql(null);
-        should(model.get('email_recipient_filter')).eql('all');
+        assert.equal(model.get('email_recipient_filter'), 'all');
 
         // We should not have an email
         let email = await models.Email.findOne({
@@ -1448,7 +1448,7 @@ describe('Posts API', function () {
         }, testUtils.context.internal);
 
         should(model.get('newsletter_id')).eql(null);
-        should(model.get('email_recipient_filter')).eql('all');
+        assert.equal(model.get('email_recipient_filter'), 'all');
 
         should(publishedPost.newsletter).eql(null);
         assert.equal(publishedPost.newsletter_id, undefined);
@@ -1512,8 +1512,8 @@ describe('Posts API', function () {
         }, testUtils.context.internal);
 
         should(model.get('newsletter_id')).eql(newsletterId);
-        should(model.get('status')).eql('scheduled');
-        should(model.get('email_recipient_filter')).eql('all');
+        assert.equal(model.get('status'), 'scheduled');
+        assert.equal(model.get('email_recipient_filter'), 'all');
 
         // We should not have an email
         let email = await models.Email.findOne({
@@ -1541,8 +1541,8 @@ describe('Posts API', function () {
         }, testUtils.context.internal);
 
         should(model.get('newsletter_id')).eql(newsletterId);
-        should(model.get('status')).eql('sent');
-        should(model.get('email_recipient_filter')).eql('all');
+        assert.equal(model.get('status'), 'sent');
+        assert.equal(model.get('email_recipient_filter'), 'all');
 
         publishedPost.newsletter.id.should.eql(newsletterId);
         assert.equal(publishedPost.newsletter_id, undefined);
@@ -1553,7 +1553,7 @@ describe('Posts API', function () {
         }, testUtils.context.internal);
 
         should(email.get('newsletter_id')).eql(newsletterId);
-        should(email.get('recipient_filter')).eql('all');
+        assert.equal(email.get('recipient_filter'), 'all');
         should(email.get('status')).equalOneOf('pending', 'submitted', 'submitting');
     });
 
@@ -1599,7 +1599,7 @@ describe('Posts API', function () {
 
         // Check newsletter relation is loaded in response
         should(res2.body.posts[0].newsletter.id).eql(newsletterId);
-        should(res2.body.posts[0].email_segment).eql('status:-free');
+        assert.equal(res2.body.posts[0].email_segment, 'status:-free');
 
         assert.equal(res2.body.posts[0].newsletter_id, undefined);
 
@@ -1608,7 +1608,7 @@ describe('Posts API', function () {
             status: 'published'
         }, testUtils.context.internal);
         should(model.get('newsletter_id')).eql(newsletterId);
-        should(model.get('email_recipient_filter')).eql('status:-free');
+        assert.equal(model.get('email_recipient_filter'), 'status:-free');
 
         // Check email is sent to the correct newsletter
         let email = await models.Email.findOne({
@@ -1616,7 +1616,7 @@ describe('Posts API', function () {
         }, testUtils.context.internal);
 
         should(email.get('newsletter_id')).eql(newsletterId);
-        should(email.get('recipient_filter')).eql('status:-free');
+        assert.equal(email.get('recipient_filter'), 'status:-free');
         should(email.get('status')).equalOneOf('pending', 'submitted', 'submitting');
 
         const unpublished = {
@@ -1635,7 +1635,7 @@ describe('Posts API', function () {
         // Check newsletter relation is loaded in response
         // We should keep it, because we already sent an email
         should(res3.body.posts[0].newsletter.id).eql(newsletterId);
-        should(res2.body.posts[0].email_segment).eql('status:-free');
+        assert.equal(res2.body.posts[0].email_segment, 'status:-free');
         assert.equal(res3.body.posts[0].newsletter_id, undefined);
 
         model = await models.Post.findOne({
@@ -1670,7 +1670,7 @@ describe('Posts API', function () {
         // Check newsletter relation is loaded in response
         // + did update the newsletter id
         should(res4.body.posts[0].newsletter.id).eql(newsletterId);
-        should(res4.body.posts[0].email_segment).eql('status:-free');
+        assert.equal(res4.body.posts[0].email_segment, 'status:-free');
         assert.equal(res4.body.posts[0].newsletter_id, undefined);
 
         model = await models.Post.findOne({
@@ -1691,7 +1691,7 @@ describe('Posts API', function () {
         // Check newsletter relation is loaded in response
         // + did not update the newsletter id
         should(res5.body.posts[0].newsletter.id).eql(newsletterId);
-        should(res5.body.posts[0].email_segment).eql('status:-free');
+        assert.equal(res5.body.posts[0].email_segment, 'status:-free');
         assert.equal(res5.body.posts[0].newsletter_id, undefined);
 
         model = await models.Post.findOne({
@@ -1780,7 +1780,7 @@ describe('Posts API', function () {
 
             // Check newsletter relation is loaded in response
             should(finalPost.body.posts[0].newsletter.id).eql(newsletterId);
-            should(finalPost.body.posts[0].email_segment).eql('all');
+            assert.equal(finalPost.body.posts[0].email_segment, 'all');
             assert.equal(finalPost.body.posts[0].newsletter_id, undefined);
 
             const model = await models.Post.findOne({
@@ -1850,9 +1850,9 @@ describe('Posts API', function () {
                 status: 'all'
             }, testUtils.context.internal);
 
-            should(model.get('status')).eql('sent');
+            assert.equal(model.get('status'), 'sent');
             should(model.get('newsletter_id')).eql(newsletterId);
-            should(model.get('email_recipient_filter')).eql('all');
+            assert.equal(model.get('email_recipient_filter'), 'all');
 
             // We should have an email
             const email = await models.Email.findOne({
@@ -1860,7 +1860,7 @@ describe('Posts API', function () {
             }, testUtils.context.internal);
 
             should(email.get('newsletter_id')).eql(newsletterId);
-            should(email.get('recipient_filter')).eql('all');
+            assert.equal(email.get('recipient_filter'), 'all');
             should(email.get('status')).equalOneOf('pending', 'submitted', 'submitting');
         });
     });

--- a/ghost/core/test/e2e-api/members-comments/comments.test.js
+++ b/ghost/core/test/e2e-api/members-comments/comments.test.js
@@ -487,10 +487,10 @@ describe('Comments API', function () {
                 data2.body.comments.forEach((comment) => {
                     if (comment.id === hiddenComment.id) {
                         should(comment.replies.length).eql(1);
-                        should(comment.replies[0].html).eql('This is a reply to a hidden comment');
+                        assert.equal(comment.replies[0].html, 'This is a reply to a hidden comment');
                     } else if (comment.id === deletedComment.id) {
                         should(comment.replies.length).eql(1);
-                        should(comment.replies[0].html).eql('This is a reply to a deleted comment');
+                        assert.equal(comment.replies[0].html, 'This is a reply to a deleted comment');
                     }
                 });
             });

--- a/ghost/core/test/e2e-api/members-comments/comments.test.js
+++ b/ghost/core/test/e2e-api/members-comments/comments.test.js
@@ -1028,7 +1028,7 @@ describe('Comments API', function () {
                         // Check liked + likes working for replies too
                         should(body.comments[2].id).eql(replies[2].get('id'));
                         should(body.comments[2].count.likes).eql(1);
-                        should(body.comments[2].liked).eql(true);
+                        assert.equal(body.comments[2].liked, true);
                     });
             });
 

--- a/ghost/core/test/e2e-api/members/create-stripe-checkout-session.test.js
+++ b/ghost/core/test/e2e-api/members/create-stripe-checkout-session.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const querystring = require('querystring');
 const {agentProvider, mockManager, fixtureManager, matchers} = require('../../utils/e2e-framework');
 const nock = require('nock');
@@ -320,8 +321,8 @@ describe('Create Stripe Checkout Session', function () {
                 .reply((uri, body) => {
                     if (uri === '/v1/checkout/sessions') {
                         const parsed = new URLSearchParams(body);
-                        should(parsed.get('metadata[attribution_url]')).eql('/test');
-                        should(parsed.get('metadata[attribution_type]')).eql('url');
+                        assert.equal(parsed.get('metadata[attribution_url]'), '/test');
+                        assert.equal(parsed.get('metadata[attribution_type]'), 'url');
                         should(parsed.get('metadata[attribution_id]')).be.null();
 
                         return [200, {id: 'cs_123', url: 'https://site.com'}];
@@ -405,7 +406,7 @@ describe('Create Stripe Checkout Session', function () {
                     if (uri === '/v1/checkout/sessions') {
                         const parsed = new URLSearchParams(body);
                         should(parsed.get('metadata[attribution_url]')).eql(url);
-                        should(parsed.get('metadata[attribution_type]')).eql('post');
+                        assert.equal(parsed.get('metadata[attribution_type]'), 'post');
                         should(parsed.get('metadata[attribution_id]')).eql(post.id);
 
                         return [200, {id: 'cs_123', url: 'https://site.com'}];
@@ -565,11 +566,11 @@ describe('Create Stripe Checkout Session', function () {
                         const parsed = new URLSearchParams(body);
 
                         // Check UTM parameters are passed through
-                        should(parsed.get('subscription_data[metadata][utm_source]')).eql('newsletter');
-                        should(parsed.get('subscription_data[metadata][utm_medium]')).eql('email');
-                        should(parsed.get('subscription_data[metadata][utm_campaign]')).eql('spring_sale');
-                        should(parsed.get('subscription_data[metadata][utm_term]')).eql('ghost_pro');
-                        should(parsed.get('subscription_data[metadata][utm_content]')).eql('header_link');
+                        assert.equal(parsed.get('subscription_data[metadata][utm_source]'), 'newsletter');
+                        assert.equal(parsed.get('subscription_data[metadata][utm_medium]'), 'email');
+                        assert.equal(parsed.get('subscription_data[metadata][utm_campaign]'), 'spring_sale');
+                        assert.equal(parsed.get('subscription_data[metadata][utm_term]'), 'ghost_pro');
+                        assert.equal(parsed.get('subscription_data[metadata][utm_content]'), 'header_link');
 
                         return [200, {id: 'cs_123', url: 'https://site.com'}];
                     }

--- a/ghost/core/test/e2e-api/members/create-stripe-checkout-session.test.js
+++ b/ghost/core/test/e2e-api/members/create-stripe-checkout-session.test.js
@@ -360,7 +360,7 @@ describe('Create Stripe Checkout Session', function () {
                 .matchBodySnapshot()
                 .matchHeaderSnapshot();
 
-            should(scope.isDone()).eql(true);
+            assert.equal(scope.isDone(), true);
         });
 
         it('Does pass post attribution source to session metadata', async function () {
@@ -444,7 +444,7 @@ describe('Create Stripe Checkout Session', function () {
                 .matchBodySnapshot()
                 .matchHeaderSnapshot();
 
-            should(scope.isDone()).eql(true);
+            assert.equal(scope.isDone(), true);
         });
 
         it('Ignores attribution_* values in metadata', async function () {
@@ -522,7 +522,7 @@ describe('Create Stripe Checkout Session', function () {
                 .matchBodySnapshot()
                 .matchHeaderSnapshot();
 
-            should(scope.isDone()).eql(true);
+            assert.equal(scope.isDone(), true);
         });
 
         it('Does pass UTM parameters to session metadata', async function () {
@@ -615,7 +615,7 @@ describe('Create Stripe Checkout Session', function () {
                 .matchBodySnapshot()
                 .matchHeaderSnapshot();
 
-            should(scope.isDone()).eql(true);
+            assert.equal(scope.isDone(), true);
         });
     });
 });

--- a/ghost/core/test/e2e-api/members/donation-checkout-session.test.js
+++ b/ghost/core/test/e2e-api/members/donation-checkout-session.test.js
@@ -390,11 +390,11 @@ describe('Create Stripe Checkout Session for Donations', function () {
 
         // Verify that the Stripe mocker captured the UTM parameters in metadata
         const checkoutSession = stripeMocker.checkoutSessions[stripeMocker.checkoutSessions.length - 1];
-        should(checkoutSession.metadata.utm_source).eql('weekly_newsletter');
-        should(checkoutSession.metadata.utm_medium).eql('email');
-        should(checkoutSession.metadata.utm_campaign).eql('donation_drive_2024');
-        should(checkoutSession.metadata.utm_term).eql('support_ghost');
-        should(checkoutSession.metadata.utm_content).eql('footer_cta');
+        assert.equal(checkoutSession.metadata.utm_source, 'weekly_newsletter');
+        assert.equal(checkoutSession.metadata.utm_medium, 'email');
+        assert.equal(checkoutSession.metadata.utm_campaign, 'donation_drive_2024');
+        assert.equal(checkoutSession.metadata.utm_term, 'support_ghost');
+        assert.equal(checkoutSession.metadata.utm_content, 'footer_cta');
 
         // Send a webhook to complete the donation and verify UTM storage
         await stripeMocker.sendWebhook({

--- a/ghost/core/test/e2e-server/services/member-attribution.test.js
+++ b/ghost/core/test/e2e-server/services/member-attribution.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const {agentProvider, fixtureManager, configUtils} = require('../../utils/e2e-framework');
 const should = require('should');
 const models = require('../../../core/server/models');
@@ -105,7 +106,7 @@ describe('Member Attribution Service', function () {
             it('resolves pages', async function () {
                 const id = fixtureManager.get('posts', 5).id;
                 const post = await models.Post.where('id', id).fetch({require: true});
-                should(post.get('type')).eql('page');
+                assert.equal(post.get('type'), 'page');
 
                 const url = urlService.getUrlByResourceId(post.id, {absolute: false, withSubdirectory: true});
 
@@ -291,7 +292,7 @@ describe('Member Attribution Service', function () {
             it('resolves pages', async function () {
                 const id = fixtureManager.get('posts', 5).id;
                 const post = await models.Post.where('id', id).fetch({require: true});
-                should(post.get('type')).eql('page');
+                assert.equal(post.get('type'), 'page');
 
                 const url = urlService.getUrlByResourceId(post.id, {absolute: false, withSubdirectory: true});
                 const urlWithoutSubdirectory = urlService.getUrlByResourceId(post.id, {absolute: false, withSubdirectory: false});

--- a/ghost/core/test/integration/importer/v1.test.js
+++ b/ghost/core/test/integration/importer/v1.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const testUtils = require('../../utils');
 const {exportedBodyV1} = require('../../utils/fixtures/export/body-generator');
@@ -98,7 +99,7 @@ describe('Importer 1.0', function () {
                     const posts = result[0].data.map(model => model.toJSON(options));
 
                     posts.length.should.eql(1);
-                    should(posts[0].html).eql('<h1 id="this-is-my-post-content">This is my post content.</h1>');
+                    assert.equal(posts[0].html, '<h1 id="this-is-my-post-content">This is my post content.</h1>');
                     posts[0].mobiledoc.should.eql('{"version":"0.3.1","atoms":[],"cards":[],"markups":[],"sections":[[1,"h1",[[0,[],0,"This is my post content."]]]]}');
                 });
         });

--- a/ghost/core/test/legacy/api/admin/db.test.js
+++ b/ghost/core/test/legacy/api/admin/db.test.js
@@ -361,7 +361,7 @@ describe('DB API', function () {
         should.exist(newsletter);
         newsletter.get('name').should.equal('Ghost Inc.');
         // Make sure sender_email is not set
-        should(newsletter.get('sender_email')).equal(null);
+        assert.equal(newsletter.get('sender_email'), null);
 
         // Check posts
         const post = await models.Post.findOne({slug: 'test-newsletter'}, {withRelated: ['tiers']});
@@ -463,7 +463,7 @@ describe('DB API (cleaned)', function () {
         should.exist(newsletter);
         newsletter.get('name').should.equal('Ghost Inc.');
         // Make sure sender_email is not set
-        should(newsletter.get('sender_email')).equal(null);
+        assert.equal(newsletter.get('sender_email'), null);
 
         // Check posts
         const post = await models.Post.findOne({slug: 'test-newsletter'}, {withRelated: ['tiers']});

--- a/ghost/core/test/legacy/api/admin/members-importer.test.js
+++ b/ghost/core/test/legacy/api/admin/members-importer.test.js
@@ -72,8 +72,8 @@ describe('Members Importer API', function () {
 
                 const importedMember1 = jsonResponse.members.find(m => m.email === 'member+labels_1@example.com');
                 should.exist(importedMember1);
-                should(importedMember1.name).equal(null);
-                should(importedMember1.note).equal(null);
+                assert.equal(importedMember1.name, null);
+                assert.equal(importedMember1.note, null);
                 importedMember1.subscribed.should.equal(true);
                 importedMember1.comped.should.equal(false);
                 importedMember1.subscriptions.should.not.be.undefined();
@@ -139,9 +139,9 @@ describe('Members Importer API', function () {
                 should.exist(jsonResponse.members[0]);
 
                 const importedMember1 = jsonResponse.members[0];
-                should(importedMember1.email).equal('member+mapped_1@example.com');
-                should(importedMember1.name).equal('Hannah');
-                should(importedMember1.note).equal('do map me');
+                assert.equal(importedMember1.email, 'member+mapped_1@example.com');
+                assert.equal(importedMember1.name, 'Hannah');
+                assert.equal(importedMember1.note, 'do map me');
                 importedMember1.subscribed.should.equal(true);
                 importedMember1.comped.should.equal(false);
                 importedMember1.subscriptions.should.not.be.undefined();
@@ -185,8 +185,8 @@ describe('Members Importer API', function () {
                 should.exist(jsonResponse.members);
 
                 const defaultMember1 = jsonResponse.members.find(member => (member.email === 'member+defaults_1@example.com'));
-                should(defaultMember1.name).equal(null);
-                should(defaultMember1.note).equal(null);
+                assert.equal(defaultMember1.name, null);
+                assert.equal(defaultMember1.note, null);
                 defaultMember1.subscribed.should.equal(true);
                 defaultMember1.comped.should.equal(false);
                 defaultMember1.subscriptions.should.not.be.undefined();

--- a/ghost/core/test/unit/api/canary/utils/index.test.js
+++ b/ghost/core/test/unit/api/canary/utils/index.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const utils = require('../../../../../core/server/api/endpoints/utils');
@@ -12,7 +13,7 @@ describe('Unit: endpoints/utils/index', function () {
             const frame = {
                 apiType: 'content'
             };
-            should(utils.isContentAPI(frame)).equal(true);
+            assert.equal(utils.isContentAPI(frame), true);
         });
 
         it('is false when apiType is admin', function () {
@@ -24,7 +25,7 @@ describe('Unit: endpoints/utils/index', function () {
                     }
                 }
             };
-            should(utils.isContentAPI(frame)).equal(false);
+            assert.equal(utils.isContentAPI(frame), false);
         });
     });
 });

--- a/ghost/core/test/unit/frontend/meta/author-fb-url.test.js
+++ b/ghost/core/test/unit/frontend/meta/author-fb-url.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const getAuthorFacebookUrl = require('../../../../core/frontend/meta/author-fb-url');
 
@@ -25,7 +26,7 @@ describe('getAuthorFacebookUrl', function () {
                     }
                 }
             });
-            should(facebookUrl).equal(null);
+            assert.equal(facebookUrl, null);
         });
 
     it('should return null if context does not contain author and is a post', function () {
@@ -33,7 +34,7 @@ describe('getAuthorFacebookUrl', function () {
             context: ['post'],
             post: {}
         });
-        should(facebookUrl).equal(null);
+        assert.equal(facebookUrl, null);
     });
 
     it('should return author facebook url if author and has url',
@@ -55,13 +56,13 @@ describe('getAuthorFacebookUrl', function () {
                     facebook: ''
                 }
             });
-            should(facebookUrl).equal(null);
+            assert.equal(facebookUrl, null);
         });
 
     it('should return null if context is not a post', function () {
         const facebookUrl = getAuthorFacebookUrl({
             context: ['tag']
         });
-        should(facebookUrl).equal(null);
+        assert.equal(facebookUrl, null);
     });
 });

--- a/ghost/core/test/unit/frontend/meta/author-image.test.js
+++ b/ghost/core/test/unit/frontend/meta/author-image.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const getAuthorImage = require('../../../../core/frontend/meta/author-image');
@@ -43,7 +44,7 @@ describe('getAuthorImage', function () {
             }
         });
 
-        should(imageUrl).equal(null);
+        assert.equal(imageUrl, null);
     });
 
     it('should return null if context does not contain author and is a post', function () {
@@ -52,7 +53,7 @@ describe('getAuthorImage', function () {
             post: {}
         });
 
-        should(imageUrl).equal(null);
+        assert.equal(imageUrl, null);
     });
 
     it('should return null if context is not a post', function () {
@@ -60,6 +61,6 @@ describe('getAuthorImage', function () {
             context: ['tag']
         });
 
-        should(imageUrl).equal(null);
+        assert.equal(imageUrl, null);
     });
 });

--- a/ghost/core/test/unit/frontend/meta/cover-image.test.js
+++ b/ghost/core/test/unit/frontend/meta/cover-image.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const getCoverImage = require('../../../../core/frontend/meta/cover-image');
 
@@ -40,7 +41,7 @@ describe('getCoverImage', function () {
             context: ['post'],
             post: {}
         });
-        should(coverImageUrl).equal(null);
+        assert.equal(coverImageUrl, null);
     });
 
     it('should return null if author missing cover', function () {
@@ -48,7 +49,7 @@ describe('getCoverImage', function () {
             context: ['author'],
             author: {}
         });
-        should(coverImageUrl).equal(null);
+        assert.equal(coverImageUrl, null);
     });
 
     it('should return null if home missing cover', function () {
@@ -56,6 +57,6 @@ describe('getCoverImage', function () {
             context: ['home'],
             home: {}
         });
-        should(coverImageUrl).equal(null);
+        assert.equal(coverImageUrl, null);
     });
 });

--- a/ghost/core/test/unit/frontend/meta/creator-url.test.js
+++ b/ghost/core/test/unit/frontend/meta/creator-url.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const getCreatorTwitterUrl = require('../../../../core/frontend/meta/creator-url');
 
@@ -25,7 +26,7 @@ describe('getCreatorTwitterUrl', function () {
                     }
                 }
             });
-            should(twitterUrl).equal(null);
+            assert.equal(twitterUrl, null);
         });
 
     it('should return null if context does not contain author and is a post', function () {
@@ -33,7 +34,7 @@ describe('getCreatorTwitterUrl', function () {
             context: ['post'],
             post: {}
         });
-        should(twitterUrl).equal(null);
+        assert.equal(twitterUrl, null);
     });
 
     it('should return author twitter url if author and has url',
@@ -55,13 +56,13 @@ describe('getCreatorTwitterUrl', function () {
                     twitter: ''
                 }
             });
-            should(twitterUrl).equal(null);
+            assert.equal(twitterUrl, null);
         });
 
     it('should return null if context is not a post', function () {
         const twitterUrl = getCreatorTwitterUrl({
             context: ['tag']
         });
-        should(twitterUrl).equal(null);
+        assert.equal(twitterUrl, null);
     });
 });

--- a/ghost/core/test/unit/frontend/meta/description.test.js
+++ b/ghost/core/test/unit/frontend/meta/description.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const getMetaDescription = require('../../../../core/frontend/meta/description');
@@ -50,9 +51,7 @@ describe('getMetaDescription', function () {
 
             localSettingsCache.description = '';
 
-            should(
-                getMetaDescription({}, {context: 'home'})
-            ).equal(null);
+            assert.equal(getMetaDescription({}, {context: 'home'}), null);
         });
 
         it('has correct fallbacks for context: post', function () {
@@ -65,15 +64,11 @@ describe('getMetaDescription', function () {
 
             post.meta_description = '';
 
-            should(
-                getMetaDescription({post}, {context: 'post'})
-            ).equal(null);
+            assert.equal(getMetaDescription({post}, {context: 'post'}), null);
 
             post.custom_excerpt = 'Custom excerpt';
 
-            should(
-                getMetaDescription({post}, {context: 'post'})
-            ).equal('Custom excerpt');
+            assert.equal(getMetaDescription({post}, {context: 'post'}), 'Custom excerpt');
         });
 
         it('has correct fallbacks for context: page', function () {
@@ -86,15 +81,11 @@ describe('getMetaDescription', function () {
 
             page.meta_description = '';
 
-            should(
-                getMetaDescription({page}, {context: 'page'})
-            ).equal(null);
+            assert.equal(getMetaDescription({page}, {context: 'page'}), null);
 
             page.custom_excerpt = 'Custom excerpt';
 
-            should(
-                getMetaDescription({page}, {context: 'page'})
-            ).equal('Custom excerpt');
+            assert.equal(getMetaDescription({page}, {context: 'page'}), 'Custom excerpt');
         });
 
         // NOTE: this is a legacy format and should be resolved with https://github.com/TryGhost/Ghost/issues/10042
@@ -108,9 +99,7 @@ describe('getMetaDescription', function () {
 
             post.meta_description = '';
 
-            should(
-                getMetaDescription({post}, {context: 'page'})
-            ).equal(null);
+            assert.equal(getMetaDescription({post}, {context: 'page'}), null);
         });
 
         it('has correct fallbacks for context: author', function () {
@@ -129,9 +118,7 @@ describe('getMetaDescription', function () {
 
             author.bio = '';
 
-            should(
-                getMetaDescription({author}, {context: 'author'})
-            ).equal(null);
+            assert.equal(getMetaDescription({author}, {context: 'author'}), null);
         });
 
         it('has correct fallbacks for context: author_paged', function () {
@@ -140,9 +127,7 @@ describe('getMetaDescription', function () {
                 bio: 'Author bio'
             };
 
-            should(
-                getMetaDescription({author}, {context: ['author', 'paged']})
-            ).equal(null);
+            assert.equal(getMetaDescription({author}, {context: ['author', 'paged']}), null);
         });
 
         it('has correct fallbacks for context: tag', function () {
@@ -161,9 +146,7 @@ describe('getMetaDescription', function () {
 
             tag.description = '';
 
-            should(
-                getMetaDescription({tag}, {context: 'tag'})
-            ).equal(null);
+            assert.equal(getMetaDescription({tag}, {context: 'tag'}), null);
         });
 
         it('has correct fallbacks for context: tag_paged', function () {
@@ -172,9 +155,7 @@ describe('getMetaDescription', function () {
                 description: 'Tag description'
             };
 
-            should(
-                getMetaDescription({tag}, {context: ['tag', 'paged']})
-            ).equal(null);
+            assert.equal(getMetaDescription({tag}, {context: ['tag', 'paged']}), null);
         });
     });
 
@@ -201,9 +182,7 @@ describe('getMetaDescription', function () {
 
             localSettingsCache.description = '';
 
-            should(
-                getMetaDescription({}, {context: 'home'}, options)
-            ).equal(null);
+            assert.equal(getMetaDescription({}, {context: 'home'}, options), null);
         });
 
         it('has correct fallbacks for context: post', function () {
@@ -324,9 +303,7 @@ describe('getMetaDescription', function () {
 
             localSettingsCache.meta_description = '';
 
-            should(
-                getMetaDescription({author}, {context: 'author'}, options)
-            ).equal(null);
+            assert.equal(getMetaDescription({author}, {context: 'author'}, options), null);
         });
 
         it('has correct fallbacks for context: author_paged', function () {
@@ -350,9 +327,7 @@ describe('getMetaDescription', function () {
 
             localSettingsCache.meta_description = '';
 
-            should(
-                getMetaDescription({author}, {context: ['author', 'paged']}, options)
-            ).equal(null);
+            assert.equal(getMetaDescription({author}, {context: ['author', 'paged']}, options), null);
         });
 
         it('has correct fallbacks for context: tag', function () {
@@ -376,9 +351,7 @@ describe('getMetaDescription', function () {
 
             localSettingsCache.meta_description = '';
 
-            should(
-                getMetaDescription({tag}, {context: 'tag'}, options)
-            ).equal(null);
+            assert.equal(getMetaDescription({tag}, {context: 'tag'}, options), null);
         });
 
         it('has correct fallbacks for context: tag_paged', function () {
@@ -402,9 +375,7 @@ describe('getMetaDescription', function () {
 
             localSettingsCache.meta_description = '';
 
-            should(
-                getMetaDescription({tag}, {context: ['tag', 'paged']}, options)
-            ).equal(null);
+            assert.equal(getMetaDescription({tag}, {context: ['tag', 'paged']}, options), null);
         });
     });
 
@@ -431,9 +402,7 @@ describe('getMetaDescription', function () {
 
             localSettingsCache.description = '';
 
-            should(
-                getMetaDescription({}, {context: 'home'}, options)
-            ).equal(null);
+            assert.equal(getMetaDescription({}, {context: 'home'}, options), null);
         });
 
         it('has correct fallbacks for context: post', function () {
@@ -554,9 +523,7 @@ describe('getMetaDescription', function () {
 
             localSettingsCache.meta_description = '';
 
-            should(
-                getMetaDescription({author}, {context: 'author'}, options)
-            ).equal(null);
+            assert.equal(getMetaDescription({author}, {context: 'author'}, options), null);
         });
 
         it('has correct fallbacks for context: author_paged', function () {
@@ -580,9 +547,7 @@ describe('getMetaDescription', function () {
 
             localSettingsCache.meta_description = '';
 
-            should(
-                getMetaDescription({author}, {context: ['author', 'paged']}, options)
-            ).equal(null);
+            assert.equal(getMetaDescription({author}, {context: ['author', 'paged']}, options), null);
         });
 
         it('has correct fallbacks for context: tag', function () {
@@ -606,9 +571,7 @@ describe('getMetaDescription', function () {
 
             localSettingsCache.meta_description = '';
 
-            should(
-                getMetaDescription({tag}, {context: 'tag'}, options)
-            ).equal(null);
+            assert.equal(getMetaDescription({tag}, {context: 'tag'}, options), null);
         });
 
         it('has correct fallbacks for context: tag_paged', function () {
@@ -632,9 +595,7 @@ describe('getMetaDescription', function () {
 
             localSettingsCache.meta_description = '';
 
-            should(
-                getMetaDescription({tag}, {context: ['tag', 'paged']}, options)
-            ).equal(null);
+            assert.equal(getMetaDescription({tag}, {context: ['tag', 'paged']}, options), null);
         });
     });
 

--- a/ghost/core/test/unit/frontend/meta/og-image.test.js
+++ b/ghost/core/test/unit/frontend/meta/og-image.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const getOgImage = require('../../../../core/frontend/meta/og-image');
@@ -31,9 +32,7 @@ describe('getOgImage', function () {
 
         localSettingsCache.cover_image = '';
 
-        should(
-            getOgImage({context: ['home'], home: {}})
-        ).equal(null);
+        assert.equal(getOgImage({context: ['home'], home: {}}), null);
     });
 
     it('has correct fallbacks for context: post', function () {
@@ -67,9 +66,7 @@ describe('getOgImage', function () {
 
         localSettingsCache.cover_image = '';
 
-        should(
-            getOgImage({context: ['post'], post})
-        ).equal(null);
+        assert.equal(getOgImage({context: ['post'], post}), null);
     });
 
     it('has correct fallbacks for context: page', function () {
@@ -103,9 +100,7 @@ describe('getOgImage', function () {
 
         localSettingsCache.cover_image = '';
 
-        should(
-            getOgImage({context: ['page'], page})
-        ).equal(null);
+        assert.equal(getOgImage({context: ['page'], page}), null);
     });
 
     it('has correct fallbacks for context: page (legacy format)', function () {
@@ -139,9 +134,7 @@ describe('getOgImage', function () {
 
         localSettingsCache.cover_image = '';
 
-        should(
-            getOgImage({context: ['page'], post})
-        ).equal(null);
+        assert.equal(getOgImage({context: ['page'], post}), null);
     });
 
     it('has correct fallbacks for context: author', function () {
@@ -157,9 +150,7 @@ describe('getOgImage', function () {
 
         author.cover_image = '';
 
-        should(
-            getOgImage({context: ['author'], author})
-        ).equal(null);
+        assert.equal(getOgImage({context: ['author'], author}), null);
     });
 
     it('has correct fallbacks for context: author_paged', function () {
@@ -175,9 +166,7 @@ describe('getOgImage', function () {
 
         author.cover_image = '';
 
-        should(
-            getOgImage({context: ['author', 'paged'], author})
-        ).equal(null);
+        assert.equal(getOgImage({context: ['author', 'paged'], author}), null);
     });
 
     it('has correct fallbacks for context: tag', function () {
@@ -198,9 +187,7 @@ describe('getOgImage', function () {
 
         localSettingsCache.cover_image = '';
 
-        should(
-            getOgImage({context: ['tag'], tag})
-        ).equal(null);
+        assert.equal(getOgImage({context: ['tag'], tag}), null);
     });
 
     it('has correct fallbacks for context: tag_paged', function () {
@@ -221,8 +208,6 @@ describe('getOgImage', function () {
 
         localSettingsCache.cover_image = '';
 
-        should(
-            getOgImage({context: ['tag', 'paged'], tag})
-        ).equal(null);
+        assert.equal(getOgImage({context: ['tag', 'paged'], tag}), null);
     });
 });

--- a/ghost/core/test/unit/frontend/meta/twitter-image.test.js
+++ b/ghost/core/test/unit/frontend/meta/twitter-image.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const getTwitterImage = require('../../../../core/frontend/meta/twitter-image');
@@ -31,9 +32,7 @@ describe('getTwitterImage', function () {
 
         localSettingsCache.cover_image = '';
 
-        should(
-            getTwitterImage({context: ['home'], home: {}})
-        ).equal(null);
+        assert.equal(getTwitterImage({context: ['home'], home: {}}), null);
     });
 
     it('has correct fallbacks for context: post', function () {
@@ -67,9 +66,7 @@ describe('getTwitterImage', function () {
 
         localSettingsCache.cover_image = '';
 
-        should(
-            getTwitterImage({context: ['post'], post})
-        ).equal(null);
+        assert.equal(getTwitterImage({context: ['post'], post}), null);
     });
 
     it('has correct fallbacks for context: page', function () {
@@ -103,9 +100,7 @@ describe('getTwitterImage', function () {
 
         localSettingsCache.cover_image = '';
 
-        should(
-            getTwitterImage({context: ['page'], page})
-        ).equal(null);
+        assert.equal(getTwitterImage({context: ['page'], page}), null);
     });
 
     it('has correct fallbacks for context: page (legacy format)', function () {
@@ -139,9 +134,7 @@ describe('getTwitterImage', function () {
 
         localSettingsCache.cover_image = '';
 
-        should(
-            getTwitterImage({context: ['page'], post})
-        ).equal(null);
+        assert.equal(getTwitterImage({context: ['page'], post}), null);
     });
 
     it('has correct fallbacks for context: author', function () {
@@ -157,9 +150,7 @@ describe('getTwitterImage', function () {
 
         author.cover_image = '';
 
-        should(
-            getTwitterImage({context: ['author'], author})
-        ).equal(null);
+        assert.equal(getTwitterImage({context: ['author'], author}), null);
     });
 
     it('has correct fallbacks for context: author_paged', function () {
@@ -175,9 +166,7 @@ describe('getTwitterImage', function () {
 
         author.cover_image = '';
 
-        should(
-            getTwitterImage({context: ['author', 'paged'], author})
-        ).equal(null);
+        assert.equal(getTwitterImage({context: ['author', 'paged'], author}), null);
     });
 
     it('has correct fallbacks for context: tag', function () {
@@ -198,9 +187,7 @@ describe('getTwitterImage', function () {
 
         localSettingsCache.cover_image = '';
 
-        should(
-            getTwitterImage({context: ['tag'], tag})
-        ).equal(null);
+        assert.equal(getTwitterImage({context: ['tag'], tag}), null);
     });
 
     it('has correct fallbacks for context: tag_paged', function () {
@@ -221,8 +208,6 @@ describe('getTwitterImage', function () {
 
         localSettingsCache.cover_image = '';
 
-        should(
-            getTwitterImage({context: ['tag', 'paged'], tag})
-        ).equal(null);
+        assert.equal(getTwitterImage({context: ['tag', 'paged'], tag}), null);
     });
 });

--- a/ghost/core/test/unit/frontend/services/theme-engine/preview.test.js
+++ b/ghost/core/test/unit/frontend/services/theme-engine/preview.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 
 const preview = require('../../../../../core/frontend/services/theme-engine/preview');
@@ -37,7 +38,7 @@ describe('Theme Preview', function () {
         let siteData = preview.handle(req, {});
 
         siteData.should.be.an.Object().with.properties('accent_color');
-        should(siteData.accent_color).eql('#f02d2d');
+        assert.equal(siteData.accent_color, '#f02d2d');
     });
 
     it('can handle multiple values', function () {
@@ -46,7 +47,7 @@ describe('Theme Preview', function () {
         let siteData = preview.handle(req, {});
         siteData.should.be.an.Object().with.properties('accent_color', 'icon', 'logo', 'cover_image');
 
-        should(siteData.accent_color).eql('#f02d2d');
+        assert.equal(siteData.accent_color, '#f02d2d');
         should(siteData.icon).be.null();
         should(siteData.logo).be.null();
         should(siteData.cover_image).be.null();

--- a/ghost/core/test/unit/server/models/post.test.js
+++ b/ghost/core/test/unit/server/models/post.test.js
@@ -304,7 +304,7 @@ describe('Unit: models/post', function () {
 
             const filter = enforcedFilters({}, options);
 
-            should(filter).equal(null);
+            assert.equal(filter, null);
         });
     });
 
@@ -322,7 +322,7 @@ describe('Unit: models/post', function () {
 
             const filter = defaultFilters({}, options);
 
-            should(filter).equal(null);
+            assert.equal(filter, null);
         });
 
         it('returns type:post filter for public context', function () {

--- a/ghost/core/test/unit/server/services/comments/comments-service-emails.test.js
+++ b/ghost/core/test/unit/server/services/comments/comments-service-emails.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const CommentsServiceEmails = require('../../../../../core/server/services/comments/comments-service-emails');
@@ -34,7 +35,7 @@ describe('Comments Service: CommentsServiceEmails', function () {
 
             const result = instance.getPostUrl('123', '456');
 
-            should(result).equal('https://example.com/my-post/#ghost-comments-456');
+            assert.equal(result, 'https://example.com/my-post/#ghost-comments-456');
         });
 
         it('returns post URL with ghost-comments-root when commentPermalinks lab flag is disabled', function () {
@@ -44,7 +45,7 @@ describe('Comments Service: CommentsServiceEmails', function () {
 
             const result = instance.getPostUrl('123', '456');
 
-            should(result).equal('https://example.com/my-post/#ghost-comments-root');
+            assert.equal(result, 'https://example.com/my-post/#ghost-comments-root');
         });
     });
 });

--- a/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
+++ b/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
@@ -1415,7 +1415,7 @@ describe('Email renderer', function () {
             ]);
 
             response.plaintext.should.containEql('http://example.com');
-            should($('.preheader').text()).eql('Test plaintext for post');
+            assert.equal($('.preheader').text(), 'Test plaintext for post');
             response.html.should.containEql('Test Post');
             response.html.should.containEql('http://example.com');
 
@@ -1447,7 +1447,7 @@ describe('Email renderer', function () {
             );
 
             const $ = cheerio.load(response.html);
-            should($('.preheader').text()).eql('Custom excerpt');
+            assert.equal($('.preheader').text(), 'Custom excerpt');
         });
 
         it('does not include members-only content in preheader for non-members', async function () {
@@ -1481,7 +1481,7 @@ describe('Email renderer', function () {
             );
 
             const $ = cheerio.load(response.html);
-            should($('.preheader').text()).eql('Lexical Test some text for both');
+            assert.equal($('.preheader').text(), 'Lexical Test some text for both');
         });
 
         it('does not include paid segmented content in preheader for non-paying members', async function () {
@@ -1515,7 +1515,7 @@ describe('Email renderer', function () {
             );
 
             const $ = cheerio.load(response.html);
-            should($('.preheader').text()).eql('Lexical Test some text for both');
+            assert.equal($('.preheader').text(), 'Lexical Test some text for both');
         });
 
         it('only includes first author if more than 2', async function () {

--- a/ghost/core/test/unit/server/services/link-redirection/link-redirect-repository.test.js
+++ b/ghost/core/test/unit/server/services/link-redirection/link-redirect-repository.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const ObjectID = require('bson-objectid').default;
@@ -87,8 +88,8 @@ describe('UNIT: LinkRedirectRepository class', function () {
             });
             linkRedirectRepository = createLinkRedirectRepository();
             const linkRedirect = linkRedirectRepository.fromModel(model);
-            should(linkRedirect.from.href).equal('https://example.com/r/1234abcd');
-            should(linkRedirect.to.href).equal('https://google.com/');
+            assert.equal(linkRedirect.from.href, 'https://example.com/r/1234abcd');
+            assert.equal(linkRedirect.to.href, 'https://google.com/');
             should(linkRedirect.edited).be.false();
             should(ObjectID.isValid(linkRedirect.link_id)).be.true();
         });
@@ -100,8 +101,8 @@ describe('UNIT: LinkRedirectRepository class', function () {
             });
             linkRedirectRepository = createLinkRedirectRepository();
             const linkRedirect = linkRedirectRepository.fromModel(model);
-            should(linkRedirect.from.href).equal('https://example.com/r/1234abcd');
-            should(linkRedirect.to.href).equal('https://google.com/');
+            assert.equal(linkRedirect.from.href, 'https://example.com/r/1234abcd');
+            assert.equal(linkRedirect.to.href, 'https://google.com/');
             should(linkRedirect.edited).be.false();
             should(ObjectID.isValid(linkRedirect.link_id)).be.true();
         });
@@ -113,8 +114,8 @@ describe('UNIT: LinkRedirectRepository class', function () {
             });
             linkRedirectRepository = createLinkRedirectRepository();
             const linkRedirect = linkRedirectRepository.fromModel(model);
-            should(linkRedirect.from.href).equal('https://example.com/r/1234abcd');
-            should(linkRedirect.to.href).equal('https://google.com/');
+            assert.equal(linkRedirect.from.href, 'https://example.com/r/1234abcd');
+            assert.equal(linkRedirect.to.href, 'https://google.com/');
             should(linkRedirect.edited).be.true();
             should(ObjectID.isValid(linkRedirect.link_id)).be.true();
         });
@@ -125,10 +126,10 @@ describe('UNIT: LinkRedirectRepository class', function () {
             linkRedirectRepository = createLinkRedirectRepository();
             const linkRedirects = await linkRedirectRepository.getAll({});
             should(linkRedirects).be.an.Array();
-            should(linkRedirects.length).equal(1);
+            assert.equal(linkRedirects.length, 1);
             const linkRedirect = linkRedirects[0];
-            should(linkRedirect.from.href).equal('https://example.com/r/1234abcd');
-            should(linkRedirect.to.href).equal('https://google.com/');
+            assert.equal(linkRedirect.from.href, 'https://example.com/r/1234abcd');
+            assert.equal(linkRedirect.to.href, 'https://google.com/');
             should(linkRedirect.edited).be.true();
             should(ObjectID.isValid(linkRedirect.link_id)).be.true();
         });
@@ -139,8 +140,8 @@ describe('UNIT: LinkRedirectRepository class', function () {
             linkRedirectRepository = createLinkRedirectRepository();
             const linkIds = await linkRedirectRepository.getFilteredIds({});
             should(linkIds).be.an.Array();
-            should(linkIds.length).equal(1);
-            should(linkIds[0]).equal('662194931d0ba6fb37c080ee');
+            assert.equal(linkIds.length, 1);
+            assert.equal(linkIds[0], '662194931d0ba6fb37c080ee');
         });
     });
 
@@ -150,8 +151,8 @@ describe('UNIT: LinkRedirectRepository class', function () {
             linkRedirectRepository = createLinkRedirectRepository();
             const result = await linkRedirectRepository.getByURL(url);
             should(result).be.an.Object();
-            should(result.from.href).equal(url.href);
-            should(result.to.href).equal('https://google.com/');
+            assert.equal(result.from.href, url.href);
+            assert.equal(result.to.href, 'https://google.com/');
         });
 
         it('should return a LinkRedirect instance from cache if enabled and key exists', async function () {
@@ -170,8 +171,8 @@ describe('UNIT: LinkRedirectRepository class', function () {
             });
             const result = await linkRedirectRepository.getByURL(url);
             should(result).be.an.Object();
-            should(result.from.href).equal('https://example.com/r/1234abcd');
-            should(result.to.href).equal('https://google.com/');
+            assert.equal(result.from.href, 'https://example.com/r/1234abcd');
+            assert.equal(result.to.href, 'https://google.com/');
             should(result.edited).be.true();
             should(ObjectID.isValid(result.link_id)).be.true();
         });
@@ -188,8 +189,8 @@ describe('UNIT: LinkRedirectRepository class', function () {
             });
             const result = await linkRedirectRepository.getByURL(url);
             should(result).be.an.Object();
-            should(result.from.href).equal('https://example.com/r/1234abcd');
-            should(result.to.href).equal('https://google.com/');
+            assert.equal(result.from.href, 'https://example.com/r/1234abcd');
+            assert.equal(result.to.href, 'https://google.com/');
             should(result.edited).be.true();
             should(ObjectID.isValid(result.link_id)).be.true();
             should(cacheAdapterStub.set.calledOnce).be.true();

--- a/ghost/core/test/unit/server/services/link-tracking/link-click-tracking-service.test.js
+++ b/ghost/core/test/unit/server/services/link-tracking/link-click-tracking-service.test.js
@@ -256,7 +256,7 @@ describe('LinkClickTrackingService', function () {
             });
 
             const [filterOptions] = linkRedirectServiceStub.getFilteredIds.firstCall.args;
-            should(filterOptions.filter).equal('post_id:\'1\'+to:\'https://example.com/path\'');
+            assert.equal(filterOptions.filter, 'post_id:\'1\'+to:\'https://example.com/path\'');
         });
 
         //test for #parseLinkFilter method
@@ -305,7 +305,7 @@ describe('LinkClickTrackingService', function () {
             });
 
             const [filterOptions] = linkRedirectServiceStub.getFilteredIds.firstCall.args;
-            should(filterOptions.filter).equal('post_id:\'1\'+to:\'https://example.com/path%2Ftestpath\'');
+            assert.equal(filterOptions.filter, 'post_id:\'1\'+to:\'https://example.com/path%2Ftestpath\'');
         });
 
         //test for #parseLinkFilter method

--- a/ghost/core/test/unit/server/services/member-attribution/outbound-link-tagger.test.js
+++ b/ghost/core/test/unit/server/services/member-attribution/outbound-link-tagger.test.js
@@ -19,7 +19,7 @@ describe('OutboundLinkTagger', function () {
             const url = new URL('https://example.com/');
             const updatedUrl = await service.addToUrl(url);
 
-            should(updatedUrl.toString()).equal('https://example.com/?ref=blog.com');
+            assert.equal(updatedUrl.toString(), 'https://example.com/?ref=blog.com');
         });
 
         it('does not add if disabled', async function () {
@@ -30,7 +30,7 @@ describe('OutboundLinkTagger', function () {
             const url = new URL('https://example.com/');
             const updatedUrl = await service.addToUrl(url);
 
-            should(updatedUrl.toString()).equal('https://example.com/');
+            assert.equal(updatedUrl.toString(), 'https://example.com/');
         });
 
         it('uses sluggified newsletter name for internal urls', async function () {
@@ -50,7 +50,7 @@ describe('OutboundLinkTagger', function () {
 
             const updatedUrl = await service.addToUrl(url, newsletter);
 
-            should(updatedUrl.toString()).equal('https://example.com/?ref=used-newsletter-name-newsletter');
+            assert.equal(updatedUrl.toString(), 'https://example.com/?ref=used-newsletter-name-newsletter');
         });
 
         it('does not repeat newsletter at the end of the newsletter name', async function () {
@@ -69,7 +69,7 @@ describe('OutboundLinkTagger', function () {
             };
             const updatedUrl = await service.addToUrl(url, newsletter);
 
-            should(updatedUrl.toString()).equal('https://example.com/?ref=weekly-newsletter');
+            assert.equal(updatedUrl.toString(), 'https://example.com/?ref=weekly-newsletter');
         });
 
         it('does not add ref to blocked domains', async function () {
@@ -80,12 +80,12 @@ describe('OutboundLinkTagger', function () {
             const url = new URL('https://facebook.com/');
             const updatedUrl = await service.addToUrl(url);
 
-            should(updatedUrl.toString()).equal('https://facebook.com/');
+            assert.equal(updatedUrl.toString(), 'https://facebook.com/');
 
             const urlTwo = new URL('https://web.archive.org/');
             const updatedUrlTwo = await service.addToUrl(urlTwo);
 
-            should(updatedUrlTwo.toString()).equal('https://web.archive.org/');
+            assert.equal(updatedUrlTwo.toString(), 'https://web.archive.org/');
         });
 
         it('does not add ref if utm_source is present', async function () {
@@ -95,7 +95,7 @@ describe('OutboundLinkTagger', function () {
             });
             const url = new URL('https://example.com/?utm_source=hello');
             const updatedUrl = await service.addToUrl(url);
-            should(updatedUrl.toString()).equal('https://example.com/?utm_source=hello');
+            assert.equal(updatedUrl.toString(), 'https://example.com/?utm_source=hello');
         });
 
         it('does not add ref if ref is present', async function () {
@@ -105,7 +105,7 @@ describe('OutboundLinkTagger', function () {
             });
             const url = new URL('https://example.com/?ref=hello');
             const updatedUrl = await service.addToUrl(url);
-            should(updatedUrl.toString()).equal('https://example.com/?ref=hello');
+            assert.equal(updatedUrl.toString(), 'https://example.com/?ref=hello');
         });
 
         it('does not add ref if source is present', async function () {
@@ -115,7 +115,7 @@ describe('OutboundLinkTagger', function () {
             });
             const url = new URL('https://example.com/?source=hello');
             const updatedUrl = await service.addToUrl(url);
-            should(updatedUrl.toString()).equal('https://example.com/?source=hello');
+            assert.equal(updatedUrl.toString(), 'https://example.com/?source=hello');
         });
 
         it('does not add ref if the protocol is not http(s)', async function () {
@@ -126,7 +126,7 @@ describe('OutboundLinkTagger', function () {
             const urlStr = 'javascript:alert("Hello, World!")';
             const url = new URL(urlStr);
             const updatedUrl = await service.addToUrl(url);
-            should(updatedUrl.toString()).equal(urlStr);
+            assert.equal(updatedUrl.toString(), urlStr);
         });
     });
 

--- a/ghost/core/test/unit/server/services/member-attribution/service.test.js
+++ b/ghost/core/test/unit/server/services/member-attribution/service.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 
 const MemberAttributionService = require('../../../../../core/server/services/member-attribution/member-attribution-service');
@@ -244,8 +245,8 @@ describe('MemberAttributionService', function () {
 
             const result = service.addPostAttributionTracking(url, post);
 
-            should(result.searchParams.get('attribution_id')).equal('post_123');
-            should(result.searchParams.get('attribution_type')).equal('post');
+            assert.equal(result.searchParams.get('attribution_id'), 'post_123');
+            assert.equal(result.searchParams.get('attribution_type'), 'post');
         });
 
         it('does not overwrite existing attribution params', function () {
@@ -255,8 +256,8 @@ describe('MemberAttributionService', function () {
 
             const result = service.addPostAttributionTracking(url, post);
 
-            should(result.searchParams.get('attribution_id')).equal('existing');
-            should(result.searchParams.get('attribution_type')).equal('existing');
+            assert.equal(result.searchParams.get('attribution_id'), 'existing');
+            assert.equal(result.searchParams.get('attribution_type'), 'existing');
         });
     });
 

--- a/ghost/core/test/unit/shared/custom-theme-settings-cache/cache.test.js
+++ b/ghost/core/test/unit/shared/custom-theme-settings-cache/cache.test.js
@@ -59,7 +59,7 @@ describe('Cache', function () {
 
             const returned = cache.populate(settings1);
 
-            should(returned).equal(undefined);
+            assert.equal(returned, undefined);
         });
     });
 
@@ -86,13 +86,13 @@ describe('Cache', function () {
 
             cache.populate(settings);
 
-            should(cache.get('unknown')).equal(undefined);
+            assert.equal(cache.get('unknown'), undefined);
         });
 
         it('returns undefined when cache is empty', function () {
             const cache = new Cache();
 
-            should(cache.get('unknown')).equal(undefined);
+            assert.equal(cache.get('unknown'), undefined);
         });
     });
 


### PR DESCRIPTION
This test-only change should have no user impact.

All I did was run these three commands and then make sure `assert` was imported:

```sh
ast-grep \
    -p 'should($ACTUAL).eql(true)' \
    --rewrite 'assert.equal($ACTUAL, true)' \
    --update-all
```

```sh
ast-grep \
    -p "should(\$ACTUAL).eql('\$EXPECTED')" \
    --rewrite "assert.equal(\$ACTUAL, '\$EXPECTED')" \
    --update-all
```

```sh
ast-grep \
    -p 'should($ACTUAL).equal($EXPECTED)' \
    --rewrite 'assert.equal($ACTUAL, $EXPECTED)' \
    --update-all
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test assertions to use standardized assertion patterns across test suites for improved consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->