### PR TITLE
Added display of members who have liked a comment

### DIFF
--- a/apps/admin-x-framework/src/api/comments.ts
+++ b/apps/admin-x-framework/src/api/comments.ts
@@ -45,6 +45,15 @@ export type CommentReport = {
     member?: Member;
 };
 
+export type CommentLike = {
+    id: string;
+    comment_id: string;
+    member_id: string;
+    created_at: string;
+    updated_at: string;
+    member?: Member;
+};
+
 export interface CommentsResponseType {
     meta?: Meta;
     comments: Comment[];
@@ -157,4 +166,23 @@ const useBrowseCommentReportsQuery = createQueryWithId<CommentReportsResponseTyp
 
 export const useBrowseCommentReports = (commentId: string, options?: {enabled?: boolean}) => {
     return useBrowseCommentReportsQuery(commentId, {...options});
+};
+
+export interface CommentLikesResponseType {
+    meta?: Meta;
+    comment_likes: CommentLike[];
+}
+
+const useBrowseCommentLikesQuery = createQueryWithId<CommentLikesResponseType>({
+    dataType: 'CommentLikesResponseType',
+    path: id => `/comments/${id}/likes/`,
+    defaultSearchParams: {
+        include: 'member',
+        limit: '100',
+        order: 'created_at desc'
+    }
+});
+
+export const useBrowseCommentLikes = (commentId: string, options?: {enabled?: boolean}) => {
+    return useBrowseCommentLikesQuery(commentId, {...options});
 };

--- a/apps/posts/src/views/comments/components/comment-likes-modal.tsx
+++ b/apps/posts/src/views/comments/components/comment-likes-modal.tsx
@@ -1,0 +1,115 @@
+import {
+    Button,
+    Dialog,
+    DialogContent,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    LoadingIndicator,
+    LucideIcon,
+    formatTimestamp
+} from '@tryghost/shade';
+import {Comment, useBrowseCommentLikes} from '@tryghost/admin-x-framework/api/comments';
+import {CommentAvatar} from './comment-avatar';
+
+interface CommentLikesModalProps {
+    comment: Comment;
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+}
+
+function CommentLikesModal({comment, open, onOpenChange}: CommentLikesModalProps) {
+    const {data, isLoading} = useBrowseCommentLikes(comment.id, {enabled: open});
+    const likes = data?.comment_likes ?? [];
+    const likeCount = comment.count?.likes ?? 0;
+    const remainingCount = likeCount - likes.length;
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent aria-describedby={undefined}>
+                <DialogHeader>
+                    <DialogTitle>
+                        {likeCount} {likeCount === 1 ? 'like' : 'likes'}
+                    </DialogTitle>
+                </DialogHeader>
+
+                {/* Comment context */}
+                <div className="overflow-hidden rounded-md border p-3 opacity-60">
+                    <div className="flex min-w-0 items-start gap-3">
+                        <CommentAvatar
+                            avatarImage={comment.member?.avatar_image}
+                            className="shrink-0"
+                            memberId={comment.member?.id}
+                        />
+                        <div className="flex min-w-0 flex-col overflow-hidden">
+                            <div className="flex min-w-0 items-center gap-1 text-sm">
+                                <span className="shrink-0 font-semibold">
+                                    {comment.member?.name || 'Unknown'}
+                                </span>
+                                <LucideIcon.Dot className="shrink-0 text-muted-foreground/50" size={16} />
+                                <span className="shrink-0 text-muted-foreground">
+                                    {comment.created_at && formatTimestamp(comment.created_at)}
+                                </span>
+                                <span className="shrink-0 text-muted-foreground">on</span>
+                                <span className="min-w-0 truncate font-medium text-gray-800 dark:text-gray-400">
+                                    {comment.post?.title || 'Unknown post'}
+                                </span>
+                            </div>
+                            <div
+                                dangerouslySetInnerHTML={{__html: comment.html || ''}}
+                                className="prose mt-2 line-clamp-2 text-sm [&_*]:text-sm [&_*]:leading-[1.5em] [&_p]:m-0"
+                            />
+                        </div>
+                    </div>
+                </div>
+
+                {/* Likers list */}
+                <div className="-mx-1 max-h-64 overflow-y-auto px-1">
+                    {isLoading ? (
+                        <div className="flex justify-center py-4">
+                            <LoadingIndicator size="md" />
+                        </div>
+                    ) : (
+                        <div className="flex flex-col gap-3 pb-1">
+                            {likes.map(like => (
+                                <div key={like.id} className="flex items-center justify-between gap-3">
+                                    <div className="flex items-center gap-3">
+                                        <div className="relative shrink-0">
+                                            <CommentAvatar
+                                                avatarImage={like.member?.avatar_image}
+                                                memberId={like.member?.id}
+                                            />
+                                            {/* Heart overlay */}
+                                            <div className="absolute -bottom-0.5 -right-0.5 flex size-4 items-center justify-center rounded-full bg-pink-500 text-white">
+                                                <LucideIcon.Heart className="size-2.5" fill="currentColor" />
+                                            </div>
+                                        </div>
+                                        <span className="font-medium">
+                                            {like.member?.name || 'Deleted member'}
+                                        </span>
+                                    </div>
+                                    <span className="shrink-0 text-sm text-muted-foreground">
+                                        {formatTimestamp(like.created_at)}
+                                    </span>
+                                </div>
+                            ))}
+                            {remainingCount > 0 && (
+                                <div className="pt-1 text-center text-sm text-muted-foreground">
+                                    and {remainingCount} more
+                                </div>
+                            )}
+                        </div>
+                    )}
+                </div>
+
+                <DialogFooter>
+                    <Button onClick={() => onOpenChange(false)}>
+                        OK
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}
+
+export default CommentLikesModal;

--- a/apps/posts/src/views/comments/components/comment-metrics.tsx
+++ b/apps/posts/src/views/comments/components/comment-metrics.tsx
@@ -1,3 +1,4 @@
+import CommentLikesModal from './comment-likes-modal';
 import CommentReportsModal from './comment-reports-modal';
 import {Comment} from '@tryghost/admin-x-framework/api/comments';
 import {
@@ -66,12 +67,14 @@ export function CommentMetrics({
     onRepliesClick,
     className
 }: CommentMetricsProps) {
+    const [likesModalOpen, setLikesModalOpen] = useState(false);
     const [reportsModalOpen, setReportsModalOpen] = useState(false);
 
     const repliesCount = comment.count?.replies ?? comment.replies?.length ?? 0;
     const likesCount = comment.count?.likes ?? 0;
     const reportsCount = comment.count?.reports ?? 0;
     const hasReplies = repliesCount > 0;
+    const hasLikes = likesCount > 0;
     const hasReports = reportsCount > 0;
 
     return (
@@ -87,6 +90,7 @@ export function CommentMetrics({
                     count={likesCount}
                     icon={<LucideIcon.Heart size={16} strokeWidth={1.5} />}
                     label="Likes"
+                    onClick={hasLikes ? () => setLikesModalOpen(true) : undefined}
                 />
                 <Metric
                     className={hasReports ? 'font-semibold text-red' : undefined}
@@ -96,6 +100,11 @@ export function CommentMetrics({
                     onClick={hasReports ? () => setReportsModalOpen(true) : undefined}
                 />
             </div>
+            <CommentLikesModal
+                comment={comment}
+                open={likesModalOpen}
+                onOpenChange={setLikesModalOpen}
+            />
             <CommentReportsModal
                 comment={comment}
                 open={reportsModalOpen}

--- a/ghost/core/core/server/api/endpoints/comment-likes.js
+++ b/ghost/core/core/server/api/endpoints/comment-likes.js
@@ -1,0 +1,34 @@
+// Endpoint for the admin API to return likers for a comment
+
+const commentsService = require('../../services/comments');
+
+/** @type {import('@tryghost/api-framework').Controller} */
+const controller = {
+    docName: 'comment_likes',
+    browse: {
+        headers: {
+            cacheInvalidate: false
+        },
+        options: [
+            'id',
+            'page',
+            'limit'
+        ],
+        validation: {
+            options: {
+                id: {
+                    required: true
+                }
+            }
+        },
+        // Use comment permissions - browsing likes is part of comment moderation
+        permissions: {
+            docName: 'comments'
+        },
+        query(frame) {
+            return commentsService.controller.getCommentLikes(frame);
+        }
+    }
+};
+
+module.exports = controller;

--- a/ghost/core/core/server/api/endpoints/index.js
+++ b/ghost/core/core/server/api/endpoints/index.js
@@ -217,6 +217,10 @@ module.exports = {
         return apiFramework.pipeline(require('./comment-reports'), localUtils);
     },
 
+    get commentLikes() {
+        return apiFramework.pipeline(require('./comment-likes'), localUtils);
+    },
+
     get links() {
         return apiFramework.pipeline(require('./links'), localUtils);
     },

--- a/ghost/core/core/server/services/comments/comments-controller.js
+++ b/ghost/core/core/server/services/comments/comments-controller.js
@@ -361,4 +361,16 @@ module.exports = class CommentsController {
             limit: frame.options.limit
         });
     }
+
+    /**
+     * Get likes for a specific comment (admin only)
+     * @param {Frame} frame
+     */
+    async getCommentLikes(frame) {
+        const commentId = frame.options.id;
+        return await this.service.getCommentLikes(commentId, {
+            page: frame.options.page,
+            limit: frame.options.limit
+        });
+    }
 };

--- a/ghost/core/core/server/services/comments/comments-service.js
+++ b/ghost/core/core/server/services/comments/comments-service.js
@@ -258,6 +258,31 @@ class CommentsService {
     }
 
     /**
+     * Get likes for a comment (admin only)
+     * @param {string} commentId - The ID of the Comment to get likes for
+     * @param {any} options - Query options (page, limit)
+     */
+    async getCommentLikes(commentId, options = {}) {
+        const comment = await this.models.Comment.findOne({id: commentId});
+        if (!comment) {
+            throw new errors.NotFoundError({
+                message: tpl(messages.commentNotFound)
+            });
+        }
+
+        const {page, limit} = options;
+        const result = await this.models.CommentLike.findPage({
+            filter: `comment_id:'${commentId}'`,
+            withRelated: ['member'],
+            order: 'created_at desc',
+            page,
+            limit
+        });
+
+        return result;
+    }
+
+    /**
      * @param {string} id - The ID of the Comment to get
      * @param {any} options
      */

--- a/ghost/core/core/server/web/api/endpoints/admin/routes.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/routes.js
@@ -47,6 +47,7 @@ module.exports = function apiRoutes() {
     router.get('/comments/:id', mw.authAdminApi, http(api.commentReplies.read));
     router.get('/comments/:id/replies', mw.authAdminApi, http(api.commentReplies.browse));
     router.get('/comments/:id/reports', mw.authAdminApi, http(api.commentReports.browse));
+    router.get('/comments/:id/likes', mw.authAdminApi, http(api.commentLikes.browse));
     router.get('/comments/post/:post_id', mw.authAdminApi, http(api.comments.browse));
     router.post('/comments', mw.authAdminApi, http(api.comments.add));
     router.put('/comments/:id', mw.authAdminApi, http(api.comments.edit));

--- a/ghost/core/test/e2e-api/admin/__snapshots__/comments.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/comments.test.js.snap
@@ -874,6 +874,125 @@ Object {
 }
 `;
 
+exports[`Admin Comments API Comment Likes Can browse comment likes 1: [body] 1`] = `
+Object {
+  "comment_likes": Array [
+    Object {
+      "comment_id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "member": Object {
+        "avatar_image": null,
+        "can_comment": true,
+        "commenting": Object {
+          "disabled": false,
+          "disabled_reason": null,
+          "disabled_until": null,
+        },
+        "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+        "email": "member2@test.com",
+        "email_count": 0,
+        "email_disabled": false,
+        "email_open_rate": 50,
+        "email_opened_count": 0,
+        "enable_comment_notifications": true,
+        "expertise": null,
+        "geolocation": null,
+        "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+        "last_commented_at": Nullable<StringMatching>,
+        "last_seen_at": Nullable<StringMatching>,
+        "name": null,
+        "note": null,
+        "status": "free",
+        "transient_id": Any<String>,
+        "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+        "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      },
+      "member_id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+    },
+    Object {
+      "comment_id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "member": Object {
+        "avatar_image": null,
+        "can_comment": true,
+        "commenting": Object {
+          "disabled": false,
+          "disabled_reason": null,
+          "disabled_until": null,
+        },
+        "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+        "email": "paid@test.com",
+        "email_count": 0,
+        "email_disabled": false,
+        "email_open_rate": 80,
+        "email_opened_count": 0,
+        "enable_comment_notifications": true,
+        "expertise": null,
+        "geolocation": null,
+        "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+        "last_commented_at": Nullable<StringMatching>,
+        "last_seen_at": Nullable<StringMatching>,
+        "name": "Egon Spengler",
+        "note": null,
+        "status": "paid",
+        "transient_id": Any<String>,
+        "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+        "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      },
+      "member_id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+    },
+  ],
+  "meta": Object {
+    "pagination": Object {
+      "limit": 15,
+      "next": null,
+      "page": 1,
+      "pages": 1,
+      "prev": null,
+      "total": 2,
+    },
+  },
+}
+`;
+
+exports[`Admin Comments API Comment Likes Returns 404 for non-existent comment 1: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": null,
+      "context": "Comment could not be found",
+      "details": null,
+      "ghostErrorCode": null,
+      "help": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "Resource not found error, cannot list comment_likes.",
+      "property": null,
+      "type": "NotFoundError",
+    },
+  ],
+}
+`;
+
+exports[`Admin Comments API Comment Likes Returns empty list for comment with no likes 1: [body] 1`] = `
+Object {
+  "comment_likes": Array [],
+  "meta": Object {
+    "pagination": Object {
+      "limit": 15,
+      "next": null,
+      "page": 1,
+      "pages": 1,
+      "prev": null,
+      "total": 0,
+    },
+  },
+}
+`;
+
 exports[`Admin Comments API Comment Reports Can browse reporters for a comment 1: [body] 1`] = `
 Object {
   "comment_reports": Array [

--- a/ghost/core/test/e2e-api/admin/comments.test.js
+++ b/ghost/core/test/e2e-api/admin/comments.test.js
@@ -1691,6 +1691,129 @@ describe(`Admin Comments API`, function () {
         });
     });
 
+    describe('Comment Likes', function () {
+        const likeMatcher = {
+            id: anyObjectId,
+            comment_id: anyObjectId,
+            member_id: anyObjectId,
+            created_at: anyISODateTime,
+            updated_at: anyISODateTime,
+            member: {
+                id: anyObjectId,
+                uuid: anyUuid,
+                created_at: anyISODateTime,
+                updated_at: anyISODateTime,
+                transient_id: anyString,
+                last_seen_at: nullable(anyISODateTime),
+                last_commented_at: nullable(anyISODateTime)
+            }
+        };
+
+        it('Can browse comment likes', async function () {
+            const comment = await dbFns.addComment({
+                member_id: fixtureManager.get('members', 0).id,
+                html: '<p>Liked comment</p>'
+            });
+
+            // Add likes from different members
+            await models.CommentLike.add({
+                comment_id: comment.id,
+                member_id: fixtureManager.get('members', 1).id
+            });
+            await models.CommentLike.add({
+                comment_id: comment.id,
+                member_id: fixtureManager.get('members', 2).id
+            });
+
+            await adminApi.get(`/comments/${comment.id}/likes/`)
+                .expectStatus(200)
+                .matchBodySnapshot({
+                    comment_likes: [likeMatcher, likeMatcher]
+                });
+        });
+
+        it('Returns empty list for comment with no likes', async function () {
+            const comment = await dbFns.addComment({
+                member_id: fixtureManager.get('members', 0).id,
+                html: '<p>Unliked comment</p>'
+            });
+
+            await adminApi.get(`/comments/${comment.id}/likes/`)
+                .expectStatus(200)
+                .matchBodySnapshot({
+                    comment_likes: []
+                });
+        });
+
+        it('Supports pagination', async function () {
+            const comment = await dbFns.addComment({
+                member_id: fixtureManager.get('members', 0).id,
+                html: '<p>Popular comment</p>'
+            });
+
+            // Add likes from multiple members
+            await models.CommentLike.add({
+                comment_id: comment.id,
+                member_id: fixtureManager.get('members', 1).id
+            });
+            await models.CommentLike.add({
+                comment_id: comment.id,
+                member_id: fixtureManager.get('members', 2).id
+            });
+            await models.CommentLike.add({
+                comment_id: comment.id,
+                member_id: fixtureManager.get('members', 3).id
+            });
+
+            const res = await adminApi.get(`/comments/${comment.id}/likes/?limit=2`);
+            assert.equal(res.body.comment_likes.length, 2);
+            assert.equal(res.body.meta.pagination.total, 3);
+            assert.equal(res.body.meta.pagination.pages, 2);
+        });
+
+        it('Orders likes by created_at desc', async function () {
+            const comment = await dbFns.addComment({
+                member_id: fixtureManager.get('members', 0).id,
+                html: '<p>Liked comment</p>'
+            });
+
+            // Add likes at different times
+            const olderLike = await models.CommentLike.add({
+                comment_id: comment.id,
+                member_id: fixtureManager.get('members', 1).id
+            });
+            await db.knex('comment_likes')
+                .where('id', olderLike.id)
+                .update({created_at: new Date('2023-01-01')});
+
+            const newerLike = await models.CommentLike.add({
+                comment_id: comment.id,
+                member_id: fixtureManager.get('members', 2).id
+            });
+            await db.knex('comment_likes')
+                .where('id', newerLike.id)
+                .update({created_at: new Date('2023-06-01')});
+
+            const res = await adminApi.get(`/comments/${comment.id}/likes/`);
+            assert.equal(res.body.comment_likes.length, 2);
+            // Newer like should be first
+            assert.equal(res.body.comment_likes[0].member_id, fixtureManager.get('members', 2).id);
+            assert.equal(res.body.comment_likes[1].member_id, fixtureManager.get('members', 1).id);
+        });
+
+        it('Returns 404 for non-existent comment', async function () {
+            const fakeCommentId = '507f1f77bcf86cd799439011';
+
+            await adminApi.get(`/comments/${fakeCommentId}/likes/`)
+                .expectStatus(404)
+                .matchBodySnapshot({
+                    errors: [{
+                        id: anyErrorId
+                    }]
+                });
+        });
+    });
+
     describe('API Key Permissions', function () {
         let restrictedApiKeyId;
         let restrictedApiKeySecret;


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3197

- Adds a "Who Liked" modal that shows which members liked a comment
- Clicking the likes count in comment metrics opens the modal
- Displays member avatars, names, and timestamps in a scrollable list
- Follows the same pattern as the existing "Who Reported" modal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * View who liked a comment via a modal showing likers with avatars, names (falls back for deleted accounts), timestamps, and the comment's context (author, date, post). Likes count is interactive—click to open the modal; large liker lists support pagination and are ordered newest-first.
* **Tests**
  * Added end-to-end tests covering browsing, pagination, ordering, empty results, and not-found handling for comment likes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->