### PR TITLE
Added post context to thread sidebar

### DIFF
--- a/apps/posts/src/views/comments/components/comment-thread-list.tsx
+++ b/apps/posts/src/views/comments/components/comment-thread-list.tsx
@@ -145,7 +145,7 @@ const CommentThreadList: React.FC<CommentThreadListProps> = ({
     const commentWithReplies: Comment = {...parentComment, replies};
 
     return (
-        <div className="-mt-4 flex flex-col pt-8 lg:-mt-8" data-testid="comment-thread-list">
+        <div className="flex flex-col" data-testid="comment-thread-list">
             <CommentRow
                 comment={commentWithReplies}
                 commentPermalinksEnabled={commentPermalinksEnabled}

--- a/apps/posts/src/views/comments/components/comment-thread-sidebar.tsx
+++ b/apps/posts/src/views/comments/components/comment-thread-sidebar.tsx
@@ -5,6 +5,7 @@ import {
     EmptyIndicator,
     LoadingIndicator,
     LucideIcon,
+    Separator,
     Sheet,
     SheetContent,
     SheetHeader,
@@ -50,9 +51,33 @@ const CommentThreadSidebar: React.FC<CommentThreadSidebarProps> = ({
     return (
         <Sheet open={open} onOpenChange={onOpenChange}>
             <SheetContent className='overflow-y-auto px-6 pt-0 sm:max-w-[600px]'>
-                <SheetHeader className='sticky top-0 z-40 -mx-6 bg-background/60 p-6 pb-4 backdrop-blur'>
-                    <SheetTitle className='mb-2'>Thread</SheetTitle>
+                <SheetHeader className='sticky top-0 z-40 -mx-6 bg-background/60 p-6 backdrop-blur'>
+                    <SheetTitle className='text-md'>Thread</SheetTitle>
                 </SheetHeader>
+                {parentComment?.post && (
+                    <>
+                        <div className="flex items-center gap-4">
+                            <div className="min-w-0 flex-1">
+                                <h3 className="line-clamp-1 text-xl font-semibold text-foreground">
+                                    {parentComment.post.title}
+                                </h3>
+                                {parentComment.post.excerpt && (
+                                    <p className="mt-1 line-clamp-2 text-sm text-muted-foreground">
+                                        {parentComment.post.excerpt}
+                                    </p>
+                                )}
+                            </div>
+                            {parentComment.post.feature_image && (
+                                <img
+                                    alt={parentComment.post.title || 'Post feature image'}
+                                    className="hidden aspect-video h-18 shrink-0 rounded object-cover lg:block"
+                                    src={parentComment.post.feature_image}
+                                />
+                            )}
+                        </div>
+                        <Separator className="-mx-6 my-6 w-auto" />
+                    </>
+                )}
                 <div>
                     {isLoading ? (
                         <div className="flex h-full items-center justify-center py-8">

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/mappers/comments.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/mappers/comments.js
@@ -93,6 +93,13 @@ const commentMapper = (model, frame) => {
         // We could use the post mapper here, but we need less field + don't need all the async behavior support
         url.forPost(jsonModel.post.id, jsonModel.post, frame);
         response.post = _.pick(jsonModel.post, postFields);
+
+        // Compute excerpt from custom_excerpt or plaintext (same logic as post serializer)
+        if (jsonModel.post.custom_excerpt) {
+            response.post.excerpt = jsonModel.post.custom_excerpt;
+        } else if (jsonModel.post.plaintext) {
+            response.post.excerpt = jsonModel.post.plaintext.substring(0, 500);
+        }
     }
 
     if (jsonModel.count && jsonModel.count.liked !== undefined) {

--- a/ghost/core/test/e2e-api/admin/__snapshots__/activity-feed.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/activity-feed.test.js.snap
@@ -22699,7 +22699,7 @@ exports[`Activity Feed API Can filter events by post id 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "18494",
+  "content-length": "18572",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -22871,7 +22871,7 @@ exports[`Activity Feed API Filter splitting Can use NQL OR for type only 2: [hea
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "5656",
+  "content-length": "5734",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/e2e-api/admin/__snapshots__/activity-feed.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/activity-feed.test.js.snap
@@ -23987,7 +23987,7 @@ exports[`Activity Feed API Returns comments in activity feed 2: [headers] 1`] = 
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "1762",
+  "content-length": "1840",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/e2e-api/admin/__snapshots__/comments.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/comments.test.js.snap
@@ -67,6 +67,9 @@ Object {
       },
       "parent_id": Nullable<StringMatching>,
       "post": Object {
+        "excerpt": "HTML Ipsum Presents
+
+Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum o",
         "feature_image": "http://127.0.0.1:2369/content/images/2018/hey.jpg",
         "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
         "title": "Ghostly Kitchen Sink",
@@ -120,6 +123,7 @@ Object {
       },
       "parent_id": Nullable<StringMatching>,
       "post": Object {
+        "excerpt": "This is my custom excerpt!",
         "feature_image": "https://example.com/super_photo.jpg",
         "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
         "title": "HTML Ipsum",
@@ -156,6 +160,9 @@ Object {
       },
       "parent_id": Nullable<StringMatching>,
       "post": Object {
+        "excerpt": "HTML Ipsum Presents
+
+Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum o",
         "feature_image": "http://127.0.0.1:2369/content/images/2018/hey.jpg",
         "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
         "title": "Ghostly Kitchen Sink",
@@ -209,6 +216,9 @@ Object {
       },
       "parent_id": Nullable<StringMatching>,
       "post": Object {
+        "excerpt": "HTML Ipsum Presents
+
+Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum o",
         "feature_image": "http://127.0.0.1:2369/content/images/2018/hey.jpg",
         "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
         "title": "Ghostly Kitchen Sink",
@@ -262,6 +272,9 @@ Object {
       },
       "parent_id": Nullable<StringMatching>,
       "post": Object {
+        "excerpt": "HTML Ipsum Presents
+
+Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum o",
         "feature_image": "http://127.0.0.1:2369/content/images/2018/hey.jpg",
         "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
         "title": "Ghostly Kitchen Sink",
@@ -315,6 +328,9 @@ Object {
       },
       "parent_id": Nullable<StringMatching>,
       "post": Object {
+        "excerpt": "HTML Ipsum Presents
+
+Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum o",
         "feature_image": "http://127.0.0.1:2369/content/images/2018/hey.jpg",
         "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
         "title": "Ghostly Kitchen Sink",
@@ -351,6 +367,9 @@ Object {
       },
       "parent_id": Nullable<StringMatching>,
       "post": Object {
+        "excerpt": "HTML Ipsum Presents
+
+Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum o",
         "feature_image": "http://127.0.0.1:2369/content/images/2018/hey.jpg",
         "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
         "title": "Ghostly Kitchen Sink",
@@ -404,6 +423,9 @@ Object {
       },
       "parent_id": Nullable<StringMatching>,
       "post": Object {
+        "excerpt": "HTML Ipsum Presents
+
+Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum o",
         "feature_image": "http://127.0.0.1:2369/content/images/2018/hey.jpg",
         "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
         "title": "Ghostly Kitchen Sink",
@@ -468,6 +490,9 @@ Object {
       },
       "parent_id": Nullable<StringMatching>,
       "post": Object {
+        "excerpt": "HTML Ipsum Presents
+
+Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum o",
         "feature_image": "http://127.0.0.1:2369/content/images/2018/hey.jpg",
         "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
         "title": "Ghostly Kitchen Sink",
@@ -521,6 +546,9 @@ Object {
       },
       "parent_id": Nullable<StringMatching>,
       "post": Object {
+        "excerpt": "HTML Ipsum Presents
+
+Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum o",
         "feature_image": "http://127.0.0.1:2369/content/images/2018/hey.jpg",
         "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
         "title": "Ghostly Kitchen Sink",
@@ -574,6 +602,9 @@ Object {
       },
       "parent_id": Nullable<StringMatching>,
       "post": Object {
+        "excerpt": "HTML Ipsum Presents
+
+Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum o",
         "feature_image": "http://127.0.0.1:2369/content/images/2018/hey.jpg",
         "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
         "title": "Ghostly Kitchen Sink",
@@ -610,6 +641,9 @@ Object {
       },
       "parent_id": Nullable<StringMatching>,
       "post": Object {
+        "excerpt": "HTML Ipsum Presents
+
+Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum o",
         "feature_image": "http://127.0.0.1:2369/content/images/2018/hey.jpg",
         "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
         "title": "Ghostly Kitchen Sink",
@@ -663,6 +697,9 @@ Object {
       },
       "parent_id": Nullable<StringMatching>,
       "post": Object {
+        "excerpt": "HTML Ipsum Presents
+
+Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum o",
         "feature_image": "http://127.0.0.1:2369/content/images/2018/hey.jpg",
         "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
         "title": "Ghostly Kitchen Sink",
@@ -710,6 +747,9 @@ Object {
       },
       "parent_id": Nullable<StringMatching>,
       "post": Object {
+        "excerpt": "HTML Ipsum Presents
+
+Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum o",
         "feature_image": "http://127.0.0.1:2369/content/images/2018/hey.jpg",
         "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
         "title": "Ghostly Kitchen Sink",
@@ -763,6 +803,9 @@ Object {
       },
       "parent_id": Nullable<StringMatching>,
       "post": Object {
+        "excerpt": "HTML Ipsum Presents
+
+Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum o",
         "feature_image": "http://127.0.0.1:2369/content/images/2018/hey.jpg",
         "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
         "title": "Ghostly Kitchen Sink",
@@ -816,6 +859,9 @@ Object {
       },
       "parent_id": Nullable<StringMatching>,
       "post": Object {
+        "excerpt": "HTML Ipsum Presents
+
+Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum o",
         "feature_image": "http://127.0.0.1:2369/content/images/2018/hey.jpg",
         "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
         "title": "Ghostly Kitchen Sink",
@@ -852,6 +898,9 @@ Object {
       },
       "parent_id": Nullable<StringMatching>,
       "post": Object {
+        "excerpt": "HTML Ipsum Presents
+
+Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum o",
         "feature_image": "http://127.0.0.1:2369/content/images/2018/hey.jpg",
         "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
         "title": "Ghostly Kitchen Sink",


### PR DESCRIPTION
No ref

We now show a post snippet at the top of a thread to provide additional context.

<img width="620" height="449" alt="Screenshot 2026-02-05 at 09 59 21" src="https://github.com/user-attachments/assets/2e4e4d49-2fa8-4a4a-9f90-f8001a7c886f" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Comment thread sidebars now display parent post information including title, excerpt, and feature image when available, providing better context.
  * Post excerpt data now included in comment API responses.

* **Style**
  * Adjusted vertical spacing in comment thread layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->