### PR TITLE
Tweaked styles on the comments page

### DIFF
--- a/apps/posts/src/views/comments/components/comment-content.tsx
+++ b/apps/posts/src/views/comments/components/comment-content.tsx
@@ -47,7 +47,7 @@ function CommentContent({item}: {item: Comment}) {
                     dangerouslySetInnerHTML={{__html: item.html || ''}}
                     ref={contentRef}
                     className={cn(
-                        'prose flex-1 text-base leading-[1.5em] [&_*]:leading-[1.5em] [&_*]:text-base [&_*]:font-normal [&_blockquote]:border-l-[3px] [&_blockquote]:border-foreground [&_blockquote]:p-0 [&_blockquote]:pl-3 [&_blockquote_p]:mt-0 [&_a]:underline',
+                        'prose flex-1 text-base max-w-[80ch] balance leading-[1.5em] [&_*]:leading-[1.5em] [&_*]:text-base [&_*]:font-normal [&_blockquote]:border-l-[3px] [&_blockquote]:border-foreground [&_blockquote]:p-0 [&_blockquote]:pl-3 [&_blockquote_p]:mt-0 [&_a]:underline',
                         (isExpanded ?
                             '-mb-1 [&_p]:mb-[0.85em]'
                             :

--- a/apps/posts/src/views/comments/components/comment-likes-modal.tsx
+++ b/apps/posts/src/views/comments/components/comment-likes-modal.tsx
@@ -34,7 +34,7 @@ function CommentLikesModal({comment, open, onOpenChange}: CommentLikesModalProps
                 </DialogHeader>
 
                 {/* Comment context */}
-                <div className="overflow-hidden rounded-md border p-3 opacity-60">
+                <div className="overflow-hidden rounded-md border p-3">
                     <div className="flex min-w-0 items-start gap-3">
                         <CommentAvatar
                             avatarImage={comment.member?.avatar_image}

--- a/apps/posts/src/views/comments/components/comments-list.tsx
+++ b/apps/posts/src/views/comments/components/comments-list.tsx
@@ -173,7 +173,7 @@ function CommentsList({
                                         />
 
                                         {item.in_reply_to_snippet && (
-                                            <div className={`mb-1 line-clamp-1 text-sm ${item.status === 'hidden' && 'opacity-50'}`}>
+                                            <div className={`mb-1 line-clamp-1 max-w-3xl text-sm ${item.status === 'hidden' && 'opacity-50'}`}>
                                                 <span className="text-muted-foreground">Replied to:</span>&nbsp;
                                                 <Link
                                                     className="text-sm font-normal text-muted-foreground hover:text-foreground"


### PR DESCRIPTION
No ref.

- Removed the opacity from the comment in the likes modal.
- Added a max character width to comment content and balanced it across lines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined comment content layout with a tighter max-width and improved text balance for easier reading.
  * Applied a width constraint to "Replied to" lines to reduce overly long lines and improve consistency.
  * Increased the visual prominence of the comment likes modal so context is clearer when viewing likes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->