### PR TITLE
Added CTRF test reporting for E2E tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1187,6 +1187,14 @@ jobs:
           path: e2e/test-results
           retention-days: 7
 
+      - name: Upload CTRF report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ctrf-report-${{ matrix.shardIndex }}
+          path: e2e/ctrf-report.json
+          retention-days: 30
+
       - uses: tryghost/actions/actions/slack-build@main
         if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/main'
         with:
@@ -1230,6 +1238,58 @@ jobs:
           else
             echo "has_reports=false" >> $GITHUB_OUTPUT
           fi
+
+      - name: Download CTRF reports from GitHub Actions Artifacts
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          path: e2e/all-ctrf-reports
+          pattern: ctrf-report-*
+          merge-multiple: true
+
+      - name: Merge CTRF reports
+        id: ctrf
+        run: |
+          if [ -d "e2e/all-ctrf-reports" ] && [ -n "$(ls -A e2e/all-ctrf-reports 2>/dev/null)" ]; then
+            echo "has_ctrf=true" >> $GITHUB_OUTPUT
+            # Merge all CTRF JSON files into one
+            node -e "
+              const fs = require('fs');
+              const path = require('path');
+              const dir = 'e2e/all-ctrf-reports';
+              const files = fs.readdirSync(dir).filter(f => f.endsWith('.json'));
+              const merged = { results: { tool: { name: 'playwright' }, summary: { tests: 0, passed: 0, failed: 0, skipped: 0, pending: 0, other: 0 }, tests: [] }};
+              for (const file of files) {
+                const data = JSON.parse(fs.readFileSync(path.join(dir, file)));
+                if (data.results && data.results.tests) {
+                  merged.results.tests.push(...data.results.tests);
+                  merged.results.summary.tests += data.results.summary?.tests || 0;
+                  merged.results.summary.passed += data.results.summary?.passed || 0;
+                  merged.results.summary.failed += data.results.summary?.failed || 0;
+                  merged.results.summary.skipped += data.results.summary?.skipped || 0;
+                  merged.results.summary.pending += data.results.summary?.pending || 0;
+                  merged.results.summary.other += data.results.summary?.other || 0;
+                }
+              }
+              fs.writeFileSync('e2e/ctrf-report-merged.json', JSON.stringify(merged, null, 2));
+              console.log('Merged', files.length, 'CTRF reports:', merged.results.summary);
+            "
+          else
+            echo "has_ctrf=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Annotate failed tests
+        if: steps.ctrf.outputs.has_ctrf == 'true'
+        run: npx github-actions-ctrf e2e/ctrf-report-merged.json
+        continue-on-error: true
+
+      - name: Upload merged CTRF report
+        if: steps.ctrf.outputs.has_ctrf == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ctrf-report
+          path: e2e/ctrf-report-merged.json
+          retention-days: 30
 
       - name: Download test results from GitHub Actions Artifacts
         if: steps.check.outputs.has_reports == 'true'

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -31,16 +31,17 @@
     "@tryghost/debug": "0.1.35",
     "@tryghost/logging": "2.4.23",
     "@types/dockerode": "3.3.44",
-    "typescript-eslint": "8.49.0",
     "c8": "10.1.3",
     "dockerode": "4.0.9",
     "dotenv": "16.6.1",
-    "eslint-plugin-playwright": "2.5.0",
     "eslint-plugin-no-relative-import-paths": "^1.6.1",
+    "eslint-plugin-playwright": "2.5.0",
     "knex": "3.1.0",
     "mysql2": "3.15.2",
+    "playwright-ctrf-json-reporter": "^0.0.27",
     "ts-node": "10.9.2",
-    "typescript": "5.8.3"
+    "typescript": "5.8.3",
+    "typescript-eslint": "8.49.0"
   },
   "dependencies": {}
 }

--- a/e2e/playwright.config.mjs
+++ b/e2e/playwright.config.mjs
@@ -25,7 +25,13 @@ const config = {
     maxFailures: 1,
     workers: parseInt(process.env.TEST_WORKERS_COUNT, 10) || getWorkerCount(),
     fullyParallel: true,
-    reporter: process.env.CI ? [['list', {printSteps: true}], ['blob']] : [['list', {printSteps: true}], ['html']],
+    reporter: process.env.CI
+        ? [
+            ['list', {printSteps: true}],
+            ['blob'],
+            ['playwright-ctrf-json-reporter', {outputFile: 'ctrf-report.json'}]
+        ]
+        : [['list', {printSteps: true}], ['html']],
     use: {
         // Base URL will be set dynamically per test via fixture
         baseURL: process.env.GHOST_BASE_URL || 'http://localhost:2368',

--- a/e2e/playwright.config.mjs
+++ b/e2e/playwright.config.mjs
@@ -29,7 +29,7 @@ const config = {
         ? [
             ['list', {printSteps: true}],
             ['blob'],
-            ['playwright-ctrf-json-reporter', {outputFile: 'ctrf-report.json'}]
+            ['playwright-ctrf-json-reporter', {outputDir: '.', outputFile: 'ctrf-report.json'}]
         ]
         : [['list', {printSteps: true}], ['html']],
     use: {

--- a/e2e/tests/admin/ctrf-demo-failure.test.ts
+++ b/e2e/tests/admin/ctrf-demo-failure.test.ts
@@ -1,0 +1,26 @@
+import {expect, test} from '@/helpers/playwright/fixture';
+
+/**
+ * TEMPORARY TEST - DELETE AFTER CTRF DEMO
+ *
+ * This test intentionally fails to demonstrate CTRF reporting in CI.
+ * It should be deleted after verifying CTRF annotations work correctly.
+ */
+test.describe('Ghost Admin - CTRF Demo', () => {
+    test('this test intentionally fails to demo CTRF reporting', async ({page}) => {
+        // Navigate to admin
+        await page.goto('/ghost');
+
+        // This assertion will fail - the title won't contain this text
+        await expect(page).toHaveTitle(/CTRF Demo - This Will Fail/);
+    });
+
+    test('this test also fails with a different error message', async ({page}) => {
+        // Navigate to admin
+        await page.goto('/ghost');
+
+        // Look for an element that doesn't exist
+        const nonExistentElement = page.locator('[data-testid="ctrf-demo-element-does-not-exist"]');
+        await expect(nonExistentElement).toBeVisible({timeout: 5000});
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -8853,7 +8853,7 @@
   resolved "https://registry.yarnpkg.com/@tryghost/domain-events/-/domain-events-1.0.2.tgz#0d4b134a997802946f3615385a09b82c4904d8c7"
   integrity sha512-y2sam/cOhCDViWLzLFmGn7ZIwNpz7dTOK1zygxwVrojhwrORWPtbA9MSoVrT6zUF9IplOx53/MAgnE1CYXSfng==
 
-"@tryghost/elasticsearch@^3.0.24":
+"@tryghost/elasticsearch@^3.0.22", "@tryghost/elasticsearch@^3.0.24":
   version "3.0.24"
   resolved "https://registry.yarnpkg.com/@tryghost/elasticsearch/-/elasticsearch-3.0.24.tgz#291d51d6a6cc607fa860612dfc37098c4ebdedc4"
   integrity sha512-/ocoCYS74+Dc1qH9yJCgqHtOyxQMvwmY71MPAqhfLHAfa4vpsd8VJNa2EsO/rkLRsw+cmf8p/8ZILUXXnBOheg==
@@ -8883,7 +8883,15 @@
     focus-trap "^6.7.2"
     postcss-preset-env "^7.3.1"
 
-"@tryghost/errors@1.3.6", "@tryghost/errors@1.3.8", "@tryghost/errors@^1.2.26", "@tryghost/errors@^1.2.3", "@tryghost/errors@^1.3.7", "@tryghost/errors@^1.3.8":
+"@tryghost/errors@1.3.6":
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/@tryghost/errors/-/errors-1.3.6.tgz#b34993d03122a59f29bf7050a3c0bc90a23a7254"
+  integrity sha512-qxl6wF5tlhr646Earjmfcz3km6d+B0tzUmocyVu3tY8StI4pH8mLgzHDtkiTAls9ABPichBxZQe6a8PDcVJbFw==
+  dependencies:
+    "@stdlib/utils-copy" "^0.2.0"
+    uuid "^9.0.0"
+
+"@tryghost/errors@1.3.8", "@tryghost/errors@^1.2.26", "@tryghost/errors@^1.2.3", "@tryghost/errors@^1.3.8":
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/@tryghost/errors/-/errors-1.3.8.tgz#d4212b52e876360b4fa8e303ae13ef86f3e95846"
   integrity sha512-2+4ExAAWM0rFWC7FlzxQMzIvIEQKt/vQLxLyqJqCmAcJa4i2uqUPJHqd/X5BBRuSTuftgca7EAo7adESbHEkZw==
@@ -8931,7 +8939,7 @@
   resolved "https://registry.yarnpkg.com/@tryghost/http-cache-utils/-/http-cache-utils-0.1.20.tgz#5a513593a2d5d944389a88eb56a8614cd0599350"
   integrity sha512-8+GbDQ/xo97orv5UUYv2x92e3RovVurYoFcBY+e0IJlExgSxP7oOqskqgFfZVs5Hhwi+SpZs6gFw2cv1OlUY9g==
 
-"@tryghost/http-stream@^0.1.37":
+"@tryghost/http-stream@^0.1.34", "@tryghost/http-stream@^0.1.37":
   version "0.1.37"
   resolved "https://registry.yarnpkg.com/@tryghost/http-stream/-/http-stream-0.1.37.tgz#319f0c8691b75fc5949a1a9c866bd410f6c52f05"
   integrity sha512-QY9UhDrjHEdrlnnQaJ49kshdAU2pDCBHg6+QzyRVOIqvq+UHpydhhkxy3QDN1b+EII2DjpDMlOK1SSL9q6fXew==
@@ -9148,7 +9156,41 @@
     lodash "^4.17.21"
     luxon "^1.26.0"
 
-"@tryghost/logging@2.4.19", "@tryghost/logging@2.4.23", "@tryghost/logging@2.5.0", "@tryghost/logging@^2.4.23", "@tryghost/logging@^2.4.7":
+"@tryghost/logging@2.4.19":
+  version "2.4.19"
+  resolved "https://registry.yarnpkg.com/@tryghost/logging/-/logging-2.4.19.tgz#8aab372486268b6fc8e31615b6e79d59b299a44f"
+  integrity sha512-NCCElue4AqvfhLnJLjDDR1uXBXQwfDOuGZTSI9/relqj+cfxwezQuPGG66EkPEB29ZAdtnHLOqMJTF2k6/s/hw==
+  dependencies:
+    "@tryghost/bunyan-rotating-filestream" "^0.0.7"
+    "@tryghost/elasticsearch" "^3.0.22"
+    "@tryghost/http-stream" "^0.1.34"
+    "@tryghost/pretty-stream" "^0.1.27"
+    "@tryghost/root-utils" "^0.3.31"
+    bunyan "^1.8.15"
+    bunyan-loggly "^1.4.2"
+    fs-extra "^11.0.0"
+    gelf-stream "^1.1.1"
+    json-stringify-safe "^5.0.1"
+    lodash "^4.17.21"
+
+"@tryghost/logging@2.4.23":
+  version "2.4.23"
+  resolved "https://registry.yarnpkg.com/@tryghost/logging/-/logging-2.4.23.tgz#a2351b55c0d413e3f06ee41cbcfe7bbdff785972"
+  integrity sha512-xmindrXwW0zKvuxdTNkyK3TM1exPvgkqqSRXOdf8G1SDZpuvemWGlrllAFQuj2J/K4dy9CWcYl9GpM1wYaG1CQ==
+  dependencies:
+    "@tryghost/bunyan-rotating-filestream" "^0.0.7"
+    "@tryghost/elasticsearch" "^3.0.24"
+    "@tryghost/http-stream" "^0.1.37"
+    "@tryghost/pretty-stream" "^0.2.0"
+    "@tryghost/root-utils" "^0.3.33"
+    bunyan "^1.8.15"
+    bunyan-loggly "^1.4.2"
+    fs-extra "^11.0.0"
+    gelf-stream "^1.1.1"
+    json-stringify-safe "^5.0.1"
+    lodash "^4.17.21"
+
+"@tryghost/logging@2.5.0", "@tryghost/logging@^2.4.23", "@tryghost/logging@^2.4.7":
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/@tryghost/logging/-/logging-2.5.0.tgz#239fc3518cba48ff18794dfa24be44c5d2ba7a45"
   integrity sha512-fLPWNbghbdsUIH/7+CPmhT8l1MhZPI6za1Zm65rcwjGpaX+1Cr1ehcj22rMm91sl4A8AVe8vpYofRKM3UL8GIQ==
@@ -9272,6 +9314,15 @@
     chalk "^4.1.0"
     sywac "^1.3.0"
 
+"@tryghost/pretty-stream@^0.1.27":
+  version "0.1.29"
+  resolved "https://registry.yarnpkg.com/@tryghost/pretty-stream/-/pretty-stream-0.1.29.tgz#e0bbab7333a6cac38fdfa19d3da86aeaaded7f02"
+  integrity sha512-HByPoCd5R63bRg34wZ4D7bfCeBsLTP3gLCi5xVsOnETxB4GiHHo31/vm+kI8pZd7mnWMre3nnDdVR0Sf72U0eQ==
+  dependencies:
+    date-format "^4.0.14"
+    lodash "^4.17.21"
+    prettyjson "^1.2.5"
+
 "@tryghost/pretty-stream@^0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@tryghost/pretty-stream/-/pretty-stream-0.2.0.tgz#622e6c37a6a8f3f724e10e2980f51ec8efae96bc"
@@ -9318,7 +9369,7 @@
     got "13.0.0"
     lodash "^4.17.21"
 
-"@tryghost/root-utils@0.3.33", "@tryghost/root-utils@^0.3.24", "@tryghost/root-utils@^0.3.33":
+"@tryghost/root-utils@0.3.33", "@tryghost/root-utils@^0.3.24", "@tryghost/root-utils@^0.3.31", "@tryghost/root-utils@^0.3.33":
   version "0.3.33"
   resolved "https://registry.yarnpkg.com/@tryghost/root-utils/-/root-utils-0.3.33.tgz#208e3d15520131c2d4157c7e62fe74771a7a110f"
   integrity sha512-Gmc/TrKtiRT7PV9JOPoSZ7jAOl/jJDWJFKNaLZbDQaiJIBP5C6PucqEfRqGb2Ko/S9j73HzEEBu6B7+qZMvbBg==
@@ -22633,10 +22684,10 @@ iterator.prototype@^1.1.4:
     has-symbols "^1.1.0"
     set-function-name "^2.0.2"
 
-jackspeak@2.3.6, jackspeak@^3.1.2:
-  version "2.3.6"
-  resolved "https://registry.yarnpkg.com/jackspeak/-/jackspeak-2.3.6.tgz#647ecc472238aee4b06ac0e461acc21a8c505ca8"
-  integrity sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==
+jackspeak@^3.1.2:
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/jackspeak/-/jackspeak-3.4.3.tgz#8833a9d89ab4acde6188942bd1c53b6390ed5a8a"
+  integrity sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==
   dependencies:
     "@isaacs/cliui" "^8.0.2"
   optionalDependencies:
@@ -25686,17 +25737,34 @@ module-details-from-path@^1.0.3:
   resolved "https://registry.yarnpkg.com/module-details-from-path/-/module-details-from-path-1.0.4.tgz#b662fdcd93f6c83d3f25289da0ce81c8d9685b94"
   integrity sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==
 
-moment-timezone@0.5.45, moment-timezone@^0.5.23, moment-timezone@^0.5.31, moment-timezone@^0.5.33, moment-timezone@^0.5.48:
+moment-timezone@0.5.45, moment-timezone@^0.5.23, moment-timezone@^0.5.31, moment-timezone@^0.5.33:
   version "0.5.45"
   resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.45.tgz#cb685acd56bac10e69d93c536366eb65aa6bcf5c"
   integrity sha512-HIWmqA86KcmCAhnMAN0wuDOARV/525R2+lOLotuGFzn4HO+FH+/645z2wx0Dt3iDv6/p61SIvKnDstISainhLQ==
   dependencies:
     moment "^2.29.4"
 
-moment@2.24.0, moment@2.27.0, moment@2.30.1, moment@^2.10.2, moment@^2.18.1, moment@^2.19.3, moment@^2.27.0, moment@^2.29.4:
+moment-timezone@^0.5.48:
+  version "0.5.48"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.48.tgz#111727bb274734a518ae154b5ca589283f058967"
+  integrity sha512-f22b8LV1gbTO2ms2j2z13MuPogNoh5UzxL3nzNAYKGraILnbGc9NEE6dyiiiLv46DGRb8A4kg8UKWLjPthxBHw==
+  dependencies:
+    moment "^2.29.4"
+
+moment@2.24.0, moment@^2.10.2, moment@^2.18.1, moment@^2.19.3:
   version "2.24.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
   integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
+
+moment@2.27.0:
+  version "2.27.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.27.0.tgz#8bff4e3e26a236220dfe3e36de756b6ebaa0105d"
+  integrity sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ==
+
+moment@2.30.1, moment@^2.27.0, moment@^2.29.4:
+  version "2.30.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.30.1.tgz#f8c91c07b7a786e30c59926df530b4eac96974ae"
+  integrity sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==
 
 moo@^0.5.0, moo@^0.5.1:
   version "0.5.2"
@@ -26411,7 +26479,7 @@ numbered@^1.1.0:
   resolved "https://registry.yarnpkg.com/numbered/-/numbered-1.1.0.tgz#9fcd79564c73a84b9574e8370c3d8e58fe3c133c"
   integrity sha512-pv/ue2Odr7IfYOO0byC1KgBI10wo5YDauLhxY6/saNzAdAs0r1SotGCPzzCLNPL0xtrAwWRialLu23AAu9xO1g==
 
-nwsapi@2.2.12, nwsapi@^2.2.0, nwsapi@^2.2.10, nwsapi@^2.2.12:
+nwsapi@^2.2.0, nwsapi@^2.2.10, nwsapi@^2.2.12:
   version "2.2.12"
   resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.12.tgz#fb6af5c0ec35b27b4581eb3bbad34ec9e5c696f8"
   integrity sha512-qXDmcVlZV4XRtKFzddidpfVP4oMSGhga+xdMc25mv8kaLUHtgzCDhUxkrN8exkGdTlLNaXj7CV3GtON7zuGZ+w==
@@ -27426,6 +27494,11 @@ playwright-core@1.55.1:
   version "1.55.1"
   resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.55.1.tgz#5d3bb1846bc4289d364ea1a9dcb33f14545802e9"
   integrity sha512-Z6Mh9mkwX+zxSlHqdr5AOcJnfp+xUWLCt9uKV18fhzA8eyxUd8NUWzAjxUh55RZKSYwDGX0cfaySdhZJGMoJ+w==
+
+playwright-ctrf-json-reporter@^0.0.27:
+  version "0.0.27"
+  resolved "https://registry.yarnpkg.com/playwright-ctrf-json-reporter/-/playwright-ctrf-json-reporter-0.0.27.tgz#3fde61bdf7fc6dd38c747312347f343995a83dba"
+  integrity sha512-FZ8KadoHJc7xhf5XM0R9F8XBsTSm4vywa5/fhmeo2nZhN31UmapYwRfxaBsGk6AbsvGmft5G+MVmkBjTJZic/Q==
 
 playwright@1.55.1:
   version "1.55.1"


### PR DESCRIPTION
ref https://linear.app/ghost/issue/NY-1005/

- Added playwright-ctrf-json-reporter to e2e package
- Updated Playwright config to output CTRF JSON in CI
- Updated CI workflow to upload and merge CTRF reports
- Added github-actions-ctrf for test failure annotations
- Added temporary failing test to demo CTRF output (delete after verification)

This provides structured test result data for CI observability tooling and adds GitHub annotations for failed tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced CI to produce, collect, merge, and upload CTRF test reports across parallel shards for consolidated test visibility.
  * Added artifact management to include CTRF report files alongside existing test artifacts.
* **Tests**
  * Added end-to-end demo tests that generate CTRF output (intentionally failing to exercise CTRF reporting).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->