### PR TITLE
Fixed comment filter labels for author/post IDs

### DIFF
--- a/apps/admin-x-framework/src/api/members.ts
+++ b/apps/admin-x-framework/src/api/members.ts
@@ -1,4 +1,4 @@
-import {Meta, createMutation, createQuery} from '../utils/api/hooks';
+import {Meta, createMutation, createQuery, createQueryWithId} from '../utils/api/hooks';
 
 export type Member = {
     id: string;
@@ -23,6 +23,11 @@ const dataType = 'MembersResponseType';
 export const useBrowseMembers = createQuery<MembersResponseType>({
     dataType,
     path: '/members/'
+});
+
+export const getMember = createQueryWithId<MembersResponseType>({
+    dataType,
+    path: id => `/members/${id}/`
 });
 
 export const useDisableMemberCommenting = createMutation<

--- a/apps/posts/src/views/comments/components/comments-filters.tsx
+++ b/apps/posts/src/views/comments/components/comments-filters.tsx
@@ -6,6 +6,8 @@ import {
     LucideIcon,
     cn
 } from '@tryghost/shade';
+import {getMember} from '@tryghost/admin-x-framework/api/members';
+import {getPost} from '@tryghost/admin-x-framework/api/posts';
 import {useFilterOptions} from '../hooks/use-filter-options';
 import {useSearchMembers} from '../hooks/use-search-members';
 import {useSearchPosts} from '../hooks/use-search-posts';
@@ -26,6 +28,7 @@ const CommentsFilters: React.FC<CommentsFiltersProps> = ({
     const posts = useFilterOptions({
         knownItems: knownPosts,
         useSearch: useSearchPosts,
+        useGetById: getPost,
         searchFieldName: 'posts',
         filters,
         filterFieldName: 'post',
@@ -38,6 +41,7 @@ const CommentsFilters: React.FC<CommentsFiltersProps> = ({
     const members = useFilterOptions({
         knownItems: knownMembers,
         useSearch: useSearchMembers,
+        useGetById: getMember,
         searchFieldName: 'members',
         filters,
         filterFieldName: 'author',

--- a/apps/posts/test/unit/hooks/use-filter-options.test.tsx
+++ b/apps/posts/test/unit/hooks/use-filter-options.test.tsx
@@ -1,0 +1,94 @@
+import {describe, expect, it} from 'vitest';
+import {renderHook} from '@testing-library/react';
+import {useFilterOptions} from '@src/views/comments/hooks/use-filter-options';
+import type {Filter} from '@tryghost/shade';
+
+type MemberItem = {id: string; name?: string; email?: string};
+type MemberOption = {value: string; label: string; detail?: string};
+
+describe('useFilterOptions', () => {
+    const buildFilters = (value: string): Filter[] => ([
+        {id: 'author', field: 'author', operator: 'is', values: [value]}
+    ]);
+
+    it('uses by-id data when active filter is missing from known/search results', () => {
+        const knownItems: MemberItem[] = [];
+        const filters = buildFilters('member-123');
+        const searchResults: MemberItem[] = [];
+        const byIdResults: MemberItem[] = [
+            {id: 'member-123', name: 'Jane Doe', email: 'jane@example.com'}
+        ];
+        let lastEnabled: boolean | undefined;
+
+        const useSearch = () => ({
+            data: {members: searchResults},
+            isLoading: false
+        });
+
+        const useGetById = (_id: string, options?: {enabled?: boolean}) => {
+            lastEnabled = options?.enabled;
+            return {
+                data: options?.enabled ? {members: byIdResults} : undefined,
+                isLoading: false
+            };
+        };
+
+        const {result} = renderHook(() => useFilterOptions<MemberItem, MemberOption, 'members'>({
+            knownItems,
+            useSearch,
+            useGetById,
+            searchFieldName: 'members',
+            filters,
+            filterFieldName: 'author',
+            toOption: member => ({
+                value: member.id,
+                label: member.name || 'Unknown name',
+                detail: member.email ?? '(Unknown email)'
+            })
+        }));
+
+        expect(lastEnabled).toBe(true);
+        expect(result.current.options).toContainEqual({
+            value: 'member-123',
+            label: 'Jane Doe',
+            detail: 'jane@example.com'
+        });
+        expect(result.current.options.some(option => option.label === 'ID: member-123')).toBe(false);
+    });
+
+    it('falls back to ID when by-id fetch returns no results', () => {
+        const knownItems: MemberItem[] = [];
+        const filters = buildFilters('member-456');
+        const searchResults: MemberItem[] = [];
+        const byIdResults: MemberItem[] = [];
+
+        const useSearch = () => ({
+            data: {members: searchResults},
+            isLoading: false
+        });
+
+        const useGetById = (_id: string, options?: {enabled?: boolean}) => ({
+            data: options?.enabled ? {members: byIdResults} : undefined,
+            isLoading: false
+        });
+
+        const {result} = renderHook(() => useFilterOptions<MemberItem, MemberOption, 'members'>({
+            knownItems,
+            useSearch,
+            useGetById,
+            searchFieldName: 'members',
+            filters,
+            filterFieldName: 'author',
+            toOption: member => ({
+                value: member.id,
+                label: member.name || 'Unknown name',
+                detail: member.email ?? '(Unknown email)'
+            })
+        }));
+
+        expect(result.current.options).toContainEqual({
+            value: 'member-456',
+            label: 'ID: member-456'
+        });
+    });
+});


### PR DESCRIPTION
fixes https://linear.app/ghost/issue/BER-3265/filter-author-rewrite-bug

We used to populate the filter based on a combination of the visible authors in the table and the auto complete search result. This PR adds a fallback that fetches the author if we have a value that is "unknown". 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added API method to retrieve members by ID
  * Enhanced comment filtering to fetch posts and members by ID with automatic fallback support for unavailable items

<!-- end of auto-generated comment: release notes by coderabbit.ai -->