### PR TITLE
Fixed an issue with opacity in the reports modal

### DIFF
--- a/apps/posts/src/views/comments/components/comment-reports-modal.tsx
+++ b/apps/posts/src/views/comments/components/comment-reports-modal.tsx
@@ -33,7 +33,7 @@ function CommentReportsModal({comment, open, onOpenChange}: CommentReportsModalP
                 </DialogHeader>
 
                 {/* Comment context */}
-                <div className="overflow-hidden rounded-md border p-3 opacity-60">
+                <div className="overflow-hidden rounded-md border p-3">
                     <div className="flex min-w-0 items-start gap-3">
                         <CommentAvatar
                             avatarImage={comment.member?.avatar_image}


### PR DESCRIPTION
No ref

Style change to remove an opacity adjustment on the comment in the reports modal for comments.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced visibility of comment interface elements by adjusting opacity rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->