### PR TITLE
Fixed `yarn knex-migrator` being unable to find module './bulk-filters'

### DIFF
--- a/ghost/core/MigratorConfig.js
+++ b/ghost/core/MigratorConfig.js
@@ -12,6 +12,21 @@ const ghostVersion = require('@tryghost/version');
  */
 require('./core/server/overrides');
 
+/**
+ * Register tsx so that require() can resolve .ts files used in server code.
+ *
+ * tsx is a devDependency, so this is a no-op in production where Ghost runs
+ * migrations on boot through its own process (which uses --import=tsx) or in
+ * CI environments where a build has already run and the TS is already compiled
+ */
+try {
+    require('tsx/cjs');
+} catch (err) {
+    if (err.code !== 'MODULE_NOT_FOUND') {
+        throw err;
+    }
+}
+
 module.exports = {
     currentVersion: ghostVersion.safe,
     database: config.get('database'),


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/pull/25906

In #25906 we added a `.ts` file (`bulk-filters.ts`) that is required directly from a `.js` model file. Ghost's own boot process and tests use `--import=tsx` so this works fine, but `knex-migrator` runs as a standalone CLI without `tsx` registered, causing `MODULE_NOT_FOUND` when it loads the model chain. This adds `require('tsx/cjs')` to the `knex-migrator` config, which is the entry point `knex-migrator` loads from the project, making it consistent with how every other Ghost entry point handles `.ts` files


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, isolated change to migration CLI startup that only affects module loading; minimal impact beyond making `.ts` requires work during migrations.
> 
> **Overview**
> Fixes `yarn knex-migrator` failing to resolve server-side `.ts` modules by registering `tsx` in `ghost/core/MigratorConfig.js`.
> 
> The config now attempts to `require('tsx/cjs')` (ignoring `MODULE_NOT_FOUND`) so migrations run consistently when invoked via the standalone `knex-migrator` CLI.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e960bb9403d30e5e1745633ebfac51f3582e53c7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated internal runtime initialization to improve module handling for certain file types. No changes to public APIs or user-facing behavior; no action required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->