### PR TITLE
Replaced more Should.js calls with node:assert

### DIFF
--- a/ghost/core/test/e2e-api/admin/actions.test.js
+++ b/ghost/core/test/e2e-api/admin/actions.test.js
@@ -50,12 +50,12 @@ describe('Actions API', function () {
         localUtils.API.checkResponse(res2.body, 'actions');
         localUtils.API.checkResponse(res2.body.actions[0], 'action');
 
-        res2.body.actions.length.should.eql(1);
+        assert.equal(res2.body.actions.length, 1);
 
-        res2.body.actions[0].resource_type.should.eql('post');
-        res2.body.actions[0].actor_type.should.eql('user');
-        res2.body.actions[0].event.should.eql('added');
-        Object.keys(res2.body.actions[0].actor).length.should.eql(4);
+        assert.equal(res2.body.actions[0].resource_type, 'post');
+        assert.equal(res2.body.actions[0].actor_type, 'user');
+        assert.equal(res2.body.actions[0].event, 'added');
+        assert.equal(Object.keys(res2.body.actions[0].actor).length, 4);
         res2.body.actions[0].actor.id.should.eql(testUtils.DataGenerator.Content.users[0].id);
         res2.body.actions[0].actor.image.should.eql(testUtils.DataGenerator.Content.users[0].profile_image);
         res2.body.actions[0].actor.name.should.eql(testUtils.DataGenerator.Content.users[0].name);
@@ -88,12 +88,12 @@ describe('Actions API', function () {
         localUtils.API.checkResponse(res4.body, 'actions');
         localUtils.API.checkResponse(res4.body.actions[0], 'action');
 
-        res4.body.actions.length.should.eql(2);
+        assert.equal(res4.body.actions.length, 2);
 
-        res4.body.actions[0].resource_type.should.eql('post');
-        res4.body.actions[0].actor_type.should.eql('user');
-        res4.body.actions[0].event.should.eql('edited');
-        Object.keys(res4.body.actions[0].actor).length.should.eql(4);
+        assert.equal(res4.body.actions[0].resource_type, 'post');
+        assert.equal(res4.body.actions[0].actor_type, 'user');
+        assert.equal(res4.body.actions[0].event, 'edited');
+        assert.equal(Object.keys(res4.body.actions[0].actor).length, 4);
         res4.body.actions[0].actor.id.should.eql(testUtils.DataGenerator.Content.users[0].id);
         res4.body.actions[0].actor.image.should.eql(testUtils.DataGenerator.Content.users[0].profile_image);
         res4.body.actions[0].actor.name.should.eql(testUtils.DataGenerator.Content.users[0].name);
@@ -126,12 +126,12 @@ describe('Actions API', function () {
         localUtils.API.checkResponse(res5.body, 'actions');
         localUtils.API.checkResponse(res5.body.actions[0], 'action');
 
-        res5.body.actions.length.should.eql(3);
+        assert.equal(res5.body.actions.length, 3);
 
-        res5.body.actions[0].resource_type.should.eql('post');
-        res5.body.actions[0].actor_type.should.eql('integration');
-        res5.body.actions[0].event.should.eql('edited');
-        Object.keys(res5.body.actions[0].actor).length.should.eql(4);
+        assert.equal(res5.body.actions[0].resource_type, 'post');
+        assert.equal(res5.body.actions[0].actor_type, 'integration');
+        assert.equal(res5.body.actions[0].event, 'edited');
+        assert.equal(Object.keys(res5.body.actions[0].actor).length, 4);
         res5.body.actions[0].actor.id.should.eql(testUtils.DataGenerator.Content.integrations[0].id);
         assert.equal(res5.body.actions[0].actor.image, null);
         res5.body.actions[0].actor.name.should.eql(testUtils.DataGenerator.Content.integrations[0].name);

--- a/ghost/core/test/e2e-api/admin/email-previews.test.js
+++ b/ghost/core/test/e2e-api/admin/email-previews.test.js
@@ -249,15 +249,15 @@ describe('Email Preview API', function () {
                 .expectStatus(200)
                 .expect(({body}) => {
                     const html = body.email_previews[0].html;
-                    html.should.containEql(`${siteUrl}/content/images/feature.jpg`);
-                    html.should.containEql(`${siteUrl}/content/images/inline.jpg`);
-                    html.should.containEql(`${siteUrl}/content/images/gallery-1.jpg`);
-                    html.should.containEql(`${siteUrl}/content/images/video-thumb.jpg`);
-                    html.should.containEql(`${siteUrl}/content/images/audio-thumb.jpg`);
-                    html.should.containEql(`${siteUrl}/content/images/snippet-inline.jpg`);
-                    html.should.containEql(`${siteUrl}/content/images/snippet-video-thumb.jpg`);
-                    html.should.containEql(`${siteUrl}/content/images/snippet-audio-thumb.jpg`);
-                    html.should.not.containEql('__GHOST_URL__');
+                    assert(html.includes(`${siteUrl}/content/images/feature.jpg`));
+                    assert(html.includes(`${siteUrl}/content/images/inline.jpg`));
+                    assert(html.includes(`${siteUrl}/content/images/gallery-1.jpg`));
+                    assert(html.includes(`${siteUrl}/content/images/video-thumb.jpg`));
+                    assert(html.includes(`${siteUrl}/content/images/audio-thumb.jpg`));
+                    assert(html.includes(`${siteUrl}/content/images/snippet-inline.jpg`));
+                    assert(html.includes(`${siteUrl}/content/images/snippet-video-thumb.jpg`));
+                    assert(html.includes(`${siteUrl}/content/images/snippet-audio-thumb.jpg`));
+                    assert(!html.includes('__GHOST_URL__'));
                 });
         });
 
@@ -270,15 +270,15 @@ describe('Email Preview API', function () {
                 .expectStatus(200)
                 .expect(({body}) => {
                     const html = body.email_previews[0].html;
-                    html.should.containEql(`${siteUrl}/content/images/feature.jpg`);
-                    html.should.containEql(`${siteUrl}/content/images/inline.jpg`);
-                    html.should.containEql(`${siteUrl}/content/images/gallery-1.jpg`);
-                    html.should.containEql(`${siteUrl}/content/images/video-thumb.jpg`);
-                    html.should.containEql(`${siteUrl}/content/images/audio-thumb.jpg`);
-                    html.should.containEql(`${siteUrl}/content/images/snippet-inline.jpg`);
-                    html.should.containEql(`${siteUrl}/content/images/snippet-video-thumb.jpg`);
-                    html.should.containEql(`${siteUrl}/content/images/snippet-audio-thumb.jpg`);
-                    html.should.not.containEql('__GHOST_URL__');
+                    assert(html.includes(`${siteUrl}/content/images/feature.jpg`));
+                    assert(html.includes(`${siteUrl}/content/images/inline.jpg`));
+                    assert(html.includes(`${siteUrl}/content/images/gallery-1.jpg`));
+                    assert(html.includes(`${siteUrl}/content/images/video-thumb.jpg`));
+                    assert(html.includes(`${siteUrl}/content/images/audio-thumb.jpg`));
+                    assert(html.includes(`${siteUrl}/content/images/snippet-inline.jpg`));
+                    assert(html.includes(`${siteUrl}/content/images/snippet-video-thumb.jpg`));
+                    assert(html.includes(`${siteUrl}/content/images/snippet-audio-thumb.jpg`));
+                    assert(!html.includes('__GHOST_URL__'));
                 });
         });
 
@@ -296,15 +296,15 @@ describe('Email Preview API', function () {
                 .expectStatus(200)
                 .expect(({body}) => {
                     const html = body.email_previews[0].html;
-                    html.should.containEql(`${siteUrl}/content/images/feature.jpg`);
-                    html.should.containEql(`${siteUrl}/content/images/inline.jpg`);
-                    html.should.containEql(`${siteUrl}/content/images/gallery-1.jpg`);
-                    html.should.containEql(`${siteUrl}/content/images/video-thumb.jpg`);
-                    html.should.containEql(`${siteUrl}/content/images/audio-thumb.jpg`);
-                    html.should.containEql(`${siteUrl}/content/images/snippet-inline.jpg`);
-                    html.should.containEql(`${siteUrl}/content/images/snippet-video-thumb.jpg`);
-                    html.should.containEql(`${siteUrl}/content/images/snippet-audio-thumb.jpg`);
-                    html.should.not.containEql('__GHOST_URL__');
+                    assert(html.includes(`${siteUrl}/content/images/feature.jpg`));
+                    assert(html.includes(`${siteUrl}/content/images/inline.jpg`));
+                    assert(html.includes(`${siteUrl}/content/images/gallery-1.jpg`));
+                    assert(html.includes(`${siteUrl}/content/images/video-thumb.jpg`));
+                    assert(html.includes(`${siteUrl}/content/images/audio-thumb.jpg`));
+                    assert(html.includes(`${siteUrl}/content/images/snippet-inline.jpg`));
+                    assert(html.includes(`${siteUrl}/content/images/snippet-video-thumb.jpg`));
+                    assert(html.includes(`${siteUrl}/content/images/snippet-audio-thumb.jpg`));
+                    assert(!html.includes('__GHOST_URL__'));
                 });
         });
 
@@ -322,15 +322,15 @@ describe('Email Preview API', function () {
                 .expectStatus(200)
                 .expect(({body}) => {
                     const html = body.email_previews[0].html;
-                    html.should.containEql(`${siteUrl}/content/images/feature.jpg`);
-                    html.should.containEql(`${siteUrl}/content/images/inline.jpg`);
-                    html.should.containEql(`${siteUrl}/content/images/gallery-1.jpg`);
-                    html.should.containEql(`${siteUrl}/content/images/video-thumb.jpg`);
-                    html.should.containEql(`${siteUrl}/content/images/audio-thumb.jpg`);
-                    html.should.containEql(`${siteUrl}/content/images/snippet-inline.jpg`);
-                    html.should.containEql(`${siteUrl}/content/images/snippet-video-thumb.jpg`);
-                    html.should.containEql(`${siteUrl}/content/images/snippet-audio-thumb.jpg`);
-                    html.should.not.containEql('__GHOST_URL__');
+                    assert(html.includes(`${siteUrl}/content/images/feature.jpg`));
+                    assert(html.includes(`${siteUrl}/content/images/inline.jpg`));
+                    assert(html.includes(`${siteUrl}/content/images/gallery-1.jpg`));
+                    assert(html.includes(`${siteUrl}/content/images/video-thumb.jpg`));
+                    assert(html.includes(`${siteUrl}/content/images/audio-thumb.jpg`));
+                    assert(html.includes(`${siteUrl}/content/images/snippet-inline.jpg`));
+                    assert(html.includes(`${siteUrl}/content/images/snippet-video-thumb.jpg`));
+                    assert(html.includes(`${siteUrl}/content/images/snippet-audio-thumb.jpg`));
+                    assert(!html.includes('__GHOST_URL__'));
                 });
         });
     });

--- a/ghost/core/test/e2e-api/admin/files.test.js
+++ b/ghost/core/test/e2e-api/admin/files.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const path = require('path');
 const fs = require('fs-extra');
 const should = require('should');
@@ -29,8 +30,8 @@ describe('Files API', function () {
             .attach('file', path.join(__dirname, '/../../utils/fixtures/images/loadingcat_square.gif'))
             .expect(201);
 
-        res.body.files[0].url.should.match(new RegExp(`${config.get('url')}/content/files/\\d+/\\d+/loadingcat_square.gif`));
-        res.body.files[0].ref.should.equal('934203942');
+        assert.match(res.body.files[0].url, new RegExp(`${config.get('url')}/content/files/\\d+/\\d+/loadingcat_square.gif`));
+        assert.equal(res.body.files[0].ref, '934203942');
 
         files.push(res.body.files[0].url.replace(config.get('url'), ''));
     });

--- a/ghost/core/test/e2e-api/admin/integrations.test.js
+++ b/ghost/core/test/e2e-api/admin/integrations.test.js
@@ -81,7 +81,7 @@ describe('Integrations API', function () {
         should.exist(id);
         assert.equal(id, adminApiKey.id);
         should.exist(secret);
-        secret.length.should.equal(64);
+        assert.equal(secret.length, 64);
 
         should.exist(res.headers.location);
         res.headers.location.should.equal(`http://127.0.0.1:2369${localUtils.API.getApiQuery('integrations/')}${res.body.integrations[0].id}/`);
@@ -362,7 +362,7 @@ describe('Integrations API', function () {
             .set('Origin', config.get('url'))
             .expect(404);
 
-        editRes.body.errors[0].context.should.eql('Integration not found.');
+        assert.equal(editRes.body.errors[0].context, 'Integration not found.');
     });
 
     describe('As Administrator', function () {

--- a/ghost/core/test/e2e-api/admin/invites.test.js
+++ b/ghost/core/test/e2e-api/admin/invites.test.js
@@ -36,20 +36,20 @@ describe('Invites API', function () {
             const jsonResponse = res.body;
             should.exist(jsonResponse);
             should.exist(jsonResponse.invites);
-            jsonResponse.invites.should.have.length(2);
+            assert.equal(jsonResponse.invites.length, 2);
 
             localUtils.API.checkResponse(jsonResponse, 'invites');
             localUtils.API.checkResponse(jsonResponse.invites[0], 'invite');
 
-            jsonResponse.invites[0].status.should.eql('sent');
-            jsonResponse.invites[0].email.should.eql('test1@ghost.org');
+            assert.equal(jsonResponse.invites[0].status, 'sent');
+            assert.equal(jsonResponse.invites[0].email, 'test1@ghost.org');
             jsonResponse.invites[0].role_id.should.eql(testUtils.roles.ids.admin);
 
-            jsonResponse.invites[1].status.should.eql('sent');
-            jsonResponse.invites[1].email.should.eql('test2@ghost.org');
+            assert.equal(jsonResponse.invites[1].status, 'sent');
+            assert.equal(jsonResponse.invites[1].email, 'test2@ghost.org');
             jsonResponse.invites[1].role_id.should.eql(testUtils.roles.ids.author);
 
-            mailService.GhostMailer.prototype.send.called.should.be.false();
+            assert.equal(mailService.GhostMailer.prototype.send.called, false);
         });
 
         it('Can read an invitation by id', async function () {
@@ -63,11 +63,11 @@ describe('Invites API', function () {
             const jsonResponse = res.body;
             should.exist(jsonResponse);
             should.exist(jsonResponse.invites);
-            jsonResponse.invites.should.have.length(1);
+            assert.equal(jsonResponse.invites.length, 1);
 
             localUtils.API.checkResponse(jsonResponse.invites[0], 'invite');
 
-            mailService.GhostMailer.prototype.send.called.should.be.false();
+            assert.equal(mailService.GhostMailer.prototype.send.called, false);
         });
 
         it('Can add a new invite', async function () {
@@ -85,12 +85,12 @@ describe('Invites API', function () {
             const jsonResponse = res.body;
             should.exist(jsonResponse);
             should.exist(jsonResponse.invites);
-            jsonResponse.invites.should.have.length(1);
+            assert.equal(jsonResponse.invites.length, 1);
 
             localUtils.API.checkResponse(jsonResponse.invites[0], 'invite');
             jsonResponse.invites[0].role_id.should.eql(testUtils.getExistingData().roles[1].id);
 
-            mailService.GhostMailer.prototype.send.called.should.be.true();
+            assert.equal(mailService.GhostMailer.prototype.send.called, true);
 
             should.exist(res.headers.location);
             res.headers.location.should.equal(`http://127.0.0.1:2369${localUtils.API.getApiQuery('invites/')}${res.body.invites[0].id}/`);
@@ -102,7 +102,7 @@ describe('Invites API', function () {
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(204);
 
-            mailService.GhostMailer.prototype.send.called.should.be.false();
+            assert.equal(mailService.GhostMailer.prototype.send.called, false);
         });
 
         it('Cannot destroy an non-existent invite', async function () {
@@ -111,10 +111,10 @@ describe('Invites API', function () {
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(404)
                 .expect((res) => {
-                    res.body.errors[0].message.should.eql('Resource not found error, cannot delete invite.');
+                    assert.equal(res.body.errors[0].message, 'Resource not found error, cannot delete invite.');
                 });
 
-            mailService.GhostMailer.prototype.send.called.should.be.false();
+            assert.equal(mailService.GhostMailer.prototype.send.called, false);
         });
     });
     
@@ -149,12 +149,12 @@ describe('Invites API', function () {
             const jsonResponse = res.body;
             should.exist(jsonResponse);
             should.exist(jsonResponse.invites);
-            jsonResponse.invites.should.have.length(1);
+            assert.equal(jsonResponse.invites.length, 1);
 
             localUtils.API.checkResponse(jsonResponse.invites[0], 'invite');
             jsonResponse.invites[0].role_id.should.eql(roleId);
 
-            mailService.GhostMailer.prototype.send.called.should.be.true();
+            assert.equal(mailService.GhostMailer.prototype.send.called, true);
 
             should.exist(res.headers.location);
             res.headers.location.should.equal(`http://127.0.0.1:2369${localUtils.API.getApiQuery('invites/')}${res.body.invites[0].id}/`);
@@ -176,12 +176,12 @@ describe('Invites API', function () {
             const jsonResponse = res.body;
             should.exist(jsonResponse);
             should.exist(jsonResponse.invites);
-            jsonResponse.invites.should.have.length(1);
+            assert.equal(jsonResponse.invites.length, 1);
 
             localUtils.API.checkResponse(jsonResponse.invites[0], 'invite');
             jsonResponse.invites[0].role_id.should.eql(roleId);
 
-            mailService.GhostMailer.prototype.send.called.should.be.true();
+            assert.equal(mailService.GhostMailer.prototype.send.called, true);
 
             should.exist(res.headers.location);
             res.headers.location.should.equal(`http://127.0.0.1:2369${localUtils.API.getApiQuery('invites/')}${res.body.invites[0].id}/`);
@@ -203,12 +203,12 @@ describe('Invites API', function () {
             const jsonResponse = res.body;
             should.exist(jsonResponse);
             should.exist(jsonResponse.invites);
-            jsonResponse.invites.should.have.length(1);
+            assert.equal(jsonResponse.invites.length, 1);
 
             localUtils.API.checkResponse(jsonResponse.invites[0], 'invite');
             jsonResponse.invites[0].role_id.should.eql(roleId);
 
-            mailService.GhostMailer.prototype.send.called.should.be.true();
+            assert.equal(mailService.GhostMailer.prototype.send.called, true);
 
             should.exist(res.headers.location);
             res.headers.location.should.equal(`http://127.0.0.1:2369${localUtils.API.getApiQuery('invites/')}${res.body.invites[0].id}/`);
@@ -230,12 +230,12 @@ describe('Invites API', function () {
             const jsonResponse = res.body;
             should.exist(jsonResponse);
             should.exist(jsonResponse.invites);
-            jsonResponse.invites.should.have.length(1);
+            assert.equal(jsonResponse.invites.length, 1);
 
             localUtils.API.checkResponse(jsonResponse.invites[0], 'invite');
             jsonResponse.invites[0].role_id.should.eql(roleId);
 
-            mailService.GhostMailer.prototype.send.called.should.be.true();
+            assert.equal(mailService.GhostMailer.prototype.send.called, true);
 
             should.exist(res.headers.location);
             res.headers.location.should.equal(`http://127.0.0.1:2369${localUtils.API.getApiQuery('invites/')}${res.body.invites[0].id}/`);

--- a/ghost/core/test/e2e-api/admin/key-authentication.test.js
+++ b/ghost/core/test/e2e-api/admin/key-authentication.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const supertest = require('supertest');
 const testUtils = require('../../utils');
@@ -75,7 +76,7 @@ describe('Admin API key authentication', function () {
             .expect(201);
 
         // falls back to owner user
-        res.body.posts[0].authors.length.should.eql(1);
+        assert.equal(res.body.posts[0].authors.length, 1);
     });
 
     it('Can read users', async function () {
@@ -116,8 +117,8 @@ describe('Admin API key authentication', function () {
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(403);
 
-            firstResponse.body.errors[0].type.should.equal('HostLimitError');
-            firstResponse.body.errors[0].message.should.equal('Custom limit error message');
+            assert.equal(firstResponse.body.errors[0].type, 'HostLimitError');
+            assert.equal(firstResponse.body.errors[0].message, 'Custom limit error message');
             sinon.assert.calledOnce(loggingStub);
 
             // CASE: Test with a different API key, related to a core integration

--- a/ghost/core/test/e2e-api/admin/max-limit-cap.test.js
+++ b/ghost/core/test/e2e-api/admin/max-limit-cap.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const {agentProvider, fixtureManager} = require('../../utils/e2e-framework');
 const should = require('should');
 const sinon = require('sinon');
@@ -204,8 +205,8 @@ describe('Admin API - Max Limit Cap', function () {
             const {body} = await agent.get('posts/?limit=3')
                 .expectStatus(200);
 
-            body.posts.length.should.equal(3);
-            body.meta.pagination.limit.should.equal(3);
+            assert.equal(body.posts.length, 3);
+            assert.equal(body.meta.pagination.limit, 3);
         });
 
         it('should allow large limits for export endpoint', async function () {
@@ -272,8 +273,8 @@ describe('Admin API - Max Limit Cap', function () {
                 .expectStatus(200);
 
             // Exception endpoint should return all 10 batches
-            batchesBody.batches.length.should.equal(10);
-            batchesBody.meta.pagination.limit.should.equal(10);
+            assert.equal(batchesBody.batches.length, 10);
+            assert.equal(batchesBody.meta.pagination.limit, 10);
         });
 
         it('should bypass limit cap for emails recipient-failures endpoint', async function () {
@@ -286,8 +287,8 @@ describe('Admin API - Max Limit Cap', function () {
                 .expectStatus(200);
 
             // Exception endpoint should return all 10 failures
-            failuresBody.failures.length.should.equal(10);
-            failuresBody.meta.pagination.limit.should.equal(10);
+            assert.equal(failuresBody.failures.length, 10);
+            assert.equal(failuresBody.meta.pagination.limit, 10);
         });
 
         it('should allow "all" for exception endpoints', async function () {
@@ -300,16 +301,16 @@ describe('Admin API - Max Limit Cap', function () {
                 .expectStatus(200);
 
             // Should return all batches (10)
-            batchesBody.batches.length.should.equal(10);
-            batchesBody.meta.pagination.limit.should.equal('all');
+            assert.equal(batchesBody.batches.length, 10);
+            assert.equal(batchesBody.meta.pagination.limit, 'all');
 
             // Test failures with limit=all
             const {body: failuresBody} = await agent.get(`emails/${testEmail.id}/recipient-failures/?limit=all`)
                 .expectStatus(200);
 
             // Should return all failures (10)
-            failuresBody.failures.length.should.equal(10);
-            failuresBody.meta.pagination.limit.should.equal('all');
+            assert.equal(failuresBody.failures.length, 10);
+            assert.equal(failuresBody.meta.pagination.limit, 'all');
         });
     });
 

--- a/ghost/core/test/e2e-api/admin/media.test.js
+++ b/ghost/core/test/e2e-api/admin/media.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const path = require('path');
 const fs = require('fs-extra');
 const should = require('should');
@@ -38,9 +39,9 @@ describe('Media API', function () {
                 .attach('thumbnail', path.join(__dirname, '/../../utils/fixtures/images/ghost-logo.png'))
                 .expect(201);
 
-            res.body.media[0].url.should.match(new RegExp(`${config.get('url')}/content/media/\\d+/\\d+/sample_640x360.mp4`));
-            res.body.media[0].thumbnail_url.should.match(new RegExp(`${config.get('url')}/content/media/\\d+/\\d+/sample_640x360_thumb.png`));
-            res.body.media[0].ref.should.equal('https://ghost.org/sample_640x360.mp4');
+            assert.match(res.body.media[0].url, new RegExp(`${config.get('url')}/content/media/\\d+/\\d+/sample_640x360.mp4`));
+            assert.match(res.body.media[0].thumbnail_url, new RegExp(`${config.get('url')}/content/media/\\d+/\\d+/sample_640x360_thumb.png`));
+            assert.equal(res.body.media[0].ref, 'https://ghost.org/sample_640x360.mp4');
 
             media.push(res.body.media[0].url.replace(config.get('url'), ''));
             media.push(res.body.media[0].thumbnail_url.replace(config.get('url'), ''));
@@ -54,9 +55,9 @@ describe('Media API', function () {
                 .attach('file', path.join(__dirname, '/../../utils/fixtures/media/sample_640x360.webm'))
                 .expect(201);
 
-            res.body.media[0].url.should.match(new RegExp(`${config.get('url')}/content/media/\\d+/\\d+/sample_640x360.webm`));
-            should(res.body.media[0].thumbnail_url).eql(null);
-            res.body.media[0].ref.should.equal('https://ghost.org/sample_640x360.webm');
+            assert.match(res.body.media[0].url, new RegExp(`${config.get('url')}/content/media/\\d+/\\d+/sample_640x360.webm`));
+            assert.equal(res.body.media[0].thumbnail_url, null);
+            assert.equal(res.body.media[0].ref, 'https://ghost.org/sample_640x360.webm');
 
             media.push(res.body.media[0].url.replace(config.get('url'), ''));
         });
@@ -70,8 +71,8 @@ describe('Media API', function () {
                 .attach('thumbnail', path.join(__dirname, '/../../utils/fixtures/images/ghost-logo.png'))
                 .expect(201);
 
-            res.body.media[0].url.should.match(new RegExp(`${config.get('url')}/content/media/\\d+/\\d+/sample_640x360.ogv`));
-            res.body.media[0].ref.should.equal('https://ghost.org/sample_640x360.ogv');
+            assert.match(res.body.media[0].url, new RegExp(`${config.get('url')}/content/media/\\d+/\\d+/sample_640x360.ogv`));
+            assert.equal(res.body.media[0].ref, 'https://ghost.org/sample_640x360.ogv');
 
             media.push(res.body.media[0].url.replace(config.get('url'), ''));
         });
@@ -84,8 +85,8 @@ describe('Media API', function () {
                 .attach('file', path.join(__dirname, '/../../utils/fixtures/media/sample.mp3'))
                 .expect(201);
 
-            res.body.media[0].url.should.match(new RegExp(`${config.get('url')}/content/media/\\d+/\\d+/sample.mp3`));
-            res.body.media[0].ref.should.equal('audio_file_123');
+            assert.match(res.body.media[0].url, new RegExp(`${config.get('url')}/content/media/\\d+/\\d+/sample.mp3`));
+            assert.equal(res.body.media[0].ref, 'audio_file_123');
 
             media.push(res.body.media[0].url.replace(config.get('url'), ''));
         });
@@ -98,8 +99,8 @@ describe('Media API', function () {
                 .attach('file', path.join(__dirname, '/../../utils/fixtures/media/sample.m4a'), {filename: 'audio-mp4.m4a', contentType: 'audio/mp4'})
                 .expect(201);
 
-            res.body.media[0].url.should.match(new RegExp(`${config.get('url')}/content/media/\\d+/\\d+/audio-mp4.m4a`));
-            res.body.media[0].ref.should.equal('audio_file_mp4');
+            assert.match(res.body.media[0].url, new RegExp(`${config.get('url')}/content/media/\\d+/\\d+/audio-mp4.m4a`));
+            assert.equal(res.body.media[0].ref, 'audio_file_mp4');
 
             media.push(res.body.media[0].url.replace(config.get('url'), ''));
         });
@@ -112,8 +113,8 @@ describe('Media API', function () {
                 .attach('file', path.join(__dirname, '/../../utils/fixtures/media/sample.m4a'), {filename: 'audio-x-m4a.m4a', contentType: 'audio/x-m4a'})
                 .expect(201);
 
-            res.body.media[0].url.should.match(new RegExp(`${config.get('url')}/content/media/\\d+/\\d+/audio-x-m4a.m4a`));
-            res.body.media[0].ref.should.equal('audio_file_x_m4a');
+            assert.match(res.body.media[0].url, new RegExp(`${config.get('url')}/content/media/\\d+/\\d+/audio-x-m4a.m4a`));
+            assert.equal(res.body.media[0].ref, 'audio_file_x_m4a');
 
             media.push(res.body.media[0].url.replace(config.get('url'), ''));
         });
@@ -127,7 +128,7 @@ describe('Media API', function () {
                 .attach('thumbnail', path.join(__dirname, '/../../utils/fixtures/images/ghost-logo.png'))
                 .expect(415);
 
-            res.body.errors[0].message.should.match(/select a valid media file/gi);
+            assert.match(res.body.errors[0].message, /select a valid media file/gi);
             sinon.assert.calledOnce(loggingStub);
         });
 
@@ -150,7 +151,7 @@ describe('Media API', function () {
                 .send(brokenDataBlob)
                 .expect(400);
 
-            res.body.errors[0].message.should.match(/The request could not be understood./gi);
+            assert.match(res.body.errors[0].message, /The request could not be understood./gi);
         });
 
         it('Errors when media request body is broken #2', async function () {
@@ -174,7 +175,7 @@ describe('Media API', function () {
                 .send(brokenDataBlob)
                 .expect(400);
 
-            res.body.errors[0].message.should.match(/The request could not be understood./gi);
+            assert.match(res.body.errors[0].message, /The request could not be understood./gi);
         });
     });
 
@@ -188,7 +189,7 @@ describe('Media API', function () {
                 .attach('thumbnail', path.join(__dirname, '/../../utils/fixtures/images/ghost-logo.png'))
                 .expect(201);
 
-            res.body.media[0].ref.should.equal('https://ghost.org/sample_640x360.mp4');
+            assert.equal(res.body.media[0].ref, 'https://ghost.org/sample_640x360.mp4');
 
             media.push(res.body.media[0].url.replace(config.get('url'), ''));
             media.push(res.body.media[0].thumbnail_url.replace(config.get('url'), ''));
@@ -203,7 +204,7 @@ describe('Media API', function () {
 
             const thumbnailUrl = res.body.media[0].url.replace('.mp4', '_thumb.jpg');
             thumbnailRes.body.media[0].url.should.equal(thumbnailUrl);
-            thumbnailRes.body.media[0].ref.should.equal('updated_thumbnail');
+            assert.equal(thumbnailRes.body.media[0].ref, 'updated_thumbnail');
             media.push(thumbnailRes.body.media[0].url.replace(config.get('url'), ''));
         });
 
@@ -227,7 +228,7 @@ describe('Media API', function () {
 
             const thumbnailUrl = res.body.media[0].url.replace('.mp4', '_thumb.jpg');
             thumbnailRes.body.media[0].url.should.equal(thumbnailUrl);
-            thumbnailRes.body.media[0].ref.should.equal('updated_thumbnail_2');
+            assert.equal(thumbnailRes.body.media[0].ref, 'updated_thumbnail_2');
 
             media.push(thumbnailRes.body.media[0].url.replace(config.get('url'), ''));
         });

--- a/ghost/core/test/e2e-api/admin/members-exporter.test.js
+++ b/ghost/core/test/e2e-api/admin/members-exporter.test.js
@@ -28,7 +28,7 @@ function basicAsserts(member, row) {
     should(row.name).eql(member.get('name'));
     should(row.note).eql(member.get('note') || '');
 
-    should(row.deleted_at).eql('');
+    assert.equal(row.deleted_at, '');
     should(row.created_at).eql(moment(member.get('created_at')).toISOString());
 }
 
@@ -52,7 +52,7 @@ async function testOutput(member, asserts, filters = []) {
                 'content-disposition': anyString
             });
 
-        res.text.should.match(/id,email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,tiers/);
+        assert.match(res.text, /id,email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,tiers/);
 
         let csv = Papa.parse(res.text, {header: true});
         let row = csv.data.find(r => r.id === member.id);
@@ -61,7 +61,7 @@ async function testOutput(member, asserts, filters = []) {
         asserts(row);
 
         if (filter === `filter=id:'${member.id}'`) {
-            csv.data.length.should.eql(1);
+            assert.equal(csv.data.length, 1);
         }
     }
 }
@@ -118,7 +118,7 @@ describe('Members API — exportCSV', function () {
         await testOutput(member, (row) => {
             basicAsserts(member, row);
             assert.equal(row.subscribed_to_emails, 'false');
-            should(row.complimentary_plan).eql('');
+            assert.equal(row.complimentary_plan, '');
             should(row.tiers.split(',').sort().join(',')).eql(tiersList);
         }, [`filter=tier:[${tiers[0].get('slug')}]`, 'filter=subscribed:false']);
     });
@@ -133,8 +133,8 @@ describe('Members API — exportCSV', function () {
         await testOutput(member, (row) => {
             basicAsserts(member, row);
             assert.equal(row.subscribed_to_emails, 'false');
-            should(row.complimentary_plan).eql('');
-            should(row.tiers).eql('');
+            assert.equal(row.complimentary_plan, '');
+            assert.equal(row.tiers, '');
         }, ['filter=subscribed:false']);
     });
 
@@ -155,9 +155,9 @@ describe('Members API — exportCSV', function () {
         await testOutput(member, (row) => {
             basicAsserts(member, row);
             assert.equal(row.subscribed_to_emails, 'false');
-            should(row.complimentary_plan).eql('');
+            assert.equal(row.complimentary_plan, '');
             should(row.labels.split(',').sort().join(',')).eql(labelsList);
-            should(row.tiers).eql('');
+            assert.equal(row.tiers, '');
         }, [`filter=label:${labels[0].get('slug')}`, 'filter=subscribed:false']);
     });
 
@@ -173,8 +173,8 @@ describe('Members API — exportCSV', function () {
             basicAsserts(member, row);
             assert.equal(row.subscribed_to_emails, 'false');
             assert.equal(row.complimentary_plan, 'true');
-            should(row.labels).eql('');
-            should(row.tiers).eql('');
+            assert.equal(row.labels, '');
+            assert.equal(row.tiers, '');
         }, ['filter=status:comped', 'filter=subscribed:false']);
     });
 
@@ -191,9 +191,9 @@ describe('Members API — exportCSV', function () {
         await testOutput(member, (row) => {
             basicAsserts(member, row);
             assert.equal(row.subscribed_to_emails, 'true');
-            should(row.complimentary_plan).eql('');
-            should(row.labels).eql('');
-            should(row.tiers).eql('');
+            assert.equal(row.complimentary_plan, '');
+            assert.equal(row.labels, '');
+            assert.equal(row.tiers, '');
         }, ['filter=subscribed:true']);
     });
 
@@ -230,9 +230,9 @@ describe('Members API — exportCSV', function () {
         await testOutput(member, (row) => {
             basicAsserts(member, row);
             assert.equal(row.subscribed_to_emails, 'false');
-            should(row.complimentary_plan).eql('');
-            should(row.labels).eql('');
-            should(row.tiers).eql('');
+            assert.equal(row.complimentary_plan, '');
+            assert.equal(row.labels, '');
+            assert.equal(row.tiers, '');
             assert.equal(row.stripe_customer_id, 'cus_12345');
         }, ['filter=subscribed:false', 'filter=subscriptions.subscription_id:sub_123']);
     });

--- a/ghost/core/test/e2e-api/admin/members-importer.test.js
+++ b/ghost/core/test/e2e-api/admin/members-importer.test.js
@@ -49,9 +49,9 @@ describe('Members Importer API', function () {
         should.exist(jsonResponse.meta);
         should.exist(jsonResponse.meta.stats);
 
-        jsonResponse.meta.stats.imported.should.equal(2);
-        jsonResponse.meta.stats.invalid.length.should.equal(0);
-        jsonResponse.meta.import_label.name.should.match(/^Import \d{4}-\d{2}-\d{2} \d{2}:\d{2}$/);
+        assert.equal(jsonResponse.meta.stats.imported, 2);
+        assert.equal(jsonResponse.meta.stats.invalid.length, 0);
+        assert.match(jsonResponse.meta.import_label.name, /^Import \d{4}-\d{2}-\d{2} \d{2}:\d{2}$/);
 
         const importLabel = jsonResponse.meta.import_label;
 
@@ -65,32 +65,32 @@ describe('Members Importer API', function () {
         const jsonResponse2 = res2.body;
         should.exist(jsonResponse2);
         should.exist(jsonResponse2.members);
-        jsonResponse2.members.should.have.length(2);
+        assert.equal(jsonResponse2.members.length, 2);
 
         const importedMember1 = jsonResponse2.members.find(m => m.email === 'jbloggs@example.com');
         should.exist(importedMember1);
-        importedMember1.name.should.equal('joe');
+        assert.equal(importedMember1.name, 'joe');
         assert.equal(importedMember1.note, null);
-        importedMember1.subscribed.should.equal(true);
+        assert.equal(importedMember1.subscribed, true);
         importedMember1.newsletters.length.should.equal(filteredNewsletters.length);
-        importedMember1.labels.length.should.equal(1);
-        testUtils.API.isISO8601(importedMember1.created_at).should.be.true();
-        importedMember1.comped.should.equal(false);
+        assert.equal(importedMember1.labels.length, 1);
+        assert.equal(testUtils.API.isISO8601(importedMember1.created_at), true);
+        assert.equal(importedMember1.comped, false);
         importedMember1.subscriptions.should.not.be.undefined();
-        importedMember1.subscriptions.length.should.equal(0);
+        assert.equal(importedMember1.subscriptions.length, 0);
 
         const importedMember2 = jsonResponse2.members.find(m => m.email === 'test@example.com');
         should.exist(importedMember2);
-        importedMember2.name.should.equal('test');
+        assert.equal(importedMember2.name, 'test');
         assert.equal(importedMember2.note, 'test note');
-        importedMember2.subscribed.should.equal(false);
-        importedMember2.newsletters.length.should.equal(0);
-        importedMember2.labels.length.should.equal(2);
-        testUtils.API.isISO8601(importedMember2.created_at).should.be.true();
-        importedMember2.created_at.should.equal('1991-10-02T20:30:31.000Z');
-        importedMember2.comped.should.equal(false);
+        assert.equal(importedMember2.subscribed, false);
+        assert.equal(importedMember2.newsletters.length, 0);
+        assert.equal(importedMember2.labels.length, 2);
+        assert.equal(testUtils.API.isISO8601(importedMember2.created_at), true);
+        assert.equal(importedMember2.created_at, '1991-10-02T20:30:31.000Z');
+        assert.equal(importedMember2.comped, false);
         importedMember2.subscriptions.should.not.be.undefined();
-        importedMember2.subscriptions.length.should.equal(0);
+        assert.equal(importedMember2.subscriptions.length, 0);
     });
 
     //TODO: fix this test and uncomment it
@@ -191,7 +191,7 @@ describe('Members Importer API', function () {
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(200);
 
-        browseResponse.body.members.should.have.length(8);
+        assert.equal(browseResponse.body.members.length, 8);
         const allMembersSubscribed = browseResponse.body.members.every((member) => {
             return member.subscribed && member.newsletters.length > 0;
         });
@@ -223,7 +223,7 @@ describe('Members Importer API', function () {
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(200);
 
-        postUnsubscribeBrowseResponse.body.members.should.have.length(8);
+        assert.equal(postUnsubscribeBrowseResponse.body.members.length, 8);
         const allMembersUnsubscribed = postUnsubscribeBrowseResponse.body.members.every((member) => {
             return member.newsletters.length === 0;
         });
@@ -279,7 +279,7 @@ describe('Members Importer API', function () {
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(200);
 
-        postLabelAddBrowseResponse.body.members.should.have.length(8);
+        assert.equal(postLabelAddBrowseResponse.body.members.length, 8);
 
         const labelToRemove = newLabelResponse.body.labels[0];
 
@@ -311,7 +311,7 @@ describe('Members Importer API', function () {
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(200);
 
-        postLabelRemoveBrowseResponse.body.members.should.have.length(0);
+        assert.equal(postLabelRemoveBrowseResponse.body.members.length, 0);
     });
 
     it('Can handle empty body', async function () {

--- a/ghost/core/test/e2e-api/admin/members.test.js
+++ b/ghost/core/test/e2e-api/admin/members.test.js
@@ -475,7 +475,7 @@ describe('Members API - member attribution', function () {
                 })
             })
             .expect(({body}) => {
-                should(body.events.find(e => e.type !== 'signup_event')).be.undefined();
+                assert.equal(body.events.find(e => e.type !== 'signup_event'), undefined);
                 should(body.events.map(e => e.data.attribution)).containDeep(signupAttributions);
             });
     });
@@ -1849,7 +1849,7 @@ describe('Members API', function () {
 
         // Check that the product that we are going to add is not the same as the existing one
         const product = await getOtherPaidProduct();
-        should(memberWithPaidSubscription.tiers).have.length(1);
+        assert.equal(memberWithPaidSubscription.tiers.length, 1);
         should(memberWithPaidSubscription.tiers[0].id).not.eql(product.id);
 
         // Add it manually
@@ -2383,7 +2383,7 @@ describe('Members API', function () {
 
             // email_disabled should be true
             await testMember.refresh();
-            should(testMember.get('email_disabled')).be.true();
+            assert.equal(testMember.get('email_disabled'), true);
 
             // Now update the email address of that member to a non-suppressed email
             await agent
@@ -2393,7 +2393,7 @@ describe('Members API', function () {
 
             // email_disabled should be false
             await testMember.refresh();
-            should(testMember.get('email_disabled')).be.false();
+            assert.equal(testMember.get('email_disabled'), false);
         });
     });
 
@@ -2421,10 +2421,10 @@ describe('Members API', function () {
                     });
 
                 await suppressedMember.refresh();
-                should(suppressedMember.get('email_disabled')).be.false();
+                assert.equal(suppressedMember.get('email_disabled'), false);
 
                 const suppressionRecord = await models.Suppression.findOne({email: 'suppression-test@email.com'});
-                should(suppressionRecord).be.null();
+                assert.equal(suppressionRecord, null);
             } finally {
                 await models.Member.destroy({id: suppressedMember.id});
                 try {
@@ -2476,7 +2476,7 @@ describe('Members API', function () {
 
                 // Verify email_disabled was NOT changed since the operation failed
                 await suppressedMember.refresh();
-                should(suppressedMember.get('email_disabled')).be.true();
+                assert.equal(suppressedMember.get('email_disabled'), true);
             } finally {
                 removeEmailStub.restore();
                 await models.Member.destroy({id: suppressedMember.id});
@@ -2579,7 +2579,7 @@ describe('Members API', function () {
                 'content-disposition': anyString
             });
 
-        res.text.should.match(/id,email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,tiers/);
+        assert.match(res.text, /id,email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,tiers/);
 
         const csv = Papa.parse(res.text, {header: true});
         should.exist(csv.data.find(row => row.name === 'Mr Egg'));
@@ -2600,7 +2600,7 @@ describe('Members API', function () {
                 'content-disposition': anyString
             });
 
-        res.text.should.match(/id,email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,tiers/);
+        assert.match(res.text, /id,email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,tiers/);
 
         const csv = Papa.parse(res.text, {header: true});
         should.exist(csv.data.find(row => row.name === 'Mr Egg'));
@@ -3363,7 +3363,7 @@ describe('Members API Bulk operations', function () {
         const newsletterCount = 2;
 
         const model = await models.Member.findOne({id: member.id}, {withRelated: 'newsletters'});
-        should(model.relations.newsletters.models.length).equal(newsletterCount, 'This test requires a member with 2 or more newsletters');
+        assert.equal(model.relations.newsletters.models.length, newsletterCount, 'This test requires a member with 2 or more newsletters');
 
         await agent
             .put(`/members/bulk/?filter=id:'${member.id}'`)
@@ -3390,7 +3390,7 @@ describe('Members API Bulk operations', function () {
             });
 
         const updatedModel = await models.Member.findOne({id: member.id}, {withRelated: 'newsletters'});
-        should(updatedModel.relations.newsletters.models.length).equal(0, 'This member should be unsubscribed from all newsletters');
+        assert.equal(updatedModel.relations.newsletters.models.length, 0, 'This member should be unsubscribed from all newsletters');
 
         // When we do it again, we should still receive a count of 1, because we unsubcribed one member (who happens to be already unsubscribed)
         await agent
@@ -3423,7 +3423,7 @@ describe('Members API Bulk operations', function () {
         const newsletterCount = 2;
 
         const model = await models.Member.findOne({id: member.id}, {withRelated: 'newsletters'});
-        should(model.relations.newsletters.models.length).equal(newsletterCount, 'This test requires a member with 2 or more newsletters');
+        assert.equal(model.relations.newsletters.models.length, newsletterCount, 'This test requires a member with 2 or more newsletters');
 
         await agent
             .put(`/members/bulk/?all=true`)
@@ -3507,7 +3507,7 @@ describe('Members API Bulk operations', function () {
             if (model.id === ignoredMember.id) {
                 continue;
             }
-            should(model.relations.newsletters.models.length).equal(0, 'This member should be unsubscribed from all newsletters');
+            assert.equal(model.relations.newsletters.models.length, 0, 'This member should be unsubscribed from all newsletters');
         }
     });
 

--- a/ghost/core/test/e2e-api/admin/oembed.test.js
+++ b/ghost/core/test/e2e-api/admin/oembed.test.js
@@ -66,7 +66,7 @@ describe('Oembed API', function () {
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(200);
 
-        requestMock.isDone().should.be.true();
+        assert.equal(requestMock.isDone(), true);
         should.exist(res.body.html);
     });
 
@@ -90,8 +90,8 @@ describe('Oembed API', function () {
             .expect('Content-Type', /json/)
             .expect('Cache-Control', testUtils.cacheRules.private);
 
-        httpMock.isDone().should.be.false();
-        httpsMock.isDone().should.be.true();
+        assert.equal(httpMock.isDone(), false);
+        assert.equal(httpsMock.isDone(), true);
         should.exist(res.body.html);
     });
 
@@ -121,9 +121,9 @@ describe('Oembed API', function () {
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(422);
 
-        requestMock.isDone().should.be.true();
+        assert.equal(requestMock.isDone(), true);
         should.exist(res.body.errors);
-        res.body.errors[0].context.should.match(/URL contains a private resource/i);
+        assert.match(res.body.errors[0].context, /URL contains a private resource/i);
     });
 
     describe('type: bookmark', function () {
@@ -143,10 +143,10 @@ describe('Oembed API', function () {
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(200);
 
-            pageMock.isDone().should.be.true();
-            res.body.type.should.eql('bookmark');
-            res.body.url.should.eql('http://example.com');
-            res.body.metadata.title.should.eql('TESTING');
+            assert.equal(pageMock.isDone(), true);
+            assert.equal(res.body.type, 'bookmark');
+            assert.equal(res.body.url, 'http://example.com');
+            assert.equal(res.body.metadata.title, 'TESTING');
         });
 
         it('falls back to bookmark without ?type=embed and no oembed metatag', async function () {
@@ -166,10 +166,10 @@ describe('Oembed API', function () {
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(200);
 
-            pageMock.isDone().should.be.true();
-            res.body.type.should.eql('bookmark');
-            res.body.url.should.eql('http://example.com');
-            res.body.metadata.title.should.eql('TESTING');
+            assert.equal(pageMock.isDone(), true);
+            assert.equal(res.body.type, 'bookmark');
+            assert.equal(res.body.url, 'http://example.com');
+            assert.equal(res.body.metadata.title, 'TESTING');
         });
 
         it('errors with useful message when title is unavailable', async function () {
@@ -188,9 +188,9 @@ describe('Oembed API', function () {
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(422);
 
-            pageMock.isDone().should.be.true();
+            assert.equal(pageMock.isDone(), true);
             should.exist(res.body.errors);
-            res.body.errors[0].context.should.match(/insufficient metadata/i);
+            assert.match(res.body.errors[0].context, /insufficient metadata/i);
         });
 
         it('errors when fetched url is an IP address', async function () {
@@ -219,7 +219,7 @@ describe('Oembed API', function () {
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(422);
 
-            pageMock.isDone().should.be.false(); // we shouldn't hit this; blocked by externalRequest
+            assert.equal(pageMock.isDone(), false); // we shouldn't hit this; blocked by externalRequest
             should.exist(res.body.errors);
         });
 
@@ -252,10 +252,10 @@ describe('Oembed API', function () {
                 .expect(200);
 
             // Check that the icon URL mock was loaded
-            pageMock.isDone().should.be.true();
+            assert.equal(pageMock.isDone(), true);
 
             // Check that the substitute icon URL is returned in place of the original
-            res.body.metadata.icon.should.eql('https://static.ghost.org/v5.0.0/images/link-icon.svg');
+            assert.equal(res.body.metadata.icon, 'https://static.ghost.org/v5.0.0/images/link-icon.svg');
         });
     });
 
@@ -277,7 +277,7 @@ describe('Oembed API', function () {
             .expect(200);
 
         // Check that the icon URL mock was loaded
-        pageMock.isDone().should.be.true();
+        assert.equal(pageMock.isDone(), true);
 
         // Check that the substitute icon URL is returned in place of the original
         res.body.metadata.icon.should.eql(`${urlUtils.urlFor('home', true)}content/images/icon/image-01.png`);
@@ -301,7 +301,7 @@ describe('Oembed API', function () {
             .expect(200);
 
         // Check that the thumbnail URL mock was loaded
-        pageMock.isDone().should.be.true();
+        assert.equal(pageMock.isDone(), true);
 
         // Check that the substitute thumbnail URL is returned in place of the original
         res.body.metadata.thumbnail.should.eql(`${urlUtils.urlFor('home', true)}content/images/thumbnail/image-01.png`);
@@ -348,15 +348,15 @@ describe('Oembed API', function () {
             .expect(200);
 
         // Check that the attacker page was called
-        attackerPageMock.isDone().should.be.true();
+        assert.equal(attackerPageMock.isDone(), true);
 
         // Check if the internal service was called - this indicates SSRF occurred
         internalServiceThumbnailMock.isDone().should.be.false('Thumbnail SSRF occurred');
         internalServiceIconMock.isDone().should.be.false('Icon SSRF occurred');
 
         // Body contains the fallback data after requests failed
-        res.body.metadata.icon.should.eql('https://static.ghost.org/v5.0.0/images/link-icon.svg');
-        res.body.metadata.thumbnail.should.eql('http://127.0.0.1:5555/secret-thumbnail');
+        assert.equal(res.body.metadata.icon, 'https://static.ghost.org/v5.0.0/images/link-icon.svg');
+        assert.equal(res.body.metadata.thumbnail, 'http://127.0.0.1:5555/secret-thumbnail');
     });
 
     describe('with unknown provider', function () {
@@ -383,9 +383,9 @@ describe('Oembed API', function () {
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(200);
 
-            redirectMock.isDone().should.be.true();
-            pageMock.isDone().should.be.true();
-            oembedMock.isDone().should.be.true();
+            assert.equal(redirectMock.isDone(), true);
+            assert.equal(pageMock.isDone(), true);
+            assert.equal(oembedMock.isDone(), true);
         });
 
         it('fetches url and follows <link rel="alternate">', async function () {
@@ -407,8 +407,8 @@ describe('Oembed API', function () {
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(200);
 
-            pageMock.isDone().should.be.true();
-            oembedMock.isDone().should.be.true();
+            assert.equal(pageMock.isDone(), true);
+            assert.equal(oembedMock.isDone(), true);
         });
 
         it('follows redirects when fetching <link rel="alternate">', async function () {
@@ -434,9 +434,9 @@ describe('Oembed API', function () {
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(200);
 
-            pageMock.isDone().should.be.true();
-            alternateRedirectMock.isDone().should.be.true();
-            alternateMock.isDone().should.be.true();
+            assert.equal(pageMock.isDone(), true);
+            assert.equal(alternateRedirectMock.isDone(), true);
+            assert.equal(alternateMock.isDone(), true);
         });
 
         it('rejects invalid oembed responses', async function () {
@@ -458,8 +458,8 @@ describe('Oembed API', function () {
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(422);
 
-            pageMock.isDone().should.be.true();
-            oembedMock.isDone().should.be.true();
+            assert.equal(pageMock.isDone(), true);
+            assert.equal(oembedMock.isDone(), true);
         });
 
         it('rejects unknown oembed types', async function () {
@@ -481,8 +481,8 @@ describe('Oembed API', function () {
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(422);
 
-            pageMock.isDone().should.be.true();
-            oembedMock.isDone().should.be.true();
+            assert.equal(pageMock.isDone(), true);
+            assert.equal(oembedMock.isDone(), true);
         });
 
         it('rejects invalid photo responses', async function () {
@@ -506,8 +506,8 @@ describe('Oembed API', function () {
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(422);
 
-            pageMock.isDone().should.be.true();
-            oembedMock.isDone().should.be.true();
+            assert.equal(pageMock.isDone(), true);
+            assert.equal(oembedMock.isDone(), true);
         });
 
         it('rejects invalid video responses', async function () {
@@ -531,8 +531,8 @@ describe('Oembed API', function () {
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(422);
 
-            pageMock.isDone().should.be.true();
-            oembedMock.isDone().should.be.true();
+            assert.equal(pageMock.isDone(), true);
+            assert.equal(oembedMock.isDone(), true);
         });
 
         it('strips unknown response fields', async function () {
@@ -558,8 +558,8 @@ describe('Oembed API', function () {
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(200);
 
-            pageMock.isDone().should.be.true();
-            oembedMock.isDone().should.be.true();
+            assert.equal(pageMock.isDone(), true);
+            assert.equal(oembedMock.isDone(), true);
 
             res.body.should.deepEqual({
                 version: '1.0',
@@ -599,8 +599,8 @@ describe('Oembed API', function () {
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(422);
 
-            pageMock.isDone().should.be.true();
-            oembedMock.isDone().should.be.false();
+            assert.equal(pageMock.isDone(), true);
+            assert.equal(oembedMock.isDone(), false);
         });
 
         it('skips fetching IPv6 addresses', async function () {
@@ -631,8 +631,8 @@ describe('Oembed API', function () {
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(422);
 
-            pageMock.isDone().should.be.true();
-            oembedMock.isDone().should.be.false();
+            assert.equal(pageMock.isDone(), true);
+            assert.equal(oembedMock.isDone(), false);
         });
 
         it('skips fetching localhost', async function () {
@@ -664,8 +664,8 @@ describe('Oembed API', function () {
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(422);
 
-            pageMock.isDone().should.be.true();
-            oembedMock.isDone().should.be.false();
+            assert.equal(pageMock.isDone(), true);
+            assert.equal(oembedMock.isDone(), false);
         });
 
         it('skips fetching url that resolves to private IP', async function () {
@@ -696,8 +696,8 @@ describe('Oembed API', function () {
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(422);
 
-            pageMock.isDone().should.be.false();
-            oembedMock.isDone().should.be.false();
+            assert.equal(pageMock.isDone(), false);
+            assert.equal(oembedMock.isDone(), false);
         });
 
         it('aborts fetching if a redirect resolves to private IP', async function () {
@@ -732,9 +732,9 @@ describe('Oembed API', function () {
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(422);
 
-            redirectMock.isDone().should.be.true();
-            pageMock.isDone().should.be.false();
-            oembedMock.isDone().should.be.false();
+            assert.equal(redirectMock.isDone(), true);
+            assert.equal(pageMock.isDone(), false);
+            assert.equal(oembedMock.isDone(), false);
         });
 
         it('skips fetching <link rel="alternate"> if it resolves to a private IP', async function () {
@@ -765,8 +765,8 @@ describe('Oembed API', function () {
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(422);
 
-            pageMock.isDone().should.be.true();
-            oembedMock.isDone().should.be.false();
+            assert.equal(pageMock.isDone(), true);
+            assert.equal(oembedMock.isDone(), false);
         });
 
         it('falls back to bookmark card for WP oembeds', async function () {
@@ -792,8 +792,8 @@ describe('Oembed API', function () {
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(200);
 
-            pageMock.isDone().should.be.true();
-            oembedMock.isDone().should.be.false();
+            assert.equal(pageMock.isDone(), true);
+            assert.equal(oembedMock.isDone(), false);
         });
 
         it('decodes non utf-8 charsets', async function () {
@@ -820,9 +820,9 @@ describe('Oembed API', function () {
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(200);
 
-            pageMock.isDone().should.be.true();
-            res.body.type.should.eql('bookmark');
-            res.body.url.should.eql('http://example.com');
+            assert.equal(pageMock.isDone(), true);
+            assert.equal(res.body.type, 'bookmark');
+            assert.equal(res.body.url, 'http://example.com');
             res.body.metadata.title.should.eql(utfString);
         });
 
@@ -842,10 +842,10 @@ describe('Oembed API', function () {
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(200);
 
-            pageMock.isDone().should.be.true();
-            res.body.type.should.eql('bookmark');
-            res.body.url.should.eql('http://example.com');
-            res.body.metadata.title.should.eql('TESTING');
+            assert.equal(pageMock.isDone(), true);
+            assert.equal(res.body.type, 'bookmark');
+            assert.equal(res.body.url, 'http://example.com');
+            assert.equal(res.body.metadata.title, 'TESTING');
         });
     });
 });

--- a/ghost/core/test/e2e-api/admin/offers.test.js
+++ b/ghost/core/test/e2e-api/admin/offers.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const {agentProvider, fixtureManager, matchers} = require('../../utils/e2e-framework');
 const {anyContentVersion, anyEtag, anyObjectId, anyLocationFor, anyErrorId, anyISODateTime} = matchers;
 const should = require('should');
@@ -149,7 +150,7 @@ describe('Offers API', function () {
                 }]
             })
             .expect(({body}) => {
-                body.offers[0].code.should.eql('summer-sale');
+                assert.equal(body.offers[0].code, 'summer-sale');
             });
     });
 
@@ -567,7 +568,7 @@ describe('Offers API', function () {
                 })
             })
             .expect(({body}) => {
-                body.offers[0].cadence.should.eql('year');
+                assert.equal(body.offers[0].cadence, 'year');
             });
     });
 
@@ -596,7 +597,7 @@ describe('Offers API', function () {
                 })
             })
             .expect(({body}) => {
-                body.offers[0].amount.should.eql(12);
+                assert.equal(body.offers[0].amount, 12);
             });
     });
 

--- a/ghost/core/test/e2e-api/admin/pages-legacy.test.js
+++ b/ghost/core/test/e2e-api/admin/pages-legacy.test.js
@@ -28,14 +28,14 @@ describe('Pages API', function () {
         const jsonResponse = res.body;
         should.exist(jsonResponse.pages);
         localUtils.API.checkResponse(jsonResponse, 'pages');
-        jsonResponse.pages.should.have.length(6);
+        assert.equal(jsonResponse.pages.length, 6);
 
         localUtils.API.checkResponse(jsonResponse.pages[0], 'page', ['reading_time']);
         localUtils.API.checkResponse(jsonResponse.meta.pagination, 'pagination');
-        _.isBoolean(jsonResponse.pages[0].featured).should.eql(true);
+        assert.equal(_.isBoolean(jsonResponse.pages[0].featured), true);
 
         // Absolute urls by default
-        jsonResponse.pages[0].url.should.match(new RegExp(`${config.get('url')}/p/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}`));
+        assert.match(jsonResponse.pages[0].url, new RegExp(`${config.get('url')}/p/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}`));
         jsonResponse.pages[1].url.should.eql(`${config.get('url')}/contribute/`);
     });
 
@@ -50,7 +50,7 @@ describe('Pages API', function () {
         const jsonResponse = res.body;
         should.exist(jsonResponse.pages);
         localUtils.API.checkResponse(jsonResponse, 'pages');
-        jsonResponse.pages.should.have.length(6);
+        assert.equal(jsonResponse.pages.length, 6);
 
         const additionalProperties = ['lexical', 'reading_time'];
         const missingProperties = ['mobiledoc'];
@@ -73,7 +73,7 @@ describe('Pages API', function () {
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(201);
 
-        res.body.pages.length.should.eql(1);
+        assert.equal(res.body.pages.length, 1);
 
         localUtils.API.checkResponse(res.body.pages[0], 'page');
         should.exist(res.headers['x-cache-invalidate']);
@@ -89,7 +89,7 @@ describe('Pages API', function () {
 
         modelJson.title.should.eql(page.title);
         modelJson.status.should.eql(page.status);
-        modelJson.type.should.eql('page');
+        assert.equal(modelJson.type, 'page');
 
         modelJson.posts_meta.feature_image_alt.should.eql(page.feature_image_alt);
         modelJson.posts_meta.feature_image_caption.should.eql(page.feature_image_caption);
@@ -119,7 +119,7 @@ describe('Pages API', function () {
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(201);
 
-        res.body.pages.length.should.eql(1);
+        assert.equal(res.body.pages.length, 1);
         const [returnedPage] = res.body.pages;
 
         const additionalProperties = ['reading_time'];
@@ -170,7 +170,7 @@ describe('Pages API', function () {
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(201);
 
-        res.body.pages.length.should.eql(1);
+        assert.equal(res.body.pages.length, 1);
         const [returnedPage] = res.body.pages;
 
         const additionalProperties = ['html', 'reading_time'];
@@ -240,8 +240,8 @@ describe('Pages API', function () {
             .expect(422);
 
         const [error] = res.body.errors;
-        error.type.should.equal('ValidationError');
-        error.property.should.equal('lexical');
+        assert.equal(error.type, 'ValidationError');
+        assert.equal(error.property, 'lexical');
     });
 
     it('Can include free and paid tiers for public page', async function () {
@@ -258,7 +258,7 @@ describe('Pages API', function () {
             .set('Origin', config.get('url'))
             .expect(200);
         const publicPostData = publicPostRes.body.pages[0];
-        publicPostData.tiers.length.should.eql(2);
+        assert.equal(publicPostData.tiers.length, 2);
     });
 
     it('Can include free and paid tiers for members only page', async function () {
@@ -275,7 +275,7 @@ describe('Pages API', function () {
             .set('Origin', config.get('url'))
             .expect(200);
         const membersPostData = membersPostRes.body.pages[0];
-        membersPostData.tiers.length.should.eql(2);
+        assert.equal(membersPostData.tiers.length, 2);
     });
 
     it('Can include only paid tier for paid page', async function () {
@@ -292,7 +292,7 @@ describe('Pages API', function () {
             .set('Origin', config.get('url'))
             .expect(200);
         const paidPostData = paidPostRes.body.pages[0];
-        paidPostData.tiers.length.should.eql(1);
+        assert.equal(paidPostData.tiers.length, 1);
     });
 
     it('Can include specific tier for page with tiers visibility', async function () {
@@ -323,7 +323,7 @@ describe('Pages API', function () {
             .expect(200);
         const tiersPageData = tiersPageRes.body.pages[0];
 
-        tiersPageData.tiers.length.should.eql(1);
+        assert.equal(tiersPageData.tiers.length, 1);
     });
 
     it('Can update a page', async function () {
@@ -353,7 +353,7 @@ describe('Pages API', function () {
             id: res2.body.pages[0].id
         }, testUtils.context.internal);
 
-        model.get('type').should.eql('page');
+        assert.equal(model.get('type'), 'page');
     });
 
     it('Can update a page with restricted access to specific tier', async function () {
@@ -397,7 +397,7 @@ describe('Pages API', function () {
             id: res2.body.pages[0].id
         }, testUtils.context.internal);
 
-        model.get('type').should.eql('page');
+        assert.equal(model.get('type'), 'page');
     });
 
     it('Cannot get page via posts endpoint', async function () {
@@ -429,6 +429,6 @@ describe('Pages API', function () {
             .expect(204);
 
         res.body.should.be.empty();
-        res.headers['x-cache-invalidate'].should.eql('/*');
+        assert.equal(res.headers['x-cache-invalidate'], '/*');
     });
 });

--- a/ghost/core/test/e2e-api/admin/posts-legacy.test.js
+++ b/ghost/core/test/e2e-api/admin/posts-legacy.test.js
@@ -54,25 +54,25 @@ describe('Posts API', function () {
         const jsonResponse = res.body;
         should.exist(jsonResponse.posts);
         localUtils.API.checkResponse(jsonResponse, 'posts');
-        jsonResponse.posts.should.have.length(15);
+        assert.equal(jsonResponse.posts.length, 15);
         localUtils.API.checkResponse(jsonResponse.posts[0], 'post');
         localUtils.API.checkResponse(jsonResponse.meta.pagination, 'pagination');
-        _.isBoolean(jsonResponse.posts[0].featured).should.eql(true);
-        _.isBoolean(jsonResponse.posts[0].email_only).should.eql(true);
-        jsonResponse.posts[0].email_only.should.eql(false);
+        assert.equal(_.isBoolean(jsonResponse.posts[0].featured), true);
+        assert.equal(_.isBoolean(jsonResponse.posts[0].email_only), true);
+        assert.equal(jsonResponse.posts[0].email_only, false);
 
         // Ensure default order
-        jsonResponse.posts[0].slug.should.eql('scheduled-post');
-        jsonResponse.posts[14].slug.should.eql('html-ipsum');
+        assert.equal(jsonResponse.posts[0].slug, 'scheduled-post');
+        assert.equal(jsonResponse.posts[14].slug, 'html-ipsum');
 
         // Absolute urls by default
-        jsonResponse.posts[0].url.should.match(new RegExp(`${config.get('url')}/p/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}`));
+        assert.match(jsonResponse.posts[0].url, new RegExp(`${config.get('url')}/p/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}`));
         jsonResponse.posts[2].url.should.eql(`${config.get('url')}/welcome/`);
         jsonResponse.posts[13].feature_image.should.eql(`${config.get('url')}/content/images/2018/hey.jpg`);
 
-        jsonResponse.posts[0].tags.length.should.eql(0);
-        jsonResponse.posts[2].tags.length.should.eql(1);
-        jsonResponse.posts[2].authors.length.should.eql(1);
+        assert.equal(jsonResponse.posts[0].tags.length, 0);
+        assert.equal(jsonResponse.posts[2].tags.length, 1);
+        assert.equal(jsonResponse.posts[2].authors.length, 1);
         jsonResponse.posts[2].tags[0].url.should.eql(`${config.get('url')}/tag/getting-started/`);
         jsonResponse.posts[2].authors[0].url.should.eql(`${config.get('url')}/author/ghost/`);
 
@@ -81,7 +81,7 @@ describe('Posts API', function () {
         jsonResponse.posts[14].newsletter.id.should.eql(testUtils.DataGenerator.Content.newsletters[0].id);
         assert.equal(jsonResponse.posts[14].newsletter_id, undefined);
 
-        should(jsonResponse.posts[0].newsletter).be.null();
+        assert.equal(jsonResponse.posts[0].newsletter, null);
         assert.equal(jsonResponse.posts[0].newsletter_id, undefined);
     });
 
@@ -96,13 +96,13 @@ describe('Posts API', function () {
         const jsonResponse = res.body;
         should.exist(jsonResponse.posts);
         localUtils.API.checkResponse(jsonResponse, 'posts');
-        jsonResponse.posts.should.have.length(3);
+        assert.equal(jsonResponse.posts.length, 3);
         localUtils.API.checkResponse(jsonResponse.posts[0], 'post', ['plaintext']);
         localUtils.API.checkResponse(jsonResponse.meta.pagination, 'pagination');
-        _.isBoolean(jsonResponse.posts[0].featured).should.eql(true);
+        assert.equal(_.isBoolean(jsonResponse.posts[0].featured), true);
 
         // ensure order works
-        jsonResponse.posts[0].slug.should.eql('portal');
+        assert.equal(jsonResponse.posts[0].slug, 'portal');
     });
 
     it('Can include single relation', async function () {
@@ -116,7 +116,7 @@ describe('Posts API', function () {
         const jsonResponse = res.body;
         should.exist(jsonResponse.posts);
         localUtils.API.checkResponse(jsonResponse, 'posts');
-        jsonResponse.posts.should.have.length(15);
+        assert.equal(jsonResponse.posts.length, 15);
         localUtils.API.checkResponse(
             jsonResponse.posts[0],
             'post',
@@ -138,7 +138,7 @@ describe('Posts API', function () {
         const jsonResponse = res.body;
         should.exist(jsonResponse.posts);
         localUtils.API.checkResponse(jsonResponse, 'posts');
-        jsonResponse.posts.should.have.length(2);
+        assert.equal(jsonResponse.posts.length, 2);
         localUtils.API.checkResponse(jsonResponse.posts[0], 'post');
         localUtils.API.checkResponse(jsonResponse.meta.pagination, 'pagination');
     });
@@ -178,9 +178,9 @@ describe('Posts API', function () {
         localUtils.API.checkResponse(jsonResponse.posts[0], 'post');
         jsonResponse.posts[0].id.should.equal(testUtils.DataGenerator.Content.posts[0].id);
 
-        _.isBoolean(jsonResponse.posts[0].featured).should.eql(true);
+        assert.equal(_.isBoolean(jsonResponse.posts[0].featured), true);
 
-        testUtils.API.isISO8601(jsonResponse.posts[0].created_at).should.be.true();
+        assert.equal(testUtils.API.isISO8601(jsonResponse.posts[0].created_at), true);
 
         // Check if the newsletter relation is loaded by default and newsletter_id is not returned
         jsonResponse.posts[0].newsletter.id.should.eql(testUtils.DataGenerator.Content.newsletters[0].id);
@@ -201,12 +201,12 @@ describe('Posts API', function () {
         localUtils.API.checkResponse(jsonResponse.posts[0], 'post');
         jsonResponse.posts[0].id.should.equal(testUtils.DataGenerator.Content.posts[1].id);
 
-        _.isBoolean(jsonResponse.posts[0].featured).should.eql(true);
+        assert.equal(_.isBoolean(jsonResponse.posts[0].featured), true);
 
-        testUtils.API.isISO8601(jsonResponse.posts[0].created_at).should.be.true();
+        assert.equal(testUtils.API.isISO8601(jsonResponse.posts[0].created_at), true);
 
         // Newsletter should be returned as null
-        should(jsonResponse.posts[0].newsletter).be.null();
+        assert.equal(jsonResponse.posts[0].newsletter, null);
         assert.equal(jsonResponse.posts[0].newsletter_id, undefined);
     });
 
@@ -222,12 +222,12 @@ describe('Posts API', function () {
         should.exist(jsonResponse);
         should.exist(jsonResponse.posts);
         localUtils.API.checkResponse(jsonResponse.posts[0], 'post');
-        jsonResponse.posts[0].slug.should.equal('welcome');
+        assert.equal(jsonResponse.posts[0].slug, 'welcome');
 
-        _.isBoolean(jsonResponse.posts[0].featured).should.eql(true);
+        assert.equal(_.isBoolean(jsonResponse.posts[0].featured), true);
 
         // Newsletter should be returned as null
-        should(jsonResponse.posts[0].newsletter).be.null();
+        assert.equal(jsonResponse.posts[0].newsletter, null);
         assert.equal(jsonResponse.posts[0].newsletter_id, undefined);
     });
 
@@ -278,16 +278,16 @@ describe('Posts API', function () {
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(201);
 
-        res.body.posts.length.should.eql(1);
+        assert.equal(res.body.posts.length, 1);
         localUtils.API.checkResponse(res.body.posts[0], 'post');
-        res.body.posts[0].url.should.match(new RegExp(`${config.get('url')}/p/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}`));
+        assert.match(res.body.posts[0].url, new RegExp(`${config.get('url')}/p/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}`));
         assert.equal(res.headers['x-cache-invalidate'], undefined);
 
         should.exist(res.headers.location);
         res.headers.location.should.equal(`http://127.0.0.1:2369${localUtils.API.getApiQuery('posts/')}${res.body.posts[0].id}/`);
 
         // Newsletter should be returned as null
-        should(res.body.posts[0].newsletter).be.null();
+        assert.equal(res.body.posts[0].newsletter, null);
         assert.equal(res.body.posts[0].newsletter_id, undefined);
 
         const model = await models.Post.findOne({
@@ -299,7 +299,7 @@ describe('Posts API', function () {
 
         modelJson.title.should.eql(post.title);
         modelJson.status.should.eql(post.status);
-        modelJson.published_at.toISOString().should.eql('2016-05-30T07:00:00.000Z');
+        assert.equal(modelJson.published_at.toISOString(), '2016-05-30T07:00:00.000Z');
         modelJson.created_at.toISOString().should.not.eql(post.created_at.toISOString());
         modelJson.updated_at.toISOString().should.not.eql(post.updated_at.toISOString());
 
@@ -320,7 +320,7 @@ describe('Posts API', function () {
             .set('Origin', config.get('url'))
             .expect(200);
         const publicPostData = publicPostRes.body.posts[0];
-        publicPostData.tiers.length.should.eql(2);
+        assert.equal(publicPostData.tiers.length, 2);
     });
 
     it('Can include free and paid tiers for members only post', async function () {
@@ -336,7 +336,7 @@ describe('Posts API', function () {
             .set('Origin', config.get('url'))
             .expect(200);
         const membersPostData = membersPostRes.body.posts[0];
-        membersPostData.tiers.length.should.eql(2);
+        assert.equal(membersPostData.tiers.length, 2);
     });
 
     it('Can include only paid tier for paid post', async function () {
@@ -352,7 +352,7 @@ describe('Posts API', function () {
             .set('Origin', config.get('url'))
             .expect(200);
         const paidPostData = paidPostRes.body.posts[0];
-        paidPostData.tiers.length.should.eql(1);
+        assert.equal(paidPostData.tiers.length, 1);
     });
 
     it('Can include specific tier for post with tiers visibility', async function () {
@@ -382,7 +382,7 @@ describe('Posts API', function () {
             .expect(200);
         const tiersPostData = tiersPostRes.body.posts[0];
 
-        tiersPostData.tiers.length.should.eql(1);
+        assert.equal(tiersPostData.tiers.length, 1);
     });
 
     it('Can update draft', async function () {
@@ -409,7 +409,7 @@ describe('Posts API', function () {
         res2.headers['x-cache-invalidate'].should.eql(expectedPattern);
 
         // Newsletter should be returned as null
-        should(res2.body.posts[0].newsletter).be.null();
+        assert.equal(res2.body.posts[0].newsletter, null);
         assert.equal(res2.body.posts[0].newsletter_id, undefined);
     });
 
@@ -447,16 +447,16 @@ describe('Posts API', function () {
         const expectedPattern = `/p/${uuid}/, /p/${uuid}/?member_status=anonymous, /p/${uuid}/?member_status=free, /p/${uuid}/?member_status=paid`;
         res2.headers['x-cache-invalidate'].should.eql(expectedPattern);
 
-        unsplashMock.isDone().should.be.true();
+        assert.equal(unsplashMock.isDone(), true);
 
         // mobiledoc is updated with image sizes
         const resMobiledoc = JSON.parse(res2.body.posts[0].mobiledoc);
         const cardPayload = resMobiledoc.cards[mobiledoc.cards.length - 1][1];
-        cardPayload.width.should.eql(800);
-        cardPayload.height.should.eql(257);
+        assert.equal(cardPayload.width, 800);
+        assert.equal(cardPayload.height, 257);
 
         // html is re-rendered to include srcset
-        res2.body.posts[0].html.should.match(/srcset="https:\/\/images\.unsplash\.com\/favicon_too_large\?ixlib=rb-1\.2\.1&amp;q=80&amp;fm=jpg&amp;crop=entropy&amp;cs=tinysrgb&amp;w=600&amp;fit=max&amp;ixid=eyJhcHBfaWQiOjExNzczfQ 600w, https:\/\/images\.unsplash\.com\/favicon_too_large\?ixlib=rb-1\.2\.1&amp;q=80&amp;fm=jpg&amp;crop=entropy&amp;cs=tinysrgb&amp;w=800&amp;fit=max&amp;ixid=eyJhcHBfaWQiOjExNzczfQ 800w"/);
+        assert.match(res2.body.posts[0].html, /srcset="https:\/\/images\.unsplash\.com\/favicon_too_large\?ixlib=rb-1\.2\.1&amp;q=80&amp;fm=jpg&amp;crop=entropy&amp;cs=tinysrgb&amp;w=600&amp;fit=max&amp;ixid=eyJhcHBfaWQiOjExNzczfQ 600w, https:\/\/images\.unsplash\.com\/favicon_too_large\?ixlib=rb-1\.2\.1&amp;q=80&amp;fm=jpg&amp;crop=entropy&amp;cs=tinysrgb&amp;w=800&amp;fit=max&amp;ixid=eyJhcHBfaWQiOjExNzczfQ 800w"/);
     });
 
     it('Can unpublish a post', async function () {
@@ -479,8 +479,8 @@ describe('Posts API', function () {
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(200);
 
-        res2.headers['x-cache-invalidate'].should.eql('/*');
-        res2.body.posts[0].status.should.eql('draft');
+        assert.equal(res2.headers['x-cache-invalidate'], '/*');
+        assert.equal(res2.body.posts[0].status, 'draft');
     });
 
     it(`Can't change the newsletter of a post from the post body`, async function () {
@@ -494,7 +494,7 @@ describe('Posts API', function () {
             id: postId
         }, testUtils.context.internal);
 
-        should(modelBefore.get('newsletter_id')).eql(null, 'This test requires the initial post to not have a newsletter');
+        assert.equal(modelBefore.get('newsletter_id'), null, 'This test requires the initial post to not have a newsletter');
 
         const res = await request
             .get(localUtils.API.getApiQuery(`posts/${postId}/?`))
@@ -515,7 +515,7 @@ describe('Posts API', function () {
             id: postId
         }, testUtils.context.internal);
 
-        should(model.get('newsletter_id')).eql(null);
+        assert.equal(model.get('newsletter_id'), null);
     });
 
     it(`Can't change the newsletter of a post from the post body`, async function () {
@@ -531,7 +531,7 @@ describe('Posts API', function () {
             id: postId
         }, testUtils.context.internal);
 
-        should(modelBefore.get('newsletter_id')).eql(null, 'This test requires the initial post to not have a newsletter');
+        assert.equal(modelBefore.get('newsletter_id'), null, 'This test requires the initial post to not have a newsletter');
 
         const res = await request
             .get(localUtils.API.getApiQuery(`posts/${postId}/?`))
@@ -552,7 +552,7 @@ describe('Posts API', function () {
             id: postId
         }, testUtils.context.internal);
 
-        should(model.get('newsletter_id')).eql(null);
+        assert.equal(model.get('newsletter_id'), null);
     });
 
     it('Cannot change the newsletter via body when adding', async function () {
@@ -579,7 +579,7 @@ describe('Posts API', function () {
 
         // Check that the default newsletter is used instead of the one in body (not allowed)
         assert.equal(res.body.posts[0].status, 'draft');
-        should(res.body.posts[0].newsletter).eql(null);
+        assert.equal(res.body.posts[0].newsletter, null);
         assert.equal(res.body.posts[0].newsletter_id, undefined);
 
         const id = res.body.posts[0].id;
@@ -589,13 +589,13 @@ describe('Posts API', function () {
             status: 'draft' // Fix for default filter
         }, testUtils.context.internal);
 
-        should(model.get('newsletter_id')).eql(null);
+        assert.equal(model.get('newsletter_id'), null);
     });
 
     it('Cannot send to an archived newsletter', async function () {
         const newsletterSlug = testUtils.DataGenerator.Content.newsletters[2].slug;
 
-        should(testUtils.DataGenerator.Content.newsletters[2].status).eql('archived', 'This test expects an archived newsletter in the test fixtures');
+        assert.equal(testUtils.DataGenerator.Content.newsletters[2].status, 'archived', 'This test expects an archived newsletter in the test fixtures');
 
         const post = {
             title: 'My archived newsletter post',
@@ -615,7 +615,7 @@ describe('Posts API', function () {
             .expect(201);
 
         // Check newsletter relation is loaded, but null in response.
-        should(res.body.posts[0].newsletter).eql(null);
+        assert.equal(res.body.posts[0].newsletter, null);
         assert.equal(res.body.posts[0].email_segment, 'all');
         assert.equal(res.body.posts[0].newsletter_id, undefined);
 
@@ -674,7 +674,7 @@ describe('Posts API', function () {
             .expect(200);
 
         const scheduledPost = scheduledRes.body.posts[0];
-        scheduledPost.status.should.eql('scheduled');
+        assert.equal(scheduledPost.status, 'scheduled');
 
         // Verify the post is scheduled in the database
         let model = await models.Post.findOne({
@@ -702,14 +702,14 @@ describe('Posts API', function () {
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(403);
 
-        failedRes.body.errors[0].type.should.eql('HostLimitError');
+        assert.equal(failedRes.body.errors[0].type, 'HostLimitError');
 
         // CRITICAL: Verify the post status was NOT changed - it should still be scheduled
         model = await models.Post.findOne({
             id,
             status: 'all'
         }, testUtils.context.internal);
-        should(model.get('status')).eql('scheduled', 'Post should remain scheduled when email sending fails');
+        assert.equal(model.get('status'), 'scheduled', 'Post should remain scheduled when email sending fails');
 
         // No email should have been created
         const email = await models.Email.findOne({
@@ -740,7 +740,7 @@ describe('Posts API', function () {
             .expect(201);
 
         // Check newsletter relation is loaded, but null in response.
-        should(res.body.posts[0].newsletter).eql(null);
+        assert.equal(res.body.posts[0].newsletter, null);
         assert.equal(res.body.posts[0].newsletter_id, undefined);
 
         const id = res.body.posts[0].id;
@@ -758,7 +758,7 @@ describe('Posts API', function () {
             .expect(200);
 
         // Check newsletter relation is loaded in response
-        should(finalPost.body.posts[0].newsletter).eql(null);
+        assert.equal(finalPost.body.posts[0].newsletter, null);
         assert.equal(finalPost.body.posts[0].email_segment, 'all');
         assert.equal(finalPost.body.posts[0].newsletter_id, undefined);
 
@@ -766,7 +766,7 @@ describe('Posts API', function () {
             id
         }, testUtils.context.internal);
 
-        should(model.get('newsletter_id')).eql(null);
+        assert.equal(model.get('newsletter_id'), null);
 
         // Check email
         // Note: we only create an email if we have members susbcribed to the newsletter
@@ -796,7 +796,7 @@ describe('Posts API', function () {
             .expect(201);
 
         // Check newsletter relation is loaded, but null in response.
-        should(res.body.posts[0].newsletter).eql(null);
+        assert.equal(res.body.posts[0].newsletter, null);
         assert.equal(res.body.posts[0].newsletter_id, undefined);
 
         const id = res.body.posts[0].id;
@@ -820,18 +820,18 @@ describe('Posts API', function () {
             .expect(200);
 
         // Check newsletter relation is loaded in response
-        should(finalPost.body.posts[0].newsletter).eql(null);
+        assert.equal(finalPost.body.posts[0].newsletter, null);
         assert.equal(finalPost.body.posts[0].email_segment, 'all');
         assert.equal(finalPost.body.posts[0].newsletter_id, undefined);
 
         // Check status is set to published
-        finalPost.body.posts[0].status.should.eql('published');
+        assert.equal(finalPost.body.posts[0].status, 'published');
 
         const model = await models.Post.findOne({
             id
         }, testUtils.context.internal);
 
-        should(model.get('newsletter_id')).eql(null);
+        assert.equal(model.get('newsletter_id'), null);
         should.exist(model.get('published_by'));
 
         // Check email
@@ -865,7 +865,7 @@ describe('Posts API', function () {
             .expect(201);
 
         // Check newsletter relation is loaded, but null in response.
-        should(res.body.posts[0].newsletter).eql(null);
+        assert.equal(res.body.posts[0].newsletter, null);
         assert.equal(res.body.posts[0].newsletter_id, undefined);
 
         const id = res.body.posts[0].id;
@@ -933,7 +933,7 @@ describe('Posts API', function () {
             .expect(201);
 
         // Check newsletter relation is loaded, but null in response.
-        should(res.body.posts[0].newsletter).eql(null);
+        assert.equal(res.body.posts[0].newsletter, null);
         assert.equal(res.body.posts[0].newsletter_id, undefined);
 
         const id = res.body.posts[0].id;
@@ -1028,8 +1028,8 @@ describe('Posts API', function () {
         const publishedPost = publishedRes.body.posts[0];
 
         publishedPost.newsletter.id.should.eql(newsletterId);
-        publishedPost.email_segment.should.eql('all');
-        publishedPost.status.should.eql('sent');
+        assert.equal(publishedPost.email_segment, 'all');
+        assert.equal(publishedPost.status, 'sent');
         assert.equal(publishedPost.newsletter_id, undefined);
 
         let model = await models.Post.findOne({
@@ -1097,8 +1097,8 @@ describe('Posts API', function () {
         const publishedPost = publishedRes.body.posts[0];
 
         publishedPost.newsletter.id.should.eql(newsletterId);
-        publishedPost.email_segment.should.eql('status:free');
-        publishedPost.status.should.eql('sent');
+        assert.equal(publishedPost.email_segment, 'status:free');
+        assert.equal(publishedPost.status, 'sent');
         assert.equal(publishedPost.newsletter_id, undefined);
 
         let model = await models.Post.findOne({
@@ -1166,8 +1166,8 @@ describe('Posts API', function () {
         const publishedPost = publishedRes.body.posts[0];
 
         publishedPost.newsletter.id.should.eql(newsletterId);
-        publishedPost.email_segment.should.eql('status:free');
-        publishedPost.status.should.eql('sent');
+        assert.equal(publishedPost.email_segment, 'status:free');
+        assert.equal(publishedPost.status, 'sent');
         assert.equal(publishedPost.newsletter_id, undefined);
 
         let model = await models.Post.findOne({
@@ -1229,7 +1229,7 @@ describe('Posts API', function () {
         const scheduledPost = scheduledRes.body.posts[0];
 
         scheduledPost.newsletter.id.should.eql(newsletterId);
-        scheduledPost.email_segment.should.eql('all');
+        assert.equal(scheduledPost.email_segment, 'all');
         assert.equal(scheduledPost.newsletter_id, undefined);
 
         let model = await models.Post.findOne({
@@ -1322,7 +1322,7 @@ describe('Posts API', function () {
         const scheduledPost = scheduledRes.body.posts[0];
 
         scheduledPost.newsletter.id.should.eql(newsletterId);
-        scheduledPost.email_segment.should.eql('status:free');
+        assert.equal(scheduledPost.email_segment, 'status:free');
         assert.equal(scheduledPost.newsletter_id, undefined);
 
         let model = await models.Post.findOne({
@@ -1410,8 +1410,8 @@ describe('Posts API', function () {
 
         const scheduledPost = scheduledRes.body.posts[0];
 
-        should(scheduledPost.newsletter).eql(null);
-        scheduledPost.email_segment.should.eql('all'); // should be igored
+        assert.equal(scheduledPost.newsletter, null);
+        assert.equal(scheduledPost.email_segment, 'all'); // should be igored
         assert.equal(scheduledPost.newsletter_id, undefined);
 
         let model = await models.Post.findOne({
@@ -1419,7 +1419,7 @@ describe('Posts API', function () {
             status: 'scheduled'
         }, testUtils.context.internal);
 
-        should(model.get('newsletter_id')).eql(null);
+        assert.equal(model.get('newsletter_id'), null);
         assert.equal(model.get('email_recipient_filter'), 'all');
 
         // We should not have an email
@@ -1447,10 +1447,10 @@ describe('Posts API', function () {
             id
         }, testUtils.context.internal);
 
-        should(model.get('newsletter_id')).eql(null);
+        assert.equal(model.get('newsletter_id'), null);
         assert.equal(model.get('email_recipient_filter'), 'all');
 
-        should(publishedPost.newsletter).eql(null);
+        assert.equal(publishedPost.newsletter, null);
         assert.equal(publishedPost.newsletter_id, undefined);
 
         // Check email is sent to the correct newsletter
@@ -1501,9 +1501,9 @@ describe('Posts API', function () {
         const scheduledPost = scheduledRes.body.posts[0];
 
         scheduledPost.newsletter.id.should.eql(newsletterId);
-        scheduledPost.email_segment.should.eql('all');
-        scheduledPost.status.should.eql('scheduled');
-        scheduledPost.email_only.should.eql(true);
+        assert.equal(scheduledPost.email_segment, 'all');
+        assert.equal(scheduledPost.status, 'scheduled');
+        assert.equal(scheduledPost.email_only, true);
         assert.equal(scheduledPost.newsletter_id, undefined);
 
         let model = await models.Post.findOne({
@@ -1761,7 +1761,7 @@ describe('Posts API', function () {
                 .expect(201);
 
             // Check newsletter relation is loaded, but null in response.
-            should(res.body.posts[0].newsletter).eql(null);
+            assert.equal(res.body.posts[0].newsletter, null);
             assert.equal(res.body.posts[0].newsletter_id, undefined);
 
             const id = res.body.posts[0].id;
@@ -1841,8 +1841,8 @@ describe('Posts API', function () {
             const publishedPost = publishedRes.body.posts[0];
 
             publishedPost.newsletter.id.should.eql(newsletterId);
-            publishedPost.email_segment.should.eql('all');
-            publishedPost.status.should.eql('sent');
+            assert.equal(publishedPost.email_segment, 'all');
+            assert.equal(publishedPost.status, 'sent');
             assert.equal(publishedPost.newsletter_id, undefined);
 
             let model = await models.Post.findOne({
@@ -1905,8 +1905,8 @@ describe('Posts API', function () {
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(403);
 
-            response.body.errors[0].type.should.equal('HostLimitError');
-            response.body.errors[0].context.should.equal('No email shalt be sent');
+            assert.equal(response.body.errors[0].type, 'HostLimitError');
+            assert.equal(response.body.errors[0].context, 'No email shalt be sent');
             sinon.assert.calledOnce(loggingStub);
         });
     });

--- a/ghost/core/test/e2e-api/admin/posts.test.js
+++ b/ghost/core/test/e2e-api/admin/posts.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const {assertMatchSnapshot} = require('../../utils/assertions');
 const {agentProvider, fixtureManager, mockManager, matchers} = require('../../utils/e2e-framework');
@@ -264,7 +265,7 @@ describe('Posts API', function () {
                 .orderBy('created_at_ts', 'desc')
                 .fetchAll();
 
-            postRevisions.length.should.equal(1);
+            assert.equal(postRevisions.length, 1);
             postRevisions.at(0).get('lexical').should.equal(lexical);
 
             // mobiledoc revision is not created
@@ -273,7 +274,7 @@ describe('Posts API', function () {
                 .orderBy('created_at_ts', 'desc')
                 .fetchAll();
 
-            mobiledocRevisions.length.should.equal(0);
+            assert.equal(mobiledocRevisions.length, 0);
         });
 
         it('Can create a post with html', async function () {
@@ -432,7 +433,7 @@ describe('Posts API', function () {
                 .orderBy('created_at_ts', 'desc')
                 .fetchAll();
 
-            mobiledocRevisions.length.should.equal(2);
+            assert.equal(mobiledocRevisions.length, 2);
             mobiledocRevisions.at(0).get('mobiledoc').should.equal(updatedMobiledoc);
             mobiledocRevisions.at(1).get('mobiledoc').should.equal(originalMobiledoc);
 
@@ -442,7 +443,7 @@ describe('Posts API', function () {
                 .orderBy('created_at_ts', 'desc')
                 .fetchAll();
 
-            postRevisions.length.should.equal(0);
+            assert.equal(postRevisions.length, 0);
         });
 
         it('Can update a post with lexical', async function () {
@@ -486,7 +487,7 @@ describe('Posts API', function () {
                 .orderBy('created_at_ts', 'desc')
                 .fetchAll();
 
-            postRevisions.length.should.equal(2);
+            assert.equal(postRevisions.length, 2);
             postRevisions.at(0).get('lexical').should.equal(updatedLexical);
             postRevisions.at(1).get('lexical').should.equal(originalLexical);
 
@@ -496,7 +497,7 @@ describe('Posts API', function () {
                 .orderBy('created_at_ts', 'desc')
                 .fetchAll();
 
-            mobiledocRevisions.length.should.equal(0);
+            assert.equal(mobiledocRevisions.length, 0);
         });
 
         describe('Access', function () {
@@ -689,8 +690,8 @@ describe('Posts API', function () {
                 .expectStatus(201);
 
             const [postResponse] = body.posts;
-            postResponse.title.should.equal('Integration Auth Test Post');
-            postResponse.status.should.equal('published');
+            assert.equal(postResponse.title, 'Integration Auth Test Post');
+            assert.equal(postResponse.status, 'published');
             postResponse.lexical.should.equal(lexical);
 
             // Verify the post revision was created with owner user as author
@@ -699,7 +700,7 @@ describe('Posts API', function () {
                 .where('post_id', postResponse.id)
                 .fetchAll();
 
-            postRevisions.length.should.equal(1);
+            assert.equal(postRevisions.length, 1);
             const revision = postRevisions.at(0);
             revision.get('lexical').should.equal(lexical);
             revision.get('author_id').should.equal(ownerUser.get('id'));
@@ -720,7 +721,7 @@ describe('Posts API', function () {
                 .orderBy('created_at_ts', 'desc')
                 .fetchAll();
 
-            updatedRevisions.length.should.equal(2);
+            assert.equal(updatedRevisions.length, 2);
             const latestRevision = updatedRevisions.at(0);
             latestRevision.get('lexical').should.equal(updatedLexical);
             latestRevision.get('author_id').should.equal(ownerUser.get('id'));
@@ -758,11 +759,11 @@ describe('Posts API', function () {
             mobiledoc.cards.find(c => c[0] === 'file')[1].src.should.equal(`${siteUrl}/content/files/document.pdf`);
             mobiledoc.cards.find(c => c[0] === 'video')[1].src.should.equal(`${siteUrl}/content/media/video.mp4`);
             mobiledoc.cards.find(c => c[0] === 'audio')[1].src.should.equal(`${siteUrl}/content/media/audio.mp3`);
-            post.mobiledoc.should.containEql(`${siteUrl}/content/images/snippet-inline.jpg`);
-            post.mobiledoc.should.containEql(`${siteUrl}/content/files/snippet-document.pdf`);
-            post.mobiledoc.should.containEql(`${siteUrl}/content/media/snippet-video.mp4`);
-            post.mobiledoc.should.containEql(`${siteUrl}/content/media/snippet-audio.mp3`);
-            post.mobiledoc.should.not.containEql('__GHOST_URL__');
+            assert(post.mobiledoc.includes(`${siteUrl}/content/images/snippet-inline.jpg`));
+            assert(post.mobiledoc.includes(`${siteUrl}/content/files/snippet-document.pdf`));
+            assert(post.mobiledoc.includes(`${siteUrl}/content/media/snippet-video.mp4`));
+            assert(post.mobiledoc.includes(`${siteUrl}/content/media/snippet-audio.mp3`));
+            assert(!post.mobiledoc.includes('__GHOST_URL__'));
         });
 
         it('Can read Lexical post with all URLs as absolute site URLs', async function () {
@@ -773,15 +774,15 @@ describe('Posts API', function () {
             const post = res.body.posts[0];
 
             post.feature_image.should.equal(`${siteUrl}/content/images/feature.jpg`);
-            post.lexical.should.containEql(`${siteUrl}/content/images/inline.jpg`);
-            post.lexical.should.containEql(`${siteUrl}/content/files/document.pdf`);
-            post.lexical.should.containEql(`${siteUrl}/content/media/video.mp4`);
-            post.lexical.should.containEql(`${siteUrl}/content/media/audio.mp3`);
-            post.lexical.should.containEql(`${siteUrl}/content/images/snippet-inline.jpg`);
-            post.lexical.should.containEql(`${siteUrl}/content/files/snippet-document.pdf`);
-            post.lexical.should.containEql(`${siteUrl}/content/media/snippet-video.mp4`);
-            post.lexical.should.containEql(`${siteUrl}/content/media/snippet-audio.mp3`);
-            post.lexical.should.not.containEql('__GHOST_URL__');
+            assert(post.lexical.includes(`${siteUrl}/content/images/inline.jpg`));
+            assert(post.lexical.includes(`${siteUrl}/content/files/document.pdf`));
+            assert(post.lexical.includes(`${siteUrl}/content/media/video.mp4`));
+            assert(post.lexical.includes(`${siteUrl}/content/media/audio.mp3`));
+            assert(post.lexical.includes(`${siteUrl}/content/images/snippet-inline.jpg`));
+            assert(post.lexical.includes(`${siteUrl}/content/files/snippet-document.pdf`));
+            assert(post.lexical.includes(`${siteUrl}/content/media/snippet-video.mp4`));
+            assert(post.lexical.includes(`${siteUrl}/content/media/snippet-audio.mp3`));
+            assert(!post.lexical.includes('__GHOST_URL__'));
         });
 
         it('Can read Mobiledoc post with CDN URLs for media/files when configured', async function () {
@@ -804,12 +805,12 @@ describe('Posts API', function () {
             mobiledoc.cards.find(c => c[0] === 'video')[1].src.should.equal(`${cdnUrl}/content/media/video.mp4`);
             mobiledoc.cards.find(c => c[0] === 'audio')[1].src.should.equal(`${cdnUrl}/content/media/audio.mp3`);
             // Inserted snippet images stay on site URL
-            post.mobiledoc.should.containEql(`${siteUrl}/content/images/snippet-inline.jpg`);
+            assert(post.mobiledoc.includes(`${siteUrl}/content/images/snippet-inline.jpg`));
             // Inserted snippet media/files use CDN URL
-            post.mobiledoc.should.containEql(`${cdnUrl}/content/files/snippet-document.pdf`);
-            post.mobiledoc.should.containEql(`${cdnUrl}/content/media/snippet-video.mp4`);
-            post.mobiledoc.should.containEql(`${cdnUrl}/content/media/snippet-audio.mp3`);
-            post.mobiledoc.should.not.containEql('__GHOST_URL__');
+            assert(post.mobiledoc.includes(`${cdnUrl}/content/files/snippet-document.pdf`));
+            assert(post.mobiledoc.includes(`${cdnUrl}/content/media/snippet-video.mp4`));
+            assert(post.mobiledoc.includes(`${cdnUrl}/content/media/snippet-audio.mp3`));
+            assert(!post.mobiledoc.includes('__GHOST_URL__'));
         });
 
         it('Can read Lexical post with CDN URLs for media/files when configured', async function () {
@@ -825,18 +826,18 @@ describe('Posts API', function () {
 
             // Images stay on site URL
             post.feature_image.should.equal(`${siteUrl}/content/images/feature.jpg`);
-            post.lexical.should.containEql(`${siteUrl}/content/images/inline.jpg`);
+            assert(post.lexical.includes(`${siteUrl}/content/images/inline.jpg`));
             // Media/files use CDN URL
-            post.lexical.should.containEql(`${cdnUrl}/content/files/document.pdf`);
-            post.lexical.should.containEql(`${cdnUrl}/content/media/video.mp4`);
-            post.lexical.should.containEql(`${cdnUrl}/content/media/audio.mp3`);
+            assert(post.lexical.includes(`${cdnUrl}/content/files/document.pdf`));
+            assert(post.lexical.includes(`${cdnUrl}/content/media/video.mp4`));
+            assert(post.lexical.includes(`${cdnUrl}/content/media/audio.mp3`));
             // Inserted snippet images stay on site URL
-            post.lexical.should.containEql(`${siteUrl}/content/images/snippet-inline.jpg`);
+            assert(post.lexical.includes(`${siteUrl}/content/images/snippet-inline.jpg`));
             // Inserted snippet media/files use CDN URL
-            post.lexical.should.containEql(`${cdnUrl}/content/files/snippet-document.pdf`);
-            post.lexical.should.containEql(`${cdnUrl}/content/media/snippet-video.mp4`);
-            post.lexical.should.containEql(`${cdnUrl}/content/media/snippet-audio.mp3`);
-            post.lexical.should.not.containEql('__GHOST_URL__');
+            assert(post.lexical.includes(`${cdnUrl}/content/files/snippet-document.pdf`));
+            assert(post.lexical.includes(`${cdnUrl}/content/media/snippet-video.mp4`));
+            assert(post.lexical.includes(`${cdnUrl}/content/media/snippet-audio.mp3`));
+            assert(!post.lexical.includes('__GHOST_URL__'));
         });
     });
 });

--- a/ghost/core/test/e2e-api/admin/snippets.test.js
+++ b/ghost/core/test/e2e-api/admin/snippets.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 require('should');
 const sinon = require('sinon');
 const {agentProvider, fixtureManager, matchers} = require('../../utils/e2e-framework');
@@ -272,7 +273,7 @@ describe('Snippets API', function () {
             mobiledoc.cards.find(c => c[0] === 'file')[1].src.should.equal(`${siteUrl}/content/files/snippet-document.pdf`);
             mobiledoc.cards.find(c => c[0] === 'video')[1].src.should.equal(`${siteUrl}/content/media/snippet-video.mp4`);
             mobiledoc.cards.find(c => c[0] === 'audio')[1].src.should.equal(`${siteUrl}/content/media/snippet-audio.mp3`);
-            snippet.mobiledoc.should.not.containEql('__GHOST_URL__');
+            assert(!snippet.mobiledoc.includes('__GHOST_URL__'));
         });
 
         it('Can read Lexical snippet with all URLs as absolute site URLs', async function () {
@@ -282,11 +283,11 @@ describe('Snippets API', function () {
 
             const snippet = res.body.snippets[0];
 
-            snippet.lexical.should.containEql(`${siteUrl}/content/images/snippet-inline.jpg`);
-            snippet.lexical.should.containEql(`${siteUrl}/content/files/snippet-document.pdf`);
-            snippet.lexical.should.containEql(`${siteUrl}/content/media/snippet-video.mp4`);
-            snippet.lexical.should.containEql(`${siteUrl}/content/media/snippet-audio.mp3`);
-            snippet.lexical.should.not.containEql('__GHOST_URL__');
+            assert(snippet.lexical.includes(`${siteUrl}/content/images/snippet-inline.jpg`));
+            assert(snippet.lexical.includes(`${siteUrl}/content/files/snippet-document.pdf`));
+            assert(snippet.lexical.includes(`${siteUrl}/content/media/snippet-video.mp4`));
+            assert(snippet.lexical.includes(`${siteUrl}/content/media/snippet-audio.mp3`));
+            assert(!snippet.lexical.includes('__GHOST_URL__'));
         });
 
         it('Can read Mobiledoc snippet with CDN URLs for media/files when configured', async function () {
@@ -307,7 +308,7 @@ describe('Snippets API', function () {
             mobiledoc.cards.find(c => c[0] === 'file')[1].src.should.equal(`${cdnUrl}/content/files/snippet-document.pdf`);
             mobiledoc.cards.find(c => c[0] === 'video')[1].src.should.equal(`${cdnUrl}/content/media/snippet-video.mp4`);
             mobiledoc.cards.find(c => c[0] === 'audio')[1].src.should.equal(`${cdnUrl}/content/media/snippet-audio.mp3`);
-            snippet.mobiledoc.should.not.containEql('__GHOST_URL__');
+            assert(!snippet.mobiledoc.includes('__GHOST_URL__'));
         });
 
         it('Can read Lexical snippet with CDN URLs for media/files when configured', async function () {
@@ -322,12 +323,12 @@ describe('Snippets API', function () {
             const snippet = res.body.snippets[0];
 
             // Images stay on site URL
-            snippet.lexical.should.containEql(`${siteUrl}/content/images/snippet-inline.jpg`);
+            assert(snippet.lexical.includes(`${siteUrl}/content/images/snippet-inline.jpg`));
             // Media/files use CDN URL
-            snippet.lexical.should.containEql(`${cdnUrl}/content/files/snippet-document.pdf`);
-            snippet.lexical.should.containEql(`${cdnUrl}/content/media/snippet-video.mp4`);
-            snippet.lexical.should.containEql(`${cdnUrl}/content/media/snippet-audio.mp3`);
-            snippet.lexical.should.not.containEql('__GHOST_URL__');
+            assert(snippet.lexical.includes(`${cdnUrl}/content/files/snippet-document.pdf`));
+            assert(snippet.lexical.includes(`${cdnUrl}/content/media/snippet-video.mp4`));
+            assert(snippet.lexical.includes(`${cdnUrl}/content/media/snippet-audio.mp3`));
+            assert(!snippet.lexical.includes('__GHOST_URL__'));
         });
     });
 });

--- a/ghost/core/test/e2e-api/admin/storage-adapter-switching.test.js
+++ b/ghost/core/test/e2e-api/admin/storage-adapter-switching.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const {agentProvider, fixtureManager} = require('../../utils/e2e-framework');
@@ -29,8 +30,8 @@ describe('Ghost Admin - Storage Adapter Switching', function () {
 
         let post = res.body.posts[0];
         post.feature_image.should.equal(`${siteUrl}/content/images/feature.jpg`);
-        post.lexical.should.containEql(`${siteUrl}/content/files/document.pdf`);
-        post.lexical.should.containEql(`${siteUrl}/content/media/video.mp4`);
+        assert(post.lexical.includes(`${siteUrl}/content/files/document.pdf`));
+        assert(post.lexical.includes(`${siteUrl}/content/media/video.mp4`));
 
         urlUtilsHelper.stubUrlUtilsWithCdn({
             assetBaseUrls: {media: cdnUrl, files: cdnUrl}
@@ -42,8 +43,8 @@ describe('Ghost Admin - Storage Adapter Switching', function () {
 
         post = res.body.posts[0];
         post.feature_image.should.equal(`${siteUrl}/content/images/feature.jpg`);
-        post.lexical.should.containEql(`${cdnUrl}/content/files/document.pdf`);
-        post.lexical.should.containEql(`${cdnUrl}/content/media/video.mp4`);
+        assert(post.lexical.includes(`${cdnUrl}/content/files/document.pdf`));
+        assert(post.lexical.includes(`${cdnUrl}/content/media/video.mp4`));
 
         sinon.restore();
 
@@ -53,8 +54,8 @@ describe('Ghost Admin - Storage Adapter Switching', function () {
 
         post = res.body.posts[0];
         post.feature_image.should.equal(`${siteUrl}/content/images/feature.jpg`);
-        post.lexical.should.containEql(`${siteUrl}/content/files/document.pdf`);
-        post.lexical.should.containEql(`${siteUrl}/content/media/video.mp4`);
+        assert(post.lexical.includes(`${siteUrl}/content/files/document.pdf`));
+        assert(post.lexical.includes(`${siteUrl}/content/media/video.mp4`));
 
         urlUtilsHelper.stubUrlUtilsWithCdn({
             assetBaseUrls: {media: newCdnUrl, files: newCdnUrl}
@@ -66,8 +67,8 @@ describe('Ghost Admin - Storage Adapter Switching', function () {
 
         post = res.body.posts[0];
         post.feature_image.should.equal(`${siteUrl}/content/images/feature.jpg`);
-        post.lexical.should.containEql(`${newCdnUrl}/content/files/document.pdf`);
-        post.lexical.should.containEql(`${newCdnUrl}/content/media/video.mp4`);
+        assert(post.lexical.includes(`${newCdnUrl}/content/files/document.pdf`));
+        assert(post.lexical.includes(`${newCdnUrl}/content/media/video.mp4`));
     });
 
     it('Mobiledoc posts also switch URLs correctly', async function () {
@@ -102,9 +103,9 @@ describe('Ghost Admin - Storage Adapter Switching', function () {
             .expectStatus(200);
 
         let snippetData = res.body.snippets[0];
-        snippetData.mobiledoc.should.containEql(`${siteUrl}/content/files/snippet-document.pdf`);
-        snippetData.mobiledoc.should.containEql(`${siteUrl}/content/media/snippet-video.mp4`);
-        snippetData.mobiledoc.should.containEql(`${siteUrl}/content/images/snippet-inline.jpg`);
+        assert(snippetData.mobiledoc.includes(`${siteUrl}/content/files/snippet-document.pdf`));
+        assert(snippetData.mobiledoc.includes(`${siteUrl}/content/media/snippet-video.mp4`));
+        assert(snippetData.mobiledoc.includes(`${siteUrl}/content/images/snippet-inline.jpg`));
 
         urlUtilsHelper.stubUrlUtilsWithCdn({
             assetBaseUrls: {media: cdnUrl, files: cdnUrl}
@@ -115,9 +116,9 @@ describe('Ghost Admin - Storage Adapter Switching', function () {
             .expectStatus(200);
 
         snippetData = res.body.snippets[0];
-        snippetData.mobiledoc.should.containEql(`${cdnUrl}/content/files/snippet-document.pdf`);
-        snippetData.mobiledoc.should.containEql(`${cdnUrl}/content/media/snippet-video.mp4`);
-        snippetData.mobiledoc.should.containEql(`${siteUrl}/content/images/snippet-inline.jpg`);
+        assert(snippetData.mobiledoc.includes(`${cdnUrl}/content/files/snippet-document.pdf`));
+        assert(snippetData.mobiledoc.includes(`${cdnUrl}/content/media/snippet-video.mp4`));
+        assert(snippetData.mobiledoc.includes(`${siteUrl}/content/images/snippet-inline.jpg`));
     });
 });
 

--- a/ghost/core/test/e2e-api/admin/tags.test.js
+++ b/ghost/core/test/e2e-api/admin/tags.test.js
@@ -28,10 +28,10 @@ describe('Tag API', function () {
         const jsonResponse = res.body;
         should.exist(jsonResponse);
         should.exist(jsonResponse.tags);
-        jsonResponse.tags.should.have.length(7);
+        assert.equal(jsonResponse.tags.length, 7);
         localUtils.API.checkResponse(jsonResponse.tags[0], 'tag', ['count', 'url']);
 
-        testUtils.API.isISO8601(jsonResponse.tags[0].created_at).should.be.true();
+        assert.equal(testUtils.API.isISO8601(jsonResponse.tags[0].created_at), true);
         jsonResponse.tags[0].created_at.should.be.an.instanceof(String);
 
         jsonResponse.meta.pagination.should.have.property('page', 1);
@@ -50,7 +50,7 @@ describe('Tag API', function () {
         // kitchen-sink has published posts, so it should have a valid URL
         kitchenSinkTag.url.should.eql(`${config.get('url')}/tag/kitchen-sink/`);
         should.exist(kitchenSinkTag.count.posts);
-        kitchenSinkTag.count.posts.should.equal(2);
+        assert.equal(kitchenSinkTag.count.posts, 2);
     });
 
     it('Can paginate tags', async function () {
@@ -76,10 +76,10 @@ describe('Tag API', function () {
         const jsonResponse = res.body;
         should.exist(jsonResponse);
         should.exist(jsonResponse.tags);
-        jsonResponse.tags.should.have.length(1);
+        assert.equal(jsonResponse.tags.length, 1);
         localUtils.API.checkResponse(jsonResponse.tags[0], 'tag', ['count', 'url']);
         should.exist(jsonResponse.tags[0].count.posts);
-        jsonResponse.tags[0].count.posts.should.equal(7);
+        assert.equal(jsonResponse.tags[0].count.posts, 7);
 
         jsonResponse.tags[0].url.should.eql(`${config.get('url')}/tag/getting-started/`);
     });
@@ -101,10 +101,10 @@ describe('Tag API', function () {
         const jsonResponse = res.body;
         should.exist(jsonResponse);
         should.exist(jsonResponse.tags);
-        jsonResponse.tags.should.have.length(1);
+        assert.equal(jsonResponse.tags.length, 1);
 
         localUtils.API.checkResponse(jsonResponse.tags[0], 'tag', ['url']);
-        testUtils.API.isISO8601(jsonResponse.tags[0].created_at).should.be.true();
+        assert.equal(testUtils.API.isISO8601(jsonResponse.tags[0].created_at), true);
 
         should.exist(res.headers.location);
         res.headers.location.should.equal(`http://127.0.0.1:2369${localUtils.API.getApiQuery('tags/')}${res.body.tags[0].id}/`);
@@ -129,9 +129,9 @@ describe('Tag API', function () {
         should.exist(res.headers['x-cache-invalidate']);
         const jsonResponse = res.body;
         should.exist(jsonResponse);
-        jsonResponse.tags[0].visibility.should.eql('internal');
-        jsonResponse.tags[0].name.should.eql('#test');
-        jsonResponse.tags[0].slug.should.eql('hash-test');
+        assert.equal(jsonResponse.tags[0].visibility, 'internal');
+        assert.equal(jsonResponse.tags[0].name, '#test');
+        assert.equal(jsonResponse.tags[0].slug, 'hash-test');
 
         should.exist(res.headers.location);
         res.headers.location.should.equal(`http://127.0.0.1:2369${localUtils.API.getApiQuery('tags/')}${res.body.tags[0].id}/`);
@@ -152,9 +152,9 @@ describe('Tag API', function () {
         const jsonResponse = res.body;
         should.exist(jsonResponse);
         should.exist(jsonResponse.tags);
-        jsonResponse.tags.should.have.length(1);
+        assert.equal(jsonResponse.tags.length, 1);
         localUtils.API.checkResponse(jsonResponse.tags[0], 'tag', ['url']);
-        jsonResponse.tags[0].description.should.eql('hey ho ab ins klo');
+        assert.equal(jsonResponse.tags[0].description, 'hey ho ab ins klo');
     });
 
     it('Can destroy a tag', async function () {
@@ -175,7 +175,7 @@ describe('Tag API', function () {
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(404);
 
-        res.body.errors[0].message.should.eql('Resource not found error, cannot delete tag.');
+        assert.equal(res.body.errors[0].message, 'Resource not found error, cannot delete tag.');
     });
 
     describe('URL transformations', function () {

--- a/ghost/core/test/e2e-api/admin/themes.test.js
+++ b/ghost/core/test/e2e-api/admin/themes.test.js
@@ -51,42 +51,42 @@ describe('Themes API', function () {
         const jsonResponse = res.body;
         should.exist(jsonResponse.themes);
         localUtils.API.checkResponse(jsonResponse, 'themes');
-        jsonResponse.themes.length.should.eql(7);
+        assert.equal(jsonResponse.themes.length, 7);
 
         localUtils.API.checkResponse(jsonResponse.themes[0], 'theme');
-        jsonResponse.themes[0].name.should.eql('broken-theme');
+        assert.equal(jsonResponse.themes[0].name, 'broken-theme');
         jsonResponse.themes[0].package.should.be.an.Object().with.properties('name', 'version');
-        jsonResponse.themes[0].active.should.be.false();
+        assert.equal(jsonResponse.themes[0].active, false);
 
         localUtils.API.checkResponse(jsonResponse.themes[1], 'theme');
-        jsonResponse.themes[1].name.should.eql('casper');
+        assert.equal(jsonResponse.themes[1].name, 'casper');
         jsonResponse.themes[1].package.should.be.an.Object().with.properties('name', 'version');
-        jsonResponse.themes[1].active.should.be.false();
+        assert.equal(jsonResponse.themes[1].active, false);
 
         localUtils.API.checkResponse(jsonResponse.themes[2], 'theme');
-        jsonResponse.themes[2].name.should.eql('locale-theme');
+        assert.equal(jsonResponse.themes[2].name, 'locale-theme');
         jsonResponse.themes[2].package.should.be.an.Object().with.properties('name', 'version');
-        jsonResponse.themes[2].active.should.be.false();
+        assert.equal(jsonResponse.themes[2].active, false);
 
         localUtils.API.checkResponse(jsonResponse.themes[3], 'theme');
-        jsonResponse.themes[3].name.should.eql('members-test-theme');
+        assert.equal(jsonResponse.themes[3].name, 'members-test-theme');
         jsonResponse.themes[3].package.should.be.an.Object().with.properties('name', 'version');
-        jsonResponse.themes[3].active.should.be.false();
+        assert.equal(jsonResponse.themes[3].active, false);
 
         localUtils.API.checkResponse(jsonResponse.themes[4], 'theme', 'templates');
-        jsonResponse.themes[4].name.should.eql('source');
+        assert.equal(jsonResponse.themes[4].name, 'source');
         jsonResponse.themes[4].package.should.be.an.Object().with.properties('name', 'version');
-        jsonResponse.themes[4].active.should.be.true();
+        assert.equal(jsonResponse.themes[4].active, true);
 
         localUtils.API.checkResponse(jsonResponse.themes[5], 'theme');
-        jsonResponse.themes[5].name.should.eql('test-theme');
+        assert.equal(jsonResponse.themes[5].name, 'test-theme');
         jsonResponse.themes[5].package.should.be.an.Object().with.properties('name', 'version');
-        jsonResponse.themes[5].active.should.be.false();
+        assert.equal(jsonResponse.themes[5].active, false);
 
         localUtils.API.checkResponse(jsonResponse.themes[6], 'theme');
-        jsonResponse.themes[6].name.should.eql('test-theme-channels');
-        jsonResponse.themes[6].package.should.be.false();
-        jsonResponse.themes[6].active.should.be.false();
+        assert.equal(jsonResponse.themes[6].name, 'test-theme-channels');
+        assert.equal(jsonResponse.themes[6].package, false);
+        assert.equal(jsonResponse.themes[6].active, false);
     });
 
     it('Can download a theme', async function () {
@@ -113,10 +113,10 @@ describe('Themes API', function () {
 
         should.exist(jsonResponse.themes);
         localUtils.API.checkResponse(jsonResponse, 'themes');
-        jsonResponse.themes.length.should.eql(1);
+        assert.equal(jsonResponse.themes.length, 1);
         localUtils.API.checkResponse(jsonResponse.themes[0], 'theme');
-        jsonResponse.themes[0].name.should.eql('valid');
-        jsonResponse.themes[0].active.should.be.false();
+        assert.equal(jsonResponse.themes[0].name, 'valid');
+        assert.equal(jsonResponse.themes[0].active, false);
 
         // Note: at this point, the tmpFolder can legitimately still contain a valid_34324324 backup
         // As it is deleted asynchronously
@@ -127,8 +127,8 @@ describe('Themes API', function () {
             }
         });
 
-        tmpFolderContents.should.containEql('valid');
-        tmpFolderContents.should.containEql('valid.zip');
+        assert(tmpFolderContents.includes('valid'));
+        assert(tmpFolderContents.includes('valid.zip'));
 
         // Check the Themes API returns the correct result
         const res3 = await ownerRequest
@@ -140,19 +140,19 @@ describe('Themes API', function () {
 
         should.exist(jsonResponse3.themes);
         localUtils.API.checkResponse(jsonResponse3, 'themes');
-        jsonResponse3.themes.length.should.eql(8);
+        assert.equal(jsonResponse3.themes.length, 8);
 
         // Source should be present and still active
         const sourceTheme = _.find(jsonResponse3.themes, {name: 'source'});
         should.exist(sourceTheme);
         localUtils.API.checkResponse(sourceTheme, 'theme', 'templates');
-        sourceTheme.active.should.be.true();
+        assert.equal(sourceTheme.active, true);
 
         // The added theme should be here
         const addedTheme = _.find(jsonResponse3.themes, {name: 'valid'});
         should.exist(addedTheme);
         localUtils.API.checkResponse(addedTheme, 'theme');
-        addedTheme.active.should.be.false();
+        assert.equal(addedTheme.active, false);
 
         // Note: at this point, the API should not return a valid_34324324 backup folder as a theme
         _.map(jsonResponse3.themes, 'name').should.eql([
@@ -210,13 +210,13 @@ describe('Themes API', function () {
 
         should.exist(jsonResponse2.themes);
         localUtils.API.checkResponse(jsonResponse2, 'themes');
-        jsonResponse2.themes.length.should.eql(7);
+        assert.equal(jsonResponse2.themes.length, 7);
 
         // Source should be present and still active
         const sourceTheme = _.find(jsonResponse2.themes, {name: 'source'});
         should.exist(sourceTheme);
         localUtils.API.checkResponse(sourceTheme, 'theme', 'templates');
-        sourceTheme.active.should.be.true();
+        assert.equal(sourceTheme.active, true);
 
         // The deleted theme should not be here
         const deletedTheme = _.find(jsonResponse2.themes, {name: 'valid'});
@@ -229,10 +229,10 @@ describe('Themes API', function () {
 
         should.exist(jsonResponse.themes);
         localUtils.API.checkResponse(jsonResponse, 'themes');
-        jsonResponse.themes.length.should.eql(1);
+        assert.equal(jsonResponse.themes.length, 1);
         localUtils.API.checkResponse(jsonResponse.themes[0], 'theme', ['warnings']);
-        jsonResponse.themes[0].name.should.eql('warnings');
-        jsonResponse.themes[0].active.should.be.false();
+        assert.equal(jsonResponse.themes[0].name, 'warnings');
+        assert.equal(jsonResponse.themes[0].active, false);
         jsonResponse.themes[0].warnings.should.be.an.Array();
 
         // Delete the theme to clean up after the test
@@ -252,17 +252,17 @@ describe('Themes API', function () {
 
         should.exist(jsonResponse.themes);
         localUtils.API.checkResponse(jsonResponse, 'themes');
-        jsonResponse.themes.length.should.eql(7);
+        assert.equal(jsonResponse.themes.length, 7);
 
         const sourceTheme = _.find(jsonResponse.themes, {name: 'source'});
         should.exist(sourceTheme);
         localUtils.API.checkResponse(sourceTheme, 'theme', 'templates');
-        sourceTheme.active.should.be.true();
+        assert.equal(sourceTheme.active, true);
 
         const testTheme = _.find(jsonResponse.themes, {name: 'test-theme'});
         should.exist(testTheme);
         localUtils.API.checkResponse(testTheme, 'theme');
-        testTheme.active.should.be.false();
+        assert.equal(testTheme.active, false);
 
         // Finally activate the new theme
         const res2 = await ownerRequest
@@ -275,7 +275,7 @@ describe('Themes API', function () {
         should.exist(res2.headers['x-cache-invalidate']);
         should.exist(jsonResponse2.themes);
         localUtils.API.checkResponse(jsonResponse2, 'themes');
-        jsonResponse2.themes.length.should.eql(1);
+        assert.equal(jsonResponse2.themes.length, 1);
 
         const sourceTheme2 = _.find(jsonResponse2.themes, {name: 'source'});
         assert.equal(sourceTheme2, undefined);
@@ -283,7 +283,7 @@ describe('Themes API', function () {
         const testTheme2 = _.find(jsonResponse2.themes, {name: 'test-theme'});
         should.exist(testTheme2);
         localUtils.API.checkResponse(testTheme2, 'theme', ['warnings', 'templates']);
-        testTheme2.active.should.be.true();
+        assert.equal(testTheme2.active, true);
         testTheme2.warnings.should.be.an.Array();
 
         // Result should be the same
@@ -311,17 +311,17 @@ describe('Themes API', function () {
             .post(localUtils.API.getApiQuery('themes/install/?source=github&ref=TryGhost/Test'))
             .set('Origin', config.get('url'));
 
-        githubZipball.isDone().should.be.true();
-        githubDownload.isDone().should.be.true();
+        assert.equal(githubZipball.isDone(), true);
+        assert.equal(githubDownload.isDone(), true);
 
         const jsonResponse = res.body;
 
         should.exist(jsonResponse.themes);
         localUtils.API.checkResponse(jsonResponse, 'themes');
-        jsonResponse.themes.length.should.eql(1);
+        assert.equal(jsonResponse.themes.length, 1);
         localUtils.API.checkResponse(jsonResponse.themes[0], 'theme', ['warnings']);
-        jsonResponse.themes[0].name.should.eql('test');
-        jsonResponse.themes[0].active.should.be.false();
+        assert.equal(jsonResponse.themes[0].name, 'test');
+        assert.equal(jsonResponse.themes[0].active, false);
         jsonResponse.themes[0].warnings.should.be.an.Array();
 
         // Delete the theme to clean up after the test
@@ -354,17 +354,17 @@ describe('Themes API', function () {
             .post(localUtils.API.getApiQuery('themes/install/?source=github&ref=TryGhost/Starter'))
             .set('Origin', config.get('url'));
 
-        githubZipball.isDone().should.be.true();
-        githubDownload.isDone().should.be.true();
+        assert.equal(githubZipball.isDone(), true);
+        assert.equal(githubDownload.isDone(), true);
 
         const jsonResponse = res.body;
 
         should.exist(jsonResponse.themes);
         localUtils.API.checkResponse(jsonResponse, 'themes');
-        jsonResponse.themes.length.should.eql(1);
+        assert.equal(jsonResponse.themes.length, 1);
         localUtils.API.checkResponse(jsonResponse.themes[0], 'theme', ['warnings']);
-        jsonResponse.themes[0].name.should.eql('starter');
-        jsonResponse.themes[0].active.should.be.false();
+        assert.equal(jsonResponse.themes[0].name, 'starter');
+        assert.equal(jsonResponse.themes[0].active, false);
         jsonResponse.themes[0].warnings.should.be.an.Array();
 
         // Delete the theme to clean up after the test
@@ -402,14 +402,14 @@ describe('Themes API', function () {
             .expect(403);
 
         // The GitHub API calls should NOT be made (limit check happens before download)
-        githubZipball.isDone().should.be.false();
-        githubDownload.isDone().should.be.false();
+        assert.equal(githubZipball.isDone(), false);
+        assert.equal(githubDownload.isDone(), false);
 
         const jsonResponse = res.body;
 
         should.exist(jsonResponse.errors);
-        jsonResponse.errors[0].type.should.eql('HostLimitError');
-        jsonResponse.errors[0].message.should.match(/Upgrade to use customThemes feature\./);
+        assert.equal(jsonResponse.errors[0].type, 'HostLimitError');
+        assert.match(jsonResponse.errors[0].message, /Upgrade to use customThemes feature\./);
 
         // Clean up only the limit service mocks
         mockManager.restoreLimitService();
@@ -434,9 +434,9 @@ describe('Themes API', function () {
 
         should.exist(jsonResponse.themes);
         localUtils.API.checkResponse(jsonResponse, 'themes');
-        jsonResponse.themes.length.should.eql(1);
+        assert.equal(jsonResponse.themes.length, 1);
         localUtils.API.checkResponse(jsonResponse.themes[0], 'theme', 'templates');
-        jsonResponse.themes[0].name.should.eql('valid');
-        jsonResponse.themes[0].active.should.be.true();
+        assert.equal(jsonResponse.themes[0].name, 'valid');
+        assert.equal(jsonResponse.themes[0].active, true);
     });
 });

--- a/ghost/core/test/e2e-api/content/key-authentication.test.js
+++ b/ghost/core/test/e2e-api/content/key-authentication.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const supertest = require('supertest');
 const testUtils = require('../../utils');
@@ -55,8 +56,8 @@ describe('Content API key authentication', function () {
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(403);
 
-            firstResponse.body.errors[0].type.should.equal('HostLimitError');
-            firstResponse.body.errors[0].message.should.equal('Custom limit error message');
+            assert.equal(firstResponse.body.errors[0].type, 'HostLimitError');
+            assert.equal(firstResponse.body.errors[0].message, 'Custom limit error message');
 
             // CASE: explore endpoint can only be reached by Admin API
             const secondResponse = await request.get(localUtils.API.getApiQuery('explore/'))
@@ -64,7 +65,7 @@ describe('Content API key authentication', function () {
                 .expect('Cache-Control', testUtils.cacheRules.noCache)
                 .expect(404);
 
-            secondResponse.body.errors[0].type.should.equal('NotFoundError');
+            assert.equal(secondResponse.body.errors[0].type, 'NotFoundError');
         });
     });
 });

--- a/ghost/core/test/e2e-api/content/max-limit-cap.test.js
+++ b/ghost/core/test/e2e-api/content/max-limit-cap.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const {agentProvider, fixtureManager} = require('../../utils/e2e-framework');
 const should = require('should');
 const sinon = require('sinon');
@@ -32,10 +33,10 @@ describe('Content API - Max Limit Cap', function () {
             .expectStatus(200);
 
         // Verify the middleware was called
-        middlewareSpy.called.should.be.true();
+        assert.equal(middlewareSpy.called, true);
 
         // Verify it modified the req.query param by reference
         const req = middlewareSpy.firstCall.args[0];
-        req.query.limit.should.equal(100);
+        assert.equal(req.query.limit, 100);
     });
 });

--- a/ghost/core/test/e2e-api/content/pages.test.js
+++ b/ghost/core/test/e2e-api/content/pages.test.js
@@ -91,7 +91,7 @@ describe('Pages Content API', function () {
             .get(`pages/${publicPost.id}/?include=tiers`)
             .expectStatus(200);
         const publicPostData = publicPostRes.body.pages[0];
-        publicPostData.tiers.length.should.eql(2);
+        assert.equal(publicPostData.tiers.length, 2);
     });
 
     it('Can include free and paid tiers for members only post', async function () {
@@ -107,7 +107,7 @@ describe('Pages Content API', function () {
             .get(`pages/${membersPost.id}/?include=tiers`)
             .expectStatus(200);
         const membersPostData = membersPostRes.body.pages[0];
-        membersPostData.tiers.length.should.eql(2);
+        assert.equal(membersPostData.tiers.length, 2);
     });
 
     it('Can include only paid tier for paid post', async function () {
@@ -123,7 +123,7 @@ describe('Pages Content API', function () {
             .get(`pages/${paidPost.id}/?include=tiers`)
             .expectStatus(200);
         const paidPostData = paidPostRes.body.pages[0];
-        paidPostData.tiers.length.should.eql(1);
+        assert.equal(paidPostData.tiers.length, 1);
     });
 
     it('Can include specific tier for page with tiers visibility', async function () {
@@ -151,6 +151,6 @@ describe('Pages Content API', function () {
 
         const tiersPostData = tiersPostRes.body.pages[0];
 
-        tiersPostData.tiers.length.should.eql(1);
+        assert.equal(tiersPostData.tiers.length, 1);
     });
 });

--- a/ghost/core/test/e2e-api/content/posts.test.js
+++ b/ghost/core/test/e2e-api/content/posts.test.js
@@ -319,7 +319,7 @@ describe('Posts Content API', function () {
             .get(`posts/${publicPost.id}/?include=tiers`)
             .expectStatus(200);
         const publicPostData = publicPostRes.body.posts[0];
-        publicPostData.tiers.length.should.eql(2);
+        assert.equal(publicPostData.tiers.length, 2);
     });
 
     it('Can include free and paid tiers for members only post', async function () {
@@ -334,7 +334,7 @@ describe('Posts Content API', function () {
             .get(`posts/${membersPost.id}/?include=tiers`)
             .expectStatus(200);
         const membersPostData = membersPostRes.body.posts[0];
-        membersPostData.tiers.length.should.eql(2);
+        assert.equal(membersPostData.tiers.length, 2);
     });
 
     it('Can include only paid tier for paid post', async function () {
@@ -349,7 +349,7 @@ describe('Posts Content API', function () {
             .get(`posts/${paidPost.id}/?include=tiers`)
             .expectStatus(200);
         const paidPostData = paidPostRes.body.posts[0];
-        paidPostData.tiers.length.should.eql(1);
+        assert.equal(paidPostData.tiers.length, 1);
     });
 
     it('Can include specific tier for post with tiers visibility', async function () {
@@ -376,7 +376,7 @@ describe('Posts Content API', function () {
 
         const tiersPostData = tiersPostRes.body.posts[0];
 
-        tiersPostData.tiers.length.should.eql(1);
+        assert.equal(tiersPostData.tiers.length, 1);
     });
 
     it('Can use post excerpt as field', async function () {

--- a/ghost/core/test/e2e-api/content/tags.test.js
+++ b/ghost/core/test/e2e-api/content/tags.test.js
@@ -35,7 +35,7 @@ describe('Tags Content API', function () {
         const jsonResponse = res.body;
         should.exist(jsonResponse.tags);
         localUtils.API.checkResponse(jsonResponse, 'tags');
-        jsonResponse.tags.should.have.length(5);
+        assert.equal(jsonResponse.tags.length, 5);
         localUtils.API.checkResponse(jsonResponse.tags[0], 'tag', ['url']);
         localUtils.API.checkResponse(jsonResponse.meta.pagination, 'pagination');
 
@@ -43,11 +43,11 @@ describe('Tags Content API', function () {
         // the ordering difference is described in https://github.com/TryGhost/Ghost/issues/6104
         // this condition should be removed once issue mentioned above ^ is resolved
         if (dbUtils.isMySQL()) {
-            jsonResponse.tags[0].name.should.eql('bacon');
-            jsonResponse.tags[3].name.should.eql('kitchen sink');
+            assert.equal(jsonResponse.tags[0].name, 'bacon');
+            assert.equal(jsonResponse.tags[3].name, 'kitchen sink');
         } else {
-            jsonResponse.tags[0].name.should.eql('Getting Started');
-            jsonResponse.tags[4].name.should.eql('kitchen sink');
+            assert.equal(jsonResponse.tags[0].name, 'Getting Started');
+            assert.equal(jsonResponse.tags[4].name, 'kitchen sink');
         }
 
         should.exist(res.body.tags[0].url);
@@ -66,7 +66,7 @@ describe('Tags Content API', function () {
         const jsonResponse = res.body;
         should.exist(jsonResponse.tags);
         localUtils.API.checkResponse(jsonResponse, 'tags');
-        jsonResponse.tags.should.have.length(5);
+        assert.equal(jsonResponse.tags.length, 5);
         localUtils.API.checkResponse(jsonResponse.tags[0], 'tag', ['url']);
         localUtils.API.checkResponse(jsonResponse.meta.pagination, 'pagination');
     });
@@ -82,7 +82,7 @@ describe('Tags Content API', function () {
         const jsonResponse = res.body;
         should.exist(jsonResponse.tags);
         localUtils.API.checkResponse(jsonResponse, 'tags');
-        jsonResponse.tags.should.have.length(3);
+        assert.equal(jsonResponse.tags.length, 3);
         localUtils.API.checkResponse(jsonResponse.tags[0], 'tag', ['url']);
         localUtils.API.checkResponse(jsonResponse.meta.pagination, 'pagination');
     });
@@ -100,10 +100,10 @@ describe('Tags Content API', function () {
         jsonResponse.tags.should.be.an.Array().with.lengthOf(5);
 
         // Each tag should have the correct count
-        _.find(jsonResponse.tags, {name: 'Getting Started'}).count.posts.should.eql(7);
-        _.find(jsonResponse.tags, {name: 'kitchen sink'}).count.posts.should.eql(2);
-        _.find(jsonResponse.tags, {name: 'bacon'}).count.posts.should.eql(2);
-        _.find(jsonResponse.tags, {name: 'chorizo'}).count.posts.should.eql(1);
+        assert.equal(_.find(jsonResponse.tags, {name: 'Getting Started'}).count.posts, 7);
+        assert.equal(_.find(jsonResponse.tags, {name: 'kitchen sink'}).count.posts, 2);
+        assert.equal(_.find(jsonResponse.tags, {name: 'bacon'}).count.posts, 2);
+        assert.equal(_.find(jsonResponse.tags, {name: 'chorizo'}).count.posts, 1);
     });
 
     it('Can use multiple fields and have valid url fields', async function () {

--- a/ghost/core/test/e2e-api/members-comments/comments.test.js
+++ b/ghost/core/test/e2e-api/members-comments/comments.test.js
@@ -416,7 +416,7 @@ describe('Comments API', function () {
 
                 // check that hiddenComment.id is not in the response
                 should(data2.body.comments.map(c => c.id)).not.containEql(hiddenComment.id);
-                should(data2.body.comments.length).eql(0);
+                assert.equal(data2.body.comments.length, 0);
             });
 
             it('excludes deleted comments', async function () {
@@ -436,7 +436,7 @@ describe('Comments API', function () {
                     should(comment.html).not.eql('This is a deleted comment');
                 });
 
-                data2.body.comments.length.should.eql(0);
+                assert.equal(data2.body.comments.length, 0);
             });
 
             it('shows hidden and deleted comment where there is a reply', async function () {
@@ -486,10 +486,10 @@ describe('Comments API', function () {
                 // check if the replies to hidden and deleted comments are in the response
                 data2.body.comments.forEach((comment) => {
                     if (comment.id === hiddenComment.id) {
-                        should(comment.replies.length).eql(1);
+                        assert.equal(comment.replies.length, 1);
                         assert.equal(comment.replies[0].html, 'This is a reply to a hidden comment');
                     } else if (comment.id === deletedComment.id) {
-                        should(comment.replies.length).eql(1);
+                        assert.equal(comment.replies.length, 1);
                         assert.equal(comment.replies[0].html, 'This is a reply to a deleted comment');
                     }
                 });
@@ -515,7 +515,7 @@ describe('Comments API', function () {
                     .get(`/api/comments/post/${postId}`)
                     .expectStatus(200);
 
-                should(data2.body.comments.length).eql(0);
+                assert.equal(data2.body.comments.length, 0);
             });
 
             it('cannot comment on a post', async function () {
@@ -650,8 +650,8 @@ describe('Comments API', function () {
                     });
 
                     const result = await testGetComments(`/api/comments/post/${postId}/`, []);
-                    should(result.body.comments.length).eql(0);
-                    should(result.body.meta.pagination.total).eql(0);
+                    assert.equal(result.body.comments.length, 0);
+                    assert.equal(result.body.meta.pagination.total, 0);
                 });
 
                 it('includes deleted comments if they have published replies', async function () {
@@ -683,8 +683,8 @@ describe('Comments API', function () {
                     });
 
                     const result = await testGetComments(`/api/comments/post/${postId}/`, []);
-                    should(result.body.comments.length).eql(0);
-                    should(result.body.meta.pagination.total).eql(0);
+                    assert.equal(result.body.comments.length, 0);
+                    assert.equal(result.body.meta.pagination.total, 0);
                 });
 
                 it('excludes hidden comments', async function () {
@@ -694,8 +694,8 @@ describe('Comments API', function () {
                     });
 
                     const result = await testGetComments(`/api/comments/post/${postId}/`, []);
-                    should(result.body.comments.length).eql(0);
-                    should(result.body.meta.pagination.total).eql(0);
+                    assert.equal(result.body.comments.length, 0);
+                    assert.equal(result.body.meta.pagination.total, 0);
                 });
 
                 it('includes hidden comments if they have published replies', async function () {
@@ -710,10 +710,10 @@ describe('Comments API', function () {
                     });
 
                     const result = await testGetComments(`/api/comments/post/${postId}/`, [commentMatcherWithReplies({replies: 1})]);
-                    should(result.body.comments.length).eql(1);
-                    should(result.body.comments[0].html).eql(null);
-                    should(result.body.comments[0].count.replies).eql(1);
-                    should(result.body.meta.pagination.total).eql(1);
+                    assert.equal(result.body.comments.length, 1);
+                    assert.equal(result.body.comments[0].html, null);
+                    assert.equal(result.body.comments[0].count.replies, 1);
+                    assert.equal(result.body.meta.pagination.total, 1);
                 });
 
                 it('excludes hidden comments if all replies are hidden or deleted', async function () {
@@ -731,8 +731,8 @@ describe('Comments API', function () {
                     });
 
                     const result = await testGetComments(`/api/comments/post/${postId}/`, []);
-                    should(result.body.comments.length).eql(0);
-                    should(result.body.meta.pagination.total).eql(0);
+                    assert.equal(result.body.comments.length, 0);
+                    assert.equal(result.body.meta.pagination.total, 0);
                 });
 
                 it('excludes deleted replies', async function () {
@@ -745,7 +745,7 @@ describe('Comments API', function () {
                     });
 
                     const result = await testGetComments(`/api/comments/post/${postId}/`, [commentMatcherWithReplies({replies: 0})]);
-                    should(result.body.comments[0].replies.length).eql(0);
+                    assert.equal(result.body.comments[0].replies.length, 0);
                 });
 
                 it('excludes hidden replies', async function () {
@@ -758,7 +758,7 @@ describe('Comments API', function () {
                     });
 
                     const result = await testGetComments(`/api/comments/post/${postId}/`, [commentMatcherWithReplies({replies: 0})]);
-                    should(result.body.comments[0].replies.length).eql(0);
+                    assert.equal(result.body.comments[0].replies.length, 0);
                 });
 
                 it('doesn\'t count deleted or hidden comments in replies count', async function () {
@@ -780,7 +780,7 @@ describe('Comments API', function () {
 
                     // Deleted parent returned with full data, only 1 published reply visible
                     const result = await testGetComments(`/api/comments/post/${postId}/`, [commentMatcherWithReplies({replies: 1})]);
-                    should(result.body.comments[0].replies.length).eql(1);
+                    assert.equal(result.body.comments[0].replies.length, 1);
                 });
             });
 
@@ -891,7 +891,7 @@ describe('Comments API', function () {
                 // Check if we have count.replies = 4, and replies.length == 3
                 await testGetComments(`/api/comments/${parent.get('id')}/`, [commentMatcherWithReplies({replies: 3})])
                     .expect(({body}) => {
-                        body.comments[0].count.replies.should.eql(5);
+                        assert.equal(body.comments[0].count.replies, 5);
                     });
             });
 
@@ -906,7 +906,7 @@ describe('Comments API', function () {
 
                 const res = await membersAgent.get(`/api/comments/${parent.get('id')}/`);
 
-                res.body.comments[0].count.replies.should.eql(0);
+                assert.equal(res.body.comments[0].count.replies, 0);
             });
 
             it('deleted replies are not included in the count', async function () {
@@ -920,7 +920,7 @@ describe('Comments API', function () {
 
                 const res = await membersAgent.get(`/api/comments/${parent.get('id')}/`);
 
-                res.body.comments[0].count.replies.should.eql(0);
+                assert.equal(res.body.comments[0].count.replies, 0);
             });
 
             it('Can reply to a comment with www domain', async function () {
@@ -960,8 +960,8 @@ describe('Comments API', function () {
                 // Check liked
                 await testGetComments(`/api/comments/${comment.get('id')}/`, [commentMatcher])
                     .expect(({body}) => {
-                        body.comments[0].liked.should.eql(true);
-                        body.comments[0].count.likes.should.eql(1);
+                        assert.equal(body.comments[0].liked, true);
+                        assert.equal(body.comments[0].count.likes, 1);
                     });
             });
 
@@ -1002,8 +1002,8 @@ describe('Comments API', function () {
                 // Check liked
                 await testGetComments(`/api/comments/${reply.id}/`, [commentMatcher])
                     .expect(({body}) => {
-                        body.comments[0].liked.should.eql(true);
-                        body.comments[0].count.likes.should.eql(1);
+                        assert.equal(body.comments[0].liked, true);
+                        assert.equal(body.comments[0].count.likes, 1);
                     });
             });
 
@@ -1021,13 +1021,13 @@ describe('Comments API', function () {
 
                 await testGetComments(`/api/comments/${parent.get('id')}/replies/`, new Array(7).fill(commentMatcher))
                     .expect(({body}) => {
-                        should(body.comments[0].count.replies).be.undefined();
-                        should(body.meta.pagination.total).eql(7);
-                        should(body.meta.pagination.next).eql(null);
+                        assert.equal(body.comments[0].count.replies, undefined);
+                        assert.equal(body.meta.pagination.total, 7);
+                        assert.equal(body.meta.pagination.next, null);
 
                         // Check liked + likes working for replies too
                         should(body.comments[2].id).eql(replies[2].get('id'));
-                        should(body.comments[2].count.likes).eql(1);
+                        assert.equal(body.comments[2].count.likes, 1);
                         assert.equal(body.comments[2].liked, true);
                     });
             });
@@ -1042,9 +1042,9 @@ describe('Comments API', function () {
 
                 await testGetComments(`/api/comments/${parent.get('id')}/replies/?page=3&limit=3`, [commentMatcher])
                     .expect(({body}) => {
-                        should(body.comments[0].count.replies).be.undefined();
-                        should(body.meta.pagination.total).eql(7);
-                        should(body.meta.pagination.next).eql(null);
+                        assert.equal(body.comments[0].count.replies, undefined);
+                        assert.equal(body.meta.pagination.total, 7);
+                        assert.equal(body.meta.pagination.next, null);
                     });
             });
 
@@ -1063,8 +1063,8 @@ describe('Comments API', function () {
                 // Check not liked
                 await testGetComments(`/api/comments/${comment.get('id')}/`, [commentMatcher])
                     .expect(({body}) => {
-                        body.comments[0].liked.should.eql(false);
-                        body.comments[0].count.likes.should.eql(0);
+                        assert.equal(body.comments[0].liked, false);
+                        assert.equal(body.comments[0].count.likes, 0);
                     });
             });
 
@@ -1086,7 +1086,7 @@ describe('Comments API', function () {
 
                 // Check report
                 const reports = await models.CommentReport.findAll({filter: 'comment_id:\'' + comment.get('id') + '\''});
-                reports.models.length.should.eql(1);
+                assert.equal(reports.models.length, 1);
 
                 const report = reports.models[0];
                 report.get('member_id').should.eql(loggedInMember.id);
@@ -1112,7 +1112,7 @@ describe('Comments API', function () {
 
                 // Check report should be the same (no extra created)
                 const reports = await models.CommentReport.findAll({filter: 'comment_id:\'' + comment.get('id') + '\''});
-                reports.models.length.should.eql(1);
+                assert.equal(reports.models.length, 1);
 
                 const report = reports.models[0];
                 report.get('member_id').should.eql(loggedInMember.id);
@@ -1137,9 +1137,9 @@ describe('Comments API', function () {
 
                 // Verify the reports count is NOT included in public API response
                 const res = await membersAgent.get(`/api/comments/${comment.get('id')}/`);
-                should(res.body.comments[0].count.reports).be.undefined();
+                assert.equal(res.body.comments[0].count.reports, undefined);
                 // Verify other counts are still there
-                should(res.body.comments[0].count.likes).eql(0);
+                assert.equal(res.body.comments[0].count.likes, 0);
             });
 
             it('Can edit a comment on a post', async function () {
@@ -1401,7 +1401,7 @@ describe('Comments API', function () {
 
                     // in_reply_to is set
                     newComment.in_reply_to_id.should.eql(reply.get('id'));
-                    newComment.in_reply_to_snippet.should.eql('This is a reply');
+                    assert.equal(newComment.in_reply_to_snippet, 'This is a reply');
 
                     // replied-to comment author is notified
                     // parent comment author is notified
@@ -1518,7 +1518,7 @@ describe('Comments API', function () {
                     const {body: {comments: [comment]}} = await testGetComments(`/api/comments/${newComment.id}`, [labsCommentMatcher]);
 
                     // in_reply_to_snippet is included
-                    comment.in_reply_to_snippet.should.eql('This is what was replied to');
+                    assert.equal(comment.in_reply_to_snippet, 'This is what was replied to');
                 });
 
                 ['deleted', 'hidden'].forEach((status) => {
@@ -1540,7 +1540,7 @@ describe('Comments API', function () {
 
                         const {body: {comments: [comment]}} = await testGetComments(`/api/comments/${newComment.id}`, [labsCommentMatcher]);
 
-                        comment.in_reply_to_snippet.should.eql('[removed]');
+                        assert.equal(comment.in_reply_to_snippet, '[removed]');
                     });
                 });
             });

--- a/ghost/core/test/e2e-api/members-comments/max-limit-cap.test.js
+++ b/ghost/core/test/e2e-api/members-comments/max-limit-cap.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const {agentProvider, fixtureManager} = require('../../utils/e2e-framework');
 const should = require('should');
 const sinon = require('sinon');
@@ -43,10 +44,10 @@ describe('Comments API - Max Limit Cap', function () {
             .expectStatus(200);
 
         // Verify the middleware was called
-        middlewareSpy.called.should.be.true();
+        assert.equal(middlewareSpy.called, true);
 
         // Verify it modified the req.query param by reference
         const req = middlewareSpy.firstCall.args[0];
-        req.query.limit.should.equal(100);
+        assert.equal(req.query.limit, 100);
     });
 });

--- a/ghost/core/test/e2e-api/members/create-stripe-checkout-session.test.js
+++ b/ghost/core/test/e2e-api/members/create-stripe-checkout-session.test.js
@@ -323,7 +323,7 @@ describe('Create Stripe Checkout Session', function () {
                         const parsed = new URLSearchParams(body);
                         assert.equal(parsed.get('metadata[attribution_url]'), '/test');
                         assert.equal(parsed.get('metadata[attribution_type]'), 'url');
-                        should(parsed.get('metadata[attribution_id]')).be.null();
+                        assert.equal(parsed.get('metadata[attribution_id]'), null);
 
                         return [200, {id: 'cs_123', url: 'https://site.com'}];
                     }
@@ -486,9 +486,9 @@ describe('Create Stripe Checkout Session', function () {
                 .reply((uri, body) => {
                     if (uri === '/v1/checkout/sessions') {
                         const parsed = new URLSearchParams(body);
-                        should(parsed.get('metadata[attribution_url]')).be.null();
-                        should(parsed.get('metadata[attribution_type]')).be.null();
-                        should(parsed.get('metadata[attribution_id]')).be.null();
+                        assert.equal(parsed.get('metadata[attribution_url]'), null);
+                        assert.equal(parsed.get('metadata[attribution_type]'), null);
+                        assert.equal(parsed.get('metadata[attribution_id]'), null);
 
                         return [200, {id: 'cs_123', url: 'https://site.com'}];
                     }

--- a/ghost/core/test/e2e-api/members/donation-checkout-session.test.js
+++ b/ghost/core/test/e2e-api/members/donation-checkout-session.test.js
@@ -327,7 +327,7 @@ describe('Create Stripe Checkout Session for Donations', function () {
             .orderBy('created_at', 'DESC')
             .fetch({require: true});
 
-        latestStripePrice.get('nickname').should.have.length(250);
+        assert.equal(latestStripePrice.get('nickname').length, 250);
     });
     it('Can create a checkout session with a personal note included', async function () {
         const post = await getPost(fixtureManager.get('posts', 0).id);

--- a/ghost/core/test/e2e-api/members/middleware.test.js
+++ b/ghost/core/test/e2e-api/members/middleware.test.js
@@ -62,7 +62,7 @@ describe('Comments API', function () {
         it('can update comment notifications', async function () {
             // Only via updateMemberNewsletters
             let member = await models.Member.findOne({id: fixtureManager.get('members', 0).id}, {require: true});
-            member.get('enable_comment_notifications').should.eql(true, 'This test requires the initial value to be true');
+            assert.equal(member.get('enable_comment_notifications'), true, 'This test requires the initial value to be true');
 
             sinon.stub(settingsHelpers, 'getMembersValidationKey').returns('test');
             const hmac = crypto.createHmac('sha256', 'test').update(member.get('uuid')).digest('hex');
@@ -79,10 +79,10 @@ describe('Comments API', function () {
                 .matchBodySnapshot(buildMemberMatcher(1))
                 .expect(({body}) => {
                     body.email.should.eql(member.get('email'));
-                    body.enable_comment_notifications.should.eql(false);
+                    assert.equal(body.enable_comment_notifications, false);
                 });
             member = await models.Member.findOne({id: member.id}, {require: true});
-            member.get('enable_comment_notifications').should.eql(false);
+            assert.equal(member.get('enable_comment_notifications'), false);
         });
     });
 
@@ -120,10 +120,10 @@ describe('Comments API', function () {
                 .matchBodySnapshot(memberMatcher(2))
                 .expect(({body}) => {
                     body.email.should.eql(member.get('email'));
-                    body.expertise.should.eql('Head of Testing');
+                    assert.equal(body.expertise, 'Head of Testing');
                 });
             member = await models.Member.findOne({id: member.id}, {require: true});
-            member.get('expertise').should.eql('Head of Testing');
+            assert.equal(member.get('expertise'), 'Head of Testing');
         });
 
         it('trims whitespace from expertise', async function () {
@@ -139,10 +139,10 @@ describe('Comments API', function () {
                 .matchBodySnapshot(memberMatcher(2))
                 .expect(({body}) => {
                     body.email.should.eql(member.get('email'));
-                    body.expertise.should.eql('test');
+                    assert.equal(body.expertise, 'test');
                 });
             member = await models.Member.findOne({id: member.id}, {require: true});
-            member.get('expertise').should.eql('test');
+            assert.equal(member.get('expertise'), 'test');
         });
 
         it('can update name', async function () {
@@ -158,15 +158,15 @@ describe('Comments API', function () {
                 .matchBodySnapshot(memberMatcher(2))
                 .expect(({body}) => {
                     body.email.should.eql(member.get('email'));
-                    body.name.should.eql('Test User');
-                    body.firstname.should.eql('Test');
+                    assert.equal(body.name, 'Test User');
+                    assert.equal(body.firstname, 'Test');
                 });
             member = await models.Member.findOne({id: member.id}, {require: true});
-            member.get('name').should.eql('Test User');
+            assert.equal(member.get('name'), 'Test User');
         });
 
         it('can update comment notifications', async function () {
-            member.get('enable_comment_notifications').should.eql(true, 'This test requires the initial value to be true');
+            assert.equal(member.get('enable_comment_notifications'), true, 'This test requires the initial value to be true');
 
             // Via general way
             await membersAgent
@@ -181,10 +181,10 @@ describe('Comments API', function () {
                 .matchBodySnapshot(memberMatcher(2))
                 .expect(({body}) => {
                     body.email.should.eql(member.get('email'));
-                    body.enable_comment_notifications.should.eql(false);
+                    assert.equal(body.enable_comment_notifications, false);
                 });
             member = await models.Member.findOne({id: member.id}, {require: true});
-            member.get('enable_comment_notifications').should.eql(false);
+            assert.equal(member.get('enable_comment_notifications'), false);
 
             sinon.stub(settingsHelpers, 'getMembersValidationKey').returns('test');
             const hmac = crypto.createHmac('sha256', 'test').update(member.get('uuid')).digest('hex');
@@ -202,10 +202,10 @@ describe('Comments API', function () {
                 .matchBodySnapshot(buildMemberMatcher(2))
                 .expect(({body}) => {
                     body.email.should.eql(member.get('email'));
-                    body.enable_comment_notifications.should.eql(true);
+                    assert.equal(body.enable_comment_notifications, true);
                 });
             member = await models.Member.findOne({id: member.id}, {require: true});
-            member.get('enable_comment_notifications').should.eql(true);
+            assert.equal(member.get('enable_comment_notifications'), true);
         });
 
         it('can remove a member\'s email from the suppression list', async function () {
@@ -227,12 +227,12 @@ describe('Comments API', function () {
             // check that member is removed from suppression list
             const suppression = await models.Suppression.findOne({email: member.get('email')});
 
-            should(suppression).be.null();
+            assert.equal(suppression, null);
 
             // check that member's email is enabled
             await member.refresh();
 
-            should(member.get('email_disabled')).be.false();
+            assert.equal(member.get('email_disabled'), false);
         });
     });
 

--- a/ghost/core/test/e2e-api/members/webhooks.test.js
+++ b/ghost/core/test/e2e-api/members/webhooks.test.js
@@ -3222,7 +3222,7 @@ describe('Members API', function () {
                     etag: anyEtag
                 })
                 .expect(({body}) => {
-                    should(body.events.find(e => e.type !== 'subscription_event')).be.undefined();
+                    assert.equal(body.events.find(e => e.type !== 'subscription_event'), undefined);
                     should(body.events.map(e => e.data.attribution)).containDeep(subscriptionAttributions);
                 });
         });

--- a/ghost/core/test/e2e-frontend/default-routes.test.js
+++ b/ghost/core/test/e2e-frontend/default-routes.test.js
@@ -65,12 +65,12 @@ describe('Default Frontend routing', function () {
                     const $ = cheerio.load(res.text);
 
                     // NOTE: "Ghost" is the title from the settings.
-                    $('title').text().should.equal('Ghost');
+                    assert.equal($('title').text(), 'Ghost');
 
-                    $('body.home-template').length.should.equal(1);
-                    $('article.post').length.should.equal(7);
+                    assert.equal($('body.home-template').length, 1);
+                    assert.equal($('article.post').length, 7);
 
-                    res.text.should.not.containEql('__GHOST_URL__');
+                    assert(!res.text.includes('__GHOST_URL__'));
                 });
         });
 
@@ -84,13 +84,13 @@ describe('Default Frontend routing', function () {
                     const $ = cheerio.load(res.text);
 
                     // NOTE: "Ghost" is the title from the settings.
-                    $('title').text().should.equal('Ghost - Ghost');
+                    assert.equal($('title').text(), 'Ghost - Ghost');
 
-                    $('body.author-template').length.should.equal(1);
-                    $('article.post').length.should.equal(7);
-                    $('article.tag-getting-started').length.should.equal(7);
+                    assert.equal($('body.author-template').length, 1);
+                    assert.equal($('article.post').length, 7);
+                    assert.equal($('article.tag-getting-started').length, 7);
 
-                    res.text.should.not.containEql('__GHOST_URL__');
+                    assert(!res.text.includes('__GHOST_URL__'));
                 });
         });
 
@@ -104,13 +104,13 @@ describe('Default Frontend routing', function () {
                     const $ = cheerio.load(res.text);
 
                     // NOTE: "Ghost" is the title from the settings.
-                    $('title').text().should.equal('Getting Started - Ghost');
+                    assert.equal($('title').text(), 'Getting Started - Ghost');
 
-                    $('body.tag-template').length.should.equal(1);
-                    $('article.post').length.should.equal(7);
-                    $('article.tag-getting-started').length.should.equal(7);
+                    assert.equal($('body.tag-template').length, 1);
+                    assert.equal($('article.post').length, 7);
+                    assert.equal($('article.tag-getting-started').length, 7);
 
-                    res.text.should.not.containEql('__GHOST_URL__');
+                    assert(!res.text.includes('__GHOST_URL__'));
                 });
         });
     });
@@ -124,11 +124,11 @@ describe('Default Frontend routing', function () {
                 .expect(assertCorrectFrontendHeaders)
                 .expect((res) => {
                     // Test that head and body have rendered something...
-                    res.text.should.containEql('<title>Start here for a quick overview of everything you need to know</title>');
-                    res.text.should.match(/<h1[^>]*?>Start here for a quick overview of everything you need to know<\/h1>/);
+                    assert(res.text.includes('<title>Start here for a quick overview of everything you need to know</title>'));
+                    assert.match(res.text, /<h1[^>]*?>Start here for a quick overview of everything you need to know<\/h1>/);
                     // We should write a single test for this, or encapsulate it as an assertion
                     // E.g. res.text.should.not.containInvalidUrls()
-                    res.text.should.not.containEql('__GHOST_URL__');
+                    assert(!res.text.includes('__GHOST_URL__'));
                 });
         });
 
@@ -299,8 +299,8 @@ describe('Default Frontend routing', function () {
                 .expect('Content-Type', 'application/rss+xml; charset=utf-8')
                 .expect(assertCorrectFrontendHeaders)
                 .expect((res) => {
-                    res.text.should.match(/<!\[CDATA\[Start here for a quick overview of everything you need to know\]\]>/);
-                    res.text.should.not.containEql('__GHOST_URL__');
+                    assert.match(res.text, /<!\[CDATA\[Start here for a quick overview of everything you need to know\]\]>/);
+                    assert(!res.text.includes('__GHOST_URL__'));
                 });
         });
 
@@ -311,8 +311,8 @@ describe('Default Frontend routing', function () {
                 .expect('Content-Type', 'application/rss+xml; charset=utf-8')
                 .expect(assertCorrectFrontendHeaders)
                 .expect((res) => {
-                    res.text.should.match(/<!\[CDATA\[Start here for a quick overview of everything you need to know\]\]>/);
-                    res.text.should.not.containEql('__GHOST_URL__');
+                    assert.match(res.text, /<!\[CDATA\[Start here for a quick overview of everything you need to know\]\]>/);
+                    assert(!res.text.includes('__GHOST_URL__'));
                 });
         });
 
@@ -323,8 +323,8 @@ describe('Default Frontend routing', function () {
                 .expect('Content-Type', 'application/rss+xml; charset=utf-8')
                 .expect(assertCorrectFrontendHeaders)
                 .expect((res) => {
-                    res.text.should.match(/<!\[CDATA\[Start here for a quick overview of everything you need to know\]\]>/);
-                    res.text.should.not.containEql('__GHOST_URL__');
+                    assert.match(res.text, /<!\[CDATA\[Start here for a quick overview of everything you need to know\]\]>/);
+                    assert(!res.text.includes('__GHOST_URL__'));
                 });
         });
     });
@@ -378,8 +378,8 @@ describe('Default Frontend routing', function () {
                 .expect('Content-Type', 'text/xml; charset=utf-8')
                 .expect(assertCorrectFrontendHeaders)
                 .expect((res) => {
-                    res.text.should.match(/sitemapindex/);
-                    res.text.should.not.containEql('__GHOST_URL__');
+                    assert.match(res.text, /sitemapindex/);
+                    assert(!res.text.includes('__GHOST_URL__'));
                 });
         });
 
@@ -390,8 +390,8 @@ describe('Default Frontend routing', function () {
                 .expect('Content-Type', 'text/xml; charset=utf-8')
                 .expect(assertCorrectFrontendHeaders)
                 .expect((res) => {
-                    res.text.should.match(/urlset/);
-                    res.text.should.not.containEql('__GHOST_URL__');
+                    assert.match(res.text, /urlset/);
+                    assert(!res.text.includes('__GHOST_URL__'));
                 });
         });
 
@@ -402,10 +402,10 @@ describe('Default Frontend routing', function () {
                 .expect('Content-Type', 'text/xml; charset=utf-8')
                 .expect(assertCorrectFrontendHeaders)
                 .expect((res) => {
-                    res.text.should.match(/urlset/);
+                    assert.match(res.text, /urlset/);
                     // CASE: the index page should always be present in pages sitemap
-                    res.text.should.containEql('<loc>http://127.0.0.1:2369/</loc>');
-                    res.text.should.not.containEql('__GHOST_URL__');
+                    assert(res.text.includes('<loc>http://127.0.0.1:2369/</loc>'));
+                    assert(!res.text.includes('__GHOST_URL__'));
                 });
         });
 
@@ -416,8 +416,8 @@ describe('Default Frontend routing', function () {
                 .expect('Content-Type', 'text/xml; charset=utf-8')
                 .expect(assertCorrectFrontendHeaders)
                 .expect((res) => {
-                    res.text.should.match(/urlset/);
-                    res.text.should.not.containEql('__GHOST_URL__');
+                    assert.match(res.text, /urlset/);
+                    assert(!res.text.includes('__GHOST_URL__'));
                 });
         });
 
@@ -428,8 +428,8 @@ describe('Default Frontend routing', function () {
                 .expect('Content-Type', 'text/xml; charset=utf-8')
                 .expect(assertCorrectFrontendHeaders)
                 .expect((res) => {
-                    res.text.should.match(/urlset/);
-                    res.text.should.not.containEql('__GHOST_URL__');
+                    assert.match(res.text, /urlset/);
+                    assert(!res.text.includes('__GHOST_URL__'));
                 });
         });
 
@@ -440,8 +440,8 @@ describe('Default Frontend routing', function () {
                 .expect('Content-Type', 'text/xsl')
                 .expect(assertCorrectFrontendHeaders)
                 .expect((res) => {
-                    res.text.should.match(/urlset/);
-                    res.text.should.not.containEql('__GHOST_URL__');
+                    assert.match(res.text, /urlset/);
+                    assert(!res.text.includes('__GHOST_URL__'));
                 });
         });
     });
@@ -490,7 +490,7 @@ describe('Default Frontend routing', function () {
                 .expect('Content-Type', 'application/rss+xml; charset=utf-8')
                 .expect(assertCorrectFrontendHeaders)
                 .expect((res) => {
-                    res.text.should.match(/<!\[CDATA\[Start here for a quick overview of everything you need to know\]\]>/);
+                    assert.match(res.text, /<!\[CDATA\[Start here for a quick overview of everything you need to know\]\]>/);
                 });
         });
 
@@ -501,7 +501,7 @@ describe('Default Frontend routing', function () {
                 .expect('Content-Type', 'application/rss+xml; charset=utf-8')
                 .expect(assertCorrectFrontendHeaders)
                 .expect((res) => {
-                    res.text.should.match(/<!\[CDATA\[Start here for a quick overview of everything you need to know\]\]>/);
+                    assert.match(res.text, /<!\[CDATA\[Start here for a quick overview of everything you need to know\]\]>/);
                 });
         });
 

--- a/ghost/core/test/e2e-frontend/email-routes.test.js
+++ b/ghost/core/test/e2e-frontend/email-routes.test.js
@@ -46,7 +46,7 @@ describe('Frontend Routing: Email Routes', function () {
 
         const $ = cheerio.load(res.text);
 
-        $('title').text().should.equal('I am visible through email route!');
+        assert.equal($('title').text(), 'I am visible through email route!');
 
         assert.equal(res.headers['x-cache-invalidate'], undefined);
         assert.equal(res.headers['X-CSRF-Token'], undefined);

--- a/ghost/core/test/e2e-frontend/helpers/get.test.js
+++ b/ghost/core/test/e2e-frontend/helpers/get.test.js
@@ -87,10 +87,10 @@ describe('e2e {{#get}} helper', function () {
 
     // Assert fixtures are correct
     it('has valid fixtures', function () {
-        publicPost.visibility.should.eql('public');
-        membersPost.visibility.should.eql('members');
-        paidPost.visibility.should.eql('paid');
-        basicTierPost.visibility.should.eql('tiers');
+        assert.equal(publicPost.visibility, 'public');
+        assert.equal(membersPost.visibility, 'members');
+        assert.equal(paidPost.visibility, 'paid');
+        assert.equal(basicTierPost.visibility, 'tiers');
     });
 
     beforeEach(function () {

--- a/ghost/core/test/e2e-frontend/helpers/next-post.test.js
+++ b/ghost/core/test/e2e-frontend/helpers/next-post.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const testUtils = require('../../utils');
@@ -74,11 +75,11 @@ describe('e2e {{#next_post}} helper', function () {
 
     // Assert fixtures are correct
     it('has valid fixtures', function () {
-        publicPost.visibility.should.eql('public');
-        membersPost.visibility.should.eql('members');
-        paidPost.visibility.should.eql('paid');
-        basicTierPost.visibility.should.eql('tiers');
-        publicPost2.visibility.should.eql('public');
+        assert.equal(publicPost.visibility, 'public');
+        assert.equal(membersPost.visibility, 'members');
+        assert.equal(paidPost.visibility, 'paid');
+        assert.equal(basicTierPost.visibility, 'tiers');
+        assert.equal(publicPost2.visibility, 'public');
     });
 
     beforeEach(function () {

--- a/ghost/core/test/e2e-frontend/members.test.js
+++ b/ghost/core/test/e2e-frontend/members.test.js
@@ -17,11 +17,11 @@ const membersEventsService = require('../../core/server/services/members-events'
 const crypto = require('crypto');
 
 function assertContentIsPresent(res) {
-    res.text.should.containEql('<h2 id="markdown">markdown</h2>');
+    assert(res.text.includes('<h2 id="markdown">markdown</h2>'));
 }
 
 function assertContentIsAbsent(res) {
-    res.text.should.not.containEql('<h2 id="markdown">markdown</h2>');
+    assert(!res.text.includes('<h2 id="markdown">markdown</h2>'));
 }
 
 async function createMember(data) {
@@ -58,7 +58,7 @@ describe('Front-end members behavior', function () {
             .expect((res) => {
                 const redirectUrl = new URL(res.headers.location, testUtils.API.getURL());
                 should.exist(redirectUrl.searchParams.get('success'));
-                redirectUrl.searchParams.get('success').should.eql('true');
+                assert.equal(redirectUrl.searchParams.get('success'), 'true');
             });
 
         return member;
@@ -167,7 +167,7 @@ describe('Front-end members behavior', function () {
                 .expect(404)
                 .expect('Content-Type', 'text/plain;charset=UTF-8')
                 .expect((res) => {
-                    res.text.should.eql('Could not find subscription invalid');
+                    assert.equal(res.text, 'Could not find subscription invalid');
                 });
         });
 
@@ -232,10 +232,10 @@ describe('Front-end members behavior', function () {
                 should.exist(getJsonResponse);
                 getJsonResponse.should.have.properties(['email', 'uuid', 'status', 'name', 'newsletters']);
                 getJsonResponse.should.not.have.property('id');
-                getJsonResponse.newsletters.should.have.length(1);
+                assert.equal(getJsonResponse.newsletters.length, 1);
 
                 // NOTE: these should be snapshots not code
-                Object.keys(getJsonResponse.newsletters[0]).should.have.length(5);
+                assert.equal(Object.keys(getJsonResponse.newsletters[0]).length, 5);
                 getJsonResponse.newsletters[0].should.have.properties([
                     'id',
                     'uuid',
@@ -259,7 +259,7 @@ describe('Front-end members behavior', function () {
                 should.exist(jsonResponse);
                 jsonResponse.should.have.properties(['email', 'uuid', 'status', 'name', 'newsletters']);
                 jsonResponse.should.not.have.property('id');
-                jsonResponse.newsletters.should.have.length(0);
+                assert.equal(jsonResponse.newsletters.length, 0);
 
                 const resRestored = await request.put(`/members/api/member/newsletters?uuid=${memberUUID}&key=${memberHmac}`)
                     .send({
@@ -271,9 +271,9 @@ describe('Front-end members behavior', function () {
                 should.exist(restoreJsonResponse);
                 restoreJsonResponse.should.have.properties(['email', 'uuid', 'status', 'name', 'newsletters']);
                 restoreJsonResponse.should.not.have.property('id');
-                restoreJsonResponse.newsletters.should.have.length(1);
+                assert.equal(restoreJsonResponse.newsletters.length, 1);
                 // @NOTE: this seems like too much exposed information, needs a review
-                Object.keys(restoreJsonResponse.newsletters[0]).should.have.length(5);
+                assert.equal(Object.keys(restoreJsonResponse.newsletters[0]).length, 5);
                 restoreJsonResponse.newsletters[0].should.have.properties([
                     'id',
                     'uuid',
@@ -633,7 +633,7 @@ describe('Front-end members behavior', function () {
                     .get('/email/d96d663d-c378-4921-a007-47b3158835f9/')
                     .expect(200)
                     .expect((res) => {
-                        res.text.should.match(/This post is for/);
+                        assert.match(res.text, /This post is for/);
                     });
             });
         });
@@ -803,9 +803,9 @@ describe('Front-end members behavior', function () {
                     .get('/email/d96d663d-c378-4921-a007-47b3158835f9/')
                     .expect(200)
                     .expect((res) => {
-                        res.text.should.match(/Before paywall/);
-                        res.text.should.not.match(/After paywall/);
-                        res.text.should.match(/This post is for/);
+                        assert.match(res.text, /Before paywall/);
+                        assert.doesNotMatch(res.text, /After paywall/);
+                        assert.match(res.text, /This post is for/);
                     });
             });
         });
@@ -861,7 +861,7 @@ describe('Front-end members behavior', function () {
                     .then((res) => {
                         const redirectUrl = new URL(res.headers.location, testUtils.API.getURL());
                         should.exist(redirectUrl.searchParams.get('success'));
-                        redirectUrl.searchParams.get('success').should.eql('true');
+                        assert.equal(redirectUrl.searchParams.get('success'), 'true');
                     });
             });
 
@@ -891,12 +891,12 @@ describe('Front-end members behavior', function () {
                     'email_suppression',
                     'unsubscribe_url'
                 ]);
-                Object.keys(memberData).should.have.length(16);
+                assert.equal(Object.keys(memberData).length, 16);
                 memberData.should.not.have.property('id');
-                memberData.newsletters.should.have.length(1);
+                assert.equal(memberData.newsletters.length, 1);
 
                 // @NOTE: this should be a snapshot test not code
-                Object.keys(memberData.newsletters[0]).should.have.length(5);
+                assert.equal(Object.keys(memberData.newsletters[0]).length, 5);
                 memberData.newsletters[0].should.have.properties([
                     'id',
                     'uuid',
@@ -970,9 +970,9 @@ describe('Front-end members behavior', function () {
                     .expect(200)
                     .expect(assertContentIsAbsent)
                     .expect((res) => {
-                        res.text.should.match(/Before paywall/);
-                        res.text.should.match(/After paywall/);
-                        res.text.should.not.match(/This post is for/);
+                        assert.match(res.text, /Before paywall/);
+                        assert.match(res.text, /After paywall/);
+                        assert.doesNotMatch(res.text, /This post is for/);
                     });
             });
         });

--- a/ghost/core/test/e2e-frontend/preview-routes.test.js
+++ b/ghost/core/test/e2e-frontend/preview-routes.test.js
@@ -69,8 +69,8 @@ describe('Frontend Routing: Preview Routes', function () {
                 assert.equal(res.headers['set-cookie'], undefined);
                 should.exist(res.headers.date);
 
-                $('title').text().should.equal('Not finished yet');
-                $('meta[name="description"]').attr('content').should.equal('meta description for draft post');
+                assert.equal($('title').text(), 'Not finished yet');
+                assert.equal($('meta[name="description"]').attr('content'), 'meta description for draft post');
 
                 // @TODO: use theme from fixtures and don't rely on content/themes/casper
                 // $('.content .post').length.should.equal(1);

--- a/ghost/core/test/e2e-frontend/rendered-content.test.js
+++ b/ghost/core/test/e2e-frontend/rendered-content.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const supertest = require('supertest');
 
@@ -29,16 +30,16 @@ describe('Post Rendering', function () {
                 .expect('Content-Type', /html/)
                 .expect(200)
                 .expect((res) => {
-                    res.text.should.containEql(`${siteUrl}/content/images/feature.jpg`);
-                    res.text.should.containEql(`${siteUrl}/content/images/inline.jpg`);
-                    res.text.should.containEql(`${siteUrl}/content/files/document.pdf`);
-                    res.text.should.containEql(`${siteUrl}/content/media/video.mp4`);
-                    res.text.should.containEql(`${siteUrl}/content/media/audio.mp3`);
-                    res.text.should.containEql(`${siteUrl}/content/images/snippet-inline.jpg`);
-                    res.text.should.containEql(`${siteUrl}/content/files/snippet-document.pdf`);
-                    res.text.should.containEql(`${siteUrl}/content/media/snippet-video.mp4`);
-                    res.text.should.containEql(`${siteUrl}/content/media/snippet-audio.mp3`);
-                    res.text.should.not.containEql('__GHOST_URL__');
+                    assert(res.text.includes(`${siteUrl}/content/images/feature.jpg`));
+                    assert(res.text.includes(`${siteUrl}/content/images/inline.jpg`));
+                    assert(res.text.includes(`${siteUrl}/content/files/document.pdf`));
+                    assert(res.text.includes(`${siteUrl}/content/media/video.mp4`));
+                    assert(res.text.includes(`${siteUrl}/content/media/audio.mp3`));
+                    assert(res.text.includes(`${siteUrl}/content/images/snippet-inline.jpg`));
+                    assert(res.text.includes(`${siteUrl}/content/files/snippet-document.pdf`));
+                    assert(res.text.includes(`${siteUrl}/content/media/snippet-video.mp4`));
+                    assert(res.text.includes(`${siteUrl}/content/media/snippet-audio.mp3`));
+                    assert(!res.text.includes('__GHOST_URL__'));
                 });
         });
 
@@ -47,16 +48,16 @@ describe('Post Rendering', function () {
                 .expect('Content-Type', /html/)
                 .expect(200)
                 .expect((res) => {
-                    res.text.should.containEql(`${siteUrl}/content/images/feature.jpg`);
-                    res.text.should.containEql(`${siteUrl}/content/images/inline.jpg`);
-                    res.text.should.containEql(`${siteUrl}/content/files/document.pdf`);
-                    res.text.should.containEql(`${siteUrl}/content/media/video.mp4`);
-                    res.text.should.containEql(`${siteUrl}/content/media/audio.mp3`);
-                    res.text.should.containEql(`${siteUrl}/content/images/snippet-inline.jpg`);
-                    res.text.should.containEql(`${siteUrl}/content/files/snippet-document.pdf`);
-                    res.text.should.containEql(`${siteUrl}/content/media/snippet-video.mp4`);
-                    res.text.should.containEql(`${siteUrl}/content/media/snippet-audio.mp3`);
-                    res.text.should.not.containEql('__GHOST_URL__');
+                    assert(res.text.includes(`${siteUrl}/content/images/feature.jpg`));
+                    assert(res.text.includes(`${siteUrl}/content/images/inline.jpg`));
+                    assert(res.text.includes(`${siteUrl}/content/files/document.pdf`));
+                    assert(res.text.includes(`${siteUrl}/content/media/video.mp4`));
+                    assert(res.text.includes(`${siteUrl}/content/media/audio.mp3`));
+                    assert(res.text.includes(`${siteUrl}/content/images/snippet-inline.jpg`));
+                    assert(res.text.includes(`${siteUrl}/content/files/snippet-document.pdf`));
+                    assert(res.text.includes(`${siteUrl}/content/media/snippet-video.mp4`));
+                    assert(res.text.includes(`${siteUrl}/content/media/snippet-audio.mp3`));
+                    assert(!res.text.includes('__GHOST_URL__'));
                 });
         });
 
@@ -70,16 +71,16 @@ describe('Post Rendering', function () {
                 .expect('Content-Type', /html/)
                 .expect(200)
                 .expect((res) => {
-                    res.text.should.containEql(`${cdnUrl}/content/files/document.pdf`);
-                    res.text.should.containEql(`${cdnUrl}/content/media/video.mp4`);
-                    res.text.should.containEql(`${cdnUrl}/content/media/audio.mp3`);
-                    res.text.should.containEql(`${cdnUrl}/content/files/snippet-document.pdf`);
-                    res.text.should.containEql(`${cdnUrl}/content/media/snippet-video.mp4`);
-                    res.text.should.containEql(`${cdnUrl}/content/media/snippet-audio.mp3`);
-                    res.text.should.containEql(`${siteUrl}/content/images/feature.jpg`);
-                    res.text.should.containEql(`${siteUrl}/content/images/inline.jpg`);
-                    res.text.should.containEql(`${siteUrl}/content/images/snippet-inline.jpg`);
-                    res.text.should.not.containEql('__GHOST_URL__');
+                    assert(res.text.includes(`${cdnUrl}/content/files/document.pdf`));
+                    assert(res.text.includes(`${cdnUrl}/content/media/video.mp4`));
+                    assert(res.text.includes(`${cdnUrl}/content/media/audio.mp3`));
+                    assert(res.text.includes(`${cdnUrl}/content/files/snippet-document.pdf`));
+                    assert(res.text.includes(`${cdnUrl}/content/media/snippet-video.mp4`));
+                    assert(res.text.includes(`${cdnUrl}/content/media/snippet-audio.mp3`));
+                    assert(res.text.includes(`${siteUrl}/content/images/feature.jpg`));
+                    assert(res.text.includes(`${siteUrl}/content/images/inline.jpg`));
+                    assert(res.text.includes(`${siteUrl}/content/images/snippet-inline.jpg`));
+                    assert(!res.text.includes('__GHOST_URL__'));
                 });
         });
 
@@ -93,16 +94,16 @@ describe('Post Rendering', function () {
                 .expect('Content-Type', /html/)
                 .expect(200)
                 .expect((res) => {
-                    res.text.should.containEql(`${cdnUrl}/content/files/document.pdf`);
-                    res.text.should.containEql(`${cdnUrl}/content/media/video.mp4`);
-                    res.text.should.containEql(`${cdnUrl}/content/media/audio.mp3`);
-                    res.text.should.containEql(`${cdnUrl}/content/files/snippet-document.pdf`);
-                    res.text.should.containEql(`${cdnUrl}/content/media/snippet-video.mp4`);
-                    res.text.should.containEql(`${cdnUrl}/content/media/snippet-audio.mp3`);
-                    res.text.should.containEql(`${siteUrl}/content/images/feature.jpg`);
-                    res.text.should.containEql(`${siteUrl}/content/images/inline.jpg`);
-                    res.text.should.containEql(`${siteUrl}/content/images/snippet-inline.jpg`);
-                    res.text.should.not.containEql('__GHOST_URL__');
+                    assert(res.text.includes(`${cdnUrl}/content/files/document.pdf`));
+                    assert(res.text.includes(`${cdnUrl}/content/media/video.mp4`));
+                    assert(res.text.includes(`${cdnUrl}/content/media/audio.mp3`));
+                    assert(res.text.includes(`${cdnUrl}/content/files/snippet-document.pdf`));
+                    assert(res.text.includes(`${cdnUrl}/content/media/snippet-video.mp4`));
+                    assert(res.text.includes(`${cdnUrl}/content/media/snippet-audio.mp3`));
+                    assert(res.text.includes(`${siteUrl}/content/images/feature.jpg`));
+                    assert(res.text.includes(`${siteUrl}/content/images/inline.jpg`));
+                    assert(res.text.includes(`${siteUrl}/content/images/snippet-inline.jpg`));
+                    assert(!res.text.includes('__GHOST_URL__'));
                 });
         });
     });
@@ -113,16 +114,16 @@ describe('Post Rendering', function () {
                 .expect(200)
                 .expect('Content-Type', 'application/rss+xml; charset=utf-8')
                 .expect((res) => {
-                    res.text.should.containEql(`${siteUrl}/content/images/feature.jpg`);
-                    res.text.should.containEql(`${siteUrl}/content/images/inline.jpg`);
-                    res.text.should.containEql(`${siteUrl}/content/files/document.pdf`);
-                    res.text.should.containEql(`${siteUrl}/content/media/video.mp4`);
-                    res.text.should.containEql(`${siteUrl}/content/media/audio.mp3`);
-                    res.text.should.containEql(`${siteUrl}/content/images/snippet-inline.jpg`);
-                    res.text.should.containEql(`${siteUrl}/content/files/snippet-document.pdf`);
-                    res.text.should.containEql(`${siteUrl}/content/media/snippet-video.mp4`);
-                    res.text.should.containEql(`${siteUrl}/content/media/snippet-audio.mp3`);
-                    res.text.should.not.containEql('__GHOST_URL__');
+                    assert(res.text.includes(`${siteUrl}/content/images/feature.jpg`));
+                    assert(res.text.includes(`${siteUrl}/content/images/inline.jpg`));
+                    assert(res.text.includes(`${siteUrl}/content/files/document.pdf`));
+                    assert(res.text.includes(`${siteUrl}/content/media/video.mp4`));
+                    assert(res.text.includes(`${siteUrl}/content/media/audio.mp3`));
+                    assert(res.text.includes(`${siteUrl}/content/images/snippet-inline.jpg`));
+                    assert(res.text.includes(`${siteUrl}/content/files/snippet-document.pdf`));
+                    assert(res.text.includes(`${siteUrl}/content/media/snippet-video.mp4`));
+                    assert(res.text.includes(`${siteUrl}/content/media/snippet-audio.mp3`));
+                    assert(!res.text.includes('__GHOST_URL__'));
                 });
         });
 
@@ -136,16 +137,16 @@ describe('Post Rendering', function () {
                 .expect(200)
                 .expect('Content-Type', 'application/rss+xml; charset=utf-8')
                 .expect((res) => {
-                    res.text.should.containEql(`${cdnUrl}/content/files/document.pdf`);
-                    res.text.should.containEql(`${cdnUrl}/content/media/video.mp4`);
-                    res.text.should.containEql(`${cdnUrl}/content/media/audio.mp3`);
-                    res.text.should.containEql(`${cdnUrl}/content/files/snippet-document.pdf`);
-                    res.text.should.containEql(`${cdnUrl}/content/media/snippet-video.mp4`);
-                    res.text.should.containEql(`${cdnUrl}/content/media/snippet-audio.mp3`);
-                    res.text.should.containEql(`${siteUrl}/content/images/feature.jpg`);
-                    res.text.should.containEql(`${siteUrl}/content/images/inline.jpg`);
-                    res.text.should.containEql(`${siteUrl}/content/images/snippet-inline.jpg`);
-                    res.text.should.not.containEql('__GHOST_URL__');
+                    assert(res.text.includes(`${cdnUrl}/content/files/document.pdf`));
+                    assert(res.text.includes(`${cdnUrl}/content/media/video.mp4`));
+                    assert(res.text.includes(`${cdnUrl}/content/media/audio.mp3`));
+                    assert(res.text.includes(`${cdnUrl}/content/files/snippet-document.pdf`));
+                    assert(res.text.includes(`${cdnUrl}/content/media/snippet-video.mp4`));
+                    assert(res.text.includes(`${cdnUrl}/content/media/snippet-audio.mp3`));
+                    assert(res.text.includes(`${siteUrl}/content/images/feature.jpg`));
+                    assert(res.text.includes(`${siteUrl}/content/images/inline.jpg`));
+                    assert(res.text.includes(`${siteUrl}/content/images/snippet-inline.jpg`));
+                    assert(!res.text.includes('__GHOST_URL__'));
                 });
         });
     });

--- a/ghost/core/test/e2e-server/admin.test.js
+++ b/ghost/core/test/e2e-server/admin.test.js
@@ -148,7 +148,7 @@ describe('Admin Routing', function () {
                 .expect(200);
 
             should.exist(res.headers.etag);
-            res.headers.etag.should.equal('8793333e8e91cde411b1336c58ec6ef3');
+            assert.equal(res.headers.etag, '8793333e8e91cde411b1336c58ec6ef3');
         });
     });
 });

--- a/ghost/core/test/e2e-server/services/member-attribution.test.js
+++ b/ghost/core/test/e2e-server/services/member-attribution.test.js
@@ -228,7 +228,7 @@ describe('Member Attribution Service', function () {
                 const urlWithoutSubdirectory = urlService.getUrlByResourceId(post.id, {absolute: false, withSubdirectory: false});
 
                 // Check if we are actually testing with subdirectories
-                should(url).startWith('/subdirectory/');
+                assert(url.startsWith('/subdirectory/'));
 
                 const attribution = await memberAttributionService.service.getAttribution([
                     {
@@ -262,7 +262,7 @@ describe('Member Attribution Service', function () {
                 const absoluteUrl = urlService.getUrlByResourceId(post.id, {absolute: true, withSubdirectory: true});
 
                 // Check if we are actually testing with subdirectories
-                should(url).startWith('/subdirectory/');
+                assert(url.startsWith('/subdirectory/'));
 
                 const attribution = await memberAttributionService.service.getAttribution([
                     {

--- a/ghost/core/test/e2e-server/services/stats/mrr-stats-service.test.js
+++ b/ghost/core/test/e2e-server/services/stats/mrr-stats-service.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const statsService = require('../../../../core/server/services/stats');
 const {agentProvider, fixtureManager, mockManager} = require('../../../utils/e2e-framework');
 require('should');
@@ -174,7 +175,7 @@ describe('MRR Stats Service', function () {
             await createMemberWithSubscription('month', 2, 'usd', moment(today).toISOString());
 
             const results = await statsService.api.mrr.fetchAllDeltas();
-            results.length.should.equal(3);
+            assert.equal(results.length, 3);
             results.should.match([
                 {
                     date: ninetyDaysAgo,
@@ -213,7 +214,7 @@ describe('MRR Stats Service', function () {
             };
             results.length.should.be.above(0);
             results.forEach((result) => {
-                isWithinLast90Days(result.date).should.equal(true);
+                assert.equal(isWithinLast90Days(result.date), true);
             });
         });
     });

--- a/ghost/core/test/integration/importer/legacy.test.js
+++ b/ghost/core/test/integration/importer/legacy.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const testUtils = require('../../utils');
 const importer = require('../../../core/server/data/importer');
 const dataImporter = importer.importers.find((instance) => {
@@ -19,10 +20,10 @@ describe('Importer Legacy', function () {
 
         return dataImporter.doImport(exportData, importOptions)
             .then(function () {
-                '0'.should.eql(1, 'Legacy import should fail');
+                assert.equal('0', 1, 'Legacy import should fail');
             })
             .catch(function (err) {
-                err.message.should.eql('Detected unsupported file structure.');
+                assert.equal(err.message, 'Detected unsupported file structure.');
             });
     });
 });

--- a/ghost/core/test/integration/importer/v1.test.js
+++ b/ghost/core/test/integration/importer/v1.test.js
@@ -38,9 +38,9 @@ describe('Importer 1.0', function () {
             }).then(function (result) {
                 const posts = result[0].data.map(model => model.toJSON());
 
-                posts.length.should.eql(2);
+                assert.equal(posts.length, 2);
                 posts[0].comment_id.should.eql(exportData.data.posts[1].id);
-                posts[1].comment_id.should.eql('2');
+                assert.equal(posts[1].comment_id, '2');
             });
     });
 
@@ -69,12 +69,12 @@ describe('Importer 1.0', function () {
                 }).then(function (result) {
                     const posts = result[0].data.map(model => model.toJSON(options));
 
-                    posts.length.should.eql(2);
-                    should(posts[0].html).eql(null);
-                    posts[0].mobiledoc.should.eql('{"version":"0.3.1","ghostVersion":"4.0","markups":[],"atoms":[],"cards":[],"sections":[[1,"p",[[0,[],0,""]]]]}');
+                    assert.equal(posts.length, 2);
+                    assert.equal(posts[0].html, null);
+                    assert.equal(posts[0].mobiledoc, '{"version":"0.3.1","ghostVersion":"4.0","markups":[],"atoms":[],"cards":[],"sections":[[1,"p",[[0,[],0,""]]]]}');
 
-                    should(posts[1].html).eql(null);
-                    posts[1].mobiledoc.should.eql('{"version":"0.3.1","ghostVersion":"4.0","markups":[],"atoms":[],"cards":[],"sections":[[1,"p",[[0,[],0,""]]]]}');
+                    assert.equal(posts[1].html, null);
+                    assert.equal(posts[1].mobiledoc, '{"version":"0.3.1","ghostVersion":"4.0","markups":[],"atoms":[],"cards":[],"sections":[[1,"p",[[0,[],0,""]]]]}');
                 });
         });
 
@@ -98,9 +98,9 @@ describe('Importer 1.0', function () {
                 }).then(function (result) {
                     const posts = result[0].data.map(model => model.toJSON(options));
 
-                    posts.length.should.eql(1);
+                    assert.equal(posts.length, 1);
                     assert.equal(posts[0].html, '<h1 id="this-is-my-post-content">This is my post content.</h1>');
-                    posts[0].mobiledoc.should.eql('{"version":"0.3.1","atoms":[],"cards":[],"markups":[],"sections":[[1,"h1",[[0,[],0,"This is my post content."]]]]}');
+                    assert.equal(posts[0].mobiledoc, '{"version":"0.3.1","atoms":[],"cards":[],"markups":[],"sections":[[1,"h1",[[0,[],0,"This is my post content."]]]]}');
                 });
         });
 
@@ -125,10 +125,10 @@ describe('Importer 1.0', function () {
                 }).then(function (result) {
                     const posts = result[0].data.map(model => model.toJSON(options));
 
-                    posts.length.should.eql(1);
-                    should(posts[0].html).eql(null);
-                    should(posts[0].mobiledoc).eql(null);
-                    posts[0].lexical.should.eql('{"root":{"children":[{"children":[],"direction":null,"format":"","indent":0,"type":"paragraph","version":1}],"direction":null,"format":"","indent":0,"type":"root","version":1}}');
+                    assert.equal(posts.length, 1);
+                    assert.equal(posts[0].html, null);
+                    assert.equal(posts[0].mobiledoc, null);
+                    assert.equal(posts[0].lexical, '{"root":{"children":[{"children":[],"direction":null,"format":"","indent":0,"type":"paragraph","version":1}],"direction":null,"format":"","indent":0,"type":"root","version":1}}');
                 });
         });
 
@@ -151,9 +151,9 @@ describe('Importer 1.0', function () {
                 }).then(function (result) {
                     const posts = result[0].data.map(model => model.toJSON(options));
 
-                    posts.length.should.eql(1);
-                    posts[0].html.should.eql('<!--kg-card-begin: markdown--><h2 id="markdown">markdown</h2>\n<!--kg-card-end: markdown-->');
-                    posts[0].mobiledoc.should.eql('{"version":"0.3.1","markups":[],"atoms":[],"cards":[["markdown",{"markdown":"## markdown"}]],"sections":[[10,0]],"ghostVersion":"3.0"}');
+                    assert.equal(posts.length, 1);
+                    assert.equal(posts[0].html, '<!--kg-card-begin: markdown--><h2 id="markdown">markdown</h2>\n<!--kg-card-end: markdown-->');
+                    assert.equal(posts[0].mobiledoc, '{"version":"0.3.1","markups":[],"atoms":[],"cards":[["markdown",{"markdown":"## markdown"}]],"sections":[[10,0]],"ghostVersion":"3.0"}');
                 });
         });
 
@@ -176,8 +176,8 @@ describe('Importer 1.0', function () {
                 }).then(function (result) {
                     const posts = result[0].data.map(model => model.toJSON(options));
 
-                    posts.length.should.eql(1);
-                    posts[0].html.should.eql('<!--kg-card-begin: markdown--><h1 id="thisismypostcontent">This is my post content</h1>\n<!--kg-card-end: markdown-->');
+                    assert.equal(posts.length, 1);
+                    assert.equal(posts[0].html, '<!--kg-card-begin: markdown--><h1 id="thisismypostcontent">This is my post content</h1>\n<!--kg-card-end: markdown-->');
                     const expectedMobiledoc = JSON.parse(exportData.data.posts[0].mobiledoc);
                     expectedMobiledoc.ghostVersion = '3.0';
                     posts[0].mobiledoc.should.eql(JSON.stringify(expectedMobiledoc));
@@ -238,13 +238,13 @@ describe('Importer 1.0', function () {
                 }).then(function (result) {
                     const posts = result[0].data.map(model => model.toJSON(options));
 
-                    posts.length.should.eql(2);
+                    assert.equal(posts.length, 2);
 
-                    posts[0].mobiledoc.should.eql('{"version":"0.3.1","markups":[],"atoms":[],"cards":[["markdown",{"markdown":"## Post Content"}],["image",{"src":"source2","cardWidth":"not-wide"}]],"sections":[[10,0],[10,1]],"ghostVersion":"3.0"}');
-                    posts[0].html.should.eql('<!--kg-card-begin: markdown--><h2 id="postcontent">Post Content</h2>\n<!--kg-card-end: markdown--><figure class="kg-card kg-image-card kg-width-not-wide"><img src="source2" class="kg-image" alt loading="lazy"></figure>');
+                    assert.equal(posts[0].mobiledoc, '{"version":"0.3.1","markups":[],"atoms":[],"cards":[["markdown",{"markdown":"## Post Content"}],["image",{"src":"source2","cardWidth":"not-wide"}]],"sections":[[10,0],[10,1]],"ghostVersion":"3.0"}');
+                    assert.equal(posts[0].html, '<!--kg-card-begin: markdown--><h2 id="postcontent">Post Content</h2>\n<!--kg-card-end: markdown--><figure class="kg-card kg-image-card kg-width-not-wide"><img src="source2" class="kg-image" alt loading="lazy"></figure>');
 
-                    posts[1].mobiledoc.should.eql('{"version":"0.3.1","markups":[],"atoms":[],"cards":[["image",{"src":"source","cardWidth":"wide"}],["markdown",{"markdown":"# Post Content"}]],"sections":[[10,0],[10,1]],"ghostVersion":"3.0"}');
-                    posts[1].html.should.eql('<figure class="kg-card kg-image-card kg-width-wide"><img src="source" class="kg-image" alt loading="lazy"></figure><!--kg-card-begin: markdown--><h1 id="postcontent">Post Content</h1>\n<!--kg-card-end: markdown-->');
+                    assert.equal(posts[1].mobiledoc, '{"version":"0.3.1","markups":[],"atoms":[],"cards":[["image",{"src":"source","cardWidth":"wide"}],["markdown",{"markdown":"# Post Content"}]],"sections":[[10,0],[10,1]],"ghostVersion":"3.0"}');
+                    assert.equal(posts[1].html, '<figure class="kg-card kg-image-card kg-width-wide"><img src="source" class="kg-image" alt loading="lazy"></figure><!--kg-card-begin: markdown--><h1 id="postcontent">Post Content</h1>\n<!--kg-card-end: markdown-->');
                 });
         });
     });

--- a/ghost/core/test/integration/importer/v2.test.js
+++ b/ghost/core/test/integration/importer/v2.test.js
@@ -44,8 +44,8 @@ describe('Importer', function () {
             return dataImporter.doImport(exportedBodyV2().db[0], importOptions)
                 .then(function (importResult) {
                     should.exist(importResult);
-                    importResult.hasOwnProperty('data').should.be.true();
-                    importResult.hasOwnProperty('problems').should.be.true();
+                    assert.equal(importResult.hasOwnProperty('data'), true);
+                    assert.equal(importResult.hasOwnProperty('problems'), true);
                 });
         });
 
@@ -79,17 +79,17 @@ describe('Importer', function () {
             return dataImporter.doImport(exportData, importOptions)
                 .then(function (importResult) {
                     should.exist(importResult.data.posts);
-                    importResult.data.posts.length.should.equal(2);
-                    importResult.problems.length.should.eql(1);
+                    assert.equal(importResult.data.posts.length, 2);
+                    assert.equal(importResult.problems.length, 1);
 
                     importResult.problems[0].message.should.eql('Date is in a wrong format and invalid. ' +
                         'It was replaced with the current timestamp.');
-                    importResult.problems[0].help.should.eql('Post');
+                    assert.equal(importResult.problems[0].help, 'Post');
 
-                    moment(importResult.data.posts[0].created_at).isValid().should.eql(true);
-                    moment(importResult.data.posts[0].updated_at).format().should.eql('2013-10-18T23:58:44Z');
-                    moment(importResult.data.posts[0].published_at).format().should.eql('2013-12-29T11:58:30Z');
-                    moment(importResult.data.tags[0].updated_at).format().should.eql('2016-07-17T12:02:54Z');
+                    assert.equal(moment(importResult.data.posts[0].created_at).isValid(), true);
+                    assert.equal(moment(importResult.data.posts[0].updated_at).format(), '2013-10-18T23:58:44Z');
+                    assert.equal(moment(importResult.data.posts[0].published_at).format(), '2013-12-29T11:58:30Z');
+                    assert.equal(moment(importResult.data.tags[0].updated_at).format(), '2016-07-17T12:02:54Z');
 
                     // Ensure sqlite3 & mysql import of dates works as expected
                     assert.equal(moment(importResult.data.posts[1].created_at).valueOf(), 1388318310000);
@@ -109,12 +109,12 @@ describe('Importer', function () {
 
             return dataImporter.doImport(exportData, importOptions)
                 .then(function (importResult) {
-                    importResult.problems.length.should.eql(1);
-                    importResult.problems[0].message.should.eql('Theme not imported, please upload in Settings - Design');
+                    assert.equal(importResult.problems.length, 1);
+                    assert.equal(importResult.problems[0].message, 'Theme not imported, please upload in Settings - Design');
                     return models.Settings.findOne(_.merge({key: 'active_theme'}, testUtils.context.internal));
                 })
                 .then(function (result) {
-                    result.attributes.value.should.eql('source');
+                    assert.equal(result.attributes.value, 'source');
                 });
         });
 
@@ -132,11 +132,11 @@ describe('Importer', function () {
             return dataImporter.doImport(exportData, importOptions)
                 .then(function (importResult) {
                     should.exist(importResult.data.users);
-                    importResult.data.users.length.should.equal(1);
-                    importResult.problems.length.should.eql(1);
+                    assert.equal(importResult.data.users.length, 1);
+                    assert.equal(importResult.problems.length, 1);
 
-                    importResult.problems[0].message.should.eql('Entry was not imported and ignored. Detected duplicated entry.');
-                    importResult.problems[0].help.should.eql('User');
+                    assert.equal(importResult.problems[0].message, 'Entry was not imported and ignored. Detected duplicated entry.');
+                    assert.equal(importResult.problems[0].help, 'User');
                 });
         });
 
@@ -154,11 +154,11 @@ describe('Importer', function () {
             return dataImporter.doImport(exportData, importOptions)
                 .then(function (importResult) {
                     should.exist(importResult.data.posts);
-                    importResult.data.posts.length.should.equal(1);
-                    importResult.problems.length.should.eql(1);
+                    assert.equal(importResult.data.posts.length, 1);
+                    assert.equal(importResult.problems.length, 1);
 
-                    importResult.problems[0].message.should.eql('Entry was not imported and ignored. Detected duplicated entry.');
-                    importResult.problems[0].help.should.eql('Post');
+                    assert.equal(importResult.problems[0].message, 'Entry was not imported and ignored. Detected duplicated entry.');
+                    assert.equal(importResult.problems[0].help, 'Post');
                 });
         });
 
@@ -176,14 +176,14 @@ describe('Importer', function () {
             return dataImporter.doImport(exportData, importOptions)
                 .then(function (importResult) {
                     should.exist(importResult.data.posts);
-                    importResult.data.posts.length.should.equal(2);
-                    importResult.problems.length.should.eql(0);
+                    assert.equal(importResult.data.posts.length, 2);
+                    assert.equal(importResult.problems.length, 0);
 
-                    importResult.data.posts[0].title.should.equal('duplicate title');
-                    importResult.data.posts[1].title.should.equal('duplicate title');
+                    assert.equal(importResult.data.posts[0].title, 'duplicate title');
+                    assert.equal(importResult.data.posts[1].title, 'duplicate title');
 
-                    importResult.data.posts[0].slug.should.equal('duplicate-title');
-                    importResult.data.posts[1].slug.should.equal('duplicate-title-2');
+                    assert.equal(importResult.data.posts[0].slug, 'duplicate-title');
+                    assert.equal(importResult.data.posts[1].slug, 'duplicate-title-2');
                 });
         });
 
@@ -228,17 +228,17 @@ describe('Importer', function () {
                     should.exist(importResult.data.tags);
                     should.exist(importResult.originalData.posts_tags);
 
-                    importResult.data.tags.length.should.equal(1);
+                    assert.equal(importResult.data.tags.length, 1);
 
                     // Check we imported all posts_tags associations
-                    importResult.originalData.posts_tags.length.should.equal(2);
+                    assert.equal(importResult.originalData.posts_tags.length, 2);
 
                     // Check the post_tag.tag_id was updated when we removed duplicate tag
                     _.every(importResult.originalData.posts_tags, function (postTag) {
                         return postTag.tag_id !== 2;
                     });
 
-                    importResult.problems.length.should.equal(0);
+                    assert.equal(importResult.problems.length, 0);
                 });
         });
 
@@ -261,9 +261,9 @@ describe('Importer', function () {
                     ]);
                 })
                 .then(function (data) {
-                    data[0].data.length.should.eql(1);
-                    data[0].data[0].toJSON().slug.should.eql('welcome-to-ghost-2');
-                    data[0].data[0].toJSON().tags.length.should.eql(0);
+                    assert.equal(data[0].data.length, 1);
+                    assert.equal(data[0].data[0].toJSON().slug, 'welcome-to-ghost-2');
+                    assert.equal(data[0].data[0].toJSON().tags.length, 0);
                 });
         });
 
@@ -278,9 +278,9 @@ describe('Importer', function () {
                     return models.Post.findPage(testUtils.context.internal);
                 })
                 .then(function (result) {
-                    result.data.length.should.equal(exportData.data.posts.length, 'Wrong number of posts');
-                    result.data[0].toJSON().status.should.eql('scheduled');
-                    result.data[1].toJSON().status.should.eql('published');
+                    assert.equal(result.data.length, exportData.data.posts.length, 'Wrong number of posts');
+                    assert.equal(result.data[0].toJSON().status, 'scheduled');
+                    assert.equal(result.data[1].toJSON().status, 'published');
                 });
         });
 
@@ -301,7 +301,7 @@ describe('Importer', function () {
                 .then(function (importedData) {
                     should.exist(importedData);
 
-                    importedData.length.should.equal(4, 'Did not get data successfully');
+                    assert.equal(importedData.length, 4, 'Did not get data successfully');
 
                     const users = importedData[0];
                     const posts = importedData[1].data;
@@ -309,11 +309,11 @@ describe('Importer', function () {
                     const tags = importedData[3];
 
                     // we always have 1 user, the owner user we added
-                    users.length.should.equal(1, 'There should only be one user');
+                    assert.equal(users.length, 1, 'There should only be one user');
 
                     settings.length.should.be.above(0, 'Wrong number of settings');
-                    posts.length.should.equal(exportData.data.posts.length, 'no new posts');
-                    tags.length.should.equal(exportData.data.tags.length, 'no new tags');
+                    assert.equal(posts.length, exportData.data.posts.length, 'no new posts');
+                    assert.equal(tags.length, exportData.data.tags.length, 'no new tags');
                 });
         });
 
@@ -330,7 +330,7 @@ describe('Importer', function () {
                     return models.User.findAll(Object.assign({withRelated: ['roles']}, testUtils.context.internal));
                 })
                 .then(function (result) {
-                    result.models.length.should.eql(2);
+                    assert.equal(result.models.length, 2);
 
                     result.models[0].get('email').should.equal(testUtils.DataGenerator.Content.users[0].email);
                     result.models[0].get('slug').should.equal(testUtils.DataGenerator.Content.users[0].slug);
@@ -354,7 +354,7 @@ describe('Importer', function () {
 
             return dataImporter.doImport(exportData, importOptions)
                 .then(function (importResult) {
-                    importResult.problems.length.should.eql(0);
+                    assert.equal(importResult.problems.length, 0);
                     importResult.data.posts[0].comment_id.should.eql(exportData.data.posts[0].id.toString());
                 });
         });
@@ -383,28 +383,28 @@ describe('Importer', function () {
 
             return dataImporter.doImport(exportData, importOptions)
                 .then(function () {
-                    (1).should.eql(0, 'Allowed import of duplicate data.');
+                    assert.equal((1), 0, 'Allowed import of duplicate data.');
                 })
                 .catch(function (response) {
-                    response.length.should.equal(6);
+                    assert.equal(response.length, 6);
                     // NOTE: a duplicated tag.slug is a warning
-                    response[0].errorType.should.equal('ValidationError');
-                    response[0].message.should.eql('Value in [users.bio] exceeds maximum length of 250 characters.');
+                    assert.equal(response[0].errorType, 'ValidationError');
+                    assert.equal(response[0].message, 'Value in [users.bio] exceeds maximum length of 250 characters.');
 
-                    response[1].errorType.should.equal('ValidationError');
-                    response[1].message.should.eql('Validation (isEmail) failed for email');
+                    assert.equal(response[1].errorType, 'ValidationError');
+                    assert.equal(response[1].message, 'Validation (isEmail) failed for email');
 
-                    response[2].errorType.should.equal('ValidationError');
-                    response[2].message.should.eql('Value in [tags.meta_title] exceeds maximum length of 300 characters.');
+                    assert.equal(response[2].errorType, 'ValidationError');
+                    assert.equal(response[2].message, 'Value in [tags.meta_title] exceeds maximum length of 300 characters.');
 
-                    response[3].errorType.should.equal('ValidationError');
-                    response[3].message.should.eql('Value in [settings.key] cannot be blank.');
+                    assert.equal(response[3].errorType, 'ValidationError');
+                    assert.equal(response[3].message, 'Value in [settings.key] cannot be blank.');
 
-                    response[4].message.should.eql('Value in [posts.title] cannot be blank.');
-                    response[4].errorType.should.eql('ValidationError');
+                    assert.equal(response[4].message, 'Value in [posts.title] cannot be blank.');
+                    assert.equal(response[4].errorType, 'ValidationError');
 
-                    response[5].errorType.should.equal('ValidationError');
-                    response[5].message.should.eql('Value in [posts.title] exceeds maximum length of 255 characters.');
+                    assert.equal(response[5].errorType, 'ValidationError');
+                    assert.equal(response[5].message, 'Value in [posts.title] exceeds maximum length of 255 characters.');
                 });
         });
 
@@ -416,11 +416,11 @@ describe('Importer', function () {
 
             return dataImporter.doImport(exportData, importOptions)
                 .then(function (importedData) {
-                    importedData.problems.length.should.eql(1);
+                    assert.equal(importedData.problems.length, 1);
 
                     importedData.problems[0].message.should.eql('Entry was imported, but we were not able to ' +
                         'resolve the following user references: author_id, published_by. The user does not exist, fallback to owner user.');
-                    importedData.problems[0].help.should.eql('Post');
+                    assert.equal(importedData.problems[0].help, 'Post');
 
                     // Grab the data from tables
                     return Promise.all([
@@ -434,13 +434,13 @@ describe('Importer', function () {
                 .then(function (importedData) {
                     should.exist(importedData);
 
-                    importedData.length.should.equal(2, 'Did not get data successfully');
+                    assert.equal(importedData.length, 2, 'Did not get data successfully');
 
                     const users = importedData[0].data.map(model => model.toJSON());
                     const posts = importedData[1].data.map(model => model.toJSON());
 
-                    posts.length.should.equal(1, 'Wrong number of posts');
-                    users.length.should.equal(2, 'Wrong number of users');
+                    assert.equal(posts.length, 1, 'Wrong number of posts');
+                    assert.equal(users.length, 2, 'Wrong number of users');
 
                     // NOTE: we fallback to owner user for invalid user references
 
@@ -502,28 +502,28 @@ describe('Importer', function () {
                     const posts = result[0].data.map(model => model.toJSON());
                     const tags = result[1].data.map(model => model.toJSON());
 
-                    posts.length.should.equal(exportData.data.posts.length, 'Wrong number of posts');
+                    assert.equal(posts.length, exportData.data.posts.length, 'Wrong number of posts');
 
                     // post1
                     posts[0].slug.should.eql(exportData.data.posts[0].slug);
-                    posts[0].tags.length.should.eql(1);
+                    assert.equal(posts[0].tags.length, 1);
                     posts[0].tags[0].slug.should.eql(exportData.data.tags[0].slug);
 
                     // post3, has a specific sort_order
                     posts[1].slug.should.eql(exportData.data.posts[2].slug);
-                    posts[1].tags.length.should.eql(3);
+                    assert.equal(posts[1].tags.length, 3);
                     posts[1].tags[0].slug.should.eql(exportData.data.tags[2].slug);
                     posts[1].tags[1].slug.should.eql(exportData.data.tags[0].slug);
                     posts[1].tags[2].slug.should.eql(exportData.data.tags[1].slug);
 
                     // post2, sort_order property is missing (order depends on the posts_tags entries)
                     posts[2].slug.should.eql(exportData.data.posts[1].slug);
-                    posts[2].tags.length.should.eql(2);
+                    assert.equal(posts[2].tags.length, 2);
                     posts[2].tags[0].slug.should.eql(exportData.data.tags[1].slug);
                     posts[2].tags[1].slug.should.eql(exportData.data.tags[0].slug);
 
                     // test tags
-                    tags.length.should.equal(exportData.data.tags.length, 'no new tags');
+                    assert.equal(tags.length, exportData.data.tags.length, 'no new tags');
                 });
         });
 
@@ -600,7 +600,7 @@ describe('Importer', function () {
                     const tags = result[1].data.map(model => model.toJSON(tagOptions));
                     const users = result[2].data.map(model => model.toJSON(userOptions));
 
-                    posts.length.should.equal(exportData.data.posts.length, 'Wrong number of posts');
+                    assert.equal(posts.length, exportData.data.posts.length, 'Wrong number of posts');
 
                     // findPage returns the posts in correct order (latest created post is the first)
                     posts[0].title.should.equal(exportData.data.posts[2].title);
@@ -619,10 +619,10 @@ describe('Importer', function () {
                     posts[1].published_by.should.equal(users[2].id);
                     posts[2].published_by.should.equal(users[2].id);
 
-                    tags.length.should.equal(exportData.data.tags.length, 'Wrong number of tags');
+                    assert.equal(tags.length, exportData.data.tags.length, 'Wrong number of tags');
 
                     // 4 imported users + 1 owner user
-                    users.length.should.equal(exportData.data.users.length + 1, 'Wrong number of users');
+                    assert.equal(users.length, exportData.data.users.length + 1, 'Wrong number of users');
 
                     users[0].email.should.equal(testUtils.DataGenerator.Content.users[0].email);
                     users[1].email.should.equal(exportData.data.users[0].email);
@@ -630,11 +630,11 @@ describe('Importer', function () {
                     users[3].email.should.equal(exportData.data.users[2].email);
                     users[4].email.should.equal(exportData.data.users[3].email);
 
-                    users[0].status.should.equal('active');
-                    users[1].status.should.equal('locked');
-                    users[2].status.should.equal('locked');
-                    users[3].status.should.equal('locked');
-                    users[4].status.should.equal('locked');
+                    assert.equal(users[0].status, 'active');
+                    assert.equal(users[1].status, 'locked');
+                    assert.equal(users[2].status, 'locked');
+                    assert.equal(users[3].status, 'locked');
+                    assert.equal(users[4].status, 'locked');
 
                     users[1].created_at.toISOString().should.equal(moment(exportData.data.users[0].created_at).startOf('seconds').toISOString());
                     users[2].created_at.toISOString().should.equal(moment(exportData.data.users[1].created_at).startOf('seconds').toISOString());
@@ -683,10 +683,10 @@ describe('Importer', function () {
                 }).then(function (result) {
                     const users = result[0].data.map(model => model.toJSON());
 
-                    users.length.should.eql(2);
+                    assert.equal(users.length, 2);
                     users[1].slug.should.eql(exportData.data.users[0].slug);
                     users[1].slug.should.eql(exportData.data.users[0].slug);
-                    users[1].roles.length.should.eql(1);
+                    assert.equal(users[1].roles.length, 1);
                     users[1].roles[0].id.should.eql(testUtils.DataGenerator.Content.roles[4].id);
                 });
         });
@@ -719,7 +719,7 @@ describe('Importer', function () {
 
             return dataImporter.doImport(exportData, importOptions)
                 .then(function (imported) {
-                    imported.problems.length.should.eql(0);
+                    assert.equal(imported.problems.length, 0);
 
                     return Promise.all([
                         models.Tag.findPage(Object.assign({order: 'slug ASC'}, testUtils.context.internal)),
@@ -729,14 +729,14 @@ describe('Importer', function () {
                     const tags = result[0].data.map(model => model.toJSON());
                     const posts = result[1].data.map(model => model.toJSON());
 
-                    posts.length.should.eql(1);
-                    tags.length.should.eql(3);
+                    assert.equal(posts.length, 1);
+                    assert.equal(tags.length, 3);
 
-                    posts[0].tags.length.should.eql(3);
-                    tags[0].name.should.eql('first tag');
-                    tags[0].slug.should.eql('first-tag');
-                    tags[1].name.should.eql('second tag');
-                    tags[2].name.should.eql('third tag');
+                    assert.equal(posts[0].tags.length, 3);
+                    assert.equal(tags[0].name, 'first tag');
+                    assert.equal(tags[0].slug, 'first-tag');
+                    assert.equal(tags[1].name, 'second tag');
+                    assert.equal(tags[2].name, 'third tag');
                 });
         });
 
@@ -755,7 +755,7 @@ describe('Importer', function () {
 
             return dataImporter.doImport(exportData, importOptions)
                 .then(function (imported) {
-                    imported.problems.length.should.eql(0);
+                    assert.equal(imported.problems.length, 0);
 
                     return Promise.all([
                         models.Tag.findPage(Object.assign({order: 'slug ASC'}, testUtils.context.internal)),
@@ -765,11 +765,11 @@ describe('Importer', function () {
                     const tags = result[0].data.map(model => model.toJSON());
                     const posts = result[1].data.map(model => model.toJSON());
 
-                    posts.length.should.eql(1);
-                    tags.length.should.eql(1);
+                    assert.equal(posts.length, 1);
+                    assert.equal(tags.length, 1);
 
-                    posts[0].tags.length.should.eql(1);
-                    tags[0].slug.should.eql('tag-1');
+                    assert.equal(posts[0].tags.length, 1);
+                    assert.equal(tags[0].slug, 'tag-1');
                 });
         });
 
@@ -783,7 +783,7 @@ describe('Importer', function () {
 
             return dataImporter.doImport(exportData, importOptions)
                 .then(function (imported) {
-                    imported.problems.length.should.eql(0);
+                    assert.equal(imported.problems.length, 0);
                     return models.Settings.findOne(_.merge({key: 'labs'}, testUtils.context.internal));
                 })
                 .then(function (result) {
@@ -803,7 +803,7 @@ describe('Importer', function () {
 
             return dataImporter.doImport(exportData, importOptions)
                 .then(function (imported) {
-                    imported.problems.length.should.eql(0);
+                    assert.equal(imported.problems.length, 0);
                     return models.Settings.findOne(_.merge({key: 'labs'}, testUtils.context.internal));
                 })
                 .then(function (result) {
@@ -823,11 +823,11 @@ describe('Importer', function () {
 
             return dataImporter.doImport(exportData, importOptions)
                 .then(function (imported) {
-                    imported.problems.length.should.eql(0);
+                    assert.equal(imported.problems.length, 0);
                     return models.Settings.findOne(_.merge({key: 'slack_url'}, testUtils.context.internal));
                 })
                 .then(function (result) {
-                    result.attributes.value.should.eql('');
+                    assert.equal(result.attributes.value, '');
                 });
         });
 
@@ -841,11 +841,11 @@ describe('Importer', function () {
 
             return dataImporter.doImport(exportData, importOptions)
                 .then(function (imported) {
-                    imported.problems.length.should.eql(0);
+                    assert.equal(imported.problems.length, 0);
                     return models.Settings.findOne(_.merge({key: 'slack_url'}, testUtils.context.internal));
                 })
                 .then(function (result) {
-                    result.attributes.value.should.eql('');
+                    assert.equal(result.attributes.value, '');
                 });
         });
 
@@ -868,17 +868,17 @@ describe('Importer', function () {
 
             return dataImporter.doImport(exportData, importOptions)
                 .then(function (imported) {
-                    imported.problems.length.should.eql(0);
+                    assert.equal(imported.problems.length, 0);
                     return models.Settings.findOne(_.merge({key: 'locale'}, testUtils.context.internal));
                 })
                 .then(function (result) {
-                    result.attributes.value.should.eql('ua');
+                    assert.equal(result.attributes.value, 'ua');
                 })
                 .then(function () {
                     return models.Settings.findOne(_.merge({key: 'timezone'}, testUtils.context.internal));
                 })
                 .then(function (result) {
-                    result.attributes.value.should.eql('Pacific/Auckland');
+                    assert.equal(result.attributes.value, 'Pacific/Auckland');
                 });
         });
 
@@ -896,11 +896,11 @@ describe('Importer', function () {
 
             return dataImporter.doImport(exportData, importOptions)
                 .then(function (imported) {
-                    imported.problems.length.should.eql(0);
+                    assert.equal(imported.problems.length, 0);
                     return models.Settings.findOne(_.merge({key: 'locale'}, testUtils.context.internal));
                 })
                 .then(function (result) {
-                    result.attributes.value.should.eql('ua');
+                    assert.equal(result.attributes.value, 'ua');
                 });
         });
 
@@ -919,29 +919,29 @@ describe('Importer', function () {
 
             return dataImporter.doImport(exportData, importOptions)
                 .then(function (imported) {
-                    imported.problems.length.should.eql(0);
+                    assert.equal(imported.problems.length, 0);
                     return models.Settings.findOne(_.merge({key: 'portal_button'}, testUtils.context.internal));
                 })
                 .then(function (result) {
-                    result.attributes.value.should.eql(true);
+                    assert.equal(result.attributes.value, true);
                     return models.Settings.findOne(_.merge({key: 'is_private'}, testUtils.context.internal));
                 })
                 .then(function (result) {
-                    result.attributes.value.should.eql(false);
+                    assert.equal(result.attributes.value, false);
 
                     return db
                         .knex('settings')
                         .where('key', 'portal_button');
                 })
                 .then(function (result) {
-                    result[0].value.should.eql('true');
+                    assert.equal(result[0].value, 'true');
 
                     return db
                         .knex('settings')
                         .where('key', 'is_private');
                 })
                 .then(function (result) {
-                    result[0].value.should.eql('false');
+                    assert.equal(result[0].value, 'false');
                 });
         });
 
@@ -963,7 +963,7 @@ describe('Importer', function () {
                 }).then(function (result) {
                     const posts = result[0].data.map(model => model.toJSON());
 
-                    posts.length.should.eql(2);
+                    assert.equal(posts.length, 2);
                     posts[0].comment_id.should.eql(exportData.data.posts[1].id);
                     posts[1].comment_id.should.eql(exportData.data.posts[0].comment_id);
                 });
@@ -1016,9 +1016,9 @@ describe('Importer', function () {
             return dataImporter.doImport(exportData, importOptions)
                 .then(function (imported) {
                     // one user is a duplicate
-                    imported.problems.length.should.eql(2);
-                    imported.problems[0].context.should.match(/user4@ghost.org/);
-                    imported.problems[1].context.should.match(/user5/);
+                    assert.equal(imported.problems.length, 2);
+                    assert.match(imported.problems[0].context, /user4@ghost.org/);
+                    assert.match(imported.problems[1].context, /user5/);
 
                     return Promise.all([
                         models.Post.findPage(Object.assign({withRelated: ['authors']}, testUtils.context.internal)),
@@ -1030,24 +1030,24 @@ describe('Importer', function () {
 
                     // 2 duplicates, 1 owner, 4 imported users
                     users.length.should.eql(exportData.data.users.length - 2 + 1);
-                    posts.length.should.eql(3);
+                    assert.equal(posts.length, 3);
 
                     // has 4 posts_authors relations, but 3 of them are invalid
                     posts[0].slug.should.eql(exportData.data.posts[2].slug);
-                    posts[0].authors.length.should.eql(1);
+                    assert.equal(posts[0].authors.length, 1);
                     posts[0].authors[0].id.should.eql(users[4].id);
                     posts[0].primary_author.id.should.eql(users[4].id);
 
                     // no valid authors reference, use owner author_id
                     posts[1].slug.should.eql(exportData.data.posts[1].slug);
-                    posts[1].authors.length.should.eql(1);
+                    assert.equal(posts[1].authors.length, 1);
                     posts[1].primary_author.id.should.eql(testUtils.DataGenerator.Content.users[0].id);
                     posts[1].authors[0].id.should.eql(testUtils.DataGenerator.Content.users[0].id);
 
                     posts[2].slug.should.eql(exportData.data.posts[0].slug);
-                    posts[2].authors.length.should.eql(3);
+                    assert.equal(posts[2].authors.length, 3);
                     posts[2].primary_author.id.should.eql(users[2].id);
-                    posts[2].authors.length.should.eql(3);
+                    assert.equal(posts[2].authors.length, 3);
                     posts[2].authors[0].id.should.eql(users[2].id);
                     posts[2].authors[1].id.should.eql(users[1].id);
                     posts[2].authors[2].id.should.eql(users[3].id);
@@ -1088,10 +1088,10 @@ describe('Importer', function () {
                 }).then(function (result) {
                     const posts = result[0].data.map(model => model.toJSON(options));
 
-                    posts.length.should.eql(1);
+                    assert.equal(posts.length, 1);
 
-                    posts[0].mobiledoc.should.eql('{"version":"0.3.1","markups":[],"atoms":[],"cards":[["image",{"src":"source","cardWidth":"wide"}],["markdown",{"markdown":"# Post Content"}]],"sections":[[10,0],[10,1]],"ghostVersion":"3.0"}');
-                    posts[0].html.should.eql('<figure class="kg-card kg-image-card kg-width-wide"><img src="source" class="kg-image" alt loading="lazy"></figure><!--kg-card-begin: markdown--><h1 id="postcontent">Post Content</h1>\n<!--kg-card-end: markdown-->');
+                    assert.equal(posts[0].mobiledoc, '{"version":"0.3.1","markups":[],"atoms":[],"cards":[["image",{"src":"source","cardWidth":"wide"}],["markdown",{"markdown":"# Post Content"}]],"sections":[[10,0],[10,1]],"ghostVersion":"3.0"}');
+                    assert.equal(posts[0].html, '<figure class="kg-card kg-image-card kg-width-wide"><img src="source" class="kg-image" alt loading="lazy"></figure><!--kg-card-begin: markdown--><h1 id="postcontent">Post Content</h1>\n<!--kg-card-end: markdown-->');
                 });
         });
 
@@ -1149,13 +1149,13 @@ describe('Importer', function () {
                 }).then(function (result) {
                     const posts = result[0].data.map(model => model.toJSON(options));
 
-                    posts.length.should.eql(2);
+                    assert.equal(posts.length, 2);
 
-                    posts[0].mobiledoc.should.eql('{"version":"0.3.1","markups":[],"atoms":[],"cards":[["markdown",{"markdown":"## Post Content"}],["image",{"src":"source2","cardWidth":"not-wide"}]],"sections":[[10,0],[10,1]],"ghostVersion":"3.0"}');
-                    posts[0].html.should.eql('<!--kg-card-begin: markdown--><h2 id="postcontent">Post Content</h2>\n<!--kg-card-end: markdown--><figure class="kg-card kg-image-card kg-width-not-wide"><img src="source2" class="kg-image" alt loading="lazy"></figure>');
+                    assert.equal(posts[0].mobiledoc, '{"version":"0.3.1","markups":[],"atoms":[],"cards":[["markdown",{"markdown":"## Post Content"}],["image",{"src":"source2","cardWidth":"not-wide"}]],"sections":[[10,0],[10,1]],"ghostVersion":"3.0"}');
+                    assert.equal(posts[0].html, '<!--kg-card-begin: markdown--><h2 id="postcontent">Post Content</h2>\n<!--kg-card-end: markdown--><figure class="kg-card kg-image-card kg-width-not-wide"><img src="source2" class="kg-image" alt loading="lazy"></figure>');
 
-                    posts[1].mobiledoc.should.eql('{"version":"0.3.1","markups":[],"atoms":[],"cards":[["image",{"src":"source","cardWidth":"wide"}],["markdown",{"markdown":"# Post Content"}]],"sections":[[10,0],[10,1]],"ghostVersion":"3.0"}');
-                    posts[1].html.should.eql('<figure class="kg-card kg-image-card kg-width-wide"><img src="source" class="kg-image" alt loading="lazy"></figure><!--kg-card-begin: markdown--><h1 id="postcontent">Post Content</h1>\n<!--kg-card-end: markdown-->');
+                    assert.equal(posts[1].mobiledoc, '{"version":"0.3.1","markups":[],"atoms":[],"cards":[["image",{"src":"source","cardWidth":"wide"}],["markdown",{"markdown":"# Post Content"}]],"sections":[[10,0],[10,1]],"ghostVersion":"3.0"}');
+                    assert.equal(posts[1].html, '<figure class="kg-card kg-image-card kg-width-wide"><img src="source" class="kg-image" alt loading="lazy"></figure><!--kg-card-begin: markdown--><h1 id="postcontent">Post Content</h1>\n<!--kg-card-end: markdown-->');
                 });
         });
 
@@ -1272,10 +1272,10 @@ describe('Importer', function () {
                     const tags = result[1].data.map(model => model.toJSON(tagOptions));
                     const users = result[2].data.map(model => model.toJSON(userOptions));
 
-                    posts.length.should.equal(exportData.data.posts.length + testUtils.DataGenerator.Content.posts.length, 'Wrong number of posts');
-                    tags.length.should.equal(exportData.data.tags.length + testUtils.DataGenerator.Content.tags.length, 'Wrong number of tags');
+                    assert.equal(posts.length, exportData.data.posts.length + testUtils.DataGenerator.Content.posts.length, 'Wrong number of posts');
+                    assert.equal(tags.length, exportData.data.tags.length + testUtils.DataGenerator.Content.tags.length, 'Wrong number of tags');
                     // the test env only inserts the user defined in the `forKnex` array
-                    users.length.should.equal(exportData.data.users.length + testUtils.DataGenerator.forKnex.users.length, 'Wrong number of users');
+                    assert.equal(users.length, exportData.data.users.length + testUtils.DataGenerator.forKnex.users.length, 'Wrong number of users');
                 });
         });
     });

--- a/ghost/core/test/integration/importer/v5.js
+++ b/ghost/core/test/integration/importer/v5.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const importer = require('../../../core/server/data/importer');
 const models = require('../../../core/server/models');
 const testUtils = require('../../utils');
@@ -62,19 +63,19 @@ describe('Importing 5.x export', function () {
         const users = await models.User.findPage(userOptions);
         const posts = await models.Post.findPage(postOptions);
 
-        users.data.length.should.equal(2);
+        assert.equal(users.data.length, 2);
 
         const user1 = users.data[0].toJSON();
         const user2 = users.data[1].toJSON();
 
         // Current owner user
-        user1.email.should.equal('jbloggs@example.com');
+        assert.equal(user1.email, 'jbloggs@example.com');
 
         // Imported user
-        user2.email.should.equal('import-test-user@ghost.org');
+        assert.equal(user2.email, 'import-test-user@ghost.org');
         user2.id.should.not.equal(LEGACY_HARDCODED_USER_ID);
 
-        posts.data.length.should.equal(2);
+        assert.equal(posts.data.length, 2);
 
         const post1 = posts.data[0].toJSON();
         const post2 = posts.data[1].toJSON();

--- a/ghost/core/test/integration/settings/settings.test.js
+++ b/ghost/core/test/integration/settings/settings.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const db = require('../../../core/server/data/db');
 const testUtils = require('../../utils');
 
@@ -42,7 +43,7 @@ describe('Settings', function () {
             .count('*')
             .then(function (data) {
                 const countResult = data[0]['count(*)'];
-                countResult.should.eql(0);
+                assert.equal(countResult, 0);
             })
             .catch(function (err) {
             // CASE: table does not exist

--- a/ghost/core/test/integration/url-service.test.js
+++ b/ghost/core/test/integration/url-service.test.js
@@ -52,57 +52,57 @@ describe('Integration: services/url/UrlService', function () {
         it('getUrl', function () {
             urlService.urlGenerators.forEach(function (generator) {
                 if (generator.resourceType === 'posts') {
-                    generator.getUrls().length.should.eql(4);
+                    assert.equal(generator.getUrls().length, 4);
                 }
 
                 if (generator.resourceType === 'pages') {
-                    generator.getUrls().length.should.eql(1);
+                    assert.equal(generator.getUrls().length, 1);
                 }
 
                 if (generator.resourceType === 'tags') {
-                    generator.getUrls().length.should.eql(4);
+                    assert.equal(generator.getUrls().length, 4);
                 }
 
                 if (generator.resourceType === 'authors') {
-                    generator.getUrls().length.should.eql(2);
+                    assert.equal(generator.getUrls().length, 2);
                 }
             });
 
             let url = urlService.getUrlByResourceId(testUtils.DataGenerator.forKnex.posts[0].id);
-            url.should.eql('/html-ipsum/');
+            assert.equal(url, '/html-ipsum/');
 
             url = urlService.getUrlByResourceId(testUtils.DataGenerator.forKnex.posts[1].id);
-            url.should.eql('/ghostly-kitchen-sink/');
+            assert.equal(url, '/ghostly-kitchen-sink/');
 
             url = urlService.getUrlByResourceId(testUtils.DataGenerator.forKnex.posts[2].id);
-            url.should.eql('/404/');
+            assert.equal(url, '/404/');
 
             url = urlService.getUrlByResourceId(testUtils.DataGenerator.forKnex.tags[0].id);
-            url.should.eql('/tag/kitchen-sink/');
+            assert.equal(url, '/tag/kitchen-sink/');
 
             url = urlService.getUrlByResourceId(testUtils.DataGenerator.forKnex.tags[1].id);
-            url.should.eql('/tag/bacon/');
+            assert.equal(url, '/tag/bacon/');
 
             url = urlService.getUrlByResourceId(testUtils.DataGenerator.forKnex.tags[2].id);
-            url.should.eql('/tag/chorizo/');
+            assert.equal(url, '/tag/chorizo/');
 
             url = urlService.getUrlByResourceId(testUtils.DataGenerator.forKnex.tags[3].id);
-            url.should.eql('/404/'); // tags with no posts should not be public
+            assert.equal(url, '/404/'); // tags with no posts should not be public
 
             url = urlService.getUrlByResourceId(testUtils.DataGenerator.forKnex.users[0].id);
-            url.should.eql('/author/joe-bloggs/');
+            assert.equal(url, '/author/joe-bloggs/');
 
             url = urlService.getUrlByResourceId(testUtils.DataGenerator.forKnex.users[1].id);
-            url.should.eql('/404/'); // users with no posts should not be public
+            assert.equal(url, '/404/'); // users with no posts should not be public
 
             url = urlService.getUrlByResourceId(testUtils.DataGenerator.forKnex.users[2].id);
-            url.should.eql('/404/'); // users with no posts should not be public
+            assert.equal(url, '/404/'); // users with no posts should not be public
 
             url = urlService.getUrlByResourceId(testUtils.DataGenerator.forKnex.users[3].id);
-            url.should.eql('/author/slimer-mcectoplasm/');
+            assert.equal(url, '/author/slimer-mcectoplasm/');
 
             url = urlService.getUrlByResourceId(testUtils.DataGenerator.forKnex.users[4].id);
-            url.should.eql('/404/'); // users with no posts should not be public
+            assert.equal(url, '/404/'); // users with no posts should not be public
         });
 
         it('getResource', function () {
@@ -153,62 +153,62 @@ describe('Integration: services/url/UrlService', function () {
         it('getUrl', function () {
             urlService.urlGenerators.forEach(function (generator) {
                 if (generator.resourceType === 'posts' && generator.filter === 'type:post') {
-                    generator.getUrls().length.should.eql(4);
+                    assert.equal(generator.getUrls().length, 4);
                 }
 
                 if (generator.resourceType === 'posts' && generator.filter === 'featured:true') {
-                    generator.getUrls().length.should.eql(2);
+                    assert.equal(generator.getUrls().length, 2);
                 }
 
                 if (generator.resourceType === 'pages') {
-                    generator.getUrls().length.should.eql(1);
+                    assert.equal(generator.getUrls().length, 1);
                 }
 
                 if (generator.resourceType === 'tags') {
-                    generator.getUrls().length.should.eql(4);
+                    assert.equal(generator.getUrls().length, 4);
                 }
 
                 if (generator.resourceType === 'authors') {
-                    generator.getUrls().length.should.eql(2);
+                    assert.equal(generator.getUrls().length, 2);
                 }
             });
 
             let url = urlService.getUrlByResourceId(testUtils.DataGenerator.forKnex.posts[0].id);
-            url.should.eql('/collection/2015/html-ipsum/');
+            assert.equal(url, '/collection/2015/html-ipsum/');
 
             url = urlService.getUrlByResourceId(testUtils.DataGenerator.forKnex.posts[1].id);
-            url.should.eql('/collection/2015/ghostly-kitchen-sink/');
+            assert.equal(url, '/collection/2015/ghostly-kitchen-sink/');
 
             // featured
             url = urlService.getUrlByResourceId(testUtils.DataGenerator.forKnex.posts[2].id);
-            url.should.eql('/podcast/short-and-sweet/');
+            assert.equal(url, '/podcast/short-and-sweet/');
 
             url = urlService.getUrlByResourceId(testUtils.DataGenerator.forKnex.tags[0].id);
-            url.should.eql('/category/kitchen-sink/');
+            assert.equal(url, '/category/kitchen-sink/');
 
             url = urlService.getUrlByResourceId(testUtils.DataGenerator.forKnex.tags[1].id);
-            url.should.eql('/category/bacon/');
+            assert.equal(url, '/category/bacon/');
 
             url = urlService.getUrlByResourceId(testUtils.DataGenerator.forKnex.tags[2].id);
-            url.should.eql('/category/chorizo/');
+            assert.equal(url, '/category/chorizo/');
 
             url = urlService.getUrlByResourceId(testUtils.DataGenerator.forKnex.tags[3].id);
-            url.should.eql('/404/'); // tags with no posts should not be public
+            assert.equal(url, '/404/'); // tags with no posts should not be public
 
             url = urlService.getUrlByResourceId(testUtils.DataGenerator.forKnex.users[0].id);
-            url.should.eql('/persons/joe-bloggs/');
+            assert.equal(url, '/persons/joe-bloggs/');
 
             url = urlService.getUrlByResourceId(testUtils.DataGenerator.forKnex.users[1].id);
-            url.should.eql('/404/'); // users with no posts should not be public
+            assert.equal(url, '/404/'); // users with no posts should not be public
 
             url = urlService.getUrlByResourceId(testUtils.DataGenerator.forKnex.users[2].id);
-            url.should.eql('/404/'); // users with no posts should not be public
+            assert.equal(url, '/404/'); // users with no posts should not be public
 
             url = urlService.getUrlByResourceId(testUtils.DataGenerator.forKnex.users[3].id);
-            url.should.eql('/persons/slimer-mcectoplasm/');
+            assert.equal(url, '/persons/slimer-mcectoplasm/');
 
             url = urlService.getUrlByResourceId(testUtils.DataGenerator.forKnex.users[4].id);
-            url.should.eql('/404/'); // users with no posts should not be public
+            assert.equal(url, '/404/'); // users with no posts should not be public
         });
     });
 
@@ -247,62 +247,62 @@ describe('Integration: services/url/UrlService', function () {
         it('getUrl', function () {
             urlService.urlGenerators.forEach(function (generator) {
                 if (generator.resourceType === 'posts' && generator.filter === 'featured:false') {
-                    generator.getUrls().length.should.eql(4);
+                    assert.equal(generator.getUrls().length, 4);
                 }
 
                 if (generator.resourceType === 'posts' && generator.filter === 'featured:true') {
-                    generator.getUrls().length.should.eql(2);
+                    assert.equal(generator.getUrls().length, 2);
                 }
 
                 if (generator.resourceType === 'pages') {
-                    generator.getUrls().length.should.eql(1);
+                    assert.equal(generator.getUrls().length, 1);
                 }
 
                 if (generator.resourceType === 'tags') {
-                    generator.getUrls().length.should.eql(4);
+                    assert.equal(generator.getUrls().length, 4);
                 }
 
                 if (generator.resourceType === 'authors') {
-                    generator.getUrls().length.should.eql(2);
+                    assert.equal(generator.getUrls().length, 2);
                 }
             });
 
             let url = urlService.getUrlByResourceId(testUtils.DataGenerator.forKnex.posts[0].id);
-            url.should.eql('/collection/2015/html-ipsum/');
+            assert.equal(url, '/collection/2015/html-ipsum/');
 
             url = urlService.getUrlByResourceId(testUtils.DataGenerator.forKnex.posts[1].id);
-            url.should.eql('/collection/2015/ghostly-kitchen-sink/');
+            assert.equal(url, '/collection/2015/ghostly-kitchen-sink/');
 
             // featured
             url = urlService.getUrlByResourceId(testUtils.DataGenerator.forKnex.posts[2].id);
-            url.should.eql('/podcast/short-and-sweet/');
+            assert.equal(url, '/podcast/short-and-sweet/');
 
             url = urlService.getUrlByResourceId(testUtils.DataGenerator.forKnex.tags[0].id);
-            url.should.eql('/category/kitchen-sink/');
+            assert.equal(url, '/category/kitchen-sink/');
 
             url = urlService.getUrlByResourceId(testUtils.DataGenerator.forKnex.tags[1].id);
-            url.should.eql('/category/bacon/');
+            assert.equal(url, '/category/bacon/');
 
             url = urlService.getUrlByResourceId(testUtils.DataGenerator.forKnex.tags[2].id);
-            url.should.eql('/category/chorizo/');
+            assert.equal(url, '/category/chorizo/');
 
             url = urlService.getUrlByResourceId(testUtils.DataGenerator.forKnex.tags[3].id);
-            url.should.eql('/404/'); // tags with no posts should not be public
+            assert.equal(url, '/404/'); // tags with no posts should not be public
 
             url = urlService.getUrlByResourceId(testUtils.DataGenerator.forKnex.users[0].id);
-            url.should.eql('/persons/joe-bloggs/');
+            assert.equal(url, '/persons/joe-bloggs/');
 
             url = urlService.getUrlByResourceId(testUtils.DataGenerator.forKnex.users[1].id);
-            url.should.eql('/404/'); // users with no posts should not be public
+            assert.equal(url, '/404/'); // users with no posts should not be public
 
             url = urlService.getUrlByResourceId(testUtils.DataGenerator.forKnex.users[2].id);
-            url.should.eql('/404/'); // users with no posts should not be public
+            assert.equal(url, '/404/'); // users with no posts should not be public
 
             url = urlService.getUrlByResourceId(testUtils.DataGenerator.forKnex.users[3].id);
-            url.should.eql('/persons/slimer-mcectoplasm/');
+            assert.equal(url, '/persons/slimer-mcectoplasm/');
 
             url = urlService.getUrlByResourceId(testUtils.DataGenerator.forKnex.users[4].id);
-            url.should.eql('/404/'); // users with no posts should not be public
+            assert.equal(url, '/404/'); // users with no posts should not be public
         });
     });
 });

--- a/ghost/core/test/legacy/api/admin/db.test.js
+++ b/ghost/core/test/legacy/api/admin/db.test.js
@@ -49,7 +49,7 @@ describe('DB API', function () {
             .then((res) => {
                 const jsonResponse = res.body;
                 should.exist(jsonResponse.db);
-                jsonResponse.db.should.have.length(1);
+                assert.equal(jsonResponse.db.length, 1);
 
                 // NOTE: default tables + 1 from include parameters
                 Object.keys(jsonResponse.db[0].data).length.should.eql(TABLE_ALLOWLIST_LENGTH + 1);
@@ -94,7 +94,7 @@ describe('DB API', function () {
                     .expect(200);
             })
             .then((res) => {
-                res.body.problems.length.should.eql(6);
+                assert.equal(res.body.problems.length, 6);
                 fs.removeSync(exportFolder);
             });
     });
@@ -151,7 +151,7 @@ describe('DB API', function () {
         const jsonResponse = res.body;
         should.exist(jsonResponse.db);
         should.exist(jsonResponse.problems);
-        jsonResponse.problems.should.have.length(2);
+        assert.equal(jsonResponse.problems.length, 2);
 
         const postsResponse = await request.get(localUtils.API.getApiQuery('posts/'))
             .set('Origin', config.get('url'))
@@ -159,7 +159,7 @@ describe('DB API', function () {
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(200);
 
-        postsResponse.body.posts.should.have.length(7);
+        assert.equal(postsResponse.body.posts.length, 7);
 
         const usersResponse = await request.get(localUtils.API.getApiQuery('users/'))
             .set('Origin', config.get('url'))
@@ -167,7 +167,7 @@ describe('DB API', function () {
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(200);
 
-        usersResponse.body.users.should.have.length(3);
+        assert.equal(usersResponse.body.users.length, 3);
     });
 
     it('Can import a JSON database exported from Ghost 3.x', async function () {
@@ -198,7 +198,7 @@ describe('DB API', function () {
         const jsonResponse = res.body;
         should.exist(jsonResponse.db);
         should.exist(jsonResponse.problems);
-        jsonResponse.problems.should.have.length(2);
+        assert.equal(jsonResponse.problems.length, 2);
 
         const res2 = await request.get(localUtils.API.getApiQuery('posts/'))
             .set('Origin', config.get('url'))
@@ -206,7 +206,7 @@ describe('DB API', function () {
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(200);
 
-        res2.body.posts.should.have.length(7);
+        assert.equal(res2.body.posts.length, 7);
 
         const usersResponse = await request.get(localUtils.API.getApiQuery('users/'))
             .set('Origin', config.get('url'))
@@ -214,7 +214,7 @@ describe('DB API', function () {
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(200);
 
-        usersResponse.body.users.should.have.length(3);
+        assert.equal(usersResponse.body.users.length, 3);
     });
 
     it('Can import a JSON database exported from Ghost 4.x', async function () {
@@ -245,7 +245,7 @@ describe('DB API', function () {
         const jsonResponse = res.body;
         should.exist(jsonResponse.db);
         should.exist(jsonResponse.problems);
-        jsonResponse.problems.should.have.length(2);
+        assert.equal(jsonResponse.problems.length, 2);
 
         const res2 = await request.get(localUtils.API.getApiQuery('posts/'))
             .set('Origin', config.get('url'))
@@ -253,7 +253,7 @@ describe('DB API', function () {
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(200);
 
-        res2.body.posts.should.have.length(7);
+        assert.equal(res2.body.posts.length, 7);
 
         const usersResponse = await request.get(localUtils.API.getApiQuery('users/'))
             .set('Origin', config.get('url'))
@@ -261,7 +261,7 @@ describe('DB API', function () {
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(200);
 
-        usersResponse.body.users.should.have.length(3);
+        assert.equal(usersResponse.body.users.length, 3);
     });
 
     it('Can import a JSON database exported from Ghost 5.x', async function () {
@@ -296,7 +296,7 @@ describe('DB API', function () {
         // 2 expected problems:
         // - Theme not imported
         // - Duplicate free product not imported
-        jsonResponse.problems.should.have.length(2);
+        assert.equal(jsonResponse.problems.length, 2);
 
         const res2 = await request.get(localUtils.API.getApiQuery('posts/'))
             .set('Origin', config.get('url'))
@@ -304,7 +304,7 @@ describe('DB API', function () {
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(200);
 
-        res2.body.posts.should.have.length(1);
+        assert.equal(res2.body.posts.length, 1);
 
         // Ensure the author is not imported with the legacy hardcoded user id
         res2.body.posts[0].authors[0].id.should.not.equal(LEGACY_HARDCODED_USER_ID);
@@ -316,7 +316,7 @@ describe('DB API', function () {
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(200);
 
-        usersResponse.body.users.should.have.length(3);
+        assert.equal(usersResponse.body.users.length, 3);
 
         // Ensure user is not imported with the legacy hardcoded user id
         usersResponse.body.users[0].id.should.not.equal(LEGACY_HARDCODED_USER_ID);
@@ -341,9 +341,9 @@ describe('DB API', function () {
         const product = await models.Product.findOne({slug: 'ghost-inc'});
         should.exist(product);
 
-        product.get('name').should.equal('Ghost Inc.');
-        product.get('description').should.equal('Our daily newsletter');
-        product.get('welcome_page_url').should.equal('/welcome');
+        assert.equal(product.get('name'), 'Ghost Inc.');
+        assert.equal(product.get('description'), 'Our daily newsletter');
+        assert.equal(product.get('welcome_page_url'), '/welcome');
 
         // Check settings
         const portalProducts = await models.Settings.findOne({key: 'portal_products'});
@@ -353,13 +353,13 @@ describe('DB API', function () {
         // Check stripe products
         const stripeProduct = await models.StripeProduct.findOne({product_id: product.id});
         should.exist(stripeProduct);
-        stripeProduct.get('stripe_product_id').should.equal('prod_d2c1708c21');
-        stripeProduct.id.should.not.equal('60be1fc9bd3af33564cfb337');
+        assert.equal(stripeProduct.get('stripe_product_id'), 'prod_d2c1708c21');
+        assert.notEqual(stripeProduct.id, '60be1fc9bd3af33564cfb337');
 
         // Check newsletters
         const newsletter = await models.Newsletter.findOne({slug: 'test'});
         should.exist(newsletter);
-        newsletter.get('name').should.equal('Ghost Inc.');
+        assert.equal(newsletter.get('name'), 'Ghost Inc.');
         // Make sure sender_email is not set
         assert.equal(newsletter.get('sender_email'), null);
 
@@ -368,8 +368,8 @@ describe('DB API', function () {
         should.exist(post);
 
         post.get('newsletter_id').should.equal(newsletter.id);
-        post.get('visibility').should.equal('public');
-        post.get('email_recipient_filter').should.equal('status:-free');
+        assert.equal(post.get('visibility'), 'public');
+        assert.equal(post.get('email_recipient_filter'), 'status:-free');
 
         // Check this post is connected to the imported product
         post.relations.tiers.models.map(m => m.id).should.match([product.id]);
@@ -381,17 +381,17 @@ describe('DB API', function () {
         const yearlyPrice = await models.StripePrice.findOne({id: product.get('yearly_price_id')});
         should.exist(yearlyPrice);
 
-        monthlyPrice.get('amount').should.equal(500);
-        monthlyPrice.get('currency').should.equal('usd');
-        monthlyPrice.get('interval').should.equal('month');
-        monthlyPrice.get('stripe_price_id').should.equal('price_a425520db0');
-        monthlyPrice.get('stripe_product_id').should.equal('prod_d2c1708c21');
+        assert.equal(monthlyPrice.get('amount'), 500);
+        assert.equal(monthlyPrice.get('currency'), 'usd');
+        assert.equal(monthlyPrice.get('interval'), 'month');
+        assert.equal(monthlyPrice.get('stripe_price_id'), 'price_a425520db0');
+        assert.equal(monthlyPrice.get('stripe_product_id'), 'prod_d2c1708c21');
 
-        yearlyPrice.get('amount').should.equal(4800);
-        yearlyPrice.get('currency').should.equal('usd');
-        yearlyPrice.get('interval').should.equal('year');
-        yearlyPrice.get('stripe_price_id').should.equal('price_d04baebb73');
-        yearlyPrice.get('stripe_product_id').should.equal('prod_d2c1708c21');
+        assert.equal(yearlyPrice.get('amount'), 4800);
+        assert.equal(yearlyPrice.get('currency'), 'usd');
+        assert.equal(yearlyPrice.get('interval'), 'year');
+        assert.equal(yearlyPrice.get('stripe_price_id'), 'price_d04baebb73');
+        assert.equal(yearlyPrice.get('stripe_product_id'), 'prod_d2c1708c21');
     });
 
     it('Can not import a ZIP-file with symlinks', async function () {
@@ -443,9 +443,9 @@ describe('DB API (cleaned)', function () {
         const product = await models.Product.findOne({slug: 'ghost-inc'});
         should.exist(product);
         product.id.should.equal(existingProduct.id);
-        product.get('slug').should.equal('ghost-inc');
-        product.get('name').should.equal('Ghost Inc.');
-        product.get('description').should.equal('Our daily newsletter');
+        assert.equal(product.get('slug'), 'ghost-inc');
+        assert.equal(product.get('name'), 'Ghost Inc.');
+        assert.equal(product.get('description'), 'Our daily newsletter');
 
         // Check settings
         const portalProducts = await models.Settings.findOne({key: 'portal_products'});
@@ -455,13 +455,13 @@ describe('DB API (cleaned)', function () {
         // Check stripe products
         const stripeProduct = await models.StripeProduct.findOne({product_id: product.id});
         should.exist(stripeProduct);
-        stripeProduct.get('stripe_product_id').should.equal('prod_d2c1708c21');
-        stripeProduct.id.should.not.equal('60be1fc9bd3af33564cfb337');
+        assert.equal(stripeProduct.get('stripe_product_id'), 'prod_d2c1708c21');
+        assert.notEqual(stripeProduct.id, '60be1fc9bd3af33564cfb337');
 
         // Check newsletters
         const newsletter = await models.Newsletter.findOne({slug: 'test'});
         should.exist(newsletter);
-        newsletter.get('name').should.equal('Ghost Inc.');
+        assert.equal(newsletter.get('name'), 'Ghost Inc.');
         // Make sure sender_email is not set
         assert.equal(newsletter.get('sender_email'), null);
 
@@ -470,8 +470,8 @@ describe('DB API (cleaned)', function () {
         should.exist(post);
 
         post.get('newsletter_id').should.equal(newsletter.id);
-        post.get('visibility').should.equal('public');
-        post.get('email_recipient_filter').should.equal('status:-free');
+        assert.equal(post.get('visibility'), 'public');
+        assert.equal(post.get('email_recipient_filter'), 'status:-free');
 
         // Check this post is connected to the imported product
         post.relations.tiers.models.map(m => m.id).should.match([product.id]);
@@ -483,16 +483,16 @@ describe('DB API (cleaned)', function () {
         const yearlyPrice = await models.StripePrice.findOne({stripe_price_id: 'price_d04baebb73'});
         should.exist(yearlyPrice);
 
-        monthlyPrice.get('amount').should.equal(500);
-        monthlyPrice.get('currency').should.equal('usd');
-        monthlyPrice.get('interval').should.equal('month');
-        monthlyPrice.get('stripe_price_id').should.equal('price_a425520db0');
-        monthlyPrice.get('stripe_product_id').should.equal('prod_d2c1708c21');
+        assert.equal(monthlyPrice.get('amount'), 500);
+        assert.equal(monthlyPrice.get('currency'), 'usd');
+        assert.equal(monthlyPrice.get('interval'), 'month');
+        assert.equal(monthlyPrice.get('stripe_price_id'), 'price_a425520db0');
+        assert.equal(monthlyPrice.get('stripe_product_id'), 'prod_d2c1708c21');
 
-        yearlyPrice.get('amount').should.equal(4800);
-        yearlyPrice.get('currency').should.equal('usd');
-        yearlyPrice.get('interval').should.equal('year');
-        yearlyPrice.get('stripe_price_id').should.equal('price_d04baebb73');
-        yearlyPrice.get('stripe_product_id').should.equal('prod_d2c1708c21');
+        assert.equal(yearlyPrice.get('amount'), 4800);
+        assert.equal(yearlyPrice.get('currency'), 'usd');
+        assert.equal(yearlyPrice.get('interval'), 'year');
+        assert.equal(yearlyPrice.get('stripe_price_id'), 'price_d04baebb73');
+        assert.equal(yearlyPrice.get('stripe_product_id'), 'prod_d2c1708c21');
     });
 });

--- a/ghost/core/test/legacy/api/admin/identities.test.js
+++ b/ghost/core/test/legacy/api/admin/identities.test.js
@@ -60,8 +60,8 @@ describe('Identities API', function () {
                     return verifyJWKS(`${request.app}/ghost/.well-known/jwks.json`, identity.token);
                 })
                 .then((decoded) => {
-                    decoded.sub.should.equal('jbloggs@example.com');
-                    decoded.role.should.equal('Owner');
+                    assert.equal(decoded.sub, 'jbloggs@example.com');
+                    assert.equal(decoded.role, 'Owner');
                 });
         });
     });
@@ -106,8 +106,8 @@ describe('Identities API', function () {
                     return verifyJWKS(`${request.app}/ghost/.well-known/jwks.json`, identity.token);
                 })
                 .then((decoded) => {
-                    decoded.sub.should.equal('admin+1@ghost.org');
-                    decoded.role.should.equal('Administrator');
+                    assert.equal(decoded.sub, 'admin+1@ghost.org');
+                    assert.equal(decoded.role, 'Administrator');
                 });
         });
     });

--- a/ghost/core/test/legacy/api/admin/members-importer.test.js
+++ b/ghost/core/test/legacy/api/admin/members-importer.test.js
@@ -50,9 +50,9 @@ describe('Members Importer API', function () {
                 should.exist(jsonResponse.meta.stats);
 
                 should.exist(jsonResponse.meta.import_label);
-                jsonResponse.meta.import_label.slug.should.match(/^import-/);
-                jsonResponse.meta.stats.imported.should.equal(2);
-                jsonResponse.meta.stats.invalid.length.should.equal(0);
+                assert.match(jsonResponse.meta.import_label.slug, /^import-/);
+                assert.equal(jsonResponse.meta.stats.imported, 2);
+                assert.equal(jsonResponse.meta.stats.invalid.length, 0);
 
                 importLabel = jsonResponse.meta.import_label.slug;
                 return request
@@ -74,14 +74,14 @@ describe('Members Importer API', function () {
                 should.exist(importedMember1);
                 assert.equal(importedMember1.name, null);
                 assert.equal(importedMember1.note, null);
-                importedMember1.subscribed.should.equal(true);
-                importedMember1.comped.should.equal(false);
+                assert.equal(importedMember1.subscribed, true);
+                assert.equal(importedMember1.comped, false);
                 importedMember1.subscriptions.should.not.be.undefined();
-                importedMember1.subscriptions.length.should.equal(0);
+                assert.equal(importedMember1.subscriptions.length, 0);
 
                 // check label order
                 // 1 unique global + 1 record labels + 1 auto generated label
-                importedMember1.labels.length.should.equal(3);
+                assert.equal(importedMember1.labels.length, 3);
                 should.exist(importedMember1.labels.find(({slug}) => slug === 'label'));
                 should.exist(importedMember1.labels.find(({slug}) => slug === 'global-label-1'));
                 should.exist(importedMember1.labels.find(({slug}) => slug.match(/^import-/)));
@@ -89,7 +89,7 @@ describe('Members Importer API', function () {
                 const importedMember2 = jsonResponse.members.find(m => m.email === 'member+labels_2@example.com');
                 should.exist(importedMember2);
                 // 1 unique global + 2 record labels
-                importedMember2.labels.length.should.equal(4);
+                assert.equal(importedMember2.labels.length, 4);
                 should.exist(importedMember2.labels.find(({slug}) => slug === 'another-label'));
                 should.exist(importedMember2.labels.find(({slug}) => slug === 'and-one-more'));
                 should.exist(importedMember2.labels.find(({slug}) => slug === 'global-label-1'));
@@ -116,11 +116,11 @@ describe('Members Importer API', function () {
                 should.exist(jsonResponse.meta);
                 should.exist(jsonResponse.meta.stats);
 
-                jsonResponse.meta.stats.imported.should.equal(1);
-                jsonResponse.meta.stats.invalid.length.should.equal(0);
+                assert.equal(jsonResponse.meta.stats.imported, 1);
+                assert.equal(jsonResponse.meta.stats.invalid.length, 0);
 
                 should.exist(jsonResponse.meta.import_label);
-                jsonResponse.meta.import_label.slug.should.match(/^import-/);
+                assert.match(jsonResponse.meta.import_label.slug, /^import-/);
             })
             .then(() => {
                 return request
@@ -142,11 +142,11 @@ describe('Members Importer API', function () {
                 assert.equal(importedMember1.email, 'member+mapped_1@example.com');
                 assert.equal(importedMember1.name, 'Hannah');
                 assert.equal(importedMember1.note, 'do map me');
-                importedMember1.subscribed.should.equal(true);
-                importedMember1.comped.should.equal(false);
+                assert.equal(importedMember1.subscribed, true);
+                assert.equal(importedMember1.comped, false);
                 importedMember1.subscriptions.should.not.be.undefined();
-                importedMember1.subscriptions.length.should.equal(0);
-                importedMember1.labels.length.should.equal(1); // auto-generated import label
+                assert.equal(importedMember1.subscriptions.length, 0);
+                assert.equal(importedMember1.labels.length, 1); // auto-generated import label
             });
     });
 
@@ -166,8 +166,8 @@ describe('Members Importer API', function () {
                 should.exist(jsonResponse.meta);
                 should.exist(jsonResponse.meta.stats);
 
-                jsonResponse.meta.stats.imported.should.equal(2);
-                jsonResponse.meta.stats.invalid.length.should.equal(0);
+                assert.equal(jsonResponse.meta.stats.imported, 2);
+                assert.equal(jsonResponse.meta.stats.invalid.length, 0);
             })
             .then(() => {
                 return request
@@ -187,11 +187,11 @@ describe('Members Importer API', function () {
                 const defaultMember1 = jsonResponse.members.find(member => (member.email === 'member+defaults_1@example.com'));
                 assert.equal(defaultMember1.name, null);
                 assert.equal(defaultMember1.note, null);
-                defaultMember1.subscribed.should.equal(true);
-                defaultMember1.comped.should.equal(false);
+                assert.equal(defaultMember1.subscribed, true);
+                assert.equal(defaultMember1.comped, false);
                 defaultMember1.subscriptions.should.not.be.undefined();
-                defaultMember1.subscriptions.length.should.equal(0);
-                defaultMember1.labels.length.should.equal(1); // auto-generated import label
+                assert.equal(defaultMember1.subscriptions.length, 0);
+                assert.equal(defaultMember1.labels.length, 1); // auto-generated import label
 
                 const defaultMember2 = jsonResponse.members.find(member => (member.email === 'member+defaults_2@example.com'));
                 should(defaultMember2).not.be.undefined();
@@ -233,14 +233,14 @@ describe('Members Importer API', function () {
                 should.exist(jsonResponse.meta);
                 should.exist(jsonResponse.meta.stats);
 
-                jsonResponse.meta.stats.imported.should.equal(1);
-                jsonResponse.meta.stats.invalid.length.should.equal(2);
+                assert.equal(jsonResponse.meta.stats.imported, 1);
+                assert.equal(jsonResponse.meta.stats.invalid.length, 2);
 
-                jsonResponse.meta.stats.invalid[0].error.should.match(/Invalid Email/);
-                jsonResponse.meta.stats.invalid[1].error.should.match(/Invalid Email/);
+                assert.match(jsonResponse.meta.stats.invalid[0].error, /Invalid Email/);
+                assert.match(jsonResponse.meta.stats.invalid[1].error, /Invalid Email/);
 
                 should.exist(jsonResponse.meta.import_label);
-                jsonResponse.meta.import_label.slug.should.match(/^import-/);
+                assert.match(jsonResponse.meta.import_label.slug, /^import-/);
             });
     });
 
@@ -269,8 +269,8 @@ describe('Members Importer API', function () {
         should.exist(jsonResponse.meta);
         should.exist(jsonResponse.meta.stats);
 
-        jsonResponse.meta.stats.imported.should.equal(10);
-        jsonResponse.meta.stats.invalid.length.should.equal(0);
+        assert.equal(jsonResponse.meta.stats.imported, 10);
+        assert.equal(jsonResponse.meta.stats.invalid.length, 0);
 
         assert(!!settingsCache.get('email_verification_required'), 'Email verification should now be required');
 
@@ -295,8 +295,8 @@ describe('Members Importer API', function () {
         should.exist(jsonResponse.meta);
         should.exist(jsonResponse.meta.stats);
 
-        jsonResponse.meta.stats.imported.should.equal(10);
-        jsonResponse.meta.stats.invalid.length.should.equal(0);
+        assert.equal(jsonResponse.meta.stats.imported, 10);
+        assert.equal(jsonResponse.meta.stats.invalid.length, 0);
 
         assert(!!settingsCache.get('email_verification_required'), 'Email verification should now be required');
 

--- a/ghost/core/test/legacy/api/admin/members-signin-url.test.js
+++ b/ghost/core/test/legacy/api/admin/members-signin-url.test.js
@@ -33,7 +33,7 @@ describe('Members Sigin URL API', function () {
                     const jsonResponse = res.body;
                     should.exist(jsonResponse);
                     should.exist(jsonResponse.member_signin_urls);
-                    jsonResponse.member_signin_urls.should.have.length(1);
+                    assert.equal(jsonResponse.member_signin_urls.length, 1);
                     localUtils.API.checkResponse(jsonResponse.member_signin_urls[0], 'member_signin_url');
                 });
         });
@@ -64,7 +64,7 @@ describe('Members Sigin URL API', function () {
                     const jsonResponse = res.body;
                     should.exist(jsonResponse);
                     should.exist(jsonResponse.member_signin_urls);
-                    jsonResponse.member_signin_urls.should.have.length(1);
+                    assert.equal(jsonResponse.member_signin_urls.length, 1);
                     localUtils.API.checkResponse(jsonResponse.member_signin_urls[0], 'member_signin_url');
                 });
         });
@@ -131,7 +131,7 @@ describe('Members Sigin URL API', function () {
                     const jsonResponse = res.body;
                     should.exist(jsonResponse);
                     should.exist(jsonResponse.member_signin_urls);
-                    jsonResponse.member_signin_urls.should.have.length(1);
+                    assert.equal(jsonResponse.member_signin_urls.length, 1);
                     localUtils.API.checkResponse(jsonResponse.member_signin_urls[0], 'member_signin_url');
                 });
         }); 

--- a/ghost/core/test/legacy/api/admin/pages.test.js
+++ b/ghost/core/test/legacy/api/admin/pages.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const supertest = require('supertest');
 const testUtils = require('../../../utils');
@@ -19,7 +20,7 @@ describe('Pages API', function () {
                 .set('Origin', config.get('url'))
                 .expect(200)
                 .then((res) => {
-                    res.body.pages[0].slug.should.equal('static-page-test');
+                    assert.equal(res.body.pages[0].slug, 'static-page-test');
 
                     return request
                         .put(localUtils.API.getApiQuery('pages/' + testUtils.DataGenerator.Content.posts[5].id + '/?source=html'))
@@ -35,7 +36,7 @@ describe('Pages API', function () {
                         .expect(200);
                 })
                 .then((res) => {
-                    res.body.pages[0].mobiledoc.should.equal('{"version":"0.3.1","atoms":[],"cards":[],"markups":[],"sections":[[1,"p",[[0,[],0,"HTML Ipsum presents"]]]]}');
+                    assert.equal(res.body.pages[0].mobiledoc, '{"version":"0.3.1","atoms":[],"cards":[],"markups":[],"sections":[[1,"p",[[0,[],0,"HTML Ipsum presents"]]]]}');
                 });
         });
     });

--- a/ghost/core/test/legacy/api/admin/posts.test.js
+++ b/ghost/core/test/legacy/api/admin/posts.test.js
@@ -47,7 +47,7 @@ describe('Posts API', function () {
                     const jsonResponse = res.body;
                     should.exist(jsonResponse.posts);
                     localUtils.API.checkResponse(jsonResponse, 'posts');
-                    jsonResponse.posts.should.have.length(15);
+                    assert.equal(jsonResponse.posts.length, 15);
 
                     localUtils.API.checkResponse(
                         jsonResponse.posts[0],
@@ -78,7 +78,7 @@ describe('Posts API', function () {
                     const jsonResponse = res.body;
                     should.exist(jsonResponse.posts);
                     localUtils.API.checkResponse(jsonResponse, 'posts');
-                    jsonResponse.posts.should.have.length(15);
+                    assert.equal(jsonResponse.posts.length, 15);
 
                     localUtils.API.checkResponse(
                         jsonResponse.posts[0],
@@ -109,7 +109,7 @@ describe('Posts API', function () {
                     const jsonResponse = res.body;
                     should.exist(jsonResponse.posts);
                     localUtils.API.checkResponse(jsonResponse, 'posts');
-                    jsonResponse.posts.should.have.length(2);
+                    assert.equal(jsonResponse.posts.length, 2);
                     jsonResponse.posts.forEach((post) => {
                         should.notEqual(post.meta_description, null);
                     });
@@ -140,9 +140,9 @@ describe('Posts API', function () {
                     const jsonResponse = res.body;
                     should.exist(jsonResponse.posts);
                     localUtils.API.checkResponse(jsonResponse, 'posts');
-                    jsonResponse.posts.should.have.length(1);
+                    assert.equal(jsonResponse.posts.length, 1);
                     jsonResponse.posts[0].id.should.equal(testUtils.DataGenerator.Content.posts[2].id);
-                    jsonResponse.posts[0].meta_description.should.equal('meta description for short and sweet');
+                    assert.equal(jsonResponse.posts[0].meta_description, 'meta description for short and sweet');
 
                     localUtils.API.checkResponse(
                         jsonResponse.posts[0],
@@ -170,11 +170,11 @@ describe('Posts API', function () {
                     const jsonResponse = res.body;
                     should.exist(jsonResponse.posts);
                     localUtils.API.checkResponse(jsonResponse, 'posts');
-                    jsonResponse.posts.should.have.length(15);
+                    assert.equal(jsonResponse.posts.length, 15);
 
                     assert.equal(jsonResponse.posts[0].meta_description, null);
-                    jsonResponse.posts[14].slug.should.equal('short-and-sweet');
-                    jsonResponse.posts[14].meta_description.should.equal('meta description for short and sweet');
+                    assert.equal(jsonResponse.posts[14].slug, 'short-and-sweet');
+                    assert.equal(jsonResponse.posts[14].meta_description, 'meta description for short and sweet');
 
                     localUtils.API.checkResponse(
                         jsonResponse.posts[0],
@@ -235,10 +235,10 @@ describe('Posts API', function () {
                     const jsonResponse = res.body;
                     should.exist(jsonResponse.posts);
                     localUtils.API.checkResponse(jsonResponse, 'posts');
-                    jsonResponse.posts.should.have.length(15);
+                    assert.equal(jsonResponse.posts.length, 15);
 
-                    jsonResponse.posts[0].slug.should.equal('80-open-rate', 'DESC 1st');
-                    jsonResponse.posts[1].slug.should.equal('60-open-rate', 'DESC 2nd');
+                    assert.equal(jsonResponse.posts[0].slug, '80-open-rate', 'DESC 1st');
+                    assert.equal(jsonResponse.posts[1].slug, '60-open-rate', 'DESC 2nd');
 
                     localUtils.API.checkResponse(jsonResponse.meta.pagination, 'pagination');
                 });
@@ -250,8 +250,8 @@ describe('Posts API', function () {
                 .expect(200)
                 .then((res) => {
                     const jsonResponse = res.body;
-                    jsonResponse.posts[0].slug.should.equal('60-open-rate', 'ASC 1st');
-                    jsonResponse.posts[1].slug.should.equal('80-open-rate', 'ASC 2nd');
+                    assert.equal(jsonResponse.posts[0].slug, '60-open-rate', 'ASC 1st');
+                    assert.equal(jsonResponse.posts[1].slug, '80-open-rate', 'ASC 2nd');
                 });
         });
     });
@@ -313,7 +313,7 @@ describe('Posts API', function () {
                 .then((res) => {
                     should.exist(res.body.posts);
                     should.exist(res.body.posts[0].title);
-                    res.body.posts[0].title.should.equal('(Untitled)');
+                    assert.equal(res.body.posts[0].title, '(Untitled)');
 
                     should.exist(res.headers.location);
                     res.headers.location.should.equal(`http://127.0.0.1:2369${localUtils.API.getApiQuery('posts/')}${res.body.posts[0].id}/`);
@@ -336,10 +336,10 @@ describe('Posts API', function () {
                 .then((res) => {
                     should.exist(res.body.posts);
                     should.exist(res.body.posts[0].title);
-                    res.body.posts[0].title.should.equal('Tags test 1');
-                    res.body.posts[0].tags.length.should.equal(2);
-                    res.body.posts[0].tags[0].slug.should.equal('one');
-                    res.body.posts[0].tags[1].slug.should.equal('two');
+                    assert.equal(res.body.posts[0].title, 'Tags test 1');
+                    assert.equal(res.body.posts[0].tags.length, 2);
+                    assert.equal(res.body.posts[0].tags[0].slug, 'one');
+                    assert.equal(res.body.posts[0].tags[1].slug, 'two');
                 });
         });
 
@@ -359,10 +359,10 @@ describe('Posts API', function () {
                 .then((res) => {
                     should.exist(res.body.posts);
                     should.exist(res.body.posts[0].title);
-                    res.body.posts[0].title.should.equal('Tags test 2');
-                    res.body.posts[0].tags.length.should.equal(2);
-                    res.body.posts[0].tags[0].slug.should.equal('one');
-                    res.body.posts[0].tags[1].slug.should.equal('two');
+                    assert.equal(res.body.posts[0].title, 'Tags test 2');
+                    assert.equal(res.body.posts[0].tags.length, 2);
+                    assert.equal(res.body.posts[0].tags[0].slug, 'one');
+                    assert.equal(res.body.posts[0].tags[1].slug, 'two');
                 });
         });
 
@@ -382,10 +382,10 @@ describe('Posts API', function () {
                 .then((res) => {
                     should.exist(res.body.posts);
                     should.exist(res.body.posts[0].title);
-                    res.body.posts[0].title.should.equal('Tags test 3');
-                    res.body.posts[0].tags.length.should.equal(2);
-                    res.body.posts[0].tags[0].slug.should.equal('one');
-                    res.body.posts[0].tags[1].slug.should.equal('two');
+                    assert.equal(res.body.posts[0].title, 'Tags test 3');
+                    assert.equal(res.body.posts[0].tags.length, 2);
+                    assert.equal(res.body.posts[0].tags[0].slug, 'one');
+                    assert.equal(res.body.posts[0].tags[1].slug, 'two');
                 });
         });
 
@@ -405,10 +405,10 @@ describe('Posts API', function () {
                 .then((res) => {
                     should.exist(res.body.posts);
                     should.exist(res.body.posts[0].title);
-                    res.body.posts[0].title.should.equal('Tags test 4');
-                    res.body.posts[0].tags.length.should.equal(2);
-                    res.body.posts[0].tags[0].slug.should.equal('three');
-                    res.body.posts[0].tags[1].slug.should.equal('four');
+                    assert.equal(res.body.posts[0].title, 'Tags test 4');
+                    assert.equal(res.body.posts[0].tags.length, 2);
+                    assert.equal(res.body.posts[0].tags[0].slug, 'three');
+                    assert.equal(res.body.posts[0].tags[1].slug, 'four');
                 });
         });
 
@@ -428,12 +428,12 @@ describe('Posts API', function () {
 
             should.exist(res.body.posts);
             should.exist(res.body.posts[0].title);
-            res.body.posts[0].title.should.equal('Tags test 5');
-            res.body.posts[0].tags.length.should.equal(1);
-            res.body.posts[0].tags[0].slug.should.equal('five-spaces');
+            assert.equal(res.body.posts[0].title, 'Tags test 5');
+            assert.equal(res.body.posts[0].tags.length, 1);
+            assert.equal(res.body.posts[0].tags[0].slug, 'five-spaces');
 
             // Expected behavior when creating a slug with spaces:
-            res.body.posts[0].tags[0].name.should.equal('five-spaces');
+            assert.equal(res.body.posts[0].tags[0].name, 'five-spaces');
 
             // If we create another post again now that the five-spaces tag exists,
             // we need to make sure it matches correctly and doesn't create a new tag again
@@ -453,8 +453,8 @@ describe('Posts API', function () {
 
             should.exist(res2.body.posts);
             should.exist(res2.body.posts[0].title);
-            res2.body.posts[0].title.should.equal('Tags test 6');
-            res2.body.posts[0].tags.length.should.equal(1);
+            assert.equal(res2.body.posts[0].title, 'Tags test 6');
+            assert.equal(res2.body.posts[0].tags.length, 1);
             res2.body.posts[0].tags[0].id.should.equal(res.body.posts[0].tags[0].id);
         });
 
@@ -476,10 +476,10 @@ describe('Posts API', function () {
 
             should.exist(res.body.posts);
             should.exist(res.body.posts[0].title);
-            res.body.posts[0].title.should.equal('Tags test 7');
-            res.body.posts[0].tags.length.should.equal(1);
-            res.body.posts[0].tags[0].slug.should.equal('six-spaces');
-            res.body.posts[0].tags[0].name.should.equal('Not automated name for six spaces');
+            assert.equal(res.body.posts[0].title, 'Tags test 7');
+            assert.equal(res.body.posts[0].tags.length, 1);
+            assert.equal(res.body.posts[0].tags[0].slug, 'six-spaces');
+            assert.equal(res.body.posts[0].tags[0].name, 'Not automated name for six spaces');
 
             // If we create another post again now that the five-spaces tag exists,
             // we need to make sure it matches correctly and doesn't create a new tag again
@@ -499,8 +499,8 @@ describe('Posts API', function () {
 
             should.exist(res2.body.posts);
             should.exist(res2.body.posts[0].title);
-            res2.body.posts[0].title.should.equal('Tags test 8');
-            res2.body.posts[0].tags.length.should.equal(1);
+            assert.equal(res2.body.posts[0].title, 'Tags test 8');
+            assert.equal(res2.body.posts[0].tags.length, 1);
             res2.body.posts[0].tags[0].id.should.equal(res.body.posts[0].tags[0].id);
         });
 
@@ -522,8 +522,8 @@ describe('Posts API', function () {
 
             should.exist(res.body.posts);
             should.exist(res.body.posts[0].title);
-            res.body.posts[0].title.should.equal('Tags test 9');
-            res.body.posts[0].tags.length.should.equal(1);
+            assert.equal(res.body.posts[0].title, 'Tags test 9');
+            assert.equal(res.body.posts[0].tags.length, 1);
             res.body.posts[0].tags[0].slug.should.equal(tooLongSlug.substring(0, 185));
 
             // If we create another post again now that the very long tag exists,
@@ -544,8 +544,8 @@ describe('Posts API', function () {
 
             should.exist(res2.body.posts);
             should.exist(res2.body.posts[0].title);
-            res2.body.posts[0].title.should.equal('Tags test 10');
-            res2.body.posts[0].tags.length.should.equal(1);
+            assert.equal(res2.body.posts[0].title, 'Tags test 10');
+            assert.equal(res2.body.posts[0].tags.length, 1);
             res2.body.posts[0].tags[0].id.should.equal(res.body.posts[0].tags[0].id);
         });
     });
@@ -594,9 +594,9 @@ describe('Posts API', function () {
 
             should.exist(res.body.posts);
             should.exist(res.body.posts[0].title);
-            res.body.posts[0].title.should.equal('Email me');
-            res.body.posts[0].email_only.should.be.true();
-            res.body.posts[0].status.should.equal('draft');
+            assert.equal(res.body.posts[0].title, 'Email me');
+            assert.equal(res.body.posts[0].email_only, true);
+            assert.equal(res.body.posts[0].status, 'draft');
 
             should.exist(res.headers.location);
             res.headers.location.should.equal(`http://127.0.0.1:2369${localUtils.API.getApiQuery('posts/')}${res.body.posts[0].id}/`);
@@ -615,11 +615,11 @@ describe('Posts API', function () {
                 .expect(200);
 
             should.exist(publishedRes.body.posts);
-            res.body.posts[0].email_only.should.be.true();
-            publishedRes.body.posts[0].status.should.equal('sent');
+            assert.equal(res.body.posts[0].email_only, true);
+            assert.equal(publishedRes.body.posts[0].status, 'sent');
 
             should.exist(publishedRes.body.posts[0].email);
-            publishedRes.body.posts[0].email.email_count.should.equal(4);
+            assert.equal(publishedRes.body.posts[0].email.email_count, 4);
         });
 
         it('publishes a post while setting email_only flag sends an email to paid', async function () {
@@ -637,9 +637,9 @@ describe('Posts API', function () {
 
             should.exist(res.body.posts);
             should.exist(res.body.posts[0].title);
-            res.body.posts[0].title.should.equal('Email me');
-            res.body.posts[0].email_only.should.be.false();
-            res.body.posts[0].status.should.equal('draft');
+            assert.equal(res.body.posts[0].title, 'Email me');
+            assert.equal(res.body.posts[0].email_only, false);
+            assert.equal(res.body.posts[0].status, 'draft');
 
             should.exist(res.headers.location);
             res.headers.location.should.equal(`http://127.0.0.1:2369${localUtils.API.getApiQuery('posts/')}${res.body.posts[0].id}/`);
@@ -659,10 +659,10 @@ describe('Posts API', function () {
                 .expect(200);
 
             should.exist(publishedRes.body.posts);
-            publishedRes.body.posts[0].status.should.equal('sent');
+            assert.equal(publishedRes.body.posts[0].status, 'sent');
 
             should.exist(publishedRes.body.posts[0].email);
-            publishedRes.body.posts[0].email.email_count.should.equal(2);
+            assert.equal(publishedRes.body.posts[0].email.email_count, 2);
         });
 
         it('only send an email to paid subscribed members of the selected newsletter', async function () {
@@ -680,9 +680,9 @@ describe('Posts API', function () {
 
             should.exist(res.body.posts);
             should.exist(res.body.posts[0].title);
-            res.body.posts[0].title.should.equal('Email me');
-            res.body.posts[0].email_only.should.be.false();
-            res.body.posts[0].status.should.equal('draft');
+            assert.equal(res.body.posts[0].title, 'Email me');
+            assert.equal(res.body.posts[0].email_only, false);
+            assert.equal(res.body.posts[0].status, 'draft');
 
             should.exist(res.headers.location);
             res.headers.location.should.equal(`http://127.0.0.1:2369${localUtils.API.getApiQuery('posts/')}${res.body.posts[0].id}/`);
@@ -702,10 +702,10 @@ describe('Posts API', function () {
                 .expect(200);
 
             should.exist(publishedRes.body.posts);
-            publishedRes.body.posts[0].status.should.equal('sent');
+            assert.equal(publishedRes.body.posts[0].status, 'sent');
 
             should.exist(publishedRes.body.posts[0].email);
-            publishedRes.body.posts[0].email.email_count.should.equal(2);
+            assert.equal(publishedRes.body.posts[0].email.email_count, 2);
         });
 
         it('read-only value do not cause errors when edited', function () {
@@ -764,7 +764,7 @@ describe('Posts API', function () {
                     }, testUtils.context.internal);
                 })
                 .then((model) => {
-                    model.get('plaintext').should.equal('HTML Ipsum presents');
+                    assert.equal(model.get('plaintext'), 'HTML Ipsum presents');
                 });
         });
 
@@ -830,7 +830,7 @@ describe('Posts API', function () {
                 .set('Origin', config.get('url'))
                 .expect(200)
                 .then((res) => {
-                    res.body.posts[0].status.should.eql('scheduled');
+                    assert.equal(res.body.posts[0].status, 'scheduled');
 
                     return request
                         .put(localUtils.API.getApiQuery('posts/' + testUtils.DataGenerator.Content.posts[7].id + '/'))
@@ -902,7 +902,7 @@ describe('Posts API', function () {
                 .then((res) => {
                     should.exist(res.body.posts);
                     should.exist(res.body.posts[0].slug);
-                    res.body.posts[0].slug.should.equal('this-is-invisible');
+                    assert.equal(res.body.posts[0].slug, 'this-is-invisible');
                 });
         });
 
@@ -928,7 +928,7 @@ describe('Posts API', function () {
                 .then((res) => {
                     should.exist(res.body.posts);
                     should.exist(res.body.posts[0].visibility);
-                    res.body.posts[0].visibility.should.equal('members');
+                    assert.equal(res.body.posts[0].visibility, 'members');
                 });
         });
 
@@ -1005,7 +1005,7 @@ describe('Posts API', function () {
                 .then((res) => {
                     should.exist(res.body.posts);
                     should.exist(res.body.posts[0].title);
-                    res.body.posts[0].title.should.equal('Has a title by no other content');
+                    assert.equal(res.body.posts[0].title, 'Has a title by no other content');
                     assert.equal(res.body.posts[0].html, undefined);
                     assert.equal(res.body.posts[0].plaintext, undefined);
 
@@ -1027,7 +1027,7 @@ describe('Posts API', function () {
                     assert.equal(res.headers['x-cache-invalidate'], undefined);
 
                     should.exist(res.body.posts);
-                    res.body.posts[0].title.should.equal('Has a title by no other content');
+                    assert.equal(res.body.posts[0].title, 'Has a title by no other content');
                     assert.equal(res.body.posts[0].html, undefined);
                     assert.equal(res.body.posts[0].plaintext, undefined);
                 });
@@ -1063,7 +1063,7 @@ describe('Posts API', function () {
                         .expect(400);
                 })
                 .then((res) => {
-                    res.text.should.match(/valid filter/i);
+                    assert.match(res.text, /valid filter/i);
                 });
         });
     });

--- a/ghost/core/test/legacy/api/admin/redirects.test.js
+++ b/ghost/core/test/legacy/api/admin/redirects.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const supertest = require('supertest');
 const fs = require('fs-extra');
@@ -54,17 +55,17 @@ describe('Redirects API', function () {
                             .expect(200);
                     })
                     .then((res) => {
-                        res.headers['x-cache-invalidate'].should.eql('/*');
+                        assert.equal(res.headers['x-cache-invalidate'], '/*');
 
                         return request
                             .get('/k/')
                             .expect(302);
                     })
                     .then((response) => {
-                        response.headers.location.should.eql('/l');
+                        assert.equal(response.headers.location, '/l');
 
                         const dataFiles = fs.readdirSync(config.getContentPath('data'));
-                        dataFiles.join(',').match(/(redirects)/g).length.should.eql(2);
+                        assert.equal(dataFiles.join(',').match(/(redirects)/g).length, 2);
 
                         const fileContent = fs.readFileSync(path.join(contentFolder, 'data', 'redirects.json'), 'utf-8');
                         fileContent.should.eql(JSON.stringify([{
@@ -86,7 +87,7 @@ describe('Redirects API', function () {
                             .expect(200);
                     })
                     .then((res) => {
-                        res.headers['x-cache-invalidate'].should.eql('/*');
+                        assert.equal(res.headers['x-cache-invalidate'], '/*');
 
                         return request
                             .get('/my-old-blog-post/')
@@ -98,10 +99,10 @@ describe('Redirects API', function () {
                             .expect(302);
                     })
                     .then((response) => {
-                        response.headers.location.should.eql('/d');
+                        assert.equal(response.headers.location, '/d');
 
                         const fileContent = fs.readFileSync(path.join(config.get('paths:contentPath'), 'data', 'redirects.yaml'), 'utf-8');
-                        fileContent.should.eql('302:\n  c: d');
+                        assert.equal(fileContent, '302:\n  c: d');
                     });
             });
         });

--- a/ghost/core/test/legacy/api/admin/schedules.test.js
+++ b/ghost/core/test/legacy/api/admin/schedules.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const _ = require('lodash');
 const should = require('should');
 const supertest = require('supertest');
@@ -85,7 +86,7 @@ describe('Schedules API', function () {
             return models.Post.add(post, {context: {internal: true}});
         }));
 
-        result.length.should.eql(5);
+        assert.equal(result.length, 5);
     });
 
     describe('publish', function () {
@@ -109,7 +110,7 @@ describe('Schedules API', function () {
             const jsonResponse = res.body;
             should.exist(jsonResponse);
             jsonResponse.posts[0].id.should.eql(resources[0].id);
-            jsonResponse.posts[0].status.should.eql('published');
+            assert.equal(jsonResponse.posts[0].status, 'published');
         });
 
         it('publishes page', async function () {
@@ -123,7 +124,7 @@ describe('Schedules API', function () {
             const jsonResponse = res.body;
             should.exist(jsonResponse);
             jsonResponse.pages[0].id.should.eql(resources[4].id);
-            jsonResponse.pages[0].status.should.eql('published');
+            assert.equal(jsonResponse.pages[0].status, 'published');
         });
 
         it('no access', function () {

--- a/ghost/core/test/legacy/api/admin/settings.test.js
+++ b/ghost/core/test/legacy/api/admin/settings.test.js
@@ -27,7 +27,7 @@ describe('Settings API', function () {
             .expect(200)
             .expect((response) => {
                 should.exist(response.headers['x-cache-invalidate']);
-                response.headers['x-cache-invalidate'].should.eql('/*');
+                assert.equal(response.headers['x-cache-invalidate'], '/*');
             });
 
         // Check if not changed (also check internal ones)
@@ -124,7 +124,7 @@ describe('Settings API', function () {
                 .expect(200);
 
             const putBody = body;
-            headers['x-cache-invalidate'].should.eql('/*');
+            assert.equal(headers['x-cache-invalidate'], '/*');
             should.exist(putBody);
 
             let setting = putBody.settings.find(s => s.key === 'unsplash');
@@ -154,12 +154,12 @@ describe('Settings API', function () {
                 .expect(200);
 
             const putBody = body;
-            headers['x-cache-invalidate'].should.eql('/*');
+            assert.equal(headers['x-cache-invalidate'], '/*');
             should.exist(putBody);
 
             localUtils.API.checkResponse(putBody, 'settings');
             const setting = putBody.settings.find(s => s.key === 'slack_username');
-            setting.value.should.eql('can edit me');
+            assert.equal(setting.value, 'can edit me');
         });
 
         it('Can edit URLs without internal storage format leaking', async function () {
@@ -392,7 +392,7 @@ describe('Settings API', function () {
 
             const setting = jsonResponse.settings.find(s => s.key === 'email_verification_required');
             should.exist(setting);
-            setting.value.should.eql(true);
+            assert.equal(setting.value, true);
         });
     });
 });

--- a/ghost/core/test/legacy/api/admin/webhooks.test.js
+++ b/ghost/core/test/legacy/api/admin/webhooks.test.js
@@ -42,12 +42,12 @@ describe('Webhooks API', function () {
                 should.exist(jsonResponse.webhooks[0].event);
                 should.exist(jsonResponse.webhooks[0].target_url);
 
-                jsonResponse.webhooks[0].event.should.eql('test.create');
-                jsonResponse.webhooks[0].target_url.should.eql('http://example.com/webhooks/test/extra/canary');
+                assert.equal(jsonResponse.webhooks[0].event, 'test.create');
+                assert.equal(jsonResponse.webhooks[0].target_url, 'http://example.com/webhooks/test/extra/canary');
                 jsonResponse.webhooks[0].integration_id.should.eql(testUtils.DataGenerator.Content.api_keys[0].integration_id);
-                jsonResponse.webhooks[0].name.should.eql('test');
-                jsonResponse.webhooks[0].secret.should.eql('thisissecret');
-                jsonResponse.webhooks[0].api_version.should.eql('canary');
+                assert.equal(jsonResponse.webhooks[0].name, 'test');
+                assert.equal(jsonResponse.webhooks[0].secret, 'thisissecret');
+                assert.equal(jsonResponse.webhooks[0].api_version, 'canary');
 
                 localUtils.API.checkResponse(jsonResponse.webhooks[0], 'webhook');
             });

--- a/ghost/core/test/legacy/api/content/authors.test.js
+++ b/ghost/core/test/legacy/api/content/authors.test.js
@@ -121,9 +121,9 @@ describe('Authors Content API', function () {
                 const jsonResponse = res.body;
 
                 jsonResponse.authors.should.be.an.Array().with.lengthOf(3);
-                jsonResponse.authors[0].slug.should.equal('joe-bloggs');
-                jsonResponse.authors[1].slug.should.equal('ghost');
-                jsonResponse.authors[2].slug.should.equal('slimer-mcectoplasm');
+                assert.equal(jsonResponse.authors[0].slug, 'joe-bloggs');
+                assert.equal(jsonResponse.authors[1].slug, 'ghost');
+                assert.equal(jsonResponse.authors[2].slug, 'slimer-mcectoplasm');
             });
     });
 });

--- a/ghost/core/test/legacy/api/content/pages.test.js
+++ b/ghost/core/test/legacy/api/content/pages.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const supertest = require('supertest');
 const testUtils = require('../../../utils');
@@ -114,7 +115,7 @@ describe('api/endpoints/content/pages', function () {
                 const jsonResponse = res.body;
 
                 jsonResponse.pages.should.be.an.Array().with.lengthOf(1);
-                jsonResponse.pages[0].slug.should.equal('static-page-test');
+                assert.equal(jsonResponse.pages[0].slug, 'static-page-test');
             });
     });
 

--- a/ghost/core/test/legacy/api/content/posts.test.js
+++ b/ghost/core/test/legacy/api/content/posts.test.js
@@ -112,29 +112,29 @@ describe('api/endpoints/content/posts', function () {
                     return done(err);
                 }
 
-                res.headers.vary.should.eql('Accept-Version, Accept-Encoding');
+                assert.equal(res.headers.vary, 'Accept-Version, Accept-Encoding');
                 should.exist(res.headers['access-control-allow-origin']);
                 assert.equal(res.headers['x-cache-invalidate'], undefined);
 
                 const jsonResponse = res.body;
                 should.exist(jsonResponse.posts);
                 localUtils.API.checkResponse(jsonResponse, 'posts');
-                jsonResponse.posts.should.have.length(13);
+                assert.equal(jsonResponse.posts.length, 13);
                 localUtils.API.checkResponse(jsonResponse.posts[0], 'post');
                 localUtils.API.checkResponse(jsonResponse.meta.pagination, 'pagination');
-                _.isBoolean(jsonResponse.posts[0].featured).should.eql(true);
+                assert.equal(_.isBoolean(jsonResponse.posts[0].featured), true);
 
                 // Default order 'published_at desc' check
-                jsonResponse.posts[0].slug.should.eql('welcome');
-                jsonResponse.posts[6].slug.should.eql('integrations');
+                assert.equal(jsonResponse.posts[0].slug, 'welcome');
+                assert.equal(jsonResponse.posts[6].slug, 'integrations');
 
                 // check meta response for this test
-                jsonResponse.meta.pagination.page.should.eql(1);
-                jsonResponse.meta.pagination.limit.should.eql(15);
-                jsonResponse.meta.pagination.pages.should.eql(1);
-                jsonResponse.meta.pagination.total.should.eql(13);
-                jsonResponse.meta.pagination.hasOwnProperty('next').should.be.true();
-                jsonResponse.meta.pagination.hasOwnProperty('prev').should.be.true();
+                assert.equal(jsonResponse.meta.pagination.page, 1);
+                assert.equal(jsonResponse.meta.pagination.limit, 15);
+                assert.equal(jsonResponse.meta.pagination.pages, 1);
+                assert.equal(jsonResponse.meta.pagination.total, 13);
+                assert.equal(jsonResponse.meta.pagination.hasOwnProperty('next'), true);
+                assert.equal(jsonResponse.meta.pagination.hasOwnProperty('prev'), true);
                 assert.equal(jsonResponse.meta.pagination.next, null);
                 assert.equal(jsonResponse.meta.pagination.prev, null);
 
@@ -153,14 +153,14 @@ describe('api/endpoints/content/posts', function () {
                     return done(err);
                 }
 
-                res.headers.vary.should.eql('Accept-Version, Accept-Encoding');
+                assert.equal(res.headers.vary, 'Accept-Version, Accept-Encoding');
                 should.exist(res.headers['access-control-allow-origin']);
                 assert.equal(res.headers['x-cache-invalidate'], undefined);
 
                 const jsonResponse = res.body;
                 should.exist(jsonResponse.posts);
                 localUtils.API.checkResponse(jsonResponse, 'posts');
-                jsonResponse.posts.should.have.length(13);
+                assert.equal(jsonResponse.posts.length, 13);
                 localUtils.API.checkResponse(
                     jsonResponse.posts[0],
                     'post',
@@ -169,19 +169,19 @@ describe('api/endpoints/content/posts', function () {
                 );
 
                 localUtils.API.checkResponse(jsonResponse.meta.pagination, 'pagination');
-                _.isBoolean(jsonResponse.posts[0].featured).should.eql(true);
+                assert.equal(_.isBoolean(jsonResponse.posts[0].featured), true);
 
                 // Default order 'published_at desc' check
-                jsonResponse.posts[0].slug.should.eql('welcome');
-                jsonResponse.posts[6].slug.should.eql('integrations');
+                assert.equal(jsonResponse.posts[0].slug, 'welcome');
+                assert.equal(jsonResponse.posts[6].slug, 'integrations');
 
                 // check meta response for this test
-                jsonResponse.meta.pagination.page.should.eql(1);
-                jsonResponse.meta.pagination.limit.should.eql(15);
-                jsonResponse.meta.pagination.pages.should.eql(1);
-                jsonResponse.meta.pagination.total.should.eql(13);
-                jsonResponse.meta.pagination.hasOwnProperty('next').should.be.true();
-                jsonResponse.meta.pagination.hasOwnProperty('prev').should.be.true();
+                assert.equal(jsonResponse.meta.pagination.page, 1);
+                assert.equal(jsonResponse.meta.pagination.limit, 15);
+                assert.equal(jsonResponse.meta.pagination.pages, 1);
+                assert.equal(jsonResponse.meta.pagination.total, 13);
+                assert.equal(jsonResponse.meta.pagination.hasOwnProperty('next'), true);
+                assert.equal(jsonResponse.meta.pagination.hasOwnProperty('prev'), true);
                 assert.equal(jsonResponse.meta.pagination.next, null);
                 assert.equal(jsonResponse.meta.pagination.prev, null);
 
@@ -222,9 +222,9 @@ describe('api/endpoints/content/posts', function () {
                 const jsonResponse = res.body;
 
                 jsonResponse.posts.should.be.an.Array().with.lengthOf(3);
-                jsonResponse.posts[0].slug.should.equal('write');
-                jsonResponse.posts[1].slug.should.equal('ghostly-kitchen-sink');
-                jsonResponse.posts[2].slug.should.equal('grow');
+                assert.equal(jsonResponse.posts[0].slug, 'write');
+                assert.equal(jsonResponse.posts[1].slug, 'ghostly-kitchen-sink');
+                assert.equal(jsonResponse.posts[2].slug, 'grow');
             });
     });
 
@@ -237,9 +237,9 @@ describe('api/endpoints/content/posts', function () {
                 const jsonResponse = res.body;
 
                 jsonResponse.posts.should.be.an.Array().with.lengthOf(3);
-                jsonResponse.posts[0].slug.should.equal('write');
-                jsonResponse.posts[1].slug.should.equal('grow');
-                jsonResponse.posts[2].slug.should.equal('ghostly-kitchen-sink');
+                assert.equal(jsonResponse.posts[0].slug, 'write');
+                assert.equal(jsonResponse.posts[1].slug, 'grow');
+                assert.equal(jsonResponse.posts[2].slug, 'ghostly-kitchen-sink');
             });
     });
 
@@ -258,7 +258,7 @@ describe('api/endpoints/content/posts', function () {
                     return done(err);
                 }
 
-                res.headers.vary.should.eql('Accept-Version, Accept, Accept-Encoding');
+                assert.equal(res.headers.vary, 'Accept-Version, Accept, Accept-Encoding');
                 res.headers.location.should.eql(`http://localhost:9999/ghost/api/content/posts/?key=${validKey}`);
                 should.exist(res.headers['access-control-allow-origin']);
                 assert.equal(res.headers['x-cache-invalidate'], undefined);
@@ -288,7 +288,7 @@ describe('api/endpoints/content/posts', function () {
                 localUtils.API.checkResponse(res.body.posts[0], 'post', null, null, ['id', 'title', 'slug', 'excerpt', 'plaintext']);
 
                 // excerpt should transform links to absolute URLs
-                res.body.posts[0].excerpt.should.match(/\* Aliquam/);
+                assert.match(res.body.posts[0].excerpt, /\* Aliquam/);
             });
     });
 
@@ -346,9 +346,9 @@ describe('api/endpoints/content/posts', function () {
                     const post = jsonResponse.posts[0];
 
                     localUtils.API.checkResponse(post, 'post', null, null, ['id', 'slug', 'html', 'plaintext']);
-                    post.slug.should.eql('free-to-see');
-                    post.html.should.not.eql('');
-                    post.plaintext.should.not.eql('');
+                    assert.equal(post.slug, 'free-to-see');
+                    assert.notEqual(post.html, '');
+                    assert.notEqual(post.plaintext, '');
                 });
         });
 
@@ -365,9 +365,9 @@ describe('api/endpoints/content/posts', function () {
                     const post = jsonResponse.posts[0];
 
                     localUtils.API.checkResponse(post, 'post', null, null);
-                    post.slug.should.eql('thou-shalt-not-be-seen');
-                    post.html.should.eql('');
-                    post.excerpt.should.eql('');
+                    assert.equal(post.slug, 'thou-shalt-not-be-seen');
+                    assert.equal(post.html, '');
+                    assert.equal(post.excerpt, '');
                 });
         });
 
@@ -384,9 +384,9 @@ describe('api/endpoints/content/posts', function () {
                     const post = jsonResponse.posts[0];
 
                     localUtils.API.checkResponse(post, 'post', null, null);
-                    post.slug.should.eql('thou-shalt-be-paid-for');
-                    post.html.should.eql('');
-                    post.excerpt.should.eql('');
+                    assert.equal(post.slug, 'thou-shalt-be-paid-for');
+                    assert.equal(post.html, '');
+                    assert.equal(post.excerpt, '');
                 });
         });
 
@@ -403,8 +403,8 @@ describe('api/endpoints/content/posts', function () {
                     const post = jsonResponse.posts[0];
 
                     localUtils.API.checkResponse(post, 'post', null, null, ['id', 'html', 'plaintext']);
-                    post.html.should.eql('');
-                    post.plaintext.should.eql('');
+                    assert.equal(post.html, '');
+                    assert.equal(post.plaintext, '');
                 });
         });
 
@@ -421,9 +421,9 @@ describe('api/endpoints/content/posts', function () {
                     const post = jsonResponse.posts[0];
 
                     localUtils.API.checkResponse(post, 'post', ['plaintext']);
-                    post.html.should.eql('<p>Free content</p>');
-                    post.plaintext.should.eql('Free content');
-                    post.excerpt.should.eql('Free content');
+                    assert.equal(post.html, '<p>Free content</p>');
+                    assert.equal(post.plaintext, 'Free content');
+                    assert.equal(post.excerpt, 'Free content');
                 });
         });
 
@@ -434,17 +434,17 @@ describe('api/endpoints/content/posts', function () {
                 .expect('Cache-Control', testUtils.cacheRules.public)
                 .expect(200)
                 .then((res) => {
-                    res.headers.vary.should.eql('Accept-Version, Accept-Encoding');
+                    assert.equal(res.headers.vary, 'Accept-Version, Accept-Encoding');
                     should.exist(res.headers['access-control-allow-origin']);
                     assert.equal(res.headers['x-cache-invalidate'], undefined);
 
                     const jsonResponse = res.body;
                     should.exist(jsonResponse.posts);
                     localUtils.API.checkResponse(jsonResponse, 'posts');
-                    jsonResponse.posts.should.have.length(15);
+                    assert.equal(jsonResponse.posts.length, 15);
                     localUtils.API.checkResponse(jsonResponse.posts[0], 'post', null, null);
                     localUtils.API.checkResponse(jsonResponse.meta.pagination, 'pagination');
-                    _.isBoolean(jsonResponse.posts[0].featured).should.eql(true);
+                    assert.equal(_.isBoolean(jsonResponse.posts[0].featured), true);
 
                     const membersOnlySlugs = [
                         'thou-shalt-not-be-seen',
@@ -461,12 +461,12 @@ describe('api/endpoints/content/posts', function () {
 
                     jsonResponse.posts.forEach((post) => {
                         if (membersOnlySlugs.indexOf(post.slug) > -1) {
-                            post.html.should.eql('');
-                            post.excerpt.should.eql('');
+                            assert.equal(post.html, '');
+                            assert.equal(post.excerpt, '');
                             seen += 1;
                         } else if (freeToSeeSlugs.indexOf(post.slug) > -1) {
-                            post.html.should.not.eql('');
-                            post.excerpt.should.not.eql('');
+                            assert.notEqual(post.html, '');
+                            assert.notEqual(post.excerpt, '');
                             seen += 1;
                         }
                     });
@@ -474,13 +474,13 @@ describe('api/endpoints/content/posts', function () {
                     seen.should.eql(membersOnlySlugs.length + freeToSeeSlugs.length);
 
                     // check meta response for this test
-                    jsonResponse.meta.pagination.page.should.eql(1);
-                    jsonResponse.meta.pagination.limit.should.eql(15);
-                    jsonResponse.meta.pagination.pages.should.eql(2);
-                    jsonResponse.meta.pagination.total.should.eql(17);
-                    jsonResponse.meta.pagination.hasOwnProperty('next').should.be.true();
-                    jsonResponse.meta.pagination.hasOwnProperty('prev').should.be.true();
-                    jsonResponse.meta.pagination.next.should.eql(2);
+                    assert.equal(jsonResponse.meta.pagination.page, 1);
+                    assert.equal(jsonResponse.meta.pagination.limit, 15);
+                    assert.equal(jsonResponse.meta.pagination.pages, 2);
+                    assert.equal(jsonResponse.meta.pagination.total, 17);
+                    assert.equal(jsonResponse.meta.pagination.hasOwnProperty('next'), true);
+                    assert.equal(jsonResponse.meta.pagination.hasOwnProperty('prev'), true);
+                    assert.equal(jsonResponse.meta.pagination.next, 2);
                     assert.equal(jsonResponse.meta.pagination.prev, null);
                 });
         });

--- a/ghost/core/test/legacy/api/content/tags.test.js
+++ b/ghost/core/test/legacy/api/content/tags.test.js
@@ -47,7 +47,7 @@ describe('api/endpoints/content/tags', function () {
                 const jsonResponse = res.body;
                 should.exist(jsonResponse);
                 should.exist(jsonResponse.tags);
-                jsonResponse.tags.should.have.length(5);
+                assert.equal(jsonResponse.tags.length, 5);
                 localUtils.API.checkResponse(jsonResponse.tags[0], 'tag', ['count', 'url']);
 
                 jsonResponse.meta.pagination.should.have.property('page', 1);
@@ -59,10 +59,10 @@ describe('api/endpoints/content/tags', function () {
 
                 should.exist(jsonResponse.tags[0].count.posts);
                 // Each tag should have the correct count
-                _.find(jsonResponse.tags, {name: 'Getting Started'}).count.posts.should.eql(7);
-                _.find(jsonResponse.tags, {name: 'kitchen sink'}).count.posts.should.eql(2);
-                _.find(jsonResponse.tags, {name: 'bacon'}).count.posts.should.eql(2);
-                _.find(jsonResponse.tags, {name: 'chorizo'}).count.posts.should.eql(1);
+                assert.equal(_.find(jsonResponse.tags, {name: 'Getting Started'}).count.posts, 7);
+                assert.equal(_.find(jsonResponse.tags, {name: 'kitchen sink'}).count.posts, 2);
+                assert.equal(_.find(jsonResponse.tags, {name: 'bacon'}).count.posts, 2);
+                assert.equal(_.find(jsonResponse.tags, {name: 'chorizo'}).count.posts, 1);
             });
     });
 
@@ -75,9 +75,9 @@ describe('api/endpoints/content/tags', function () {
                 const jsonResponse = res.body;
 
                 jsonResponse.tags.should.be.an.Array().with.lengthOf(3);
-                jsonResponse.tags[0].slug.should.equal('kitchen-sink');
-                jsonResponse.tags[1].slug.should.equal('bacon');
-                jsonResponse.tags[2].slug.should.equal('chorizo');
+                assert.equal(jsonResponse.tags[0].slug, 'kitchen-sink');
+                assert.equal(jsonResponse.tags[1].slug, 'bacon');
+                assert.equal(jsonResponse.tags[2].slug, 'chorizo');
             });
     });
 });

--- a/ghost/core/test/legacy/mock-express-style/api-vs-frontend.test.js
+++ b/ghost/core/test/legacy/mock-express-style/api-vs-frontend.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const cheerio = require('cheerio');
@@ -58,8 +59,8 @@ describe('Frontend behavior tests', function () {
 
                 return localUtils.mockExpress.invoke(app, req)
                     .then(function (response) {
-                        response.statusCode.should.eql(200);
-                        response.template.should.eql('post');
+                        assert.equal(response.statusCode, 200);
+                        assert.equal(response.template, 'post');
                     });
             });
 
@@ -72,8 +73,8 @@ describe('Frontend behavior tests', function () {
 
                 return localUtils.mockExpress.invoke(app, req)
                     .then(function (response) {
-                        response.statusCode.should.eql(404);
-                        response.template.should.eql('error-404');
+                        assert.equal(response.statusCode, 404);
+                        assert.equal(response.template, 'error-404');
                     });
             });
 
@@ -86,8 +87,8 @@ describe('Frontend behavior tests', function () {
 
                 return localUtils.mockExpress.invoke(app, req)
                     .then(function (response) {
-                        response.statusCode.should.eql(200);
-                        response.template.should.eql('page');
+                        assert.equal(response.statusCode, 200);
+                        assert.equal(response.template, 'page');
                     });
             });
 
@@ -100,12 +101,12 @@ describe('Frontend behavior tests', function () {
 
                 return localUtils.mockExpress.invoke(app, req)
                     .then(function (response) {
-                        response.statusCode.should.eql(200);
-                        response.template.should.eql('author');
+                        assert.equal(response.statusCode, 200);
+                        assert.equal(response.template, 'author');
 
                         const bodyClasses = response.body.match(/<body[^>]*class="([^"]*?)">/)[1].split(' ');
-                        bodyClasses.should.containEql('author-template');
-                        bodyClasses.should.containEql('author-joe-bloggs');
+                        assert(bodyClasses.includes('author-template'));
+                        assert(bodyClasses.includes('author-joe-bloggs'));
                     });
             });
 
@@ -117,12 +118,12 @@ describe('Frontend behavior tests', function () {
                 };
 
                 const response = await localUtils.mockExpress.invoke(app, req);
-                response.statusCode.should.eql(200);
-                response.template.should.eql('tag');
+                assert.equal(response.statusCode, 200);
+                assert.equal(response.template, 'tag');
 
-                postSpy.args[0][0].filter.should.eql('tags:\'bacon\'+tags.visibility:public');
-                postSpy.args[0][0].page.should.eql(1);
-                postSpy.args[0][0].limit.should.eql(2);
+                assert.equal(postSpy.args[0][0].filter, 'tags:\'bacon\'+tags.visibility:public');
+                assert.equal(postSpy.args[0][0].page, 1);
+                assert.equal(postSpy.args[0][0].limit, 2);
             });
 
             it('serve tag rss', function () {
@@ -134,7 +135,7 @@ describe('Frontend behavior tests', function () {
 
                 return localUtils.mockExpress.invoke(app, req)
                     .then(function (response) {
-                        response.statusCode.should.eql(200);
+                        assert.equal(response.statusCode, 200);
                     });
             });
 
@@ -149,10 +150,10 @@ describe('Frontend behavior tests', function () {
                     .then(function (response) {
                         const $ = cheerio.load(response.body);
 
-                        response.statusCode.should.eql(200);
-                        response.template.should.eql('index');
+                        assert.equal(response.statusCode, 200);
+                        assert.equal(response.template, 'index');
 
-                        $('.post-card').length.should.equal(2);
+                        assert.equal($('.post-card').length, 2);
 
                         should.exist(response.res.locals.context);
                         should.exist(response.res.locals.version);
@@ -174,10 +175,10 @@ describe('Frontend behavior tests', function () {
                     .then(function (response) {
                         const $ = cheerio.load(response.body);
 
-                        response.statusCode.should.eql(200);
-                        response.template.should.eql('index');
+                        assert.equal(response.statusCode, 200);
+                        assert.equal(response.template, 'index');
 
-                        $('.post-card').length.should.equal(2);
+                        assert.equal($('.post-card').length, 2);
                     });
             });
 
@@ -190,7 +191,7 @@ describe('Frontend behavior tests', function () {
 
                 return localUtils.mockExpress.invoke(app, req)
                     .then(function (response) {
-                        response.statusCode.should.eql(200);
+                        assert.equal(response.statusCode, 200);
                     });
             });
         });
@@ -206,8 +207,8 @@ describe('Frontend behavior tests', function () {
 
                 return localUtils.mockExpress.invoke(app, req)
                     .then(function (response) {
-                        response.statusCode.should.eql(301);
-                        response.headers.location.should.eql('/prettify-me/');
+                        assert.equal(response.statusCode, 301);
+                        assert.equal(response.headers.location, '/prettify-me/');
                     });
             });
         });
@@ -224,8 +225,8 @@ describe('Frontend behavior tests', function () {
 
                     return localUtils.mockExpress.invoke(app, req)
                         .then(function (response) {
-                            response.statusCode.should.eql(301);
-                            response.headers.location.should.eql('/');
+                            assert.equal(response.statusCode, 301);
+                            assert.equal(response.headers.location, '/');
                         });
                 });
             });
@@ -241,8 +242,8 @@ describe('Frontend behavior tests', function () {
 
                     return localUtils.mockExpress.invoke(app, req)
                         .then(function (response) {
-                            response.statusCode.should.eql(301);
-                            response.headers.location.should.eql('/rss/');
+                            assert.equal(response.statusCode, 301);
+                            assert.equal(response.headers.location, '/rss/');
                         });
                 });
             });
@@ -271,8 +272,8 @@ describe('Frontend behavior tests', function () {
 
                 return localUtils.mockExpress.invoke(app, req)
                     .then(function (response) {
-                        response.statusCode.should.eql(301);
-                        response.headers.location.should.eql('https://example.com/html-ipsum/');
+                        assert.equal(response.statusCode, 301);
+                        assert.equal(response.headers.location, 'https://example.com/html-ipsum/');
                     });
             });
 
@@ -286,8 +287,8 @@ describe('Frontend behavior tests', function () {
 
                 return localUtils.mockExpress.invoke(app, req)
                     .then(function (response) {
-                        response.statusCode.should.eql(301);
-                        response.headers.location.should.eql('https://example.com/html-ipsum/');
+                        assert.equal(response.statusCode, 301);
+                        assert.equal(response.headers.location, 'https://example.com/html-ipsum/');
                     });
             });
         });
@@ -303,8 +304,8 @@ describe('Frontend behavior tests', function () {
 
                 return localUtils.mockExpress.invoke(app, req)
                     .then(function (response) {
-                        response.statusCode.should.eql(301);
-                        response.headers.location.should.eql('https://example.com/favicon.png');
+                        assert.equal(response.statusCode, 301);
+                        assert.equal(response.headers.location, 'https://example.com/favicon.png');
                     });
             });
 
@@ -318,8 +319,8 @@ describe('Frontend behavior tests', function () {
 
                 return localUtils.mockExpress.invoke(app, req)
                     .then(function (response) {
-                        response.statusCode.should.eql(301);
-                        response.headers.location.should.eql('https://example.com/assets/css/main.css');
+                        assert.equal(response.statusCode, 301);
+                        assert.equal(response.headers.location, 'https://example.com/assets/css/main.css');
                     });
             });
         });
@@ -379,8 +380,8 @@ describe('Frontend behavior tests', function () {
 
                 return localUtils.mockExpress.invoke(app, req)
                     .then(function (response) {
-                        response.statusCode.should.eql(200);
-                        response.template.should.eql('home');
+                        assert.equal(response.statusCode, 200);
+                        assert.equal(response.template, 'home');
                     });
             });
 
@@ -393,7 +394,7 @@ describe('Frontend behavior tests', function () {
 
                 return localUtils.mockExpress.invoke(app, req)
                     .then(function (response) {
-                        response.statusCode.should.eql(200);
+                        assert.equal(response.statusCode, 200);
                     });
             });
 
@@ -406,8 +407,8 @@ describe('Frontend behavior tests', function () {
 
                 return localUtils.mockExpress.invoke(app, req)
                     .then(function (response) {
-                        response.statusCode.should.eql(200);
-                        response.template.should.eql('post');
+                        assert.equal(response.statusCode, 200);
+                        assert.equal(response.template, 'post');
                     });
             });
 
@@ -422,10 +423,10 @@ describe('Frontend behavior tests', function () {
                     .then(function (response) {
                         const $ = cheerio.load(response.body);
 
-                        response.statusCode.should.eql(200);
-                        response.template.should.eql('index');
+                        assert.equal(response.statusCode, 200);
+                        assert.equal(response.template, 'index');
 
-                        $('.post-card').length.should.equal(2);
+                        assert.equal($('.post-card').length, 2);
                     });
             });
 
@@ -438,8 +439,8 @@ describe('Frontend behavior tests', function () {
 
                 return localUtils.mockExpress.invoke(app, req)
                     .then(function (response) {
-                        response.statusCode.should.eql(200);
-                        response.template.should.eql('something');
+                        assert.equal(response.statusCode, 200);
+                        assert.equal(response.template, 'something');
                     });
             });
         });
@@ -484,8 +485,8 @@ describe('Frontend behavior tests', function () {
 
                 return localUtils.mockExpress.invoke(app, req)
                     .then(function (response) {
-                        response.statusCode.should.eql(200);
-                        response.template.should.eql('something');
+                        assert.equal(response.statusCode, 200);
+                        assert.equal(response.template, 'something');
                     });
             });
         });
@@ -539,8 +540,8 @@ describe('Frontend behavior tests', function () {
                 return localUtils.mockExpress.invoke(app, req)
                     .then(function (response) {
                         // We can't find a post with the slug "featured"
-                        response.statusCode.should.eql(404);
-                        response.template.should.eql('error-404');
+                        assert.equal(response.statusCode, 404);
+                        assert.equal(response.template, 'error-404');
                     });
             });
 
@@ -553,8 +554,8 @@ describe('Frontend behavior tests', function () {
 
                 return localUtils.mockExpress.invoke(app, req)
                     .then(function (response) {
-                        response.statusCode.should.eql(200);
-                        response.template.should.eql('post');
+                        assert.equal(response.statusCode, 200);
+                        assert.equal(response.template, 'post');
                     });
             });
 
@@ -567,8 +568,8 @@ describe('Frontend behavior tests', function () {
 
                 return localUtils.mockExpress.invoke(app, req)
                     .then(function (response) {
-                        response.statusCode.should.eql(404);
-                        response.template.should.eql('error-404');
+                        assert.equal(response.statusCode, 404);
+                        assert.equal(response.template, 'error-404');
                     });
             });
 
@@ -581,8 +582,8 @@ describe('Frontend behavior tests', function () {
 
                 return localUtils.mockExpress.invoke(app, req)
                     .then(function (response) {
-                        response.statusCode.should.eql(404);
-                        response.template.should.eql('error-404');
+                        assert.equal(response.statusCode, 404);
+                        assert.equal(response.template, 'error-404');
                     });
             });
         });
@@ -629,8 +630,8 @@ describe('Frontend behavior tests', function () {
 
                 return localUtils.mockExpress.invoke(app, req)
                     .then(function (response) {
-                        response.statusCode.should.eql(200);
-                        response.template.should.eql('post');
+                        assert.equal(response.statusCode, 200);
+                        assert.equal(response.template, 'post');
                     });
             });
 
@@ -643,8 +644,8 @@ describe('Frontend behavior tests', function () {
 
                 return localUtils.mockExpress.invoke(app, req)
                     .then(function (response) {
-                        response.statusCode.should.eql(404);
-                        response.template.should.eql('error-404');
+                        assert.equal(response.statusCode, 404);
+                        assert.equal(response.template, 'error-404');
                     });
             });
 
@@ -657,8 +658,8 @@ describe('Frontend behavior tests', function () {
 
                 return localUtils.mockExpress.invoke(app, req)
                     .then(function (response) {
-                        response.statusCode.should.eql(200);
-                        response.template.should.eql('page');
+                        assert.equal(response.statusCode, 200);
+                        assert.equal(response.template, 'page');
                     });
             });
         });
@@ -705,8 +706,8 @@ describe('Frontend behavior tests', function () {
 
                 return localUtils.mockExpress.invoke(app, req)
                     .then(function (response) {
-                        response.statusCode.should.eql(200);
-                        response.template.should.eql('post');
+                        assert.equal(response.statusCode, 200);
+                        assert.equal(response.template, 'post');
                     });
             });
 
@@ -719,8 +720,8 @@ describe('Frontend behavior tests', function () {
 
                 return localUtils.mockExpress.invoke(app, req)
                     .then(function (response) {
-                        response.statusCode.should.eql(404);
-                        response.template.should.eql('error-404');
+                        assert.equal(response.statusCode, 404);
+                        assert.equal(response.template, 'error-404');
                     });
             });
 
@@ -733,8 +734,8 @@ describe('Frontend behavior tests', function () {
 
                 return localUtils.mockExpress.invoke(app, req)
                     .then(function (response) {
-                        response.statusCode.should.eql(404);
-                        response.template.should.eql('error-404');
+                        assert.equal(response.statusCode, 404);
+                        assert.equal(response.template, 'error-404');
                     });
             });
 
@@ -747,8 +748,8 @@ describe('Frontend behavior tests', function () {
 
                 return localUtils.mockExpress.invoke(app, req)
                     .then(function (response) {
-                        response.statusCode.should.eql(200);
-                        response.template.should.eql('page');
+                        assert.equal(response.statusCode, 200);
+                        assert.equal(response.template, 'page');
                     });
             });
         });
@@ -852,8 +853,8 @@ describe('Frontend behavior tests', function () {
 
                 return localUtils.mockExpress.invoke(app, req)
                     .then(function (response) {
-                        response.statusCode.should.eql(200);
-                        response.template.should.eql('index');
+                        assert.equal(response.statusCode, 200);
+                        assert.equal(response.template, 'index');
                     });
             });
 
@@ -866,7 +867,7 @@ describe('Frontend behavior tests', function () {
 
                 return localUtils.mockExpress.invoke(app, req)
                     .then(function (response) {
-                        response.statusCode.should.eql(301);
+                        assert.equal(response.statusCode, 301);
                     });
             });
 
@@ -879,8 +880,8 @@ describe('Frontend behavior tests', function () {
 
                 return localUtils.mockExpress.invoke(app, req)
                     .then(function (response) {
-                        response.statusCode.should.eql(200);
-                        response.template.should.eql('index');
+                        assert.equal(response.statusCode, 200);
+                        assert.equal(response.template, 'index');
                     });
             });
 
@@ -893,7 +894,7 @@ describe('Frontend behavior tests', function () {
 
                 return localUtils.mockExpress.invoke(app, req)
                     .then(function (response) {
-                        response.statusCode.should.eql(200);
+                        assert.equal(response.statusCode, 200);
                     });
             });
 
@@ -906,7 +907,7 @@ describe('Frontend behavior tests', function () {
 
                 return localUtils.mockExpress.invoke(app, req)
                     .then(function (response) {
-                        response.statusCode.should.eql(200);
+                        assert.equal(response.statusCode, 200);
                     });
             });
         });
@@ -954,8 +955,8 @@ describe('Frontend behavior tests', function () {
 
                 return localUtils.mockExpress.invoke(app, req)
                     .then(function (response) {
-                        response.statusCode.should.eql(200);
-                        response.template.should.eql('default');
+                        assert.equal(response.statusCode, 200);
+                        assert.equal(response.template, 'default');
                     });
             });
 
@@ -968,8 +969,8 @@ describe('Frontend behavior tests', function () {
 
                 return localUtils.mockExpress.invoke(app, req)
                     .then(function (response) {
-                        response.statusCode.should.eql(200);
-                        response.template.should.eql('index');
+                        assert.equal(response.statusCode, 200);
+                        assert.equal(response.template, 'index');
                     });
             });
         });
@@ -1015,8 +1016,8 @@ describe('Frontend behavior tests', function () {
 
                 return localUtils.mockExpress.invoke(app, req)
                     .then(function (response) {
-                        response.statusCode.should.eql(200);
-                        response.template.should.eql('default');
+                        assert.equal(response.statusCode, 200);
+                        assert.equal(response.template, 'default');
                     });
             });
         });
@@ -1063,8 +1064,8 @@ describe('Frontend behavior tests', function () {
 
                 return localUtils.mockExpress.invoke(app, req)
                     .then(function (response) {
-                        response.statusCode.should.eql(200);
-                        response.template.should.eql('home');
+                        assert.equal(response.statusCode, 200);
+                        assert.equal(response.template, 'home');
                     });
             });
 
@@ -1077,8 +1078,8 @@ describe('Frontend behavior tests', function () {
 
                 return localUtils.mockExpress.invoke(app, req)
                     .then(function (response) {
-                        response.statusCode.should.eql(200);
-                        response.template.should.eql('something');
+                        assert.equal(response.statusCode, 200);
+                        assert.equal(response.template, 'something');
                     });
             });
         });
@@ -1243,10 +1244,10 @@ describe('Frontend behavior tests', function () {
                     .then(function (response) {
                         const $ = cheerio.load(response.body);
 
-                        response.statusCode.should.eql(200);
-                        response.template.should.eql('index');
+                        assert.equal(response.statusCode, 200);
+                        assert.equal(response.template, 'index');
 
-                        $('.post-card').length.should.equal(2);
+                        assert.equal($('.post-card').length, 2);
                     });
             });
 
@@ -1259,8 +1260,8 @@ describe('Frontend behavior tests', function () {
 
                 return localUtils.mockExpress.invoke(app, req)
                     .then(function (response) {
-                        response.statusCode.should.eql(200);
-                        response.headers['content-type'].should.eql('application/rss+xml; charset=UTF-8');
+                        assert.equal(response.statusCode, 200);
+                        assert.equal(response.headers['content-type'], 'application/rss+xml; charset=UTF-8');
                     });
             });
 
@@ -1275,11 +1276,11 @@ describe('Frontend behavior tests', function () {
                     .then(function (response) {
                         const $ = cheerio.load(response.body);
 
-                        response.statusCode.should.eql(200);
-                        response.template.should.eql('default');
+                        assert.equal(response.statusCode, 200);
+                        assert.equal(response.template, 'default');
 
                         // default template does not list posts
-                        $('.post-card').length.should.equal(0);
+                        assert.equal($('.post-card').length, 0);
                     });
             });
 
@@ -1292,8 +1293,8 @@ describe('Frontend behavior tests', function () {
 
                 return localUtils.mockExpress.invoke(app, req)
                     .then(function (response) {
-                        response.statusCode.should.eql(200);
-                        response.template.should.eql('channel3');
+                        assert.equal(response.statusCode, 200);
+                        assert.equal(response.template, 'channel3');
                     });
             });
 
@@ -1308,10 +1309,10 @@ describe('Frontend behavior tests', function () {
                     .then(function (response) {
                         const $ = cheerio.load(response.body);
 
-                        response.statusCode.should.eql(200);
-                        response.template.should.eql('index');
+                        assert.equal(response.statusCode, 200);
+                        assert.equal(response.template, 'index');
 
-                        $('.post-card').length.should.equal(6);
+                        assert.equal($('.post-card').length, 6);
                     });
             });
 
@@ -1326,10 +1327,10 @@ describe('Frontend behavior tests', function () {
                     .then(function (response) {
                         const $ = cheerio.load(response.body);
 
-                        response.statusCode.should.eql(200);
-                        response.template.should.eql('index');
+                        assert.equal(response.statusCode, 200);
+                        assert.equal(response.template, 'index');
 
-                        $('.post-card').length.should.equal(10);
+                        assert.equal($('.post-card').length, 10);
                     });
             });
 
@@ -1344,10 +1345,10 @@ describe('Frontend behavior tests', function () {
                     .then(function (response) {
                         const $ = cheerio.load(response.body);
 
-                        response.statusCode.should.eql(200);
-                        response.template.should.eql('index');
+                        assert.equal(response.statusCode, 200);
+                        assert.equal(response.template, 'index');
 
-                        $('.post-card').length.should.equal(10);
+                        assert.equal($('.post-card').length, 10);
                     });
             });
 
@@ -1360,8 +1361,8 @@ describe('Frontend behavior tests', function () {
 
                 return localUtils.mockExpress.invoke(app, req)
                     .then(function (response) {
-                        response.statusCode.should.eql(301);
-                        response.headers.location.should.eql('/channel1/');
+                        assert.equal(response.statusCode, 301);
+                        assert.equal(response.headers.location, '/channel1/');
                     });
             });
 
@@ -1374,8 +1375,8 @@ describe('Frontend behavior tests', function () {
 
                 return localUtils.mockExpress.invoke(app, req)
                     .then(function (response) {
-                        response.statusCode.should.eql(301);
-                        response.headers.location.should.eql('/channel6/');
+                        assert.equal(response.statusCode, 301);
+                        assert.equal(response.headers.location, '/channel6/');
                     });
             });
 
@@ -1388,7 +1389,7 @@ describe('Frontend behavior tests', function () {
 
                 return localUtils.mockExpress.invoke(app, req)
                     .then(function (response) {
-                        response.statusCode.should.eql(200);
+                        assert.equal(response.statusCode, 200);
                     });
             });
 
@@ -1402,7 +1403,7 @@ describe('Frontend behavior tests', function () {
 
                 return localUtils.mockExpress.invoke(app, req)
                     .then(function (response) {
-                        response.statusCode.should.eql(200);
+                        assert.equal(response.statusCode, 200);
                     });
             });
         });
@@ -1472,7 +1473,7 @@ describe('Frontend behavior tests', function () {
 
             return localUtils.mockExpress.invoke(app, req)
                 .then(function (response) {
-                    response.statusCode.should.eql(200);
+                    assert.equal(response.statusCode, 200);
                 });
         });
 
@@ -1485,7 +1486,7 @@ describe('Frontend behavior tests', function () {
 
             return localUtils.mockExpress.invoke(app, req)
                 .then(function (response) {
-                    response.statusCode.should.eql(404);
+                    assert.equal(response.statusCode, 404);
                 });
         });
 
@@ -1498,7 +1499,7 @@ describe('Frontend behavior tests', function () {
 
             return localUtils.mockExpress.invoke(app, req)
                 .then(function (response) {
-                    response.statusCode.should.eql(404);
+                    assert.equal(response.statusCode, 404);
                 });
         });
 
@@ -1511,7 +1512,7 @@ describe('Frontend behavior tests', function () {
 
             return localUtils.mockExpress.invoke(app, req)
                 .then(function (response) {
-                    response.statusCode.should.eql(200);
+                    assert.equal(response.statusCode, 200);
                 });
         });
 
@@ -1524,10 +1525,10 @@ describe('Frontend behavior tests', function () {
 
             return localUtils.mockExpress.invoke(app, req)
                 .then(function (response) {
-                    response.statusCode.should.eql(200);
-                    response.template.should.eql('podcast/rss');
-                    response.headers['content-type'].should.eql('application/rss+xml');
-                    response.body.match(/<link>/g).length.should.eql(2);
+                    assert.equal(response.statusCode, 200);
+                    assert.equal(response.template, 'podcast/rss');
+                    assert.equal(response.headers['content-type'], 'application/rss+xml');
+                    assert.equal(response.body.match(/<link>/g).length, 2);
                 });
         });
 
@@ -1541,8 +1542,8 @@ describe('Frontend behavior tests', function () {
             return localUtils.mockExpress.invoke(app, req)
                 .then(function (response) {
                     const $ = cheerio.load(response.body);
-                    response.statusCode.should.eql(200);
-                    $('head link')[1].attribs.href.should.eql('http://127.0.0.1:2369/rss/');
+                    assert.equal(response.statusCode, 200);
+                    assert.equal($('head link')[1].attribs.href, 'http://127.0.0.1:2369/rss/');
                 });
         });
     });

--- a/ghost/core/test/legacy/mock-express-style/parent-app-vhosts.test.js
+++ b/ghost/core/test/legacy/mock-express-style/parent-app-vhosts.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const path = require('path');
@@ -51,7 +52,7 @@ describe('Integration - Web - vhosts', function () {
 
             return localUtils.mockExpress.invoke(app, req)
                 .then(function (response) {
-                    response.statusCode.should.eql(200);
+                    assert.equal(response.statusCode, 200);
                 });
         });
 
@@ -65,7 +66,7 @@ describe('Integration - Web - vhosts', function () {
 
             return localUtils.mockExpress.invoke(app, req)
                 .then(function (response) {
-                    response.statusCode.should.eql(200);
+                    assert.equal(response.statusCode, 200);
                 });
         });
 
@@ -79,7 +80,7 @@ describe('Integration - Web - vhosts', function () {
 
             return localUtils.mockExpress.invoke(app, req)
                 .then(function (response) {
-                    response.statusCode.should.eql(200);
+                    assert.equal(response.statusCode, 200);
                 });
         });
 
@@ -93,7 +94,7 @@ describe('Integration - Web - vhosts', function () {
 
             return localUtils.mockExpress.invoke(app, req)
                 .then(function (response) {
-                    response.statusCode.should.eql(200);
+                    assert.equal(response.statusCode, 200);
                 });
         });
 
@@ -107,7 +108,7 @@ describe('Integration - Web - vhosts', function () {
 
             return localUtils.mockExpress.invoke(app, req)
                 .then(function (response) {
-                    response.statusCode.should.eql(200);
+                    assert.equal(response.statusCode, 200);
                 });
         });
 
@@ -121,7 +122,7 @@ describe('Integration - Web - vhosts', function () {
 
             return localUtils.mockExpress.invoke(app, req)
                 .then(function (response) {
-                    response.statusCode.should.eql(200);
+                    assert.equal(response.statusCode, 200);
                 });
         });
     });
@@ -158,7 +159,7 @@ describe('Integration - Web - vhosts', function () {
 
             return localUtils.mockExpress.invoke(app, req)
                 .then(function (response) {
-                    response.statusCode.should.eql(200);
+                    assert.equal(response.statusCode, 200);
                 });
         });
 
@@ -172,7 +173,7 @@ describe('Integration - Web - vhosts', function () {
 
             return localUtils.mockExpress.invoke(app, req)
                 .then(function (response) {
-                    response.statusCode.should.eql(200);
+                    assert.equal(response.statusCode, 200);
                 });
         });
 
@@ -186,8 +187,8 @@ describe('Integration - Web - vhosts', function () {
 
             return localUtils.mockExpress.invoke(app, req)
                 .then(function (response) {
-                    response.statusCode.should.eql(301);
-                    response.headers.location.should.eql('https://admin.example.com/ghost/');
+                    assert.equal(response.statusCode, 301);
+                    assert.equal(response.headers.location, 'https://admin.example.com/ghost/');
                 });
         });
 
@@ -201,7 +202,7 @@ describe('Integration - Web - vhosts', function () {
 
             return localUtils.mockExpress.invoke(app, req)
                 .then(function (response) {
-                    response.statusCode.should.eql(301);
+                    assert.equal(response.statusCode, 301);
                     response.headers.location.should.eql(`https://admin.example.com${ADMIN_API_URL}/site/`);
                 });
         });
@@ -216,7 +217,7 @@ describe('Integration - Web - vhosts', function () {
 
             return localUtils.mockExpress.invoke(app, req)
                 .then(function (response) {
-                    response.statusCode.should.eql(301);
+                    assert.equal(response.statusCode, 301);
                     response.headers.location.should.eql(`https://admin.example.com${ADMIN_API_URL}/site/`);
                 });
         });
@@ -231,7 +232,7 @@ describe('Integration - Web - vhosts', function () {
 
             return localUtils.mockExpress.invoke(app, req)
                 .then(function (response) {
-                    response.statusCode.should.eql(200);
+                    assert.equal(response.statusCode, 200);
                 });
         });
 
@@ -245,7 +246,7 @@ describe('Integration - Web - vhosts', function () {
 
             return localUtils.mockExpress.invoke(app, req)
                 .then(function (response) {
-                    response.statusCode.should.eql(200);
+                    assert.equal(response.statusCode, 200);
                 });
         });
 
@@ -259,8 +260,8 @@ describe('Integration - Web - vhosts', function () {
 
             return localUtils.mockExpress.invoke(app, req)
                 .then(function (response) {
-                    response.statusCode.should.eql(301);
-                    response.headers.location.should.eql('https://admin.example.com/ghost/');
+                    assert.equal(response.statusCode, 301);
+                    assert.equal(response.headers.location, 'https://admin.example.com/ghost/');
                 });
         });
 
@@ -274,7 +275,7 @@ describe('Integration - Web - vhosts', function () {
 
             return localUtils.mockExpress.invoke(app, req)
                 .then(function (response) {
-                    response.statusCode.should.eql(404);
+                    assert.equal(response.statusCode, 404);
                 });
         });
     });
@@ -312,7 +313,7 @@ describe('Integration - Web - vhosts', function () {
 
             return localUtils.mockExpress.invoke(app, req)
                 .then(function (response) {
-                    response.statusCode.should.eql(404);
+                    assert.equal(response.statusCode, 404);
                 });
         });
 
@@ -326,7 +327,7 @@ describe('Integration - Web - vhosts', function () {
 
             return localUtils.mockExpress.invoke(app, req)
                 .then(function (response) {
-                    response.statusCode.should.eql(404);
+                    assert.equal(response.statusCode, 404);
                 });
         });
     });
@@ -358,7 +359,7 @@ describe('Integration - Web - vhosts', function () {
 
             return localUtils.mockExpress.invoke(app, req)
                 .then(function (response) {
-                    response.statusCode.should.eql(200);
+                    assert.equal(response.statusCode, 200);
                 });
         });
 
@@ -372,7 +373,7 @@ describe('Integration - Web - vhosts', function () {
 
             return localUtils.mockExpress.invoke(app, req)
                 .then(function (response) {
-                    response.statusCode.should.eql(200);
+                    assert.equal(response.statusCode, 200);
                 });
         });
 
@@ -386,7 +387,7 @@ describe('Integration - Web - vhosts', function () {
 
             return localUtils.mockExpress.invoke(app, req)
                 .then(function (response) {
-                    response.statusCode.should.eql(200);
+                    assert.equal(response.statusCode, 200);
                 });
         });
 
@@ -400,8 +401,8 @@ describe('Integration - Web - vhosts', function () {
 
             return localUtils.mockExpress.invoke(app, req)
                 .then(function (response) {
-                    response.statusCode.should.eql(301);
-                    response.headers.location.should.eql('https://example.com/ghost/');
+                    assert.equal(response.statusCode, 301);
+                    assert.equal(response.headers.location, 'https://example.com/ghost/');
                 });
         });
 
@@ -415,8 +416,8 @@ describe('Integration - Web - vhosts', function () {
 
             return localUtils.mockExpress.invoke(app, req)
                 .then(function (response) {
-                    response.statusCode.should.eql(301);
-                    response.headers.location.should.eql('https://example.com/ghost/');
+                    assert.equal(response.statusCode, 301);
+                    assert.equal(response.headers.location, 'https://example.com/ghost/');
                 });
         });
 
@@ -430,7 +431,7 @@ describe('Integration - Web - vhosts', function () {
 
             return localUtils.mockExpress.invoke(app, req)
                 .then(function (response) {
-                    response.statusCode.should.eql(301);
+                    assert.equal(response.statusCode, 301);
                     response.headers.location.should.eql(`https://example.com${ADMIN_API_URL}/site/`);
                 });
         });
@@ -445,7 +446,7 @@ describe('Integration - Web - vhosts', function () {
 
             return localUtils.mockExpress.invoke(app, req)
                 .then(function (response) {
-                    response.statusCode.should.eql(200);
+                    assert.equal(response.statusCode, 200);
                 });
         });
 
@@ -459,8 +460,8 @@ describe('Integration - Web - vhosts', function () {
 
             return localUtils.mockExpress.invoke(app, req)
                 .then(function (response) {
-                    response.statusCode.should.eql(301);
-                    response.headers.location.should.eql('https://example.com/ghost/');
+                    assert.equal(response.statusCode, 301);
+                    assert.equal(response.headers.location, 'https://example.com/ghost/');
                 });
         });
 
@@ -474,7 +475,7 @@ describe('Integration - Web - vhosts', function () {
 
             return localUtils.mockExpress.invoke(app, req)
                 .then(function (response) {
-                    response.statusCode.should.eql(200);
+                    assert.equal(response.statusCode, 200);
                 });
         });
 
@@ -488,7 +489,7 @@ describe('Integration - Web - vhosts', function () {
 
             return localUtils.mockExpress.invoke(app, req)
                 .then(function (response) {
-                    response.statusCode.should.eql(301);
+                    assert.equal(response.statusCode, 301);
                     response.headers.location.should.eql(`https://example.com${ADMIN_API_URL}/site/`);
                 });
         });

--- a/ghost/core/test/legacy/models/base/listeners.test.js
+++ b/ghost/core/test/legacy/models/base/listeners.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const moment = require('moment-timezone');
@@ -66,7 +67,7 @@ describe('Models: listeners', function () {
                 Promise.all(scope.posts.map(function (post) {
                     return models.Post.add(post, testUtils.context.owner);
                 })).then(function (result) {
-                    result.length.should.eql(3);
+                    assert.equal(result.length, 3);
                     posts = result;
                     done();
                 }).catch(function (err) {
@@ -262,7 +263,7 @@ describe('Models: listeners', function () {
 
                 models.Post.findAll({context: {internal: true}})
                     .then(function (results) {
-                        results.length.should.eql(0);
+                        assert.equal(results.length, 0);
                         done();
                     })
                     .catch(done);
@@ -297,7 +298,7 @@ describe('Models: listeners', function () {
 
                     return models.Settings.findOne({key: 'notifications'}, testUtils.context.internal);
                 }).then(function (model) {
-                    JSON.parse(model.get('value')).length.should.eql(3);
+                    assert.equal(JSON.parse(model.get('value')).length, 3);
                     done();
                 }).catch(done);
         });
@@ -326,7 +327,7 @@ describe('Models: listeners', function () {
                     setTimeout(function () {
                         return models.Settings.findOne({key: 'notifications'}, testUtils.context.internal)
                             .then(function (model) {
-                                JSON.parse(model.get('value')).length.should.eql(2);
+                                assert.equal(JSON.parse(model.get('value')).length, 2);
                                 done();
                             })
                             .catch(done);

--- a/ghost/core/test/legacy/models/base/overrides.test.js
+++ b/ghost/core/test/legacy/models/base/overrides.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const testUtils = require('../../../utils');
 const db = require('../../../../core/server/data/db');
@@ -25,19 +26,19 @@ describe('Models: Base plugins: Overrides', function () {
 
             // direct knex query for sense-check
             const afterInsert = await db.knex('custom_theme_settings').where({id: modelToUpdate.id});
-            afterInsert.length.should.equal(1);
-            afterInsert[0].value.should.equal('https://example.com/image.png');
+            assert.equal(afterInsert.length, 1);
+            assert.equal(afterInsert[0].value, 'https://example.com/image.png');
 
             // do the actual update
             const modelAfterUpdate = await models.CustomThemeSetting.edit({value: '/image.png'}, {id: modelToUpdate.id});
 
             // model.value should return an absolute URL
-            modelAfterUpdate.get('value').should.equal('http://127.0.0.1:2369/image.png');
+            assert.equal(modelAfterUpdate.get('value'), 'http://127.0.0.1:2369/image.png');
 
             // direct knex query to check raw db value
             const afterUpdate = await db.knex('custom_theme_settings').where({id: modelToUpdate.id});
-            afterUpdate.length.should.equal(1);
-            afterUpdate[0].value.should.equal('__GHOST_URL__/image.png');
+            assert.equal(afterUpdate.length, 1);
+            assert.equal(afterUpdate[0].value, '__GHOST_URL__/image.png');
         });
 
         it('formats values correctly on insert', async function () {
@@ -49,12 +50,12 @@ describe('Models: Base plugins: Overrides', function () {
             });
 
             // model.value should return an absolute URL
-            insertedModel.get('value').should.equal('http://127.0.0.1:2369/image.png');
+            assert.equal(insertedModel.get('value'), 'http://127.0.0.1:2369/image.png');
 
             // direct knex query to check raw db value
             const rawInsertDate = await db.knex('custom_theme_settings').where({id: insertedModel.id});
-            rawInsertDate.length.should.equal(1);
-            rawInsertDate[0].value.should.equal('__GHOST_URL__/image.png');
+            assert.equal(rawInsertDate.length, 1);
+            assert.equal(rawInsertDate[0].value, '__GHOST_URL__/image.png');
         });
 
         it('is not called unnecessarily', async function () {
@@ -71,14 +72,14 @@ describe('Models: Base plugins: Overrides', function () {
             await modelInstance.save(null, {method: 'insert'});
 
             // sanity check
-            modelInstance.get('value').should.equal('http://127.0.0.1:2369/image.png');
+            assert.equal(modelInstance.get('value'), 'http://127.0.0.1:2369/image.png');
 
             // called twice because format is also called on fetch
             // see https://github.com/TryGhost/Ghost/commit/426cbeec0f57886fbb4c7a1ebd2ce696913b03eb
-            format.callCount.should.equal(2);
+            assert.equal(format.callCount, 2);
 
             // only called once for the actual write
-            formatOnWrite.callCount.should.equal(1);
+            assert.equal(formatOnWrite.callCount, 1);
         });
     });
 });

--- a/ghost/core/test/legacy/models/model-members.test.js
+++ b/ghost/core/test/legacy/models/model-members.test.js
@@ -270,8 +270,8 @@ describe('Member Model', function run() {
 
         it('can use search query', function (done) {
             Member.findAll({search: 'egg'}).then(function (queryResult) {
-                queryResult.length.should.equal(1);
-                queryResult.models[0].get('name').should.equal('Mr Egg');
+                assert.equal(queryResult.length, 1);
+                assert.equal(queryResult.models[0].get('name'), 'Mr Egg');
                 done();
             }).catch(done);
         });

--- a/ghost/core/test/legacy/models/model-posts.test.js
+++ b/ghost/core/test/legacy/models/model-posts.test.js
@@ -89,51 +89,51 @@ describe('Post Model', function () {
                     it('can findPage, with various options', function (done) {
                         models.Post.findPage({page: 2})
                             .then(function (paginationResult) {
-                                paginationResult.meta.pagination.page.should.equal(2);
-                                paginationResult.meta.pagination.limit.should.equal(15);
-                                paginationResult.meta.pagination.pages.should.equal(4);
-                                paginationResult.data.length.should.equal(15);
+                                assert.equal(paginationResult.meta.pagination.page, 2);
+                                assert.equal(paginationResult.meta.pagination.limit, 15);
+                                assert.equal(paginationResult.meta.pagination.pages, 4);
+                                assert.equal(paginationResult.data.length, 15);
 
                                 return models.Post.findPage({page: 5});
                             }).then(function (paginationResult) {
-                                paginationResult.meta.pagination.page.should.equal(5);
-                                paginationResult.meta.pagination.limit.should.equal(15);
-                                paginationResult.meta.pagination.pages.should.equal(4);
-                                paginationResult.data.length.should.equal(0);
+                                assert.equal(paginationResult.meta.pagination.page, 5);
+                                assert.equal(paginationResult.meta.pagination.limit, 15);
+                                assert.equal(paginationResult.meta.pagination.pages, 4);
+                                assert.equal(paginationResult.data.length, 0);
 
                                 return models.Post.findPage({limit: 30});
                             }).then(function (paginationResult) {
-                                paginationResult.meta.pagination.page.should.equal(1);
-                                paginationResult.meta.pagination.limit.should.equal(30);
-                                paginationResult.meta.pagination.pages.should.equal(2);
-                                paginationResult.data.length.should.equal(30);
+                                assert.equal(paginationResult.meta.pagination.page, 1);
+                                assert.equal(paginationResult.meta.pagination.limit, 30);
+                                assert.equal(paginationResult.meta.pagination.pages, 2);
+                                assert.equal(paginationResult.data.length, 30);
 
                                 // Test featured pages
                                 return models.Post.findPage({limit: 10, filter: 'featured:true'});
                             }).then(function (paginationResult) {
-                                paginationResult.meta.pagination.page.should.equal(1);
-                                paginationResult.meta.pagination.limit.should.equal(10);
-                                paginationResult.meta.pagination.pages.should.equal(1);
-                                paginationResult.data.length.should.equal(2);
+                                assert.equal(paginationResult.meta.pagination.page, 1);
+                                assert.equal(paginationResult.meta.pagination.limit, 10);
+                                assert.equal(paginationResult.meta.pagination.pages, 1);
+                                assert.equal(paginationResult.data.length, 2);
 
                                 // Test both boolean formats for featured pages
                                 return models.Post.findPage({limit: 10, filter: 'featured:1'});
                             }).then(function (paginationResult) {
-                                paginationResult.meta.pagination.page.should.equal(1);
-                                paginationResult.meta.pagination.limit.should.equal(10);
-                                paginationResult.meta.pagination.pages.should.equal(1);
-                                paginationResult.data.length.should.equal(2);
+                                assert.equal(paginationResult.meta.pagination.page, 1);
+                                assert.equal(paginationResult.meta.pagination.limit, 10);
+                                assert.equal(paginationResult.meta.pagination.pages, 1);
+                                assert.equal(paginationResult.data.length, 2);
 
                                 return models.Post.findPage({limit: 10, page: 2, status: 'all'});
                             }).then(function (paginationResult) {
-                                paginationResult.meta.pagination.pages.should.equal(11);
+                                assert.equal(paginationResult.meta.pagination.pages, 11);
 
                                 return models.Post.findPage({limit: 'all', status: 'all'});
                             }).then(function (paginationResult) {
-                                paginationResult.meta.pagination.page.should.equal(1);
-                                paginationResult.meta.pagination.limit.should.equal('all');
-                                paginationResult.meta.pagination.pages.should.equal(1);
-                                paginationResult.data.length.should.equal(110);
+                                assert.equal(paginationResult.meta.pagination.page, 1);
+                                assert.equal(paginationResult.meta.pagination.limit, 'all');
+                                assert.equal(paginationResult.meta.pagination.pages, 1);
+                                assert.equal(paginationResult.data.length, 110);
 
                                 done();
                             }).catch(done);
@@ -143,31 +143,31 @@ describe('Post Model', function () {
                         // Test tag filter
                         models.Post.findPage({page: 1, filter: 'tags:bacon'})
                             .then(function (paginationResult) {
-                                paginationResult.meta.pagination.page.should.equal(1);
-                                paginationResult.meta.pagination.limit.should.equal(15);
-                                paginationResult.meta.pagination.pages.should.equal(1);
-                                paginationResult.data.length.should.equal(2);
+                                assert.equal(paginationResult.meta.pagination.page, 1);
+                                assert.equal(paginationResult.meta.pagination.limit, 15);
+                                assert.equal(paginationResult.meta.pagination.pages, 1);
+                                assert.equal(paginationResult.data.length, 2);
 
                                 return models.Post.findPage({page: 1, filter: 'tags:kitchen-sink'});
                             }).then(function (paginationResult) {
-                                paginationResult.meta.pagination.page.should.equal(1);
-                                paginationResult.meta.pagination.limit.should.equal(15);
-                                paginationResult.meta.pagination.pages.should.equal(1);
-                                paginationResult.data.length.should.equal(2);
+                                assert.equal(paginationResult.meta.pagination.page, 1);
+                                assert.equal(paginationResult.meta.pagination.limit, 15);
+                                assert.equal(paginationResult.meta.pagination.pages, 1);
+                                assert.equal(paginationResult.data.length, 2);
 
                                 return models.Post.findPage({page: 1, filter: 'tags:injection'});
                             }).then(function (paginationResult) {
-                                paginationResult.meta.pagination.page.should.equal(1);
-                                paginationResult.meta.pagination.limit.should.equal(15);
-                                paginationResult.meta.pagination.pages.should.equal(2);
-                                paginationResult.data.length.should.equal(15);
+                                assert.equal(paginationResult.meta.pagination.page, 1);
+                                assert.equal(paginationResult.meta.pagination.limit, 15);
+                                assert.equal(paginationResult.meta.pagination.pages, 2);
+                                assert.equal(paginationResult.data.length, 15);
 
                                 return models.Post.findPage({page: 2, filter: 'tags:injection'});
                             }).then(function (paginationResult) {
-                                paginationResult.meta.pagination.page.should.equal(2);
-                                paginationResult.meta.pagination.limit.should.equal(15);
-                                paginationResult.meta.pagination.pages.should.equal(2);
-                                paginationResult.data.length.should.equal(11);
+                                assert.equal(paginationResult.meta.pagination.page, 2);
+                                assert.equal(paginationResult.meta.pagination.limit, 15);
+                                assert.equal(paginationResult.meta.pagination.pages, 2);
+                                assert.equal(paginationResult.data.length, 11);
 
                                 done();
                             }).catch(done);
@@ -224,7 +224,7 @@ describe('Post Model', function () {
                         });
                 }).catch(function () {
                     // txn was rolled back
-                    Object.keys(eventsTriggered).length.should.eql(0);
+                    assert.equal(Object.keys(eventsTriggered).length, 0);
                 });
             });
 
@@ -244,7 +244,7 @@ describe('Post Model', function () {
                         });
                 }).then(function () {
                     // txn was successful
-                    Object.keys(eventsTriggered).length.should.eql(4);
+                    assert.equal(Object.keys(eventsTriggered).length, 4);
                 });
             });
 
@@ -256,14 +256,14 @@ describe('Post Model', function () {
                     should.exist(results);
                     post = results.toJSON();
                     post.id.should.equal(postId);
-                    post.title.should.not.equal('new title');
+                    assert.notEqual(post.title, 'new title');
 
                     return models.Post.edit({title: 'new title'}, _.extend({}, context, {id: postId}));
                 }).then(function (edited) {
                     should.exist(edited);
-                    edited.attributes.title.should.equal('new title');
+                    assert.equal(edited.attributes.title, 'new title');
 
-                    Object.keys(eventsTriggered).length.should.eql(2);
+                    assert.equal(Object.keys(eventsTriggered).length, 2);
                     should.exist(eventsTriggered['post.published.edited']);
                     should.exist(eventsTriggered['post.edited']);
 
@@ -286,7 +286,7 @@ describe('Post Model', function () {
                 }).then(function () {
                     done(new Error('expected validation error'));
                 }).catch(function (err) {
-                    err[0].name.should.eql('ValidationError');
+                    assert.equal(err[0].name, 'ValidationError');
                     done();
                 });
             });
@@ -299,14 +299,14 @@ describe('Post Model', function () {
                     should.exist(results);
                     post = results.toJSON();
                     post.id.should.equal(postId);
-                    post.status.should.equal('draft');
+                    assert.equal(post.status, 'draft');
 
                     return models.Post.edit({status: 'published'}, _.extend({}, context, {id: postId}));
                 }).then(function (edited) {
                     should.exist(edited);
-                    edited.attributes.status.should.equal('published');
+                    assert.equal(edited.attributes.status, 'published');
 
-                    Object.keys(eventsTriggered).length.should.eql(4);
+                    assert.equal(Object.keys(eventsTriggered).length, 4);
                     should.exist(eventsTriggered['post.published']);
                     should.exist(eventsTriggered['post.edited']);
                     should.exist(eventsTriggered['tag.attached']);
@@ -324,14 +324,14 @@ describe('Post Model', function () {
                     should.exist(results);
                     post = results.toJSON();
                     post.id.should.equal(postId);
-                    post.status.should.equal('published');
+                    assert.equal(post.status, 'published');
 
                     return models.Post.edit({status: 'draft'}, _.extend({}, context, {id: postId}));
                 }).then(function (edited) {
                     should.exist(edited);
-                    edited.attributes.status.should.equal('draft');
+                    assert.equal(edited.attributes.status, 'draft');
 
-                    Object.keys(eventsTriggered).length.should.eql(4);
+                    assert.equal(Object.keys(eventsTriggered).length, 4);
                     should.exist(eventsTriggered['post.unpublished']);
                     should.exist(eventsTriggered['post.edited']);
 
@@ -345,7 +345,7 @@ describe('Post Model', function () {
                 models.Post.findOne({status: 'draft'}).then(function (results) {
                     should.exist(results);
                     post = results.toJSON();
-                    post.status.should.equal('draft');
+                    assert.equal(post.status, 'draft');
 
                     results.set('published_at', null);
                     return results.save();
@@ -357,7 +357,7 @@ describe('Post Model', function () {
                     done(new Error('expected error'));
                 }).catch(function (err) {
                     should.exist(err);
-                    (err instanceof errors.ValidationError).should.eql(true);
+                    assert.equal((err instanceof errors.ValidationError), true);
                     done();
                 });
             });
@@ -370,7 +370,7 @@ describe('Post Model', function () {
 
                     should.exist(results);
                     post = results.toJSON();
-                    post.status.should.equal('draft');
+                    assert.equal(post.status, 'draft');
 
                     return models.Post.edit({
                         status: 'scheduled',
@@ -378,12 +378,12 @@ describe('Post Model', function () {
                     }, _.extend({}, context, {id: post.id}));
                 }).then(function (edited) {
                     should.exist(edited);
-                    edited.attributes.status.should.equal('scheduled');
+                    assert.equal(edited.attributes.status, 'scheduled');
 
                     // mysql does not store ms
-                    moment(edited.attributes.published_at).startOf('seconds').diff(moment(newPublishedAt).startOf('seconds')).should.eql(0);
+                    assert.equal(moment(edited.attributes.published_at).startOf('seconds').diff(moment(newPublishedAt).startOf('seconds')), 0);
 
-                    Object.keys(eventsTriggered).length.should.eql(2);
+                    assert.equal(Object.keys(eventsTriggered).length, 2);
                     should.exist(eventsTriggered['post.scheduled']);
                     should.exist(eventsTriggered['post.edited']);
 
@@ -397,16 +397,16 @@ describe('Post Model', function () {
 
                     should.exist(results);
                     post = results.toJSON();
-                    post.status.should.equal('scheduled');
+                    assert.equal(post.status, 'scheduled');
 
                     return models.Post.edit({
                         status: 'draft'
                     }, _.extend({}, context, {id: post.id}));
                 }).then(function (edited) {
                     should.exist(edited);
-                    edited.attributes.status.should.equal('draft');
+                    assert.equal(edited.attributes.status, 'draft');
 
-                    Object.keys(eventsTriggered).length.should.eql(2);
+                    assert.equal(Object.keys(eventsTriggered).length, 2);
                     should.exist(eventsTriggered['post.unscheduled']);
                     should.exist(eventsTriggered['post.edited']);
 
@@ -420,7 +420,7 @@ describe('Post Model', function () {
 
                     should.exist(results);
                     post = results.toJSON();
-                    post.status.should.equal('scheduled');
+                    assert.equal(post.status, 'scheduled');
 
                     return models.Post.edit({
                         status: 'scheduled',
@@ -428,9 +428,9 @@ describe('Post Model', function () {
                     }, _.extend({}, context, {id: post.id}));
                 }).then(function (edited) {
                     should.exist(edited);
-                    edited.attributes.status.should.equal('scheduled');
+                    assert.equal(edited.attributes.status, 'scheduled');
 
-                    Object.keys(eventsTriggered).length.should.eql(2);
+                    assert.equal(Object.keys(eventsTriggered).length, 2);
                     should.exist(eventsTriggered['post.rescheduled']);
                     should.exist(eventsTriggered['post.edited']);
 
@@ -444,17 +444,17 @@ describe('Post Model', function () {
 
                     should.exist(results);
                     post = results.toJSON();
-                    post.status.should.equal('scheduled');
+                    assert.equal(post.status, 'scheduled');
 
                     return models.Post.edit({
                         status: 'scheduled'
                     }, _.extend({}, context, {id: post.id}));
                 }).then(function (edited) {
                     should.exist(edited);
-                    edited.attributes.status.should.equal('scheduled');
+                    assert.equal(edited.attributes.status, 'scheduled');
 
                     // nothing has changed
-                    Object.keys(eventsTriggered).length.should.eql(0);
+                    assert.equal(Object.keys(eventsTriggered).length, 0);
 
                     done();
                 }).catch(done);
@@ -466,12 +466,12 @@ describe('Post Model', function () {
                 models.Post.findOne({status: 'scheduled'}).then(function (results) {
                     should.exist(results);
                     post = results.toJSON();
-                    post.status.should.equal('scheduled');
+                    assert.equal(post.status, 'scheduled');
 
                     results.set('published_at', moment().add(2, 'minutes').add(2, 'seconds').toDate());
                     return results.save();
                 }).then(function () {
-                    Object.keys(eventsTriggered).length.should.eql(2);
+                    assert.equal(Object.keys(eventsTriggered).length, 2);
                     should.exist(eventsTriggered['post.edited']);
                     should.exist(eventsTriggered['post.rescheduled']);
                     eventsTriggered = {};
@@ -485,9 +485,9 @@ describe('Post Model', function () {
                     }, _.extend({}, context, {id: post.id}));
                 }).then(function (edited) {
                     should.exist(edited);
-                    edited.attributes.status.should.equal('scheduled');
+                    assert.equal(edited.attributes.status, 'scheduled');
 
-                    Object.keys(eventsTriggered).length.should.eql(1);
+                    assert.equal(Object.keys(eventsTriggered).length, 1);
                     should.exist(eventsTriggered['post.edited']);
 
                     done();
@@ -502,7 +502,7 @@ describe('Post Model', function () {
                     should.exist(results);
                     post = results.toJSON();
                     post.id.should.equal(postId);
-                    post.status.should.equal('published');
+                    assert.equal(post.status, 'published');
 
                     return models.Post.edit({
                         status: 'scheduled',
@@ -512,7 +512,7 @@ describe('Post Model', function () {
                     done(new Error('change status from published to scheduled is not allowed right now!'));
                 }).catch(function (err) {
                     should.exist(err);
-                    (err instanceof errors.ValidationError).should.eql(true);
+                    assert.equal((err instanceof errors.ValidationError), true);
                     done();
                 });
             });
@@ -525,25 +525,25 @@ describe('Post Model', function () {
                     should.exist(results);
                     post = results.toJSON();
                     post.id.should.equal(postId);
-                    post.status.should.equal('draft');
+                    assert.equal(post.status, 'draft');
 
                     return models.Post.edit({type: 'page'}, _.extend({}, context, {id: postId}));
                 }).then(function (edited) {
                     should.exist(edited);
-                    edited.attributes.status.should.equal('draft');
-                    edited.attributes.type.should.equal('page');
+                    assert.equal(edited.attributes.status, 'draft');
+                    assert.equal(edited.attributes.type, 'page');
 
-                    Object.keys(eventsTriggered).length.should.eql(2);
+                    assert.equal(Object.keys(eventsTriggered).length, 2);
                     should.exist(eventsTriggered['post.deleted']);
                     should.exist(eventsTriggered['page.added']);
 
                     return models.Post.edit({type: 'post'}, _.extend({}, context, {id: postId}));
                 }).then(function (edited) {
                     should.exist(edited);
-                    edited.attributes.status.should.equal('draft');
-                    edited.attributes.type.should.equal('post');
+                    assert.equal(edited.attributes.status, 'draft');
+                    assert.equal(edited.attributes.type, 'post');
 
-                    Object.keys(eventsTriggered).length.should.eql(4);
+                    assert.equal(Object.keys(eventsTriggered).length, 4);
                     should.exist(eventsTriggered['post.deleted']);
                     should.exist(eventsTriggered['page.added']);
                     should.exist(eventsTriggered['post.deleted']);
@@ -558,7 +558,7 @@ describe('Post Model', function () {
                     let post;
                     should.exist(results);
                     post = results.toJSON();
-                    post.status.should.equal('draft');
+                    assert.equal(post.status, 'draft');
 
                     return models.Post.edit({
                         type: 'page',
@@ -567,10 +567,10 @@ describe('Post Model', function () {
                     }, _.extend({}, context, {id: post.id}));
                 }).then(function (edited) {
                     should.exist(edited);
-                    edited.attributes.status.should.equal('scheduled');
-                    edited.attributes.type.should.equal('page');
+                    assert.equal(edited.attributes.status, 'scheduled');
+                    assert.equal(edited.attributes.type, 'page');
 
-                    Object.keys(eventsTriggered).length.should.eql(3);
+                    assert.equal(Object.keys(eventsTriggered).length, 3);
                     should.exist(eventsTriggered['post.deleted']);
                     should.exist(eventsTriggered['page.added']);
                     should.exist(eventsTriggered['page.scheduled']);
@@ -578,10 +578,10 @@ describe('Post Model', function () {
                     return models.Post.edit({type: 'post'}, _.extend({}, context, {id: edited.id}));
                 }).then(function (edited) {
                     should.exist(edited);
-                    edited.attributes.status.should.equal('scheduled');
-                    edited.attributes.type.should.equal('post');
+                    assert.equal(edited.attributes.status, 'scheduled');
+                    assert.equal(edited.attributes.type, 'post');
 
-                    Object.keys(eventsTriggered).length.should.eql(7);
+                    assert.equal(Object.keys(eventsTriggered).length, 7);
                     should.exist(eventsTriggered['page.unscheduled']);
                     should.exist(eventsTriggered['page.deleted']);
                     should.exist(eventsTriggered['post.added']);
@@ -599,15 +599,15 @@ describe('Post Model', function () {
                     should.exist(results);
                     post = results.toJSON();
                     post.id.should.equal(postId);
-                    post.status.should.equal('published');
+                    assert.equal(post.status, 'published');
 
                     return models.Post.edit({type: 'page'}, _.extend({}, context, {id: postId}));
                 }).then(function (edited) {
                     should.exist(edited);
-                    edited.attributes.status.should.equal('published');
-                    edited.attributes.type.should.equal('page');
+                    assert.equal(edited.attributes.status, 'published');
+                    assert.equal(edited.attributes.type, 'page');
 
-                    Object.keys(eventsTriggered).length.should.eql(4);
+                    assert.equal(Object.keys(eventsTriggered).length, 4);
                     should.exist(eventsTriggered['post.unpublished']);
                     should.exist(eventsTriggered['post.deleted']);
                     should.exist(eventsTriggered['page.added']);
@@ -616,10 +616,10 @@ describe('Post Model', function () {
                     return models.Post.edit({type: 'post'}, _.extend({}, context, {id: postId}));
                 }).then(function (edited) {
                     should.exist(edited);
-                    edited.attributes.status.should.equal('published');
-                    edited.attributes.type.should.equal('post');
+                    assert.equal(edited.attributes.status, 'published');
+                    assert.equal(edited.attributes.type, 'post');
 
-                    Object.keys(eventsTriggered).length.should.eql(8);
+                    assert.equal(Object.keys(eventsTriggered).length, 8);
                     should.exist(eventsTriggered['page.unpublished']);
                     should.exist(eventsTriggered['page.deleted']);
                     should.exist(eventsTriggered['post.added']);
@@ -637,15 +637,15 @@ describe('Post Model', function () {
                     should.exist(results);
                     post = results.toJSON();
                     post.id.should.equal(postId);
-                    post.status.should.equal('draft');
+                    assert.equal(post.status, 'draft');
 
                     return models.Post.edit({type: 'page', status: 'published'}, _.extend({}, context, {id: postId}));
                 }).then(function (edited) {
                     should.exist(edited);
-                    edited.attributes.status.should.equal('published');
-                    edited.attributes.type.should.equal('page');
+                    assert.equal(edited.attributes.status, 'published');
+                    assert.equal(edited.attributes.type, 'page');
 
-                    Object.keys(eventsTriggered).length.should.eql(5);
+                    assert.equal(Object.keys(eventsTriggered).length, 5);
                     should.exist(eventsTriggered['post.deleted']);
                     should.exist(eventsTriggered['page.added']);
                     should.exist(eventsTriggered['page.published']);
@@ -655,10 +655,10 @@ describe('Post Model', function () {
                     return models.Post.edit({type: 'post', status: 'draft'}, _.extend({}, context, {id: postId}));
                 }).then(function (edited) {
                     should.exist(edited);
-                    edited.attributes.status.should.equal('draft');
-                    edited.attributes.type.should.equal('post');
+                    assert.equal(edited.attributes.status, 'draft');
+                    assert.equal(edited.attributes.type, 'post');
 
-                    Object.keys(eventsTriggered).length.should.eql(8);
+                    assert.equal(Object.keys(eventsTriggered).length, 8);
                     should.exist(eventsTriggered['page.unpublished']);
                     should.exist(eventsTriggered['page.deleted']);
                     should.exist(eventsTriggered['post.added']);
@@ -675,7 +675,7 @@ describe('Post Model', function () {
                     should.exist(results);
                     post = results.toJSON();
                     post.id.should.equal(postId);
-                    post.status.should.equal('draft');
+                    assert.equal(post.status, 'draft');
 
                     // Test changing status and published_by at the same time
                     return models.Post.edit({
@@ -684,14 +684,14 @@ describe('Post Model', function () {
                     }, _.extend({}, context, {id: postId}));
                 }).then(function (edited) {
                     should.exist(edited);
-                    edited.attributes.status.should.equal('published');
+                    assert.equal(edited.attributes.status, 'published');
                     edited.attributes.published_by.should.equal(context.context.user);
 
                     // Test changing status and published_by on its own
                     return models.Post.edit({published_by: 4}, _.extend({}, context, {id: postId}));
                 }).then(function (edited) {
                     should.exist(edited);
-                    edited.attributes.status.should.equal('published');
+                    assert.equal(edited.attributes.status, 'published');
                     edited.attributes.published_by.should.equal(context.context.user);
 
                     done();
@@ -736,23 +736,23 @@ describe('Post Model', function () {
                     return models.Post.findOne({id: createdPost.id, status: 'all'}, {withRelated: ['authors']});
                 }).then(function (createdPost) {
                     should.exist(createdPost);
-                    createdPost.has('uuid').should.equal(true);
-                    createdPost.get('status').should.equal('draft');
-                    createdPost.get('title').should.equal(newPost.title, 'title is correct');
-                    createdPost.get('mobiledoc').should.equal(newPost.mobiledoc, 'mobiledoc is correct');
-                    createdPost.has('html').should.equal(true);
+                    assert.equal(createdPost.has('uuid'), true);
+                    assert.equal(createdPost.get('status'), 'draft');
+                    assert.equal(createdPost.get('title'), newPost.title, 'title is correct');
+                    assert.equal(createdPost.get('mobiledoc'), newPost.mobiledoc, 'mobiledoc is correct');
+                    assert.equal(createdPost.has('html'), true);
                     createdPost.get('html').should.equal(newPostDB.html);
-                    createdPost.has('plaintext').should.equal(true);
-                    createdPost.get('plaintext').should.match(/^testing/);
+                    assert.equal(createdPost.has('plaintext'), true);
+                    assert.match(createdPost.get('plaintext'), /^testing/);
                     createdPost.get('slug').should.equal(newPostDB.slug + '-2');
-                    (!!createdPost.get('featured')).should.equal(false);
-                    (!!createdPost.get('page')).should.equal(false);
+                    assert.equal((!!createdPost.get('featured')), false);
+                    assert.equal((!!createdPost.get('page')), false);
 
                     assert.equal(createdPost.get('locale'), null);
                     assert.equal(createdPost.get('visibility'), 'public');
 
                     // testing for nulls
-                    (createdPost.get('feature_image') === null).should.equal(true);
+                    assert.equal((createdPost.get('feature_image') === null), true);
 
                     createdPost.get('created_at').should.be.above(new Date(0).getTime());
                     createdPost.relations.authors.models[0].id.should.equal(testUtils.DataGenerator.Content.users[0].id);
@@ -762,7 +762,7 @@ describe('Post Model', function () {
 
                     createdPostUpdatedDate = createdPost.get('updated_at');
 
-                    Object.keys(eventsTriggered).length.should.eql(2);
+                    assert.equal(Object.keys(eventsTriggered).length, 2);
                     should.exist(eventsTriggered['post.added']);
                     should.exist(eventsTriggered['user.attached']);
 
@@ -774,7 +774,7 @@ describe('Post Model', function () {
                     publishedPost.get('updated_at').should.be.instanceOf(Date);
                     publishedPost.get('updated_at').should.not.equal(createdPostUpdatedDate);
 
-                    Object.keys(eventsTriggered).length.should.eql(4);
+                    assert.equal(Object.keys(eventsTriggered).length, 4);
                     should.exist(eventsTriggered['post.published']);
                     should.exist(eventsTriggered['post.edited']);
 
@@ -805,23 +805,23 @@ describe('Post Model', function () {
                     return models.Post.findOne({id: createdPost.id, status: 'all'}, {withRelated: ['authors']});
                 }).then(function (createdPost) {
                     should.exist(createdPost);
-                    createdPost.has('uuid').should.equal(true);
-                    createdPost.get('status').should.equal('draft');
-                    createdPost.get('title').should.equal(newPost.title, 'title is correct');
-                    createdPost.get('mobiledoc').should.equal(newPost.mobiledoc, 'mobiledoc is correct');
-                    createdPost.has('html').should.equal(true);
+                    assert.equal(createdPost.has('uuid'), true);
+                    assert.equal(createdPost.get('status'), 'draft');
+                    assert.equal(createdPost.get('title'), newPost.title, 'title is correct');
+                    assert.equal(createdPost.get('mobiledoc'), newPost.mobiledoc, 'mobiledoc is correct');
+                    assert.equal(createdPost.has('html'), true);
                     createdPost.get('html').should.equal(newPostDB.html);
-                    createdPost.has('plaintext').should.equal(true);
-                    createdPost.get('plaintext').should.match(/^testing/);
+                    assert.equal(createdPost.has('plaintext'), true);
+                    assert.match(createdPost.get('plaintext'), /^testing/);
                     // createdPost.get('slug').should.equal(newPostDB.slug + '-3');
-                    (!!createdPost.get('featured')).should.equal(false);
-                    (!!createdPost.get('page')).should.equal(false);
+                    assert.equal((!!createdPost.get('featured')), false);
+                    assert.equal((!!createdPost.get('page')), false);
 
                     assert.equal(createdPost.get('locale'), null);
                     assert.equal(createdPost.get('visibility'), 'paid');
 
                     // testing for nulls
-                    (createdPost.get('feature_image') === null).should.equal(true);
+                    assert.equal((createdPost.get('feature_image') === null), true);
 
                     createdPost.get('created_at').should.be.above(new Date(0).getTime());
                     createdPost.relations.authors.models[0].id.should.equal(testUtils.DataGenerator.Content.users[0].id);
@@ -831,7 +831,7 @@ describe('Post Model', function () {
 
                     createdPostUpdatedDate = createdPost.get('updated_at');
 
-                    Object.keys(eventsTriggered).length.should.eql(2);
+                    assert.equal(Object.keys(eventsTriggered).length, 2);
                     should.exist(eventsTriggered['post.added']);
                     should.exist(eventsTriggered['user.attached']);
 
@@ -843,7 +843,7 @@ describe('Post Model', function () {
                     publishedPost.get('updated_at').should.be.instanceOf(Date);
                     publishedPost.get('updated_at').should.not.equal(createdPostUpdatedDate);
 
-                    Object.keys(eventsTriggered).length.should.eql(4);
+                    assert.equal(Object.keys(eventsTriggered).length, 4);
                     should.exist(eventsTriggered['post.published']);
                     should.exist(eventsTriggered['post.edited']);
 
@@ -863,7 +863,7 @@ describe('Post Model', function () {
                     should.exist(newPost);
                     new Date(newPost.get('published_at')).getTime().should.equal(previousPublishedAtDate.getTime());
 
-                    Object.keys(eventsTriggered).length.should.eql(3);
+                    assert.equal(Object.keys(eventsTriggered).length, 3);
                     should.exist(eventsTriggered['post.added']);
                     should.exist(eventsTriggered['post.published']);
                     should.exist(eventsTriggered['user.attached']);
@@ -881,7 +881,7 @@ describe('Post Model', function () {
                     should.exist(newPost);
                     assert.equal(newPost.get('published_at'), null);
 
-                    Object.keys(eventsTriggered).length.should.eql(2);
+                    assert.equal(Object.keys(eventsTriggered).length, 2);
                     should.exist(eventsTriggered['post.added']);
                     should.exist(eventsTriggered['user.attached']);
 
@@ -901,7 +901,7 @@ describe('Post Model', function () {
                 }, _.merge({withRelated: ['authors']}, context)).then(function (newPost) {
                     should.exist(newPost);
                     newPost.toJSON().primary_author.id.should.eql(testUtils.DataGenerator.forKnex.users[0].id);
-                    newPost.toJSON().authors.length.should.eql(1);
+                    assert.equal(newPost.toJSON().authors.length, 1);
                     newPost.toJSON().authors[0].id.should.eql(testUtils.DataGenerator.forKnex.users[0].id);
                     done();
                 }).catch(done);
@@ -917,7 +917,7 @@ describe('Post Model', function () {
                     should.exist(newPost);
                     should.exist(newPost.get('published_at'));
 
-                    Object.keys(eventsTriggered).length.should.eql(2);
+                    assert.equal(Object.keys(eventsTriggered).length, 2);
                     should.exist(eventsTriggered['post.added']);
                     should.exist(eventsTriggered['user.attached']);
 
@@ -932,8 +932,8 @@ describe('Post Model', function () {
                     mobiledoc: markdownToMobiledoc('This is some content')
                 }, context).catch(function (err) {
                     should.exist(err);
-                    (err instanceof errors.ValidationError).should.eql(true);
-                    Object.keys(eventsTriggered).length.should.eql(0);
+                    assert.equal((err instanceof errors.ValidationError), true);
+                    assert.equal(Object.keys(eventsTriggered).length, 0);
                     done();
                 });
             });
@@ -946,8 +946,8 @@ describe('Post Model', function () {
                     mobiledoc: markdownToMobiledoc('This is some content')
                 }, context).catch(function (err) {
                     should.exist(err);
-                    (err instanceof errors.ValidationError).should.eql(true);
-                    Object.keys(eventsTriggered).length.should.eql(0);
+                    assert.equal((err instanceof errors.ValidationError), true);
+                    assert.equal(Object.keys(eventsTriggered).length, 0);
                     done();
                 });
             });
@@ -961,7 +961,7 @@ describe('Post Model', function () {
                 }, context);
                 should.exist(post);
 
-                Object.keys(eventsTriggered).length.should.eql(3);
+                assert.equal(Object.keys(eventsTriggered).length, 3);
                 should.exist(eventsTriggered['post.added']);
                 should.exist(eventsTriggered['post.scheduled']);
                 should.exist(eventsTriggered['user.attached']);
@@ -976,7 +976,7 @@ describe('Post Model', function () {
                 }, context).then(function (post) {
                     should.exist(post);
 
-                    Object.keys(eventsTriggered).length.should.eql(3);
+                    assert.equal(Object.keys(eventsTriggered).length, 3);
                     should.exist(eventsTriggered['post.added']);
                     should.exist(eventsTriggered['post.scheduled']);
                     should.exist(eventsTriggered['user.attached']);
@@ -996,7 +996,7 @@ describe('Post Model', function () {
                     };
                 })).then(function (createdPosts) {
                     // Should have created 12 posts
-                    createdPosts.length.should.equal(12);
+                    assert.equal(createdPosts.length, 12);
 
                     // Should have unique slugs and contents
                     _(createdPosts).each(function (post, i) {
@@ -1004,17 +1004,17 @@ describe('Post Model', function () {
 
                         // First one has normal title
                         if (num === 1) {
-                            post.get('slug').should.equal('test-title');
+                            assert.equal(post.get('slug'), 'test-title');
                             return;
                         }
 
                         post.get('slug').should.equal('test-title-' + num);
                         JSON.parse(post.get('mobiledoc')).cards[0][1].markdown.should.equal('Test Content ' + num);
 
-                        Object.keys(eventsTriggered).length.should.eql(2);
+                        assert.equal(Object.keys(eventsTriggered).length, 2);
                         should.exist(eventsTriggered['post.added']);
                         should.exist(eventsTriggered['user.attached']);
-                        eventsTriggered['post.added'].length.should.eql(12);
+                        assert.equal(eventsTriggered['post.added'].length, 12);
                     });
 
                     done();
@@ -1028,9 +1028,9 @@ describe('Post Model', function () {
                 };
 
                 models.Post.add(newPost, context).then(function (createdPost) {
-                    createdPost.get('slug').should.equal('apprehensive-titles-have-too-many-spaces-and-m-dashes-and-also-n-dashes');
+                    assert.equal(createdPost.get('slug'), 'apprehensive-titles-have-too-many-spaces-and-m-dashes-and-also-n-dashes');
 
-                    Object.keys(eventsTriggered).length.should.eql(2);
+                    assert.equal(Object.keys(eventsTriggered).length, 2);
                     should.exist(eventsTriggered['post.added']);
                     should.exist(eventsTriggered['user.attached']);
 
@@ -1045,9 +1045,9 @@ describe('Post Model', function () {
                 };
 
                 models.Post.add(newPost, context).then(function (createdPost) {
-                    createdPost.get('slug').should.not.equal('rss');
+                    assert.notEqual(createdPost.get('slug'), 'rss');
 
-                    Object.keys(eventsTriggered).length.should.eql(2);
+                    assert.equal(Object.keys(eventsTriggered).length, 2);
                     should.exist(eventsTriggered['post.added']);
                     should.exist(eventsTriggered['user.attached']);
 
@@ -1062,7 +1062,7 @@ describe('Post Model', function () {
                 };
 
                 models.Post.add(newPost, context).then(function (createdPost) {
-                    createdPost.get('slug').should.equal('bhute-dhddkii-bhrvnnaaraa-aahet');
+                    assert.equal(createdPost.get('slug'), 'bhute-dhddkii-bhrvnnaaraa-aahet');
                     done();
                 }).catch(done);
             });
@@ -1084,7 +1084,7 @@ describe('Post Model', function () {
                         // Store the slug for later
                         firstPost.slug = createdFirstPost.get('slug');
 
-                        Object.keys(eventsTriggered).length.should.eql(2);
+                        assert.equal(Object.keys(eventsTriggered).length, 2);
                         should.exist(eventsTriggered['post.added']);
                         should.exist(eventsTriggered['user.attached']);
 
@@ -1094,7 +1094,7 @@ describe('Post Model', function () {
                     // Store the slug for comparison later
                         secondPost.slug = createdSecondPost.get('slug');
 
-                        Object.keys(eventsTriggered).length.should.eql(2);
+                        assert.equal(Object.keys(eventsTriggered).length, 2);
                         should.exist(eventsTriggered['post.added']);
                         should.exist(eventsTriggered['user.attached']);
 
@@ -1108,7 +1108,7 @@ describe('Post Model', function () {
                         // Should not have a conflicted slug from the first
                         updatedSecondPost.get('slug').should.not.equal(firstPost.slug);
 
-                        Object.keys(eventsTriggered).length.should.eql(3);
+                        assert.equal(Object.keys(eventsTriggered).length, 3);
                         should.exist(eventsTriggered['post.edited']);
 
                         return models.Post.findOne({
@@ -1141,19 +1141,19 @@ describe('Post Model', function () {
                 };
 
                 models.Post.add(post, context).then((createdPost) => {
-                    createdPost.get('mobiledoc').should.equal('{"version":"0.3.1","atoms":[],"cards":[["image",{"src":"http://127.0.0.1:2369/content/images/card.jpg"}]],"markups":[["a",["href","http://127.0.0.1:2369/test"]]],"sections":[[1,"p",[[0,[0],1,"Testing"]]],[10,0]]}');
-                    createdPost.get('html').should.equal('<p><a href="http://127.0.0.1:2369/test">Testing</a></p><figure class="kg-card kg-image-card"><img src="http://127.0.0.1:2369/content/images/card.jpg" class="kg-image" alt loading="lazy"></figure>');
-                    createdPost.get('plaintext').should.containEql('Testing');
-                    createdPost.get('custom_excerpt').should.equal('Testing <a href="http://127.0.0.1:2369/internal">links</a> in custom excerpts');
-                    createdPost.get('codeinjection_head').should.equal('<script src="http://127.0.0.1:2369/assets/head.js"></script>');
-                    createdPost.get('codeinjection_foot').should.equal('<script src="http://127.0.0.1:2369/assets/foot.js"></script>');
-                    createdPost.get('feature_image').should.equal('http://127.0.0.1:2369/content/images/feature.png');
-                    createdPost.get('canonical_url').should.equal('http://127.0.0.1:2369/canonical');
+                    assert.equal(createdPost.get('mobiledoc'), '{"version":"0.3.1","atoms":[],"cards":[["image",{"src":"http://127.0.0.1:2369/content/images/card.jpg"}]],"markups":[["a",["href","http://127.0.0.1:2369/test"]]],"sections":[[1,"p",[[0,[0],1,"Testing"]]],[10,0]]}');
+                    assert.equal(createdPost.get('html'), '<p><a href="http://127.0.0.1:2369/test">Testing</a></p><figure class="kg-card kg-image-card"><img src="http://127.0.0.1:2369/content/images/card.jpg" class="kg-image" alt loading="lazy"></figure>');
+                    assert(createdPost.get('plaintext').includes('Testing'));
+                    assert.equal(createdPost.get('custom_excerpt'), 'Testing <a href="http://127.0.0.1:2369/internal">links</a> in custom excerpts');
+                    assert.equal(createdPost.get('codeinjection_head'), '<script src="http://127.0.0.1:2369/assets/head.js"></script>');
+                    assert.equal(createdPost.get('codeinjection_foot'), '<script src="http://127.0.0.1:2369/assets/foot.js"></script>');
+                    assert.equal(createdPost.get('feature_image'), 'http://127.0.0.1:2369/content/images/feature.png');
+                    assert.equal(createdPost.get('canonical_url'), 'http://127.0.0.1:2369/canonical');
 
                     const postMeta = createdPost.relations.posts_meta;
 
-                    postMeta.get('og_image').should.equal('http://127.0.0.1:2369/content/images/og.png');
-                    postMeta.get('twitter_image').should.equal('http://127.0.0.1:2369/content/images/twitter.png');
+                    assert.equal(postMeta.get('og_image'), 'http://127.0.0.1:2369/content/images/og.png');
+                    assert.equal(postMeta.get('twitter_image'), 'http://127.0.0.1:2369/content/images/twitter.png');
 
                     // ensure canonical_url is not transformed when protocol does not match
                     return createdPost.save({
@@ -1162,22 +1162,22 @@ describe('Post Model', function () {
                         feature_image: 'http://127.0.0.1:2369/content/images/updated_feature.png'
                     });
                 }).then((updatedPost) => {
-                    updatedPost.get('canonical_url').should.equal('https://127.0.0.1:2369/https-internal');
-                    updatedPost.get('feature_image').should.equal('http://127.0.0.1:2369/content/images/updated_feature.png');
+                    assert.equal(updatedPost.get('canonical_url'), 'https://127.0.0.1:2369/https-internal');
+                    assert.equal(updatedPost.get('feature_image'), 'http://127.0.0.1:2369/content/images/updated_feature.png');
 
                     return updatedPost;
                 }).then((updatedPost) => {
                     return db.knex('posts').where({id: updatedPost.id});
                 }).then((knexResult) => {
                     const [knexPost] = knexResult;
-                    knexPost.mobiledoc.should.equal('{"version":"0.3.1","atoms":[],"cards":[["image",{"src":"__GHOST_URL__/content/images/card.jpg"}]],"markups":[["a",["href","__GHOST_URL__/test"]]],"sections":[[1,"p",[[0,[0],1,"Testing"]]],[10,0]]}');
-                    knexPost.html.should.equal('<p><a href="__GHOST_URL__/test">Testing</a></p><figure class="kg-card kg-image-card"><img src="__GHOST_URL__/content/images/card.jpg" class="kg-image" alt loading="lazy"></figure>');
-                    knexPost.plaintext.should.containEql('Testing');
-                    knexPost.custom_excerpt.should.equal('Testing <a href="__GHOST_URL__/internal">links</a> in custom excerpts');
-                    knexPost.codeinjection_head.should.equal('<script src="__GHOST_URL__/assets/head.js"></script>');
-                    knexPost.codeinjection_foot.should.equal('<script src="__GHOST_URL__/assets/foot.js"></script>');
-                    knexPost.feature_image.should.equal('__GHOST_URL__/content/images/updated_feature.png');
-                    knexPost.canonical_url.should.equal('https://127.0.0.1:2369/https-internal');
+                    assert.equal(knexPost.mobiledoc, '{"version":"0.3.1","atoms":[],"cards":[["image",{"src":"__GHOST_URL__/content/images/card.jpg"}]],"markups":[["a",["href","__GHOST_URL__/test"]]],"sections":[[1,"p",[[0,[0],1,"Testing"]]],[10,0]]}');
+                    assert.equal(knexPost.html, '<p><a href="__GHOST_URL__/test">Testing</a></p><figure class="kg-card kg-image-card"><img src="__GHOST_URL__/content/images/card.jpg" class="kg-image" alt loading="lazy"></figure>');
+                    assert(knexPost.plaintext.includes('Testing'));
+                    assert.equal(knexPost.custom_excerpt, 'Testing <a href="__GHOST_URL__/internal">links</a> in custom excerpts');
+                    assert.equal(knexPost.codeinjection_head, '<script src="__GHOST_URL__/assets/head.js"></script>');
+                    assert.equal(knexPost.codeinjection_foot, '<script src="__GHOST_URL__/assets/foot.js"></script>');
+                    assert.equal(knexPost.feature_image, '__GHOST_URL__/content/images/updated_feature.png');
+                    assert.equal(knexPost.canonical_url, 'https://127.0.0.1:2369/https-internal');
 
                     done();
                 }).catch(done);
@@ -1191,11 +1191,11 @@ describe('Post Model', function () {
                 };
 
                 const createdPost = await models.Post.add(post, context);
-                createdPost.get('lexical').should.equal(`{"root":{"children":[{"type":"image","src":"http://127.0.0.1:2369/content/images/card.jpg"},{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"local link","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"link","version":1,"rel":null,"target":null,"url":"http://127.0.0.1:2369/local"}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1},{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"external link","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"link","version":1,"rel":null,"target":null,"url":"https://example.com/external"}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}}`, 'Post.add result');
+                assert.equal(createdPost.get('lexical'), `{"root":{"children":[{"type":"image","src":"http://127.0.0.1:2369/content/images/card.jpg"},{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"local link","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"link","version":1,"rel":null,"target":null,"url":"http://127.0.0.1:2369/local"}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1},{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"external link","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"link","version":1,"rel":null,"target":null,"url":"https://example.com/external"}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}}`, 'Post.add result');
 
                 const knexResult = await db.knex('posts').where({id: createdPost.id});
                 const [knexPost] = knexResult;
-                knexPost.lexical.should.equal('{"root":{"children":[{"type":"image","src":"__GHOST_URL__/content/images/card.jpg"},{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"local link","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"link","version":1,"rel":null,"target":null,"url":"__GHOST_URL__/local"}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1},{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"external link","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"link","version":1,"rel":null,"target":null,"url":"https://example.com/external"}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}}', 'knex result');
+                assert.equal(knexPost.lexical, '{"root":{"children":[{"type":"image","src":"__GHOST_URL__/content/images/card.jpg"},{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"local link","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"link","version":1,"rel":null,"target":null,"url":"__GHOST_URL__/local"}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1},{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"external link","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"link","version":1,"rel":null,"target":null,"url":"https://example.com/external"}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}}', 'knex result');
             });
 
             describe('URL transformations without CDN config', function () {
@@ -1290,28 +1290,28 @@ describe('Post Model', function () {
 
                     it('transforms all media URLs to absolute site URLs', function () {
                         // Verify all expected URLs are present as absolute URLs
-                        lexicalString.should.containEql(`${siteUrl}/content/images/inline.jpg`);
-                        lexicalString.should.containEql(`${siteUrl}/content/images/gallery-1.jpg`);
-                        lexicalString.should.containEql(`${siteUrl}/content/images/gallery-2.jpg`);
-                        lexicalString.should.containEql(`${siteUrl}/content/images/gallery-3.jpg`);
-                        lexicalString.should.containEql(`${siteUrl}/content/files/document.pdf`);
-                        lexicalString.should.containEql(`${siteUrl}/content/media/video.mp4`);
-                        lexicalString.should.containEql(`${siteUrl}/content/images/video-thumb.jpg`);
-                        lexicalString.should.containEql(`${siteUrl}/content/media/audio.mp3`);
-                        lexicalString.should.containEql(`${siteUrl}/content/images/audio-thumb.jpg`);
-                        lexicalString.should.containEql(`${siteUrl}/snippet-link`);
+                        assert(lexicalString.includes(`${siteUrl}/content/images/inline.jpg`));
+                        assert(lexicalString.includes(`${siteUrl}/content/images/gallery-1.jpg`));
+                        assert(lexicalString.includes(`${siteUrl}/content/images/gallery-2.jpg`));
+                        assert(lexicalString.includes(`${siteUrl}/content/images/gallery-3.jpg`));
+                        assert(lexicalString.includes(`${siteUrl}/content/files/document.pdf`));
+                        assert(lexicalString.includes(`${siteUrl}/content/media/video.mp4`));
+                        assert(lexicalString.includes(`${siteUrl}/content/images/video-thumb.jpg`));
+                        assert(lexicalString.includes(`${siteUrl}/content/media/audio.mp3`));
+                        assert(lexicalString.includes(`${siteUrl}/content/images/audio-thumb.jpg`));
+                        assert(lexicalString.includes(`${siteUrl}/snippet-link`));
 
                         // Verify no __GHOST_URL__ placeholders remain
-                        lexicalString.should.not.containEql('__GHOST_URL__');
+                        assert(!lexicalString.includes('__GHOST_URL__'));
                     });
 
                     it('transforms inserted snippet URLs to absolute site URLs', function () {
-                        lexicalString.should.containEql(`${siteUrl}/content/images/snippet-inline.jpg`);
-                        lexicalString.should.containEql(`${siteUrl}/content/files/snippet-document.pdf`);
-                        lexicalString.should.containEql(`${siteUrl}/content/media/snippet-video.mp4`);
-                        lexicalString.should.containEql(`${siteUrl}/content/images/snippet-video-thumb.jpg`);
-                        lexicalString.should.containEql(`${siteUrl}/content/media/snippet-audio.mp3`);
-                        lexicalString.should.containEql(`${siteUrl}/content/images/snippet-audio-thumb.jpg`);
+                        assert(lexicalString.includes(`${siteUrl}/content/images/snippet-inline.jpg`));
+                        assert(lexicalString.includes(`${siteUrl}/content/files/snippet-document.pdf`));
+                        assert(lexicalString.includes(`${siteUrl}/content/media/snippet-video.mp4`));
+                        assert(lexicalString.includes(`${siteUrl}/content/images/snippet-video-thumb.jpg`));
+                        assert(lexicalString.includes(`${siteUrl}/content/media/snippet-audio.mp3`));
+                        assert(lexicalString.includes(`${siteUrl}/content/images/snippet-audio-thumb.jpg`));
                     });
                 });
             });
@@ -1354,9 +1354,9 @@ describe('Post Model', function () {
                     it('transforms inserted snippet file/media URLs to CDN URLs', async function () {
                         const post = await models.Post.findOne({slug: 'post-with-all-media-types-mobiledoc'}, {withRelated: ['tags']});
                         const mobiledocString = post.get('mobiledoc');
-                        mobiledocString.should.containEql(`${cdnUrl}/content/files/snippet-document.pdf`);
-                        mobiledocString.should.containEql(`${cdnUrl}/content/media/snippet-video.mp4`);
-                        mobiledocString.should.containEql(`${cdnUrl}/content/media/snippet-audio.mp3`);
+                        assert(mobiledocString.includes(`${cdnUrl}/content/files/snippet-document.pdf`));
+                        assert(mobiledocString.includes(`${cdnUrl}/content/media/snippet-video.mp4`));
+                        assert(mobiledocString.includes(`${cdnUrl}/content/media/snippet-audio.mp3`));
                     });
 
                     it('transforms feature_image to absolute site URL(NOT CDN)', async function () {
@@ -1370,7 +1370,7 @@ describe('Post Model', function () {
                         const galleryCard = mobiledoc.cards.find(card => card[0] === 'gallery');
                         galleryCard[1].images.forEach((image) => {
                             image.src.should.startWith(siteUrl);
-                            image.src.should.containEql('/content/images/');
+                            assert(image.src.includes('/content/images/'));
                         });
                     });
 
@@ -1393,22 +1393,22 @@ describe('Post Model', function () {
                     it('transforms file URLs to files CDN URL', async function () {
                         const post = await models.Post.findOne({slug: 'post-with-all-media-types-lexical'}, {withRelated: ['tags']});
                         const lexicalString = post.get('lexical');
-                        lexicalString.should.containEql(`${cdnUrl}/content/files/document.pdf`);
+                        assert(lexicalString.includes(`${cdnUrl}/content/files/document.pdf`));
                     });
 
                     it('transforms video/audio URLs to media CDN URL', async function () {
                         const post = await models.Post.findOne({slug: 'post-with-all-media-types-lexical'}, {withRelated: ['tags']});
                         const lexicalString = post.get('lexical');
-                        lexicalString.should.containEql(`${cdnUrl}/content/media/video.mp4`);
-                        lexicalString.should.containEql(`${cdnUrl}/content/media/audio.mp3`);
+                        assert(lexicalString.includes(`${cdnUrl}/content/media/video.mp4`));
+                        assert(lexicalString.includes(`${cdnUrl}/content/media/audio.mp3`));
                     });
 
                     it('transforms inserted snippet file/media URLs to CDN URLs', async function () {
                         const post = await models.Post.findOne({slug: 'post-with-all-media-types-lexical'}, {withRelated: ['tags']});
                         const lexicalString = post.get('lexical');
-                        lexicalString.should.containEql(`${cdnUrl}/content/files/snippet-document.pdf`);
-                        lexicalString.should.containEql(`${cdnUrl}/content/media/snippet-video.mp4`);
-                        lexicalString.should.containEql(`${cdnUrl}/content/media/snippet-audio.mp3`);
+                        assert(lexicalString.includes(`${cdnUrl}/content/files/snippet-document.pdf`));
+                        assert(lexicalString.includes(`${cdnUrl}/content/media/snippet-video.mp4`));
+                        assert(lexicalString.includes(`${cdnUrl}/content/media/snippet-audio.mp3`));
                     });
 
                     it('transforms feature_image to absolute site URL(NOT CDN)', async function () {
@@ -1419,21 +1419,21 @@ describe('Post Model', function () {
                     it('transforms gallery images to absolute site URL(NOT CDN)', async function () {
                         const post = await models.Post.findOne({slug: 'post-with-all-media-types-lexical'}, {withRelated: ['tags']});
                         const lexicalString = post.get('lexical');
-                        lexicalString.should.containEql(`${siteUrl}/content/images/gallery-1.jpg`);
-                        lexicalString.should.containEql(`${siteUrl}/content/images/gallery-2.jpg`);
+                        assert(lexicalString.includes(`${siteUrl}/content/images/gallery-1.jpg`));
+                        assert(lexicalString.includes(`${siteUrl}/content/images/gallery-2.jpg`));
                     });
 
                     it('transforms inline images to absolute site URL(NOT CDN)', async function () {
                         const post = await models.Post.findOne({slug: 'post-with-all-media-types-lexical'}, {withRelated: ['tags']});
                         const lexicalString = post.get('lexical');
-                        lexicalString.should.containEql(`${siteUrl}/content/images/inline.jpg`);
+                        assert(lexicalString.includes(`${siteUrl}/content/images/inline.jpg`));
                     });
 
                     it('transforms video/audio thumbnails to absolute site URL(NOT CDN)', async function () {
                         const post = await models.Post.findOne({slug: 'post-with-all-media-types-lexical'}, {withRelated: ['tags']});
                         const lexicalString = post.get('lexical');
-                        lexicalString.should.containEql(`${siteUrl}/content/images/video-thumb.jpg`);
-                        lexicalString.should.containEql(`${siteUrl}/content/images/audio-thumb.jpg`);
+                        assert(lexicalString.includes(`${siteUrl}/content/images/video-thumb.jpg`));
+                        assert(lexicalString.includes(`${siteUrl}/content/images/audio-thumb.jpg`));
                     });
                 });
             });
@@ -1476,8 +1476,8 @@ describe('Post Model', function () {
                     should.exist(results);
                     post = results.toJSON();
                     post.id.should.equal(firstItemData.id);
-                    post.status.should.equal('published');
-                    post.tags.should.have.length(2);
+                    assert.equal(post.status, 'published');
+                    assert.equal(post.tags.length, 2);
                     post.tags[0].id.should.equal(testUtils.DataGenerator.Content.tags[0].id);
 
                     // Destroy the post
@@ -1487,7 +1487,7 @@ describe('Post Model', function () {
 
                     assert.equal(deleted.author, undefined);
 
-                    Object.keys(eventsTriggered).length.should.eql(5);
+                    assert.equal(Object.keys(eventsTriggered).length, 5);
                     should.exist(eventsTriggered['post.unpublished']);
                     should.exist(eventsTriggered['post.deleted']);
                     should.exist(eventsTriggered['user.detached']);
@@ -1518,7 +1518,7 @@ describe('Post Model', function () {
                     should.exist(results);
                     post = results.toJSON();
                     post.id.should.equal(firstItemData.id);
-                    post.tags.should.have.length(1);
+                    assert.equal(post.tags.length, 1);
                     post.tags[0].id.should.equal(testUtils.DataGenerator.Content.tags[3].id);
 
                     // Destroy the post
@@ -1528,7 +1528,7 @@ describe('Post Model', function () {
 
                     assert.equal(deleted.author, undefined);
 
-                    Object.keys(eventsTriggered).length.should.eql(4);
+                    assert.equal(Object.keys(eventsTriggered).length, 4);
                     should.exist(eventsTriggered['post.deleted']);
                     should.exist(eventsTriggered['tag.detached']);
                     should.exist(eventsTriggered['post.tag.detached']);
@@ -1558,8 +1558,8 @@ describe('Post Model', function () {
                     should.exist(results);
                     page = results.toJSON();
                     page.id.should.equal(firstItemData.id);
-                    page.status.should.equal('published');
-                    page.type.should.equal('page');
+                    assert.equal(page.status, 'published');
+                    assert.equal(page.type, 'page');
 
                     // Destroy the page
                     return results.destroy(firstItemData);
@@ -1568,7 +1568,7 @@ describe('Post Model', function () {
 
                     assert.equal(deleted.author, undefined);
 
-                    Object.keys(eventsTriggered).length.should.eql(3);
+                    assert.equal(Object.keys(eventsTriggered).length, 3);
                     should.exist(eventsTriggered['page.unpublished']);
                     should.exist(eventsTriggered['page.deleted']);
                     should.exist(eventsTriggered['user.detached']);
@@ -1605,7 +1605,7 @@ describe('Post Model', function () {
 
                     assert.equal(deleted.author, undefined);
 
-                    Object.keys(eventsTriggered).length.should.eql(2);
+                    assert.equal(Object.keys(eventsTriggered).length, 2);
                     should.exist(eventsTriggered['page.deleted']);
                     should.exist(eventsTriggered['user.detached']);
 
@@ -1651,7 +1651,7 @@ describe('Post Model', function () {
                         throw new Error('expected no success');
                     })
                     .catch(function (err) {
-                        err.code.should.eql('UPDATE_COLLISION');
+                        assert.equal(err.code, 'UPDATE_COLLISION');
                     });
             });
 
@@ -1666,7 +1666,7 @@ describe('Post Model', function () {
                         throw new Error('expected no success');
                     })
                     .catch(function (err) {
-                        err.code.should.eql('UPDATE_COLLISION');
+                        assert.equal(err.code, 'UPDATE_COLLISION');
                     });
             });
 
@@ -1681,7 +1681,7 @@ describe('Post Model', function () {
                         throw new Error('expected no success');
                     })
                     .catch(function (err) {
-                        err.code.should.eql('UPDATE_COLLISION');
+                        assert.equal(err.code, 'UPDATE_COLLISION');
                     });
             });
 
@@ -1855,7 +1855,7 @@ describe('Post Model', function () {
                 filter: `authors:${ownerData.slug}`,
                 context: {internal: true}
             });
-            preReassignOwnerWithPosts.length.should.equal(2);
+            assert.equal(preReassignOwnerWithPosts.length, 2);
 
             await models.Post.reassignByAuthor(authorData);
 
@@ -1868,7 +1868,7 @@ describe('Post Model', function () {
                 context: {internal: true}
             });
             // 2 own and 2 reassigned from the other author
-            postReassignOwnerWithPosts.length.should.equal(4);
+            assert.equal(postReassignOwnerWithPosts.length, 4);
         });
 
         it('can reassign posts with mixed primary and secondary authors', async function () {
@@ -1915,14 +1915,14 @@ describe('Post Model', function () {
                 context: {internal: true}
             });
             // 2 from 'posts:mu' fixtures and 3 inserted in the test case
-            preReassignAuthorWithPosts.length.should.equal(5);
+            assert.equal(preReassignAuthorWithPosts.length, 5);
 
             const preReassignOtherAuthorWithPosts = await models.Post.findAll({
                 filter: `authors:${otherAuthorDate.slug}`,
                 context: {internal: true}
             });
             // 2 from 'posts:mu' fixtures and 1 inserted in the test case
-            preReassignOtherAuthorWithPosts.length.should.equal(3);
+            assert.equal(preReassignOtherAuthorWithPosts.length, 3);
 
             await models.Post.reassignByAuthor(authorData);
 
@@ -1931,21 +1931,21 @@ describe('Post Model', function () {
                 context: {internal: true}
             });
             // author under test should own nothing after reassignment
-            postReassignAuthorWithPosts.length.should.equal(0);
+            assert.equal(postReassignAuthorWithPosts.length, 0);
 
             const postReassignOtherAuthorWithPosts = await models.Post.findAll({
                 filter: `authors:${otherAuthorDate.slug}`,
                 context: {internal: true}
             });
             // should stay the same as preassignment for another author
-            postReassignOtherAuthorWithPosts.length.should.equal(3);
+            assert.equal(postReassignOtherAuthorWithPosts.length, 3);
 
             const postReassignOwnerWithPosts = await models.Post.findAll({
                 filter: `authors:${ownerData.slug}`,
                 context: {internal: true}
             });
             // 5 from this test case's author under test + 4 from the test above (if executed exclusively will fail)
-            postReassignOwnerWithPosts.length.should.equal(9);
+            assert.equal(postReassignOwnerWithPosts.length, 9);
         });
     });
 
@@ -2010,19 +2010,19 @@ describe('Post Model', function () {
             should.exist(tagJSON);
             tagJSON.should.be.an.Array().with.lengthOf(3);
 
-            tagJSON[0].name.should.eql('existing tag a');
-            tagJSON[1].name.should.eql('existing-tag-b');
-            tagJSON[2].name.should.eql('existing_tag_c');
+            assert.equal(tagJSON[0].name, 'existing tag a');
+            assert.equal(tagJSON[1].name, 'existing-tag-b');
+            assert.equal(tagJSON[2].name, 'existing_tag_c');
 
             // creates a test post with an array of tags in the correct order
             should.exist(postJSON);
-            postJSON.title.should.eql('HTML Ipsum');
+            assert.equal(postJSON.title, 'HTML Ipsum');
             should.exist(postJSON.tags);
             postJSON.tags.should.be.an.Array().and.have.lengthOf(3);
 
-            postJSON.tags[0].name.should.eql('tag1');
-            postJSON.tags[1].name.should.eql('tag2');
-            postJSON.tags[2].name.should.eql('tag3');
+            assert.equal(postJSON.tags[0].name, 'tag1');
+            assert.equal(postJSON.tags[1].name, 'tag2');
+            assert.equal(postJSON.tags[2].name, 'tag3');
 
             done();
         });
@@ -2037,9 +2037,9 @@ describe('Post Model', function () {
             return models.Post.edit(newJSON, editOptions).then(function (updatedPost) {
                 updatedPost = updatedPost.toJSON({withRelated: ['tags']});
 
-                updatedPost.tags.should.have.lengthOf(1);
+                assert.equal(updatedPost.tags.length, 1);
                 updatedPost.tags[0].name.should.eql(postJSON.tags[0].name);
-                updatedPost.tags[0].slug.should.eql('eins');
+                assert.equal(updatedPost.tags[0].slug, 'eins');
                 updatedPost.tags[0].id.should.eql(postJSON.tags[0].id);
             });
         });
@@ -2068,7 +2068,7 @@ describe('Post Model', function () {
                 .then(function (updatedPost) {
                     updatedPost = updatedPost.toJSON({withRelated: ['tags']});
 
-                    updatedPost.tags.should.have.lengthOf(1);
+                    assert.equal(updatedPost.tags.length, 1);
                     updatedPost.tags[0].should.have.properties({
                         name: postJSON.tags[0].name,
                         slug: postJSON.tags[0].slug,
@@ -2098,7 +2098,7 @@ describe('Post Model', function () {
             return models.Post.edit(newJSON, editOptions).then(function (updatedPost) {
                 updatedPost = updatedPost.toJSON({withRelated: ['tags']});
 
-                updatedPost.tags.should.have.lengthOf(3);
+                assert.equal(updatedPost.tags.length, 3);
                 updatedPost.tags[0].should.have.properties({
                     name: 'tag4'
                 });
@@ -2128,7 +2128,7 @@ describe('Post Model', function () {
             return models.Post.edit(newJSON, editOptions).then(function (updatedPost) {
                 updatedPost = updatedPost.toJSON({withRelated: ['tags']});
 
-                updatedPost.tags.should.have.lengthOf(3);
+                assert.equal(updatedPost.tags.length, 3);
 
                 updatedPost.tags[0].should.have.properties({name: 'C', slug: 'c'});
                 updatedPost.tags[1].should.have.properties({name: 'C++', slug: 'c-2'});
@@ -2148,7 +2148,7 @@ describe('Post Model', function () {
             return models.Post.edit(newJSON, editOptions).then(function (updatedPost) {
                 updatedPost = updatedPost.toJSON({withRelated: ['tags']});
 
-                updatedPost.tags.should.have.lengthOf(1);
+                assert.equal(updatedPost.tags.length, 1);
             });
         });
     });

--- a/ghost/core/test/legacy/models/model-settings.test.js
+++ b/ghost/core/test/legacy/models/model-settings.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const testUtils = require('../../utils');
 const db = require('../../../core/server/data/db');
@@ -14,7 +15,7 @@ describe('Settings Model', function () {
     describe('defaults', function () {
         it('populates all defaults', async function () {
             const settings = await models.Settings.findAll();
-            settings.length.should.equal(0);
+            assert.equal(settings.length, 0);
 
             await models.Settings.populateDefaults();
 
@@ -37,7 +38,7 @@ describe('Settings Model', function () {
                 });
 
             const settings = await models.Settings.findAll();
-            settings.length.should.equal(1);
+            assert.equal(settings.length, 1);
 
             await models.Settings.populateDefaults();
 
@@ -45,10 +46,10 @@ describe('Settings Model', function () {
             settingsPopulated.length.should.equal(SETTINGS_LENGTH);
 
             const titleSetting = settingsPopulated.models.find(s => s.get('key') === 'title');
-            titleSetting.get('value').should.equal('Testing Defaults');
+            assert.equal(titleSetting.get('value'), 'Testing Defaults');
 
             const descriptionSetting = settingsPopulated.models.find(s => s.get('key') === 'description');
-            descriptionSetting.get('value').should.equal('Thoughts, stories and ideas');
+            assert.equal(descriptionSetting.get('value'), 'Thoughts, stories and ideas');
         });
     });
 });

--- a/ghost/core/test/legacy/models/model-snippets.test.js
+++ b/ghost/core/test/legacy/models/model-snippets.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const testUtils = require('../../utils');
@@ -79,16 +80,16 @@ describe('Snippet Model', function () {
             });
 
             it('transforms all media URLs to absolute site URLs', function () {
-                lexicalString.should.containEql(`${siteUrl}/content/images/snippet-inline.jpg`);
-                lexicalString.should.containEql(`${siteUrl}/content/files/snippet-document.pdf`);
-                lexicalString.should.containEql(`${siteUrl}/content/media/snippet-video.mp4`);
-                lexicalString.should.containEql(`${siteUrl}/content/images/snippet-video-thumb.jpg`);
-                lexicalString.should.containEql(`${siteUrl}/content/media/snippet-audio.mp3`);
-                lexicalString.should.containEql(`${siteUrl}/content/images/snippet-audio-thumb.jpg`);
-                lexicalString.should.containEql(`${siteUrl}/snippet-link`);
+                assert(lexicalString.includes(`${siteUrl}/content/images/snippet-inline.jpg`));
+                assert(lexicalString.includes(`${siteUrl}/content/files/snippet-document.pdf`));
+                assert(lexicalString.includes(`${siteUrl}/content/media/snippet-video.mp4`));
+                assert(lexicalString.includes(`${siteUrl}/content/images/snippet-video-thumb.jpg`));
+                assert(lexicalString.includes(`${siteUrl}/content/media/snippet-audio.mp3`));
+                assert(lexicalString.includes(`${siteUrl}/content/images/snippet-audio-thumb.jpg`));
+                assert(lexicalString.includes(`${siteUrl}/snippet-link`));
 
                 // Verify no __GHOST_URL__ placeholders remain
-                lexicalString.should.not.containEql('__GHOST_URL__');
+                assert(!lexicalString.includes('__GHOST_URL__'));
             });
         });
     });
@@ -158,7 +159,7 @@ describe('Snippet Model', function () {
                 const snippet = snippets.models.find(s => s.get('name') === 'Snippet with all media types - Lexical');
                 const lexicalString = snippet.get('lexical');
 
-                lexicalString.should.containEql(`${cdnUrl}/content/files/snippet-document.pdf`);
+                assert(lexicalString.includes(`${cdnUrl}/content/files/snippet-document.pdf`));
             });
 
             it('transforms video/audio URLs to media CDN URL', async function () {
@@ -166,8 +167,8 @@ describe('Snippet Model', function () {
                 const snippet = snippets.models.find(s => s.get('name') === 'Snippet with all media types - Lexical');
                 const lexicalString = snippet.get('lexical');
 
-                lexicalString.should.containEql(`${cdnUrl}/content/media/snippet-video.mp4`);
-                lexicalString.should.containEql(`${cdnUrl}/content/media/snippet-audio.mp3`);
+                assert(lexicalString.includes(`${cdnUrl}/content/media/snippet-video.mp4`));
+                assert(lexicalString.includes(`${cdnUrl}/content/media/snippet-audio.mp3`));
             });
 
             it('transforms image URLs to absolute site URL(NOT CDN)', async function () {
@@ -175,9 +176,9 @@ describe('Snippet Model', function () {
                 const snippet = snippets.models.find(s => s.get('name') === 'Snippet with all media types - Lexical');
                 const lexicalString = snippet.get('lexical');
 
-                lexicalString.should.containEql(`${siteUrl}/content/images/snippet-inline.jpg`);
-                lexicalString.should.containEql(`${siteUrl}/content/images/snippet-video-thumb.jpg`);
-                lexicalString.should.containEql(`${siteUrl}/content/images/snippet-audio-thumb.jpg`);
+                assert(lexicalString.includes(`${siteUrl}/content/images/snippet-inline.jpg`));
+                assert(lexicalString.includes(`${siteUrl}/content/images/snippet-video-thumb.jpg`));
+                assert(lexicalString.includes(`${siteUrl}/content/images/snippet-audio-thumb.jpg`));
             });
         });
     });

--- a/ghost/core/test/legacy/models/model-users.test.js
+++ b/ghost/core/test/legacy/models/model-users.test.js
@@ -47,8 +47,8 @@ describe('User Model', function run() {
 
             UserModel.add(userData, context).then(function (createdUser) {
                 should.exist(createdUser);
-                createdUser.has('slug').should.equal(true);
-                createdUser.attributes.slug.should.equal('jimothy');
+                assert.equal(createdUser.has('slug'), true);
+                assert.equal(createdUser.attributes.slug, 'jimothy');
                 done();
             }).catch(done);
         });
@@ -58,20 +58,20 @@ describe('User Model', function run() {
 
             UserModel.add(userData, context).then(function (createdUser) {
                 should.exist(createdUser);
-                createdUser.has('slug').should.equal(true);
-                createdUser.attributes.slug.should.equal('jimothy');
+                assert.equal(createdUser.has('slug'), true);
+                assert.equal(createdUser.attributes.slug, 'jimothy');
             }).then(function () {
                 userData.email = 'newmail@mail.com';
                 UserModel.add(userData, context).then(function (createdUser) {
                     should.exist(createdUser);
-                    createdUser.has('slug').should.equal(true);
-                    createdUser.attributes.slug.should.equal('jimothy-bogendath');
+                    assert.equal(createdUser.has('slug'), true);
+                    assert.equal(createdUser.attributes.slug, 'jimothy-bogendath');
                 }).then(function () {
                     userData.email = 'newmail2@mail.com';
                     UserModel.add(userData, context).then(function (createdUser) {
                         should.exist(createdUser);
-                        createdUser.has('slug').should.equal(true);
-                        createdUser.attributes.slug.should.equal('jimothy-bogendath-2');
+                        assert.equal(createdUser.has('slug'), true);
+                        assert.equal(createdUser.attributes.slug, 'jimothy-bogendath-2');
                         done();
                     });
                 });
@@ -98,9 +98,7 @@ describe('User Model', function run() {
 
             UserModel.add(userData, context).then(function (createdUser) {
                 should.exist(createdUser);
-                createdUser.attributes.profile_image.should.eql(
-                    'http://www.gravatar.com/avatar/2fab21a4c4ed88e76add10650c73bae1?d=404', 'Gravatar found'
-                );
+                assert.equal(createdUser.attributes.profile_image, 'http://www.gravatar.com/avatar/2fab21a4c4ed88e76add10650c73bae1?d=404', 'Gravatar found');
                 done();
             }).catch(done);
         });
@@ -145,7 +143,7 @@ describe('User Model', function run() {
                 // Test incorrect email address - swapped capital O for number 0
                 return UserModel.getByEmail('jb0gendAth@example.com').then(null, function (error) {
                     should.exist(error);
-                    error.message.should.eql('NotFound');
+                    assert.equal(error.message, 'NotFound');
                 });
             }).then(function () {
                 done();
@@ -204,10 +202,10 @@ describe('User Model', function run() {
             return testUtils.fixtures.createExtraUsers().then(function () {
                 return UserModel.findPage({limit: 'all'});
             }).then(function (results) {
-                results.meta.pagination.page.should.equal(1);
-                results.meta.pagination.limit.should.equal('all');
-                results.meta.pagination.pages.should.equal(1);
-                results.data.length.should.equal(10);
+                assert.equal(results.meta.pagination.page, 1);
+                assert.equal(results.meta.pagination.limit, 'all');
+                assert.equal(results.meta.pagination.pages, 1);
+                assert.equal(results.data.length, 10);
             });
         });
 
@@ -230,8 +228,8 @@ describe('User Model', function run() {
                 should.exist(owner.roles);
                 should.exist(editor.roles);
 
-                owner.roles[0].name.should.equal('Owner');
-                editor.roles[0].name.should.equal('Editor');
+                assert.equal(owner.roles[0].name, 'Owner');
+                assert.equal(editor.roles[0].name, 'Editor');
             });
         });
 
@@ -246,9 +244,9 @@ describe('User Model', function run() {
                 should.exist(createdUser);
                 createdUser.get('password').should.not.equal(userData.password, 'password was hashed');
                 createdUser.get('email').should.eql(userData.email, 'email address correct');
-                createdUser.related('roles').toJSON()[0].name.should.eql('Administrator', 'role set correctly');
+                assert.equal(createdUser.related('roles').toJSON()[0].name, 'Administrator', 'role set correctly');
 
-                Object.keys(eventsTriggered).length.should.eql(2);
+                assert.equal(Object.keys(eventsTriggered).length, 2);
                 should.exist(eventsTriggered['user.added']);
                 should.exist(eventsTriggered['user.activated']);
 
@@ -285,9 +283,9 @@ describe('User Model', function run() {
                 return UserModel.edit({website: 'http://some.newurl.com'}, {id: firstUser});
             }).then(function (edited) {
                 should.exist(edited);
-                edited.attributes.website.should.equal('http://some.newurl.com');
+                assert.equal(edited.attributes.website, 'http://some.newurl.com');
 
-                Object.keys(eventsTriggered).length.should.eql(2);
+                assert.equal(Object.keys(eventsTriggered).length, 2);
                 should.exist(eventsTriggered['user.activated.edited']);
                 should.exist(eventsTriggered['user.edited']);
 
@@ -316,7 +314,7 @@ describe('User Model', function run() {
                     done(new Error('Already existing email address was accepted'));
                 })
                 .catch(function (err) {
-                    (err instanceof errors.ValidationError).should.eql(true);
+                    assert.equal((err instanceof errors.ValidationError), true);
                     done();
                 });
         });
@@ -335,7 +333,7 @@ describe('User Model', function run() {
                 }, testUtils.context.owner).then(function () {
                     done(new Error('expected error!'));
                 }).catch(function (err) {
-                    (err instanceof errors.ValidationError).should.eql(true);
+                    assert.equal((err instanceof errors.ValidationError), true);
                     done();
                 });
             });
@@ -349,7 +347,7 @@ describe('User Model', function run() {
                 }, testUtils.context.owner).then(function () {
                     done(new Error('expected error!'));
                 }).catch(function (err) {
-                    (err instanceof errors.ValidationError).should.eql(true);
+                    assert.equal((err instanceof errors.ValidationError), true);
                     done();
                 });
             });
@@ -363,7 +361,7 @@ describe('User Model', function run() {
                 }, testUtils.context.owner).then(function () {
                     done(new Error('expected error!'));
                 }).catch(function (err) {
-                    (err instanceof errors.ValidationError).should.eql(true);
+                    assert.equal((err instanceof errors.ValidationError), true);
                     done();
                 });
             });
@@ -377,7 +375,7 @@ describe('User Model', function run() {
                 }, testUtils.context.owner).then(function () {
                     done(new Error('expected error!'));
                 }).catch(function (err) {
-                    (err instanceof errors.ValidationError).should.eql(true);
+                    assert.equal((err instanceof errors.ValidationError), true);
                     done();
                 });
             });
@@ -391,7 +389,7 @@ describe('User Model', function run() {
                 }, testUtils.context.owner).then(function () {
                     done(new Error('expected error!'));
                 }).catch(function (err) {
-                    (err instanceof errors.ValidationError).should.eql(true);
+                    assert.equal((err instanceof errors.ValidationError), true);
                     done();
                 });
             });
@@ -405,7 +403,7 @@ describe('User Model', function run() {
                 }, testUtils.context.owner).then(function () {
                     done(new Error('expected error!'));
                 }).catch(function (err) {
-                    (err instanceof errors.ValidationError).should.eql(true);
+                    assert.equal((err instanceof errors.ValidationError), true);
                     done();
                 });
             });
@@ -419,7 +417,7 @@ describe('User Model', function run() {
                 }, testUtils.context.owner).then(function () {
                     done(new Error('expected error!'));
                 }).catch(function (err) {
-                    (err instanceof errors.ValidationError).should.eql(true);
+                    assert.equal((err instanceof errors.ValidationError), true);
                     done();
                 });
             });
@@ -433,7 +431,7 @@ describe('User Model', function run() {
                 }, testUtils.context.owner).then(function () {
                     done(new Error('expected error!'));
                 }).catch(function (err) {
-                    (err instanceof errors.ValidationError).should.eql(true);
+                    assert.equal((err instanceof errors.ValidationError), true);
                     done();
                 });
             });
@@ -454,7 +452,7 @@ describe('User Model', function run() {
                 .then(function (user) {
                     user.get('name').should.eql(userData.name);
                     user.get('email').should.eql(userData.email);
-                    user.get('slug').should.eql('max');
+                    assert.equal(user.get('slug'), 'max');
 
                     // naive check that password was hashed
                     user.get('password').should.not.eql(userData.password);

--- a/ghost/core/test/legacy/site/dynamic-routing.test.js
+++ b/ghost/core/test/legacy/site/dynamic-routing.test.js
@@ -64,9 +64,9 @@ describe('Dynamic Routing', function () {
                     assert.equal(res.headers['set-cookie'], undefined);
                     should.exist(res.headers.date);
 
-                    $('title').text().should.equal('Ghost');
-                    $('body.home-template').length.should.equal(1);
-                    $('article.post').length.should.equal(7);
+                    assert.equal($('title').text(), 'Ghost');
+                    assert.equal($('body.home-template').length, 1);
+                    assert.equal($('article.post').length, 7);
 
                     done();
                 });
@@ -137,8 +137,8 @@ describe('Dynamic Routing', function () {
                     assert.equal(res.headers['set-cookie'], undefined);
                     should.exist(res.headers.date);
 
-                    $('body').attr('class').should.eql('tag-template tag-getting-started has-sans-title has-sans-body');
-                    $('article.post').length.should.equal(5);
+                    assert.equal($('body').attr('class'), 'tag-template tag-getting-started has-sans-title has-sans-body');
+                    assert.equal($('article.post').length, 5);
 
                     done();
                 });

--- a/ghost/core/test/legacy/site/frontend.test.js
+++ b/ghost/core/test/legacy/site/frontend.test.js
@@ -128,9 +128,9 @@ describe('Frontend Routing', function () {
                         assert.equal(res.headers['set-cookie'], undefined);
                         should.exist(res.headers.date);
 
-                        $('title').text().should.equal('This is a static page');
-                        $('body.page-template').length.should.equal(1);
-                        $('article.post').length.should.equal(1);
+                        assert.equal($('title').text(), 'This is a static page');
+                        assert.equal($('body.page-template').length, 1);
+                        assert.equal($('article.post').length, 1);
 
                         doEnd(done)(err, res);
                     });

--- a/ghost/core/test/unit/api/canary/utils/serializers/output/mapper.test.js
+++ b/ghost/core/test/unit/api/canary/utils/serializers/output/mapper.test.js
@@ -66,17 +66,17 @@ describe('Unit: utils/serializers/output/mappers', function () {
 
             await mappers.posts(post, frame);
 
-            dateUtil.forPost.callCount.should.equal(1);
+            assert.equal(dateUtil.forPost.callCount, 1);
 
-            extraAttrsUtils.forPost.callCount.should.equal(1);
+            assert.equal(extraAttrsUtils.forPost.callCount, 1);
 
-            cleanUtil.post.callCount.should.eql(1);
-            cleanUtil.tag.callCount.should.eql(1);
-            cleanUtil.author.callCount.should.eql(1);
+            assert.equal(cleanUtil.post.callCount, 1);
+            assert.equal(cleanUtil.tag.callCount, 1);
+            assert.equal(cleanUtil.author.callCount, 1);
 
-            urlUtil.forPost.callCount.should.equal(1);
-            urlUtil.forTag.callCount.should.equal(1);
-            urlUtil.forUser.callCount.should.equal(1);
+            assert.equal(urlUtil.forPost.callCount, 1);
+            assert.equal(urlUtil.forTag.callCount, 1);
+            assert.equal(urlUtil.forUser.callCount, 1);
 
             urlUtil.forTag.getCall(0).args.should.eql(['id3', {id: 'id3', feature_image: 'value'}, frame.options]);
             urlUtil.forUser.getCall(0).args.should.eql(['id4', {name: 'Ghosty', id: 'id4'}, frame.options]);
@@ -103,9 +103,9 @@ describe('Unit: utils/serializers/output/mappers', function () {
 
             mappers.users(user, frame);
 
-            urlUtil.forUser.callCount.should.equal(1);
+            assert.equal(urlUtil.forUser.callCount, 1);
             urlUtil.forUser.getCall(0).args.should.eql(['id1', user, frame.options]);
-            cleanUtil.author.callCount.should.equal(1);
+            assert.equal(cleanUtil.author.callCount, 1);
         });
     });
 
@@ -129,9 +129,9 @@ describe('Unit: utils/serializers/output/mappers', function () {
 
             mappers.tags(tag, frame);
 
-            urlUtil.forTag.callCount.should.equal(1);
+            assert.equal(urlUtil.forTag.callCount, 1);
             urlUtil.forTag.getCall(0).args.should.eql(['id3', tag, frame.options]);
-            cleanUtil.tag.callCount.should.equal(1);
+            assert.equal(cleanUtil.tag.callCount, 1);
         });
     });
 
@@ -699,7 +699,7 @@ describe('Unit: utils/serializers/output/mappers', function () {
 
             const mapped = mappers.comments(model, frame);
 
-            converterSpy.calledOnce.should.eql(true, 'htmlToPlaintext.commentSnippet was not called');
+            assert.equal(converterSpy.calledOnce, true, 'htmlToPlaintext.commentSnippet was not called');
 
             mapped.should.eql({
                 in_reply_to_snippet: 'First paragraph with link, and new line. Second paragraph',

--- a/ghost/core/test/unit/frontend/apps/private-blogging/controller.test.js
+++ b/ghost/core/test/unit/frontend/apps/private-blogging/controller.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const path = require('path');
@@ -67,7 +68,7 @@ describe('Private Controller', function () {
         hasTemplateStub.withArgs('private').returns(true);
 
         res.render = function (view, context) {
-            view.should.eql('private');
+            assert.equal(view, 'private');
             should.exist(context);
             done();
         };

--- a/ghost/core/test/unit/frontend/apps/private-blogging/middleware.test.js
+++ b/ghost/core/test/unit/frontend/apps/private-blogging/middleware.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const errors = require('@tryghost/errors');
 const should = require('should');
 const sinon = require('sinon');
@@ -36,16 +37,16 @@ describe('Private Blogging', function () {
             settingsStub.withArgs('is_private').returns(false);
 
             privateBlogging.checkIsPrivate(req, res, next);
-            next.called.should.be.true();
-            res.isPrivateBlog.should.be.false();
+            assert.equal(next.called, true);
+            assert.equal(res.isPrivateBlog, false);
         });
 
         it('Sets res.isPrivateBlog true if setting is true', function () {
             settingsStub.withArgs('is_private').returns(true);
 
             privateBlogging.checkIsPrivate(req, res, next);
-            next.called.should.be.true();
-            res.isPrivateBlog.should.be.true();
+            assert.equal(next.called, true);
+            assert.equal(res.isPrivateBlog, true);
         });
     });
 
@@ -57,7 +58,7 @@ describe('Private Blogging', function () {
 
         it('filterPrivateRoutes should call next', function () {
             privateBlogging.filterPrivateRoutes(req, res, next);
-            next.called.should.be.true();
+            assert.equal(next.called, true);
         });
 
         it('redirectPrivateToHomeIfLoggedIn should redirect to home', function () {
@@ -66,14 +67,14 @@ describe('Private Blogging', function () {
                 isPrivateBlog: false
             };
             privateBlogging.redirectPrivateToHomeIfLoggedIn(req, res, next);
-            res.redirect.called.should.be.true();
-            res.redirect.calledWith('http://127.0.0.1:2369/').should.be.true();
+            assert.equal(res.redirect.called, true);
+            assert.equal(res.redirect.calledWith('http://127.0.0.1:2369/'), true);
         });
 
         it('handle404 should still 404', function () {
             privateBlogging.handle404(new errors.NotFoundError(), req, res, next);
-            next.called.should.be.true();
-            (next.firstCall.args[0] instanceof errors.NotFoundError).should.eql(true);
+            assert.equal(next.called, true);
+            assert.equal((next.firstCall.args[0] instanceof errors.NotFoundError), true);
         });
     });
 
@@ -104,40 +105,40 @@ describe('Private Blogging', function () {
             it('authenticatePrivateSession should redirect', function () {
                 req.path = req.url = '/welcome/';
                 privateBlogging.authenticatePrivateSession(req, res, next);
-                next.called.should.be.false();
-                res.redirect.called.should.be.true();
-                res.redirect.calledWith('/private/?r=%2Fwelcome%2F').should.be.true();
+                assert.equal(next.called, false);
+                assert.equal(res.redirect.called, true);
+                assert.equal(res.redirect.calledWith('/private/?r=%2Fwelcome%2F'), true);
             });
 
             it('handle404 should redirect', function () {
                 req.path = req.url = '/welcome/';
                 privateBlogging.handle404(new errors.NotFoundError(), req, res, next);
-                next.called.should.be.false();
-                res.redirect.called.should.be.true();
-                res.redirect.calledWith('/private/?r=%2Fwelcome%2F').should.be.true();
+                assert.equal(next.called, false);
+                assert.equal(res.redirect.called, true);
+                assert.equal(res.redirect.calledWith('/private/?r=%2Fwelcome%2F'), true);
             });
 
             describe('Site privacy managed by filterPrivateRoutes', function () {
                 it('should call next for the /private/ route', function () {
                     req.path = req.url = '/private/';
                     privateBlogging.filterPrivateRoutes(req, res, next);
-                    next.called.should.be.true();
+                    assert.equal(next.called, true);
                 });
 
                 it('should redirect to /private/ for private route with extra path', function () {
                     req.path = req.url = '/private/welcome/';
 
                     privateBlogging.filterPrivateRoutes(req, res, next);
-                    res.redirect.calledOnce.should.be.true();
-                    res.redirect.calledWith('/private/?r=%2Fprivate%2Fwelcome%2F').should.be.true();
+                    assert.equal(res.redirect.calledOnce, true);
+                    assert.equal(res.redirect.calledWith('/private/?r=%2Fprivate%2Fwelcome%2F'), true);
                 });
 
                 it('should redirect to /private/ for sitemap', function () {
                     req.path = req.url = '/sitemap.xml';
 
                     privateBlogging.filterPrivateRoutes(req, res, next);
-                    res.redirect.calledOnce.should.be.true();
-                    res.redirect.calledWith('/private/?r=%2Fsitemap.xml').should.be.true();
+                    assert.equal(res.redirect.calledOnce, true);
+                    assert.equal(res.redirect.calledWith('/private/?r=%2Fsitemap.xml'), true);
                 });
 
                 it('should redirect to /private/ for sitemap with params', function () {
@@ -145,40 +146,40 @@ describe('Private Blogging', function () {
                     req.path = '/sitemap.xml';
 
                     privateBlogging.filterPrivateRoutes(req, res, next);
-                    res.redirect.calledOnce.should.be.true();
-                    res.redirect.calledWith('/private/?r=%2Fsitemap.xml%3Fweird%3Dparam').should.be.true();
+                    assert.equal(res.redirect.calledOnce, true);
+                    assert.equal(res.redirect.calledWith('/private/?r=%2Fsitemap.xml%3Fweird%3Dparam'), true);
                 });
 
                 it('should redirect to /private/ for /rss/', function () {
                     req.path = req.url = '/rss/';
 
                     privateBlogging.filterPrivateRoutes(req, res, next);
-                    res.redirect.calledOnce.should.be.true();
-                    res.redirect.calledWith('/private/?r=%2Frss%2F').should.be.true();
+                    assert.equal(res.redirect.calledOnce, true);
+                    assert.equal(res.redirect.calledWith('/private/?r=%2Frss%2F'), true);
                 });
 
                 it('should redirect to /private/ for author rss', function () {
                     req.path = req.url = '/author/halfdan/rss/';
 
                     privateBlogging.filterPrivateRoutes(req, res, next);
-                    res.redirect.calledOnce.should.be.true();
-                    res.redirect.calledWith('/private/?r=%2Fauthor%2Fhalfdan%2Frss%2F').should.be.true();
+                    assert.equal(res.redirect.calledOnce, true);
+                    assert.equal(res.redirect.calledWith('/private/?r=%2Fauthor%2Fhalfdan%2Frss%2F'), true);
                 });
 
                 it('should redirect to /private/ for tag rss', function () {
                     req.path = req.url = '/tag/slimer/rss/';
 
                     privateBlogging.filterPrivateRoutes(req, res, next);
-                    res.redirect.calledOnce.should.be.true();
-                    res.redirect.calledWith('/private/?r=%2Ftag%2Fslimer%2Frss%2F').should.be.true();
+                    assert.equal(res.redirect.calledOnce, true);
+                    assert.equal(res.redirect.calledWith('/private/?r=%2Ftag%2Fslimer%2Frss%2F'), true);
                 });
 
                 it('should redirect to /private/ for rss with extra path', function () {
                     req.path = req.url = '/rss/sometag';
 
                     privateBlogging.filterPrivateRoutes(req, res, next);
-                    res.redirect.calledOnce.should.be.true();
-                    res.redirect.calledWith('/private/?r=%2Frss%2Fsometag').should.be.true();
+                    assert.equal(res.redirect.calledOnce, true);
+                    assert.equal(res.redirect.calledWith('/private/?r=%2Frss%2Fsometag'), true);
                 });
 
                 it('should render custom robots.txt', function () {
@@ -191,8 +192,8 @@ describe('Private Blogging', function () {
                         cb(null, 'User-agent: * Disallow: /');
                     });
                     privateBlogging.filterPrivateRoutes(req, res, next);
-                    res.writeHead.called.should.be.true();
-                    res.end.called.should.be.true();
+                    assert.equal(res.writeHead.called, true);
+                    assert.equal(res.end.called, true);
                 });
 
                 it('should allow private /rss/ feed', function () {
@@ -200,8 +201,8 @@ describe('Private Blogging', function () {
                     req.params = {};
 
                     privateBlogging.filterPrivateRoutes(req, res, next);
-                    next.called.should.be.true();
-                    req.url.should.eql('/rss/');
+                    assert.equal(next.called, true);
+                    assert.equal(req.url, '/rss/');
                 });
 
                 it('should allow private tag /rss/ feed', function () {
@@ -209,23 +210,23 @@ describe('Private Blogging', function () {
                     req.params = {};
 
                     privateBlogging.filterPrivateRoutes(req, res, next);
-                    next.called.should.be.true();
-                    req.url.should.eql('/tag/getting-started/rss/');
+                    assert.equal(next.called, true);
+                    assert.equal(req.url, '/tag/getting-started/rss/');
                 });
 
                 it('should redirect to /private/ for private rss with extra path', function () {
                     req.url = req.originalUrl = req.path = '/777aaa/rss/hackme/';
 
                     privateBlogging.filterPrivateRoutes(req, res, next);
-                    res.redirect.calledOnce.should.be.true();
-                    res.redirect.calledWith('/private/?r=%2F777aaa%2Frss%2Fhackme%2F').should.be.true();
+                    assert.equal(res.redirect.calledOnce, true);
+                    assert.equal(res.redirect.calledWith('/private/?r=%2F777aaa%2Frss%2Fhackme%2F'), true);
                 });
             });
 
             describe('/private/ route', function () {
                 it('redirectPrivateToHomeIfLoggedIn should allow /private/ to be rendered', function () {
                     privateBlogging.redirectPrivateToHomeIfLoggedIn(req, res, next);
-                    next.called.should.be.true();
+                    assert.equal(next.called, true);
                 });
             });
         });
@@ -234,7 +235,7 @@ describe('Private Blogging', function () {
             it('doLoginToPrivateSite should call next if error', function () {
                 res.error = 'Test Error';
                 privateBlogging.doLoginToPrivateSite(req, res, next);
-                next.called.should.be.true();
+                assert.equal(next.called, true);
             });
 
             it('doLoginToPrivateSite should return next if password is incorrect', function () {
@@ -242,7 +243,7 @@ describe('Private Blogging', function () {
 
                 privateBlogging.doLoginToPrivateSite(req, res, next);
                 res.error.should.not.be.empty();
-                next.called.should.be.true();
+                assert.equal(next.called, true);
             });
 
             it('doLoginToPrivateSite should redirect if password is correct', function () {
@@ -251,7 +252,7 @@ describe('Private Blogging', function () {
                 res.redirect = sinon.spy();
 
                 privateBlogging.doLoginToPrivateSite(req, res, next);
-                res.redirect.called.should.be.true();
+                assert.equal(res.redirect.called, true);
             });
 
             it('doLoginToPrivateSite should redirect to "/" if r param is a full url', function () {
@@ -263,7 +264,7 @@ describe('Private Blogging', function () {
                 res.redirect = sinon.spy();
 
                 privateBlogging.doLoginToPrivateSite(req, res, next);
-                res.redirect.called.should.be.true();
+                assert.equal(res.redirect.called, true);
                 res.redirect.args[0][0].should.be.equal('/');
             });
 
@@ -276,7 +277,7 @@ describe('Private Blogging', function () {
                 res.redirect = sinon.spy();
 
                 privateBlogging.doLoginToPrivateSite(req, res, next);
-                res.redirect.called.should.be.true();
+                assert.equal(res.redirect.called, true);
                 res.redirect.args[0][0].should.be.equal('/test');
             });
 
@@ -289,7 +290,7 @@ describe('Private Blogging', function () {
                 res.redirect = sinon.spy();
 
                 privateBlogging.doLoginToPrivateSite(req, res, next);
-                res.redirect.called.should.be.true();
+                assert.equal(res.redirect.called, true);
                 res.redirect.args[0][0].should.be.equal('/?utm_source=twitter&utm_campaign=test');
             });
 
@@ -302,7 +303,7 @@ describe('Private Blogging', function () {
                 res.redirect = sinon.spy();
 
                 privateBlogging.doLoginToPrivateSite(req, res, next);
-                res.redirect.called.should.be.true();
+                assert.equal(res.redirect.called, true);
                 res.redirect.args[0][0].should.be.equal('/welcome/?ref=newsletter&utm_medium=email');
             });
 
@@ -315,7 +316,7 @@ describe('Private Blogging', function () {
                 res.redirect = sinon.spy();
 
                 privateBlogging.doLoginToPrivateSite(req, res, next);
-                res.redirect.called.should.be.true();
+                assert.equal(res.redirect.called, true);
                 res.redirect.args[0][0].should.be.equal('/');
             });
 
@@ -328,15 +329,15 @@ describe('Private Blogging', function () {
                 });
                 it('redirectPrivateToHomeIfLoggedIn should return next', function () {
                     privateBlogging.redirectPrivateToHomeIfLoggedIn(req, res, next);
-                    next.called.should.be.true();
+                    assert.equal(next.called, true);
                 });
 
                 it('authenticatePrivateSession should redirect', function () {
                     req.url = '/welcome';
 
                     privateBlogging.authenticatePrivateSession(req, res, next);
-                    res.redirect.called.should.be.true();
-                    res.redirect.calledWith('/private/?r=%2Fwelcome').should.be.true();
+                    assert.equal(res.redirect.called, true);
+                    assert.equal(res.redirect.calledWith('/private/?r=%2Fwelcome'), true);
                 });
             });
         });
@@ -353,13 +354,13 @@ describe('Private Blogging', function () {
 
             it('authenticatePrivateSession should return next', function () {
                 privateBlogging.authenticatePrivateSession(req, res, next);
-                next.called.should.be.true();
+                assert.equal(next.called, true);
             });
 
             it('handle404 should still 404', function () {
                 privateBlogging.handle404(new errors.NotFoundError(), req, res, next);
-                next.called.should.be.true();
-                (next.firstCall.args[0] instanceof errors.NotFoundError).should.eql(true);
+                assert.equal(next.called, true);
+                assert.equal((next.firstCall.args[0] instanceof errors.NotFoundError), true);
             });
 
             describe('Site privacy managed by filterPrivateRoutes', function () {
@@ -367,32 +368,32 @@ describe('Private Blogging', function () {
                     req.url = req.path = '/rss/';
 
                     privateBlogging.filterPrivateRoutes(req, res, next);
-                    next.called.should.be.true();
-                    (next.firstCall.args[0] instanceof errors.NotFoundError).should.eql(true);
+                    assert.equal(next.called, true);
+                    assert.equal((next.firstCall.args[0] instanceof errors.NotFoundError), true);
                 });
 
                 it('should 404 for standard public tag rss requests', function () {
                     req.url = req.path = '/tag/welcome/rss/';
 
                     privateBlogging.filterPrivateRoutes(req, res, next);
-                    next.called.should.be.true();
-                    (next.firstCall.args[0] instanceof errors.NotFoundError).should.eql(true);
+                    assert.equal(next.called, true);
+                    assert.equal((next.firstCall.args[0] instanceof errors.NotFoundError), true);
                 });
 
                 it('should allow a tag to contain the word rss', function () {
                     req.url = req.path = '/tag/rss-test/';
 
                     privateBlogging.filterPrivateRoutes(req, res, next);
-                    next.called.should.be.true();
-                    next.firstCall.args.length.should.equal(0);
+                    assert.equal(next.called, true);
+                    assert.equal(next.firstCall.args.length, 0);
                 });
 
                 it('should not 404 for very short post url', function () {
                     req.url = req.path = '/ab/';
 
                     privateBlogging.filterPrivateRoutes(req, res, next);
-                    next.called.should.be.true();
-                    next.firstCall.args.length.should.equal(0);
+                    assert.equal(next.called, true);
+                    assert.equal(next.firstCall.args.length, 0);
                 });
 
                 it('should allow private /rss/ feed', function () {
@@ -400,8 +401,8 @@ describe('Private Blogging', function () {
                     req.params = {};
 
                     privateBlogging.filterPrivateRoutes(req, res, next);
-                    next.called.should.be.true();
-                    req.url.should.eql('/rss/');
+                    assert.equal(next.called, true);
+                    assert.equal(req.url, '/rss/');
                 });
 
                 it('should allow private tag /rss/ feed', function () {
@@ -409,15 +410,15 @@ describe('Private Blogging', function () {
                     req.params = {};
 
                     privateBlogging.filterPrivateRoutes(req, res, next);
-                    next.called.should.be.true();
-                    req.url.should.eql('/tag/getting-started/rss/');
+                    assert.equal(next.called, true);
+                    assert.equal(req.url, '/tag/getting-started/rss/');
                 });
             });
 
             describe('/private/ route', function () {
                 it('redirectPrivateToHomeIfLoggedIn should redirect to home', function () {
                     privateBlogging.redirectPrivateToHomeIfLoggedIn(req, res, next);
-                    res.redirect.called.should.be.true();
+                    assert.equal(res.redirect.called, true);
                 });
             });
         });

--- a/ghost/core/test/unit/frontend/helpers/asset.test.js
+++ b/ghost/core/test/unit/frontend/helpers/asset.test.js
@@ -1,6 +1,7 @@
 // NOTE: the sole purpose of this suite is to test is it calls through to getAssetUrlHelper
 //       more complicated use cases are tested directly in asset_url.spec
 
+const assert = require('node:assert/strict');
 const should = require('should');
 
 const sinon = require('sinon');
@@ -30,13 +31,13 @@ describe('{{asset}} helper', function () {
         it('handles favicon correctly', function () {
             rendered = asset('favicon.ico');
             should.exist(rendered);
-            String(rendered).should.equal('/favicon.ico');
+            assert.equal(String(rendered), '/favicon.ico');
         });
 
         it('handles ghost.css for default templates correctly', function () {
             rendered = asset('public/ghost.css');
             should.exist(rendered);
-            String(rendered).should.equal('/public/ghost.css?v=abc');
+            assert.equal(String(rendered), '/public/ghost.css?v=abc');
         });
 
         it('handles custom favicon correctly', function () {
@@ -44,25 +45,25 @@ describe('{{asset}} helper', function () {
             localSettingsCache.icon = '/content/images/favicon.png';
             rendered = asset('favicon.png');
             should.exist(rendered);
-            String(rendered).should.equal('/content/images/size/w256h256/favicon.png');
+            assert.equal(String(rendered), '/content/images/size/w256h256/favicon.png');
 
             // with ico
             localSettingsCache.icon = '/content/images/favicon.ico';
             rendered = asset('favicon.ico');
             should.exist(rendered);
-            String(rendered).should.equal('/content/images/favicon.ico');
+            assert.equal(String(rendered), '/content/images/favicon.ico');
 
             // with webp
             localSettingsCache.icon = '/content/images/favicon.webp';
             rendered = asset('favicon.png');
             should.exist(rendered);
-            String(rendered).should.equal('/content/images/size/w256h256/format/png/favicon.webp');
+            assert.equal(String(rendered), '/content/images/size/w256h256/format/png/favicon.webp');
 
             // with svg
             localSettingsCache.icon = '/content/images/favicon.svg';
             rendered = asset('favicon.png');
             should.exist(rendered);
-            String(rendered).should.equal('/content/images/size/w256h256/format/png/favicon.svg');
+            assert.equal(String(rendered), '/content/images/size/w256h256/format/png/favicon.svg');
         });
 
         it('handles public assets correctly', function () {
@@ -70,19 +71,19 @@ describe('{{asset}} helper', function () {
 
             rendered = asset('public/asset.js');
             should.exist(rendered);
-            String(rendered).should.equal('/public/asset.js?v=abc');
+            assert.equal(String(rendered), '/public/asset.js?v=abc');
         });
 
         it('handles theme assets correctly', function () {
             rendered = asset('js/asset.js');
             should.exist(rendered);
-            String(rendered).should.equal('/assets/js/asset.js?v=abc');
+            assert.equal(String(rendered), '/assets/js/asset.js?v=abc');
         });
 
         it('handles hasMinFile assets correctly', function () {
             rendered = asset('js/asset.js', {hash: {hasMinFile: true}});
             should.exist(rendered);
-            String(rendered).should.equal('/assets/js/asset.min.js?v=abc');
+            assert.equal(String(rendered), '/assets/js/asset.min.js?v=abc');
         });
     });
 
@@ -99,13 +100,13 @@ describe('{{asset}} helper', function () {
         it('handles favicon correctly', function () {
             rendered = asset('favicon.ico');
             should.exist(rendered);
-            String(rendered).should.equal('http://127.0.0.1/favicon.ico');
+            assert.equal(String(rendered), 'http://127.0.0.1/favicon.ico');
         });
 
         it('handles ghost.css for default templates correctly', function () {
             rendered = asset('public/ghost.css');
             should.exist(rendered);
-            String(rendered).should.equal('http://127.0.0.1/public/ghost.css?v=abc');
+            assert.equal(String(rendered), 'http://127.0.0.1/public/ghost.css?v=abc');
         });
     });
 });

--- a/ghost/core/test/unit/frontend/helpers/authors.test.js
+++ b/ghost/core/test/unit/frontend/helpers/authors.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const urlService = require('../../../../core/server/services/url');
@@ -29,7 +30,7 @@ describe('{{authors}} helper', function () {
         const rendered = authorsHelper.call({authors: authors}, {hash: {autolink: 'false'}});
         should.exist(rendered);
 
-        String(rendered).should.equal('Michael, Thomas');
+        assert.equal(String(rendered), 'Michael, Thomas');
     });
 
     it('can return string with authors with special chars', function () {
@@ -41,7 +42,7 @@ describe('{{authors}} helper', function () {
         const rendered = authorsHelper.call({authors: authors}, {hash: {autolink: 'false'}});
         should.exist(rendered);
 
-        String(rendered).should.equal('John O&#x27;Nolan, AB&#x3D;CD&#x60;EF');
+        assert.equal(String(rendered), 'John O&#x27;Nolan, AB&#x3D;CD&#x60;EF');
     });
 
     it('can use a different separator', function () {
@@ -53,7 +54,7 @@ describe('{{authors}} helper', function () {
         const rendered = authorsHelper.call({authors: authors}, {hash: {separator: '|', autolink: 'false'}});
         should.exist(rendered);
 
-        String(rendered).should.equal('haunted|ghost');
+        assert.equal(String(rendered), 'haunted|ghost');
     });
 
     it('can add a single prefix to multiple authors', function () {
@@ -65,7 +66,7 @@ describe('{{authors}} helper', function () {
         const rendered = authorsHelper.call({authors: authors}, {hash: {prefix: 'on ', autolink: 'false'}});
         should.exist(rendered);
 
-        String(rendered).should.equal('on haunted, ghost');
+        assert.equal(String(rendered), 'on haunted, ghost');
     });
 
     it('can add a single suffix to multiple authors', function () {
@@ -77,7 +78,7 @@ describe('{{authors}} helper', function () {
         const rendered = authorsHelper.call({authors: authors}, {hash: {suffix: ' forever', autolink: 'false'}});
         should.exist(rendered);
 
-        String(rendered).should.equal('haunted, ghost forever');
+        assert.equal(String(rendered), 'haunted, ghost forever');
     });
 
     it('can add a prefix and suffix to multiple authors', function () {
@@ -89,7 +90,7 @@ describe('{{authors}} helper', function () {
         const rendered = authorsHelper.call({authors: authors}, {hash: {suffix: ' forever', prefix: 'on ', autolink: 'false'}});
         should.exist(rendered);
 
-        String(rendered).should.equal('on haunted, ghost forever');
+        assert.equal(String(rendered), 'on haunted, ghost forever');
     });
 
     it('can add a prefix and suffix with HTML', function () {
@@ -101,14 +102,14 @@ describe('{{authors}} helper', function () {
         const rendered = authorsHelper.call({authors: authors}, {hash: {suffix: ' &bull;', prefix: '&hellip; ', autolink: 'false'}});
         should.exist(rendered);
 
-        String(rendered).should.equal('&hellip; haunted, ghost &bull;');
+        assert.equal(String(rendered), '&hellip; haunted, ghost &bull;');
     });
 
     it('does not add prefix or suffix if no authors exist', function () {
         const rendered = authorsHelper.call({}, {hash: {prefix: 'on ', suffix: ' forever', autolink: 'false'}});
         should.exist(rendered);
 
-        String(rendered).should.equal('');
+        assert.equal(String(rendered), '');
     });
 
     it('can autolink authors to author pages', function () {
@@ -123,7 +124,7 @@ describe('{{authors}} helper', function () {
         const rendered = authorsHelper.call({authors: authors});
         should.exist(rendered);
 
-        String(rendered).should.equal('<a href="author url 1">foo</a>, <a href="author url 2">bar</a>');
+        assert.equal(String(rendered), '<a href="author url 1">foo</a>, <a href="author url 2">bar</a>');
     });
 
     it('can limit no. authors output to 1', function () {
@@ -137,7 +138,7 @@ describe('{{authors}} helper', function () {
         const rendered = authorsHelper.call({authors: authors}, {hash: {limit: '1'}});
         should.exist(rendered);
 
-        String(rendered).should.equal('<a href="author url 1">foo</a>');
+        assert.equal(String(rendered), '<a href="author url 1">foo</a>');
     });
 
     it('can list authors from a specified no.', function () {
@@ -151,7 +152,7 @@ describe('{{authors}} helper', function () {
         const rendered = authorsHelper.call({authors: authors}, {hash: {from: '2'}});
         should.exist(rendered);
 
-        String(rendered).should.equal('<a href="author url 2">bar</a>');
+        assert.equal(String(rendered), '<a href="author url 2">bar</a>');
     });
 
     it('can list authors to a specified no.', function () {
@@ -165,7 +166,7 @@ describe('{{authors}} helper', function () {
         const rendered = authorsHelper.call({authors: authors}, {hash: {to: '1'}});
         should.exist(rendered);
 
-        String(rendered).should.equal('<a href="author url">foo</a>');
+        assert.equal(String(rendered), '<a href="author url">foo</a>');
     });
 
     it('can list authors in a range', function () {
@@ -181,7 +182,7 @@ describe('{{authors}} helper', function () {
         const rendered = authorsHelper.call({authors: authors}, {hash: {from: '2', to: '3'}});
         should.exist(rendered);
 
-        String(rendered).should.equal('<a href="author url 2">bar</a>, <a href="author url 3">baz</a>');
+        assert.equal(String(rendered), '<a href="author url 2">bar</a>, <a href="author url 3">baz</a>');
     });
 
     it('can limit no. authors and output from 2', function () {
@@ -196,7 +197,7 @@ describe('{{authors}} helper', function () {
         const rendered = authorsHelper.call({authors: authors}, {hash: {from: '2', limit: '1'}});
         should.exist(rendered);
 
-        String(rendered).should.equal('<a href="author url x">bar</a>');
+        assert.equal(String(rendered), '<a href="author url x">bar</a>');
     });
 
     it('can list authors in a range (ignore limit)', function () {
@@ -213,6 +214,6 @@ describe('{{authors}} helper', function () {
         const rendered = authorsHelper.call({authors: authors}, {hash: {from: '1', to: '3', limit: '2'}});
         should.exist(rendered);
 
-        String(rendered).should.equal('<a href="author url a">foo</a>, <a href="author url b">bar</a>, <a href="author url c">baz</a>');
+        assert.equal(String(rendered), '<a href="author url a">foo</a>, <a href="author url b">bar</a>, <a href="author url c">baz</a>');
     });
 });

--- a/ghost/core/test/unit/frontend/helpers/body-class.test.js
+++ b/ghost/core/test/unit/frontend/helpers/body-class.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const themeList = require('../../../../core/server/services/themes/list');
 const sinon = require('sinon');
@@ -46,7 +47,7 @@ describe('{{body_class}} helper', function () {
         const rendered = body_class.call({}, options);
         should.exist(rendered);
 
-        rendered.string.should.equal('home-template');
+        assert.equal(rendered.string, 'home-template');
     });
 
     describe('can render class string for context', function () {
@@ -64,7 +65,7 @@ describe('{{body_class}} helper', function () {
                 {relativeUrl: '/'}
             );
 
-            rendered.string.should.equal('home-template');
+            assert.equal(rendered.string, 'home-template');
         });
 
         it('a post', function () {
@@ -73,7 +74,7 @@ describe('{{body_class}} helper', function () {
                 {relativeUrl: '/a-post-title', post: {}}
             );
 
-            rendered.string.should.equal('post-template');
+            assert.equal(rendered.string, 'post-template');
         });
 
         it('paginated index', function () {
@@ -82,7 +83,7 @@ describe('{{body_class}} helper', function () {
                 {relativeUrl: '/page/4'}
             );
 
-            rendered.string.should.equal('paged');
+            assert.equal(rendered.string, 'paged');
         });
 
         it('tag page', function () {
@@ -91,7 +92,7 @@ describe('{{body_class}} helper', function () {
                 {relativeUrl: '/tag/foo', tag: {slug: 'foo'}}
             );
 
-            rendered.string.should.equal('tag-template tag-foo');
+            assert.equal(rendered.string, 'tag-template tag-foo');
         });
 
         it('paginated tag page', function () {
@@ -100,7 +101,7 @@ describe('{{body_class}} helper', function () {
                 {relativeUrl: '/tag/foo/page/2', tag: {slug: 'foo'}}
             );
 
-            rendered.string.should.equal('tag-template tag-foo paged');
+            assert.equal(rendered.string, 'tag-template tag-foo paged');
         });
 
         it('author page', function () {
@@ -109,7 +110,7 @@ describe('{{body_class}} helper', function () {
                 {relativeUrl: '/author/bar', author: {slug: 'bar'}}
             );
 
-            rendered.string.should.equal('author-template author-bar');
+            assert.equal(rendered.string, 'author-template author-bar');
         });
 
         it('paginated author page', function () {
@@ -118,7 +119,7 @@ describe('{{body_class}} helper', function () {
                 {relativeUrl: '/author/bar/page/2', author: {slug: 'bar'}}
             );
 
-            rendered.string.should.equal('author-template author-bar paged');
+            assert.equal(rendered.string, 'author-template author-bar paged');
         });
 
         it('private route for password protection', function () {
@@ -127,7 +128,7 @@ describe('{{body_class}} helper', function () {
                 {relativeUrl: '/private/'}
             );
 
-            rendered.string.should.equal('private-template');
+            assert.equal(rendered.string, 'private-template');
         });
 
         it('post with tags', function () {
@@ -136,7 +137,7 @@ describe('{{body_class}} helper', function () {
                 {relativeUrl: '/my-awesome-post/', post: {tags: [{slug: 'foo'}, {slug: 'bar'}]}}
             );
 
-            rendered.string.should.equal('post-template tag-foo tag-bar');
+            assert.equal(rendered.string, 'post-template tag-foo tag-bar');
         });
 
         it('a static page', function () {
@@ -145,7 +146,7 @@ describe('{{body_class}} helper', function () {
                 {relativeUrl: '/about', page: {page: true, slug: 'about'}}
             );
 
-            rendered.string.should.equal('page-template page-about');
+            assert.equal(rendered.string, 'page-template page-about');
         });
 
         it('a static page with custom template (is now the same as one without)', function () {
@@ -158,7 +159,7 @@ describe('{{body_class}} helper', function () {
                 }
             );
 
-            rendered.string.should.equal('page-template page-about');
+            assert.equal(rendered.string, 'page-template page-about');
         });
     });
 
@@ -200,7 +201,7 @@ describe('{{body_class}} helper', function () {
                 {relativeUrl: '/my-awesome-post/', post: {tags: [{slug: 'foo'}, {slug: 'bar'}]}}
             );
 
-            rendered.string.should.equal('post-template tag-foo tag-bar gh-font-heading-space-grotesk gh-font-body-noto-sans');
+            assert.equal(rendered.string, 'post-template tag-foo tag-bar gh-font-heading-space-grotesk gh-font-body-noto-sans');
         });
 
         it('includes custom font for post when set in settings cache and no preview', function () {
@@ -212,7 +213,7 @@ describe('{{body_class}} helper', function () {
                 {relativeUrl: '/my-awesome-post/', post: {tags: [{slug: 'foo'}, {slug: 'bar'}]}}
             );
 
-            rendered.string.should.equal('post-template tag-foo tag-bar gh-font-heading-space-grotesk gh-font-body-noto-sans');
+            assert.equal(rendered.string, 'post-template tag-foo tag-bar gh-font-heading-space-grotesk gh-font-body-noto-sans');
         });
 
         it('does not include custom font classes when custom fonts are not enabled', function () {
@@ -221,7 +222,7 @@ describe('{{body_class}} helper', function () {
                 {relativeUrl: '/my-awesome-post/', post: {tags: [{slug: 'foo'}, {slug: 'bar'}]}}
             );
 
-            rendered.string.should.equal('post-template tag-foo tag-bar');
+            assert.equal(rendered.string, 'post-template tag-foo tag-bar');
         });
 
         it('includes custom font classes for home page when set in options data object', function () {
@@ -234,7 +235,7 @@ describe('{{body_class}} helper', function () {
                 {relativeUrl: '/'}
             );
 
-            rendered.string.should.equal('home-template gh-font-heading-space-grotesk');
+            assert.equal(rendered.string, 'home-template gh-font-heading-space-grotesk');
         });
 
         it('does not inject custom fonts when preview is set and default font was selected (empty string)', function () {
@@ -251,7 +252,7 @@ describe('{{body_class}} helper', function () {
                 {relativeUrl: '/'}
             );
 
-            rendered.string.should.equal('home-template');
+            assert.equal(rendered.string, 'home-template');
         });
 
         it('can handle preview being set and custom font keys missing', function () {
@@ -265,7 +266,7 @@ describe('{{body_class}} helper', function () {
                 {relativeUrl: '/my-awesome-post/', post: {tags: [{slug: 'foo'}, {slug: 'bar'}]}}
             );
 
-            rendered.string.should.equal('post-template tag-foo tag-bar');
+            assert.equal(rendered.string, 'post-template tag-foo tag-bar');
         });
     });
 });

--- a/ghost/core/test/unit/frontend/helpers/cancel-link.test.js
+++ b/ghost/core/test/unit/frontend/helpers/cancel-link.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const hbs = require('../../../../core/frontend/services/theme-engine/engine');
@@ -51,7 +52,7 @@ describe('{{cancel_link}} helper', function () {
         should.exist(rendered);
 
         rendered.string.should.match(defaultLinkClass);
-        rendered.string.should.match(/data-members-cancel-subscription="sub_cancel"/);
+        assert.match(rendered.string, /data-members-cancel-subscription="sub_cancel"/);
         rendered.string.should.match(defaultCancelLinkText);
 
         rendered.string.should.match(defaultErrorElementClass);
@@ -65,7 +66,7 @@ describe('{{cancel_link}} helper', function () {
         should.exist(rendered);
 
         rendered.string.should.match(defaultLinkClass);
-        rendered.string.should.match(/data-members-continue-subscription="sub_continue"/);
+        assert.match(rendered.string, /data-members-continue-subscription="sub_continue"/);
         rendered.string.should.match(defaultContinueLinkText);
     });
 
@@ -80,7 +81,7 @@ describe('{{cancel_link}} helper', function () {
         });
         should.exist(rendered);
 
-        rendered.string.should.match(/custom-link-class/);
+        assert.match(rendered.string, /custom-link-class/);
     });
 
     it('can render custom error class', function () {
@@ -94,7 +95,7 @@ describe('{{cancel_link}} helper', function () {
         });
         should.exist(rendered);
 
-        rendered.string.should.match(/custom-error-class/);
+        assert.match(rendered.string, /custom-error-class/);
     });
 
     it('can render custom cancel subscription link attributes', function () {
@@ -108,7 +109,7 @@ describe('{{cancel_link}} helper', function () {
         });
         should.exist(rendered);
 
-        rendered.string.should.match(/custom cancel link text/);
+        assert.match(rendered.string, /custom cancel link text/);
     });
 
     it('can render custom continue subscription link attributes', function () {
@@ -122,7 +123,7 @@ describe('{{cancel_link}} helper', function () {
         });
         should.exist(rendered);
 
-        rendered.string.should.match(/custom continue link text/);
+        assert.match(rendered.string, /custom continue link text/);
     });
 
     it('is disabled if labs flag is not set', function () {
@@ -136,8 +137,8 @@ describe('{{cancel_link}} helper', function () {
 
         should.exist(rendered);
 
-        rendered.string.should.match(/^<script/);
-        rendered.string.should.match(/helper is not available/);
+        assert.match(rendered.string, /^<script/);
+        assert.match(rendered.string, /helper is not available/);
 
         sinon.assert.calledOnce(loggingStub);
     });

--- a/ghost/core/test/unit/frontend/helpers/comments.test.js
+++ b/ghost/core/test/unit/frontend/helpers/comments.test.js
@@ -57,18 +57,18 @@ describe('{{comments}} helper', function () {
             }
         });
         should.exist(rendered);
-        rendered.string.should.containEql('<script defer src="https://cdn.jsdelivr.net/ghost/comments-ui');
-        rendered.string.should.containEql('data-ghost-comments="http://127.0.0.1:2369/"');
-        rendered.string.should.containEql('data-api="http://127.0.0.1:2369/ghost/api/content/"');
-        rendered.string.should.containEql('data-admin="http://127.0.0.1:2369/ghost/"');
-        rendered.string.should.containEql('data-key="xyz"');
-        rendered.string.should.containEql('data-title="null"');
-        rendered.string.should.containEql('data-count="true"');
-        rendered.string.should.containEql('data-post-id="post_id_123"');
-        rendered.string.should.containEql('data-color-scheme="auto"');
-        rendered.string.should.containEql('data-avatar-saturation="60"');
-        rendered.string.should.containEql('data-accent-color=""');
-        rendered.string.should.containEql('data-comments-enabled="all"');
+        assert(rendered.string.includes('<script defer src="https://cdn.jsdelivr.net/ghost/comments-ui'));
+        assert(rendered.string.includes('data-ghost-comments="http://127.0.0.1:2369/"'));
+        assert(rendered.string.includes('data-api="http://127.0.0.1:2369/ghost/api/content/"'));
+        assert(rendered.string.includes('data-admin="http://127.0.0.1:2369/ghost/"'));
+        assert(rendered.string.includes('data-key="xyz"'));
+        assert(rendered.string.includes('data-title="null"'));
+        assert(rendered.string.includes('data-count="true"'));
+        assert(rendered.string.includes('data-post-id="post_id_123"'));
+        assert(rendered.string.includes('data-color-scheme="auto"'));
+        assert(rendered.string.includes('data-avatar-saturation="60"'));
+        assert(rendered.string.includes('data-accent-color=""'));
+        assert(rendered.string.includes('data-comments-enabled="all"'));
     });
 
     it('returns a script tag for paid only commenting', async function () {
@@ -86,18 +86,18 @@ describe('{{comments}} helper', function () {
             }
         });
         should.exist(rendered);
-        rendered.string.should.containEql('<script defer src="https://cdn.jsdelivr.net/ghost/comments-ui');
-        rendered.string.should.containEql('data-ghost-comments="http://127.0.0.1:2369/"');
-        rendered.string.should.containEql('data-api="http://127.0.0.1:2369/ghost/api/content/"');
-        rendered.string.should.containEql('data-admin="http://127.0.0.1:2369/ghost/"');
-        rendered.string.should.containEql('data-key="xyz"');
-        rendered.string.should.containEql('data-title="null"');
-        rendered.string.should.containEql('data-count="true"');
-        rendered.string.should.containEql('data-post-id="post_id_123"');
-        rendered.string.should.containEql('data-color-scheme="auto"');
-        rendered.string.should.containEql('data-avatar-saturation="60"');
-        rendered.string.should.containEql('data-accent-color=""');
-        rendered.string.should.containEql('data-comments-enabled="paid"');
+        assert(rendered.string.includes('<script defer src="https://cdn.jsdelivr.net/ghost/comments-ui'));
+        assert(rendered.string.includes('data-ghost-comments="http://127.0.0.1:2369/"'));
+        assert(rendered.string.includes('data-api="http://127.0.0.1:2369/ghost/api/content/"'));
+        assert(rendered.string.includes('data-admin="http://127.0.0.1:2369/ghost/"'));
+        assert(rendered.string.includes('data-key="xyz"'));
+        assert(rendered.string.includes('data-title="null"'));
+        assert(rendered.string.includes('data-count="true"'));
+        assert(rendered.string.includes('data-post-id="post_id_123"'));
+        assert(rendered.string.includes('data-color-scheme="auto"'));
+        assert(rendered.string.includes('data-avatar-saturation="60"'));
+        assert(rendered.string.includes('data-accent-color=""'));
+        assert(rendered.string.includes('data-comments-enabled="paid"'));
     });
 
     it('returns undefined when comments are disabled', async function () {

--- a/ghost/core/test/unit/frontend/helpers/content-api-url.test.js
+++ b/ghost/core/test/unit/frontend/helpers/content-api-url.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const configUtils = require('../../../utils/config-utils');
@@ -28,24 +29,21 @@ describe('{{content_api_url}} helper', function () {
 
         it('should output an absolute url', async function () {
             let result = content_api_url();
-            const rendered = new String(result);
-            should.exist(rendered);
-            rendered.should.equal('https://admin.tld:65535/ghost/api/content/');
-            logWarnStub.called.should.be.false();
+            const rendered = String(result);
+            assert.equal(rendered, 'https://admin.tld:65535/ghost/api/content/');
+            assert.equal(logWarnStub.called, false);
         });
         it('should output an absolute url when passed true', async function () {
             let result = content_api_url(true);
-            const rendered = new String(result);
-            should.exist(rendered);
-            rendered.should.equal('https://admin.tld:65535/ghost/api/content/');
-            logWarnStub.called.should.be.false();
+            const rendered = String(result);
+            assert.equal(rendered, 'https://admin.tld:65535/ghost/api/content/');
+            assert.equal(logWarnStub.called, false);
         });
         it('should output a relative url when passed false', async function () {
             let result = content_api_url(false);
-            const rendered = new String(result);
-            should.exist(rendered);
-            rendered.should.equal('/ghost/api/content/');
-            logWarnStub.called.should.be.false();
+            const rendered = String(result);
+            assert.equal(rendered, '/ghost/api/content/');
+            assert.equal(logWarnStub.called, false);
         });
     });
     describe('with a sub-directory', function () {
@@ -59,24 +57,21 @@ describe('{{content_api_url}} helper', function () {
 
         it('should output an absolute url', async function () {
             let result = content_api_url();
-            const rendered = new String(result);
-            should.exist(rendered);
-            rendered.should.equal('https://admin.tld:65535/blog/ghost/api/content/');
-            logWarnStub.called.should.be.false();
+            const rendered = String(result);
+            assert.equal(rendered, 'https://admin.tld:65535/blog/ghost/api/content/');
+            assert.equal(logWarnStub.called, false);
         });
         it('should output an absolute url when passed true', async function () {
             let result = content_api_url(true);
-            const rendered = new String(result);
-            should.exist(rendered);
-            rendered.should.equal('https://admin.tld:65535/blog/ghost/api/content/');
-            logWarnStub.called.should.be.false();
+            const rendered = String(result);
+            assert.equal(rendered, 'https://admin.tld:65535/blog/ghost/api/content/');
+            assert.equal(logWarnStub.called, false);
         });
         it('should output a relative url when passed false', async function () {
             let result = content_api_url(false);
-            const rendered = new String(result);
-            should.exist(rendered);
-            rendered.should.equal('/blog/ghost/api/content/');
-            logWarnStub.called.should.be.false();
+            const rendered = String(result);
+            assert.equal(rendered, '/blog/ghost/api/content/');
+            assert.equal(logWarnStub.called, false);
         });
     });
     describe('uses the site url if no admin:url is set', function () {
@@ -90,18 +85,16 @@ describe('{{content_api_url}} helper', function () {
 
         it('gives the site url without a subdirectory', async function () {
             let result = content_api_url();
-            const rendered = new String(result);
-            should.exist(rendered);
-            rendered.should.equal('http://localhost:65535/ghost/api/content/');
-            logWarnStub.called.should.be.false();
+            const rendered = String(result);
+            assert.equal(rendered, 'http://localhost:65535/ghost/api/content/');
+            assert.equal(logWarnStub.called, false);
         });
         it('gives the site url with a subdirectory', async function () {
             configUtils.set({url: 'http://localhost:65535/blog', 'admin:url': undefined});
             let result = content_api_url();
-            const rendered = new String(result);
-            should.exist(rendered);
-            rendered.should.equal('http://localhost:65535/blog/ghost/api/content/');
-            logWarnStub.called.should.be.false();
+            const rendered = String(result);
+            assert.equal(rendered, 'http://localhost:65535/blog/ghost/api/content/');
+            assert.equal(logWarnStub.called, false);
         });
     });
 });

--- a/ghost/core/test/unit/frontend/helpers/content.test.js
+++ b/ghost/core/test/unit/frontend/helpers/content.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const hbs = require('../../../../core/frontend/services/theme-engine/engine');
 const configUtils = require('../../../utils/config-utils');
@@ -22,7 +23,7 @@ describe('{{content}} helper', function () {
         const rendered = content.call({html: html});
 
         should.exist(rendered);
-        rendered.string.should.equal('');
+        assert.equal(rendered.string, '');
     });
 
     it('can render content', function () {
@@ -45,7 +46,7 @@ describe('{{content}} helper', function () {
         );
 
         should.exist(rendered);
-        rendered.string.should.equal('<p>Hello <strong>World!</strong></p>');
+        assert.equal(rendered.string, '<p>Hello <strong>World!</strong></p>');
     });
 
     it('can truncate html to 0 words', function () {
@@ -60,7 +61,7 @@ describe('{{content}} helper', function () {
         );
 
         should.exist(rendered);
-        rendered.string.should.equal('');
+        assert.equal(rendered.string, '');
     });
 
     it('can truncate html by character', function () {
@@ -75,7 +76,7 @@ describe('{{content}} helper', function () {
         );
 
         should.exist(rendered);
-        rendered.string.should.equal('<p>Hello <strong>Wo</strong></p>');
+        assert.equal(rendered.string, '<p>Hello <strong>Wo</strong></p>');
     });
 });
 
@@ -105,10 +106,10 @@ describe('{{content}} helper with no access', function () {
     it('can render default template', function () {
         const html = '';
         const rendered = content.call({html: html, access: false}, optionsData);
-        rendered.string.should.containEql('gh-post-upgrade-cta');
-        rendered.string.should.containEql('gh-post-upgrade-cta-content');
-        rendered.string.should.containEql('"background-color: #abcdef"');
-        rendered.string.should.containEql('"color:#abcdef"');
+        assert(rendered.string.includes('gh-post-upgrade-cta'));
+        assert(rendered.string.includes('gh-post-upgrade-cta-content'));
+        assert(rendered.string.includes('"background-color: #abcdef"'));
+        assert(rendered.string.includes('"color:#abcdef"'));
 
         should.exist(rendered);
     });
@@ -117,10 +118,10 @@ describe('{{content}} helper with no access', function () {
         // html will be included when there is free content available
         const html = 'Free content';
         const rendered = content.call({html: html, access: false}, optionsData);
-        rendered.string.should.containEql('Free content');
-        rendered.string.should.containEql('gh-post-upgrade-cta');
-        rendered.string.should.containEql('gh-post-upgrade-cta-content');
-        rendered.string.should.containEql('"background-color: #abcdef"');
+        assert(rendered.string.includes('Free content'));
+        assert(rendered.string.includes('gh-post-upgrade-cta'));
+        assert(rendered.string.includes('gh-post-upgrade-cta-content'));
+        assert(rendered.string.includes('"background-color: #abcdef"'));
     });
 
     it('can render default template with right message for post resource', function () {
@@ -130,11 +131,11 @@ describe('{{content}} helper with no access', function () {
             post: {}
         };
         const rendered = content.call({html: html, access: false, visibility: 'members'}, optionsData);
-        rendered.string.should.containEql('Free content');
-        rendered.string.should.containEql('gh-post-upgrade-cta');
-        rendered.string.should.containEql('gh-post-upgrade-cta-content');
-        rendered.string.should.containEql('"background-color: #abcdef"');
-        rendered.string.should.containEql('This post is for');
+        assert(rendered.string.includes('Free content'));
+        assert(rendered.string.includes('gh-post-upgrade-cta'));
+        assert(rendered.string.includes('gh-post-upgrade-cta-content'));
+        assert(rendered.string.includes('"background-color: #abcdef"'));
+        assert(rendered.string.includes('This post is for'));
     });
 
     it('can render default template with right message for page resource', function () {
@@ -144,11 +145,11 @@ describe('{{content}} helper with no access', function () {
             context: ['page']
         };
         const rendered = content.call({html: html, access: false, visibility: 'members'}, optionsData);
-        rendered.string.should.containEql('Free content');
-        rendered.string.should.containEql('gh-post-upgrade-cta');
-        rendered.string.should.containEql('gh-post-upgrade-cta-content');
-        rendered.string.should.containEql('"background-color: #abcdef"');
-        rendered.string.should.containEql('This page is for');
+        assert(rendered.string.includes('Free content'));
+        assert(rendered.string.includes('gh-post-upgrade-cta'));
+        assert(rendered.string.includes('gh-post-upgrade-cta-content'));
+        assert(rendered.string.includes('"background-color: #abcdef"'));
+        assert(rendered.string.includes('This page is for'));
     });
 
     it('can render default template for upgrade case', function () {
@@ -158,9 +159,9 @@ describe('{{content}} helper with no access', function () {
             id: '123'
         };
         const rendered = content.call({html: html, access: false, visibility: 'members'}, optionsData);
-        rendered.string.should.containEql('Free content');
-        rendered.string.should.containEql('Upgrade your account');
-        rendered.string.should.containEql('color:#abcdef');
+        assert(rendered.string.includes('Free content'));
+        assert(rendered.string.includes('Upgrade your account'));
+        assert(rendered.string.includes('color:#abcdef'));
     });
 });
 
@@ -180,9 +181,9 @@ describe('{{content}} helper with custom template', function () {
     it('can render custom template', function () {
         const html = 'Hello World';
         const rendered = content.call({html: html, access: false}, optionsData);
-        rendered.string.should.not.containEql('gh-post-upgrade-cta');
-        rendered.string.should.containEql('custom-post-upgrade-cta');
-        rendered.string.should.containEql('custom-post-upgrade-cta-content');
+        assert(!rendered.string.includes('gh-post-upgrade-cta'));
+        assert(rendered.string.includes('custom-post-upgrade-cta'));
+        assert(rendered.string.includes('custom-post-upgrade-cta-content'));
 
         should.exist(rendered);
     });
@@ -197,9 +198,9 @@ describe('{{content}} helper with custom template', function () {
                 }
             }
         });
-        rendered.string.should.not.containEql('gh-post-upgrade-cta');
-        rendered.string.should.containEql('custom-post-upgrade-cta');
-        rendered.string.should.containEql('custom-post-upgrade-cta-content');
-        rendered.string.should.containEql('This page is for');
+        assert(!rendered.string.includes('gh-post-upgrade-cta'));
+        assert(rendered.string.includes('custom-post-upgrade-cta'));
+        assert(rendered.string.includes('custom-post-upgrade-cta-content'));
+        assert(rendered.string.includes('This page is for'));
     });
 });

--- a/ghost/core/test/unit/frontend/helpers/date.test.js
+++ b/ghost/core/test/unit/frontend/helpers/date.test.js
@@ -155,7 +155,7 @@ describe('{{date}} helper', function () {
         // No date falls back to now
         rendered = date.call({}, context);
         should.exist(rendered);
-        String(rendered).should.equal('a few seconds ago');
+        assert.equal(String(rendered), 'a few seconds ago');
     });
 
     it('ignores an invalid date, defaulting to now', function () {
@@ -178,12 +178,12 @@ describe('{{date}} helper', function () {
         rendered = date.call({published_at: invalidDate}, context);
 
         should.exist(rendered);
-        String(rendered).should.equal('a few seconds ago');
+        assert.equal(String(rendered), 'a few seconds ago');
 
         rendered = date.call({}, invalidDate, context);
 
         should.exist(rendered);
-        String(rendered).should.equal('a few seconds ago');
+        assert.equal(String(rendered), 'a few seconds ago');
     });
 
     it('allows user to override the site\'s locale and timezone', function () {
@@ -201,18 +201,18 @@ describe('{{date}} helper', function () {
 
         // Using the site locale by default, none specified in hash
         const published_at = '2013-12-31T23:58:58.593+02:00';
-        String(date.call({published_at}, context)).should.equal('水, 01 1月 2014 06:58:58 +0900');
+        assert.equal(String(date.call({published_at}, context)), '水, 01 1月 2014 06:58:58 +0900');
 
         // Overriding the site locale and timezone in hash
         context.hash.timezone = 'Europe/Paris';
         context.hash.locale = 'fr-fr';
-        String(date.call({published_at}, context)).should.equal('mar., 31 déc. 2013 22:58:58 +0100');
+        assert.equal(String(date.call({published_at}, context)), 'mar., 31 déc. 2013 22:58:58 +0100');
 
         context.hash.timezone = 'Europe/Moscow';
         context.hash.locale = 'ru-ru';
-        String(date.call({published_at}, context)).should.equal('ср, 01 янв. 2014 01:58:58 +0400');
+        assert.equal(String(date.call({published_at}, context)), 'ср, 01 янв. 2014 01:58:58 +0400');
 
         context.hash.locale = 'en-us';
-        String(date.call({published_at}, context)).should.equal('Wed, 01 Jan 2014 01:58:58 +0400');
+        assert.equal(String(date.call({published_at}, context)), 'Wed, 01 Jan 2014 01:58:58 +0400');
     });
 });

--- a/ghost/core/test/unit/frontend/helpers/facebook-url.test.js
+++ b/ghost/core/test/unit/frontend/helpers/facebook-url.test.js
@@ -14,20 +14,19 @@ describe('{{facebook_url}} helper', function () {
     it('should output the facebook url for @site, if no other facebook username is provided', function () {
         options.data.site = {facebook: 'hey'};
 
-        facebook_url.call({}, options).should.equal('https://www.facebook.com/hey');
+        assert.equal(facebook_url.call({}, options), 'https://www.facebook.com/hey');
     });
 
     it('should output the facebook url for the local object, if it has one', function () {
         options.data.site = {facebook: 'hey'};
 
-        facebook_url.call({facebook: 'you/there'}, options).should.equal('https://www.facebook.com/you/there');
+        assert.equal(facebook_url.call({facebook: 'you/there'}, options), 'https://www.facebook.com/you/there');
     });
 
     it('should output the facebook url for the provided username when it is explicitly passed in', function () {
         options.data.site = {facebook: 'hey'};
 
-        facebook_url.call({facebook: 'you/there'}, 'i/see/you/over/there', options)
-            .should.equal('https://www.facebook.com/i/see/you/over/there');
+        assert.equal(facebook_url.call({facebook: 'you/there'}, 'i/see/you/over/there', options), 'https://www.facebook.com/i/see/you/over/there');
     });
 
     it('should return null if there are no facebook usernames', function () {

--- a/ghost/core/test/unit/frontend/helpers/foreach.test.js
+++ b/ghost/core/test/unit/frontend/helpers/foreach.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const _ = require('lodash');
@@ -46,12 +47,12 @@ describe('{{#foreach}} helper', function () {
 
             runTest(_this, context, options);
 
-            options.fn.called.should.be.true();
+            assert.equal(options.fn.called, true);
             options.fn.getCalls().length.should.eql(_.size(context));
 
             _.each(context, function (value, index) {
                 options.fn.getCall(index).args[0].should.eql(value);
-                should(options.fn.getCall(index).args[1].data).be.undefined();
+                assert.equal(options.fn.getCall(index).args[1].data, undefined);
             });
         });
 
@@ -71,12 +72,12 @@ describe('{{#foreach}} helper', function () {
 
             runTest(_this, context, options);
 
-            options.fn.called.should.be.true();
+            assert.equal(options.fn.called, true);
             options.fn.getCalls().length.should.eql(_.size(context));
 
             _.each(_.keys(context), function (value, index) {
                 options.fn.getCall(index).args[0].should.eql(context[value]);
-                should(options.fn.getCall(index).args[1].data).be.undefined();
+                assert.equal(options.fn.getCall(index).args[1].data, undefined);
             });
         });
 
@@ -97,7 +98,7 @@ describe('{{#foreach}} helper', function () {
 
             runTest(_this, context, options);
 
-            options.fn.called.should.be.true();
+            assert.equal(options.fn.called, true);
             options.fn.getCalls().length.should.eql(_.size(context));
 
             _.each(context, function (value, index) {
@@ -139,7 +140,7 @@ describe('{{#foreach}} helper', function () {
 
             runTest(_this, context, options);
 
-            options.fn.called.should.be.true();
+            assert.equal(options.fn.called, true);
             options.fn.getCalls().length.should.eql(_.size(context));
 
             _.each(_.keys(context), function (value, index) {
@@ -174,7 +175,7 @@ describe('{{#foreach}} helper', function () {
             context = 'hello world this is ghost'.split(' ');
             runTest(_this, context, options);
 
-            options.fn.called.should.be.true();
+            assert.equal(options.fn.called, true);
             options.fn.getCalls().length.should.eql(_.size(context));
 
             _.each(context, function (value, index) {
@@ -216,7 +217,7 @@ describe('{{#foreach}} helper', function () {
 
             runTest(_this, context, options);
 
-            options.fn.called.should.be.true();
+            assert.equal(options.fn.called, true);
             options.fn.getCalls().length.should.eql(_.size(context));
 
             _.each(_.keys(context), function (value, index) {
@@ -243,9 +244,9 @@ describe('{{#foreach}} helper', function () {
 
             runTest(_this, context, options);
 
-            options.fn.called.should.be.false();
-            options.inverse.called.should.be.true();
-            options.inverse.calledOnce.should.be.true();
+            assert.equal(options.fn.called, false);
+            assert.equal(options.inverse.called, true);
+            assert.equal(options.inverse.calledOnce, true);
         });
     });
 

--- a/ghost/core/test/unit/frontend/helpers/get.test.js
+++ b/ghost/core/test/unit/frontend/helpers/get.test.js
@@ -97,7 +97,7 @@ describe('{{#get}} helper', function () {
                 'posts',
                 {hash: {}, data: locals, fn: fn, inverse: inverse}
             ).then(function () {
-                fn.called.should.be.true();
+                assert.equal(fn.called, true);
                 fn.firstCall.args[0].should.be.an.Object().with.property('posts');
 
                 fn.firstCall.args[0].posts[0].feature_image_caption.should.be.an.instanceOf(SafeString);
@@ -126,10 +126,10 @@ describe('{{#get}} helper', function () {
                 'authors',
                 {hash: {}, data: locals, fn: fn, inverse: inverse}
             ).then(function () {
-                fn.called.should.be.true();
+                assert.equal(fn.called, true);
                 fn.firstCall.args[0].should.be.an.Object().with.property('authors');
                 fn.firstCall.args[0].authors.should.eql([]);
-                inverse.called.should.be.false();
+                assert.equal(inverse.called, false);
 
                 done();
             }).catch(done);
@@ -155,10 +155,10 @@ describe('{{#get}} helper', function () {
                 'newsletters',
                 {hash: {}, data: locals, fn: fn, inverse: inverse}
             ).then(function () {
-                fn.called.should.be.true();
+                assert.equal(fn.called, true);
                 fn.firstCall.args[0].should.be.an.Object().with.property('newsletters');
                 fn.firstCall.args[0].newsletters.should.eql([]);
-                inverse.called.should.be.false();
+                assert.equal(inverse.called, false);
 
                 done();
             }).catch(done);
@@ -172,11 +172,11 @@ describe('{{#get}} helper', function () {
                 'magic',
                 {hash: {}, data: locals, fn: fn, inverse: inverse}
             ).then(function () {
-                fn.called.should.be.false();
-                inverse.calledOnce.should.be.true();
+                assert.equal(fn.called, false);
+                assert.equal(inverse.calledOnce, true);
                 inverse.firstCall.args[1].should.be.an.Object().and.have.property('data');
                 inverse.firstCall.args[1].data.should.be.an.Object().and.have.property('error');
-                inverse.firstCall.args[1].data.error.should.eql('Invalid "magic" resource given to get helper');
+                assert.equal(inverse.firstCall.args[1].data.error, 'Invalid "magic" resource given to get helper');
 
                 done();
             }).catch(done);
@@ -188,11 +188,11 @@ describe('{{#get}} helper', function () {
                 'posts',
                 {hash: {slug: 'thing!'}, data: locals, fn: fn, inverse: inverse}
             ).then(function () {
-                fn.called.should.be.false();
-                inverse.calledOnce.should.be.true();
+                assert.equal(fn.called, false);
+                assert.equal(inverse.calledOnce, true);
                 inverse.firstCall.args[1].should.be.an.Object().and.have.property('data');
                 inverse.firstCall.args[1].data.should.be.an.Object().and.have.property('error');
-                inverse.firstCall.args[1].data.error.should.match(/^Validation/);
+                assert.match(inverse.firstCall.args[1].data.error, /^Validation/);
 
                 done();
             }).catch(done);
@@ -204,8 +204,8 @@ describe('{{#get}} helper', function () {
                 'posts',
                 {data: locals}
             ).then(function () {
-                fn.called.should.be.false();
-                inverse.called.should.be.false();
+                assert.equal(fn.called, false);
+                assert.equal(inverse.called, false);
 
                 done();
             }).catch(done);
@@ -240,7 +240,7 @@ describe('{{#get}} helper', function () {
             ).then(function () {
                 browseStub.firstCall.args.should.be.an.Array().with.lengthOf(1);
                 browseStub.firstCall.args[0].should.be.an.Object().with.property('filter');
-                browseStub.firstCall.args[0].filter.should.eql('tags:[test,magic]');
+                assert.equal(browseStub.firstCall.args[0].filter, 'tags:[test,magic]');
 
                 done();
             }).catch(done);
@@ -254,7 +254,7 @@ describe('{{#get}} helper', function () {
             ).then(function () {
                 browseStub.firstCall.args.should.be.an.Array().with.lengthOf(1);
                 browseStub.firstCall.args[0].should.be.an.Object().with.property('filter');
-                browseStub.firstCall.args[0].filter.should.eql('author:cameron');
+                assert.equal(browseStub.firstCall.args[0].filter, 'author:cameron');
 
                 done();
             }).catch(done);
@@ -268,7 +268,7 @@ describe('{{#get}} helper', function () {
             ).then(function () {
                 browseStub.firstCall.args.should.be.an.Array().with.lengthOf(1);
                 browseStub.firstCall.args[0].should.be.an.Object().with.property('filter');
-                browseStub.firstCall.args[0].filter.should.eql('id:-3');
+                assert.equal(browseStub.firstCall.args[0].filter, 'id:-3');
 
                 done();
             }).catch(done);
@@ -282,7 +282,7 @@ describe('{{#get}} helper', function () {
             ).then(function () {
                 browseStub.firstCall.args.should.be.an.Array().with.lengthOf(1);
                 browseStub.firstCall.args[0].should.be.an.Object().with.property('filter');
-                browseStub.firstCall.args[0].filter.should.eql('tags:test');
+                assert.equal(browseStub.firstCall.args[0].filter, 'tags:test');
 
                 done();
             }).catch(done);
@@ -310,7 +310,7 @@ describe('{{#get}} helper', function () {
             ).then(function () {
                 browseStub.firstCall.args.should.be.an.Array().with.lengthOf(1);
                 browseStub.firstCall.args[0].should.be.an.Object().with.property('filter');
-                browseStub.firstCall.args[0].filter.should.eql('id:');
+                assert.equal(browseStub.firstCall.args[0].filter, 'id:');
 
                 done();
             }).catch(done);
@@ -324,7 +324,7 @@ describe('{{#get}} helper', function () {
             ).then(function () {
                 browseStub.firstCall.args.should.be.an.Array().with.lengthOf(1);
                 browseStub.firstCall.args[0].should.be.an.Object().with.property('filter');
-                browseStub.firstCall.args[0].filter.should.eql('slug:bar');
+                assert.equal(browseStub.firstCall.args[0].filter, 'slug:bar');
 
                 done();
             }).catch(done);
@@ -351,7 +351,7 @@ describe('{{#get}} helper', function () {
                 'posts',
                 {hash: {limit: 'all'}, data: locals, fn: fn, inverse: inverse}
             );
-            browseStub.firstCall.args[0].limit.should.eql(100);
+            assert.equal(browseStub.firstCall.args[0].limit, 100);
         });
 
         it('allows "all" when allowLimitAll is true', async function () {
@@ -363,7 +363,7 @@ describe('{{#get}} helper', function () {
                 'posts',
                 {hash: {limit: 'all'}, data: locals, fn: fn, inverse: inverse}
             );
-            browseStub.firstCall.args[0].limit.should.eql('all');
+            assert.equal(browseStub.firstCall.args[0].limit, 'all');
         });
 
         it('caps numeric limits exceeding maxLimit', async function () {
@@ -373,7 +373,7 @@ describe('{{#get}} helper', function () {
                 'posts',
                 {hash: {limit: 150}, data: locals, fn: fn, inverse: inverse}
             );
-            browseStub.firstCall.args[0].limit.should.eql(100);
+            assert.equal(browseStub.firstCall.args[0].limit, 100);
         });
 
         it('leaves numeric limits below maxLimit unchanged', async function () {
@@ -383,7 +383,7 @@ describe('{{#get}} helper', function () {
                 'posts',
                 {hash: {limit: 50}, data: locals, fn: fn, inverse: inverse}
             );
-            browseStub.firstCall.args[0].limit.should.eql(50);
+            assert.equal(browseStub.firstCall.args[0].limit, 50);
         });
 
         it('uses custom maxLimit when configured', async function () {
@@ -395,7 +395,7 @@ describe('{{#get}} helper', function () {
                 'posts',
                 {hash: {limit: 'all'}, data: locals, fn: fn, inverse: inverse}
             );
-            browseStub.firstCall.args[0].limit.should.eql(50);
+            assert.equal(browseStub.firstCall.args[0].limit, 50);
         });
 
         it('caps invalid string limits to maxLimit', async function () {
@@ -405,7 +405,7 @@ describe('{{#get}} helper', function () {
                 'posts',
                 {hash: {limit: 'invalid'}, data: locals, fn: fn, inverse: inverse}
             );
-            browseStub.firstCall.args[0].limit.should.eql(100);
+            assert.equal(browseStub.firstCall.args[0].limit, 100);
         });
     });
 
@@ -466,9 +466,9 @@ describe('{{#get}} helper', function () {
             );
 
             // A log message will be output
-            logging.warn.calledOnce.should.be.true();
+            assert.equal(logging.warn.calledOnce, true);
             // The get helper will return as per usual
-            fn.calledOnce.should.be.true();
+            assert.equal(fn.calledOnce, true);
             fn.firstCall.args[0].should.be.an.Object().with.property('posts');
             fn.firstCall.args[0].posts.should.be.an.Array().with.lengthOf(1);
         });
@@ -484,9 +484,9 @@ describe('{{#get}} helper', function () {
 
             assert(result.toString().includes('data-aborted-get-helper'));
             // A log message will be output
-            logging.error.calledOnce.should.be.true();
+            assert.equal(logging.error.calledOnce, true);
             // The get helper gets called with an empty array of results
-            fn.calledOnce.should.be.true();
+            assert.equal(fn.calledOnce, true);
             fn.firstCall.args[0].should.be.an.Object().with.property('posts');
             fn.firstCall.args[0].posts.should.be.an.Array().with.lengthOf(0);
         });

--- a/ghost/core/test/unit/frontend/helpers/ghost-foot.test.js
+++ b/ghost/core/test/unit/frontend/helpers/ghost-foot.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const ghost_foot = require('../../../../core/frontend/helpers/ghost_foot');
@@ -19,7 +20,7 @@ describe('{{ghost_foot}} helper', function () {
 
         const rendered = ghost_foot({data: {}});
         should.exist(rendered);
-        rendered.string.should.match(/<script>var test = 'I am a variable!'<\/script>/);
+        assert.match(rendered.string, /<script>var test = 'I am a variable!'<\/script>/);
     });
 
     it('outputs post injected code', function () {
@@ -35,8 +36,8 @@ describe('{{ghost_foot}} helper', function () {
             }
         });
         should.exist(rendered);
-        rendered.string.should.match(/<script>var test = 'I am a variable!'<\/script>/);
-        rendered.string.should.match(/post-codeinjection/);
+        assert.match(rendered.string, /<script>var test = 'I am a variable!'<\/script>/);
+        assert.match(rendered.string, /post-codeinjection/);
     });
 
     it('handles post injected code being null', function () {
@@ -52,8 +53,8 @@ describe('{{ghost_foot}} helper', function () {
             }
         });
         should.exist(rendered);
-        rendered.string.should.match(/<script>var test = 'I am a variable!'<\/script>/);
-        rendered.string.should.not.match(/post-codeinjection/);
+        assert.match(rendered.string, /<script>var test = 'I am a variable!'<\/script>/);
+        assert.doesNotMatch(rendered.string, /post-codeinjection/);
     });
 
     it('handles post injected code being empty', function () {
@@ -69,8 +70,8 @@ describe('{{ghost_foot}} helper', function () {
             }
         });
         should.exist(rendered);
-        rendered.string.should.match(/<script>var test = 'I am a variable!'<\/script>/);
-        rendered.string.should.not.match(/post-codeinjection/);
+        assert.match(rendered.string, /<script>var test = 'I am a variable!'<\/script>/);
+        assert.doesNotMatch(rendered.string, /post-codeinjection/);
     });
 
     it('handles global empty code injection', function () {
@@ -78,7 +79,7 @@ describe('{{ghost_foot}} helper', function () {
 
         const rendered = ghost_foot({data: {}});
         should.exist(rendered);
-        rendered.string.should.eql('');
+        assert.equal(rendered.string, '');
     });
 
     it('handles global undefined code injection', function () {
@@ -86,6 +87,6 @@ describe('{{ghost_foot}} helper', function () {
 
         const rendered = ghost_foot({data: {}});
         should.exist(rendered);
-        rendered.string.should.eql('');
+        assert.equal(rendered.string, '');
     });
 });

--- a/ghost/core/test/unit/frontend/helpers/ghost-head.test.js
+++ b/ghost/core/test/unit/frontend/helpers/ghost-head.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 
 const sinon = require('sinon');
@@ -1267,7 +1268,7 @@ describe('{{ghost_head}} helper', function () {
                 }
             }));
 
-            rendered.should.match(/sodo-search@/);
+            assert.match(rendered, /sodo-search@/);
         });
 
         it('includes locale in search', async function () {
@@ -1279,7 +1280,7 @@ describe('{{ghost_head}} helper', function () {
                 }
             }));
 
-            rendered.should.match(/sodo-search@[^>]*?data-locale="en"/);
+            assert.match(rendered, /sodo-search@[^>]*?data-locale="en"/);
         });
     });
 
@@ -1351,7 +1352,7 @@ describe('{{ghost_head}} helper', function () {
                 }
             }));
 
-            rendered.should.match(/script defer src="\/public\/ghost-stats\.min\.js/);
+            assert.match(rendered, /script defer src="\/public\/ghost-stats\.min\.js/);
         });
 
         it('does not include tracker script when web analytics is not enabled', async function () {
@@ -1365,7 +1366,7 @@ describe('{{ghost_head}} helper', function () {
                 }
             }));
 
-            rendered.should.not.match(/script defer src="\/public\/ghost-stats\.min\.js/);
+            assert.doesNotMatch(rendered, /script defer src="\/public\/ghost-stats\.min\.js/);
         });
 
         it('includes tracker script with subdir', async function () {
@@ -1379,7 +1380,7 @@ describe('{{ghost_head}} helper', function () {
                 }
             }));
 
-            rendered.should.match(/script defer src="\/blog\/public\/ghost-stats\.min\.js/);
+            assert.match(rendered, /script defer src="\/blog\/public\/ghost-stats\.min\.js/);
         });
 
         it('with all tb_variables set to undefined on logged out home page', async function () {
@@ -1453,7 +1454,7 @@ describe('{{ghost_head}} helper', function () {
                 }
             }));
 
-            rendered.should.match(/data-datasource="analytics_events"/);
+            assert.match(rendered, /data-datasource="analytics_events"/);
         });
 
         it('does not include tracker script when preview is set', async function () {
@@ -1463,7 +1464,7 @@ describe('{{ghost_head}} helper', function () {
                 }
             }));
 
-            rendered.should.not.match(/script defer src="\/public\/ghost-stats\.min\.js"/);
+            assert.doesNotMatch(rendered, /script defer src="\/public\/ghost-stats\.min\.js"/);
         });
 
         it('uses the provided host/endpoint from config', async function () {
@@ -1475,7 +1476,7 @@ describe('{{ghost_head}} helper', function () {
                 }
             }));
 
-            rendered.should.match(/data-host="https:\/\/e.ghost.org\/tb\/web_analytics"/);
+            assert.match(rendered, /data-host="https:\/\/e.ghost.org\/tb\/web_analytics"/);
         });
 
         it('includes local tracker script when local is set', async function () {
@@ -1489,7 +1490,7 @@ describe('{{ghost_head}} helper', function () {
                 }
             }));
 
-            rendered.should.match(/data-host="http:\/\/localhost:7181\/v0\/events"/);
+            assert.match(rendered, /data-host="http:\/\/localhost:7181\/v0\/events"/);
         });
 
         it('does not include tracker token when it is not set', async function () {
@@ -1502,7 +1503,7 @@ describe('{{ghost_head}} helper', function () {
                 }
             }));
 
-            rendered.should.not.match(/data-token=/);
+            assert.doesNotMatch(rendered, /data-token=/);
         });
 
         it('does not include tracker token when env is production', async function () {
@@ -1516,7 +1517,7 @@ describe('{{ghost_head}} helper', function () {
                 }
             }));
 
-            rendered.should.not.match(/data-token=/);
+            assert.doesNotMatch(rendered, /data-token=/);
         });
 
         it('does not include tracker script in preview context', async function () {
@@ -1527,7 +1528,7 @@ describe('{{ghost_head}} helper', function () {
                     safeVersion: '4.3'
                 }
             }));
-            rendered.should.not.match(/script defer src="\/public\/ghost-stats\.min\.js/);
+            assert.doesNotMatch(rendered, /script defer src="\/public\/ghost-stats\.min\.js/);
         });
     });
 
@@ -1543,9 +1544,9 @@ describe('{{ghost_head}} helper', function () {
                     safeVersion: '4.3'
                 }
             })});
-            rendered.should.match(/portal@/);
-            rendered.should.match(/sodo-search@/);
-            rendered.should.match(/js.stripe.com/);
+            assert.match(rendered, /portal@/);
+            assert.match(rendered, /sodo-search@/);
+            assert.match(rendered, /js.stripe.com/);
         });
         it('when exclude contains search', async function () {
             getStub.withArgs('members_enabled').returns(true);
@@ -1558,9 +1559,9 @@ describe('{{ghost_head}} helper', function () {
                     safeVersion: '4.3'
                 }
             })});
-            rendered.should.not.match(/sodo-search@/);
-            rendered.should.match(/portal@/);
-            rendered.should.match(/js.stripe.com/);
+            assert.doesNotMatch(rendered, /sodo-search@/);
+            assert.match(rendered, /portal@/);
+            assert.match(rendered, /js.stripe.com/);
         });
         it('when exclude contains portal', async function () {
             getStub.withArgs('members_enabled').returns(true);
@@ -1573,9 +1574,9 @@ describe('{{ghost_head}} helper', function () {
                     safeVersion: '4.3'
                 }
             })});
-            rendered.should.match(/sodo-search@/);
-            rendered.should.not.match(/portal@/);
-            rendered.should.match(/js.stripe.com/);
+            assert.match(rendered, /sodo-search@/);
+            assert.doesNotMatch(rendered, /portal@/);
+            assert.match(rendered, /js.stripe.com/);
         });
         it('can handle multiple excludes', async function () {
             getStub.withArgs('members_enabled').returns(true);
@@ -1588,9 +1589,9 @@ describe('{{ghost_head}} helper', function () {
                     safeVersion: '4.3'
                 }
             })});
-            rendered.should.not.match(/sodo-search@/);
-            rendered.should.not.match(/portal@/);
-            rendered.should.match(/js.stripe.com/);
+            assert.doesNotMatch(rendered, /sodo-search@/);
+            assert.doesNotMatch(rendered, /portal@/);
+            assert.match(rendered, /js.stripe.com/);
         });
 
         it('shows the announcement when exclude does not contain announcement', async function () {
@@ -1606,10 +1607,10 @@ describe('{{ghost_head}} helper', function () {
                     safeVersion: '4.3'
                 }
             })});
-            rendered.should.match(/sodo-search@/);
-            rendered.should.match(/portal@/);
-            rendered.should.match(/js.stripe.com/);
-            rendered.should.match(/announcement-bar@/);
+            assert.match(rendered, /sodo-search@/);
+            assert.match(rendered, /portal@/);
+            assert.match(rendered, /js.stripe.com/);
+            assert.match(rendered, /announcement-bar@/);
         });
         it('does not show the announcement when exclude contains announcement', async function () {
             getStub.withArgs('members_enabled').returns(true);
@@ -1624,11 +1625,11 @@ describe('{{ghost_head}} helper', function () {
                     safeVersion: '4.3'
                 }
             })});
-            rendered.should.match(/sodo-search@/);
-            rendered.should.match(/portal@/);
-            rendered.should.match(/js.stripe.com/);
-            rendered.should.match(/generator/);
-            rendered.should.not.match(/announcement-bar@/);
+            assert.match(rendered, /sodo-search@/);
+            assert.match(rendered, /portal@/);
+            assert.match(rendered, /js.stripe.com/);
+            assert.match(rendered, /generator/);
+            assert.doesNotMatch(rendered, /announcement-bar@/);
         });
 
         it('does not load the comments script when exclude contains comment_counts', async function () {
@@ -1640,7 +1641,7 @@ describe('{{ghost_head}} helper', function () {
                     safeVersion: '0.3'
                 }
             })});
-            rendered.should.not.match(/comment-counts.min.js/);
+            assert.doesNotMatch(rendered, /comment-counts.min.js/);
         });
 
         it('loads card assets when not excluded', async function () {
@@ -1654,8 +1655,8 @@ describe('{{ghost_head}} helper', function () {
                     safeVersion: '0.3'
                 }
             })});
-            rendered.should.match(/cards.min.js/);
-            rendered.should.match(/cards.min.css/);
+            assert.match(rendered, /cards.min.js/);
+            assert.match(rendered, /cards.min.css/);
         });
         it('does not load card assets when excluded with card_assets', async function () {
             sinon.stub(cardAssets, 'hasFile').returns(true);
@@ -1666,8 +1667,8 @@ describe('{{ghost_head}} helper', function () {
                     safeVersion: '0.3'
                 }
             })});
-            rendered.should.not.match(/cards.min.js/);
-            rendered.should.not.match(/cards.min.css/);
+            assert.doesNotMatch(rendered, /cards.min.js/);
+            assert.doesNotMatch(rendered, /cards.min.css/);
         });
         it('does not load meta tags when excluded with metadata', async function () {
             let rendered = await testGhostHead({hash: {exclude: 'metadata'}, ...testUtils.createHbsResponse({
@@ -1677,7 +1678,7 @@ describe('{{ghost_head}} helper', function () {
                     safeVersion: '0.3'
                 }
             })});
-            rendered.should.not.match(/<link rel="canonical"/);
+            assert.doesNotMatch(rendered, /<link rel="canonical"/);
         });
         it('does not load schema when excluded with schema', async function () {
             let rendered = await testGhostHead({hash: {exclude: 'schema'}, ...testUtils.createHbsResponse({
@@ -1687,7 +1688,7 @@ describe('{{ghost_head}} helper', function () {
                     safeVersion: '0.3'
                 }
             })});
-            rendered.should.not.match(/<script type="application\/ld\+json"/);
+            assert.doesNotMatch(rendered, /<script type="application\/ld\+json"/);
         });
         it('does not load og: or twitter: attributes when excludd with social_data', async function () {
             let rendered = await testGhostHead({hash: {exclude: 'social_data'}, ...testUtils.createHbsResponse({
@@ -1697,8 +1698,8 @@ describe('{{ghost_head}} helper', function () {
                     safeVersion: '0.3'
                 }
             })});
-            rendered.should.not.match(/<meta property="og:/);
-            rendered.should.not.match(/<meta property="twitter:/);
+            assert.doesNotMatch(rendered, /<meta property="og:/);
+            assert.doesNotMatch(rendered, /<meta property="twitter:/);
         });
         it('does not load cta styles when excluded with cta_styles', async function () {
             getStub.withArgs('members_enabled').returns(true);
@@ -1710,7 +1711,7 @@ describe('{{ghost_head}} helper', function () {
                     safeVersion: '0.3'
                 }
             })});
-            rendered.should.not.match(/.gh-post-upgrade-cta-content/);
+            assert.doesNotMatch(rendered, /.gh-post-upgrade-cta-content/);
         });
     });
 });

--- a/ghost/core/test/unit/frontend/helpers/has.test.js
+++ b/ghost/core/test/unit/frontend/helpers/has.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 
@@ -42,8 +43,8 @@ describe('{{#has}} helper', function () {
             // {{#has tag="invalid, bar, wat"}}
             callHasHelper(thisCtx, {tag: 'invalid, bar, wat'});
 
-            fn.called.should.be.true();
-            inverse.called.should.be.false();
+            assert.equal(fn.called, true);
+            assert.equal(inverse.called, false);
         });
 
         it('should handle tags with case-insensitivity', function () {
@@ -52,8 +53,8 @@ describe('{{#has}} helper', function () {
             // {{#has tag="GhoSt"}}
             callHasHelper(thisCtx, {tag: 'GhoSt'});
 
-            fn.called.should.be.true();
-            inverse.called.should.be.false();
+            assert.equal(fn.called, true);
+            assert.equal(inverse.called, false);
         });
 
         it('should match exact tags, not superstrings', function () {
@@ -61,8 +62,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {tag: 'magic'});
 
-            fn.called.should.be.false();
-            inverse.called.should.be.true();
+            assert.equal(fn.called, false);
+            assert.equal(inverse.called, true);
         });
 
         it('should match exact tags, not substrings', function () {
@@ -70,8 +71,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {tag: 'magical'});
 
-            fn.called.should.be.false();
-            inverse.called.should.be.true();
+            assert.equal(fn.called, false);
+            assert.equal(inverse.called, true);
         });
 
         it('should handle tag list that validates false', function () {
@@ -79,8 +80,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {tag: 'much, such, wow'});
 
-            fn.called.should.be.false();
-            inverse.called.should.be.true();
+            assert.equal(fn.called, false);
+            assert.equal(inverse.called, true);
         });
 
         it('should not do anything if there are no attributes', function () {
@@ -88,8 +89,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx);
 
-            fn.called.should.be.false();
-            inverse.called.should.be.false();
+            assert.equal(fn.called, false);
+            assert.equal(inverse.called, false);
         });
 
         it('should not do anything when an invalid attribute is given', function () {
@@ -97,8 +98,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {invalid: 'nonsense'});
 
-            fn.called.should.be.false();
-            inverse.called.should.be.false();
+            assert.equal(fn.called, false);
+            assert.equal(inverse.called, false);
         });
 
         it('count:0', function () {
@@ -106,8 +107,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {tag: 'count:0'});
 
-            fn.called.should.be.false();
-            inverse.called.should.be.true();
+            assert.equal(fn.called, false);
+            assert.equal(inverse.called, true);
         });
 
         it('count:3', function () {
@@ -115,8 +116,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {tag: 'count:3'});
 
-            fn.called.should.be.true();
-            inverse.called.should.be.false();
+            assert.equal(fn.called, true);
+            assert.equal(inverse.called, false);
         });
 
         it('count:11', function () {
@@ -124,8 +125,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {tag: 'count:11'});
 
-            fn.called.should.be.false();
-            inverse.called.should.be.true();
+            assert.equal(fn.called, false);
+            assert.equal(inverse.called, true);
         });
 
         it('count:>3', function () {
@@ -133,8 +134,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {tag: 'count:>3'});
 
-            fn.called.should.be.false();
-            inverse.called.should.be.true();
+            assert.equal(fn.called, false);
+            assert.equal(inverse.called, true);
         });
 
         it('count:>2', function () {
@@ -142,8 +143,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {tag: 'count:>2'});
 
-            fn.called.should.be.true();
-            inverse.called.should.be.false();
+            assert.equal(fn.called, true);
+            assert.equal(inverse.called, false);
         });
 
         it('count:<1', function () {
@@ -151,8 +152,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {tag: 'count:<1'});
 
-            fn.called.should.be.false();
-            inverse.called.should.be.true();
+            assert.equal(fn.called, false);
+            assert.equal(inverse.called, true);
         });
 
         it('count:<3', function () {
@@ -160,8 +161,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {tag: 'count:<3'});
 
-            fn.called.should.be.true();
-            inverse.called.should.be.false();
+            assert.equal(fn.called, true);
+            assert.equal(inverse.called, false);
         });
     });
 
@@ -171,8 +172,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {author: 'joe, sam, pat'});
 
-            fn.called.should.be.true();
-            inverse.called.should.be.false();
+            assert.equal(fn.called, true);
+            assert.equal(inverse.called, false);
         });
 
         it('should handle author list that evaluates to false', function () {
@@ -180,8 +181,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {author: 'joe, sam, pat'});
 
-            fn.called.should.be.false();
-            inverse.called.should.be.true();
+            assert.equal(fn.called, false);
+            assert.equal(inverse.called, true);
         });
 
         it('should handle authors with case-insensitivity', function () {
@@ -189,8 +190,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {author: 'joe, sAm, pat'});
 
-            fn.called.should.be.true();
-            inverse.called.should.be.false();
+            assert.equal(fn.called, true);
+            assert.equal(inverse.called, false);
         });
 
         it('should handle tags and authors like an OR query (pass)', function () {
@@ -198,8 +199,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {author: 'joe, sam, pat', tag: 'much, such, wow'});
 
-            fn.called.should.be.true();
-            inverse.called.should.be.false();
+            assert.equal(fn.called, true);
+            assert.equal(inverse.called, false);
         });
 
         it('should handle tags and authors like an OR query when match both author and tag (pass)', function () {
@@ -207,8 +208,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {author: 'joe, sam, pat', tag: 'much, such, wow'});
 
-            fn.called.should.be.true();
-            inverse.called.should.be.false();
+            assert.equal(fn.called, true);
+            assert.equal(inverse.called, false);
         });
 
         it('should handle tags and authors like an OR query (fail)', function () {
@@ -216,8 +217,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {author: 'joe, sam, pat', tag: 'much, such, wow'});
 
-            fn.called.should.be.false();
-            inverse.called.should.be.true();
+            assert.equal(fn.called, false);
+            assert.equal(inverse.called, true);
         });
 
         it('count:0', function () {
@@ -225,8 +226,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {author: 'count:0'});
 
-            fn.called.should.be.false();
-            inverse.called.should.be.true();
+            assert.equal(fn.called, false);
+            assert.equal(inverse.called, true);
         });
 
         it('count:1', function () {
@@ -234,8 +235,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {author: 'count:1'});
 
-            fn.called.should.be.true();
-            inverse.called.should.be.false();
+            assert.equal(fn.called, true);
+            assert.equal(inverse.called, false);
         });
 
         it('count:>1 (fail)', function () {
@@ -243,8 +244,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {author: 'count:>1'});
 
-            fn.called.should.be.false();
-            inverse.called.should.be.true();
+            assert.equal(fn.called, false);
+            assert.equal(inverse.called, true);
         });
 
         it('count:>1 (pass)', function () {
@@ -252,8 +253,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {author: 'count:>1'});
 
-            fn.called.should.be.true();
-            inverse.called.should.be.false();
+            assert.equal(fn.called, true);
+            assert.equal(inverse.called, false);
         });
 
         it('count:>2', function () {
@@ -261,8 +262,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {author: 'count:>2'});
 
-            fn.called.should.be.false();
-            inverse.called.should.be.true();
+            assert.equal(fn.called, false);
+            assert.equal(inverse.called, true);
         });
 
         it('count:<1', function () {
@@ -270,8 +271,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {author: 'count:<1'});
 
-            fn.called.should.be.false();
-            inverse.called.should.be.true();
+            assert.equal(fn.called, false);
+            assert.equal(inverse.called, true);
         });
 
         it('count:<3', function () {
@@ -279,8 +280,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {author: 'count:<3'});
 
-            fn.called.should.be.true();
-            inverse.called.should.be.false();
+            assert.equal(fn.called, true);
+            assert.equal(inverse.called, false);
         });
     });
 
@@ -290,8 +291,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {number: '6'});
 
-            fn.called.should.be.true();
-            inverse.called.should.be.false();
+            assert.equal(fn.called, true);
+            assert.equal(inverse.called, false);
         });
 
         it('will match on an exact number (fail)', function () {
@@ -299,8 +300,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {number: '6'});
 
-            fn.called.should.be.false();
-            inverse.called.should.be.true();
+            assert.equal(fn.called, false);
+            assert.equal(inverse.called, true);
         });
 
         it('will match on an exact number (loop)', function () {
@@ -310,9 +311,9 @@ describe('{{#has}} helper', function () {
                 callHasHelper(thisCtx, {number: '6'});
             }
 
-            fn.calledOnce.should.be.true();
-            inverse.called.should.be.true();
-            inverse.callCount.should.eql(7);
+            assert.equal(fn.calledOnce, true);
+            assert.equal(inverse.called, true);
+            assert.equal(inverse.callCount, 7);
         });
 
         it('will match on a number list (pass)', function () {
@@ -320,8 +321,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {number: '1, 3, 6,12'});
 
-            fn.called.should.be.true();
-            inverse.called.should.be.false();
+            assert.equal(fn.called, true);
+            assert.equal(inverse.called, false);
         });
 
         it('will match on a number list (fail)', function () {
@@ -329,8 +330,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {number: '1, 3, 6,12'});
 
-            fn.called.should.be.false();
-            inverse.called.should.be.true();
+            assert.equal(fn.called, false);
+            assert.equal(inverse.called, true);
         });
 
         it('will match on a number list (loop)', function () {
@@ -340,10 +341,10 @@ describe('{{#has}} helper', function () {
                 callHasHelper(thisCtx, {number: '1, 3, 6,12'});
             }
 
-            fn.called.should.be.true();
-            fn.callCount.should.eql(3);
-            inverse.called.should.be.true();
-            inverse.callCount.should.eql(5);
+            assert.equal(fn.called, true);
+            assert.equal(fn.callCount, 3);
+            assert.equal(inverse.called, true);
+            assert.equal(inverse.callCount, 5);
         });
 
         it('will match on a nth pattern (pass)', function () {
@@ -351,8 +352,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {number: 'nth:3'});
 
-            fn.called.should.be.true();
-            inverse.called.should.be.false();
+            assert.equal(fn.called, true);
+            assert.equal(inverse.called, false);
         });
 
         it('will match on a nth pattern (fail)', function () {
@@ -360,8 +361,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {number: 'nth:3'});
 
-            fn.called.should.be.false();
-            inverse.called.should.be.true();
+            assert.equal(fn.called, false);
+            assert.equal(inverse.called, true);
         });
 
         it('will match on a nth pattern (loop)', function () {
@@ -371,10 +372,10 @@ describe('{{#has}} helper', function () {
                 callHasHelper(thisCtx, {number: 'nth:3'});
             }
 
-            fn.called.should.be.true();
-            fn.callCount.should.eql(2);
-            inverse.called.should.be.true();
-            inverse.callCount.should.eql(6);
+            assert.equal(fn.called, true);
+            assert.equal(fn.callCount, 2);
+            assert.equal(inverse.called, true);
+            assert.equal(inverse.callCount, 6);
         });
 
         it('fails gracefully if there is no number property', function () {
@@ -382,8 +383,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {number: 'nth:3'});
 
-            fn.called.should.be.false();
-            inverse.called.should.be.true();
+            assert.equal(fn.called, false);
+            assert.equal(inverse.called, true);
         });
 
         it('fails gracefully if there is no data property', function () {
@@ -391,8 +392,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {number: 'nth:3'});
 
-            fn.called.should.be.false();
-            inverse.called.should.be.true();
+            assert.equal(fn.called, false);
+            assert.equal(inverse.called, true);
         });
     });
 
@@ -402,8 +403,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {index: '6'});
 
-            fn.called.should.be.true();
-            inverse.called.should.be.false();
+            assert.equal(fn.called, true);
+            assert.equal(inverse.called, false);
         });
 
         it('will match on an exact index (fail)', function () {
@@ -411,8 +412,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {index: '6'});
 
-            fn.called.should.be.false();
-            inverse.called.should.be.true();
+            assert.equal(fn.called, false);
+            assert.equal(inverse.called, true);
         });
 
         it('will match on an exact index (loop)', function () {
@@ -422,9 +423,9 @@ describe('{{#has}} helper', function () {
                 callHasHelper(thisCtx, {index: '6'});
             }
 
-            fn.calledOnce.should.be.true();
-            inverse.called.should.be.true();
-            inverse.callCount.should.eql(7);
+            assert.equal(fn.calledOnce, true);
+            assert.equal(inverse.called, true);
+            assert.equal(inverse.callCount, 7);
         });
 
         it('will match on an index list (pass)', function () {
@@ -432,8 +433,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {index: '1, 3, 6,12'});
 
-            fn.called.should.be.true();
-            inverse.called.should.be.false();
+            assert.equal(fn.called, true);
+            assert.equal(inverse.called, false);
         });
 
         it('will match on an index list (fail)', function () {
@@ -441,8 +442,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {index: '1, 3, 6,12'});
 
-            fn.called.should.be.false();
-            inverse.called.should.be.true();
+            assert.equal(fn.called, false);
+            assert.equal(inverse.called, true);
         });
 
         it('will match on an index list (loop)', function () {
@@ -452,10 +453,10 @@ describe('{{#has}} helper', function () {
                 callHasHelper(thisCtx, {index: '1, 3, 6,12'});
             }
 
-            fn.called.should.be.true();
-            fn.callCount.should.eql(3);
-            inverse.called.should.be.true();
-            inverse.callCount.should.eql(5);
+            assert.equal(fn.called, true);
+            assert.equal(fn.callCount, 3);
+            assert.equal(inverse.called, true);
+            assert.equal(inverse.callCount, 5);
         });
 
         it('will match on a nth pattern (pass)', function () {
@@ -463,8 +464,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {index: 'nth:3'});
 
-            fn.called.should.be.true();
-            inverse.called.should.be.false();
+            assert.equal(fn.called, true);
+            assert.equal(inverse.called, false);
         });
 
         it('will match on a nth pattern (fail)', function () {
@@ -472,8 +473,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {index: 'nth:3'});
 
-            fn.called.should.be.false();
-            inverse.called.should.be.true();
+            assert.equal(fn.called, false);
+            assert.equal(inverse.called, true);
         });
 
         it('will match on a nth pattern (loop)', function () {
@@ -483,10 +484,10 @@ describe('{{#has}} helper', function () {
                 callHasHelper(thisCtx, {index: 'nth:3'});
             }
 
-            fn.called.should.be.true();
-            fn.callCount.should.eql(3);
-            inverse.called.should.be.true();
-            inverse.callCount.should.eql(5);
+            assert.equal(fn.called, true);
+            assert.equal(fn.callCount, 3);
+            assert.equal(inverse.called, true);
+            assert.equal(inverse.callCount, 5);
         });
 
         it('fails gracefully if there is no index property', function () {
@@ -494,8 +495,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {index: 'nth:3'});
 
-            fn.called.should.be.false();
-            inverse.called.should.be.true();
+            assert.equal(fn.called, false);
+            assert.equal(inverse.called, true);
         });
     });
 
@@ -506,8 +507,8 @@ describe('{{#has}} helper', function () {
             // {{#has slug="welcome"}}
             callHasHelper(thisCtx, {slug: 'welcome'});
 
-            fn.called.should.be.true();
-            inverse.called.should.be.false();
+            assert.equal(fn.called, true);
+            assert.equal(inverse.called, false);
         });
 
         it('matches on an exact slug (fail)', function () {
@@ -516,8 +517,8 @@ describe('{{#has}} helper', function () {
             // {{#has slug="welcome-to-ghost"}}
             callHasHelper(thisCtx, {slug: 'welcome-to-ghost'});
 
-            fn.called.should.be.false();
-            inverse.called.should.be.true();
+            assert.equal(fn.called, false);
+            assert.equal(inverse.called, true);
         });
 
         it('fails gracefully if there is no slug (fail)', function () {
@@ -526,8 +527,8 @@ describe('{{#has}} helper', function () {
             // {{#has slug="welcome-to-ghost"}}
             callHasHelper(thisCtx, {slug: 'welcome-to-ghost'});
 
-            fn.called.should.be.false();
-            inverse.called.should.be.true();
+            assert.equal(fn.called, false);
+            assert.equal(inverse.called, true);
         });
     });
 
@@ -538,8 +539,8 @@ describe('{{#has}} helper', function () {
             // {{#has visibility="paid"}}
             callHasHelper(thisCtx, {visibility: 'paid'});
 
-            fn.called.should.be.true();
-            inverse.called.should.be.false();
+            assert.equal(fn.called, true);
+            assert.equal(inverse.called, false);
         });
 
         it('matches on an exact visibility (fail)', function () {
@@ -548,8 +549,8 @@ describe('{{#has}} helper', function () {
             // {{#has visibility="members"}}
             callHasHelper(thisCtx, {visibility: 'members'});
 
-            fn.called.should.be.false();
-            inverse.called.should.be.true();
+            assert.equal(fn.called, false);
+            assert.equal(inverse.called, true);
         });
 
         it('fails gracefully if there is no visibility (fail)', function () {
@@ -558,8 +559,8 @@ describe('{{#has}} helper', function () {
             // {{#has visibility="welcome-to-ghost"}}
             callHasHelper(thisCtx, {visibility: 'paid'});
 
-            fn.called.should.be.false();
-            inverse.called.should.be.true();
+            assert.equal(fn.called, false);
+            assert.equal(inverse.called, true);
         });
     });
 
@@ -570,8 +571,8 @@ describe('{{#has}} helper', function () {
             // {{#has id="5981fbed98141579627e9a5a"}}
             callHasHelper(thisCtx, {id: '5981fbed98141579627e9a5a'});
 
-            fn.called.should.be.true();
-            inverse.called.should.be.false();
+            assert.equal(fn.called, true);
+            assert.equal(inverse.called, false);
         });
 
         it('matches on an exact id (fail)', function () {
@@ -580,8 +581,8 @@ describe('{{#has}} helper', function () {
             // {{#has id="5981fbed98141579627e9a5a"}}
             callHasHelper(thisCtx, {id: '5981fbed98141579627e9abc'});
 
-            fn.called.should.be.false();
-            inverse.called.should.be.true();
+            assert.equal(fn.called, false);
+            assert.equal(inverse.called, true);
         });
 
         it('fails gracefully if there is no id (fail)', function () {
@@ -590,8 +591,8 @@ describe('{{#has}} helper', function () {
             // {{#has id="5981fbed98141579627e9a5a"}}
             callHasHelper(thisCtx, {id: '5981fbed98141579627e9abc'});
 
-            fn.called.should.be.false();
-            inverse.called.should.be.true();
+            assert.equal(fn.called, false);
+            assert.equal(inverse.called, true);
         });
     });
 
@@ -606,8 +607,8 @@ describe('{{#has}} helper', function () {
             // {{#has any="twitter"}}
             callHasHelper(thisCtx, {any: 'twitter'});
 
-            fn.called.should.be.true();
-            inverse.called.should.be.false();
+            assert.equal(fn.called, true);
+            assert.equal(inverse.called, false);
         });
 
         it('matches on a single property (fail)', function () {
@@ -620,8 +621,8 @@ describe('{{#has}} helper', function () {
             // {{#has any="facebook"}}
             callHasHelper(thisCtx, {any: 'facebook'});
 
-            fn.called.should.be.false();
-            inverse.called.should.be.true();
+            assert.equal(fn.called, false);
+            assert.equal(inverse.called, true);
         });
 
         it('matches on multiple properties (pass)', function () {
@@ -634,8 +635,8 @@ describe('{{#has}} helper', function () {
             // {{#has any="twitter, facebook,website"}}
             callHasHelper(thisCtx, {any: 'twitter, facebook,website'});
 
-            fn.called.should.be.true();
-            inverse.called.should.be.false();
+            assert.equal(fn.called, true);
+            assert.equal(inverse.called, false);
         });
 
         it('matches on multiple properties (fail)', function () {
@@ -648,8 +649,8 @@ describe('{{#has}} helper', function () {
             // {{#has any="facebook,website, foo"}}
             callHasHelper(thisCtx, {any: 'facebook,website, foo'});
 
-            fn.called.should.be.false();
-            inverse.called.should.be.true();
+            assert.equal(fn.called, false);
+            assert.equal(inverse.called, true);
         });
 
         it('matches on global properties (pass)', function () {
@@ -665,8 +666,8 @@ describe('{{#has}} helper', function () {
             // {{#has any="@site.twitter, @site.facebook,@site.website"}}
             callHasHelper(thisCtx, {any: '@site.twitter, @site.facebook,@site.website'});
 
-            fn.called.should.be.true();
-            inverse.called.should.be.false();
+            assert.equal(fn.called, true);
+            assert.equal(inverse.called, false);
         });
 
         it('matches on global properties (fail)', function () {
@@ -682,8 +683,8 @@ describe('{{#has}} helper', function () {
             // {{#has any="@site.facebook,@site.website, @site.foo"}}
             callHasHelper(thisCtx, {any: '@site.facebook,@site.website, @not.foo'});
 
-            fn.called.should.be.false();
-            inverse.called.should.be.true();
+            assert.equal(fn.called, false);
+            assert.equal(inverse.called, true);
         });
 
         it('matches on path expressions (pass)', function () {
@@ -698,8 +699,8 @@ describe('{{#has}} helper', function () {
             // {{#has any="author.twitter, author.facebook,author.website"}}
             callHasHelper(thisCtx, {any: 'author.twitter, author.facebook,author.website'});
 
-            fn.called.should.be.true();
-            inverse.called.should.be.false();
+            assert.equal(fn.called, true);
+            assert.equal(inverse.called, false);
         });
 
         it('matches on path expressions (fail)', function () {
@@ -714,8 +715,8 @@ describe('{{#has}} helper', function () {
             // {{#has any="author.facebook,author.website, author.foo"}}
             callHasHelper(thisCtx, {any: 'author.facebook,author.website, fred.foo'});
 
-            fn.called.should.be.false();
-            inverse.called.should.be.true();
+            assert.equal(fn.called, false);
+            assert.equal(inverse.called, true);
         });
     });
 
@@ -730,8 +731,8 @@ describe('{{#has}} helper', function () {
             // {{#has all="twitter"}}
             callHasHelper(thisCtx, {all: 'twitter'});
 
-            fn.called.should.be.true();
-            inverse.called.should.be.false();
+            assert.equal(fn.called, true);
+            assert.equal(inverse.called, false);
         });
 
         it('matches on a single property (fail)', function () {
@@ -744,8 +745,8 @@ describe('{{#has}} helper', function () {
             // {{#has all="website"}}
             callHasHelper(thisCtx, {all: 'website'});
 
-            fn.called.should.be.false();
-            inverse.called.should.be.true();
+            assert.equal(fn.called, false);
+            assert.equal(inverse.called, true);
         });
 
         it('matches on multiple properties (pass)', function () {
@@ -758,8 +759,8 @@ describe('{{#has}} helper', function () {
             // {{#has all="twitter, facebook"}}
             callHasHelper(thisCtx, {all: 'twitter, facebook'});
 
-            fn.called.should.be.true();
-            inverse.called.should.be.false();
+            assert.equal(fn.called, true);
+            assert.equal(inverse.called, false);
         });
 
         it('matches on multiple properties (fail)', function () {
@@ -772,8 +773,8 @@ describe('{{#has}} helper', function () {
             // {{#has all="facebook,website, foo"}}
             callHasHelper(thisCtx, {all: 'facebook,website, foo'});
 
-            fn.called.should.be.false();
-            inverse.called.should.be.true();
+            assert.equal(fn.called, false);
+            assert.equal(inverse.called, true);
         });
 
         it('matches on global properties (pass)', function () {
@@ -789,8 +790,8 @@ describe('{{#has}} helper', function () {
             // {{#has all="@site.twitter, @site.facebook"}}
             callHasHelper(thisCtx, {all: '@site.twitter, @site.facebook'});
 
-            fn.called.should.be.true();
-            inverse.called.should.be.false();
+            assert.equal(fn.called, true);
+            assert.equal(inverse.called, false);
         });
 
         it('matches on global properties (fail)', function () {
@@ -806,8 +807,8 @@ describe('{{#has}} helper', function () {
             // {{#has all="@site.facebook,@site.website, @site.foo"}}
             callHasHelper(thisCtx, {all: '@site.facebook,@site.website, @not.foo'});
 
-            fn.called.should.be.false();
-            inverse.called.should.be.true();
+            assert.equal(fn.called, false);
+            assert.equal(inverse.called, true);
         });
 
         it('matches on path expressions (pass)', function () {
@@ -822,8 +823,8 @@ describe('{{#has}} helper', function () {
             // {{#has all="author.twitter, author.facebook"}}
             callHasHelper(thisCtx, {all: 'author.twitter, author.facebook'});
 
-            fn.called.should.be.true();
-            inverse.called.should.be.false();
+            assert.equal(fn.called, true);
+            assert.equal(inverse.called, false);
         });
 
         it('matches on path expressions (fail)', function () {
@@ -838,8 +839,8 @@ describe('{{#has}} helper', function () {
             // {{#has all="author.facebook,author.website, author.foo"}}
             callHasHelper(thisCtx, {all: 'author.facebook,author.website, fred.foo'});
 
-            fn.called.should.be.false();
-            inverse.called.should.be.true();
+            assert.equal(fn.called, false);
+            assert.equal(inverse.called, true);
         });
     });
 });

--- a/ghost/core/test/unit/frontend/helpers/img-url.test.js
+++ b/ghost/core/test/unit/frontend/helpers/img-url.test.js
@@ -31,53 +31,53 @@ describe('{{img_url}} helper', function () {
         it('should output relative url of image', function () {
             const rendered = img_url('/content/images/image-relative-url.png', {});
             should.exist(rendered);
-            rendered.should.equal('/content/images/image-relative-url.png');
-            logWarnStub.called.should.be.false();
+            assert.equal(rendered, '/content/images/image-relative-url.png');
+            assert.equal(logWarnStub.called, false);
         });
 
         it('should output relative url of image if the input is absolute', function () {
             const rendered = img_url('http://localhost:65535/content/images/image-relative-url.png', {});
             should.exist(rendered);
-            rendered.should.equal('/content/images/image-relative-url.png');
-            logWarnStub.called.should.be.false();
+            assert.equal(rendered, '/content/images/image-relative-url.png');
+            assert.equal(logWarnStub.called, false);
         });
 
         it('should output absolute url of image if the option is present ', function () {
             const rendered = img_url('/content/images/image-relative-url.png', {hash: {absolute: 'true'}});
             should.exist(rendered);
-            rendered.should.equal('http://localhost:65535/content/images/image-relative-url.png');
-            logWarnStub.called.should.be.false();
+            assert.equal(rendered, 'http://localhost:65535/content/images/image-relative-url.png');
+            assert.equal(logWarnStub.called, false);
         });
 
         it('should NOT output absolute url of image if the option is "false" ', function () {
             const rendered = img_url('/content/images/image-relative-url.png', {hash: {absolute: 'false'}});
             should.exist(rendered);
-            rendered.should.equal('/content/images/image-relative-url.png');
+            assert.equal(rendered, '/content/images/image-relative-url.png');
         });
 
         it('should output author url', function () {
             const rendered = img_url('/content/images/author-image-relative-url.png', {});
             should.exist(rendered);
-            rendered.should.equal('/content/images/author-image-relative-url.png');
-            logWarnStub.called.should.be.false();
+            assert.equal(rendered, '/content/images/author-image-relative-url.png');
+            assert.equal(logWarnStub.called, false);
         });
 
         it('should have no output if the image attribute is not provided (with warning)', function () {
             const rendered = img_url({hash: {absolute: 'true'}});
             assert.equal(rendered, undefined);
-            logWarnStub.calledOnce.should.be.true();
+            assert.equal(logWarnStub.calledOnce, true);
         });
 
         it('should have no output if the image attribute evaluates to undefined (with warning)', function () {
             const rendered = img_url(undefined, {hash: {absolute: 'true'}});
             assert.equal(rendered, undefined);
-            logWarnStub.calledOnce.should.be.true();
+            assert.equal(logWarnStub.calledOnce, true);
         });
 
         it('should have no output if the image attribute evaluates to null (no waring)', function () {
             const rendered = img_url(null, {hash: {absolute: 'true'}});
             assert.equal(rendered, undefined);
-            logWarnStub.calledOnce.should.be.false();
+            assert.equal(logWarnStub.calledOnce, false);
         });
     });
 
@@ -93,19 +93,19 @@ describe('{{img_url}} helper', function () {
         it('should output relative url of image', function () {
             const rendered = img_url('/blog/content/images/image-relative-url.png', {});
             should.exist(rendered);
-            rendered.should.equal('/blog/content/images/image-relative-url.png');
+            assert.equal(rendered, '/blog/content/images/image-relative-url.png');
         });
 
         it('should output absolute url of image if the option is present ', function () {
             const rendered = img_url('/blog/content/images/image-relative-url.png', {hash: {absolute: 'true'}});
             should.exist(rendered);
-            rendered.should.equal('http://localhost:65535/blog/content/images/image-relative-url.png');
+            assert.equal(rendered, 'http://localhost:65535/blog/content/images/image-relative-url.png');
         });
 
         it('should not change output for an external url', function () {
             const rendered = img_url('http://example.com/picture.jpg', {});
             should.exist(rendered);
-            rendered.should.equal('http://example.com/picture.jpg');
+            assert.equal(rendered, 'http://example.com/picture.jpg');
         });
     });
 
@@ -134,7 +134,7 @@ describe('{{img_url}} helper', function () {
                 }
             });
             should.exist(rendered);
-            rendered.should.equal('/content/images/size/w400/my-coole-img.jpg');
+            assert.equal(rendered, '/content/images/size/w400/my-coole-img.jpg');
         });
 
         it('should output the correct url for protocol relative urls', function () {
@@ -153,7 +153,7 @@ describe('{{img_url}} helper', function () {
                 }
             });
             should.exist(rendered);
-            rendered.should.equal('//website.com/whatever/my-coole-img.jpg');
+            assert.equal(rendered, '//website.com/whatever/my-coole-img.jpg');
         });
 
         it('should output the correct url for relative paths', function () {
@@ -172,7 +172,7 @@ describe('{{img_url}} helper', function () {
                 }
             });
             should.exist(rendered);
-            rendered.should.equal('/content/images/size/w400/my-coole-img.jpg');
+            assert.equal(rendered, '/content/images/size/w400/my-coole-img.jpg');
         });
 
         it('should output the correct url for relative paths without leading slash', function () {
@@ -191,14 +191,14 @@ describe('{{img_url}} helper', function () {
                 }
             });
             should.exist(rendered);
-            rendered.should.equal('content/images/size/w400/my-coole-img.jpg');
+            assert.equal(rendered, 'content/images/size/w400/my-coole-img.jpg');
         });
 
         it('ignores invalid size options', function () {
             const rendered = img_url('/content/images/author-image-relative-url.png', {hash: {size: 'invalid-size'}});
             should.exist(rendered);
-            rendered.should.equal('/content/images/author-image-relative-url.png');
-            logWarnStub.called.should.be.false();
+            assert.equal(rendered, '/content/images/author-image-relative-url.png');
+            assert.equal(logWarnStub.called, false);
         });
 
         it('ignores misconfigured sizes', function () {
@@ -215,8 +215,8 @@ describe('{{img_url}} helper', function () {
                 }
             });
             should.exist(rendered);
-            rendered.should.equal('/content/images/author-image-relative-url.png');
-            logWarnStub.called.should.be.false();
+            assert.equal(rendered, '/content/images/author-image-relative-url.png');
+            assert.equal(logWarnStub.called, false);
         });
 
         it('ignores format if size is missing', function () {
@@ -233,8 +233,8 @@ describe('{{img_url}} helper', function () {
                 }
             });
             should.exist(rendered);
-            rendered.should.equal('/content/images/author-image-relative-url.png');
-            logWarnStub.called.should.be.false();
+            assert.equal(rendered, '/content/images/author-image-relative-url.png');
+            assert.equal(logWarnStub.called, false);
         });
 
         it('adds format and size options', function () {
@@ -252,8 +252,8 @@ describe('{{img_url}} helper', function () {
                 }
             });
             should.exist(rendered);
-            rendered.should.equal('/content/images/size/w600/format/webp/author-image-relative-url.png');
-            logWarnStub.called.should.be.false();
+            assert.equal(rendered, '/content/images/size/w600/format/webp/author-image-relative-url.png');
+            assert.equal(logWarnStub.called, false);
         });
 
         it('ignores invalid formats', function () {
@@ -271,8 +271,8 @@ describe('{{img_url}} helper', function () {
                 }
             });
             should.exist(rendered);
-            rendered.should.equal('/content/images/size/w600/author-image-relative-url.png');
-            logWarnStub.called.should.be.false();
+            assert.equal(rendered, '/content/images/size/w600/author-image-relative-url.png');
+            assert.equal(logWarnStub.called, false);
         });
     });
 
@@ -299,7 +299,7 @@ describe('{{img_url}} helper', function () {
                 }
             });
             should.exist(rendered);
-            rendered.should.equal('https://images.unsplash.com/photo-1657816793628-191deb91e20f?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=MnwxMTc3M3wwfDF8YWxsfDJ8fHx8fHwyfHwxNjU3ODkzNjU5&ixlib=rb-1.2.1&q=80&w=2000');
+            assert.equal(rendered, 'https://images.unsplash.com/photo-1657816793628-191deb91e20f?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=MnwxMTc3M3wwfDF8YWxsfDJ8fHx8fHwyfHwxNjU3ODkzNjU5&ixlib=rb-1.2.1&q=80&w=2000');
         });
 
         it('can change the output width', function () {
@@ -318,7 +318,7 @@ describe('{{img_url}} helper', function () {
                 }
             });
             should.exist(rendered);
-            rendered.should.equal('https://images.unsplash.com/photo-1657816793628-191deb91e20f?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=MnwxMTc3M3wwfDF8YWxsfDJ8fHx8fHwyfHwxNjU3ODkzNjU5&ixlib=rb-1.2.1&q=80&w=400');
+            assert.equal(rendered, 'https://images.unsplash.com/photo-1657816793628-191deb91e20f?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=MnwxMTc3M3wwfDF8YWxsfDJ8fHx8fHwyfHwxNjU3ODkzNjU5&ixlib=rb-1.2.1&q=80&w=400');
         });
 
         it('can change the output height', function () {
@@ -337,7 +337,7 @@ describe('{{img_url}} helper', function () {
                 }
             });
             should.exist(rendered);
-            rendered.should.equal('https://images.unsplash.com/photo-1657816793628-191deb91e20f?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=MnwxMTc3M3wwfDF8YWxsfDJ8fHx8fHwyfHwxNjU3ODkzNjU5&ixlib=rb-1.2.1&q=80&h=400');
+            assert.equal(rendered, 'https://images.unsplash.com/photo-1657816793628-191deb91e20f?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=MnwxMTc3M3wwfDF8YWxsfDJ8fHx8fHwyfHwxNjU3ODkzNjU5&ixlib=rb-1.2.1&q=80&h=400');
         });
 
         it('ignores invalid image size configurations', function () {
@@ -356,7 +356,7 @@ describe('{{img_url}} helper', function () {
                 }
             });
             should.exist(rendered);
-            rendered.should.equal('https://images.unsplash.com/photo-1657816793628-191deb91e20f?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=MnwxMTc3M3wwfDF8YWxsfDJ8fHx8fHwyfHwxNjU3ODkzNjU5&ixlib=rb-1.2.1&q=80');
+            assert.equal(rendered, 'https://images.unsplash.com/photo-1657816793628-191deb91e20f?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=MnwxMTc3M3wwfDF8YWxsfDJ8fHx8fHwyfHwxNjU3ODkzNjU5&ixlib=rb-1.2.1&q=80');
         });
 
         it('ignores invalid urls', function () {
@@ -395,7 +395,7 @@ describe('{{img_url}} helper', function () {
                 }
             });
             should.exist(rendered);
-            rendered.should.equal('https://images.unsplash.com/photo-1657816793628-191deb91e20f?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=MnwxMTc3M3wwfDF8YWxsfDJ8fHx8fHwyfHwxNjU3ODkzNjU5&ixlib=rb-1.2.1&q=80&w=2000');
+            assert.equal(rendered, 'https://images.unsplash.com/photo-1657816793628-191deb91e20f?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=MnwxMTc3M3wwfDF8YWxsfDJ8fHx8fHwyfHwxNjU3ODkzNjU5&ixlib=rb-1.2.1&q=80&w=2000');
         });
 
         it('can change the output format', function () {
@@ -414,7 +414,7 @@ describe('{{img_url}} helper', function () {
                 }
             });
             should.exist(rendered);
-            rendered.should.equal('https://images.unsplash.com/photo-1657816793628-191deb91e20f?crop=entropy&cs=tinysrgb&fit=max&fm=webp&ixid=MnwxMTc3M3wwfDF8YWxsfDJ8fHx8fHwyfHwxNjU3ODkzNjU5&ixlib=rb-1.2.1&q=80&w=2000');
+            assert.equal(rendered, 'https://images.unsplash.com/photo-1657816793628-191deb91e20f?crop=entropy&cs=tinysrgb&fit=max&fm=webp&ixid=MnwxMTc3M3wwfDF8YWxsfDJ8fHx8fHwyfHwxNjU3ODkzNjU5&ixlib=rb-1.2.1&q=80&w=2000');
         });
 
         it('ignores invalid formats', function () {
@@ -433,7 +433,7 @@ describe('{{img_url}} helper', function () {
                 }
             });
             should.exist(rendered);
-            rendered.should.equal('https://images.unsplash.com/photo-1657816793628-191deb91e20f?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=MnwxMTc3M3wwfDF8YWxsfDJ8fHx8fHwyfHwxNjU3ODkzNjU5&ixlib=rb-1.2.1&q=80&w=2000');
+            assert.equal(rendered, 'https://images.unsplash.com/photo-1657816793628-191deb91e20f?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=MnwxMTc3M3wwfDF8YWxsfDJ8fHx8fHwyfHwxNjU3ODkzNjU5&ixlib=rb-1.2.1&q=80&w=2000');
         });
 
         it('transforms jpeg to jpg', function () {
@@ -452,7 +452,7 @@ describe('{{img_url}} helper', function () {
                 }
             });
             should.exist(rendered);
-            rendered.should.equal('https://images.unsplash.com/photo-1657816793628-191deb91e20f?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=MnwxMTc3M3wwfDF8YWxsfDJ8fHx8fHwyfHwxNjU3ODkzNjU5&ixlib=rb-1.2.1&q=80&w=2000');
+            assert.equal(rendered, 'https://images.unsplash.com/photo-1657816793628-191deb91e20f?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=MnwxMTc3M3wwfDF8YWxsfDJ8fHx8fHwyfHwxNjU3ODkzNjU5&ixlib=rb-1.2.1&q=80&w=2000');
         });
 
         it('can change the output format and size', function () {
@@ -472,7 +472,7 @@ describe('{{img_url}} helper', function () {
                 }
             });
             should.exist(rendered);
-            rendered.should.equal('https://images.unsplash.com/photo-1657816793628-191deb91e20f?crop=entropy&cs=tinysrgb&fit=max&fm=webp&ixid=MnwxMTc3M3wwfDF8YWxsfDJ8fHx8fHwyfHwxNjU3ODkzNjU5&ixlib=rb-1.2.1&q=80&w=400');
+            assert.equal(rendered, 'https://images.unsplash.com/photo-1657816793628-191deb91e20f?crop=entropy&cs=tinysrgb&fit=max&fm=webp&ixid=MnwxMTc3M3wwfDF8YWxsfDJ8fHx8fHwyfHwxNjU3ODkzNjU5&ixlib=rb-1.2.1&q=80&w=400');
         });
     });
 });

--- a/ghost/core/test/unit/frontend/helpers/link-class.test.js
+++ b/ghost/core/test/unit/frontend/helpers/link-class.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const concat = require('../../../../core/frontend/helpers/concat');
 const link_class = require('../../../../core/frontend/helpers/link_class');
@@ -44,240 +45,199 @@ describe('{{link_class}} helper', function () {
     });
 
     it('silently accepts an empty for...', function () {
-        compile('{{link_class for=tag.slug}}')
-            .with({tag: null})
-            .should.eql('');
+        assert.equal(compile('{{link_class for=tag.slug}}')
+            .with({tag: null}), '');
     });
 
     it('silently accepts an empty SafeString', function () {
-        compile('{{link_class for=blank_safe_string}}')
-            .with({blank_safe_string: new handlebars.SafeString('')})
-            .should.eql('');
+        assert.equal(compile('{{link_class for=blank_safe_string}}')
+            .with({blank_safe_string: new handlebars.SafeString('')}), '');
     });
 
     describe('activeClass', function () {
         it('gets applied correctly', function () {
             // Test matching relative URL
-            compile('{{link_class for="/about/"}}')
-                .with({relativeUrl: '/about/'})
-                .should.eql('nav-current');
+            assert.equal(compile('{{link_class for="/about/"}}')
+                .with({relativeUrl: '/about/'}), 'nav-current');
 
             // Test non-matching relative URL
-            compile('{{link_class for="/about/"}}')
-                .with({relativeUrl: '/'})
-                .should.eql('');
+            assert.equal(compile('{{link_class for="/about/"}}')
+                .with({relativeUrl: '/'}), '');
         });
 
         it('ignores anchors', function () {
             // Anchor in href
-            compile('{{link_class for="/about/#me"}}')
-                .with({relativeUrl: '/about/'})
-                .should.eql('nav-current');
+            assert.equal(compile('{{link_class for="/about/#me"}}')
+                .with({relativeUrl: '/about/'}), 'nav-current');
 
             // Anchor in relative URL
-            compile('{{link_class for="/about/"}}')
-                .with({relativeUrl: '/about/#me'})
-                .should.eql('nav-current');
+            assert.equal(compile('{{link_class for="/about/"}}')
+                .with({relativeUrl: '/about/#me'}), 'nav-current');
         });
 
         it('handles missing trailing slashes', function () {
-            compile('{{link_class for="/about"}}')
-                .with({relativeUrl: '/about/'})
-                .should.eql('nav-current');
+            assert.equal(compile('{{link_class for="/about"}}')
+                .with({relativeUrl: '/about/'}), 'nav-current');
         });
 
         it('handles absolute URLs', function () {
             // Correct URL gets class
-            compile('{{link_class for="https://siteurl.com/about/"}}')
-                .with({relativeUrl: '/about/'})
-                .should.eql('nav-current');
+            assert.equal(compile('{{link_class for="https://siteurl.com/about/"}}')
+                .with({relativeUrl: '/about/'}), 'nav-current');
 
             // Incorrect URL doesn't get class
-            compile('{{link_class for="https://othersite.com/about/"}}')
-                .with({relativeUrl: '/about/'})
-                .should.eql('');
+            assert.equal(compile('{{link_class for="https://othersite.com/about/"}}')
+                .with({relativeUrl: '/about/'}), '');
         });
 
         it('handles absolute URL with missing trailing slash', function () {
-            compile('{{link_class for="https://siteurl.com/about"}}')
-                .with({relativeUrl: '/about/'})
-                .should.eql('nav-current');
+            assert.equal(compile('{{link_class for="https://siteurl.com/about"}}')
+                .with({relativeUrl: '/about/'}), 'nav-current');
         });
 
         it('activeClass can be customised', function () {
-            compile('{{link_class for="/about/" activeClass="nav-active"}}')
-                .with({relativeUrl: '/about/'})
-                .should.eql('nav-active');
+            assert.equal(compile('{{link_class for="/about/" activeClass="nav-active"}}')
+                .with({relativeUrl: '/about/'}), 'nav-active');
 
-            compile('{{link_class for="/about/" activeClass=slug}}')
-                .with({relativeUrl: '/about/', slug: 'fred'})
-                .should.eql('fred');
+            assert.equal(compile('{{link_class for="/about/" activeClass=slug}}')
+                .with({relativeUrl: '/about/', slug: 'fred'}), 'fred');
 
-            compile('{{link_class for="/about/" activeClass=(concat slug "active" separator="-")}}')
-                .with({relativeUrl: '/about/', slug: 'fred'})
-                .should.eql('fred-active');
+            assert.equal(compile('{{link_class for="/about/" activeClass=(concat slug "active" separator="-")}}')
+                .with({relativeUrl: '/about/', slug: 'fred'}), 'fred-active');
         });
 
         it('activeClass and other classes work together', function () {
             // Single extra class
-            compile('{{link_class for="/about/" class="about"}}')
-                .with({relativeUrl: '/about/'})
-                .should.eql('about nav-current');
+            assert.equal(compile('{{link_class for="/about/" class="about"}}')
+                .with({relativeUrl: '/about/'}), 'about nav-current');
 
             // Multiple extra classes
-            compile('{{link_class for="/about/" class="about my-link"}}')
-                .with({relativeUrl: '/about/'})
-                .should.eql('about my-link nav-current');
+            assert.equal(compile('{{link_class for="/about/" class="about my-link"}}')
+                .with({relativeUrl: '/about/'}), 'about my-link nav-current');
         });
 
         it('can disable activeClass with falsey values', function () {
             // Empty string
-            compile('{{link_class for="/about/" activeClass=""}}')
-                .with({relativeUrl: '/about/'})
-                .should.eql('');
+            assert.equal(compile('{{link_class for="/about/" activeClass=""}}')
+                .with({relativeUrl: '/about/'}), '');
 
             // false
-            compile('{{link_class for="/about/" activeClass=false}}')
-                .with({relativeUrl: '/about/'})
-                .should.eql('');
+            assert.equal(compile('{{link_class for="/about/" activeClass=false}}')
+                .with({relativeUrl: '/about/'}), '');
         });
     });
 
     describe('parentActiveClass', function () {
         it('gets applied correctly', function () {
             // Parent and child links with PARENT as relative URL
-            compile('<li class="{{link_class for="/about/"}}">parent</li><li class="{{link_class for="/about/team/"}}">child</li>')
-                .with({relativeUrl: '/about/'})
-                .should.eql('<li class="nav-current">parent</li><li class="">child</li>');
+            assert.equal(compile('<li class="{{link_class for="/about/"}}">parent</li><li class="{{link_class for="/about/team/"}}">child</li>')
+                .with({relativeUrl: '/about/'}), '<li class="nav-current">parent</li><li class="">child</li>');
 
             // Parent and child links with CHILD as relative URL
-            compile('<li class="{{link_class for="/about/"}}">parent</li><li class="{{link_class for="/about/team/"}}">child</li>')
-                .with({relativeUrl: '/about/team/'})
-                .should.eql('<li class="nav-current-parent">parent</li><li class="nav-current">child</li>');
+            assert.equal(compile('<li class="{{link_class for="/about/"}}">parent</li><li class="{{link_class for="/about/team/"}}">child</li>')
+                .with({relativeUrl: '/about/team/'}), '<li class="nav-current-parent">parent</li><li class="nav-current">child</li>');
         });
 
         it('ignores anchors', function () {
             // Anchor in href
 
             // Parent and child links with PARENT as relative URL
-            compile('<li class="{{link_class for="/about/#me"}}">parent</li><li class="{{link_class for="/about/team/"}}">child</li>')
-                .with({relativeUrl: '/about/'})
-                .should.eql('<li class="nav-current">parent</li><li class="">child</li>');
+            assert.equal(compile('<li class="{{link_class for="/about/#me"}}">parent</li><li class="{{link_class for="/about/team/"}}">child</li>')
+                .with({relativeUrl: '/about/'}), '<li class="nav-current">parent</li><li class="">child</li>');
 
             // Parent and child links with CHILD as relative URL
-            compile('<li class="{{link_class for="/about/#me"}}">parent</li><li class="{{link_class for="/about/team/"}}">child</li>')
-                .with({relativeUrl: '/about/team/'})
-                .should.eql('<li class="nav-current-parent">parent</li><li class="nav-current">child</li>');
+            assert.equal(compile('<li class="{{link_class for="/about/#me"}}">parent</li><li class="{{link_class for="/about/team/"}}">child</li>')
+                .with({relativeUrl: '/about/team/'}), '<li class="nav-current-parent">parent</li><li class="nav-current">child</li>');
 
             // Anchor in relative URL
 
             // Parent and child links with PARENT as relative URL
-            compile('<li class="{{link_class for="/about/"}}">parent</li><li class="{{link_class for="/about/team/"}}">child</li>')
-                .with({relativeUrl: '/about/#me'})
-                .should.eql('<li class="nav-current">parent</li><li class="">child</li>');
+            assert.equal(compile('<li class="{{link_class for="/about/"}}">parent</li><li class="{{link_class for="/about/team/"}}">child</li>')
+                .with({relativeUrl: '/about/#me'}), '<li class="nav-current">parent</li><li class="">child</li>');
 
             // Parent and child links with CHILD as relative URL
-            compile('<li class="{{link_class for="/about/"}}">parent</li><li class="{{link_class for="/about/team/"}}">child</li>')
-                .with({relativeUrl: '/about/team/#me'})
-                .should.eql('<li class="nav-current-parent">parent</li><li class="nav-current">child</li>');
+            assert.equal(compile('<li class="{{link_class for="/about/"}}">parent</li><li class="{{link_class for="/about/team/"}}">child</li>')
+                .with({relativeUrl: '/about/team/#me'}), '<li class="nav-current-parent">parent</li><li class="nav-current">child</li>');
         });
 
         it('handles missing trailing slashes', function () {
             // Parent and child links with PARENT as relative URL
-            compile('<li class="{{link_class for="/about"}}">parent</li><li class="{{link_class for="/about/team"}}">child</li>')
-                .with({relativeUrl: '/about/'})
-                .should.eql('<li class="nav-current">parent</li><li class="">child</li>');
+            assert.equal(compile('<li class="{{link_class for="/about"}}">parent</li><li class="{{link_class for="/about/team"}}">child</li>')
+                .with({relativeUrl: '/about/'}), '<li class="nav-current">parent</li><li class="">child</li>');
 
             // Parent and child links with CHILD as relative URL
-            compile('<li class="{{link_class for="/about"}}">parent</li><li class="{{link_class for="/about/team"}}">child</li>')
-                .with({relativeUrl: '/about/team/'})
-                .should.eql('<li class="nav-current-parent">parent</li><li class="nav-current">child</li>');
+            assert.equal(compile('<li class="{{link_class for="/about"}}">parent</li><li class="{{link_class for="/about/team"}}">child</li>')
+                .with({relativeUrl: '/about/team/'}), '<li class="nav-current-parent">parent</li><li class="nav-current">child</li>');
         });
 
         it('handles absolute URLs', function () {
             // Correct URL gets class
 
             // Parent and child links with PARENT as relative URL
-            compile('<li class="{{link_class for="https://siteurl.com/about/"}}">parent</li><li class="{{link_class for="https://siteurl.com/about/team/"}}">child</li>')
-                .with({relativeUrl: '/about/'})
-                .should.eql('<li class="nav-current">parent</li><li class="">child</li>');
+            assert.equal(compile('<li class="{{link_class for="https://siteurl.com/about/"}}">parent</li><li class="{{link_class for="https://siteurl.com/about/team/"}}">child</li>')
+                .with({relativeUrl: '/about/'}), '<li class="nav-current">parent</li><li class="">child</li>');
 
             // Parent and child links with CHILD as relative URL
-            compile('<li class="{{link_class for="https://siteurl.com/about/"}}">parent</li><li class="{{link_class for="https://siteurl.com/about/team/"}}">child</li>')
-                .with({relativeUrl: '/about/team/'})
-                .should.eql('<li class="nav-current-parent">parent</li><li class="nav-current">child</li>');
+            assert.equal(compile('<li class="{{link_class for="https://siteurl.com/about/"}}">parent</li><li class="{{link_class for="https://siteurl.com/about/team/"}}">child</li>')
+                .with({relativeUrl: '/about/team/'}), '<li class="nav-current-parent">parent</li><li class="nav-current">child</li>');
 
             // Incorrect URL doesn't get class
 
             // Parent and child links with PARENT as relative URL
-            compile('<li class="{{link_class for="https://othersite.com/about/"}}">parent</li><li class="{{link_class for="https://othersite.com/about/team/"}}">child</li>')
-                .with({relativeUrl: '/about/'})
-                .should.eql('<li class="">parent</li><li class="">child</li>');
+            assert.equal(compile('<li class="{{link_class for="https://othersite.com/about/"}}">parent</li><li class="{{link_class for="https://othersite.com/about/team/"}}">child</li>')
+                .with({relativeUrl: '/about/'}), '<li class="">parent</li><li class="">child</li>');
 
             // Parent and child links with CHILD as relative URL
-            compile('<li class="{{link_class for="https://othersite.com/about/"}}">parent</li><li class="{{link_class for="https://othersite.com/about/team/"}}">child</li>')
-                .with({relativeUrl: '/about/team/'})
-                .should.eql('<li class="">parent</li><li class="">child</li>');
+            assert.equal(compile('<li class="{{link_class for="https://othersite.com/about/"}}">parent</li><li class="{{link_class for="https://othersite.com/about/team/"}}">child</li>')
+                .with({relativeUrl: '/about/team/'}), '<li class="">parent</li><li class="">child</li>');
         });
 
         it('handles absolute URLs with missing trailing slashes', function () {
             // Parent and child links with PARENT as relative URL
-            compile('<li class="{{link_class for="https://siteurl.com/about"}}">parent</li><li class="{{link_class for="https://siteurl.com/about/team"}}">child</li>')
-                .with({relativeUrl: '/about/'})
-                .should.eql('<li class="nav-current">parent</li><li class="">child</li>');
+            assert.equal(compile('<li class="{{link_class for="https://siteurl.com/about"}}">parent</li><li class="{{link_class for="https://siteurl.com/about/team"}}">child</li>')
+                .with({relativeUrl: '/about/'}), '<li class="nav-current">parent</li><li class="">child</li>');
 
             // Parent and child links with CHILD as relative URL
-            compile('<li class="{{link_class for="https://siteurl.com/about"}}">parent</li><li class="{{link_class for="https://siteurl.com/about/team"}}">child</li>')
-                .with({relativeUrl: '/about/team/'})
-                .should.eql('<li class="nav-current-parent">parent</li><li class="nav-current">child</li>');
+            assert.equal(compile('<li class="{{link_class for="https://siteurl.com/about"}}">parent</li><li class="{{link_class for="https://siteurl.com/about/team"}}">child</li>')
+                .with({relativeUrl: '/about/team/'}), '<li class="nav-current-parent">parent</li><li class="nav-current">child</li>');
         });
 
         it('parentActiveClass can be customised', function () {
-            compile('<li class="{{link_class for="/about/" parentActiveClass="parent"}}">parent</li><li class="{{link_class for="/about/team/"}}">child</li>')
-                .with({relativeUrl: '/about/team/'})
-                .should.eql('<li class="parent">parent</li><li class="nav-current">child</li>');
+            assert.equal(compile('<li class="{{link_class for="/about/" parentActiveClass="parent"}}">parent</li><li class="{{link_class for="/about/team/"}}">child</li>')
+                .with({relativeUrl: '/about/team/'}), '<li class="parent">parent</li><li class="nav-current">child</li>');
 
-            compile('<li class="{{link_class for="/about/" parentActiveClass="parent"}}">parent</li><li class="{{link_class for="/about/team/" parentActiveClass="parent"}}">child</li>')
-                .with({relativeUrl: '/about/team/'})
-                .should.eql('<li class="parent">parent</li><li class="nav-current">child</li>');
+            assert.equal(compile('<li class="{{link_class for="/about/" parentActiveClass="parent"}}">parent</li><li class="{{link_class for="/about/team/" parentActiveClass="parent"}}">child</li>')
+                .with({relativeUrl: '/about/team/'}), '<li class="parent">parent</li><li class="nav-current">child</li>');
 
-            compile('<li class="{{link_class for="/about/" parentActiveClass=slug}}">parent</li><li class="{{link_class for="/about/team/" parentActiveClass="parent"}}">child</li>')
-                .with({relativeUrl: '/about/team/', slug: 'fred'})
-                .should.eql('<li class="fred">parent</li><li class="nav-current">child</li>');
+            assert.equal(compile('<li class="{{link_class for="/about/" parentActiveClass=slug}}">parent</li><li class="{{link_class for="/about/team/" parentActiveClass="parent"}}">child</li>')
+                .with({relativeUrl: '/about/team/', slug: 'fred'}), '<li class="fred">parent</li><li class="nav-current">child</li>');
 
-            compile('<li class="{{link_class for="/about/" parentActiveClass=(concat slug "-parent")}}">parent</li><li class="{{link_class for="/about/team/" parentActiveClass="parent"}}">child</li>')
-                .with({relativeUrl: '/about/team/', slug: 'fred'})
-                .should.eql('<li class="fred-parent">parent</li><li class="nav-current">child</li>');
+            assert.equal(compile('<li class="{{link_class for="/about/" parentActiveClass=(concat slug "-parent")}}">parent</li><li class="{{link_class for="/about/team/" parentActiveClass="parent"}}">child</li>')
+                .with({relativeUrl: '/about/team/', slug: 'fred'}), '<li class="fred-parent">parent</li><li class="nav-current">child</li>');
         });
 
         it('customising activeClass also customises parentActiveClass', function () {
-            compile('<li class="{{link_class for="/about/" activeClass="active"}}">parent</li><li class="{{link_class for="/about/team/" activeClass="active"}}">child</li>')
-                .with({relativeUrl: '/about/team/'})
-                .should.eql('<li class="active-parent">parent</li><li class="active">child</li>');
+            assert.equal(compile('<li class="{{link_class for="/about/" activeClass="active"}}">parent</li><li class="{{link_class for="/about/team/" activeClass="active"}}">child</li>')
+                .with({relativeUrl: '/about/team/'}), '<li class="active-parent">parent</li><li class="active">child</li>');
 
-            compile('<li class="{{link_class for="/about/" activeClass="active" parentActiveClass="parent"}}">parent</li><li class="{{link_class for="/about/team/" activeClass="active"}}">child</li>')
-                .with({relativeUrl: '/about/team/'})
-                .should.eql('<li class="parent">parent</li><li class="active">child</li>');
+            assert.equal(compile('<li class="{{link_class for="/about/" activeClass="active" parentActiveClass="parent"}}">parent</li><li class="{{link_class for="/about/team/" activeClass="active"}}">child</li>')
+                .with({relativeUrl: '/about/team/'}), '<li class="parent">parent</li><li class="active">child</li>');
         });
 
         it('can disable parentActiveClass with falsey values', function () {
-            compile('{{link_class for="/about/" parentActiveClass=""}}')
-                .with({relativeUrl: '/about/team/'})
-                .should.eql('');
+            assert.equal(compile('{{link_class for="/about/" parentActiveClass=""}}')
+                .with({relativeUrl: '/about/team/'}), '');
 
-            compile('{{link_class for="/about/" parentActiveClass=false}}')
-                .with({relativeUrl: '/about/team/'})
-                .should.eql('');
+            assert.equal(compile('{{link_class for="/about/" parentActiveClass=false}}')
+                .with({relativeUrl: '/about/team/'}), '');
         });
 
         it('disabling activeClass does not affect parentActiveClass', function () {
-            compile('<li class="{{link_class for="/about/" activeClass=""}}">parent</li><li class="{{link_class for="/about/team/" activeClass=""}}">child</li>')
-                .with({relativeUrl: '/about/team/'})
-                .should.eql('<li class="nav-current-parent">parent</li><li class="">child</li>');
+            assert.equal(compile('<li class="{{link_class for="/about/" activeClass=""}}">parent</li><li class="{{link_class for="/about/team/" activeClass=""}}">child</li>')
+                .with({relativeUrl: '/about/team/'}), '<li class="nav-current-parent">parent</li><li class="">child</li>');
 
-            compile('<li class="{{link_class for="/about/" activeClass=false parentActiveClass="parent"}}">parent</li><li class="{{link_class for="/about/team/" activeClass=false}}">child</li>')
-                .with({relativeUrl: '/about/team/'})
-                .should.eql('<li class="parent">parent</li><li class="">child</li>');
+            assert.equal(compile('<li class="{{link_class for="/about/" activeClass=false parentActiveClass="parent"}}">parent</li><li class="{{link_class for="/about/team/" activeClass=false}}">child</li>')
+                .with({relativeUrl: '/about/team/'}), '<li class="parent">parent</li><li class="">child</li>');
         });
     });
 });

--- a/ghost/core/test/unit/frontend/helpers/link.test.js
+++ b/ghost/core/test/unit/frontend/helpers/link.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const concat = require('../../../../core/frontend/helpers/concat');
 const link = require('../../../../core/frontend/helpers/link');
@@ -47,77 +48,65 @@ describe('{{link}} helper', function () {
         });
 
         it('silently accepts an empty href...', function () {
-            compile('{{#link href=tag.slug}}text{{/link}}')
-                .with({tag: null})
-                .should.eql('<a href="">text</a>');
+            assert.equal(compile('{{#link href=tag.slug}}text{{/link}}')
+                .with({tag: null}), '<a href="">text</a>');
         });
 
         it('<a> tag with a specific URL', function () {
-            compile('{{#link href="/about/"}}text{{/link}}')
-                .with({})
-                .should.eql('<a href="/about/">text</a>');
+            assert.equal(compile('{{#link href="/about/"}}text{{/link}}')
+                .with({}), '<a href="/about/">text</a>');
         });
 
         it('<a> tag with an anchor', function () {
-            compile('{{#link href="#myheading"}}text{{/link}}')
-                .with({})
-                .should.eql('<a href="#myheading">text</a>');
+            assert.equal(compile('{{#link href="#myheading"}}text{{/link}}')
+                .with({}), '<a href="#myheading">text</a>');
         });
 
         it('<a> tag with global variable', function () {
-            compile('{{#link href=@site.url}}text{{/link}}')
-                .with({})
-                .should.eql('<a href="https://siteurl.com">text</a>');
+            assert.equal(compile('{{#link href=@site.url}}text{{/link}}')
+                .with({}), '<a href="https://siteurl.com">text</a>');
         });
 
         it('<a> tag with local variable', function () {
-            compile('{{#link href=tag.slug}}text{{/link}}')
-                .with({tag: {slug: 'my-tag'}})
-                .should.eql('<a href="my-tag">text</a>');
+            assert.equal(compile('{{#link href=tag.slug}}text{{/link}}')
+                .with({tag: {slug: 'my-tag'}}), '<a href="my-tag">text</a>');
         });
 
         it('<a> tag with nested helpers', function () {
-            compile('{{#link href=(url)}}{{title}}{{/link}}')
+            assert.equal(compile('{{#link href=(url)}}{{title}}{{/link}}')
             // Simulate a post - using a draft to prove url helper gets called
             // because published posts get their urls from a cache that we don't have access to, so we just get 404
-                .with({title: 'My Draft Post', slug: 'my-post', html: '<p>My Post</p>', uuid: '1234'})
-                .should.eql('<a href="/p/1234/">My Draft Post</a>');
+                .with({title: 'My Draft Post', slug: 'my-post', html: '<p>My Post</p>', uuid: '1234'}), '<a href="/p/1234/">My Draft Post</a>');
         });
 
         it('can wrap html content', function () {
-            compile('{{#link href="/"}}<img src="myfile.jpg" />{{/link}}')
-                .with({})
-                .should.eql('<a href="/"><img src="myfile.jpg" /></a>');
+            assert.equal(compile('{{#link href="/"}}<img src="myfile.jpg" />{{/link}}')
+                .with({}), '<a href="/"><img src="myfile.jpg" /></a>');
         });
 
         it('honours class attribute', function () {
-            compile('{{#link href="#myheading" class="my-class"}}text{{/link}}')
-                .with({})
-                .should.eql('<a class="my-class" href="#myheading">text</a>');
+            assert.equal(compile('{{#link href="#myheading" class="my-class"}}text{{/link}}')
+                .with({}), '<a class="my-class" href="#myheading">text</a>');
         });
 
         it('supports multiple classes', function () {
-            compile('{{#link href="#myheading" class="my-class and-stuff"}}text{{/link}}')
-                .with({})
-                .should.eql('<a class="my-class and-stuff" href="#myheading">text</a>');
+            assert.equal(compile('{{#link href="#myheading" class="my-class and-stuff"}}text{{/link}}')
+                .with({}), '<a class="my-class and-stuff" href="#myheading">text</a>');
         });
 
         it('can handle classes that come from variables', function () {
-            compile('{{#link href="#myheading" class=slug}}text{{/link}}')
-                .with({slug: 'fred'})
-                .should.eql('<a class="fred" href="#myheading">text</a>');
+            assert.equal(compile('{{#link href="#myheading" class=slug}}text{{/link}}')
+                .with({slug: 'fred'}), '<a class="fred" href="#myheading">text</a>');
         });
 
         it('can handle classes that come from helpers', function () {
-            compile('{{#link href="#myheading" class=(concat "my-" slug)}}text{{/link}}')
-                .with({slug: 'fred'})
-                .should.eql('<a class="my-fred" href="#myheading">text</a>');
+            assert.equal(compile('{{#link href="#myheading" class=(concat "my-" slug)}}text{{/link}}')
+                .with({slug: 'fred'}), '<a class="my-fred" href="#myheading">text</a>');
         });
 
         it('supports multiple attributes', function () {
-            compile('{{#link href="#myheading" class="my-class" target="_blank"}}text{{/link}}')
-                .with({})
-                .should.eql('<a class="my-class" href="#myheading" target="_blank">text</a>');
+            assert.equal(compile('{{#link href="#myheading" class="my-class" target="_blank"}}text{{/link}}')
+                .with({}), '<a class="my-class" href="#myheading" target="_blank">text</a>');
         });
     });
 
@@ -125,226 +114,187 @@ describe('{{link}} helper', function () {
         describe('activeClass', function () {
             it('gets applied correctly', function () {
                 // Test matching relative URL
-                compile('{{#link href="/about/"}}text{{/link}}')
-                    .with({relativeUrl: '/about/'})
-                    .should.eql('<a class="nav-current" href="/about/">text</a>');
+                assert.equal(compile('{{#link href="/about/"}}text{{/link}}')
+                    .with({relativeUrl: '/about/'}), '<a class="nav-current" href="/about/">text</a>');
 
                 // Test non-matching relative URL
-                compile('{{#link href="/about/"}}text{{/link}}')
-                    .with({relativeUrl: '/'})
-                    .should.eql('<a href="/about/">text</a>');
+                assert.equal(compile('{{#link href="/about/"}}text{{/link}}')
+                    .with({relativeUrl: '/'}), '<a href="/about/">text</a>');
             });
 
             it('ignores anchors', function () {
                 // Anchor in href
-                compile('{{#link href="/about/#me"}}text{{/link}}')
-                    .with({relativeUrl: '/about/'})
-                    .should.eql('<a class="nav-current" href="/about/#me">text</a>');
+                assert.equal(compile('{{#link href="/about/#me"}}text{{/link}}')
+                    .with({relativeUrl: '/about/'}), '<a class="nav-current" href="/about/#me">text</a>');
 
                 // Anchor in relative URL
-                compile('{{#link href="/about/"}}text{{/link}}')
-                    .with({relativeUrl: '/about/#me'})
-                    .should.eql('<a class="nav-current" href="/about/">text</a>');
+                assert.equal(compile('{{#link href="/about/"}}text{{/link}}')
+                    .with({relativeUrl: '/about/#me'}), '<a class="nav-current" href="/about/">text</a>');
             });
 
             it('handles missing trailing slashes', function () {
-                compile('{{#link href="/about"}}text{{/link}}')
-                    .with({relativeUrl: '/about/'})
-                    .should.eql('<a class="nav-current" href="/about">text</a>');
+                assert.equal(compile('{{#link href="/about"}}text{{/link}}')
+                    .with({relativeUrl: '/about/'}), '<a class="nav-current" href="/about">text</a>');
             });
 
             it('handles absolute URLs', function () {
                 // Correct URL gets class
-                compile('{{#link href="https://siteurl.com/about/"}}text{{/link}}')
-                    .with({relativeUrl: '/about/'})
-                    .should.eql('<a class="nav-current" href="https://siteurl.com/about/">text</a>');
+                assert.equal(compile('{{#link href="https://siteurl.com/about/"}}text{{/link}}')
+                    .with({relativeUrl: '/about/'}), '<a class="nav-current" href="https://siteurl.com/about/">text</a>');
 
                 // Incorrect URL doesn't get class
-                compile('{{#link href="https://othersite.com/about/"}}text{{/link}}')
-                    .with({relativeUrl: '/about/'})
-                    .should.eql('<a href="https://othersite.com/about/">text</a>');
+                assert.equal(compile('{{#link href="https://othersite.com/about/"}}text{{/link}}')
+                    .with({relativeUrl: '/about/'}), '<a href="https://othersite.com/about/">text</a>');
             });
 
             it('handles absolute URL with missing trailing slash', function () {
-                compile('{{#link href="https://siteurl.com/about"}}text{{/link}}')
-                    .with({relativeUrl: '/about/'})
-                    .should.eql('<a class="nav-current" href="https://siteurl.com/about">text</a>');
+                assert.equal(compile('{{#link href="https://siteurl.com/about"}}text{{/link}}')
+                    .with({relativeUrl: '/about/'}), '<a class="nav-current" href="https://siteurl.com/about">text</a>');
             });
 
             it('activeClass can be customised', function () {
-                compile('{{#link href="/about/" activeClass="nav-active"}}text{{/link}}')
-                    .with({relativeUrl: '/about/'})
-                    .should.eql('<a class="nav-active" href="/about/">text</a>');
+                assert.equal(compile('{{#link href="/about/" activeClass="nav-active"}}text{{/link}}')
+                    .with({relativeUrl: '/about/'}), '<a class="nav-active" href="/about/">text</a>');
 
-                compile('{{#link href="/about/" activeClass=slug}}text{{/link}}')
-                    .with({relativeUrl: '/about/', slug: 'fred'})
-                    .should.eql('<a class="fred" href="/about/">text</a>');
+                assert.equal(compile('{{#link href="/about/" activeClass=slug}}text{{/link}}')
+                    .with({relativeUrl: '/about/', slug: 'fred'}), '<a class="fred" href="/about/">text</a>');
 
-                compile('{{#link href="/about/" activeClass=(concat slug "active" separator="-")}}text{{/link}}')
-                    .with({relativeUrl: '/about/', slug: 'fred'})
-                    .should.eql('<a class="fred-active" href="/about/">text</a>');
+                assert.equal(compile('{{#link href="/about/" activeClass=(concat slug "active" separator="-")}}text{{/link}}')
+                    .with({relativeUrl: '/about/', slug: 'fred'}), '<a class="fred-active" href="/about/">text</a>');
             });
 
             it('activeClass and other classes work together', function () {
                 // Single extra class
-                compile('{{#link href="/about/" class="about"}}text{{/link}}')
-                    .with({relativeUrl: '/about/'})
-                    .should.eql('<a class="about nav-current" href="/about/">text</a>');
+                assert.equal(compile('{{#link href="/about/" class="about"}}text{{/link}}')
+                    .with({relativeUrl: '/about/'}), '<a class="about nav-current" href="/about/">text</a>');
 
                 // Multiple extra classes
-                compile('{{#link href="/about/" class="about my-link"}}text{{/link}}')
-                    .with({relativeUrl: '/about/'})
-                    .should.eql('<a class="about my-link nav-current" href="/about/">text</a>');
+                assert.equal(compile('{{#link href="/about/" class="about my-link"}}text{{/link}}')
+                    .with({relativeUrl: '/about/'}), '<a class="about my-link nav-current" href="/about/">text</a>');
             });
 
             it('can disable activeClass with falsey values', function () {
                 // Empty string
-                compile('{{#link href="/about/" activeClass=""}}text{{/link}}')
-                    .with({relativeUrl: '/about/'})
-                    .should.eql('<a href="/about/">text</a>');
+                assert.equal(compile('{{#link href="/about/" activeClass=""}}text{{/link}}')
+                    .with({relativeUrl: '/about/'}), '<a href="/about/">text</a>');
 
                 // false
-                compile('{{#link href="/about/" activeClass=false}}text{{/link}}')
-                    .with({relativeUrl: '/about/'})
-                    .should.eql('<a href="/about/">text</a>');
+                assert.equal(compile('{{#link href="/about/" activeClass=false}}text{{/link}}')
+                    .with({relativeUrl: '/about/'}), '<a href="/about/">text</a>');
             });
         });
 
         describe('parentActiveClass', function () {
             it('gets applied correctly', function () {
                 // Parent and child links with PARENT as relative URL
-                compile('{{#link href="/about/"}}parent{{/link}}{{#link href="/about/team/"}}child{{/link}}')
-                    .with({relativeUrl: '/about/'})
-                    .should.eql('<a class="nav-current" href="/about/">parent</a><a href="/about/team/">child</a>');
+                assert.equal(compile('{{#link href="/about/"}}parent{{/link}}{{#link href="/about/team/"}}child{{/link}}')
+                    .with({relativeUrl: '/about/'}), '<a class="nav-current" href="/about/">parent</a><a href="/about/team/">child</a>');
 
                 // Parent and child links with CHILD as relative URL
-                compile('{{#link href="/about/"}}parent{{/link}}{{#link href="/about/team/"}}child{{/link}}')
-                    .with({relativeUrl: '/about/team/'})
-                    .should.eql('<a class="nav-current-parent" href="/about/">parent</a><a class="nav-current" href="/about/team/">child</a>');
+                assert.equal(compile('{{#link href="/about/"}}parent{{/link}}{{#link href="/about/team/"}}child{{/link}}')
+                    .with({relativeUrl: '/about/team/'}), '<a class="nav-current-parent" href="/about/">parent</a><a class="nav-current" href="/about/team/">child</a>');
             });
 
             it('ignores anchors', function () {
                 // Anchor in href
 
                 // Parent and child links with PARENT as relative URL
-                compile('{{#link href="/about/#me"}}parent{{/link}}{{#link href="/about/team/"}}child{{/link}}')
-                    .with({relativeUrl: '/about/'})
-                    .should.eql('<a class="nav-current" href="/about/#me">parent</a><a href="/about/team/">child</a>');
+                assert.equal(compile('{{#link href="/about/#me"}}parent{{/link}}{{#link href="/about/team/"}}child{{/link}}')
+                    .with({relativeUrl: '/about/'}), '<a class="nav-current" href="/about/#me">parent</a><a href="/about/team/">child</a>');
 
                 // Parent and child links with CHILD as relative URL
-                compile('{{#link href="/about/#me"}}parent{{/link}}{{#link href="/about/team/"}}child{{/link}}')
-                    .with({relativeUrl: '/about/team/'})
-                    .should.eql('<a class="nav-current-parent" href="/about/#me">parent</a><a class="nav-current" href="/about/team/">child</a>');
+                assert.equal(compile('{{#link href="/about/#me"}}parent{{/link}}{{#link href="/about/team/"}}child{{/link}}')
+                    .with({relativeUrl: '/about/team/'}), '<a class="nav-current-parent" href="/about/#me">parent</a><a class="nav-current" href="/about/team/">child</a>');
 
                 // Anchor in relative URL
 
                 // Parent and child links with PARENT as relative URL
-                compile('{{#link href="/about/"}}parent{{/link}}{{#link href="/about/team/"}}child{{/link}}')
-                    .with({relativeUrl: '/about/#me'})
-                    .should.eql('<a class="nav-current" href="/about/">parent</a><a href="/about/team/">child</a>');
+                assert.equal(compile('{{#link href="/about/"}}parent{{/link}}{{#link href="/about/team/"}}child{{/link}}')
+                    .with({relativeUrl: '/about/#me'}), '<a class="nav-current" href="/about/">parent</a><a href="/about/team/">child</a>');
 
                 // Parent and child links with CHILD as relative URL
-                compile('{{#link href="/about/"}}parent{{/link}}{{#link href="/about/team/"}}child{{/link}}')
-                    .with({relativeUrl: '/about/team/#me'})
-                    .should.eql('<a class="nav-current-parent" href="/about/">parent</a><a class="nav-current" href="/about/team/">child</a>');
+                assert.equal(compile('{{#link href="/about/"}}parent{{/link}}{{#link href="/about/team/"}}child{{/link}}')
+                    .with({relativeUrl: '/about/team/#me'}), '<a class="nav-current-parent" href="/about/">parent</a><a class="nav-current" href="/about/team/">child</a>');
             });
 
             it('handles missing trailing slashes', function () {
                 // Parent and child links with PARENT as relative URL
-                compile('{{#link href="/about"}}parent{{/link}}{{#link href="/about/team"}}child{{/link}}')
-                    .with({relativeUrl: '/about/'})
-                    .should.eql('<a class="nav-current" href="/about">parent</a><a href="/about/team">child</a>');
+                assert.equal(compile('{{#link href="/about"}}parent{{/link}}{{#link href="/about/team"}}child{{/link}}')
+                    .with({relativeUrl: '/about/'}), '<a class="nav-current" href="/about">parent</a><a href="/about/team">child</a>');
 
                 // Parent and child links with CHILD as relative URL
-                compile('{{#link href="/about"}}parent{{/link}}{{#link href="/about/team"}}child{{/link}}')
-                    .with({relativeUrl: '/about/team/'})
-                    .should.eql('<a class="nav-current-parent" href="/about">parent</a><a class="nav-current" href="/about/team">child</a>');
+                assert.equal(compile('{{#link href="/about"}}parent{{/link}}{{#link href="/about/team"}}child{{/link}}')
+                    .with({relativeUrl: '/about/team/'}), '<a class="nav-current-parent" href="/about">parent</a><a class="nav-current" href="/about/team">child</a>');
             });
 
             it('handles absolute URLs', function () {
                 // Correct URL gets class
 
                 // Parent and child links with PARENT as relative URL
-                compile('{{#link href="https://siteurl.com/about/"}}parent{{/link}}{{#link href="https://siteurl.com/about/team/"}}child{{/link}}')
-                    .with({relativeUrl: '/about/'})
-                    .should.eql('<a class="nav-current" href="https://siteurl.com/about/">parent</a><a href="https://siteurl.com/about/team/">child</a>');
+                assert.equal(compile('{{#link href="https://siteurl.com/about/"}}parent{{/link}}{{#link href="https://siteurl.com/about/team/"}}child{{/link}}')
+                    .with({relativeUrl: '/about/'}), '<a class="nav-current" href="https://siteurl.com/about/">parent</a><a href="https://siteurl.com/about/team/">child</a>');
 
                 // Parent and child links with CHILD as relative URL
-                compile('{{#link href="https://siteurl.com/about/"}}parent{{/link}}{{#link href="https://siteurl.com/about/team/"}}child{{/link}}')
-                    .with({relativeUrl: '/about/team/'})
-                    .should.eql('<a class="nav-current-parent" href="https://siteurl.com/about/">parent</a><a class="nav-current" href="https://siteurl.com/about/team/">child</a>');
+                assert.equal(compile('{{#link href="https://siteurl.com/about/"}}parent{{/link}}{{#link href="https://siteurl.com/about/team/"}}child{{/link}}')
+                    .with({relativeUrl: '/about/team/'}), '<a class="nav-current-parent" href="https://siteurl.com/about/">parent</a><a class="nav-current" href="https://siteurl.com/about/team/">child</a>');
 
                 // Incorrect URL doesn't get class
 
                 // Parent and child links with PARENT as relative URL
-                compile('{{#link href="https://othersite.com/about/"}}parent{{/link}}{{#link href="https://othersite.com/about/team/"}}child{{/link}}')
-                    .with({relativeUrl: '/about/'})
-                    .should.eql('<a href="https://othersite.com/about/">parent</a><a href="https://othersite.com/about/team/">child</a>');
+                assert.equal(compile('{{#link href="https://othersite.com/about/"}}parent{{/link}}{{#link href="https://othersite.com/about/team/"}}child{{/link}}')
+                    .with({relativeUrl: '/about/'}), '<a href="https://othersite.com/about/">parent</a><a href="https://othersite.com/about/team/">child</a>');
 
                 // Parent and child links with CHILD as relative URL
-                compile('{{#link href="https://othersite.com/about/"}}parent{{/link}}{{#link href="https://othersite.com/about/team/"}}child{{/link}}')
-                    .with({relativeUrl: '/about/team/'})
-                    .should.eql('<a href="https://othersite.com/about/">parent</a><a href="https://othersite.com/about/team/">child</a>');
+                assert.equal(compile('{{#link href="https://othersite.com/about/"}}parent{{/link}}{{#link href="https://othersite.com/about/team/"}}child{{/link}}')
+                    .with({relativeUrl: '/about/team/'}), '<a href="https://othersite.com/about/">parent</a><a href="https://othersite.com/about/team/">child</a>');
             });
 
             it('handles absolute URLs with missing trailing slashes', function () {
                 // Parent and child links with PARENT as relative URL
-                compile('{{#link href="https://siteurl.com/about"}}parent{{/link}}{{#link href="https://siteurl.com/about/team"}}child{{/link}}')
-                    .with({relativeUrl: '/about/'})
-                    .should.eql('<a class="nav-current" href="https://siteurl.com/about">parent</a><a href="https://siteurl.com/about/team">child</a>');
+                assert.equal(compile('{{#link href="https://siteurl.com/about"}}parent{{/link}}{{#link href="https://siteurl.com/about/team"}}child{{/link}}')
+                    .with({relativeUrl: '/about/'}), '<a class="nav-current" href="https://siteurl.com/about">parent</a><a href="https://siteurl.com/about/team">child</a>');
 
                 // Parent and child links with CHILD as relative URL
-                compile('{{#link href="https://siteurl.com/about"}}parent{{/link}}{{#link href="https://siteurl.com/about/team"}}child{{/link}}')
-                    .with({relativeUrl: '/about/team/'})
-                    .should.eql('<a class="nav-current-parent" href="https://siteurl.com/about">parent</a><a class="nav-current" href="https://siteurl.com/about/team">child</a>');
+                assert.equal(compile('{{#link href="https://siteurl.com/about"}}parent{{/link}}{{#link href="https://siteurl.com/about/team"}}child{{/link}}')
+                    .with({relativeUrl: '/about/team/'}), '<a class="nav-current-parent" href="https://siteurl.com/about">parent</a><a class="nav-current" href="https://siteurl.com/about/team">child</a>');
             });
 
             it('parentActiveClass can be customised', function () {
-                compile('{{#link href="/about/" parentActiveClass="parent"}}parent{{/link}}{{#link href="/about/team/"}}child{{/link}}')
-                    .with({relativeUrl: '/about/team/'})
-                    .should.eql('<a class="parent" href="/about/">parent</a><a class="nav-current" href="/about/team/">child</a>');
+                assert.equal(compile('{{#link href="/about/" parentActiveClass="parent"}}parent{{/link}}{{#link href="/about/team/"}}child{{/link}}')
+                    .with({relativeUrl: '/about/team/'}), '<a class="parent" href="/about/">parent</a><a class="nav-current" href="/about/team/">child</a>');
 
-                compile('{{#link href="/about/" parentActiveClass="parent"}}parent{{/link}}{{#link href="/about/team/" parentActiveClass="parent"}}child{{/link}}')
-                    .with({relativeUrl: '/about/team/'})
-                    .should.eql('<a class="parent" href="/about/">parent</a><a class="nav-current" href="/about/team/">child</a>');
+                assert.equal(compile('{{#link href="/about/" parentActiveClass="parent"}}parent{{/link}}{{#link href="/about/team/" parentActiveClass="parent"}}child{{/link}}')
+                    .with({relativeUrl: '/about/team/'}), '<a class="parent" href="/about/">parent</a><a class="nav-current" href="/about/team/">child</a>');
 
-                compile('{{#link href="/about/" parentActiveClass=slug}}parent{{/link}}{{#link href="/about/team/" parentActiveClass="parent"}}child{{/link}}')
-                    .with({relativeUrl: '/about/team/', slug: 'fred'})
-                    .should.eql('<a class="fred" href="/about/">parent</a><a class="nav-current" href="/about/team/">child</a>');
+                assert.equal(compile('{{#link href="/about/" parentActiveClass=slug}}parent{{/link}}{{#link href="/about/team/" parentActiveClass="parent"}}child{{/link}}')
+                    .with({relativeUrl: '/about/team/', slug: 'fred'}), '<a class="fred" href="/about/">parent</a><a class="nav-current" href="/about/team/">child</a>');
 
-                compile('{{#link href="/about/" parentActiveClass=(concat slug "-parent")}}parent{{/link}}{{#link href="/about/team/" parentActiveClass="parent"}}child{{/link}}')
-                    .with({relativeUrl: '/about/team/', slug: 'fred'})
-                    .should.eql('<a class="fred-parent" href="/about/">parent</a><a class="nav-current" href="/about/team/">child</a>');
+                assert.equal(compile('{{#link href="/about/" parentActiveClass=(concat slug "-parent")}}parent{{/link}}{{#link href="/about/team/" parentActiveClass="parent"}}child{{/link}}')
+                    .with({relativeUrl: '/about/team/', slug: 'fred'}), '<a class="fred-parent" href="/about/">parent</a><a class="nav-current" href="/about/team/">child</a>');
             });
 
             it('customising activeClass also customises parentActiveClass', function () {
-                compile('{{#link href="/about/" activeClass="active"}}parent{{/link}}{{#link href="/about/team/" activeClass="active"}}child{{/link}}')
-                    .with({relativeUrl: '/about/team/'})
-                    .should.eql('<a class="active-parent" href="/about/">parent</a><a class="active" href="/about/team/">child</a>');
+                assert.equal(compile('{{#link href="/about/" activeClass="active"}}parent{{/link}}{{#link href="/about/team/" activeClass="active"}}child{{/link}}')
+                    .with({relativeUrl: '/about/team/'}), '<a class="active-parent" href="/about/">parent</a><a class="active" href="/about/team/">child</a>');
 
-                compile('{{#link href="/about/" activeClass="active" parentActiveClass="parent"}}parent{{/link}}{{#link href="/about/team/" activeClass="active"}}child{{/link}}')
-                    .with({relativeUrl: '/about/team/'})
-                    .should.eql('<a class="parent" href="/about/">parent</a><a class="active" href="/about/team/">child</a>');
+                assert.equal(compile('{{#link href="/about/" activeClass="active" parentActiveClass="parent"}}parent{{/link}}{{#link href="/about/team/" activeClass="active"}}child{{/link}}')
+                    .with({relativeUrl: '/about/team/'}), '<a class="parent" href="/about/">parent</a><a class="active" href="/about/team/">child</a>');
             });
 
             it('can disable parentActiveClass with falsey values', function () {
-                compile('{{#link href="/about/" parentActiveClass=""}}text{{/link}}')
-                    .with({relativeUrl: '/about/team/'})
-                    .should.eql('<a href="/about/">text</a>');
+                assert.equal(compile('{{#link href="/about/" parentActiveClass=""}}text{{/link}}')
+                    .with({relativeUrl: '/about/team/'}), '<a href="/about/">text</a>');
 
-                compile('{{#link href="/about/" parentActiveClass=false}}text{{/link}}')
-                    .with({relativeUrl: '/about/team/'})
-                    .should.eql('<a href="/about/">text</a>');
+                assert.equal(compile('{{#link href="/about/" parentActiveClass=false}}text{{/link}}')
+                    .with({relativeUrl: '/about/team/'}), '<a href="/about/">text</a>');
             });
 
             it('disabling activeClass does not affect parentActiveClass', function () {
-                compile('{{#link href="/about/" activeClass=""}}parent{{/link}}{{#link href="/about/team/" activeClass=""}}child{{/link}}')
-                    .with({relativeUrl: '/about/team/'})
-                    .should.eql('<a class="nav-current-parent" href="/about/">parent</a><a href="/about/team/">child</a>');
+                assert.equal(compile('{{#link href="/about/" activeClass=""}}parent{{/link}}{{#link href="/about/team/" activeClass=""}}child{{/link}}')
+                    .with({relativeUrl: '/about/team/'}), '<a class="nav-current-parent" href="/about/">parent</a><a href="/about/team/">child</a>');
 
-                compile('{{#link href="/about/" activeClass=false parentActiveClass="parent"}}parent{{/link}}{{#link href="/about/team/" activeClass=false}}child{{/link}}')
-                    .with({relativeUrl: '/about/team/'})
-                    .should.eql('<a class="parent" href="/about/">parent</a><a href="/about/team/">child</a>');
+                assert.equal(compile('{{#link href="/about/" activeClass=false parentActiveClass="parent"}}parent{{/link}}{{#link href="/about/team/" activeClass=false}}child{{/link}}')
+                    .with({relativeUrl: '/about/team/'}), '<a class="parent" href="/about/">parent</a><a href="/about/team/">child</a>');
             });
         });
     });

--- a/ghost/core/test/unit/frontend/helpers/meta-description.test.js
+++ b/ghost/core/test/unit/frontend/helpers/meta-description.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const meta_description = require('../../../../core/frontend/helpers/meta_description');
@@ -28,7 +29,7 @@ describe('{{meta_description}} helper', function () {
             );
 
             should.exist(rendered);
-            String(rendered).should.equal('The professional publishing platform');
+            assert.equal(String(rendered), 'The professional publishing platform');
         });
 
         it('returns empty description on paginated page', function () {
@@ -38,7 +39,7 @@ describe('{{meta_description}} helper', function () {
             );
 
             should.exist(rendered);
-            String(rendered).should.equal('');
+            assert.equal(String(rendered), '');
         });
 
         it('returns empty description for a tag page', function () {
@@ -48,7 +49,7 @@ describe('{{meta_description}} helper', function () {
             );
 
             should.exist(rendered);
-            String(rendered).should.equal('');
+            assert.equal(String(rendered), '');
         });
 
         it('returns empty description for a paginated tag page', function () {
@@ -58,7 +59,7 @@ describe('{{meta_description}} helper', function () {
             );
 
             should.exist(rendered);
-            String(rendered).should.equal('');
+            assert.equal(String(rendered), '');
         });
 
         it('returns tag meta_description if present for a tag page', function () {
@@ -68,7 +69,7 @@ describe('{{meta_description}} helper', function () {
             );
 
             should.exist(rendered);
-            String(rendered).should.equal('Rasper is the Cool Red Casper');
+            assert.equal(String(rendered), 'Rasper is the Cool Red Casper');
         });
 
         it('returns empty description on paginated tag page that has meta data', function () {
@@ -78,7 +79,7 @@ describe('{{meta_description}} helper', function () {
             );
 
             should.exist(rendered);
-            String(rendered).should.equal('');
+            assert.equal(String(rendered), '');
         });
 
         it('returns author bio for an author page', function () {
@@ -88,7 +89,7 @@ describe('{{meta_description}} helper', function () {
             );
 
             should.exist(rendered);
-            String(rendered).should.equal('I am a Duck.');
+            assert.equal(String(rendered), 'I am a Duck.');
         });
 
         it('returns empty description for a paginated author page', function () {
@@ -98,7 +99,7 @@ describe('{{meta_description}} helper', function () {
             );
 
             should.exist(rendered);
-            String(rendered).should.equal('');
+            assert.equal(String(rendered), '');
         });
 
         it('returns empty description when meta_description is not set', function () {
@@ -108,7 +109,7 @@ describe('{{meta_description}} helper', function () {
             );
 
             should.exist(rendered);
-            String(rendered).should.equal('');
+            assert.equal(String(rendered), '');
         });
 
         it('returns meta_description on post with meta_description set', function () {
@@ -118,7 +119,7 @@ describe('{{meta_description}} helper', function () {
             );
 
             should.exist(rendered);
-            String(rendered).should.equal('Nice post about stuff.');
+            assert.equal(String(rendered), 'Nice post about stuff.');
         });
 
         it('returns meta_description on post when used within {{#foreach posts}}', function () {
@@ -128,7 +129,7 @@ describe('{{meta_description}} helper', function () {
             );
 
             should.exist(rendered);
-            String(rendered).should.equal('Nice post about stuff.');
+            assert.equal(String(rendered), 'Nice post about stuff.');
         });
     });
 
@@ -144,7 +145,7 @@ describe('{{meta_description}} helper', function () {
             );
 
             should.exist(rendered);
-            String(rendered).should.equal('Meta description of the professional publishing platform');
+            assert.equal(String(rendered), 'Meta description of the professional publishing platform');
         });
 
         it('returns tag meta_description if present for a tag page', function () {
@@ -154,7 +155,7 @@ describe('{{meta_description}} helper', function () {
             );
 
             should.exist(rendered);
-            String(rendered).should.equal('Rasper is the Cool Red Casper');
+            assert.equal(String(rendered), 'Rasper is the Cool Red Casper');
         });
     });
 });

--- a/ghost/core/test/unit/frontend/helpers/meta-title.test.js
+++ b/ghost/core/test/unit/frontend/helpers/meta-title.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const configUtils = require('../../../utils/config-utils');
@@ -26,7 +27,7 @@ describe('{{meta_title}} helper', function () {
             );
 
             should.exist(rendered);
-            String(rendered).should.equal('Ghost');
+            assert.equal(String(rendered), 'Ghost');
         });
 
         it('returns correct title for paginated page', function () {
@@ -36,7 +37,7 @@ describe('{{meta_title}} helper', function () {
             );
 
             should.exist(rendered);
-            String(rendered).should.equal('Ghost (Page 2)');
+            assert.equal(String(rendered), 'Ghost (Page 2)');
         });
 
         it('returns correct title for a post', function () {
@@ -46,7 +47,7 @@ describe('{{meta_title}} helper', function () {
             );
 
             should.exist(rendered);
-            String(rendered).should.equal('Post Title');
+            assert.equal(String(rendered), 'Post Title');
         });
 
         it('returns correct title for a post with meta_title set', function () {
@@ -56,7 +57,7 @@ describe('{{meta_title}} helper', function () {
             );
 
             should.exist(rendered);
-            String(rendered).should.equal('Awesome Post');
+            assert.equal(String(rendered), 'Awesome Post');
         });
 
         it('returns correct title for a page with meta_title set', function () {
@@ -66,7 +67,7 @@ describe('{{meta_title}} helper', function () {
             );
 
             should.exist(rendered);
-            String(rendered).should.equal('All about my awesomeness');
+            assert.equal(String(rendered), 'All about my awesomeness');
         });
 
         it('returns correct title for a tag page', function () {
@@ -78,7 +79,7 @@ describe('{{meta_title}} helper', function () {
             );
 
             should.exist(rendered);
-            String(rendered).should.equal('Rasper Red - Ghost');
+            assert.equal(String(rendered), 'Rasper Red - Ghost');
         });
 
         it('returns correct title for a paginated tag page', function () {
@@ -88,7 +89,7 @@ describe('{{meta_title}} helper', function () {
             );
 
             should.exist(rendered);
-            String(rendered).should.equal('Rasper Red - Ghost (Page 2)');
+            assert.equal(String(rendered), 'Rasper Red - Ghost (Page 2)');
         });
 
         it('uses tag meta_title to override default response on tag page', function () {
@@ -98,7 +99,7 @@ describe('{{meta_title}} helper', function () {
             );
 
             should.exist(rendered);
-            String(rendered).should.equal('Sasper Red');
+            assert.equal(String(rendered), 'Sasper Red');
         });
 
         it('uses tag meta_title to override default response on paginated tag page', function () {
@@ -108,7 +109,7 @@ describe('{{meta_title}} helper', function () {
             );
 
             should.exist(rendered);
-            String(rendered).should.equal('Sasper Red');
+            assert.equal(String(rendered), 'Sasper Red');
         });
 
         it('returns correct title for an author page', function () {
@@ -118,7 +119,7 @@ describe('{{meta_title}} helper', function () {
             );
 
             should.exist(rendered);
-            String(rendered).should.equal('Donald Duck - Ghost');
+            assert.equal(String(rendered), 'Donald Duck - Ghost');
         });
 
         it('returns correct title for a paginated author page', function () {
@@ -128,7 +129,7 @@ describe('{{meta_title}} helper', function () {
             );
 
             should.exist(rendered);
-            String(rendered).should.equal('Donald Duck - Ghost (Page 2)');
+            assert.equal(String(rendered), 'Donald Duck - Ghost (Page 2)');
         });
 
         it('returns correctly escaped title of a post', function () {
@@ -138,7 +139,7 @@ describe('{{meta_title}} helper', function () {
             );
 
             should.exist(rendered);
-            String(rendered).should.equal('Post Title "</>');
+            assert.equal(String(rendered), 'Post Title "</>');
         });
 
         it('returns meta_title on post when used within {{#foreach posts}}', function () {
@@ -148,7 +149,7 @@ describe('{{meta_title}} helper', function () {
             );
 
             should.exist(rendered);
-            String(rendered).should.equal('Awesome Post');
+            assert.equal(String(rendered), 'Awesome Post');
         });
     });
 
@@ -167,7 +168,7 @@ describe('{{meta_title}} helper', function () {
             );
 
             should.exist(rendered);
-            String(rendered).should.equal('Meta Title Ghost');
+            assert.equal(String(rendered), 'Meta Title Ghost');
         });
 
         it('returns correct title for paginated page', function () {
@@ -177,7 +178,7 @@ describe('{{meta_title}} helper', function () {
             );
 
             should.exist(rendered);
-            String(rendered).should.equal('Ghost (Page 2)');
+            assert.equal(String(rendered), 'Ghost (Page 2)');
         });
 
         it('returns correct title for a tag page', function () {
@@ -189,7 +190,7 @@ describe('{{meta_title}} helper', function () {
             );
 
             should.exist(rendered);
-            String(rendered).should.equal('Rasper Red - Ghost');
+            assert.equal(String(rendered), 'Rasper Red - Ghost');
         });
 
         it('returns correct title for an author page', function () {
@@ -199,7 +200,7 @@ describe('{{meta_title}} helper', function () {
             );
 
             should.exist(rendered);
-            String(rendered).should.equal('Donald Duck - Ghost');
+            assert.equal(String(rendered), 'Donald Duck - Ghost');
         });
 
         it('returns correct title for a paginated author page', function () {
@@ -209,7 +210,7 @@ describe('{{meta_title}} helper', function () {
             );
 
             should.exist(rendered);
-            String(rendered).should.equal('Donald Duck - Ghost (Page 2)');
+            assert.equal(String(rendered), 'Donald Duck - Ghost (Page 2)');
         });
     });
 });

--- a/ghost/core/test/unit/frontend/helpers/navigation.test.js
+++ b/ghost/core/test/unit/frontend/helpers/navigation.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const hbs = require('../../../../core/frontend/services/theme-engine/engine');
 const configUtils = require('../../../utils/config-utils');
@@ -81,9 +82,9 @@ describe('{{navigation}} helper', function () {
 
         optionsData.data.site.navigation = [singleItem];
         rendered = runHelper(optionsData);
-        rendered.string.should.containEql('li');
-        rendered.string.should.containEql('nav-foo');
-        rendered.string.should.containEql('/foo');
+        assert(rendered.string.includes('li'));
+        assert(rendered.string.includes('nav-foo'));
+        assert(rendered.string.includes('/foo'));
     });
 
     it('can render one item', function () {
@@ -95,9 +96,9 @@ describe('{{navigation}} helper', function () {
         rendered = runHelper(optionsData);
 
         should.exist(rendered);
-        rendered.string.should.containEql('li');
-        rendered.string.should.containEql('nav-foo');
-        rendered.string.should.containEql(testUrl);
+        assert(rendered.string.includes('li'));
+        assert(rendered.string.includes('nav-foo'));
+        assert(rendered.string.includes(testUrl));
     });
 
     it('can render multiple items', function () {
@@ -111,10 +112,10 @@ describe('{{navigation}} helper', function () {
         rendered = runHelper(optionsData);
 
         should.exist(rendered);
-        rendered.string.should.containEql('nav-foo');
-        rendered.string.should.containEql('nav-bar-baz-qux');
-        rendered.string.should.containEql(testUrl);
-        rendered.string.should.containEql(testUrl2);
+        assert(rendered.string.includes('nav-foo'));
+        assert(rendered.string.includes('nav-bar-baz-qux'));
+        assert(rendered.string.includes(testUrl));
+        assert(rendered.string.includes(testUrl2));
     });
 
     it('can annotate the current url', function () {
@@ -127,10 +128,10 @@ describe('{{navigation}} helper', function () {
         rendered = runHelper(optionsData);
 
         should.exist(rendered);
-        rendered.string.should.containEql('nav-foo');
-        rendered.string.should.containEql('nav-current');
-        rendered.string.should.containEql('nav-foo nav-current');
-        rendered.string.should.containEql('nav-bar"');
+        assert(rendered.string.includes('nav-foo'));
+        assert(rendered.string.includes('nav-current'));
+        assert(rendered.string.includes('nav-foo nav-current'));
+        assert(rendered.string.includes('nav-bar"'));
     });
 
     it('can annotate current url with trailing slash', function () {
@@ -143,10 +144,10 @@ describe('{{navigation}} helper', function () {
         rendered = runHelper(optionsData);
 
         should.exist(rendered);
-        rendered.string.should.containEql('nav-foo');
-        rendered.string.should.containEql('nav-current');
-        rendered.string.should.containEql('nav-foo nav-current');
-        rendered.string.should.containEql('nav-bar"');
+        assert(rendered.string.includes('nav-foo'));
+        assert(rendered.string.includes('nav-current'));
+        assert(rendered.string.includes('nav-foo nav-current'));
+        assert(rendered.string.includes('nav-bar"'));
     });
 
     it('doesn\'t html-escape URLs', function () {
@@ -157,9 +158,9 @@ describe('{{navigation}} helper', function () {
         rendered = runHelper(optionsData);
 
         should.exist(rendered);
-        rendered.string.should.not.containEql('&#x3D;');
-        rendered.string.should.not.containEql('&amp;');
-        rendered.string.should.containEql('/?foo=bar&baz=qux');
+        assert(!rendered.string.includes('&#x3D;'));
+        assert(!rendered.string.includes('&amp;'));
+        assert(rendered.string.includes('/?foo=bar&baz=qux'));
     });
 
     it('encodes URLs', function () {
@@ -170,9 +171,9 @@ describe('{{navigation}} helper', function () {
         rendered = runHelper(optionsData);
 
         should.exist(rendered);
-        rendered.string.should.containEql('foo=space%20bar');
-        rendered.string.should.not.containEql('<script>alert("gotcha")</script>');
-        rendered.string.should.containEql('%3Cscript%3Ealert(%22gotcha%22)%3C/script%3E');
+        assert(rendered.string.includes('foo=space%20bar'));
+        assert(!rendered.string.includes('<script>alert("gotcha")</script>'));
+        assert(rendered.string.includes('%3Cscript%3Ealert(%22gotcha%22)%3C/script%3E'));
     });
 
     it('doesn\'t double-encode URLs', function () {
@@ -183,7 +184,7 @@ describe('{{navigation}} helper', function () {
         rendered = runHelper(optionsData);
 
         should.exist(rendered);
-        rendered.string.should.not.containEql('foo=space%2520bar');
+        assert(!rendered.string.includes('foo=space%2520bar'));
     });
 
     describe('type="secondary"', function () {
@@ -197,9 +198,9 @@ describe('{{navigation}} helper', function () {
             rendered = runHelper(optionsData);
 
             should.exist(rendered);
-            rendered.string.should.containEql('li');
-            rendered.string.should.containEql('nav-foo');
-            rendered.string.should.containEql(testUrl);
+            assert(rendered.string.includes('li'));
+            assert(rendered.string.includes('nav-foo'));
+            assert(rendered.string.includes(testUrl));
         });
 
         it('can render multiple items', function () {
@@ -214,10 +215,10 @@ describe('{{navigation}} helper', function () {
             rendered = runHelper(optionsData);
 
             should.exist(rendered);
-            rendered.string.should.containEql('nav-foo');
-            rendered.string.should.containEql('nav-bar-baz-qux');
-            rendered.string.should.containEql(testUrl);
-            rendered.string.should.containEql(testUrl2);
+            assert(rendered.string.includes('nav-foo'));
+            assert(rendered.string.includes('nav-bar-baz-qux'));
+            assert(rendered.string.includes(testUrl));
+            assert(rendered.string.includes(testUrl2));
         });
     });
 });
@@ -257,11 +258,11 @@ describe('{{navigation}} helper with custom template', function () {
         rendered = runHelper(optionsData);
 
         should.exist(rendered);
-        rendered.string.should.containEql('Chaos is a ladder');
-        rendered.string.should.not.containEql('isHeader is set');
-        rendered.string.should.not.containEql('Jeremy Bearimy baby!');
-        rendered.string.should.containEql(testUrl);
-        rendered.string.should.containEql('Foo');
+        assert(rendered.string.includes('Chaos is a ladder'));
+        assert(!rendered.string.includes('isHeader is set'));
+        assert(!rendered.string.includes('Jeremy Bearimy baby!'));
+        assert(rendered.string.includes(testUrl));
+        assert(rendered.string.includes('Foo'));
     });
 
     it('can pass attributes through', function () {
@@ -274,11 +275,11 @@ describe('{{navigation}} helper with custom template', function () {
         rendered = runHelper(optionsData);
 
         should.exist(rendered);
-        rendered.string.should.not.containEql('Chaos is a ladder');
-        rendered.string.should.containEql('isHeader is set');
-        rendered.string.should.not.containEql('Jeremy Bearimy baby!');
-        rendered.string.should.containEql(testUrl);
-        rendered.string.should.containEql('Foo');
+        assert(!rendered.string.includes('Chaos is a ladder'));
+        assert(rendered.string.includes('isHeader is set'));
+        assert(!rendered.string.includes('Jeremy Bearimy baby!'));
+        assert(rendered.string.includes(testUrl));
+        assert(rendered.string.includes('Foo'));
     });
 
     it('sets isSecondary for type=secondary', function () {
@@ -291,11 +292,11 @@ describe('{{navigation}} helper with custom template', function () {
         rendered = runHelper(optionsData);
 
         should.exist(rendered);
-        rendered.string.should.not.containEql('Chaos is a ladder');
-        rendered.string.should.not.containEql('isHeader is set');
-        rendered.string.should.containEql('Jeremy Bearimy baby!');
-        rendered.string.should.containEql(testUrl);
-        rendered.string.should.containEql('Fighters');
+        assert(!rendered.string.includes('Chaos is a ladder'));
+        assert(!rendered.string.includes('isHeader is set'));
+        assert(rendered.string.includes('Jeremy Bearimy baby!'));
+        assert(rendered.string.includes(testUrl));
+        assert(rendered.string.includes('Fighters'));
     });
 
     describe('using compile', function () {
@@ -329,15 +330,13 @@ describe('{{navigation}} helper with custom template', function () {
         });
 
         it('can render both primary and secondary nav in order', function () {
-            compile('{{navigation}}{{navigation type="secondary"}}')
-                .with({})
-                .should.eql('\n\n\n\nPrime time!\n\n    <a href="">Foo</a>\n\n\n\n\nJeremy Bearimy baby!\n\n    <a href="">Fighters</a>\n');
+            assert.equal(compile('{{navigation}}{{navigation type="secondary"}}')
+                .with({}), '\n\n\n\nPrime time!\n\n    <a href="">Foo</a>\n\n\n\n\nJeremy Bearimy baby!\n\n    <a href="">Fighters</a>\n');
         });
 
         it('can render both primary and secondary nav in reverse order', function () {
-            compile('{{navigation type="secondary"}}{{navigation}}')
-                .with({})
-                .should.eql('\n\n\n\nJeremy Bearimy baby!\n\n    <a href="">Fighters</a>\n\n\n\n\nPrime time!\n\n    <a href="">Foo</a>\n');
+            assert.equal(compile('{{navigation type="secondary"}}{{navigation}}')
+                .with({}), '\n\n\n\nJeremy Bearimy baby!\n\n    <a href="">Fighters</a>\n\n\n\n\nPrime time!\n\n    <a href="">Foo</a>\n');
         });
     });
 });

--- a/ghost/core/test/unit/frontend/helpers/next-post.test.js
+++ b/ghost/core/test/unit/frontend/helpers/next-post.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const errors = require('@tryghost/errors');
 const sinon = require('sinon');
 const markdownToMobiledoc = require('../../../utils/fixtures/data-generator').markdownToMobiledoc;
@@ -55,14 +56,14 @@ describe('{{next_post}} helper', function () {
                     published_at: new Date(0),
                     url: '/current/'
                 }, optionsData);
-            fn.calledOnce.should.be.true();
-            inverse.calledOnce.should.be.false();
+            assert.equal(fn.calledOnce, true);
+            assert.equal(inverse.calledOnce, false);
 
-            fn.firstCall.args.should.have.lengthOf(2);
+            assert.equal(fn.firstCall.args.length, 2);
             fn.firstCall.args[0].should.have.properties('slug', 'title');
             fn.firstCall.args[1].should.be.an.Object().and.have.property('data');
-            browsePostsStub.calledOnce.should.be.true();
-            browsePostsStub.firstCall.args[0].include.should.eql('author,authors,tags,tiers');
+            assert.equal(browsePostsStub.calledOnce, true);
+            assert.equal(browsePostsStub.firstCall.args[0].include, 'author,authors,tags,tiers');
         });
     });
 
@@ -92,10 +93,10 @@ describe('{{next_post}} helper', function () {
                     published_at: new Date(0),
                     url: '/current/'
                 }, optionsData);
-            fn.called.should.be.false();
-            inverse.called.should.be.true();
+            assert.equal(fn.called, false);
+            assert.equal(inverse.called, true);
 
-            inverse.firstCall.args.should.have.lengthOf(2);
+            assert.equal(inverse.firstCall.args.length, 2);
             inverse.firstCall.args[0].should.have.properties('slug', 'title');
             inverse.firstCall.args[1].should.be.an.Object().and.have.property('data');
         });
@@ -117,9 +118,9 @@ describe('{{next_post}} helper', function () {
 
             await next_post
                 .call({}, optionsData);
-            fn.called.should.be.false();
-            inverse.called.should.be.true();
-            browsePostsStub.called.should.be.false();
+            assert.equal(fn.called, false);
+            assert.equal(inverse.called, true);
+            assert.equal(browsePostsStub.called, false);
         });
     });
 
@@ -155,8 +156,8 @@ describe('{{next_post}} helper', function () {
                     url: '/current/',
                     page: true
                 }, optionsData);
-            fn.called.should.be.false();
-            inverse.called.should.be.true();
+            assert.equal(fn.called, false);
+            assert.equal(inverse.called, true);
         });
     });
 
@@ -190,8 +191,8 @@ describe('{{next_post}} helper', function () {
                     created_at: new Date(0),
                     url: '/current/'
                 }, optionsData);
-            fn.called.should.be.false();
-            inverse.called.should.be.true();
+            assert.equal(fn.called, false);
+            assert.equal(inverse.called, true);
         });
     });
 
@@ -223,15 +224,15 @@ describe('{{next_post}} helper', function () {
                     url: '/current/'
                 }, optionsData);
 
-            fn.calledOnce.should.be.true();
-            inverse.calledOnce.should.be.false();
+            assert.equal(fn.calledOnce, true);
+            assert.equal(inverse.calledOnce, false);
 
-            fn.firstCall.args.should.have.lengthOf(2);
+            assert.equal(fn.firstCall.args.length, 2);
             fn.firstCall.args[0].should.have.properties('slug', 'title');
             fn.firstCall.args[1].should.be.an.Object().and.have.property('data');
-            browsePostsStub.calledOnce.should.be.true();
-            browsePostsStub.firstCall.args[0].include.should.eql('author,authors,tags,tiers');
-            browsePostsStub.firstCall.args[0].filter.should.match(/\+primary_tag:test/);
+            assert.equal(browsePostsStub.calledOnce, true);
+            assert.equal(browsePostsStub.firstCall.args[0].include, 'author,authors,tags,tiers');
+            assert.match(browsePostsStub.firstCall.args[0].filter, /\+primary_tag:test/);
         });
 
         it('shows \'if\' template with prev post data with primary_author set', async function () {
@@ -251,15 +252,15 @@ describe('{{next_post}} helper', function () {
                     url: '/current/'
                 }, optionsData);
 
-            fn.calledOnce.should.be.true();
-            inverse.calledOnce.should.be.false();
+            assert.equal(fn.calledOnce, true);
+            assert.equal(inverse.calledOnce, false);
 
-            fn.firstCall.args.should.have.lengthOf(2);
+            assert.equal(fn.firstCall.args.length, 2);
             fn.firstCall.args[0].should.have.properties('slug', 'title');
             fn.firstCall.args[1].should.be.an.Object().and.have.property('data');
-            browsePostsStub.calledOnce.should.be.true();
-            browsePostsStub.firstCall.args[0].include.should.eql('author,authors,tags,tiers');
-            browsePostsStub.firstCall.args[0].filter.should.match(/\+primary_author:hans/);
+            assert.equal(browsePostsStub.calledOnce, true);
+            assert.equal(browsePostsStub.firstCall.args[0].include, 'author,authors,tags,tiers');
+            assert.match(browsePostsStub.firstCall.args[0].filter, /\+primary_author:hans/);
         });
 
         it('shows \'if\' template with prev post data with author set', async function () {
@@ -279,15 +280,15 @@ describe('{{next_post}} helper', function () {
                     url: '/current/'
                 }, optionsData);
 
-            fn.calledOnce.should.be.true();
-            inverse.calledOnce.should.be.false();
+            assert.equal(fn.calledOnce, true);
+            assert.equal(inverse.calledOnce, false);
 
-            fn.firstCall.args.should.have.lengthOf(2);
+            assert.equal(fn.firstCall.args.length, 2);
             fn.firstCall.args[0].should.have.properties('slug', 'title');
             fn.firstCall.args[1].should.be.an.Object().and.have.property('data');
-            browsePostsStub.calledOnce.should.be.true();
-            browsePostsStub.firstCall.args[0].include.should.eql('author,authors,tags,tiers');
-            browsePostsStub.firstCall.args[0].filter.should.match(/\+author:author-name/);
+            assert.equal(browsePostsStub.calledOnce, true);
+            assert.equal(browsePostsStub.firstCall.args[0].include, 'author,authors,tags,tiers');
+            assert.match(browsePostsStub.firstCall.args[0].filter, /\+author:author-name/);
         });
 
         it('shows \'if\' template with prev post data & ignores in author if author isnt present', async function () {
@@ -306,15 +307,15 @@ describe('{{next_post}} helper', function () {
                     url: '/current/'
                 }, optionsData);
 
-            fn.calledOnce.should.be.true();
-            inverse.calledOnce.should.be.false();
+            assert.equal(fn.calledOnce, true);
+            assert.equal(inverse.calledOnce, false);
 
-            fn.firstCall.args.should.have.lengthOf(2);
+            assert.equal(fn.firstCall.args.length, 2);
             fn.firstCall.args[0].should.have.properties('slug', 'title');
             fn.firstCall.args[1].should.be.an.Object().and.have.property('data');
-            browsePostsStub.calledOnce.should.be.true();
-            browsePostsStub.firstCall.args[0].include.should.eql('author,authors,tags,tiers');
-            browsePostsStub.firstCall.args[0].filter.should.not.match(/\+author:/);
+            assert.equal(browsePostsStub.calledOnce, true);
+            assert.equal(browsePostsStub.firstCall.args[0].include, 'author,authors,tags,tiers');
+            assert.doesNotMatch(browsePostsStub.firstCall.args[0].filter, /\+author:/);
         });
 
         it('shows \'if\' template with prev post data & ignores unknown in value', async function () {
@@ -334,15 +335,15 @@ describe('{{next_post}} helper', function () {
                     url: '/current/'
                 }, optionsData);
 
-            fn.calledOnce.should.be.true();
-            inverse.calledOnce.should.be.false();
+            assert.equal(fn.calledOnce, true);
+            assert.equal(inverse.calledOnce, false);
 
-            fn.firstCall.args.should.have.lengthOf(2);
+            assert.equal(fn.firstCall.args.length, 2);
             fn.firstCall.args[0].should.have.properties('slug', 'title');
             fn.firstCall.args[1].should.be.an.Object().and.have.property('data');
-            browsePostsStub.calledOnce.should.be.true();
-            browsePostsStub.firstCall.args[0].include.should.eql('author,authors,tags,tiers');
-            browsePostsStub.firstCall.args[0].filter.should.not.match(/\+magic/);
+            assert.equal(browsePostsStub.calledOnce, true);
+            assert.equal(browsePostsStub.firstCall.args[0].include, 'author,authors,tags,tiers');
+            assert.doesNotMatch(browsePostsStub.firstCall.args[0].filter, /\+magic/);
         });
     });
 
@@ -370,13 +371,13 @@ describe('{{next_post}} helper', function () {
                     url: '/current/'
                 }, optionsData);
 
-            fn.called.should.be.false();
-            inverse.calledOnce.should.be.true();
-            loggingStub.calledOnce.should.be.true();
+            assert.equal(fn.called, false);
+            assert.equal(inverse.calledOnce, true);
+            assert.equal(loggingStub.calledOnce, true);
 
             inverse.firstCall.args[1].should.be.an.Object().and.have.property('data');
             inverse.firstCall.args[1].data.should.be.an.Object().and.have.property('error');
-            inverse.firstCall.args[1].data.error.should.match(/^Something wasn't found/);
+            assert.match(inverse.firstCall.args[1].data.error, /^Something wasn't found/);
         });
 
         it('should show warning for call without any options', async function () {
@@ -390,8 +391,8 @@ describe('{{next_post}} helper', function () {
                     optionsData
                 );
 
-            fn.called.should.be.false();
-            inverse.called.should.be.false();
+            assert.equal(fn.called, false);
+            assert.equal(inverse.called, false);
         });
     });
 
@@ -430,14 +431,14 @@ describe('{{next_post}} helper', function () {
                     url: '/current/'
                 }, optionsData);
 
-            fn.calledOnce.should.be.true();
-            inverse.calledOnce.should.be.false();
+            assert.equal(fn.calledOnce, true);
+            assert.equal(inverse.calledOnce, false);
 
-            fn.firstCall.args.should.have.lengthOf(2);
+            assert.equal(fn.firstCall.args.length, 2);
             fn.firstCall.args[0].should.have.properties('slug', 'title');
             fn.firstCall.args[1].should.be.an.Object().and.have.property('data');
-            browsePostsStub.calledOnce.should.be.true();
-            browsePostsStub.firstCall.args[0].include.should.eql('author,authors,tags,tiers');
+            assert.equal(browsePostsStub.calledOnce, true);
+            assert.equal(browsePostsStub.firstCall.args[0].include, 'author,authors,tags,tiers');
 
             // Check context passed
             browsePostsStub.firstCall.args[0].context.member.should.eql(member);

--- a/ghost/core/test/unit/frontend/helpers/page-url.test.js
+++ b/ghost/core/test/unit/frontend/helpers/page-url.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 
 // Stuff we are testing
@@ -15,11 +16,11 @@ describe('{{page_url}} helper', function () {
         options.data.root.pagination.next = 3;
         options.data.root.pagination.prev = 6;
 
-        page_url(1, options).should.equal('/');
-        page_url(2, options).should.equal('/page/2/');
-        page_url(50, options).should.equal('/page/50/');
-        page_url('next', options).should.eql('/page/3/');
-        page_url('prev', options).should.eql('/page/6/');
+        assert.equal(page_url(1, options), '/');
+        assert.equal(page_url(2, options), '/page/2/');
+        assert.equal(page_url(50, options), '/page/50/');
+        assert.equal(page_url('next', options), '/page/3/');
+        assert.equal(page_url('prev', options), '/page/6/');
     });
 
     it('can return a valid url when the relative url has a path', function () {
@@ -27,11 +28,11 @@ describe('{{page_url}} helper', function () {
         options.data.root.pagination.next = 10;
         options.data.root.pagination.prev = 2;
 
-        page_url(1, options).should.equal('/tag/pumpkin/');
-        page_url(2, options).should.equal('/tag/pumpkin/page/2/');
-        page_url(50, options).should.equal('/tag/pumpkin/page/50/');
-        page_url('next', options).should.eql('/tag/pumpkin/page/10/');
-        page_url('prev', options).should.eql('/tag/pumpkin/page/2/');
+        assert.equal(page_url(1, options), '/tag/pumpkin/');
+        assert.equal(page_url(2, options), '/tag/pumpkin/page/2/');
+        assert.equal(page_url(50, options), '/tag/pumpkin/page/50/');
+        assert.equal(page_url('next', options), '/tag/pumpkin/page/10/');
+        assert.equal(page_url('prev', options), '/tag/pumpkin/page/2/');
     });
 
     it('should assume 1 if page is undefined', function () {

--- a/ghost/core/test/unit/frontend/helpers/pagination.test.js
+++ b/ghost/core/test/unit/frontend/helpers/pagination.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const hbs = require('../../../../core/frontend/services/theme-engine/engine');
 const configUtils = require('../../../utils/config-utils');
@@ -46,7 +47,7 @@ describe('{{pagination}} helper', function () {
         // strip out carriage returns and compare.
         rendered.string.should.match(paginationRegex);
         rendered.string.should.match(pageRegex);
-        rendered.string.should.match(/Page 1 of 1/);
+        assert.match(rendered.string, /Page 1 of 1/);
         rendered.string.should.not.match(newerRegex);
         rendered.string.should.not.match(olderRegex);
     });
@@ -60,7 +61,7 @@ describe('{{pagination}} helper', function () {
         rendered.string.should.match(paginationRegex);
         rendered.string.should.match(pageRegex);
         rendered.string.should.match(olderRegex);
-        rendered.string.should.match(/Page 1 of 3/);
+        assert.match(rendered.string, /Page 1 of 3/);
         rendered.string.should.not.match(newerRegex);
     });
 
@@ -74,7 +75,7 @@ describe('{{pagination}} helper', function () {
         rendered.string.should.match(pageRegex);
         rendered.string.should.match(olderRegex);
         rendered.string.should.match(newerRegex);
-        rendered.string.should.match(/Page 2 of 3/);
+        assert.match(rendered.string, /Page 2 of 3/);
     });
 
     it('can render last page of many with newer posts link', function () {
@@ -86,7 +87,7 @@ describe('{{pagination}} helper', function () {
         rendered.string.should.match(paginationRegex);
         rendered.string.should.match(pageRegex);
         rendered.string.should.match(newerRegex);
-        rendered.string.should.match(/Page 3 of 3/);
+        assert.match(rendered.string, /Page 3 of 3/);
         rendered.string.should.not.match(olderRegex);
     });
 
@@ -144,9 +145,9 @@ describe('{{pagination}} helper with custom template', function () {
         });
         should.exist(rendered);
         // strip out carriage returns and compare.
-        rendered.string.should.match(/Page 1 of 1/);
-        rendered.string.should.containEql('Chaos is a ladder');
-        rendered.string.should.not.containEql('isHeader is set');
+        assert.match(rendered.string, /Page 1 of 1/);
+        assert(rendered.string.includes('Chaos is a ladder'));
+        assert(!rendered.string.includes('isHeader is set'));
     });
 
     it('can pass attributes through', function () {
@@ -161,8 +162,8 @@ describe('{{pagination}} helper with custom template', function () {
         });
         should.exist(rendered);
         // strip out carriage returns and compare.
-        rendered.string.should.match(/Page 1 of 1/);
-        rendered.string.should.not.containEql('Chaos is a ladder');
-        rendered.string.should.containEql('isHeader is set');
+        assert.match(rendered.string, /Page 1 of 1/);
+        assert(!rendered.string.includes('Chaos is a ladder'));
+        assert(rendered.string.includes('isHeader is set'));
     });
 });

--- a/ghost/core/test/unit/frontend/helpers/post-class.test.js
+++ b/ghost/core/test/unit/frontend/helpers/post-class.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 
 // Stuff we are testing
@@ -8,14 +9,14 @@ describe('{{post_class}} helper', function () {
         const rendered = post_class.call({});
 
         should.exist(rendered);
-        rendered.string.should.equal('post no-image');
+        assert.equal(rendered.string, 'post no-image');
     });
 
     it('can render class string without no-image class', function () {
         const rendered = post_class.call({feature_image: 'blah'});
 
         should.exist(rendered);
-        rendered.string.should.equal('post');
+        assert.equal(rendered.string, 'post');
     });
 
     it('can render featured class', function () {
@@ -23,7 +24,7 @@ describe('{{post_class}} helper', function () {
         const rendered = post_class.call(post);
 
         should.exist(rendered);
-        rendered.string.should.equal('post featured no-image');
+        assert.equal(rendered.string, 'post featured no-image');
     });
 
     it('can render featured class without no-image class', function () {
@@ -31,7 +32,7 @@ describe('{{post_class}} helper', function () {
         const rendered = post_class.call(post);
 
         should.exist(rendered);
-        rendered.string.should.equal('post featured');
+        assert.equal(rendered.string, 'post featured');
     });
 
     it('can render page class', function () {
@@ -39,7 +40,7 @@ describe('{{post_class}} helper', function () {
         const rendered = post_class.call(post);
 
         should.exist(rendered);
-        rendered.string.should.equal('post no-image page');
+        assert.equal(rendered.string, 'post no-image page');
     });
 
     it('can render page class without no-image class', function () {
@@ -47,6 +48,6 @@ describe('{{post_class}} helper', function () {
         const rendered = post_class.call(post);
 
         should.exist(rendered);
-        rendered.string.should.equal('post page');
+        assert.equal(rendered.string, 'post page');
     });
 });

--- a/ghost/core/test/unit/frontend/helpers/prev-post.test.js
+++ b/ghost/core/test/unit/frontend/helpers/prev-post.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const errors = require('@tryghost/errors');
 const sinon = require('sinon');
 const markdownToMobiledoc = require('../../../utils/fixtures/data-generator').markdownToMobiledoc;
@@ -56,14 +57,14 @@ describe('{{prev_post}} helper', function () {
                     url: '/current/'
                 }, optionsData);
 
-            fn.calledOnce.should.be.true();
-            inverse.calledOnce.should.be.false();
+            assert.equal(fn.calledOnce, true);
+            assert.equal(inverse.calledOnce, false);
 
-            fn.firstCall.args.should.have.lengthOf(2);
+            assert.equal(fn.firstCall.args.length, 2);
             fn.firstCall.args[0].should.have.properties('slug', 'title');
             fn.firstCall.args[1].should.be.an.Object().and.have.property('data');
-            browsePostsStub.calledOnce.should.be.true();
-            browsePostsStub.firstCall.args[0].include.should.eql('author,authors,tags,tiers');
+            assert.equal(browsePostsStub.calledOnce, true);
+            assert.equal(browsePostsStub.firstCall.args[0].include, 'author,authors,tags,tiers');
         });
     });
 
@@ -92,10 +93,10 @@ describe('{{prev_post}} helper', function () {
                     url: '/current/'
                 }, optionsData);
 
-            fn.called.should.be.false();
-            inverse.called.should.be.true();
+            assert.equal(fn.called, false);
+            assert.equal(inverse.called, true);
 
-            inverse.firstCall.args.should.have.lengthOf(2);
+            assert.equal(inverse.firstCall.args.length, 2);
             inverse.firstCall.args[0].should.have.properties('slug', 'title');
             inverse.firstCall.args[1].should.be.an.Object().and.have.property('data');
         });
@@ -118,9 +119,9 @@ describe('{{prev_post}} helper', function () {
             await prev_post
                 .call({}, optionsData);
 
-            fn.called.should.be.false();
-            inverse.called.should.be.true();
-            browsePostsStub.called.should.be.false();
+            assert.equal(fn.called, false);
+            assert.equal(inverse.called, true);
+            assert.equal(browsePostsStub.called, false);
         });
     });
 
@@ -157,8 +158,8 @@ describe('{{prev_post}} helper', function () {
                     page: true
                 }, optionsData);
 
-            fn.called.should.be.false();
-            inverse.called.should.be.true();
+            assert.equal(fn.called, false);
+            assert.equal(inverse.called, true);
         });
     });
 
@@ -194,8 +195,8 @@ describe('{{prev_post}} helper', function () {
                     url: '/current/'
                 }, optionsData);
 
-            fn.called.should.be.false();
-            inverse.called.should.be.true();
+            assert.equal(fn.called, false);
+            assert.equal(inverse.called, true);
         });
     });
 
@@ -227,15 +228,15 @@ describe('{{prev_post}} helper', function () {
                     url: '/current/'
                 }, optionsData);
 
-            fn.calledOnce.should.be.true();
-            inverse.calledOnce.should.be.false();
+            assert.equal(fn.calledOnce, true);
+            assert.equal(inverse.calledOnce, false);
 
-            fn.firstCall.args.should.have.lengthOf(2);
+            assert.equal(fn.firstCall.args.length, 2);
             fn.firstCall.args[0].should.have.properties('slug', 'title');
             fn.firstCall.args[1].should.be.an.Object().and.have.property('data');
-            browsePostsStub.calledOnce.should.be.true();
-            browsePostsStub.firstCall.args[0].include.should.eql('author,authors,tags,tiers');
-            browsePostsStub.firstCall.args[0].filter.should.match(/\+primary_tag:test/);
+            assert.equal(browsePostsStub.calledOnce, true);
+            assert.equal(browsePostsStub.firstCall.args[0].include, 'author,authors,tags,tiers');
+            assert.match(browsePostsStub.firstCall.args[0].filter, /\+primary_tag:test/);
         });
 
         it('shows \'if\' template with prev post data with primary_author set', async function () {
@@ -255,15 +256,15 @@ describe('{{prev_post}} helper', function () {
                     url: '/current/'
                 }, optionsData);
 
-            fn.calledOnce.should.be.true();
-            inverse.calledOnce.should.be.false();
+            assert.equal(fn.calledOnce, true);
+            assert.equal(inverse.calledOnce, false);
 
-            fn.firstCall.args.should.have.lengthOf(2);
+            assert.equal(fn.firstCall.args.length, 2);
             fn.firstCall.args[0].should.have.properties('slug', 'title');
             fn.firstCall.args[1].should.be.an.Object().and.have.property('data');
-            browsePostsStub.calledOnce.should.be.true();
-            browsePostsStub.firstCall.args[0].include.should.eql('author,authors,tags,tiers');
-            browsePostsStub.firstCall.args[0].filter.should.match(/\+primary_author:hans/);
+            assert.equal(browsePostsStub.calledOnce, true);
+            assert.equal(browsePostsStub.firstCall.args[0].include, 'author,authors,tags,tiers');
+            assert.match(browsePostsStub.firstCall.args[0].filter, /\+primary_author:hans/);
         });
 
         it('shows \'if\' template with prev post data with author set', async function () {
@@ -283,15 +284,15 @@ describe('{{prev_post}} helper', function () {
                     url: '/current/'
                 }, optionsData);
 
-            fn.calledOnce.should.be.true();
-            inverse.calledOnce.should.be.false();
+            assert.equal(fn.calledOnce, true);
+            assert.equal(inverse.calledOnce, false);
 
-            fn.firstCall.args.should.have.lengthOf(2);
+            assert.equal(fn.firstCall.args.length, 2);
             fn.firstCall.args[0].should.have.properties('slug', 'title');
             fn.firstCall.args[1].should.be.an.Object().and.have.property('data');
-            browsePostsStub.calledOnce.should.be.true();
-            browsePostsStub.firstCall.args[0].include.should.eql('author,authors,tags,tiers');
-            browsePostsStub.firstCall.args[0].filter.should.match(/\+author:author-name/);
+            assert.equal(browsePostsStub.calledOnce, true);
+            assert.equal(browsePostsStub.firstCall.args[0].include, 'author,authors,tags,tiers');
+            assert.match(browsePostsStub.firstCall.args[0].filter, /\+author:author-name/);
         });
 
         it('shows \'if\' template with prev post data & ignores in author if author isnt present', async function () {
@@ -310,15 +311,15 @@ describe('{{prev_post}} helper', function () {
                     url: '/current/'
                 }, optionsData);
 
-            fn.calledOnce.should.be.true();
-            inverse.calledOnce.should.be.false();
+            assert.equal(fn.calledOnce, true);
+            assert.equal(inverse.calledOnce, false);
 
-            fn.firstCall.args.should.have.lengthOf(2);
+            assert.equal(fn.firstCall.args.length, 2);
             fn.firstCall.args[0].should.have.properties('slug', 'title');
             fn.firstCall.args[1].should.be.an.Object().and.have.property('data');
-            browsePostsStub.calledOnce.should.be.true();
-            browsePostsStub.firstCall.args[0].include.should.eql('author,authors,tags,tiers');
-            browsePostsStub.firstCall.args[0].filter.should.not.match(/\+author:/);
+            assert.equal(browsePostsStub.calledOnce, true);
+            assert.equal(browsePostsStub.firstCall.args[0].include, 'author,authors,tags,tiers');
+            assert.doesNotMatch(browsePostsStub.firstCall.args[0].filter, /\+author:/);
         });
 
         it('shows \'if\' template with prev post data & ignores unknown in value', async function () {
@@ -338,15 +339,15 @@ describe('{{prev_post}} helper', function () {
                     url: '/current/'
                 }, optionsData);
 
-            fn.calledOnce.should.be.true();
-            inverse.calledOnce.should.be.false();
+            assert.equal(fn.calledOnce, true);
+            assert.equal(inverse.calledOnce, false);
 
-            fn.firstCall.args.should.have.lengthOf(2);
+            assert.equal(fn.firstCall.args.length, 2);
             fn.firstCall.args[0].should.have.properties('slug', 'title');
             fn.firstCall.args[1].should.be.an.Object().and.have.property('data');
-            browsePostsStub.calledOnce.should.be.true();
-            browsePostsStub.firstCall.args[0].include.should.eql('author,authors,tags,tiers');
-            browsePostsStub.firstCall.args[0].filter.should.not.match(/\+magic/);
+            assert.equal(browsePostsStub.calledOnce, true);
+            assert.equal(browsePostsStub.firstCall.args[0].include, 'author,authors,tags,tiers');
+            assert.doesNotMatch(browsePostsStub.firstCall.args[0].filter, /\+magic/);
         });
     });
 
@@ -374,13 +375,13 @@ describe('{{prev_post}} helper', function () {
                     url: '/current/'
                 }, optionsData);
 
-            fn.called.should.be.false();
-            inverse.calledOnce.should.be.true();
-            loggingStub.calledOnce.should.be.true();
+            assert.equal(fn.called, false);
+            assert.equal(inverse.calledOnce, true);
+            assert.equal(loggingStub.calledOnce, true);
 
             inverse.firstCall.args[1].should.be.an.Object().and.have.property('data');
             inverse.firstCall.args[1].data.should.be.an.Object().and.have.property('error');
-            inverse.firstCall.args[1].data.error.should.match(/^Something wasn't found/);
+            assert.match(inverse.firstCall.args[1].data.error, /^Something wasn't found/);
         });
 
         it('should show warning for call without any options', async function () {
@@ -394,8 +395,8 @@ describe('{{prev_post}} helper', function () {
                     optionsData
                 );
 
-            fn.called.should.be.false();
-            inverse.called.should.be.false();
+            assert.equal(fn.called, false);
+            assert.equal(inverse.called, false);
         });
     });
 
@@ -434,14 +435,14 @@ describe('{{prev_post}} helper', function () {
                     url: '/current/'
                 }, optionsData);
 
-            fn.calledOnce.should.be.true();
-            inverse.calledOnce.should.be.false();
+            assert.equal(fn.calledOnce, true);
+            assert.equal(inverse.calledOnce, false);
 
-            fn.firstCall.args.should.have.lengthOf(2);
+            assert.equal(fn.firstCall.args.length, 2);
             fn.firstCall.args[0].should.have.properties('slug', 'title');
             fn.firstCall.args[1].should.be.an.Object().and.have.property('data');
-            browsePostsStub.calledOnce.should.be.true();
-            browsePostsStub.firstCall.args[0].include.should.eql('author,authors,tags,tiers');
+            assert.equal(browsePostsStub.calledOnce, true);
+            assert.equal(browsePostsStub.firstCall.args[0].include, 'author,authors,tags,tiers');
 
             // Check context passed
             browsePostsStub.firstCall.args[0].context.member.should.eql(member);

--- a/ghost/core/test/unit/frontend/helpers/raw.test.js
+++ b/ghost/core/test/unit/frontend/helpers/raw.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const raw = require('../../../../core/frontend/helpers/raw');
 const handlebars = require('../../../../core/frontend/services/theme-engine/engine').handlebars;
@@ -21,20 +22,17 @@ describe('{{raw}} helper', function () {
     });
 
     it('can correctly compile space', function () {
-        compile('{{{{raw}}}} {{{{/raw}}}}')
-            .with({})
-            .should.eql(' ');
+        assert.equal(compile('{{{{raw}}}} {{{{/raw}}}}')
+            .with({}), ' ');
     });
 
     it('can correctly ignore handlebars', function () {
-        compile('{{{{raw}}}}{{test}}{{{{/raw}}}}')
-            .with({tag: {}})
-            .should.eql('{{test}}');
+        assert.equal(compile('{{{{raw}}}}{{test}}{{{{/raw}}}}')
+            .with({tag: {}}), '{{test}}');
     });
 
     it('can correctly compile recursive', function () {
-        compile('{{{{raw}}}}{{{{raw}}}}{{{{/raw}}}}{{{{/raw}}}}')
-            .with({tag: {}})
-            .should.eql('{{{{raw}}}}{{{{/raw}}}}');
+        assert.equal(compile('{{{{raw}}}}{{{{raw}}}}{{{{/raw}}}}{{{{/raw}}}}')
+            .with({tag: {}}), '{{{{raw}}}}{{{{/raw}}}}');
     });
 });

--- a/ghost/core/test/unit/frontend/helpers/reading-time.test.js
+++ b/ghost/core/test/unit/frontend/helpers/reading-time.test.js
@@ -44,7 +44,7 @@ describe('{{reading_time}} helper', function () {
 
         const result = reading_time.call(data);
 
-        String(result).should.equal('1 min read');
+        assert.equal(String(result), '1 min read');
     });
 
     it('[success] renders reading time for one minute text as one minute', function () {
@@ -58,7 +58,7 @@ describe('{{reading_time}} helper', function () {
 
         const result = reading_time.call(data);
 
-        String(result).should.equal('1 min read');
+        assert.equal(String(result), '1 min read');
     });
 
     it('[success] renders reading time for just under 1.5 minutes text as one minute', function () {
@@ -70,7 +70,7 @@ describe('{{reading_time}} helper', function () {
 
         const result = reading_time.call(data);
 
-        String(result).should.equal('1 min read');
+        assert.equal(String(result), '1 min read');
     });
 
     it('[success] adds time for feature image', function () {
@@ -85,7 +85,7 @@ describe('{{reading_time}} helper', function () {
 
         // The reading time for this HTML snippet would 89 seconds without the image
         // Adding the 12 additional seconds for the image results in a readng time of over 1.5 minutes, rounded to 2
-        String(result).should.equal('2 min read');
+        assert.equal(String(result), '2 min read');
     });
 
     it('[success] adds time for inline images', function () {
@@ -100,7 +100,7 @@ describe('{{reading_time}} helper', function () {
 
         // The reading time for this HTML snippet would 89 seconds without the image
         // Adding the 12 additional seconds for the image results in a readng time of over 1.5 minutes, rounded to 2
-        String(result).should.equal('2 min read');
+        assert.equal(String(result), '2 min read');
     });
 
     it('[failure] does not render reading time when not post', function () {

--- a/ghost/core/test/unit/frontend/helpers/recommendations.test.js
+++ b/ghost/core/test/unit/frontend/helpers/recommendations.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const models = require('../../../../core/server/models');
@@ -124,7 +125,7 @@ describe('{{#recommendations}} helper', function () {
 
             // No HTML is rendered
             response.should.be.an.Object().with.property('string');
-            response.string.should.equal('');
+            assert.equal(response.string, '');
         });
     });
 
@@ -141,7 +142,7 @@ describe('{{#recommendations}} helper', function () {
 
             // No HTML is rendered
             response.should.be.an.Object().with.property('string');
-            response.string.should.equal('');
+            assert.equal(response.string, '');
         });
     });
 
@@ -171,11 +172,11 @@ describe('{{#recommendations}} helper', function () {
             );
 
             // An error message is logged
-            logging.error.calledOnce.should.be.true();
+            assert.equal(logging.error.calledOnce, true);
 
             // No HTML is rendered
             response.should.be.an.Object().with.property('string');
-            response.string.should.equal('');
+            assert.equal(response.string, '');
         });
     });
 });

--- a/ghost/core/test/unit/frontend/helpers/social-url.test.js
+++ b/ghost/core/test/unit/frontend/helpers/social-url.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const handlebars = require('../../../../core/frontend/services/theme-engine/engine').handlebars;
 const helpers = require('../../../../core/frontend/services/helpers');
@@ -67,32 +68,27 @@ describe('{{social_url}} helper', function () {
 
     it('should return empty string if the type hash parameter is missing', function () {
         const templateString = `{{social_url}}`; // No type hash
-        compile(templateString)
-            .with(socialData)
-            .should.equal('');
+        assert.equal(compile(templateString)
+            .with(socialData), '');
     });
 
     it('should return empty string if the type hash parameter is not a supported platform', function () {
         const templateString = `{{social_url type="unknownplatform"}}`;
-        compile(templateString)
-            .with(socialData)
-            .should.equal('');
+        assert.equal(compile(templateString)
+            .with(socialData), '');
     });
 
     it('should return empty string if the user does not have a new platform set in their profile', function () {
         const templateString = `{{social_url type="instagram"}}`;
-        compile(templateString)
-            .with({})
-            .should.equal('');
+        assert.equal(compile(templateString)
+            .with({}), '');
     });
 
     it('but for facebook and twitter, we do fall back to site data, same as the facebook and twitter url helpers', function () {
-        compile(`{{social_url type="facebook"}}`)
-            .with({})
-            .should.equal('https://www.facebook.com/testuser-fb');
+        assert.equal(compile(`{{social_url type="facebook"}}`)
+            .with({}), 'https://www.facebook.com/testuser-fb');
 
-        compile(`{{social_url type="twitter"}}`)
-            .with({})
-            .should.equal('https://x.com/testuser-tw');
+        assert.equal(compile(`{{social_url type="twitter"}}`)
+            .with({}), 'https://x.com/testuser-tw');
     });
 });

--- a/ghost/core/test/unit/frontend/helpers/t-new.test.js
+++ b/ghost/core/test/unit/frontend/helpers/t-new.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const path = require('path');
 const sinon = require('sinon');
@@ -30,7 +31,7 @@ describe('NEW{{t}} helper', function () {
             hash: {}
         });
 
-        rendered.should.eql('Oben Links.');
+        assert.equal(rendered, 'Oben Links.');
     });
 
     it('theme translation is EN', function () {
@@ -40,7 +41,7 @@ describe('NEW{{t}} helper', function () {
             hash: {}
         });
 
-        rendered.should.eql('Left Button on Top');
+        assert.equal(rendered, 'Left Button on Top');
     });
 
     it('[fallback] no theme translation file found for FR', function () {
@@ -50,7 +51,7 @@ describe('NEW{{t}} helper', function () {
             hash: {}
         });
 
-        rendered.should.eql('Left Button on Top');
+        assert.equal(rendered, 'Left Button on Top');
     });
 
     it('[fallback] no theme files at all, use key as translation', function () {
@@ -60,7 +61,7 @@ describe('NEW{{t}} helper', function () {
             hash: {}
         });
 
-        rendered.should.eql('Top left Button');
+        assert.equal(rendered, 'Top left Button');
     });
 
     it('returns an empty string if translation key is an empty string', function () {
@@ -68,7 +69,7 @@ describe('NEW{{t}} helper', function () {
             hash: {}
         });
 
-        rendered.should.eql('');
+        assert.equal(rendered, '');
     });
 
     it('returns an empty string if translation key is missing', function () {
@@ -76,7 +77,7 @@ describe('NEW{{t}} helper', function () {
             hash: {}
         });
 
-        rendered.should.eql('');
+        assert.equal(rendered, '');
     });
 
     it('returns a translated string even if no options are passed', function () {
@@ -84,6 +85,6 @@ describe('NEW{{t}} helper', function () {
 
         let rendered = t.call({}, 'Top left Button');
 
-        rendered.should.eql('Left Button on Top');
+        assert.equal(rendered, 'Left Button on Top');
     });
 });

--- a/ghost/core/test/unit/frontend/helpers/t.test.js
+++ b/ghost/core/test/unit/frontend/helpers/t.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const path = require('path');
 const t = require('../../../../core/frontend/helpers/t');
@@ -21,7 +22,7 @@ describe('{{t}} helper', function () {
             hash: {}
         });
 
-        rendered.should.eql('Oben Links.');
+        assert.equal(rendered, 'Oben Links.');
     });
 
     it('theme translation is EN', function () {
@@ -31,7 +32,7 @@ describe('{{t}} helper', function () {
             hash: {}
         });
 
-        rendered.should.eql('Left Button on Top');
+        assert.equal(rendered, 'Left Button on Top');
     });
 
     it('[fallback] no theme translation file found for FR', function () {
@@ -41,7 +42,7 @@ describe('{{t}} helper', function () {
             hash: {}
         });
 
-        rendered.should.eql('Left Button on Top');
+        assert.equal(rendered, 'Left Button on Top');
     });
 
     it('[fallback] no theme files at all, use key as translation', function () {
@@ -51,7 +52,7 @@ describe('{{t}} helper', function () {
             hash: {}
         });
 
-        rendered.should.eql('Top left Button');
+        assert.equal(rendered, 'Top left Button');
     });
 
     it('returns an empty string if translation key is an empty string', function () {
@@ -59,7 +60,7 @@ describe('{{t}} helper', function () {
             hash: {}
         });
 
-        rendered.should.eql('');
+        assert.equal(rendered, '');
     });
 
     it('returns an empty string if translation key is missing', function () {
@@ -67,7 +68,7 @@ describe('{{t}} helper', function () {
             hash: {}
         });
 
-        rendered.should.eql('');
+        assert.equal(rendered, '');
     });
 
     it('returns a translated string even if no options are passed', function () {
@@ -75,6 +76,6 @@ describe('{{t}} helper', function () {
 
         let rendered = t.call({}, 'Top left Button');
 
-        rendered.should.eql('Left Button on Top');
+        assert.equal(rendered, 'Left Button on Top');
     });
 });

--- a/ghost/core/test/unit/frontend/helpers/tags.test.js
+++ b/ghost/core/test/unit/frontend/helpers/tags.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const testUtils = require('../../../utils');
@@ -29,7 +30,7 @@ describe('{{tags}} helper', function () {
         const rendered = tagsHelper.call({tags: tags}, {hash: {autolink: 'false'}});
         should.exist(rendered);
 
-        String(rendered).should.equal('foo, bar');
+        assert.equal(String(rendered), 'foo, bar');
     });
 
     it('can use a different separator', function () {
@@ -41,7 +42,7 @@ describe('{{tags}} helper', function () {
         const rendered = tagsHelper.call({tags: tags}, {hash: {separator: '|', autolink: 'false'}});
         should.exist(rendered);
 
-        String(rendered).should.equal('haunted|ghost');
+        assert.equal(String(rendered), 'haunted|ghost');
     });
 
     it('can add a single prefix to multiple tags', function () {
@@ -53,7 +54,7 @@ describe('{{tags}} helper', function () {
         const rendered = tagsHelper.call({tags: tags}, {hash: {prefix: 'on ', autolink: 'false'}});
         should.exist(rendered);
 
-        String(rendered).should.equal('on haunted, ghost');
+        assert.equal(String(rendered), 'on haunted, ghost');
     });
 
     it('can add a single suffix to multiple tags', function () {
@@ -65,7 +66,7 @@ describe('{{tags}} helper', function () {
         const rendered = tagsHelper.call({tags: tags}, {hash: {suffix: ' forever', autolink: 'false'}});
         should.exist(rendered);
 
-        String(rendered).should.equal('haunted, ghost forever');
+        assert.equal(String(rendered), 'haunted, ghost forever');
     });
 
     it('can add a prefix and suffix to multiple tags', function () {
@@ -77,7 +78,7 @@ describe('{{tags}} helper', function () {
         const rendered = tagsHelper.call({tags: tags}, {hash: {suffix: ' forever', prefix: 'on ', autolink: 'false'}});
         should.exist(rendered);
 
-        String(rendered).should.equal('on haunted, ghost forever');
+        assert.equal(String(rendered), 'on haunted, ghost forever');
     });
 
     it('can add a prefix and suffix with HTML', function () {
@@ -89,14 +90,14 @@ describe('{{tags}} helper', function () {
         const rendered = tagsHelper.call({tags: tags}, {hash: {suffix: ' &bull;', prefix: '&hellip; ', autolink: 'false'}});
         should.exist(rendered);
 
-        String(rendered).should.equal('&hellip; haunted, ghost &bull;');
+        assert.equal(String(rendered), '&hellip; haunted, ghost &bull;');
     });
 
     it('does not add prefix or suffix if no tags exist', function () {
         const rendered = tagsHelper.call({}, {hash: {prefix: 'on ', suffix: ' forever', autolink: 'false'}});
         should.exist(rendered);
 
-        String(rendered).should.equal('');
+        assert.equal(String(rendered), '');
     });
 
     it('can autolink tags to tag pages', function () {
@@ -111,7 +112,7 @@ describe('{{tags}} helper', function () {
         const rendered = tagsHelper.call({tags: tags});
         should.exist(rendered);
 
-        String(rendered).should.equal('<a href="tag url 1">foo</a>, <a href="tag url 2">bar</a>');
+        assert.equal(String(rendered), '<a href="tag url 1">foo</a>, <a href="tag url 2">bar</a>');
     });
 
     it('can limit no. tags output to 1', function () {
@@ -125,7 +126,7 @@ describe('{{tags}} helper', function () {
         const rendered = tagsHelper.call({tags: tags}, {hash: {limit: '1'}});
         should.exist(rendered);
 
-        String(rendered).should.equal('<a href="tag url 1">foo</a>');
+        assert.equal(String(rendered), '<a href="tag url 1">foo</a>');
     });
 
     it('can list tags from a specified no.', function () {
@@ -139,7 +140,7 @@ describe('{{tags}} helper', function () {
         const rendered = tagsHelper.call({tags: tags}, {hash: {from: '2'}});
         should.exist(rendered);
 
-        String(rendered).should.equal('<a href="tag url 2">bar</a>');
+        assert.equal(String(rendered), '<a href="tag url 2">bar</a>');
     });
 
     it('can list tags to a specified no.', function () {
@@ -153,7 +154,7 @@ describe('{{tags}} helper', function () {
         const rendered = tagsHelper.call({tags: tags}, {hash: {to: '1'}});
         should.exist(rendered);
 
-        String(rendered).should.equal('<a href="tag url x">foo</a>');
+        assert.equal(String(rendered), '<a href="tag url x">foo</a>');
     });
 
     it('can list tags in a range', function () {
@@ -169,7 +170,7 @@ describe('{{tags}} helper', function () {
         const rendered = tagsHelper.call({tags: tags}, {hash: {from: '2', to: '3'}});
         should.exist(rendered);
 
-        String(rendered).should.equal('<a href="tag url b">bar</a>, <a href="tag url c">baz</a>');
+        assert.equal(String(rendered), '<a href="tag url b">bar</a>, <a href="tag url c">baz</a>');
     });
 
     it('can limit no. tags and output from 2', function () {
@@ -184,7 +185,7 @@ describe('{{tags}} helper', function () {
         const rendered = tagsHelper.call({tags: tags}, {hash: {from: '2', limit: '1'}});
         should.exist(rendered);
 
-        String(rendered).should.equal('<a href="tag url b">bar</a>');
+        assert.equal(String(rendered), '<a href="tag url b">bar</a>');
     });
 
     it('can list tags in a range (ignore limit)', function () {
@@ -201,7 +202,7 @@ describe('{{tags}} helper', function () {
         const rendered = tagsHelper.call({tags: tags}, {hash: {from: '1', to: '3', limit: '2'}});
         should.exist(rendered);
 
-        String(rendered).should.equal('<a href="tag url a">foo</a>, <a href="tag url b">bar</a>, <a href="tag url c">baz</a>');
+        assert.equal(String(rendered), '<a href="tag url a">foo</a>, <a href="tag url b">bar</a>, <a href="tag url c">baz</a>');
     });
 
     describe('Internal tags', function () {
@@ -275,14 +276,14 @@ describe('{{tags}} helper', function () {
             const rendered = tagsHelper.call({tags: tags}, {hash: {visibility: 'internal'}});
             should.exist(rendered);
 
-            String(rendered).should.equal('<a href="2">#bar</a>');
+            assert.equal(String(rendered), '<a href="2">#bar</a>');
         });
 
         it('should output nothing if all tags are internal', function () {
             const rendered = tagsHelper.call({tags: tags1}, {hash: {prefix: 'stuff'}});
             should.exist(rendered);
 
-            String(rendered).should.equal('');
+            assert.equal(String(rendered), '');
         });
     });
 });

--- a/ghost/core/test/unit/frontend/helpers/tiers.test.js
+++ b/ghost/core/test/unit/frontend/helpers/tiers.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const tiersHelper = require('../../../../core/frontend/helpers/tiers');
 
@@ -12,7 +13,7 @@ describe('{{tiers}} helper', function () {
         const rendered = tiersHelper.call({tiers: tiers}, {hash: {}});
         should.exist(rendered);
 
-        String(rendered).should.equal('tier 1, tier 2 and tier 3 tiers');
+        assert.equal(String(rendered), 'tier 1, tier 2 and tier 3 tiers');
     });
 
     it('can use a different separator', function () {
@@ -25,7 +26,7 @@ describe('{{tiers}} helper', function () {
         const rendered = tiersHelper.call({tiers: tiers}, {hash: {separator: '|'}});
         should.exist(rendered);
 
-        String(rendered).should.equal('tier 1|tier 2 and tier 3 tiers');
+        assert.equal(String(rendered), 'tier 1|tier 2 and tier 3 tiers');
     });
 
     it('can use a different final separator', function () {
@@ -38,7 +39,7 @@ describe('{{tiers}} helper', function () {
         const rendered = tiersHelper.call({tiers: tiers}, {hash: {lastSeparator: ' as well as '}});
         should.exist(rendered);
 
-        String(rendered).should.equal('tier 1, tier 2 as well as tier 3 tiers');
+        assert.equal(String(rendered), 'tier 1, tier 2 as well as tier 3 tiers');
     });
 
     it('can add a single prefix to multiple tiers', function () {
@@ -51,7 +52,7 @@ describe('{{tiers}} helper', function () {
         const rendered = tiersHelper.call({tiers: tiers}, {hash: {prefix: 'on '}});
         should.exist(rendered);
 
-        String(rendered).should.equal('on tier 1, tier 2 and tier 3 tiers');
+        assert.equal(String(rendered), 'on tier 1, tier 2 and tier 3 tiers');
     });
 
     it('can add a single suffix to multiple tiers', function () {
@@ -64,7 +65,7 @@ describe('{{tiers}} helper', function () {
         const rendered = tiersHelper.call({tiers: tiers}, {hash: {suffix: ' products'}});
         should.exist(rendered);
 
-        String(rendered).should.equal('tier 1, tier 2 and tier 3 products');
+        assert.equal(String(rendered), 'tier 1, tier 2 and tier 3 products');
     });
 
     it('can override empty suffix to multiple tiers', function () {
@@ -77,7 +78,7 @@ describe('{{tiers}} helper', function () {
         const rendered = tiersHelper.call({tiers: tiers}, {hash: {suffix: ''}});
         should.exist(rendered);
 
-        String(rendered).should.equal('tier 1, tier 2 and tier 3');
+        assert.equal(String(rendered), 'tier 1, tier 2 and tier 3');
     });
 
     it('can add a prefix and suffix to multiple tiers', function () {
@@ -90,7 +91,7 @@ describe('{{tiers}} helper', function () {
         const rendered = tiersHelper.call({tiers: tiers}, {hash: {prefix: 'on ', suffix: ' products'}});
         should.exist(rendered);
 
-        String(rendered).should.equal('on tier 1, tier 2 and tier 3 products');
+        assert.equal(String(rendered), 'on tier 1, tier 2 and tier 3 products');
     });
 
     it('can add a prefix and suffix with HTML', function () {
@@ -103,13 +104,13 @@ describe('{{tiers}} helper', function () {
         const rendered = tiersHelper.call({tiers: tiers}, {hash: {suffix: ' &bull;', prefix: '&hellip; '}});
         should.exist(rendered);
 
-        String(rendered).should.equal('&hellip; tier 1, tier 2 and tier 3 &bull;');
+        assert.equal(String(rendered), '&hellip; tier 1, tier 2 and tier 3 &bull;');
     });
 
     it('does not add prefix or suffix if no tiers exist', function () {
         const rendered = tiersHelper.call({}, {hash: {prefix: 'on ', suffix: ' products'}});
         should.exist(rendered);
 
-        String(rendered).should.equal('');
+        assert.equal(String(rendered), '');
     });
 });

--- a/ghost/core/test/unit/frontend/helpers/title.test.js
+++ b/ghost/core/test/unit/frontend/helpers/title.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 
 // Stuff we are testing
@@ -8,24 +9,24 @@ describe('{{title}} Helper', function () {
         const rendered = title.call({title: 'Hello World'});
 
         should.exist(rendered);
-        rendered.string.should.equal('Hello World');
+        assert.equal(rendered.string, 'Hello World');
     });
 
     it('escapes correctly', function () {
         const rendered = title.call({title: '<h1>I am a title</h1>'});
 
-        rendered.string.should.equal('&lt;h1&gt;I am a title&lt;/h1&gt;');
+        assert.equal(rendered.string, '&lt;h1&gt;I am a title&lt;/h1&gt;');
     });
 
     it('returns a blank string where title is missing', function () {
         const rendered = title.call({title: null});
 
-        rendered.string.should.equal('');
+        assert.equal(rendered.string, '');
     });
 
     it('returns a blank string where data missing', function () {
         const rendered = title.call({});
 
-        rendered.string.should.equal('');
+        assert.equal(rendered.string, '');
     });
 });

--- a/ghost/core/test/unit/frontend/helpers/twitter-url.test.js
+++ b/ghost/core/test/unit/frontend/helpers/twitter-url.test.js
@@ -14,20 +14,19 @@ describe('{{twitter_url}} helper', function () {
     it('should output the twitter url for @site, if no other twitter username is provided', function () {
         options.data.site = {twitter: '@hey'};
 
-        twitter_url.call({}, options).should.equal('https://x.com/hey');
+        assert.equal(twitter_url.call({}, options), 'https://x.com/hey');
     });
 
     it('should output the twitter url for the local object, if it has one', function () {
         options.data.site = {twitter: '@hey'};
 
-        twitter_url.call({twitter: '@youthere'}, options).should.equal('https://x.com/youthere');
+        assert.equal(twitter_url.call({twitter: '@youthere'}, options), 'https://x.com/youthere');
     });
 
     it('should output the twitter url for the provided username when it is explicitly passed in', function () {
         options.data.site = {twitter: '@hey'};
 
-        twitter_url.call({twitter: '@youthere'}, '@iseeyouoverthere', options)
-            .should.equal('https://x.com/iseeyouoverthere');
+        assert.equal(twitter_url.call({twitter: '@youthere'}, '@iseeyouoverthere', options), 'https://x.com/iseeyouoverthere');
     });
 
     it('should return null if there are no twitter usernames', function () {

--- a/ghost/core/test/unit/frontend/helpers/url.test.js
+++ b/ghost/core/test/unit/frontend/helpers/url.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const testUtils = require('../../../utils');
@@ -50,7 +51,7 @@ describe('{{url}} helper', function () {
 
             rendered = url.call(post);
             should.exist(rendered);
-            rendered.string.should.equal('/slug/');
+            assert.equal(rendered.string, '/slug/');
         });
 
         it('should output an absolute URL if the option is present', function () {
@@ -67,7 +68,7 @@ describe('{{url}} helper', function () {
 
             rendered = url.call(post, {hash: {absolute: 'true'}});
             should.exist(rendered);
-            rendered.string.should.equal('http://localhost:65535/slug/');
+            assert.equal(rendered.string, 'http://localhost:65535/slug/');
         });
 
         it('should return the slug with a prefixed /tag/ if the context is a tag', function () {
@@ -82,7 +83,7 @@ describe('{{url}} helper', function () {
 
             rendered = url.call(tag);
             should.exist(rendered);
-            rendered.string.should.equal('/tag/the-tag/');
+            assert.equal(rendered.string, '/tag/the-tag/');
         });
 
         it('should return the slug with a prefixed /author/ if the context is author', function () {
@@ -98,20 +99,20 @@ describe('{{url}} helper', function () {
 
             rendered = url.call(user);
             should.exist(rendered);
-            rendered.string.should.equal('/author/some-author/');
+            assert.equal(rendered.string, '/author/some-author/');
         });
 
         it('should return / if not a post or tag', function () {
             rendered = url.call({something: 'key'});
             should.exist(rendered);
-            rendered.string.should.equal('/');
+            assert.equal(rendered.string, '/');
         });
 
         it('should return a relative url if passed through a nav context', function () {
             rendered = url.call(
                 {url: '/foo', label: 'Foo', slug: 'foo', current: true});
             should.exist(rendered);
-            rendered.string.should.equal('/foo');
+            assert.equal(rendered.string, '/foo');
         });
 
         it('should return an absolute url if passed through a nav context', function () {
@@ -119,7 +120,7 @@ describe('{{url}} helper', function () {
                 {url: '/bar', label: 'Bar', slug: 'bar', current: true},
                 {hash: {absolute: 'true'}});
             should.exist(rendered);
-            rendered.string.should.equal('http://localhost:65535/bar');
+            assert.equal(rendered.string, 'http://localhost:65535/bar');
         });
 
         it('external urls should be retained in a nav context', function () {
@@ -127,7 +128,7 @@ describe('{{url}} helper', function () {
                 {url: 'http://casper.website/baz', label: 'Baz', slug: 'baz', current: true},
                 {hash: {absolute: 'true'}});
             should.exist(rendered);
-            rendered.string.should.equal('http://casper.website/baz');
+            assert.equal(rendered.string, 'http://casper.website/baz');
         });
 
         it('should handle hosted urls in a nav context', function () {
@@ -135,7 +136,7 @@ describe('{{url}} helper', function () {
                 {url: 'http://localhost:65535/qux', label: 'Qux', slug: 'qux', current: true},
                 {hash: {absolute: 'true'}});
             should.exist(rendered);
-            rendered.string.should.equal('http://localhost:65535/qux');
+            assert.equal(rendered.string, 'http://localhost:65535/qux');
         });
 
         it('should handle hosted urls with the wrong protocol in a nav context', function () {
@@ -143,7 +144,7 @@ describe('{{url}} helper', function () {
                 {url: 'https://localhost:65535/quux', label: 'Quux', slug: 'quux', current: true},
                 {hash: {absolute: 'true'}});
             should.exist(rendered);
-            rendered.string.should.equal('http://localhost:65535/quux');
+            assert.equal(rendered.string, 'http://localhost:65535/quux');
         });
 
         it('should pass through protocol-less URLs regardless of absolute setting', function () {
@@ -151,13 +152,13 @@ describe('{{url}} helper', function () {
                 {url: '//casper.website/baz', label: 'Baz', slug: 'baz', current: true},
                 {hash: {}});
             should.exist(rendered);
-            rendered.string.should.equal('//casper.website/baz');
+            assert.equal(rendered.string, '//casper.website/baz');
 
             rendered = url.call(
                 {url: '//casper.website/baz', label: 'Baz', slug: 'baz', current: true},
                 {hash: {absolute: 'true'}});
             should.exist(rendered);
-            rendered.string.should.equal('//casper.website/baz');
+            assert.equal(rendered.string, '//casper.website/baz');
         });
 
         it('should pass through URLs with alternative schemes regardless of absolute setting', function () {
@@ -165,25 +166,25 @@ describe('{{url}} helper', function () {
                 {url: 'tel:01234567890', label: 'Baz', slug: 'baz', current: true},
                 {hash: {}});
             should.exist(rendered);
-            rendered.string.should.equal('tel:01234567890');
+            assert.equal(rendered.string, 'tel:01234567890');
 
             rendered = url.call(
                 {url: 'mailto:example@ghost.org', label: 'Baz', slug: 'baz', current: true},
                 {hash: {}});
             should.exist(rendered);
-            rendered.string.should.equal('mailto:example@ghost.org');
+            assert.equal(rendered.string, 'mailto:example@ghost.org');
 
             rendered = url.call(
                 {url: 'tel:01234567890', label: 'Baz', slug: 'baz', current: true},
                 {hash: {absolute: 'true'}});
             should.exist(rendered);
-            rendered.string.should.equal('tel:01234567890');
+            assert.equal(rendered.string, 'tel:01234567890');
 
             rendered = url.call(
                 {url: 'mailto:example@ghost.org', label: 'Baz', slug: 'baz', current: true},
                 {hash: {absolute: 'true'}});
             should.exist(rendered);
-            rendered.string.should.equal('mailto:example@ghost.org');
+            assert.equal(rendered.string, 'mailto:example@ghost.org');
         });
 
         it('should pass through anchor-only URLs  regardless of absolute setting', function () {
@@ -191,41 +192,41 @@ describe('{{url}} helper', function () {
                 {url: '#thatsthegoodstuff', label: 'Baz', slug: 'baz', current: true},
                 {hash: {}});
             should.exist(rendered);
-            rendered.string.should.equal('#thatsthegoodstuff');
+            assert.equal(rendered.string, '#thatsthegoodstuff');
 
             rendered = url.call(
                 {url: '#thatsthegoodstuff', label: 'Baz', slug: 'baz', current: true},
                 {hash: {absolute: 'true'}});
             should.exist(rendered);
-            rendered.string.should.equal('#thatsthegoodstuff');
+            assert.equal(rendered.string, '#thatsthegoodstuff');
         });
 
         it('should not HTML-escape URLs', function () {
             rendered = url.call(
                 {url: '/foo?foo=bar&baz=qux', label: 'Foo', slug: 'foo', current: true});
             should.exist(rendered);
-            rendered.string.should.equal('/foo?foo=bar&baz=qux');
+            assert.equal(rendered.string, '/foo?foo=bar&baz=qux');
         });
 
         it('should encode URLs', function () {
             rendered = url.call(
                 {url: '/foo?foo=bar&baz=qux&<script>alert("gotcha")</script>', label: 'Foo', slug: 'foo', current: true});
             should.exist(rendered);
-            rendered.string.should.equal('/foo?foo=bar&baz=qux&%3Cscript%3Ealert(%22gotcha%22)%3C/script%3E');
+            assert.equal(rendered.string, '/foo?foo=bar&baz=qux&%3Cscript%3Ealert(%22gotcha%22)%3C/script%3E');
         });
 
         it('should not double-encode URLs', function () {
             rendered = url.call(
                 {url: '/?foo=space%20bar', label: 'Foo', slug: 'foo', current: true});
             should.exist(rendered);
-            rendered.string.should.equal('/?foo=space%20bar');
+            assert.equal(rendered.string, '/?foo=space%20bar');
         });
 
         it('should return an empty string when we can\'t parse a string', function () {
             const loggingStub = sinon.stub(logging, 'error');
             rendered = url.call({url: '/?foo=space%%bar', label: 'Baz', slug: 'baz', current: true});
             should.exist(rendered);
-            rendered.string.should.equal('');
+            assert.equal(rendered.string, '');
             sinon.assert.calledOnce(loggingStub);
         });
 
@@ -234,7 +235,7 @@ describe('{{url}} helper', function () {
                 {url: 'http://[ffff::]:2368/baz', label: 'Baz', slug: 'baz', current: true},
                 {hash: {absolute: 'true'}});
             should.exist(rendered);
-            rendered.string.should.equal('http://[ffff::]:2368/baz');
+            assert.equal(rendered.string, 'http://[ffff::]:2368/baz');
         });
     });
 
@@ -252,7 +253,7 @@ describe('{{url}} helper', function () {
                 {url: 'http://casper.website/baz', label: 'Baz', slug: 'baz', current: true},
                 {hash: {absolute: 'true'}});
             should.exist(rendered);
-            rendered.string.should.equal('http://casper.website/baz');
+            assert.equal(rendered.string, 'http://casper.website/baz');
         });
 
         it('should handle subdir being set in nav context', function () {
@@ -260,7 +261,7 @@ describe('{{url}} helper', function () {
                 {url: '/xyzzy', label: 'xyzzy', slug: 'xyzzy', current: true},
                 {hash: {absolute: 'true'}});
             should.exist(rendered);
-            rendered.string.should.equal('http://localhost:65535/blog/xyzzy');
+            assert.equal(rendered.string, 'http://localhost:65535/blog/xyzzy');
         });
     });
 });

--- a/ghost/core/test/unit/frontend/meta/asset-url.test.js
+++ b/ghost/core/test/unit/frontend/meta/asset-url.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const {SafeString} = require('../../../../core/frontend/services/handlebars');
@@ -47,24 +48,24 @@ describe('getAssetUrl', function () {
     describe('favicon', function () {
         it('should not add asset to url if favicon.ico', function () {
             const testUrl = getAssetUrl('favicon.ico');
-            testUrl.should.equal('/favicon.ico');
+            assert.equal(testUrl, '/favicon.ico');
         });
 
         it('should not add asset to url if favicon.png', function () {
             const testUrl = getAssetUrl('favicon.png');
-            testUrl.should.equal('/favicon.ico');
+            assert.equal(testUrl, '/favicon.ico');
         });
 
         it('should correct favicon path for custom png', function () {
             sinon.stub(settingsCache, 'get').withArgs('icon').returns('/content/images/2017/04/my-icon.png');
             const testUrl = getAssetUrl('favicon.ico');
-            testUrl.should.equal('/content/images/size/w256h256/2017/04/my-icon.png');
+            assert.equal(testUrl, '/content/images/size/w256h256/2017/04/my-icon.png');
         });
 
         it('should correct favicon path for custom svg', function () {
             sinon.stub(settingsCache, 'get').withArgs('icon').returns('/content/images/2017/04/my-icon.svg');
             const testUrl = getAssetUrl('favicon.ico');
-            testUrl.should.equal('/content/images/size/w256h256/format/png/2017/04/my-icon.svg');
+            assert.equal(testUrl, '/content/images/size/w256h256/format/png/2017/04/my-icon.svg');
         });
     });
 
@@ -127,20 +128,20 @@ describe('getAssetUrl', function () {
             it('should not add asset to url if favicon.ico', function () {
                 sinon.stub(imageLib.blogIcon, 'getIconUrl').returns('/blog/favicon.ico');
                 const testUrl = getAssetUrl('favicon.ico');
-                testUrl.should.equal('/blog/favicon.ico');
+                assert.equal(testUrl, '/blog/favicon.ico');
             });
 
             it('should not add asset to url if favicon.png', function () {
                 sinon.stub(imageLib.blogIcon, 'getIconUrl').returns('/blog/favicon.ico');
                 const testUrl = getAssetUrl('favicon.png');
-                testUrl.should.equal('/blog/favicon.ico');
+                assert.equal(testUrl, '/blog/favicon.ico');
             });
 
             it('should return correct favicon path for custom png', function () {
                 sinon.stub(imageLib.blogIcon, 'getIconUrl').returns('/blog/favicon.png');
                 sinon.stub(settingsCache, 'get').withArgs('icon').returns('/content/images/2017/04/my-icon.png');
                 const testUrl = getAssetUrl('favicon.ico');
-                testUrl.should.equal('/blog/favicon.png');
+                assert.equal(testUrl, '/blog/favicon.png');
             });
         });
 

--- a/ghost/core/test/unit/frontend/meta/author-fb-url.test.js
+++ b/ghost/core/test/unit/frontend/meta/author-fb-url.test.js
@@ -13,7 +13,7 @@ describe('getAuthorFacebookUrl', function () {
                     }
                 }
             });
-            facebookUrl.should.equal('https://www.facebook.com/user');
+            assert.equal(facebookUrl, 'https://www.facebook.com/user');
         });
 
     it('should return null if context does not contain author facebook url and is a post',
@@ -45,7 +45,7 @@ describe('getAuthorFacebookUrl', function () {
                     facebook: 'https://www.facebook.com/user'
                 }
             });
-            facebookUrl.should.equal('https://www.facebook.com/user');
+            assert.equal(facebookUrl, 'https://www.facebook.com/user');
         });
 
     it('should return null if context does not contain author facebook url and is a author',

--- a/ghost/core/test/unit/frontend/meta/author-image.test.js
+++ b/ghost/core/test/unit/frontend/meta/author-image.test.js
@@ -18,7 +18,7 @@ describe('getAuthorImage', function () {
             }
         }, false);
 
-        imageUrl.should.equal('/content/images/2016/01/myimage.jpg');
+        assert.equal(imageUrl, '/content/images/2016/01/myimage.jpg');
     });
 
     it('should return absolute author image url if post and has url', function () {
@@ -30,8 +30,8 @@ describe('getAuthorImage', function () {
                 }
             }
         }, true);
-        imageUrl.should.not.equal('/content/images/2016/01/myimage.jpg');
-        imageUrl.should.match(/\/content\/images\/2016\/01\/myimage\.jpg$/);
+        assert.notEqual(imageUrl, '/content/images/2016/01/myimage.jpg');
+        assert.match(imageUrl, /\/content\/images\/2016\/01\/myimage\.jpg$/);
     });
 
     it('should return null if context does not contain author image url and is a post', function () {

--- a/ghost/core/test/unit/frontend/meta/canonical-url.test.js
+++ b/ghost/core/test/unit/frontend/meta/canonical-url.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const rewire = require('rewire');
 const urlUtils = require('../../../../core/shared/url-utils');
@@ -30,32 +31,32 @@ describe('getCanonicalUrl', function () {
         getUrlStub.withArgs(post, false).returns('/post-url/');
         urlJoinStub.withArgs('http://localhost:9999', '/post-url/').returns('canonical url');
 
-        getCanonicalUrl(post).should.eql('canonical url');
+        assert.equal(getCanonicalUrl(post), 'canonical url');
 
-        urlJoinStub.calledOnce.should.be.true();
-        urlForStub.calledOnce.should.be.true();
-        getUrlStub.calledOnce.should.be.true();
+        assert.equal(urlJoinStub.calledOnce, true);
+        assert.equal(urlForStub.calledOnce, true);
+        assert.equal(getUrlStub.calledOnce, true);
     });
 
     it('should return canonical url field if present', function () {
         const post = testUtils.DataGenerator.forKnex.createPost({canonical_url: 'https://example.com/canonical'});
 
-        getCanonicalUrl({
+        assert.equal(getCanonicalUrl({
             context: ['post'],
             post: post
-        }).should.eql('https://example.com/canonical');
+        }), 'https://example.com/canonical');
 
-        getUrlStub.called.should.equal(false);
+        assert.equal(getUrlStub.called, false);
     });
 
     it('should return home if empty secure data', function () {
         getUrlStub.withArgs({secure: true}, false).returns('/');
         urlJoinStub.withArgs('http://localhost:9999', '/').returns('canonical url');
 
-        getCanonicalUrl({secure: true}).should.eql('canonical url');
+        assert.equal(getCanonicalUrl({secure: true}), 'canonical url');
 
-        urlJoinStub.calledOnce.should.be.true();
-        urlForStub.calledOnce.should.be.true();
-        getUrlStub.calledOnce.should.be.true();
+        assert.equal(urlJoinStub.calledOnce, true);
+        assert.equal(urlForStub.calledOnce, true);
+        assert.equal(getUrlStub.calledOnce, true);
     });
 });

--- a/ghost/core/test/unit/frontend/meta/cover-image.test.js
+++ b/ghost/core/test/unit/frontend/meta/cover-image.test.js
@@ -10,8 +10,8 @@ describe('getCoverImage', function () {
                 cover_image: '/content/images/my-test-image.jpg'
             }
         });
-        coverImageUrl.should.not.equal('/content/images/my-test-image.jpg');
-        coverImageUrl.should.match(/\/content\/images\/my-test-image\.jpg$/);
+        assert.notEqual(coverImageUrl, '/content/images/my-test-image.jpg');
+        assert.match(coverImageUrl, /\/content\/images\/my-test-image\.jpg$/);
     });
 
     it('should return absolute cover image url for author', function () {
@@ -21,8 +21,8 @@ describe('getCoverImage', function () {
                 cover_image: '/content/images/my-test-image.jpg'
             }
         });
-        coverImageUrl.should.not.equal('/content/images/my-test-image.jpg');
-        coverImageUrl.should.match(/\/content\/images\/my-test-image\.jpg$/);
+        assert.notEqual(coverImageUrl, '/content/images/my-test-image.jpg');
+        assert.match(coverImageUrl, /\/content\/images\/my-test-image\.jpg$/);
     });
 
     it('should return absolute image url for post', function () {
@@ -32,8 +32,8 @@ describe('getCoverImage', function () {
                 feature_image: '/content/images/my-test-image.jpg'
             }
         });
-        coverImageUrl.should.not.equal('/content/images/my-test-image.jpg');
-        coverImageUrl.should.match(/\/content\/images\/my-test-image\.jpg$/);
+        assert.notEqual(coverImageUrl, '/content/images/my-test-image.jpg');
+        assert.match(coverImageUrl, /\/content\/images\/my-test-image\.jpg$/);
     });
 
     it('should return null if missing image', function () {

--- a/ghost/core/test/unit/frontend/meta/creator-url.test.js
+++ b/ghost/core/test/unit/frontend/meta/creator-url.test.js
@@ -13,7 +13,7 @@ describe('getCreatorTwitterUrl', function () {
                     }
                 }
             });
-            twitterUrl.should.equal('https://twitter.com/user');
+            assert.equal(twitterUrl, 'https://twitter.com/user');
         });
 
     it('should return null if context does not contain author twitter url and is a post',
@@ -45,7 +45,7 @@ describe('getCreatorTwitterUrl', function () {
                     twitter: 'https://twitter.com/user'
                 }
             });
-            twitterUrl.should.equal('https://twitter.com/user');
+            assert.equal(twitterUrl, 'https://twitter.com/user');
         });
 
     it('should return null if context does not contain author twitter url and is a author',

--- a/ghost/core/test/unit/frontend/meta/description.test.js
+++ b/ghost/core/test/unit/frontend/meta/description.test.js
@@ -35,19 +35,17 @@ describe('getMetaDescription', function () {
             context: 'home'
         });
 
-        description.should.equal('My data meta description');
+        assert.equal(description, 'My data meta description');
     });
 
     // <meta name="description">
     describe('property: null', function () {
         it('has correct fallbacks for context: home', function () {
-            getMetaDescription({}, {context: 'home'})
-                .should.equal('Site meta description');
+            assert.equal(getMetaDescription({}, {context: 'home'}), 'Site meta description');
 
             localSettingsCache.meta_description = '';
 
-            getMetaDescription({}, {context: 'home'})
-                .should.equal('Site description');
+            assert.equal(getMetaDescription({}, {context: 'home'}), 'Site description');
 
             localSettingsCache.description = '';
 
@@ -59,8 +57,7 @@ describe('getMetaDescription', function () {
                 meta_description: 'Post meta description'
             };
 
-            getMetaDescription({post}, {context: 'post'})
-                .should.equal('Post meta description');
+            assert.equal(getMetaDescription({post}, {context: 'post'}), 'Post meta description');
 
             post.meta_description = '';
 
@@ -76,8 +73,7 @@ describe('getMetaDescription', function () {
                 meta_description: 'Page meta description'
             };
 
-            getMetaDescription({page}, {context: 'page'})
-                .should.equal('Page meta description');
+            assert.equal(getMetaDescription({page}, {context: 'page'}), 'Page meta description');
 
             page.meta_description = '';
 
@@ -94,8 +90,7 @@ describe('getMetaDescription', function () {
                 meta_description: 'Page meta description'
             };
 
-            getMetaDescription({post}, {context: 'page'})
-                .should.equal('Page meta description');
+            assert.equal(getMetaDescription({post}, {context: 'page'}), 'Page meta description');
 
             post.meta_description = '';
 
@@ -108,13 +103,11 @@ describe('getMetaDescription', function () {
                 bio: 'Author bio'
             };
 
-            getMetaDescription({author}, {context: 'author'})
-                .should.equal('Author meta description');
+            assert.equal(getMetaDescription({author}, {context: 'author'}), 'Author meta description');
 
             author.meta_description = '';
 
-            getMetaDescription({author}, {context: 'author'})
-                .should.equal('Author bio');
+            assert.equal(getMetaDescription({author}, {context: 'author'}), 'Author bio');
 
             author.bio = '';
 
@@ -136,13 +129,11 @@ describe('getMetaDescription', function () {
                 description: 'Tag description'
             };
 
-            getMetaDescription({tag}, {context: 'tag'})
-                .should.equal('Tag meta description');
+            assert.equal(getMetaDescription({tag}, {context: 'tag'}), 'Tag meta description');
 
             tag.meta_description = '';
 
-            getMetaDescription({tag}, {context: 'tag'})
-                .should.equal('Tag description');
+            assert.equal(getMetaDescription({tag}, {context: 'tag'}), 'Tag description');
 
             tag.description = '';
 
@@ -167,18 +158,15 @@ describe('getMetaDescription', function () {
         });
 
         it('has correct fallbacks for context: home', function () {
-            getMetaDescription({}, {context: 'home'}, options)
-                .should.equal('Site og description');
+            assert.equal(getMetaDescription({}, {context: 'home'}, options), 'Site og description');
 
             localSettingsCache.og_description = '';
 
-            getMetaDescription({}, {context: 'home'}, options)
-                .should.equal('Site meta description');
+            assert.equal(getMetaDescription({}, {context: 'home'}, options), 'Site meta description');
 
             localSettingsCache.meta_description = '';
 
-            getMetaDescription({}, {context: 'home'}, options)
-                .should.equal('Site description');
+            assert.equal(getMetaDescription({}, {context: 'home'}, options), 'Site description');
 
             localSettingsCache.description = '';
 
@@ -193,28 +181,23 @@ describe('getMetaDescription', function () {
                 og_description: 'Post og description'
             };
 
-            getMetaDescription({post}, {context: 'post'}, options)
-                .should.equal('Post og description');
+            assert.equal(getMetaDescription({post}, {context: 'post'}, options), 'Post og description');
 
             post.og_description = '';
 
-            getMetaDescription({post}, {context: 'post'}, options)
-                .should.equal('Post custom excerpt');
+            assert.equal(getMetaDescription({post}, {context: 'post'}, options), 'Post custom excerpt');
 
             post.custom_excerpt = '';
 
-            getMetaDescription({post}, {context: 'post'}, options)
-                .should.equal('Post meta description');
+            assert.equal(getMetaDescription({post}, {context: 'post'}, options), 'Post meta description');
 
             post.meta_description = '';
 
-            getMetaDescription({post}, {context: 'post'}, options)
-                .should.equal('Post html');
+            assert.equal(getMetaDescription({post}, {context: 'post'}, options), 'Post html');
 
             post.excerpt = '';
 
-            getMetaDescription({post}, {context: 'post'}, options)
-                .should.equal('Site description');
+            assert.equal(getMetaDescription({post}, {context: 'post'}, options), 'Site description');
         });
 
         it('has correct fallbacks for context: page', function () {
@@ -225,28 +208,23 @@ describe('getMetaDescription', function () {
                 og_description: 'Page og description'
             };
 
-            getMetaDescription({page}, {context: 'page'}, options)
-                .should.equal('Page og description');
+            assert.equal(getMetaDescription({page}, {context: 'page'}, options), 'Page og description');
 
             page.og_description = '';
 
-            getMetaDescription({page}, {context: 'page'}, options)
-                .should.equal('Page custom excerpt');
+            assert.equal(getMetaDescription({page}, {context: 'page'}, options), 'Page custom excerpt');
 
             page.custom_excerpt = '';
 
-            getMetaDescription({page}, {context: 'page'}, options)
-                .should.equal('Page meta description');
+            assert.equal(getMetaDescription({page}, {context: 'page'}, options), 'Page meta description');
 
             page.meta_description = '';
 
-            getMetaDescription({page}, {context: 'page'}, options)
-                .should.equal('Page html');
+            assert.equal(getMetaDescription({page}, {context: 'page'}, options), 'Page html');
 
             page.excerpt = '';
 
-            getMetaDescription({page}, {context: 'page'}, options)
-                .should.equal('Site description');
+            assert.equal(getMetaDescription({page}, {context: 'page'}, options), 'Site description');
         });
 
         // NOTE: this is a legacy format and should be resolved with https://github.com/TryGhost/Ghost/issues/10042
@@ -258,28 +236,23 @@ describe('getMetaDescription', function () {
                 og_description: 'Page og description'
             };
 
-            getMetaDescription({post}, {context: 'page'}, options)
-                .should.equal('Page og description');
+            assert.equal(getMetaDescription({post}, {context: 'page'}, options), 'Page og description');
 
             post.og_description = '';
 
-            getMetaDescription({post}, {context: 'page'}, options)
-                .should.equal('Page custom excerpt');
+            assert.equal(getMetaDescription({post}, {context: 'page'}, options), 'Page custom excerpt');
 
             post.custom_excerpt = '';
 
-            getMetaDescription({post}, {context: 'page'}, options)
-                .should.equal('Page meta description');
+            assert.equal(getMetaDescription({post}, {context: 'page'}, options), 'Page meta description');
 
             post.meta_description = '';
 
-            getMetaDescription({post}, {context: 'page'}, options)
-                .should.equal('Page html');
+            assert.equal(getMetaDescription({post}, {context: 'page'}, options), 'Page html');
 
             post.excerpt = '';
 
-            getMetaDescription({post}, {context: 'page'}, options)
-                .should.equal('Site description');
+            assert.equal(getMetaDescription({post}, {context: 'page'}, options), 'Site description');
         });
 
         it('has correct fallbacks for context: author', function () {
@@ -288,18 +261,15 @@ describe('getMetaDescription', function () {
                 bio: 'Author bio'
             };
 
-            getMetaDescription({author}, {context: 'author'}, options)
-                .should.equal('Author meta description');
+            assert.equal(getMetaDescription({author}, {context: 'author'}, options), 'Author meta description');
 
             author.meta_description = '';
 
-            getMetaDescription({author}, {context: 'author'}, options)
-                .should.equal('Author bio');
+            assert.equal(getMetaDescription({author}, {context: 'author'}, options), 'Author bio');
 
             author.bio = '';
 
-            getMetaDescription({author}, {context: 'author'}, options)
-                .should.equal('Site meta description');
+            assert.equal(getMetaDescription({author}, {context: 'author'}, options), 'Site meta description');
 
             localSettingsCache.meta_description = '';
 
@@ -312,18 +282,15 @@ describe('getMetaDescription', function () {
                 bio: 'Author bio'
             };
 
-            getMetaDescription({author}, {context: ['author', 'paged']}, options)
-                .should.equal('Author meta description');
+            assert.equal(getMetaDescription({author}, {context: ['author', 'paged']}, options), 'Author meta description');
 
             author.meta_description = '';
 
-            getMetaDescription({author}, {context: ['author', 'paged']}, options)
-                .should.equal('Author bio');
+            assert.equal(getMetaDescription({author}, {context: ['author', 'paged']}, options), 'Author bio');
 
             author.bio = '';
 
-            getMetaDescription({author}, {context: ['author', 'paged']}, options)
-                .should.equal('Site meta description');
+            assert.equal(getMetaDescription({author}, {context: ['author', 'paged']}, options), 'Site meta description');
 
             localSettingsCache.meta_description = '';
 
@@ -336,18 +303,15 @@ describe('getMetaDescription', function () {
                 description: 'Tag description'
             };
 
-            getMetaDescription({tag}, {context: 'tag'}, options)
-                .should.equal('Tag meta description');
+            assert.equal(getMetaDescription({tag}, {context: 'tag'}, options), 'Tag meta description');
 
             tag.meta_description = '';
 
-            getMetaDescription({tag}, {context: 'tag'}, options)
-                .should.equal('Tag description');
+            assert.equal(getMetaDescription({tag}, {context: 'tag'}, options), 'Tag description');
 
             tag.description = '';
 
-            getMetaDescription({tag}, {context: 'tag'}, options)
-                .should.equal('Site meta description');
+            assert.equal(getMetaDescription({tag}, {context: 'tag'}, options), 'Site meta description');
 
             localSettingsCache.meta_description = '';
 
@@ -360,18 +324,15 @@ describe('getMetaDescription', function () {
                 description: 'Tag description'
             };
 
-            getMetaDescription({tag}, {context: ['tag', 'paged']}, options)
-                .should.equal('Tag meta description');
+            assert.equal(getMetaDescription({tag}, {context: ['tag', 'paged']}, options), 'Tag meta description');
 
             tag.meta_description = '';
 
-            getMetaDescription({tag}, {context: ['tag', 'paged']}, options)
-                .should.equal('Tag description');
+            assert.equal(getMetaDescription({tag}, {context: ['tag', 'paged']}, options), 'Tag description');
 
             tag.description = '';
 
-            getMetaDescription({tag}, {context: ['tag', 'paged']}, options)
-                .should.equal('Site meta description');
+            assert.equal(getMetaDescription({tag}, {context: ['tag', 'paged']}, options), 'Site meta description');
 
             localSettingsCache.meta_description = '';
 
@@ -387,18 +348,15 @@ describe('getMetaDescription', function () {
         });
 
         it('has correct fallbacks for context: home', function () {
-            getMetaDescription({}, {context: 'home'}, options)
-                .should.equal('Site twitter description');
+            assert.equal(getMetaDescription({}, {context: 'home'}, options), 'Site twitter description');
 
             localSettingsCache.twitter_description = '';
 
-            getMetaDescription({}, {context: 'home'}, options)
-                .should.equal('Site meta description');
+            assert.equal(getMetaDescription({}, {context: 'home'}, options), 'Site meta description');
 
             localSettingsCache.meta_description = '';
 
-            getMetaDescription({}, {context: 'home'}, options)
-                .should.equal('Site description');
+            assert.equal(getMetaDescription({}, {context: 'home'}, options), 'Site description');
 
             localSettingsCache.description = '';
 
@@ -413,28 +371,23 @@ describe('getMetaDescription', function () {
                 twitter_description: 'Post twitter description'
             };
 
-            getMetaDescription({post}, {context: 'post'}, options)
-                .should.equal('Post twitter description');
+            assert.equal(getMetaDescription({post}, {context: 'post'}, options), 'Post twitter description');
 
             post.twitter_description = '';
 
-            getMetaDescription({post}, {context: 'post'}, options)
-                .should.equal('Post custom excerpt');
+            assert.equal(getMetaDescription({post}, {context: 'post'}, options), 'Post custom excerpt');
 
             post.custom_excerpt = '';
 
-            getMetaDescription({post}, {context: 'post'}, options)
-                .should.equal('Post meta description');
+            assert.equal(getMetaDescription({post}, {context: 'post'}, options), 'Post meta description');
 
             post.meta_description = '';
 
-            getMetaDescription({post}, {context: 'post'}, options)
-                .should.equal('Post html');
+            assert.equal(getMetaDescription({post}, {context: 'post'}, options), 'Post html');
 
             post.excerpt = '';
 
-            getMetaDescription({post}, {context: 'post'}, options)
-                .should.equal('Site description');
+            assert.equal(getMetaDescription({post}, {context: 'post'}, options), 'Site description');
         });
 
         it('has correct fallbacks for context: page', function () {
@@ -445,28 +398,23 @@ describe('getMetaDescription', function () {
                 twitter_description: 'Page twitter description'
             };
 
-            getMetaDescription({page}, {context: 'page'}, options)
-                .should.equal('Page twitter description');
+            assert.equal(getMetaDescription({page}, {context: 'page'}, options), 'Page twitter description');
 
             page.twitter_description = '';
 
-            getMetaDescription({page}, {context: 'page'}, options)
-                .should.equal('Page custom excerpt');
+            assert.equal(getMetaDescription({page}, {context: 'page'}, options), 'Page custom excerpt');
 
             page.custom_excerpt = '';
 
-            getMetaDescription({page}, {context: 'page'}, options)
-                .should.equal('Page meta description');
+            assert.equal(getMetaDescription({page}, {context: 'page'}, options), 'Page meta description');
 
             page.meta_description = '';
 
-            getMetaDescription({page}, {context: 'page'}, options)
-                .should.equal('Page html');
+            assert.equal(getMetaDescription({page}, {context: 'page'}, options), 'Page html');
 
             page.excerpt = '';
 
-            getMetaDescription({page}, {context: 'page'}, options)
-                .should.equal('Site description');
+            assert.equal(getMetaDescription({page}, {context: 'page'}, options), 'Site description');
         });
 
         // NOTE: this is a legacy format and should be resolved with https://github.com/TryGhost/Ghost/issues/10042
@@ -478,28 +426,23 @@ describe('getMetaDescription', function () {
                 twitter_description: 'Page twitter description'
             };
 
-            getMetaDescription({post}, {context: 'page'}, options)
-                .should.equal('Page twitter description');
+            assert.equal(getMetaDescription({post}, {context: 'page'}, options), 'Page twitter description');
 
             post.twitter_description = '';
 
-            getMetaDescription({post}, {context: 'page'}, options)
-                .should.equal('Page custom excerpt');
+            assert.equal(getMetaDescription({post}, {context: 'page'}, options), 'Page custom excerpt');
 
             post.custom_excerpt = '';
 
-            getMetaDescription({post}, {context: 'page'}, options)
-                .should.equal('Page meta description');
+            assert.equal(getMetaDescription({post}, {context: 'page'}, options), 'Page meta description');
 
             post.meta_description = '';
 
-            getMetaDescription({post}, {context: 'page'}, options)
-                .should.equal('Page html');
+            assert.equal(getMetaDescription({post}, {context: 'page'}, options), 'Page html');
 
             post.excerpt = '';
 
-            getMetaDescription({post}, {context: 'page'}, options)
-                .should.equal('Site description');
+            assert.equal(getMetaDescription({post}, {context: 'page'}, options), 'Site description');
         });
 
         it('has correct fallbacks for context: author', function () {
@@ -508,18 +451,15 @@ describe('getMetaDescription', function () {
                 bio: 'Author bio'
             };
 
-            getMetaDescription({author}, {context: 'author'}, options)
-                .should.equal('Author meta description');
+            assert.equal(getMetaDescription({author}, {context: 'author'}, options), 'Author meta description');
 
             author.meta_description = '';
 
-            getMetaDescription({author}, {context: 'author'}, options)
-                .should.equal('Author bio');
+            assert.equal(getMetaDescription({author}, {context: 'author'}, options), 'Author bio');
 
             author.bio = '';
 
-            getMetaDescription({author}, {context: 'author'}, options)
-                .should.equal('Site meta description');
+            assert.equal(getMetaDescription({author}, {context: 'author'}, options), 'Site meta description');
 
             localSettingsCache.meta_description = '';
 
@@ -532,18 +472,15 @@ describe('getMetaDescription', function () {
                 bio: 'Author bio'
             };
 
-            getMetaDescription({author}, {context: ['author', 'paged']}, options)
-                .should.equal('Author meta description');
+            assert.equal(getMetaDescription({author}, {context: ['author', 'paged']}, options), 'Author meta description');
 
             author.meta_description = '';
 
-            getMetaDescription({author}, {context: ['author', 'paged']}, options)
-                .should.equal('Author bio');
+            assert.equal(getMetaDescription({author}, {context: ['author', 'paged']}, options), 'Author bio');
 
             author.bio = '';
 
-            getMetaDescription({author}, {context: ['author', 'paged']}, options)
-                .should.equal('Site meta description');
+            assert.equal(getMetaDescription({author}, {context: ['author', 'paged']}, options), 'Site meta description');
 
             localSettingsCache.meta_description = '';
 
@@ -556,18 +493,15 @@ describe('getMetaDescription', function () {
                 description: 'Tag description'
             };
 
-            getMetaDescription({tag}, {context: 'tag'}, options)
-                .should.equal('Tag meta description');
+            assert.equal(getMetaDescription({tag}, {context: 'tag'}, options), 'Tag meta description');
 
             tag.meta_description = '';
 
-            getMetaDescription({tag}, {context: 'tag'}, options)
-                .should.equal('Tag description');
+            assert.equal(getMetaDescription({tag}, {context: 'tag'}, options), 'Tag description');
 
             tag.description = '';
 
-            getMetaDescription({tag}, {context: 'tag'}, options)
-                .should.equal('Site meta description');
+            assert.equal(getMetaDescription({tag}, {context: 'tag'}, options), 'Site meta description');
 
             localSettingsCache.meta_description = '';
 
@@ -580,18 +514,15 @@ describe('getMetaDescription', function () {
                 description: 'Tag description'
             };
 
-            getMetaDescription({tag}, {context: ['tag', 'paged']}, options)
-                .should.equal('Tag meta description');
+            assert.equal(getMetaDescription({tag}, {context: ['tag', 'paged']}, options), 'Tag meta description');
 
             tag.meta_description = '';
 
-            getMetaDescription({tag}, {context: ['tag', 'paged']}, options)
-                .should.equal('Tag description');
+            assert.equal(getMetaDescription({tag}, {context: ['tag', 'paged']}, options), 'Tag description');
 
             tag.description = '';
 
-            getMetaDescription({tag}, {context: ['tag', 'paged']}, options)
-                .should.equal('Site meta description');
+            assert.equal(getMetaDescription({tag}, {context: ['tag', 'paged']}, options), 'Site meta description');
 
             localSettingsCache.meta_description = '';
 
@@ -607,6 +538,6 @@ describe('getMetaDescription', function () {
         }, {
             context: ['page']
         });
-        description.should.equal('Best page ever!');
+        assert.equal(description, 'Best page ever!');
     });
 });

--- a/ghost/core/test/unit/frontend/meta/image-dimensions.test.js
+++ b/ghost/core/test/unit/frontend/meta/image-dimensions.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const _ = require('lodash');
 const should = require('should');
 const sinon = require('sinon');
@@ -45,10 +46,10 @@ describe('getImageDimensions', function () {
 
         getImageDimensions(metaData).then(function (result) {
             should.exist(result);
-            sizeOfStub.calledWith(metaData.coverImage.url).should.be.true();
-            sizeOfStub.calledWith(metaData.authorImage.url).should.be.true();
-            sizeOfStub.calledWith(metaData.ogImage.url).should.be.true();
-            sizeOfStub.calledWith(metaData.site.logo.url).should.be.true();
+            assert.equal(sizeOfStub.calledWith(metaData.coverImage.url), true);
+            assert.equal(sizeOfStub.calledWith(metaData.authorImage.url), true);
+            assert.equal(sizeOfStub.calledWith(metaData.ogImage.url), true);
+            assert.equal(sizeOfStub.calledWith(metaData.site.logo.url), true);
             result.coverImage.should.have.property('dimensions');
             result.coverImage.should.have.property('url');
             result.coverImage.dimensions.should.have.property('width', 50);
@@ -98,10 +99,10 @@ describe('getImageDimensions', function () {
 
         getImageDimensions(metaData).then(function (result) {
             should.exist(result);
-            sizeOfStub.calledWith(metaData.coverImage.url).should.be.true();
-            sizeOfStub.calledWith(metaData.authorImage.url).should.be.true();
-            sizeOfStub.calledWith(metaData.ogImage.url).should.be.true();
-            sizeOfStub.calledWith(metaData.site.logo.url).should.be.true();
+            assert.equal(sizeOfStub.calledWith(metaData.coverImage.url), true);
+            assert.equal(sizeOfStub.calledWith(metaData.authorImage.url), true);
+            assert.equal(sizeOfStub.calledWith(metaData.ogImage.url), true);
+            assert.equal(sizeOfStub.calledWith(metaData.site.logo.url), true);
             result.coverImage.should.not.have.property('dimensions');
             result.coverImage.should.have.property('url');
             result.authorImage.should.not.have.property('dimensions');
@@ -144,10 +145,10 @@ describe('getImageDimensions', function () {
 
         getImageDimensions(metaData).then(function (result) {
             should.exist(result);
-            sizeOfStub.calledWith(metaData.coverImage.url).should.be.true();
-            sizeOfStub.calledWith(metaData.authorImage.url).should.be.true();
-            sizeOfStub.calledWith(metaData.ogImage.url).should.be.true();
-            sizeOfStub.calledWith(metaData.site.logo.url).should.be.true();
+            assert.equal(sizeOfStub.calledWith(metaData.coverImage.url), true);
+            assert.equal(sizeOfStub.calledWith(metaData.authorImage.url), true);
+            assert.equal(sizeOfStub.calledWith(metaData.ogImage.url), true);
+            assert.equal(sizeOfStub.calledWith(metaData.site.logo.url), true);
             result.coverImage.should.have.property('url');
             result.coverImage.should.have.property('dimensions');
             result.coverImage.dimensions.should.have.property('height', 480);
@@ -198,10 +199,10 @@ describe('getImageDimensions', function () {
 
         getImageDimensions(metaData).then(function (result) {
             should.exist(result);
-            sizeOfStub.calledWith(metaData.coverImage.url).should.be.true();
-            sizeOfStub.calledWith(metaData.authorImage.url).should.be.true();
-            sizeOfStub.calledWith(metaData.ogImage.url).should.be.true();
-            sizeOfStub.calledWith(metaData.site.logo.url).should.be.true();
+            assert.equal(sizeOfStub.calledWith(metaData.coverImage.url), true);
+            assert.equal(sizeOfStub.calledWith(metaData.authorImage.url), true);
+            assert.equal(sizeOfStub.calledWith(metaData.ogImage.url), true);
+            assert.equal(sizeOfStub.calledWith(metaData.site.logo.url), true);
             result.coverImage.should.have.property('dimensions');
             result.coverImage.should.have.property('url');
             result.coverImage.dimensions.should.have.property('height', 480);
@@ -258,27 +259,27 @@ describe('getImageDimensions', function () {
 
         getImageDimensions(metaData).then(function (result) {
             should.exist(result);
-            sizeOfStub.calledWith(originalMetaData.coverImage.url).should.be.true();
-            sizeOfStub.calledWith(originalMetaData.authorImage.url).should.be.true();
-            sizeOfStub.calledWith(originalMetaData.ogImage.url).should.be.true();
-            sizeOfStub.calledWith(originalMetaData.twitterImage).should.be.true();
-            sizeOfStub.calledWith(originalMetaData.site.logo.url).should.be.true();
+            assert.equal(sizeOfStub.calledWith(originalMetaData.coverImage.url), true);
+            assert.equal(sizeOfStub.calledWith(originalMetaData.authorImage.url), true);
+            assert.equal(sizeOfStub.calledWith(originalMetaData.ogImage.url), true);
+            assert.equal(sizeOfStub.calledWith(originalMetaData.twitterImage), true);
+            assert.equal(sizeOfStub.calledWith(originalMetaData.site.logo.url), true);
             result.coverImage.should.have.property('url');
-            result.coverImage.url.should.eql('http://mysite.com/content/images/size/w1200/mypostcoverimage.jpg');
+            assert.equal(result.coverImage.url, 'http://mysite.com/content/images/size/w1200/mypostcoverimage.jpg');
             result.coverImage.should.have.property('dimensions');
             result.coverImage.dimensions.should.have.property('width', 1200);
             result.coverImage.dimensions.should.have.property('height', 720);
             result.authorImage.should.have.property('url');
-            result.authorImage.url.should.eql('http://mysite.com/content/images/size/w1200/me.jpg');
+            assert.equal(result.authorImage.url, 'http://mysite.com/content/images/size/w1200/me.jpg');
             result.authorImage.should.have.property('dimensions');
             result.authorImage.dimensions.should.have.property('width', 1200);
             result.authorImage.dimensions.should.have.property('height', 720);
             result.ogImage.should.have.property('url');
-            result.ogImage.url.should.eql('http://mysite.com/content/images/size/w1200/super-facebook-image.jpg');
+            assert.equal(result.ogImage.url, 'http://mysite.com/content/images/size/w1200/super-facebook-image.jpg');
             result.ogImage.should.have.property('dimensions');
             result.ogImage.dimensions.should.have.property('width', 1200);
             result.ogImage.dimensions.should.have.property('height', 720);
-            result.twitterImage.should.eql('http://mysite.com/content/images/size/w1200/super-twitter-image.jpg');
+            assert.equal(result.twitterImage, 'http://mysite.com/content/images/size/w1200/super-twitter-image.jpg');
             done();
         }).catch(done);
     });
@@ -317,13 +318,13 @@ describe('getImageDimensions', function () {
         getImageDimensions(metaData).then(function (result) {
             should.exist(result);
             result.coverImage.should.have.property('url');
-            result.coverImage.url.should.eql('http://anothersite.com/some/storage/mypostcoverimage.jpg');
+            assert.equal(result.coverImage.url, 'http://anothersite.com/some/storage/mypostcoverimage.jpg');
             result.authorImage.should.have.property('url');
-            result.authorImage.url.should.eql('http://anothersite.com/some/storage/me.jpg');
+            assert.equal(result.authorImage.url, 'http://anothersite.com/some/storage/me.jpg');
             result.ogImage.should.have.property('url');
-            result.ogImage.url.should.eql('http://anothersite.com/some/storage/super-facebook-image.jpg');
+            assert.equal(result.ogImage.url, 'http://anothersite.com/some/storage/super-facebook-image.jpg');
             result.site.logo.should.have.property('url');
-            result.site.logo.url.should.eql('http://anothersite.com/some/storage/logo.jpg');
+            assert.equal(result.site.logo.url, 'http://anothersite.com/some/storage/logo.jpg');
             done();
         }).catch(done);
     });

--- a/ghost/core/test/unit/frontend/meta/og-image.test.js
+++ b/ghost/core/test/unit/frontend/meta/og-image.test.js
@@ -54,15 +54,11 @@ describe('getOgImage', function () {
 
         post.feature_image = '';
 
-        should(
-            getOgImage({context: ['post'], post})
-        ).endWith('settings-og.jpg');
+        assert(getOgImage({context: ['post'], post}).endsWith('settings-og.jpg'));
 
         localSettingsCache.og_image = '';
 
-        should(
-            getOgImage({context: ['post'], post})
-        ).endWith('settings-cover.jpg');
+        assert(getOgImage({context: ['post'], post}).endsWith('settings-cover.jpg'));
 
         localSettingsCache.cover_image = '';
 
@@ -88,15 +84,11 @@ describe('getOgImage', function () {
 
         page.feature_image = '';
 
-        should(
-            getOgImage({context: ['page'], page})
-        ).endWith('settings-og.jpg');
+        assert(getOgImage({context: ['page'], page}).endsWith('settings-og.jpg'));
 
         localSettingsCache.og_image = '';
 
-        should(
-            getOgImage({context: ['page'], page})
-        ).endWith('settings-cover.jpg');
+        assert(getOgImage({context: ['page'], page}).endsWith('settings-cover.jpg'));
 
         localSettingsCache.cover_image = '';
 
@@ -122,15 +114,11 @@ describe('getOgImage', function () {
 
         post.feature_image = '';
 
-        should(
-            getOgImage({context: ['page'], post})
-        ).endWith('settings-og.jpg');
+        assert(getOgImage({context: ['page'], post}).endsWith('settings-og.jpg'));
 
         localSettingsCache.og_image = '';
 
-        should(
-            getOgImage({context: ['page'], post})
-        ).endWith('settings-cover.jpg');
+        assert(getOgImage({context: ['page'], post}).endsWith('settings-cover.jpg'));
 
         localSettingsCache.cover_image = '';
 

--- a/ghost/core/test/unit/frontend/meta/rss-url.test.js
+++ b/ghost/core/test/unit/frontend/meta/rss-url.test.js
@@ -24,6 +24,6 @@ describe('getRssUrl', function () {
     it('forwards absolute flags', function () {
         getRssUrl({}, true);
 
-        routing.registry.getRssUrl.calledWith({absolute: true}).should.be.true();
+        assert.equal(routing.registry.getRssUrl.calledWith({absolute: true}), true);
     });
 });

--- a/ghost/core/test/unit/frontend/meta/title.test.js
+++ b/ghost/core/test/unit/frontend/meta/title.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const getTitle = require('../../../../core/frontend/meta/title');
@@ -22,7 +23,7 @@ describe('getTitle', function () {
             meta_title: 'My test title'
         });
 
-        title.should.equal('My test title');
+        assert.equal(title, 'My test title');
     });
 
     describe('property: null', function () {
@@ -30,13 +31,11 @@ describe('getTitle', function () {
             localSettingsCache.title = 'My site title';
             localSettingsCache.meta_title = 'My site meta title';
 
-            getTitle({}, {context: 'home'})
-                .should.equal('My site meta title');
+            assert.equal(getTitle({}, {context: 'home'}), 'My site meta title');
 
             localSettingsCache.meta_title = '';
 
-            getTitle({}, {context: 'home'})
-                .should.equal('My site title');
+            assert.equal(getTitle({}, {context: 'home'}), 'My site title');
         });
 
         it('has correct fallbacks for context: post', function () {
@@ -46,18 +45,15 @@ describe('getTitle', function () {
                 meta_title: 'Post meta title'
             };
 
-            getTitle({post}, {context: 'post'})
-                .should.equal('Post meta title');
+            assert.equal(getTitle({post}, {context: 'post'}), 'Post meta title');
 
             post.meta_title = '';
 
-            getTitle({post}, {context: 'post'})
-                .should.equal('Post title');
+            assert.equal(getTitle({post}, {context: 'post'}), 'Post title');
 
             post.title = '';
 
-            getTitle({post}, {context: 'post'})
-                .should.equal('');
+            assert.equal(getTitle({post}, {context: 'post'}), '');
         });
 
         it('has correct fallbacks for context: page', function () {
@@ -67,18 +63,15 @@ describe('getTitle', function () {
                 meta_title: 'Page meta title'
             };
 
-            getTitle({page}, {context: 'page'})
-                .should.equal('Page meta title');
+            assert.equal(getTitle({page}, {context: 'page'}), 'Page meta title');
 
             page.meta_title = '';
 
-            getTitle({page}, {context: 'page'})
-                .should.equal('Page title');
+            assert.equal(getTitle({page}, {context: 'page'}), 'Page title');
 
             page.title = '';
 
-            getTitle({page}, {context: 'page'})
-                .should.equal('');
+            assert.equal(getTitle({page}, {context: 'page'}), '');
         });
 
         // NOTE: this is a legacy format and should be resolved with https://github.com/TryGhost/Ghost/issues/10042
@@ -89,18 +82,15 @@ describe('getTitle', function () {
                 meta_title: 'Page meta title'
             };
 
-            getTitle({post}, {context: 'page'})
-                .should.equal('Page meta title');
+            assert.equal(getTitle({post}, {context: 'page'}), 'Page meta title');
 
             post.meta_title = '';
 
-            getTitle({post}, {context: 'page'})
-                .should.equal('Page title');
+            assert.equal(getTitle({post}, {context: 'page'}), 'Page title');
 
             post.title = '';
 
-            getTitle({post}, {context: 'page'})
-                .should.equal('');
+            assert.equal(getTitle({post}, {context: 'page'}), '');
         });
 
         it('has correct fallbacks for context: author', function () {
@@ -110,8 +100,7 @@ describe('getTitle', function () {
                 name: 'Author name'
             };
 
-            getTitle({author}, {context: 'author'})
-                .should.equal('Author name - Site title');
+            assert.equal(getTitle({author}, {context: 'author'}), 'Author name - Site title');
         });
 
         it('has correct fallbacks for context: author_paged', function () {
@@ -121,8 +110,7 @@ describe('getTitle', function () {
                 name: 'Author name'
             };
 
-            getTitle({author}, {context: ['author', 'paged'], pagination: {total: 40, page: 3}})
-                .should.equal('Author name - Site title (Page 3)');
+            assert.equal(getTitle({author}, {context: ['author', 'paged'], pagination: {total: 40, page: 3}}), 'Author name - Site title (Page 3)');
         });
 
         it('has correct fallbacks for context: tag', function () {
@@ -133,13 +121,11 @@ describe('getTitle', function () {
                 meta_title: 'Tag meta title'
             };
 
-            getTitle({tag}, {context: 'tag'})
-                .should.equal('Tag meta title');
+            assert.equal(getTitle({tag}, {context: 'tag'}), 'Tag meta title');
 
             tag.meta_title = '';
 
-            getTitle({tag}, {context: 'tag'})
-                .should.equal('Tag name - Site title');
+            assert.equal(getTitle({tag}, {context: 'tag'}), 'Tag name - Site title');
         });
 
         it('has correct fallbacks for context: tag_paged', function () {
@@ -150,13 +136,11 @@ describe('getTitle', function () {
                 meta_title: 'Tag meta title'
             };
 
-            getTitle({tag}, {context: ['tag', 'paged'], pagination: {total: 40, page: 3}})
-                .should.equal('Tag meta title');
+            assert.equal(getTitle({tag}, {context: ['tag', 'paged'], pagination: {total: 40, page: 3}}), 'Tag meta title');
 
             tag.meta_title = '';
 
-            getTitle({tag}, {context: ['tag', 'paged'], pagination: {total: 40, page: 3}})
-                .should.equal('Tag name - Site title (Page 3)');
+            assert.equal(getTitle({tag}, {context: ['tag', 'paged'], pagination: {total: 40, page: 3}}), 'Tag name - Site title (Page 3)');
         });
     });
 
@@ -166,13 +150,11 @@ describe('getTitle', function () {
             localSettingsCache.meta_title = 'My site meta title';
             localSettingsCache.og_title = 'My site og title';
 
-            getTitle({}, {context: 'home'}, {property: 'og'})
-                .should.equal('My site og title');
+            assert.equal(getTitle({}, {context: 'home'}, {property: 'og'}), 'My site og title');
 
             localSettingsCache.og_title = '';
 
-            getTitle({}, {context: 'home'}, {property: 'og'})
-                .should.equal('My site title');
+            assert.equal(getTitle({}, {context: 'home'}, {property: 'og'}), 'My site title');
         });
 
         it('has correct fallbacks for context: post', function () {
@@ -182,18 +164,15 @@ describe('getTitle', function () {
                 og_title: 'Post og title'
             };
 
-            getTitle({post}, {context: 'post'}, {property: 'og'})
-                .should.equal('Post og title');
+            assert.equal(getTitle({post}, {context: 'post'}, {property: 'og'}), 'Post og title');
 
             post.og_title = '';
 
-            getTitle({post}, {context: 'post'}, {property: 'og'})
-                .should.equal('Post meta title');
+            assert.equal(getTitle({post}, {context: 'post'}, {property: 'og'}), 'Post meta title');
 
             post.meta_title = '';
 
-            getTitle({post}, {context: 'post'}, {property: 'og'})
-                .should.equal('Post title');
+            assert.equal(getTitle({post}, {context: 'post'}, {property: 'og'}), 'Post title');
         });
 
         it('has correct fallbacks for context: page', function () {
@@ -204,18 +183,15 @@ describe('getTitle', function () {
                 og_title: 'Page og title'
             };
 
-            getTitle({page}, {context: 'page'}, {property: 'og'})
-                .should.equal('Page og title');
+            assert.equal(getTitle({page}, {context: 'page'}, {property: 'og'}), 'Page og title');
 
             page.og_title = '';
 
-            getTitle({page}, {context: 'page'}, {property: 'og'})
-                .should.equal('Page meta title');
+            assert.equal(getTitle({page}, {context: 'page'}, {property: 'og'}), 'Page meta title');
 
             page.meta_title = '';
 
-            getTitle({page}, {context: 'page'}, {property: 'og'})
-                .should.equal('Page title');
+            assert.equal(getTitle({page}, {context: 'page'}, {property: 'og'}), 'Page title');
         });
 
         // NOTE: this is a legacy format and should be resolved with https://github.com/TryGhost/Ghost/issues/10042
@@ -227,18 +203,15 @@ describe('getTitle', function () {
                 og_title: 'Page og title'
             };
 
-            getTitle({post}, {context: 'page'}, {property: 'og'})
-                .should.equal('Page og title');
+            assert.equal(getTitle({post}, {context: 'page'}, {property: 'og'}), 'Page og title');
 
             post.og_title = '';
 
-            getTitle({post}, {context: 'page'}, {property: 'og'})
-                .should.equal('Page meta title');
+            assert.equal(getTitle({post}, {context: 'page'}, {property: 'og'}), 'Page meta title');
 
             post.meta_title = '';
 
-            getTitle({post}, {context: 'page'}, {property: 'og'})
-                .should.equal('Page title');
+            assert.equal(getTitle({post}, {context: 'page'}, {property: 'og'}), 'Page title');
         });
 
         it('has correct fallbacks for context: author', function () {
@@ -248,8 +221,7 @@ describe('getTitle', function () {
                 name: 'Author name'
             };
 
-            getTitle({author}, {context: 'author'}, {property: 'og'})
-                .should.equal('Author name - Site title');
+            assert.equal(getTitle({author}, {context: 'author'}, {property: 'og'}), 'Author name - Site title');
         });
 
         it('has correct fallbacks for context: author_paged', function () {
@@ -259,8 +231,7 @@ describe('getTitle', function () {
                 name: 'Author name'
             };
 
-            getTitle({author}, {context: ['author', 'paged'], pagination: {total: 40, page: 3}}, {property: 'og'})
-                .should.equal('Author name - Site title (Page 3)');
+            assert.equal(getTitle({author}, {context: ['author', 'paged'], pagination: {total: 40, page: 3}}, {property: 'og'}), 'Author name - Site title (Page 3)');
         });
 
         it('has correct fallbacks for context: tag', function () {
@@ -271,13 +242,11 @@ describe('getTitle', function () {
                 meta_title: 'Tag meta title'
             };
 
-            getTitle({tag}, {context: 'tag'}, {property: 'og'})
-                .should.equal('Tag meta title');
+            assert.equal(getTitle({tag}, {context: 'tag'}, {property: 'og'}), 'Tag meta title');
 
             tag.meta_title = '';
 
-            getTitle({tag}, {context: 'tag'}, {property: 'og'})
-                .should.equal('Tag name - Site title');
+            assert.equal(getTitle({tag}, {context: 'tag'}, {property: 'og'}), 'Tag name - Site title');
         });
 
         it('has correct fallbacks for context: tag_paged', function () {
@@ -288,13 +257,11 @@ describe('getTitle', function () {
                 meta_title: 'Tag meta title'
             };
 
-            getTitle({tag}, {context: ['tag', 'paged'], pagination: {total: 40, page: 3}}, {property: 'og'})
-                .should.equal('Tag meta title');
+            assert.equal(getTitle({tag}, {context: ['tag', 'paged'], pagination: {total: 40, page: 3}}, {property: 'og'}), 'Tag meta title');
 
             tag.meta_title = '';
 
-            getTitle({tag}, {context: ['tag', 'paged'], pagination: {total: 40, page: 3}}, {property: 'og'})
-                .should.equal('Tag name - Site title (Page 3)');
+            assert.equal(getTitle({tag}, {context: ['tag', 'paged'], pagination: {total: 40, page: 3}}, {property: 'og'}), 'Tag name - Site title (Page 3)');
         });
     });
 
@@ -304,13 +271,11 @@ describe('getTitle', function () {
             localSettingsCache.meta_title = 'My site meta title';
             localSettingsCache.twitter_title = 'My site twitter title';
 
-            getTitle({}, {context: 'home'}, {property: 'twitter'})
-                .should.equal('My site twitter title');
+            assert.equal(getTitle({}, {context: 'home'}, {property: 'twitter'}), 'My site twitter title');
 
             localSettingsCache.twitter_title = '';
 
-            getTitle({}, {context: 'home'}, {property: 'twitter'})
-                .should.equal('My site title');
+            assert.equal(getTitle({}, {context: 'home'}, {property: 'twitter'}), 'My site title');
         });
 
         it('has correct fallbacks for context: post', function () {
@@ -320,18 +285,15 @@ describe('getTitle', function () {
                 twitter_title: 'Post twitter title'
             };
 
-            getTitle({post}, {context: 'post'}, {property: 'twitter'})
-                .should.equal('Post twitter title');
+            assert.equal(getTitle({post}, {context: 'post'}, {property: 'twitter'}), 'Post twitter title');
 
             post.twitter_title = '';
 
-            getTitle({post}, {context: 'post'}, {property: 'twitter'})
-                .should.equal('Post meta title');
+            assert.equal(getTitle({post}, {context: 'post'}, {property: 'twitter'}), 'Post meta title');
 
             post.meta_title = '';
 
-            getTitle({post}, {context: 'post'}, {property: 'twitter'})
-                .should.equal('Post title');
+            assert.equal(getTitle({post}, {context: 'post'}, {property: 'twitter'}), 'Post title');
         });
 
         it('has correct fallbacks for context: page', function () {
@@ -342,18 +304,15 @@ describe('getTitle', function () {
                 twitter_title: 'Page twitter title'
             };
 
-            getTitle({page}, {context: 'page'}, {property: 'twitter'})
-                .should.equal('Page twitter title');
+            assert.equal(getTitle({page}, {context: 'page'}, {property: 'twitter'}), 'Page twitter title');
 
             page.twitter_title = '';
 
-            getTitle({page}, {context: 'page'}, {property: 'twitter'})
-                .should.equal('Page meta title');
+            assert.equal(getTitle({page}, {context: 'page'}, {property: 'twitter'}), 'Page meta title');
 
             page.meta_title = '';
 
-            getTitle({page}, {context: 'page'}, {property: 'twitter'})
-                .should.equal('Page title');
+            assert.equal(getTitle({page}, {context: 'page'}, {property: 'twitter'}), 'Page title');
         });
 
         // NOTE: this is a legacy format and should be resolved with https://github.com/TryGhost/Ghost/issues/10042
@@ -365,18 +324,15 @@ describe('getTitle', function () {
                 twitter_title: 'Page twitter title'
             };
 
-            getTitle({post}, {context: 'page'}, {property: 'twitter'})
-                .should.equal('Page twitter title');
+            assert.equal(getTitle({post}, {context: 'page'}, {property: 'twitter'}), 'Page twitter title');
 
             post.twitter_title = '';
 
-            getTitle({post}, {context: 'page'}, {property: 'twitter'})
-                .should.equal('Page meta title');
+            assert.equal(getTitle({post}, {context: 'page'}, {property: 'twitter'}), 'Page meta title');
 
             post.meta_title = '';
 
-            getTitle({post}, {context: 'page'}, {property: 'twitter'})
-                .should.equal('Page title');
+            assert.equal(getTitle({post}, {context: 'page'}, {property: 'twitter'}), 'Page title');
         });
 
         it('has correct fallbacks for context: author', function () {
@@ -386,8 +342,7 @@ describe('getTitle', function () {
                 name: 'Author name'
             };
 
-            getTitle({author}, {context: 'author'}, {property: 'twitter'})
-                .should.equal('Author name - Site title');
+            assert.equal(getTitle({author}, {context: 'author'}, {property: 'twitter'}), 'Author name - Site title');
         });
 
         it('has correct fallbacks for context: author_paged', function () {
@@ -397,8 +352,7 @@ describe('getTitle', function () {
                 name: 'Author name'
             };
 
-            getTitle({author}, {context: ['author', 'paged'], pagination: {total: 40, page: 3}}, {property: 'twitter'})
-                .should.equal('Author name - Site title (Page 3)');
+            assert.equal(getTitle({author}, {context: ['author', 'paged'], pagination: {total: 40, page: 3}}, {property: 'twitter'}), 'Author name - Site title (Page 3)');
         });
 
         it('has correct fallbacks for context: tag', function () {
@@ -409,13 +363,11 @@ describe('getTitle', function () {
                 meta_title: 'Tag meta title'
             };
 
-            getTitle({tag}, {context: 'tag'}, {property: 'twitter'})
-                .should.equal('Tag meta title');
+            assert.equal(getTitle({tag}, {context: 'tag'}, {property: 'twitter'}), 'Tag meta title');
 
             tag.meta_title = '';
 
-            getTitle({tag}, {context: 'tag'}, {property: 'twitter'})
-                .should.equal('Tag name - Site title');
+            assert.equal(getTitle({tag}, {context: 'tag'}, {property: 'twitter'}), 'Tag name - Site title');
         });
 
         it('has correct fallbacks for context: tag_paged', function () {
@@ -426,13 +378,11 @@ describe('getTitle', function () {
                 meta_title: 'Tag meta title'
             };
 
-            getTitle({tag}, {context: ['tag', 'paged'], pagination: {total: 40, page: 3}}, {property: 'twitter'})
-                .should.equal('Tag meta title');
+            assert.equal(getTitle({tag}, {context: ['tag', 'paged'], pagination: {total: 40, page: 3}}, {property: 'twitter'}), 'Tag meta title');
 
             tag.meta_title = '';
 
-            getTitle({tag}, {context: ['tag', 'paged'], pagination: {total: 40, page: 3}}, {property: 'twitter'})
-                .should.equal('Tag name - Site title (Page 3)');
+            assert.equal(getTitle({tag}, {context: ['tag', 'paged'], pagination: {total: 40, page: 3}}, {property: 'twitter'}), 'Tag name - Site title (Page 3)');
         });
     });
 
@@ -447,7 +397,7 @@ describe('getTitle', function () {
             }
         });
 
-        title.should.equal('My site title 4 (Page 35)');
+        assert.equal(title, 'My site title 4 (Page 35)');
     });
 
     it('should not display "null" for an undefined site title', function () {
@@ -461,7 +411,7 @@ describe('getTitle', function () {
             context: ['tag']
         });
 
-        title.should.equal('My tag');
+        assert.equal(title, 'My tag');
 
         title = getTitle({
             tag: {
@@ -475,7 +425,7 @@ describe('getTitle', function () {
             }
         });
 
-        title.should.equal('My tag - (Page 35)');
+        assert.equal(title, 'My tag - (Page 35)');
 
         title = getTitle({
             author: {
@@ -485,7 +435,7 @@ describe('getTitle', function () {
             context: ['author']
         });
 
-        title.should.equal('My name');
+        assert.equal(title, 'My name');
 
         title = getTitle({
             author: {
@@ -499,6 +449,6 @@ describe('getTitle', function () {
             }
         });
 
-        title.should.equal('My name - (Page 35)');
+        assert.equal(title, 'My name - (Page 35)');
     });
 });

--- a/ghost/core/test/unit/frontend/meta/twitter-image.test.js
+++ b/ghost/core/test/unit/frontend/meta/twitter-image.test.js
@@ -54,15 +54,11 @@ describe('getTwitterImage', function () {
 
         post.feature_image = '';
 
-        should(
-            getTwitterImage({context: ['post'], post})
-        ).endWith('settings-twitter.jpg');
+        assert(getTwitterImage({context: ['post'], post}).endsWith('settings-twitter.jpg'));
 
         localSettingsCache.twitter_image = '';
 
-        should(
-            getTwitterImage({context: ['post'], post})
-        ).endWith('settings-cover.jpg');
+        assert(getTwitterImage({context: ['post'], post}).endsWith('settings-cover.jpg'));
 
         localSettingsCache.cover_image = '';
 
@@ -88,15 +84,11 @@ describe('getTwitterImage', function () {
 
         page.feature_image = '';
 
-        should(
-            getTwitterImage({context: ['page'], page})
-        ).endWith('settings-twitter.jpg');
+        assert(getTwitterImage({context: ['page'], page}).endsWith('settings-twitter.jpg'));
 
         localSettingsCache.twitter_image = '';
 
-        should(
-            getTwitterImage({context: ['page'], page})
-        ).endWith('settings-cover.jpg');
+        assert(getTwitterImage({context: ['page'], page}).endsWith('settings-cover.jpg'));
 
         localSettingsCache.cover_image = '';
 
@@ -122,15 +114,11 @@ describe('getTwitterImage', function () {
 
         post.feature_image = '';
 
-        should(
-            getTwitterImage({context: ['page'], post})
-        ).endWith('settings-twitter.jpg');
+        assert(getTwitterImage({context: ['page'], post}).endsWith('settings-twitter.jpg'));
 
         localSettingsCache.twitter_image = '';
 
-        should(
-            getTwitterImage({context: ['page'], post})
-        ).endWith('settings-cover.jpg');
+        assert(getTwitterImage({context: ['page'], post}).endsWith('settings-cover.jpg'));
 
         localSettingsCache.cover_image = '';
 

--- a/ghost/core/test/unit/frontend/meta/url.test.js
+++ b/ghost/core/test/unit/frontend/meta/url.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const urlUtils = require('../../../../core/shared/url-utils');
 const urlService = require('../../../../core/server/services/url');
@@ -23,7 +24,7 @@ describe('getUrl', function () {
         urlServiceGetUrlByResourceIdStub.withArgs(post.id, {absolute: undefined, withSubdirectory: true})
             .returns('post url');
 
-        getUrl(post).should.eql('post url');
+        assert.equal(getUrl(post), 'post url');
     });
 
     describe('preview url: drafts/scheduled posts', function () {
@@ -33,11 +34,11 @@ describe('getUrl', function () {
             urlUtilsUrlForStub.withArgs({relativeUrl: '/p/' + post.uuid + '/'}, null, undefined).returns('relative');
             let url = getUrl(post);
 
-            urlServiceGetUrlByResourceIdStub.calledOnce.should.be.true();
-            urlUtilsUrlForStub.withArgs({relativeUrl: '/p/' + post.uuid + '/'}, null, undefined)
-                .calledOnce.should.be.true();
+            assert.equal(urlServiceGetUrlByResourceIdStub.calledOnce, true);
+            assert.equal(urlUtilsUrlForStub.withArgs({relativeUrl: '/p/' + post.uuid + '/'}, null, undefined)
+                .calledOnce, true);
 
-            url.should.eql('relative');
+            assert.equal(url, 'relative');
         });
 
         it('absolute', function () {
@@ -46,11 +47,11 @@ describe('getUrl', function () {
             urlUtilsUrlForStub.withArgs({relativeUrl: '/p/' + post.uuid + '/'}, null, true).returns('absolute');
             let url = getUrl(post, true);
 
-            urlServiceGetUrlByResourceIdStub.calledOnce.should.be.true();
-            urlUtilsUrlForStub.withArgs({relativeUrl: '/p/' + post.uuid + '/'}, null, true)
-                .calledOnce.should.be.true();
+            assert.equal(urlServiceGetUrlByResourceIdStub.calledOnce, true);
+            assert.equal(urlUtilsUrlForStub.withArgs({relativeUrl: '/p/' + post.uuid + '/'}, null, true)
+                .calledOnce, true);
 
-            url.should.eql('absolute');
+            assert.equal(url, 'absolute');
         });
     });
 
@@ -60,7 +61,7 @@ describe('getUrl', function () {
         urlServiceGetUrlByResourceIdStub.withArgs(post.id, {absolute: true, withSubdirectory: true})
             .returns('absolute post url');
 
-        getUrl(post, true).should.eql('absolute post url');
+        assert.equal(getUrl(post, true), 'absolute post url');
     });
 
     it('should return url for a tag', function () {
@@ -74,7 +75,7 @@ describe('getUrl', function () {
         urlServiceGetUrlByResourceIdStub.withArgs(tag.id, {absolute: undefined, withSubdirectory: true})
             .returns('tag url');
 
-        getUrl(tag).should.eql('tag url');
+        assert.equal(getUrl(tag), 'tag url');
     });
 
     it('should return url for a author', function () {
@@ -83,7 +84,7 @@ describe('getUrl', function () {
         urlServiceGetUrlByResourceIdStub.withArgs(author.id, {absolute: undefined, withSubdirectory: true})
             .returns('author url');
 
-        getUrl(author).should.eql('author url');
+        assert.equal(getUrl(author), 'author url');
     });
 
     it('should return absolute url for a author', function () {
@@ -92,7 +93,7 @@ describe('getUrl', function () {
         urlServiceGetUrlByResourceIdStub.withArgs(author.id, {absolute: true, withSubdirectory: true})
             .returns('absolute author url');
 
-        getUrl(author, true).should.eql('absolute author url');
+        assert.equal(getUrl(author, true), 'absolute author url');
     });
 
     it('should return url for a nav', function () {
@@ -106,7 +107,7 @@ describe('getUrl', function () {
         urlUtilsUrlForStub.withArgs('nav', {nav: data}, undefined)
             .returns('nav url');
 
-        getUrl(data).should.equal('nav url');
+        assert.equal(getUrl(data), 'nav url');
     });
 
     it('should return absolute url for a nav', function () {
@@ -120,6 +121,6 @@ describe('getUrl', function () {
         urlUtilsUrlForStub.withArgs('nav', {nav: data}, true)
             .returns('absolute nav url');
 
-        getUrl(data, true).should.equal('absolute nav url');
+        assert.equal(getUrl(data, true), 'absolute nav url');
     });
 });

--- a/ghost/core/test/unit/frontend/services/apps/proxy.test.js
+++ b/ghost/core/test/unit/frontend/services/apps/proxy.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const helpers = require('../../../../../core/frontend/services/helpers');
@@ -31,7 +32,7 @@ describe('Apps', function () {
 
             appProxy.helperService.registerHelper('myTestHelper', sinon.stub().returns('test result'));
 
-            registerSpy.called.should.equal(true);
+            assert.equal(registerSpy.called, true);
         });
     });
 });

--- a/ghost/core/test/unit/frontend/services/assets-minification/minifier.test.js
+++ b/ghost/core/test/unit/frontend/services/assets-minification/minifier.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 
 const path = require('path');
@@ -91,7 +92,7 @@ describe('Minifier', function () {
 
             const outputPath = minifier.getFullDest(result[0]);
             const content = await fs.readFile(outputPath, {encoding: 'utf8'});
-            content.should.match(/randomword/);
+            assert.match(content, /randomword/);
         });
     });
 
@@ -122,8 +123,8 @@ describe('Minifier', function () {
                 should.fail(minifier, 'Should have errored');
             } catch (err) {
                 should.exist(err);
-                err.errorType.should.eql('IncorrectUsageError');
-                err.message.should.match(/Unexpected destination/);
+                assert.equal(err.errorType, 'IncorrectUsageError');
+                assert.match(err.message, /Unexpected destination/);
             }
         });
 
@@ -136,8 +137,8 @@ describe('Minifier', function () {
                 should.fail(minifier, 'Should have errored');
             } catch (err) {
                 should.exist(err);
-                err.errorType.should.eql('IncorrectUsageError');
-                err.message.should.match(/Unable to read/);
+                assert.equal(err.errorType, 'IncorrectUsageError');
+                assert.match(err.message, /Unable to read/);
             }
         });
 

--- a/ghost/core/test/unit/frontend/services/data/checks.test.js
+++ b/ghost/core/test/unit/frontend/services/data/checks.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const {checks} = require('../../../../../core/frontend/services/data');
 
@@ -13,48 +14,48 @@ describe('Checks', function () {
         ]);
     });
     it('isPost', function () {
-        checks.isPost({}).should.eql(false);
-        checks.isPost({title: 'Test'}).should.eql(false);
-        checks.isPost({title: 'Test', slug: 'test'}).should.eql(false);
-        checks.isPost({title: 'Test', slug: 'test', html: ''}).should.eql(true);
+        assert.equal(checks.isPost({}), false);
+        assert.equal(checks.isPost({title: 'Test'}), false);
+        assert.equal(checks.isPost({title: 'Test', slug: 'test'}), false);
+        assert.equal(checks.isPost({title: 'Test', slug: 'test', html: ''}), true);
     });
 
     it('isPage', function () {
-        checks.isPage(undefined).should.eql(false);
-        checks.isPage({}).should.eql(false);
-        checks.isPage({title: 'Test'}).should.eql(false);
-        checks.isPage({title: 'Test', show_title_and_feature_image: false}).should.eql(true);
-        checks.isPage({title: 'Test', show_title_and_feature_image: true}).should.eql(true);
+        assert.equal(checks.isPage(undefined), false);
+        assert.equal(checks.isPage({}), false);
+        assert.equal(checks.isPage({title: 'Test'}), false);
+        assert.equal(checks.isPage({title: 'Test', show_title_and_feature_image: false}), true);
+        assert.equal(checks.isPage({title: 'Test', show_title_and_feature_image: true}), true);
     });
 
     it('isNewsletter', function () {
-        checks.isNewsletter({}).should.eql(false);
-        checks.isNewsletter({name: 'Test'}).should.eql(false);
-        checks.isNewsletter({name: 'Test', visibility: 'members', subscribe_on_signup: true}).should.eql(true);
-        checks.isNewsletter({name: 'Test', visibility: 'paid', subscribe_on_signup: false}).should.eql(true);
+        assert.equal(checks.isNewsletter({}), false);
+        assert.equal(checks.isNewsletter({name: 'Test'}), false);
+        assert.equal(checks.isNewsletter({name: 'Test', visibility: 'members', subscribe_on_signup: true}), true);
+        assert.equal(checks.isNewsletter({name: 'Test', visibility: 'paid', subscribe_on_signup: false}), true);
     });
 
     it('isTag', function () {
-        checks.isTag({}).should.eql(false);
-        checks.isTag({name: 'Test'}).should.eql(false);
-        checks.isTag({name: 'Test', slug: 'test'}).should.eql(false);
-        checks.isTag({name: 'Test', slug: 'test', description: ''}).should.eql(false);
-        checks.isTag({name: 'Test', slug: 'test', description: '', feature_image: ''}).should.eql(true);
+        assert.equal(checks.isTag({}), false);
+        assert.equal(checks.isTag({name: 'Test'}), false);
+        assert.equal(checks.isTag({name: 'Test', slug: 'test'}), false);
+        assert.equal(checks.isTag({name: 'Test', slug: 'test', description: ''}), false);
+        assert.equal(checks.isTag({name: 'Test', slug: 'test', description: '', feature_image: ''}), true);
     });
 
     it('isUser', function () {
-        checks.isUser({}).should.eql(false);
-        checks.isUser({bio: 'Test'}).should.eql(false);
-        checks.isUser({bio: 'Test', website: 'test'}).should.eql(false);
-        checks.isUser({bio: 'Test', website: 'test', profile_image: ''}).should.eql(false);
-        checks.isUser({bio: 'Test', website: 'test', profile_image: '', location: ''}).should.eql(true);
+        assert.equal(checks.isUser({}), false);
+        assert.equal(checks.isUser({bio: 'Test'}), false);
+        assert.equal(checks.isUser({bio: 'Test', website: 'test'}), false);
+        assert.equal(checks.isUser({bio: 'Test', website: 'test', profile_image: ''}), false);
+        assert.equal(checks.isUser({bio: 'Test', website: 'test', profile_image: '', location: ''}), true);
     });
 
     it('isNav', function () {
-        checks.isNav({}).should.eql(false);
-        checks.isNav({label: 'Test'}).should.eql(false);
-        checks.isNav({label: 'Test', slug: 'test'}).should.eql(false);
-        checks.isNav({label: 'Test', slug: 'test', url: ''}).should.eql(false);
-        checks.isNav({label: 'Test', slug: 'test', url: '', current: false}).should.eql(true);
+        assert.equal(checks.isNav({}), false);
+        assert.equal(checks.isNav({label: 'Test'}), false);
+        assert.equal(checks.isNav({label: 'Test', slug: 'test'}), false);
+        assert.equal(checks.isNav({label: 'Test', slug: 'test', url: ''}), false);
+        assert.equal(checks.isNav({label: 'Test', slug: 'test', url: '', current: false}), true);
     });
 });

--- a/ghost/core/test/unit/frontend/services/data/entry-lookup.test.js
+++ b/ghost/core/test/unit/frontend/services/data/entry-lookup.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 
@@ -54,11 +55,11 @@ describe('Unit - frontend/data/entry-lookup', function () {
             const testUrl = 'http://127.0.0.1:2369' + pages[0].url;
 
             return data.entryLookup(testUrl, routerOptions, locals).then(function (lookup) {
-                postsReadStub.called.should.be.false();
-                pagesReadStub.calledOnce.should.be.true();
+                assert.equal(postsReadStub.called, false);
+                assert.equal(pagesReadStub.calledOnce, true);
                 should.exist(lookup.entry);
                 lookup.entry.should.have.property('url', pages[0].url);
-                lookup.isEditURL.should.be.false();
+                assert.equal(lookup.isEditURL, false);
             });
         });
     });
@@ -105,11 +106,11 @@ describe('Unit - frontend/data/entry-lookup', function () {
             const testUrl = 'http://127.0.0.1:2369' + posts[0].url;
 
             return data.entryLookup(testUrl, routerOptions, locals).then(function (lookup) {
-                postsReadStub.calledOnce.should.be.true();
-                pagesReadStub.called.should.be.false();
+                assert.equal(postsReadStub.calledOnce, true);
+                assert.equal(pagesReadStub.called, false);
                 should.exist(lookup.entry);
                 lookup.entry.should.have.property('url', posts[0].url);
-                lookup.isEditURL.should.be.false();
+                assert.equal(lookup.isEditURL, false);
             });
         });
 
@@ -117,11 +118,11 @@ describe('Unit - frontend/data/entry-lookup', function () {
             const testUrl = `http://127.0.0.1:2369${posts[0].url}edit/`;
 
             return data.entryLookup(testUrl, routerOptions, locals).then(function (lookup) {
-                postsReadStub.calledOnce.should.be.true();
-                pagesReadStub.called.should.be.false();
+                assert.equal(postsReadStub.calledOnce, true);
+                assert.equal(pagesReadStub.called, false);
                 should.exist(lookup.entry);
                 lookup.entry.should.have.property('url', posts[0].url);
-                lookup.isEditURL.should.be.true();
+                assert.equal(lookup.isEditURL, true);
             });
         });
     });

--- a/ghost/core/test/unit/frontend/services/data/fetch-data.test.js
+++ b/ghost/core/test/unit/frontend/services/data/fetch-data.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 
@@ -61,7 +62,7 @@ describe('Unit - frontend/data/fetch-data', function () {
             result.should.be.an.Object().with.properties('posts', 'meta');
             result.should.not.have.property('data');
 
-            browsePostsStub.calledOnce.should.be.true();
+            assert.equal(browsePostsStub.calledOnce, true);
             browsePostsStub.firstCall.args[0].should.be.an.Object();
             browsePostsStub.firstCall.args[0].should.have.property('include');
             browsePostsStub.firstCall.args[0].should.not.have.property('filter');
@@ -78,7 +79,7 @@ describe('Unit - frontend/data/fetch-data', function () {
 
             result.posts.length.should.eql(posts.length);
 
-            browsePostsStub.calledOnce.should.be.true();
+            assert.equal(browsePostsStub.calledOnce, true);
             browsePostsStub.firstCall.args[0].should.be.an.Object();
             browsePostsStub.firstCall.args[0].should.have.property('include');
             browsePostsStub.firstCall.args[0].should.have.property('limit', 10);
@@ -112,7 +113,7 @@ describe('Unit - frontend/data/fetch-data', function () {
             result.posts.length.should.eql(posts.length);
             result.data.featured.length.should.eql(posts.length);
 
-            browsePostsStub.calledTwice.should.be.true();
+            assert.equal(browsePostsStub.calledTwice, true);
             browsePostsStub.firstCall.args[0].should.have.property('include', 'authors,tags,tiers');
             browsePostsStub.secondCall.args[0].should.have.property('filter', 'featured:true');
             browsePostsStub.secondCall.args[0].should.have.property('limit', 3);
@@ -144,7 +145,7 @@ describe('Unit - frontend/data/fetch-data', function () {
             result.posts.length.should.eql(posts.length);
             result.data.featured.length.should.eql(posts.length);
 
-            browsePostsStub.calledTwice.should.be.true();
+            assert.equal(browsePostsStub.calledTwice, true);
             browsePostsStub.firstCall.args[0].should.have.property('include', 'authors,tags,tiers');
             browsePostsStub.firstCall.args[0].should.have.property('page', 2);
             browsePostsStub.secondCall.args[0].should.have.property('filter', 'featured:true');
@@ -178,7 +179,7 @@ describe('Unit - frontend/data/fetch-data', function () {
             result.posts.length.should.eql(posts.length);
             result.data.tag.length.should.eql(tags.length);
 
-            browsePostsStub.calledOnce.should.be.true();
+            assert.equal(browsePostsStub.calledOnce, true);
             browsePostsStub.firstCall.args[0].should.have.property('include');
             browsePostsStub.firstCall.args[0].should.have.property('filter', 'tags:testing');
             browsePostsStub.firstCall.args[0].should.not.have.property('slug');

--- a/ghost/core/test/unit/frontend/services/rendering/context.test.js
+++ b/ghost/core/test/unit/frontend/services/rendering/context.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const testUtils = require('../../../../utils');
@@ -55,7 +56,7 @@ describe('Contexts', function () {
 
             should.exist(res.locals.context);
             res.locals.context.should.be.an.Array().with.lengthOf(1);
-            res.locals.context[0].should.eql('index');
+            assert.equal(res.locals.context[0], 'index');
         });
 
         it('should correctly identify / as home', function () {
@@ -68,8 +69,8 @@ describe('Contexts', function () {
             // Check context
             should.exist(res.locals.context);
             res.locals.context.should.be.an.Array().with.lengthOf(2);
-            res.locals.context[0].should.eql('home');
-            res.locals.context[1].should.eql('index');
+            assert.equal(res.locals.context[0], 'home');
+            assert.equal(res.locals.context[1], 'index');
         });
 
         it('will not identify / as index without config', function () {
@@ -82,7 +83,7 @@ describe('Contexts', function () {
             // Check context
             should.exist(res.locals.context);
             res.locals.context.should.be.an.Array().with.lengthOf(1);
-            res.locals.context[0].should.eql('home');
+            assert.equal(res.locals.context[0], 'home');
         });
 
         it('will not identify /page/2/ as index & paged without page param', function () {
@@ -93,7 +94,7 @@ describe('Contexts', function () {
 
             should.exist(res.locals.context);
             res.locals.context.should.be.an.Array().with.lengthOf(1);
-            res.locals.context[0].should.eql('index');
+            assert.equal(res.locals.context[0], 'index');
         });
 
         it('should identify /page/2/ as index & paged with page param', function () {
@@ -105,8 +106,8 @@ describe('Contexts', function () {
 
             should.exist(res.locals.context);
             res.locals.context.should.be.an.Array().with.lengthOf(2);
-            res.locals.context[0].should.eql('paged');
-            res.locals.context[1].should.eql('index');
+            assert.equal(res.locals.context[0], 'paged');
+            assert.equal(res.locals.context[1], 'index');
         });
     });
 
@@ -119,7 +120,7 @@ describe('Contexts', function () {
 
             should.exist(res.locals.context);
             res.locals.context.should.be.an.Array().with.lengthOf(1);
-            res.locals.context[0].should.eql('tag');
+            assert.equal(res.locals.context[0], 'tag');
         });
 
         it('will not identify tag channel url without config', function () {
@@ -140,7 +141,7 @@ describe('Contexts', function () {
 
             should.exist(res.locals.context);
             res.locals.context.should.be.an.Array().with.lengthOf(1);
-            res.locals.context[0].should.eql('tag');
+            assert.equal(res.locals.context[0], 'tag');
         });
 
         it('should correctly identify /page/2/ as paged with page param', function () {
@@ -152,8 +153,8 @@ describe('Contexts', function () {
 
             should.exist(res.locals.context);
             res.locals.context.should.be.an.Array().with.lengthOf(2);
-            res.locals.context[0].should.eql('paged');
-            res.locals.context[1].should.eql('tag');
+            assert.equal(res.locals.context[0], 'paged');
+            assert.equal(res.locals.context[1], 'tag');
         });
     });
 
@@ -166,7 +167,7 @@ describe('Contexts', function () {
 
             should.exist(res.locals.context);
             res.locals.context.should.be.an.Array().with.lengthOf(1);
-            res.locals.context[0].should.eql('author');
+            assert.equal(res.locals.context[0], 'author');
         });
 
         it('will not identify author channel url without config', function () {
@@ -187,7 +188,7 @@ describe('Contexts', function () {
 
             should.exist(res.locals.context);
             res.locals.context.should.be.an.Array().with.lengthOf(1);
-            res.locals.context[0].should.eql('author');
+            assert.equal(res.locals.context[0], 'author');
         });
 
         it('should correctly identify /page/2/ as paged with page param', function () {
@@ -199,8 +200,8 @@ describe('Contexts', function () {
 
             should.exist(res.locals.context);
             res.locals.context.should.be.an.Array().with.lengthOf(2);
-            res.locals.context[0].should.eql('paged');
-            res.locals.context[1].should.eql('author');
+            assert.equal(res.locals.context[0], 'paged');
+            assert.equal(res.locals.context[1], 'author');
         });
     });
 
@@ -213,8 +214,8 @@ describe('Contexts', function () {
 
             should.exist(res.locals.context);
             res.locals.context.should.be.an.Array().with.lengthOf(2);
-            res.locals.context[0].should.eql('custom-context');
-            res.locals.context[1].should.eql('test');
+            assert.equal(res.locals.context[0], 'custom-context');
+            assert.equal(res.locals.context[1], 'test');
         });
     });
 
@@ -227,7 +228,7 @@ describe('Contexts', function () {
 
             should.exist(res.locals.context);
             res.locals.context.should.be.an.Array().with.lengthOf(1);
-            res.locals.context[0].should.eql('post');
+            assert.equal(res.locals.context[0], 'post');
         });
     });
 
@@ -240,7 +241,7 @@ describe('Contexts', function () {
 
             should.exist(res.locals.context);
             res.locals.context.should.be.an.Array().with.lengthOf(1);
-            res.locals.context[0].should.eql('private');
+            assert.equal(res.locals.context[0], 'private');
         });
     });
 
@@ -255,7 +256,7 @@ describe('Contexts', function () {
 
             should.exist(res.locals.context);
             res.locals.context.should.be.an.Array().with.lengthOf(1);
-            res.locals.context[0].should.eql('post');
+            assert.equal(res.locals.context[0], 'post');
         });
     });
 });

--- a/ghost/core/test/unit/frontend/services/rendering/error.test.js
+++ b/ghost/core/test/unit/frontend/services/rendering/error.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const errors = require('@tryghost/errors');
@@ -18,7 +19,7 @@ describe('handleError', function () {
         const notFoundError = new errors.NotFoundError({message: 'Something wasn\'t found'});
         helpers.handleError(next)(notFoundError);
 
-        next.calledOnce.should.be.true();
+        assert.equal(next.calledOnce, true);
         next.firstCall.args.should.be.empty();
     });
 
@@ -28,8 +29,8 @@ describe('handleError', function () {
 
         helpers.handleError(next)(otherError);
 
-        next.calledOnce.should.be.true();
-        next.firstCall.args.should.have.lengthOf(1);
+        assert.equal(next.calledOnce, true);
+        assert.equal(next.firstCall.args.length, 1);
         next.firstCall.args[0].should.be.an.Object();
         next.firstCall.args[0].should.be.instanceof(Error);
     });

--- a/ghost/core/test/unit/frontend/services/rendering/format-response.test.js
+++ b/ghost/core/test/unit/frontend/services/rendering/format-response.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const testUtils = require('../../../../utils');
 const helpers = require('../../../../../core/frontend/services/rendering');
@@ -49,7 +50,7 @@ describe('Unit - services/routing/helpers/format-response', function () {
 
             locals.should.be.an.Object().with.properties('_templateOptions');
             locals._templateOptions.data.should.be.an.Object().with.properties('page');
-            locals._templateOptions.data.page.show_title_and_feature_image.should.be.true();
+            assert.equal(locals._templateOptions.data.page.show_title_and_feature_image, true);
         });
 
         it('should set up @page local for pages', function () {
@@ -62,7 +63,7 @@ describe('Unit - services/routing/helpers/format-response', function () {
 
             locals.should.be.an.Object().with.properties('_templateOptions');
             locals._templateOptions.data.should.be.an.Object().with.properties('page');
-            locals._templateOptions.data.page.show_title_and_feature_image.should.be.true();
+            assert.equal(locals._templateOptions.data.page.show_title_and_feature_image, true);
         });
 
         it('should assign properties on @page for pages', function () {
@@ -75,7 +76,7 @@ describe('Unit - services/routing/helpers/format-response', function () {
 
             locals.should.be.an.Object().with.properties('_templateOptions');
             locals._templateOptions.data.should.be.an.Object().with.properties('page');
-            locals._templateOptions.data.page.show_title_and_feature_image.should.be.false();
+            assert.equal(locals._templateOptions.data.page.show_title_and_feature_image, false);
         });
     });
 
@@ -166,7 +167,7 @@ describe('Unit - services/routing/helpers/format-response', function () {
 
             locals.should.be.an.Object().with.properties('_templateOptions');
             locals._templateOptions.data.should.be.an.Object().with.properties('page');
-            locals._templateOptions.data.page.show_title_and_feature_image.should.be.false();
+            assert.equal(locals._templateOptions.data.page.show_title_and_feature_image, false);
         });
     });
 });

--- a/ghost/core/test/unit/frontend/services/rendering/templates.test.js
+++ b/ghost/core/test/unit/frontend/services/rendering/templates.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const rewire = require('rewire');
@@ -84,13 +85,13 @@ describe('templates', function () {
         it('returns fallback if there is no active_theme', function () {
             getActiveThemeStub.returns(undefined);
 
-            _private.pickTemplate(['tag-test', 'tag', 'index'], 'fallback').should.eql('fallback');
-            _private.pickTemplate(['page-my-post', 'page', 'post'], 'fallback').should.eql('fallback');
+            assert.equal(_private.pickTemplate(['tag-test', 'tag', 'index'], 'fallback'), 'fallback');
+            assert.equal(_private.pickTemplate(['page-my-post', 'page', 'post'], 'fallback'), 'fallback');
         });
 
         it('returns fallback if active_theme has no templates', function () {
-            _private.pickTemplate(['tag-test', 'tag', 'index'], 'fallback').should.eql('fallback');
-            _private.pickTemplate(['page-about', 'page', 'post'], 'fallback').should.eql('fallback');
+            assert.equal(_private.pickTemplate(['tag-test', 'tag', 'index'], 'fallback'), 'fallback');
+            assert.equal(_private.pickTemplate(['page-about', 'page', 'post'], 'fallback'), 'fallback');
         });
 
         describe('with many templates', function () {
@@ -104,14 +105,14 @@ describe('templates', function () {
             });
 
             it('returns first matching template', function () {
-                _private.pickTemplate(['page-about', 'page', 'post'], 'fallback').should.eql('page-about');
-                _private.pickTemplate(['page-magic', 'page', 'post'], 'fallback').should.eql('page');
-                _private.pickTemplate(['page', 'post'], 'fallback').should.eql('page');
+                assert.equal(_private.pickTemplate(['page-about', 'page', 'post'], 'fallback'), 'page-about');
+                assert.equal(_private.pickTemplate(['page-magic', 'page', 'post'], 'fallback'), 'page');
+                assert.equal(_private.pickTemplate(['page', 'post'], 'fallback'), 'page');
             });
 
             it('returns correctly if template list is a string', function () {
-                _private.pickTemplate('subscribe', 'fallback').should.eql('fallback');
-                _private.pickTemplate('post', 'fallback').should.eql('post');
+                assert.equal(_private.pickTemplate('subscribe', 'fallback'), 'fallback');
+                assert.equal(_private.pickTemplate('post', 'fallback'), 'post');
             });
         });
     });
@@ -130,7 +131,7 @@ describe('templates', function () {
 
             const view = _private.getTemplateForEntry({title: 'hey'}, 'page');
             should.exist(view);
-            view.should.eql('post');
+            assert.equal(view, 'post');
         });
 
         describe('with many templates', function () {
@@ -149,7 +150,7 @@ describe('templates', function () {
                     slug: 'test-post'
                 });
                 should.exist(view);
-                view.should.eql('post');
+                assert.equal(view, 'post');
             });
 
             it('post with custom slug template', function () {
@@ -159,7 +160,7 @@ describe('templates', function () {
                     slug: 'welcome-to-ghost'
                 });
                 should.exist(view);
-                view.should.eql('post-welcome-to-ghost');
+                assert.equal(view, 'post-welcome-to-ghost');
             });
 
             it('page without custom slug template', function () {
@@ -167,7 +168,7 @@ describe('templates', function () {
                     slug: 'contact'
                 }, 'page');
                 should.exist(view);
-                view.should.eql('page');
+                assert.equal(view, 'page');
             });
 
             it('page with custom slug template', function () {
@@ -175,7 +176,7 @@ describe('templates', function () {
                     slug: 'about'
                 }, 'page');
                 should.exist(view);
-                view.should.eql('page-about');
+                assert.equal(view, 'page-about');
             });
 
             it('post with custom template', function () {
@@ -186,7 +187,7 @@ describe('templates', function () {
                     custom_template: 'custom-about'
                 });
                 should.exist(view);
-                view.should.eql('custom-about');
+                assert.equal(view, 'custom-about');
             });
 
             it('page with custom template', function () {
@@ -197,7 +198,7 @@ describe('templates', function () {
                     custom_template: 'custom-about'
                 });
                 should.exist(view);
-                view.should.eql('custom-about');
+                assert.equal(view, 'custom-about');
             });
 
             it('post with custom template configured, but the template is missing', function () {
@@ -208,7 +209,7 @@ describe('templates', function () {
                     custom_template: 'custom-about'
                 });
                 should.exist(view);
-                view.should.eql('post');
+                assert.equal(view, 'post');
             });
 
             it('page with custom template configured, but the template is missing', function () {
@@ -218,7 +219,7 @@ describe('templates', function () {
                     custom_template: 'custom-about'
                 }, 'page');
                 should.exist(view);
-                view.should.eql('page');
+                assert.equal(view, 'page');
             });
 
             it('post with custom template configured, but slug template exists', function () {
@@ -231,7 +232,7 @@ describe('templates', function () {
                     custom_template: 'custom-about'
                 });
                 should.exist(view);
-                view.should.eql('post-about');
+                assert.equal(view, 'post-about');
             });
 
             it('post with custom template configured, but slug template exists, but can\'t be found', function () {
@@ -244,7 +245,7 @@ describe('templates', function () {
                     custom_template: 'custom-about'
                 });
                 should.exist(view);
-                view.should.eql('post');
+                assert.equal(view, 'post');
             });
         });
     });
@@ -267,7 +268,7 @@ describe('templates', function () {
             it('will return correct view for a tag', function () {
                 const view = _private.getTemplateForEntries({name: 'tag', slugTemplate: true}, {slugParam: 'development'});
                 should.exist(view);
-                view.should.eql('index');
+                assert.equal(view, 'index');
             });
         });
 
@@ -282,20 +283,20 @@ describe('templates', function () {
             it('will return correct view for a tag when template exists', function () {
                 const view = _private.getTemplateForEntries({name: 'tag', slugTemplate: true}, {slugParam: 'design'});
                 should.exist(view);
-                view.should.eql('tag-design');
+                assert.equal(view, 'tag-design');
             });
 
             it('will return correct view for a tag', function () {
                 const view = _private.getTemplateForEntries({name: 'tag', slugTemplate: true}, {slugParam: 'development'});
                 should.exist(view);
-                view.should.eql('tag');
+                assert.equal(view, 'tag');
             });
         });
 
         it('will fall back to index even if no index.hbs', function () {
             const view = _private.getTemplateForEntries({name: 'tag', slugTemplate: true}, {slugParam: 'development'});
             should.exist(view);
-            view.should.eql('index');
+            assert.equal(view, 'index');
         });
     });
 
@@ -311,33 +312,33 @@ describe('templates', function () {
         it('will fall back to default if there is no active_theme', function () {
             getActiveThemeStub.returns(undefined);
 
-            _private.getTemplateForError(500).should.match(/core\/server\/views\/error.hbs$/);
+            assert.match(_private.getTemplateForError(500), /core\/server\/views\/error.hbs$/);
         });
 
         it('will fall back to default for all statusCodes with no custom error templates', function () {
-            _private.getTemplateForError(500).should.match(/core\/server\/views\/error.hbs$/);
-            _private.getTemplateForError(503).should.match(/core\/server\/views\/error.hbs$/);
-            _private.getTemplateForError(422).should.match(/core\/server\/views\/error.hbs$/);
-            _private.getTemplateForError(404).should.match(/core\/server\/views\/error.hbs$/);
+            assert.match(_private.getTemplateForError(500), /core\/server\/views\/error.hbs$/);
+            assert.match(_private.getTemplateForError(503), /core\/server\/views\/error.hbs$/);
+            assert.match(_private.getTemplateForError(422), /core\/server\/views\/error.hbs$/);
+            assert.match(_private.getTemplateForError(404), /core\/server\/views\/error.hbs$/);
         });
 
         it('will use custom error.hbs for all statusCodes if there are no other templates', function () {
             hasTemplateStub.withArgs('error').returns(true);
 
-            _private.getTemplateForError(500).should.eql('error');
-            _private.getTemplateForError(503).should.eql('error');
-            _private.getTemplateForError(422).should.eql('error');
-            _private.getTemplateForError(404).should.eql('error');
+            assert.equal(_private.getTemplateForError(500), 'error');
+            assert.equal(_private.getTemplateForError(503), 'error');
+            assert.equal(_private.getTemplateForError(422), 'error');
+            assert.equal(_private.getTemplateForError(404), 'error');
         });
 
         it('will use more specific error-4xx.hbs for all 4xx statusCodes if available', function () {
             hasTemplateStub.withArgs('error').returns(true);
             hasTemplateStub.withArgs('error-4xx').returns(true);
 
-            _private.getTemplateForError(500).should.eql('error');
-            _private.getTemplateForError(503).should.eql('error');
-            _private.getTemplateForError(422).should.eql('error-4xx');
-            _private.getTemplateForError(404).should.eql('error-4xx');
+            assert.equal(_private.getTemplateForError(500), 'error');
+            assert.equal(_private.getTemplateForError(503), 'error');
+            assert.equal(_private.getTemplateForError(422), 'error-4xx');
+            assert.equal(_private.getTemplateForError(404), 'error-4xx');
         });
 
         it('will use explicit error-404.hbs for 404 statusCode if available', function () {
@@ -345,10 +346,10 @@ describe('templates', function () {
             hasTemplateStub.withArgs('error-4xx').returns(true);
             hasTemplateStub.withArgs('error-404').returns(true);
 
-            _private.getTemplateForError(500).should.eql('error');
-            _private.getTemplateForError(503).should.eql('error');
-            _private.getTemplateForError(422).should.eql('error-4xx');
-            _private.getTemplateForError(404).should.eql('error-404');
+            assert.equal(_private.getTemplateForError(500), 'error');
+            assert.equal(_private.getTemplateForError(503), 'error');
+            assert.equal(_private.getTemplateForError(422), 'error-4xx');
+            assert.equal(_private.getTemplateForError(404), 'error-404');
         });
 
         it('cascade works the same for 500 errors', function () {
@@ -356,10 +357,10 @@ describe('templates', function () {
             hasTemplateStub.withArgs('error-5xx').returns(true);
             hasTemplateStub.withArgs('error-503').returns(true);
 
-            _private.getTemplateForError(500).should.eql('error-5xx');
-            _private.getTemplateForError(503).should.eql('error-503');
-            _private.getTemplateForError(422).should.eql('error');
-            _private.getTemplateForError(404).should.eql('error');
+            assert.equal(_private.getTemplateForError(500), 'error-5xx');
+            assert.equal(_private.getTemplateForError(503), 'error-503');
+            assert.equal(_private.getTemplateForError(422), 'error');
+            assert.equal(_private.getTemplateForError(404), 'error');
         });
 
         it('cascade works with many specific templates', function () {
@@ -369,12 +370,12 @@ describe('templates', function () {
             hasTemplateStub.withArgs('error-4xx').returns(true);
             hasTemplateStub.withArgs('error-404').returns(true);
 
-            _private.getTemplateForError(500).should.eql('error-5xx');
-            _private.getTemplateForError(503).should.eql('error-503');
-            _private.getTemplateForError(422).should.eql('error-4xx');
-            _private.getTemplateForError(404).should.eql('error-404');
-            _private.getTemplateForError(401).should.eql('error-4xx');
-            _private.getTemplateForError(501).should.eql('error-5xx');
+            assert.equal(_private.getTemplateForError(500), 'error-5xx');
+            assert.equal(_private.getTemplateForError(503), 'error-503');
+            assert.equal(_private.getTemplateForError(422), 'error-4xx');
+            assert.equal(_private.getTemplateForError(404), 'error-404');
+            assert.equal(_private.getTemplateForError(401), 'error-4xx');
+            assert.equal(_private.getTemplateForError(501), 'error-5xx');
         });
     });
 
@@ -405,13 +406,13 @@ describe('templates', function () {
             templates.setTemplate(req, res, data);
 
             // It hasn't changed
-            res._template.should.eql('thing');
+            assert.equal(res._template, 'thing');
 
             // And nothing got called
-            stubs.pickTemplate.called.should.be.false();
-            stubs.getTemplateForEntry.called.should.be.false();
-            stubs.getTemplateForEntries.called.should.be.false();
-            stubs.getTemplateForError.called.should.be.false();
+            assert.equal(stubs.pickTemplate.called, false);
+            assert.equal(stubs.getTemplateForEntry.called, false);
+            assert.equal(stubs.getTemplateForEntries.called, false);
+            assert.equal(stubs.getTemplateForError.called, false);
         });
 
         it('defaults to index', function () {
@@ -421,13 +422,13 @@ describe('templates', function () {
             templates.setTemplate(req, res, data);
 
             // It should be index
-            res._template.should.eql('index');
+            assert.equal(res._template, 'index');
 
             // And nothing got called
-            stubs.pickTemplate.called.should.be.false();
-            stubs.getTemplateForEntry.called.should.be.false();
-            stubs.getTemplateForEntries.called.should.be.false();
-            stubs.getTemplateForError.called.should.be.false();
+            assert.equal(stubs.pickTemplate.called, false);
+            assert.equal(stubs.getTemplateForEntry.called, false);
+            assert.equal(stubs.getTemplateForEntries.called, false);
+            assert.equal(stubs.getTemplateForError.called, false);
         });
 
         it('calls pickTemplate for custom routes', function () {
@@ -441,15 +442,15 @@ describe('templates', function () {
             templates.setTemplate(req, res, data);
 
             // should be testFromPickTemplate
-            res._template.should.eql('testFromPickTemplate');
+            assert.equal(res._template, 'testFromPickTemplate');
 
             // Only pickTemplate got called
-            stubs.pickTemplate.called.should.be.true();
-            stubs.getTemplateForEntry.called.should.be.false();
-            stubs.getTemplateForEntries.called.should.be.false();
-            stubs.getTemplateForError.called.should.be.false();
+            assert.equal(stubs.pickTemplate.called, true);
+            assert.equal(stubs.getTemplateForEntry.called, false);
+            assert.equal(stubs.getTemplateForEntries.called, false);
+            assert.equal(stubs.getTemplateForError.called, false);
 
-            stubs.pickTemplate.calledWith('test', 'path/to/local/test.hbs').should.be.true();
+            assert.equal(stubs.pickTemplate.calledWith('test', 'path/to/local/test.hbs'), true);
         });
 
         it('calls getTemplateForEntry for entry routes', function () {
@@ -464,15 +465,15 @@ describe('templates', function () {
             templates.setTemplate(req, res, data);
 
             // should be getTemplateForEntry
-            res._template.should.eql('testFromEntry');
+            assert.equal(res._template, 'testFromEntry');
 
             // Only pickTemplate got called
-            stubs.pickTemplate.called.should.be.false();
-            stubs.getTemplateForEntry.called.should.be.true();
-            stubs.getTemplateForEntries.called.should.be.false();
-            stubs.getTemplateForError.called.should.be.false();
+            assert.equal(stubs.pickTemplate.called, false);
+            assert.equal(stubs.getTemplateForEntry.called, true);
+            assert.equal(stubs.getTemplateForEntries.called, false);
+            assert.equal(stubs.getTemplateForError.called, false);
 
-            stubs.getTemplateForEntry.calledWith({slug: 'test'}).should.be.true();
+            assert.equal(stubs.getTemplateForEntry.calledWith({slug: 'test'}), true);
         });
 
         it('calls getTemplateForEntries for type collection', function () {
@@ -487,15 +488,15 @@ describe('templates', function () {
             // Call setTemplate
             templates.setTemplate(req, res, data);
 
-            res._template.should.eql('testFromEntries');
+            assert.equal(res._template, 'testFromEntries');
 
             // Only pickTemplate got called
-            stubs.pickTemplate.called.should.be.false();
-            stubs.getTemplateForEntry.called.should.be.false();
-            stubs.getTemplateForEntries.called.should.be.true();
-            stubs.getTemplateForError.called.should.be.false();
+            assert.equal(stubs.pickTemplate.called, false);
+            assert.equal(stubs.getTemplateForEntry.called, false);
+            assert.equal(stubs.getTemplateForEntries.called, true);
+            assert.equal(stubs.getTemplateForError.called, false);
 
-            stubs.getTemplateForEntries.calledWith({testCollection: 'test', type: 'collection'}).should.be.true();
+            assert.equal(stubs.getTemplateForEntries.calledWith({testCollection: 'test', type: 'collection'}), true);
         });
 
         it('calls getTemplateForEntries for type channel', function () {
@@ -510,15 +511,15 @@ describe('templates', function () {
             // Call setTemplate
             templates.setTemplate(req, res, data);
 
-            res._template.should.eql('testFromEntries');
+            assert.equal(res._template, 'testFromEntries');
 
             // Only pickTemplate got called
-            stubs.pickTemplate.called.should.be.false();
-            stubs.getTemplateForEntry.called.should.be.false();
-            stubs.getTemplateForEntries.called.should.be.true();
-            stubs.getTemplateForError.called.should.be.false();
+            assert.equal(stubs.pickTemplate.called, false);
+            assert.equal(stubs.getTemplateForEntry.called, false);
+            assert.equal(stubs.getTemplateForEntries.called, true);
+            assert.equal(stubs.getTemplateForError.called, false);
 
-            stubs.getTemplateForEntries.calledWith({testChannel: 'test', type: 'channel'}).should.be.true();
+            assert.equal(stubs.getTemplateForEntries.calledWith({testChannel: 'test', type: 'channel'}), true);
         });
 
         it('calls getTemplateForError if there is an error', function () {
@@ -537,15 +538,15 @@ describe('templates', function () {
             templates.setTemplate(req, res, data);
 
             // should be testFromError
-            res._template.should.eql('testFromError');
+            assert.equal(res._template, 'testFromError');
 
             // Only pickTemplate got called
-            stubs.pickTemplate.called.should.be.false();
-            stubs.getTemplateForEntry.called.should.be.false();
-            stubs.getTemplateForEntries.called.should.be.false();
-            stubs.getTemplateForError.called.should.be.true();
+            assert.equal(stubs.pickTemplate.called, false);
+            assert.equal(stubs.getTemplateForEntry.called, false);
+            assert.equal(stubs.getTemplateForEntries.called, false);
+            assert.equal(stubs.getTemplateForError.called, true);
 
-            stubs.getTemplateForError.calledWith(404).should.be.true();
+            assert.equal(stubs.getTemplateForError.calledWith(404), true);
         });
     });
 });

--- a/ghost/core/test/unit/frontend/services/routing/bootstrap.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/bootstrap.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const CollectionRouter = require('../../../../../core/frontend/services/routing/collection-router');
@@ -37,7 +38,7 @@ describe('UNIT: services/routing/router-manager', function () {
                     _previousAttributes: {value: 'Europe/London'}
                 });
 
-                routerUpdatedSpy.called.should.be.false();
+                assert.equal(routerUpdatedSpy.called, false);
             });
 
             it('tz has not changed', function () {
@@ -56,7 +57,7 @@ describe('UNIT: services/routing/router-manager', function () {
                     _previousAttributes: {value: 'America/Los_Angeles'}
                 });
 
-                routerUpdatedSpy.called.should.be.false();
+                assert.equal(routerUpdatedSpy.called, false);
             });
         });
 
@@ -77,7 +78,7 @@ describe('UNIT: services/routing/router-manager', function () {
                     _previousAttributes: {value: 'Europe/London'}
                 });
 
-                routerUpdatedSpy.called.should.be.true();
+                assert.equal(routerUpdatedSpy.called, true);
             });
 
             it('tz has not changed', function () {
@@ -96,7 +97,7 @@ describe('UNIT: services/routing/router-manager', function () {
                     _previousAttributes: {value: 'America/Los_Angeles'}
                 });
 
-                routerUpdatedSpy.called.should.be.false();
+                assert.equal(routerUpdatedSpy.called, false);
             });
         });
     });

--- a/ghost/core/test/unit/frontend/services/routing/collection-router.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/collection-router.test.js
@@ -43,30 +43,30 @@ describe('UNIT - services/routing/CollectionRouter', function () {
             should.exist(collectionRouter.router);
 
             assert.equal(collectionRouter.filter, undefined);
-            collectionRouter.getResourceType().should.eql('posts');
+            assert.equal(collectionRouter.getResourceType(), 'posts');
             collectionRouter.templates.should.eql([]);
-            collectionRouter.getPermalinks().getValue().should.eql('/:slug/');
+            assert.equal(collectionRouter.getPermalinks().getValue(), '/:slug/');
 
-            routerCreatedSpy.calledOnce.should.be.true();
-            routerCreatedSpy.calledWith(collectionRouter).should.be.true();
+            assert.equal(routerCreatedSpy.calledOnce, true);
+            assert.equal(routerCreatedSpy.calledWith(collectionRouter), true);
 
-            mountRouteSpy.callCount.should.eql(3);
-            express.Router.param.callCount.should.eql(2);
+            assert.equal(mountRouteSpy.callCount, 3);
+            assert.equal(express.Router.param.callCount, 2);
 
             // parent route
-            mountRouteSpy.args[0][0].should.eql('/');
+            assert.equal(mountRouteSpy.args[0][0], '/');
             mountRouteSpy.args[0][1].should.eql(controllers.collection);
 
             // pagination feature
-            mountRouteSpy.args[1][0].should.eql('/page/:page(\\d+)');
+            assert.equal(mountRouteSpy.args[1][0], '/page/:page(\\d+)');
             mountRouteSpy.args[1][1].should.eql(controllers.collection);
 
             // permalinks
-            mountRouteSpy.args[2][0].should.eql('/:slug/:options(edit)?/');
+            assert.equal(mountRouteSpy.args[2][0], '/:slug/:options(edit)?/');
             mountRouteSpy.args[2][1].should.eql(controllers.entry);
 
-            mountRouterSpy.callCount.should.eql(1);
-            mountRouterSpy.args[0][0].should.eql('/');
+            assert.equal(mountRouterSpy.callCount, 1);
+            assert.equal(mountRouterSpy.args[0][0], '/');
             mountRouterSpy.args[0][1].should.eql(collectionRouter.rssRouter.router());
         });
 
@@ -75,9 +75,9 @@ describe('UNIT - services/routing/CollectionRouter', function () {
             const collectionRouter2 = new CollectionRouter('/podcast/', {permalink: '/:slug/'}, RESOURCE_CONFIG, routerCreatedSpy);
             const collectionRouter3 = new CollectionRouter('/hello/world/', {permalink: '/:slug/'}, RESOURCE_CONFIG, routerCreatedSpy);
 
-            collectionRouter1.routerName.should.eql('index');
-            collectionRouter2.routerName.should.eql('podcast');
-            collectionRouter3.routerName.should.eql('helloworld');
+            assert.equal(collectionRouter1.routerName, 'index');
+            assert.equal(collectionRouter2.routerName, 'podcast');
+            assert.equal(collectionRouter3.routerName, 'helloworld');
 
             collectionRouter1.context.should.eql(['index']);
             collectionRouter2.context.should.eql(['podcast']);
@@ -90,36 +90,36 @@ describe('UNIT - services/routing/CollectionRouter', function () {
             should.exist(collectionRouter.router);
 
             assert.equal(collectionRouter.filter, undefined);
-            collectionRouter.getResourceType().should.eql('posts');
+            assert.equal(collectionRouter.getResourceType(), 'posts');
             collectionRouter.templates.should.eql([]);
-            collectionRouter.getPermalinks().getValue().should.eql('/blog/:year/:slug/');
+            assert.equal(collectionRouter.getPermalinks().getValue(), '/blog/:year/:slug/');
 
-            routerCreatedSpy.calledOnce.should.be.true();
-            routerCreatedSpy.calledWith(collectionRouter).should.be.true();
+            assert.equal(routerCreatedSpy.calledOnce, true);
+            assert.equal(routerCreatedSpy.calledWith(collectionRouter), true);
 
-            mountRouteSpy.callCount.should.eql(3);
+            assert.equal(mountRouteSpy.callCount, 3);
 
             // parent route
-            mountRouteSpy.args[0][0].should.eql('/blog/');
+            assert.equal(mountRouteSpy.args[0][0], '/blog/');
             mountRouteSpy.args[0][1].should.eql(controllers.collection);
 
             // pagination feature
-            mountRouteSpy.args[1][0].should.eql('/blog/page/:page(\\d+)');
+            assert.equal(mountRouteSpy.args[1][0], '/blog/page/:page(\\d+)');
             mountRouteSpy.args[1][1].should.eql(controllers.collection);
 
             // permalinks
-            mountRouteSpy.args[2][0].should.eql('/blog/:year/:slug/:options(edit)?/');
+            assert.equal(mountRouteSpy.args[2][0], '/blog/:year/:slug/:options(edit)?/');
             mountRouteSpy.args[2][1].should.eql(controllers.entry);
 
-            mountRouterSpy.callCount.should.eql(1);
-            mountRouterSpy.args[0][0].should.eql('/blog/');
+            assert.equal(mountRouterSpy.callCount, 1);
+            assert.equal(mountRouterSpy.args[0][0], '/blog/');
             mountRouterSpy.args[0][1].should.eql(collectionRouter.rssRouter.router());
         });
 
         it('with custom filter', function () {
             const collectionRouter = new CollectionRouter('/', {permalink: '/:slug/', filter: 'featured:true'}, RESOURCE_CONFIG, routerCreatedSpy);
 
-            collectionRouter.filter.should.eql('featured:true');
+            assert.equal(collectionRouter.filter, 'featured:true');
         });
 
         it('with templates', function () {
@@ -136,7 +136,7 @@ describe('UNIT - services/routing/CollectionRouter', function () {
 
             collectionRouter._prepareEntriesContext(req, res, next);
 
-            next.calledOnce.should.be.true();
+            assert.equal(next.calledOnce, true);
             res.routerOptions.should.eql({
                 type: 'collection',
                 filter: undefined,
@@ -164,7 +164,7 @@ describe('UNIT - services/routing/CollectionRouter', function () {
 
             collectionRouter._prepareEntriesContext(req, res, next);
 
-            next.calledOnce.should.be.true();
+            assert.equal(next.calledOnce, true);
             res.routerOptions.should.eql({
                 type: 'collection',
                 filter: undefined,

--- a/ghost/core/test/unit/frontend/services/routing/controllers/channel.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/controllers/channel.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const errors = require('@tryghost/errors');
 const should = require('should');
 const sinon = require('sinon');
@@ -42,7 +43,7 @@ describe('Unit - services/routing/controllers/channel', function () {
         sinon.stub(themeEngine, 'getActive').returns({
             updateTemplateOptions: sinon.stub(),
             config: function (key) {
-                key.should.eql('posts_per_page');
+                assert.equal(key, 'posts_per_page');
                 return postsPerPage;
             }
         });
@@ -78,9 +79,9 @@ describe('Unit - services/routing/controllers/channel', function () {
             });
 
         controllers.channel(req, res, failTest(done)).then(function () {
-            themeEngine.getActive.calledOnce.should.be.true();
-            security.string.safe.calledOnce.should.be.false();
-            fetchDataStub.calledOnce.should.be.true();
+            assert.equal(themeEngine.getActive.calledOnce, true);
+            assert.equal(security.string.safe.calledOnce, false);
+            assert.equal(fetchDataStub.calledOnce, true);
             done();
         }).catch(done);
     });
@@ -99,9 +100,9 @@ describe('Unit - services/routing/controllers/channel', function () {
             });
 
         controllers.channel(req, res, failTest(done)).then(function () {
-            themeEngine.getActive.calledOnce.should.be.true();
-            security.string.safe.calledOnce.should.be.false();
-            fetchDataStub.calledOnce.should.be.true();
+            assert.equal(themeEngine.getActive.calledOnce, true);
+            assert.equal(security.string.safe.calledOnce, false);
+            assert.equal(fetchDataStub.calledOnce, true);
             done();
         }).catch(done);
     });
@@ -121,10 +122,10 @@ describe('Unit - services/routing/controllers/channel', function () {
             });
 
         controllers.channel(req, res, failTest(done)).then(function () {
-            themeEngine.getActive.calledOnce.should.be.true();
-            themeEngine.getActive().updateTemplateOptions.withArgs({data: {config: {posts_per_page: 3}}}).calledOnce.should.be.true();
-            security.string.safe.calledOnce.should.be.false();
-            fetchDataStub.calledOnce.should.be.true();
+            assert.equal(themeEngine.getActive.calledOnce, true);
+            assert.equal(themeEngine.getActive().updateTemplateOptions.withArgs({data: {config: {posts_per_page: 3}}}).calledOnce, true);
+            assert.equal(security.string.safe.calledOnce, false);
+            assert.equal(fetchDataStub.calledOnce, true);
             done();
         }).catch(done);
     });
@@ -143,12 +144,12 @@ describe('Unit - services/routing/controllers/channel', function () {
             });
 
         controllers.channel(req, res, function (err) {
-            (err instanceof errors.NotFoundError).should.be.true();
+            assert.equal((err instanceof errors.NotFoundError), true);
 
-            themeEngine.getActive.calledOnce.should.be.true();
-            security.string.safe.calledOnce.should.be.false();
-            fetchDataStub.calledOnce.should.be.true();
-            renderStub.calledOnce.should.be.false();
+            assert.equal(themeEngine.getActive.calledOnce, true);
+            assert.equal(security.string.safe.calledOnce, false);
+            assert.equal(fetchDataStub.calledOnce, true);
+            assert.equal(renderStub.calledOnce, false);
             done();
         });
     });
@@ -167,9 +168,9 @@ describe('Unit - services/routing/controllers/channel', function () {
             });
 
         controllers.channel(req, res, failTest(done)).then(function () {
-            themeEngine.getActive.calledOnce.should.be.true();
-            security.string.safe.calledOnce.should.be.true();
-            fetchDataStub.calledOnce.should.be.true();
+            assert.equal(themeEngine.getActive.calledOnce, true);
+            assert.equal(security.string.safe.calledOnce, true);
+            assert.equal(fetchDataStub.calledOnce, true);
             done();
         }).catch(done);
     });
@@ -188,9 +189,9 @@ describe('Unit - services/routing/controllers/channel', function () {
             });
 
         controllers.channel(req, res, failTest(done)).then(function () {
-            themeEngine.getActive.calledOnce.should.be.true();
-            security.string.safe.calledOnce.should.be.false();
-            fetchDataStub.calledOnce.should.be.true();
+            assert.equal(themeEngine.getActive.calledOnce, true);
+            assert.equal(security.string.safe.calledOnce, false);
+            assert.equal(fetchDataStub.calledOnce, true);
             done();
         }).catch(done);
     });

--- a/ghost/core/test/unit/frontend/services/routing/controllers/collection.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/controllers/collection.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const errors = require('@tryghost/errors');
 const should = require('should');
 const sinon = require('sinon');
@@ -44,7 +45,7 @@ describe('Unit - services/routing/controllers/collection', function () {
         sinon.stub(themeEngine, 'getActive').returns({
             updateTemplateOptions: sinon.stub(),
             config: function (key) {
-                key.should.eql('posts_per_page');
+                assert.equal(key, 'posts_per_page');
                 return postsPerPage;
             }
         });
@@ -85,10 +86,10 @@ describe('Unit - services/routing/controllers/collection', function () {
             });
 
         controllers.collection(req, res, failTest(done)).then(function () {
-            themeEngine.getActive.calledOnce.should.be.true();
-            security.string.safe.calledOnce.should.be.false();
-            fetchDataStub.calledOnce.should.be.true();
-            ownsStub.calledOnce.should.be.true();
+            assert.equal(themeEngine.getActive.calledOnce, true);
+            assert.equal(security.string.safe.calledOnce, false);
+            assert.equal(fetchDataStub.calledOnce, true);
+            assert.equal(ownsStub.calledOnce, true);
             done();
         }).catch(done);
     });
@@ -107,10 +108,10 @@ describe('Unit - services/routing/controllers/collection', function () {
             });
 
         controllers.collection(req, res, failTest(done)).then(function () {
-            themeEngine.getActive.calledOnce.should.be.true();
-            security.string.safe.calledOnce.should.be.false();
-            fetchDataStub.calledOnce.should.be.true();
-            ownsStub.calledOnce.should.be.true();
+            assert.equal(themeEngine.getActive.calledOnce, true);
+            assert.equal(security.string.safe.calledOnce, false);
+            assert.equal(fetchDataStub.calledOnce, true);
+            assert.equal(ownsStub.calledOnce, true);
             done();
         }).catch(done);
     });
@@ -130,11 +131,11 @@ describe('Unit - services/routing/controllers/collection', function () {
             });
 
         controllers.collection(req, res, failTest(done)).then(function () {
-            themeEngine.getActive.calledOnce.should.be.true();
-            themeEngine.getActive().updateTemplateOptions.withArgs({data: {config: {posts_per_page: 3}}}).calledOnce.should.be.true();
-            security.string.safe.calledOnce.should.be.false();
-            fetchDataStub.calledOnce.should.be.true();
-            ownsStub.calledOnce.should.be.true();
+            assert.equal(themeEngine.getActive.calledOnce, true);
+            assert.equal(themeEngine.getActive().updateTemplateOptions.withArgs({data: {config: {posts_per_page: 3}}}).calledOnce, true);
+            assert.equal(security.string.safe.calledOnce, false);
+            assert.equal(fetchDataStub.calledOnce, true);
+            assert.equal(ownsStub.calledOnce, true);
             done();
         }).catch(done);
     });
@@ -153,13 +154,13 @@ describe('Unit - services/routing/controllers/collection', function () {
             });
 
         controllers.collection(req, res, function (err) {
-            (err instanceof errors.NotFoundError).should.be.true();
+            assert.equal((err instanceof errors.NotFoundError), true);
 
-            themeEngine.getActive.calledOnce.should.be.true();
-            security.string.safe.calledOnce.should.be.false();
-            fetchDataStub.calledOnce.should.be.true();
-            renderStub.calledOnce.should.be.false();
-            ownsStub.calledOnce.should.be.false();
+            assert.equal(themeEngine.getActive.calledOnce, true);
+            assert.equal(security.string.safe.calledOnce, false);
+            assert.equal(fetchDataStub.calledOnce, true);
+            assert.equal(renderStub.calledOnce, false);
+            assert.equal(ownsStub.calledOnce, false);
             done();
         });
     });
@@ -178,10 +179,10 @@ describe('Unit - services/routing/controllers/collection', function () {
             });
 
         controllers.collection(req, res, failTest(done)).then(function () {
-            themeEngine.getActive.calledOnce.should.be.true();
-            security.string.safe.calledOnce.should.be.true();
-            fetchDataStub.calledOnce.should.be.true();
-            ownsStub.calledOnce.should.be.true();
+            assert.equal(themeEngine.getActive.calledOnce, true);
+            assert.equal(security.string.safe.calledOnce, true);
+            assert.equal(fetchDataStub.calledOnce, true);
+            assert.equal(ownsStub.calledOnce, true);
             done();
         }).catch(done);
     });
@@ -200,10 +201,10 @@ describe('Unit - services/routing/controllers/collection', function () {
             });
 
         controllers.collection(req, res, failTest(done)).then(function () {
-            themeEngine.getActive.calledOnce.should.be.true();
-            security.string.safe.calledOnce.should.be.false();
-            fetchDataStub.calledOnce.should.be.true();
-            ownsStub.calledOnce.should.be.true();
+            assert.equal(themeEngine.getActive.calledOnce, true);
+            assert.equal(security.string.safe.calledOnce, false);
+            assert.equal(fetchDataStub.calledOnce, true);
+            assert.equal(ownsStub.calledOnce, true);
             done();
         }).catch(done);
     });
@@ -238,10 +239,10 @@ describe('Unit - services/routing/controllers/collection', function () {
             });
 
         controllers.collection(req, res, failTest(done)).then(function () {
-            themeEngine.getActive.calledOnce.should.be.true();
-            security.string.safe.calledOnce.should.be.false();
-            fetchDataStub.calledOnce.should.be.true();
-            ownsStub.callCount.should.eql(4);
+            assert.equal(themeEngine.getActive.calledOnce, true);
+            assert.equal(security.string.safe.calledOnce, false);
+            assert.equal(fetchDataStub.calledOnce, true);
+            assert.equal(ownsStub.callCount, 4);
             done();
         }).catch(done);
     });

--- a/ghost/core/test/unit/frontend/services/routing/controllers/entry.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/controllers/entry.test.js
@@ -119,7 +119,7 @@ describe('Unit - services/routing/controllers/entry', function () {
                 });
 
             urlUtilsRedirectToAdminStub.callsFake(function (statusCode, _res, editorUrl) {
-                statusCode.should.eql(302);
+                assert.equal(statusCode, 302);
                 editorUrl.should.eql(EDITOR_URL + post.id);
                 done();
             });
@@ -147,7 +147,7 @@ describe('Unit - services/routing/controllers/entry', function () {
 
             controllers.entry(req, res, async (err) => {
                 await configUtils.restore();
-                urlUtilsRedirectToAdminStub.called.should.eql(false);
+                assert.equal(urlUtilsRedirectToAdminStub.called, false);
                 assert.equal(err, undefined);
                 done(err);
             });

--- a/ghost/core/test/unit/frontend/services/routing/controllers/previews.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/controllers/previews.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const testUtils = require('../../../../../utils');
@@ -82,7 +83,7 @@ describe('Unit - services/routing/controllers/previews', function () {
 
     it('should render post', function (done) {
         controllers.previews(req, res, failTest(done)).then(function () {
-            renderStub.called.should.be.true();
+            assert.equal(renderStub.called, true);
             done();
         }).catch(done);
     });

--- a/ghost/core/test/unit/frontend/services/routing/controllers/rss.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/controllers/rss.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const testUtils = require('../../../../../utils');
 const security = require('@tryghost/security');
@@ -65,10 +66,10 @@ describe('Unit - services/routing/controllers/rss', function () {
         });
 
         rssServiceRenderStub.callsFake(function (_res, baseUrl, data) {
-            baseUrl.should.eql('/rss/');
+            assert.equal(baseUrl, '/rss/');
             data.posts.should.eql(posts);
-            data.title.should.eql('Ghost');
-            data.description.should.eql('Ghost is cool!');
+            assert.equal(data.title, 'Ghost');
+            assert.equal(data.description, 'Ghost is cool!');
             done();
         });
 

--- a/ghost/core/test/unit/frontend/services/routing/controllers/static.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/controllers/static.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 
@@ -77,8 +78,8 @@ describe('Unit - services/routing/controllers/static', function () {
 
     it('no extra data to fetch', function (done) {
         renderer.renderer.callsFake(function () {
-            renderer.formatResponse.entries.calledOnce.should.be.true();
-            tagsReadStub.called.should.be.false();
+            assert.equal(renderer.formatResponse.entries.calledOnce, true);
+            assert.equal(tagsReadStub.called, false);
             done();
         });
 
@@ -100,8 +101,8 @@ describe('Unit - services/routing/controllers/static', function () {
         tagsReadStub = sinon.stub().resolves({tags: [{slug: 'bacon'}]});
 
         renderer.renderer.callsFake(function () {
-            tagsReadStub.called.should.be.true();
-            renderer.formatResponse.entries.calledOnce.should.be.true();
+            assert.equal(tagsReadStub.called, true);
+            assert.equal(renderer.formatResponse.entries.calledOnce, true);
             done();
         });
 

--- a/ghost/core/test/unit/frontend/services/routing/middlewares/page-param.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/middlewares/page-param.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const errors = require('@tryghost/errors');
@@ -29,9 +30,9 @@ describe('UNIT: services/routing/middleware/page-param', function () {
 
         middleware.pageParam(req, res, next, 2);
 
-        urlUtils.redirect301.called.should.be.false();
-        next.calledOnce.should.be.true();
-        req.params.page.should.eql(2);
+        assert.equal(urlUtils.redirect301.called, false);
+        assert.equal(next.calledOnce, true);
+        assert.equal(req.params.page, 2);
     });
 
     it('redirect for /page/1/', function () {
@@ -40,8 +41,8 @@ describe('UNIT: services/routing/middleware/page-param', function () {
 
         middleware.pageParam(req, res, next, 1);
 
-        urlUtils.redirect301.calledOnce.should.be.true();
-        next.called.should.be.false();
+        assert.equal(urlUtils.redirect301.calledOnce, true);
+        assert.equal(next.called, false);
     });
 
     it('404 for /page/0/', function () {
@@ -50,9 +51,9 @@ describe('UNIT: services/routing/middleware/page-param', function () {
 
         middleware.pageParam(req, res, next, 0);
 
-        urlUtils.redirect301.called.should.be.false();
-        next.calledOnce.should.be.true();
-        (next.args[0][0] instanceof errors.NotFoundError).should.be.true();
+        assert.equal(urlUtils.redirect301.called, false);
+        assert.equal(next.calledOnce, true);
+        assert.equal((next.args[0][0] instanceof errors.NotFoundError), true);
     });
 
     it('404 for /page/something/', function () {
@@ -61,9 +62,9 @@ describe('UNIT: services/routing/middleware/page-param', function () {
 
         middleware.pageParam(req, res, next, 'something');
 
-        urlUtils.redirect301.called.should.be.false();
-        next.calledOnce.should.be.true();
-        (next.args[0][0] instanceof errors.NotFoundError).should.be.true();
+        assert.equal(urlUtils.redirect301.called, false);
+        assert.equal(next.calledOnce, true);
+        assert.equal((next.args[0][0] instanceof errors.NotFoundError), true);
     });
 
     it('redirect for /rss/page/1/', function () {
@@ -72,7 +73,7 @@ describe('UNIT: services/routing/middleware/page-param', function () {
 
         middleware.pageParam(req, res, next, 1);
 
-        urlUtils.redirect301.calledOnce.should.be.true();
-        next.called.should.be.false();
+        assert.equal(urlUtils.redirect301.calledOnce, true);
+        assert.equal(next.called, false);
     });
 });

--- a/ghost/core/test/unit/frontend/services/routing/parent-router.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/parent-router.test.js
@@ -75,8 +75,8 @@ describe('UNIT - services/routing/ParentRouter', function () {
             }];
 
             parentRouter._respectDominantRouter(req, res, next, 'bacon');
-            next.called.should.eql(false);
-            redirect301Stub.withArgs(res, '/channel/').calledOnce.should.be.true();
+            assert.equal(next.called, false);
+            assert.equal(redirect301Stub.withArgs(res, '/channel/').calledOnce, true);
         });
 
         it('redirect with query params', function () {
@@ -105,8 +105,8 @@ describe('UNIT - services/routing/ParentRouter', function () {
             }];
 
             parentRouter._respectDominantRouter(req, res, next, 'bacon');
-            next.called.should.eql(false);
-            redirect301Stub.withArgs(res, '/channel/?a=b').calledOnce.should.be.true();
+            assert.equal(next.called, false);
+            assert.equal(redirect301Stub.withArgs(res, '/channel/?a=b').calledOnce, true);
         });
 
         it('redirect rss', function () {
@@ -135,8 +135,8 @@ describe('UNIT - services/routing/ParentRouter', function () {
             }];
 
             parentRouter._respectDominantRouter(req, res, next, 'bacon');
-            next.called.should.eql(false);
-            redirect301Stub.withArgs(res, '/channel/rss/').calledOnce.should.be.true();
+            assert.equal(next.called, false);
+            assert.equal(redirect301Stub.withArgs(res, '/channel/rss/').calledOnce, true);
         });
 
         it('redirect pagination', function () {
@@ -165,8 +165,8 @@ describe('UNIT - services/routing/ParentRouter', function () {
             }];
 
             parentRouter._respectDominantRouter(req, res, next, 'bacon');
-            next.called.should.eql(false);
-            redirect301Stub.withArgs(res, '/channel/page/2/').calledOnce.should.be.true();
+            assert.equal(next.called, false);
+            assert.equal(redirect301Stub.withArgs(res, '/channel/page/2/').calledOnce, true);
         });
 
         it('redirect correctly with subdirectory', function () {
@@ -197,8 +197,8 @@ describe('UNIT - services/routing/ParentRouter', function () {
             }];
 
             parentRouter._respectDominantRouter(req, res, next, 'bacon');
-            next.called.should.eql(false);
-            redirect301Stub.withArgs(res, '/blog/channel/').calledOnce.should.be.true();
+            assert.equal(next.called, false);
+            assert.equal(redirect301Stub.withArgs(res, '/blog/channel/').calledOnce, true);
         });
 
         it('no redirect: different data key', function () {
@@ -224,8 +224,8 @@ describe('UNIT - services/routing/ParentRouter', function () {
             }];
 
             parentRouter._respectDominantRouter(req, res, next, 'bacon');
-            next.called.should.eql(true);
-            redirect301Stub.called.should.be.false();
+            assert.equal(next.called, true);
+            assert.equal(redirect301Stub.called, false);
         });
 
         it('no redirect: no channel defined', function () {
@@ -246,8 +246,8 @@ describe('UNIT - services/routing/ParentRouter', function () {
             }];
 
             parentRouter._respectDominantRouter(req, res, next, 'bacon');
-            next.called.should.eql(true);
-            redirect301Stub.called.should.be.false();
+            assert.equal(next.called, true);
+            assert.equal(redirect301Stub.called, false);
         });
 
         it('redirect primary tag permalink', function () {
@@ -276,8 +276,8 @@ describe('UNIT - services/routing/ParentRouter', function () {
             }];
 
             parentRouter._respectDominantRouter(req, res, next, 'welcome');
-            next.called.should.eql(false);
-            redirect301Stub.withArgs(res, '/route/?x=y').calledOnce.should.be.true();
+            assert.equal(next.called, false);
+            assert.equal(redirect301Stub.withArgs(res, '/route/?x=y').calledOnce, true);
         });
     });
 
@@ -285,7 +285,7 @@ describe('UNIT - services/routing/ParentRouter', function () {
         it('data is undefined', function () {
             const parentRouter = new ParentRouter();
             parentRouter.data = undefined;
-            parentRouter.isRedirectEnabled('tags', 'bacon').should.be.false();
+            assert.equal(parentRouter.isRedirectEnabled('tags', 'bacon'), false);
         });
 
         it('data keys are undefined', function () {

--- a/ghost/core/test/unit/frontend/services/routing/registry.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/registry.test.js
@@ -27,7 +27,7 @@ describe('UNIT: services/routing/registry', function () {
                 getRssUrl: sinon.stub().returns('/podcast/rss/')
             });
 
-            registry.getRssUrl().should.eql('/podcast/rss/');
+            assert.equal(registry.getRssUrl(), '/podcast/rss/');
         });
 
         it('single collection, no index collection, rss disabled', function () {
@@ -53,7 +53,7 @@ describe('UNIT: services/routing/registry', function () {
                 getRssUrl: sinon.stub().returns('/rss/')
             });
 
-            registry.getRssUrl().should.eql('/rss/');
+            assert.equal(registry.getRssUrl(), '/rss/');
         });
 
         it('multiple collections without index collection', function () {
@@ -69,7 +69,7 @@ describe('UNIT: services/routing/registry', function () {
                 getRssUrl: sinon.stub().returns('/podcast/rss/')
             });
 
-            registry.getRssUrl().should.eql('/blog/rss/');
+            assert.equal(registry.getRssUrl(), '/blog/rss/');
         });
 
         it('multiple collections without index, first has RSS disabled', function () {
@@ -85,7 +85,7 @@ describe('UNIT: services/routing/registry', function () {
                 getRssUrl: sinon.stub().returns('/podcast/rss/')
             });
 
-            registry.getRssUrl().should.eql('/podcast/rss/');
+            assert.equal(registry.getRssUrl(), '/podcast/rss/');
         });
 
         it('multiple collections without index, all have RSS disabled', function () {

--- a/ghost/core/test/unit/frontend/services/routing/rss-router.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/rss-router.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const configUtils = require('../../../../utils/config-utils');
@@ -23,14 +24,14 @@ describe('UNIT - services/routing/RSSRouter', function () {
             const rssRouter = new RSSRouter();
 
             should.exist(rssRouter.router);
-            rssRouter.route.value.should.eql('/rss/');
+            assert.equal(rssRouter.route.value, '/rss/');
 
-            rssRouter.mountRoute.callCount.should.eql(2);
+            assert.equal(rssRouter.mountRoute.callCount, 2);
 
-            rssRouter.mountRoute.args[0][0].should.eql('/rss/');
+            assert.equal(rssRouter.mountRoute.args[0][0], '/rss/');
             rssRouter.mountRoute.args[0][1].should.eql(controllers.rss);
 
-            rssRouter.mountRoute.args[1][0].should.eql('/feed/');
+            assert.equal(rssRouter.mountRoute.args[1][0], '/feed/');
         });
 
         it('subdirectory is enabled', function () {
@@ -38,14 +39,14 @@ describe('UNIT - services/routing/RSSRouter', function () {
             const rssRouter = new RSSRouter();
 
             should.exist(rssRouter.router);
-            rssRouter.route.value.should.eql('/rss/');
+            assert.equal(rssRouter.route.value, '/rss/');
 
-            rssRouter.mountRoute.callCount.should.eql(2);
+            assert.equal(rssRouter.mountRoute.callCount, 2);
 
-            rssRouter.mountRoute.args[0][0].should.eql('/rss/');
+            assert.equal(rssRouter.mountRoute.args[0][0], '/rss/');
             rssRouter.mountRoute.args[0][1].should.eql(controllers.rss);
 
-            rssRouter.mountRoute.args[1][0].should.eql('/feed/');
+            assert.equal(rssRouter.mountRoute.args[1][0], '/feed/');
         });
     });
 });

--- a/ghost/core/test/unit/frontend/services/routing/static-routes-router.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/static-routes-router.test.js
@@ -43,13 +43,13 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
 
             staticRoutesRouter.templates.should.eql(['test']);
 
-            routerCreatedSpy.calledOnce.should.be.true();
-            routerCreatedSpy.calledWith(staticRoutesRouter).should.be.true();
+            assert.equal(routerCreatedSpy.calledOnce, true);
+            assert.equal(routerCreatedSpy.calledWith(staticRoutesRouter), true);
 
-            mountRouteSpy.callCount.should.eql(1);
+            assert.equal(mountRouteSpy.callCount, 1);
 
             // parent route
-            mountRouteSpy.args[0][0].should.eql('/about/');
+            assert.equal(mountRouteSpy.args[0][0], '/about/');
             mountRouteSpy.args[0][1].should.eql(controllers.static);
         });
 
@@ -65,13 +65,13 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
             assert.equal(staticRoutesRouter.filter, undefined);
             staticRoutesRouter.templates.should.eql([]);
 
-            routerCreatedSpy.calledOnce.should.be.true();
-            routerCreatedSpy.calledWith(staticRoutesRouter).should.be.true();
+            assert.equal(routerCreatedSpy.calledOnce, true);
+            assert.equal(routerCreatedSpy.calledWith(staticRoutesRouter), true);
 
-            mountRouteSpy.callCount.should.eql(1);
+            assert.equal(mountRouteSpy.callCount, 1);
 
             // parent route
-            mountRouteSpy.args[0][0].should.eql('/about/');
+            assert.equal(mountRouteSpy.args[0][0], '/about/');
             mountRouteSpy.args[0][1].should.eql(controllers.static);
         });
 
@@ -79,16 +79,16 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
             const staticRoutesRouter = new StaticRoutesRouter('/about/', {templates: []}, routerCreatedSpy);
 
             staticRoutesRouter._prepareStaticRouteContext(req, res, next);
-            next.called.should.be.true();
+            assert.equal(next.called, true);
 
             res.routerOptions.should.have.properties('type', 'templates', 'defaultTemplate', 'context', 'data', 'contentType');
-            res.routerOptions.type.should.eql('custom');
+            assert.equal(res.routerOptions.type, 'custom');
             res.routerOptions.templates.should.eql([]);
             res.routerOptions.defaultTemplate.should.be.a.Function();
             res.routerOptions.context.should.eql(['about']);
             res.routerOptions.data.should.eql({});
 
-            should(res.routerOptions.contentType).be.undefined();
+            assert.equal(res.routerOptions.contentType, undefined);
             assert.equal(res.locals.slug, undefined);
         });
 
@@ -96,10 +96,10 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
             const staticRoutesRouter = new StaticRoutesRouter('/', {templates: []}, routerCreatedSpy);
 
             staticRoutesRouter._prepareStaticRouteContext(req, res, next);
-            next.called.should.be.true();
+            assert.equal(next.called, true);
 
             res.routerOptions.should.have.properties('type', 'templates', 'defaultTemplate', 'context', 'data', 'contentType');
-            res.routerOptions.type.should.eql('custom');
+            assert.equal(res.routerOptions.type, 'custom');
             res.routerOptions.templates.should.eql([]);
             res.routerOptions.defaultTemplate.should.be.a.Function();
             res.routerOptions.context.should.eql(['index']);
@@ -121,21 +121,21 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
                 should.exist(staticRoutesRouter.router);
 
                 assert.equal(staticRoutesRouter.getPermalinks(), undefined);
-                staticRoutesRouter.filter.should.eql('tag:test');
+                assert.equal(staticRoutesRouter.filter, 'tag:test');
                 staticRoutesRouter.templates.should.eql([]);
                 should.exist(staticRoutesRouter.data);
 
-                routerCreatedSpy.calledOnce.should.be.true();
-                routerCreatedSpy.calledWith(staticRoutesRouter).should.be.true();
+                assert.equal(routerCreatedSpy.calledOnce, true);
+                assert.equal(routerCreatedSpy.calledWith(staticRoutesRouter), true);
 
-                mountRouteSpy.callCount.should.eql(2);
+                assert.equal(mountRouteSpy.callCount, 2);
 
                 // parent route
-                mountRouteSpy.args[0][0].should.eql('/channel/');
+                assert.equal(mountRouteSpy.args[0][0], '/channel/');
                 mountRouteSpy.args[0][1].should.eql(controllers.channel);
 
                 // pagination feature
-                mountRouteSpy.args[1][0].should.eql('/channel/page/:page(\\d+)');
+                assert.equal(mountRouteSpy.args[1][0], '/channel/page/:page(\\d+)');
                 mountRouteSpy.args[1][1].should.eql(controllers.channel);
             });
 
@@ -148,21 +148,21 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
                 should.exist(staticRoutesRouter.router);
 
                 assert.equal(staticRoutesRouter.getPermalinks(), undefined);
-                staticRoutesRouter.filter.should.eql('tag:test');
+                assert.equal(staticRoutesRouter.filter, 'tag:test');
 
                 staticRoutesRouter.templates.should.eql([]);
 
-                routerCreatedSpy.calledOnce.should.be.true();
-                routerCreatedSpy.calledWith(staticRoutesRouter).should.be.true();
+                assert.equal(routerCreatedSpy.calledOnce, true);
+                assert.equal(routerCreatedSpy.calledWith(staticRoutesRouter), true);
 
-                mountRouteSpy.callCount.should.eql(2);
+                assert.equal(mountRouteSpy.callCount, 2);
 
                 // parent route
-                mountRouteSpy.args[0][0].should.eql('/channel/');
+                assert.equal(mountRouteSpy.args[0][0], '/channel/');
                 mountRouteSpy.args[0][1].should.eql(controllers.channel);
 
                 // pagination feature
-                mountRouteSpy.args[1][0].should.eql('/channel/page/:page(\\d+)');
+                assert.equal(mountRouteSpy.args[1][0], '/channel/page/:page(\\d+)');
                 mountRouteSpy.args[1][1].should.eql(controllers.channel);
             });
 
@@ -184,14 +184,14 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
                     filter: 'author:michi'
                 }, routerCreatedSpy);
 
-                mountRouteSpy.callCount.should.eql(2);
+                assert.equal(mountRouteSpy.callCount, 2);
 
                 // parent route
-                mountRouteSpy.args[0][0].should.eql('/channel/');
+                assert.equal(mountRouteSpy.args[0][0], '/channel/');
                 mountRouteSpy.args[0][1].should.eql(controllers.channel);
 
                 // pagination feature
-                mountRouteSpy.args[1][0].should.eql('/channel/page/:page(\\d+)');
+                assert.equal(mountRouteSpy.args[1][0], '/channel/page/:page(\\d+)');
                 mountRouteSpy.args[1][1].should.eql(controllers.channel);
             });
         });
@@ -205,7 +205,7 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
                 }, routerCreatedSpy);
 
                 staticRoutesRouter._prepareChannelContext(req, res, next);
-                next.calledOnce.should.eql(true);
+                assert.equal(next.calledOnce, true);
                 res.routerOptions.should.eql({
                     type: 'channel',
                     context: ['channel'],
@@ -225,7 +225,7 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
                 }, routerCreatedSpy);
 
                 staticRoutesRouter._prepareChannelContext(req, res, next);
-                next.calledOnce.should.eql(true);
+                assert.equal(next.calledOnce, true);
                 res.routerOptions.should.eql({
                     type: 'channel',
                     context: ['nothingcomparestoyou'],
@@ -245,7 +245,7 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
                 }, routerCreatedSpy);
 
                 staticRoutesRouter._prepareChannelContext(req, res, next);
-                next.calledOnce.should.eql(true);
+                assert.equal(next.calledOnce, true);
                 res.routerOptions.should.eql({
                     type: 'channel',
                     context: ['channel'],
@@ -267,7 +267,7 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
                 }, routerCreatedSpy);
 
                 staticRoutesRouter._prepareChannelContext(req, res, next);
-                next.calledOnce.should.eql(true);
+                assert.equal(next.calledOnce, true);
                 res.routerOptions.should.eql({
                     type: 'channel',
                     context: ['channel'],

--- a/ghost/core/test/unit/frontend/services/routing/taxonomy-router.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/taxonomy-router.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const settingsCache = require('../../../../../core/shared/settings-cache');
@@ -37,35 +38,35 @@ describe('UNIT - services/routing/TaxonomyRouter', function () {
         should.exist(taxonomyRouter.router);
         should.exist(taxonomyRouter.rssRouter);
 
-        taxonomyRouter.taxonomyKey.should.eql('tag');
-        taxonomyRouter.getPermalinks().getValue().should.eql('/tag/:slug/');
+        assert.equal(taxonomyRouter.taxonomyKey, 'tag');
+        assert.equal(taxonomyRouter.getPermalinks().getValue(), '/tag/:slug/');
 
-        routerCreatedSpy.calledOnce.should.be.true();
-        routerCreatedSpy.calledWith(taxonomyRouter).should.be.true();
+        assert.equal(routerCreatedSpy.calledOnce, true);
+        assert.equal(routerCreatedSpy.calledWith(taxonomyRouter), true);
 
-        taxonomyRouter.mountRouter.callCount.should.eql(1);
-        taxonomyRouter.mountRouter.args[0][0].should.eql('/tag/:slug/');
+        assert.equal(taxonomyRouter.mountRouter.callCount, 1);
+        assert.equal(taxonomyRouter.mountRouter.args[0][0], '/tag/:slug/');
         taxonomyRouter.mountRouter.args[0][1].should.eql(taxonomyRouter.rssRouter.router());
 
-        taxonomyRouter.mountRoute.callCount.should.eql(3);
+        assert.equal(taxonomyRouter.mountRoute.callCount, 3);
 
         // permalink route
-        taxonomyRouter.mountRoute.args[0][0].should.eql('/tag/:slug/');
+        assert.equal(taxonomyRouter.mountRoute.args[0][0], '/tag/:slug/');
         taxonomyRouter.mountRoute.args[0][1].should.eql(controllers.channel);
 
         // pagination feature
-        taxonomyRouter.mountRoute.args[1][0].should.eql('/tag/:slug/page/:page(\\d+)');
+        assert.equal(taxonomyRouter.mountRoute.args[1][0], '/tag/:slug/page/:page(\\d+)');
         taxonomyRouter.mountRoute.args[1][1].should.eql(controllers.channel);
 
         // edit feature
-        taxonomyRouter.mountRoute.args[2][0].should.eql('/tag/:slug/edit');
+        assert.equal(taxonomyRouter.mountRoute.args[2][0], '/tag/:slug/edit');
         taxonomyRouter.mountRoute.args[2][1].should.eql(taxonomyRouter._redirectEditOption.bind(taxonomyRouter));
     });
 
     it('_prepareContext behaves as expected', function () {
         const taxonomyRouter = new TaxonomyRouter('tag', '/tag/:slug/', RESOURCE_CONFIG, routerCreatedSpy);
         taxonomyRouter._prepareContext(req, res, next);
-        next.calledOnce.should.eql(true);
+        assert.equal(next.calledOnce, true);
 
         res.routerOptions.should.eql({
             type: 'channel',

--- a/ghost/core/test/unit/frontend/services/rss/cache.test.js
+++ b/ghost/core/test/unit/frontend/services/rss/cache.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const rewire = require('rewire');
@@ -35,7 +36,7 @@ describe('RSS: Cache', function () {
                 xmlData1 = _xmlData;
 
                 // We should have called generateFeed
-                generateSpy.callCount.should.eql(1);
+                assert.equal(generateSpy.callCount, 1);
 
                 // Call RSS again to check that we didn't rebuild
                 return rssCache.getXML('/rss/', data);
@@ -44,7 +45,7 @@ describe('RSS: Cache', function () {
                 // Assertions
 
                 // We should not have called generateFeed again
-                generateSpy.callCount.should.eql(1);
+                assert.equal(generateSpy.callCount, 1);
 
                 // The data should be identical, no changing lastBuildDate
                 xmlData1.should.equal(xmlData2);

--- a/ghost/core/test/unit/frontend/services/rss/generate-feed.test.js
+++ b/ghost/core/test/unit/frontend/services/rss/generate-feed.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const _ = require('lodash');
@@ -66,24 +67,24 @@ describe('RSS: Generate Feed', function () {
                 should.exist(xmlData);
 
                 // xml & rss tags
-                xmlData.should.match(/^<\?xml version="1.0" encoding="UTF-8"\?>/);
-                xmlData.should.match(/<rss/);
-                xmlData.should.match(/xmlns:dc="http:\/\/purl.org\/dc\/elements\/1.1\/"/);
-                xmlData.should.match(/xmlns:content="http:\/\/purl.org\/rss\/1.0\/modules\/content\/"/);
-                xmlData.should.match(/xmlns:atom="http:\/\/www.w3.org\/2005\/Atom"/);
-                xmlData.should.match(/version="2.0"/);
-                xmlData.should.match(/xmlns:media="http:\/\/search.yahoo.com\/mrss\/"/);
+                assert.match(xmlData, /^<\?xml version="1.0" encoding="UTF-8"\?>/);
+                assert.match(xmlData, /<rss/);
+                assert.match(xmlData, /xmlns:dc="http:\/\/purl.org\/dc\/elements\/1.1\/"/);
+                assert.match(xmlData, /xmlns:content="http:\/\/purl.org\/rss\/1.0\/modules\/content\/"/);
+                assert.match(xmlData, /xmlns:atom="http:\/\/www.w3.org\/2005\/Atom"/);
+                assert.match(xmlData, /version="2.0"/);
+                assert.match(xmlData, /xmlns:media="http:\/\/search.yahoo.com\/mrss\/"/);
 
                 // channel tags
-                xmlData.should.match(/<channel><title><!\[CDATA\[Test Title\]\]><\/title>/);
-                xmlData.should.match(/<description><!\[CDATA\[Testing Desc\]\]><\/description>/);
-                xmlData.should.match(/<link>http:\/\/my-ghost-blog.com\/<\/link>/);
-                xmlData.should.match(/<image><url>http:\/\/my-ghost-blog.com\/favicon.png<\/url><title>Test Title<\/title><link>http:\/\/my-ghost-blog.com\/<\/link><\/image>/);
-                xmlData.should.match(/<generator>Ghost 0.6<\/generator>/);
-                xmlData.should.match(/<lastBuildDate>.*?<\/lastBuildDate>/);
-                xmlData.should.match(/<atom:link href="http:\/\/my-ghost-blog.com\/rss\/" rel="self"/);
-                xmlData.should.match(/type="application\/rss\+xml"\/><ttl>60<\/ttl>/);
-                xmlData.should.match(/<\/channel><\/rss>$/);
+                assert.match(xmlData, /<channel><title><!\[CDATA\[Test Title\]\]><\/title>/);
+                assert.match(xmlData, /<description><!\[CDATA\[Testing Desc\]\]><\/description>/);
+                assert.match(xmlData, /<link>http:\/\/my-ghost-blog.com\/<\/link>/);
+                assert.match(xmlData, /<image><url>http:\/\/my-ghost-blog.com\/favicon.png<\/url><title>Test Title<\/title><link>http:\/\/my-ghost-blog.com\/<\/link><\/image>/);
+                assert.match(xmlData, /<generator>Ghost 0.6<\/generator>/);
+                assert.match(xmlData, /<lastBuildDate>.*?<\/lastBuildDate>/);
+                assert.match(xmlData, /<atom:link href="http:\/\/my-ghost-blog.com\/rss\/" rel="self"/);
+                assert.match(xmlData, /type="application\/rss\+xml"\/><ttl>60<\/ttl>/);
+                assert.match(xmlData, /<\/channel><\/rss>$/);
 
                 done();
             }).catch(done);
@@ -100,16 +101,16 @@ describe('RSS: Generate Feed', function () {
                 should.exist(xmlData);
 
                 // item tags
-                xmlData.should.match(/<item><title><!\[CDATA\[HTML Ipsum\]\]><\/title>/);
-                xmlData.should.match(/<description><!\[CDATA\[<h1>HTML Ipsum Presents<\/h1>/);
-                xmlData.should.match(/<link>http:\/\/my-ghost-blog.com\/html-ipsum\/<\/link>/);
-                xmlData.should.match(/<image><url>http:\/\/my-ghost-blog.com\/favicon.png<\/url><title>Test Title<\/title><link>http:\/\/my-ghost-blog.com\/<\/link><\/image>/);
-                xmlData.should.match(/<guid isPermaLink="false">/);
-                xmlData.should.match(/<\/guid><dc:creator><!\[CDATA\[Joe Bloggs\]\]><\/dc:creator>/);
-                xmlData.should.match(/<pubDate>Thu, 01 Jan 2015/);
-                xmlData.should.match(/<content:encoded><!\[CDATA\[<h1>HTML Ipsum Presents<\/h1>/);
-                xmlData.should.match(/<\/code><\/pre>\]\]><\/content:encoded><\/item>/);
-                xmlData.should.not.match(/<author>/);
+                assert.match(xmlData, /<item><title><!\[CDATA\[HTML Ipsum\]\]><\/title>/);
+                assert.match(xmlData, /<description><!\[CDATA\[<h1>HTML Ipsum Presents<\/h1>/);
+                assert.match(xmlData, /<link>http:\/\/my-ghost-blog.com\/html-ipsum\/<\/link>/);
+                assert.match(xmlData, /<image><url>http:\/\/my-ghost-blog.com\/favicon.png<\/url><title>Test Title<\/title><link>http:\/\/my-ghost-blog.com\/<\/link><\/image>/);
+                assert.match(xmlData, /<guid isPermaLink="false">/);
+                assert.match(xmlData, /<\/guid><dc:creator><!\[CDATA\[Joe Bloggs\]\]><\/dc:creator>/);
+                assert.match(xmlData, /<pubDate>Thu, 01 Jan 2015/);
+                assert.match(xmlData, /<content:encoded><!\[CDATA\[<h1>HTML Ipsum Presents<\/h1>/);
+                assert.match(xmlData, /<\/code><\/pre>\]\]><\/content:encoded><\/item>/);
+                assert.doesNotMatch(xmlData, /<author>/);
 
                 // basic structure check
                 const postEnd = '<\/code><\/pre>\]\]><\/content:encoded>';
@@ -137,14 +138,14 @@ describe('RSS: Generate Feed', function () {
             generateFeed(baseUrl, data).then(function (xmlData) {
                 should.exist(xmlData);
                 // item tags
-                xmlData.should.match(/<title><!\[CDATA\[Short and Sweet\]\]>/);
-                xmlData.should.match(/<description><!\[CDATA\[test stuff/);
-                xmlData.should.match(/<content:encoded><!\[CDATA\[<!--kg-card-begin: markdown--><h2 id="testing">testing<\/h2>\n/);
-                xmlData.should.match(/<img src="http:\/\/placekitten.com\/500\/200"/);
-                xmlData.should.match(/<media:content url="http:\/\/placekitten.com\/500\/200" medium="image"\/>/);
-                xmlData.should.match(/<category><!\[CDATA\[public\]\]/);
-                xmlData.should.match(/<category><!\[CDATA\[visibility\]\]/);
-                xmlData.should.not.match(/<category><!\[CDATA\[internal\]\]/);
+                assert.match(xmlData, /<title><!\[CDATA\[Short and Sweet\]\]>/);
+                assert.match(xmlData, /<description><!\[CDATA\[test stuff/);
+                assert.match(xmlData, /<content:encoded><!\[CDATA\[<!--kg-card-begin: markdown--><h2 id="testing">testing<\/h2>\n/);
+                assert.match(xmlData, /<img src="http:\/\/placekitten.com\/500\/200"/);
+                assert.match(xmlData, /<media:content url="http:\/\/placekitten.com\/500\/200" medium="image"\/>/);
+                assert.match(xmlData, /<category><!\[CDATA\[public\]\]/);
+                assert.match(xmlData, /<category><!\[CDATA\[visibility\]\]/);
+                assert.doesNotMatch(xmlData, /<category><!\[CDATA\[internal\]\]/);
                 done();
             }).catch(done);
         });
@@ -156,12 +157,12 @@ describe('RSS: Generate Feed', function () {
                 should.exist(xmlData);
 
                 // special/optional tags
-                xmlData.should.match(/<title><!\[CDATA\[Short and Sweet\]\]>/);
-                xmlData.should.match(/<description><!\[CDATA\[test stuff/);
-                xmlData.should.match(/<content:encoded><!\[CDATA\[<!--kg-card-begin: markdown--><h2 id="testing">testing<\/h2>\n/);
-                xmlData.should.match(/<img src="http:\/\/placekitten.com\/500\/200"/);
-                xmlData.should.match(/<media:content url="http:\/\/placekitten.com\/500\/200" medium="image"\/>/);
-                xmlData.should.not.match(/<dc:creator>/);
+                assert.match(xmlData, /<title><!\[CDATA\[Short and Sweet\]\]>/);
+                assert.match(xmlData, /<description><!\[CDATA\[test stuff/);
+                assert.match(xmlData, /<content:encoded><!\[CDATA\[<!--kg-card-begin: markdown--><h2 id="testing">testing<\/h2>\n/);
+                assert.match(xmlData, /<img src="http:\/\/placekitten.com\/500\/200"/);
+                assert.match(xmlData, /<media:content url="http:\/\/placekitten.com\/500\/200" medium="image"\/>/);
+                assert.doesNotMatch(xmlData, /<dc:creator>/);
 
                 done();
             }).catch(done);
@@ -174,11 +175,11 @@ describe('RSS: Generate Feed', function () {
                 should.exist(xmlData);
 
                 // special/optional tags
-                xmlData.should.match(/<title><!\[CDATA\[Short and Sweet\]\]>/);
-                xmlData.should.match(/<description><!\[CDATA\[test stuff/);
-                xmlData.should.match(/<content:encoded\/>/);
-                xmlData.should.match(/<media:content url="http:\/\/placekitten.com\/500\/200" medium="image"\/>/);
-                xmlData.should.match(/<dc:creator>/);
+                assert.match(xmlData, /<title><!\[CDATA\[Short and Sweet\]\]>/);
+                assert.match(xmlData, /<description><!\[CDATA\[test stuff/);
+                assert.match(xmlData, /<content:encoded\/>/);
+                assert.match(xmlData, /<media:content url="http:\/\/placekitten.com\/500\/200" medium="image"\/>/);
+                assert.match(xmlData, /<dc:creator>/);
 
                 done();
             }).catch(done);
@@ -191,11 +192,11 @@ describe('RSS: Generate Feed', function () {
                 should.exist(xmlData);
 
                 // special/optional tags
-                xmlData.should.match(/<title><!\[CDATA\[Short and Sweet\]\]>/);
-                xmlData.should.match(/<description><!\[CDATA\[test stuff/);
-                xmlData.should.match(/<content:encoded><!\[CDATA\[<!--kg-card-begin: markdown--><h2 id="testing">testing<\/h2>\n/);
-                xmlData.should.match(/<img src="http:\/\/placekitten.com\/500\/200"/);
-                xmlData.should.match(/<media:content url="http:\/\/placekitten.com\/500\/200" medium="image"\/>/);
+                assert.match(xmlData, /<title><!\[CDATA\[Short and Sweet\]\]>/);
+                assert.match(xmlData, /<description><!\[CDATA\[test stuff/);
+                assert.match(xmlData, /<content:encoded><!\[CDATA\[<!--kg-card-begin: markdown--><h2 id="testing">testing<\/h2>\n/);
+                assert.match(xmlData, /<img src="http:\/\/placekitten.com\/500\/200"/);
+                assert.match(xmlData, /<media:content url="http:\/\/placekitten.com\/500\/200" medium="image"\/>/);
 
                 done();
             }).catch(done);
@@ -212,8 +213,8 @@ describe('RSS: Generate Feed', function () {
                 should.exist(xmlData);
 
                 // special/optional tags
-                xmlData.should.match(/<title><!\[CDATA\[HTML Ipsum\]\]>/);
-                xmlData.should.match(/<description><!\[CDATA\[This is my custom excerpt!/);
+                assert.match(xmlData, /<title><!\[CDATA\[HTML Ipsum\]\]>/);
+                assert.match(xmlData, /<description><!\[CDATA\[This is my custom excerpt!/);
 
                 done();
             }).catch(done);
@@ -226,16 +227,16 @@ describe('RSS: Generate Feed', function () {
                 should.exist(xmlData);
 
                 // anchor URL - <a href="#nowhere" title="Anchor URL">
-                xmlData.should.match(/<a href="#nowhere" title="Anchor URL">/);
+                assert.match(xmlData, /<a href="#nowhere" title="Anchor URL">/);
 
                 // relative URL - <a href="/about#nowhere" title="Relative URL">
-                xmlData.should.match(/<a href="http:\/\/my-ghost-blog.com\/about#nowhere" title="Relative URL">/);
+                assert.match(xmlData, /<a href="http:\/\/my-ghost-blog.com\/about#nowhere" title="Relative URL">/);
 
                 // protocol relative URL - <a href="//somewhere.com/link#nowhere" title="Protocol Relative URL">
-                xmlData.should.match(/<a href="\/\/somewhere.com\/link#nowhere" title="Protocol Relative URL">/);
+                assert.match(xmlData, /<a href="\/\/somewhere.com\/link#nowhere" title="Protocol Relative URL">/);
 
                 // absolute URL - <a href="http://somewhere.com/link#nowhere" title="Absolute URL">
-                xmlData.should.match(/<a href="http:\/\/somewhere.com\/link#nowhere" title="Absolute URL">/);
+                assert.match(xmlData, /<a href="http:\/\/somewhere.com\/link#nowhere" title="Absolute URL">/);
 
                 done();
             }).catch(done);

--- a/ghost/core/test/unit/frontend/services/rss/renderer.test.js
+++ b/ghost/core/test/unit/frontend/services/rss/renderer.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const rssCache = require('../../../../../core/frontend/services/rss/cache');
@@ -28,14 +29,14 @@ describe('RSS: Renderer', function () {
         rssCacheStub.returns(Promise.resolve('dummyxml'));
 
         renderer.render(res, baseUrl).then(function () {
-            rssCacheStub.calledOnce.should.be.true();
+            assert.equal(rssCacheStub.calledOnce, true);
             rssCacheStub.firstCall.args.should.eql(['/rss/', {}]);
 
-            res.set.calledOnce.should.be.true();
-            res.set.calledWith('Content-Type', 'application/rss+xml; charset=UTF-8').should.be.true();
+            assert.equal(res.set.calledOnce, true);
+            assert.equal(res.set.calledWith('Content-Type', 'application/rss+xml; charset=UTF-8'), true);
 
-            res.send.calledOnce.should.be.true();
-            res.send.calledWith('dummyxml').should.be.true();
+            assert.equal(res.send.calledOnce, true);
+            assert.equal(res.send.calledWith('dummyxml'), true);
 
             done();
         }).catch(done);
@@ -47,14 +48,14 @@ describe('RSS: Renderer', function () {
         res.locals = {foo: 'bar'};
 
         renderer.render(res, baseUrl).then(function () {
-            rssCacheStub.calledOnce.should.be.true();
+            assert.equal(rssCacheStub.calledOnce, true);
             rssCacheStub.firstCall.args.should.eql(['/rss/', {foo: 'bar'}]);
 
-            res.set.calledOnce.should.be.true();
-            res.set.calledWith('Content-Type', 'application/rss+xml; charset=UTF-8').should.be.true();
+            assert.equal(res.set.calledOnce, true);
+            assert.equal(res.set.calledWith('Content-Type', 'application/rss+xml; charset=UTF-8'), true);
 
-            res.send.calledOnce.should.be.true();
-            res.send.calledWith('dummyxml').should.be.true();
+            assert.equal(res.send.calledOnce, true);
+            assert.equal(res.send.calledWith('dummyxml'), true);
 
             done();
         }).catch(done);
@@ -67,14 +68,14 @@ describe('RSS: Renderer', function () {
         const data = {foo: 'baz', fizz: 'buzz'};
 
         renderer.render(res, baseUrl, data).then(function () {
-            rssCacheStub.calledOnce.should.be.true();
+            assert.equal(rssCacheStub.calledOnce, true);
             rssCacheStub.firstCall.args.should.eql(['/rss/', {foo: 'baz', fizz: 'buzz'}]);
 
-            res.set.calledOnce.should.be.true();
-            res.set.calledWith('Content-Type', 'application/rss+xml; charset=UTF-8').should.be.true();
+            assert.equal(res.set.calledOnce, true);
+            assert.equal(res.set.calledWith('Content-Type', 'application/rss+xml; charset=UTF-8'), true);
 
-            res.send.calledOnce.should.be.true();
-            res.send.calledWith('dummyxml').should.be.true();
+            assert.equal(res.send.calledOnce, true);
+            assert.equal(res.send.calledWith('dummyxml'), true);
 
             done();
         }).catch(done);
@@ -86,13 +87,13 @@ describe('RSS: Renderer', function () {
         renderer.render(res, baseUrl).then(function () {
             done('This should have errored');
         }).catch(function (err) {
-            err.message.should.eql('Fake Error');
+            assert.equal(err.message, 'Fake Error');
 
-            rssCacheStub.calledOnce.should.be.true();
+            assert.equal(rssCacheStub.calledOnce, true);
             rssCacheStub.firstCall.args.should.eql(['/rss/', {}]);
 
-            res.set.called.should.be.false();
-            res.send.called.should.be.false();
+            assert.equal(res.set.called, false);
+            assert.equal(res.send.called, false);
 
             done();
         });

--- a/ghost/core/test/unit/frontend/services/sitemap/manager.test.js
+++ b/ghost/core/test/unit/frontend/services/sitemap/manager.test.js
@@ -60,7 +60,7 @@ describe('Unit: sitemap/manager', function () {
 
         it('can create a SiteMapManager instance', function () {
             should.exist(manager);
-            Object.keys(eventsToRemember).length.should.eql(4);
+            assert.equal(Object.keys(eventsToRemember).length, 4);
             should.exist(eventsToRemember['url.added']);
             should.exist(eventsToRemember['url.removed']);
             should.exist(eventsToRemember['router.created']);
@@ -82,7 +82,7 @@ describe('Unit: sitemap/manager', function () {
                     }
                 });
 
-                PostGenerator.prototype.addUrl.calledOnce.should.be.true();
+                assert.equal(PostGenerator.prototype.addUrl.calledOnce, true);
             });
 
             it('url.removed', function () {
@@ -99,7 +99,7 @@ describe('Unit: sitemap/manager', function () {
                     }
                 });
 
-                PostGenerator.prototype.removeUrl.calledOnce.should.be.true();
+                assert.equal(PostGenerator.prototype.removeUrl.calledOnce, true);
             });
 
             it('Listens to URLResourceUpdatedEvent event', async function () {
@@ -116,14 +116,14 @@ describe('Unit: sitemap/manager', function () {
 
         it('fn: getSiteMapXml', function () {
             PostGenerator.prototype.getXml.returns('xml');
-            manager.getSiteMapXml('posts').should.eql('xml');
-            PostGenerator.prototype.getXml.calledOnce.should.be.true();
+            assert.equal(manager.getSiteMapXml('posts'), 'xml');
+            assert.equal(PostGenerator.prototype.getXml.calledOnce, true);
         });
 
         it('fn: getIndexXml', function () {
             IndexGenerator.prototype.getXml.returns('xml');
-            manager.getIndexXml().should.eql('xml');
-            IndexGenerator.prototype.getXml.calledOnce.should.be.true();
+            assert.equal(manager.getIndexXml(), 'xml');
+            assert.equal(IndexGenerator.prototype.getXml.calledOnce, true);
         });
     });
 });

--- a/ghost/core/test/unit/frontend/services/theme-engine/active.test.js
+++ b/ghost/core/test/unit/frontend/services/theme-engine/active.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const config = require('../../../../../core/shared/config');
@@ -53,28 +54,28 @@ describe('Themes', function () {
                 const theme = activeTheme.set(fakeSettings, fakeLoadedTheme, fakeCheckedTheme);
 
                 // Check the theme is not yet mounted
-                activeTheme.get().mounted.should.be.false();
+                assert.equal(activeTheme.get().mounted, false);
 
                 // Call mount!
                 theme.mount(fakeBlogApp);
 
                 // Check the asset hash gets reset
-                configStub.calledOnce.should.be.true();
-                configStub.calledWith('assetHash', null).should.be.true();
+                assert.equal(configStub.calledOnce, true);
+                assert.equal(configStub.calledWith('assetHash', null), true);
 
                 // Check te view cache was cleared
                 fakeBlogApp.cache.should.eql({});
 
                 // Check the views were set correctly
-                fakeBlogApp.set.calledOnce.should.be.true();
-                fakeBlogApp.set.calledWith('views', 'my/fake/theme/path').should.be.true();
+                assert.equal(fakeBlogApp.set.calledOnce, true);
+                assert.equal(fakeBlogApp.set.calledWith('views', 'my/fake/theme/path'), true);
 
                 // Check handlebars was configured correctly
-                engineStub.calledOnce.should.be.true();
-                engineStub.calledWith('my/fake/theme/path/partials').should.be.true();
+                assert.equal(engineStub.calledOnce, true);
+                assert.equal(engineStub.calledWith('my/fake/theme/path/partials'), true);
 
                 // Check the theme is now mounted
-                activeTheme.get().mounted.should.be.true();
+                assert.equal(activeTheme.get().mounted, true);
             });
 
             it('should mount active theme without partials', function () {
@@ -84,28 +85,28 @@ describe('Themes', function () {
                 const theme = activeTheme.set(fakeSettings, fakeLoadedTheme, fakeCheckedTheme);
 
                 // Check the theme is not yet mounted
-                activeTheme.get().mounted.should.be.false();
+                assert.equal(activeTheme.get().mounted, false);
 
                 // Call mount!
                 theme.mount(fakeBlogApp);
 
                 // Check the asset hash gets reset
-                configStub.calledOnce.should.be.true();
-                configStub.calledWith('assetHash', null).should.be.true();
+                assert.equal(configStub.calledOnce, true);
+                assert.equal(configStub.calledWith('assetHash', null), true);
 
                 // Check te view cache was cleared
                 fakeBlogApp.cache.should.eql({});
 
                 // Check the views were set correctly
-                fakeBlogApp.set.calledOnce.should.be.true();
-                fakeBlogApp.set.calledWith('views', 'my/fake/theme/path').should.be.true();
+                assert.equal(fakeBlogApp.set.calledOnce, true);
+                assert.equal(fakeBlogApp.set.calledWith('views', 'my/fake/theme/path'), true);
 
                 // Check handlebars was configured correctly
-                engineStub.calledOnce.should.be.true();
-                engineStub.calledWith().should.be.true();
+                assert.equal(engineStub.calledOnce, true);
+                assert.equal(engineStub.calledWith(), true);
 
                 // Check the theme is now mounted
-                activeTheme.get().mounted.should.be.true();
+                assert.equal(activeTheme.get().mounted, true);
             });
         });
     });

--- a/ghost/core/test/unit/frontend/services/theme-engine/i18n.test.js
+++ b/ghost/core/test/unit/frontend/services/theme-engine/i18n.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 
@@ -8,12 +9,12 @@ const logging = require('@tryghost/logging');
 describe('I18n Class behavior', function () {
     it('defaults to en', function () {
         const i18n = new I18n();
-        i18n.locale().should.eql('en');
+        assert.equal(i18n.locale(), 'en');
     });
 
     it('can have a different locale set', function () {
         const i18n = new I18n({locale: 'fr'});
-        i18n.locale().should.eql('fr');
+        assert.equal(i18n.locale(), 'fr');
     });
 
     describe('file loading behavior', function () {
@@ -22,12 +23,12 @@ describe('I18n Class behavior', function () {
 
             let fileSpy = sinon.spy(i18n, '_readTranslationsFile');
 
-            i18n.locale().should.eql('fr');
+            assert.equal(i18n.locale(), 'fr');
             i18n.init();
 
-            i18n.locale().should.eql('fr');
-            fileSpy.calledTwice.should.be.true();
-            fileSpy.secondCall.args[0].should.eql('en');
+            assert.equal(i18n.locale(), 'fr');
+            assert.equal(fileSpy.calledTwice, true);
+            assert.equal(fileSpy.secondCall.args[0], 'en');
         });
     });
 
@@ -48,12 +49,12 @@ describe('I18n Class behavior', function () {
         });
 
         it('correctly uses dot notation', function () {
-            i18n.t('test.string.path').should.eql('I am correct');
+            assert.equal(i18n.t('test.string.path'), 'I am correct');
         });
 
         it('uses key fallback correctly', function () {
             const loggingStub = sinon.stub(logging, 'error');
-            i18n.t('unknown.string').should.eql('An error occurred');
+            assert.equal(i18n.t('unknown.string'), 'An error occurred');
             sinon.assert.calledOnce(loggingStub);
         });
 
@@ -83,11 +84,11 @@ describe('I18n Class behavior', function () {
         });
 
         it('correctly uses fulltext with bracket notation', function () {
-            i18n.t('Full text').should.eql('I am correct');
+            assert.equal(i18n.t('Full text'), 'I am correct');
         });
 
         it('uses key fallback correctly', function () {
-            i18n.t('unknown string').should.eql('unknown string');
+            assert.equal(i18n.t('unknown string'), 'unknown string');
         });
     });
 });

--- a/ghost/core/test/unit/frontend/services/theme-engine/i18next.test.js
+++ b/ghost/core/test/unit/frontend/services/theme-engine/i18next.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const ThemeI18n = require('../../../../../core/frontend/services/theme-engine/i18next/theme-i18n');
@@ -16,36 +17,36 @@ describe('NEW i18nextThemeI18n Class behavior', function () {
     });
 
     it('defaults to en', function () {
-        i18n._locale.should.eql('en');
+        assert.equal(i18n._locale, 'en');
     });
 
     it('can have a different locale set', function () {
         i18n.init({activeTheme: 'locale-theme', locale: 'fr'});
-        i18n._locale.should.eql('fr');
+        assert.equal(i18n._locale, 'fr');
     });
 
     it('initializes with theme path', function () {
         i18n.init({activeTheme: 'locale-theme', locale: 'de'});
         const result = i18n.t('Top left Button');
-        result.should.eql('Oben Links.');
+        assert.equal(result, 'Oben Links.');
     });
 
     it('falls back to en when translation not found', function () {
         i18n.init({activeTheme: 'locale-theme', locale: 'fr'});
         const result = i18n.t('Top left Button');
-        result.should.eql('Left Button on Top');
+        assert.equal(result, 'Left Button on Top');
     });
 
     it('uses key as fallback when no translation files exist', function () {
         i18n.init({activeTheme: 'locale-theme-1.4', locale: 'de'});
         const result = i18n.t('Top left Button');
-        result.should.eql('Top left Button');
+        assert.equal(result, 'Top left Button');
     });
 
     it('returns empty string for empty key', function () {
         i18n.init({activeTheme: 'locale-theme', locale: 'en'});
         const result = i18n.t('');
-        result.should.eql('');
+        assert.equal(result, '');
     });
 
     it('throws error if used before initialization', function () {
@@ -57,6 +58,6 @@ describe('NEW i18nextThemeI18n Class behavior', function () {
     it('uses key fallback correctly', function () {
         i18n.init({activeTheme: 'locale-theme', locale: 'en'});
         const result = i18n.t('unknown string');
-        result.should.eql('unknown string');
+        assert.equal(result, 'unknown string');
     });
 });

--- a/ghost/core/test/unit/frontend/services/theme-engine/middleware.test.js
+++ b/ghost/core/test/unit/frontend/services/theme-engine/middleware.test.js
@@ -95,8 +95,8 @@ describe('Themes middleware', function () {
             try {
                 assert.equal(err, undefined);
 
-                fakeActiveTheme.mount.called.should.be.true();
-                fakeActiveTheme.mount.calledWith(req.app).should.be.true();
+                assert.equal(fakeActiveTheme.mount.called, true);
+                assert.equal(fakeActiveTheme.mount.calledWith(req.app), true);
 
                 done();
             } catch (error) {
@@ -112,7 +112,7 @@ describe('Themes middleware', function () {
             try {
                 assert.equal(err, undefined);
 
-                fakeActiveTheme.mount.called.should.be.false();
+                assert.equal(fakeActiveTheme.mount.called, false);
 
                 done();
             } catch (error) {
@@ -130,10 +130,10 @@ describe('Themes middleware', function () {
             try {
                 // Did throw an error
                 should.exist(err);
-                err.message.should.eql('The currently active theme "bacon-sensation" is missing.');
+                assert.equal(err.message, 'The currently active theme "bacon-sensation" is missing.');
 
-                activeThemeGetStub.called.should.be.true();
-                fakeActiveTheme.mount.called.should.be.false();
+                assert.equal(activeThemeGetStub.called, true);
+                assert.equal(fakeActiveTheme.mount.called, false);
 
                 done();
             } catch (error) {
@@ -150,7 +150,7 @@ describe('Themes middleware', function () {
                 try {
                     assert.equal(err, undefined);
 
-                    hbsUpdateTemplateOptionsStub.calledOnce.should.be.true();
+                    assert.equal(hbsUpdateTemplateOptionsStub.calledOnce, true);
                     const templateOptions = hbsUpdateTemplateOptionsStub.firstCall.args[0];
                     const data = templateOptions.data;
 
@@ -161,7 +161,7 @@ describe('Themes middleware', function () {
                         .with.properties(themeDataExpectedProps)
                         .and.size(themeDataExpectedProps.length);
                     // posts per page should be set according to the stub
-                    data.config.posts_per_page.should.eql(2);
+                    assert.equal(data.config.posts_per_page, 2);
 
                     // Check labs config
                     assert.deepEqual(data.labs, fakeLabsData);
@@ -195,7 +195,7 @@ describe('Themes middleware', function () {
                     const data = templateOptions.data;
 
                     should.exist(data.site.signup_url);
-                    data.site.signup_url.should.equal('https://feedly.com/i/subscription/feed/http%3A%2F%2F127.0.0.1%3A2369%2Frss%2F');
+                    assert.equal(data.site.signup_url, 'https://feedly.com/i/subscription/feed/http%3A%2F%2F127.0.0.1%3A2369%2Frss%2F');
 
                     done();
                 } catch (error) {
@@ -216,7 +216,7 @@ describe('Themes middleware', function () {
                 try {
                     assert.equal(err, undefined);
 
-                    hbsUpdateLocalTemplateOptionsStub.calledOnce.should.be.true();
+                    assert.equal(hbsUpdateLocalTemplateOptionsStub.calledOnce, true);
                     const templateOptions = hbsUpdateLocalTemplateOptionsStub.firstCall.args[1];
                     const data = templateOptions.data;
 
@@ -224,7 +224,7 @@ describe('Themes middleware', function () {
 
                     data.site.should.be.an.Object().with.properties('accent_color', '_preview');
                     data.site._preview.should.eql(previewString);
-                    data.site.accent_color.should.eql('#000fff');
+                    assert.equal(data.site.accent_color, '#000fff');
 
                     done();
                 } catch (error) {
@@ -243,7 +243,7 @@ describe('Themes middleware', function () {
                 try {
                     assert.equal(err, undefined);
 
-                    hbsUpdateLocalTemplateOptionsStub.calledOnce.should.be.true();
+                    assert.equal(hbsUpdateLocalTemplateOptionsStub.calledOnce, true);
                     const templateOptions = hbsUpdateLocalTemplateOptionsStub.firstCall.args[1];
                     const data = templateOptions.data;
 
@@ -251,8 +251,8 @@ describe('Themes middleware', function () {
 
                     data.site.should.be.an.Object().with.properties('accent_color', 'icon', '_preview');
                     data.site._preview.should.eql(previewString);
-                    data.site.accent_color.should.eql('#000fff');
-                    data.site.icon.should.eql('/content/images/myimg.png');
+                    assert.equal(data.site.accent_color, '#000fff');
+                    assert.equal(data.site.icon, '/content/images/myimg.png');
 
                     done();
                 } catch (error) {
@@ -272,14 +272,14 @@ describe('Themes middleware', function () {
                 try {
                     assert.equal(err, undefined);
 
-                    hbsUpdateLocalTemplateOptionsStub.calledOnce.should.be.true();
+                    assert.equal(hbsUpdateLocalTemplateOptionsStub.calledOnce, true);
                     const templateOptions = hbsUpdateLocalTemplateOptionsStub.firstCall.args[1];
                     const data = templateOptions.data;
 
                     data.should.be.an.Object().with.properties('site', 'custom');
 
                     data.custom.should.be.an.Object().with.properties('header_typography');
-                    data.custom.header_typography.should.eql('Serif');
+                    assert.equal(data.custom.header_typography, 'Serif');
 
                     done();
                 } catch (error) {
@@ -299,14 +299,14 @@ describe('Themes middleware', function () {
                 try {
                     assert.equal(err, undefined);
 
-                    hbsUpdateLocalTemplateOptionsStub.calledOnce.should.be.true();
+                    assert.equal(hbsUpdateLocalTemplateOptionsStub.calledOnce, true);
                     const templateOptions = hbsUpdateLocalTemplateOptionsStub.firstCall.args[1];
                     const data = templateOptions.data;
 
                     data.should.be.an.Object().with.properties('site', 'custom');
 
                     data.custom.should.be.an.Object().with.properties('header_typography');
-                    data.custom.header_typography.should.eql('Serif');
+                    assert.equal(data.custom.header_typography, 'Serif');
 
                     data.custom.should.not.have.property('unknown_setting');
 
@@ -327,7 +327,7 @@ describe('Themes middleware', function () {
                 try {
                     assert.equal(err, undefined);
 
-                    hbsUpdateLocalTemplateOptionsStub.calledOnce.should.be.true();
+                    assert.equal(hbsUpdateLocalTemplateOptionsStub.calledOnce, true);
                     const templateOptions = hbsUpdateLocalTemplateOptionsStub.firstCall.args[1];
                     const data = templateOptions.data;
 
@@ -353,7 +353,7 @@ describe('Themes middleware', function () {
                 try {
                     assert.equal(err, undefined);
 
-                    hbsUpdateLocalTemplateOptionsStub.calledOnce.should.be.true();
+                    assert.equal(hbsUpdateLocalTemplateOptionsStub.calledOnce, true);
                     const templateOptions = hbsUpdateLocalTemplateOptionsStub.firstCall.args[1];
                     const data = templateOptions.data;
 

--- a/ghost/core/test/unit/frontend/services/theme-engine/preview.test.js
+++ b/ghost/core/test/unit/frontend/services/theme-engine/preview.test.js
@@ -20,7 +20,7 @@ describe('Theme Preview', function () {
         let siteData = preview.handle(req, {});
 
         siteData.should.be.an.Object().with.properties('logo');
-        should(siteData.logo).be.null();
+        assert.equal(siteData.logo, null);
     });
 
     it('can handle nulls', function () {
@@ -29,7 +29,7 @@ describe('Theme Preview', function () {
         let siteData = preview.handle(req, {});
 
         siteData.should.be.an.Object().with.properties('cover_image');
-        should(siteData.cover_image).be.null();
+        assert.equal(siteData.cover_image, null);
     });
 
     it('can handle URIEncoded accent colors', function () {
@@ -48,8 +48,8 @@ describe('Theme Preview', function () {
         siteData.should.be.an.Object().with.properties('accent_color', 'icon', 'logo', 'cover_image');
 
         assert.equal(siteData.accent_color, '#f02d2d');
-        should(siteData.icon).be.null();
-        should(siteData.logo).be.null();
-        should(siteData.cover_image).be.null();
+        assert.equal(siteData.icon, null);
+        assert.equal(siteData.logo, null);
+        assert.equal(siteData.cover_image, null);
     });
 });

--- a/ghost/core/test/unit/frontend/services/theme-engine/theme-i18n.test.js
+++ b/ghost/core/test/unit/frontend/services/theme-engine/theme-i18n.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 
 const ThemeI18n = require('../../../../../core/frontend/services/theme-engine/i18n').ThemeI18n;
@@ -5,6 +6,6 @@ const ThemeI18n = require('../../../../../core/frontend/services/theme-engine/i1
 describe('ThemeI18n Class behavior', function () {
     it('defaults to en', function () {
         const i18n = new ThemeI18n();
-        i18n.locale().should.eql('en');
+        assert.equal(i18n.locale(), 'en');
     });
 });

--- a/ghost/core/test/unit/frontend/web/middleware/error-handler.test.js
+++ b/ghost/core/test/unit/frontend/web/middleware/error-handler.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const errors = require('@tryghost/errors');
@@ -40,18 +41,18 @@ describe('Frontend Error Handler', function () {
 
     // Helper functions to reduce assertion duplication
     function assertPlainTextResponse(response, statusCode, message) {
-        response.status.calledOnceWithExactly(statusCode).should.be.true();
-        response.type.calledOnceWithExactly('text/plain').should.be.true();
-        response.send.calledOnce.should.be.true();
+        assert.equal(response.status.calledOnceWithExactly(statusCode), true);
+        assert.equal(response.type.calledOnceWithExactly('text/plain'), true);
+        assert.equal(response.send.calledOnce, true);
         response.send.firstCall.args[0].should.equal(message);
-        response.render.called.should.be.false();
+        assert.equal(response.render.called, false);
     }
 
     function assertHtmlResponse(response, expectedHtml) {
-        response.render.calledOnce.should.be.true();
-        response.send.calledOnceWithExactly(expectedHtml).should.be.true();
-        response.status.called.should.be.false();
-        response.type.called.should.be.false();
+        assert.equal(response.render.calledOnce, true);
+        assert.equal(response.send.calledOnceWithExactly(expectedHtml), true);
+        assert.equal(response.status.called, false);
+        assert.equal(response.type.called, false);
     }
 
     describe('themeErrorRenderer', function () {
@@ -196,7 +197,7 @@ describe('Frontend Error Handler', function () {
             await themeErrorRenderer(err, req, res, next);
 
             assertHtmlResponse(res, mockHtml);
-            next.called.should.be.false();
+            assert.equal(next.called, false);
         });
 
         it('should render HTML for paths with trailing slash', async function () {
@@ -214,7 +215,7 @@ describe('Frontend Error Handler', function () {
             await themeErrorRenderer(err, req, res, next);
 
             assertHtmlResponse(res, mockHtml);
-            next.called.should.be.false();
+            assert.equal(next.called, false);
         });
 
         it('should handle render failures gracefully', async function () {
@@ -231,13 +232,13 @@ describe('Frontend Error Handler', function () {
 
             await themeErrorRenderer(err, req, res, next);
 
-            res.render.calledOnce.should.be.true();
-            res.status.calledOnceWithExactly(500).should.be.true();
-            res.send.calledOnce.should.be.true();
+            assert.equal(res.render.calledOnce, true);
+            assert.equal(res.status.calledOnceWithExactly(500), true);
+            assert.equal(res.send.calledOnce, true);
             
             const errorHtml = res.send.firstCall.args[0];
-            errorHtml.should.containEql('Oops, seems there is an error in the error template');
-            errorHtml.should.containEql('Template rendering failed');
+            assert(errorHtml.includes('Oops, seems there is an error in the error template'));
+            assert(errorHtml.includes('Template rendering failed'));
         });
     });
 });

--- a/ghost/core/test/unit/frontend/web/middleware/handle-image-sizes.test.js
+++ b/ghost/core/test/unit/frontend/web/middleware/handle-image-sizes.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const storage = require('../../../../../core/server/adapters/storage');
@@ -139,7 +140,7 @@ describe('handleImageSizes middleware', function () {
             const fakeRes = {
                 redirect(url) {
                     try {
-                        url.should.equal('/blog/content/images/image.jpg');
+                        assert.equal(url, '/blog/content/images/image.jpg');
                     } catch (e) {
                         return done(e);
                     }
@@ -163,7 +164,7 @@ describe('handleImageSizes middleware', function () {
             const fakeRes = {
                 redirect(url) {
                     try {
-                        url.should.equal('/blog/content/images/image.jpg');
+                        assert.equal(url, '/blog/content/images/image.jpg');
                     } catch (e) {
                         return done(e);
                     }
@@ -187,7 +188,7 @@ describe('handleImageSizes middleware', function () {
             const fakeRes = {
                 redirect(url) {
                     try {
-                        url.should.equal('/blog/content/images/image.jpg');
+                        assert.equal(url, '/blog/content/images/image.jpg');
                     } catch (e) {
                         return done(e);
                     }
@@ -223,7 +224,7 @@ describe('handleImageSizes middleware', function () {
             const fakeRes = {
                 redirect(url) {
                     try {
-                        url.should.equal('/blog/content/images/blank.png');
+                        assert.equal(url, '/blog/content/images/blank.png');
                     } catch (e) {
                         return done(e);
                     }
@@ -250,7 +251,7 @@ describe('handleImageSizes middleware', function () {
             const fakeRes = {
                 redirect(url) {
                     try {
-                        url.should.equal('/blog/content/images/blank.png');
+                        assert.equal(url, '/blog/content/images/blank.png');
                     } catch (e) {
                         return done(e);
                     }
@@ -277,7 +278,7 @@ describe('handleImageSizes middleware', function () {
             const fakeRes = {
                 redirect(url) {
                     try {
-                        url.should.equal('/blog/content/images/blank.png');
+                        assert.equal(url, '/blog/content/images/blank.png');
                     } catch (e) {
                         return done(e);
                     }
@@ -318,7 +319,7 @@ describe('handleImageSizes middleware', function () {
             const fakeRes = {
                 redirect(url) {
                     try {
-                        url.should.equal('/blog/content/images/blank.png');
+                        assert.equal(url, '/blog/content/images/blank.png');
                     } catch (e) {
                         return done(e);
                     }
@@ -385,7 +386,7 @@ describe('handleImageSizes middleware', function () {
                     return done(err);
                 }
                 try {
-                    spy.calledOnceWithExactly({path: '/blank_o.png'}).should.be.true();
+                    assert.equal(spy.calledOnceWithExactly({path: '/blank_o.png'}), true);
                 } catch (e) {
                     return done(e);
                 }
@@ -419,8 +420,8 @@ describe('handleImageSizes middleware', function () {
                     return done(err);
                 }
                 try {
-                    spy.calledOnceWithExactly({path: '/blank_o.png'}).should.be.true();
-                    typeStub.calledOnceWithExactly('webp').should.be.true();
+                    assert.equal(spy.calledOnceWithExactly({path: '/blank_o.png'}), true);
+                    assert.equal(typeStub.calledOnceWithExactly('webp'), true);
                 } catch (e) {
                     return done(e);
                 }
@@ -440,7 +441,7 @@ describe('handleImageSizes middleware', function () {
             const fakeRes = {
                 redirect(url) {
                     try {
-                        url.should.equal('/blog/content/images/blank.svg');
+                        assert.equal(url, '/blog/content/images/blank.svg');
                     } catch (e) {
                         return done(e);
                     }
@@ -469,7 +470,7 @@ describe('handleImageSizes middleware', function () {
             const fakeRes = {
                 redirect(url) {
                     try {
-                        url.should.equal('/blog/content/images/blank.png');
+                        assert.equal(url, '/blog/content/images/blank.png');
                     } catch (e) {
                         return done(e);
                     }
@@ -498,7 +499,7 @@ describe('handleImageSizes middleware', function () {
             const fakeRes = {
                 redirect(url) {
                     try {
-                        url.should.equal('/blog/content/images/blank.ico');
+                        assert.equal(url, '/blog/content/images/blank.ico');
                     } catch (e) {
                         return done(e);
                     }
@@ -527,7 +528,7 @@ describe('handleImageSizes middleware', function () {
             const fakeRes = {
                 redirect(url) {
                     try {
-                        url.should.equal('/blog/content/images/blank.png');
+                        assert.equal(url, '/blog/content/images/blank.png');
                     } catch (e) {
                         return done(e);
                     }
@@ -567,13 +568,13 @@ describe('handleImageSizes middleware', function () {
                     return done(err);
                 }
                 try {
-                    resizeFromBufferStub.calledOnceWithExactly(buffer, {
+                    assert.equal(resizeFromBufferStub.calledOnceWithExactly(buffer, {
                         withoutEnlargement: false,
                         width: 1000,
                         format: 'png',
                         timeout: handleImageSizes.RESIZE_TIMEOUT_SECONDS
-                    }).should.be.true();
-                    typeStub.calledOnceWithExactly('png').should.be.true();
+                    }), true);
+                    assert.equal(typeStub.calledOnceWithExactly('png'), true);
                 } catch (e) {
                     return done(e);
                 }
@@ -607,13 +608,13 @@ describe('handleImageSizes middleware', function () {
                     return done(err);
                 }
                 try {
-                    resizeFromBufferStub.calledOnceWithExactly(buffer, {
+                    assert.equal(resizeFromBufferStub.calledOnceWithExactly(buffer, {
                         withoutEnlargement: true,
                         width: 1000,
                         format: 'webp',
                         timeout: handleImageSizes.RESIZE_TIMEOUT_SECONDS
-                    }).should.be.true();
-                    typeStub.calledOnceWithExactly('webp').should.be.true();
+                    }), true);
+                    assert.equal(typeStub.calledOnceWithExactly('webp'), true);
                 } catch (e) {
                     return done(e);
                 }
@@ -647,13 +648,13 @@ describe('handleImageSizes middleware', function () {
                     return done(err);
                 }
                 try {
-                    resizeFromBufferStub.calledOnceWithExactly(buffer, {
+                    assert.equal(resizeFromBufferStub.calledOnceWithExactly(buffer, {
                         withoutEnlargement: true,
                         width: 1000,
                         format: 'avif',
                         timeout: handleImageSizes.RESIZE_TIMEOUT_SECONDS
-                    }).should.be.true();
-                    typeStub.calledOnceWithExactly('image/avif').should.be.true();
+                    }), true);
+                    assert.equal(typeStub.calledOnceWithExactly('image/avif'), true);
                 } catch (e) {
                     return done(e);
                 }
@@ -687,13 +688,13 @@ describe('handleImageSizes middleware', function () {
                     return done(err);
                 }
                 try {
-                    resizeFromBufferStub.calledOnceWithExactly(buffer, {
+                    assert.equal(resizeFromBufferStub.calledOnceWithExactly(buffer, {
                         withoutEnlargement: true,
                         width: 1000,
                         format: 'webp',
                         timeout: handleImageSizes.RESIZE_TIMEOUT_SECONDS
-                    }).should.be.true();
-                    typeStub.calledOnceWithExactly('webp').should.be.true();
+                    }), true);
+                    assert.equal(typeStub.calledOnceWithExactly('webp'), true);
                 } catch (e) {
                     return done(e);
                 }
@@ -727,13 +728,13 @@ describe('handleImageSizes middleware', function () {
                     return done(err);
                 }
                 try {
-                    resizeFromBufferStub.calledOnceWithExactly(buffer, {
+                    assert.equal(resizeFromBufferStub.calledOnceWithExactly(buffer, {
                         withoutEnlargement: true,
                         width: 1000,
                         format: 'gif',
                         timeout: handleImageSizes.RESIZE_TIMEOUT_SECONDS
-                    }).should.be.true();
-                    typeStub.calledOnceWithExactly('gif').should.be.true();
+                    }), true);
+                    assert.equal(typeStub.calledOnceWithExactly('gif'), true);
                 } catch (e) {
                     return done(e);
                 }

--- a/ghost/core/test/unit/frontend/web/middleware/redirect-ghost-to-admin.test.js
+++ b/ghost/core/test/unit/frontend/web/middleware/redirect-ghost-to-admin.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const redirectGhostToAdmin = require('../../../../../core/frontend/web/middleware/redirect-ghost-to-admin');
@@ -30,8 +31,8 @@ describe('Redirect Ghost To Admin', function () {
     const expectPathCallsRedirectToAdminWith = (inputPath, expectedAdminPath) => {
         req.path = inputPath;
         handleAdminRedirect(req, res);
-        redirectToAdminStub.calledOnce.should.be.true();
-        redirectToAdminStub.calledWith(301, res, expectedAdminPath).should.be.true();
+        assert.equal(redirectToAdminStub.calledOnce, true);
+        assert.equal(redirectToAdminStub.calledWith(301, res, expectedAdminPath), true);
     };
 
     describe('handleAdminRedirect function', function () {
@@ -56,7 +57,7 @@ describe('Redirect Ghost To Admin', function () {
 
             // When disabled, no ghost redirect routes should be added
             const ghostRoutes = router.stack.filter(layer => layer.regexp.source.includes('ghost'));
-            ghostRoutes.should.have.length(0);
+            assert.equal(ghostRoutes.length, 0);
         });
 
         it('should add admin redirect route when admin:redirects is enabled', function () {
@@ -76,14 +77,14 @@ describe('Redirect Ghost To Admin', function () {
             const route = router.stack.find(layer => layer.regexp.source.includes('ghost'));
 
             // Test that the regex matches the expected paths
-            route.regexp.test('/ghost').should.be.true();
-            route.regexp.test('/ghost/').should.be.true();
-            route.regexp.test('/ghost/api/admin/site/').should.be.true();
+            assert.equal(route.regexp.test('/ghost'), true);
+            assert.equal(route.regexp.test('/ghost/'), true);
+            assert.equal(route.regexp.test('/ghost/api/admin/site/'), true);
 
             // Test that it doesn't match unrelated paths
-            route.regexp.test('/admin').should.be.false();
-            route.regexp.test('/.ghost/').should.be.false();
-            route.regexp.test('/tag/ghost/').should.be.false();
+            assert.equal(route.regexp.test('/admin'), false);
+            assert.equal(route.regexp.test('/.ghost/'), false);
+            assert.equal(route.regexp.test('/tag/ghost/'), false);
         });
     });
 });

--- a/ghost/core/test/unit/frontend/web/middleware/serve-public-file.test.js
+++ b/ghost/core/test/unit/frontend/web/middleware/serve-public-file.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const fs = require('fs-extra');
@@ -28,7 +29,7 @@ describe('servePublicFile', function () {
         const middleware = servePublicFile('static', 'robots.txt', 'text/plain', 3600);
         req.path = '/favicon.ico';
         middleware(req, res, next);
-        next.called.should.be.true();
+        assert.equal(next.called, true);
     });
 
     it('should load the file and send it with the correct headers', function () {
@@ -47,14 +48,14 @@ describe('servePublicFile', function () {
 
         middleware(req, res, next);
 
-        next.called.should.be.false();
+        assert.equal(next.called, false);
         fileStub.firstCall.args[0].should.endWith('core/frontend/public/robots.txt');
-        res.writeHead.called.should.be.true();
-        res.writeHead.args[0][0].should.equal(200);
-        res.writeHead.calledWith(200, sinon.match.has('Content-Type')).should.be.true();
-        res.writeHead.calledWith(200, sinon.match.has('Content-Length')).should.be.true();
-        res.writeHead.calledWith(200, sinon.match.has('ETag')).should.be.true();
-        res.writeHead.calledWith(200, sinon.match.has('Cache-Control', 'public, max-age=3600')).should.be.true();
+        assert.equal(res.writeHead.called, true);
+        assert.equal(res.writeHead.args[0][0], 200);
+        assert.equal(res.writeHead.calledWith(200, sinon.match.has('Content-Type')), true);
+        assert.equal(res.writeHead.calledWith(200, sinon.match.has('Content-Length')), true);
+        assert.equal(res.writeHead.calledWith(200, sinon.match.has('ETag')), true);
+        assert.equal(res.writeHead.calledWith(200, sinon.match.has('Cache-Control', 'public, max-age=3600')), true);
     });
 
     it('should send the file from the cache the second time', function () {
@@ -74,19 +75,19 @@ describe('servePublicFile', function () {
         middleware(req, res, next);
         middleware(req, res, next);
 
-        next.called.should.be.false();
+        assert.equal(next.called, false);
 
         // File only gets read onece
-        fileStub.calledOnce.should.be.true();
+        assert.equal(fileStub.calledOnce, true);
         fileStub.firstCall.args[0].should.endWith('core/frontend/public/robots.txt');
 
         // File gets served twice
-        res.writeHead.calledTwice.should.be.true();
-        res.writeHead.args[0][0].should.equal(200);
-        res.writeHead.calledWith(200, sinon.match.has('Content-Type')).should.be.true();
-        res.writeHead.calledWith(200, sinon.match.has('Content-Length')).should.be.true();
-        res.writeHead.calledWith(200, sinon.match.has('ETag')).should.be.true();
-        res.writeHead.calledWith(200, sinon.match.has('Cache-Control', 'public, max-age=3600')).should.be.true();
+        assert.equal(res.writeHead.calledTwice, true);
+        assert.equal(res.writeHead.args[0][0], 200);
+        assert.equal(res.writeHead.calledWith(200, sinon.match.has('Content-Type')), true);
+        assert.equal(res.writeHead.calledWith(200, sinon.match.has('Content-Length')), true);
+        assert.equal(res.writeHead.calledWith(200, sinon.match.has('ETag')), true);
+        assert.equal(res.writeHead.calledWith(200, sinon.match.has('Cache-Control', 'public, max-age=3600')), true);
     });
 
     it('should not cache files requested with a different v tag', function () {
@@ -111,18 +112,18 @@ describe('servePublicFile', function () {
         req.query = {v: 2};
         middleware(req, res, next);
 
-        fileStub.calledTwice.should.be.true();
+        assert.equal(fileStub.calledTwice, true);
 
-        next.called.should.be.false();
+        assert.equal(next.called, false);
         fileStub.firstCall.args[0].should.endWith('core/frontend/public/robots.txt');
         fileStub.secondCall.args[0].should.endWith('core/frontend/public/robots.txt');
 
-        res.writeHead.calledThrice.should.be.true();
-        res.writeHead.args[0][0].should.equal(200);
-        res.writeHead.calledWith(200, sinon.match.has('Content-Type')).should.be.true();
-        res.writeHead.calledWith(200, sinon.match.has('Content-Length')).should.be.true();
-        res.writeHead.calledWith(200, sinon.match.has('ETag')).should.be.true();
-        res.writeHead.calledWith(200, sinon.match.has('Cache-Control', 'public, max-age=3600')).should.be.true();
+        assert.equal(res.writeHead.calledThrice, true);
+        assert.equal(res.writeHead.args[0][0], 200);
+        assert.equal(res.writeHead.calledWith(200, sinon.match.has('Content-Type')), true);
+        assert.equal(res.writeHead.calledWith(200, sinon.match.has('Content-Length')), true);
+        assert.equal(res.writeHead.calledWith(200, sinon.match.has('ETag')), true);
+        assert.equal(res.writeHead.calledWith(200, sinon.match.has('Cache-Control', 'public, max-age=3600')), true);
     });
 
     it('should replace {{blog-url}} in text/plain', function () {
@@ -140,10 +141,10 @@ describe('servePublicFile', function () {
         };
 
         middleware(req, res, next);
-        next.called.should.be.false();
-        res.writeHead.called.should.be.true();
+        assert.equal(next.called, false);
+        assert.equal(res.writeHead.called, true);
 
-        res.end.calledWith('User-agent: http://127.0.0.1:2369').should.be.true();
+        assert.equal(res.end.calledWith('User-agent: http://127.0.0.1:2369'), true);
     });
 
     it('should 404 for ENOENT on general files', function () {
@@ -163,8 +164,8 @@ describe('servePublicFile', function () {
 
         middleware(req, res, next);
 
-        next.called.should.be.true();
-        next.calledWith(sinon.match({errorType: 'NotFoundError', code: 'PUBLIC_FILE_NOT_FOUND'})).should.be.true();
+        assert.equal(next.called, true);
+        assert.equal(next.calledWith(sinon.match({errorType: 'NotFoundError', code: 'PUBLIC_FILE_NOT_FOUND'})), true);
     });
 
     it('can serve a built asset file as well as public files', function () {
@@ -183,9 +184,9 @@ describe('servePublicFile', function () {
 
         middleware(req, res, next);
 
-        next.called.should.be.false();
-        res.writeHead.called.should.be.true();
-        res.writeHead.args[0][0].should.equal(200);
+        assert.equal(next.called, false);
+        assert.equal(res.writeHead.called, true);
+        assert.equal(res.writeHead.args[0][0], 200);
 
         fileStub.firstCall.args[0].should.endWith('/public/something.css');
     });

--- a/ghost/core/test/unit/frontend/web/middleware/static-theme.test.js
+++ b/ghost/core/test/unit/frontend/web/middleware/static-theme.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 
@@ -34,8 +35,8 @@ describe('staticTheme', function () {
         req.path = 'mytemplate.hbs';
 
         staticTheme()(req, res, function next() {
-            activeThemeStub.called.should.be.false();
-            expressStaticStub.called.should.be.false();
+            assert.equal(activeThemeStub.called, false);
+            assert.equal(expressStaticStub.called, false);
 
             done();
         });
@@ -45,8 +46,8 @@ describe('staticTheme', function () {
         req.path = 'README.md';
 
         staticTheme()(req, res, function next() {
-            activeThemeStub.called.should.be.false();
-            expressStaticStub.called.should.be.false();
+            assert.equal(activeThemeStub.called, false);
+            assert.equal(expressStaticStub.called, false);
 
             done();
         });
@@ -56,8 +57,8 @@ describe('staticTheme', function () {
         req.path = 'sample.json';
 
         staticTheme()(req, res, function next() {
-            activeThemeStub.called.should.be.false();
-            expressStaticStub.called.should.be.false();
+            assert.equal(activeThemeStub.called, false);
+            assert.equal(expressStaticStub.called, false);
 
             done();
         });
@@ -67,8 +68,8 @@ describe('staticTheme', function () {
         req.path = 'yarn.lock';
 
         staticTheme()(req, res, function next() {
-            activeThemeStub.called.should.be.false();
-            expressStaticStub.called.should.be.false();
+            assert.equal(activeThemeStub.called, false);
+            assert.equal(expressStaticStub.called, false);
 
             done();
         });
@@ -78,8 +79,8 @@ describe('staticTheme', function () {
         req.path = 'gulpfile.js';
 
         staticTheme()(req, res, function next() {
-            activeThemeStub.called.should.be.false();
-            expressStaticStub.called.should.be.false();
+            assert.equal(activeThemeStub.called, false);
+            assert.equal(expressStaticStub.called, false);
 
             done();
         });
@@ -89,8 +90,8 @@ describe('staticTheme', function () {
         req.path = 'Gulpfile.js';
 
         staticTheme()(req, res, function next() {
-            activeThemeStub.called.should.be.false();
-            expressStaticStub.called.should.be.false();
+            assert.equal(activeThemeStub.called, false);
+            assert.equal(expressStaticStub.called, false);
 
             done();
         });
@@ -101,12 +102,12 @@ describe('staticTheme', function () {
 
         staticTheme()(req, res, function next() {
             // Specifically gets called twice
-            activeThemeStub.calledTwice.should.be.true();
-            expressStaticStub.called.should.be.true();
+            assert.equal(activeThemeStub.calledTwice, true);
+            assert.equal(expressStaticStub.called, true);
 
             // Check that express static gets called with the theme path + maxAge
             should.exist(expressStaticStub.firstCall.args);
-            expressStaticStub.firstCall.args[0].should.eql('my/fake/path');
+            assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
             expressStaticStub.firstCall.args[1].should.be.an.Object().with.property('maxAge');
 
             done();
@@ -118,12 +119,12 @@ describe('staticTheme', function () {
 
         staticTheme()(req, res, function next() {
             // Specifically gets called twice
-            activeThemeStub.calledTwice.should.be.true();
-            expressStaticStub.called.should.be.true();
+            assert.equal(activeThemeStub.calledTwice, true);
+            assert.equal(expressStaticStub.called, true);
 
             // Check that express static gets called with the theme path + maxAge
             should.exist(expressStaticStub.firstCall.args);
-            expressStaticStub.firstCall.args[0].should.eql('my/fake/path');
+            assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
             expressStaticStub.firstCall.args[1].should.be.an.Object().with.property('maxAge');
 
             done();
@@ -137,8 +138,8 @@ describe('staticTheme', function () {
         activeThemeStub.returns(undefined);
 
         staticTheme()(req, res, function next() {
-            activeThemeStub.calledOnce.should.be.true();
-            expressStaticStub.called.should.be.false();
+            assert.equal(activeThemeStub.calledOnce, true);
+            assert.equal(expressStaticStub.called, false);
 
             done();
         });
@@ -149,12 +150,12 @@ describe('staticTheme', function () {
 
         staticTheme()(req, res, function next() {
             // Specifically gets called twice
-            activeThemeStub.calledTwice.should.be.true();
-            expressStaticStub.called.should.be.true();
+            assert.equal(activeThemeStub.calledTwice, true);
+            assert.equal(expressStaticStub.called, true);
 
             // Check that express static gets called with the theme path + maxAge
             should.exist(expressStaticStub.firstCall.args);
-            expressStaticStub.firstCall.args[0].should.eql('my/fake/path');
+            assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
             expressStaticStub.firstCall.args[1].should.be.an.Object().with.property('maxAge');
 
             done();
@@ -166,12 +167,12 @@ describe('staticTheme', function () {
 
         staticTheme()(req, res, function next() {
             // Specifically gets called twice
-            activeThemeStub.calledTwice.should.be.true();
-            expressStaticStub.called.should.be.true();
+            assert.equal(activeThemeStub.calledTwice, true);
+            assert.equal(expressStaticStub.called, true);
 
             // Check that express static gets called with the theme path + maxAge
             should.exist(expressStaticStub.firstCall.args);
-            expressStaticStub.firstCall.args[0].should.eql('my/fake/path');
+            assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
             expressStaticStub.firstCall.args[1].should.be.an.Object().with.property('maxAge');
 
             done();
@@ -183,12 +184,12 @@ describe('staticTheme', function () {
 
         staticTheme()(req, res, function next() {
             // Specifically gets called twice
-            activeThemeStub.calledTwice.should.be.true();
-            expressStaticStub.called.should.be.true();
+            assert.equal(activeThemeStub.calledTwice, true);
+            assert.equal(expressStaticStub.called, true);
 
             // Check that express static gets called with the theme path + maxAge
             should.exist(expressStaticStub.firstCall.args);
-            expressStaticStub.firstCall.args[0].should.eql('my/fake/path');
+            assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
             expressStaticStub.firstCall.args[1].should.be.an.Object().with.property('maxAge');
 
             done();
@@ -199,8 +200,8 @@ describe('staticTheme', function () {
         req.path = '/assets/mytemplate.hbs';
 
         staticTheme()(req, res, function next() {
-            activeThemeStub.called.should.be.false();
-            expressStaticStub.called.should.be.false();
+            assert.equal(activeThemeStub.called, false);
+            assert.equal(expressStaticStub.called, false);
 
             done();
         });
@@ -211,8 +212,8 @@ describe('staticTheme', function () {
         req.method = 'GET';
 
         staticTheme()(req, res, function next() {
-            activeThemeStub.called.should.be.false();
-            expressStaticStub.called.should.be.false();
+            assert.equal(activeThemeStub.called, false);
+            assert.equal(expressStaticStub.called, false);
 
             done();
         });
@@ -223,8 +224,8 @@ describe('staticTheme', function () {
         req.method = 'GET';
 
         staticTheme()(req, res, function next() {
-            activeThemeStub.called.should.be.false();
-            expressStaticStub.called.should.be.false();
+            assert.equal(activeThemeStub.called, false);
+            assert.equal(expressStaticStub.called, false);
 
             done();
         });
@@ -235,8 +236,8 @@ describe('staticTheme', function () {
             req.path = '/';
 
             staticTheme()(req, res, function next() {
-                activeThemeStub.called.should.be.false();
-                expressStaticStub.called.should.be.false();
+                assert.equal(activeThemeStub.called, false);
+                assert.equal(expressStaticStub.called, false);
 
                 done();
             });
@@ -246,8 +247,8 @@ describe('staticTheme', function () {
             req.path = '/about/';
 
             staticTheme()(req, res, function next() {
-                activeThemeStub.called.should.be.false();
-                expressStaticStub.called.should.be.false();
+                assert.equal(activeThemeStub.called, false);
+                assert.equal(expressStaticStub.called, false);
 
                 done();
             });
@@ -257,8 +258,8 @@ describe('staticTheme', function () {
             req.path = '/blog/my-post/';
 
             staticTheme()(req, res, function next() {
-                activeThemeStub.called.should.be.false();
-                expressStaticStub.called.should.be.false();
+                assert.equal(activeThemeStub.called, false);
+                assert.equal(expressStaticStub.called, false);
 
                 done();
             });
@@ -268,8 +269,8 @@ describe('staticTheme', function () {
             req.path = '/contact';
 
             staticTheme()(req, res, function next() {
-                activeThemeStub.called.should.be.false();
-                expressStaticStub.called.should.be.false();
+                assert.equal(activeThemeStub.called, false);
+                assert.equal(expressStaticStub.called, false);
 
                 done();
             });
@@ -280,12 +281,12 @@ describe('staticTheme', function () {
 
             staticTheme()(req, res, function next() {
                 // Specifically gets called twice
-                activeThemeStub.calledTwice.should.be.true();
-                expressStaticStub.called.should.be.true();
+                assert.equal(activeThemeStub.calledTwice, true);
+                assert.equal(expressStaticStub.called, true);
 
                 // Check that express static gets called with the theme path + maxAge
                 should.exist(expressStaticStub.firstCall.args);
-                expressStaticStub.firstCall.args[0].should.eql('my/fake/path');
+                assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
                 expressStaticStub.firstCall.args[1].should.be.an.Object().with.property('maxAge');
 
                 done();
@@ -297,12 +298,12 @@ describe('staticTheme', function () {
 
             staticTheme()(req, res, function next() {
                 // Specifically gets called twice
-                activeThemeStub.calledTwice.should.be.true();
-                expressStaticStub.called.should.be.true();
+                assert.equal(activeThemeStub.calledTwice, true);
+                assert.equal(expressStaticStub.called, true);
 
                 // Check that express static gets called with the theme path + maxAge
                 should.exist(expressStaticStub.firstCall.args);
-                expressStaticStub.firstCall.args[0].should.eql('my/fake/path');
+                assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
                 expressStaticStub.firstCall.args[1].should.be.an.Object().with.property('maxAge');
 
                 done();
@@ -314,12 +315,12 @@ describe('staticTheme', function () {
 
             staticTheme()(req, res, function next() {
                 // Specifically gets called twice
-                activeThemeStub.calledTwice.should.be.true();
-                expressStaticStub.called.should.be.true();
+                assert.equal(activeThemeStub.calledTwice, true);
+                assert.equal(expressStaticStub.called, true);
 
                 // Check that express static gets called with the theme path + maxAge
                 should.exist(expressStaticStub.firstCall.args);
-                expressStaticStub.firstCall.args[0].should.eql('my/fake/path');
+                assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
                 expressStaticStub.firstCall.args[1].should.be.an.Object().with.property('maxAge');
 
                 done();
@@ -338,15 +339,15 @@ describe('staticTheme', function () {
             req.path = '/.well-known/apple-app-site-association';
 
             staticTheme()(req, res, function next() {
-                activeThemeStub.called.should.be.true();
-                expressStaticStub.called.should.be.true();
+                assert.equal(activeThemeStub.called, true);
+                assert.equal(expressStaticStub.called, true);
 
                 const options = expressStaticStub.firstCall.args[1];
                 should.exist(options.setHeaders);
 
                 const setHeaderStub = sinon.stub();
                 options.setHeaders({setHeader: setHeaderStub});
-                setHeaderStub.calledWith('Content-Type', 'application/json').should.be.true();
+                assert.equal(setHeaderStub.calledWith('Content-Type', 'application/json'), true);
 
                 done();
             });
@@ -356,7 +357,7 @@ describe('staticTheme', function () {
             req.path = '/.WELL-KNOWN/apple-app-site-association.json';
 
             staticTheme()(req, res, function next() {
-                expressStaticStub.called.should.be.false();
+                assert.equal(expressStaticStub.called, false);
                 done();
             });
         });
@@ -368,12 +369,12 @@ describe('staticTheme', function () {
 
             staticTheme()(req, res, function next() {
                 // Specifically gets called twice
-                activeThemeStub.calledTwice.should.be.true();
-                expressStaticStub.called.should.be.true();
+                assert.equal(activeThemeStub.calledTwice, true);
+                assert.equal(expressStaticStub.called, true);
 
                 // Check that express static gets called with correct options
                 should.exist(expressStaticStub.firstCall.args);
-                expressStaticStub.firstCall.args[0].should.eql('my/fake/path');
+                assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
 
                 const options = expressStaticStub.firstCall.args[1];
                 options.should.be.an.Object();
@@ -389,12 +390,12 @@ describe('staticTheme', function () {
 
             staticTheme()(req, res, function next() {
                 // Specifically gets called twice
-                activeThemeStub.calledTwice.should.be.true();
-                expressStaticStub.called.should.be.true();
+                assert.equal(activeThemeStub.calledTwice, true);
+                assert.equal(expressStaticStub.called, true);
 
                 // Check that express static gets called with correct options
                 should.exist(expressStaticStub.firstCall.args);
-                expressStaticStub.firstCall.args[0].should.eql('my/fake/path');
+                assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
 
                 const options = expressStaticStub.firstCall.args[1];
                 options.should.be.an.Object();
@@ -410,12 +411,12 @@ describe('staticTheme', function () {
 
             staticTheme()(req, res, function next() {
                 // Specifically gets called twice
-                activeThemeStub.calledTwice.should.be.true();
-                expressStaticStub.called.should.be.true();
+                assert.equal(activeThemeStub.calledTwice, true);
+                assert.equal(expressStaticStub.called, true);
 
                 // Check that express static gets called with correct options
                 should.exist(expressStaticStub.firstCall.args);
-                expressStaticStub.firstCall.args[0].should.eql('my/fake/path');
+                assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
 
                 const options = expressStaticStub.firstCall.args[1];
                 options.should.be.an.Object();
@@ -430,11 +431,11 @@ describe('staticTheme', function () {
             req.path = '/sitemap-posts-2.xml';
 
             staticTheme()(req, res, function next() {
-                activeThemeStub.calledTwice.should.be.true();
-                expressStaticStub.called.should.be.true();
+                assert.equal(activeThemeStub.calledTwice, true);
+                assert.equal(expressStaticStub.called, true);
 
                 should.exist(expressStaticStub.firstCall.args);
-                expressStaticStub.firstCall.args[0].should.eql('my/fake/path');
+                assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
 
                 const options = expressStaticStub.firstCall.args[1];
                 options.should.be.an.Object();
@@ -449,8 +450,8 @@ describe('staticTheme', function () {
             req.path = '/sitemap-posts-99.xml';
 
             staticTheme()(req, res, function next() {
-                activeThemeStub.calledTwice.should.be.true();
-                expressStaticStub.called.should.be.true();
+                assert.equal(activeThemeStub.calledTwice, true);
+                assert.equal(expressStaticStub.called, true);
 
                 const options = expressStaticStub.firstCall.args[1];
                 options.should.have.property('fallthrough', true);
@@ -463,8 +464,8 @@ describe('staticTheme', function () {
             req.path = '/sitemap-tags-3.xml';
 
             staticTheme()(req, res, function next() {
-                activeThemeStub.calledTwice.should.be.true();
-                expressStaticStub.called.should.be.true();
+                assert.equal(activeThemeStub.calledTwice, true);
+                assert.equal(expressStaticStub.called, true);
 
                 const options = expressStaticStub.firstCall.args[1];
                 options.should.have.property('fallthrough', true);
@@ -477,8 +478,8 @@ describe('staticTheme', function () {
             req.path = '/sitemap-authors-2.xml';
 
             staticTheme()(req, res, function next() {
-                activeThemeStub.calledTwice.should.be.true();
-                expressStaticStub.called.should.be.true();
+                assert.equal(activeThemeStub.calledTwice, true);
+                assert.equal(expressStaticStub.called, true);
 
                 const options = expressStaticStub.firstCall.args[1];
                 options.should.have.property('fallthrough', true);
@@ -492,12 +493,12 @@ describe('staticTheme', function () {
 
             staticTheme()(req, res, function next() {
                 // Specifically gets called twice
-                activeThemeStub.calledTwice.should.be.true();
-                expressStaticStub.called.should.be.true();
+                assert.equal(activeThemeStub.calledTwice, true);
+                assert.equal(expressStaticStub.called, true);
 
                 // Check that express static gets called with correct options
                 should.exist(expressStaticStub.firstCall.args);
-                expressStaticStub.firstCall.args[0].should.eql('my/fake/path');
+                assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
 
                 const options = expressStaticStub.firstCall.args[1];
                 options.should.be.an.Object();
@@ -513,12 +514,12 @@ describe('staticTheme', function () {
 
             staticTheme()(req, res, function next() {
                 // Specifically gets called twice
-                activeThemeStub.calledTwice.should.be.true();
-                expressStaticStub.called.should.be.true();
+                assert.equal(activeThemeStub.calledTwice, true);
+                assert.equal(expressStaticStub.called, true);
 
                 // Check that express static gets called with correct options
                 should.exist(expressStaticStub.firstCall.args);
-                expressStaticStub.firstCall.args[0].should.eql('my/fake/path');
+                assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
 
                 const options = expressStaticStub.firstCall.args[1];
                 options.should.be.an.Object();
@@ -534,12 +535,12 @@ describe('staticTheme', function () {
 
             staticTheme()(req, res, function next() {
                 // Specifically gets called twice
-                activeThemeStub.calledTwice.should.be.true();
-                expressStaticStub.called.should.be.true();
+                assert.equal(activeThemeStub.calledTwice, true);
+                assert.equal(expressStaticStub.called, true);
 
                 // Check that express static gets called with correct options
                 should.exist(expressStaticStub.firstCall.args);
-                expressStaticStub.firstCall.args[0].should.eql('my/fake/path');
+                assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
 
                 const options = expressStaticStub.firstCall.args[1];
                 options.should.be.an.Object();

--- a/ghost/core/test/unit/server/adapters/scheduling/post-scheduling/post-scheduler.test.js
+++ b/ghost/core/test/unit/server/adapters/scheduling/post-scheduling/post-scheduler.test.js
@@ -74,13 +74,13 @@ describe('Scheduling: Post Scheduler', function () {
                     setTimeout(resolve, 100);
                 });
 
-                adapter.schedule.called.should.eql(true);
+                assert.equal(adapter.schedule.called, true);
 
-                adapter.schedule.calledOnce.should.eql(true);
+                assert.equal(adapter.schedule.calledOnce, true);
 
                 adapter.schedule.args[0][0].time.should.equal(moment(post.get('published_at')).valueOf());
                 adapter.schedule.args[0][0].url.should.startWith(urlUtils.urlJoin('http://scheduler.local:1111/', 'schedules', 'posts', post.get('id'), '?token='));
-                adapter.schedule.args[0][0].extra.httpMethod.should.eql('PUT');
+                assert.equal(adapter.schedule.args[0][0].extra.httpMethod, 'PUT');
                 assert.equal(null, adapter.schedule.args[0][0].extra.oldTime);
             });
         });
@@ -91,7 +91,7 @@ describe('Scheduling: Post Scheduler', function () {
                     new PostScheduler();
                     throw new Error('should have thrown');
                 } catch (err) {
-                    (err instanceof errors.IncorrectUsageError).should.eql(true);
+                    assert.equal((err instanceof errors.IncorrectUsageError), true);
                 }
             });
         });

--- a/ghost/core/test/unit/server/adapters/scheduling/scheduling-default.test.js
+++ b/ghost/core/test/unit/server/adapters/scheduling/scheduling-default.test.js
@@ -50,7 +50,7 @@ describe('Scheduling Default Adapter', function () {
             // 2 jobs get immediately executed
             assert.equal(scope.adapter.allJobs[moment(dates[1]).valueOf()], undefined);
             assert.equal(scope.adapter.allJobs[moment(dates[7]).valueOf()], undefined);
-            scope.adapter._execute.calledTwice.should.eql(true);
+            assert.equal(scope.adapter._execute.calledTwice, true);
 
             Object.keys(scope.adapter.allJobs).length.should.eql(dates.length - 2);
             Object.keys(scope.adapter.allJobs).should.eql([
@@ -97,7 +97,7 @@ describe('Scheduling Default Adapter', function () {
 
             clock.tick(50);
 
-            scope.adapter._pingUrl.calledOnce.should.eql(true);
+            assert.equal(scope.adapter._pingUrl.calledOnce, true);
             done();
         });
 
@@ -125,7 +125,7 @@ describe('Scheduling Default Adapter', function () {
             });
 
             clock.tick(50);
-            scope.adapter._pingUrl.calledOnce.should.eql(true);
+            assert.equal(scope.adapter._pingUrl.calledOnce, true);
             done();
         });
 
@@ -138,7 +138,7 @@ describe('Scheduling Default Adapter', function () {
             const allJobs = {};
 
             sinon.stub(scope.adapter, '_execute').callsFake(function (nextJobs) {
-                Object.keys(nextJobs).length.should.eql(121);
+                assert.equal(Object.keys(nextJobs).length, 121);
                 Object.keys(scope.adapter.allJobs).length.should.eql(1000 - 121);
                 done();
             });
@@ -235,15 +235,15 @@ describe('Scheduling Default Adapter', function () {
                     return retry();
                 }
 
-                Object.keys(scope.adapter.deletedJobs).length.should.eql(2);
-                pinged.should.eql(2);
+                assert.equal(Object.keys(scope.adapter.deletedJobs).length, 2);
+                assert.equal(pinged, 2);
                 done();
             })();
         });
 
         it('delete job (unschedule): time is null', function () {
             scope.adapter._deleteJob({time: null, url: '/test'});
-            Object.keys(scope.adapter.deletedJobs).length.should.eql(0);
+            assert.equal(Object.keys(scope.adapter.deletedJobs).length, 0);
         });
 
         describe('pingUrl', function () {
@@ -291,7 +291,7 @@ describe('Scheduling Default Adapter', function () {
                 });
 
                 clock.runToLast();
-                ping.isDone().should.be.true();
+                assert.equal(ping.isDone(), true);
             });
 
             it('pingUrl (PUT, and detect publish in the past)', async function () {
@@ -309,7 +309,7 @@ describe('Scheduling Default Adapter', function () {
                 });
 
                 clock.runToLast();
-                ping.isDone().should.be.true();
+                assert.equal(ping.isDone(), true);
             });
 
             it('pingUrl (GET, and detect publish in the past)', async function () {
@@ -327,7 +327,7 @@ describe('Scheduling Default Adapter', function () {
                 });
 
                 clock.runToLast();
-                ping.isDone().should.be.true();
+                assert.equal(ping.isDone(), true);
             });
 
             it('pingUrl, but blog returns 503', function (done) {

--- a/ghost/core/test/unit/server/adapters/storage/index.test.js
+++ b/ghost/core/test/unit/server/adapters/storage/index.test.js
@@ -27,8 +27,8 @@ describe('storage: index_spec', function () {
 
     it('default image storage is local file storage', function () {
         const chosenStorage = storage.getStorage();
-        (chosenStorage instanceof StorageBase).should.eql(true);
-        (chosenStorage instanceof LocalStorageBase).should.eql(true);
+        assert.equal((chosenStorage instanceof StorageBase), true);
+        assert.equal((chosenStorage instanceof LocalStorageBase), true);
     });
 
     it('custom adapter', function () {
@@ -56,10 +56,10 @@ describe('storage: index_spec', function () {
 
         fs.writeFileSync(scope.adapter, jsFile);
 
-        configUtils.config.get('storage:active').should.eql('custom-adapter');
+        assert.equal(configUtils.config.get('storage:active'), 'custom-adapter');
         chosenStorage = storage.getStorage();
-        (chosenStorage instanceof LocalStorageBase).should.eql(false);
-        (chosenStorage instanceof StorageBase).should.eql(true);
+        assert.equal((chosenStorage instanceof LocalStorageBase), false);
+        assert.equal((chosenStorage instanceof StorageBase), true);
     });
 
     it('create bad adapter: exists fn is missing', function () {

--- a/ghost/core/test/unit/server/adapters/storage/local-base-storage.test.js
+++ b/ghost/core/test/unit/server/adapters/storage/local-base-storage.test.js
@@ -45,8 +45,7 @@ describe('Local Storage Base', function () {
 
             // urlToPath now returns relative path, not absolute path
             // This matches S3Storage behavior and allows callers to pass result to save/exists/delete
-            localStorageBase.urlToPath('http://example.com/blog/content/media/2021/11/media.mp4')
-                .should.eql('2021/11/media.mp4');
+            assert.equal(localStorageBase.urlToPath('http://example.com/blog/content/media/2021/11/media.mp4'), '2021/11/media.mp4');
         });
 
         it('throws if the url does not match current site', function () {
@@ -60,7 +59,7 @@ describe('Local Storage Base', function () {
                 localStorageBase.urlToPath('http://anothersite.com/blog/content/media/2021/11/media.mp4');
                 should.fail('urlToPath when urls do not match');
             } catch (error) {
-                error.message.should.eql('The URL "http://anothersite.com/blog/content/media/2021/11/media.mp4" is not a valid URL for this site.');
+                assert.equal(error.message, 'The URL "http://anothersite.com/blog/content/media/2021/11/media.mp4" is not a valid URL for this site.');
             }
         });
     });

--- a/ghost/core/test/unit/server/adapters/storage/local-images-storage.test.js
+++ b/ghost/core/test/unit/server/adapters/storage/local-images-storage.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const errors = require('@tryghost/errors');
 const should = require('should');
 const sinon = require('sinon');
@@ -52,7 +53,7 @@ describe('Local Images Storage', function () {
 
     it('should send correct path to image when date is in Sep 2013', function (done) {
         localFileStore.save(image).then(function (url) {
-            url.should.equal('/content/images/2013/09/IMAGE.jpg');
+            assert.equal(url, '/content/images/2013/09/IMAGE.jpg');
 
             done();
         }).catch(done);
@@ -61,7 +62,7 @@ describe('Local Images Storage', function () {
     it('should send correct path to image when original file has spaces', function (done) {
         image.name = 'AN IMAGE.jpg';
         localFileStore.save(image).then(function (url) {
-            url.should.equal('/content/images/2013/09/AN-IMAGE.jpg');
+            assert.equal(url, '/content/images/2013/09/AN-IMAGE.jpg');
 
             done();
         }).catch(done);
@@ -70,7 +71,7 @@ describe('Local Images Storage', function () {
     it('should allow "@" symbol to image for Apple hi-res (retina) modifier', function (done) {
         image.name = 'photo@2x.jpg';
         localFileStore.save(image).then(function (url) {
-            url.should.equal('/content/images/2013/09/photo@2x.jpg');
+            assert.equal(url, '/content/images/2013/09/photo@2x.jpg');
 
             done();
         }).catch(done);
@@ -80,7 +81,7 @@ describe('Local Images Storage', function () {
         fakeDate(1, 2014);
 
         localFileStore.save(image).then(function (url) {
-            url.should.equal('/content/images/2014/01/IMAGE.jpg');
+            assert.equal(url, '/content/images/2014/01/IMAGE.jpg');
 
             done();
         }).catch(done);
@@ -88,7 +89,7 @@ describe('Local Images Storage', function () {
 
     it('should create month and year directory', function (done) {
         localFileStore.save(image).then(function () {
-            fsMkdirsStub.calledOnce.should.be.true();
+            assert.equal(fsMkdirsStub.calledOnce, true);
             fsMkdirsStub.args[0][0].should.equal(path.resolve('./content/images/2013/09'));
 
             done();
@@ -97,8 +98,8 @@ describe('Local Images Storage', function () {
 
     it('should copy temp file to new location', function (done) {
         localFileStore.save(image).then(function () {
-            fsCopyStub.calledOnce.should.be.true();
-            fsCopyStub.args[0][0].should.equal('tmp/123456.jpg');
+            assert.equal(fsCopyStub.calledOnce, true);
+            assert.equal(fsCopyStub.args[0][0], 'tmp/123456.jpg');
             fsCopyStub.args[0][1].should.equal(path.resolve('./content/images/2013/09/IMAGE.jpg'));
 
             done();
@@ -115,7 +116,7 @@ describe('Local Images Storage', function () {
         fsStatStub.withArgs(path.resolve('.\\content\\images\\2013\\Sep\\IMAGE-1.jpg')).rejects();
 
         localFileStore.save(image).then(function (url) {
-            url.should.equal('/content/images/2013/09/IMAGE-1.jpg');
+            assert.equal(url, '/content/images/2013/09/IMAGE-1.jpg');
 
             done();
         }).catch(done);
@@ -136,7 +137,7 @@ describe('Local Images Storage', function () {
         fsStatStub.withArgs(path.resolve('.\\content\\images\\2013\\Sep\\IMAGE-4.jpg')).rejects();
 
         localFileStore.save(image).then(function (url) {
-            url.should.equal('/content/images/2013/09/IMAGE-4.jpg');
+            assert.equal(url, '/content/images/2013/09/IMAGE-4.jpg');
 
             done();
         }).catch(done);
@@ -151,7 +152,7 @@ describe('Local Images Storage', function () {
         it('success', function (done) {
             localFileStore.read({path: 'ghost-logo.png'})
                 .then(function (bytes) {
-                    bytes.length.should.eql(8638);
+                    assert.equal(bytes.length, 8638);
                     done();
                 });
         });
@@ -159,7 +160,7 @@ describe('Local Images Storage', function () {
         it('success (leading and trailing slashes)', function (done) {
             localFileStore.read({path: '/ghost-logo.png/'})
                 .then(function (bytes) {
-                    bytes.length.should.eql(8638);
+                    assert.equal(bytes.length, 8638);
                     done();
                 });
         });
@@ -170,8 +171,8 @@ describe('Local Images Storage', function () {
                     done(new Error('image should not exist'));
                 })
                 .catch(function (err) {
-                    (err instanceof errors.NotFoundError).should.eql(true);
-                    err.code.should.eql('ENOENT');
+                    assert.equal((err instanceof errors.NotFoundError), true);
+                    assert.equal(err.code, 'ENOENT');
                     done();
                 });
         });
@@ -214,7 +215,7 @@ describe('Local Images Storage', function () {
 
         it('should send the correct path to image', function (done) {
             localFileStore.save(image).then(function (url) {
-                url.should.equal('/content/images/2013/09/IMAGE.jpg');
+                assert.equal(url, '/content/images/2013/09/IMAGE.jpg');
 
                 done();
             }).catch(done);
@@ -241,13 +242,13 @@ describe('Local Images Storage', function () {
 
             localFileStore.save(image).then(function (url) {
                 if (truePathSep === '\\') {
-                    url.should.equal('/content/images/2013/09/IMAGE.jpg');
+                    assert.equal(url, '/content/images/2013/09/IMAGE.jpg');
                 } else {
                     // if this unit test is run on an OS that uses forward slash separators,
                     // localfilesystem.save() will use a path.relative() call on
                     // one path with backslash separators and one path with forward
                     // slashes and it returns a path that needs to be normalized
-                    path.normalize(url).should.equal('/content/images/2013/09/IMAGE.jpg');
+                    assert.equal(path.normalize(url), '/content/images/2013/09/IMAGE.jpg');
                 }
 
                 done();

--- a/ghost/core/test/unit/server/data/db/backup.test.js
+++ b/ghost/core/test/unit/server/data/db/backup.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const fs = require('fs-extra');
@@ -27,9 +28,9 @@ describe('Backup', function () {
 
     it('should create a backup JSON file', function (done) {
         dbBackup.backup().then(function () {
-            exportStub.calledOnce.should.be.true();
-            filenameStub.calledOnce.should.be.true();
-            fsStub.calledOnce.should.be.true();
+            assert.equal(exportStub.calledOnce, true);
+            assert.equal(filenameStub.calledOnce, true);
+            assert.equal(fsStub.calledOnce, true);
 
             done();
         }).catch(done);
@@ -39,9 +40,9 @@ describe('Backup', function () {
         configUtils.set('disableJSBackups', true);
 
         dbBackup.backup().then(function () {
-            exportStub.called.should.be.false();
-            filenameStub.called.should.be.false();
-            fsStub.called.should.be.false();
+            assert.equal(exportStub.called, false);
+            assert.equal(filenameStub.called, false);
+            assert.equal(fsStub.called, false);
 
             done();
         }).catch(done);

--- a/ghost/core/test/unit/server/data/exporter/index.test.js
+++ b/ghost/core/test/unit/server/data/exporter/index.test.js
@@ -45,10 +45,10 @@ describe('Exporter', function () {
 
                 should.exist(exportData);
 
-                exportData.meta.version.should.match(/\d+.\d+.\d+/gi);
+                assert.match(exportData.meta.version, /\d+.\d+.\d+/gi);
 
-                tablesStub.calledOnce.should.be.true();
-                db.knex.called.should.be.true();
+                assert.equal(tablesStub.calledOnce, true);
+                assert.equal(db.knex.called, true);
 
                 knexMock.callCount.should.eql(expectedCallCount);
                 queryMock.select.callCount.should.have.eql(expectedCallCount);
@@ -96,11 +96,11 @@ describe('Exporter', function () {
 
                 should.exist(exportData);
 
-                exportData.meta.version.should.match(/\d+.\d+.\d+/gi);
+                assert.match(exportData.meta.version, /\d+.\d+.\d+/gi);
 
-                tablesStub.calledOnce.should.be.true();
-                db.knex.called.should.be.true();
-                queryMock.select.called.should.be.true();
+                assert.equal(tablesStub.calledOnce, true);
+                assert.equal(db.knex.called, true);
+                assert.equal(queryMock.select.called, true);
 
                 knexMock.callCount.should.eql(expectedCallCount);
                 queryMock.select.callCount.should.have.eql(expectedCallCount);
@@ -149,7 +149,7 @@ describe('Exporter', function () {
                     done(new Error('expected error for export'));
                 })
                 .catch(function (err) {
-                    (err instanceof errors.DataExportError).should.eql(true);
+                    assert.equal((err instanceof errors.DataExportError), true);
                     done();
                 });
         });
@@ -167,8 +167,8 @@ describe('Exporter', function () {
 
             exporter.fileName().then(function (result) {
                 should.exist(result);
-                settingsStub.calledOnce.should.be.true();
-                result.should.match(/^testblog\.ghost\.[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{2}-[0-9]{2}-[0-9]{2}\.json$/);
+                assert.equal(settingsStub.calledOnce, true);
+                assert.match(result, /^testblog\.ghost\.[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{2}-[0-9]{2}-[0-9]{2}\.json$/);
 
                 done();
             }).catch(done);
@@ -181,8 +181,8 @@ describe('Exporter', function () {
 
             exporter.fileName().then(function (result) {
                 should.exist(result);
-                settingsStub.calledOnce.should.be.true();
-                result.should.match(/^ghost\.[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{2}-[0-9]{2}-[0-9]{2}\.json$/);
+                assert.equal(settingsStub.calledOnce, true);
+                assert.match(result, /^ghost\.[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{2}-[0-9]{2}-[0-9]{2}\.json$/);
 
                 done();
             }).catch(done);
@@ -196,9 +196,9 @@ describe('Exporter', function () {
 
             exporter.fileName().then(function (result) {
                 should.exist(result);
-                settingsStub.calledOnce.should.be.true();
-                loggingStub.calledOnce.should.be.true();
-                result.should.match(/^ghost\.[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{2}-[0-9]{2}-[0-9]{2}\.json$/);
+                assert.equal(settingsStub.calledOnce, true);
+                assert.equal(loggingStub.calledOnce, true);
+                assert.match(result, /^ghost\.[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{2}-[0-9]{2}-[0-9]{2}\.json$/);
 
                 done();
             }).catch(done);

--- a/ghost/core/test/unit/server/data/importer/handlers/image.test.js
+++ b/ghost/core/test/unit/server/data/importer/handlers/image.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 require('should');
 const sinon = require('sinon');
 const _ = require('lodash');
@@ -15,24 +16,24 @@ describe('ImageHandler', function () {
     });
 
     it('has the correct interface', function () {
-        ImageHandler.type.should.eql('images');
+        assert.equal(ImageHandler.type, 'images');
         ImageHandler.extensions.should.be.instanceof(Array).and.have.lengthOf(8);
-        ImageHandler.extensions.should.containEql('.jpg');
-        ImageHandler.extensions.should.containEql('.jpeg');
-        ImageHandler.extensions.should.containEql('.gif');
-        ImageHandler.extensions.should.containEql('.png');
-        ImageHandler.extensions.should.containEql('.svg');
-        ImageHandler.extensions.should.containEql('.svgz');
-        ImageHandler.extensions.should.containEql('.ico');
-        ImageHandler.extensions.should.containEql('.webp');
+        assert(ImageHandler.extensions.includes('.jpg'));
+        assert(ImageHandler.extensions.includes('.jpeg'));
+        assert(ImageHandler.extensions.includes('.gif'));
+        assert(ImageHandler.extensions.includes('.png'));
+        assert(ImageHandler.extensions.includes('.svg'));
+        assert(ImageHandler.extensions.includes('.svgz'));
+        assert(ImageHandler.extensions.includes('.ico'));
+        assert(ImageHandler.extensions.includes('.webp'));
         ImageHandler.contentTypes.should.be.instanceof(Array).and.have.lengthOf(7);
-        ImageHandler.contentTypes.should.containEql('image/jpeg');
-        ImageHandler.contentTypes.should.containEql('image/png');
-        ImageHandler.contentTypes.should.containEql('image/gif');
-        ImageHandler.contentTypes.should.containEql('image/svg+xml');
-        ImageHandler.contentTypes.should.containEql('image/x-icon');
-        ImageHandler.contentTypes.should.containEql('image/vnd.microsoft.icon');
-        ImageHandler.contentTypes.should.containEql('image/webp');
+        assert(ImageHandler.contentTypes.includes('image/jpeg'));
+        assert(ImageHandler.contentTypes.includes('image/png'));
+        assert(ImageHandler.contentTypes.includes('image/gif'));
+        assert(ImageHandler.contentTypes.includes('image/svg+xml'));
+        assert(ImageHandler.contentTypes.includes('image/x-icon'));
+        assert(ImageHandler.contentTypes.includes('image/vnd.microsoft.icon'));
+        assert(ImageHandler.contentTypes.includes('image/webp'));
         ImageHandler.loadFile.should.be.instanceof(Function);
     });
 
@@ -48,11 +49,11 @@ describe('ImageHandler', function () {
         const storageSpy = sinon.spy(storage, 'getStorage');
 
         ImageHandler.loadFile(_.clone(file)).then(function () {
-            storageSpy.calledOnce.should.be.true();
-            storeSpy.calledOnce.should.be.true();
-            storeSpy.firstCall.args[0].originalPath.should.equal('test-image.jpeg');
-            storeSpy.firstCall.args[0].targetDir.should.match(/(\/|\\)content(\/|\\)images$/);
-            storeSpy.firstCall.args[0].newPath.should.eql('/content/images/test-image.jpeg');
+            assert.equal(storageSpy.calledOnce, true);
+            assert.equal(storeSpy.calledOnce, true);
+            assert.equal(storeSpy.firstCall.args[0].originalPath, 'test-image.jpeg');
+            assert.match(storeSpy.firstCall.args[0].targetDir, /(\/|\\)content(\/|\\)images$/);
+            assert.equal(storeSpy.firstCall.args[0].newPath, '/content/images/test-image.jpeg');
 
             done();
         }).catch(done);
@@ -70,11 +71,11 @@ describe('ImageHandler', function () {
         const storageSpy = sinon.spy(storage, 'getStorage');
 
         ImageHandler.loadFile(_.clone(file)).then(function () {
-            storageSpy.calledOnce.should.be.true();
-            storeSpy.calledOnce.should.be.true();
-            storeSpy.firstCall.args[0].originalPath.should.equal('photos/my-cat.jpeg');
-            storeSpy.firstCall.args[0].targetDir.should.match(/(\/|\\)content(\/|\\)images(\/|\\)photos$/);
-            storeSpy.firstCall.args[0].newPath.should.eql('/content/images/photos/my-cat.jpeg');
+            assert.equal(storageSpy.calledOnce, true);
+            assert.equal(storeSpy.calledOnce, true);
+            assert.equal(storeSpy.firstCall.args[0].originalPath, 'photos/my-cat.jpeg');
+            assert.match(storeSpy.firstCall.args[0].targetDir, /(\/|\\)content(\/|\\)images(\/|\\)photos$/);
+            assert.equal(storeSpy.firstCall.args[0].newPath, '/content/images/photos/my-cat.jpeg');
 
             done();
         }).catch(done);
@@ -92,11 +93,11 @@ describe('ImageHandler', function () {
         const storageSpy = sinon.spy(storage, 'getStorage');
 
         ImageHandler.loadFile(_.clone(file)).then(function () {
-            storageSpy.calledOnce.should.be.true();
-            storeSpy.calledOnce.should.be.true();
-            storeSpy.firstCall.args[0].originalPath.should.equal('content/images/my-cat.jpeg');
-            storeSpy.firstCall.args[0].targetDir.should.match(/(\/|\\)content(\/|\\)images$/);
-            storeSpy.firstCall.args[0].newPath.should.eql('/content/images/my-cat.jpeg');
+            assert.equal(storageSpy.calledOnce, true);
+            assert.equal(storeSpy.calledOnce, true);
+            assert.equal(storeSpy.firstCall.args[0].originalPath, 'content/images/my-cat.jpeg');
+            assert.match(storeSpy.firstCall.args[0].targetDir, /(\/|\\)content(\/|\\)images$/);
+            assert.equal(storeSpy.firstCall.args[0].newPath, '/content/images/my-cat.jpeg');
 
             done();
         }).catch(done);
@@ -116,11 +117,11 @@ describe('ImageHandler', function () {
         const storageSpy = sinon.spy(storage, 'getStorage');
 
         ImageHandler.loadFile(_.clone(file)).then(function () {
-            storageSpy.calledOnce.should.be.true();
-            storeSpy.calledOnce.should.be.true();
-            storeSpy.firstCall.args[0].originalPath.should.equal('test-image.jpeg');
-            storeSpy.firstCall.args[0].targetDir.should.match(/(\/|\\)content(\/|\\)images$/);
-            storeSpy.firstCall.args[0].newPath.should.eql('/subdir/content/images/test-image.jpeg');
+            assert.equal(storageSpy.calledOnce, true);
+            assert.equal(storeSpy.calledOnce, true);
+            assert.equal(storeSpy.firstCall.args[0].originalPath, 'test-image.jpeg');
+            assert.match(storeSpy.firstCall.args[0].targetDir, /(\/|\\)content(\/|\\)images$/);
+            assert.equal(storeSpy.firstCall.args[0].newPath, '/subdir/content/images/test-image.jpeg');
 
             done();
         }).catch(done);
@@ -148,20 +149,20 @@ describe('ImageHandler', function () {
         const storageSpy = sinon.spy(storage, 'getStorage');
 
         ImageHandler.loadFile(_.clone(files)).then(function () {
-            storageSpy.calledOnce.should.be.true();
-            storeSpy.callCount.should.eql(4);
-            storeSpy.firstCall.args[0].originalPath.should.equal('testing.png');
-            storeSpy.firstCall.args[0].targetDir.should.match(/(\/|\\)content(\/|\\)images$/);
-            storeSpy.firstCall.args[0].newPath.should.eql('/content/images/testing.png');
-            storeSpy.secondCall.args[0].originalPath.should.equal('photo/kitten.jpg');
-            storeSpy.secondCall.args[0].targetDir.should.match(/(\/|\\)content(\/|\\)images(\/|\\)photo$/);
-            storeSpy.secondCall.args[0].newPath.should.eql('/content/images/photo/kitten.jpg');
-            storeSpy.thirdCall.args[0].originalPath.should.equal('content/images/animated/bunny.gif');
-            storeSpy.thirdCall.args[0].targetDir.should.match(/(\/|\\)content(\/|\\)images(\/|\\)animated$/);
-            storeSpy.thirdCall.args[0].newPath.should.eql('/content/images/animated/bunny.gif');
-            storeSpy.lastCall.args[0].originalPath.should.equal('images/puppy.jpg');
-            storeSpy.lastCall.args[0].targetDir.should.match(/(\/|\\)content(\/|\\)images$/);
-            storeSpy.lastCall.args[0].newPath.should.eql('/content/images/puppy.jpg');
+            assert.equal(storageSpy.calledOnce, true);
+            assert.equal(storeSpy.callCount, 4);
+            assert.equal(storeSpy.firstCall.args[0].originalPath, 'testing.png');
+            assert.match(storeSpy.firstCall.args[0].targetDir, /(\/|\\)content(\/|\\)images$/);
+            assert.equal(storeSpy.firstCall.args[0].newPath, '/content/images/testing.png');
+            assert.equal(storeSpy.secondCall.args[0].originalPath, 'photo/kitten.jpg');
+            assert.match(storeSpy.secondCall.args[0].targetDir, /(\/|\\)content(\/|\\)images(\/|\\)photo$/);
+            assert.equal(storeSpy.secondCall.args[0].newPath, '/content/images/photo/kitten.jpg');
+            assert.equal(storeSpy.thirdCall.args[0].originalPath, 'content/images/animated/bunny.gif');
+            assert.match(storeSpy.thirdCall.args[0].targetDir, /(\/|\\)content(\/|\\)images(\/|\\)animated$/);
+            assert.equal(storeSpy.thirdCall.args[0].newPath, '/content/images/animated/bunny.gif');
+            assert.equal(storeSpy.lastCall.args[0].originalPath, 'images/puppy.jpg');
+            assert.match(storeSpy.lastCall.args[0].targetDir, /(\/|\\)content(\/|\\)images$/);
+            assert.equal(storeSpy.lastCall.args[0].newPath, '/content/images/puppy.jpg');
 
             done();
         }).catch(done);

--- a/ghost/core/test/unit/server/data/importer/importers/data/newsletters.test.js
+++ b/ghost/core/test/unit/server/data/importer/importers/data/newsletters.test.js
@@ -42,7 +42,7 @@ describe('NewslettersImporter', function () {
             const importer = new NewslettersImporter({newsletters: fakeNewsletters});
 
             importer.beforeImport();
-            importer.dataToImport.should.have.length(2);
+            assert.equal(importer.dataToImport.length, 2);
 
             const newsletter1 = importer.dataToImport[0];
             const newsletter2 = importer.dataToImport[1];

--- a/ghost/core/test/unit/server/data/importer/importers/data/posts.test.js
+++ b/ghost/core/test/unit/server/data/importer/importers/data/posts.test.js
@@ -28,25 +28,25 @@ describe('PostsImporter', function () {
             should.exist(pageFalse);
             should.not.exist(pageFalse.page, 'pageFalse.page should not exist');
             should.exist(pageFalse.type, 'pageFalse.type should exist');
-            pageFalse.type.should.equal('post');
+            assert.equal(pageFalse.type, 'post');
 
             const pageTrue = find(importer.dataToImport, {slug: 'page-true'});
             should.exist(pageTrue);
             should.not.exist(pageTrue.page, 'pageTrue.page should not exist');
             should.exist(pageTrue.type, 'pageTrue.type should exist');
-            pageTrue.type.should.equal('page');
+            assert.equal(pageTrue.type, 'page');
 
             const typePost = find(importer.dataToImport, {slug: 'type-post'});
             should.exist(typePost);
             should.not.exist(typePost.page, 'typePost.page should not exist');
             should.exist(typePost.type, 'typePost.type should exist');
-            typePost.type.should.equal('post');
+            assert.equal(typePost.type, 'post');
 
             const typePage = find(importer.dataToImport, {slug: 'type-page'});
             should.exist(typePage);
             should.not.exist(typePage.page, 'typePage.page should not exist');
             should.exist(typePage.type, 'typePage.type should exist');
-            typePage.type.should.equal('page');
+            assert.equal(typePage.type, 'page');
         });
 
         it('gives precedence to post.type when post.page is also present', function () {
@@ -74,19 +74,19 @@ describe('PostsImporter', function () {
 
             const pageFalseTypePage = find(importer.dataToImport, {slug: 'page-false-type-page'});
             should.exist(pageFalseTypePage);
-            pageFalseTypePage.type.should.equal('page', 'pageFalseTypePage.type');
+            assert.equal(pageFalseTypePage.type, 'page', 'pageFalseTypePage.type');
 
             const pageTrueTypePage = find(importer.dataToImport, {slug: 'page-true-type-page'});
             should.exist(pageTrueTypePage);
-            pageTrueTypePage.type.should.equal('page', 'pageTrueTypePage.type');
+            assert.equal(pageTrueTypePage.type, 'page', 'pageTrueTypePage.type');
 
             const pageFalseTypePost = find(importer.dataToImport, {slug: 'page-false-type-post'});
             should.exist(pageFalseTypePost);
-            pageFalseTypePost.type.should.equal('post', 'pageFalseTypePost.type');
+            assert.equal(pageFalseTypePost.type, 'post', 'pageFalseTypePost.type');
 
             const pageTrueTypePost = find(importer.dataToImport, {slug: 'page-true-type-post'});
             should.exist(pageTrueTypePost);
-            pageTrueTypePost.type.should.equal('post', 'pageTrueTypePost.type');
+            assert.equal(pageTrueTypePost.type, 'post', 'pageTrueTypePost.type');
         });
 
         it('Does not remove the newsletter_id column', function () {
@@ -116,7 +116,7 @@ describe('PostsImporter', function () {
 
             const post = find(importer.dataToImport, {slug: 'post-with-newsletter'});
             should.exist(post);
-            post.email_recipient_filter.should.eql('all');
+            assert.equal(post.email_recipient_filter, 'all');
             assert.equal(post.send_email_when_published, undefined);
             // @TODO: need to check this mapping
             //post.newsletter_id.should.eql();

--- a/ghost/core/test/unit/server/data/importer/importers/data/settings.test.js
+++ b/ghost/core/test/unit/server/data/importer/importers/data/settings.test.js
@@ -169,11 +169,11 @@ describe('SettingsImporter', function () {
 
             importer.beforeImport();
 
-            importer.problems.length.should.equal(0);
+            assert.equal(importer.problems.length, 0);
 
-            importer.dataToImport.length.should.equal(1);
-            importer.dataToImport[0].key.should.equal('slack_username');
-            importer.dataToImport[0].value.should.equal('Test Name');
+            assert.equal(importer.dataToImport.length, 1);
+            assert.equal(importer.dataToImport[0].key, 'slack_username');
+            assert.equal(importer.dataToImport[0].value, 'Test Name');
         });
 
         it('Renames the members_allow_free_signup setting', function () {
@@ -187,12 +187,12 @@ describe('SettingsImporter', function () {
 
             importer.beforeImport();
 
-            importer.problems.length.should.equal(0);
+            assert.equal(importer.problems.length, 0);
 
-            importer.dataToImport.length.should.equal(1);
-            importer.dataToImport[0].key.should.equal('members_signup_access');
-            importer.dataToImport[0].value.should.equal('invite');
-            importer.dataToImport[0].type.should.equal('string');
+            assert.equal(importer.dataToImport.length, 1);
+            assert.equal(importer.dataToImport[0].key, 'members_signup_access');
+            assert.equal(importer.dataToImport[0].value, 'invite');
+            assert.equal(importer.dataToImport[0].type, 'string');
         });
     });
 });

--- a/ghost/core/test/unit/server/data/importer/index.test.js
+++ b/ghost/core/test/unit/server/data/importer/index.test.js
@@ -40,113 +40,101 @@ describe('Importer', function () {
 
         it('gets the correct extensions', function () {
             ImportManager.getExtensions().should.be.instanceof(Array).and.have.lengthOf(32);
-            ImportManager.getExtensions().should.containEql('.csv');
-            ImportManager.getExtensions().should.containEql('.json');
-            ImportManager.getExtensions().should.containEql('.zip');
-            ImportManager.getExtensions().should.containEql('.jpg');
-            ImportManager.getExtensions().should.containEql('.md');
-            ImportManager.getExtensions().should.containEql('.webp');
-            ImportManager.getExtensions().should.containEql('.mp4');
-            ImportManager.getExtensions().should.containEql('.ogv');
-            ImportManager.getExtensions().should.containEql('.mp3');
-            ImportManager.getExtensions().should.containEql('.wav');
-            ImportManager.getExtensions().should.containEql('.ogg');
-            ImportManager.getExtensions().should.containEql('.m4a');
+            assert(ImportManager.getExtensions().includes('.csv'));
+            assert(ImportManager.getExtensions().includes('.json'));
+            assert(ImportManager.getExtensions().includes('.zip'));
+            assert(ImportManager.getExtensions().includes('.jpg'));
+            assert(ImportManager.getExtensions().includes('.md'));
+            assert(ImportManager.getExtensions().includes('.webp'));
+            assert(ImportManager.getExtensions().includes('.mp4'));
+            assert(ImportManager.getExtensions().includes('.ogv'));
+            assert(ImportManager.getExtensions().includes('.mp3'));
+            assert(ImportManager.getExtensions().includes('.wav'));
+            assert(ImportManager.getExtensions().includes('.ogg'));
+            assert(ImportManager.getExtensions().includes('.m4a'));
 
-            ImportManager.getExtensions().should.containEql('.pdf');
-            ImportManager.getExtensions().should.containEql('.json');
-            ImportManager.getExtensions().should.containEql('.jsonld');
-            ImportManager.getExtensions().should.containEql('.odp');
-            ImportManager.getExtensions().should.containEql('.ods');
-            ImportManager.getExtensions().should.containEql('.odt');
-            ImportManager.getExtensions().should.containEql('.ppt');
-            ImportManager.getExtensions().should.containEql('.pptx');
-            ImportManager.getExtensions().should.containEql('.rtf');
-            ImportManager.getExtensions().should.containEql('.txt');
-            ImportManager.getExtensions().should.containEql('.xls');
-            ImportManager.getExtensions().should.containEql('.xlsx');
-            ImportManager.getExtensions().should.containEql('.xml');
+            assert(ImportManager.getExtensions().includes('.pdf'));
+            assert(ImportManager.getExtensions().includes('.json'));
+            assert(ImportManager.getExtensions().includes('.jsonld'));
+            assert(ImportManager.getExtensions().includes('.odp'));
+            assert(ImportManager.getExtensions().includes('.ods'));
+            assert(ImportManager.getExtensions().includes('.odt'));
+            assert(ImportManager.getExtensions().includes('.ppt'));
+            assert(ImportManager.getExtensions().includes('.pptx'));
+            assert(ImportManager.getExtensions().includes('.rtf'));
+            assert(ImportManager.getExtensions().includes('.txt'));
+            assert(ImportManager.getExtensions().includes('.xls'));
+            assert(ImportManager.getExtensions().includes('.xlsx'));
+            assert(ImportManager.getExtensions().includes('.xml'));
         });
 
         it('gets the correct types', function () {
             ImportManager.getContentTypes().should.be.instanceof(Array).and.have.lengthOf(35);
-            ImportManager.getContentTypes().should.containEql('image/jpeg');
-            ImportManager.getContentTypes().should.containEql('image/png');
-            ImportManager.getContentTypes().should.containEql('image/gif');
-            ImportManager.getContentTypes().should.containEql('image/svg+xml');
-            ImportManager.getContentTypes().should.containEql('image/x-icon');
-            ImportManager.getContentTypes().should.containEql('image/vnd.microsoft.icon');
-            ImportManager.getContentTypes().should.containEql('image/webp');
+            assert(ImportManager.getContentTypes().includes('image/jpeg'));
+            assert(ImportManager.getContentTypes().includes('image/png'));
+            assert(ImportManager.getContentTypes().includes('image/gif'));
+            assert(ImportManager.getContentTypes().includes('image/svg+xml'));
+            assert(ImportManager.getContentTypes().includes('image/x-icon'));
+            assert(ImportManager.getContentTypes().includes('image/vnd.microsoft.icon'));
+            assert(ImportManager.getContentTypes().includes('image/webp'));
 
-            ImportManager.getContentTypes().should.containEql('video/mp4');
-            ImportManager.getContentTypes().should.containEql('video/webm');
-            ImportManager.getContentTypes().should.containEql('video/ogg');
-            ImportManager.getContentTypes().should.containEql('audio/mp4');
-            ImportManager.getContentTypes().should.containEql('audio/mpeg');
-            ImportManager.getContentTypes().should.containEql('audio/vnd.wav');
-            ImportManager.getContentTypes().should.containEql('audio/wave');
-            ImportManager.getContentTypes().should.containEql('audio/wav');
-            ImportManager.getContentTypes().should.containEql('audio/x-wav');
-            ImportManager.getContentTypes().should.containEql('audio/ogg');
-            ImportManager.getContentTypes().should.containEql('audio/x-m4a');
+            assert(ImportManager.getContentTypes().includes('video/mp4'));
+            assert(ImportManager.getContentTypes().includes('video/webm'));
+            assert(ImportManager.getContentTypes().includes('video/ogg'));
+            assert(ImportManager.getContentTypes().includes('audio/mp4'));
+            assert(ImportManager.getContentTypes().includes('audio/mpeg'));
+            assert(ImportManager.getContentTypes().includes('audio/vnd.wav'));
+            assert(ImportManager.getContentTypes().includes('audio/wave'));
+            assert(ImportManager.getContentTypes().includes('audio/wav'));
+            assert(ImportManager.getContentTypes().includes('audio/x-wav'));
+            assert(ImportManager.getContentTypes().includes('audio/ogg'));
+            assert(ImportManager.getContentTypes().includes('audio/x-m4a'));
 
-            ImportManager.getContentTypes().should.containEql('application/pdf');
-            ImportManager.getContentTypes().should.containEql('application/json');
-            ImportManager.getContentTypes().should.containEql('application/ld+json');
-            ImportManager.getContentTypes().should.containEql('application/vnd.oasis.opendocument.presentation');
-            ImportManager.getContentTypes().should.containEql('application/vnd.oasis.opendocument.spreadsheet');
-            ImportManager.getContentTypes().should.containEql('application/vnd.oasis.opendocument.text');
-            ImportManager.getContentTypes().should.containEql('application/vnd.ms-powerpoint');
-            ImportManager.getContentTypes().should.containEql('application/vnd.openxmlformats-officedocument.presentationml.presentation');
-            ImportManager.getContentTypes().should.containEql('application/rtf');
-            ImportManager.getContentTypes().should.containEql('text/plain');
-            ImportManager.getContentTypes().should.containEql('application/vnd.ms-excel');
-            ImportManager.getContentTypes().should.containEql('application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
-            ImportManager.getContentTypes().should.containEql('application/xml');
-            ImportManager.getContentTypes().should.containEql('application/atom+xml');
+            assert(ImportManager.getContentTypes().includes('application/pdf'));
+            assert(ImportManager.getContentTypes().includes('application/json'));
+            assert(ImportManager.getContentTypes().includes('application/ld+json'));
+            assert(ImportManager.getContentTypes().includes('application/vnd.oasis.opendocument.presentation'));
+            assert(ImportManager.getContentTypes().includes('application/vnd.oasis.opendocument.spreadsheet'));
+            assert(ImportManager.getContentTypes().includes('application/vnd.oasis.opendocument.text'));
+            assert(ImportManager.getContentTypes().includes('application/vnd.ms-powerpoint'));
+            assert(ImportManager.getContentTypes().includes('application/vnd.openxmlformats-officedocument.presentationml.presentation'));
+            assert(ImportManager.getContentTypes().includes('application/rtf'));
+            assert(ImportManager.getContentTypes().includes('text/plain'));
+            assert(ImportManager.getContentTypes().includes('application/vnd.ms-excel'));
+            assert(ImportManager.getContentTypes().includes('application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'));
+            assert(ImportManager.getContentTypes().includes('application/xml'));
+            assert(ImportManager.getContentTypes().includes('application/atom+xml'));
 
-            ImportManager.getContentTypes().should.containEql('application/octet-stream');
-            ImportManager.getContentTypes().should.containEql('application/json');
+            assert(ImportManager.getContentTypes().includes('application/octet-stream'));
+            assert(ImportManager.getContentTypes().includes('application/json'));
 
-            ImportManager.getContentTypes().should.containEql('text/plain');
+            assert(ImportManager.getContentTypes().includes('text/plain'));
 
-            ImportManager.getContentTypes().should.containEql('application/zip');
-            ImportManager.getContentTypes().should.containEql('application/x-zip-compressed');
+            assert(ImportManager.getContentTypes().includes('application/zip'));
+            assert(ImportManager.getContentTypes().includes('application/x-zip-compressed'));
         });
 
         it('gets the correct directories', function () {
             ImportManager.getDirectories().should.be.instanceof(Array).and.have.lengthOf(4);
-            ImportManager.getDirectories().should.containEql('images');
-            ImportManager.getDirectories().should.containEql('content');
-            ImportManager.getDirectories().should.containEql('media');
-            ImportManager.getDirectories().should.containEql('files');
+            assert(ImportManager.getDirectories().includes('images'));
+            assert(ImportManager.getDirectories().includes('content'));
+            assert(ImportManager.getDirectories().includes('media'));
+            assert(ImportManager.getDirectories().includes('files'));
         });
 
         it('globs extensions correctly', function () {
-            ImportManager.getGlobPattern(ImportManager.getExtensions())
-                .should.equal('+(.jpg|.jpeg|.gif|.png|.svg|.svgz|.ico|.webp|.mp4|.webm|.ogv|.mp3|.wav|.ogg|.m4a|.pdf|.json|.jsonld|.odp|.ods|.odt|.ppt|.pptx|.rtf|.txt|.xls|.xlsx|.xml|.csv|.md|.markdown|.zip)');
-            ImportManager.getGlobPattern(ImportManager.getDirectories())
-                .should.equal('+(images|content|media|files)');
-            ImportManager.getGlobPattern(JSONHandler.extensions)
-                .should.equal('+(.json)');
-            ImportManager.getGlobPattern(ImageHandler.extensions)
-                .should.equal('+(.jpg|.jpeg|.gif|.png|.svg|.svgz|.ico|.webp)');
-            ImportManager.getExtensionGlob(ImportManager.getExtensions())
-                .should.equal('*+(.jpg|.jpeg|.gif|.png|.svg|.svgz|.ico|.webp|.mp4|.webm|.ogv|.mp3|.wav|.ogg|.m4a|.pdf|.json|.jsonld|.odp|.ods|.odt|.ppt|.pptx|.rtf|.txt|.xls|.xlsx|.xml|.csv|.md|.markdown|.zip)');
-            ImportManager.getDirectoryGlob(ImportManager.getDirectories())
-                .should.equal('+(images|content|media|files)');
-            ImportManager.getExtensionGlob(ImportManager.getExtensions(), 0)
-                .should.equal('*+(.jpg|.jpeg|.gif|.png|.svg|.svgz|.ico|.webp|.mp4|.webm|.ogv|.mp3|.wav|.ogg|.m4a|.pdf|.json|.jsonld|.odp|.ods|.odt|.ppt|.pptx|.rtf|.txt|.xls|.xlsx|.xml|.csv|.md|.markdown|.zip)');
-            ImportManager.getDirectoryGlob(ImportManager.getDirectories(), 0)
-                .should.equal('+(images|content|media|files)');
-            ImportManager.getExtensionGlob(ImportManager.getExtensions(), 1)
-                .should.equal('{*/*,*}+(.jpg|.jpeg|.gif|.png|.svg|.svgz|.ico|.webp|.mp4|.webm|.ogv|.mp3|.wav|.ogg|.m4a|.pdf|.json|.jsonld|.odp|.ods|.odt|.ppt|.pptx|.rtf|.txt|.xls|.xlsx|.xml|.csv|.md|.markdown|.zip)');
-            ImportManager.getDirectoryGlob(ImportManager.getDirectories(), 1)
-                .should.equal('{*/,}+(images|content|media|files)');
-            ImportManager.getExtensionGlob(ImportManager.getExtensions(), 2)
-                .should.equal('**/*+(.jpg|.jpeg|.gif|.png|.svg|.svgz|.ico|.webp|.mp4|.webm|.ogv|.mp3|.wav|.ogg|.m4a|.pdf|.json|.jsonld|.odp|.ods|.odt|.ppt|.pptx|.rtf|.txt|.xls|.xlsx|.xml|.csv|.md|.markdown|.zip)');
-            ImportManager.getDirectoryGlob(ImportManager.getDirectories(), 2)
-                .should.equal('**/+(images|content|media|files)');
+            assert.equal(ImportManager.getGlobPattern(ImportManager.getExtensions()), '+(.jpg|.jpeg|.gif|.png|.svg|.svgz|.ico|.webp|.mp4|.webm|.ogv|.mp3|.wav|.ogg|.m4a|.pdf|.json|.jsonld|.odp|.ods|.odt|.ppt|.pptx|.rtf|.txt|.xls|.xlsx|.xml|.csv|.md|.markdown|.zip)');
+            assert.equal(ImportManager.getGlobPattern(ImportManager.getDirectories()), '+(images|content|media|files)');
+            assert.equal(ImportManager.getGlobPattern(JSONHandler.extensions), '+(.json)');
+            assert.equal(ImportManager.getGlobPattern(ImageHandler.extensions), '+(.jpg|.jpeg|.gif|.png|.svg|.svgz|.ico|.webp)');
+            assert.equal(ImportManager.getExtensionGlob(ImportManager.getExtensions()), '*+(.jpg|.jpeg|.gif|.png|.svg|.svgz|.ico|.webp|.mp4|.webm|.ogv|.mp3|.wav|.ogg|.m4a|.pdf|.json|.jsonld|.odp|.ods|.odt|.ppt|.pptx|.rtf|.txt|.xls|.xlsx|.xml|.csv|.md|.markdown|.zip)');
+            assert.equal(ImportManager.getDirectoryGlob(ImportManager.getDirectories()), '+(images|content|media|files)');
+            assert.equal(ImportManager.getExtensionGlob(ImportManager.getExtensions(), 0), '*+(.jpg|.jpeg|.gif|.png|.svg|.svgz|.ico|.webp|.mp4|.webm|.ogv|.mp3|.wav|.ogg|.m4a|.pdf|.json|.jsonld|.odp|.ods|.odt|.ppt|.pptx|.rtf|.txt|.xls|.xlsx|.xml|.csv|.md|.markdown|.zip)');
+            assert.equal(ImportManager.getDirectoryGlob(ImportManager.getDirectories(), 0), '+(images|content|media|files)');
+            assert.equal(ImportManager.getExtensionGlob(ImportManager.getExtensions(), 1), '{*/*,*}+(.jpg|.jpeg|.gif|.png|.svg|.svgz|.ico|.webp|.mp4|.webm|.ogv|.mp3|.wav|.ogg|.m4a|.pdf|.json|.jsonld|.odp|.ods|.odt|.ppt|.pptx|.rtf|.txt|.xls|.xlsx|.xml|.csv|.md|.markdown|.zip)');
+            assert.equal(ImportManager.getDirectoryGlob(ImportManager.getDirectories(), 1), '{*/,}+(images|content|media|files)');
+            assert.equal(ImportManager.getExtensionGlob(ImportManager.getExtensions(), 2), '**/*+(.jpg|.jpeg|.gif|.png|.svg|.svgz|.ico|.webp|.mp4|.webm|.ogv|.mp3|.wav|.ogg|.m4a|.pdf|.json|.jsonld|.odp|.ods|.odt|.ppt|.pptx|.rtf|.txt|.xls|.xlsx|.xml|.csv|.md|.markdown|.zip)');
+            assert.equal(ImportManager.getDirectoryGlob(ImportManager.getDirectories(), 2), '**/+(images|content|media|files)');
         });
 
         it('cleans up', async function () {
@@ -155,8 +143,8 @@ describe('Importer', function () {
             const removeStub = sinon.stub(fs, 'remove').withArgs(file).returns(Promise.resolve());
 
             await ImportManager.cleanUp();
-            removeStub.calledOnce.should.be.true();
-            should(ImportManager.fileToDelete).be.null();
+            assert.equal(removeStub.calledOnce, true);
+            assert.equal(ImportManager.fileToDelete, null);
         });
 
         it('doesn\'t clean up', async function () {
@@ -164,7 +152,7 @@ describe('Importer', function () {
             const removeStub = sinon.stub(fs, 'remove').returns(Promise.resolve());
 
             await ImportManager.cleanUp();
-            removeStub.called.should.be.false();
+            assert.equal(removeStub.called, false);
         });
 
         it('silently ignores clean up errors', async function () {
@@ -174,9 +162,9 @@ describe('Importer', function () {
             const removeStub = sinon.stub(fs, 'remove').withArgs(file).returns(Promise.reject(new Error('Unknown file')));
 
             await ImportManager.cleanUp();
-            removeStub.calledOnce.should.be.true();
-            loggingStub.calledOnce.should.be.true();
-            should(ImportManager.fileToDelete).be.null();
+            assert.equal(removeStub.calledOnce, true);
+            assert.equal(loggingStub.calledOnce, true);
+            assert.equal(ImportManager.fileToDelete, null);
         });
 
         // Step 1 of importing is loadFile
@@ -187,8 +175,8 @@ describe('Importer', function () {
                 const fileSpy = sinon.stub(ImportManager, 'processFile').returns(Promise.resolve({}));
 
                 ImportManager.loadFile(testFile).then(function () {
-                    zipSpy.calledOnce.should.be.false();
-                    fileSpy.calledOnce.should.be.true();
+                    assert.equal(zipSpy.calledOnce, false);
+                    assert.equal(fileSpy.calledOnce, true);
                     done();
                 }).catch(done);
             });
@@ -200,8 +188,8 @@ describe('Importer', function () {
                 const fileSpy = sinon.stub(ImportManager, 'processFile').resolves({});
 
                 ImportManager.loadFile(testZip).then(function () {
-                    zipSpy.calledOnce.should.be.true();
-                    fileSpy.calledOnce.should.be.false();
+                    assert.equal(zipSpy.calledOnce, true);
+                    assert.equal(fileSpy.calledOnce, false);
                     done();
                 }).catch(done);
             });
@@ -226,17 +214,17 @@ describe('Importer', function () {
                 getFileSpy.withArgs(RevueHandler, sinon.match.string).returns([{path: '/tmp/dir/myFile.json', name: 'myFile.json'}]);
 
                 ImportManager.processZip(testZip).then(function (zipResult) {
-                    extractSpy.calledOnce.should.be.true();
-                    validSpy.calledOnce.should.be.true();
-                    baseDirSpy.calledOnce.should.be.true();
-                    getFileSpy.callCount.should.eql(6);
-                    jsonSpy.calledOnce.should.be.true();
-                    imageSpy.called.should.be.false();
-                    mdSpy.called.should.be.false();
-                    revueSpy.called.should.be.true();
+                    assert.equal(extractSpy.calledOnce, true);
+                    assert.equal(validSpy.calledOnce, true);
+                    assert.equal(baseDirSpy.calledOnce, true);
+                    assert.equal(getFileSpy.callCount, 6);
+                    assert.equal(jsonSpy.calledOnce, true);
+                    assert.equal(imageSpy.called, false);
+                    assert.equal(mdSpy.called, false);
+                    assert.equal(revueSpy.called, true);
 
                     ImportManager.processFile(testFile, '.json').then(function (fileResult) {
-                        jsonSpy.calledTwice.should.be.true();
+                        assert.equal(jsonSpy.calledTwice, true);
 
                         // They should both have data keys, and they should be equivalent
                         zipResult.should.have.property('data');
@@ -325,8 +313,8 @@ describe('Importer', function () {
 
                     const zipResult = await ImportManager.processZip(testZip);
                     zipResult.data.should.not.be.undefined();
-                    should(zipResult.images).be.undefined();
-                    extractSpy.calledOnce.should.be.true();
+                    assert.equal(zipResult.images, undefined);
+                    assert.equal(extractSpy.calledOnce, true);
                 });
 
                 it('accepts a zip without a base directory', async function () {
@@ -335,8 +323,8 @@ describe('Importer', function () {
 
                     const zipResult = await ImportManager.processZip(testZip);
                     zipResult.data.should.not.be.undefined();
-                    should(zipResult.images).be.undefined();
-                    extractSpy.calledOnce.should.be.true();
+                    assert.equal(zipResult.images, undefined);
+                    assert.equal(extractSpy.calledOnce, true);
                 });
 
                 it('accepts a zip with an image directory', async function () {
@@ -344,9 +332,9 @@ describe('Importer', function () {
                     const extractSpy = sinon.stub(ImportManager, 'extractZip').returns(Promise.resolve(testDir));
 
                     const zipResult = await ImportManager.processZip(testZip);
-                    zipResult.images.length.should.eql(1);
-                    should(zipResult.data).be.undefined();
-                    extractSpy.calledOnce.should.be.true();
+                    assert.equal(zipResult.images.length, 1);
+                    assert.equal(zipResult.data, undefined);
+                    assert.equal(extractSpy.calledOnce, true);
                 });
 
                 it('accepts a zip with uppercase image extensions', async function () {
@@ -354,9 +342,9 @@ describe('Importer', function () {
                     const extractSpy = sinon.stub(ImportManager, 'extractZip').returns(Promise.resolve(testDir));
 
                     const zipResult = await ImportManager.processZip(testZip);
-                    zipResult.images.length.should.eql(1);
-                    should(zipResult.data).be.undefined();
-                    extractSpy.calledOnce.should.be.true();
+                    assert.equal(zipResult.images.length, 1);
+                    assert.equal(zipResult.data, undefined);
+                    assert.equal(extractSpy.calledOnce, true);
                 });
 
                 it('throws zipContainsMultipleDataFormats', async function () {
@@ -364,7 +352,7 @@ describe('Importer', function () {
                     const extractSpy = sinon.stub(ImportManager, 'extractZip').returns(Promise.resolve(testDir));
 
                     await should(ImportManager.processZip(testZip)).rejectedWith(/multiple data formats/);
-                    extractSpy.calledOnce.should.be.true();
+                    assert.equal(extractSpy.calledOnce, true);
                 });
 
                 it('throws noContentToImport', async function () {
@@ -372,7 +360,7 @@ describe('Importer', function () {
                     const extractSpy = sinon.stub(ImportManager, 'extractZip').returns(Promise.resolve(testDir));
 
                     await should(ImportManager.processZip(testZip)).rejectedWith(/not include any content/);
-                    extractSpy.calledOnce.should.be.true();
+                    assert.equal(extractSpy.calledOnce, true);
                 });
             });
 
@@ -380,13 +368,13 @@ describe('Importer', function () {
                 it('returns string for base directory', function () {
                     const testDir = path.resolve('test/utils/fixtures/import/zips/zip-with-base-dir');
 
-                    ImportManager.getBaseDirectory(testDir).should.equal('basedir');
+                    assert.equal(ImportManager.getBaseDirectory(testDir), 'basedir');
                 });
 
                 it('returns string for double base directory', function () {
                     const testDir = path.resolve('test/utils/fixtures/import/zips/zip-with-double-base-dir');
 
-                    ImportManager.getBaseDirectory(testDir).should.equal('basedir');
+                    assert.equal(ImportManager.getBaseDirectory(testDir), 'basedir');
                 });
 
                 it('returns empty for no base directory', function () {
@@ -417,8 +405,8 @@ describe('Importer', function () {
                             throw new Error('should have failed');
                         })
                         .catch((err) => {
-                            err.message.should.match(/EISDIR/);
-                            err.code.should.match(/EISDIR/);
+                            assert.match(err.message, /EISDIR/);
+                            assert.match(err.code, /EISDIR/);
                         });
                 });
             });
@@ -443,12 +431,12 @@ describe('Importer', function () {
                 const revueSpy = sinon.spy(RevueImporter, 'preProcess');
 
                 ImportManager.preProcess(inputCopy).then(function (output) {
-                    revueSpy.calledOnce.should.be.true();
-                    revueSpy.calledWith(inputCopy).should.be.true();
-                    dataSpy.calledOnce.should.be.true();
-                    dataSpy.calledWith(inputCopy).should.be.true();
-                    imageSpy.calledOnce.should.be.true();
-                    imageSpy.calledWith(inputCopy).should.be.true();
+                    assert.equal(revueSpy.calledOnce, true);
+                    assert.equal(revueSpy.calledWith(inputCopy), true);
+                    assert.equal(dataSpy.calledOnce, true);
+                    assert.equal(dataSpy.calledWith(inputCopy), true);
+                    assert.equal(imageSpy.calledOnce, true);
+                    assert.equal(imageSpy.calledWith(inputCopy), true);
                     // eql checks for equality
                     // equal checks the references are for the same object
                     output.should.not.equal(input);
@@ -487,8 +475,8 @@ describe('Importer', function () {
                 ImportManager.doImport(inputCopy).then(function (output) {
                     // eql checks for equality
                     // equal checks the references are for the same object
-                    dataSpy.calledOnce.should.be.true();
-                    imageSpy.calledOnce.should.be.true();
+                    assert.equal(dataSpy.calledOnce, true);
+                    assert.equal(imageSpy.calledOnce, true);
                     dataSpy.getCall(0).args[0].should.eql(expectedData);
                     imageSpy.getCall(0).args[0].should.eql(expectedImages);
 
@@ -521,11 +509,11 @@ describe('Importer', function () {
                 const cleanupSpy = sinon.stub(ImportManager, 'cleanUp').returns(Promise.resolve());
 
                 ImportManager.importFromFile({name: 'test.json', path: '/test.json'}).then(function () {
-                    loadFileSpy.calledOnce.should.be.true();
-                    preProcessSpy.calledOnce.should.be.true();
-                    doImportSpy.calledOnce.should.be.true();
-                    generateReportSpy.calledOnce.should.be.true();
-                    cleanupSpy.calledOnce.should.be.true();
+                    assert.equal(loadFileSpy.calledOnce, true);
+                    assert.equal(preProcessSpy.calledOnce, true);
+                    assert.equal(doImportSpy.calledOnce, true);
+                    assert.equal(generateReportSpy.calledOnce, true);
+                    assert.equal(cleanupSpy.calledOnce, true);
                     sinon.assert.callOrder(loadFileSpy, preProcessSpy, doImportSpy, generateReportSpy, cleanupSpy);
 
                     done();
@@ -536,12 +524,12 @@ describe('Importer', function () {
 
     describe('JSONHandler', function () {
         it('has the correct interface', function () {
-            JSONHandler.type.should.eql('data');
+            assert.equal(JSONHandler.type, 'data');
             JSONHandler.extensions.should.be.instanceof(Array).and.have.lengthOf(1);
-            JSONHandler.extensions.should.containEql('.json');
+            assert(JSONHandler.extensions.includes('.json'));
             JSONHandler.contentTypes.should.be.instanceof(Array).and.have.lengthOf(2);
-            JSONHandler.contentTypes.should.containEql('application/octet-stream');
-            JSONHandler.contentTypes.should.containEql('application/json');
+            assert(JSONHandler.contentTypes.includes('application/octet-stream'));
+            assert(JSONHandler.contentTypes.includes('application/json'));
             JSONHandler.loadFile.should.be.instanceof(Function);
         });
 
@@ -551,8 +539,8 @@ describe('Importer', function () {
                 name: 'valid.json'
             }];
             JSONHandler.loadFile(file).then(function (result) {
-                _.keys(result).should.containEql('meta');
-                _.keys(result).should.containEql('data');
+                assert(_.keys(result).includes('meta'));
+                assert(_.keys(result).includes('data'));
                 done();
             }).catch(done);
         });
@@ -566,7 +554,7 @@ describe('Importer', function () {
             JSONHandler.loadFile(file).then(function () {
                 done(new Error('Didn\'t error for bad db api wrapper'));
             }).catch(function (response) {
-                response.errorType.should.equal('BadRequestError');
+                assert.equal(response.errorType, 'BadRequestError');
                 done();
             }).catch(done);
         });
@@ -574,13 +562,13 @@ describe('Importer', function () {
 
     describe('MarkdownHandler', function () {
         it('has the correct interface', function () {
-            MarkdownHandler.type.should.eql('data');
+            assert.equal(MarkdownHandler.type, 'data');
             MarkdownHandler.extensions.should.be.instanceof(Array).and.have.lengthOf(2);
-            MarkdownHandler.extensions.should.containEql('.md');
-            MarkdownHandler.extensions.should.containEql('.markdown');
+            assert(MarkdownHandler.extensions.includes('.md'));
+            assert(MarkdownHandler.extensions.includes('.markdown'));
             MarkdownHandler.contentTypes.should.be.instanceof(Array).and.have.lengthOf(2);
-            MarkdownHandler.contentTypes.should.containEql('application/octet-stream');
-            MarkdownHandler.contentTypes.should.containEql('text/plain');
+            assert(MarkdownHandler.contentTypes.includes('application/octet-stream'));
+            assert(MarkdownHandler.contentTypes.includes('text/plain'));
             MarkdownHandler.loadFile.should.be.instanceof(Function);
         });
 
@@ -593,12 +581,12 @@ describe('Importer', function () {
             }];
 
             MarkdownHandler.loadFile(file).then(function (result) {
-                result.data.posts[0].markdown.should.eql('You\'re live! Nice.');
-                result.data.posts[0].status.should.eql('draft');
-                result.data.posts[0].slug.should.eql('test-1');
-                result.data.posts[0].title.should.eql('test-1');
-                result.data.posts[0].created_at.should.eql(1418990400000);
-                moment.utc(result.data.posts[0].created_at).format('DD MM YY HH:mm').should.eql('19 12 14 12:00');
+                assert.equal(result.data.posts[0].markdown, 'You\'re live! Nice.');
+                assert.equal(result.data.posts[0].status, 'draft');
+                assert.equal(result.data.posts[0].slug, 'test-1');
+                assert.equal(result.data.posts[0].title, 'test-1');
+                assert.equal(result.data.posts[0].created_at, 1418990400000);
+                assert.equal(moment.utc(result.data.posts[0].created_at).format('DD MM YY HH:mm'), '19 12 14 12:00');
                 result.data.posts[0].should.not.have.property('image');
 
                 done();
@@ -614,11 +602,11 @@ describe('Importer', function () {
             }];
 
             MarkdownHandler.loadFile(file).then(function (result) {
-                result.data.posts[0].markdown.should.eql('You\'re live! Nice.');
-                result.data.posts[0].status.should.eql('draft');
-                result.data.posts[0].slug.should.eql('test-2');
-                result.data.posts[0].title.should.eql('Welcome to Ghost');
-                result.data.posts[0].created_at.should.eql(1418990400000);
+                assert.equal(result.data.posts[0].markdown, 'You\'re live! Nice.');
+                assert.equal(result.data.posts[0].status, 'draft');
+                assert.equal(result.data.posts[0].slug, 'test-2');
+                assert.equal(result.data.posts[0].title, 'Welcome to Ghost');
+                assert.equal(result.data.posts[0].created_at, 1418990400000);
                 result.data.posts[0].should.not.have.property('image');
 
                 done();
@@ -634,12 +622,12 @@ describe('Importer', function () {
             }];
 
             MarkdownHandler.loadFile(file).then(function (result) {
-                result.data.posts[0].markdown.should.eql('You\'re live! Nice.');
-                result.data.posts[0].status.should.eql('draft');
-                result.data.posts[0].slug.should.eql('test-3');
-                result.data.posts[0].title.should.eql('Welcome to Ghost');
-                result.data.posts[0].created_at.should.eql(1418990400000);
-                result.data.posts[0].image.should.eql('/images/kitten.jpg');
+                assert.equal(result.data.posts[0].markdown, 'You\'re live! Nice.');
+                assert.equal(result.data.posts[0].status, 'draft');
+                assert.equal(result.data.posts[0].slug, 'test-3');
+                assert.equal(result.data.posts[0].title, 'Welcome to Ghost');
+                assert.equal(result.data.posts[0].created_at, 1418990400000);
+                assert.equal(result.data.posts[0].image, '/images/kitten.jpg');
 
                 done();
             }).catch(done);
@@ -654,12 +642,12 @@ describe('Importer', function () {
             }];
 
             MarkdownHandler.loadFile(file).then(function (result) {
-                result.data.posts[0].markdown.should.eql('You\'re live! Nice.');
-                result.data.posts[0].status.should.eql('published');
-                result.data.posts[0].slug.should.eql('test-1');
-                result.data.posts[0].title.should.eql('Welcome to Ghost');
-                result.data.posts[0].published_at.should.eql(1418990400000);
-                moment.utc(result.data.posts[0].published_at).format('DD MM YY HH:mm').should.eql('19 12 14 12:00');
+                assert.equal(result.data.posts[0].markdown, 'You\'re live! Nice.');
+                assert.equal(result.data.posts[0].status, 'published');
+                assert.equal(result.data.posts[0].slug, 'test-1');
+                assert.equal(result.data.posts[0].title, 'Welcome to Ghost');
+                assert.equal(result.data.posts[0].published_at, 1418990400000);
+                assert.equal(moment.utc(result.data.posts[0].published_at).format('DD MM YY HH:mm'), '19 12 14 12:00');
                 result.data.posts[0].should.not.have.property('image');
 
                 done();
@@ -703,21 +691,21 @@ describe('Importer', function () {
                 const two = one === 0 ? 1 : 0;
 
                 // published-2014-12-19-test-1.md
-                result.data.posts[one].markdown.should.eql('You\'re live! Nice.');
-                result.data.posts[one].status.should.eql('published');
-                result.data.posts[one].slug.should.eql('test-1');
-                result.data.posts[one].title.should.eql('Welcome to Ghost');
-                result.data.posts[one].published_at.should.eql(1418990400000);
-                moment.utc(result.data.posts[one].published_at).format('DD MM YY HH:mm').should.eql('19 12 14 12:00');
+                assert.equal(result.data.posts[one].markdown, 'You\'re live! Nice.');
+                assert.equal(result.data.posts[one].status, 'published');
+                assert.equal(result.data.posts[one].slug, 'test-1');
+                assert.equal(result.data.posts[one].title, 'Welcome to Ghost');
+                assert.equal(result.data.posts[one].published_at, 1418990400000);
+                assert.equal(moment.utc(result.data.posts[one].published_at).format('DD MM YY HH:mm'), '19 12 14 12:00');
                 result.data.posts[one].should.not.have.property('image');
 
                 // draft-2014-12-19-test-3.md
-                result.data.posts[two].markdown.should.eql('You\'re live! Nice.');
-                result.data.posts[two].status.should.eql('draft');
-                result.data.posts[two].slug.should.eql('test-3');
-                result.data.posts[two].title.should.eql('Welcome to Ghost');
-                result.data.posts[two].created_at.should.eql(1418990400000);
-                result.data.posts[two].image.should.eql('/images/kitten.jpg');
+                assert.equal(result.data.posts[two].markdown, 'You\'re live! Nice.');
+                assert.equal(result.data.posts[two].status, 'draft');
+                assert.equal(result.data.posts[two].slug, 'test-3');
+                assert.equal(result.data.posts[two].title, 'Welcome to Ghost');
+                assert.equal(result.data.posts[two].created_at, 1418990400000);
+                assert.equal(result.data.posts[two].image, '/images/kitten.jpg');
 
                 done();
             }).catch(done);
@@ -726,7 +714,7 @@ describe('Importer', function () {
 
     describe('DataImporter', function () {
         it('has the correct interface', function () {
-            DataImporter.type.should.eql('data');
+            assert.equal(DataImporter.type, 'data');
             DataImporter.preProcess.should.be.instanceof(Function);
             DataImporter.doImport.should.be.instanceof(Function);
         });

--- a/ghost/core/test/unit/server/data/migrations/utils.test.js
+++ b/ghost/core/test/unit/server/data/migrations/utils.test.js
@@ -395,7 +395,7 @@ describe('migrations/utils/permissions', function () {
                     should.fail('addPermissionToRole up migration did not throw');
                 } catch (err) {
                     assert.equal(errors.utils.isGhostError(err), true);
-                    err.message.should.equal('Cannot add permission(Unimaginable) with role(Not there) - permission does not exist');
+                    assert.equal(err.message, 'Cannot add permission(Unimaginable) with role(Not there) - permission does not exist');
                 }
             });
 
@@ -428,7 +428,7 @@ describe('migrations/utils/permissions', function () {
                     should.fail('addPermissionToRole did not throw');
                 } catch (err) {
                     assert.equal(errors.utils.isGhostError(err), true);
-                    err.message.should.equal('Cannot add permission(Permission Name) with role(Not there) - role does not exist');
+                    assert.equal(err.message, 'Cannot add permission(Permission Name) with role(Not there) - role does not exist');
                 }
             });
 

--- a/ghost/core/test/unit/server/data/schema/commands.test.js
+++ b/ghost/core/test/unit/server/data/schema/commands.test.js
@@ -16,7 +16,7 @@ describe('schema commands', function () {
             should.fail('addForeign did not throw');
         } catch (err) {
             assert.equal(errors.utils.isGhostError(err), true);
-            err.message.should.equal('Must use hasForeignSQLite3 on an SQLite3 database');
+            assert.equal(err.message, 'Must use hasForeignSQLite3 on an SQLite3 database');
         }
     });
 
@@ -31,7 +31,7 @@ describe('schema commands', function () {
             should.fail('hasPrimaryKeySQLite did not throw');
         } catch (err) {
             assert.equal(errors.utils.isGhostError(err), true);
-            err.message.should.equal('Must use hasPrimaryKeySQLite on an SQLite3 database');
+            assert.equal(err.message, 'Must use hasPrimaryKeySQLite on an SQLite3 database');
         }
     });
 });

--- a/ghost/core/test/unit/server/data/schema/fixtures/fixture-manager.test.js
+++ b/ghost/core/test/unit/server/data/schema/fixtures/fixture-manager.test.js
@@ -41,8 +41,8 @@ describe('Migration Fixture Utils', function () {
             const manager = new FixtureManager(testFixtures, placeholderMap);
             const processed = manager.fixtures;
 
-            processed.models[0].entries[0].id.should.equal('user123');
-            processed.models[0].entries[0].email.should.equal('test@example.com');
+            assert.equal(processed.models[0].entries[0].id, 'user123');
+            assert.equal(processed.models[0].entries[0].email, 'test@example.com');
         });
 
         it('should handle nested structures', function () {
@@ -70,7 +70,7 @@ describe('Migration Fixture Utils', function () {
             const manager = new FixtureManager(testFixtures, placeholderMap);
             const processed = manager.fixtures;
 
-            processed.models[0].entries[0].authors[0].id.should.equal('user123');
+            assert.equal(processed.models[0].entries[0].authors[0].id, 'user123');
         });
 
         it('should handle arrays of values', function () {
@@ -132,7 +132,7 @@ describe('Migration Fixture Utils', function () {
             const second = manager.fixtures;
             const third = manager.fixtures;
 
-            callCount.should.equal(1);
+            assert.equal(callCount, 1);
             first.should.equal(second);
             second.should.equal(third);
         });
@@ -181,7 +181,7 @@ describe('Migration Fixture Utils', function () {
             const manager = new FixtureManager(testFixtures, placeholderMap);
             const processed = manager.fixtures;
 
-            processed.models[0].entries[0].id.should.equal('user123');
+            assert.equal(processed.models[0].entries[0].id, 'user123');
 
             should.exist(receivedModels);
 
@@ -207,7 +207,7 @@ describe('Migration Fixture Utils', function () {
             const processed = manager.fixtures;
 
             // Should leave placeholder unchanged if no handler
-            processed.models[0].entries[0].id.should.equal('__MISSING_HANDLER__');
+            assert.equal(processed.models[0].entries[0].id, '__MISSING_HANDLER__');
         });
 
         it('should handle multiple different placeholders in one value', function () {
@@ -232,7 +232,7 @@ describe('Migration Fixture Utils', function () {
             const manager = new FixtureManager(testFixtures, placeholderMap);
             const processed = manager.fixtures;
 
-            processed.models[0].entries[0].content.should.equal('This is a test post created by John Doe on 2025-06-26');
+            assert.equal(processed.models[0].entries[0].content, 'This is a test post created by John Doe on 2025-06-26');
         });
     });
 
@@ -247,64 +247,64 @@ describe('Migration Fixture Utils', function () {
         });
 
         it('should match undefined with no args', function () {
-            matchFunc()({get: getStub}).should.be.true();
-            getStub.calledOnce.should.be.true();
-            getStub.calledWith(undefined).should.be.true();
+            assert.equal(matchFunc()({get: getStub}), true);
+            assert.equal(getStub.calledOnce, true);
+            assert.equal(getStub.calledWith(undefined), true);
         });
 
         it('should match key with match string', function () {
-            matchFunc('foo', 'bar')({get: getStub}).should.be.true();
-            getStub.calledOnce.should.be.true();
-            getStub.calledWith('foo').should.be.true();
+            assert.equal(matchFunc('foo', 'bar')({get: getStub}), true);
+            assert.equal(getStub.calledOnce, true);
+            assert.equal(getStub.calledWith('foo'), true);
 
-            matchFunc('foo', 'buz')({get: getStub}).should.be.false();
-            getStub.calledTwice.should.be.true();
-            getStub.secondCall.calledWith('foo').should.be.true();
+            assert.equal(matchFunc('foo', 'buz')({get: getStub}), false);
+            assert.equal(getStub.calledTwice, true);
+            assert.equal(getStub.secondCall.calledWith('foo'), true);
         });
 
         it('should match value when key is 0', function () {
-            matchFunc('foo', 0, 'bar')({get: getStub}).should.be.true();
-            getStub.calledOnce.should.be.true();
-            getStub.calledWith('foo').should.be.true();
+            assert.equal(matchFunc('foo', 0, 'bar')({get: getStub}), true);
+            assert.equal(getStub.calledOnce, true);
+            assert.equal(getStub.calledWith('foo'), true);
 
-            matchFunc('foo', 0, 'buz')({get: getStub}).should.be.false();
-            getStub.calledTwice.should.be.true();
-            getStub.secondCall.calledWith('foo').should.be.true();
+            assert.equal(matchFunc('foo', 0, 'buz')({get: getStub}), false);
+            assert.equal(getStub.calledTwice, true);
+            assert.equal(getStub.secondCall.calledWith('foo'), true);
         });
 
         it('should match key & value when match is array', function () {
-            matchFunc(['foo', 'fun'], 'bar', 'baz')({get: getStub}).should.be.true();
-            getStub.calledTwice.should.be.true();
-            getStub.getCall(0).calledWith('fun').should.be.true();
-            getStub.getCall(1).calledWith('foo').should.be.true();
+            assert.equal(matchFunc(['foo', 'fun'], 'bar', 'baz')({get: getStub}), true);
+            assert.equal(getStub.calledTwice, true);
+            assert.equal(getStub.getCall(0).calledWith('fun'), true);
+            assert.equal(getStub.getCall(1).calledWith('foo'), true);
 
-            matchFunc(['foo', 'fun'], 'baz', 'bar')({get: getStub}).should.be.false();
-            getStub.callCount.should.eql(4);
-            getStub.getCall(2).calledWith('fun').should.be.true();
-            getStub.getCall(3).calledWith('foo').should.be.true();
+            assert.equal(matchFunc(['foo', 'fun'], 'baz', 'bar')({get: getStub}), false);
+            assert.equal(getStub.callCount, 4);
+            assert.equal(getStub.getCall(2).calledWith('fun'), true);
+            assert.equal(getStub.getCall(3).calledWith('foo'), true);
         });
 
         it('should match key only when match is array, but value is all', function () {
-            matchFunc(['foo', 'fun'], 'bar', 'all')({get: getStub}).should.be.true();
-            getStub.calledOnce.should.be.true();
-            getStub.calledWith('foo').should.be.true();
+            assert.equal(matchFunc(['foo', 'fun'], 'bar', 'all')({get: getStub}), true);
+            assert.equal(getStub.calledOnce, true);
+            assert.equal(getStub.calledWith('foo'), true);
 
-            matchFunc(['foo', 'fun'], 'all', 'bar')({get: getStub}).should.be.false();
-            getStub.callCount.should.eql(3);
-            getStub.getCall(1).calledWith('fun').should.be.true();
-            getStub.getCall(2).calledWith('foo').should.be.true();
+            assert.equal(matchFunc(['foo', 'fun'], 'all', 'bar')({get: getStub}), false);
+            assert.equal(getStub.callCount, 3);
+            assert.equal(getStub.getCall(1).calledWith('fun'), true);
+            assert.equal(getStub.getCall(2).calledWith('foo'), true);
         });
 
         it('should match key & value when match and value are arrays', function () {
-            matchFunc(['foo', 'fun'], 'bar', ['baz', 'buz'])({get: getStub}).should.be.true();
-            getStub.calledTwice.should.be.true();
-            getStub.getCall(0).calledWith('fun').should.be.true();
-            getStub.getCall(1).calledWith('foo').should.be.true();
+            assert.equal(matchFunc(['foo', 'fun'], 'bar', ['baz', 'buz'])({get: getStub}), true);
+            assert.equal(getStub.calledTwice, true);
+            assert.equal(getStub.getCall(0).calledWith('fun'), true);
+            assert.equal(getStub.getCall(1).calledWith('foo'), true);
 
-            matchFunc(['foo', 'fun'], 'bar', ['biz', 'buz'])({get: getStub}).should.be.false();
-            getStub.callCount.should.eql(4);
-            getStub.getCall(2).calledWith('fun').should.be.true();
-            getStub.getCall(3).calledWith('foo').should.be.true();
+            assert.equal(matchFunc(['foo', 'fun'], 'bar', ['biz', 'buz'])({get: getStub}), false);
+            assert.equal(getStub.callCount, 4);
+            assert.equal(getStub.getCall(2).calledWith('fun'), true);
+            assert.equal(getStub.getCall(3).calledWith('foo'), true);
         });
     });
 
@@ -341,8 +341,8 @@ describe('Migration Fixture Utils', function () {
                 result.should.have.property('expected', 11);
                 result.should.have.property('done', 11);
 
-                postOneStub.callCount.should.eql(11);
-                postAddStub.callCount.should.eql(11);
+                assert.equal(postOneStub.callCount, 11);
+                assert.equal(postAddStub.callCount, 11);
 
                 done();
             }).catch(done);
@@ -362,8 +362,8 @@ describe('Migration Fixture Utils', function () {
                 result.should.have.property('expected', 1);
                 result.should.have.property('done', 1);
 
-                newsletterOneStub.callCount.should.eql(1);
-                newsletterAddStub.callCount.should.eql(1);
+                assert.equal(newsletterOneStub.callCount, 1);
+                assert.equal(newsletterAddStub.callCount, 1);
 
                 done();
             }).catch(done);
@@ -383,8 +383,8 @@ describe('Migration Fixture Utils', function () {
                 result.should.have.property('expected', 11);
                 result.should.have.property('done', 0);
 
-                postOneStub.callCount.should.eql(11);
-                postAddStub.callCount.should.eql(0);
+                assert.equal(postOneStub.callCount, 11);
+                assert.equal(postAddStub.callCount, 0);
 
                 done();
             }).catch(done);
@@ -417,10 +417,10 @@ describe('Migration Fixture Utils', function () {
                 result.should.have.property('done', FIXTURE_COUNT);
 
                 // Permissions & Roles
-                permsAllStub.calledOnce.should.be.true();
-                rolesAllStub.calledOnce.should.be.true();
+                assert.equal(permsAllStub.calledOnce, true);
+                assert.equal(rolesAllStub.calledOnce, true);
                 dataMethodStub.filter.callCount.should.eql(FIXTURE_COUNT);
-                dataMethodStub.find.callCount.should.eql(10);
+                assert.equal(dataMethodStub.find.callCount, 10);
                 baseUtilAttachStub.callCount.should.eql(FIXTURE_COUNT);
 
                 fromItem.related.callCount.should.eql(FIXTURE_COUNT);
@@ -454,13 +454,13 @@ describe('Migration Fixture Utils', function () {
                 result.should.have.property('done', 7);
 
                 // Posts & Tags
-                postsAllStub.calledOnce.should.be.true();
-                tagsAllStub.calledOnce.should.be.true();
-                dataMethodStub.filter.callCount.should.eql(7);
-                dataMethodStub.find.callCount.should.eql(7);
-                fromItem.related.callCount.should.eql(7);
-                fromItem.find.callCount.should.eql(7);
-                baseUtilAttachStub.callCount.should.eql(7);
+                assert.equal(postsAllStub.calledOnce, true);
+                assert.equal(tagsAllStub.calledOnce, true);
+                assert.equal(dataMethodStub.filter.callCount, 7);
+                assert.equal(dataMethodStub.find.callCount, 7);
+                assert.equal(fromItem.related.callCount, 7);
+                assert.equal(fromItem.find.callCount, 7);
+                assert.equal(baseUtilAttachStub.callCount, 7);
 
                 done();
             }).catch(done);
@@ -491,16 +491,16 @@ describe('Migration Fixture Utils', function () {
                 result.should.have.property('done', 0);
 
                 // Posts & Tags
-                postsAllStub.calledOnce.should.be.true();
-                tagsAllStub.calledOnce.should.be.true();
-                dataMethodStub.filter.callCount.should.eql(7);
-                dataMethodStub.find.callCount.should.eql(7);
+                assert.equal(postsAllStub.calledOnce, true);
+                assert.equal(tagsAllStub.calledOnce, true);
+                assert.equal(dataMethodStub.filter.callCount, 7);
+                assert.equal(dataMethodStub.find.callCount, 7);
 
-                fromItem.related.callCount.should.eql(7);
-                fromItem.find.callCount.should.eql(7);
+                assert.equal(fromItem.related.callCount, 7);
+                assert.equal(fromItem.find.callCount, 7);
 
-                fromItem.tags.called.should.be.false();
-                fromItem.attach.called.should.be.false();
+                assert.equal(fromItem.tags.called, false);
+                assert.equal(fromItem.attach.called, false);
 
                 done();
             }).catch(done);

--- a/ghost/core/test/unit/server/data/schema/validator.test.js
+++ b/ghost/core/test/unit/server/data/schema/validator.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const _ = require('lodash');
 const ObjectId = require('bson-objectid').default;
@@ -23,7 +24,7 @@ describe('Validate Schema', function () {
                         throw err;
                     }
 
-                    err.length.should.eql(5);
+                    assert.equal(err.length, 5);
 
                     const errorMessages = _.map(err, function (object) {
                         return object.message;
@@ -51,8 +52,8 @@ describe('Validate Schema', function () {
                         throw err;
                     }
 
-                    err.length.should.eql(1);
-                    err[0].message.should.match(/posts\.id/);
+                    assert.equal(err.length, 1);
+                    assert.match(err[0].message, /posts\.id/);
                 });
         });
 
@@ -66,19 +67,19 @@ describe('Validate Schema', function () {
 
         it('transforms 0 and 1 (boolean)', async function () {
             const user = models.User.forge(testUtils.DataGenerator.forKnex.createUser({email: 'test@example.com', comment_notifications: 0}));
-            user.get('comment_notifications').should.eql(0);
+            assert.equal(user.get('comment_notifications'), 0);
 
             await validateSchema('users', user, {method: 'insert'});
-            user.get('comment_notifications').should.eql(false);
+            assert.equal(user.get('comment_notifications'), false);
         });
 
         it('keeps true or false', function () {
             const post = models.Post.forge(testUtils.DataGenerator.forKnex.createPost({slug: 'test', featured: true}));
-            post.get('featured').should.eql(true);
+            assert.equal(post.get('featured'), true);
 
             return validateSchema('posts', post, {method: 'insert'})
                 .then(function () {
-                    post.get('featured').should.eql(true);
+                    assert.equal(post.get('featured'), true);
                 });
         });
     });
@@ -100,9 +101,9 @@ describe('Validate Schema', function () {
                         throw err;
                     }
 
-                    err.length.should.eql(1);
-                    err[0].errorType.should.eql('ValidationError');
-                    err[0].message.should.match(/isLowercase/);
+                    assert.equal(err.length, 1);
+                    assert.equal(err[0].errorType, 'ValidationError');
+                    assert.match(err[0].message, /isLowercase/);
                 });
         });
     });
@@ -122,8 +123,8 @@ describe('Validate Schema', function () {
                         throw err;
                     }
 
-                    err.length.should.eql(1);
-                    err[0].message.should.match(/isUUID/);
+                    assert.equal(err.length, 1);
+                    assert.match(err[0].message, /isUUID/);
                 });
         });
 
@@ -141,8 +142,8 @@ describe('Validate Schema', function () {
                         throw err;
                     }
 
-                    err.length.should.eql(1);
-                    err[0].message.should.match(/posts\.created_at/);
+                    assert.equal(err.length, 1);
+                    assert.match(err[0].message, /posts\.created_at/);
                 });
         });
     });

--- a/ghost/core/test/unit/server/data/seeders/data-generator.test.js
+++ b/ghost/core/test/unit/server/data/seeders/data-generator.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 require('should');
 
 const knex = require('knex').default;
@@ -159,8 +160,8 @@ describe('Importer', function () {
 
         const products = await db.select('id', 'name').from('products');
 
-        products.length.should.eql(4);
-        products[0].name.should.eql('Free');
+        assert.equal(products.length, 4);
+        assert.equal(products[0].name, 'Free');
     });
 
     it('Should import an item for each entry in an array', async function () {
@@ -174,7 +175,7 @@ describe('Importer', function () {
 
         const results = await db.select('id').from('stripe_products');
 
-        results.length.should.eql(4);
+        assert.equal(results.length, 4);
     });
 
     it('Should update products to reference price ids', async function () {
@@ -195,8 +196,8 @@ describe('Importer', function () {
 
         const results = await db.select('id', 'name', 'monthly_price_id', 'yearly_price_id').from('products');
 
-        results.length.should.eql(4);
-        results[0].name.should.eql('Free');
+        assert.equal(results.length, 4);
+        assert.equal(results[0].name, 'Free');
     });
 });
 

--- a/ghost/core/test/unit/server/lib/image/blog-icon.test.js
+++ b/ghost/core/test/unit/server/lib/image/blog-icon.test.js
@@ -103,7 +103,7 @@ describe('lib/image: blog icon', function () {
             }});
 
             blogIcon.getIconPath();
-            stub.calledOnce.should.be.true();
+            assert.equal(stub.calledOnce, true);
         });
 
         it('custom uploaded png blog icon', function () {
@@ -119,7 +119,7 @@ describe('lib/image: blog icon', function () {
             }});
 
             blogIcon.getIconPath();
-            stub.calledOnce.should.be.true();
+            assert.equal(stub.calledOnce, true);
         });
 
         it('default ico blog icon', function () {
@@ -140,12 +140,12 @@ describe('lib/image: blog icon', function () {
     describe('getIconType', function () {
         it('returns x-icon for ico icons', function () {
             const blogIcon = new BlogIcon({config: {}, storageUtils: {}, urlUtils: {}, settingsCache: {}});
-            blogIcon.getIconType('favicon.ico').should.eql('x-icon');
+            assert.equal(blogIcon.getIconType('favicon.ico'), 'x-icon');
         });
 
         it('returns png for png icon', function () {
             const blogIcon = new BlogIcon({config: {}, storageUtils: {}, urlUtils: {}, settingsCache: {}});
-            blogIcon.getIconType('favicon.png').should.eql('png');
+            assert.equal(blogIcon.getIconType('favicon.png'), 'png');
         });
 
         it('returns x-icon for ico icons when the icon is cached', function () {
@@ -156,7 +156,7 @@ describe('lib/image: blog icon', function () {
                     }
                 }
             }});
-            blogIcon.getIconType().should.eql('x-icon');
+            assert.equal(blogIcon.getIconType(), 'x-icon');
         });
 
         it('returns png for png icon when the icon is cached', function () {
@@ -167,7 +167,7 @@ describe('lib/image: blog icon', function () {
                     }
                 }
             }});
-            blogIcon.getIconType().should.eql('png');
+            assert.equal(blogIcon.getIconType(), 'png');
         });
     });
 
@@ -218,7 +218,7 @@ describe('lib/image: blog icon', function () {
             blogIcon.getIconDimensions(path.join(__dirname, '../../../../utils/fixtures/images/favicon_multi_sizes_FILE_DOES_NOT_EXIST.ico'))
                 .catch(function (error) {
                     should.exist(error);
-                    error.message.should.eql('Could not fetch icon dimensions.');
+                    assert.equal(error.message, 'Could not fetch icon dimensions.');
                     done();
                 });
         });

--- a/ghost/core/test/unit/server/lib/image/cached-image-size-from-url.test.js
+++ b/ghost/core/test/unit/server/lib/image/cached-image-size-from-url.test.js
@@ -50,8 +50,8 @@ describe('lib/image: image size cache', function () {
         // second call to check if values get returned from cache
         await cachedImageSizeFromUrl.getCachedImageSizeFromUrl(url);
 
-        imageSizeSpy.calledOnce.should.be.true();
-        imageSizeSpy.calledTwice.should.be.false();
+        assert.equal(imageSizeSpy.calledOnce, true);
+        assert.equal(imageSizeSpy.calledTwice, false);
 
         cacheStore.get(url).should.not.be.undefined;
         const image2 = cacheStore.get(url);

--- a/ghost/core/test/unit/server/lib/image/gravatar.test.js
+++ b/ghost/core/test/unit/server/lib/image/gravatar.test.js
@@ -15,10 +15,10 @@ describe('lib/image: gravatar', function () {
             }
         }, request: () => {}});
 
-        gravatar.url('exists@example.com', {
+        assert.equal(gravatar.url('exists@example.com', {
             size: 180,
             rating: 'r'
-        }).should.eql('https://www.gravatar.com/avatar/ef6dcde5c99bb8f685dd451ccc3e050a?s=180&r=r&d=blank');
+        }), 'https://www.gravatar.com/avatar/ef6dcde5c99bb8f685dd451ccc3e050a?s=180&r=r&d=blank');
     });
 
     it('can successfully lookup a gravatar url', function (done) {
@@ -34,7 +34,7 @@ describe('lib/image: gravatar', function () {
         gravatar.lookup({email: 'exists@example.com'}).then(function (result) {
             should.exist(result);
             should.exist(result.image);
-            result.image.should.eql('https://www.gravatar.com/avatar/ef6dcde5c99bb8f685dd451ccc3e050a?s=250&r=x&d=mp');
+            assert.equal(result.image, 'https://www.gravatar.com/avatar/ef6dcde5c99bb8f685dd451ccc3e050a?s=250&r=x&d=mp');
 
             done();
         }).catch(done);

--- a/ghost/core/test/unit/server/lib/image/image-size.test.js
+++ b/ghost/core/test/unit/server/lib/image/image-size.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const nock = require('nock');
@@ -46,7 +47,7 @@ describe('lib/image: image size', function () {
             }, urlUtils: {}, request: {}, probe});
 
             imageSize.getImageSizeFromUrl(url).then(function (res) {
-                requestMock.isDone().should.be.true();
+                assert.equal(requestMock.isDone(), true);
                 should.exist(res);
                 res.width.should.be.equal(expectedImageObject.width);
                 res.height.should.be.equal(expectedImageObject.height);
@@ -81,7 +82,7 @@ describe('lib/image: image size', function () {
             }, probe});
 
             imageSize.getImageSizeFromUrl(url).then(function (res) {
-                requestMock.isDone().should.be.false();
+                assert.equal(requestMock.isDone(), false);
                 should.exist(res);
                 res.width.should.be.equal(expectedImageObject.width);
                 res.height.should.be.equal(expectedImageObject.height);
@@ -111,7 +112,7 @@ describe('lib/image: image size', function () {
             }, urlUtils: {}, request: {}, probe});
 
             imageSize.getImageSizeFromUrl(url).then(function (res) {
-                requestMock.isDone().should.be.true();
+                assert.equal(requestMock.isDone(), true);
                 should.exist(res);
                 res.width.should.be.equal(expectedImageObject.width);
                 res.height.should.be.equal(expectedImageObject.height);
@@ -142,8 +143,8 @@ describe('lib/image: image size', function () {
             }, urlUtils: {}, request: {}, probe});
 
             imageSize.getImageSizeFromUrl(url).then(function (res) {
-                requestMockNotFound.isDone().should.be.false();
-                requestMock.isDone().should.be.true();
+                assert.equal(requestMockNotFound.isDone(), false);
+                assert.equal(requestMock.isDone(), true);
                 should.exist(res);
                 res.width.should.be.equal(expectedImageObject.width);
                 res.height.should.be.equal(expectedImageObject.height);
@@ -192,7 +193,7 @@ describe('lib/image: image size', function () {
             }, probe});
 
             imageSize.getImageSizeFromUrl(url).then(function (res) {
-                requestMock.isDone().should.be.true();
+                assert.equal(requestMock.isDone(), true);
                 should.exist(res);
                 res.width.should.be.equal(expectedImageObject.width);
                 res.height.should.be.equal(expectedImageObject.height);
@@ -222,7 +223,7 @@ describe('lib/image: image size', function () {
             }, urlUtils: {}, request: {}, probe});
 
             imageSize.getImageSizeFromUrl(url).then(function (res) {
-                requestMock.isDone().should.be.true();
+                assert.equal(requestMock.isDone(), true);
                 should.exist(res);
                 res.width.should.be.equal(expectedImageObject.width);
                 res.height.should.be.equal(expectedImageObject.height);
@@ -258,8 +259,8 @@ describe('lib/image: image size', function () {
             }, urlUtils: {}, request: {}, probe});
 
             imageSize.getImageSizeFromUrl(url).then(function (res) {
-                requestMock.isDone().should.be.true();
-                secondRequestMock.isDone().should.be.true();
+                assert.equal(requestMock.isDone(), true);
+                assert.equal(secondRequestMock.isDone(), true);
                 should.exist(res);
                 res.width.should.be.equal(expectedImageObject.width);
                 res.height.should.be.equal(expectedImageObject.height);
@@ -304,7 +305,7 @@ describe('lib/image: image size', function () {
             }, request: {}, probe});
 
             imageSize.getImageSizeFromUrl(url).then(function (res) {
-                requestMock.isDone().should.be.false();
+                assert.equal(requestMock.isDone(), false);
                 should.exist(res);
                 should.exist(res.width);
                 res.width.should.be.equal(expectedImageObject.width);
@@ -333,7 +334,7 @@ describe('lib/image: image size', function () {
 
             imageSize.getImageSizeFromUrl(url)
                 .catch(function (err) {
-                    requestMock.isDone().should.be.true();
+                    assert.equal(requestMock.isDone(), true);
                     should.exist(err);
                     err.errorType.should.be.equal('NotFoundError');
                     err.message.should.be.equal('Image not found.');
@@ -371,7 +372,7 @@ describe('lib/image: image size', function () {
 
             imageSize.getImageSizeFromUrl(url)
                 .catch(function (err) {
-                    requestMock.isDone().should.be.false();
+                    assert.equal(requestMock.isDone(), false);
                     should.exist(err);
                     err.errorType.should.be.equal('NotFoundError');
                     err.message.should.be.equal('Image not found.');
@@ -425,7 +426,7 @@ describe('lib/image: image size', function () {
 
             imageSize.getImageSizeFromUrl(url)
                 .catch(function (err) {
-                    requestMock.isDone().should.be.true();
+                    assert.equal(requestMock.isDone(), true);
                     should.exist(err);
                     err.errorType.should.be.equal('InternalServerError');
                     err.message.should.be.equal('Request timed out.');
@@ -453,7 +454,7 @@ describe('lib/image: image size', function () {
                     true.should.be.false('succeeded when expecting failure');
                 })
                 .catch(function (err) {
-                    requestMock.isDone().should.be.true();
+                    assert.equal(requestMock.isDone(), true);
                     should.exist(err);
                     err.errorType.should.be.equal('InternalServerError');
                     done();
@@ -487,7 +488,7 @@ describe('lib/image: image size', function () {
                     true.should.be.false('succeeded when expecting failure');
                 })
                 .catch(function (err) {
-                    requestMock.isDone().should.be.false();
+                    assert.equal(requestMock.isDone(), false);
                     should.exist(err);
                     err.errorType.should.be.equal('InternalServerError');
                     done();
@@ -540,7 +541,7 @@ describe('lib/image: image size', function () {
 
             imageSize.getImageSizeFromUrl(url)
                 .catch(function (err) {
-                    requestMock.isDone().should.be.true();
+                    assert.equal(requestMock.isDone(), true);
                     should.exist(err);
                     err.errorType.should.be.equal('InternalServerError');
                     err.message.should.be.equal('Probe unresponsive.');
@@ -753,7 +754,7 @@ describe('lib/image: image size', function () {
             imageSize.getImageSizeFromStoragePath(url)
                 .catch(function (err) {
                     should.exist(err);
-                    (err instanceof errors.NotFoundError).should.eql(true);
+                    assert.equal((err instanceof errors.NotFoundError), true);
                     done();
                 }).catch(done);
         });

--- a/ghost/core/test/unit/server/lib/lexical.test.js
+++ b/ghost/core/test/unit/server/lib/lexical.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const jsdom = require('jsdom');
@@ -13,7 +14,7 @@ describe('lib/lexical', function () {
             const lexical = `{"root":{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"Lexical is ","type":"text","version":1},{"detail":0,"format":3,"mode":"normal","style":"","text":"rendering.","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}}`;
 
             const renderedHtml = await lexicalLib.render(lexical);
-            renderedHtml.should.eql('<p>Lexical is <strong><em>rendering.</em></strong></p>');
+            assert.equal(renderedHtml, '<p>Lexical is <strong><em>rendering.</em></strong></p>');
         });
 
         it('renders all default cards', async function () {
@@ -47,8 +48,8 @@ describe('lib/lexical', function () {
 
             const rendered = await lexicalLib.render(lexicalState);
 
-            rendered.should.containEql('<figure class="kg-card kg-image-card kg-width-wide kg-card-hascaption">');
-            rendered.should.containEql('<div class="kg-card kg-audio-card">');
+            assert(rendered.includes('<figure class="kg-card kg-image-card kg-width-wide kg-card-hascaption">'));
+            assert(rendered.includes('<div class="kg-card kg-audio-card">'));
         });
 
         it(`calls custom renderers`, async function () {
@@ -88,7 +89,7 @@ describe('lib/lexical', function () {
 
             const rendered = await lexicalLib.render(lexicalState);
 
-            rendered.should.containEql('<span>CUSTOM</span>');
+            assert(rendered.includes('<span>CUSTOM</span>'));
         });
     });
 });

--- a/ghost/core/test/unit/server/lib/mobiledoc.test.js
+++ b/ghost/core/test/unit/server/lib/mobiledoc.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const path = require('path');
 const should = require('should');
 const sinon = require('sinon');
@@ -80,8 +81,7 @@ describe('lib/mobiledoc', function () {
                 ]
             };
 
-            mobiledocLib.mobiledocHtmlRenderer.render(mobiledoc)
-                .should.eql('<p>One<br>Two</p><!--kg-card-begin: markdown--><h1 id="markdowncard">Markdown card</h1>\n<p>Some markdown</p>\n<!--kg-card-end: markdown--><p>Three</p><!--members-only--><hr><figure class="kg-card kg-image-card kg-width-wide kg-card-hascaption"><img src="/content/images/2018/04/NatGeo06.jpg" class="kg-image" alt loading="lazy" width="2000" height="1000" srcset="/content/images/size/w600/2018/04/NatGeo06.jpg 600w, /content/images/size/w1000/2018/04/NatGeo06.jpg 1000w, /content/images/size/w1600/2018/04/NatGeo06.jpg 1600w, /content/images/size/w2400/2018/04/NatGeo06.jpg 2400w" sizes="(min-width: 1200px) 1200px"><figcaption>Birdies</figcaption></figure><p>Four</p><!--kg-card-begin: html--><h2>HTML card</h2>\n<div><p>Some HTML</p></div><!--kg-card-end: html--><figure class="kg-card kg-embed-card"><h2>Embed card</h2></figure><figure class="kg-card kg-gallery-card kg-width-wide"><div class="kg-gallery-container"><div class="kg-gallery-row"><div class="kg-gallery-image"><img src="/content/images/test.png" width="1000" height="500" loading="lazy" alt srcset="/content/images/size/w600/test.png 600w, /content/images/test.png 1000w" sizes="(min-width: 720px) 720px"></div></div></div></figure>');
+            assert.equal(mobiledocLib.mobiledocHtmlRenderer.render(mobiledoc), '<p>One<br>Two</p><!--kg-card-begin: markdown--><h1 id="markdowncard">Markdown card</h1>\n<p>Some markdown</p>\n<!--kg-card-end: markdown--><p>Three</p><!--members-only--><hr><figure class="kg-card kg-image-card kg-width-wide kg-card-hascaption"><img src="/content/images/2018/04/NatGeo06.jpg" class="kg-image" alt loading="lazy" width="2000" height="1000" srcset="/content/images/size/w600/2018/04/NatGeo06.jpg 600w, /content/images/size/w1000/2018/04/NatGeo06.jpg 1000w, /content/images/size/w1600/2018/04/NatGeo06.jpg 1600w, /content/images/size/w2400/2018/04/NatGeo06.jpg 2400w" sizes="(min-width: 1200px) 1200px"><figcaption>Birdies</figcaption></figure><p>Four</p><!--kg-card-begin: html--><h2>HTML card</h2>\n<div><p>Some HTML</p></div><!--kg-card-end: html--><figure class="kg-card kg-embed-card"><h2>Embed card</h2></figure><figure class="kg-card kg-gallery-card kg-width-wide"><div class="kg-gallery-container"><div class="kg-gallery-row"><div class="kg-gallery-image"><img src="/content/images/test.png" width="1000" height="500" loading="lazy" alt srcset="/content/images/size/w600/test.png 600w, /content/images/test.png 1000w" sizes="(min-width: 720px) 720px"></div></div></div></figure>');
         });
 
         it('renders according to ghostVersion', function () {
@@ -103,8 +103,7 @@ describe('lib/mobiledoc', function () {
                 ]
             };
 
-            mobiledocLib.mobiledocHtmlRenderer.render(mobiledoc)
-                .should.eql('<!--kg-card-begin: markdown--><h1 id="header-one">Header One</h1>\n<!--kg-card-end: markdown--><h2 id="h%C3%A9ader-two">Héader Two</h2>');
+            assert.equal(mobiledocLib.mobiledocHtmlRenderer.render(mobiledoc), '<!--kg-card-begin: markdown--><h1 id="header-one">Header One</h1>\n<!--kg-card-end: markdown--><h2 id="h%C3%A9ader-two">Héader Two</h2>');
         });
 
         it('renders srcsets for __GHOST_URL__ relative images', function () {
@@ -136,8 +135,7 @@ describe('lib/mobiledoc', function () {
                 ]
             };
 
-            mobiledocLib.mobiledocHtmlRenderer.render(mobiledoc)
-                .should.eql('<figure class="kg-card kg-image-card kg-width-wide kg-card-hascaption"><img src="__GHOST_URL__/content/images/2018/04/NatGeo06.jpg" class="kg-image" alt loading="lazy" width="2000" height="1000" srcset="__GHOST_URL__/content/images/size/w600/2018/04/NatGeo06.jpg 600w, __GHOST_URL__/content/images/size/w1000/2018/04/NatGeo06.jpg 1000w, __GHOST_URL__/content/images/size/w1600/2018/04/NatGeo06.jpg 1600w, __GHOST_URL__/content/images/size/w2400/2018/04/NatGeo06.jpg 2400w" sizes="(min-width: 1200px) 1200px"><figcaption>Birdies</figcaption></figure><figure class="kg-card kg-gallery-card kg-width-wide"><div class="kg-gallery-container"><div class="kg-gallery-row"><div class="kg-gallery-image"><img src="__GHOST_URL__/content/images/test.png" width="1000" height="500" loading="lazy" alt srcset="__GHOST_URL__/content/images/size/w600/test.png 600w, __GHOST_URL__/content/images/test.png 1000w" sizes="(min-width: 720px) 720px"></div></div></div></figure>');
+            assert.equal(mobiledocLib.mobiledocHtmlRenderer.render(mobiledoc), '<figure class="kg-card kg-image-card kg-width-wide kg-card-hascaption"><img src="__GHOST_URL__/content/images/2018/04/NatGeo06.jpg" class="kg-image" alt loading="lazy" width="2000" height="1000" srcset="__GHOST_URL__/content/images/size/w600/2018/04/NatGeo06.jpg 600w, __GHOST_URL__/content/images/size/w1000/2018/04/NatGeo06.jpg 1000w, __GHOST_URL__/content/images/size/w1600/2018/04/NatGeo06.jpg 1600w, __GHOST_URL__/content/images/size/w2400/2018/04/NatGeo06.jpg 2400w" sizes="(min-width: 1200px) 1200px"><figcaption>Birdies</figcaption></figure><figure class="kg-card kg-gallery-card kg-width-wide"><div class="kg-gallery-container"><div class="kg-gallery-row"><div class="kg-gallery-image"><img src="__GHOST_URL__/content/images/test.png" width="1000" height="500" loading="lazy" alt srcset="__GHOST_URL__/content/images/size/w600/test.png 600w, __GHOST_URL__/content/images/test.png 1000w" sizes="(min-width: 720px) 720px"></div></div></div></figure>');
         });
 
         it('renders srcsets for absolute images', function () {
@@ -169,8 +167,7 @@ describe('lib/mobiledoc', function () {
                 ]
             };
 
-            mobiledocLib.mobiledocHtmlRenderer.render(mobiledoc)
-                .should.eql('<figure class="kg-card kg-image-card kg-width-wide kg-card-hascaption"><img src="http://127.0.0.1:2369/content/images/2018/04/NatGeo06.jpg" class="kg-image" alt loading="lazy" width="2000" height="1000" srcset="http://127.0.0.1:2369/content/images/size/w600/2018/04/NatGeo06.jpg 600w, http://127.0.0.1:2369/content/images/size/w1000/2018/04/NatGeo06.jpg 1000w, http://127.0.0.1:2369/content/images/size/w1600/2018/04/NatGeo06.jpg 1600w, http://127.0.0.1:2369/content/images/size/w2400/2018/04/NatGeo06.jpg 2400w" sizes="(min-width: 1200px) 1200px"><figcaption>Birdies</figcaption></figure><figure class="kg-card kg-gallery-card kg-width-wide"><div class="kg-gallery-container"><div class="kg-gallery-row"><div class="kg-gallery-image"><img src="http://127.0.0.1:2369/content/images/test.png" width="1000" height="500" loading="lazy" alt srcset="http://127.0.0.1:2369/content/images/size/w600/test.png 600w, http://127.0.0.1:2369/content/images/test.png 1000w" sizes="(min-width: 720px) 720px"></div></div></div></figure>');
+            assert.equal(mobiledocLib.mobiledocHtmlRenderer.render(mobiledoc), '<figure class="kg-card kg-image-card kg-width-wide kg-card-hascaption"><img src="http://127.0.0.1:2369/content/images/2018/04/NatGeo06.jpg" class="kg-image" alt loading="lazy" width="2000" height="1000" srcset="http://127.0.0.1:2369/content/images/size/w600/2018/04/NatGeo06.jpg 600w, http://127.0.0.1:2369/content/images/size/w1000/2018/04/NatGeo06.jpg 1000w, http://127.0.0.1:2369/content/images/size/w1600/2018/04/NatGeo06.jpg 1600w, http://127.0.0.1:2369/content/images/size/w2400/2018/04/NatGeo06.jpg 2400w" sizes="(min-width: 1200px) 1200px"><figcaption>Birdies</figcaption></figure><figure class="kg-card kg-gallery-card kg-width-wide"><div class="kg-gallery-container"><div class="kg-gallery-row"><div class="kg-gallery-image"><img src="http://127.0.0.1:2369/content/images/test.png" width="1000" height="500" loading="lazy" alt srcset="http://127.0.0.1:2369/content/images/size/w600/test.png 600w, http://127.0.0.1:2369/content/images/test.png 1000w" sizes="(min-width: 720px) 720px"></div></div></div></figure>');
         });
 
         it('respects srcsets config', function () {
@@ -204,8 +201,7 @@ describe('lib/mobiledoc', function () {
                 ]
             };
 
-            mobiledocLib.mobiledocHtmlRenderer.render(mobiledoc)
-                .should.eql('<figure class="kg-card kg-image-card kg-width-wide kg-card-hascaption"><img src="/content/images/2018/04/NatGeo06.jpg" class="kg-image" alt loading="lazy" width="2000" height="1000"><figcaption>Birdies</figcaption></figure><figure class="kg-card kg-gallery-card kg-width-wide"><div class="kg-gallery-container"><div class="kg-gallery-row"><div class="kg-gallery-image"><img src="/content/images/test.png" width="1000" height="500" loading="lazy" alt></div></div></div></figure>');
+            assert.equal(mobiledocLib.mobiledocHtmlRenderer.render(mobiledoc), '<figure class="kg-card kg-image-card kg-width-wide kg-card-hascaption"><img src="/content/images/2018/04/NatGeo06.jpg" class="kg-image" alt loading="lazy" width="2000" height="1000"><figcaption>Birdies</figcaption></figure><figure class="kg-card kg-gallery-card kg-width-wide"><div class="kg-gallery-container"><div class="kg-gallery-row"><div class="kg-gallery-image"><img src="/content/images/test.png" width="1000" height="500" loading="lazy" alt></div></div></div></figure>');
         });
 
         it('does render srcsets for animated images', function () {
@@ -224,8 +220,7 @@ describe('lib/mobiledoc', function () {
                 sections: [[10, 0]]
             };
 
-            mobiledocLib.mobiledocHtmlRenderer.render(mobiledoc)
-                .should.eql('<figure class="kg-card kg-image-card"><img src="/content/images/2020/07/animated.gif" class="kg-image" alt loading="lazy" width="2000" height="1000" srcset="/content/images/size/w600/2020/07/animated.gif 600w, /content/images/size/w1000/2020/07/animated.gif 1000w, /content/images/size/w1600/2020/07/animated.gif 1600w, /content/images/size/w2400/2020/07/animated.gif 2400w" sizes="(min-width: 720px) 720px"></figure>');
+            assert.equal(mobiledocLib.mobiledocHtmlRenderer.render(mobiledoc), '<figure class="kg-card kg-image-card"><img src="/content/images/2020/07/animated.gif" class="kg-image" alt loading="lazy" width="2000" height="1000" srcset="/content/images/size/w600/2020/07/animated.gif 600w, /content/images/size/w1000/2020/07/animated.gif 1000w, /content/images/size/w1600/2020/07/animated.gif 1600w, /content/images/size/w2400/2020/07/animated.gif 2400w" sizes="(min-width: 720px) 720px"></figure>');
         });
 
         it('does not render srcsets for non-resizable images', function () {
@@ -244,8 +239,7 @@ describe('lib/mobiledoc', function () {
                 sections: [[10, 0]]
             };
 
-            mobiledocLib.mobiledocHtmlRenderer.render(mobiledoc)
-                .should.eql('<figure class="kg-card kg-image-card"><img src="/content/images/2020/07/vector.svg" class="kg-image" alt loading="lazy" width="4000" height="2000"></figure>');
+            assert.equal(mobiledocLib.mobiledocHtmlRenderer.render(mobiledoc), '<figure class="kg-card kg-image-card"><img src="/content/images/2020/07/vector.svg" class="kg-image" alt loading="lazy" width="4000" height="2000"></figure>');
         });
 
         it('does not render srcsets when sharp is not available', function () {
@@ -267,8 +261,7 @@ describe('lib/mobiledoc', function () {
                 ]
             };
 
-            mobiledocLib.mobiledocHtmlRenderer.render(mobiledoc)
-                .should.eql('<figure class="kg-card kg-image-card"><img src="/content/images/2018/04/NatGeo06.jpg" class="kg-image" alt loading="lazy" width="4000" height="2000"></figure>');
+            assert.equal(mobiledocLib.mobiledocHtmlRenderer.render(mobiledoc), '<figure class="kg-card kg-image-card"><img src="/content/images/2018/04/NatGeo06.jpg" class="kg-image" alt loading="lazy" width="4000" height="2000"></figure>');
         });
 
         it('does not render srcsets with incompatible storage engine', function () {
@@ -290,8 +283,7 @@ describe('lib/mobiledoc', function () {
                 ]
             };
 
-            mobiledocLib.mobiledocHtmlRenderer.render(mobiledoc)
-                .should.eql('<figure class="kg-card kg-image-card"><img src="/content/images/2018/04/NatGeo06.jpg" class="kg-image" alt loading="lazy" width="4000" height="2000"></figure>');
+            assert.equal(mobiledocLib.mobiledocHtmlRenderer.render(mobiledoc), '<figure class="kg-card kg-image-card"><img src="/content/images/2018/04/NatGeo06.jpg" class="kg-image" alt loading="lazy" width="4000" height="2000"></figure>');
         });
     });
 
@@ -334,10 +326,10 @@ describe('lib/mobiledoc', function () {
             const transformedMobiledoc = await mobiledocLib.populateImageSizes(JSON.stringify(mobiledoc));
             const transformed = JSON.parse(transformedMobiledoc);
 
-            unsplashMock.isDone().should.be.true();
+            assert.equal(unsplashMock.isDone(), true);
             sinon.assert.calledOnce(loggingStub);
 
-            transformed.cards.length.should.equal(4);
+            assert.equal(transformed.cards.length, 4);
         });
 
         // images can be stored with and without subdir when a subdir is configured
@@ -357,17 +349,17 @@ describe('lib/mobiledoc', function () {
             const transformedMobiledoc = await mobiledocLib.populateImageSizes(JSON.stringify(mobiledoc));
             const transformed = JSON.parse(transformedMobiledoc);
 
-            transformed.cards.length.should.equal(2);
+            assert.equal(transformed.cards.length, 2);
 
             should.exist(transformed.cards[0][1].width);
-            transformed.cards[0][1].width.should.equal(800);
+            assert.equal(transformed.cards[0][1].width, 800);
             should.exist(transformed.cards[0][1].height);
-            transformed.cards[0][1].height.should.equal(257);
+            assert.equal(transformed.cards[0][1].height, 257);
 
             should.exist(transformed.cards[1][1].width);
-            transformed.cards[1][1].width.should.equal(800);
+            assert.equal(transformed.cards[1][1].width, 800);
             should.exist(transformed.cards[1][1].height);
-            transformed.cards[1][1].height.should.equal(257);
+            assert.equal(transformed.cards[1][1].height, 257);
         });
     });
 });

--- a/ghost/core/test/unit/server/lib/package-json/filter.test.js
+++ b/ghost/core/test/unit/server/lib/package-json/filter.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 require('should');
 
 const packageJSON = require('../../../../../core/server/lib/package-json');
@@ -48,9 +49,9 @@ describe('package-json filter', function () {
 
         package1.should.be.an.Object().with.properties('name', 'package', 'active');
         Object.keys(package1).should.be.an.Array().with.lengthOf(3);
-        package1.name.should.eql('casper');
+        assert.equal(package1.name, 'casper');
         package1.package.should.be.an.Object().with.properties('name', 'version');
-        package1.active.should.be.false();
+        assert.equal(package1.active, false);
     });
 
     it('should filter packages and handle a single active package string', function () {
@@ -64,15 +65,15 @@ describe('package-json filter', function () {
 
         package1.should.be.an.Object().with.properties('name', 'package', 'active');
         Object.keys(package1).should.be.an.Array().with.lengthOf(3);
-        package1.name.should.eql('casper');
+        assert.equal(package1.name, 'casper');
         package1.package.should.be.an.Object().with.properties('name', 'version');
-        package1.active.should.be.true();
+        assert.equal(package1.active, true);
 
         package2.should.be.an.Object().with.properties('name', 'package', 'active');
         Object.keys(package2).should.be.an.Array().with.lengthOf(3);
-        package2.name.should.eql('simple');
+        assert.equal(package2.name, 'simple');
         package2.package.should.be.an.Object().with.properties('name', 'version');
-        package2.active.should.be.false();
+        assert.equal(package2.active, false);
     });
 
     it('should filter packages and handle an array of active packages', function () {
@@ -86,15 +87,15 @@ describe('package-json filter', function () {
 
         package1.should.be.an.Object().with.properties('name', 'package', 'active');
         Object.keys(package1).should.be.an.Array().with.lengthOf(3);
-        package1.name.should.eql('casper');
+        assert.equal(package1.name, 'casper');
         package1.package.should.be.an.Object().with.properties('name', 'version');
-        package1.active.should.be.true();
+        assert.equal(package1.active, true);
 
         package2.should.be.an.Object().with.properties('name', 'package', 'active');
         Object.keys(package2).should.be.an.Array().with.lengthOf(3);
-        package2.name.should.eql('simple');
+        assert.equal(package2.name, 'simple');
         package2.package.should.be.an.Object().with.properties('name', 'version');
-        package2.active.should.be.true();
+        assert.equal(package2.active, true);
     });
 
     it('handles packages with no package.json even though this makes us sad', function () {
@@ -108,15 +109,15 @@ describe('package-json filter', function () {
 
         package1.should.be.an.Object().with.properties('name', 'package', 'active');
         Object.keys(package1).should.be.an.Array().with.lengthOf(3);
-        package1.name.should.eql('casper');
+        assert.equal(package1.name, 'casper');
         package1.package.should.be.an.Object().with.properties('name', 'version');
-        package1.active.should.be.true();
+        assert.equal(package1.active, true);
 
         package2.should.be.an.Object().with.properties('name', 'package', 'active');
         Object.keys(package2).should.be.an.Array().with.lengthOf(3);
-        package2.name.should.eql('missing');
-        package2.package.should.be.false();
-        package2.active.should.be.false();
+        assert.equal(package2.name, 'missing');
+        assert.equal(package2.package, false);
+        assert.equal(package2.active, false);
     });
 
     it('filters out things which are not packages', function () {

--- a/ghost/core/test/unit/server/lib/package-json/parse.test.js
+++ b/ghost/core/test/unit/server/lib/package-json/parse.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 require('should');
 
 const tmp = require('tmp');
@@ -46,9 +47,9 @@ describe('package-json parse', function () {
                 done(new Error('packageJSON.parse succeeded, but should\'ve failed'));
             })
             .catch(function (err) {
-                err.message.should.equal('"name" or "version" is missing from theme package.json file.');
+                assert.equal(err.message, '"name" or "version" is missing from theme package.json file.');
                 err.context.should.equal(tmpFile.name);
-                err.help.should.equal('This will be required in future. Please see https://ghost.org/docs/themes/');
+                assert.equal(err.help, 'This will be required in future. Please see https://ghost.org/docs/themes/');
 
                 done();
             })
@@ -72,9 +73,9 @@ describe('package-json parse', function () {
                 done(new Error('packageJSON.parse succeeded, but should\'ve failed'));
             })
             .catch(function (err) {
-                err.message.should.equal('"name" or "version" is missing from theme package.json file.');
+                assert.equal(err.message, '"name" or "version" is missing from theme package.json file.');
                 err.context.should.equal(tmpFile.name);
-                err.help.should.equal('This will be required in future. Please see https://ghost.org/docs/themes/');
+                assert.equal(err.help, 'This will be required in future. Please see https://ghost.org/docs/themes/');
 
                 done();
             })
@@ -96,9 +97,9 @@ describe('package-json parse', function () {
                 done(new Error('packageJSON.parse succeeded, but should\'ve failed'));
             })
             .catch(function (err) {
-                err.message.should.equal('Theme package.json file is malformed');
+                assert.equal(err.message, 'Theme package.json file is malformed');
                 err.context.should.equal(tmpFile.name);
-                err.help.should.equal('This will be required in future. Please see https://ghost.org/docs/themes/');
+                assert.equal(err.help, 'This will be required in future. Please see https://ghost.org/docs/themes/');
 
                 done();
             })
@@ -115,7 +116,7 @@ describe('package-json parse', function () {
                 done(new Error('packageJSON.parse succeeded, but should\'ve failed'));
             })
             .catch(function (err) {
-                err.message.should.equal('Could not read package.json file');
+                assert.equal(err.message, 'Could not read package.json file');
                 err.context.should.equal(tmpFile.name);
 
                 done();

--- a/ghost/core/test/unit/server/lib/package-json/read.test.js
+++ b/ghost/core/test/unit/server/lib/package-json/read.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 require('should');
 
 const tmp = require('tmp');
@@ -304,7 +305,7 @@ describe('package-json read', function () {
                     done('Should have thrown an error');
                 })
                 .catch(function (err) {
-                    err.message.should.eql('Package not found');
+                    assert.equal(err.message, 'Package not found');
                     done();
                 })
                 .finally(packagePath.removeCallback);

--- a/ghost/core/test/unit/server/lib/request-external.test.js
+++ b/ghost/core/test/unit/server/lib/request-external.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const should = require('should');
 const nock = require('nock');
@@ -44,7 +45,7 @@ describe('External Request', function () {
                 .reply(200, 'Response body');
 
             return externalRequest(url, options).then(function (res) {
-                requestMock.isDone().should.be.true();
+                assert.equal(requestMock.isDone(), true);
                 should.exist(res);
                 should.exist(res.body);
                 res.body.should.be.equal(expectedResponse.body);
@@ -75,7 +76,7 @@ describe('External Request', function () {
                 .reply(200, 'Response body');
 
             return externalRequest(url, options).then(function (res) {
-                requestMock.isDone().should.be.true();
+                assert.equal(requestMock.isDone(), true);
                 should.exist(res);
                 should.exist(res.body);
                 res.body.should.be.equal(expectedResponse.body);
@@ -139,7 +140,7 @@ describe('External Request', function () {
             }, (err) => {
                 should.exist(err);
                 err.message.should.be.equal('URL resolves to a non-permitted private IP block');
-                requestMock.isDone().should.be.false();
+                assert.equal(requestMock.isDone(), false);
             });
         });
 
@@ -169,8 +170,8 @@ describe('External Request', function () {
             }, (err) => {
                 should.exist(err);
                 err.message.should.be.equal('URL resolves to a non-permitted private IP block');
-                requestMock.isDone().should.be.true();
-                secondRequestMock.isDone().should.be.false();
+                assert.equal(requestMock.isDone(), true);
+                assert.equal(secondRequestMock.isDone(), false);
             });
         });
     });
@@ -206,7 +207,7 @@ describe('External Request', function () {
                 .reply(200, 'Response body');
 
             return externalRequest(url, options).then(function (res) {
-                requestMock.isDone().should.be.true();
+                assert.equal(requestMock.isDone(), true);
                 should.exist(res);
                 should.exist(res.body);
                 res.body.should.be.equal(expectedResponse.body);
@@ -242,8 +243,8 @@ describe('External Request', function () {
                 .reply(200, 'Redirected response');
 
             return externalRequest(url, options).then(function (res) {
-                requestMock.isDone().should.be.true();
-                secondRequestMock.isDone().should.be.true();
+                assert.equal(requestMock.isDone(), true);
+                assert.equal(secondRequestMock.isDone(), true);
                 should.exist(res);
                 should.exist(res.body);
                 res.body.should.be.equal(expectedResponse.body);
@@ -302,7 +303,7 @@ describe('External Request', function () {
             return externalRequest(url, options).then(() => {
                 throw new Error('Request should have errored');
             }, (err) => {
-                requestMock.isDone().should.be.true();
+                assert.equal(requestMock.isDone(), true);
                 should.exist(err);
                 err.response.statusMessage.should.be.equal('Not Found');
             });
@@ -324,7 +325,7 @@ describe('External Request', function () {
             return externalRequest(url, options).then(() => {
                 throw new Error('Request should have errored with an awful error');
             }, (err) => {
-                requestMock.isDone().should.be.true();
+                assert.equal(requestMock.isDone(), true);
                 should.exist(err);
                 err.response.statusMessage.should.be.equal(`Internal Server Error`);
             });

--- a/ghost/core/test/unit/server/models/base/bulk-filters.test.js
+++ b/ghost/core/test/unit/server/models/base/bulk-filters.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const bulkFilters = require('../../../../../core/server/models/base/plugins/bulk-filters');
 const {byNQL, byColumnValues, byIds} = bulkFilters;
@@ -12,7 +13,7 @@ describe('Models: bulk-filters', function () {
             const strategy = byNQL('status:published');
             const results = [...strategy];
 
-            results.length.should.equal(1);
+            assert.equal(results.length, 1);
             results[0].should.be.a.Function();
         });
     });
@@ -24,7 +25,7 @@ describe('Models: bulk-filters', function () {
             const results = [...strategy];
 
             // Should produce 2 chunks: 100 + 50
-            results.length.should.equal(2);
+            assert.equal(results.length, 2);
         });
 
         it('yields single chunk for values less than chunk size', function () {
@@ -32,14 +33,14 @@ describe('Models: bulk-filters', function () {
             const strategy = byColumnValues('id', ids);
             const results = [...strategy];
 
-            results.length.should.equal(1);
+            assert.equal(results.length, 1);
         });
 
         it('yields no chunks for empty array', function () {
             const strategy = byColumnValues('id', []);
             const results = [...strategy];
 
-            results.length.should.equal(0);
+            assert.equal(results.length, 0);
         });
 
         it('applies whereIn to query builder for each chunk', function () {
@@ -53,8 +54,8 @@ describe('Models: bulk-filters', function () {
 
             applyWhere(mockQb);
 
-            mockQb.whereIn.calledOnce.should.be.true();
-            mockQb.whereIn.calledWith('member_id', ids).should.be.true();
+            assert.equal(mockQb.whereIn.calledOnce, true);
+            assert.equal(mockQb.whereIn.calledWith('member_id', ids), true);
         });
 
         it('allows custom chunk size', function () {
@@ -63,7 +64,7 @@ describe('Models: bulk-filters', function () {
             const results = [...strategy];
 
             // Should produce 3 chunks: 10 + 10 + 5
-            results.length.should.equal(3);
+            assert.equal(results.length, 3);
         });
     });
 
@@ -79,8 +80,8 @@ describe('Models: bulk-filters', function () {
 
             applyWhere(mockQb);
 
-            mockQb.whereIn.calledOnce.should.be.true();
-            mockQb.whereIn.calledWith('id', ids).should.be.true();
+            assert.equal(mockQb.whereIn.calledOnce, true);
+            assert.equal(mockQb.whereIn.calledWith('id', ids), true);
         });
     });
 });

--- a/ghost/core/test/unit/server/models/base/crud.test.js
+++ b/ghost/core/test/unit/server/models/base/crud.test.js
@@ -222,7 +222,7 @@ describe('Models: crud', function () {
             return models.Base.Model.edit(data, unfilteredOptions).then(() => {
                 throw new Error('That should not happen');
             }).catch((err) => {
-                (err instanceof errors.NotFoundError).should.be.true();
+                assert.equal((err instanceof errors.NotFoundError), true);
             });
         });
     });

--- a/ghost/core/test/unit/server/models/base/index.test.js
+++ b/ghost/core/test/unit/server/models/base/index.test.js
@@ -36,7 +36,7 @@ describe('Models: base', function () {
 
             return models.Base.Model.generateSlug(Model, 'My-Slug', options)
                 .then((slug) => {
-                    slug.should.eql('my-slug');
+                    assert.equal(slug, 'my-slug');
                 });
         });
 
@@ -54,7 +54,7 @@ describe('Models: base', function () {
 
             return models.Base.Model.generateSlug(Model, 'My-Slug', {modelId: 'incorrect-model-id'})
                 .then((slug) => {
-                    slug.should.eql('my-slug-2');
+                    assert.equal(slug, 'my-slug-2');
                 });
         });
 
@@ -72,7 +72,7 @@ describe('Models: base', function () {
 
             return models.Base.Model.generateSlug(Model, 'My-Slug', {modelId: 'correct-model-id'})
                 .then((slug) => {
-                    slug.should.eql('my-slug');
+                    assert.equal(slug, 'my-slug');
                 });
         });
 
@@ -90,7 +90,7 @@ describe('Models: base', function () {
 
             return models.Base.Model.generateSlug(Model, 'My-Slug', options)
                 .then((slug) => {
-                    slug.should.eql('my-slug-2');
+                    assert.equal(slug, 'my-slug-2');
                 });
         });
 
@@ -114,7 +114,7 @@ describe('Models: base', function () {
 
             return models.Base.Model.generateSlug(Model, slug, options)
                 .then((generatedSlug) => {
-                    generatedSlug.should.eql('upsi-tableName');
+                    assert.equal(generatedSlug, 'upsi-tableName');
                 });
         });
 
@@ -130,7 +130,7 @@ describe('Models: base', function () {
 
             return models.Base.Model.generateSlug(Model, slug, options)
                 .then((generatedSlug) => {
-                    generatedSlug.should.eql('hash-#lul');
+                    assert.equal(generatedSlug, 'hash-#lul');
                 });
         });
 
@@ -140,7 +140,7 @@ describe('Models: base', function () {
 
             return models.Base.Model.generateSlug(Model, 'abc\u0008', options)
                 .then((slug) => {
-                    slug.should.eql('abc');
+                    assert.equal(slug, 'abc');
                 });
         });
     });
@@ -153,7 +153,7 @@ describe('Models: base', function () {
                 models.Base.Model.sanitizeData
                     .bind({prototype: {tableName: 'posts'}})(data);
             } catch (err) {
-                err.code.should.eql('DATE_INVALID');
+                assert.equal(err.code, 'DATE_INVALID');
             }
         });
 
@@ -198,7 +198,7 @@ describe('Models: base', function () {
                     }
                 })(data);
 
-            data.authors[0].name.should.eql('Thomas');
+            assert.equal(data.authors[0].name, 'Thomas');
             data.authors[0].updated_at.should.be.a.Date();
         });
     });
@@ -210,11 +210,11 @@ describe('Models: base', function () {
             base.getNullableStringProperties = sinon.stub();
             base.getNullableStringProperties.returns(['a']);
 
-            base.get('a').should.eql('');
-            base.get('b').should.eql('');
+            assert.equal(base.get('a'), '');
+            assert.equal(base.get('b'), '');
             base.setEmptyValuesToNull();
             assert.equal(base.get('a'), null);
-            base.get('b').should.eql('');
+            assert.equal(base.get('b'), '');
         });
     });
 });

--- a/ghost/core/test/unit/server/models/base/relations.test.js
+++ b/ghost/core/test/unit/server/models/base/relations.test.js
@@ -35,15 +35,15 @@ describe('Models: getLazyRelation', function () {
         const options = {test: true};
         const modelA = TestModel.forge({id: '1'});
         (await modelA.getLazyRelation('tiers', options)).should.eql(rel);
-        fetchStub.calledOnceWithExactly(options).should.be.true();
+        assert.equal(fetchStub.calledOnceWithExactly(options), true);
 
         // Check if it can reuse it again
         (await modelA.getLazyRelation('tiers', options)).should.eql(rel);
-        fetchStub.calledOnceWithExactly(options).should.be.true();
+        assert.equal(fetchStub.calledOnceWithExactly(options), true);
 
         // Check if we can force reload
         await should(modelA.getLazyRelation('tiers', {forceRefresh: true})).rejectedWith(/Called twice/);
-        fetchStub.calledTwice.should.be.true();
+        assert.equal(fetchStub.calledTwice, true);
     });
 
     it('can fetch models', async function () {
@@ -70,15 +70,15 @@ describe('Models: getLazyRelation', function () {
         const options = {test: true};
         const modelA = TestModel.forge({id: '1'});
         (await modelA.getLazyRelation('other', options)).should.eql(rel);
-        fetchStub.calledOnceWithExactly(options).should.be.true();
+        assert.equal(fetchStub.calledOnceWithExactly(options), true);
 
         // Check if it can reuse it again
         (await modelA.getLazyRelation('other', options)).should.eql(rel);
-        fetchStub.calledOnceWithExactly(options).should.be.true();
+        assert.equal(fetchStub.calledOnceWithExactly(options), true);
 
         // Check if we can force reload
         await should(modelA.getLazyRelation('other', {forceRefresh: true})).rejectedWith(/Called twice/);
-        fetchStub.calledTwice.should.be.true();
+        assert.equal(fetchStub.calledTwice, true);
     });
 
     it('can handle fetch of model without id for optional relations', async function () {

--- a/ghost/core/test/unit/server/models/integration.test.js
+++ b/ghost/core/test/unit/server/models/integration.test.js
@@ -60,8 +60,8 @@ describe('Unit: models/integration', function () {
             }, {
                 filter: 'type:[custom,builtin,core]'
             }).then(() => {
-                queries.length.should.eql(1);
-                queries[0].sql.should.eql('select `integrations`.* from `integrations` where `integrations`.`type` in (?, ?, ?) and `integrations`.`id` = ? limit ?');
+                assert.equal(queries.length, 1);
+                assert.equal(queries[0].sql, 'select `integrations`.* from `integrations` where `integrations`.`type` in (?, ?, ?) and `integrations`.`id` = ? limit ?');
                 queries[0].bindings.should.eql(['custom', 'builtin', 'core', '123', 1]);
             });
         });
@@ -90,8 +90,8 @@ describe('Unit: models/integration', function () {
             });
 
             return models.Integration.getInternalFrontendKey().then(() => {
-                queries.length.should.eql(1);
-                queries[0].sql.should.eql('select `integrations`.* from `integrations` where `integrations`.`slug` = ? limit ?');
+                assert.equal(queries.length, 1);
+                assert.equal(queries[0].sql, 'select `integrations`.* from `integrations` where `integrations`.`slug` = ? limit ?');
                 queries[0].bindings.should.eql(['ghost-internal-frontend', 1]);
             });
         });

--- a/ghost/core/test/unit/server/models/member-created-event.test.js
+++ b/ghost/core/test/unit/server/models/member-created-event.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const errors = require('@tryghost/errors');
@@ -19,9 +20,9 @@ describe('Unit: models/MemberCreatedEvent', function () {
                     throw new Error('expected ValidationError');
                 })
                 .catch(function (err) {
-                    should(err).lengthOf(1);
-                    (err[0] instanceof errors.ValidationError).should.eql(true);
-                    err[0].context.should.match(/members_created_events\.attribution_type/);
+                    assert.equal(err.length, 1);
+                    assert.equal((err[0] instanceof errors.ValidationError), true);
+                    assert.match(err[0].context, /members_created_events\.attribution_type/);
                 });
         });
 
@@ -31,9 +32,9 @@ describe('Unit: models/MemberCreatedEvent', function () {
                     throw new Error('expected ValidationError');
                 })
                 .catch(function (err) {
-                    should(err).lengthOf(1);
-                    (err[0] instanceof errors.ValidationError).should.eql(true);
-                    err[0].context.should.match(/members_created_events\.member_id/);
+                    assert.equal(err.length, 1);
+                    assert.equal((err[0] instanceof errors.ValidationError), true);
+                    assert.match(err[0].context, /members_created_events\.member_id/);
                 });
         });
 
@@ -43,9 +44,9 @@ describe('Unit: models/MemberCreatedEvent', function () {
                     throw new Error('expected ValidationError');
                 })
                 .catch(function (err) {
-                    should(err).lengthOf(1);
-                    (err[0] instanceof errors.ValidationError).should.eql(true);
-                    err[0].context.should.match(/members_created_events\.source/);
+                    assert.equal(err.length, 1);
+                    assert.equal((err[0] instanceof errors.ValidationError), true);
+                    assert.match(err[0].context, /members_created_events\.source/);
                 });
         });
 
@@ -55,9 +56,9 @@ describe('Unit: models/MemberCreatedEvent', function () {
                     throw new Error('expected ValidationError');
                 })
                 .catch(function (err) {
-                    should(err).lengthOf(1);
-                    (err[0] instanceof errors.ValidationError).should.eql(true);
-                    err[0].context.should.match(/members_created_events\.source/);
+                    assert.equal(err.length, 1);
+                    assert.equal((err[0] instanceof errors.ValidationError), true);
+                    assert.match(err[0].context, /members_created_events\.source/);
                 });
         });
     });

--- a/ghost/core/test/unit/server/models/member-feedback.test.js
+++ b/ghost/core/test/unit/server/models/member-feedback.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const errors = require('@tryghost/errors');
@@ -19,9 +20,9 @@ describe('Unit: models/MemberFeedback', function () {
                     throw new Error('expected ValidationError');
                 })
                 .catch(function (err) {
-                    should(err).lengthOf(1);
-                    (err[0] instanceof errors.ValidationError).should.eql(true);
-                    err[0].context.should.match(/members_feedback\.member_id/);
+                    assert.equal(err.length, 1);
+                    assert.equal((err[0] instanceof errors.ValidationError), true);
+                    assert.match(err[0].context, /members_feedback\.member_id/);
                 });
         });
 
@@ -31,9 +32,9 @@ describe('Unit: models/MemberFeedback', function () {
                     throw new Error('expected ValidationError');
                 })
                 .catch(function (err) {
-                    should(err).lengthOf(1);
-                    (err[0] instanceof errors.ValidationError).should.eql(true);
-                    err[0].context.should.match(/members_feedback\.post_id/);
+                    assert.equal(err.length, 1);
+                    assert.equal((err[0] instanceof errors.ValidationError), true);
+                    assert.match(err[0].context, /members_feedback\.post_id/);
                 });
         });
     });
@@ -44,7 +45,7 @@ describe('Unit: models/MemberFeedback', function () {
                 throw new Error('expected IncorrectUsageError');
             })
             .catch(function (err) {
-                (err instanceof errors.IncorrectUsageError).should.eql(true);
+                assert.equal((err instanceof errors.IncorrectUsageError), true);
             });
     });
 

--- a/ghost/core/test/unit/server/models/member-subscribe-event.test.js
+++ b/ghost/core/test/unit/server/models/member-subscribe-event.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const errors = require('@tryghost/errors');
@@ -19,9 +20,9 @@ describe('Unit: models/MemberSubscribeEvent', function () {
                     throw new Error('expected ValidationError');
                 })
                 .catch(function (err) {
-                    should(err).lengthOf(1);
-                    (err[0] instanceof errors.ValidationError).should.eql(true);
-                    err[0].context.should.match(/members_subscribe_events\.source/);
+                    assert.equal(err.length, 1);
+                    assert.equal((err[0] instanceof errors.ValidationError), true);
+                    assert.match(err[0].context, /members_subscribe_events\.source/);
                 });
         });
     });

--- a/ghost/core/test/unit/server/models/member.test.js
+++ b/ghost/core/test/unit/server/models/member.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const should = require('should');
 const models = require('../../../../core/server/models');
@@ -48,7 +49,7 @@ describe('Unit: models/member', function () {
             config.set('privacy:useGravatar', false);
             const json = toJSON(member);
 
-            should(json.avatar_image).eql(null);
+            assert.equal(json.avatar_image, null);
         });
     });
 
@@ -75,7 +76,7 @@ describe('Unit: models/member', function () {
                 id: '1'
             }]);
 
-            updatePivot.calledWith({expiry_at: new Date(expiry)}, {query: {where: {product_id: '1'}}}).should.be.true();
+            assert.equal(updatePivot.calledWith({expiry_at: new Date(expiry)}, {query: {where: {product_id: '1'}}}), true);
         });
 
         it('calls updatePivot on member products to remove expiry', function () {
@@ -83,7 +84,7 @@ describe('Unit: models/member', function () {
                 id: '1'
             }]);
 
-            updatePivot.calledWith({expiry_at: null}, {query: {where: {product_id: '1'}}}).should.be.true();
+            assert.equal(updatePivot.calledWith({expiry_at: null}, {query: {where: {product_id: '1'}}}), true);
         });
     });
 });

--- a/ghost/core/test/unit/server/models/newsletter.test.js
+++ b/ghost/core/test/unit/server/models/newsletter.test.js
@@ -1,4 +1,5 @@
 /* eslint no-invalid-this:0 */
+const assert = require('node:assert/strict');
 const errors = require('@tryghost/errors');
 const sinon = require('sinon');
 const should = require('should');
@@ -21,11 +22,11 @@ describe('Unit: models/newsletter', function () {
                         throw new Error('expected ValidationError');
                     })
                     .catch(function (err) {
-                        err.length.should.eql(2);
-                        (err[0] instanceof errors.ValidationError).should.eql(true);
-                        (err[1] instanceof errors.ValidationError).should.eql(true);
-                        err[0].message.should.match(/newsletters\.name/);
-                        err[1].message.should.match(/newsletters\.slug/);
+                        assert.equal(err.length, 2);
+                        assert.equal((err[0] instanceof errors.ValidationError), true);
+                        assert.equal((err[1] instanceof errors.ValidationError), true);
+                        assert.match(err[0].message, /newsletters\.name/);
+                        assert.match(err[1].message, /newsletters\.slug/);
                     });
             });
         });

--- a/ghost/core/test/unit/server/models/permission.test.js
+++ b/ghost/core/test/unit/server/models/permission.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const models = require('../../../../core/server/models');
@@ -17,10 +18,10 @@ describe('Unit: models/permission', function () {
         it('[error] validation', function () {
             return models.Permission.add({})
                 .then(function () {
-                    'Should fail'.should.be.true();
+                    assert.equal('Should fail', true);
                 })
                 .catch(function (err) {
-                    err.length.should.eql(3);
+                    assert.equal(err.length, 3);
                 });
         });
     });

--- a/ghost/core/test/unit/server/models/post.test.js
+++ b/ghost/core/test/unit/server/models/post.test.js
@@ -42,8 +42,8 @@ describe('Unit: models/post', function () {
                 limit: 3,
                 withRelated: ['tags']
             }).then(() => {
-                queries.length.should.eql(2);
-                queries[0].sql.should.eql('select count(distinct posts.id) as aggregate from `posts` where ((`posts`.`id` != ? and `posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` inner join `tags` on `tags`.`id` = `posts_tags`.`tag_id` where `tags`.`slug` in (?, ?))) and (`posts`.`type` = ? and `posts`.`status` = ?))');
+                assert.equal(queries.length, 2);
+                assert.equal(queries[0].sql, 'select count(distinct posts.id) as aggregate from `posts` where ((`posts`.`id` != ? and `posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` inner join `tags` on `tags`.`id` = `posts_tags`.`tag_id` where `tags`.`slug` in (?, ?))) and (`posts`.`type` = ? and `posts`.`status` = ?))');
                 queries[0].bindings.should.eql([
                     testUtils.filterData.data.posts[3].id,
                     'photo',
@@ -52,7 +52,7 @@ describe('Unit: models/post', function () {
                     'published'
                 ]);
 
-                queries[1].sql.should.eql('select `posts`.* from `posts` where ((`posts`.`id` != ? and `posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` inner join `tags` on `tags`.`id` = `posts_tags`.`tag_id` where `tags`.`slug` in (?, ?))) and (`posts`.`type` = ? and `posts`.`status` = ?)) order by (SELECT count(*) FROM posts_tags WHERE post_id = posts.id) DESC, CASE WHEN posts.status = \'scheduled\' THEN 1 WHEN posts.status = \'draft\' THEN 2 ELSE 3 END ASC,CASE WHEN posts.status != \'draft\' THEN posts.published_at END DESC,posts.updated_at DESC,posts.id DESC limit ?');
+                assert.equal(queries[1].sql, 'select `posts`.* from `posts` where ((`posts`.`id` != ? and `posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` inner join `tags` on `tags`.`id` = `posts_tags`.`tag_id` where `tags`.`slug` in (?, ?))) and (`posts`.`type` = ? and `posts`.`status` = ?)) order by (SELECT count(*) FROM posts_tags WHERE post_id = posts.id) DESC, CASE WHEN posts.status = \'scheduled\' THEN 1 WHEN posts.status = \'draft\' THEN 2 ELSE 3 END ASC,CASE WHEN posts.status != \'draft\' THEN posts.published_at END DESC,posts.updated_at DESC,posts.id DESC limit ?');
                 queries[1].bindings.should.eql([
                     testUtils.filterData.data.posts[3].id,
                     'photo',
@@ -77,8 +77,8 @@ describe('Unit: models/post', function () {
                 filter: 'authors:[leslie,pat]+(tag:hash-audio,feature_image:-null)',
                 withRelated: ['authors', 'tags']
             }).then(() => {
-                queries.length.should.eql(2);
-                queries[0].sql.should.eql('select count(distinct posts.id) as aggregate from `posts` where (((`posts`.`feature_image` is not null or `posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` inner join `tags` on `tags`.`id` = `posts_tags`.`tag_id` where `tags`.`slug` = ?)) and `posts`.`id` in (select `posts_authors`.`post_id` from `posts_authors` inner join `users` as `authors` on `authors`.`id` = `posts_authors`.`author_id` where `authors`.`slug` in (?, ?))) and (`posts`.`type` = ? and `posts`.`status` = ?))');
+                assert.equal(queries.length, 2);
+                assert.equal(queries[0].sql, 'select count(distinct posts.id) as aggregate from `posts` where (((`posts`.`feature_image` is not null or `posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` inner join `tags` on `tags`.`id` = `posts_tags`.`tag_id` where `tags`.`slug` = ?)) and `posts`.`id` in (select `posts_authors`.`post_id` from `posts_authors` inner join `users` as `authors` on `authors`.`id` = `posts_authors`.`author_id` where `authors`.`slug` in (?, ?))) and (`posts`.`type` = ? and `posts`.`status` = ?))');
                 queries[0].bindings.should.eql([
                     'hash-audio',
                     'leslie',
@@ -87,7 +87,7 @@ describe('Unit: models/post', function () {
                     'published'
                 ]);
 
-                queries[1].sql.should.eql('select `posts`.* from `posts` where (((`posts`.`feature_image` is not null or `posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` inner join `tags` on `tags`.`id` = `posts_tags`.`tag_id` where `tags`.`slug` = ?)) and `posts`.`id` in (select `posts_authors`.`post_id` from `posts_authors` inner join `users` as `authors` on `authors`.`id` = `posts_authors`.`author_id` where `authors`.`slug` in (?, ?))) and (`posts`.`type` = ? and `posts`.`status` = ?)) order by (SELECT count(*) FROM posts_authors WHERE post_id = posts.id) DESC, CASE WHEN posts.status = \'scheduled\' THEN 1 WHEN posts.status = \'draft\' THEN 2 ELSE 3 END ASC,CASE WHEN posts.status != \'draft\' THEN posts.published_at END DESC,posts.updated_at DESC,posts.id DESC limit ?');
+                assert.equal(queries[1].sql, 'select `posts`.* from `posts` where (((`posts`.`feature_image` is not null or `posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` inner join `tags` on `tags`.`id` = `posts_tags`.`tag_id` where `tags`.`slug` = ?)) and `posts`.`id` in (select `posts_authors`.`post_id` from `posts_authors` inner join `users` as `authors` on `authors`.`id` = `posts_authors`.`author_id` where `authors`.`slug` in (?, ?))) and (`posts`.`type` = ? and `posts`.`status` = ?)) order by (SELECT count(*) FROM posts_authors WHERE post_id = posts.id) DESC, CASE WHEN posts.status = \'scheduled\' THEN 1 WHEN posts.status = \'draft\' THEN 2 ELSE 3 END ASC,CASE WHEN posts.status != \'draft\' THEN posts.published_at END DESC,posts.updated_at DESC,posts.id DESC limit ?');
                 queries[1].bindings.should.eql([
                     'hash-audio',
                     'leslie',
@@ -113,15 +113,15 @@ describe('Unit: models/post', function () {
                 limit: 5,
                 withRelated: ['tags']
             }).then(() => {
-                queries.length.should.eql(2);
-                queries[0].sql.should.eql('select count(distinct posts.id) as aggregate from `posts` where (`posts`.`published_at` > ? and (`posts`.`type` = ? and `posts`.`status` = ?))');
+                assert.equal(queries.length, 2);
+                assert.equal(queries[0].sql, 'select count(distinct posts.id) as aggregate from `posts` where (`posts`.`published_at` > ? and (`posts`.`type` = ? and `posts`.`status` = ?))');
                 queries[0].bindings.should.eql([
                     '2015-07-20',
                     'post',
                     'published'
                 ]);
 
-                queries[1].sql.should.eql('select `posts`.* from `posts` where (`posts`.`published_at` > ? and (`posts`.`type` = ? and `posts`.`status` = ?)) order by CASE WHEN posts.status = \'scheduled\' THEN 1 WHEN posts.status = \'draft\' THEN 2 ELSE 3 END ASC,CASE WHEN posts.status != \'draft\' THEN posts.published_at END DESC,posts.updated_at DESC,posts.id DESC limit ?');
+                assert.equal(queries[1].sql, 'select `posts`.* from `posts` where (`posts`.`published_at` > ? and (`posts`.`type` = ? and `posts`.`status` = ?)) order by CASE WHEN posts.status = \'scheduled\' THEN 1 WHEN posts.status = \'draft\' THEN 2 ELSE 3 END ASC,CASE WHEN posts.status != \'draft\' THEN posts.published_at END DESC,posts.updated_at DESC,posts.id DESC limit ?');
                 queries[1].bindings.should.eql([
                     '2015-07-20',
                     'post',
@@ -145,8 +145,8 @@ describe('Unit: models/post', function () {
                     filter: 'primary_tag:photo',
                     withRelated: ['tags']
                 }).then(() => {
-                    queries.length.should.eql(2);
-                    queries[0].sql.should.eql('select count(distinct posts.id) as aggregate from `posts` where ((`posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` inner join `tags` on `tags`.`id` = `posts_tags`.`tag_id` and `posts_tags`.`sort_order` = 0 where `tags`.`slug` = ? and `tags`.`visibility` = ?)) and (`posts`.`type` = ? and `posts`.`status` = ?))');
+                    assert.equal(queries.length, 2);
+                    assert.equal(queries[0].sql, 'select count(distinct posts.id) as aggregate from `posts` where ((`posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` inner join `tags` on `tags`.`id` = `posts_tags`.`tag_id` and `posts_tags`.`sort_order` = 0 where `tags`.`slug` = ? and `tags`.`visibility` = ?)) and (`posts`.`type` = ? and `posts`.`status` = ?))');
                     queries[0].bindings.should.eql([
                         'photo',
                         'public',
@@ -154,7 +154,7 @@ describe('Unit: models/post', function () {
                         'published'
                     ]);
 
-                    queries[1].sql.should.eql('select `posts`.* from `posts` where ((`posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` inner join `tags` on `tags`.`id` = `posts_tags`.`tag_id` and `posts_tags`.`sort_order` = 0 where `tags`.`slug` = ? and `tags`.`visibility` = ?)) and (`posts`.`type` = ? and `posts`.`status` = ?)) order by CASE WHEN posts.status = \'scheduled\' THEN 1 WHEN posts.status = \'draft\' THEN 2 ELSE 3 END ASC,CASE WHEN posts.status != \'draft\' THEN posts.published_at END DESC,posts.updated_at DESC,posts.id DESC limit ?');
+                    assert.equal(queries[1].sql, 'select `posts`.* from `posts` where ((`posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` inner join `tags` on `tags`.`id` = `posts_tags`.`tag_id` and `posts_tags`.`sort_order` = 0 where `tags`.`slug` = ? and `tags`.`visibility` = ?)) and (`posts`.`type` = ? and `posts`.`status` = ?)) order by CASE WHEN posts.status = \'scheduled\' THEN 1 WHEN posts.status = \'draft\' THEN 2 ELSE 3 END ASC,CASE WHEN posts.status != \'draft\' THEN posts.published_at END DESC,posts.updated_at DESC,posts.id DESC limit ?');
                     queries[1].bindings.should.eql([
                         'photo',
                         'public',
@@ -178,8 +178,8 @@ describe('Unit: models/post', function () {
                     filter: 'primary_author:leslie',
                     withRelated: ['authors']
                 }).then(() => {
-                    queries.length.should.eql(2);
-                    queries[0].sql.should.eql('select count(distinct posts.id) as aggregate from `posts` where ((`posts`.`id` in (select `posts_authors`.`post_id` from `posts_authors` inner join `users` as `authors` on `authors`.`id` = `posts_authors`.`author_id` and `posts_authors`.`sort_order` = 0 where `authors`.`slug` = ? and `authors`.`visibility` = ?)) and (`posts`.`type` = ? and `posts`.`status` = ?))');
+                    assert.equal(queries.length, 2);
+                    assert.equal(queries[0].sql, 'select count(distinct posts.id) as aggregate from `posts` where ((`posts`.`id` in (select `posts_authors`.`post_id` from `posts_authors` inner join `users` as `authors` on `authors`.`id` = `posts_authors`.`author_id` and `posts_authors`.`sort_order` = 0 where `authors`.`slug` = ? and `authors`.`visibility` = ?)) and (`posts`.`type` = ? and `posts`.`status` = ?))');
                     queries[0].bindings.should.eql([
                         'leslie',
                         'public',
@@ -187,7 +187,7 @@ describe('Unit: models/post', function () {
                         'published'
                     ]);
 
-                    queries[1].sql.should.eql('select `posts`.* from `posts` where ((`posts`.`id` in (select `posts_authors`.`post_id` from `posts_authors` inner join `users` as `authors` on `authors`.`id` = `posts_authors`.`author_id` and `posts_authors`.`sort_order` = 0 where `authors`.`slug` = ? and `authors`.`visibility` = ?)) and (`posts`.`type` = ? and `posts`.`status` = ?)) order by CASE WHEN posts.status = \'scheduled\' THEN 1 WHEN posts.status = \'draft\' THEN 2 ELSE 3 END ASC,CASE WHEN posts.status != \'draft\' THEN posts.published_at END DESC,posts.updated_at DESC,posts.id DESC limit ?');
+                    assert.equal(queries[1].sql, 'select `posts`.* from `posts` where ((`posts`.`id` in (select `posts_authors`.`post_id` from `posts_authors` inner join `users` as `authors` on `authors`.`id` = `posts_authors`.`author_id` and `posts_authors`.`sort_order` = 0 where `authors`.`slug` = ? and `authors`.`visibility` = ?)) and (`posts`.`type` = ? and `posts`.`status` = ?)) order by CASE WHEN posts.status = \'scheduled\' THEN 1 WHEN posts.status = \'draft\' THEN 2 ELSE 3 END ASC,CASE WHEN posts.status != \'draft\' THEN posts.published_at END DESC,posts.updated_at DESC,posts.id DESC limit ?');
                     queries[1].bindings.should.eql([
                         'leslie',
                         'public',
@@ -221,9 +221,9 @@ describe('Unit: models/post', function () {
                         }]
                     }
                 }).then(() => {
-                    queries.length.should.eql(1);
+                    assert.equal(queries.length, 1);
 
-                    queries[0].sql.should.eql('select `posts`.* from `posts` where ((`posts`.`status` in (?, ?) and `posts`.`status` = ?) and (`posts`.`type` = ?)) order by CASE WHEN posts.status = \'scheduled\' THEN 1 WHEN posts.status = \'draft\' THEN 2 ELSE 3 END ASC,CASE WHEN posts.status != \'draft\' THEN posts.published_at END DESC,posts.updated_at DESC,posts.id DESC');
+                    assert.equal(queries[0].sql, 'select `posts`.* from `posts` where ((`posts`.`status` in (?, ?) and `posts`.`status` = ?) and (`posts`.`type` = ?)) order by CASE WHEN posts.status = \'scheduled\' THEN 1 WHEN posts.status = \'draft\' THEN 2 ELSE 3 END ASC,CASE WHEN posts.status != \'draft\' THEN posts.published_at END DESC,posts.updated_at DESC,posts.id DESC');
                     queries[0].bindings.should.eql([
                         'published',
                         'draft',
@@ -274,7 +274,7 @@ describe('Unit: models/post', function () {
             };
 
             const filter = new models.Post().extraFilters(options);
-            filter.should.eql('status:published');
+            assert.equal(filter, 'status:published');
         });
     });
 
@@ -292,7 +292,7 @@ describe('Unit: models/post', function () {
 
             const filter = enforcedFilters({}, options);
 
-            filter.should.equal('status:published');
+            assert.equal(filter, 'status:published');
         });
 
         it('returns no status filter for non public context', function () {
@@ -334,7 +334,7 @@ describe('Unit: models/post', function () {
 
             const filter = defaultFilters({}, options);
 
-            filter.should.equal('type:post');
+            assert.equal(filter, 'type:post');
         });
 
         it('returns type:post+status:published filter for non public context', function () {
@@ -344,7 +344,7 @@ describe('Unit: models/post', function () {
 
             const filter = defaultFilters({}, options);
 
-            filter.should.equal('type:post+status:published');
+            assert.equal(filter, 'type:post+status:published');
         });
     });
 
@@ -455,8 +455,8 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         done(new Error('Permissible function should have rejected.'));
                     }).catch((error) => {
                         error.should.be.an.instanceof(errors.NoPermissionError);
-                        should(mockPostObj.get.called).be.false();
-                        should(mockPostObj.related.calledTwice).be.false();
+                        assert.equal(mockPostObj.get.called, false);
+                        assert.equal(mockPostObj.related.calledTwice, false);
                         done();
                     });
                 });
@@ -483,9 +483,9 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         false
                     ).then((result) => {
                         should.exist(result);
-                        should(result.excludedAttrs).deepEqual(['authors', 'tags']);
-                        should(mockPostObj.get.callCount).eql(2);
-                        should(mockPostObj.related.callCount).eql(2);
+                        assert.deepEqual(result.excludedAttrs, ['authors', 'tags']);
+                        assert.equal(mockPostObj.get.callCount, 2);
+                        assert.equal(mockPostObj.related.callCount, 2);
                         done();
                     }).catch(done);
                 });
@@ -514,8 +514,8 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         done(new Error('Permissible function should have rejected.'));
                     }).catch((error) => {
                         error.should.be.an.instanceof(errors.NoPermissionError);
-                        should(mockPostObj.get.callCount).eql(2);
-                        should(mockPostObj.related.callCount).eql(1);
+                        assert.equal(mockPostObj.get.callCount, 2);
+                        assert.equal(mockPostObj.related.callCount, 1);
                         done();
                     });
                 });
@@ -543,7 +543,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         done(new Error('Permissible function should have rejected.'));
                     }).catch((error) => {
                         error.should.be.an.instanceof(errors.NoPermissionError);
-                        should(mockPostObj.related.callCount).eql(1);
+                        assert.equal(mockPostObj.related.callCount, 1);
                         done();
                     });
                 });
@@ -570,9 +570,9 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         false
                     ).then((result) => {
                         should.exist(result);
-                        should(result.excludedAttrs).deepEqual(['authors', 'tags']);
-                        should(mockPostObj.get.callCount).eql(2);
-                        should(mockPostObj.related.callCount).eql(1);
+                        assert.deepEqual(result.excludedAttrs, ['authors', 'tags']);
+                        assert.equal(mockPostObj.get.callCount, 2);
+                        assert.equal(mockPostObj.related.callCount, 1);
                     });
                 });
             });
@@ -598,7 +598,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         done(new Error('Permissible function should have rejected.'));
                     }).catch((error) => {
                         error.should.be.an.instanceof(errors.NoPermissionError);
-                        should(mockPostObj.get.called).be.false();
+                        assert.equal(mockPostObj.get.called, false);
                         done();
                     });
                 });
@@ -623,7 +623,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         done(new Error('Permissible function should have rejected.'));
                     }).catch((error) => {
                         error.should.be.an.instanceof(errors.NoPermissionError);
-                        should(mockPostObj.get.called).be.false();
+                        assert.equal(mockPostObj.get.called, false);
                         done();
                     });
                 });
@@ -648,7 +648,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         done(new Error('Permissible function should have rejected.'));
                     }).catch((error) => {
                         error.should.be.an.instanceof(errors.NoPermissionError);
-                        should(mockPostObj.get.called).be.false();
+                        assert.equal(mockPostObj.get.called, false);
                         done();
                     });
                 });
@@ -671,8 +671,8 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         true
                     ).then((result) => {
                         should.exist(result);
-                        should(result.excludedAttrs).deepEqual(['authors', 'tags']);
-                        should(mockPostObj.get.called).be.false();
+                        assert.deepEqual(result.excludedAttrs, ['authors', 'tags']);
+                        assert.equal(mockPostObj.get.called, false);
                         done();
                     }).catch(done);
                 });
@@ -701,8 +701,8 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         done(new Error('Permissible function should have rejected.'));
                     }).catch((error) => {
                         error.should.be.an.instanceof(errors.NoPermissionError);
-                        should(mockPostObj.get.calledOnce).be.true();
-                        should(mockPostObj.related.calledOnce).be.true();
+                        assert.equal(mockPostObj.get.calledOnce, true);
+                        assert.equal(mockPostObj.related.calledOnce, true);
                         done();
                     });
                 });
@@ -730,8 +730,8 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         done(new Error('Permissible function should have rejected.'));
                     }).catch((error) => {
                         error.should.be.an.instanceof(errors.NoPermissionError);
-                        should(mockPostObj.get.calledOnce).be.true();
-                        should(mockPostObj.related.calledOnce).be.true();
+                        assert.equal(mockPostObj.get.calledOnce, true);
+                        assert.equal(mockPostObj.related.calledOnce, true);
                         done();
                     });
                 });
@@ -757,9 +757,9 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         true
                     ).then((result) => {
                         should.exist(result);
-                        should(result.excludedAttrs).deepEqual(['authors', 'tags']);
-                        should(mockPostObj.get.calledOnce).be.true();
-                        should(mockPostObj.related.calledOnce).be.true();
+                        assert.deepEqual(result.excludedAttrs, ['authors', 'tags']);
+                        assert.equal(mockPostObj.get.calledOnce, true);
+                        assert.equal(mockPostObj.related.calledOnce, true);
                     });
                 });
             });
@@ -790,8 +790,8 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         done(new Error('Permissible function should have rejected.'));
                     }).catch((error) => {
                         error.should.be.an.instanceof(errors.NoPermissionError);
-                        should(mockPostObj.get.called).be.false();
-                        should(mockPostObj.related.calledOnce).be.true();
+                        assert.equal(mockPostObj.get.called, false);
+                        assert.equal(mockPostObj.related.calledOnce, true);
                         done();
                     });
                 });
@@ -820,8 +820,8 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         done(new Error('Permissible function should have rejected.'));
                     }).catch((error) => {
                         error.should.be.an.instanceof(errors.NoPermissionError);
-                        should(mockPostObj.get.called).be.false();
-                        should(mockPostObj.related.calledOnce).be.true();
+                        assert.equal(mockPostObj.get.called, false);
+                        assert.equal(mockPostObj.related.calledOnce, true);
                         done();
                     });
                 });
@@ -849,8 +849,8 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         done(new Error('Permissible function should have rejected.'));
                     }).catch((error) => {
                         error.should.be.an.instanceof(errors.NoPermissionError);
-                        should(mockPostObj.get.called).be.false();
-                        should(mockPostObj.related.calledTwice).be.true();
+                        assert.equal(mockPostObj.get.called, false);
+                        assert.equal(mockPostObj.related.calledTwice, true);
                         done();
                     });
                 });
@@ -878,8 +878,8 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         done(new Error('Permissible function should have rejected.'));
                     }).catch((error) => {
                         error.should.be.an.instanceof(errors.NoPermissionError);
-                        should(mockPostObj.get.called).be.false();
-                        should(mockPostObj.related.calledTwice).be.true();
+                        assert.equal(mockPostObj.get.called, false);
+                        assert.equal(mockPostObj.related.calledTwice, true);
                         done();
                     });
                 });
@@ -903,7 +903,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         true,
                         true
                     ).then(() => {
-                        should(mockPostObj.related.calledOnce).be.true();
+                        assert.equal(mockPostObj.related.calledOnce, true);
                     });
                 });
             });
@@ -929,7 +929,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         done(new Error('Permissible function should have rejected.'));
                     }).catch((error) => {
                         error.should.be.an.instanceof(errors.NoPermissionError);
-                        should(mockPostObj.get.called).be.false();
+                        assert.equal(mockPostObj.get.called, false);
                         done();
                     });
                 });
@@ -957,7 +957,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         done(new Error('Permissible function should have rejected.'));
                     }).catch((error) => {
                         error.should.be.an.instanceof(errors.NoPermissionError);
-                        should(mockPostObj.get.called).be.false();
+                        assert.equal(mockPostObj.get.called, false);
                         done();
                     });
                 });
@@ -988,8 +988,8 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                     done(new Error('Permissible function should have rejected.'));
                 }).catch((error) => {
                     error.should.be.an.instanceof(errors.NoPermissionError);
-                    should(mockPostObj.get.called).be.false();
-                    should(mockPostObj.related.calledOnce).be.true();
+                    assert.equal(mockPostObj.get.called, false);
+                    assert.equal(mockPostObj.related.calledOnce, true);
                     done();
                 });
             });
@@ -1011,7 +1011,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                     true,
                     true
                 ).then(() => {
-                    should(mockPostObj.get.called).be.false();
+                    assert.equal(mockPostObj.get.called, false);
                 });
             });
 
@@ -1036,8 +1036,8 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                     true,
                     true
                 ).then(() => {
-                    should(mockPostObj.get.called).be.false();
-                    should(mockPostObj.related.calledOnce).be.true();
+                    assert.equal(mockPostObj.get.called, false);
+                    assert.equal(mockPostObj.related.calledOnce, true);
                     done();
                 }).catch(() => {
                     done(new Error('Permissible function should have passed for owner.'));
@@ -1065,8 +1065,8 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                     true,
                     true
                 ).then(() => {
-                    should(mockPostObj.get.called).be.false();
-                    should(mockPostObj.related.calledOnce).be.true();
+                    assert.equal(mockPostObj.get.called, false);
+                    assert.equal(mockPostObj.related.calledOnce, true);
                     done();
                 }).catch(() => {
                     done(new Error('Permissible function should have passed for administrator.'));

--- a/ghost/core/test/unit/server/models/set-is-roles.test.js
+++ b/ghost/core/test/unit/server/models/set-is-roles.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const {setIsRoles} = require('../../../../core/server/models/role-utils');
 
@@ -66,93 +67,93 @@ describe('setIsRoles function behavior', function () {
     it('returns the correct object for Editor', function () {
         let result = setIsRoles(loadedPermissionsEditor);
         result.should.be.an.Object();
-        result.isOwner.should.equal(false);
-        result.isAdmin.should.equal(false);
-        result.isEditor.should.equal(true);
-        result.isAuthor.should.equal(false);
-        result.isContributor.should.equal(false);
-        result.isSuperEditor.should.equal(false);
-        result.isEitherEditor.should.equal(true);
+        assert.equal(result.isOwner, false);
+        assert.equal(result.isAdmin, false);
+        assert.equal(result.isEditor, true);
+        assert.equal(result.isAuthor, false);
+        assert.equal(result.isContributor, false);
+        assert.equal(result.isSuperEditor, false);
+        assert.equal(result.isEitherEditor, true);
     });
 
     it('returns the correct object for Administrator', function () {
         let result = setIsRoles(loadedPermissionsAdmin);
         result.should.be.an.Object();
-        result.isOwner.should.equal(false);
-        result.isAdmin.should.equal(true);
-        result.isEditor.should.equal(false);
-        result.isAuthor.should.equal(false);
-        result.isContributor.should.equal(false);
-        result.isSuperEditor.should.equal(false);
-        result.isEitherEditor.should.equal(false);
+        assert.equal(result.isOwner, false);
+        assert.equal(result.isAdmin, true);
+        assert.equal(result.isEditor, false);
+        assert.equal(result.isAuthor, false);
+        assert.equal(result.isContributor, false);
+        assert.equal(result.isSuperEditor, false);
+        assert.equal(result.isEitherEditor, false);
     });
 
     it('returns the correct object for Author', function () {
         let result = setIsRoles(loadedPermissionsAuthor);
         result.should.be.an.Object();
-        result.isOwner.should.equal(false);
-        result.isAdmin.should.equal(false);
-        result.isEditor.should.equal(false);
-        result.isAuthor.should.equal(true);
-        result.isContributor.should.equal(false);
-        result.isSuperEditor.should.equal(false);
-        result.isEitherEditor.should.equal(false);
+        assert.equal(result.isOwner, false);
+        assert.equal(result.isAdmin, false);
+        assert.equal(result.isEditor, false);
+        assert.equal(result.isAuthor, true);
+        assert.equal(result.isContributor, false);
+        assert.equal(result.isSuperEditor, false);
+        assert.equal(result.isEitherEditor, false);
     });
 
     it('returns the correct object for Super Editor', function () {
         let result = setIsRoles(loadedPermissionsSuperEditor);
         result.should.be.an.Object();
-        result.isOwner.should.equal(false);
-        result.isAdmin.should.equal(false);
-        result.isEditor.should.equal(false);
-        result.isAuthor.should.equal(false);
-        result.isContributor.should.equal(false);
-        result.isSuperEditor.should.equal(true);
-        result.isEitherEditor.should.equal(true);
+        assert.equal(result.isOwner, false);
+        assert.equal(result.isAdmin, false);
+        assert.equal(result.isEditor, false);
+        assert.equal(result.isAuthor, false);
+        assert.equal(result.isContributor, false);
+        assert.equal(result.isSuperEditor, true);
+        assert.equal(result.isEitherEditor, true);
     });
 
     it('returns the correct object for multiple roles', function () {
         let result = setIsRoles(loadedPermissionsWithMultipleRoles);
         result.should.be.an.Object();
-        result.isOwner.should.equal(false);
-        result.isAdmin.should.equal(false);
-        result.isEditor.should.equal(true);
-        result.isAuthor.should.equal(true);
-        result.isContributor.should.equal(false);
-        result.isSuperEditor.should.equal(false);
-        result.isEitherEditor.should.equal(true);
+        assert.equal(result.isOwner, false);
+        assert.equal(result.isAdmin, false);
+        assert.equal(result.isEditor, true);
+        assert.equal(result.isAuthor, true);
+        assert.equal(result.isContributor, false);
+        assert.equal(result.isSuperEditor, false);
+        assert.equal(result.isEitherEditor, true);
     });
     it('returns the correct object for no roles', function () {
         let result = setIsRoles(loadedPermissionsWithNoRoles);
         result.should.be.an.Object();
-        result.isOwner.should.equal(false);
-        result.isAdmin.should.equal(false);
-        result.isEditor.should.equal(false);
-        result.isAuthor.should.equal(false);
-        result.isContributor.should.equal(false);
-        result.isSuperEditor.should.equal(false);
-        result.isEitherEditor.should.equal(false);
+        assert.equal(result.isOwner, false);
+        assert.equal(result.isAdmin, false);
+        assert.equal(result.isEditor, false);
+        assert.equal(result.isAuthor, false);
+        assert.equal(result.isContributor, false);
+        assert.equal(result.isSuperEditor, false);
+        assert.equal(result.isEitherEditor, false);
     });
     it('returns the correct object for no user', function () {
         let result = setIsRoles(loadedPermissionsWithNoUser);
         result.should.be.an.Object();
-        result.isOwner.should.equal(false);
-        result.isAdmin.should.equal(false);
-        result.isEditor.should.equal(false);
-        result.isAuthor.should.equal(false);
-        result.isContributor.should.equal(false);
-        result.isSuperEditor.should.equal(false);
-        result.isEitherEditor.should.equal(false);
+        assert.equal(result.isOwner, false);
+        assert.equal(result.isAdmin, false);
+        assert.equal(result.isEditor, false);
+        assert.equal(result.isAuthor, false);
+        assert.equal(result.isContributor, false);
+        assert.equal(result.isSuperEditor, false);
+        assert.equal(result.isEitherEditor, false);
     });
     it('returns the correct object for permissions without role', function () {
         let result = setIsRoles(loadedPermissionswithPermissions);
         result.should.be.an.Object();
-        result.isOwner.should.equal(false);
-        result.isAdmin.should.equal(false);
-        result.isEditor.should.equal(false);
-        result.isAuthor.should.equal(false);
-        result.isContributor.should.equal(false);
-        result.isSuperEditor.should.equal(false);
-        result.isEitherEditor.should.equal(false);
+        assert.equal(result.isOwner, false);
+        assert.equal(result.isAdmin, false);
+        assert.equal(result.isEditor, false);
+        assert.equal(result.isAuthor, false);
+        assert.equal(result.isContributor, false);
+        assert.equal(result.isSuperEditor, false);
+        assert.equal(result.isEitherEditor, false);
     });
 });

--- a/ghost/core/test/unit/server/models/settings.test.js
+++ b/ghost/core/test/unit/server/models/settings.test.js
@@ -50,9 +50,9 @@ describe('Unit: models/settings', function () {
                 type: 'string'
             })
                 .then(() => {
-                    eventSpy.calledTwice.should.be.true();
-                    eventSpy.firstCall.calledWith('settings.added').should.be.true();
-                    eventSpy.secondCall.calledWith('settings.description.added').should.be.true();
+                    assert.equal(eventSpy.calledTwice, true);
+                    assert.equal(eventSpy.firstCall.calledWith('settings.added'), true);
+                    assert.equal(eventSpy.secondCall.calledWith('settings.description.added'), true);
                 });
         });
 
@@ -74,9 +74,9 @@ describe('Unit: models/settings', function () {
                 value: 'edited value'
             })
                 .then(() => {
-                    eventSpy.calledTwice.should.be.true();
-                    eventSpy.firstCall.calledWith('settings.edited').should.be.true();
-                    eventSpy.secondCall.calledWith('settings.description.edited').should.be.true();
+                    assert.equal(eventSpy.calledTwice, true);
+                    assert.equal(eventSpy.firstCall.calledWith('settings.edited'), true);
+                    assert.equal(eventSpy.secondCall.calledWith('settings.description.edited'), true);
                 });
         });
     });

--- a/ghost/core/test/unit/server/models/subscription-created-event.test.js
+++ b/ghost/core/test/unit/server/models/subscription-created-event.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const errors = require('@tryghost/errors');
@@ -19,9 +20,9 @@ describe('Unit: models/SubscriptionCreatedEvent', function () {
                     throw new Error('expected ValidationError');
                 })
                 .catch(function (err) {
-                    should(err).lengthOf(1);
-                    (err[0] instanceof errors.ValidationError).should.eql(true);
-                    err[0].context.should.match(/members_subscription_created_events\.attribution_type/);
+                    assert.equal(err.length, 1);
+                    assert.equal((err[0] instanceof errors.ValidationError), true);
+                    assert.match(err[0].context, /members_subscription_created_events\.attribution_type/);
                 });
         });
 
@@ -31,9 +32,9 @@ describe('Unit: models/SubscriptionCreatedEvent', function () {
                     throw new Error('expected ValidationError');
                 })
                 .catch(function (err) {
-                    should(err).lengthOf(1);
-                    (err[0] instanceof errors.ValidationError).should.eql(true);
-                    err[0].context.should.match(/members_subscription_created_events\.member_id/);
+                    assert.equal(err.length, 1);
+                    assert.equal((err[0] instanceof errors.ValidationError), true);
+                    assert.match(err[0].context, /members_subscription_created_events\.member_id/);
                 });
         });
 
@@ -43,9 +44,9 @@ describe('Unit: models/SubscriptionCreatedEvent', function () {
                     throw new Error('expected ValidationError');
                 })
                 .catch(function (err) {
-                    should(err).lengthOf(1);
-                    (err[0] instanceof errors.ValidationError).should.eql(true);
-                    err[0].context.should.match(/members_subscription_created_events\.subscription_id/);
+                    assert.equal(err.length, 1);
+                    assert.equal((err[0] instanceof errors.ValidationError), true);
+                    assert.match(err[0].context, /members_subscription_created_events\.subscription_id/);
                 });
         });
     });

--- a/ghost/core/test/unit/server/models/tag.test.js
+++ b/ghost/core/test/unit/server/models/tag.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const models = require('../../../../core/server/models');
@@ -44,9 +45,9 @@ describe('Unit: models/tag', function () {
                 limit: 'all',
                 withRelated: ['count.posts']
             }).then(() => {
-                queries.length.should.eql(1);
+                assert.equal(queries.length, 1);
 
-                queries[0].sql.should.eql('select `tags`.*, (select count(`posts`.`id`) from `posts` left outer join `posts_tags` on `posts`.`id` = `posts_tags`.`post_id` where posts_tags.tag_id = tags.id) as `count__posts` from `tags` where `count`.`posts` >= ? order by `count__posts` DESC');
+                assert.equal(queries[0].sql, 'select `tags`.*, (select count(`posts`.`id`) from `posts` left outer join `posts_tags` on `posts`.`id` = `posts_tags`.`post_id` where posts_tags.tag_id = tags.id) as `count__posts` from `tags` where `count`.`posts` >= ? order by `count__posts` DESC');
                 queries[0].bindings.should.eql([
                     1
                 ]);

--- a/ghost/core/test/unit/server/models/user.test.js
+++ b/ghost/core/test/unit/server/models/user.test.js
@@ -55,8 +55,8 @@ describe('Unit: models/user', function () {
                         throw new Error('expected ValidationError');
                     })
                     .catch(function (err) {
-                        (err instanceof errors.ValidationError).should.eql(true);
-                        err.message.should.match(/users\.name/);
+                        assert.equal((err instanceof errors.ValidationError), true);
+                        assert.match(err.message, /users\.name/);
                     });
             });
 
@@ -70,8 +70,8 @@ describe('Unit: models/user', function () {
                     })
                     .catch(function (err) {
                         err.should.be.an.Array();
-                        (err[0] instanceof errors.ValidationError).should.eql(true);
-                        err[0].message.should.match(/users\.email/);
+                        assert.equal((err[0] instanceof errors.ValidationError), true);
+                        assert.match(err[0].message, /users\.email/);
                     });
             });
         });
@@ -129,7 +129,7 @@ describe('Unit: models/user', function () {
 
             return models.User.check({email: user.get('email'), password: 'test'})
                 .catch(function (err) {
-                    (err instanceof errors.ValidationError).should.eql(true);
+                    assert.equal((err instanceof errors.ValidationError), true);
                 });
         });
 
@@ -143,7 +143,7 @@ describe('Unit: models/user', function () {
 
             return models.User.check({email: user.get('email'), password: 'test'})
                 .catch(function (err) {
-                    (err instanceof errors.PasswordResetRequiredError).should.eql(true);
+                    assert.equal((err instanceof errors.PasswordResetRequiredError), true);
                 });
         });
     });
@@ -170,7 +170,7 @@ describe('Unit: models/user', function () {
                 done(new Error('Permissible function should have errored'));
             }).catch((error) => {
                 error.should.be.an.instanceof(errors.NoPermissionError);
-                should(mockUser.hasRole.calledOnce).be.true();
+                assert.equal(mockUser.hasRole.calledOnce, true);
                 done();
             });
         });
@@ -180,7 +180,7 @@ describe('Unit: models/user', function () {
             const context = {user: 3};
 
             return models.User.permissible(mockUser, 'edit', context, {}, testUtils.permissions.contributor, false, true, true).then(() => {
-                should(mockUser.get.calledOnce).be.true();
+                assert.equal(mockUser.get.calledOnce, true);
             });
         });
 
@@ -206,7 +206,7 @@ describe('Unit: models/user', function () {
 
             return models.User.permissible(mockUser, 'edit', context, {}, testUtils.permissions.contributor, false, true, true)
                 .then(() => {
-                    models.User.findOne.calledOnce.should.be.true();
+                    assert.equal(models.User.findOne.calledOnce, true);
                 });
         });
 
@@ -259,7 +259,7 @@ describe('Unit: models/user', function () {
 
                 return models.User.permissible(mockUser, 'edit', context, unsafeAttrs, testUtils.permissions.owner, false, true, true)
                     .then(() => {
-                        models.User.getOwnerUser.calledOnce.should.be.true();
+                        assert.equal(models.User.getOwnerUser.calledOnce, true);
                     });
             });
 
@@ -288,8 +288,8 @@ describe('Unit: models/user', function () {
 
                 return models.User.permissible(mockUser, 'edit', context, unsafeAttrs, testUtils.permissions.admin, true, true, true)
                     .then(() => {
-                        models.User.getOwnerUser.calledOnce.should.be.true();
-                        permissions.canThis.calledOnce.should.be.true();
+                        assert.equal(models.User.getOwnerUser.calledOnce, true);
+                        assert.equal(permissions.canThis.calledOnce, true);
                     });
             });
 
@@ -321,8 +321,8 @@ describe('Unit: models/user', function () {
                     done(new Error('Permissible function should have errored'));
                 }).catch((error) => {
                     error.should.be.an.instanceof(errors.NoPermissionError);
-                    should(mockUser.hasRole.called).be.true();
-                    should(mockUser.get.calledOnce).be.true();
+                    assert.equal(mockUser.hasRole.called, true);
+                    assert.equal(mockUser.get.calledOnce, true);
                     done();
                 });
             });
@@ -335,8 +335,8 @@ describe('Unit: models/user', function () {
                     done(new Error('Permissible function should have errored'));
                 }).catch((error) => {
                     error.should.be.an.instanceof(errors.NoPermissionError);
-                    should(mockUser.hasRole.called).be.true();
-                    should(mockUser.get.calledOnce).be.true();
+                    assert.equal(mockUser.hasRole.called, true);
+                    assert.equal(mockUser.get.calledOnce, true);
                     done();
                 });
             });
@@ -349,8 +349,8 @@ describe('Unit: models/user', function () {
                     done(new Error('Permissible function should have errored'));
                 }).catch((error) => {
                     error.should.be.an.instanceof(errors.NoPermissionError);
-                    should(mockUser.hasRole.called).be.true();
-                    should(mockUser.get.calledOnce).be.true();
+                    assert.equal(mockUser.hasRole.called, true);
+                    assert.equal(mockUser.get.calledOnce, true);
                     done();
                 });
             });
@@ -360,8 +360,8 @@ describe('Unit: models/user', function () {
                 const context = {user: 2};
 
                 return models.User.permissible(mockUser, 'edit', context, {}, testUtils.permissions.editor, true, true, true).then(() => {
-                    should(mockUser.hasRole.called).be.true();
-                    should(mockUser.get.calledOnce).be.true();
+                    assert.equal(mockUser.hasRole.called, true);
+                    assert.equal(mockUser.get.calledOnce, true);
                 });
             });
 
@@ -370,8 +370,8 @@ describe('Unit: models/user', function () {
                 const context = {user: 2};
 
                 return models.User.permissible(mockUser, 'edit', context, {}, testUtils.permissions.editor, true, true, true).then(() => {
-                    should(mockUser.hasRole.called).be.true();
-                    should(mockUser.get.calledOnce).be.true();
+                    assert.equal(mockUser.hasRole.called, true);
+                    assert.equal(mockUser.get.calledOnce, true);
                 });
             });
 
@@ -380,8 +380,8 @@ describe('Unit: models/user', function () {
                 const context = {user: 3};
 
                 return models.User.permissible(mockUser, 'destroy', context, {}, testUtils.permissions.editor, true, true, true).then(() => {
-                    should(mockUser.hasRole.called).be.true();
-                    should(mockUser.get.calledOnce).be.true();
+                    assert.equal(mockUser.hasRole.called, true);
+                    assert.equal(mockUser.get.calledOnce, true);
                 });
             });
 
@@ -393,8 +393,8 @@ describe('Unit: models/user', function () {
                     done(new Error('Permissible function should have errored'));
                 }).catch((error) => {
                     error.should.be.an.instanceof(errors.NoPermissionError);
-                    should(mockUser.hasRole.called).be.true();
-                    should(mockUser.get.calledOnce).be.true();
+                    assert.equal(mockUser.hasRole.called, true);
+                    assert.equal(mockUser.get.calledOnce, true);
                     done();
                 });
             });
@@ -407,8 +407,8 @@ describe('Unit: models/user', function () {
                     done(new Error('Permissible function should have errored'));
                 }).catch((error) => {
                     error.should.be.an.instanceof(errors.NoPermissionError);
-                    should(mockUser.hasRole.called).be.true();
-                    should(mockUser.get.calledOnce).be.true();
+                    assert.equal(mockUser.hasRole.called, true);
+                    assert.equal(mockUser.get.calledOnce, true);
                     done();
                 });
             });
@@ -418,8 +418,8 @@ describe('Unit: models/user', function () {
                 const context = {user: 2};
 
                 return models.User.permissible(mockUser, 'destroy', context, {}, testUtils.permissions.editor, true, true, true).then(() => {
-                    should(mockUser.hasRole.called).be.true();
-                    should(mockUser.get.calledOnce).be.true();
+                    assert.equal(mockUser.hasRole.called, true);
+                    assert.equal(mockUser.get.calledOnce, true);
                 });
             });
 
@@ -428,8 +428,8 @@ describe('Unit: models/user', function () {
                 const context = {user: 2};
 
                 return models.User.permissible(mockUser, 'destroy', context, {}, testUtils.permissions.editor, true, true, true).then(() => {
-                    should(mockUser.hasRole.called).be.true();
-                    should(mockUser.get.calledOnce).be.true();
+                    assert.equal(mockUser.hasRole.called, true);
+                    assert.equal(mockUser.get.calledOnce, true);
                 });
             });
         });
@@ -577,7 +577,7 @@ describe('Unit: models/user', function () {
 
             return models.User.transferOwnership({id: userToChange.context.user}, loggedInUser)
                 .then(() => {
-                    clearSpy.calledOnce.should.be.true();
+                    assert.equal(clearSpy.calledOnce, true);
                     assert.equal(models.User.ownerIdCache.get(), null);
                 })
                 .finally(() => {
@@ -607,9 +607,9 @@ describe('Unit: models/user', function () {
                 .resolves(users);
 
             return models.User.getEmailAlertUsers('free-signup', {}).then((alertUsers) => {
-                alertUsers.length.should.eql(2);
-                alertUsers[0].roles[0].name.should.eql('Owner');
-                alertUsers[1].roles[0].name.should.eql('Administrator');
+                assert.equal(alertUsers.length, 2);
+                assert.equal(alertUsers[0].roles[0].name, 'Owner');
+                assert.equal(alertUsers[1].roles[0].name, 'Administrator');
             });
         });
     });
@@ -620,7 +620,7 @@ describe('Unit: models/user', function () {
 
             return models.User.isSetup()
                 .then((result) => {
-                    result.should.be.true();
+                    assert.equal(result, true);
                 });
         });
 
@@ -629,7 +629,7 @@ describe('Unit: models/user', function () {
 
             return models.User.isSetup()
                 .then((result) => {
-                    result.should.be.false();
+                    assert.equal(result, false);
                 });
         });
     });
@@ -670,7 +670,7 @@ describe('Unit: models/user', function () {
             return models.User.getOwnerId()
                 .then((ownerId) => {
                     assert.equal(ownerId, 'abc123');
-                    models.User.getOwnerUser.called.should.be.false();
+                    assert.equal(models.User.getOwnerUser.called, false);
                 });
         });
 
@@ -684,7 +684,7 @@ describe('Unit: models/user', function () {
             return models.User.getOwnerId()
                 .then((ownerId) => {
                     assert.equal(ownerId, mockOwner.id);
-                    models.User.getOwnerUser.calledOnce.should.be.true();
+                    assert.equal(models.User.getOwnerUser.calledOnce, true);
                     assert.equal(models.User.ownerIdCache.get(), mockOwner.id);
                 });
         });
@@ -699,13 +699,13 @@ describe('Unit: models/user', function () {
             return models.User.getOwnerId()
                 .then((ownerId) => {
                     assert.equal(ownerId, mockOwner.id);
-                    models.User.getOwnerUser.calledOnce.should.be.true();
+                    assert.equal(models.User.getOwnerUser.calledOnce, true);
 
                     return models.User.getOwnerId();
                 })
                 .then((ownerId) => {
                     assert.equal(ownerId, mockOwner.id);
-                    models.User.getOwnerUser.calledOnce.should.be.true();
+                    assert.equal(models.User.getOwnerUser.calledOnce, true);
                 });
         });
 
@@ -721,8 +721,8 @@ describe('Unit: models/user', function () {
 
             return models.User.getOwnerId(options)
                 .then(() => {
-                    models.User.getOwnerUser.calledOnce.should.be.true();
-                    models.User.getOwnerUser.calledWith(options).should.be.true();
+                    assert.equal(models.User.getOwnerUser.calledOnce, true);
+                    assert.equal(models.User.getOwnerUser.calledWith(options), true);
                 });
         });
     });

--- a/ghost/core/test/unit/server/notify.test.js
+++ b/ghost/core/test/unit/server/notify.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 
@@ -40,24 +41,24 @@ describe('Notify', function () {
         it('it communicates with IPC correctly on success', function () {
             notify.notifyServerStarted();
 
-            process.send.calledOnce.should.be.true();
+            assert.equal(process.send.calledOnce, true);
 
             let message = process.send.firstCall.args[0];
             message.should.be.an.Object().with.properties('started', 'debug');
             message.should.not.have.property('error');
-            message.started.should.be.true();
+            assert.equal(message.started, true);
         });
 
         it('communicates with IPC correctly on failure', function () {
             notify.notifyServerStarted(new Error('something went wrong'));
 
-            process.send.calledOnce.should.be.true();
+            assert.equal(process.send.calledOnce, true);
 
             let message = process.send.firstCall.args[0];
             message.should.be.an.Object().with.properties('started', 'debug', 'error');
-            message.started.should.be.false();
+            assert.equal(message.started, false);
             message.error.should.be.an.Object().with.properties('message');
-            message.error.message.should.eql('something went wrong');
+            assert.equal(message.error.message, 'something went wrong');
         });
 
         it('communicates via bootstrap socket correctly on success', function () {
@@ -65,13 +66,13 @@ describe('Notify', function () {
 
             notify.notifyServerStarted();
 
-            socketStub.calledOnce.should.be.true();
-            socketStub.firstCall.args[0].should.eql('testing');
+            assert.equal(socketStub.calledOnce, true);
+            assert.equal(socketStub.firstCall.args[0], 'testing');
 
             let message = socketStub.firstCall.args[1];
             message.should.be.an.Object().with.properties('started', 'debug');
             message.should.not.have.property('error');
-            message.started.should.be.true();
+            assert.equal(message.started, true);
         });
 
         it('communicates via bootstrap socket correctly on failure', function () {
@@ -79,14 +80,14 @@ describe('Notify', function () {
 
             notify.notifyServerStarted(new Error('something went wrong'));
 
-            socketStub.calledOnce.should.be.true();
-            socketStub.firstCall.args[0].should.eql('testing');
+            assert.equal(socketStub.calledOnce, true);
+            assert.equal(socketStub.firstCall.args[0], 'testing');
 
             let message = socketStub.firstCall.args[1];
             message.should.be.an.Object().with.properties('started', 'debug', 'error');
-            message.started.should.be.false();
+            assert.equal(message.started, false);
             message.error.should.be.an.Object().with.properties('message');
-            message.error.message.should.eql('something went wrong');
+            assert.equal(message.error.message, 'something went wrong');
         });
 
         it('can be called multiple times, but only communicates once', function () {
@@ -96,8 +97,8 @@ describe('Notify', function () {
             notify.notifyServerStarted(new Error('something went wrong'));
             notify.notifyServerStarted();
 
-            process.send.calledOnce.should.be.true();
-            socketStub.calledOnce.should.be.true();
+            assert.equal(process.send.calledOnce, true);
+            assert.equal(socketStub.calledOnce, true);
         });
     });
 });

--- a/ghost/core/test/unit/server/services/adapter-manager/options-resolver.test.js
+++ b/ghost/core/test/unit/server/services/adapter-manager/options-resolver.test.js
@@ -15,7 +15,7 @@ describe('Adapter Manager: options resolver', function () {
 
         const {adapterClassName, adapterConfig} = resolveAdapterOptions(name, adapterServiceConfig);
 
-        adapterClassName.should.equal('Memory');
+        assert.equal(adapterClassName, 'Memory');
         assert.equal(adapterConfig, undefined);
     });
 
@@ -32,7 +32,7 @@ describe('Adapter Manager: options resolver', function () {
 
         const {adapterClassName, adapterConfig} = resolveAdapterOptions(name, adapterServiceConfig);
 
-        adapterClassName.should.equal('cloud-storage');
+        assert.equal(adapterClassName, 'cloud-storage');
         adapterConfig.should.deepEqual({
             custom: 'configValue'
         });
@@ -55,7 +55,7 @@ describe('Adapter Manager: options resolver', function () {
 
         const {adapterClassName, adapterConfig} = resolveAdapterOptions(name, adapterServiceConfig);
 
-        adapterClassName.should.equal('local-storage');
+        assert.equal(adapterClassName, 'local-storage');
         adapterConfig.should.deepEqual({
             custom: 'localStorageConfig'
         });
@@ -79,7 +79,7 @@ describe('Adapter Manager: options resolver', function () {
 
         const {adapterClassName, adapterConfig} = resolveAdapterOptions(name, adapterServiceConfig);
 
-        adapterClassName.should.equal('cloud-storage');
+        assert.equal(adapterClassName, 'cloud-storage');
         adapterConfig.should.deepEqual({
             custom: 'configValue'
         });
@@ -106,7 +106,7 @@ describe('Adapter Manager: options resolver', function () {
 
         const {adapterClassName, adapterConfig} = resolveAdapterOptions(primaryadapterClassName, adapterServiceConfig);
 
-        adapterClassName.should.equal('Redis');
+        assert.equal(adapterClassName, 'Redis');
         adapterConfig.should.deepEqual({
             commonConfigValue: 'common_config_value',
             adapterConfigValue: 'images_redis_value'
@@ -114,7 +114,7 @@ describe('Adapter Manager: options resolver', function () {
 
         const {adapterClassName: secondadapterClassName, adapterConfig: secondAdapterConfig} = resolveAdapterOptions(secondaryadapterClassName, adapterServiceConfig);
 
-        secondadapterClassName.should.equal('Redis');
+        assert.equal(secondadapterClassName, 'Redis');
         secondAdapterConfig.should.deepEqual({
             commonConfigValue: 'common_config_value',
             adapterConfigValue: 'settings_redis_value'
@@ -139,14 +139,14 @@ describe('Adapter Manager: options resolver', function () {
 
         const {adapterClassName, adapterConfig} = resolveAdapterOptions(primaryadapterClassName, adapterServiceConfig);
 
-        adapterClassName.should.equal('Redis');
+        assert.equal(adapterClassName, 'Redis');
         adapterConfig.should.deepEqual({
             adapterConfigValue: 'images_redis_value'
         });
 
         const {adapterClassName: secondadapterClassName, adapterConfig: secondAdapterConfig} = resolveAdapterOptions(secondaryadapterClassName, adapterServiceConfig);
 
-        secondadapterClassName.should.equal('Redis');
+        assert.equal(secondadapterClassName, 'Redis');
         secondAdapterConfig.should.deepEqual({
             adapterConfigValue: 'settings_redis_value'
         });
@@ -170,7 +170,7 @@ describe('Adapter Manager: options resolver', function () {
 
         const {adapterClassName, adapterConfig} = resolveAdapterOptions(primaryadapterClassName, adapterServiceConfig);
 
-        adapterClassName.should.equal('Redis');
+        assert.equal(adapterClassName, 'Redis');
         adapterConfig.should.deepEqual({
             commonConfigValue: 'common_config_value',
             adapterConfigValue: 'images_redis_value',

--- a/ghost/core/test/unit/server/services/auth/api-key/admin.test.js
+++ b/ghost/core/test/unit/server/services/auth/api-key/admin.test.js
@@ -129,7 +129,7 @@ describe('Admin API Key Auth', function () {
         apiKeyAuth.admin.authenticate(req, res, (err) => {
             should.exist(err);
             assert.equal(err instanceof errors.UnauthorizedError, true);
-            err.code.should.eql('INVALID_JWT');
+            assert.equal(err.code, 'INVALID_JWT');
             assert.equal(req.api_key, undefined);
             done();
         });
@@ -147,7 +147,7 @@ describe('Admin API Key Auth', function () {
         apiKeyAuth.admin.authenticate(req, res, function next(err) {
             should.exist(err);
             assert.equal(err instanceof errors.UnauthorizedError, true);
-            err.code.should.eql('INVALID_AUTH_HEADER');
+            assert.equal(err.code, 'INVALID_AUTH_HEADER');
             assert.equal(req.api_key, undefined);
             done();
         });
@@ -165,7 +165,7 @@ describe('Admin API Key Auth', function () {
         apiKeyAuth.admin.authenticate(req, res, function next(err) {
             should.exist(err);
             assert.equal(err instanceof errors.BadRequestError, true);
-            err.code.should.eql('INVALID_JWT');
+            assert.equal(err.code, 'INVALID_JWT');
             assert.equal(req.api_key, undefined);
             done();
         });
@@ -192,7 +192,7 @@ describe('Admin API Key Auth', function () {
         apiKeyAuth.admin.authenticate(req, res, function next(err) {
             should.exist(err);
             assert.equal(err instanceof errors.UnauthorizedError, true);
-            err.code.should.eql('UNKNOWN_ADMIN_API_KEY');
+            assert.equal(err.code, 'UNKNOWN_ADMIN_API_KEY');
             assert.equal(req.api_key, undefined);
             done();
         });
@@ -221,8 +221,8 @@ describe('Admin API Key Auth', function () {
         apiKeyAuth.admin.authenticate(req, res, function next(err) {
             should.exist(err);
             assert.equal(err instanceof errors.UnauthorizedError, true);
-            err.code.should.eql('INVALID_JWT');
-            err.message.should.match(/jwt expired/);
+            assert.equal(err.code, 'INVALID_JWT');
+            assert.match(err.message, /jwt expired/);
             assert.equal(req.api_key, undefined);
             done();
         });
@@ -251,8 +251,8 @@ describe('Admin API Key Auth', function () {
         apiKeyAuth.admin.authenticate(req, res, function next(err) {
             should.exist(err);
             assert.equal(err instanceof errors.UnauthorizedError, true);
-            err.code.should.eql('INVALID_JWT');
-            err.message.should.match(/maxAge exceeded/);
+            assert.equal(err.code, 'INVALID_JWT');
+            assert.match(err.message, /maxAge exceeded/);
             assert.equal(req.api_key, undefined);
             done();
         });
@@ -281,7 +281,7 @@ describe('Admin API Key Auth', function () {
         apiKeyAuth.admin.authenticate(req, res, function next(err) {
             should.exist(err);
             assert.equal(err instanceof errors.UnauthorizedError, true);
-            err.code.should.eql('INVALID_API_KEY_TYPE');
+            assert.equal(err.code, 'INVALID_API_KEY_TYPE');
             assert.equal(req.api_key, undefined);
             done();
         });

--- a/ghost/core/test/unit/server/services/auth/api-key/content.test.js
+++ b/ghost/core/test/unit/server/services/auth/api-key/content.test.js
@@ -54,7 +54,7 @@ describe('Content API Key Auth', function () {
         authenticateContentApiKey(req, res, function next(err) {
             should.exist(err);
             assert.equal(err instanceof errors.UnauthorizedError, true);
-            err.code.should.eql('UNKNOWN_CONTENT_API_KEY');
+            assert.equal(err.code, 'UNKNOWN_CONTENT_API_KEY');
             assert.equal(req.api_key, undefined);
             done();
         });
@@ -73,7 +73,7 @@ describe('Content API Key Auth', function () {
         authenticateContentApiKey(req, res, function next(err) {
             should.exist(err);
             assert.equal(err instanceof errors.UnauthorizedError, true);
-            err.code.should.eql('INVALID_API_KEY_TYPE');
+            assert.equal(err.code, 'INVALID_API_KEY_TYPE');
             assert.equal(req.api_key, undefined);
             done();
         });
@@ -90,7 +90,7 @@ describe('Content API Key Auth', function () {
         authenticateContentApiKey(req, res, function next(err) {
             should.exist(err);
             assert.equal(err instanceof errors.BadRequestError, true);
-            err.code.should.eql('INVALID_REQUEST');
+            assert.equal(err.code, 'INVALID_REQUEST');
             assert.equal(req.api_key, undefined);
             done();
         });

--- a/ghost/core/test/unit/server/services/auth/session/session-service.test.js
+++ b/ghost/core/test/unit/server/services/auth/session/session-service.test.js
@@ -505,7 +505,7 @@ describe('SessionService', function () {
         should.ok(mailer.send.calledOnce);
         const emailArgs = mailer.send.firstCall.args[0];
         assert.equal(emailArgs.to, 'test@example.com');
-        emailArgs.subject.should.match(/Ghost sign in verification code/);
+        assert.match(emailArgs.subject, /Ghost sign in verification code/);
     });
 
     it('throws an error when mail fails to send', async function () {

--- a/ghost/core/test/unit/server/services/email-analytics/email-analytics-service.test.js
+++ b/ghost/core/test/unit/server/services/email-analytics/email-analytics-service.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 require('should');
 
 const sinon = require('sinon');
@@ -124,7 +125,7 @@ describe('EmailAnalyticsService', function () {
                     }]
                 });
                 await service.fetchLatestOpenedEvents();
-                fetchLatestSpy.calledOnce.should.be.true();
+                assert.equal(fetchLatestSpy.calledOnce, true);
                 fetchLatestSpy.getCall(0).args[1].should.have.property('events', ['opened']);
             });
 
@@ -142,7 +143,7 @@ describe('EmailAnalyticsService', function () {
                     }]
                 });
                 await service.fetchLatestOpenedEvents();
-                fetchLatestSpy.calledOnce.should.be.false();
+                assert.equal(fetchLatestSpy.calledOnce, false);
             });
         });
 
@@ -161,7 +162,7 @@ describe('EmailAnalyticsService', function () {
                     }]
                 });
                 await service.fetchLatestNonOpenedEvents();
-                fetchLatestSpy.calledOnce.should.be.true();
+                assert.equal(fetchLatestSpy.calledOnce, true);
                 fetchLatestSpy.getCall(0).args[1].should.have.property('events', ['delivered', 'failed', 'unsubscribed', 'complained']);
             });
 
@@ -179,7 +180,7 @@ describe('EmailAnalyticsService', function () {
                     }]
                 });
                 await service.fetchLatestNonOpenedEvents();
-                fetchLatestSpy.calledOnce.should.be.false();
+                assert.equal(fetchLatestSpy.calledOnce, false);
             });
         });
         describe('fetchScheduled', function () {
@@ -215,9 +216,9 @@ describe('EmailAnalyticsService', function () {
 
             it('returns 0 when nothing is scheduled', async function () {
                 const result = await service.fetchScheduled();
-                result.eventCount.should.equal(0);
-                processEventBatchStub.called.should.be.false();
-                aggregateStatsStub.called.should.be.false();
+                assert.equal(result.eventCount, 0);
+                assert.equal(processEventBatchStub.called, false);
+                assert.equal(aggregateStatsStub.called, false);
             });
 
             it('returns 0 when fetch is canceled', async function () {
@@ -227,9 +228,9 @@ describe('EmailAnalyticsService', function () {
                 });
                 service.cancelScheduled();
                 const result = await service.fetchScheduled();
-                result.eventCount.should.equal(0);
-                processEventBatchStub.called.should.be.false();
-                aggregateStatsStub.called.should.be.false();
+                assert.equal(result.eventCount, 0);
+                assert.equal(processEventBatchStub.called, false);
+                assert.equal(aggregateStatsStub.called, false);
             });
 
             it('fetches events with correct parameters', async function () {
@@ -240,9 +241,9 @@ describe('EmailAnalyticsService', function () {
 
                 const result = await service.fetchScheduled({maxEvents: 100});
 
-                result.eventCount.should.equal(10);
-                setJobStatusStub.calledOnce.should.be.true();
-                processEventBatchStub.calledOnce.should.be.true();
+                assert.equal(result.eventCount, 10);
+                assert.equal(setJobStatusStub.calledOnce, true);
+                assert.equal(processEventBatchStub.calledOnce, true);
             });
 
             it('bails when end date is before begin date', async function () {
@@ -251,7 +252,7 @@ describe('EmailAnalyticsService', function () {
                     end: new Date(2023, 0, 1)
                 });
                 const result = await service.fetchScheduled({maxEvents: 100});
-                result.eventCount.should.equal(0);
+                assert.equal(result.eventCount, 0);
             });
 
             it('resets fetchScheduledData when no events are fetched', async function () {
@@ -273,7 +274,7 @@ describe('EmailAnalyticsService', function () {
                     end: new Date(2023, 0, 2)
                 });
                 const result = await service.fetchScheduled({maxEvents: 100});
-                result.eventCount.should.equal(0);
+                assert.equal(result.eventCount, 0);
             });
         });
 
@@ -292,7 +293,7 @@ describe('EmailAnalyticsService', function () {
                     }]
                 });
                 await service.fetchMissing();
-                fetchLatestSpy.calledOnce.should.be.true();
+                assert.equal(fetchLatestSpy.calledOnce, true);
             });
         });
     });
@@ -383,8 +384,8 @@ describe('EmailAnalyticsService', function () {
                             timestamp: new Date(3)
                         }], result, fetchData);
 
-                        eventProcessor.handleDelivered.callCount.should.eql(2);
-                        eventProcessor.handleOpened.callCount.should.eql(1);
+                        assert.equal(eventProcessor.handleDelivered.callCount, 2);
+                        assert.equal(eventProcessor.handleOpened.callCount, 1);
 
                         result.should.deepEqual(new EventProcessingResult({
                             delivered: 2,
@@ -414,7 +415,7 @@ describe('EmailAnalyticsService', function () {
                             timestamp: new Date(1)
                         }], result, fetchData);
 
-                        eventProcessor.handleOpened.calledOnce.should.be.true();
+                        assert.equal(eventProcessor.handleOpened.calledOnce, true);
 
                         result.should.deepEqual(new EventProcessingResult({
                             delivered: 0,
@@ -444,7 +445,7 @@ describe('EmailAnalyticsService', function () {
                             timestamp: new Date(1)
                         }], result, fetchData);
 
-                        eventProcessor.handleDelivered.calledOnce.should.be.true();
+                        assert.equal(eventProcessor.handleDelivered.calledOnce, true);
 
                         result.should.deepEqual(new EventProcessingResult({
                             delivered: 1,
@@ -475,7 +476,7 @@ describe('EmailAnalyticsService', function () {
                             timestamp: new Date(1)
                         }], result, fetchData);
 
-                        eventProcessor.handlePermanentFailed.calledOnce.should.be.true();
+                        assert.equal(eventProcessor.handlePermanentFailed.calledOnce, true);
 
                         result.should.deepEqual(new EventProcessingResult({
                             permanentFailed: 1,
@@ -504,7 +505,7 @@ describe('EmailAnalyticsService', function () {
                             timestamp: new Date(1)
                         }], result, fetchData);
 
-                        eventProcessor.handleTemporaryFailed.calledOnce.should.be.true();
+                        assert.equal(eventProcessor.handleTemporaryFailed.calledOnce, true);
 
                         result.should.deepEqual(new EventProcessingResult({
                             temporaryFailed: 1,
@@ -532,9 +533,9 @@ describe('EmailAnalyticsService', function () {
                             timestamp: new Date(1)
                         }], result, fetchData);
 
-                        eventProcessor.handleUnsubscribed.calledOnce.should.be.true();
-                        eventProcessor.handleDelivered.called.should.be.false();
-                        eventProcessor.handleOpened.called.should.be.false();
+                        assert.equal(eventProcessor.handleUnsubscribed.calledOnce, true);
+                        assert.equal(eventProcessor.handleDelivered.called, false);
+                        assert.equal(eventProcessor.handleOpened.called, false);
 
                         result.should.deepEqual(new EventProcessingResult({
                             unsubscribed: 1,
@@ -562,9 +563,9 @@ describe('EmailAnalyticsService', function () {
                             timestamp: new Date(1)
                         }], result, fetchData);
 
-                        eventProcessor.handleComplained.calledOnce.should.be.true();
-                        eventProcessor.handleDelivered.called.should.be.false();
-                        eventProcessor.handleOpened.called.should.be.false();
+                        assert.equal(eventProcessor.handleComplained.calledOnce, true);
+                        assert.equal(eventProcessor.handleDelivered.called, false);
+                        assert.equal(eventProcessor.handleOpened.called, false);
 
                         result.should.deepEqual(new EventProcessingResult({
                             complained: 1,
@@ -592,8 +593,8 @@ describe('EmailAnalyticsService', function () {
                             timestamp: new Date(1)
                         }], result, fetchData);
 
-                        eventProcessor.handleDelivered.called.should.be.false();
-                        eventProcessor.handleOpened.called.should.be.false();
+                        assert.equal(eventProcessor.handleDelivered.called, false);
+                        assert.equal(eventProcessor.handleOpened.called, false);
 
                         result.should.deepEqual(new EventProcessingResult({
                             unhandled: 1
@@ -764,12 +765,12 @@ describe('EmailAnalyticsService', function () {
 
                     if (batchProcessing) {
                         // In batched mode, should call batchGetRecipients and flushBatchedUpdates
-                        eventProcessor.batchGetRecipients.calledOnce.should.be.true();
-                        eventProcessor.flushBatchedUpdates.calledOnce.should.be.true();
+                        assert.equal(eventProcessor.batchGetRecipients.calledOnce, true);
+                        assert.equal(eventProcessor.flushBatchedUpdates.calledOnce, true);
                     } else {
                         // In sequential mode, should not call batch methods
-                        eventProcessor.batchGetRecipients.called.should.be.false();
-                        eventProcessor.flushBatchedUpdates.called.should.be.false();
+                        assert.equal(eventProcessor.batchGetRecipients.called, false);
+                        assert.equal(eventProcessor.flushBatchedUpdates.called, false);
                     }
                 });
             });
@@ -805,16 +806,16 @@ describe('EmailAnalyticsService', function () {
                     memberIds: ['m-1', 'm-2']
                 });
 
-                service.queries.aggregateEmailStats.calledTwice.should.be.true();
-                service.queries.aggregateEmailStats.calledWith('e-1').should.be.true();
-                service.queries.aggregateEmailStats.calledWith('e-2').should.be.true();
+                assert.equal(service.queries.aggregateEmailStats.calledTwice, true);
+                assert.equal(service.queries.aggregateEmailStats.calledWith('e-1'), true);
+                assert.equal(service.queries.aggregateEmailStats.calledWith('e-2'), true);
 
                 // In batched mode, aggregateMemberStatsBatch should be called
-                service.queries.aggregateMemberStatsBatch.calledOnce.should.be.true();
-                service.queries.aggregateMemberStatsBatch.calledWith(['m-1', 'm-2']).should.be.true();
+                assert.equal(service.queries.aggregateMemberStatsBatch.calledOnce, true);
+                assert.equal(service.queries.aggregateMemberStatsBatch.calledWith(['m-1', 'm-2']), true);
 
                 // Sequential method should not be called
-                service.queries.aggregateMemberStats.called.should.be.false();
+                assert.equal(service.queries.aggregateMemberStats.called, false);
             });
         });
 
@@ -843,17 +844,17 @@ describe('EmailAnalyticsService', function () {
                     memberIds: ['m-1', 'm-2']
                 });
 
-                service.queries.aggregateEmailStats.calledTwice.should.be.true();
-                service.queries.aggregateEmailStats.calledWith('e-1').should.be.true();
-                service.queries.aggregateEmailStats.calledWith('e-2').should.be.true();
+                assert.equal(service.queries.aggregateEmailStats.calledTwice, true);
+                assert.equal(service.queries.aggregateEmailStats.calledWith('e-1'), true);
+                assert.equal(service.queries.aggregateEmailStats.calledWith('e-2'), true);
 
                 // In sequential mode, aggregateMemberStats should be called for each member
-                service.queries.aggregateMemberStats.calledTwice.should.be.true();
-                service.queries.aggregateMemberStats.calledWith('m-1').should.be.true();
-                service.queries.aggregateMemberStats.calledWith('m-2').should.be.true();
+                assert.equal(service.queries.aggregateMemberStats.calledTwice, true);
+                assert.equal(service.queries.aggregateMemberStats.calledWith('m-1'), true);
+                assert.equal(service.queries.aggregateMemberStats.calledWith('m-2'), true);
 
                 // Batch method should not be called
-                service.queries.aggregateMemberStatsBatch.called.should.be.false();
+                assert.equal(service.queries.aggregateMemberStatsBatch.called, false);
             });
         });
     });
@@ -869,7 +870,7 @@ describe('EmailAnalyticsService', function () {
 
             await service.aggregateEmailStats('memberId');
 
-            service.queries.aggregateEmailStats.calledOnce.should.be.true();
+            assert.equal(service.queries.aggregateEmailStats.calledOnce, true);
             service.queries.aggregateEmailStats.calledWith('memberId').should.be.true;
         });
     });
@@ -885,7 +886,7 @@ describe('EmailAnalyticsService', function () {
 
             await service.aggregateMemberStats('memberId');
 
-            service.queries.aggregateMemberStats.calledOnce.should.be.true();
+            assert.equal(service.queries.aggregateMemberStats.calledOnce, true);
             service.queries.aggregateMemberStats.calledWith('memberId').should.be.true;
         });
     });

--- a/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
+++ b/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
@@ -912,7 +912,7 @@ describe('Email renderer', function () {
                 loaded: ['posts_meta']
             });
             let response = emailRenderer.getSubject(post);
-            response.should.equal('Test Newsletter');
+            assert.equal(response, 'Test Newsletter');
         });
 
         it('returns a post with correct subject from title', function () {
@@ -924,7 +924,7 @@ describe('Email renderer', function () {
                 loaded: ['posts_meta']
             });
             let response = emailRenderer.getSubject(post);
-            response.should.equal('Sample Post');
+            assert.equal(response, 'Sample Post');
         });
 
         it('adds [TEST] prefix for test emails', function () {
@@ -936,7 +936,7 @@ describe('Email renderer', function () {
                 loaded: ['posts_meta']
             });
             let response = emailRenderer.getSubject(post, true);
-            response.should.equal('[TEST] Sample Post');
+            assert.equal(response, '[TEST] Sample Post');
         });
     });
 
@@ -971,7 +971,7 @@ describe('Email renderer', function () {
                 sender_name: 'Ghost'
             });
             const response = emailRenderer.getFromAddress({}, newsletter);
-            response.should.equal('"Ghost" <ghost@example.com>');
+            assert.equal(response, '"Ghost" <ghost@example.com>');
         });
 
         it('defaults to site title and domain', function () {
@@ -980,7 +980,7 @@ describe('Email renderer', function () {
                 sender_name: ''
             });
             const response = emailRenderer.getFromAddress({}, newsletter);
-            response.should.equal('"Test Blog" <reply@example.com>');
+            assert.equal(response, '"Test Blog" <reply@example.com>');
         });
 
         it('changes localhost domain to proper domain in development', function () {
@@ -989,7 +989,7 @@ describe('Email renderer', function () {
                 sender_name: ''
             });
             const response = emailRenderer.getFromAddress({}, newsletter);
-            response.should.equal('"Test Blog" <localhost@example.com>');
+            assert.equal(response, '"Test Blog" <localhost@example.com>');
         });
 
         it('ignores empty sender names', function () {
@@ -999,7 +999,7 @@ describe('Email renderer', function () {
                 sender_name: ''
             });
             const response = emailRenderer.getFromAddress({}, newsletter);
-            response.should.equal('example@example.com');
+            assert.equal(response, 'example@example.com');
         });
     });
 
@@ -1039,7 +1039,7 @@ describe('Email renderer', function () {
                 sender_reply_to: 'support'
             });
             const response = emailRenderer.getReplyToAddress({}, newsletter);
-            response.should.equal('support@example.com');
+            assert.equal(response, 'support@example.com');
         });
 
         it('[legacy] returns correct reply to address for newsletter', function () {
@@ -1393,12 +1393,12 @@ describe('Email renderer', function () {
 
             const $ = cheerio.load(response.html);
 
-            response.plaintext.should.containEql('Test Post');
+            assert(response.plaintext.includes('Test Post'));
 
             // Unsubscribe button included
-            response.plaintext.should.containEql('Unsubscribe [%%{unsubscribe_url}%%]');
-            response.html.should.containEql('Unsubscribe');
-            response.replacements.length.should.eql(4);
+            assert(response.plaintext.includes('Unsubscribe [%%{unsubscribe_url}%%]'));
+            assert(response.html.includes('Unsubscribe'));
+            assert.equal(response.replacements.length, 4);
             response.replacements.should.match([
                 {
                     id: 'uuid'
@@ -1414,17 +1414,17 @@ describe('Email renderer', function () {
                 }
             ]);
 
-            response.plaintext.should.containEql('http://example.com');
+            assert(response.plaintext.includes('http://example.com'));
             assert.equal($('.preheader').text(), 'Test plaintext for post');
-            response.html.should.containEql('Test Post');
-            response.html.should.containEql('http://example.com');
+            assert(response.html.includes('Test Post'));
+            assert(response.html.includes('http://example.com'));
 
             // Does not include Ghost badge
-            response.html.should.not.containEql('https://ghost.org/');
+            assert(!response.html.includes('https://ghost.org/'));
 
             // Test feedback buttons included
-            response.html.should.containEql('http://feedback-link.com/?score=1');
-            response.html.should.containEql('http://feedback-link.com/?score=0');
+            assert(response.html.includes('http://feedback-link.com/?score=1'));
+            assert(response.html.includes('http://feedback-link.com/?score=0'));
         });
 
         it('uses custom excerpt as preheader', async function () {
@@ -1573,7 +1573,7 @@ describe('Email renderer', function () {
                 options
             );
 
-            response.html.should.containEql('http://icon.example.com');
+            assert(response.html.includes('http://icon.example.com'));
             assert.match(response.html, /class="site-title"[^>]*?>Test Blog/);
             assert.match(response.html, /class="site-subtitle"[^>]*?>Test Newsletter/);
         });
@@ -1601,7 +1601,7 @@ describe('Email renderer', function () {
                 options
             );
 
-            response.html.should.containEql('http://icon.example.com');
+            assert(response.html.includes('http://icon.example.com'));
             assert.match(response.html, /class="site-title"[^>]*?>Test Newsletter/);
         });
 
@@ -1627,8 +1627,8 @@ describe('Email renderer', function () {
             assert.match(response.html, /https:\/\/ghost.org\//);
 
             // Test feedback buttons not included
-            response.html.should.not.containEql('http://feedback-link.com/?score=1');
-            response.html.should.not.containEql('http://feedback-link.com/?score=0');
+            assert(!response.html.includes('http://feedback-link.com/?score=1'));
+            assert(!response.html.includes('http://feedback-link.com/?score=0'));
         });
 
         it('includes newsletter footer as raw html', async function () {
@@ -1651,8 +1651,8 @@ describe('Email renderer', function () {
             );
 
             // Test footer
-            response.html.should.containEql('Test footer</p>'); // begin tag skipped because style is inlined in that tag
-            response.plaintext.should.containEql('Test footer');
+            assert(response.html.includes('Test footer</p>')); // begin tag skipped because style is inlined in that tag
+            assert(response.plaintext.includes('Test footer'));
         });
 
         it('works in dark mode', async function () {
@@ -1735,14 +1735,14 @@ describe('Email renderer', function () {
                     continue;
                 }
                 if (href.includes('unsubscribe_url')) {
-                    href.should.eql('%%{unsubscribe_url}%%');
+                    assert.equal(href, '%%{unsubscribe_url}%%');
                 } else if (href.includes('feedback-link.com')) {
-                    href.should.containEql('%%{uuid}%%');
+                    assert(href.includes('%%{uuid}%%'));
                 } else if (href.includes('https://ghost.org/?via=pbg-newsletter')) {
-                    href.should.not.containEql('tracked-link.com');
+                    assert(!href.includes('tracked-link.com'));
                 } else {
-                    href.should.containEql('tracked-link.com');
-                    href.should.containEql('m=%%{uuid}%%');
+                    assert(href.includes('tracked-link.com'));
+                    assert(href.includes('m=%%{uuid}%%'));
                 }
             }
 
@@ -1762,14 +1762,14 @@ describe('Email renderer', function () {
             ]);
 
             // Check uuid in replacements
-            response.replacements.length.should.eql(4);
-            response.replacements[0].id.should.eql('uuid');
+            assert.equal(response.replacements.length, 4);
+            assert.equal(response.replacements[0].id, 'uuid');
             response.replacements[0].token.should.eql(/%%\{uuid\}%%/g);
-            response.replacements[1].id.should.eql('key');
+            assert.equal(response.replacements[1].id, 'key');
             response.replacements[1].token.should.eql(/%%\{key\}%%/g);
-            response.replacements[2].id.should.eql('unsubscribe_url');
+            assert.equal(response.replacements[2].id, 'unsubscribe_url');
             response.replacements[2].token.should.eql(/%%\{unsubscribe_url\}%%/g);
-            response.replacements[3].id.should.eql('list_unsubscribe');
+            assert.equal(response.replacements[3].id, 'list_unsubscribe');
         });
 
         it('replaces all relative links if click tracking is disabled', async function () {
@@ -1847,14 +1847,14 @@ describe('Email renderer', function () {
                 const href = $(link).attr('href');
                 links.push(href);
                 if (href.includes('unsubscribe_url')) {
-                    href.should.eql('%%{unsubscribe_url}%%');
+                    assert.equal(href, '%%{unsubscribe_url}%%');
                 } else if (href.includes('feedback-link.com')) {
-                    href.should.containEql('%%{uuid}%%');
+                    assert(href.includes('%%{uuid}%%'));
                 } else if (href.includes('https://ghost.org/?via=pbg-newsletter')) {
-                    href.should.not.containEql('tracked-link.com');
+                    assert(!href.includes('tracked-link.com'));
                 } else {
-                    href.should.containEql('tracked-link.com');
-                    href.should.containEql('m=%%{uuid}%%');
+                    assert(href.includes('tracked-link.com'));
+                    assert(href.includes('m=%%{uuid}%%'));
                 }
             }
 
@@ -1872,14 +1872,14 @@ describe('Email renderer', function () {
             ]);
 
             // Check uuid in replacements
-            response.replacements.length.should.eql(4);
-            response.replacements[0].id.should.eql('uuid');
+            assert.equal(response.replacements.length, 4);
+            assert.equal(response.replacements[0].id, 'uuid');
             response.replacements[0].token.should.eql(/%%\{uuid\}%%/g);
-            response.replacements[1].id.should.eql('key');
+            assert.equal(response.replacements[1].id, 'key');
             response.replacements[1].token.should.eql(/%%\{key\}%%/g);
-            response.replacements[2].id.should.eql('unsubscribe_url');
+            assert.equal(response.replacements[2].id, 'unsubscribe_url');
             response.replacements[2].token.should.eql(/%%\{unsubscribe_url\}%%/g);
-            response.replacements[3].id.should.eql('list_unsubscribe');
+            assert.equal(response.replacements[3].id, 'list_unsubscribe');
         });
 
         it('tracks links containing %%{uuid}%% and preserves placeholder in destination', async function () {
@@ -1906,7 +1906,7 @@ describe('Email renderer', function () {
             );
 
             // Verify tracking was called for the Transistor link
-            addTrackingToUrlStub.called.should.be.true();
+            assert.equal(addTrackingToUrlStub.called, true);
             const transistorCall = addTrackingToUrlStub.getCalls().find(
                 call => call.args[0].href.includes('transistor.fm')
             );
@@ -1997,16 +1997,16 @@ describe('Email renderer', function () {
                 options
             );
 
-            response.plaintext.should.containEql('Test Post');
-            response.plaintext.should.containEql('Unsubscribe [%%{unsubscribe_url}%%]');
-            response.plaintext.should.containEql('http://example.com');
+            assert(response.plaintext.includes('Test Post'));
+            assert(response.plaintext.includes('Unsubscribe [%%{unsubscribe_url}%%]'));
+            assert(response.plaintext.includes('http://example.com'));
 
             // Check contains the post name twice
             assert.equal(response.html.match(/Test Post/g).length, 3, 'Should contain the post name 3 times: in the title element, the preheader and in the post title section');
 
-            response.html.should.containEql('Unsubscribe');
-            response.html.should.containEql('http://example.com');
-            response.replacements.length.should.eql(4);
+            assert(response.html.includes('Unsubscribe'));
+            assert(response.html.includes('http://example.com'));
+            assert.equal(response.replacements.length, 4);
             response.replacements.should.match([
                 {
                     id: 'uuid'
@@ -2021,10 +2021,10 @@ describe('Email renderer', function () {
                     id: 'list_unsubscribe'
                 }
             ]);
-            response.html.should.not.containEql('members only section');
-            response.html.should.containEql('some text for both');
-            response.html.should.not.containEql('finishing part only for members');
-            response.html.should.containEql('Become a paid member of Test Blog to get access to all');
+            assert(!response.html.includes('members only section'));
+            assert(response.html.includes('some text for both'));
+            assert(!response.html.includes('finishing part only for members'));
+            assert(response.html.includes('Become a paid member of Test Blog to get access to all'));
 
             let responsePaid = await emailRenderer.renderBody(
                 post,
@@ -2032,10 +2032,10 @@ describe('Email renderer', function () {
                 'status:-free',
                 options
             );
-            responsePaid.html.should.containEql('members only section');
-            responsePaid.html.should.containEql('some text for both');
-            responsePaid.html.should.containEql('finishing part only for members');
-            responsePaid.html.should.not.containEql('Become a paid member of Test Blog to get access to all');
+            assert(responsePaid.html.includes('members only section'));
+            assert(responsePaid.html.includes('some text for both'));
+            assert(responsePaid.html.includes('finishing part only for members'));
+            assert(!responsePaid.html.includes('Become a paid member of Test Blog to get access to all'));
         });
 
         it('should output valid HTML and escape HTML characters in mobiledoc', async function () {
@@ -2168,7 +2168,7 @@ describe('Email renderer', function () {
                 await validateHtml(response.html);
 
                 assert.equal(response.html.match(/This is an excerpt/g).length, 1, 'Subtitle should only appear once (preheader, excerpt section skipped)');
-                response.html.should.not.containEql('post-excerpt-wrapper');
+                assert(!response.html.includes('post-excerpt-wrapper'));
             });
 
             it('does not render when enabled and customExcerpt is not present', async function () {
@@ -2189,7 +2189,7 @@ describe('Email renderer', function () {
 
                 await validateHtml(response.html);
 
-                response.html.should.not.containEql('post-excerpt-wrapper');
+                assert(!response.html.includes('post-excerpt-wrapper'));
             });
         });
 
@@ -3283,11 +3283,11 @@ describe('Email renderer', function () {
                 options
             );
 
-            response.html.should.not.containEql('members only section');
-            response.html.should.containEql('some text for both');
-            response.html.should.not.containEql('finishing part only for members');
-            response.html.should.containEql('Devenez un(e) abonn&#xE9;(e) payant de Cathy&#39;s Blog pour acc&#xE9;der &#xE0; du contenu exclusif');
-            response.plaintext.should.containEql('Devenez un(e) abonné(e) payant de Cathy\'s Blog pour accéder à du contenu exclusif');
+            assert(!response.html.includes('members only section'));
+            assert(response.html.includes('some text for both'));
+            assert(!response.html.includes('finishing part only for members'));
+            assert(response.html.includes('Devenez un(e) abonn&#xE9;(e) payant de Cathy&#39;s Blog pour acc&#xE9;der &#xE0; du contenu exclusif'));
+            assert(response.plaintext.includes('Devenez un(e) abonné(e) payant de Cathy\'s Blog pour accéder à du contenu exclusif'));
         });
     });
 });

--- a/ghost/core/test/unit/server/services/indexnow.test.js
+++ b/ghost/core/test/unit/server/services/indexnow.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const _ = require('lodash');
 const nock = require('nock');
@@ -34,9 +35,9 @@ describe('IndexNow', function () {
     describe('listen()', function () {
         it('should initialise events correctly', function () {
             indexnow.listen();
-            eventStub.calledTwice.should.be.true();
-            eventStub.calledWith('post.published').should.be.true();
-            eventStub.calledWith('post.published.edited').should.be.true();
+            assert.equal(eventStub.calledTwice, true);
+            assert.equal(eventStub.calledWith('post.published'), true);
+            assert.equal(eventStub.calledWith('post.published.edited'), true);
         });
     });
 
@@ -72,8 +73,8 @@ describe('IndexNow', function () {
 
             listener(testModel);
 
-            pingStub.calledOnce.should.be.true();
-            pingStub.calledWith(testPost).should.be.true();
+            assert.equal(pingStub.calledOnce, true);
+            assert.equal(pingStub.calledWith(testPost), true);
 
             resetIndexNow();
         });
@@ -99,7 +100,7 @@ describe('IndexNow', function () {
 
             listener(testModel, {importing: true});
 
-            pingStub.calledOnce.should.be.false();
+            assert.equal(pingStub.calledOnce, false);
 
             resetIndexNow();
         });
@@ -145,7 +146,7 @@ describe('IndexNow', function () {
 
             listener(testModel);
 
-            pingStub.calledOnce.should.be.false();
+            assert.equal(pingStub.calledOnce, false);
 
             resetIndexNow();
         });
@@ -177,7 +178,7 @@ describe('IndexNow', function () {
 
             listener(testModel);
 
-            pingStub.calledOnce.should.be.true();
+            assert.equal(pingStub.calledOnce, true);
 
             resetIndexNow();
         });
@@ -209,7 +210,7 @@ describe('IndexNow', function () {
 
             listener(testModel);
 
-            pingStub.calledOnce.should.be.true();
+            assert.equal(pingStub.calledOnce, true);
 
             resetIndexNow();
         });
@@ -241,7 +242,7 @@ describe('IndexNow', function () {
 
             listener(testModel);
 
-            pingStub.calledOnce.should.be.true();
+            assert.equal(pingStub.calledOnce, true);
 
             resetIndexNow();
         });
@@ -259,7 +260,7 @@ describe('IndexNow', function () {
 
             await ping(testPost);
 
-            loggingStub.calledOnce.should.be.true();
+            assert.equal(loggingStub.calledOnce, true);
         });
 
         it('with default post should not execute ping', async function () {
@@ -272,7 +273,7 @@ describe('IndexNow', function () {
 
             await ping(testPost);
 
-            pingRequest.isDone().should.be.false();
+            assert.equal(pingRequest.isDone(), false);
         });
 
         it('with a page should not execute ping', async function () {
@@ -283,7 +284,7 @@ describe('IndexNow', function () {
 
             await ping(testPage);
 
-            pingRequest.isDone().should.be.false();
+            assert.equal(pingRequest.isDone(), false);
         });
 
         it('when labs.indexnow is false should not execute ping', async function () {
@@ -296,7 +297,7 @@ describe('IndexNow', function () {
 
             await ping(testPost);
 
-            pingRequest.isDone().should.be.false();
+            assert.equal(pingRequest.isDone(), false);
         });
 
         it('when site is private should not execute ping', async function () {
@@ -309,7 +310,7 @@ describe('IndexNow', function () {
 
             await ping(testPost);
 
-            pingRequest.isDone().should.be.false();
+            assert.equal(pingRequest.isDone(), false);
         });
 
         it('when no API key is set should not execute ping and log warning', async function () {
@@ -324,10 +325,10 @@ describe('IndexNow', function () {
             await ping(testPost);
 
             // Should NOT have made the ping request
-            pingRequest.isDone().should.be.false();
+            assert.equal(pingRequest.isDone(), false);
             // Should have logged a warning
-            loggingStub.calledOnce.should.be.true();
-            loggingStub.args[0][0].should.containEql('API key not available');
+            assert.equal(loggingStub.calledOnce, true);
+            assert(loggingStub.args[0][0].includes('API key not available'));
         });
 
         it('should handle 202 response as success', async function () {
@@ -339,8 +340,8 @@ describe('IndexNow', function () {
 
             await ping(testPost);
 
-            pingRequest.isDone().should.be.true();
-            loggingStub.calledOnce.should.be.true();
+            assert.equal(pingRequest.isDone(), true);
+            assert.equal(loggingStub.calledOnce, true);
         });
 
         it('captures && logs errors from 400 requests', async function () {
@@ -352,8 +353,8 @@ describe('IndexNow', function () {
 
             await ping(testPost);
 
-            pingRequest.isDone().should.be.true();
-            loggingStub.calledOnce.should.be.true();
+            assert.equal(pingRequest.isDone(), true);
+            assert.equal(loggingStub.calledOnce, true);
         });
 
         it('captures && logs validation errors from 422 requests', async function () {
@@ -365,9 +366,9 @@ describe('IndexNow', function () {
 
             await ping(testPost);
 
-            pingRequest.isDone().should.be.true();
-            loggingStub.calledOnce.should.be.true();
-            loggingStub.args[0][0].message.should.containEql('key validation failed');
+            assert.equal(pingRequest.isDone(), true);
+            assert.equal(loggingStub.calledOnce, true);
+            assert(loggingStub.args[0][0].message.includes('key validation failed'));
         });
 
         it('should behave correctly when getting a 429', async function () {
@@ -379,8 +380,8 @@ describe('IndexNow', function () {
 
             await ping(testPost);
 
-            pingRequest.isDone().should.be.true();
-            loggingStub.calledOnce.should.be.true();
+            assert.equal(pingRequest.isDone(), true);
+            assert.equal(loggingStub.calledOnce, true);
         });
     });
 
@@ -397,7 +398,7 @@ describe('IndexNow', function () {
             settingsCacheStub.withArgs('indexnow_api_key').returns(null);
 
             const key = indexnow.getApiKey();
-            (key === null).should.be.true();
+            assert.equal((key === null), true);
         });
     });
 });

--- a/ghost/core/test/unit/server/services/lib/dynamic-redirect-manager.test.js
+++ b/ghost/core/test/unit/server/services/lib/dynamic-redirect-manager.test.js
@@ -125,7 +125,7 @@ describe('DynamicRedirectManager', function () {
                 manager.addRedirect(from , to);
                 should.fail(false, 'Should have thrown an error');
             } catch (e) {
-                e.message.should.equal('Unknown error');
+                assert.equal(e.message, 'Unknown error');
             }
         });
 

--- a/ghost/core/test/unit/server/services/link-redirection/link-redirect-repository.test.js
+++ b/ghost/core/test/unit/server/services/link-redirection/link-redirect-repository.test.js
@@ -90,8 +90,8 @@ describe('UNIT: LinkRedirectRepository class', function () {
             const linkRedirect = linkRedirectRepository.fromModel(model);
             assert.equal(linkRedirect.from.href, 'https://example.com/r/1234abcd');
             assert.equal(linkRedirect.to.href, 'https://google.com/');
-            should(linkRedirect.edited).be.false();
-            should(ObjectID.isValid(linkRedirect.link_id)).be.true();
+            assert.equal(linkRedirect.edited, false);
+            assert.equal(ObjectID.isValid(linkRedirect.link_id), true);
         });
 
         it('should set edited to false if updated_at is within 1 second of created_at', function () {
@@ -103,8 +103,8 @@ describe('UNIT: LinkRedirectRepository class', function () {
             const linkRedirect = linkRedirectRepository.fromModel(model);
             assert.equal(linkRedirect.from.href, 'https://example.com/r/1234abcd');
             assert.equal(linkRedirect.to.href, 'https://google.com/');
-            should(linkRedirect.edited).be.false();
-            should(ObjectID.isValid(linkRedirect.link_id)).be.true();
+            assert.equal(linkRedirect.edited, false);
+            assert.equal(ObjectID.isValid(linkRedirect.link_id), true);
         });
 
         it('should set edited to true if updated_at is greater than created_at by more than 1 second', function () {
@@ -116,8 +116,8 @@ describe('UNIT: LinkRedirectRepository class', function () {
             const linkRedirect = linkRedirectRepository.fromModel(model);
             assert.equal(linkRedirect.from.href, 'https://example.com/r/1234abcd');
             assert.equal(linkRedirect.to.href, 'https://google.com/');
-            should(linkRedirect.edited).be.true();
-            should(ObjectID.isValid(linkRedirect.link_id)).be.true();
+            assert.equal(linkRedirect.edited, true);
+            assert.equal(ObjectID.isValid(linkRedirect.link_id), true);
         });
     });
 
@@ -125,13 +125,13 @@ describe('UNIT: LinkRedirectRepository class', function () {
         it('should return an array of LinkRedirect instances', async function () {
             linkRedirectRepository = createLinkRedirectRepository();
             const linkRedirects = await linkRedirectRepository.getAll({});
-            should(linkRedirects).be.an.Array();
+            assert(Array.isArray(linkRedirects));
             assert.equal(linkRedirects.length, 1);
             const linkRedirect = linkRedirects[0];
             assert.equal(linkRedirect.from.href, 'https://example.com/r/1234abcd');
             assert.equal(linkRedirect.to.href, 'https://google.com/');
-            should(linkRedirect.edited).be.true();
-            should(ObjectID.isValid(linkRedirect.link_id)).be.true();
+            assert.equal(linkRedirect.edited, true);
+            assert.equal(ObjectID.isValid(linkRedirect.link_id), true);
         });
     });
 
@@ -139,7 +139,7 @@ describe('UNIT: LinkRedirectRepository class', function () {
         it('should return an array of link ids', async function () {
             linkRedirectRepository = createLinkRedirectRepository();
             const linkIds = await linkRedirectRepository.getFilteredIds({});
-            should(linkIds).be.an.Array();
+            assert(Array.isArray(linkIds));
             assert.equal(linkIds.length, 1);
             assert.equal(linkIds[0], '662194931d0ba6fb37c080ee');
         });
@@ -173,8 +173,8 @@ describe('UNIT: LinkRedirectRepository class', function () {
             should(result).be.an.Object();
             assert.equal(result.from.href, 'https://example.com/r/1234abcd');
             assert.equal(result.to.href, 'https://google.com/');
-            should(result.edited).be.true();
-            should(ObjectID.isValid(result.link_id)).be.true();
+            assert.equal(result.edited, true);
+            assert.equal(ObjectID.isValid(result.link_id), true);
         });
 
         it('should return a LinkRedirect instance from the DB if cache is enabled and key does not exist', async function () {
@@ -191,9 +191,9 @@ describe('UNIT: LinkRedirectRepository class', function () {
             should(result).be.an.Object();
             assert.equal(result.from.href, 'https://example.com/r/1234abcd');
             assert.equal(result.to.href, 'https://google.com/');
-            should(result.edited).be.true();
-            should(ObjectID.isValid(result.link_id)).be.true();
-            should(cacheAdapterStub.set.calledOnce).be.true();
+            assert.equal(result.edited, true);
+            assert.equal(ObjectID.isValid(result.link_id), true);
+            assert.equal(cacheAdapterStub.set.calledOnce, true);
         });
     });
 
@@ -211,7 +211,7 @@ describe('UNIT: LinkRedirectRepository class', function () {
                 to: new URL('https://google.com')
             });
             await linkRedirectRepository.save(linkRedirect);
-            should(cacheAdapterStub.set.calledOnce).be.true();
+            assert.equal(cacheAdapterStub.set.calledOnce, true);
         });
 
         it('should clear cache on site.changed event', function () {
@@ -226,7 +226,7 @@ describe('UNIT: LinkRedirectRepository class', function () {
             });
 
             EventRegistry.emit('site.changed');
-            should(reset.calledOnce).be.true();
+            assert.equal(reset.calledOnce, true);
         });
     });
 });

--- a/ghost/core/test/unit/server/services/link-tracking/link-click-tracking-service.test.js
+++ b/ghost/core/test/unit/server/services/link-tracking/link-click-tracking-service.test.js
@@ -247,7 +247,7 @@ describe('LinkClickTrackingService', function () {
 
             const result = await service.bulkEdit(data, options);
 
-            should(postLinkRepositoryStub.updateLinks.calledOnce).be.true();
+            assert.equal(postLinkRepositoryStub.updateLinks.calledOnce, true);
             should(result).eql({
                 successful: 0,
                 unsuccessful: 0,
@@ -296,7 +296,7 @@ describe('LinkClickTrackingService', function () {
 
             const result = await service.bulkEdit(data, options);
 
-            should(postLinkRepositoryStub.updateLinks.calledOnce).be.true();
+            assert.equal(postLinkRepositoryStub.updateLinks.calledOnce, true);
             should(result).eql({
                 successful: 0,
                 unsuccessful: 0,

--- a/ghost/core/test/unit/server/services/mail/ghost-mailer.test.js
+++ b/ghost/core/test/unit/server/services/mail/ghost-mailer.test.js
@@ -65,7 +65,7 @@ describe('Mail: Ghostmailer', function () {
         mailer = new mail.GhostMailer();
 
         mailer.should.have.property('transport');
-        mailer.transport.transporter.name.should.eql('SMTP');
+        assert.equal(mailer.transport.transporter.name, 'SMTP');
         mailer.transport.sendMail.should.be.a.Function();
     });
 
@@ -75,7 +75,7 @@ describe('Mail: Ghostmailer', function () {
         mailer = new mail.GhostMailer();
 
         mailer.should.have.property('transport');
-        mailer.transport.transporter.name.should.eql('SMTP (direct)');
+        assert.equal(mailer.transport.transporter.name, 'SMTP (direct)');
     });
 
     it('sends valid message successfully ', function (done) {
@@ -83,12 +83,12 @@ describe('Mail: Ghostmailer', function () {
 
         mailer = new mail.GhostMailer();
 
-        mailer.transport.transporter.name.should.eql('Stub');
+        assert.equal(mailer.transport.transporter.name, 'Stub');
 
         mailer.send(mailDataNoServer).then(function (response) {
             should.exist(response.response);
             should.exist(response.envelope);
-            response.envelope.to.should.containEql('joe@example.com');
+            assert(response.envelope.to.includes('joe@example.com'));
 
             done();
         }).catch(done);
@@ -99,12 +99,12 @@ describe('Mail: Ghostmailer', function () {
 
         mailer = new mail.GhostMailer();
 
-        mailer.transport.transporter.name.should.eql('Stub');
+        assert.equal(mailer.transport.transporter.name, 'Stub');
 
         mailer.send(mailDataNoServer).then(function () {
             done(new Error('Stub did not error'));
         }).catch(function (error) {
-            error.message.should.containEql('Stub made a boo boo :(');
+            assert(error.message.includes('Stub made a boo boo :('));
             done();
         }).catch(done);
     });
@@ -132,17 +132,17 @@ describe('Mail: Ghostmailer', function () {
         });
 
         it('return correct failure message for domain doesn\'t exist', async function () {
-            mailer.transport.transporter.name.should.eql('SMTP (direct)');
+            assert.equal(mailer.transport.transporter.name, 'SMTP (direct)');
             await assert.rejects(mailer.send(mailDataNoDomain), /Failed to send email/);
         });
 
         it('return correct failure message for no mail server at this address', async function () {
-            mailer.transport.transporter.name.should.eql('SMTP (direct)');
+            assert.equal(mailer.transport.transporter.name, 'SMTP (direct)');
             await assert.rejects(mailer.send(mailDataNoServer), /Failed to send email/);
         });
 
         it('return correct failure message for incomplete data', async function () {
-            mailer.transport.transporter.name.should.eql('SMTP (direct)');
+            assert.equal(mailer.transport.transporter.name, 'SMTP (direct)');
             await assert.rejects(mailer.send(mailDataIncomplete), /Incomplete message data/);
         });
     });
@@ -166,7 +166,7 @@ describe('Mail: Ghostmailer', function () {
                 html: 'content'
             });
 
-            sendMailSpy.firstCall.args[0].from.should.equal('"Blog Title" <static@example.com>');
+            assert.equal(sendMailSpy.firstCall.args[0].from, '"Blog Title" <static@example.com>');
         });
 
         describe('should fall back to [blog.title] <noreply@[blog.url]>', function () {
@@ -187,7 +187,7 @@ describe('Mail: Ghostmailer', function () {
                     html: 'content'
                 });
 
-                mailer.sendMail.firstCall.args[0].from.should.equal('"Test" <noreply@default.com>');
+                assert.equal(mailer.sendMail.firstCall.args[0].from, '"Test" <noreply@default.com>');
             });
 
             it('trailing slash', async function () {
@@ -200,7 +200,7 @@ describe('Mail: Ghostmailer', function () {
                     html: 'content'
                 });
 
-                mailer.sendMail.firstCall.args[0].from.should.equal('"Test" <noreply@default.com>');
+                assert.equal(mailer.sendMail.firstCall.args[0].from, '"Test" <noreply@default.com>');
             });
 
             it('strip port', async function () {
@@ -213,7 +213,7 @@ describe('Mail: Ghostmailer', function () {
                     html: 'content'
                 });
 
-                mailer.sendMail.firstCall.args[0].from.should.equal('"Test" <noreply@default.com>');
+                assert.equal(mailer.sendMail.firstCall.args[0].from, '"Test" <noreply@default.com>');
             });
 
             it('Escape title', async function () {
@@ -229,7 +229,7 @@ describe('Mail: Ghostmailer', function () {
                     html: 'content'
                 });
 
-                mailer.sendMail.firstCall.args[0].from.should.equal('"Test\\"" <noreply@default.com>');
+                assert.equal(mailer.sendMail.firstCall.args[0].from, '"Test\\"" <noreply@default.com>');
             });
         });
 
@@ -248,7 +248,7 @@ describe('Mail: Ghostmailer', function () {
                 html: 'content'
             });
 
-            sendMailSpy.firstCall.args[0].from.should.equal('"bar" <from@default.com>');
+            assert.equal(sendMailSpy.firstCall.args[0].from, '"bar" <from@default.com>');
         });
 
         it('should attach blog title', async function () {
@@ -267,7 +267,7 @@ describe('Mail: Ghostmailer', function () {
                 html: 'content'
             });
 
-            sendMailSpy.firstCall.args[0].from.should.equal('"Test" <from@default.com>');
+            assert.equal(sendMailSpy.firstCall.args[0].from, '"Test" <from@default.com>');
 
             // only from set
             configUtils.set({mail: {from: 'from@default.com'}});
@@ -278,7 +278,7 @@ describe('Mail: Ghostmailer', function () {
                 html: 'content'
             });
 
-            sendMailSpy.firstCall.args[0].from.should.equal('"Test" <from@default.com>');
+            assert.equal(sendMailSpy.firstCall.args[0].from, '"Test" <from@default.com>');
         });
 
         it('should ignore theme title if from address is Title <email@address.com> format', async function () {
@@ -295,7 +295,7 @@ describe('Mail: Ghostmailer', function () {
                 html: 'content'
             });
 
-            sendMailSpy.firstCall.args[0].from.should.equal('"R2D2" <from@default.com>');
+            assert.equal(sendMailSpy.firstCall.args[0].from, '"R2D2" <from@default.com>');
 
             // only from set
             configUtils.set({mail: {from: '"R2D2" <from@default.com>'}});
@@ -305,7 +305,7 @@ describe('Mail: Ghostmailer', function () {
                 html: 'content'
             });
 
-            sendMailSpy.firstCall.args[0].from.should.equal('"R2D2" <from@default.com>');
+            assert.equal(sendMailSpy.firstCall.args[0].from, '"R2D2" <from@default.com>');
         });
 
         it('should use default title if not theme title is provided', async function () {
@@ -323,7 +323,7 @@ describe('Mail: Ghostmailer', function () {
                 html: 'content'
             });
 
-            sendMailSpy.firstCall.args[0].from.should.equal('"Ghost at default.com" <noreply@default.com>');
+            assert.equal(sendMailSpy.firstCall.args[0].from, '"Ghost at default.com" <noreply@default.com>');
         });
     });
 
@@ -351,9 +351,9 @@ describe('Mail: Ghostmailer', function () {
 
             const sentMessage = sendMailSpy.firstCall.args[0];
             sentMessage['o:tag'].should.be.an.Array();
-            sentMessage['o:tag'].should.containEql('transactional-email');
-            sentMessage['o:tag'].should.containEql('blog-123123');
-            sentMessage['o:tracking-opens'].should.equal(true);
+            assert(sentMessage['o:tag'].includes('transactional-email'));
+            assert(sentMessage['o:tag'].includes('blog-123123'));
+            assert.equal(sentMessage['o:tracking-opens'], true);
         });
 
         it('should add tags but not enable open tracking when email tracking is disabled', async function () {
@@ -374,8 +374,8 @@ describe('Mail: Ghostmailer', function () {
 
             const sentMessage = sendMailSpy.firstCall.args[0];
             sentMessage['o:tag'].should.be.an.Array();
-            sentMessage['o:tag'].should.containEql('transactional-email');
-            sentMessage['o:tag'].should.containEql('blog-123123');
+            assert(sentMessage['o:tag'].includes('transactional-email'));
+            assert(sentMessage['o:tag'].includes('blog-123123'));
             assert.equal(sentMessage['o:tracking-opens'], undefined);
         });
 
@@ -396,8 +396,8 @@ describe('Mail: Ghostmailer', function () {
             });
 
             const sentMessage = sendMailSpy.firstCall.args[0];
-            sentMessage['o:tag'].should.containEql('transactional-email');
-            sentMessage['o:tag'].should.not.containEql('blog-123123');
+            assert(sentMessage['o:tag'].includes('transactional-email'));
+            assert(!sentMessage['o:tag'].includes('blog-123123'));
         });
 
         it('should not add tag when not using Mailgun transport', async function () {

--- a/ghost/core/test/unit/server/services/member-attribution/service.test.js
+++ b/ghost/core/test/unit/server/services/member-attribution/service.test.js
@@ -17,7 +17,7 @@ describe('MemberAttributionService', function () {
             });
             const attribution = await service.getAttributionFromContext();
 
-            should(attribution).be.null();
+            assert.equal(attribution, null);
         });
 
         it('returns null if tracking is disabled is provided', async function () {
@@ -26,7 +26,7 @@ describe('MemberAttributionService', function () {
             });
             const attribution = await service.getAttributionFromContext();
 
-            should(attribution).be.null();
+            assert.equal(attribution, null);
         });
 
         it('returns attribution for importer context', async function () {
@@ -219,7 +219,7 @@ describe('MemberAttributionService', function () {
                 getTrackingEnabled: () => true
             });
             const attribution = await service.getAttribution([{path: '/test'}]);
-            should(attribution).deepEqual({success: true});
+            assert.deepEqual(attribution, {success: true});
         });
 
         it('returns empty history attribution when tracking disabled', async function () {
@@ -233,7 +233,7 @@ describe('MemberAttributionService', function () {
                 getTrackingEnabled: () => false
             });
             const attribution = await service.getAttribution([{path: '/test'}]);
-            should(attribution).deepEqual({success: true});
+            assert.deepEqual(attribution, {success: true});
         });
     });
 
@@ -272,7 +272,7 @@ describe('MemberAttributionService', function () {
             });
 
             const result = await service.getMemberCreatedAttribution('member_123');
-            should(result).be.null();
+            assert.equal(result, null);
         });
 
         it('returns attribution from event', async function () {
@@ -307,7 +307,7 @@ describe('MemberAttributionService', function () {
             });
 
             const result = await service.getMemberCreatedAttribution('member_123');
-            should(result).deepEqual({
+            assert.deepEqual(result, {
                 id: 'attr_123',
                 url: '/test',
                 type: 'post',
@@ -330,7 +330,7 @@ describe('MemberAttributionService', function () {
             });
 
             const result = await service.getSubscriptionCreatedAttribution('subscription_123');
-            should(result).be.null();
+            assert.equal(result, null);
         });
 
         it('returns attribution from event', async function () {
@@ -365,7 +365,7 @@ describe('MemberAttributionService', function () {
             });
 
             const result = await service.getSubscriptionCreatedAttribution('subscription_123');
-            should(result).deepEqual({
+            assert.deepEqual(result, {
                 id: 'attr_123',
                 url: '/test',
                 type: 'post',
@@ -381,7 +381,7 @@ describe('MemberAttributionService', function () {
         it('returns null when no attribution provided', async function () {
             const service = new MemberAttributionService({});
             const result = await service.fetchResource(null);
-            should(result).be.null();
+            assert.equal(result, null);
         });
 
         it('fetches resource using attribution builder', async function () {
@@ -405,7 +405,7 @@ describe('MemberAttributionService', function () {
             };
 
             const result = await service.fetchResource(attribution);
-            should(result).deepEqual({
+            assert.deepEqual(result, {
                 id: 'attr_123',
                 type: 'post',
                 url: '/test',

--- a/ghost/core/test/unit/server/services/member-welcome-emails/member-welcome-email-renderer.test.js
+++ b/ghost/core/test/unit/server/services/member-welcome-emails/member-welcome-email-renderer.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const should = require('should');
 const rewire = require('rewire');
@@ -53,9 +54,9 @@ describe('MemberWelcomeEmailRenderer', function () {
                 siteSettings: defaultSiteSettings
             });
 
-            result.html.should.containEql('Hello John Doe');
-            result.html.should.containEql('or John!');
-            result.html.should.containEql('Contact: john@example.com');
+            assert(result.html.includes('Hello John Doe'));
+            assert(result.html.includes('or John!'));
+            assert(result.html.includes('Contact: john@example.com'));
         });
 
         it('substitutes site template variables', async function () {
@@ -69,8 +70,8 @@ describe('MemberWelcomeEmailRenderer', function () {
                 siteSettings: defaultSiteSettings
             });
 
-            result.html.should.containEql('Welcome to Test Site');
-            result.html.should.containEql('at https://example.com');
+            assert(result.html.includes('Welcome to Test Site'));
+            assert(result.html.includes('at https://example.com'));
         });
 
         it('inlines accentColor into link styles', async function () {
@@ -84,7 +85,7 @@ describe('MemberWelcomeEmailRenderer', function () {
                 siteSettings: defaultSiteSettings
             });
 
-            result.html.should.containEql('color: #ff0000');
+            assert(result.html.includes('color: #ff0000'));
         });
 
         it('substitutes template variables in subject', async function () {
@@ -97,7 +98,7 @@ describe('MemberWelcomeEmailRenderer', function () {
                 siteSettings: defaultSiteSettings
             });
 
-            result.subject.should.equal('Welcome to Test Site, John!');
+            assert.equal(result.subject, 'Welcome to Test Site, John!');
         });
 
         it('renders empty when member name is missing and no fallback specified', async function () {
@@ -111,8 +112,8 @@ describe('MemberWelcomeEmailRenderer', function () {
                 siteSettings: defaultSiteSettings
             });
 
-            result.text.should.containEql('Hello !');
-            result.html.should.not.containEql('{name}');
+            assert(result.text.includes('Hello !'));
+            assert(!result.html.includes('{name}'));
         });
 
         it('uses custom fallback when member name is missing', async function () {
@@ -126,7 +127,7 @@ describe('MemberWelcomeEmailRenderer', function () {
                 siteSettings: defaultSiteSettings
             });
 
-            result.html.should.containEql('Hello there');
+            assert(result.html.includes('Hello there'));
         });
 
         it('uses custom fallback for first_name when missing', async function () {
@@ -140,7 +141,7 @@ describe('MemberWelcomeEmailRenderer', function () {
                 siteSettings: defaultSiteSettings
             });
 
-            result.html.should.containEql('Hey friend');
+            assert(result.html.includes('Hey friend'));
         });
 
         it('ignores fallback when member name is present', async function () {
@@ -154,7 +155,7 @@ describe('MemberWelcomeEmailRenderer', function () {
                 siteSettings: defaultSiteSettings
             });
 
-            result.html.should.containEql('Hello Jane Smith');
+            assert(result.html.includes('Hello Jane Smith'));
         });
 
         it('renders empty when member email is missing', async function () {
@@ -168,8 +169,8 @@ describe('MemberWelcomeEmailRenderer', function () {
                 siteSettings: defaultSiteSettings
             });
 
-            result.text.should.containEql('Email: !');
-            result.html.should.not.containEql('{email}');
+            assert(result.text.includes('Email: !'));
+            assert(!result.html.includes('{email}'));
         });
 
         it('extracts first name correctly from full name', async function () {
@@ -183,7 +184,7 @@ describe('MemberWelcomeEmailRenderer', function () {
                 siteSettings: defaultSiteSettings
             });
 
-            result.html.should.containEql('Hi John');
+            assert(result.html.includes('Hi John'));
         });
 
         it('handles whitespace in name when extracting first_name', async function () {
@@ -196,7 +197,7 @@ describe('MemberWelcomeEmailRenderer', function () {
                 member: {name: '  Jane  Doe  ', email: 'jane@example.com'},
                 siteSettings: defaultSiteSettings
             });
-            paddedResult.html.should.containEql('Hi Jane');
+            assert(paddedResult.html.includes('Hi Jane'));
 
             const emptyResult = await renderer.render({
                 lexical: '{}',
@@ -204,7 +205,7 @@ describe('MemberWelcomeEmailRenderer', function () {
                 member: {name: '   ', email: 'empty@example.com'},
                 siteSettings: defaultSiteSettings
             });
-            emptyResult.html.should.containEql('Hi friend');
+            assert(emptyResult.html.includes('Hi friend'));
         });
 
         it('wraps content in wrapper.hbs template', async function () {
@@ -219,13 +220,13 @@ describe('MemberWelcomeEmailRenderer', function () {
                 siteSettings: defaultSiteSettings
             });
 
-            result.html.should.containEql('<!doctype html>');
-            result.html.should.containEql('<title>Test Subject</title>');
-            result.html.should.containEql('>Content</p>');
-            result.html.should.containEql('Test Site');
-            result.html.should.containEql(`&copy; ${year}`);
-            result.html.should.containEql('Manage your preferences');
-            result.html.should.containEql('https://example.com/#/portal/account');
+            assert(result.html.includes('<!doctype html>'));
+            assert(result.html.includes('<title>Test Subject</title>'));
+            assert(result.html.includes('>Content</p>'));
+            assert(result.html.includes('Test Site'));
+            assert(result.html.includes(`&copy; ${year}`));
+            assert(result.html.includes('Manage your preferences'));
+            assert(result.html.includes('https://example.com/#/portal/account'));
         });
 
         it('generates plain text from HTML', async function () {
@@ -240,7 +241,7 @@ describe('MemberWelcomeEmailRenderer', function () {
             });
 
             result.text.should.be.a.String();
-            result.text.should.containEql('Hello World');
+            assert(result.text.includes('Hello World'));
         });
 
         it('throws IncorrectUsageError for invalid Lexical', async function () {
@@ -269,7 +270,7 @@ describe('MemberWelcomeEmailRenderer', function () {
                 should.fail('Should have thrown');
             } catch (err) {
                 err.should.be.instanceof(errors.IncorrectUsageError);
-                err.context.should.equal('Parse error');
+                assert.equal(err.context, 'Parse error');
             }
         });
 
@@ -284,9 +285,9 @@ describe('MemberWelcomeEmailRenderer', function () {
                 siteSettings: defaultSiteSettings
             });
 
-            result.html.should.containEql('&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;');
-            result.html.should.not.containEql('<script>alert("xss")</script>');
-            result.subject.should.equal('Welcome <script>alert("xss")</script>!');
+            assert(result.html.includes('&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;'));
+            assert(!result.html.includes('<script>alert("xss")</script>'));
+            assert.equal(result.subject, 'Welcome <script>alert("xss")</script>!');
         });
 
         it('removes unknown tokens from output', async function () {
@@ -300,9 +301,9 @@ describe('MemberWelcomeEmailRenderer', function () {
                 siteSettings: defaultSiteSettings
             });
 
-            result.html.should.not.containEql('%%{');
-            result.html.should.not.containEql('}%%');
-            result.subject.should.equal('Welcome !');
+            assert(!result.html.includes('%%{'));
+            assert(!result.html.includes('}%%'));
+            assert.equal(result.subject, 'Welcome !');
         });
     });
 });

--- a/ghost/core/test/unit/server/services/members/content-gating.test.js
+++ b/ghost/core/test/unit/server/services/members/content-gating.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const {checkPostAccess, checkGatedBlockAccess} = require('../../../../../core/server/services/members/content-gating');
 
@@ -11,28 +12,28 @@ describe('Members Service - Content gating', function () {
             post = {visibility: 'public'};
             member = null;
             access = checkPostAccess(post, member);
-            should(access).be.true();
+            assert.equal(access, true);
         });
 
         it('should allow access to public posts with member', async function () {
             post = {visibility: 'public'};
             member = {id: 'test'};
             access = checkPostAccess(post, member);
-            should(access).be.true();
+            assert.equal(access, true);
         });
 
         it('should allow access to members only post with member', async function () {
             post = {visibility: 'members'};
             member = {id: 'test'};
             access = checkPostAccess(post, member);
-            should(access).be.true();
+            assert.equal(access, true);
         });
 
         it('should allow access to paid members only posts for paid members', async function () {
             post = {visibility: 'paid'};
             member = {id: 'test', status: 'paid'};
             access = checkPostAccess(post, member);
-            should(access).be.true();
+            assert.equal(access, true);
         });
 
         it('should allow access to tiers only post for members on allowed tier', async function () {
@@ -41,7 +42,7 @@ describe('Members Service - Content gating', function () {
                 slug: 'test-tier'
             }]};
             access = checkPostAccess(post, member);
-            should(access).be.true();
+            assert.equal(access, true);
         });
 
         it('should not error out if the slug associated with a tier is only 1 character in length', async function () {
@@ -57,28 +58,28 @@ describe('Members Service - Content gating', function () {
             post = {visibility: 'members'};
             member = null;
             access = checkPostAccess(post, member);
-            should(access).be.false();
+            assert.equal(access, false);
         });
 
         it('should block access to paid members only post without member', async function () {
             post = {visibility: 'paid'};
             member = null;
             access = checkPostAccess(post, member);
-            should(access).be.false();
+            assert.equal(access, false);
         });
 
         it('should block access to paid members only posts for free members', async function () {
             post = {visibility: 'paid'};
             member = {id: 'test', status: 'free'};
             access = checkPostAccess(post, member);
-            should(access).be.false();
+            assert.equal(access, false);
         });
 
         it('should block access to specific tiers only post without tiers list', async function () {
             post = {visibility: 'tiers'};
             member = {id: 'test'};
             access = checkPostAccess(post, member);
-            should(access).be.false();
+            assert.equal(access, false);
         });
 
         it('should block access to tiers only post for members not on allowed tier', async function () {
@@ -87,7 +88,7 @@ describe('Members Service - Content gating', function () {
                 slug: 'test-tier-2'
             }]};
             access = checkPostAccess(post, member);
-            should(access).be.false();
+            assert.equal(access, false);
         });
     });
 

--- a/ghost/core/test/unit/server/services/members/importer/members-csv-importer-stripe-utils.test.js
+++ b/ghost/core/test/unit/server/services/members/importer/members-csv-importer-stripe-utils.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 require('should');
 const sinon = require('sinon');
 const {DataImportError} = require('@tryghost/errors');
@@ -278,9 +279,9 @@ describe('MembersCSVImporterStripeUtils', function () {
             }, OPTIONS);
 
             result.stripePriceId.should.equal(stripeCustomerSubscriptionItem.price.id);
-            result.isNewStripePrice.should.be.false();
+            assert.equal(result.isNewStripePrice, false);
 
-            stripeAPIServiceStub.updateSubscriptionItemPrice.calledOnce.should.be.false();
+            assert.equal(stripeAPIServiceStub.updateSubscriptionItemPrice.calledOnce, false);
         });
 
         it('updates the Stripe customer\'s subscription if they already have a subscription, but to some other Ghost product', async function () {
@@ -299,15 +300,15 @@ describe('MembersCSVImporterStripeUtils', function () {
             }, OPTIONS);
 
             result.stripePriceId.should.equal(GHOST_PRODUCT_STRIPE_PRICE_ID);
-            result.isNewStripePrice.should.be.false();
+            assert.equal(result.isNewStripePrice, false);
 
-            stripeAPIServiceStub.updateSubscriptionItemPrice.calledOnce.should.be.true();
-            stripeAPIServiceStub.updateSubscriptionItemPrice.calledWithExactly(
+            assert.equal(stripeAPIServiceStub.updateSubscriptionItemPrice.calledOnce, true);
+            assert.equal(stripeAPIServiceStub.updateSubscriptionItemPrice.calledWithExactly(
                 stripeCustomer.subscriptions.data[0].id,
                 stripeCustomerSubscriptionItem.id,
                 GHOST_PRODUCT_STRIPE_PRICE_ID,
                 {prorationBehavior: 'none'}
-            ).should.be.true();
+            ), true);
         });
 
         it('creates a new price on the Stripe product matching the Stripe customer\'s existing subscription and updates the subscription', async function () {
@@ -341,16 +342,16 @@ describe('MembersCSVImporterStripeUtils', function () {
 
             // Assert new price was created
             result.stripePriceId.should.equal(NEW_STRIPE_PRICE_ID);
-            result.isNewStripePrice.should.be.true();
+            assert.equal(result.isNewStripePrice, true);
 
             // Assert subscription was updated
-            stripeAPIServiceStub.updateSubscriptionItemPrice.calledOnce.should.be.true();
-            stripeAPIServiceStub.updateSubscriptionItemPrice.calledWithExactly(
+            assert.equal(stripeAPIServiceStub.updateSubscriptionItemPrice.calledOnce, true);
+            assert.equal(stripeAPIServiceStub.updateSubscriptionItemPrice.calledWithExactly(
                 stripeCustomer.subscriptions.data[0].id,
                 stripeCustomerSubscriptionItem.id,
                 NEW_STRIPE_PRICE_ID,
                 {prorationBehavior: 'none'}
-            ).should.be.true();
+            ), true);
         });
 
         it('creates a new product in Stripe if one does not already existing for the Ghost product', async function () {
@@ -368,8 +369,8 @@ describe('MembersCSVImporterStripeUtils', function () {
                 product_id: PRODUCT_ID
             }, OPTIONS);
 
-            productRepositoryStub.update.calledOnce.should.be.true();
-            productRepositoryStub.update.calledWithExactly(
+            assert.equal(productRepositoryStub.update.calledOnce, true);
+            assert.equal(productRepositoryStub.update.calledWithExactly(
                 {
                     id: PRODUCT_ID,
                     name: ghostProduct.name,
@@ -383,7 +384,7 @@ describe('MembersCSVImporterStripeUtils', function () {
                     }
                 },
                 OPTIONS
-            ).should.be.true();
+            ), true);
         });
     });
 
@@ -397,8 +398,8 @@ describe('MembersCSVImporterStripeUtils', function () {
 
             await membersCSVImporterStripeUtils.archivePrice(stripePriceId);
 
-            stripeAPIServiceStub.updatePrice.calledOnce.should.be.true();
-            stripeAPIServiceStub.updatePrice.calledWithExactly(stripePriceId, {active: false}).should.be.true();
+            assert.equal(stripeAPIServiceStub.updatePrice.calledOnce, true);
+            assert.equal(stripeAPIServiceStub.updatePrice.calledWithExactly(stripePriceId, {active: false}), true);
         });
     });
 });

--- a/ghost/core/test/unit/server/services/members/importer/members-csv-importer.test.js
+++ b/ghost/core/test/unit/server/services/members/importer/members-csv-importer.test.js
@@ -121,19 +121,19 @@ describe('MembersCSVImporter', function () {
             should.exist(result.meta);
             should.exist(result.meta.stats);
             should.exist(result.meta.stats.imported);
-            result.meta.stats.imported.should.equal(2);
+            assert.equal(result.meta.stats.imported, 2);
 
             should.exist(result.meta.stats.invalid);
             assert.equal(result.meta.import_label, null);
 
             should.exist(result.meta.originalImportSize);
-            result.meta.originalImportSize.should.equal(2);
+            assert.equal(result.meta.originalImportSize, 2);
 
-            fsWriteSpy.calledOnce.should.be.true();
+            assert.equal(fsWriteSpy.calledOnce, true);
 
             // Called at least once
-            memberCreateStub.notCalled.should.be.false();
-            memberCreateStub.firstCall.lastArg.context.import.should.be.true();
+            assert.equal(memberCreateStub.notCalled, false);
+            assert.equal(memberCreateStub.firstCall.lastArg.context.import, true);
         });
 
         it('should import a CSV in the default Members export format', async function () {
@@ -170,18 +170,18 @@ describe('MembersCSVImporter', function () {
             should.exist(result.meta);
             should.exist(result.meta.stats);
             should.exist(result.meta.stats.imported);
-            result.meta.stats.imported.should.equal(2);
+            assert.equal(result.meta.stats.imported, 2);
 
             should.exist(result.meta.stats.invalid);
             assert.deepEqual(result.meta.import_label, internalLabel);
 
             should.exist(result.meta.originalImportSize);
-            result.meta.originalImportSize.should.equal(2);
+            assert.equal(result.meta.originalImportSize, 2);
 
-            fsWriteSpy.calledOnce.should.be.true();
+            assert.equal(fsWriteSpy.calledOnce, true);
 
             // member records get inserted
-            membersRepositoryStub.create.calledTwice.should.be.true();
+            assert.equal(membersRepositoryStub.create.calledTwice, true);
 
             assert.equal(membersRepositoryStub.create.args[0][1].context.import, true, 'inserts are done in the "import" context');
 
@@ -208,13 +208,13 @@ describe('MembersCSVImporter', function () {
             assert.deepEqual(membersRepositoryStub.create.args[1][0].labels, [], 'no labels should be assigned');
 
             // stripe customer import
-            membersRepositoryStub.linkStripeCustomer.calledOnce.should.be.true();
+            assert.equal(membersRepositoryStub.linkStripeCustomer.calledOnce, true);
             assert.equal(membersRepositoryStub.linkStripeCustomer.args[0][0].customer_id, 'cus_MdR9tqW6bAreiq');
             assert.equal(membersRepositoryStub.linkStripeCustomer.args[0][0].member_id, 'test_member_id');
             assert.equal(membersRepositoryStub.linkStripeCustomer.args[0][1].context.importer, true, 'linkStripeCustomer is called with importer context to prevent welcome emails');
 
             // complimentary_plan import
-            membersRepositoryStub.update.calledOnce.should.be.true();
+            assert.equal(membersRepositoryStub.update.calledOnce, true);
             assert.deepEqual(membersRepositoryStub.update.args[0][0].products, [{
                 id: defaultTierId.toString()
             }]);
@@ -316,15 +316,15 @@ describe('MembersCSVImporter', function () {
             should.exist(result.meta);
             should.exist(result.meta.stats);
             should.exist(result.meta.stats.imported);
-            result.meta.stats.imported.should.equal(5);
+            assert.equal(result.meta.stats.imported, 5);
 
             should.exist(result.meta.stats.invalid);
             assert.deepEqual(result.meta.import_label, internalLabel);
 
             should.exist(result.meta.originalImportSize);
-            result.meta.originalImportSize.should.equal(15);
+            assert.equal(result.meta.originalImportSize, 15);
 
-            fsWriteSpy.calledOnce.should.be.true();
+            assert.equal(fsWriteSpy.calledOnce, true);
 
             // member records get inserted
             assert.equal(membersRepositoryStub.create.callCount, 5);
@@ -450,7 +450,7 @@ describe('MembersCSVImporter', function () {
                 importLabel: {name: 'Test import'}
             });
 
-            sendEmailStub.calledWith({
+            assert.equal(sendEmailStub.calledWith({
                 to: 'test@example.com',
                 subject: 'Your member import was unsuccessful',
                 html: 'Import was unsuccessful',
@@ -463,7 +463,7 @@ describe('MembersCSVImporter', function () {
                         contentDisposition: 'attachment'
                     }
                 ]
-            }).should.be.true();
+            }), true);
         });
     });
 
@@ -474,12 +474,12 @@ describe('MembersCSVImporter', function () {
             const result = await membersImporter.prepare(`${csvPath}/single-column-with-header.csv`, defaultAllowedFields);
 
             should.exist(result.filePath);
-            result.filePath.should.match(/\/members\/importer\/fixtures\/Members Import/);
+            assert.match(result.filePath, /\/members\/importer\/fixtures\/Members Import/);
 
-            result.batches.should.equal(2);
+            assert.equal(result.batches, 2);
             should.exist(result.metadata);
             assert.equal(result.metadata.hasStripeData, false);
-            fsWriteSpy.calledOnce.should.be.true();
+            assert.equal(fsWriteSpy.calledOnce, true);
         });
 
         it('Does not include columns not in the original CSV or mapped', async function () {
@@ -489,7 +489,7 @@ describe('MembersCSVImporter', function () {
 
             const fileContents = fsWriteSpy.firstCall.args[1];
 
-            fileContents.should.match(/^email,labels\r\n/);
+            assert.match(fileContents, /^email,labels\r\n/);
         });
 
         it('It supports "subscribed_to_emails" column header ouf of the box', async function (){
@@ -499,7 +499,7 @@ describe('MembersCSVImporter', function () {
 
             const fileContents = fsWriteSpy.firstCall.args[1];
 
-            fileContents.should.match(/^email,subscribed_to_emails,labels\r\n/);
+            assert.match(fileContents, /^email,subscribed_to_emails,labels\r\n/);
         });
 
         it('checks for stripe data in the imported file', async function () {

--- a/ghost/core/test/unit/server/services/members/members-api/controllers/router-controller.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/controllers/router-controller.test.js
@@ -102,12 +102,12 @@ describe('RouterController', function () {
                 end: () => {}
             });
 
-            getPaymentLinkSpy.calledOnce.should.be.true();
+            assert.equal(getPaymentLinkSpy.calledOnce, true);
 
             // Payment link is called with the offer id in metadata
-            getPaymentLinkSpy.calledWith(sinon.match({
+            assert.equal(getPaymentLinkSpy.calledWith(sinon.match({
                 metadata: {offer: 'offer_123'}
-            })).should.be.true();
+            })), true);
         });
 
         it('parses newsletters from the request body', async function () {
@@ -150,13 +150,13 @@ describe('RouterController', function () {
 
             const expectedNewsletters = JSON.stringify([{id: 'abc123'}, {id: 'def456'}]);
 
-            getPaymentLinkSpy.calledOnce.should.be.true();
+            assert.equal(getPaymentLinkSpy.calledOnce, true);
 
-            getPaymentLinkSpy.calledWith(sinon.match({
+            assert.equal(getPaymentLinkSpy.calledWith(sinon.match({
                 metadata: {
                     newsletters: expectedNewsletters
                 }
-            })).should.be.true();
+            })), true);
         });
 
         describe('_getSubscriptionCheckoutData', function () {
@@ -357,16 +357,16 @@ describe('RouterController', function () {
                     writeHead: () => {},
                     end: () => {}
                 });
-                getDonationLinkSpy.calledOnce.should.be.true();
+                assert.equal(getDonationLinkSpy.calledOnce, true);
 
-                getDonationLinkSpy.calledWith(sinon.match({
+                assert.equal(getDonationLinkSpy.calledWith(sinon.match({
                     successUrl: 'https://example.com/?type=success',
                     cancelUrl: 'https://example.com/?type=cancel',
                     personalNote: 'SVP leave a note here',
                     metadata: {
                         test: 'hello'
                     }
-                })).should.be.true();
+                })), true);
             });
             it('accepts requests without a personalNote included', async function () {
                 const routerController = new RouterController({
@@ -404,16 +404,16 @@ describe('RouterController', function () {
                     writeHead: () => {},
                     end: () => {}
                 });
-                getDonationLinkSpy.calledOnce.should.be.true();
+                assert.equal(getDonationLinkSpy.calledOnce, true);
 
-                getDonationLinkSpy.calledWith(sinon.match({
+                assert.equal(getDonationLinkSpy.calledWith(sinon.match({
                     successUrl: 'https://example.com/?type=success',
                     cancelUrl: 'https://example.com/?type=cancel',
                     personalNote: '',
                     metadata: {
                         test: 'hello'
                     }
-                })).should.be.true();
+                })), true);
             });
             it('silently discards too-long personal notes', async function () {
                 const routerController = new RouterController({
@@ -452,15 +452,15 @@ describe('RouterController', function () {
                     writeHead: () => {},
                     end: () => {}
                 });
-                getDonationLinkSpy.calledOnce.should.be.true();
-                getDonationLinkSpy.calledWith(sinon.match({
+                assert.equal(getDonationLinkSpy.calledOnce, true);
+                assert.equal(getDonationLinkSpy.calledWith(sinon.match({
                     successUrl: 'https://example.com/?type=success',
                     cancelUrl: 'https://example.com/?type=cancel',
                     personalNote: '',
                     metadata: {
                         test: 'hello'
                     }
-                })).should.be.true();
+                })), true);
             });
             it('silently discards invalid personal notes', async function () {
                 const routerController = new RouterController({
@@ -499,15 +499,15 @@ describe('RouterController', function () {
                     writeHead: () => {},
                     end: () => {}
                 });
-                getDonationLinkSpy.calledOnce.should.be.true();
-                getDonationLinkSpy.calledWith(sinon.match({
+                assert.equal(getDonationLinkSpy.calledOnce, true);
+                assert.equal(getDonationLinkSpy.calledWith(sinon.match({
                     successUrl: 'https://example.com/?type=success',
                     cancelUrl: 'https://example.com/?type=cancel',
                     personalNote: '',
                     metadata: {
                         test: 'hello'
                     }
-                })).should.be.true();
+                })), true);
             });
             it('strips any html from the personal note', async function () {
                 const routerController = new RouterController({
@@ -546,15 +546,15 @@ describe('RouterController', function () {
                     writeHead: () => {},
                     end: () => {}
                 });
-                getDonationLinkSpy.calledOnce.should.be.true();
-                getDonationLinkSpy.calledWith(sinon.match({
+                assert.equal(getDonationLinkSpy.calledOnce, true);
+                assert.equal(getDonationLinkSpy.calledWith(sinon.match({
                     successUrl: 'https://example.com/?type=success',
                     cancelUrl: 'https://example.com/?type=cancel',
                     personalNote: 'Leave a note here',
                     metadata: {
                         test: 'hello'
                     }
-                })).should.be.true();
+                })), true);
             });
         });
 
@@ -612,7 +612,7 @@ describe('RouterController', function () {
 
             await routerController.createCheckoutSession(req, res);
 
-            res.end.calledOnce.should.be.true();
+            assert.equal(res.end.calledOnce, true);
             const responseBody = JSON.parse(res.end.firstCall.args[0]);
             assert.equal(responseBody.welcomePageUrl, '/welcome-page/');
         });
@@ -670,7 +670,7 @@ describe('RouterController', function () {
 
             await routerController.createCheckoutSession(req, res);
 
-            res.end.calledOnce.should.be.true();
+            assert.equal(res.end.calledOnce, true);
             const responseBody = JSON.parse(res.end.firstCall.args[0]);
             assert.equal(responseBody.welcomePageUrl, undefined);
         });
@@ -753,10 +753,10 @@ describe('RouterController', function () {
 
                 await controller.sendMagicLink(req, res);
 
-                res.writeHead.calledOnceWith(201).should.be.true();
-                res.end.calledOnceWith('{}').should.be.true();
+                assert.equal(res.writeHead.calledOnceWith(201), true);
+                assert.equal(res.end.calledOnceWith('{}'), true);
 
-                sendEmailWithMagicLinkStub.calledOnce.should.be.true();
+                assert.equal(sendEmailWithMagicLinkStub.calledOnce, true);
                 sendEmailWithMagicLinkStub.args[0][0].tokenData.newsletters.should.eql([
                     {id: newsletters[0].id},
                     {id: newsletters[1].id},
@@ -865,7 +865,7 @@ describe('RouterController', function () {
                 const controller = createRouterController();
 
                 await controller.sendMagicLink(req, res).should.be.fulfilled();
-                sendEmailWithMagicLinkStub.calledOnce.should.be.true();
+                assert.equal(sendEmailWithMagicLinkStub.calledOnce, true);
             });
 
             it('Does not send emails when honeypot is filled', async function () {
@@ -874,7 +874,7 @@ describe('RouterController', function () {
                 req.body.honeypot = 'filled!';
 
                 await controller.sendMagicLink(req, res).should.be.fulfilled();
-                sendEmailWithMagicLinkStub.notCalled.should.be.true();
+                assert.equal(sendEmailWithMagicLinkStub.notCalled, true);
             });
         });
 
@@ -928,8 +928,8 @@ describe('RouterController', function () {
 
                 await routerController.sendMagicLink(req, res);
 
-                res.writeHead.calledWith(201, {'Content-Type': 'application/json'}).should.be.true();
-                res.end.calledWith(JSON.stringify({otc_ref: 'test-token-123'})).should.be.true();
+                assert.equal(res.writeHead.calledWith(201, {'Content-Type': 'application/json'}), true);
+                assert.equal(res.end.calledWith(JSON.stringify({otc_ref: 'test-token-123'})), true);
             });
 
             it('should not return otc_ref when no otcRef', async function () {
@@ -937,8 +937,8 @@ describe('RouterController', function () {
 
                 await routerController.sendMagicLink(req, res);
 
-                res.writeHead.calledWith(201).should.be.true();
-                res.end.calledWith('{}').should.be.true();
+                assert.equal(res.writeHead.calledWith(201), true);
+                assert.equal(res.end.calledWith('{}'), true);
             });
 
             it('should not return otc_ref when otcRef is undefined', async function () {
@@ -946,8 +946,8 @@ describe('RouterController', function () {
 
                 await routerController.sendMagicLink(req, res);
 
-                res.writeHead.calledWith(201).should.be.true();
-                res.end.calledWith('{}').should.be.true();
+                assert.equal(res.writeHead.calledWith(201), true);
+                assert.equal(res.end.calledWith('{}'), true);
             });
         });
     });

--- a/ghost/core/test/unit/server/services/members/members-api/repositories/member-repository.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/repositories/member-repository.test.js
@@ -140,7 +140,7 @@ describe('MemberRepository', function () {
 
                 assert.fail('setComplimentarySubscription should have thrown');
             } catch (err) {
-                productRepository.getDefaultProduct.calledWith({withRelated: ['stripePrices'], transacting: true}).should.be.true();
+                assert.equal(productRepository.getDefaultProduct.calledWith({withRelated: ['stripePrices'], transacting: true}), true);
                 assert.equal(err.message, 'Could not find Product "default"');
             }
         });
@@ -227,7 +227,7 @@ describe('MemberRepository', function () {
                 context: {}
             });
 
-            MemberSubscribeEvent.add.calledTwice.should.be.true();
+            assert.equal(MemberSubscribeEvent.add.calledTwice, true);
         });
     });
 
@@ -365,8 +365,8 @@ describe('MemberRepository', function () {
                 context: {}
             });
 
-            subscriptionCreatedNotifySpy.calledOnce.should.be.true();
-            offerRedemptionNotifySpy.called.should.be.false();
+            assert.equal(subscriptionCreatedNotifySpy.calledOnce, true);
+            assert.equal(offerRedemptionNotifySpy.called, false);
         });
 
         it('dispatches the offer redemption event for a new member starting a subscription', async function (){
@@ -400,21 +400,21 @@ describe('MemberRepository', function () {
                 context: {}
             });
 
-            subscriptionCreatedNotifySpy.calledOnce.should.be.true();
-            subscriptionCreatedNotifySpy.calledWith(sinon.match((event) => {
+            assert.equal(subscriptionCreatedNotifySpy.calledOnce, true);
+            assert.equal(subscriptionCreatedNotifySpy.calledWith(sinon.match((event) => {
                 if (event.data.offerId === 'offer_123') {
                     return true;
                 }
                 return false;
-            })).should.be.true();
+            })), true);
 
-            offerRedemptionNotifySpy.called.should.be.true();
-            offerRedemptionNotifySpy.calledWith(sinon.match((event) => {
+            assert.equal(offerRedemptionNotifySpy.called, true);
+            assert.equal(offerRedemptionNotifySpy.calledWith(sinon.match((event) => {
                 if (event.data.offerId === 'offer_123') {
                     return true;
                 }
                 return false;
-            })).should.be.true();
+            })), true);
         });
 
         it('dispatches the offer redemption event for an existing member upgrading to a paid subscription', async function (){
@@ -449,15 +449,15 @@ describe('MemberRepository', function () {
                 context: {}
             });
 
-            subscriptionCreatedNotifySpy.calledOnce.should.be.false();
+            assert.equal(subscriptionCreatedNotifySpy.calledOnce, false);
 
-            offerRedemptionNotifySpy.called.should.be.true();
-            offerRedemptionNotifySpy.calledWith(sinon.match((event) => {
+            assert.equal(offerRedemptionNotifySpy.called, true);
+            assert.equal(offerRedemptionNotifySpy.calledWith(sinon.match((event) => {
                 if (event.data.offerId === 'offer_123') {
                     return true;
                 }
                 return false;
-            })).should.be.true();
+            })), true);
         });
 
         it('creates an offer from a Stripe coupon', async function () {
@@ -521,13 +521,13 @@ describe('MemberRepository', function () {
                 context: {}
             });
 
-            offersAPI.ensureOfferForStripeCoupon.calledOnce.should.be.true();
+            assert.equal(offersAPI.ensureOfferForStripeCoupon.calledOnce, true);
             // Verify the coupon, cadence, tier, and options are passed correctly
             offersAPI.ensureOfferForStripeCoupon.firstCall.args[0].should.deepEqual(stripeCoupon);
-            offersAPI.ensureOfferForStripeCoupon.firstCall.args[1].should.equal('month');
+            assert.equal(offersAPI.ensureOfferForStripeCoupon.firstCall.args[1], 'month');
             offersAPI.ensureOfferForStripeCoupon.firstCall.args[2].should.deepEqual({id: 'tier_1', name: 'Tier One'});
             offersAPI.ensureOfferForStripeCoupon.firstCall.args[3].transacting.should.equal(transacting);
-            StripeCustomerSubscription.add.firstCall.args[0].offer_id.should.equal('offer_new');
+            assert.equal(StripeCustomerSubscription.add.firstCall.args[0].offer_id, 'offer_new');
         });
 
         it('sets offer_id to null if Stripe coupon is known to be incompatible with Ghost offers', async function () {
@@ -599,10 +599,10 @@ describe('MemberRepository', function () {
             });
 
             // Verify ensureOfferForStripeCoupon was called
-            offersAPI.ensureOfferForStripeCoupon.calledOnce.should.be.true();
+            assert.equal(offersAPI.ensureOfferForStripeCoupon.calledOnce, true);
 
             // Verify subscription was still created, but without an offer_id
-            StripeCustomerSubscription.add.calledOnce.should.be.true();
+            assert.equal(StripeCustomerSubscription.add.calledOnce, true);
             assert.equal(StripeCustomerSubscription.add.firstCall.args[0].offer_id, null);
         });
 
@@ -679,10 +679,10 @@ describe('MemberRepository', function () {
             );
 
             // Verify ensureOfferForStripeCoupon was called
-            offersAPI.ensureOfferForStripeCoupon.calledOnce.should.be.true();
+            assert.equal(offersAPI.ensureOfferForStripeCoupon.calledOnce, true);
 
             // Verify subscription was NOT created because the error was rethrown
-            StripeCustomerSubscription.add.called.should.be.false();
+            assert.equal(StripeCustomerSubscription.add.called, false);
         });
 
         it('persists discount_start and discount_end for a new subscription', async function () {
@@ -732,7 +732,7 @@ describe('MemberRepository', function () {
             });
 
             // Verify discount_start and discount_end are set correctly
-            StripeCustomerSubscription.add.calledOnce.should.be.true();
+            assert.equal(StripeCustomerSubscription.add.calledOnce, true);
             const addedSubscriptionData = StripeCustomerSubscription.add.firstCall.args[0];
 
             assert.ok(addedSubscriptionData.discount_start instanceof Date);
@@ -790,8 +790,8 @@ describe('MemberRepository', function () {
             });
 
             // Verify edit was called (not add) since subscription exists
-            StripeCustomerSubscription.add.called.should.be.false();
-            StripeCustomerSubscription.edit.calledOnce.should.be.true();
+            assert.equal(StripeCustomerSubscription.add.called, false);
+            assert.equal(StripeCustomerSubscription.edit.calledOnce, true);
 
             const editedSubscriptionData = StripeCustomerSubscription.edit.firstCall.args[0];
 
@@ -829,7 +829,7 @@ describe('MemberRepository', function () {
                 context: {}
             });
 
-            StripeCustomerSubscription.add.calledOnce.should.be.true();
+            assert.equal(StripeCustomerSubscription.add.calledOnce, true);
             const addedSubscriptionData = StripeCustomerSubscription.add.firstCall.args[0];
 
             assert.equal(addedSubscriptionData.discount_start, null);
@@ -879,7 +879,7 @@ describe('MemberRepository', function () {
                 context: {}
             });
 
-            StripeCustomerSubscription.add.calledOnce.should.be.true();
+            assert.equal(StripeCustomerSubscription.add.calledOnce, true);
             const addedSubscriptionData = StripeCustomerSubscription.add.firstCall.args[0];
 
             assert.ok(addedSubscriptionData.discount_start instanceof Date);

--- a/ghost/core/test/unit/server/services/members/members-api/services/geolocation-service.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/services/geolocation-service.test.js
@@ -37,7 +37,7 @@ describe('lib/geolocation', function () {
 
             const result = await service.getGeolocationFromIP('188.39.113.90');
 
-            scope.isDone().should.eql(true, 'request was not made');
+            assert.equal(scope.isDone(), true, 'request was not made');
             should.exist(result, 'nothing was returned');
             result.should.deepEqual(RESPONSE, 'result didn\'t match expected response');
         });
@@ -49,7 +49,7 @@ describe('lib/geolocation', function () {
 
             const result = await service.getGeolocationFromIP('2a01:4c8:43a:13c9:8d6:128e:1fd5:6aad');
 
-            scope.isDone().should.eql(true, 'request was not made');
+            assert.equal(scope.isDone(), true, 'request was not made');
             should.exist(result, 'nothing was returned');
             result.should.deepEqual(RESPONSE, 'result didn\'t match expected response');
         });
@@ -57,22 +57,22 @@ describe('lib/geolocation', function () {
         it('handles non-IP addresses', async function () {
             let scope = nock('https://get.geojs.io').get('/v1/ip/geo/.json').reply(200, {test: true});
             let result = await service.getGeolocationFromIP('');
-            scope.isDone().should.eql(false);
+            assert.equal(scope.isDone(), false);
             assert.equal(undefined, result);
 
             scope = nock('https://get.geojs.io').get('/v1/ip/geo/null.json').reply(200, {test: true});
             result = await service.getGeolocationFromIP(null);
-            scope.isDone().should.eql(false);
+            assert.equal(scope.isDone(), false);
             assert.equal(undefined, result);
 
             scope = nock('https://get.geojs.io').get('/v1/ip/geo/undefined.json').reply(200, {test: true});
             result = await service.getGeolocationFromIP(undefined);
-            scope.isDone().should.eql(false);
+            assert.equal(scope.isDone(), false);
             assert.equal(undefined, result);
 
             scope = nock('https://get.geojs.io').get('/v1/ip/geo/test.json').reply(200, {test: true});
             result = await service.getGeolocationFromIP('test');
-            scope.isDone().should.eql(false);
+            assert.equal(scope.isDone(), false);
             assert.equal(undefined, result);
         });
     });

--- a/ghost/core/test/unit/server/services/members/middleware.test.js
+++ b/ghost/core/test/unit/server/services/members/middleware.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 
@@ -55,7 +56,7 @@ describe('Members Service Middleware', function () {
             await membersMiddleware.createSessionFromMagicLink(req, res, next);
 
             // Check behavior
-            next.calledOnce.should.be.true();
+            assert.equal(next.calledOnce, true);
             next.firstCall.args.should.be.an.Array().with.lengthOf(0);
         });
 
@@ -77,9 +78,9 @@ describe('Members Service Middleware', function () {
             await membersMiddleware.createSessionFromMagicLink(req, res, next);
 
             // Check behavior
-            next.calledOnce.should.be.false();
-            res.redirect.calledOnce.should.be.true();
-            res.redirect.firstCall.args[0].should.eql('/blah/?action=signup&success=true');
+            assert.equal(next.calledOnce, false);
+            assert.equal(res.redirect.calledOnce, true);
+            assert.equal(res.redirect.firstCall.args[0], '/blah/?action=signup&success=true');
         });
 
         it('redirects correctly on failure', async function () {
@@ -93,9 +94,9 @@ describe('Members Service Middleware', function () {
             await membersMiddleware.createSessionFromMagicLink(req, res, next);
 
             // Check behavior
-            next.calledOnce.should.be.false();
-            res.redirect.calledOnce.should.be.true();
-            res.redirect.firstCall.args[0].should.eql('/blah/?action=signup&success=false');
+            assert.equal(next.calledOnce, false);
+            assert.equal(res.redirect.calledOnce, true);
+            assert.equal(res.redirect.firstCall.args[0], '/blah/?action=signup&success=false');
         });
 
         it('redirects free member to custom redirect on signup', async function () {
@@ -116,9 +117,9 @@ describe('Members Service Middleware', function () {
             await membersMiddleware.createSessionFromMagicLink(req, res, next);
 
             // Check behavior
-            next.calledOnce.should.be.false();
-            res.redirect.calledOnce.should.be.true();
-            res.redirect.firstCall.args[0].should.eql('https://custom.com/redirect/');
+            assert.equal(next.calledOnce, false);
+            assert.equal(res.redirect.calledOnce, true);
+            assert.equal(res.redirect.firstCall.args[0], 'https://custom.com/redirect/');
         });
 
         it('redirects paid member to custom redirect on signup', async function () {
@@ -139,9 +140,9 @@ describe('Members Service Middleware', function () {
             await membersMiddleware.createSessionFromMagicLink(req, res, next);
 
             // Check behavior
-            next.calledOnce.should.be.false();
-            res.redirect.calledOnce.should.be.true();
-            res.redirect.firstCall.args[0].should.eql('https://custom.com/paid/');
+            assert.equal(next.calledOnce, false);
+            assert.equal(res.redirect.calledOnce, true);
+            assert.equal(res.redirect.firstCall.args[0], 'https://custom.com/paid/');
         });
 
         it('redirects member to referrer param path on signin if it is on the site', async function () {
@@ -155,9 +156,9 @@ describe('Members Service Middleware', function () {
             await membersMiddleware.createSessionFromMagicLink(req, res, next);
 
             // Check behavior
-            next.calledOnce.should.be.false();
-            res.redirect.calledOnce.should.be.true();
-            res.redirect.firstCall.args[0].should.eql('https://site.com/blah/my-post/?action=signin&success=true#comment-123');
+            assert.equal(next.calledOnce, false);
+            assert.equal(res.redirect.calledOnce, true);
+            assert.equal(res.redirect.firstCall.args[0], 'https://site.com/blah/my-post/?action=signin&success=true#comment-123');
         });
 
         it('redirects member to referrer param path on signup if it is on the site', async function () {
@@ -171,9 +172,9 @@ describe('Members Service Middleware', function () {
             await membersMiddleware.createSessionFromMagicLink(req, res, next);
 
             // Check behavior
-            next.calledOnce.should.be.false();
-            res.redirect.calledOnce.should.be.true();
-            res.redirect.firstCall.args[0].should.eql('https://site.com/blah/my-post/?action=signup&success=true#comment-123');
+            assert.equal(next.calledOnce, false);
+            assert.equal(res.redirect.calledOnce, true);
+            assert.equal(res.redirect.firstCall.args[0], 'https://site.com/blah/my-post/?action=signup&success=true#comment-123');
         });
 
         it('does not redirect to referrer param if it is external', async function () {
@@ -187,9 +188,9 @@ describe('Members Service Middleware', function () {
             await membersMiddleware.createSessionFromMagicLink(req, res, next);
 
             // Check behavior
-            next.calledOnce.should.be.false();
-            res.redirect.calledOnce.should.be.true();
-            res.redirect.firstCall.args[0].should.eql('/blah/?action=signin&success=true');
+            assert.equal(next.calledOnce, false);
+            assert.equal(res.redirect.calledOnce, true);
+            assert.equal(res.redirect.firstCall.args[0], '/blah/?action=signin&success=true');
         });
     });
 
@@ -219,10 +220,10 @@ describe('Members Service Middleware', function () {
             await membersMiddleware.updateMemberNewsletters(req, res);
 
             // Check behavior
-            res.writeHead.calledOnce.should.be.true();
-            res.writeHead.firstCall.args[0].should.eql(404);
-            res.end.calledOnce.should.be.true();
-            res.end.firstCall.args[0].should.eql('Email address not found.');
+            assert.equal(res.writeHead.calledOnce, true);
+            assert.equal(res.writeHead.firstCall.args[0], 404);
+            assert.equal(res.end.calledOnce, true);
+            assert.equal(res.end.firstCall.args[0], 'Email address not found.');
         });
 
         // auth happens prior to this middleware
@@ -240,10 +241,10 @@ describe('Members Service Middleware', function () {
             await membersMiddleware.updateMemberNewsletters(req, res);
 
             // Check behavior
-            res.writeHead.calledOnce.should.be.true();
-            res.writeHead.firstCall.args[0].should.eql(404);
-            res.end.calledOnce.should.be.true();
-            res.end.firstCall.args[0].should.eql('Email address not found.');
+            assert.equal(res.writeHead.calledOnce, true);
+            assert.equal(res.writeHead.firstCall.args[0], 404);
+            assert.equal(res.end.calledOnce, true);
+            assert.equal(res.end.firstCall.args[0], 'Email address not found.');
         });
 
         it('attempts to update newsletters', async function () {
@@ -269,7 +270,7 @@ describe('Members Service Middleware', function () {
             });
             await membersMiddleware.updateMemberNewsletters(req, res);
             // the stubbing of the api is difficult to test with the current design, so we just check that the response is sent
-            res.json.calledOnce.should.be.true();
+            assert.equal(res.json.calledOnce, true);
         });
 
         it('returns 400 on error', async function () {
@@ -293,10 +294,10 @@ describe('Members Service Middleware', function () {
             await membersMiddleware.updateMemberNewsletters(req, res);
 
             // Check behavior
-            res.writeHead.calledOnce.should.be.true();
-            res.writeHead.firstCall.args[0].should.eql(400);
-            res.end.calledOnce.should.be.true();
-            res.end.firstCall.args[0].should.eql('Failed to update newsletters');
+            assert.equal(res.writeHead.calledOnce, true);
+            assert.equal(res.writeHead.firstCall.args[0], 400);
+            assert.equal(res.end.calledOnce, true);
+            assert.equal(res.end.firstCall.args[0], 'Failed to update newsletters');
         });
     });
 });

--- a/ghost/core/test/unit/server/services/members/request-integrity-token-provider.test.js
+++ b/ghost/core/test/unit/server/services/members/request-integrity-token-provider.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const should = require('should');
 
@@ -27,7 +28,7 @@ describe('RequestIntegrityTokenProvider', function () {
 
             timestamp.should.equal((new Date('2021-01-01').valueOf() + 100).toString());
 
-            nonce.should.match(/[0-9a-f]{16}/);
+            assert.match(nonce, /[0-9a-f]{16}/);
 
             digest.should.be.a.String().with.lengthOf(64);
         });
@@ -38,7 +39,7 @@ describe('RequestIntegrityTokenProvider', function () {
             const token = tokenProvider.create();
             const result = tokenProvider.validate(token);
 
-            result.should.be.true();
+            assert.equal(result, true);
         });
 
         it('should fail to verify an expired token', function () {
@@ -46,14 +47,14 @@ describe('RequestIntegrityTokenProvider', function () {
             sinon.clock.tick(101);
             const result = tokenProvider.validate(token);
 
-            result.should.be.false();
+            assert.equal(result, false);
         });
 
         it('should fail to verify a malformed token', function () {
             const token = 'invalid_token';
             const result = tokenProvider.validate(token);
 
-            result.should.be.false();
+            assert.equal(result, false);
         });
 
         it('should fail to verify a token with an invalid signature', function () {
@@ -64,7 +65,7 @@ describe('RequestIntegrityTokenProvider', function () {
 
             const result = tokenProvider.validate(invalidToken);
 
-            result.should.be.false();
+            assert.equal(result, false);
         });
     });
 });

--- a/ghost/core/test/unit/server/services/members/utils.test.js
+++ b/ghost/core/test/unit/server/services/members/utils.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const should = require('should');
 const {formattedMemberResponse} = require('../../../../../core/server/services/members/utils');
@@ -33,7 +34,7 @@ describe('Members Service - utils', function () {
                 unsubscribe_url: undefined,
                 created_at: '2020-01-01T00:00:00.000Z'
             });
-            should(member1).deepEqual({
+            assert.deepEqual(member1, {
                 uuid: 'uuid-1',
                 email: 'jamie+1@example.com',
                 name: 'Jamie Larson',
@@ -80,7 +81,7 @@ describe('Members Service - utils', function () {
                 unsubscribe_url: undefined,
                 created_at: '2020-01-01T00:00:00.000Z'
             });
-            should(member1).deepEqual({
+            assert.deepEqual(member1, {
                 uuid: 'uuid-1',
                 email: 'jamie+1@example.com',
                 name: 'Jamie Larson',

--- a/ghost/core/test/unit/server/services/notifications/notifications.test.js
+++ b/ghost/core/test/unit/server/services/notifications/notifications.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 
@@ -31,20 +32,20 @@ describe('Notifications Service', function () {
                 }]
             });
 
-            allNotifications.length.should.equal(0);
-            notificationsToAdd.length.should.equal(1);
+            assert.equal(allNotifications.length, 0);
+            assert.equal(notificationsToAdd.length, 1);
 
             const createdNotification = notificationsToAdd[0];
 
             createdNotification.id.should.not.be.undefined();
-            createdNotification.custom.should.be.true();
+            assert.equal(createdNotification.custom, true);
             createdNotification.createdAt.should.not.be.undefined();
-            createdNotification.status.should.equal('alert');
-            createdNotification.type.should.equal('info');
-            createdNotification.dismissible.should.be.false();
-            createdNotification.top.should.be.true();
-            createdNotification.message.should.equal('Hello test world!');
-            createdNotification.createdAtVersion.should.equal('4.1.0');
+            assert.equal(createdNotification.status, 'alert');
+            assert.equal(createdNotification.type, 'info');
+            assert.equal(createdNotification.dismissible, false);
+            assert.equal(createdNotification.top, true);
+            assert.equal(createdNotification.message, 'Hello test world!');
+            assert.equal(createdNotification.createdAtVersion, '4.1.0');
         });
     });
 
@@ -69,7 +70,7 @@ describe('Notifications Service', function () {
             const notifications = notificationSvc.browse({user: owner});
 
             should.exist(notifications);
-            notifications.length.should.equal(1);
+            assert.equal(notifications.length, 1);
         });
 
         it('can browse major version upgrade notifications', function () {
@@ -98,7 +99,7 @@ describe('Notifications Service', function () {
             const notifications = notificationSvc.browse({user: owner});
 
             should.exist(notifications);
-            notifications.length.should.equal(1);
+            assert.equal(notifications.length, 1);
         });
 
         it('cannot see 2.0 version upgrade notifications in Ghost 3.0', function () {
@@ -127,7 +128,7 @@ describe('Notifications Service', function () {
             const notifications = notificationSvc.browse({user: owner});
 
             should.exist(notifications);
-            notifications.length.should.equal(0);
+            assert.equal(notifications.length, 0);
         });
 
         it('cannot see 4.0 version upgrade notifications in Ghost 4.0', function () {
@@ -156,7 +157,7 @@ describe('Notifications Service', function () {
             const notifications = notificationSvc.browse({user: owner});
 
             should.exist(notifications);
-            notifications.length.should.equal(0);
+            assert.equal(notifications.length, 0);
         });
 
         it('cannot see 5.0 version upgrade notifications in Ghost 5.0', function () {
@@ -185,7 +186,7 @@ describe('Notifications Service', function () {
             const notifications = notificationSvc.browse({user: owner});
 
             should.exist(notifications);
-            notifications.length.should.equal(0);
+            assert.equal(notifications.length, 0);
         });
 
         it('filters out outdated notifications', function () {
@@ -227,9 +228,9 @@ describe('Notifications Service', function () {
             const notifications = notificationSvc.browse({user: owner});
 
             should.exist(notifications);
-            notifications.length.should.equal(2);
-            notifications[0].message.should.equal('should be visible');
-            notifications[1].message.should.equal('visible even though without a created at property');
+            assert.equal(notifications.length, 2);
+            assert.equal(notifications[0].message, 'should be visible');
+            assert.equal(notifications[1].message, 'visible even though without a created at property');
         });
     });
 
@@ -252,9 +253,9 @@ describe('Notifications Service', function () {
             const notifications = notificationSvc.browse({user: owner});
 
             should.exist(notifications);
-            notifications.length.should.equal(0);
+            assert.equal(notifications.length, 0);
 
-            settingsModelStub.called.should.equal(true);
+            assert.equal(settingsModelStub.called, true);
             settingsModelStub.args[0][0].should.eql([{
                 key: 'notifications',
                 value: '[]'
@@ -280,9 +281,9 @@ describe('Notifications Service', function () {
             const notifications = notificationSvc.browse({user: owner});
 
             should.exist(notifications);
-            notifications.length.should.equal(1);
+            assert.equal(notifications.length, 1);
 
-            settingsModelStub.called.should.equal(false);
+            assert.equal(settingsModelStub.called, false);
         });
     });
 });

--- a/ghost/core/test/unit/server/services/offers/domain/models/offer.test.js
+++ b/ghost/core/test/unit/server/services/offers/domain/models/offer.test.js
@@ -58,7 +58,7 @@ describe('Offer', function () {
                 stripe_coupon_id: 'coupon_123'
             }, mockUniqueChecker);
 
-            offer.stripeCouponId.should.equal('coupon_123');
+            assert.equal(offer.stripeCouponId, 'coupon_123');
         });
 
         it('Creates a valid instance of a trial Offer', async function () {

--- a/ghost/core/test/unit/server/services/permissions/can-this.test.js
+++ b/ghost/core/test/unit/server/services/permissions/can-this.test.js
@@ -114,9 +114,9 @@ describe('Permissions', function () {
                             done(new Error('was able to edit post without permission'));
                         })
                         .catch(function (err) {
-                            err.errorType.should.eql('NoPermissionError');
+                            assert.equal(err.errorType, 'NoPermissionError');
 
-                            findPostSpy.callCount.should.eql(0);
+                            assert.equal(findPostSpy.callCount, 0);
                             done();
                         });
                 });
@@ -130,9 +130,9 @@ describe('Permissions', function () {
                             done(new Error('was able to edit post without permission'));
                         })
                         .catch(function (err) {
-                            err.errorType.should.eql('NoPermissionError');
+                            assert.equal(err.errorType, 'NoPermissionError');
 
-                            findPostSpy.callCount.should.eql(1);
+                            assert.equal(findPostSpy.callCount, 1);
                             findPostSpy.firstCall.args[0].should.eql({id: 1, status: 'all'});
                             done();
                         });
@@ -147,9 +147,9 @@ describe('Permissions', function () {
                             done(new Error('was able to edit post without permission'));
                         })
                         .catch(function (err) {
-                            err.errorType.should.eql('NoPermissionError');
+                            assert.equal(err.errorType, 'NoPermissionError');
 
-                            findPostSpy.callCount.should.eql(1);
+                            assert.equal(findPostSpy.callCount, 1);
                             findPostSpy.firstCall.args[0].should.eql({id: 1, status: 'all'});
                             done();
                         });
@@ -162,7 +162,7 @@ describe('Permissions', function () {
                         .post({id: 1}) // post id
                         .then(function () {
                             // We don't get this far, permissions are instantly granted for internal
-                            findPostSpy.callCount.should.eql(0);
+                            assert.equal(findPostSpy.callCount, 0);
                             done();
                         })
                         .catch(function () {
@@ -179,9 +179,9 @@ describe('Permissions', function () {
                             done(new Error('was able to edit post without permission'));
                         })
                         .catch(function (err) {
-                            err.errorType.should.eql('NoPermissionError');
+                            assert.equal(err.errorType, 'NoPermissionError');
 
-                            findPostSpy.callCount.should.eql(1);
+                            assert.equal(findPostSpy.callCount, 1);
                             findPostSpy.firstCall.args[0].should.eql({id: 1, status: 'all'});
                             done();
                         });
@@ -198,10 +198,10 @@ describe('Permissions', function () {
                             done(new Error('was able to edit tag without permission'));
                         })
                         .catch(function (err) {
-                            err.errorType.should.eql('NoPermissionError');
+                            assert.equal(err.errorType, 'NoPermissionError');
 
                             // We don't look up tags
-                            findTagSpy.callCount.should.eql(0);
+                            assert.equal(findTagSpy.callCount, 0);
                             done();
                         });
                 });
@@ -213,7 +213,7 @@ describe('Permissions', function () {
                         .tag({id: 1}) // tag id
                         .then(function () {
                             // We don't look up tags
-                            findTagSpy.callCount.should.eql(0);
+                            assert.equal(findTagSpy.callCount, 0);
                             done();
                         })
                         .catch(function () {
@@ -230,9 +230,9 @@ describe('Permissions', function () {
                             done(new Error('was able to edit tag without permission'));
                         })
                         .catch(function (err) {
-                            err.errorType.should.eql('NoPermissionError');
+                            assert.equal(err.errorType, 'NoPermissionError');
 
-                            findTagSpy.callCount.should.eql(0);
+                            assert.equal(findTagSpy.callCount, 0);
                             done();
                         });
                 });
@@ -261,8 +261,8 @@ describe('Permissions', function () {
                         done(new Error('was able to edit tag without permission'));
                     })
                     .catch(function (err) {
-                        userProviderStub.callCount.should.eql(1);
-                        err.errorType.should.eql('NoPermissionError');
+                        assert.equal(userProviderStub.callCount, 1);
+                        assert.equal(err.errorType, 'NoPermissionError');
                         done();
                     });
             });
@@ -281,7 +281,7 @@ describe('Permissions', function () {
                     .edit
                     .tag({id: 1}) // tag id in model syntax
                     .then(function (res) {
-                        userProviderStub.callCount.should.eql(1);
+                        assert.equal(userProviderStub.callCount, 1);
                         assert.equal(res, undefined);
                         done();
                     })
@@ -302,7 +302,7 @@ describe('Permissions', function () {
                     .edit
                     .tag() // tag id in model syntax
                     .then(function (res) {
-                        userProviderStub.callCount.should.eql(1);
+                        assert.equal(userProviderStub.callCount, 1);
                         assert.equal(res, undefined);
                         done();
                     })
@@ -324,7 +324,7 @@ describe('Permissions', function () {
                     .edit
                     .tag({id: 1}) // tag id in model syntax
                     .then(function (res) {
-                        userProviderStub.callCount.should.eql(1);
+                        assert.equal(userProviderStub.callCount, 1);
                         assert.equal(res, undefined);
                         done();
                     })
@@ -352,7 +352,7 @@ describe('Permissions', function () {
                     .edit
                     .tag({id: 1}) // tag id in model syntax
                     .then(function (res) {
-                        apiKeyProviderStub.callCount.should.eql(1);
+                        assert.equal(apiKeyProviderStub.callCount, 1);
                         assert.equal(res, undefined);
                         done();
                     })
@@ -387,8 +387,8 @@ describe('Permissions', function () {
                     .edit
                     .tag({id: 1})
                     .then(function (res) {
-                        userProviderStub.callCount.should.eql(1);
-                        apiKeyProviderStub.callCount.should.eql(1);
+                        assert.equal(userProviderStub.callCount, 1);
+                        assert.equal(apiKeyProviderStub.callCount, 1);
                         assert.equal(res, undefined);
                         done();
                     })
@@ -418,8 +418,8 @@ describe('Permissions', function () {
                     .edit
                     .tag({id: 1})
                     .then(function (res) {
-                        userProviderStub.callCount.should.eql(1);
-                        apiKeyProviderStub.callCount.should.eql(1);
+                        assert.equal(userProviderStub.callCount, 1);
+                        assert.equal(apiKeyProviderStub.callCount, 1);
                         assert.equal(res, undefined);
                         // Fixed: Now uses USER permission instead of API key logic
                         done();
@@ -455,9 +455,9 @@ describe('Permissions', function () {
                         done(new Error('Should have failed using USER permissions (ignoring API key permissions)'));
                     })
                     .catch(function (err) {
-                        userProviderStub.callCount.should.eql(1);
-                        apiKeyProviderStub.callCount.should.eql(1);
-                        err.errorType.should.eql('NoPermissionError');
+                        assert.equal(userProviderStub.callCount, 1);
+                        assert.equal(apiKeyProviderStub.callCount, 1);
+                        assert.equal(err.errorType, 'NoPermissionError');
                         // Fixed: Now uses USER permission instead of API key logic
                         done();
                     });
@@ -489,9 +489,9 @@ describe('Permissions', function () {
                         done(new Error('Should have failed due to no permissions'));
                     })
                     .catch(function (err) {
-                        userProviderStub.callCount.should.eql(1);
-                        apiKeyProviderStub.callCount.should.eql(1);
-                        err.errorType.should.eql('NoPermissionError');
+                        assert.equal(userProviderStub.callCount, 1);
+                        assert.equal(apiKeyProviderStub.callCount, 1);
+                        assert.equal(err.errorType, 'NoPermissionError');
                         done();
                     });
             });
@@ -519,8 +519,8 @@ describe('Permissions', function () {
                     .edit
                     .tag({id: 1})
                     .then(function (res) {
-                        userProviderStub.callCount.should.eql(1);
-                        apiKeyProviderStub.callCount.should.eql(1);
+                        assert.equal(userProviderStub.callCount, 1);
+                        assert.equal(apiKeyProviderStub.callCount, 1);
                         assert.equal(res, undefined);
                         done();
                     })
@@ -552,8 +552,8 @@ describe('Permissions', function () {
                         .edit
                         .tag({id: 1})
                         .then(function (res) {
-                            userProviderStub.callCount.should.eql(1);
-                            apiKeyProviderStub.callCount.should.eql(1);
+                            assert.equal(userProviderStub.callCount, 1);
+                            assert.equal(apiKeyProviderStub.callCount, 1);
                             assert.equal(res, undefined);
                             done();
                         })
@@ -588,9 +588,9 @@ describe('Permissions', function () {
                             done(new Error('Should have failed using USER permissions (ignoring API key permissions)'));
                         })
                         .catch(function (err) {
-                            userProviderStub.callCount.should.eql(1);
-                            apiKeyProviderStub.callCount.should.eql(1);
-                            err.errorType.should.eql('NoPermissionError');
+                            assert.equal(userProviderStub.callCount, 1);
+                            assert.equal(apiKeyProviderStub.callCount, 1);
+                            assert.equal(err.errorType, 'NoPermissionError');
                             done();
                         });
                 });
@@ -618,8 +618,8 @@ describe('Permissions', function () {
                         .edit
                         .tag({id: 1})
                         .then(function (res) {
-                            userProviderStub.callCount.should.eql(1);
-                            apiKeyProviderStub.callCount.should.eql(1);
+                            assert.equal(userProviderStub.callCount, 1);
+                            assert.equal(apiKeyProviderStub.callCount, 1);
                             assert.equal(res, undefined);
                             done();
                         })
@@ -658,8 +658,8 @@ describe('Permissions', function () {
                         1, 'edit', sinon.match.object, sinon.match.object, sinon.match.object, true, true
                     );
 
-                    userProviderStub.callCount.should.eql(1);
-                    err.message.should.eql('Hello World!');
+                    assert.equal(userProviderStub.callCount, 1);
+                    assert.equal(err.message, 'Hello World!');
                     done();
                 });
         });
@@ -687,7 +687,7 @@ describe('Permissions', function () {
                         1, 'edit', sinon.match.object, sinon.match.object, sinon.match.object, true, true
                     );
 
-                    userProviderStub.callCount.should.eql(1);
+                    assert.equal(userProviderStub.callCount, 1);
                     assert.equal(res, undefined);
                     done();
                 })

--- a/ghost/core/test/unit/server/services/permissions/providers.test.js
+++ b/ghost/core/test/unit/server/services/permissions/providers.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const testUtils = require('../../../../utils');
@@ -24,8 +25,8 @@ describe('Permission Providers', function () {
                     done(new Error('Should have thrown a user not found error'));
                 })
                 .catch(function (err) {
-                    findUserSpy.callCount.should.eql(1);
-                    err.errorType.should.eql('NotFoundError');
+                    assert.equal(findUserSpy.callCount, 1);
+                    assert.equal(err.errorType, 'NotFoundError');
                     done();
                 });
         });
@@ -58,7 +59,7 @@ describe('Permission Providers', function () {
             // Get permissions for the user
             providers.user(1)
                 .then(function (res) {
-                    findUserSpy.callCount.should.eql(1);
+                    assert.equal(findUserSpy.callCount, 1);
 
                     res.should.be.an.Object().with.properties('permissions', 'roles');
 
@@ -108,7 +109,7 @@ describe('Permission Providers', function () {
             // Get permissions for the user
             providers.user(1)
                 .then(function (res) {
-                    findUserSpy.callCount.should.eql(1);
+                    assert.equal(findUserSpy.callCount, 1);
 
                     res.should.be.an.Object().with.properties('permissions', 'roles');
 
@@ -159,7 +160,7 @@ describe('Permission Providers', function () {
             // Get permissions for the user
             providers.user(1)
                 .then(function (res) {
-                    findUserSpy.callCount.should.eql(1);
+                    assert.equal(findUserSpy.callCount, 1);
 
                     res.should.be.an.Object().with.properties('permissions', 'roles');
 
@@ -195,8 +196,8 @@ describe('Permission Providers', function () {
                     done(new Error('Locked user should should throw an error'));
                 })
                 .catch((err) => {
-                    err.errorType.should.equal('UnauthorizedError');
-                    findUserSpy.callCount.should.eql(1);
+                    assert.equal(err.errorType, 'UnauthorizedError');
+                    assert.equal(findUserSpy.callCount, 1);
                     done();
                 });
         });
@@ -211,8 +212,8 @@ describe('Permission Providers', function () {
                     done(new Error('Should have thrown an api key not found error'));
                 })
                 .catch((err) => {
-                    findApiKeySpy.callCount.should.eql(1);
-                    err.errorType.should.eql('NotFoundError');
+                    assert.equal(findApiKeySpy.callCount, 1);
+                    assert.equal(err.errorType, 'NotFoundError');
                     done();
                 });
         });
@@ -231,7 +232,7 @@ describe('Permission Providers', function () {
                 return Promise.resolve(fakeApiKey);
             });
             providers.apiKey(1).then((res) => {
-                findApiKeySpy.callCount.should.eql(1);
+                assert.equal(findApiKeySpy.callCount, 1);
                 res.should.be.an.Object().with.properties('permissions', 'roles');
                 res.roles.should.be.an.Array().with.lengthOf(1);
                 res.permissions[0].should.be.an.Object().with.properties('attributes', 'id');

--- a/ghost/core/test/unit/server/services/route-settings/route-settings.test.js
+++ b/ghost/core/test/unit/server/services/route-settings/route-settings.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const should = require('should');
 const fs = require('fs-extra');
@@ -44,7 +45,7 @@ describe('UNIT > Settings Service DefaultSettingsManager:', function () {
                 await defaultSettingsManager.setFromFilePath(incomingSettingsPath);
                 should.fail('should.fail');
             } catch (error) {
-                error.message.should.match(/YAMLException: bad indentation of a mapping entry/);
+                assert.match(error.message, /YAMLException: bad indentation of a mapping entry/);
             }
         });
     });

--- a/ghost/core/test/unit/server/services/route-settings/settings-loader.test.js
+++ b/ghost/core/test/unit/server/services/route-settings/settings-loader.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const should = require('should');
 const rewire = require('rewire');
@@ -54,7 +55,7 @@ describe('UNIT > SettingsLoader:', function () {
             const result = await settingsLoader.loadSettings();
             should.exist(result);
             result.should.be.an.Object().with.properties('routes', 'collections', 'taxonomies');
-            fsReadFileStub.calledOnce.should.be.true();
+            assert.equal(fsReadFileStub.calledOnce, true);
         });
 
         it('can find yaml settings file and returns a settings object', async function () {
@@ -75,8 +76,8 @@ describe('UNIT > SettingsLoader:', function () {
             should.exist(setting);
             setting.should.be.an.Object().with.properties('routes', 'collections', 'taxonomies');
 
-            fsReadFileSpy.calledOnce.should.be.true();
-            fsReadFileSpy.calledWith(expectedSettingsFile).should.be.true();
+            assert.equal(fsReadFileSpy.calledOnce, true);
+            assert.equal(fsReadFileSpy.calledWith(expectedSettingsFile), true);
             yamlParserStub.callCount.should.be.eql(1);
         });
 
@@ -98,7 +99,7 @@ describe('UNIT > SettingsLoader:', function () {
                 should.exist(err);
                 err.message.should.be.eql('could not parse yaml file');
                 err.context.should.be.eql('bad indentation of a mapping entry at line 5, column 10');
-                yamlParserStub.calledOnce.should.be.true();
+                assert.equal(yamlParserStub.calledOnce, true);
             }
         });
 
@@ -128,9 +129,9 @@ describe('UNIT > SettingsLoader:', function () {
                 await settingsLoader.loadSettings();
                 throw new Error('Should have failed already');
             } catch (err) {
-                err.message.should.match(/Error trying to load YAML setting for routes from/);
-                fsReadFileStub.calledWith(expectedSettingsFile).should.be.true();
-                yamlParserStub.calledOnce.should.be.false();
+                assert.match(err.message, /Error trying to load YAML setting for routes from/);
+                assert.equal(fsReadFileStub.calledWith(expectedSettingsFile), true);
+                assert.equal(yamlParserStub.calledOnce, false);
             }
         });
     });

--- a/ghost/core/test/unit/server/services/route-settings/settings-path-manager.test.js
+++ b/ghost/core/test/unit/server/services/route-settings/settings-path-manager.test.js
@@ -1,4 +1,5 @@
 // Switch these lines once there are useful utils
+const assert = require('node:assert/strict');
 // const testUtils = require('./utils');
 const should = require('should');
 const SettingsPathManager = require('../../../../../core/server/services/route-settings/settings-path-manager');
@@ -14,7 +15,7 @@ describe('Settings Path Manager', function () {
             should.fail(settingsPathManager, 'Should have errored');
         } catch (err) {
             should.exist(err);
-            err.message.should.match(/paths values/g);
+            assert.match(err.message, /paths values/g);
         }
     });
 
@@ -27,7 +28,7 @@ describe('Settings Path Manager', function () {
 
             const path = settingsPathManager.getDefaultFilePath();
 
-            path.should.equal('/content/settings/routes.yaml');
+            assert.equal(path, '/content/settings/routes.yaml');
         });
 
         it('returns default file path based on redirects configuration', function (){
@@ -38,7 +39,7 @@ describe('Settings Path Manager', function () {
 
             const path = settingsPathManager.getDefaultFilePath();
 
-            path.should.equal('/content/data/redirects.yaml');
+            assert.equal(path, '/content/data/redirects.yaml');
         });
 
         it('returns default file path based on redirects configuration with json extension', function (){
@@ -50,7 +51,7 @@ describe('Settings Path Manager', function () {
 
             const path = settingsPathManager.getDefaultFilePath();
 
-            path.should.equal('/content/data/redirects.json');
+            assert.equal(path, '/content/data/redirects.json');
         });
     });
 
@@ -64,7 +65,7 @@ describe('Settings Path Manager', function () {
 
             const path = settingsPathManager.getBackupFilePath();
 
-            path.should.match(/\/content\/data\/routes-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}.yaml/);
+            assert.match(path, /\/content\/data\/routes-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}.yaml/);
         });
     });
 });

--- a/ghost/core/test/unit/server/services/route-settings/validate.test.js
+++ b/ghost/core/test/unit/server/services/route-settings/validate.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const errors = require('@tryghost/errors');
 const validate = require('../../../../../core/server/services/route-settings/validate');
@@ -24,7 +25,7 @@ describe('UNIT: services/settings/validate', function () {
                 }
             });
         } catch (err) {
-            (err instanceof errors.ValidationError).should.be.true();
+            assert.equal((err instanceof errors.ValidationError), true);
             return;
         }
 
@@ -39,7 +40,7 @@ describe('UNIT: services/settings/validate', function () {
                 }
             });
         } catch (err) {
-            (err instanceof errors.ValidationError).should.be.true();
+            assert.equal((err instanceof errors.ValidationError), true);
             return;
         }
 
@@ -54,7 +55,7 @@ describe('UNIT: services/settings/validate', function () {
                 }
             });
         } catch (err) {
-            (err instanceof errors.ValidationError).should.be.true();
+            assert.equal((err instanceof errors.ValidationError), true);
             return;
         }
 
@@ -69,7 +70,7 @@ describe('UNIT: services/settings/validate', function () {
                 }
             });
         } catch (err) {
-            (err instanceof errors.ValidationError).should.be.true();
+            assert.equal((err instanceof errors.ValidationError), true);
             return;
         }
 
@@ -84,7 +85,7 @@ describe('UNIT: services/settings/validate', function () {
                 }
             });
         } catch (err) {
-            (err instanceof errors.ValidationError).should.be.true();
+            assert.equal((err instanceof errors.ValidationError), true);
             return;
         }
 
@@ -99,7 +100,7 @@ describe('UNIT: services/settings/validate', function () {
                 }
             });
         } catch (err) {
-            (err instanceof errors.ValidationError).should.be.true();
+            assert.equal((err instanceof errors.ValidationError), true);
             return;
         }
 
@@ -114,7 +115,7 @@ describe('UNIT: services/settings/validate', function () {
                 }
             });
         } catch (err) {
-            (err instanceof errors.ValidationError).should.be.true();
+            assert.equal((err instanceof errors.ValidationError), true);
             return;
         }
 
@@ -131,7 +132,7 @@ describe('UNIT: services/settings/validate', function () {
                 }
             });
         } catch (err) {
-            (err instanceof errors.ValidationError).should.be.true();
+            assert.equal((err instanceof errors.ValidationError), true);
             return;
         }
 
@@ -148,7 +149,7 @@ describe('UNIT: services/settings/validate', function () {
                 }
             });
         } catch (err) {
-            (err instanceof errors.ValidationError).should.be.true();
+            assert.equal((err instanceof errors.ValidationError), true);
             return;
         }
 
@@ -165,7 +166,7 @@ describe('UNIT: services/settings/validate', function () {
                 }
             });
         } catch (err) {
-            (err instanceof errors.ValidationError).should.be.true();
+            assert.equal((err instanceof errors.ValidationError), true);
             return;
         }
 
@@ -182,7 +183,7 @@ describe('UNIT: services/settings/validate', function () {
                 }
             });
         } catch (err) {
-            (err instanceof errors.ValidationError).should.be.true();
+            assert.equal((err instanceof errors.ValidationError), true);
             return;
         }
 
@@ -199,7 +200,7 @@ describe('UNIT: services/settings/validate', function () {
                 }
             });
         } catch (err) {
-            (err instanceof errors.ValidationError).should.be.true();
+            assert.equal((err instanceof errors.ValidationError), true);
             return;
         }
 
@@ -682,7 +683,7 @@ describe('UNIT: services/settings/validate', function () {
                     }
                 });
             } catch (err) {
-                (err instanceof errors.ValidationError).should.be.true();
+                assert.equal((err instanceof errors.ValidationError), true);
                 return;
             }
 
@@ -702,7 +703,7 @@ describe('UNIT: services/settings/validate', function () {
                     }
                 });
             } catch (err) {
-                (err instanceof errors.ValidationError).should.be.true();
+                assert.equal((err instanceof errors.ValidationError), true);
                 return;
             }
 
@@ -722,7 +723,7 @@ describe('UNIT: services/settings/validate', function () {
                     }
                 });
             } catch (err) {
-                (err instanceof errors.ValidationError).should.be.true();
+                assert.equal((err instanceof errors.ValidationError), true);
                 return;
             }
 
@@ -744,7 +745,7 @@ describe('UNIT: services/settings/validate', function () {
                     }
                 });
             } catch (err) {
-                (err instanceof errors.ValidationError).should.be.true();
+                assert.equal((err instanceof errors.ValidationError), true);
                 return;
             }
 
@@ -764,7 +765,7 @@ describe('UNIT: services/settings/validate', function () {
                     }
                 });
             } catch (err) {
-                (err instanceof errors.ValidationError).should.be.true();
+                assert.equal((err instanceof errors.ValidationError), true);
                 return;
             }
 

--- a/ghost/core/test/unit/server/services/route-settings/yaml-parser.test.js
+++ b/ghost/core/test/unit/server/services/route-settings/yaml-parser.test.js
@@ -24,7 +24,7 @@ describe('UNIT > Settings Service yaml parser:', function () {
             const result = yamlParser(file);
             should.exist(result);
             result.should.be.an.Object().with.properties('routes', 'collections', 'taxonomies');
-            yamlSpy.calledOnce.should.be.true();
+            assert.equal(yamlSpy.calledOnce, true);
         });
 
         it('rejects with clear error when parsing fails', function () {
@@ -35,10 +35,10 @@ describe('UNIT > Settings Service yaml parser:', function () {
                 assert.equal(result, undefined);
             } catch (error) {
                 should.exist(error);
-                error.message.should.eql('Could not parse provided YAML file: bad indentation of a mapping entry.');
-                error.context.should.containEql('bad indentation of a mapping entry (5:14)');
-                error.help.should.eql('Check provided file for typos and fix the named issues.');
-                yamlSpy.calledOnce.should.be.true();
+                assert.equal(error.message, 'Could not parse provided YAML file: bad indentation of a mapping entry.');
+                assert(error.context.includes('bad indentation of a mapping entry (5:14)'));
+                assert.equal(error.help, 'Check provided file for typos and fix the named issues.');
+                assert.equal(yamlSpy.calledOnce, true);
             }
         });
     });

--- a/ghost/core/test/unit/server/services/settings/default-settings-manager.test.js
+++ b/ghost/core/test/unit/server/services/settings/default-settings-manager.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const should = require('should');
 const fs = require('fs-extra');
@@ -31,7 +32,7 @@ describe('UNIT > Settings Service DefaultSettingsManager:', function () {
             await defaultSettingsManager.ensureSettingsFileExists();
 
             // Assert did not attempt to copy the default config
-            fsCopyStub.called.should.be.false();
+            assert.equal(fsCopyStub.called, false);
         });
 
         it('copies default settings file if no file found', async function () {
@@ -55,7 +56,7 @@ describe('UNIT > Settings Service DefaultSettingsManager:', function () {
             await defaultSettingsManager.ensureSettingsFileExists();
 
             // Assert attempt to copy the default config
-            fsCopyStub.calledOnce.should.be.true();
+            assert.equal(fsCopyStub.calledOnce, true);
         });
 
         it('rejects, if error is not a not found error', async function () {
@@ -79,8 +80,8 @@ describe('UNIT > Settings Service DefaultSettingsManager:', function () {
             } catch (error) {
                 should.exist(error);
                 error.message.should.be.eql(`Error trying to access settings files in ${destinationFolderPath}.`);
-                fsReadFileStub.calledOnce.should.be.true();
-                fsCopyStub.called.should.be.false();
+                assert.equal(fsReadFileStub.calledOnce, true);
+                assert.equal(fsCopyStub.called, false);
             }
         });
     });

--- a/ghost/core/test/unit/server/services/settings/settings-utils.test.js
+++ b/ghost/core/test/unit/server/services/settings/settings-utils.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const should = require('should');
 
@@ -30,8 +31,8 @@ describe('Unit: services/settings/settings-utils', function () {
             const result = getOrGenerateSiteUuid();
 
             result.should.equal(testUuid.toLowerCase());
-            configGetStub.calledOnce.should.be.true();
-            loggingInfoStub.calledOnce.should.be.true();
+            assert.equal(configGetStub.calledOnce, true);
+            assert.equal(loggingInfoStub.calledOnce, true);
         });
 
         it('generates new UUID when config value is not a valid UUID', function () {
@@ -40,9 +41,9 @@ describe('Unit: services/settings/settings-utils', function () {
             const result = getOrGenerateSiteUuid();
 
             // Should be a valid UUID v4
-            result.should.match(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
-            configGetStub.calledOnce.should.be.true();
-            loggingInfoStub.calledOnce.should.be.true();
+            assert.match(result, /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+            assert.equal(configGetStub.calledOnce, true);
+            assert.equal(loggingInfoStub.calledOnce, true);
         });
 
         it('generates new UUID when config value is null', function () {
@@ -51,9 +52,9 @@ describe('Unit: services/settings/settings-utils', function () {
             const result = getOrGenerateSiteUuid();
 
             // Should be a valid UUID v4
-            result.should.match(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
-            configGetStub.calledOnce.should.be.true();
-            loggingInfoStub.calledOnce.should.be.true();
+            assert.match(result, /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+            assert.equal(configGetStub.calledOnce, true);
+            assert.equal(loggingInfoStub.calledOnce, true);
         });
 
         it('generates new UUID when config value is undefined', function () {
@@ -62,9 +63,9 @@ describe('Unit: services/settings/settings-utils', function () {
             const result = getOrGenerateSiteUuid();
 
             // Should be a valid UUID v4
-            result.should.match(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
-            configGetStub.calledOnce.should.be.true();
-            loggingInfoStub.calledOnce.should.be.true();
+            assert.match(result, /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+            assert.equal(configGetStub.calledOnce, true);
+            assert.equal(loggingInfoStub.calledOnce, true);
         });
 
         it('generates new UUID when config throws an error', function () {
@@ -74,9 +75,9 @@ describe('Unit: services/settings/settings-utils', function () {
             const result = getOrGenerateSiteUuid();
 
             // Should be a valid UUID v4
-            result.should.match(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
-            configGetStub.calledOnce.should.be.true();
-            loggingErrorStub.calledOnce.should.be.true();
+            assert.match(result, /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+            assert.equal(configGetStub.calledOnce, true);
+            assert.equal(loggingErrorStub.calledOnce, true);
         });
 
         it('converts uppercase UUID to lowercase', function () {
@@ -86,7 +87,7 @@ describe('Unit: services/settings/settings-utils', function () {
             const result = getOrGenerateSiteUuid();
 
             result.should.equal(testUuid.toLowerCase());
-            result.should.equal('550e8400-e29b-41d4-a716-446655440000');
+            assert.equal(result, '550e8400-e29b-41d4-a716-446655440000');
         });
 
         it('handles mixed case UUID correctly', function () {
@@ -96,7 +97,7 @@ describe('Unit: services/settings/settings-utils', function () {
             const result = getOrGenerateSiteUuid();
 
             result.should.equal(testUuid.toLowerCase());
-            result.should.equal('550e8400-e29b-41d4-a716-446655440000');
+            assert.equal(result, '550e8400-e29b-41d4-a716-446655440000');
         });
 
         it('caches the UUID and returns same value on subsequent calls', function () {
@@ -109,7 +110,7 @@ describe('Unit: services/settings/settings-utils', function () {
             result1.should.equal(result2);
             result1.should.equal(testUuid.toLowerCase());
             // Config should only be called once due to caching
-            configGetStub.calledOnce.should.be.true();
+            assert.equal(configGetStub.calledOnce, true);
         });
     });
 });

--- a/ghost/core/test/unit/server/services/staff/staff-service.test.js
+++ b/ghost/core/test/unit/server/services/staff/staff-service.test.js
@@ -1,4 +1,5 @@
 // Switch these lines once there are useful utils
+const assert = require('node:assert/strict');
 // const testUtils = require('./utils');
 const sinon = require('sinon');
 const {MemberCreatedEvent, SubscriptionCancelledEvent, SubscriptionActivatedEvent} = require('../../../../../core/shared/events');
@@ -11,91 +12,91 @@ require('should');
 const StaffService = require('../../../../../core/server/services/staff/staff-service');
 
 function testCommonMailData({mailStub, getEmailAlertUsersStub}) {
-    getEmailAlertUsersStub.calledWith(
+    assert.equal(getEmailAlertUsersStub.calledWith(
         sinon.match.string,
         sinon.match({transacting: {}, forUpdate: true})
-    ).should.be.true();
+    ), true);
 
     // has right from/to address
-    mailStub.calledWith(sinon.match({
+    assert.equal(mailStub.calledWith(sinon.match({
         from: '"Default" <default@email.com>',
         to: 'owner@ghost.org'
-    })).should.be.true();
+    })), true);
 
     // Email HTML contains important bits
 
     // Has accent color
-    mailStub.calledWith(
+    assert.equal(mailStub.calledWith(
         sinon.match.has('html', sinon.match('#ffffff'))
-    ).should.be.true();
+    ), true);
 
     // Has email
-    mailStub.calledWith(
+    assert.equal(mailStub.calledWith(
         sinon.match.has('html', sinon.match('member@example.com'))
-    ).should.be.true();
+    ), true);
 
     // Has member url
-    mailStub.calledWith(
+    assert.equal(mailStub.calledWith(
         sinon.match.has('html', sinon.match('https://admin.ghost.example/#/members/abc'))
-    ).should.be.true();
+    ), true);
 
     // Has site url
-    mailStub.calledWith(
+    assert.equal(mailStub.calledWith(
         sinon.match.has('html', sinon.match('https://ghost.example'))
-    ).should.be.true();
+    ), true);
 
     // Has staff admin url
-    mailStub.calledWith(
+    assert.equal(mailStub.calledWith(
         sinon.match.has('html', sinon.match('https://admin.ghost.example/#/settings/staff/ghost/email-notifications'))
-    ).should.be.true();
+    ), true);
 }
 
 function testCommonPaidSubMailData({member, mailStub, getEmailAlertUsersStub}) {
     testCommonMailData({mailStub, getEmailAlertUsersStub});
-    getEmailAlertUsersStub.calledWith('paid-started').should.be.true();
+    assert.equal(getEmailAlertUsersStub.calledWith('paid-started'), true);
 
     if (member?.name) {
-        mailStub.calledWith(
+        assert.equal(mailStub.calledWith(
             sinon.match({subject: '💸 Paid subscription started: Ghost'})
-        ).should.be.true();
+        ), true);
 
-        mailStub.calledWith(
+        assert.equal(mailStub.calledWith(
             sinon.match.has('html', sinon.match('💸 Paid subscription started: Ghost'))
-        ).should.be.true();
+        ), true);
     } else {
-        mailStub.calledWith(
+        assert.equal(mailStub.calledWith(
             sinon.match({subject: '💸 Paid subscription started: member@example.com'})
-        ).should.be.true();
+        ), true);
 
-        mailStub.calledWith(
+        assert.equal(mailStub.calledWith(
             sinon.match.has('html', sinon.match('💸 Paid subscription started: member@example.com'))
-        ).should.be.true();
+        ), true);
     }
 
-    mailStub.calledWith(
+    assert.equal(mailStub.calledWith(
         sinon.match.has('html', sinon.match('Test Tier'))
-    ).should.be.true();
-    mailStub.calledWith(
+    ), true);
+    assert.equal(mailStub.calledWith(
         sinon.match.has('html', sinon.match('$50.00/month'))
-    ).should.be.true();
+    ), true);
 }
 
 function testCommonPaidSubCancelMailData({mailStub, getEmailAlertUsersStub}) {
     testCommonMailData({mailStub, getEmailAlertUsersStub});
-    getEmailAlertUsersStub.calledWith('paid-canceled').should.be.true();
-    mailStub.calledWith(
+    assert.equal(getEmailAlertUsersStub.calledWith('paid-canceled'), true);
+    assert.equal(mailStub.calledWith(
         sinon.match({subject: '⚠️ Cancellation: Ghost'})
-    ).should.be.true();
+    ), true);
 
-    mailStub.calledWith(
+    assert.equal(mailStub.calledWith(
         sinon.match.has('html', sinon.match('⚠️ Cancellation: Ghost'))
-    ).should.be.true();
-    mailStub.calledWith(
+    ), true);
+    assert.equal(mailStub.calledWith(
         sinon.match.has('html', sinon.match('Test Tier'))
-    ).should.be.true();
-    mailStub.calledWith(
+    ), true);
+    assert.equal(mailStub.calledWith(
         sinon.match.has('html', sinon.match('$50.00/month'))
-    ).should.be.true();
+    ), true);
 }
 
 describe('StaffService', function () {
@@ -197,11 +198,11 @@ describe('StaffService', function () {
         describe('subscribeEvents', function () {
             it('subscribes to events', async function () {
                 service.subscribeEvents();
-                subscribeStub.callCount.should.eql(4);
-                subscribeStub.calledWith(SubscriptionActivatedEvent).should.be.true();
-                subscribeStub.calledWith(SubscriptionCancelledEvent).should.be.true();
-                subscribeStub.calledWith(MemberCreatedEvent).should.be.true();
-                subscribeStub.calledWith(MilestoneCreatedEvent).should.be.true();
+                assert.equal(subscribeStub.callCount, 4);
+                assert.equal(subscribeStub.calledWith(SubscriptionActivatedEvent), true);
+                assert.equal(subscribeStub.calledWith(SubscriptionCancelledEvent), true);
+                assert.equal(subscribeStub.calledWith(MemberCreatedEvent), true);
+                assert.equal(subscribeStub.calledWith(MilestoneCreatedEvent), true);
             });
 
             it('listens to events', async function () {
@@ -231,7 +232,7 @@ describe('StaffService', function () {
                     memberId: 'member-2'
                 }));
                 await DomainEvents.allSettled();
-                service.handleEvent.calledWith(MemberCreatedEvent).should.be.true();
+                assert.equal(service.handleEvent.calledWith(MemberCreatedEvent), true);
 
                 DomainEvents.dispatch(SubscriptionActivatedEvent.create({
                     source: 'member',
@@ -241,7 +242,7 @@ describe('StaffService', function () {
                     tierId: 'tier-1'
                 }));
                 await DomainEvents.allSettled();
-                service.handleEvent.calledWith(SubscriptionActivatedEvent).should.be.true();
+                assert.equal(service.handleEvent.calledWith(SubscriptionActivatedEvent), true);
 
                 DomainEvents.dispatch(SubscriptionCancelledEvent.create({
                     source: 'member',
@@ -250,7 +251,7 @@ describe('StaffService', function () {
                     tierId: 'tier-1'
                 }));
                 await DomainEvents.allSettled();
-                service.handleEvent.calledWith(SubscriptionCancelledEvent).should.be.true();
+                assert.equal(service.handleEvent.calledWith(SubscriptionCancelledEvent), true);
 
                 DomainEvents.dispatch(MilestoneCreatedEvent.create({
                     milestone: {
@@ -260,7 +261,7 @@ describe('StaffService', function () {
                     }
                 }));
                 await DomainEvents.allSettled();
-                service.handleEvent.calledWith(MilestoneCreatedEvent).should.be.true();
+                assert.equal(service.handleEvent.calledWith(MilestoneCreatedEvent), true);
             });
         });
 
@@ -370,11 +371,11 @@ describe('StaffService', function () {
                     }
                 });
 
-                service.memberAttributionService.getMemberCreatedAttribution.called.should.be.true();
+                assert.equal(service.memberAttributionService.getMemberCreatedAttribution.called, true);
 
-                mailStub.calledWith(
+                assert.equal(mailStub.calledWith(
                     sinon.match({subject: '🥳 Free member signup: Jamie'})
-                ).should.be.true();
+                ), true);
             });
             it('handles free member created event with provided attribution', async function () {
                 await service.handleEvent(MemberCreatedEvent, {
@@ -391,12 +392,12 @@ describe('StaffService', function () {
                 });
 
                 // provided attribution should be used instead of fetching it
-                service.memberAttributionService.getMemberCreatedAttribution.called.should.be.false();
-                service.memberAttributionService.fetchResource.called.should.be.true();
+                assert.equal(service.memberAttributionService.getMemberCreatedAttribution.called, false);
+                assert.equal(service.memberAttributionService.fetchResource.called, true);
 
-                mailStub.calledWith(
+                assert.equal(mailStub.calledWith(
                     sinon.match({subject: '🥳 Free member signup: Jamie'})
-                ).should.be.true();
+                ), true);
             });
 
             it('handles paid member created event', async function () {
@@ -410,11 +411,11 @@ describe('StaffService', function () {
                     }
                 });
 
-                service.memberAttributionService.getSubscriptionCreatedAttribution.called.should.be.true();
+                assert.equal(service.memberAttributionService.getSubscriptionCreatedAttribution.called, true);
 
-                mailStub.calledWith(
+                assert.equal(mailStub.calledWith(
                     sinon.match({subject: '💸 Paid subscription started: Jamie'})
-                ).should.be.true();
+                ), true);
             });
 
             it('handles paid member created event with provided attribution', async function () {
@@ -435,20 +436,20 @@ describe('StaffService', function () {
                 });
 
                 // provided attribution should be used instead of fetching it
-                service.memberAttributionService.getSubscriptionCreatedAttribution.called.should.be.false();
-                service.memberAttributionService.fetchResource.called.should.be.true();
+                assert.equal(service.memberAttributionService.getSubscriptionCreatedAttribution.called, false);
+                assert.equal(service.memberAttributionService.fetchResource.called, true);
 
-                mailStub.calledWith(
+                assert.equal(mailStub.calledWith(
                     sinon.match({subject: '💸 Paid subscription started: Jamie'})
-                ).should.be.true();
+                ), true);
 
-                mailStub.calledWith(
+                assert.equal(mailStub.calledWith(
                     sinon.match.has('html', sinon.match('Welcome Post'))
-                ).should.be.true();
+                ), true);
 
-                mailStub.calledWith(
+                assert.equal(mailStub.calledWith(
                     sinon.match.has('html', sinon.match('Direct'))
-                ).should.be.true();
+                ), true);
             });
 
             it('handles paid member cancellation event', async function () {
@@ -461,9 +462,9 @@ describe('StaffService', function () {
                     }
                 });
 
-                mailStub.calledWith(
+                assert.equal(mailStub.calledWith(
                     sinon.match({subject: '⚠️ Cancellation: Jamie'})
-                ).should.be.true();
+                ), true);
             });
 
             it('handles milestone created event', async function () {
@@ -477,9 +478,9 @@ describe('StaffService', function () {
                         }
                     }
                 });
-                mailStub.calledWith(
+                assert.equal(mailStub.calledWith(
                     sinon.match({subject: `Ghost Site hit $1,000 ARR`})
-                ).should.be.true();
+                ), true);
             });
         });
 
@@ -495,16 +496,16 @@ describe('StaffService', function () {
 
                 await service.emails.notifyFreeMemberSignup({member}, options);
 
-                mailStub.calledOnce.should.be.true();
+                assert.equal(mailStub.calledOnce, true);
                 testCommonMailData(stubs);
-                getEmailAlertUsersStub.calledWith('free-signup').should.be.true();
+                assert.equal(getEmailAlertUsersStub.calledWith('free-signup'), true);
 
-                mailStub.calledWith(
+                assert.equal(mailStub.calledWith(
                     sinon.match({subject: '🥳 Free member signup: Ghost'})
-                ).should.be.true();
-                mailStub.calledWith(
+                ), true);
+                assert.equal(mailStub.calledWith(
                     sinon.match.has('html', sinon.match('🥳 Free member signup: Ghost'))
-                ).should.be.true();
+                ), true);
             });
 
             it('sends free member signup alert without member name', async function () {
@@ -517,16 +518,16 @@ describe('StaffService', function () {
 
                 await service.emails.notifyFreeMemberSignup({member}, options);
 
-                mailStub.calledOnce.should.be.true();
+                assert.equal(mailStub.calledOnce, true);
                 testCommonMailData(stubs);
-                getEmailAlertUsersStub.calledWith('free-signup').should.be.true();
+                assert.equal(getEmailAlertUsersStub.calledWith('free-signup'), true);
 
-                mailStub.calledWith(
+                assert.equal(mailStub.calledWith(
                     sinon.match({subject: '🥳 Free member signup: member@example.com'})
-                ).should.be.true();
-                mailStub.calledWith(
+                ), true);
+                assert.equal(mailStub.calledWith(
                     sinon.match.has('html', sinon.match('🥳 Free member signup: member@example.com'))
-                ).should.be.true();
+                ), true);
             });
 
             it('sends free member signup alert with attribution', async function () {
@@ -544,34 +545,34 @@ describe('StaffService', function () {
 
                 await service.emails.notifyFreeMemberSignup({member, attribution}, options);
 
-                mailStub.calledOnce.should.be.true();
+                assert.equal(mailStub.calledOnce, true);
                 testCommonMailData(stubs);
-                getEmailAlertUsersStub.calledWith('free-signup').should.be.true();
+                assert.equal(getEmailAlertUsersStub.calledWith('free-signup'), true);
 
-                mailStub.calledWith(
+                assert.equal(mailStub.calledWith(
                     sinon.match({subject: '🥳 Free member signup: Ghost'})
-                ).should.be.true();
-                mailStub.calledWith(
+                ), true);
+                assert.equal(mailStub.calledWith(
                     sinon.match.has('html', sinon.match('🥳 Free member signup: Ghost'))
-                ).should.be.true();
+                ), true);
 
-                mailStub.calledWith(
+                assert.equal(mailStub.calledWith(
                     sinon.match.has('html', sinon.match('Source'))
-                ).should.be.true();
+                ), true);
 
-                mailStub.calledWith(
+                assert.equal(mailStub.calledWith(
                     sinon.match.has('html', sinon.match('Twitter'))
-                ).should.be.true();
+                ), true);
 
                 // check attribution page
-                mailStub.calledWith(
+                assert.equal(mailStub.calledWith(
                     sinon.match.has('html', sinon.match('Welcome Post'))
-                ).should.be.true();
+                ), true);
 
                 // check attribution url
-                mailStub.calledWith(
+                assert.equal(mailStub.calledWith(
                     sinon.match.has('html', sinon.match('https://example.com/welcome'))
-                ).should.be.true();
+                ), true);
             });
         });
 
@@ -611,39 +612,39 @@ describe('StaffService', function () {
                 };
                 await service.emails.notifyPaidSubscriptionStarted({member, offer: null, tier, subscription, attribution}, options);
 
-                mailStub.calledOnce.should.be.true();
+                assert.equal(mailStub.calledOnce, true);
                 testCommonPaidSubMailData({...stubs, member});
 
                 // check attribution text
-                mailStub.calledWith(
+                assert.equal(mailStub.calledWith(
                     sinon.match.has('html', sinon.match('Twitter'))
-                ).should.be.true();
+                ), true);
 
                 // check attribution text
-                mailStub.calledWith(
+                assert.equal(mailStub.calledWith(
                     sinon.match.has('html', sinon.match('Source'))
-                ).should.be.true();
+                ), true);
 
                 // check attribution page
-                mailStub.calledWith(
+                assert.equal(mailStub.calledWith(
                     sinon.match.has('html', sinon.match('Welcome Post'))
-                ).should.be.true();
+                ), true);
 
                 // check attribution url
-                mailStub.calledWith(
+                assert.equal(mailStub.calledWith(
                     sinon.match.has('html', sinon.match('https://example.com/welcome'))
-                ).should.be.true();
+                ), true);
             });
 
             it('sends paid subscription start alert without offer', async function () {
                 await service.emails.notifyPaidSubscriptionStarted({member, offer: null, tier, subscription}, options);
 
-                mailStub.calledOnce.should.be.true();
+                assert.equal(mailStub.calledOnce, true);
                 testCommonPaidSubMailData({...stubs, member});
 
-                mailStub.calledWith(
+                assert.equal(mailStub.calledWith(
                     sinon.match.has('html', 'Offer')
-                ).should.be.false();
+                ), false);
             });
 
             it('sends paid subscription start alert without member name', async function () {
@@ -653,39 +654,39 @@ describe('StaffService', function () {
                 };
                 await service.emails.notifyPaidSubscriptionStarted({member: memberData, offer: null, tier, subscription}, options);
 
-                mailStub.calledOnce.should.be.true();
+                assert.equal(mailStub.calledOnce, true);
                 testCommonPaidSubMailData({...stubs, member: memberData});
 
-                mailStub.calledWith(
+                assert.equal(mailStub.calledWith(
                     sinon.match.has('html', 'Offer')
-                ).should.be.false();
+                ), false);
 
                 // check preview text
-                mailStub.calledWith(
+                assert.equal(mailStub.calledWith(
                     sinon.match.has('html', sinon.match('Test Tier: $50.00/month'))
-                ).should.be.true();
+                ), true);
             });
 
             it('sends paid subscription start alert with percent offer - first payment', async function () {
                 await service.emails.notifyPaidSubscriptionStarted({member, offer, tier, subscription}, options);
 
-                mailStub.calledOnce.should.be.true();
+                assert.equal(mailStub.calledOnce, true);
                 testCommonPaidSubMailData({...stubs, member});
 
-                mailStub.calledWith(
+                assert.equal(mailStub.calledWith(
                     sinon.match.has('html', sinon.match('Half price'))
-                ).should.be.true();
-                mailStub.calledWith(
+                ), true);
+                assert.equal(mailStub.calledWith(
                     sinon.match.has('html', sinon.match('50% off'))
-                ).should.be.true();
-                mailStub.calledWith(
+                ), true);
+                assert.equal(mailStub.calledWith(
                     sinon.match.has('html', sinon.match('first payment'))
-                ).should.be.true();
+                ), true);
 
                 // check preview text
-                mailStub.calledWith(
+                assert.equal(mailStub.calledWith(
                     sinon.match.has('html', sinon.match('Test Tier: $50.00/month - Offer: Half price - 50% off, first payment'))
-                ).should.be.true();
+                ), true);
             });
 
             it('sends paid subscription start alert with fixed type offer - repeating duration', async function () {
@@ -700,18 +701,18 @@ describe('StaffService', function () {
 
                 await service.emails.notifyPaidSubscriptionStarted({member, offer, tier, subscription}, options);
 
-                mailStub.calledOnce.should.be.true();
+                assert.equal(mailStub.calledOnce, true);
                 testCommonPaidSubMailData({...stubs, member});
 
-                mailStub.calledWith(
+                assert.equal(mailStub.calledWith(
                     sinon.match.has('html', sinon.match('Save ten'))
-                ).should.be.true();
-                mailStub.calledWith(
+                ), true);
+                assert.equal(mailStub.calledWith(
                     sinon.match.has('html', sinon.match('$10.00 off'))
-                ).should.be.true();
-                mailStub.calledWith(
+                ), true);
+                assert.equal(mailStub.calledWith(
                     sinon.match.has('html', sinon.match('first 3 months'))
-                ).should.be.true();
+                ), true);
             });
 
             it('sends paid subscription start alert with fixed type offer - forever duration', async function () {
@@ -725,18 +726,18 @@ describe('StaffService', function () {
 
                 await service.emails.notifyPaidSubscriptionStarted({member, offer, tier, subscription}, options);
 
-                mailStub.calledOnce.should.be.true();
+                assert.equal(mailStub.calledOnce, true);
                 testCommonPaidSubMailData({...stubs, member});
 
-                mailStub.calledWith(
+                assert.equal(mailStub.calledWith(
                     sinon.match.has('html', sinon.match('Save twenty'))
-                ).should.be.true();
-                mailStub.calledWith(
+                ), true);
+                assert.equal(mailStub.calledWith(
                     sinon.match.has('html', sinon.match('$20.00 off'))
-                ).should.be.true();
-                mailStub.calledWith(
+                ), true);
+                assert.equal(mailStub.calledWith(
                     sinon.match.has('html', sinon.match('forever'))
-                ).should.be.true();
+                ), true);
             });
 
             it('sends paid subscription start alert with free trial offer', async function () {
@@ -749,15 +750,15 @@ describe('StaffService', function () {
 
                 await service.emails.notifyPaidSubscriptionStarted({member, offer, tier, subscription}, options);
 
-                mailStub.calledOnce.should.be.true();
+                assert.equal(mailStub.calledOnce, true);
                 testCommonPaidSubMailData({...stubs, member});
 
-                mailStub.calledWith(
+                assert.equal(mailStub.calledWith(
                     sinon.match.has('html', sinon.match('Free week'))
-                ).should.be.true();
-                mailStub.calledWith(
+                ), true);
+                assert.equal(mailStub.calledWith(
                     sinon.match.has('html', sinon.match('7 days free'))
-                ).should.be.true();
+                ), true);
             });
         });
 
@@ -798,46 +799,46 @@ describe('StaffService', function () {
                     cancellationReason: 'Changed my mind!'
                 }, expiryAt, canceledAt, cancelNow}, options);
 
-                mailStub.calledOnce.should.be.true();
+                assert.equal(mailStub.calledOnce, true);
                 testCommonPaidSubCancelMailData(stubs);
 
                 // Expiration sentence is in the future tense
-                mailStub.calledWith(
+                assert.equal(mailStub.calledWith(
                     sinon.match.has('html', sinon.match('Expires on'))
-                ).should.be.true();
+                ), true);
 
-                mailStub.calledWith(
+                assert.equal(mailStub.calledWith(
                     sinon.match.has('html', sinon.match('5 Sep 2024'))
-                ).should.be.true();
+                ), true);
 
-                mailStub.calledWith(
+                assert.equal(mailStub.calledWith(
                     sinon.match.has('html', 'Offer')
-                ).should.be.false();
+                ), false);
 
-                mailStub.calledWith(
+                assert.equal(mailStub.calledWith(
                     sinon.match.has('html', sinon.match('Reason: Changed my mind!'))
-                ).should.be.true();
+                ), true);
             });
 
             it('sends paid subscription cancel alert when sub is canceled without reason', async function () {
                 await service.emails.notifyPaidSubscriptionCanceled({member, tier, subscription, expiryAt, cancelNow}, options);
 
-                mailStub.calledOnce.should.be.true();
+                assert.equal(mailStub.calledOnce, true);
                 testCommonPaidSubCancelMailData(stubs);
 
                 // Expiration sentence is in the future tense
-                mailStub.calledWith(
+                assert.equal(mailStub.calledWith(
                     sinon.match.has('html', sinon.match('Expires on'))
-                ).should.be.true();
+                ), true);
 
-                mailStub.calledWith(
+                assert.equal(mailStub.calledWith(
                     sinon.match.has('html', sinon.match('5 Sep 2024'))
-                ).should.be.true();
+                ), true);
 
                 // Cancellation reason block is hidden
-                mailStub.calledWith(
+                assert.equal(mailStub.calledWith(
                     sinon.match.has('html', sinon.match('Reason: '))
-                ).should.be.false();
+                ), false);
             });
 
             it('sends paid subscription cancel alert when subscription is canceled immediately', async function () {
@@ -847,30 +848,30 @@ describe('StaffService', function () {
                     cancellationReason: 'Payment failed'
                 }, expiryAt, canceledAt, cancelNow}, options);
 
-                mailStub.calledOnce.should.be.true();
+                assert.equal(mailStub.calledOnce, true);
                 testCommonPaidSubCancelMailData(stubs);
 
                 // We don't show "Canceled on" when subscription is canceled immediately
-                mailStub.calledWith(
+                assert.equal(mailStub.calledWith(
                     sinon.match.has('html', sinon.match('Canceled on'))
-                ).should.be.false();
+                ), false);
 
                 // Expiration sentence is in the past tense
-                mailStub.calledWith(
+                assert.equal(mailStub.calledWith(
                     sinon.match.has('html', sinon.match('Expired on'))
-                ).should.be.true();
+                ), true);
 
-                mailStub.calledWith(
+                assert.equal(mailStub.calledWith(
                     sinon.match.has('html', sinon.match('5 Sep 2024'))
-                ).should.be.true();
+                ), true);
 
-                mailStub.calledWith(
+                assert.equal(mailStub.calledWith(
                     sinon.match.has('html', 'Offer')
-                ).should.be.false();
+                ), false);
 
-                mailStub.calledWith(
+                assert.equal(mailStub.calledWith(
                     sinon.match.has('html', sinon.match('Reason: Payment failed'))
-                ).should.be.true();
+                ), true);
             });
         });
 
@@ -884,30 +885,30 @@ describe('StaffService', function () {
 
                 await service.emails.notifyMilestoneReceived({milestone});
 
-                getEmailAlertUsersStub.calledWith('milestone-received').should.be.true();
+                assert.equal(getEmailAlertUsersStub.calledWith('milestone-received'), true);
 
-                mailStub.calledOnce.should.be.true();
+                assert.equal(mailStub.calledOnce, true);
 
-                mailStub.calledWith(
+                assert.equal(mailStub.calledWith(
                     sinon.match.has('html', sinon.match('Ghost Site now has 25k members'))
-                ).should.be.true();
+                ), true);
 
-                mailStub.calledWith(
+                assert.equal(mailStub.calledWith(
                     sinon.match.has('html', sinon.match('Celebrating 25,000 signups'))
-                ).should.be.true();
+                ), true);
 
                 // Correct image and NO height for Members milestone
-                mailStub.calledWith(
+                assert.equal(mailStub.calledWith(
                     sinon.match.has('html', sinon.match('src="https://static.ghost.org/v5.0.0/images/milestone-email-members-25k.png" width="580" align="center"'))
-                ).should.be.true();
+                ), true);
 
-                mailStub.calledWith(
+                assert.equal(mailStub.calledWith(
                     sinon.match.has('html', sinon.match('Congrats, <strong>25k people</strong> have chosen to support and follow your work. That’s an audience big enough to sell out Madison Square Garden. What an incredible milestone!'))
-                ).should.be.true();
+                ), true);
 
-                mailStub.calledWith(
+                assert.equal(mailStub.calledWith(
                     sinon.match.has('html', sinon.match('View your dashboard'))
-                ).should.be.true();
+                ), true);
             });
 
             it('send ARR milestone email', async function () {
@@ -920,30 +921,30 @@ describe('StaffService', function () {
 
                 await service.emails.notifyMilestoneReceived({milestone});
 
-                getEmailAlertUsersStub.calledWith('milestone-received').should.be.true();
+                assert.equal(getEmailAlertUsersStub.calledWith('milestone-received'), true);
 
-                mailStub.calledOnce.should.be.true();
+                assert.equal(mailStub.calledOnce, true);
 
-                mailStub.calledWith(
+                assert.equal(mailStub.calledWith(
                     sinon.match.has('html', sinon.match('Ghost Site hit $500,000 ARR'))
-                ).should.be.true();
+                ), true);
 
-                mailStub.calledWith(
+                assert.equal(mailStub.calledWith(
                     sinon.match.has('html', sinon.match('Congrats! You reached $500k ARR'))
-                ).should.be.true();
+                ), true);
 
                 // Correct image and height for ARR milestone
-                mailStub.calledWith(
+                assert.equal(mailStub.calledWith(
                     sinon.match.has('html', sinon.match('src="https://static.ghost.org/v5.0.0/images/milestone-email-usd-500k.png" width="580" height="348" align="center"'))
-                ).should.be.true();
+                ), true);
 
-                mailStub.calledWith(
+                assert.equal(mailStub.calledWith(
                     sinon.match.has('html', sinon.match('<strong>Ghost Site</strong> is now generating <strong>$500,000</strong> in annual recurring revenue. Congratulations &mdash; this is a significant milestone.'))
-                ).should.be.true();
+                ), true);
 
-                mailStub.calledWith(
+                assert.equal(mailStub.calledWith(
                     sinon.match.has('html', sinon.match('Login to your dashboard'))
-                ).should.be.true();
+                ), true);
             });
 
             it('does not send email when no date provided', async function () {
@@ -954,9 +955,9 @@ describe('StaffService', function () {
 
                 await service.emails.notifyMilestoneReceived({milestone});
 
-                getEmailAlertUsersStub.calledWith('milestone-received').should.be.false();
+                assert.equal(getEmailAlertUsersStub.calledWith('milestone-received'), false);
 
-                mailStub.called.should.be.false();
+                assert.equal(mailStub.called, false);
             });
 
             it('does not send email when a reason not to send email was provided', async function () {
@@ -971,9 +972,9 @@ describe('StaffService', function () {
 
                 await service.emails.notifyMilestoneReceived({milestone});
 
-                getEmailAlertUsersStub.calledWith('milestone-received').should.be.false();
+                assert.equal(getEmailAlertUsersStub.calledWith('milestone-received'), false);
 
-                mailStub.called.should.be.false();
+                assert.equal(mailStub.called, false);
             });
 
             it('does not send email for a milestone without correct content', async function () {
@@ -985,11 +986,11 @@ describe('StaffService', function () {
 
                 await service.emails.notifyMilestoneReceived({milestone});
 
-                getEmailAlertUsersStub.calledWith('milestone-received').should.be.false();
+                assert.equal(getEmailAlertUsersStub.calledWith('milestone-received'), false);
 
-                loggingWarningStub.calledOnce.should.be.true();
+                assert.equal(loggingWarningStub.calledOnce, true);
 
-                mailStub.called.should.be.false();
+                assert.equal(mailStub.called, false);
             });
         });
 
@@ -1005,13 +1006,13 @@ describe('StaffService', function () {
 
                 await service.emails.notifyDonationReceived({donationPaymentEvent});
 
-                getEmailAlertUsersStub.calledWith('donation').should.be.true();
+                assert.equal(getEmailAlertUsersStub.calledWith('donation'), true);
 
-                mailStub.calledOnce.should.be.true();
+                assert.equal(mailStub.calledOnce, true);
 
-                mailStub.calledWith(
+                assert.equal(mailStub.calledWith(
                     sinon.match.has('html', sinon.match('One-time payment received: €15.00 from Simon'))
-                ).should.be.true();
+                ), true);
             });
 
             it('has donation message in text', async function () {
@@ -1025,13 +1026,13 @@ describe('StaffService', function () {
 
                 await service.emails.notifyDonationReceived({donationPaymentEvent});
 
-                getEmailAlertUsersStub.calledWith('donation').should.be.true();
+                assert.equal(getEmailAlertUsersStub.calledWith('donation'), true);
 
-                mailStub.calledOnce.should.be.true();
+                assert.equal(mailStub.calledOnce, true);
 
-                mailStub.calledWith(
+                assert.equal(mailStub.calledWith(
                     sinon.match.has('text', sinon.match('Thank you for the awesome newsletter!'))
-                ).should.be.true();
+                ), true);
             });
 
             it('has donation message in html', async function () {
@@ -1045,13 +1046,13 @@ describe('StaffService', function () {
 
                 await service.emails.notifyDonationReceived({donationPaymentEvent});
 
-                getEmailAlertUsersStub.calledWith('donation').should.be.true();
+                assert.equal(getEmailAlertUsersStub.calledWith('donation'), true);
 
-                mailStub.calledOnce.should.be.true();
+                assert.equal(mailStub.calledOnce, true);
 
-                mailStub.calledWith(
+                assert.equal(mailStub.calledWith(
                     sinon.match.has('html', sinon.match('Thank you for the awesome newsletter!'))
-                ).should.be.true();
+                ), true);
             });
 
             it('does not contain donation message in HTML if not provided', async function () {
@@ -1065,16 +1066,16 @@ describe('StaffService', function () {
 
                 await service.emails.notifyDonationReceived({donationPaymentEvent});
 
-                getEmailAlertUsersStub.calledWith('donation').should.be.true();
-                mailStub.calledOnce.should.be.true();
+                assert.equal(getEmailAlertUsersStub.calledWith('donation'), true);
+                assert.equal(mailStub.calledOnce, true);
 
                 // Check that the specific HTML block for the donation message is NOT present
-                mailStub.calledWith(
+                assert.equal(mailStub.calledWith(
                     sinon.match.has('html', sinon.match(function (html) {
                         // Ensure that the block with `{{donation.donationMessage}}` does not exist in the rendered HTML
                         return !html.includes('“') && !html.includes('”');
                     }))
-                ).should.be.true();
+                ), true);
             });
 
             // Not really a relevant test, but it's here to show that the donation message is wrapped in quotation marks
@@ -1090,14 +1091,14 @@ describe('StaffService', function () {
 
                 await service.emails.notifyDonationReceived({donationPaymentEvent});
 
-                getEmailAlertUsersStub.calledWith('donation').should.be.true();
-                mailStub.calledOnce.should.be.true();
+                assert.equal(getEmailAlertUsersStub.calledWith('donation'), true);
+                assert.equal(mailStub.calledOnce, true);
 
-                mailStub.calledWith(
+                assert.equal(mailStub.calledWith(
                     sinon.match.has('html', sinon.match(function (html) {
                         return html.includes('“') && html.includes('”');
                     }))
-                ).should.be.true();
+                ), true);
             });
 
             it('send donation email without message', async function () {
@@ -1111,13 +1112,13 @@ describe('StaffService', function () {
 
                 await service.emails.notifyDonationReceived({donationPaymentEvent});
 
-                getEmailAlertUsersStub.calledWith('donation').should.be.true();
+                assert.equal(getEmailAlertUsersStub.calledWith('donation'), true);
 
-                mailStub.calledOnce.should.be.true();
+                assert.equal(mailStub.calledOnce, true);
 
-                mailStub.calledWith(
+                assert.equal(mailStub.calledWith(
                     sinon.match.has('text', sinon.match('No message provided'))
-                ).should.be.true();
+                ), true);
             });
         });
 
@@ -1138,9 +1139,9 @@ describe('StaffService', function () {
                         }
                     ]
                 });
-                textTemplate.should.match(/- Webmentions \(https:\/\/webmention.io\/\)/);
-                textTemplate.should.match(/Ghost Demo \(https:\/\/demo.ghost.io\/\)/);
-                textTemplate.should.match(/Sent to jamie@example.com from ghost.org/);
+                assert.match(textTemplate, /- Webmentions \(https:\/\/webmention.io\/\)/);
+                assert.match(textTemplate, /Ghost Demo \(https:\/\/demo.ghost.io\/\)/);
+                assert.match(textTemplate, /Sent to jamie@example.com from ghost.org/);
             });
         });
     });

--- a/ghost/core/test/unit/server/services/stats/content.test.js
+++ b/ghost/core/test/unit/server/services/stats/content.test.js
@@ -71,17 +71,17 @@ describe('ContentStatsService', function () {
 
             should.exist(result.url);
             result.url.should.startWith('https://api.tinybird.co/v0/pipes/api_top_pages.json?');
-            result.url.should.containEql('site_uuid=site-id');
-            result.url.should.containEql('date_from=2023-01-01');
-            result.url.should.containEql('date_to=2023-01-31');
-            result.url.should.containEql('timezone=UTC');
-            result.url.should.containEql('member_status=all');
+            assert(result.url.includes('site_uuid=site-id'));
+            assert(result.url.includes('date_from=2023-01-01'));
+            assert(result.url.includes('date_to=2023-01-31'));
+            assert(result.url.includes('timezone=UTC'));
+            assert(result.url.includes('member_status=all'));
 
             should.exist(result.options);
             should.exist(result.options.headers);
-            result.options.headers.Authorization.should.equal('Bearer tb-token');
+            assert.equal(result.options.headers.Authorization, 'Bearer tb-token');
 
-            mockTinybirdClient.buildRequest.calledWith('api_top_pages', options).should.be.true();
+            assert.equal(mockTinybirdClient.buildRequest.calledWith('api_top_pages', options), true);
         });
 
         it('parseResponse handles various response formats', function () {
@@ -103,7 +103,7 @@ describe('ContentStatsService', function () {
             should.exist(result);
             result.should.be.an.Array().with.lengthOf(2);
 
-            mockTinybirdClient.parseResponse.calledWith(mockResponse).should.be.true();
+            assert.equal(mockTinybirdClient.parseResponse.calledWith(mockResponse), true);
         });
     });
 
@@ -117,8 +117,8 @@ describe('ContentStatsService', function () {
             const result = service.extractPostUuids(data);
             should.exist(result);
             result.should.be.an.Array().with.lengthOf(2);
-            result.should.containEql('post-1');
-            result.should.containEql('post-2');
+            assert(result.includes('post-1'));
+            assert(result.includes('post-2'));
         });
 
         it('filters out null/undefined/empty UUIDs', function () {
@@ -138,7 +138,7 @@ describe('ContentStatsService', function () {
         it('returns empty object for empty UUIDs array', async function () {
             const result = await service.lookupPostTitles([]);
             should.exist(result);
-            Object.keys(result).should.have.lengthOf(0);
+            assert.equal(Object.keys(result).length, 0);
         });
 
         it('queries database and builds title map', async function () {
@@ -152,9 +152,9 @@ describe('ContentStatsService', function () {
             result['post-2'].should.have.property('id', 'post-id-2');
 
             // Verify knex was called correctly
-            mockKnex.select.calledWith('uuid', 'title', 'id').should.be.true();
-            mockKnex.from.calledWith('posts').should.be.true();
-            mockKnex.whereIn.calledWith('uuid', ['post-1', 'post-2']).should.be.true();
+            assert.equal(mockKnex.select.calledWith('uuid', 'title', 'id'), true);
+            assert.equal(mockKnex.from.calledWith('posts'), true);
+            assert.equal(mockKnex.whereIn.calledWith('uuid', ['post-1', 'post-2']), true);
         });
     });
 
@@ -181,8 +181,8 @@ describe('ContentStatsService', function () {
             const result = service.getResourceTitle('/about/');
             should.exist(result);
             result.should.have.properties(['title', 'resourceType']);
-            result.title.should.equal('About Us');
-            result.resourceType.should.equal('page');
+            assert.equal(result.title, 'About Us');
+            assert.equal(result.resourceType, 'page');
         });
 
         it('returns name from resource with name property (tags, authors)', function () {
@@ -196,8 +196,8 @@ describe('ContentStatsService', function () {
             const result = service.getResourceTitle('/tag/news/');
             should.exist(result);
             result.should.have.properties(['title', 'resourceType']);
-            result.title.should.equal('News');
-            result.resourceType.should.equal('tag');
+            assert.equal(result.title, 'News');
+            assert.equal(result.resourceType, 'tag');
         });
 
         it('returns null if resource lookup fails', function () {
@@ -228,8 +228,8 @@ describe('ContentStatsService', function () {
             should.exist(result);
             result.should.be.an.Array().with.lengthOf(0);
 
-            service.extractPostUuids.called.should.be.false();
-            service.lookupPostTitles.called.should.be.false();
+            assert.equal(service.extractPostUuids.called, false);
+            assert.equal(service.lookupPostTitles.called, false);
         });
 
         it('enriches data with post_uuid titles', async function () {
@@ -246,15 +246,15 @@ describe('ContentStatsService', function () {
 
             should.exist(result);
             result.should.be.an.Array().with.lengthOf(2);
-            result[0].title.should.equal('Test Post 1');
-            result[0].post_id.should.equal('post-id-1');
-            result[0].url_exists.should.equal(true);
-            result[1].title.should.equal('Test Post 2');
-            result[1].post_id.should.equal('post-id-2');
-            result[1].url_exists.should.equal(true);
+            assert.equal(result[0].title, 'Test Post 1');
+            assert.equal(result[0].post_id, 'post-id-1');
+            assert.equal(result[0].url_exists, true);
+            assert.equal(result[1].title, 'Test Post 2');
+            assert.equal(result[1].post_id, 'post-id-2');
+            assert.equal(result[1].url_exists, true);
 
-            service.extractPostUuids.calledOnce.should.be.true();
-            service.lookupPostTitles.calledOnce.should.be.true();
+            assert.equal(service.extractPostUuids.calledOnce, true);
+            assert.equal(service.lookupPostTitles.calledOnce, true);
         });
 
         it('uses urlService for non-post pages', async function () {
@@ -273,11 +273,11 @@ describe('ContentStatsService', function () {
 
             should.exist(result);
             result.should.be.an.Array().with.lengthOf(1);
-            result[0].title.should.equal('About Us');
-            result[0].resourceType.should.equal('page');
-            result[0].url_exists.should.equal(true);
+            assert.equal(result[0].title, 'About Us');
+            assert.equal(result[0].resourceType, 'page');
+            assert.equal(result[0].url_exists, true);
 
-            service.getResourceTitle.calledWith('/about/').should.be.true();
+            assert.equal(service.getResourceTitle.calledWith('/about/'), true);
         });
 
         it('falls back to formatted pathname for unknown pages', async function () {
@@ -291,10 +291,10 @@ describe('ContentStatsService', function () {
 
             should.exist(result);
             result.should.be.an.Array().with.lengthOf(1);
-            result[0].title.should.equal('unknown-page');
-            result[0].url_exists.should.equal(false);
+            assert.equal(result[0].title, 'unknown-page');
+            assert.equal(result[0].url_exists, false);
 
-            service.getResourceTitle.calledWith('/unknown-page/').should.be.true();
+            assert.equal(service.getResourceTitle.calledWith('/unknown-page/'), true);
         });
 
         it('handles home page', async function () {
@@ -308,8 +308,8 @@ describe('ContentStatsService', function () {
 
             should.exist(result);
             result.should.be.an.Array().with.lengthOf(1);
-            result[0].title.should.equal('Homepage');
-            result[0].url_exists.should.equal(false);
+            assert.equal(result[0].title, 'Homepage');
+            assert.equal(result[0].url_exists, false);
         });
     });
 
@@ -331,14 +331,14 @@ describe('ContentStatsService', function () {
 
             should.exist(result);
             result.should.be.an.Array().with.lengthOf(1);
-            result[0].pathname.should.equal('/test/');
-            result[0].visits.should.equal(100);
+            assert.equal(result[0].pathname, '/test/');
+            assert.equal(result[0].visits, 100);
 
-            mockTinybirdClient.fetch.calledOnce.should.be.true();
+            assert.equal(mockTinybirdClient.fetch.calledOnce, true);
 
             // Verify that camelCase conversion happened - the first param should be the pipe name
             const calledWith = mockTinybirdClient.fetch.firstCall.args;
-            calledWith[0].should.equal('api_top_pages');
+            assert.equal(calledWith[0], 'api_top_pages');
 
             // The second param should have camelCase properties
             calledWith[1].should.have.property('dateFrom', '2023-01-01');
@@ -361,7 +361,7 @@ describe('ContentStatsService', function () {
 
             // Verify that camelCase conversion happened
             const calledWith = mockTinybirdClient.fetch.firstCall.args;
-            calledWith[0].should.equal('api_top_pages');
+            assert.equal(calledWith[0], 'api_top_pages');
             calledWith[1].should.have.property('dateFrom', '2023-01-01');
             calledWith[1].should.have.property('dateTo', '2023-01-31');
         });
@@ -394,7 +394,7 @@ describe('ContentStatsService', function () {
             result.data[1].should.have.property('title');
             result.data[1].should.have.property('post_id');
 
-            service.fetchRawTopContentData.calledOnce.should.be.true();
+            assert.equal(service.fetchRawTopContentData.calledOnce, true);
 
             // Verify the parameters were passed properly
             const options = service.fetchRawTopContentData.firstCall.args[0];
@@ -414,7 +414,7 @@ describe('ContentStatsService', function () {
             should.exist(result.data);
             result.data.should.be.an.Array().with.lengthOf(0);
 
-            service.fetchRawTopContentData.calledOnce.should.be.true();
+            assert.equal(service.fetchRawTopContentData.calledOnce, true);
         });
 
         it('returns empty data array on error', async function () {
@@ -470,8 +470,8 @@ describe('ContentStatsService', function () {
             result.should.be.an.Array().with.lengthOf(2);
 
             // Verify tinybird client was called with correct parameters
-            mockTinybirdClient.fetch.calledOnce.should.be.true();
-            mockTinybirdClient.fetch.firstCall.args[0].should.equal('api_top_pages');
+            assert.equal(mockTinybirdClient.fetch.calledOnce, true);
+            assert.equal(mockTinybirdClient.fetch.firstCall.args[0], 'api_top_pages');
 
             const tinybirdOptions = mockTinybirdClient.fetch.firstCall.args[1];
             tinybirdOptions.should.have.property('dateFrom', '2023-01-01');
@@ -509,8 +509,8 @@ describe('ContentStatsService', function () {
 
             await service.fetchRawTopContentData(options);
 
-            mockTinybirdClient.fetch.calledOnce.should.be.true();
-            mockTinybirdClient.fetch.firstCall.args[0].should.equal('api_top_pages');
+            assert.equal(mockTinybirdClient.fetch.calledOnce, true);
+            assert.equal(mockTinybirdClient.fetch.firstCall.args[0], 'api_top_pages');
 
             const tinybirdOptions = mockTinybirdClient.fetch.firstCall.args[1];
             // Base parameters

--- a/ghost/core/test/unit/server/services/stats/mrr.test.js
+++ b/ghost/core/test/unit/server/services/stats/mrr.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const MrrStatsService = require('../../../../../core/server/services/stats/mrr-stats-service');
 const moment = require('moment');
 const sinon = require('sinon');
@@ -127,7 +128,7 @@ describe('MrrStatsService', function () {
         it('Handles no data', async function () {
             const history = await getMrrHistory();
 
-            history.count.should.eql(1);
+            assert.equal(history.count, 1);
             assertMrrEntry(history.data[0], todayDate, 0, 'usd');
             assertTotals(history.totals, [{mrr: 0}]);
         });
@@ -140,7 +141,7 @@ describe('MrrStatsService', function () {
 
             const history = await getMrrHistory();
 
-            history.count.should.eql(2);
+            assert.equal(history.count, 2);
 
             // Currencies are always sorted ascending
             assertMrrEntry(history.data[0], todayDate, 2, 'eur');
@@ -160,7 +161,7 @@ describe('MrrStatsService', function () {
 
             const history = await getMrrHistory();
 
-            history.count.should.eql(2);
+            assert.equal(history.count, 2);
             assertMrrEntry(history.data[0], yesterdayDate, 0);
             assertMrrEntry(history.data[1], todayDate, 5);
             assertTotals(history.totals, [{mrr: 5}]);
@@ -179,7 +180,7 @@ describe('MrrStatsService', function () {
 
             const history = await getMrrHistory();
 
-            history.count.should.eql(3);
+            assert.equal(history.count, 3);
             assertMrrEntry(history.data[0], dayBeforeYesterdayDate, 0);
             assertMrrEntry(history.data[1], yesterdayDate, 2);
             assertMrrEntry(history.data[2], todayDate, 7);
@@ -204,7 +205,7 @@ describe('MrrStatsService', function () {
 
             const history = await getMrrHistory();
 
-            history.count.should.eql(6);
+            assert.equal(history.count, 6);
 
             // Day before yesterday
             assertMrrEntry(history.data[0], dayBeforeYesterdayDate, 200, 'eur');
@@ -236,7 +237,7 @@ describe('MrrStatsService', function () {
             const history = await getMrrHistory();
 
             // Invalid currency event should be ignored
-            history.count.should.eql(1);
+            assert.equal(history.count, 1);
             assertMrrEntry(history.data[0], yesterdayDate, 7);
             assertTotals(history.totals, [{mrr: 7}]);
         });
@@ -252,7 +253,7 @@ describe('MrrStatsService', function () {
 
             const history = await getMrrHistory();
 
-            history.count.should.eql(3);
+            assert.equal(history.count, 3);
             assertMrrEntry(history.data[0], dayBeforeYesterdayDate, 0);
             assertMrrEntry(history.data[1], yesterdayDate, 2);
             assertMrrEntry(history.data[2], todayDate, 7);
@@ -270,7 +271,7 @@ describe('MrrStatsService', function () {
 
             const history = await getMrrHistory();
 
-            history.count.should.eql(4);
+            assert.equal(history.count, 4);
 
             // Two days before yesterday: calculated backward from current MRR
             assertMrrEntry(history.data[0], twoDaysBeforeYesterdayDate, 5);

--- a/ghost/core/test/unit/server/services/stats/utils/tinybird.test.js
+++ b/ghost/core/test/unit/server/services/stats/utils/tinybird.test.js
@@ -60,15 +60,15 @@ describe('Tinybird Client', function () {
 
             should.exist(url);
             url.should.startWith('https://api.tinybird.co/v0/pipes/test_pipe.json?');
-            url.should.containEql('site_uuid=931ade9e-a4f1-4217-8625-34bd34250c16');
-            url.should.containEql('date_from=2023-01-01');
-            url.should.containEql('date_to=2023-01-31');
+            assert(url.includes('site_uuid=931ade9e-a4f1-4217-8625-34bd34250c16'));
+            assert(url.includes('date_from=2023-01-01'));
+            assert(url.includes('date_to=2023-01-31'));
             // url.should.containEql('timezone=UTC');
             // url.should.containEql('member_status=all');
 
             should.exist(options);
             should.exist(options.headers);
-            options.headers.Authorization.should.equal('Bearer mock-jwt-token');
+            assert.equal(options.headers.Authorization, 'Bearer mock-jwt-token');
         });
 
         it('uses version from config if provided', function () {
@@ -95,9 +95,9 @@ describe('Tinybird Client', function () {
                 memberStatus: 'paid'
             });
 
-            url.should.containEql('site_uuid=931ade9e-a4f1-4217-8625-34bd34250c16');
-            url.should.containEql('timezone=America%2FNew_York');
-            url.should.containEql('member_status=paid');
+            assert(url.includes('site_uuid=931ade9e-a4f1-4217-8625-34bd34250c16'));
+            assert(url.includes('timezone=America%2FNew_York'));
+            assert(url.includes('member_status=paid'));
         });
         
         it('uses local endpoint and token when local is enabled', function () {
@@ -115,7 +115,7 @@ describe('Tinybird Client', function () {
             const {url, options} = tinybirdClient.buildRequest('test_pipe', {});
 
             url.should.startWith('http://localhost:8000/v0/pipes/test_pipe.json?');
-            options.headers.Authorization.should.equal('Bearer mock-jwt-token');
+            assert.equal(options.headers.Authorization, 'Bearer mock-jwt-token');
         });
     });
 
@@ -133,8 +133,8 @@ describe('Tinybird Client', function () {
             const result = tinybirdClient.parseResponse(mockResponse);
             should.exist(result);
             result.should.be.an.Array().with.lengthOf(2);
-            result[0].pathname.should.equal('/test-1/');
-            result[0].visits.should.equal(100);
+            assert.equal(result[0].pathname, '/test-1/');
+            assert.equal(result[0].visits, 100);
         });
 
         it('handles JSON object in response.body', function () {
@@ -215,14 +215,14 @@ describe('Tinybird Client', function () {
             
             should.exist(result);
             result.should.be.an.Array().with.lengthOf(2);
-            result[0].pathname.should.equal('/test-1/');
-            result[0].visits.should.equal(100);
+            assert.equal(result[0].pathname, '/test-1/');
+            assert.equal(result[0].visits, 100);
             
             // Verify request was called with correct parameters
-            mockRequest.get.calledOnce.should.be.true();
+            assert.equal(mockRequest.get.calledOnce, true);
             const [url, options] = mockRequest.get.firstCall.args;
             url.should.startWith('https://api.tinybird.co/v0/pipes/test_pipe.json?');
-            options.headers.Authorization.should.equal('Bearer mock-jwt-token');
+            assert.equal(options.headers.Authorization, 'Bearer mock-jwt-token');
         });
         
         it('returns null when request fails', async function () {
@@ -232,7 +232,7 @@ describe('Tinybird Client', function () {
             const result = await tinybirdClient.fetch('test_pipe', {});
             
             assert.equal(result, null);
-            mockRequest.get.calledOnce.should.be.true();
+            assert.equal(mockRequest.get.calledOnce, true);
         });
         
         it('returns null when response parsing fails', async function () {
@@ -244,7 +244,7 @@ describe('Tinybird Client', function () {
             const result = await tinybirdClient.fetch('test_pipe', {});
             
             assert.equal(result, null);
-            mockRequest.get.calledOnce.should.be.true();
+            assert.equal(mockRequest.get.calledOnce, true);
         });
     });
 }); 

--- a/ghost/core/test/unit/server/services/stripe/stripe-api.test.js
+++ b/ghost/core/test/unit/server/services/stripe/stripe-api.test.js
@@ -180,7 +180,7 @@ describe('StripeAPI', function () {
                 }
             });
 
-            should(mockStripe.checkout.sessions.create.args[0][0].subscription_data.metadata).deepEqual({
+            assert.deepEqual(mockStripe.checkout.sessions.create.args[0][0].subscription_data.metadata, {
                 attribution_id: '123',
                 attribution_url: '/',
                 attribution_type: 'url',

--- a/ghost/core/test/unit/server/services/themes/list.test.js
+++ b/ghost/core/test/unit/server/services/themes/list.test.js
@@ -27,7 +27,7 @@ describe('Themes', function () {
 
         it('getAll() returns all themes', function () {
             themeList.getAll().should.be.an.Object().with.properties('casper', 'not-casper');
-            Object.keys(themeList.getAll()).should.have.length(2);
+            assert.equal(Object.keys(themeList.getAll()).length, 2);
         });
 
         it('set() updates an existing theme', function () {
@@ -63,9 +63,9 @@ describe('Themes', function () {
             const setSpy = sinon.spy(themeList, 'set');
 
             themeList.init({test: {a: 'b'}, casper: {c: 'd'}});
-            setSpy.calledTwice.should.be.true();
-            setSpy.firstCall.calledWith('test', {a: 'b'}).should.be.true();
-            setSpy.secondCall.calledWith('casper', {c: 'd'}).should.be.true();
+            assert.equal(setSpy.calledTwice, true);
+            assert.equal(setSpy.firstCall.calledWith('test', {a: 'b'}), true);
+            assert.equal(setSpy.secondCall.calledWith('casper', {c: 'd'}), true);
         });
 
         it('init() with empty object resets the list', function () {
@@ -74,7 +74,7 @@ describe('Themes', function () {
             should.exist(result);
             result.should.be.an.Object();
             result.should.eql({});
-            Object.keys(result).should.have.length(0);
+            assert.equal(Object.keys(result).length, 0);
         });
     });
 });

--- a/ghost/core/test/unit/server/services/themes/loader.test.js
+++ b/ghost/core/test/unit/server/services/themes/loader.test.js
@@ -135,7 +135,7 @@ describe('Themes', function () {
                         done('Should have thrown an error');
                     })
                     .catch(function (err) {
-                        err.message.should.eql('Package not found');
+                        assert.equal(err.message, 'Package not found');
                         done();
                     });
             });

--- a/ghost/core/test/unit/server/services/themes/validate.test.js
+++ b/ghost/core/test/unit/server/services/themes/validate.test.js
@@ -47,10 +47,10 @@ describe('Themes', function () {
 
             return validate.check(testTheme.name, testTheme, {isZip: true})
                 .then((checkedTheme) => {
-                    checkZipStub.calledOnce.should.be.true();
-                    checkZipStub.calledWith(testTheme).should.be.true();
+                    assert.equal(checkZipStub.calledOnce, true);
+                    assert.equal(checkZipStub.calledWith(testTheme), true);
                     checkStub.callCount.should.be.equal(0);
-                    formatStub.calledOnce.should.be.true();
+                    assert.equal(formatStub.calledOnce, true);
                     checkedTheme.should.be.an.Object();
 
                     assert.equal(validate.canActivate(checkedTheme), true);
@@ -64,9 +64,9 @@ describe('Themes', function () {
             return validate.check(testTheme.name, testTheme, {isZip: false})
                 .then((checkedTheme) => {
                     checkZipStub.callCount.should.be.equal(0);
-                    checkStub.calledOnce.should.be.true();
-                    checkStub.calledWith(testTheme.path).should.be.true();
-                    formatStub.calledOnce.should.be.true();
+                    assert.equal(checkStub.calledOnce, true);
+                    assert.equal(checkStub.calledWith(testTheme.path), true);
+                    assert.equal(formatStub.calledOnce, true);
                     checkedTheme.should.be.an.Object();
 
                     assert.equal(validate.canActivate(checkedTheme), true);
@@ -93,10 +93,10 @@ describe('Themes', function () {
 
             return validate.check(testTheme.name, testTheme, {isZip: true})
                 .then((checkedTheme) => {
-                    checkZipStub.calledOnce.should.be.true();
-                    checkZipStub.calledWith(testTheme).should.be.true();
+                    assert.equal(checkZipStub.calledOnce, true);
+                    assert.equal(checkZipStub.calledWith(testTheme), true);
                     checkStub.callCount.should.be.equal(0);
-                    formatStub.calledOnce.should.be.true();
+                    assert.equal(formatStub.calledOnce, true);
 
                     assert.equal(validate.canActivate(checkedTheme), false);
                 });
@@ -122,10 +122,10 @@ describe('Themes', function () {
 
             return validate.check(testTheme.name, testTheme, {isZip: false})
                 .then((checkedTheme) => {
-                    checkStub.calledOnce.should.be.true();
-                    checkStub.calledWith(testTheme.path).should.be.true();
+                    assert.equal(checkStub.calledOnce, true);
+                    assert.equal(checkStub.calledWith(testTheme.path), true);
                     checkZipStub.callCount.should.be.equal(0);
-                    formatStub.calledOnce.should.be.true();
+                    assert.equal(formatStub.calledOnce, true);
 
                     assert.equal(validate.canActivate(checkedTheme), false);
                 });
@@ -141,10 +141,10 @@ describe('Themes', function () {
                 }).catch((error) => {
                     error.should.be.an.Object();
                     error.message.should.be.equal('invalid zip file');
-                    checkZipStub.calledOnce.should.be.true();
-                    checkZipStub.calledWith(testTheme).should.be.true();
+                    assert.equal(checkZipStub.calledOnce, true);
+                    assert.equal(checkZipStub.calledWith(testTheme), true);
                     checkStub.callCount.should.be.equal(0);
-                    formatStub.calledOnce.should.be.false();
+                    assert.equal(formatStub.calledOnce, false);
                 });
         });
     });

--- a/ghost/core/test/unit/server/services/update-check.test.js
+++ b/ghost/core/test/unit/server/services/update-check.test.js
@@ -79,7 +79,7 @@ describe('Update Check', function () {
 
             await updateCheckService.check();
 
-            scope.isDone().should.equal(true);
+            assert.equal(scope.isDone(), true);
         });
 
         it('update check won\'t happen if it\'s too early', async function () {
@@ -101,7 +101,7 @@ describe('Update Check', function () {
 
             await updateCheckService.check();
 
-            requestStub.called.should.equal(false);
+            assert.equal(requestStub.called, false);
         });
 
         it('update check will happen if it\'s time to check', async function () {
@@ -145,7 +145,7 @@ describe('Update Check', function () {
 
             await updateCheckService.check();
 
-            scope.isDone().should.equal(true);
+            assert.equal(scope.isDone(), true);
         });
     });
 
@@ -206,16 +206,16 @@ describe('Update Check', function () {
 
             await updateCheckService.check();
 
-            scope.isDone().should.equal(true);
+            assert.equal(scope.isDone(), true);
 
-            capturedData.ghost_version.should.equal('4.0.0');
+            assert.equal(capturedData.ghost_version, '4.0.0');
             capturedData.node_version.should.equal(process.versions.node);
             capturedData.env.should.equal(process.env.NODE_ENV);
-            capturedData.database_type.should.match(/sqlite3|mysql/);
+            assert.match(capturedData.database_type, /sqlite3|mysql/);
             capturedData.blog_id.should.be.a.String();
             capturedData.blog_id.should.not.be.empty();
             capturedData.theme.should.be.equal('casperito');
-            capturedData.blog_created_at.should.equal(819846900);
+            assert.equal(capturedData.blog_created_at, 819846900);
             capturedData.user_count.should.be.equal(2);
             capturedData.post_count.should.be.equal(13);
             capturedData.npm_version.should.be.equal('10.8.2');
@@ -281,17 +281,17 @@ describe('Update Check', function () {
 
             await updateCheckService.check();
 
-            notificationsAPIAddStub.calledOnce.should.equal(true);
-            notificationsAPIAddStub.args[0][0].notifications.length.should.equal(1);
+            assert.equal(notificationsAPIAddStub.calledOnce, true);
+            assert.equal(notificationsAPIAddStub.args[0][0].notifications.length, 1);
 
             const targetNotification = notificationsAPIAddStub.args[0][0].notifications[0];
             targetNotification.dismissible.should.eql(notification.messages[0].dismissible);
             targetNotification.id.should.eql(notification.messages[0].id);
             targetNotification.top.should.eql(notification.messages[0].top);
-            targetNotification.type.should.eql('info');
+            assert.equal(targetNotification.type, 'info');
             targetNotification.message.should.eql(notification.messages[0].content);
 
-            usersBrowseStub.calledTwice.should.eql(true);
+            assert.equal(usersBrowseStub.calledTwice, true);
 
             // Second (non statistical) call should be looking for admin users with an 'active' status only
             usersBrowseStub.args[1][0].should.eql({
@@ -362,14 +362,14 @@ describe('Update Check', function () {
 
             await updateCheckService.check();
 
-            sendEmailStub.called.should.be.true();
-            sendEmailStub.args[0][0].to.should.equal('jbloggs@example.com');
-            sendEmailStub.args[0][0].subject.should.equal('Action required: Critical alert from Ghost instance http://127.0.0.1:2369');
-            sendEmailStub.args[0][0].html.should.equal('<p>Critical message. Upgrade your site!</p>');
-            sendEmailStub.args[0][0].forceTextContent.should.equal(true);
+            assert.equal(sendEmailStub.called, true);
+            assert.equal(sendEmailStub.args[0][0].to, 'jbloggs@example.com');
+            assert.equal(sendEmailStub.args[0][0].subject, 'Action required: Critical alert from Ghost instance http://127.0.0.1:2369');
+            assert.equal(sendEmailStub.args[0][0].html, '<p>Critical message. Upgrade your site!</p>');
+            assert.equal(sendEmailStub.args[0][0].forceTextContent, true);
 
-            notificationsAPIAddStub.calledOnce.should.equal(true);
-            notificationsAPIAddStub.args[0][0].notifications.length.should.equal(1);
+            assert.equal(notificationsAPIAddStub.calledOnce, true);
+            assert.equal(notificationsAPIAddStub.args[0][0].notifications.length, 1);
         });
 
         it('not create a notification if the check response has no messages', async function () {
@@ -417,7 +417,7 @@ describe('Update Check', function () {
 
             await updateCheckService.check();
 
-            notificationsAPIAddStub.calledOnce.should.equal(false);
+            assert.equal(notificationsAPIAddStub.calledOnce, false);
         });
     });
 
@@ -434,10 +434,10 @@ describe('Update Check', function () {
 
             updateCheckService.updateCheckError({});
 
-            settingsStub.called.should.be.true();
-            logging.error.called.should.be.true();
-            logging.error.args[0][0].context.should.equal('Checking for updates failed, your site will continue to function.');
-            logging.error.args[0][0].help.should.equal('If you get this error repeatedly, please seek help from https://ghost.org/docs/');
+            assert.equal(settingsStub.called, true);
+            assert.equal(logging.error.called, true);
+            assert.equal(logging.error.args[0][0].context, 'Checking for updates failed, your site will continue to function.');
+            assert.equal(logging.error.args[0][0].help, 'If you get this error repeatedly, please seek help from https://ghost.org/docs/');
         });
 
         it('logs and rethrows an error when error with rethrow configuration', function () {
@@ -456,12 +456,12 @@ describe('Update Check', function () {
                 updateCheckService.updateCheckError({});
                 assert.fail('should have thrown');
             } catch (e) {
-                settingsStub.called.should.be.true();
-                logging.error.called.should.be.true();
-                logging.error.args[0][0].context.should.equal('Checking for updates failed, your site will continue to function.');
-                logging.error.args[0][0].help.should.equal('If you get this error repeatedly, please seek help from https://ghost.org/docs/');
+                assert.equal(settingsStub.called, true);
+                assert.equal(logging.error.called, true);
+                assert.equal(logging.error.args[0][0].context, 'Checking for updates failed, your site will continue to function.');
+                assert.equal(logging.error.args[0][0].help, 'If you get this error repeatedly, please seek help from https://ghost.org/docs/');
 
-                e.context.should.equal('Checking for updates failed, your site will continue to function.');
+                assert.equal(e.context, 'Checking for updates failed, your site will continue to function.');
             }
         });
     });

--- a/ghost/core/test/unit/server/services/url/local-file-cache.test.js
+++ b/ghost/core/test/unit/server/services/url/local-file-cache.test.js
@@ -25,7 +25,7 @@ describe('Unit: services/url/LocalFileCache', function () {
             const cachedUrls = await localFileCache.read('urls');
 
             cachedUrls.should.not.be.undefined();
-            cachedUrls.urls.should.equal('urls!');
+            assert.equal(cachedUrls.urls, 'urls!');
         });
 
         it('returns null when the cache file does not exit', async function () {
@@ -65,8 +65,8 @@ describe('Unit: services/url/LocalFileCache', function () {
 
             const result = await localFileCache.write('urls', {data: 'test'});
 
-            result.should.equal(true);
-            writeFileStub.called.should.equal(true);
+            assert.equal(result, true);
+            assert.equal(writeFileStub.called, true);
         });
 
         it('does not write to the file system is writes are disabled', async function () {
@@ -83,7 +83,7 @@ describe('Unit: services/url/LocalFileCache', function () {
             const result = await localFileCache.write('urls', {data: 'test'});
 
             assert.equal(result, null);
-            writeFileStub.called.should.equal(false);
+            assert.equal(writeFileStub.called, false);
         });
     });
 });

--- a/ghost/core/test/unit/server/services/url/queue.test.js
+++ b/ghost/core/test/unit/server/services/url/queue.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const _ = require('lodash');
 const should = require('should');
 const sinon = require('sinon');
@@ -28,13 +29,13 @@ describe('Unit: services/url/Queue', function () {
         }, null);
 
         should.exist(queue.queue.chocolate);
-        queue.queue.chocolate.subscribers.length.should.eql(1);
+        assert.equal(queue.queue.chocolate.subscribers.length, 1);
 
         queue.register({
             event: 'chocolate'
         }, null);
 
-        queue.queue.chocolate.subscribers.length.should.eql(2);
+        assert.equal(queue.queue.chocolate.subscribers.length, 2);
 
         queue.register({
             event: 'nachos'
@@ -43,8 +44,8 @@ describe('Unit: services/url/Queue', function () {
         should.exist(queue.queue.chocolate);
         should.exist(queue.queue.nachos);
 
-        queue.queue.chocolate.subscribers.length.should.eql(2);
-        queue.queue.nachos.subscribers.length.should.eql(1);
+        assert.equal(queue.queue.chocolate.subscribers.length, 2);
+        assert.equal(queue.queue.nachos.subscribers.length, 1);
 
         // events have not been triggered yet
         queue.toNotify.should.eql({});
@@ -53,8 +54,8 @@ describe('Unit: services/url/Queue', function () {
     describe('fn: start (no tolerance)', function () {
         it('no subscribers', function (done) {
             queue.addListener('ended', function (event) {
-                event.should.eql('nachos');
-                queueRunSpy.callCount.should.eql(1);
+                assert.equal(event, 'nachos');
+                assert.equal(queueRunSpy.callCount, 1);
                 done();
             });
 
@@ -67,9 +68,9 @@ describe('Unit: services/url/Queue', function () {
             let notified = 0;
 
             queue.addListener('ended', function (event) {
-                event.should.eql('nachos');
-                queueRunSpy.callCount.should.eql(2);
-                notified.should.eql(1);
+                assert.equal(event, 'nachos');
+                assert.equal(queueRunSpy.callCount, 2);
+                assert.equal(notified, 1);
                 done();
             });
 
@@ -89,11 +90,11 @@ describe('Unit: services/url/Queue', function () {
             let order = [];
 
             queue.addListener('ended', function (event) {
-                event.should.eql('nachos');
+                assert.equal(event, 'nachos');
 
                 // 9 subscribers + start triggers run
-                queueRunSpy.callCount.should.eql(10);
-                notified.should.eql(9);
+                assert.equal(queueRunSpy.callCount, 10);
+                assert.equal(notified, 9);
                 order.should.eql([0, 1, 2, 3, 4, 5, 6, 7, 8]);
                 done();
             });
@@ -116,9 +117,9 @@ describe('Unit: services/url/Queue', function () {
             let notified = 0;
 
             queue.addListener('ended', function (event) {
-                event.should.eql('nachos');
-                queueRunSpy.callCount.should.eql(1);
-                notified.should.eql(0);
+                assert.equal(event, 'nachos');
+                assert.equal(queueRunSpy.callCount, 1);
+                assert.equal(notified, 0);
                 done();
             });
 
@@ -144,8 +145,8 @@ describe('Unit: services/url/Queue', function () {
                 event: 'nachos'
             });
 
-            logging.error.calledOnce.should.be.true();
-            queue.toNotify.nachos.notified.length.should.eql(0);
+            assert.equal(logging.error.calledOnce, true);
+            assert.equal(queue.toNotify.nachos.notified.length, 0);
         });
     });
 
@@ -154,8 +155,8 @@ describe('Unit: services/url/Queue', function () {
             let notified = 0;
 
             queue.addListener('ended', function (event) {
-                event.should.eql('nachos');
-                notified.should.eql(1);
+                assert.equal(event, 'nachos');
+                assert.equal(notified, 1);
                 done();
             });
 
@@ -178,9 +179,9 @@ describe('Unit: services/url/Queue', function () {
             let called = 0;
 
             queue.addListener('ended', function (event) {
-                event.should.eql('nachos');
-                notified.should.eql(1);
-                called.should.eql(1);
+                assert.equal(event, 'nachos');
+                assert.equal(notified, 1);
+                assert.equal(called, 1);
                 done();
             });
 
@@ -214,9 +215,9 @@ describe('Unit: services/url/Queue', function () {
             let called = 0;
 
             queue.addListener('ended', function (event) {
-                event.should.eql('nachos');
-                notified.should.eql(0);
-                called.should.eql(0);
+                assert.equal(event, 'nachos');
+                assert.equal(notified, 0);
+                assert.equal(called, 0);
                 done();
             });
 
@@ -238,9 +239,9 @@ describe('Unit: services/url/Queue', function () {
             let called = 0;
 
             queue.addListener('ended', function (event) {
-                event.should.eql('nachos');
-                notified.should.eql(1);
-                called.should.eql(1);
+                assert.equal(event, 'nachos');
+                assert.equal(notified, 1);
+                assert.equal(called, 1);
                 done();
             });
 

--- a/ghost/core/test/unit/server/services/url/url-generator.test.js
+++ b/ghost/core/test/unit/server/services/url/url-generator.test.js
@@ -60,7 +60,7 @@ describe('Unit: services/url/UrlGenerator', function () {
     it('ensure listeners', function () {
         const urlGenerator = new UrlGenerator({router, queue});
 
-        queue.register.calledTwice.should.be.true();
+        assert.equal(queue.register.calledTwice, true);
         assert.equal(urlGenerator.filter, undefined);
     });
 
@@ -70,7 +70,7 @@ describe('Unit: services/url/UrlGenerator', function () {
             filter: 'featured:true',
             queue
         });
-        urlGenerator.filter.should.eql('featured:true');
+        assert.equal(urlGenerator.filter, 'featured:true');
     });
 
     it('routing type has changed', function () {
@@ -98,10 +98,10 @@ describe('Unit: services/url/UrlGenerator', function () {
 
         urlGenerator.regenerateResources();
 
-        urls.removeResourceId.calledTwice.should.be.true();
-        resource.release.calledOnce.should.be.true();
-        resource2.release.calledOnce.should.be.true();
-        urlGenerator._try.calledTwice.should.be.true();
+        assert.equal(urls.removeResourceId.calledTwice, true);
+        assert.equal(resource.release.calledOnce, true);
+        assert.equal(resource2.release.calledOnce, true);
+        assert.equal(urlGenerator._try.calledTwice, true);
     });
 
     describe('fn: _onInit', function () {
@@ -118,7 +118,7 @@ describe('Unit: services/url/UrlGenerator', function () {
             sinon.stub(urlGenerator, '_try');
 
             urlGenerator._onInit();
-            urlGenerator._try.calledOnce.should.be.true();
+            assert.equal(urlGenerator._try.calledOnce, true);
         });
 
         it('no resource', function () {
@@ -134,7 +134,7 @@ describe('Unit: services/url/UrlGenerator', function () {
             sinon.stub(urlGenerator, '_try');
 
             urlGenerator._onInit();
-            urlGenerator._try.called.should.be.false();
+            assert.equal(urlGenerator._try.called, false);
         });
     });
 
@@ -152,7 +152,7 @@ describe('Unit: services/url/UrlGenerator', function () {
             sinon.stub(urlGenerator, '_try');
 
             urlGenerator._onAdded({id: 1, type: 'posts'});
-            urlGenerator._try.calledOnce.should.be.true();
+            assert.equal(urlGenerator._try.calledOnce, true);
         });
 
         it('type is not equal', function () {
@@ -166,7 +166,7 @@ describe('Unit: services/url/UrlGenerator', function () {
             sinon.stub(urlGenerator, '_try');
 
             urlGenerator._onAdded({id: 1, type: 'posts'});
-            urlGenerator._try.called.should.be.false();
+            assert.equal(urlGenerator._try.called, false);
         });
     });
 
@@ -189,10 +189,10 @@ describe('Unit: services/url/UrlGenerator', function () {
 
                 urlGenerator._try(resource);
 
-                urlGenerator._generateUrl.calledOnce.should.be.true();
-                urlGenerator._resourceListeners.calledOnce.should.be.true();
-                urls.add.calledOnce.should.be.true();
-                resource.reserve.calledOnce.should.be.true();
+                assert.equal(urlGenerator._generateUrl.calledOnce, true);
+                assert.equal(urlGenerator._resourceListeners.calledOnce, true);
+                assert.equal(urls.add.calledOnce, true);
+                assert.equal(resource.reserve.calledOnce, true);
             });
 
             it('resource is taken', function () {
@@ -213,10 +213,10 @@ describe('Unit: services/url/UrlGenerator', function () {
 
                 urlGenerator._try(resource);
 
-                urlGenerator._generateUrl.called.should.be.false();
-                urlGenerator._resourceListeners.called.should.be.false();
-                urls.add.called.should.be.false();
-                resource.reserve.called.should.be.false();
+                assert.equal(urlGenerator._generateUrl.called, false);
+                assert.equal(urlGenerator._resourceListeners.called, false);
+                assert.equal(urls.add.called, false);
+                assert.equal(resource.reserve.called, false);
             });
         });
 
@@ -239,11 +239,11 @@ describe('Unit: services/url/UrlGenerator', function () {
 
                 urlGenerator._try(resource);
 
-                urlGenerator._generateUrl.calledOnce.should.be.true();
-                urlGenerator._resourceListeners.calledOnce.should.be.true();
-                urls.add.calledOnce.should.be.true();
-                resource.reserve.calledOnce.should.be.true();
-                urlGenerator.nql.queryJSON.called.should.be.true();
+                assert.equal(urlGenerator._generateUrl.calledOnce, true);
+                assert.equal(urlGenerator._resourceListeners.calledOnce, true);
+                assert.equal(urls.add.calledOnce, true);
+                assert.equal(resource.reserve.calledOnce, true);
+                assert.equal(urlGenerator.nql.queryJSON.called, true);
             });
 
             it('no match', function () {
@@ -264,11 +264,11 @@ describe('Unit: services/url/UrlGenerator', function () {
 
                 urlGenerator._try(resource);
 
-                urlGenerator._generateUrl.calledOnce.should.be.false();
-                urlGenerator._resourceListeners.called.should.be.false();
-                urls.add.called.should.be.false();
-                resource.reserve.called.should.be.false();
-                urlGenerator.nql.queryJSON.called.should.be.true();
+                assert.equal(urlGenerator._generateUrl.calledOnce, false);
+                assert.equal(urlGenerator._resourceListeners.called, false);
+                assert.equal(urls.add.called, false);
+                assert.equal(resource.reserve.called, false);
+                assert.equal(urlGenerator.nql.queryJSON.called, true);
             });
 
             it('resource is taken', function () {
@@ -289,11 +289,11 @@ describe('Unit: services/url/UrlGenerator', function () {
 
                 urlGenerator._try(resource);
 
-                urlGenerator._generateUrl.called.should.be.false();
-                urlGenerator._resourceListeners.called.should.be.false();
-                urls.add.called.should.be.false();
-                resource.reserve.called.should.be.false();
-                urlGenerator.nql.queryJSON.called.should.be.false();
+                assert.equal(urlGenerator._generateUrl.called, false);
+                assert.equal(urlGenerator._resourceListeners.called, false);
+                assert.equal(urls.add.called, false);
+                assert.equal(resource.reserve.called, false);
+                assert.equal(urlGenerator.nql.queryJSON.called, false);
             });
 
             it('filter is malformed', function () {
@@ -313,7 +313,7 @@ describe('Unit: services/url/UrlGenerator', function () {
                 const queryJSONSpy = sinon.spy(urlGenerator.nql, 'queryJSON');
 
                 // When the filter is malformed, the resource should not be reserved
-                urlGenerator._try(resource).should.be.false();
+                assert.equal(urlGenerator._try(resource), false);
 
                 // Ensure the above false return is due to the malformed filter
                 queryJSONSpy.should.throw(new RegExp('Query Error: unexpected character in filter'));
@@ -334,8 +334,8 @@ describe('Unit: services/url/UrlGenerator', function () {
             const replacePermalink = sinon.stub().returns('/url/');
             sinon.stub(urlUtils, 'replacePermalink').get(() => replacePermalink);
 
-            urlGenerator._generateUrl(resource).should.eql('/url/');
-            replacePermalink.calledWith('/:slug/', resource.data).should.be.true();
+            assert.equal(urlGenerator._generateUrl(resource), '/url/');
+            assert.equal(replacePermalink.calledWith('/:slug/', resource.data), true);
         });
     });
 
@@ -344,8 +344,8 @@ describe('Unit: services/url/UrlGenerator', function () {
             const urlGenerator = new UrlGenerator({router, queue, resources, urls});
 
             urlGenerator._resourceListeners(resource);
-            resource.removeAllListeners.calledOnce.should.be.true();
-            resource.addListener.calledTwice.should.be.true();
+            assert.equal(resource.removeAllListeners.calledOnce, true);
+            assert.equal(resource.addListener.calledTwice, true);
         });
 
         it('resource was updated', function () {
@@ -360,10 +360,10 @@ describe('Unit: services/url/UrlGenerator', function () {
             urlGenerator._resourceListeners(resource);
             resource.addListener.args[0][1](resource);
 
-            urlGenerator._try.called.should.be.false();
-            urls.removeResourceId.called.should.be.true();
-            resource.release.called.should.be.true();
-            queue.start.called.should.be.true();
+            assert.equal(urlGenerator._try.called, false);
+            assert.equal(urls.removeResourceId.called, true);
+            assert.equal(resource.release.called, true);
+            assert.equal(queue.start.called, true);
         });
 
         it('resource got removed', function () {
@@ -375,8 +375,8 @@ describe('Unit: services/url/UrlGenerator', function () {
             };
 
             resource.addListener.args[1][1](resource);
-            urls.removeResourceId.calledOnce.should.be.true();
-            resource.release.calledOnce.should.be.true();
+            assert.equal(urls.removeResourceId.calledOnce, true);
+            assert.equal(resource.release.calledOnce, true);
         });
     });
 });

--- a/ghost/core/test/unit/server/services/url/url-service.test.js
+++ b/ghost/core/test/unit/server/services/url/url-service.test.js
@@ -48,40 +48,40 @@ describe('Unit: services/url/UrlService', function () {
         should.exist(urlService.queue);
 
         urlService.urlGenerators.should.eql([]);
-        urlService.hasFinished().should.be.false();
+        assert.equal(urlService.hasFinished(), false);
 
-        urlService.queue.addListener.calledTwice.should.be.true();
-        urlService.queue.addListener.args[0][0].should.eql('started');
-        urlService.queue.addListener.args[1][0].should.eql('ended');
+        assert.equal(urlService.queue.addListener.calledTwice, true);
+        assert.equal(urlService.queue.addListener.args[0][0], 'started');
+        assert.equal(urlService.queue.addListener.args[1][0], 'ended');
     });
 
     it('fn: _onQueueStarted', function () {
         urlService._onQueueStarted('init');
-        urlService.hasFinished().should.be.false();
+        assert.equal(urlService.hasFinished(), false);
     });
 
     it('fn: _onQueueEnded', function () {
         urlService._onQueueEnded('init');
-        urlService.hasFinished().should.be.true();
+        assert.equal(urlService.hasFinished(), true);
     });
 
     it('fn: onRouterAddedType', function () {
         urlService.onRouterAddedType({getPermalinks: sinon.stub().returns({})});
-        urlService.urlGenerators.length.should.eql(1);
+        assert.equal(urlService.urlGenerators.length, 1);
     });
 
     it('fn: getResourceById', function (done) {
         urlService.urls.getByResourceId.withArgs('id123').returns({resource: true});
-        urlService.getResourceById('id123').should.eql(true);
+        assert.equal(urlService.getResourceById('id123'), true);
 
         urlService.urls.getByResourceId.withArgs('id12345').returns(null);
 
         try {
-            urlService.getResourceById('id12345').should.eql(true);
+            assert.equal(urlService.getResourceById('id12345'), true);
             done(new Error('expected error'));
         } catch (err) {
             should.exist(err);
-            err.code.should.eql('URLSERVICE_RESOURCE_NOT_FOUND');
+            assert.equal(err.code, 'URLSERVICE_RESOURCE_NOT_FOUND');
             done();
         }
     });
@@ -95,7 +95,7 @@ describe('Unit: services/url/UrlService', function () {
                 urlService.getResource('/blog-post/');
                 throw new Error('Expected error.');
             } catch (err) {
-                errors.utils.isGhostError(err).should.be.true();
+                assert.equal(errors.utils.isGhostError(err), true);
             }
         });
 
@@ -166,7 +166,7 @@ describe('Unit: services/url/UrlService', function () {
             sinon.stub(urlService, 'getResource').withArgs('/blog-post/', {returnEverything: true})
                 .returns({generatorId: 1, resource: true});
 
-            urlService.getPermalinkByUrl('/blog-post/').should.eql('/:primary_tag/');
+            assert.equal(urlService.getPermalinkByUrl('/blog-post/'), '/:primary_tag/');
         });
 
         it('found (slug)', function () {
@@ -184,14 +184,14 @@ describe('Unit: services/url/UrlService', function () {
             sinon.stub(urlService, 'getResource').withArgs('/blog-post/', {returnEverything: true})
                 .returns({generatorId: 0, resource: true});
 
-            urlService.getPermalinkByUrl('/blog-post/').should.eql('/:slug/');
+            assert.equal(urlService.getPermalinkByUrl('/blog-post/'), '/:slug/');
         });
     });
 
     describe('fn: getUrlByResourceId', function () {
         it('not found', function () {
             urlService.urls.getByResourceId.withArgs(1).returns(null);
-            urlService.getUrlByResourceId(1).should.eql('/404/');
+            assert.equal(urlService.getUrlByResourceId(1), '/404/');
         });
 
         it('not found: absolute', function () {
@@ -201,12 +201,12 @@ describe('Unit: services/url/UrlService', function () {
             urlService.urls.getByResourceId.withArgs(1).returns(null);
             urlService.getUrlByResourceId(1, {absolute: true});
 
-            urlService.utils.createUrl.calledWith('/404/', true).should.be.true();
+            assert.equal(urlService.utils.createUrl.calledWith('/404/', true), true);
         });
 
         it('found', function () {
             urlService.urls.getByResourceId.withArgs(1).returns({url: '/post/'});
-            urlService.getUrlByResourceId(1).should.eql('/post/');
+            assert.equal(urlService.getUrlByResourceId(1), '/post/');
         });
 
         it('found: absolute', function () {
@@ -215,7 +215,7 @@ describe('Unit: services/url/UrlService', function () {
 
             urlService.urls.getByResourceId.withArgs(1).returns({url: '/post/'});
             urlService.getUrlByResourceId(1, {absolute: true});
-            urlService.utils.createUrl.calledWith('/post/', true).should.be.true();
+            assert.equal(urlService.utils.createUrl.calledWith('/post/', true), true);
         });
 
         it('not found: withSubdirectory', function () {
@@ -224,7 +224,7 @@ describe('Unit: services/url/UrlService', function () {
 
             urlService.urls.getByResourceId.withArgs(1).returns(null);
             urlService.getUrlByResourceId(1, {withSubdirectory: true});
-            urlService.utils.createUrl.calledWith('/404/', false).should.be.true();
+            assert.equal(urlService.utils.createUrl.calledWith('/404/', false), true);
         });
 
         it('not found: withSubdirectory + absolute', function () {
@@ -233,7 +233,7 @@ describe('Unit: services/url/UrlService', function () {
 
             urlService.urls.getByResourceId.withArgs(1).returns(null);
             urlService.getUrlByResourceId(1, {withSubdirectory: true, absolute: true});
-            urlService.utils.createUrl.calledWith('/404/', true).should.be.true();
+            assert.equal(urlService.utils.createUrl.calledWith('/404/', true), true);
         });
 
         it('found: withSubdirectory', function () {
@@ -242,7 +242,7 @@ describe('Unit: services/url/UrlService', function () {
 
             urlService.urls.getByResourceId.withArgs(1).returns({url: '/post/'});
             urlService.getUrlByResourceId(1, {withSubdirectory: true});
-            urlService.utils.createUrl.calledWith('/post/', false).should.be.true();
+            assert.equal(urlService.utils.createUrl.calledWith('/post/', false), true);
         });
 
         it('found: withSubdirectory + absolute', function () {
@@ -251,7 +251,7 @@ describe('Unit: services/url/UrlService', function () {
 
             urlService.urls.getByResourceId.withArgs(1).returns({url: '/post/'});
             urlService.getUrlByResourceId(1, {withSubdirectory: true, absolute: true});
-            urlService.utils.createUrl.calledWith('/post/', true).should.be.true();
+            assert.equal(urlService.utils.createUrl.calledWith('/post/', true), true);
         });
     });
 });

--- a/ghost/core/test/unit/server/services/url/urls.test.js
+++ b/ghost/core/test/unit/server/services/url/urls.test.js
@@ -65,12 +65,12 @@ describe('Unit: services/url/Urls', function () {
         });
 
         should.exist(eventsToRemember['url.added']);
-        eventsToRemember['url.added'].url.absolute.should.eql('http://127.0.0.1:2369/test/');
-        eventsToRemember['url.added'].url.relative.should.eql('/test/');
+        assert.equal(eventsToRemember['url.added'].url.absolute, 'http://127.0.0.1:2369/test/');
+        assert.equal(eventsToRemember['url.added'].url.relative, '/test/');
         should.exist(eventsToRemember['url.added'].resource);
         should.exist(eventsToRemember['url.added'].resource.data);
 
-        urls.getByResourceId('object-id-x').resource.data.slug.should.eql('a');
+        assert.equal(urls.getByResourceId('object-id-x').resource.data.slug, 'a');
 
         sinon.stub(logging, 'error');
         // add duplicate
@@ -87,21 +87,21 @@ describe('Unit: services/url/Urls', function () {
 
         should.exist(eventsToRemember['url.added']);
 
-        urls.getByResourceId('object-id-x').resource.data.slug.should.eql('b');
+        assert.equal(urls.getByResourceId('object-id-x').resource.data.slug, 'b');
     });
 
     it('fn: getByResourceId', function () {
-        urls.getByResourceId('object-id-2').url.should.eql('/something/');
+        assert.equal(urls.getByResourceId('object-id-2').url, '/something/');
         should.exist(urls.getByResourceId('object-id-2').generatorId);
-        urls.getByResourceId('object-id-2').generatorId.should.eql(1);
+        assert.equal(urls.getByResourceId('object-id-2').generatorId, 1);
     });
 
     it('fn: getByGeneratorId', function () {
-        urls.getByGeneratorId(2).length.should.eql(2);
+        assert.equal(urls.getByGeneratorId(2).length, 2);
     });
 
     it('fn: getByUrl', function () {
-        urls.getByUrl('/something/').length.should.eql(1);
+        assert.equal(urls.getByUrl('/something/').length, 1);
     });
 
     it('fn: removeResourceId', function () {

--- a/ghost/core/test/unit/server/services/verification-trigger.test.js
+++ b/ghost/core/test/unit/server/services/verification-trigger.test.js
@@ -32,7 +32,7 @@ describe('Import threshold', function () {
         });
 
         const result = await trigger.getImportThreshold();
-        result.should.eql(2);
+        assert.equal(result, 2);
     });
 
     it('Increases the import threshold to the number of members', async function () {
@@ -51,7 +51,7 @@ describe('Import threshold', function () {
         });
 
         const result = await trigger.getImportThreshold();
-        result.should.eql(3);
+        assert.equal(result, 3);
     });
 
     it('Does not check members count when config threshold is infinite', async function () {
@@ -66,7 +66,7 @@ describe('Import threshold', function () {
 
         const result = await trigger.getImportThreshold();
         result.should.eql(Infinity);
-        membersStub.callCount.should.eql(0);
+        assert.equal(membersStub.callCount, 0);
     });
 });
 
@@ -97,9 +97,9 @@ describe('Email verification flow', function () {
             throwOnTrigger: false
         });
 
-        result.needsVerification.should.eql(true);
-        emailStub.callCount.should.eql(1);
-        settingsStub.callCount.should.eql(1);
+        assert.equal(result.needsVerification, true);
+        assert.equal(emailStub.callCount, 1);
+        assert.equal(settingsStub.callCount, 1);
     });
 
     it('Does not trigger verification when already verified', async function () {
@@ -119,9 +119,9 @@ describe('Email verification flow', function () {
             throwOnTrigger: false
         });
 
-        result.needsVerification.should.eql(false);
-        emailStub.callCount.should.eql(0);
-        settingsStub.callCount.should.eql(0);
+        assert.equal(result.needsVerification, false);
+        assert.equal(emailStub.callCount, 0);
+        assert.equal(settingsStub.callCount, 0);
     });
 
     it('Does not trigger verification when already in progress', async function () {
@@ -141,9 +141,9 @@ describe('Email verification flow', function () {
             throwOnTrigger: false
         });
 
-        result.needsVerification.should.eql(false);
-        emailStub.callCount.should.eql(0);
-        settingsStub.callCount.should.eql(0);
+        assert.equal(result.needsVerification, false);
+        assert.equal(emailStub.callCount, 0);
+        assert.equal(settingsStub.callCount, 0);
     });
 
     it('Throws when `throwsOnTrigger` is true', async function () {
@@ -231,12 +231,12 @@ describe('Email verification flow', function () {
             source: 'api'
         }, new Date()));
 
-        eventStub.callCount.should.eql(1);
+        assert.equal(eventStub.callCount, 1);
         eventStub.lastCall.lastArg.should.have.property('source');
-        eventStub.lastCall.lastArg.source.should.eql('api');
+        assert.equal(eventStub.lastCall.lastArg.source, 'api');
         eventStub.lastCall.lastArg.should.have.property('created_at');
         eventStub.lastCall.lastArg.created_at.should.have.property('$gt');
-        eventStub.lastCall.lastArg.created_at.$gt.should.match(/\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/);
+        assert.match(eventStub.lastCall.lastArg.created_at.$gt, /\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/);
     });
 
     it('Does not trigger when site is already verified', async function () {
@@ -264,7 +264,7 @@ describe('Email verification flow', function () {
             source: 'api'
         }, new Date()));
 
-        eventStub.callCount.should.eql(0);
+        assert.equal(eventStub.callCount, 0);
     });
 
     it('Triggers when a number of members are imported', async function () {
@@ -305,14 +305,14 @@ describe('Email verification flow', function () {
 
         await trigger.testImportThreshold();
 
-        eventStub.callCount.should.eql(2);
+        assert.equal(eventStub.callCount, 2);
         eventStub.firstCall.lastArg.should.have.property('source');
-        eventStub.firstCall.lastArg.source.should.eql('import');
+        assert.equal(eventStub.firstCall.lastArg.source, 'import');
         eventStub.firstCall.lastArg.should.have.property('created_at');
         eventStub.firstCall.lastArg.created_at.should.have.property('$gt');
-        eventStub.firstCall.lastArg.created_at.$gt.should.match(/\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/);
+        assert.match(eventStub.firstCall.lastArg.created_at.$gt, /\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/);
 
-        emailStub.callCount.should.eql(1);
+        assert.equal(emailStub.callCount, 1);
         emailStub.lastCall.firstArg.should.eql({
             subject: 'Email needs verification',
             message: 'Email verification needed for site: {siteUrl}, has imported: {amountTriggered} members in the last 30 days.',
@@ -428,14 +428,14 @@ describe('Email verification flow', function () {
             }
         });
 
-        eventStub.callCount.should.eql(2);
+        assert.equal(eventStub.callCount, 2);
         eventStub.firstCall.lastArg.should.have.property('source');
-        eventStub.firstCall.lastArg.source.should.eql('admin');
+        assert.equal(eventStub.firstCall.lastArg.source, 'admin');
         eventStub.firstCall.lastArg.should.have.property('created_at');
         eventStub.firstCall.lastArg.created_at.should.have.property('$gt');
-        eventStub.firstCall.lastArg.created_at.$gt.should.match(/\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/);
+        assert.match(eventStub.firstCall.lastArg.created_at.$gt, /\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/);
 
-        emailStub.callCount.should.eql(1);
+        assert.equal(emailStub.callCount, 1);
         emailStub.lastCall.firstArg.should.eql({
             subject: 'Email needs verification',
             message: 'Email verification needed for site: {siteUrl} has added: {amountTriggered} members through the Admin client in the last 30 days.',
@@ -486,14 +486,14 @@ describe('Email verification flow', function () {
             }
         });
 
-        eventStub.callCount.should.eql(2);
+        assert.equal(eventStub.callCount, 2);
         eventStub.firstCall.lastArg.should.have.property('source');
-        eventStub.firstCall.lastArg.source.should.eql('api');
+        assert.equal(eventStub.firstCall.lastArg.source, 'api');
         eventStub.firstCall.lastArg.should.have.property('created_at');
         eventStub.firstCall.lastArg.created_at.should.have.property('$gt');
-        eventStub.firstCall.lastArg.created_at.$gt.should.match(/\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/);
+        assert.match(eventStub.firstCall.lastArg.created_at.$gt, /\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/);
 
-        emailStub.callCount.should.eql(1);
+        assert.equal(emailStub.callCount, 1);
         emailStub.lastCall.firstArg.should.eql({
             subject: 'Email needs verification',
             message: 'Email verification needed for site: {siteUrl} has added: {amountTriggered} members through the API in the last 30 days.',
@@ -540,9 +540,9 @@ describe('Email verification flow', function () {
         await trigger.testImportThreshold();
 
         // We shouldn't be fetching the events if the threshold is Infinity
-        eventStub.callCount.should.eql(0);
+        assert.equal(eventStub.callCount, 0);
 
         // We shouldn't be sending emails if the threshold is Infinity
-        emailStub.callCount.should.eql(0);
+        assert.equal(emailStub.callCount, 0);
     });
 });

--- a/ghost/core/test/unit/server/services/webhooks/webhook-service.test.js
+++ b/ghost/core/test/unit/server/services/webhooks/webhook-service.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 
@@ -34,7 +35,7 @@ describe('Webhook Service', function () {
             await webhookService.add(fakeWebhook, {});
             should.fail('should have thrown');
         } catch (err) {
-            err.name.should.equal('CustomTestError');
+            assert.equal(err.name, 'CustomTestError');
         }
     });
 });

--- a/ghost/core/test/unit/server/web/admin/controller.test.js
+++ b/ghost/core/test/unit/server/web/admin/controller.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 require('should');
 const sinon = require('sinon');
 const path = require('path');
@@ -26,22 +27,22 @@ describe('Admin App', function () {
             // default config: configUtils.set('adminFrameProtection', true);
             controller(req, res);
 
-            res.sendFile.called.should.be.true();
-            res.sendFile.calledWith(
+            assert.equal(res.sendFile.called, true);
+            assert.equal(res.sendFile.calledWith(
                 sinon.match.string,
                 sinon.match.hasNested('headers.X-Frame-Options', sinon.match('sameorigin'))
-            ).should.be.true();
+            ), true);
         });
 
         it('doesn\'t add x-frame-options header when adminFrameProtection is disabled', function () {
             configUtils.set('adminFrameProtection', false);
             controller(req, res);
 
-            res.sendFile.called.should.be.true();
-            res.sendFile.calledWith(
+            assert.equal(res.sendFile.called, true);
+            assert.equal(res.sendFile.calledWith(
                 sinon.match.string,
                 sinon.match.hasNested('headers.X-Frame-Options')
-            ).should.be.false();
+            ), false);
         });
     });
 });

--- a/ghost/core/test/unit/server/web/api/middleware/version-match.test.js
+++ b/ghost/core/test/unit/server/web/api/middleware/version-match.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 require('should');
 const sinon = require('sinon');
 
@@ -42,7 +43,7 @@ describe('Version Mismatch', function () {
 
         testVersionMatch(server);
 
-        nextStub.calledOnce.should.be.true();
+        assert.equal(nextStub.calledOnce, true);
         nextStub.firstCall.args.should.be.empty();
     });
 
@@ -52,7 +53,7 @@ describe('Version Mismatch', function () {
 
         testVersionMatch(server, client);
 
-        nextStub.calledOnce.should.be.true();
+        assert.equal(nextStub.calledOnce, true);
         nextStub.firstCall.args.should.be.empty();
     });
 
@@ -62,7 +63,7 @@ describe('Version Mismatch', function () {
 
         testVersionMatch(server, client);
 
-        nextStub.calledOnce.should.be.true();
+        assert.equal(nextStub.calledOnce, true);
         nextStub.firstCall.args.should.be.empty();
     });
 
@@ -72,8 +73,8 @@ describe('Version Mismatch', function () {
 
         testVersionMatch(server, client);
 
-        nextStub.calledOnce.should.be.true();
-        nextStub.firstCall.args.should.have.lengthOf(1);
+        assert.equal(nextStub.calledOnce, true);
+        assert.equal(nextStub.firstCall.args.length, 1);
         nextStub.firstCall.args[0].should.have.property('errorType', 'BadRequestError');
         nextStub.firstCall.args[0].should.have.property('statusCode', 400);
     });
@@ -84,8 +85,8 @@ describe('Version Mismatch', function () {
 
         testVersionMatch(server, client);
 
-        nextStub.calledOnce.should.be.true();
-        nextStub.firstCall.args.should.have.lengthOf(1);
+        assert.equal(nextStub.calledOnce, true);
+        assert.equal(nextStub.firstCall.args.length, 1);
         nextStub.firstCall.args[0].should.have.property('errorType', 'VersionMismatchError');
         nextStub.firstCall.args[0].should.have.property('statusCode', 400);
     });
@@ -96,8 +97,8 @@ describe('Version Mismatch', function () {
 
         testVersionMatch(server, client);
 
-        nextStub.calledOnce.should.be.true();
-        nextStub.firstCall.args.should.have.lengthOf(1);
+        assert.equal(nextStub.calledOnce, true);
+        assert.equal(nextStub.firstCall.args.length, 1);
         nextStub.firstCall.args[0].should.have.property('errorType', 'VersionMismatchError');
         nextStub.firstCall.args[0].should.have.property('statusCode', 400);
     });
@@ -108,8 +109,8 @@ describe('Version Mismatch', function () {
 
         testVersionMatch(server, client);
 
-        nextStub.calledOnce.should.be.true();
-        nextStub.firstCall.args.should.have.lengthOf(1);
+        assert.equal(nextStub.calledOnce, true);
+        assert.equal(nextStub.firstCall.args.length, 1);
         nextStub.firstCall.args[0].should.have.property('errorType', 'VersionMismatchError');
         nextStub.firstCall.args[0].should.have.property('statusCode', 400);
     });
@@ -120,7 +121,7 @@ describe('Version Mismatch', function () {
 
         testVersionMatch(server, client);
 
-        nextStub.calledOnce.should.be.true();
+        assert.equal(nextStub.calledOnce, true);
         nextStub.firstCall.args.should.be.empty();
     });
 
@@ -130,8 +131,8 @@ describe('Version Mismatch', function () {
 
         testVersionMatch(server, client);
 
-        nextStub.calledOnce.should.be.true();
-        nextStub.firstCall.args.should.have.lengthOf(1);
+        assert.equal(nextStub.calledOnce, true);
+        assert.equal(nextStub.firstCall.args.length, 1);
         nextStub.firstCall.args[0].should.have.property('errorType', 'VersionMismatchError');
         nextStub.firstCall.args[0].should.have.property('statusCode', 400);
     });

--- a/ghost/core/test/unit/server/web/parent/middleware/ghost-locals.test.js
+++ b/ghost/core/test/unit/server/web/parent/middleware/ghost-locals.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const ghostLocals = require('../../../../../../core/server/web/parent/middleware/ghost-locals');
@@ -27,7 +28,7 @@ describe('Theme Handler', function () {
             should.exist(res.locals.version);
             should.exist(res.locals.safeVersion);
             res.locals.relativeUrl.should.equal(req.path);
-            next.called.should.be.true();
+            assert.equal(next.called, true);
         });
     });
 });

--- a/ghost/core/test/unit/server/web/parent/middleware/request-id.test.js
+++ b/ghost/core/test/unit/server/web/parent/middleware/request-id.test.js
@@ -32,8 +32,8 @@ describe('Request ID middleware', function () {
         requestId(req, res, next);
 
         should.exist(req.requestId);
-        validator.isUUID(req.requestId).should.be.true();
-        res.set.calledOnce.should.be.false();
+        assert.equal(validator.isUUID(req.requestId), true);
+        assert.equal(res.set.calledOnce, false);
     });
 
     it('keeps the request ID if X-Request-ID is present', function () {
@@ -43,8 +43,8 @@ describe('Request ID middleware', function () {
         requestId(req, res, next);
 
         should.exist(req.requestId);
-        req.requestId.should.eql('abcd');
-        res.set.calledOnce.should.be.true();
-        res.set.calledWith('X-Request-ID', 'abcd').should.be.true();
+        assert.equal(req.requestId, 'abcd');
+        assert.equal(res.set.calledOnce, true);
+        assert.equal(res.set.calledWith('X-Request-ID', 'abcd'), true);
     });
 });

--- a/ghost/core/test/unit/shared/config/helpers.test.js
+++ b/ghost/core/test/unit/shared/config/helpers.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 require('should');
 const configUtils = require('../../../utils/config-utils');
 
@@ -26,16 +27,16 @@ describe('vhost utils', function () {
         });
 
         it('should use admin url and inverse as args', function () {
-            configUtils.config.getBackendMountPath().should.eql('admin.ghost.blog');
+            assert.equal(configUtils.config.getBackendMountPath(), 'admin.ghost.blog');
             configUtils.config.getFrontendMountPath().should.eql(/^(?!admin\.ghost\.blog).*/);
         });
 
         it('should have regex that excludes admin traffic on front-end', function () {
             const frontendRegex = configUtils.config.getFrontendMountPath();
 
-            frontendRegex.test('localhost').should.be.true();
-            frontendRegex.test('ghost.blog').should.be.true();
-            frontendRegex.test('admin.ghost.blog').should.be.false();
+            assert.equal(frontendRegex.test('localhost'), true);
+            assert.equal(frontendRegex.test('ghost.blog'), true);
+            assert.equal(frontendRegex.test('admin.ghost.blog'), false);
         });
     });
 

--- a/ghost/core/test/unit/shared/config/loader.test.js
+++ b/ghost/core/test/unit/shared/config/loader.test.js
@@ -46,7 +46,7 @@ describe('Config Loader', function () {
                 customConfigPath: path.join(__dirname, '../../../utils/fixtures/config')
             });
 
-            customConfig.get('database:client').should.eql('test');
+            assert.equal(customConfig.get('database:client'), 'test');
         });
 
         it('argv is stronger than env parameter', function () {
@@ -58,7 +58,7 @@ describe('Config Loader', function () {
                 customConfigPath: path.join(__dirname, '../../../utils/fixtures/config')
             });
 
-            customConfig.get('database:client').should.eql('stronger');
+            assert.equal(customConfig.get('database:client'), 'stronger');
         });
 
         it('argv or env is NOT stronger than overrides', function () {
@@ -70,7 +70,7 @@ describe('Config Loader', function () {
                 customConfigPath: path.join(__dirname, '../../../utils/fixtures/config')
             });
 
-            customConfig.get('paths:corePath').should.not.containEql('try-to-override');
+            assert(!customConfig.get('paths:corePath').includes('try-to-override'));
         });
 
         it('overrides is stronger than every other config file', function () {
@@ -79,12 +79,12 @@ describe('Config Loader', function () {
                 customConfigPath: path.join(__dirname, '../../../utils/fixtures/config')
             });
 
-            customConfig.get('paths:corePath').should.not.containEql('try-to-override');
-            customConfig.get('database:client').should.eql('sqlite3');
-            customConfig.get('database:connection:filename').should.eql('/hehe.db');
-            customConfig.get('database:debug').should.eql(true);
-            customConfig.get('url').should.eql('http://localhost:2368');
-            customConfig.get('logging:level').should.eql('error');
+            assert(!customConfig.get('paths:corePath').includes('try-to-override'));
+            assert.equal(customConfig.get('database:client'), 'sqlite3');
+            assert.equal(customConfig.get('database:connection:filename'), '/hehe.db');
+            assert.equal(customConfig.get('database:debug'), true);
+            assert.equal(customConfig.get('url'), 'http://localhost:2368');
+            assert.equal(customConfig.get('logging:level'), 'error');
             customConfig.get('logging:transports').should.eql(['stdout']);
         });
 
@@ -95,7 +95,7 @@ describe('Config Loader', function () {
                 customConfigPath: path.join(__dirname, '../../../utils/fixtures/config')
             });
 
-            customConfig.get('site_uuid').should.eql('a58fe20c-0af0-4fc6-9b1a-20873d5b7d03');
+            assert.equal(customConfig.get('site_uuid'), 'a58fe20c-0af0-4fc6-9b1a-20873d5b7d03');
             assert.equal(customConfig.get('commented'), undefined);
         });
     });

--- a/ghost/core/test/unit/shared/config/utils.test.js
+++ b/ghost/core/test/unit/shared/config/utils.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const _ = require('lodash');
 const configUtils = require('../../../../core/shared/config/utils');
@@ -30,9 +31,9 @@ describe('Config Utils', function () {
 
             configUtils.makePathsAbsolute(fakeNconf, fakeConfig.database, 'database');
 
-            changedKey.length.should.eql(1);
-            changedKey[0][0].should.eql('database:connection:filename');
-            changedKey[0][1].should.not.eql('content/data/ghost.db');
+            assert.equal(changedKey.length, 1);
+            assert.equal(changedKey[0][0], 'database:connection:filename');
+            assert.notEqual(changedKey[0][1], 'content/data/ghost.db');
         });
 
         it('ensure it skips non strings', function () {
@@ -41,7 +42,7 @@ describe('Config Utils', function () {
             };
 
             configUtils.makePathsAbsolute(fakeNconf, fakeConfig.database, 'database');
-            changedKey.length.should.eql(0);
+            assert.equal(changedKey.length, 0);
         });
 
         it('ensure we don\'t change absolute paths', function () {
@@ -53,7 +54,7 @@ describe('Config Utils', function () {
             };
 
             configUtils.makePathsAbsolute(fakeNconf, fakeConfig.database, 'database');
-            changedKey.length.should.eql(0);
+            assert.equal(changedKey.length, 0);
         });
 
         it('match paths on windows', function () {
@@ -63,9 +64,9 @@ describe('Config Utils', function () {
             };
 
             configUtils.makePathsAbsolute(fakeNconf, fakeConfig.database, 'database');
-            changedKey.length.should.eql(1);
-            changedKey[0][0].should.eql('database:filename');
-            changedKey[0][1].should.not.eql('content\\data\\ghost.db');
+            assert.equal(changedKey.length, 1);
+            assert.equal(changedKey[0][0], 'database:filename');
+            assert.notEqual(changedKey[0][1], 'content\\data\\ghost.db');
         });
     });
 });

--- a/ghost/core/test/unit/shared/custom-theme-settings-cache/cache.test.js
+++ b/ghost/core/test/unit/shared/custom-theme-settings-cache/cache.test.js
@@ -22,8 +22,8 @@ describe('Cache', function () {
                 two: 2
             });
 
-            cache.get('one').should.equal(1);
-            cache.get('two').should.equal(2);
+            assert.equal(cache.get('one'), 1);
+            assert.equal(cache.get('two'), 2);
         });
 
         it('clears cache before filling', function () {
@@ -73,8 +73,8 @@ describe('Cache', function () {
 
             cache.populate(settings);
 
-            cache.get('one').should.equal(1);
-            cache.get('two').should.equal(2);
+            assert.equal(cache.get('one'), 1);
+            assert.equal(cache.get('two'), 2);
         });
 
         it('returns undefined for unknown value', function () {


### PR DESCRIPTION
This replaces many more Should.js calls with `node:assert`:

| Before | After |
|---|---|
| `actual.should.equal(expected)` | `assert.equal(actual, expected)` |
| `actual.should.eql(primitive)` | `assert.equal(actual, primitive)` |
| `actual.should.deepEqual(expected)` | `assert.deepEqual(actual, expected)` |
| `actual.should.be.true()` | `assert.equal(actual, true)` |
| `actual.should.be.false()` | `assert.equal(actual, false)` |
| `actual.should.be.null()` | `assert.equal(actual, null)` |
| `actual.should.be.undefined()` | `assert.equal(actual, undefined)` |
| `value.should.have.length(length)` | `assert.equal(value.length, length)` |
| `str.should.match(regexp)` | `assert.match(str, regexp)` |
| `haystack.should.containEql(needle)` | `assert(haystack.includes(needle))` |
| `value.should.startWith(prefix)` | `assert(value.startsWith(prefix))` |
| `value.should.endWith(prefix)` | `assert(value.endsWith(prefix))` |
| `value.should.be.an.Array()` | `assert(Array.isArray(value))` |

All of these were done with [ast-grep]; no AI was used.

[ast-grep]: https://github.com/ast-grep/ast-grep
