### PR TITLE
Disabled Playwright `maxFailures: 1` when running in UI mode

### DIFF
--- a/e2e/playwright.config.mjs
+++ b/e2e/playwright.config.mjs
@@ -22,7 +22,7 @@ const config = {
         timeout: process.env.CI ? 30 * 1000 : 10 * 1000
     },
     retries: 0, // Retries open the door to flaky tests. If the test needs retries, it's not a good test or the app is broken.
-    maxFailures: 1,
+    maxFailures: process.argv.includes('--ui') ? 0 : 1,
     workers: parseInt(process.env.TEST_WORKERS_COUNT, 10) || getWorkerCount(),
     fullyParallel: true,
     reporter: process.env.CI ? [['list', {printSteps: true}], ['blob']] : [['list', {printSteps: true}], ['html']],


### PR DESCRIPTION
no issue

- when running the e2e tests in UI mode you usually want all tests to run and then you can dig into individual failures with the UI still open, having the tests abort on the first failure is annoying
- changed `maxFailures` to use a conditional that checks for `--ui` argument, disabling early-exit when present
