### PR TITLE
Replaced Should.js's `containEql` with `node:assert`

### DIFF
--- a/ghost/core/test/e2e-api/admin/members.test.js
+++ b/ghost/core/test/e2e-api/admin/members.test.js
@@ -3704,7 +3704,7 @@ describe('Members API Bulk operations', function () {
         const members = await models.Member.findAll({withRelated: 'labels'});
         for (const member of members) {
             const labelIds = member.relations.labels.models.map(m => m.id);
-            should(labelIds).containEql(label.id);
+            assert(labelIds.includes(label.id));
         }
     });
 
@@ -3745,7 +3745,7 @@ describe('Members API Bulk operations', function () {
 
         // Verify only member1 has the label
         const updatedMember1 = await models.Member.findOne({id: member1.id}, {withRelated: 'labels'});
-        should(updatedMember1.relations.labels.models.map(m => m.id)).containEql(label.id);
+        assert(updatedMember1.relations.labels.models.map(m => m.id).includes(label.id));
 
         const updatedMember2 = await models.Member.findOne({id: member2.id}, {withRelated: 'labels'});
         should(updatedMember2.relations.labels.models.map(m => m.id)).not.containEql(label.id);

--- a/ghost/core/test/e2e-api/admin/members.test.js
+++ b/ghost/core/test/e2e-api/admin/members.test.js
@@ -3748,7 +3748,7 @@ describe('Members API Bulk operations', function () {
         assert(updatedMember1.relations.labels.models.map(m => m.id).includes(label.id));
 
         const updatedMember2 = await models.Member.findOne({id: member2.id}, {withRelated: 'labels'});
-        should(updatedMember2.relations.labels.models.map(m => m.id)).not.containEql(label.id);
+        assert(!updatedMember2.relations.labels.models.some(m => m.id === label.id));
     });
 
     it('Handles duplicate labels gracefully when bulk adding', async function () {

--- a/ghost/core/test/e2e-api/members-comments/comments.test.js
+++ b/ghost/core/test/e2e-api/members-comments/comments.test.js
@@ -415,7 +415,7 @@ describe('Comments API', function () {
                     .expectStatus(200);
 
                 // check that hiddenComment.id is not in the response
-                should(data2.body.comments.map(c => c.id)).not.containEql(hiddenComment.id);
+                assert(!data2.body.comments.some(c => c.id === hiddenComment.id));
                 assert.equal(data2.body.comments.length, 0);
             });
 

--- a/ghost/core/test/e2e-api/members-comments/comments.test.js
+++ b/ghost/core/test/e2e-api/members-comments/comments.test.js
@@ -480,8 +480,8 @@ describe('Comments API', function () {
                 });
 
                 // check if hiddenComment.id and deletedComment.id are in the response
-                should(data2.body.comments.map(c => c.id)).containEql(hiddenComment.id);
-                should(data2.body.comments.map(c => c.id)).containEql(deletedComment.id);
+                assert(data2.body.comments.map(c => c.id).includes(hiddenComment.id));
+                assert(data2.body.comments.map(c => c.id).includes(deletedComment.id));
 
                 // check if the replies to hidden and deleted comments are in the response
                 data2.body.comments.forEach((comment) => {

--- a/ghost/core/test/unit/api/canary/utils/serializers/input/members.test.js
+++ b/ghost/core/test/unit/api/canary/utils/serializers/input/members.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const serializers = require('../../../../../../../core/server/api/endpoints/utils/serializers');
 
@@ -13,7 +14,7 @@ describe('Unit: endpoints/utils/serializers/input/members', function () {
             };
 
             serializers.input.members.all(apiConfig, frame);
-            should(frame.options.withRelated).containEql('products');
+            assert(frame.options.withRelated.includes('products'));
         });
     });
 });

--- a/ghost/core/test/unit/frontend/helpers/foreach.test.js
+++ b/ghost/core/test/unit/frontend/helpers/foreach.test.js
@@ -3,6 +3,7 @@ const should = require('should');
 const sinon = require('sinon');
 const _ = require('lodash');
 const foreach = require('../../../../core/frontend/helpers/foreach');
+const {assertObjectMatches} = require('../../../utils/assertions');
 const {registerHelper, shouldCompileToExpected} = require('./utils/handlebars');
 
 describe('{{#foreach}} helper', function () {
@@ -106,7 +107,7 @@ describe('{{#foreach}} helper', function () {
                 should(options.fn.getCall(index).args[1].data).not.be.undefined();
 
                 // Expected properties
-                resultData[index].data.should.containEql(expected[index]);
+                assertObjectMatches(resultData[index].data, expected[index]);
 
                 // Incrementing properties
                 resultData[index].data.should.have.property('key', index);
@@ -148,7 +149,7 @@ describe('{{#foreach}} helper', function () {
                 should(options.fn.getCall(index).args[1].data).not.be.undefined();
 
                 // Expected properties
-                resultData[index].data.should.containEql(expected[index]);
+                assertObjectMatches(resultData[index].data, expected[index]);
 
                 // Incrementing properties
                 resultData[index].data.should.have.property('key', value);
@@ -183,7 +184,7 @@ describe('{{#foreach}} helper', function () {
                 should(options.fn.getCall(index).args[1].data).not.be.undefined();
 
                 // Expected properties
-                resultData[index].data.should.containEql(expected[index]);
+                assertObjectMatches(resultData[index].data, expected[index]);
 
                 // Incrementing properties
                 resultData[index].data.should.have.property('key', index);
@@ -225,7 +226,7 @@ describe('{{#foreach}} helper', function () {
                 should(options.fn.getCall(index).args[1].data).not.be.undefined();
 
                 // Expected properties
-                resultData[index].data.should.containEql(expected[index]);
+                assertObjectMatches(resultData[index].data, expected[index]);
 
                 // Incrementing properties
                 resultData[index].data.should.have.property('key', value);

--- a/ghost/core/test/unit/server/services/comments/comments-service-emails-renderer.test.js
+++ b/ghost/core/test/unit/server/services/comments/comments-service-emails-renderer.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const i18nLib = require('@tryghost/i18n');
 const should = require('should');
 const CommentsServiceEmailRenderer = require('../../../../../core/server/services/comments/comments-service-email-renderer');
@@ -19,11 +20,11 @@ describe('Comments Service Email Renderer', function () {
             const result = await renderer.renderEmailTemplate('new-comment-reply', templateData);
 
             // assert
-            should(result.html).containEql('Hey there,</p>');
-            should(result.html).containEql('This message was sent from <a class="small" href="https://ghost.org"');
-            should(result.html).containEql('Someone just replied to your comment on <a href="https://ghost.org/post"');
-            should(result.text).containEql('Hey there,');
-            should(result.text).containEql('Someone just replied to your comment on Test Post.');
+            assert(result.html.includes('Hey there,</p>'));
+            assert(result.html.includes('This message was sent from <a class="small" href="https://ghost.org"'));
+            assert(result.html.includes('Someone just replied to your comment on <a href="https://ghost.org/post"'));
+            assert(result.text.includes('Hey there,'));
+            assert(result.text.includes('Someone just replied to your comment on Test Post.'));
         });
 
         it('should correctly handle apostrophes in post titles and site names', async function () {
@@ -41,9 +42,9 @@ describe('Comments Service Email Renderer', function () {
             const result = await renderer.renderEmailTemplate('new-comment-reply', templateData);
 
             // assert
-            should(result.html).containEql('Hey there,</p>');
-            should(result.html).containEql('This message was sent from <a class="small" href="https://ghost.org" style="text-decoration: underline; color: #738A94; font-size: 11px;">Cathy\'s blog</a>');
-            should(result.text).containEql('Someone just replied to your comment on Test post\'s the best post.');
+            assert(result.html.includes('Hey there,</p>'));
+            assert(result.html.includes('This message was sent from <a class="small" href="https://ghost.org" style="text-decoration: underline; color: #738A94; font-size: 11px;">Cathy\'s blog</a>'));
+            assert(result.text.includes('Someone just replied to your comment on Test post\'s the best post.'));
         });
 
         it('should render html and text templates with German locale', async function () {
@@ -61,11 +62,11 @@ describe('Comments Service Email Renderer', function () {
             const result = await renderer.renderEmailTemplate('new-comment-reply', templateData);
 
             // assert
-            should(result.html).containEql('Hallo,</p>');
-            should(result.html).containEql('Diese Nachricht wurde von <a class="small" href="https://ghost.de"');
-            should(result.html).containEql('Jemand hat auf deinen Kommentar zu <a href="https://ghost.de/post"');
-            should(result.text).containEql('Hallo,');
-            should(result.text).containEql('Jemand hat auf deinen Kommentar zu Testbeitrag geantwortet.');
+            assert(result.html.includes('Hallo,</p>'));
+            assert(result.html.includes('Diese Nachricht wurde von <a class="small" href="https://ghost.de"'));
+            assert(result.html.includes('Jemand hat auf deinen Kommentar zu <a href="https://ghost.de/post"'));
+            assert(result.text.includes('Hallo,'));
+            assert(result.text.includes('Jemand hat auf deinen Kommentar zu Testbeitrag geantwortet.'));
         });
     });
 });

--- a/ghost/core/test/unit/server/services/member-attribution/service.test.js
+++ b/ghost/core/test/unit/server/services/member-attribution/service.test.js
@@ -35,7 +35,8 @@ describe('MemberAttributionService', function () {
             });
             const attribution = await service.getAttributionFromContext({importer: true});
 
-            should(attribution).containEql({referrerSource: 'Imported', referrerMedium: 'Member Importer'});
+            assert.equal(attribution.referrerSource, 'Imported');
+            assert.equal(attribution.referrerMedium, 'Member Importer');
         });
 
         it('returns attribution for admin context', async function () {
@@ -44,7 +45,8 @@ describe('MemberAttributionService', function () {
             });
             const attribution = await service.getAttributionFromContext({user: 'abc'});
 
-            should(attribution).containEql({referrerSource: 'Created manually', referrerMedium: 'Ghost Admin'});
+            assert.equal(attribution.referrerSource, 'Created manually');
+            assert.equal(attribution.referrerMedium, 'Ghost Admin');
         });
 
         it('returns attribution for api without integration context', async function () {
@@ -55,7 +57,8 @@ describe('MemberAttributionService', function () {
                 api_key: 'abc'
             });
 
-            should(attribution).containEql({referrerSource: 'Created via API', referrerMedium: 'Admin API'});
+            assert.equal(attribution.referrerSource, 'Created via API');
+            assert.equal(attribution.referrerMedium, 'Admin API');
         });
 
         it('returns attribution for api with integration context', async function () {
@@ -76,7 +79,8 @@ describe('MemberAttributionService', function () {
                 integration: {id: 'integration_1'}
             });
 
-            should(attribution).containEql({referrerSource: 'Integration: Test Integration', referrerMedium: 'Admin API'});
+            assert.equal(attribution.referrerSource, 'Integration: Test Integration');
+            assert.equal(attribution.referrerMedium, 'Admin API');
         });
     });
 

--- a/ghost/core/test/unit/server/services/stats/utils/tinybird.test.js
+++ b/ghost/core/test/unit/server/services/stats/utils/tinybird.test.js
@@ -9,13 +9,13 @@ describe('Tinybird Client', function () {
     let mockRequest;
     let mockSettingsCache;
     let mockTinybirdService;
-    
+
     beforeEach(function () {
         // Set up mocks
         mockConfig = {
             get: sinon.stub()
         };
-        
+
         mockRequest = {
             get: sinon.stub()
         };
@@ -63,8 +63,8 @@ describe('Tinybird Client', function () {
             assert(url.includes('site_uuid=931ade9e-a4f1-4217-8625-34bd34250c16'));
             assert(url.includes('date_from=2023-01-01'));
             assert(url.includes('date_to=2023-01-31'));
-            // url.should.containEql('timezone=UTC');
-            // url.should.containEql('member_status=all');
+            // assert(url.includes('timezone=UTC'));
+            // assert(url.includes('member_status=all'));
 
             should.exist(options);
             should.exist(options.headers);
@@ -99,7 +99,7 @@ describe('Tinybird Client', function () {
             assert(url.includes('timezone=America%2FNew_York'));
             assert(url.includes('member_status=paid'));
         });
-        
+
         it('uses local endpoint and token when local is enabled', function () {
             // Update config mock to return local config
             mockConfig.get.withArgs('tinybird:stats').returns({
@@ -207,44 +207,44 @@ describe('Tinybird Client', function () {
                     ]
                 }
             });
-            
+
             const result = await tinybirdClient.fetch('test_pipe', {
                 dateFrom: '2023-01-01',
                 dateTo: '2023-01-31'
             });
-            
+
             should.exist(result);
             result.should.be.an.Array().with.lengthOf(2);
             assert.equal(result[0].pathname, '/test-1/');
             assert.equal(result[0].visits, 100);
-            
+
             // Verify request was called with correct parameters
             assert.equal(mockRequest.get.calledOnce, true);
             const [url, options] = mockRequest.get.firstCall.args;
             url.should.startWith('https://api.tinybird.co/v0/pipes/test_pipe.json?');
             assert.equal(options.headers.Authorization, 'Bearer mock-jwt-token');
         });
-        
+
         it('returns null when request fails', async function () {
             // Setup mock to throw error
             mockRequest.get.rejects(new Error('Network error'));
-            
+
             const result = await tinybirdClient.fetch('test_pipe', {});
-            
+
             assert.equal(result, null);
             assert.equal(mockRequest.get.calledOnce, true);
         });
-        
+
         it('returns null when response parsing fails', async function () {
             // Setup mock with invalid response
             mockRequest.get.resolves({
                 body: 'invalid json'
             });
-            
+
             const result = await tinybirdClient.fetch('test_pipe', {});
-            
+
             assert.equal(result, null);
             assert.equal(mockRequest.get.calledOnce, true);
         });
     });
-}); 
+});

--- a/ghost/core/test/utils/assertions.js
+++ b/ghost/core/test/utils/assertions.js
@@ -6,6 +6,24 @@ function assertMatchSnapshot(obj, properties) {
     assert(result.pass, result.message());
 }
 
+/**
+ * @template T
+ * @param {T} obj
+ * @param {Partial<T>} properties
+ * @param {string} [message]
+ * @returns {void}
+ */
+function assertObjectMatches(obj, properties, message) {
+    for (const [key, value] of Object.entries(properties)) {
+        assert.equal(
+            obj[key],
+            value,
+            message || `Property mismatch for key "${key}"`
+        );
+    }
+}
+
 module.exports = {
-    assertMatchSnapshot
+    assertMatchSnapshot,
+    assertObjectMatches
 };


### PR DESCRIPTION
no ref

*This test-only change should have no user impact.*

This replaces `should`'s `containEql` with calls to `.includes()` or a new assertion helper, `assertObjectMatches`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test assertions across the suite to use native Node.js assertion methods instead of third-party assertion libraries.
  * Added a new test utility function for object property matching to support stricter assertion validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->