### PR TITLE
Removed operators from "Reported" in comment mod.

### DIFF
--- a/apps/posts/src/views/comments/components/comments-filters.tsx
+++ b/apps/posts/src/views/comments/components/comments-filters.tsx
@@ -122,7 +122,11 @@ const CommentsFilters: React.FC<CommentsFiltersProps> = ({
                     {value: 'true', label: 'Yes'},
                     {value: 'false', label: 'No'}
                 ],
-                searchable: false
+                operators: [
+                    {value: 'is', label: 'is'}
+                ],
+                searchable: false,
+                hideOperatorSelect: true
             },
             {
                 key: 'created_at',


### PR DESCRIPTION
no ref.

- Operators such as `is not`, `is empty` etc. didn't make sense for the binary "Reported" filter field, in comment moderation filtering