### PR TITLE
Supported CDN urls for images

### DIFF
--- a/ghost/core/core/shared/url-utils.js
+++ b/ghost/core/core/shared/url-utils.js
@@ -8,7 +8,8 @@ const urlUtils = new UrlUtils({
     getAdminUrl: config.getAdminUrl,
     assetBaseUrls: {
         media: config.get('urls:media'),
-        files: config.get('urls:files')
+        files: config.get('urls:files'),
+        image: config.get('urls:image')
     },
     slugs: config.get('slugs').protected,
     redirectCacheMaxAge: config.get('caching:301:maxAge'),

--- a/ghost/core/test/e2e-api/admin/email-previews.test.js
+++ b/ghost/core/test/e2e-api/admin/email-previews.test.js
@@ -282,11 +282,10 @@ describe('Email Preview API', function () {
                 });
         });
 
-        it('Mobiledoc post email preview renders with CDN URLs for thumbnails when configured', async function () {
-            const siteUrl = config.get('url');
+        it('Mobiledoc post email preview renders with CDN URLs when configured', async function () {
             const cdnUrl = 'https://cdn.example.com/c/site-uuid';
             urlUtilsHelper.stubUrlUtilsWithCdn({
-                assetBaseUrls: {media: cdnUrl, files: cdnUrl}
+                assetBaseUrls: {media: cdnUrl, files: cdnUrl, image: cdnUrl}
             }, sinon);
 
             const post = await models.Post.findOne({slug: 'post-with-all-media-types-mobiledoc'});
@@ -296,23 +295,22 @@ describe('Email Preview API', function () {
                 .expectStatus(200)
                 .expect(({body}) => {
                     const html = body.email_previews[0].html;
-                    assert(html.includes(`${siteUrl}/content/images/feature.jpg`));
-                    assert(html.includes(`${siteUrl}/content/images/inline.jpg`));
-                    assert(html.includes(`${siteUrl}/content/images/gallery-1.jpg`));
-                    assert(html.includes(`${siteUrl}/content/images/video-thumb.jpg`));
-                    assert(html.includes(`${siteUrl}/content/images/audio-thumb.jpg`));
-                    assert(html.includes(`${siteUrl}/content/images/snippet-inline.jpg`));
-                    assert(html.includes(`${siteUrl}/content/images/snippet-video-thumb.jpg`));
-                    assert(html.includes(`${siteUrl}/content/images/snippet-audio-thumb.jpg`));
+                    assert(html.includes(`${cdnUrl}/content/images/feature.jpg`));
+                    assert(html.includes(`${cdnUrl}/content/images/inline.jpg`));
+                    assert(html.includes(`${cdnUrl}/content/images/gallery-1.jpg`));
+                    assert(html.includes(`${cdnUrl}/content/images/video-thumb.jpg`));
+                    assert(html.includes(`${cdnUrl}/content/images/audio-thumb.jpg`));
+                    assert(html.includes(`${cdnUrl}/content/images/snippet-inline.jpg`));
+                    assert(html.includes(`${cdnUrl}/content/images/snippet-video-thumb.jpg`));
+                    assert(html.includes(`${cdnUrl}/content/images/snippet-audio-thumb.jpg`));
                     assert(!html.includes('__GHOST_URL__'));
                 });
         });
 
-        it('Lexical post email preview renders with CDN URLs for thumbnails when configured', async function () {
-            const siteUrl = config.get('url');
+        it('Lexical post email preview renders with CDN URLs when configured', async function () {
             const cdnUrl = 'https://cdn.example.com/c/site-uuid';
             urlUtilsHelper.stubUrlUtilsWithCdn({
-                assetBaseUrls: {media: cdnUrl, files: cdnUrl}
+                assetBaseUrls: {media: cdnUrl, files: cdnUrl, image: cdnUrl}
             }, sinon);
 
             const post = await models.Post.findOne({slug: 'post-with-all-media-types-lexical'});
@@ -322,14 +320,14 @@ describe('Email Preview API', function () {
                 .expectStatus(200)
                 .expect(({body}) => {
                     const html = body.email_previews[0].html;
-                    assert(html.includes(`${siteUrl}/content/images/feature.jpg`));
-                    assert(html.includes(`${siteUrl}/content/images/inline.jpg`));
-                    assert(html.includes(`${siteUrl}/content/images/gallery-1.jpg`));
-                    assert(html.includes(`${siteUrl}/content/images/video-thumb.jpg`));
-                    assert(html.includes(`${siteUrl}/content/images/audio-thumb.jpg`));
-                    assert(html.includes(`${siteUrl}/content/images/snippet-inline.jpg`));
-                    assert(html.includes(`${siteUrl}/content/images/snippet-video-thumb.jpg`));
-                    assert(html.includes(`${siteUrl}/content/images/snippet-audio-thumb.jpg`));
+                    assert(html.includes(`${cdnUrl}/content/images/feature.jpg`));
+                    assert(html.includes(`${cdnUrl}/content/images/inline.jpg`));
+                    assert(html.includes(`${cdnUrl}/content/images/gallery-1.jpg`));
+                    assert(html.includes(`${cdnUrl}/content/images/video-thumb.jpg`));
+                    assert(html.includes(`${cdnUrl}/content/images/audio-thumb.jpg`));
+                    assert(html.includes(`${cdnUrl}/content/images/snippet-inline.jpg`));
+                    assert(html.includes(`${cdnUrl}/content/images/snippet-video-thumb.jpg`));
+                    assert(html.includes(`${cdnUrl}/content/images/snippet-audio-thumb.jpg`));
                     assert(!html.includes('__GHOST_URL__'));
                 });
         });

--- a/ghost/core/test/e2e-api/admin/newsletters.test.js
+++ b/ghost/core/test/e2e-api/admin/newsletters.test.js
@@ -1661,9 +1661,10 @@ describe('Newsletters API', function () {
             assert.equal(newsletter.header_image, `${siteUrl}content/images/newsletter-header.jpg`);
         });
 
-        it('Can read newsletter with header_image as absolute site URL even when CDN is configured', async function () {
+        it('Can read newsletter with header_image as CDN URL when image CDN is configured', async function () {
+            const cdnUrl = 'https://cdn.example.com';
             urlUtilsHelper.stubUrlUtilsWithCdn({
-                assetBaseUrls: {media: 'https://cdn.example.com', files: 'https://cdn.example.com'}
+                assetBaseUrls: {media: cdnUrl, image: cdnUrl}
             }, sinon);
 
             const res = await agent
@@ -1671,7 +1672,7 @@ describe('Newsletters API', function () {
                 .expectStatus(200);
 
             const newsletter = res.body.newsletters[0];
-            assert.equal(newsletter.header_image, `${siteUrl}content/images/newsletter-header.jpg`);
+            assert.equal(newsletter.header_image, `${cdnUrl}/content/images/newsletter-header.jpg`);
         });
     });
 });

--- a/ghost/core/test/e2e-api/admin/posts.test.js
+++ b/ghost/core/test/e2e-api/admin/posts.test.js
@@ -785,9 +785,9 @@ describe('Posts API', function () {
             assert(!post.lexical.includes('__GHOST_URL__'));
         });
 
-        it('Can read Mobiledoc post with CDN URLs for media/files when configured', async function () {
+        it('Can read Mobiledoc post with CDN URLs when configured', async function () {
             urlUtilsHelper.stubUrlUtilsWithCdn({
-                assetBaseUrls: {media: cdnUrl, files: cdnUrl}
+                assetBaseUrls: {media: cdnUrl, files: cdnUrl, image: cdnUrl}
             }, sinon);
 
             const res = await agent
@@ -797,25 +797,30 @@ describe('Posts API', function () {
             const post = res.body.posts[0];
             const mobiledoc = JSON.parse(post.mobiledoc);
 
-            // Images stay on site URL
-            assert.equal(post.feature_image, `${siteUrl}/content/images/feature.jpg`);
-            assert.equal(mobiledoc.cards.find(c => c[0] === 'image')[1].src, `${siteUrl}/content/images/inline.jpg`);
-            // Media/files use CDN URL
+            // All assets use CDN URL
+            assert.equal(post.feature_image, `${cdnUrl}/content/images/feature.jpg`);
+            assert.equal(mobiledoc.cards.find(c => c[0] === 'image')[1].src, `${cdnUrl}/content/images/inline.jpg`);
             assert.equal(mobiledoc.cards.find(c => c[0] === 'file')[1].src, `${cdnUrl}/content/files/document.pdf`);
             assert.equal(mobiledoc.cards.find(c => c[0] === 'video')[1].src, `${cdnUrl}/content/media/video.mp4`);
             assert.equal(mobiledoc.cards.find(c => c[0] === 'audio')[1].src, `${cdnUrl}/content/media/audio.mp3`);
-            // Inserted snippet images stay on site URL
-            assert(post.mobiledoc.includes(`${siteUrl}/content/images/snippet-inline.jpg`));
-            // Inserted snippet media/files use CDN URL
+            // Video/audio thumbnails use CDN URL
+            assert.equal(mobiledoc.cards.find(c => c[0] === 'video')[1].thumbnailSrc, `${cdnUrl}/content/images/video-thumb.jpg`);
+            // Gallery images use CDN URL
+            const galleryCard = mobiledoc.cards.find(c => c[0] === 'gallery');
+            galleryCard[1].images.forEach((image) => {
+                assert(image.src.startsWith(cdnUrl));
+            });
+            // Inserted snippet images use CDN URL
+            assert(post.mobiledoc.includes(`${cdnUrl}/content/images/snippet-inline.jpg`));
             assert(post.mobiledoc.includes(`${cdnUrl}/content/files/snippet-document.pdf`));
             assert(post.mobiledoc.includes(`${cdnUrl}/content/media/snippet-video.mp4`));
             assert(post.mobiledoc.includes(`${cdnUrl}/content/media/snippet-audio.mp3`));
             assert(!post.mobiledoc.includes('__GHOST_URL__'));
         });
 
-        it('Can read Lexical post with CDN URLs for media/files when configured', async function () {
+        it('Can read Lexical post with CDN URLs when configured', async function () {
             urlUtilsHelper.stubUrlUtilsWithCdn({
-                assetBaseUrls: {media: cdnUrl, files: cdnUrl}
+                assetBaseUrls: {media: cdnUrl, files: cdnUrl, image: cdnUrl}
             }, sinon);
 
             const res = await agent
@@ -824,16 +829,20 @@ describe('Posts API', function () {
 
             const post = res.body.posts[0];
 
-            // Images stay on site URL
-            assert.equal(post.feature_image, `${siteUrl}/content/images/feature.jpg`);
-            assert(post.lexical.includes(`${siteUrl}/content/images/inline.jpg`));
-            // Media/files use CDN URL
+            // All assets use CDN URL
+            assert.equal(post.feature_image, `${cdnUrl}/content/images/feature.jpg`);
+            assert(post.lexical.includes(`${cdnUrl}/content/images/inline.jpg`));
             assert(post.lexical.includes(`${cdnUrl}/content/files/document.pdf`));
             assert(post.lexical.includes(`${cdnUrl}/content/media/video.mp4`));
             assert(post.lexical.includes(`${cdnUrl}/content/media/audio.mp3`));
-            // Inserted snippet images stay on site URL
-            assert(post.lexical.includes(`${siteUrl}/content/images/snippet-inline.jpg`));
-            // Inserted snippet media/files use CDN URL
+            // Video/audio thumbnails use CDN URL
+            assert(post.lexical.includes(`${cdnUrl}/content/images/video-thumb.jpg`));
+            assert(post.lexical.includes(`${cdnUrl}/content/images/audio-thumb.jpg`));
+            // Gallery images use CDN URL
+            assert(post.lexical.includes(`${cdnUrl}/content/images/gallery-1.jpg`));
+            assert(post.lexical.includes(`${cdnUrl}/content/images/gallery-2.jpg`));
+            // Inserted snippet images use CDN URL
+            assert(post.lexical.includes(`${cdnUrl}/content/images/snippet-inline.jpg`));
             assert(post.lexical.includes(`${cdnUrl}/content/files/snippet-document.pdf`));
             assert(post.lexical.includes(`${cdnUrl}/content/media/snippet-video.mp4`));
             assert(post.lexical.includes(`${cdnUrl}/content/media/snippet-audio.mp3`));

--- a/ghost/core/test/e2e-api/admin/snippets.test.js
+++ b/ghost/core/test/e2e-api/admin/snippets.test.js
@@ -290,9 +290,9 @@ describe('Snippets API', function () {
             assert(!snippet.lexical.includes('__GHOST_URL__'));
         });
 
-        it('Can read Mobiledoc snippet with CDN URLs for media/files when configured', async function () {
+        it('Can read Mobiledoc snippet with CDN URLs when configured', async function () {
             urlUtilsHelper.stubUrlUtilsWithCdn({
-                assetBaseUrls: {media: cdnUrl, files: cdnUrl}
+                assetBaseUrls: {media: cdnUrl, files: cdnUrl, image: cdnUrl}
             }, sinon);
 
             const res = await agent
@@ -302,18 +302,20 @@ describe('Snippets API', function () {
             const snippet = res.body.snippets[0];
             const mobiledoc = JSON.parse(snippet.mobiledoc);
 
-            // Images stay on site URL
-            assert.equal(mobiledoc.cards.find(c => c[0] === 'image')[1].src, `${siteUrl}/content/images/snippet-inline.jpg`);
-            // Media/files use CDN URL
+            // All assets use CDN URL
+            assert.equal(mobiledoc.cards.find(c => c[0] === 'image')[1].src, `${cdnUrl}/content/images/snippet-inline.jpg`);
             assert.equal(mobiledoc.cards.find(c => c[0] === 'file')[1].src, `${cdnUrl}/content/files/snippet-document.pdf`);
             assert.equal(mobiledoc.cards.find(c => c[0] === 'video')[1].src, `${cdnUrl}/content/media/snippet-video.mp4`);
             assert.equal(mobiledoc.cards.find(c => c[0] === 'audio')[1].src, `${cdnUrl}/content/media/snippet-audio.mp3`);
+            // Video/audio thumbnails use CDN URL
+            assert.equal(mobiledoc.cards.find(c => c[0] === 'video')[1].thumbnailSrc, `${cdnUrl}/content/images/snippet-video-thumb.jpg`);
+            assert.equal(mobiledoc.cards.find(c => c[0] === 'audio')[1].thumbnailSrc, `${cdnUrl}/content/images/snippet-audio-thumb.jpg`);
             assert(!snippet.mobiledoc.includes('__GHOST_URL__'));
         });
 
-        it('Can read Lexical snippet with CDN URLs for media/files when configured', async function () {
+        it('Can read Lexical snippet with CDN URLs when configured', async function () {
             urlUtilsHelper.stubUrlUtilsWithCdn({
-                assetBaseUrls: {media: cdnUrl, files: cdnUrl}
+                assetBaseUrls: {media: cdnUrl, files: cdnUrl, image: cdnUrl}
             }, sinon);
 
             const res = await agent
@@ -322,12 +324,14 @@ describe('Snippets API', function () {
 
             const snippet = res.body.snippets[0];
 
-            // Images stay on site URL
-            assert(snippet.lexical.includes(`${siteUrl}/content/images/snippet-inline.jpg`));
-            // Media/files use CDN URL
+            // All assets use CDN URL
+            assert(snippet.lexical.includes(`${cdnUrl}/content/images/snippet-inline.jpg`));
             assert(snippet.lexical.includes(`${cdnUrl}/content/files/snippet-document.pdf`));
             assert(snippet.lexical.includes(`${cdnUrl}/content/media/snippet-video.mp4`));
             assert(snippet.lexical.includes(`${cdnUrl}/content/media/snippet-audio.mp3`));
+            // Video/audio thumbnails use CDN URL
+            assert(snippet.lexical.includes(`${cdnUrl}/content/images/snippet-video-thumb.jpg`));
+            assert(snippet.lexical.includes(`${cdnUrl}/content/images/snippet-audio-thumb.jpg`));
             assert(!snippet.lexical.includes('__GHOST_URL__'));
         });
     });

--- a/ghost/core/test/e2e-api/admin/storage-adapter-switching.test.js
+++ b/ghost/core/test/e2e-api/admin/storage-adapter-switching.test.js
@@ -35,7 +35,7 @@ describe('Ghost Admin - Storage Adapter Switching', function () {
         assert(post.lexical.includes(`${siteUrl}/content/media/video.mp4`));
 
         urlUtilsHelper.stubUrlUtilsWithCdn({
-            assetBaseUrls: {media: cdnUrl, files: cdnUrl}
+            assetBaseUrls: {media: cdnUrl, files: cdnUrl, image: cdnUrl}
         }, sinon);
 
         res = await agent
@@ -43,7 +43,7 @@ describe('Ghost Admin - Storage Adapter Switching', function () {
             .expectStatus(200);
 
         post = res.body.posts[0];
-        assert.equal(post.feature_image, `${siteUrl}/content/images/feature.jpg`);
+        assert.equal(post.feature_image, `${cdnUrl}/content/images/feature.jpg`);
         assert(post.lexical.includes(`${cdnUrl}/content/files/document.pdf`));
         assert(post.lexical.includes(`${cdnUrl}/content/media/video.mp4`));
 
@@ -59,7 +59,7 @@ describe('Ghost Admin - Storage Adapter Switching', function () {
         assert(post.lexical.includes(`${siteUrl}/content/media/video.mp4`));
 
         urlUtilsHelper.stubUrlUtilsWithCdn({
-            assetBaseUrls: {media: newCdnUrl, files: newCdnUrl}
+            assetBaseUrls: {media: newCdnUrl, files: newCdnUrl, image: newCdnUrl}
         }, sinon);
 
         res = await agent
@@ -67,7 +67,7 @@ describe('Ghost Admin - Storage Adapter Switching', function () {
             .expectStatus(200);
 
         post = res.body.posts[0];
-        assert.equal(post.feature_image, `${siteUrl}/content/images/feature.jpg`);
+        assert.equal(post.feature_image, `${newCdnUrl}/content/images/feature.jpg`);
         assert(post.lexical.includes(`${newCdnUrl}/content/files/document.pdf`));
         assert(post.lexical.includes(`${newCdnUrl}/content/media/video.mp4`));
     });
@@ -82,7 +82,7 @@ describe('Ghost Admin - Storage Adapter Switching', function () {
         assert.equal(mobiledoc.cards.find(c => c[0] === 'file')[1].src, `${siteUrl}/content/files/document.pdf`);
 
         urlUtilsHelper.stubUrlUtilsWithCdn({
-            assetBaseUrls: {media: cdnUrl, files: cdnUrl}
+            assetBaseUrls: {media: cdnUrl, files: cdnUrl, image: cdnUrl}
         }, sinon);
 
         res = await agent
@@ -92,7 +92,7 @@ describe('Ghost Admin - Storage Adapter Switching', function () {
         post = res.body.posts[0];
         mobiledoc = JSON.parse(post.mobiledoc);
         assert.equal(mobiledoc.cards.find(c => c[0] === 'file')[1].src, `${cdnUrl}/content/files/document.pdf`);
-        assert.equal(post.feature_image, `${siteUrl}/content/images/feature.jpg`);
+        assert.equal(post.feature_image, `${cdnUrl}/content/images/feature.jpg`);
     });
 
     it('Snippets also switch URLs correctly', async function () {
@@ -109,7 +109,7 @@ describe('Ghost Admin - Storage Adapter Switching', function () {
         assert(snippetData.mobiledoc.includes(`${siteUrl}/content/images/snippet-inline.jpg`));
 
         urlUtilsHelper.stubUrlUtilsWithCdn({
-            assetBaseUrls: {media: cdnUrl, files: cdnUrl}
+            assetBaseUrls: {media: cdnUrl, files: cdnUrl, image: cdnUrl}
         }, sinon);
 
         res = await agent
@@ -119,7 +119,7 @@ describe('Ghost Admin - Storage Adapter Switching', function () {
         snippetData = res.body.snippets[0];
         assert(snippetData.mobiledoc.includes(`${cdnUrl}/content/files/snippet-document.pdf`));
         assert(snippetData.mobiledoc.includes(`${cdnUrl}/content/media/snippet-video.mp4`));
-        assert(snippetData.mobiledoc.includes(`${siteUrl}/content/images/snippet-inline.jpg`));
+        assert(snippetData.mobiledoc.includes(`${cdnUrl}/content/images/snippet-inline.jpg`));
     });
 });
 

--- a/ghost/core/test/e2e-api/admin/tags.test.js
+++ b/ghost/core/test/e2e-api/admin/tags.test.js
@@ -201,9 +201,10 @@ describe('Tag API', function () {
             assert.equal(tag.twitter_image, `${siteUrl}/content/images/tag-twitter.jpg`);
         });
 
-        it('Transforms image URLs to absolute site URLs even when CDN is configured', async function () {
+        it('Transforms image URLs to CDN URLs when image CDN is configured', async function () {
+            const cdnUrl = 'https://cdn.example.com';
             urlUtilsHelper.stubUrlUtilsWithCdn({
-                assetBaseUrls: {media: 'https://cdn.example.com', files: 'https://cdn.example.com'}
+                assetBaseUrls: {media: cdnUrl, image: cdnUrl}
             }, sinon);
 
             const res = await request
@@ -215,9 +216,9 @@ describe('Tag API', function () {
 
             const tag = res.body.tags[0];
 
-            assert.equal(tag.feature_image, `${siteUrl}/content/images/tag-feature.jpg`);
-            assert.equal(tag.og_image, `${siteUrl}/content/images/tag-og.jpg`);
-            assert.equal(tag.twitter_image, `${siteUrl}/content/images/tag-twitter.jpg`);
+            assert.equal(tag.feature_image, `${cdnUrl}/content/images/tag-feature.jpg`);
+            assert.equal(tag.og_image, `${cdnUrl}/content/images/tag-og.jpg`);
+            assert.equal(tag.twitter_image, `${cdnUrl}/content/images/tag-twitter.jpg`);
         });
     });
 });

--- a/ghost/core/test/e2e-api/content/posts.test.js
+++ b/ghost/core/test/e2e-api/content/posts.test.js
@@ -530,9 +530,9 @@ describe('Posts Content API', function () {
             assert(!post.html.includes('__GHOST_URL__'));
         });
 
-        it('Can read Mobiledoc post with CDN URLs for media/files when configured', async function () {
+        it('Can read Mobiledoc post with CDN URLs when configured', async function () {
             urlUtilsHelper.stubUrlUtilsWithCdn({
-                assetBaseUrls: {media: cdnUrl, files: cdnUrl}
+                assetBaseUrls: {image: cdnUrl, media: cdnUrl, files: cdnUrl}
             }, sinon);
 
             const res = await agent
@@ -541,25 +541,28 @@ describe('Posts Content API', function () {
 
             const post = res.body.posts[0];
 
-            // Images stay on site URL
-            assert.equal(post.feature_image, `${siteUrl}/content/images/feature.jpg`);
-            assert(post.html.includes(`${siteUrl}/content/images/inline.jpg`));
-            // Media/files use CDN URL
+            // All assets use CDN URL
+            assert.equal(post.feature_image, `${cdnUrl}/content/images/feature.jpg`);
+            assert(post.html.includes(`${cdnUrl}/content/images/inline.jpg`));
             assert(post.html.includes(`${cdnUrl}/content/files/document.pdf`));
             assert(post.html.includes(`${cdnUrl}/content/media/video.mp4`));
             assert(post.html.includes(`${cdnUrl}/content/media/audio.mp3`));
-            // Inserted snippet images stay on site URL
-            assert(post.html.includes(`${siteUrl}/content/images/snippet-inline.jpg`));
-            // Inserted snippet media/files use CDN URL
+            // Video/audio thumbnails use CDN URL
+            assert(post.html.includes(`${cdnUrl}/content/images/video-thumb.jpg`));
+            // Gallery images use CDN URL
+            assert(post.html.includes(`${cdnUrl}/content/images/gallery-1.jpg`));
+            assert(post.html.includes(`${cdnUrl}/content/images/gallery-2.jpg`));
+            // Inserted snippet use CDN URL
+            assert(post.html.includes(`${cdnUrl}/content/images/snippet-inline.jpg`));
             assert(post.html.includes(`${cdnUrl}/content/files/snippet-document.pdf`));
             assert(post.html.includes(`${cdnUrl}/content/media/snippet-video.mp4`));
             assert(post.html.includes(`${cdnUrl}/content/media/snippet-audio.mp3`));
             assert(!post.html.includes('__GHOST_URL__'));
         });
 
-        it('Can read Lexical post with CDN URLs for media/files when configured', async function () {
+        it('Can read Lexical post with CDN URLs when configured', async function () {
             urlUtilsHelper.stubUrlUtilsWithCdn({
-                assetBaseUrls: {media: cdnUrl, files: cdnUrl}
+                assetBaseUrls: {media: cdnUrl, files: cdnUrl, image: cdnUrl}
             }, sinon);
 
             const res = await agent
@@ -568,15 +571,21 @@ describe('Posts Content API', function () {
 
             const post = res.body.posts[0];
 
-            // Images stay on site URL
-            assert.equal(post.feature_image, `${siteUrl}/content/images/feature.jpg`);
-            assert(post.html.includes(`${siteUrl}/content/images/inline.jpg`));
+            // Images use CDN URL
+            assert.equal(post.feature_image, `${cdnUrl}/content/images/feature.jpg`);
+            assert(post.html.includes(`${cdnUrl}/content/images/inline.jpg`));
+            // Video/audio thumbnails use CDN URL
+            assert(post.html.includes(`${cdnUrl}/content/images/video-thumb.jpg`));
+            assert(post.html.includes(`${cdnUrl}/content/images/audio-thumb.jpg`));
+            // Gallery images use CDN URL
+            assert(post.html.includes(`${cdnUrl}/content/images/gallery-1.jpg`));
+            assert(post.html.includes(`${cdnUrl}/content/images/gallery-2.jpg`));
             // Media/files use CDN URL
             assert(post.html.includes(`${cdnUrl}/content/files/document.pdf`));
             assert(post.html.includes(`${cdnUrl}/content/media/video.mp4`));
             assert(post.html.includes(`${cdnUrl}/content/media/audio.mp3`));
-            // Inserted snippet images stay on site URL
-            assert(post.html.includes(`${siteUrl}/content/images/snippet-inline.jpg`));
+            // Inserted snippet images use CDN URL
+            assert(post.html.includes(`${cdnUrl}/content/images/snippet-inline.jpg`));
             // Inserted snippet media/files use CDN URL
             assert(post.html.includes(`${cdnUrl}/content/files/snippet-document.pdf`));
             assert(post.html.includes(`${cdnUrl}/content/media/snippet-video.mp4`));

--- a/ghost/core/test/e2e-frontend/rendered-content.test.js
+++ b/ghost/core/test/e2e-frontend/rendered-content.test.js
@@ -79,13 +79,18 @@ describe('Post Rendering', function () {
                     assert(res.text.includes(`${cdnUrl}/content/media/audio.mp3`));
                     // Video/audio thumbnails use CDN URL
                     assert(res.text.includes(`${cdnUrl}/content/images/video-thumb.jpg`));
+                    assert(res.text.includes(`${cdnUrl}/content/images/audio-thumb.jpg`));
                     // Gallery images use CDN URL
                     assert(res.text.includes(`${cdnUrl}/content/images/gallery-1.jpg`));
+                    assert(res.text.includes(`${cdnUrl}/content/images/gallery-2.jpg`));
+                    assert(res.text.includes(`${cdnUrl}/content/images/gallery-3.jpg`));
                     // Snippet images use CDN URL
                     assert(res.text.includes(`${cdnUrl}/content/images/snippet-inline.jpg`));
                     assert(res.text.includes(`${cdnUrl}/content/files/snippet-document.pdf`));
                     assert(res.text.includes(`${cdnUrl}/content/media/snippet-video.mp4`));
                     assert(res.text.includes(`${cdnUrl}/content/media/snippet-audio.mp3`));
+                    assert(res.text.includes(`${cdnUrl}/content/images/snippet-video-thumb.jpg`));
+                    assert(res.text.includes(`${cdnUrl}/content/images/snippet-audio-thumb.jpg`));
                     assert(!res.text.includes('__GHOST_URL__'));
                 });
         });

--- a/ghost/core/test/e2e-frontend/rendered-content.test.js
+++ b/ghost/core/test/e2e-frontend/rendered-content.test.js
@@ -61,48 +61,62 @@ describe('Post Rendering', function () {
                 });
         });
 
-        it('Mobiledoc post renders with CDN URLs for media/files when configured', async function () {
+        it('Mobiledoc post renders with CDN URLs when image CDN is configured', async function () {
             const cdnUrl = 'https://cdn.example.com/c/site-uuid';
             urlUtilsHelper.stubUrlUtilsWithCdn({
-                assetBaseUrls: {media: cdnUrl, files: cdnUrl}
+                assetBaseUrls: {media: cdnUrl, image: cdnUrl, files: cdnUrl}
             }, sinon);
 
             await request.get('/post-with-all-media-types-mobiledoc/')
                 .expect('Content-Type', /html/)
                 .expect(200)
                 .expect((res) => {
+                    // All assets use CDN URL
+                    assert(res.text.includes(`${cdnUrl}/content/images/feature.jpg`));
+                    assert(res.text.includes(`${cdnUrl}/content/images/inline.jpg`));
                     assert(res.text.includes(`${cdnUrl}/content/files/document.pdf`));
                     assert(res.text.includes(`${cdnUrl}/content/media/video.mp4`));
                     assert(res.text.includes(`${cdnUrl}/content/media/audio.mp3`));
+                    // Video/audio thumbnails use CDN URL
+                    assert(res.text.includes(`${cdnUrl}/content/images/video-thumb.jpg`));
+                    // Gallery images use CDN URL
+                    assert(res.text.includes(`${cdnUrl}/content/images/gallery-1.jpg`));
+                    // Snippet images use CDN URL
+                    assert(res.text.includes(`${cdnUrl}/content/images/snippet-inline.jpg`));
                     assert(res.text.includes(`${cdnUrl}/content/files/snippet-document.pdf`));
                     assert(res.text.includes(`${cdnUrl}/content/media/snippet-video.mp4`));
                     assert(res.text.includes(`${cdnUrl}/content/media/snippet-audio.mp3`));
-                    assert(res.text.includes(`${siteUrl}/content/images/feature.jpg`));
-                    assert(res.text.includes(`${siteUrl}/content/images/inline.jpg`));
-                    assert(res.text.includes(`${siteUrl}/content/images/snippet-inline.jpg`));
                     assert(!res.text.includes('__GHOST_URL__'));
                 });
         });
 
-        it('Lexical post renders with CDN URLs for media/files when configured', async function () {
+        it('Lexical post renders with CDN URLs when configured', async function () {
             const cdnUrl = 'https://cdn.example.com/c/site-uuid';
             urlUtilsHelper.stubUrlUtilsWithCdn({
-                assetBaseUrls: {media: cdnUrl, files: cdnUrl}
+                assetBaseUrls: {media: cdnUrl, files: cdnUrl, image: cdnUrl}
             }, sinon);
 
             await request.get('/post-with-all-media-types-lexical/')
                 .expect('Content-Type', /html/)
                 .expect(200)
                 .expect((res) => {
+                    // All assets use CDN URL
+                    assert(res.text.includes(`${cdnUrl}/content/images/feature.jpg`));
+                    assert(res.text.includes(`${cdnUrl}/content/images/inline.jpg`));
                     assert(res.text.includes(`${cdnUrl}/content/files/document.pdf`));
                     assert(res.text.includes(`${cdnUrl}/content/media/video.mp4`));
                     assert(res.text.includes(`${cdnUrl}/content/media/audio.mp3`));
+                    // Video/audio thumbnails use CDN URL
+                    assert(res.text.includes(`${cdnUrl}/content/images/video-thumb.jpg`));
+                    assert(res.text.includes(`${cdnUrl}/content/images/audio-thumb.jpg`));
+                    // Gallery images use CDN URL
+                    assert(res.text.includes(`${cdnUrl}/content/images/gallery-1.jpg`));
+                    assert(res.text.includes(`${cdnUrl}/content/images/gallery-2.jpg`));
+                    // Snippet images use CDN URL
+                    assert(res.text.includes(`${cdnUrl}/content/images/snippet-inline.jpg`));
                     assert(res.text.includes(`${cdnUrl}/content/files/snippet-document.pdf`));
                     assert(res.text.includes(`${cdnUrl}/content/media/snippet-video.mp4`));
                     assert(res.text.includes(`${cdnUrl}/content/media/snippet-audio.mp3`));
-                    assert(res.text.includes(`${siteUrl}/content/images/feature.jpg`));
-                    assert(res.text.includes(`${siteUrl}/content/images/inline.jpg`));
-                    assert(res.text.includes(`${siteUrl}/content/images/snippet-inline.jpg`));
                     assert(!res.text.includes('__GHOST_URL__'));
                 });
         });
@@ -127,25 +141,27 @@ describe('Post Rendering', function () {
                 });
         });
 
-        it('RSS feed renders with CDN URLs for media/files when configured', async function () {
+        it('RSS feed renders with CDN URLs when configured', async function () {
             const cdnUrl = 'https://cdn.example.com/c/site-uuid';
             urlUtilsHelper.stubUrlUtilsWithCdn({
-                assetBaseUrls: {media: cdnUrl, files: cdnUrl}
+                assetBaseUrls: {media: cdnUrl, files: cdnUrl, image: cdnUrl}
             }, sinon);
 
             await request.get('/rss/')
                 .expect(200)
                 .expect('Content-Type', 'application/rss+xml; charset=utf-8')
                 .expect((res) => {
+                    // All assets use CDN URL
+                    assert(res.text.includes(`${cdnUrl}/content/images/feature.jpg`));
+                    assert(res.text.includes(`${cdnUrl}/content/images/inline.jpg`));
                     assert(res.text.includes(`${cdnUrl}/content/files/document.pdf`));
                     assert(res.text.includes(`${cdnUrl}/content/media/video.mp4`));
                     assert(res.text.includes(`${cdnUrl}/content/media/audio.mp3`));
+                    // Snippet images use CDN URL
+                    assert(res.text.includes(`${cdnUrl}/content/images/snippet-inline.jpg`));
                     assert(res.text.includes(`${cdnUrl}/content/files/snippet-document.pdf`));
                     assert(res.text.includes(`${cdnUrl}/content/media/snippet-video.mp4`));
                     assert(res.text.includes(`${cdnUrl}/content/media/snippet-audio.mp3`));
-                    assert(res.text.includes(`${siteUrl}/content/images/feature.jpg`));
-                    assert(res.text.includes(`${siteUrl}/content/images/inline.jpg`));
-                    assert(res.text.includes(`${siteUrl}/content/images/snippet-inline.jpg`));
                     assert(!res.text.includes('__GHOST_URL__'));
                 });
         });

--- a/ghost/core/test/legacy/models/model-newsletters.test.js
+++ b/ghost/core/test/legacy/models/model-newsletters.test.js
@@ -41,15 +41,16 @@ describe('Newsletter Model', function () {
             urlUtilsHelper.stubUrlUtilsWithCdn({
                 assetBaseUrls: {
                     media: cdnUrl,
-                    files: cdnUrl
+                    files: cdnUrl,
+                    image: cdnUrl
                 }
             }, sinon);
         });
 
-        it('transforms header_image to absolute site URL(NOT CDN)', async function () {
+        it('transforms header_image to CDN URL', async function () {
             const newsletter = await models.Newsletter.findOne({slug: 'new-newsletter'});
             assertExists(newsletter, 'New newsletter should exist');
-            assert.equal(newsletter.get('header_image'), `${siteUrl}/content/images/newsletter-header.jpg`);
+            assert.equal(newsletter.get('header_image'), `${cdnUrl}/content/images/newsletter-header.jpg`);
         });
     });
 });

--- a/ghost/core/test/legacy/models/model-posts.test.js
+++ b/ghost/core/test/legacy/models/model-posts.test.js
@@ -1318,14 +1318,14 @@ describe('Post Model', function () {
             });
 
             describe('URL transformations with CDN config', function () {
-                const siteUrl = 'http://127.0.0.1:2369';
                 const cdnUrl = 'https://cdn.example.com/c/site-uuid';
 
                 beforeEach(function () {
                     urlUtilsHelper.stubUrlUtilsWithCdn({
                         assetBaseUrls: {
                             media: cdnUrl,
-                            files: cdnUrl
+                            files: cdnUrl,
+                            image: cdnUrl
                         }
                     }, sinon);
                 });
@@ -1360,33 +1360,33 @@ describe('Post Model', function () {
                         assert(mobiledocString.includes(`${cdnUrl}/content/media/snippet-audio.mp3`));
                     });
 
-                    it('transforms feature_image to absolute site URL(NOT CDN)', async function () {
+                    it('transforms feature_image to CDN URL', async function () {
                         const post = await models.Post.findOne({slug: 'post-with-all-media-types-mobiledoc'}, {withRelated: ['tags']});
-                        assert.equal(post.get('feature_image'), `${siteUrl}/content/images/feature.jpg`);
+                        assert.equal(post.get('feature_image'), `${cdnUrl}/content/images/feature.jpg`);
                     });
 
-                    it('transforms gallery images to absolute site URL(NOT CDN)', async function () {
+                    it('transforms gallery images to CDN URL', async function () {
                         const post = await models.Post.findOne({slug: 'post-with-all-media-types-mobiledoc'}, {withRelated: ['tags']});
                         const mobiledoc = JSON.parse(post.get('mobiledoc'));
                         const galleryCard = mobiledoc.cards.find(card => card[0] === 'gallery');
                         galleryCard[1].images.forEach((image) => {
-                            image.src.should.startWith(siteUrl);
+                            assert(image.src.startsWith(cdnUrl));
                             assert(image.src.includes('/content/images/'));
                         });
                     });
 
-                    it('transforms inline images to absolute site URL(NOT CDN)', async function () {
+                    it('transforms inline images to CDN URL', async function () {
                         const post = await models.Post.findOne({slug: 'post-with-all-media-types-mobiledoc'}, {withRelated: ['tags']});
                         const mobiledoc = JSON.parse(post.get('mobiledoc'));
                         const imageCard = mobiledoc.cards.find(card => card[0] === 'image');
-                        assert.equal(imageCard[1].src, `${siteUrl}/content/images/inline.jpg`);
+                        assert.equal(imageCard[1].src, `${cdnUrl}/content/images/inline.jpg`);
                     });
 
-                    it('transforms video thumbnailSrc to absolute site URL(NOT CDN)', async function () {
+                    it('transforms video thumbnailSrc to CDN URL', async function () {
                         const post = await models.Post.findOne({slug: 'post-with-all-media-types-mobiledoc'}, {withRelated: ['tags']});
                         const mobiledoc = JSON.parse(post.get('mobiledoc'));
                         const videoCard = mobiledoc.cards.find(card => card[0] === 'video');
-                        assert.equal(videoCard[1].thumbnailSrc, `${siteUrl}/content/images/video-thumb.jpg`);
+                        assert.equal(videoCard[1].thumbnailSrc, `${cdnUrl}/content/images/video-thumb.jpg`);
                     });
                 });
 
@@ -1412,29 +1412,29 @@ describe('Post Model', function () {
                         assert(lexicalString.includes(`${cdnUrl}/content/media/snippet-audio.mp3`));
                     });
 
-                    it('transforms feature_image to absolute site URL(NOT CDN)', async function () {
+                    it('transforms feature_image to CDN URL', async function () {
                         const post = await models.Post.findOne({slug: 'post-with-all-media-types-lexical'}, {withRelated: ['tags']});
-                        assert.equal(post.get('feature_image'), `${siteUrl}/content/images/feature.jpg`);
+                        assert.equal(post.get('feature_image'), `${cdnUrl}/content/images/feature.jpg`);
                     });
 
-                    it('transforms gallery images to absolute site URL(NOT CDN)', async function () {
+                    it('transforms gallery images to CDN URL', async function () {
                         const post = await models.Post.findOne({slug: 'post-with-all-media-types-lexical'}, {withRelated: ['tags']});
                         const lexicalString = post.get('lexical');
-                        assert(lexicalString.includes(`${siteUrl}/content/images/gallery-1.jpg`));
-                        assert(lexicalString.includes(`${siteUrl}/content/images/gallery-2.jpg`));
+                        assert(lexicalString.includes(`${cdnUrl}/content/images/gallery-1.jpg`));
+                        assert(lexicalString.includes(`${cdnUrl}/content/images/gallery-2.jpg`));
                     });
 
-                    it('transforms inline images to absolute site URL(NOT CDN)', async function () {
+                    it('transforms inline images to CDN URL', async function () {
                         const post = await models.Post.findOne({slug: 'post-with-all-media-types-lexical'}, {withRelated: ['tags']});
                         const lexicalString = post.get('lexical');
-                        assert(lexicalString.includes(`${siteUrl}/content/images/inline.jpg`));
+                        assert(lexicalString.includes(`${cdnUrl}/content/images/inline.jpg`));
                     });
 
-                    it('transforms video/audio thumbnails to absolute site URL(NOT CDN)', async function () {
+                    it('transforms video/audio thumbnails to CDN URL', async function () {
                         const post = await models.Post.findOne({slug: 'post-with-all-media-types-lexical'}, {withRelated: ['tags']});
                         const lexicalString = post.get('lexical');
-                        assert(lexicalString.includes(`${siteUrl}/content/images/video-thumb.jpg`));
-                        assert(lexicalString.includes(`${siteUrl}/content/images/audio-thumb.jpg`));
+                        assert(lexicalString.includes(`${cdnUrl}/content/images/video-thumb.jpg`));
+                        assert(lexicalString.includes(`${cdnUrl}/content/images/audio-thumb.jpg`));
                     });
                 });
             });

--- a/ghost/core/test/legacy/models/model-snippets.test.js
+++ b/ghost/core/test/legacy/models/model-snippets.test.js
@@ -102,7 +102,8 @@ describe('Snippet Model', function () {
             urlUtilsHelper.stubUrlUtilsWithCdn({
                 assetBaseUrls: {
                     media: cdnUrl,
-                    files: cdnUrl
+                    files: cdnUrl,
+                    image: cdnUrl
                 }
             }, sinon);
         });
@@ -135,22 +136,22 @@ describe('Snippet Model', function () {
                 assert.equal(audioCard[1].src, `${cdnUrl}/content/media/snippet-audio.mp3`);
             });
 
-            it('transforms image card src to absolute site URL(NOT CDN)', async function () {
+            it('transforms image card src to CDN URL', async function () {
                 const snippets = await models.Snippet.findAll();
                 const snippet = snippets.models.find(s => s.get('name') === 'Snippet with all media types - Mobiledoc');
                 const mobiledoc = JSON.parse(snippet.get('mobiledoc'));
 
                 const imageCard = mobiledoc.cards.find(card => card[0] === 'image');
-                assert.equal(imageCard[1].src, `${siteUrl}/content/images/snippet-inline.jpg`);
+                assert.equal(imageCard[1].src, `${cdnUrl}/content/images/snippet-inline.jpg`);
             });
 
-            it('transforms video thumbnailSrc to absolute site URL(NOT CDN)', async function () {
+            it('transforms video thumbnailSrc to CDN URL', async function () {
                 const snippets = await models.Snippet.findAll();
                 const snippet = snippets.models.find(s => s.get('name') === 'Snippet with all media types - Mobiledoc');
                 const mobiledoc = JSON.parse(snippet.get('mobiledoc'));
 
                 const videoCard = mobiledoc.cards.find(card => card[0] === 'video');
-                assert.equal(videoCard[1].thumbnailSrc, `${siteUrl}/content/images/snippet-video-thumb.jpg`);
+                assert.equal(videoCard[1].thumbnailSrc, `${cdnUrl}/content/images/snippet-video-thumb.jpg`);
             });
         });
 
@@ -172,14 +173,14 @@ describe('Snippet Model', function () {
                 assert(lexicalString.includes(`${cdnUrl}/content/media/snippet-audio.mp3`));
             });
 
-            it('transforms image URLs to absolute site URL(NOT CDN)', async function () {
+            it('transforms image URLs to CDN URL', async function () {
                 const snippets = await models.Snippet.findAll();
                 const snippet = snippets.models.find(s => s.get('name') === 'Snippet with all media types - Lexical');
                 const lexicalString = snippet.get('lexical');
 
-                assert(lexicalString.includes(`${siteUrl}/content/images/snippet-inline.jpg`));
-                assert(lexicalString.includes(`${siteUrl}/content/images/snippet-video-thumb.jpg`));
-                assert(lexicalString.includes(`${siteUrl}/content/images/snippet-audio-thumb.jpg`));
+                assert(lexicalString.includes(`${cdnUrl}/content/images/snippet-inline.jpg`));
+                assert(lexicalString.includes(`${cdnUrl}/content/images/snippet-video-thumb.jpg`));
+                assert(lexicalString.includes(`${cdnUrl}/content/images/snippet-audio-thumb.jpg`));
             });
         });
     });

--- a/ghost/core/test/legacy/models/model-tags.test.js
+++ b/ghost/core/test/legacy/models/model-tags.test.js
@@ -43,17 +43,18 @@ describe('Tag Model', function () {
             urlUtilsHelper.stubUrlUtilsWithCdn({
                 assetBaseUrls: {
                     media: cdnUrl,
-                    files: cdnUrl
+                    files: cdnUrl,
+                    image: cdnUrl
                 }
             }, sinon);
         });
 
-        it('transforms feature_image, og_image, and twitter_image to absolute site URLs(NOT CDN)', async function () {
+        it('transforms feature_image, og_image, and twitter_image to CDN URLs', async function () {
             const tag = await models.Tag.findOne({slug: 'tag-with-images'});
             assertExists(tag, 'Tag with images should exist');
-            assert.equal(tag.get('feature_image'), `${siteUrl}/content/images/tag-feature.jpg`);
-            assert.equal(tag.get('og_image'), `${siteUrl}/content/images/tag-og.jpg`);
-            assert.equal(tag.get('twitter_image'), `${siteUrl}/content/images/tag-twitter.jpg`);
+            assert.equal(tag.get('feature_image'), `${cdnUrl}/content/images/tag-feature.jpg`);
+            assert.equal(tag.get('og_image'), `${cdnUrl}/content/images/tag-og.jpg`);
+            assert.equal(tag.get('twitter_image'), `${cdnUrl}/content/images/tag-twitter.jpg`);
         });
     });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/HKG-1579/

- Added `images` to assetBaseUrls in url-utils constructor. This adds support for CDN urls for images
- This adds support for replacing `__GHOST_URL__` in images with CDN urls and back
again when reading and writing to the DB. Which allows us to migrate to
using a CDN for serving image assets on a separate domain, but
being able to rollback if we run into any issues. The config required for this looks like:

```
{
  "urls": {
    "image": "https://storage.ghost.is/c/12/34/1234567890"
  }
}
```
- Updated existing tests for testing CDN urls for images
  - Updated model URL transformation tests for images
  - Updated API URL transformation tests for images
  - Updated rendering output tests for URL transformations for images
  - Updated storage adapter switching tests for images


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes global URL transformation behavior for images across API responses and rendered output; misconfiguration or edge cases could result in incorrect/partially rewritten asset URLs.
> 
> **Overview**
> Adds a new `assetBaseUrls.image` option to `core/shared/url-utils` (sourced from `urls:image`) so image URLs can be rewritten to a dedicated CDN base, matching existing CDN behavior for `media` and `files`.
> 
> Updates a broad set of API, model, rendering, and storage-adapter-switching tests to expect **all image-related URLs** (feature/inline/gallery images and video/audio thumbnails, including snippet-inserted images and newsletter/tag images) to use the configured CDN URL when present, instead of staying on the site URL.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f798a627fd54f84fab6eedbaf6cb4b787b86f86d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->