### PR TITLE
Fixed flaky Actions API test caused by fake timers

### DIFF
--- a/ghost/core/test/e2e-api/admin/actions.test.js
+++ b/ghost/core/test/e2e-api/admin/actions.test.js
@@ -23,7 +23,7 @@ describe('Actions API', function () {
     it('Can request actions for resource', async function () {
         let postUpdatedAt;
 
-        const clock = sinon.useFakeTimers();
+        const clock = sinon.useFakeTimers(Date.now());
 
         const res = await request
             .post(localUtils.API.getApiQuery('posts/'))


### PR DESCRIPTION
no ref

Using `sinon.useFakeTimers()` without arguments sets the system time to Unix epoch (1970), which causes @breejs/later to throw "Invalid start date" when Ghost's job scheduler calculates the next execution time. Passing `Date.now()` ensures scheduling uses a valid modern date.

This pattern is used in a few other files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Adjusted test infrastructure for improved timing baseline initialization.

---

**Note:** This release contains no user-facing changes. Updates are internal testing improvements only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->