### PR TITLE
Improved comment thread E2E test locators

### DIFF
--- a/apps/posts/src/views/comments/components/comment-thread-list.tsx
+++ b/apps/posts/src/views/comments/components/comment-thread-list.tsx
@@ -53,8 +53,7 @@ function CommentRow({comment, isReply = false, isSelectedComment = false, select
             <div className="grow">
                 <div
                     className="w-full"
-                    data-comment-id={comment.id}
-                    data-testid="comment-thread-row"
+                    data-testid={`comment-thread-row-${comment.id}`}
                 >
                     <div className='flex min-w-0 flex-col'>
                         <CommentHeader
@@ -70,6 +69,7 @@ function CommentRow({comment, isReply = false, isSelectedComment = false, select
                                 <span className="text-muted-foreground">Replied to:</span>&nbsp;
                                 <Link
                                     className="text-sm font-normal text-muted-foreground hover:text-foreground"
+                                    data-testid="replied-to-link"
                                     to={buildThreadLink(searchParams, comment.in_reply_to_id || comment.parent_id) || ''}
                                     onClick={(e: React.MouseEvent) => {
                                         e.stopPropagation();

--- a/apps/posts/src/views/comments/components/comments-list.tsx
+++ b/apps/posts/src/views/comments/components/comments-list.tsx
@@ -160,6 +160,7 @@ function CommentsList({
                                                 <span className="text-muted-foreground">Replied to:</span>&nbsp;
                                                 <Link
                                                     className="text-sm font-normal text-muted-foreground hover:text-foreground"
+                                                    data-testid="replied-to-link"
                                                     to={buildThreadLink(searchParams, item.in_reply_to_id || item.parent_id) || ''}
                                                     onClick={(e) => {
                                                         e.stopPropagation();

--- a/e2e/helpers/pages/admin/comments/comments-page.ts
+++ b/e2e/helpers/pages/admin/comments/comments-page.ts
@@ -39,7 +39,7 @@ export class CommentsPage extends AdminPage {
 
         this.threadSidebar = page.getByRole('dialog', {name: 'Thread'});
         this.threadSidebarTitle = this.threadSidebar.getByRole('heading', {name: 'Thread'});
-        this.threadCommentRows = page.getByTestId('comment-thread-row');
+        this.threadCommentRows = page.getByTestId(/^comment-thread-row-/);
     }
 
     async waitForComments(): Promise<void> {
@@ -89,14 +89,10 @@ export class CommentsPage extends AdminPage {
     }
 
     getThreadCommentById(commentId: string): Locator {
-        return this.page.locator(`[data-testid="comment-thread-row"][data-comment-id="${commentId}"]`);
+        return this.page.getByTestId(`comment-thread-row-${commentId}`);
     }
 
     getRepliedToLink(row: Locator): Locator {
-        return row.getByText('Replied to:').locator('..').locator('a, button');
-    }
-
-    getMainListRepliedToLink(row: Locator): Locator {
-        return row.getByText('Replied to:').locator('..').getByRole('link');
+        return row.getByTestId('replied-to-link');
     }
 }

--- a/e2e/tests/admin/comments/thread-sidebar.test.ts
+++ b/e2e/tests/admin/comments/thread-sidebar.test.ts
@@ -104,7 +104,7 @@ test.describe('Ghost Admin - Thread Sidebar', () => {
             await commentsPage.waitForComments();
 
             const replyRow = commentsPage.getCommentRowByText('Reply that shows replied to');
-            const repliedToLink = commentsPage.getMainListRepliedToLink(replyRow);
+            const repliedToLink = commentsPage.getRepliedToLink(replyRow);
             await repliedToLink.click();
 
             await commentsPage.waitForThreadSidebar();


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3276

- E2E guideline requires semantic/test-id locators instead of CSS attribute selectors and XPath parent traversal
- consolidated RepliedToLink page helpers that had identical selectors
