### PR TITLE
Refactored comments-ui to use single CommentApiProvider for auth

### DIFF
--- a/apps/comments-ui/src/actions.ts
+++ b/apps/comments-ui/src/actions.ts
@@ -125,73 +125,6 @@ async function addReply({state, commentApi, data: {reply, parent}}: {state: Edit
     };
 }
 
-async function hideComment({state, commentApi, data: comment}: {state: EditableAppContext, commentApi: CommentApi, data: {id: string}}) {
-    if (commentApi.hideComment) {
-        await commentApi.hideComment(comment.id);
-    }
-    return {
-        comments: state.comments.map((c) => {
-            const replies = c.replies.map((r) => {
-                if (r.id === comment.id) {
-                    return {
-                        ...r,
-                        status: 'hidden'
-                    };
-                }
-
-                return r;
-            });
-
-            if (c.id === comment.id) {
-                return {
-                    ...c,
-                    status: 'hidden',
-                    replies
-                };
-            }
-
-            return {
-                ...c,
-                replies
-            };
-        }),
-        commentCount: state.commentCount - 1
-    };
-}
-
-async function showComment({state, commentApi, data: comment}: {state: EditableAppContext, commentApi: CommentApi, data: {id: string}}) {
-    if (commentApi.showComment) {
-        await commentApi.showComment({id: comment.id});
-    }
-    // We need to refetch the comment, to make sure we have an up to date HTML content
-    // + all relations are loaded as the current member (not the admin)
-    const data = await commentApi.read(comment.id);
-
-    const updatedComment = data.comments[0];
-
-    return {
-        comments: state.comments.map((c) => {
-            const replies = c.replies.map((r) => {
-                if (r.id === comment.id) {
-                    return updatedComment;
-                }
-
-                return r;
-            });
-
-            if (c.id === comment.id) {
-                return updatedComment;
-            }
-
-            return {
-                ...c,
-                replies
-            };
-        }),
-        commentCount: state.commentCount + 1
-    };
-}
-
 async function updateCommentLikeState({state, data: comment}: {state: EditableAppContext, data: {id: string, liked: boolean}}) {
     return {
         comments: state.comments.map((c) => {
@@ -474,9 +407,7 @@ export const Actions = {
     // Put your actions here
     addComment,
     editComment,
-    hideComment,
     deleteComment,
-    showComment,
     likeComment,
     unlikeComment,
     reportComment,

--- a/apps/comments-ui/src/app-context.ts
+++ b/apps/comments-ui/src/app-context.ts
@@ -97,7 +97,6 @@ export type AppContextType = EditableAppContext & CommentsOptions & {
     t: TranslationFunction,
     dispatchAction: <T extends ActionType | SyncActionType>(action: T, data: Parameters<(typeof Actions & typeof SyncActions)[T]>[0] extends { data: any } ? Parameters<(typeof Actions & typeof SyncActions)[T]>[0]['data'] : any) => T extends ActionType ? Promise<void> : void,
     commentApi: CommentApi | null,
-    isAdmin: boolean,
     labs: LabsContextType,
     supportEmail: string | null,
     openFormCount: number

--- a/apps/comments-ui/src/app-context.ts
+++ b/apps/comments-ui/src/app-context.ts
@@ -57,7 +57,6 @@ export type CommentsOptions = {
     apiKey: string | undefined,
     apiUrl: string | undefined,
     postId: string,
-    adminUrl: string | undefined,
     colorScheme: string | undefined,
     avatarSaturation: number | undefined,
     accentColor: string,

--- a/apps/comments-ui/src/app-context.ts
+++ b/apps/comments-ui/src/app-context.ts
@@ -1,8 +1,8 @@
 // Ref: https://reactjs.org/docs/context.html
 import React, {useContext} from 'react';
 import {ActionType, Actions, SyncActionType, SyncActions} from './actions';
-import {AdminApi} from './utils/admin-api';
 import {Page} from './pages';
+import type {CommentApi} from './components/comment-api-provider';
 
 export type Member = {
     id: string,
@@ -70,7 +70,6 @@ export type CommentsOptions = {
 export type EditableAppContext = {
     initStatus: string,
     member: null | any,
-    admin: null | any,
     comments: Comment[],
     pagination: {
         page: number,
@@ -81,16 +80,12 @@ export type EditableAppContext = {
     commentCount: number,
     openCommentForms: OpenCommentForm[],
     popup: Page | null,
-    labs: LabsContextType,
     order: string,
-    adminApi: AdminApi | null,
     commentsIsLoading?: boolean,
     commentIdToHighlight: string | null,
     commentIdToScrollTo: string | null,
     pageUrl: string,
-    supportEmail: string | null,
     isMember: boolean,
-    isAdmin: boolean,
     isPaidOnly: boolean,
     hasRequiredTier: boolean,
     isCommentingDisabled: boolean
@@ -102,6 +97,10 @@ export type AppContextType = EditableAppContext & CommentsOptions & {
     // This part makes sure we can add automatic data and return types to the actions when using context.dispatchAction('actionName', data)
     t: TranslationFunction,
     dispatchAction: <T extends ActionType | SyncActionType>(action: T, data: Parameters<(typeof Actions & typeof SyncActions)[T]>[0] extends { data: any } ? Parameters<(typeof Actions & typeof SyncActions)[T]>[0]['data'] : any) => T extends ActionType ? Promise<void> : void,
+    commentApi: CommentApi | null,
+    isAdmin: boolean,
+    labs: LabsContextType,
+    supportEmail: string | null,
     openFormCount: number
 }
 

--- a/apps/comments-ui/src/app.tsx
+++ b/apps/comments-ui/src/app.tsx
@@ -125,6 +125,7 @@ async function loadScrollTarget(
 
 const App: React.FC<AppProps> = ({scriptTag, initialCommentId, pageUrl}) => {
     const options = useOptions(scriptTag);
+    const adminUrl = scriptTag.dataset.admin;
 
     const api = React.useMemo(() => {
         return setupGhostApi({
@@ -135,7 +136,7 @@ const App: React.FC<AppProps> = ({scriptTag, initialCommentId, pageUrl}) => {
     }, [options]);
 
     return (
-        <CommentApiProvider adminUrl={options.adminUrl} api={api}>
+        <CommentApiProvider adminUrl={adminUrl} api={api}>
             <AppInner initialCommentId={initialCommentId} pageUrl={pageUrl} scriptTag={scriptTag} />
         </CommentApiProvider>
     );

--- a/apps/comments-ui/src/app.tsx
+++ b/apps/comments-ui/src/app.tsx
@@ -208,7 +208,6 @@ const AppInner: React.FC<AppProps> = ({scriptTag, initialCommentId, pageUrl}) =>
     const context = {
         ...options,
         ...state,
-        isAdmin: commentApi?.isAdmin ?? false,
         commentApi,
         labs,
         supportEmail,

--- a/apps/comments-ui/src/app.tsx
+++ b/apps/comments-ui/src/app.tsx
@@ -6,6 +6,7 @@ import React, {useCallback, useEffect, useMemo, useState} from 'react';
 import i18nLib from '@tryghost/i18n';
 import setupGhostApi from './utils/api';
 import {ActionHandler, SyncActionHandler, isSyncAction} from './actions';
+import {AdminActionsProvider} from './components/admin-actions';
 import {AppContext, Comment, DispatchActionType, EditableAppContext} from './app-context';
 import {type CommentApi, CommentApiProvider, useCommentApi} from './components/comment-api-provider';
 import {CommentsFrame} from './components/frame';
@@ -23,8 +24,6 @@ type AppProps = {
 function isCommentLoaded(comments: Comment[], targetId: string): boolean {
     return comments.some(c => c.id === targetId || c.replies?.some(r => r.id === targetId));
 }
-
-// --- Permalink scroll-target helpers (pure functions) ---
 
 async function fetchScrollTarget(commentApi: CommentApi, targetId: string): Promise<Comment | null> {
     try {
@@ -123,8 +122,6 @@ async function loadScrollTarget(
 
     return {comments, pagination, found: isCommentLoaded(comments, targetId)};
 }
-
-// --- Components ---
 
 const App: React.FC<AppProps> = ({scriptTag, initialCommentId, pageUrl}) => {
     const options = useOptions(scriptTag);
@@ -314,12 +311,20 @@ const AppInner: React.FC<AppProps> = ({scriptTag, initialCommentId, pageUrl}) =>
 
     const done = state.initStatus === 'success';
 
-    return (
-        <AppContext.Provider value={context}>
+    const content = (
+        <>
             <CommentsFrame ref={iframeRef}>
                 <ContentBox done={done} />
             </CommentsFrame>
             <PopupBox />
+        </>
+    );
+
+    return (
+        <AppContext.Provider value={context}>
+            <AdminActionsProvider commentApi={commentApi} setState={setState}>
+                {content}
+            </AdminActionsProvider>
         </AppContext.Provider>
     );
 };

--- a/apps/comments-ui/src/components/admin-actions.tsx
+++ b/apps/comments-ui/src/components/admin-actions.tsx
@@ -1,0 +1,69 @@
+import React, {useCallback, useContext, useMemo} from 'react';
+import {Comment, EditableAppContext} from '../app-context';
+import type {CommentApi} from './comment-api-provider';
+
+export type AdminActions = {
+    hideComment(id: string): Promise<void>;
+    showComment(id: string): Promise<void>;
+};
+
+const AdminActionsContext = React.createContext<AdminActions | null>(null);
+
+export const useAdminActions = (): AdminActions | null => useContext(AdminActionsContext);
+
+type Props = {
+    commentApi: CommentApi | null;
+    setState: (updater: (state: EditableAppContext) => Partial<EditableAppContext>) => void;
+    children: React.ReactNode;
+};
+
+function updateCommentInState(comments: Comment[], commentId: string, updater: (comment: Comment) => Comment): Comment[] {
+    return comments.map((c) => {
+        const replies = c.replies.map(r => (r.id === commentId ? updater(r) : r));
+
+        if (c.id === commentId) {
+            return updater({...c, replies});
+        }
+
+        return {...c, replies};
+    });
+}
+
+export const AdminActionsProvider: React.FC<Props> = ({commentApi, setState, children}) => {
+    const hideComment = useCallback(async (id: string) => {
+        if (!commentApi?.isAdmin) {
+            return;
+        }
+        await commentApi.hideComment(id);
+        setState(state => ({
+            comments: updateCommentInState(state.comments, id, c => ({...c, status: 'hidden'})),
+            commentCount: state.commentCount - 1
+        }));
+    }, [commentApi, setState]);
+
+    const showComment = useCallback(async (id: string) => {
+        if (!commentApi?.isAdmin) {
+            return;
+        }
+        await commentApi.showComment({id});
+        const data = await commentApi.read(id);
+        const updatedComment = data.comments[0];
+        setState(state => ({
+            comments: updateCommentInState(state.comments, id, () => updatedComment),
+            commentCount: state.commentCount + 1
+        }));
+    }, [commentApi, setState]);
+
+    const actions = useMemo<AdminActions | null>(() => {
+        if (!commentApi?.isAdmin) {
+            return null;
+        }
+        return {hideComment, showComment};
+    }, [commentApi, hideComment, showComment]);
+
+    return (
+        <AdminActionsContext.Provider value={actions}>
+            {children}
+        </AdminActionsContext.Provider>
+    );
+};

--- a/apps/comments-ui/src/components/comment-api-provider.tsx
+++ b/apps/comments-ui/src/components/comment-api-provider.tsx
@@ -71,6 +71,7 @@ type CommentApiContextType = {
     member: Member | null;
     labs: LabsContextType;
     supportEmail: string | null;
+    adminUrl: string | undefined;
 };
 
 const CommentApiContext = React.createContext<CommentApiContextType>({
@@ -78,7 +79,8 @@ const CommentApiContext = React.createContext<CommentApiContextType>({
     commentApi: null,
     member: null,
     labs: {},
-    supportEmail: null
+    supportEmail: null,
+    adminUrl: undefined
 });
 
 export const useCommentApi = () => useContext(CommentApiContext);
@@ -165,8 +167,9 @@ export const CommentApiProvider: React.FC<CommentApiProviderProps> = ({api, admi
         commentApi,
         member: initData?.member ?? null,
         labs: initData?.labs ?? {},
-        supportEmail: initData?.supportEmail ?? null
-    }), [resolved, commentApi, initData]);
+        supportEmail: initData?.supportEmail ?? null,
+        adminUrl
+    }), [resolved, commentApi, initData, adminUrl]);
 
     return (
         <CommentApiContext.Provider value={value}>

--- a/apps/comments-ui/src/components/comment-api-provider.tsx
+++ b/apps/comments-ui/src/components/comment-api-provider.tsx
@@ -1,0 +1,180 @@
+import AuthFrame from '../auth-frame';
+import React, {useCallback, useContext, useEffect, useMemo, useState} from 'react';
+import {AddComment, Comment, LabsContextType, Member} from '../app-context';
+import {AdminApi, setupAdminAPI} from '../utils/admin-api';
+import {GhostApi} from '../utils/api';
+
+const ALLOWED_MODERATORS = ['Owner', 'Administrator', 'Super Editor'];
+
+// --- CommentApi type + factory ---
+
+export type CommentApi = {
+    isAdmin: boolean;
+
+    browse(params: {page: number; postId: string; order?: string}): Promise<{comments: Comment[]; meta: {pagination: any}}>;
+    replies(params: {commentId: string; afterReplyId?: string; limit?: number | 'all'}): Promise<{comments: Comment[]; meta: {pagination: any}}>;
+    read(commentId: string): Promise<{comments: Comment[]}>;
+    count(params: {postId: string | null}): Promise<any>;
+
+    add(params: {comment: AddComment}): Promise<{comments: Comment[]}>;
+    edit(params: {comment: Partial<Comment> & {id: string}}): Promise<{comments: Comment[]}>;
+    like(params: {comment: {id: string}}): Promise<string>;
+    unlike(params: {comment: {id: string}}): Promise<string>;
+    report(params: {comment: {id: string}}): Promise<string>;
+
+    updateMember(data: {name?: string; expertise?: string}): Promise<Member | null>;
+
+    hideComment: ((id: string) => Promise<any>) | null;
+    showComment: ((params: {id: string}) => Promise<any>) | null;
+};
+
+function createCommentApi(api: GhostApi, adminApi: AdminApi | null, memberUuid?: string): CommentApi {
+    if (adminApi) {
+        return {
+            isAdmin: true,
+            browse: p => adminApi.browse({...p, memberUuid}),
+            replies: p => adminApi.replies({...p, memberUuid}),
+            read: id => adminApi.read({commentId: id, memberUuid}),
+            count: p => api.comments.count(p),
+            add: p => api.comments.add(p),
+            edit: p => api.comments.edit(p),
+            like: p => api.comments.like(p),
+            unlike: p => api.comments.unlike(p),
+            report: p => api.comments.report(p),
+            updateMember: data => api.member.update(data),
+            hideComment: id => adminApi.hideComment(id),
+            showComment: p => adminApi.showComment(p)
+        };
+    }
+
+    return {
+        isAdmin: false,
+        browse: p => api.comments.browse(p),
+        replies: p => api.comments.replies(p),
+        read: id => api.comments.read(id),
+        count: p => api.comments.count(p),
+        add: p => api.comments.add(p),
+        edit: p => api.comments.edit(p),
+        like: p => api.comments.like(p),
+        unlike: p => api.comments.unlike(p),
+        report: p => api.comments.report(p),
+        updateMember: data => api.member.update(data),
+        hideComment: null,
+        showComment: null
+    };
+}
+
+// --- Context + Hook ---
+
+type CommentApiContextType = {
+    resolved: boolean;
+    commentApi: CommentApi | null;
+    member: Member | null;
+    labs: LabsContextType;
+    supportEmail: string | null;
+};
+
+const CommentApiContext = React.createContext<CommentApiContextType>({
+    resolved: false,
+    commentApi: null,
+    member: null,
+    labs: {},
+    supportEmail: null
+});
+
+export const useCommentApi = () => useContext(CommentApiContext);
+
+// --- Provider ---
+
+type CommentApiProviderProps = {
+    api: GhostApi;
+    adminUrl: string | undefined;
+    children: React.ReactNode;
+};
+
+type InitData = {
+    member: Member | null;
+    labs: LabsContextType;
+    supportEmail: string | null;
+};
+
+export const CommentApiProvider: React.FC<CommentApiProviderProps> = ({api, adminUrl, children}) => {
+    const [initData, setInitData] = useState<InitData | null>(null);
+    const [adminApi, setAdminApi] = useState<AdminApi | null | undefined>(
+        adminUrl ? undefined : null
+    );
+    const [showAuthFrame, setShowAuthFrame] = useState(false);
+
+    // Fetch member session + site settings
+    useEffect(() => {
+        api.init().then(({member, labs, supportEmail}) => {
+            setInitData({member, labs, supportEmail});
+        }).catch((e) => {
+            // eslint-disable-next-line no-console
+            console.error(`[Comments] Failed to initialize:`, e);
+            setInitData({member: null, labs: {}, supportEmail: null});
+        });
+    }, [api]);
+
+    // Check if admin auth frame is available before rendering the iframe.
+    // A 204 response means the user is not logged in to Ghost admin — skip the iframe.
+    // A 200 response means the auth frame is available — render the iframe.
+    useEffect(() => {
+        if (!adminUrl) {
+            return;
+        }
+
+        fetch(adminUrl + 'auth-frame/', {credentials: 'include'}).then((res) => {
+            if (res.ok && res.status !== 204) {
+                setShowAuthFrame(true);
+            } else {
+                setAdminApi(null);
+            }
+        }).catch(() => {
+            setAdminApi(null);
+        });
+    }, [adminUrl]);
+
+    // Auth frame load handler — resolves admin status
+    const onAdminAuthLoaded = useCallback(async () => {
+        if (!adminUrl) {
+            return;
+        }
+
+        const newAdminApi = setupAdminAPI({adminUrl});
+
+        try {
+            const admin = await newAdminApi.getUser();
+            const isAllowed = admin?.roles?.some((role: any) => ALLOWED_MODERATORS.includes(role.name));
+            setAdminApi(isAllowed ? newAdminApi : null);
+        } catch (e) {
+            // eslint-disable-next-line no-console
+            console.warn(`[Comments] Failed to fetch admin endpoint:`, e);
+            setAdminApi(null);
+        }
+    }, [adminUrl]);
+
+    const resolved = initData !== null && adminApi !== undefined;
+
+    const commentApi = useMemo(() => {
+        if (!resolved || !initData) {
+            return null;
+        }
+        return createCommentApi(api, adminApi ?? null, initData.member?.uuid);
+    }, [resolved, initData, adminApi, api]);
+
+    const value = useMemo<CommentApiContextType>(() => ({
+        resolved,
+        commentApi,
+        member: initData?.member ?? null,
+        labs: initData?.labs ?? {},
+        supportEmail: initData?.supportEmail ?? null
+    }), [resolved, commentApi, initData]);
+
+    return (
+        <CommentApiContext.Provider value={value}>
+            {children}
+            {showAuthFrame && adminUrl && <AuthFrame adminUrl={adminUrl} onLoad={onAdminAuthLoaded} />}
+        </CommentApiContext.Provider>
+    );
+};

--- a/apps/comments-ui/src/components/comment-api-provider.tsx
+++ b/apps/comments-ui/src/components/comment-api-provider.tsx
@@ -68,6 +68,7 @@ function createCommentApi(api: GhostApi, adminApi: AdminApi | null, memberUuid?:
 type CommentApiContextType = {
     resolved: boolean;
     commentApi: CommentApi | null;
+    isAdmin: boolean;
     member: Member | null;
     labs: LabsContextType;
     supportEmail: string | null;
@@ -77,6 +78,7 @@ type CommentApiContextType = {
 const CommentApiContext = React.createContext<CommentApiContextType>({
     resolved: false,
     commentApi: null,
+    isAdmin: false,
     member: null,
     labs: {},
     supportEmail: null,
@@ -165,6 +167,7 @@ export const CommentApiProvider: React.FC<CommentApiProviderProps> = ({api, admi
     const value = useMemo<CommentApiContextType>(() => ({
         resolved,
         commentApi,
+        isAdmin: commentApi?.isAdmin ?? false,
         member: initData?.member ?? null,
         labs: initData?.labs ?? {},
         supportEmail: initData?.supportEmail ?? null,

--- a/apps/comments-ui/src/components/content/comment.tsx
+++ b/apps/comments-ui/src/components/content/comment.tsx
@@ -10,6 +10,7 @@ import {Avatar, BlankAvatar} from './avatar';
 import {Comment, OpenCommentForm, useAppContext, useLabs} from '../../app-context';
 import {Transition} from '@headlessui/react';
 import {buildCommentPermalink, findCommentById, formatExplicitTime, getCommentInReplyToSnippet, getMemberNameFromComment} from '../../utils/helpers';
+import {useCommentApi} from '../comment-api-provider';
 import {useRelativeTime} from '../../utils/hooks';
 
 type AnimatedCommentProps = {
@@ -40,7 +41,8 @@ const AnimatedComment: React.FC<AnimatedCommentProps> = ({comment, parent}) => {
 };
 
 export const CommentComponent: React.FC<CommentProps> = ({comment, parent}) => {
-    const {dispatchAction, isAdmin} = useAppContext();
+    const {dispatchAction} = useAppContext();
+    const {isAdmin} = useCommentApi();
     const {showDeletedMessage, showHiddenMessage, showCommentContent} = useCommentVisibility(comment, isAdmin);
 
     const openEditMode = useCallback(() => {
@@ -83,7 +85,8 @@ type PublishedCommentProps = CommentProps & {
     openEditMode: () => void;
 }
 const PublishedComment: React.FC<PublishedCommentProps> = ({comment, parent, openEditMode}) => {
-    const {dispatchAction, openCommentForms, isAdmin, commentIdToHighlight} = useAppContext();
+    const {dispatchAction, openCommentForms, commentIdToHighlight} = useAppContext();
+    const {isAdmin} = useCommentApi();
 
     // Determine if the comment should be displayed with reduced opacity
     const isHidden = isAdmin && comment.status === 'hidden';
@@ -160,7 +163,8 @@ type UnpublishedCommentProps = {
     openEditMode: () => void;
 }
 const UnpublishedComment: React.FC<UnpublishedCommentProps> = ({comment, openEditMode}) => {
-    const {isAdmin, openCommentForms, t} = useAppContext();
+    const {openCommentForms, t} = useAppContext();
+    const {isAdmin} = useCommentApi();
 
     const avatar = (isAdmin && comment.status !== 'deleted')
         ? <Avatar member={comment.member} />
@@ -406,7 +410,8 @@ type CommentMenuProps = {
     className?: string;
 };
 const CommentMenu: React.FC<CommentMenuProps> = ({comment, openReplyForm, highlightReplyButton, openEditMode, className = ''}) => {
-    const {member, t, isMember, isAdmin, isCommentingDisabled} = useAppContext();
+    const {member, t, isMember, isCommentingDisabled} = useAppContext();
+    const {isAdmin} = useCommentApi();
 
     const isPublished = comment.status === 'published';
     const isOwnComment = member && comment.member?.uuid === member?.uuid;

--- a/apps/comments-ui/src/components/content/context-menus/admin-context-menu.tsx
+++ b/apps/comments-ui/src/components/content/context-menus/admin-context-menu.tsx
@@ -1,12 +1,14 @@
 import {Comment, useAppContext, useLabs} from '../../../app-context';
 import {useAdminActions} from '../../admin-actions';
+import {useCommentApi} from '../../comment-api-provider';
 
 type Props = {
     comment: Comment;
     close: () => void;
 };
 const AdminContextMenu: React.FC<Props> = ({comment, close}) => {
-    const {t, adminUrl} = useAppContext();
+    const {t} = useAppContext();
+    const {adminUrl} = useCommentApi();
     const labs = useLabs();
     const adminActions = useAdminActions();
 

--- a/apps/comments-ui/src/components/content/context-menus/admin-context-menu.tsx
+++ b/apps/comments-ui/src/components/content/context-menus/admin-context-menu.tsx
@@ -1,20 +1,22 @@
 import {Comment, useAppContext, useLabs} from '../../../app-context';
+import {useAdminActions} from '../../admin-actions';
 
 type Props = {
     comment: Comment;
     close: () => void;
 };
 const AdminContextMenu: React.FC<Props> = ({comment, close}) => {
-    const {dispatchAction, t, adminUrl} = useAppContext();
+    const {t, adminUrl} = useAppContext();
     const labs = useLabs();
+    const adminActions = useAdminActions();
 
     const hideComment = () => {
-        dispatchAction('hideComment', comment);
+        adminActions?.hideComment(comment.id);
         close();
     };
 
     const showComment = () => {
-        dispatchAction('showComment', comment);
+        adminActions?.showComment(comment.id);
         close();
     };
 

--- a/apps/comments-ui/src/components/content/context-menus/admin-context-menu.tsx
+++ b/apps/comments-ui/src/components/content/context-menus/admin-context-menu.tsx
@@ -13,12 +13,12 @@ const AdminContextMenu: React.FC<Props> = ({comment, close}) => {
     const adminActions = useAdminActions();
 
     const hideComment = () => {
-        adminActions?.hideComment(comment.id);
+        adminActions.hideComment(comment.id);
         close();
     };
 
     const showComment = () => {
-        adminActions?.showComment(comment.id);
+        adminActions.showComment(comment.id);
         close();
     };
 

--- a/apps/comments-ui/src/components/content/context-menus/comment-context-menu.tsx
+++ b/apps/comments-ui/src/components/content/context-menus/comment-context-menu.tsx
@@ -2,6 +2,7 @@ import AdminContextMenu from './admin-context-menu';
 import AuthorContextMenu from './author-context-menu';
 import NotAuthorContextMenu from './not-author-context-menu';
 import {Comment, useAppContext} from '../../../app-context';
+import {useCommentApi} from '../../comment-api-provider';
 import {useEffect, useRef} from 'react';
 import {useOutOfViewportClasses} from '../../../utils/hooks';
 
@@ -11,7 +12,8 @@ type Props = {
     toggleEdit: () => void;
 };
 const CommentContextMenu: React.FC<Props> = ({comment, close, toggleEdit}) => {
-    const {member, isAdmin} = useAppContext();
+    const {member} = useAppContext();
+    const {isAdmin} = useCommentApi();
     const isAuthor = member && comment.member?.uuid === member?.uuid;
     const element = useRef<HTMLDivElement>(null);
     const innerElement = useRef<HTMLDivElement>(null);

--- a/apps/comments-ui/src/utils/admin-api.ts
+++ b/apps/comments-ui/src/utils/admin-api.ts
@@ -94,7 +94,7 @@ export function setupAdminAPI({adminUrl}: {adminUrl: string}) {
 
             return response;
         },
-        async replies({commentId, afterReplyId, limit, memberUuid}: {commentId: string; afterReplyId?: string; limit?: number, memberUuid?: string}) {
+        async replies({commentId, afterReplyId, limit, memberUuid}: {commentId: string; afterReplyId?: string; limit?: number | 'all', memberUuid?: string}) {
             const params = new URLSearchParams();
 
             if (limit) {

--- a/apps/comments-ui/src/utils/options.ts
+++ b/apps/comments-ui/src/utils/options.ts
@@ -10,7 +10,6 @@ export function useOptions(scriptTag: HTMLElement) {
         const siteUrl = dataset.ghostComments || window.location.origin;
         const apiKey = dataset.key;
         const apiUrl = dataset.api;
-        const adminUrl = dataset.admin;
         const postId = dataset.postId || '';
         const colorScheme = dataset.colorScheme;
         const avatarSaturation = dataset.avatarSaturation ? parseInt(dataset.avatarSaturation) : undefined;
@@ -21,7 +20,7 @@ export function useOptions(scriptTag: HTMLElement) {
         const publication = dataset.publication ?? ''; // TODO: replace with dynamic data from script
         const locale = dataset.locale ?? 'en';
 
-        const options = {locale, siteUrl, apiKey, apiUrl, postId, adminUrl, colorScheme, avatarSaturation, accentColor, commentsEnabled, title, showCount, publication};
+        const options = {locale, siteUrl, apiKey, apiUrl, postId, colorScheme, avatarSaturation, accentColor, commentsEnabled, title, showCount, publication};
         return options;
     }, [scriptTag]);
 

--- a/apps/comments-ui/test/e2e/admin-moderation.test.ts
+++ b/apps/comments-ui/test/e2e/admin-moderation.test.ts
@@ -44,15 +44,7 @@ test.describe('Admin moderation', async () => {
         });
     }
 
-    test('skips rendering the auth frame with no comments', async ({page}) => {
-        await initializeTest(page);
-
-        const iframeElement = page.locator('iframe[data-frame="admin-auth"]');
-        await expect(iframeElement).toHaveCount(0);
-    });
-
-    test('renders the auth frame when there are comments', async ({page}) => {
-        mockedApi.addComment({html: '<p>This is comment 1</p>'});
+    test('renders the auth frame when admin URL is set', async ({page}) => {
         await initializeTest(page);
 
         const iframeElement = page.locator('iframe[data-frame="admin-auth"]');

--- a/apps/comments-ui/test/e2e/content.test.ts
+++ b/apps/comments-ui/test/e2e/content.test.ts
@@ -31,9 +31,6 @@ test.describe('Deleted and Hidden Content', async () => {
             labs: {}
         });
 
-        const iframeElement = await page.locator('iframe[data-frame="admin-auth"]');
-        await expect(iframeElement).toHaveCount(1);
-
         // Check if more actions button is visible on each comment
         const comments = await frame.getByTestId('comment-component');
         // 3 comments are visible

--- a/apps/comments-ui/test/e2e/lazy-loading.test.ts
+++ b/apps/comments-ui/test/e2e/lazy-loading.test.ts
@@ -48,23 +48,20 @@ test.describe('Lazy loading', async () => {
         await page.locator('iframe[title="comments-frame"]').waitFor({state: 'attached'});
 
         const commentsFrameSelector = 'iframe[title="comments-frame"]';
-        const adminFrameSelector = 'iframe[data-frame="admin-auth"]';
 
         const commentsFrame = page.frameLocator(commentsFrameSelector);
 
         // wait for a little bit to ensure we're not loading comments until scrolled
         await page.waitForTimeout(250);
 
-        // check that we haven't loaded comments or admin-auth yet
+        // check that we haven't loaded comments yet
         await expect(commentsFrame.getByTestId('loading')).toHaveCount(1);
-        await expect(page.locator(adminFrameSelector)).toHaveCount(0);
 
         // scroll the iframe into view
         const iframeHandle = await page.locator(commentsFrameSelector);
         iframeHandle.scrollIntoViewIfNeeded();
 
-        // loading state should be gone and admin-auth frame should be present
+        // loading state should be gone
         await expect(commentsFrame.getByTestId('loading')).toHaveCount(0);
-        await expect(page.locator(adminFrameSelector)).toHaveCount(1);
     });
 });

--- a/apps/comments-ui/test/unit/actions.test.js
+++ b/apps/comments-ui/test/unit/actions.test.js
@@ -10,21 +10,19 @@ describe('Actions', function () {
                     {id: '3'}
                 ]
             };
-            const api = {
-                comments: {
-                    browse: () => Promise.resolve({
-                        comments: [
-                            {id: '2'},
-                            {id: '3'},
-                            {id: '4'}
-                        ],
-                        meta: {
-                            pagination: {}
-                        }
-                    })
-                }
+            const commentApi = {
+                browse: () => Promise.resolve({
+                    comments: [
+                        {id: '2'},
+                        {id: '3'},
+                        {id: '4'}
+                    ],
+                    meta: {
+                        pagination: {}
+                    }
+                })
             };
-            const newState = await Actions.loadMoreComments({state, api, options: {postId: '1'}, order: 'desc'});
+            const newState = await Actions.loadMoreComments({state, commentApi, options: {postId: '1'}, order: 'desc'});
             expect(newState.comments).toEqual([
                 {id: '1'},
                 {id: '2'},


### PR DESCRIPTION
The previous comments-ui architecture had admin auth initialization happening inside the main App component as a side-effect that raced with comment loading. The raw GhostApi and AdminApi leaked into state, actions, and multiple components, making it difficult to reason about which API path was being used and when admin data was available.

This refactoring introduces a `CommentApiProvider` that resolves both the member session and admin auth before exposing a single unified `commentApi` interface to the rest of the app. The provider checks whether the admin auth frame is available (via a fetch to the auth-frame endpoint — a 204 means the user isn't logged into Ghost admin, so the iframe is skipped entirely), then sets up the admin API and verifies the user's role. The `App` component splits into `App` (creates the raw API, wraps in provider) and `AppInner` (consumes only `commentApi` from context). No component or action ever touches the raw `GhostApi` directly.

The `CommentApi` type is the single interface everything goes through — browse, replies, read, count, add, edit, like, unlike, report, updateMember, hideComment, and showComment. The factory function uses an early-return pattern for admin vs non-admin branches, which gives TypeScript clean narrowing without non-null assertions. Admin auth state is modeled as a tri-state (`AdminApi | null | undefined`) where undefined means pending, null means resolved-no-admin, and an AdminApi instance means resolved-admin.

Other cleanups bundled in: permalink scroll-target helpers extracted as pure functions (no closure over component state), dead parameters removed from `SyncActionHandler`, the `isReply` bypass in `loadMoreReplies` removed (it always goes through `commentApi.replies()` now), and immutable provider data (`isAdmin`, `labs`, `supportEmail`) moved out of mutable `EditableAppContext` into `AppContextType` where it flows directly from the provider.

This stacks on top of the bugfix PR and should be reviewed after that one merges.