### PR TITLE
Added pagination to thread sidebar view

### DIFF
--- a/apps/posts/src/views/comments/components/comment-thread-list.tsx
+++ b/apps/posts/src/views/comments/components/comment-thread-list.tsx
@@ -1,6 +1,6 @@
 import CommentContent from './comment-content';
 import React from 'react';
-import {Button, LucideIcon} from '@tryghost/shade';
+import {Button, LoadingIndicator, LucideIcon} from '@tryghost/shade';
 import {Comment, useHideComment, useShowComment} from '@tryghost/admin-x-framework/api/comments';
 import {CommentAvatar} from './comment-avatar';
 import {CommentHeader} from './comment-header';
@@ -130,13 +130,19 @@ interface CommentThreadListProps {
     replies: Comment[];
     selectedCommentId: string;
     commentPermalinksEnabled?: boolean;
+    fetchNextPage: () => void;
+    hasNextPage?: boolean;
+    isFetchingNextPage: boolean;
 }
 
 const CommentThreadList: React.FC<CommentThreadListProps> = ({
     selectedComment,
     replies,
     selectedCommentId,
-    commentPermalinksEnabled
+    commentPermalinksEnabled,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage
 }) => {
     // All replies are children of the selected comment (flat structure from API)
     const commentWithReplies: Comment = {...selectedComment, replies};
@@ -149,6 +155,24 @@ const CommentThreadList: React.FC<CommentThreadListProps> = ({
                 isSelectedComment={true}
                 selectedCommentId={selectedCommentId}
             />
+            {hasNextPage && (
+                <div className="flex justify-center pb-4">
+                    <Button
+                        disabled={isFetchingNextPage}
+                        variant="outline"
+                        onClick={() => fetchNextPage()}
+                    >
+                        {isFetchingNextPage ? (
+                            <>
+                                <LoadingIndicator size="sm" />
+                                Loading...
+                            </>
+                        ) : (
+                            'Load more replies'
+                        )}
+                    </Button>
+                </div>
+            )}
         </div>
     );
 };

--- a/apps/posts/src/views/comments/components/comment-thread-sidebar.tsx
+++ b/apps/posts/src/views/comments/components/comment-thread-sidebar.tsx
@@ -26,7 +26,14 @@ const CommentThreadSidebar: React.FC<CommentThreadSidebarProps> = ({
     onOpenChange,
     commentPermalinksEnabled
 }) => {
-    const {data: threadData, isLoading: isLoadingThread, isError: isThreadError} = useThreadComments(commentId ?? '', {
+    const {
+        data: threadData,
+        isLoading: isLoadingThread,
+        isError: isThreadError,
+        fetchNextPage,
+        hasNextPage,
+        isFetchingNextPage
+    } = useThreadComments(commentId ?? '', {
         enabled: open && !!commentId
     });
 
@@ -98,6 +105,9 @@ const CommentThreadSidebar: React.FC<CommentThreadSidebarProps> = ({
                     ) : (
                         <CommentThreadList
                             commentPermalinksEnabled={commentPermalinksEnabled}
+                            fetchNextPage={fetchNextPage}
+                            hasNextPage={hasNextPage}
+                            isFetchingNextPage={isFetchingNextPage}
                             replies={threadReplies}
                             selectedComment={selectedComment}
                             selectedCommentId={commentId ?? ''}


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3283

- Added "Load more replies" button to thread sidebar when there are more than 100 replies
- Wired up existing `fetchNextPage`, `hasNextPage`, `isFetchingNextPage` from `useThreadComments` infinite query
- Button shows loading state while fetching and hides when all replies are loaded