### PR TITLE
Added .yarnrc with network retry configuration for CI resilience

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,2 @@
+network-retries 5
+network-timeout 300000

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,2 +1,1 @@
 network-retries 5
-network-timeout 300000


### PR DESCRIPTION
## Summary

- Added `.yarnrc` at the repo root with `network-retries 5`
- This configures yarn to retry failed HTTP requests up to 5 times (default was 0)
- Addresses transient 500/502 errors from `registry.yarnpkg.com` that have been causing intermittent CI failures (4 occurrences in the last 2 weeks)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single configuration change to Yarn install behavior; low likelihood of impacting production code, with minimal risk beyond slightly longer retries on persistent network failures.
> 
> **Overview**
> Improves CI/package install resilience by adding a root `.yarnrc` that sets `network-retries 5`, causing Yarn to retry transient network/registry failures during dependency fetches.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a7d9aab51c45a98e97b58c1ea016db75df4aad2c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package manager configuration to increase the maximum number of network retry attempts, improving reliability during package installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->