### PR TITLE
Replaced Should.js's `should.exist()` with `node:assert`

### DIFF
--- a/ghost/core/test/e2e-api/admin/integrations.test.js
+++ b/ghost/core/test/e2e-api/admin/integrations.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../utils/assertions');
 const _ = require('lodash');
 const should = require('should');
 const supertest = require('supertest');
@@ -30,16 +31,16 @@ describe('Integrations API', function () {
 
         // there is no enforced order for integrations which makes order different on SQLite and MySQL
         const zapierIntegration = _.find(res.body.integrations, {name: 'Zapier'}); // from migrations
-        should.exist(zapierIntegration);
+        assertExists(zapierIntegration);
 
         const testIntegration = _.find(res.body.integrations, {name: 'Test Integration'}); // from fixtures
-        should.exist(testIntegration);
+        assertExists(testIntegration);
 
         const exploreIntegration = _.find(res.body.integrations, {name: 'Test Core Integration'}); // from fixtures
-        should.exist(exploreIntegration);
+        assertExists(exploreIntegration);
 
         const selfServeMigrationIntegration = _.find(res.body.integrations, {name: 'Self-Serve Migration Integration'}); // from fixtures
-        should.exist(selfServeMigrationIntegration);
+        assertExists(selfServeMigrationIntegration);
     });
 
     it('Can not read internal integration', async function () {
@@ -74,16 +75,16 @@ describe('Integrations API', function () {
 
         const adminApiKey = integration.api_keys.find(findBy('type', 'admin'));
         assert.equal(adminApiKey.integration_id, integration.id);
-        should.exist(adminApiKey.secret);
+        assertExists(adminApiKey.secret);
 
         // check Admin API key secret format
         const [id, secret] = adminApiKey.secret.split(':');
-        should.exist(id);
+        assertExists(id);
         assert.equal(id, adminApiKey.id);
-        should.exist(secret);
+        assertExists(secret);
         assert.equal(secret.length, 64);
 
-        should.exist(res.headers.location);
+        assertExists(res.headers.location);
         res.headers.location.should.equal(`http://127.0.0.1:2369${localUtils.API.getApiQuery('integrations/')}${res.body.integrations[0].id}/`);
     });
 
@@ -113,7 +114,7 @@ describe('Integrations API', function () {
         const webhook = integration.webhooks[0];
         assert.equal(webhook.integration_id, integration.id);
 
-        should.exist(res.headers.location);
+        assertExists(res.headers.location);
         res.headers.location.should.equal(`http://127.0.0.1:2369${localUtils.API.getApiQuery('integrations/')}${res.body.integrations[0].id}/`);
     });
 
@@ -179,10 +180,10 @@ describe('Integrations API', function () {
         assert.equal(body.meta.pagination.prev, null);
 
         body.integrations.forEach((integration) => {
-            should.exist(integration.api_keys);
+            assertExists(integration.api_keys);
             if (integration.api_keys.length) {
                 integration.api_keys.forEach((apiKey) => {
-                    should.exist(apiKey.secret);
+                    assertExists(apiKey.secret);
 
                     if (apiKey.type === 'content') {
                         assert.equal(apiKey.secret.split(':').length, 1, `${integration.name} api key secret should have correct key format without ":"`);
@@ -273,7 +274,7 @@ describe('Integrations API', function () {
         const refreshedAction = actions.find((action) => {
             return action.event === 'refreshed';
         });
-        should.exist(refreshedAction);
+        assertExists(refreshedAction);
     });
 
     it('Can successfully add and delete a created integrations webhooks', async function () {

--- a/ghost/core/test/e2e-api/admin/invites.test.js
+++ b/ghost/core/test/e2e-api/admin/invites.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../utils/assertions');
 const should = require('should');
 const supertest = require('supertest');
 const sinon = require('sinon');
@@ -34,8 +35,8 @@ describe('Invites API', function () {
 
             assert.equal(res.headers['x-cache-invalidate'], undefined);
             const jsonResponse = res.body;
-            should.exist(jsonResponse);
-            should.exist(jsonResponse.invites);
+            assertExists(jsonResponse);
+            assertExists(jsonResponse.invites);
             assert.equal(jsonResponse.invites.length, 2);
 
             localUtils.API.checkResponse(jsonResponse, 'invites');
@@ -61,8 +62,8 @@ describe('Invites API', function () {
 
             assert.equal(res.headers['x-cache-invalidate'], undefined);
             const jsonResponse = res.body;
-            should.exist(jsonResponse);
-            should.exist(jsonResponse.invites);
+            assertExists(jsonResponse);
+            assertExists(jsonResponse.invites);
             assert.equal(jsonResponse.invites.length, 1);
 
             localUtils.API.checkResponse(jsonResponse.invites[0], 'invite');
@@ -83,8 +84,8 @@ describe('Invites API', function () {
 
             assert.equal(res.headers['x-cache-invalidate'], undefined);
             const jsonResponse = res.body;
-            should.exist(jsonResponse);
-            should.exist(jsonResponse.invites);
+            assertExists(jsonResponse);
+            assertExists(jsonResponse.invites);
             assert.equal(jsonResponse.invites.length, 1);
 
             localUtils.API.checkResponse(jsonResponse.invites[0], 'invite');
@@ -92,7 +93,7 @@ describe('Invites API', function () {
 
             assert.equal(mailService.GhostMailer.prototype.send.called, true);
 
-            should.exist(res.headers.location);
+            assertExists(res.headers.location);
             res.headers.location.should.equal(`http://127.0.0.1:2369${localUtils.API.getApiQuery('invites/')}${res.body.invites[0].id}/`);
         });
 
@@ -147,8 +148,8 @@ describe('Invites API', function () {
 
             assert.equal(res.headers['x-cache-invalidate'], undefined);
             const jsonResponse = res.body;
-            should.exist(jsonResponse);
-            should.exist(jsonResponse.invites);
+            assertExists(jsonResponse);
+            assertExists(jsonResponse.invites);
             assert.equal(jsonResponse.invites.length, 1);
 
             localUtils.API.checkResponse(jsonResponse.invites[0], 'invite');
@@ -156,7 +157,7 @@ describe('Invites API', function () {
 
             assert.equal(mailService.GhostMailer.prototype.send.called, true);
 
-            should.exist(res.headers.location);
+            assertExists(res.headers.location);
             res.headers.location.should.equal(`http://127.0.0.1:2369${localUtils.API.getApiQuery('invites/')}${res.body.invites[0].id}/`);
         });
 
@@ -174,8 +175,8 @@ describe('Invites API', function () {
 
             assert.equal(res.headers['x-cache-invalidate'], undefined);
             const jsonResponse = res.body;
-            should.exist(jsonResponse);
-            should.exist(jsonResponse.invites);
+            assertExists(jsonResponse);
+            assertExists(jsonResponse.invites);
             assert.equal(jsonResponse.invites.length, 1);
 
             localUtils.API.checkResponse(jsonResponse.invites[0], 'invite');
@@ -183,7 +184,7 @@ describe('Invites API', function () {
 
             assert.equal(mailService.GhostMailer.prototype.send.called, true);
 
-            should.exist(res.headers.location);
+            assertExists(res.headers.location);
             res.headers.location.should.equal(`http://127.0.0.1:2369${localUtils.API.getApiQuery('invites/')}${res.body.invites[0].id}/`);
         });
 
@@ -201,8 +202,8 @@ describe('Invites API', function () {
 
             assert.equal(res.headers['x-cache-invalidate'], undefined);
             const jsonResponse = res.body;
-            should.exist(jsonResponse);
-            should.exist(jsonResponse.invites);
+            assertExists(jsonResponse);
+            assertExists(jsonResponse.invites);
             assert.equal(jsonResponse.invites.length, 1);
 
             localUtils.API.checkResponse(jsonResponse.invites[0], 'invite');
@@ -210,7 +211,7 @@ describe('Invites API', function () {
 
             assert.equal(mailService.GhostMailer.prototype.send.called, true);
 
-            should.exist(res.headers.location);
+            assertExists(res.headers.location);
             res.headers.location.should.equal(`http://127.0.0.1:2369${localUtils.API.getApiQuery('invites/')}${res.body.invites[0].id}/`);
         });
 
@@ -228,8 +229,8 @@ describe('Invites API', function () {
 
             assert.equal(res.headers['x-cache-invalidate'], undefined);
             const jsonResponse = res.body;
-            should.exist(jsonResponse);
-            should.exist(jsonResponse.invites);
+            assertExists(jsonResponse);
+            assertExists(jsonResponse.invites);
             assert.equal(jsonResponse.invites.length, 1);
 
             localUtils.API.checkResponse(jsonResponse.invites[0], 'invite');
@@ -237,7 +238,7 @@ describe('Invites API', function () {
 
             assert.equal(mailService.GhostMailer.prototype.send.called, true);
 
-            should.exist(res.headers.location);
+            assertExists(res.headers.location);
             res.headers.location.should.equal(`http://127.0.0.1:2369${localUtils.API.getApiQuery('invites/')}${res.body.invites[0].id}/`);
         });
 

--- a/ghost/core/test/e2e-api/admin/key-authentication.test.js
+++ b/ghost/core/test/e2e-api/admin/key-authentication.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../utils/assertions');
 const should = require('should');
 const supertest = require('supertest');
 const testUtils = require('../../utils');
@@ -128,7 +129,7 @@ describe('Admin API key authentication', function () {
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(200);
 
-            should.exist(secondResponse.body.explore);
+            assertExists(secondResponse.body.explore);
         });
     });
 });

--- a/ghost/core/test/e2e-api/admin/members-exporter.test.js
+++ b/ghost/core/test/e2e-api/admin/members-exporter.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../utils/assertions');
 const {agentProvider, mockManager, fixtureManager, matchers} = require('../../utils/e2e-framework');
 const {anyContentVersion, anyString} = matchers;
 
@@ -56,7 +57,7 @@ async function testOutput(member, asserts, filters = []) {
 
         let csv = Papa.parse(res.text, {header: true});
         let row = csv.data.find(r => r.id === member.id);
-        should.exist(row);
+        assertExists(row);
 
         asserts(row);
 

--- a/ghost/core/test/e2e-api/admin/members-importer.test.js
+++ b/ghost/core/test/e2e-api/admin/members-importer.test.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const assert = require('assert/strict');
+const {assertExists} = require('../../utils/assertions');
 const should = require('should');
 const supertest = require('supertest');
 const testUtils = require('../../utils');
@@ -45,9 +46,9 @@ describe('Members Importer API', function () {
         assert.equal(res.headers['x-cache-invalidate'], undefined);
         const jsonResponse = res.body;
 
-        should.exist(jsonResponse);
-        should.exist(jsonResponse.meta);
-        should.exist(jsonResponse.meta.stats);
+        assertExists(jsonResponse);
+        assertExists(jsonResponse.meta);
+        assertExists(jsonResponse.meta.stats);
 
         assert.equal(jsonResponse.meta.stats.imported, 2);
         assert.equal(jsonResponse.meta.stats.invalid.length, 0);
@@ -63,12 +64,12 @@ describe('Members Importer API', function () {
             .expect(200);
 
         const jsonResponse2 = res2.body;
-        should.exist(jsonResponse2);
-        should.exist(jsonResponse2.members);
+        assertExists(jsonResponse2);
+        assertExists(jsonResponse2.members);
         assert.equal(jsonResponse2.members.length, 2);
 
         const importedMember1 = jsonResponse2.members.find(m => m.email === 'jbloggs@example.com');
-        should.exist(importedMember1);
+        assertExists(importedMember1);
         assert.equal(importedMember1.name, 'joe');
         assert.equal(importedMember1.note, null);
         assert.equal(importedMember1.subscribed, true);
@@ -80,7 +81,7 @@ describe('Members Importer API', function () {
         assert.equal(importedMember1.subscriptions.length, 0);
 
         const importedMember2 = jsonResponse2.members.find(m => m.email === 'test@example.com');
-        should.exist(importedMember2);
+        assertExists(importedMember2);
         assert.equal(importedMember2.name, 'test');
         assert.equal(importedMember2.note, 'test note');
         assert.equal(importedMember2.subscribed, false);
@@ -112,10 +113,10 @@ describe('Members Importer API', function () {
 
     //             const jsonResponse = res.body;
 
-    //             should.exist(jsonResponse);
-    //             should.exist(jsonResponse.meta);
-    //             should.exist(jsonResponse.meta.stats);
-    //             should.exist(jsonResponse.meta.import_label);
+    //             assertExists(jsonResponse);
+    //             assertExists(jsonResponse.meta);
+    //             assertExists(jsonResponse.meta.stats);
+    //             assertExists(jsonResponse.meta.import_label);
 
     //             jsonResponse.meta.stats.imported.should.equal(8);
 
@@ -131,8 +132,8 @@ describe('Members Importer API', function () {
     //                 .then((res) => {
     //                     should.not.exist(res.headers['x-cache-invalidate']);
     //                     const jsonResponse = res.body;
-    //                     should.exist(jsonResponse);
-    //                     should.exist(jsonResponse.members);
+    //                     assertExists(jsonResponse);
+    //                     assertExists(jsonResponse.members);
     //                     jsonResponse.members.should.have.length(8);
     //                 })
     //                 .then(() => importLabel);
@@ -148,10 +149,10 @@ describe('Members Importer API', function () {
     //                 .then((res) => {
     //                     should.not.exist(res.headers['x-cache-invalidate']);
     //                     const jsonResponse = res.body;
-    //                     should.exist(jsonResponse);
-    //                     should.exist(jsonResponse.meta);
-    //                     should.exist(jsonResponse.meta.stats);
-    //                     should.exist(jsonResponse.meta.stats.successful);
+    //                     assertExists(jsonResponse);
+    //                     assertExists(jsonResponse.meta);
+    //                     assertExists(jsonResponse.meta.stats);
+    //                     assertExists(jsonResponse.meta.stats.successful);
     //                     assert.equal(jsonResponse.meta.stats.successful, 8);
     //                 })
     //                 .then(() => importLabel);
@@ -165,8 +166,8 @@ describe('Members Importer API', function () {
     //                 .expect(200)
     //                 .then((res) => {
     //                     const jsonResponse = res.body;
-    //                     should.exist(jsonResponse);
-    //                     should.exist(jsonResponse.members);
+    //                     assertExists(jsonResponse);
+    //                     assertExists(jsonResponse.members);
     //                     jsonResponse.members.should.have.length(0);
     //                 });
     //         });
@@ -210,10 +211,10 @@ describe('Members Importer API', function () {
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(200);
 
-        should.exist(bulkUnsubscribeResponse.body.bulk);
-        should.exist(bulkUnsubscribeResponse.body.bulk.meta);
-        should.exist(bulkUnsubscribeResponse.body.bulk.meta.stats);
-        should.exist(bulkUnsubscribeResponse.body.bulk.meta.stats.successful);
+        assertExists(bulkUnsubscribeResponse.body.bulk);
+        assertExists(bulkUnsubscribeResponse.body.bulk.meta);
+        assertExists(bulkUnsubscribeResponse.body.bulk.meta.stats);
+        assertExists(bulkUnsubscribeResponse.body.bulk.meta.stats.successful);
         assert.equal(bulkUnsubscribeResponse.body.bulk.meta.stats.successful, 8);
 
         const postUnsubscribeBrowseResponse = await request
@@ -266,10 +267,10 @@ describe('Members Importer API', function () {
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(200);
 
-        should.exist(bulkAddLabelResponse.body.bulk);
-        should.exist(bulkAddLabelResponse.body.bulk.meta);
-        should.exist(bulkAddLabelResponse.body.bulk.meta.stats);
-        should.exist(bulkAddLabelResponse.body.bulk.meta.stats.successful);
+        assertExists(bulkAddLabelResponse.body.bulk);
+        assertExists(bulkAddLabelResponse.body.bulk.meta);
+        assertExists(bulkAddLabelResponse.body.bulk.meta.stats);
+        assertExists(bulkAddLabelResponse.body.bulk.meta.stats.successful);
         assert.equal(bulkAddLabelResponse.body.bulk.meta.stats.successful, 8);
 
         const postLabelAddBrowseResponse = await request
@@ -298,10 +299,10 @@ describe('Members Importer API', function () {
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(200);
 
-        should.exist(bulkRemoveLabelResponse.body.bulk);
-        should.exist(bulkRemoveLabelResponse.body.bulk.meta);
-        should.exist(bulkRemoveLabelResponse.body.bulk.meta.stats);
-        should.exist(bulkRemoveLabelResponse.body.bulk.meta.stats.successful);
+        assertExists(bulkRemoveLabelResponse.body.bulk);
+        assertExists(bulkRemoveLabelResponse.body.bulk.meta);
+        assertExists(bulkRemoveLabelResponse.body.bulk.meta.stats);
+        assertExists(bulkRemoveLabelResponse.body.bulk.meta.stats.successful);
         assert.equal(bulkRemoveLabelResponse.body.bulk.meta.stats.successful, 8);
 
         const postLabelRemoveBrowseResponse = await request

--- a/ghost/core/test/e2e-api/admin/members.test.js
+++ b/ghost/core/test/e2e-api/admin/members.test.js
@@ -4,6 +4,7 @@ const {queryStringToken} = regexes;
 const ObjectId = require('bson-objectid').default;
 
 const assert = require('assert/strict');
+const {assertExists} = require('../../utils/assertions');
 const nock = require('nock');
 const sinon = require('sinon');
 const should = require('should');
@@ -2582,12 +2583,12 @@ describe('Members API', function () {
         assert.match(res.text, /id,email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,tiers/);
 
         const csv = Papa.parse(res.text, {header: true});
-        should.exist(csv.data.find(row => row.name === 'Mr Egg'));
-        should.exist(csv.data.find(row => row.name === 'Winston Zeddemore'));
-        should.exist(csv.data.find(row => row.name === 'Ray Stantz'));
-        should.exist(csv.data.find(row => row.email === 'member2@test.com'));
-        should.exist(csv.data.find(row => row.tiers.length > 0));
-        should.exist(csv.data.find(row => row.labels.length > 0));
+        assertExists(csv.data.find(row => row.name === 'Mr Egg'));
+        assertExists(csv.data.find(row => row.name === 'Winston Zeddemore'));
+        assertExists(csv.data.find(row => row.name === 'Ray Stantz'));
+        assertExists(csv.data.find(row => row.email === 'member2@test.com'));
+        assertExists(csv.data.find(row => row.tiers.length > 0));
+        assertExists(csv.data.find(row => row.labels.length > 0));
     });
 
     it('Can export a filtered CSV', async function () {
@@ -2603,12 +2604,12 @@ describe('Members API', function () {
         assert.match(res.text, /id,email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,tiers/);
 
         const csv = Papa.parse(res.text, {header: true});
-        should.exist(csv.data.find(row => row.name === 'Mr Egg'));
+        assertExists(csv.data.find(row => row.name === 'Mr Egg'));
         assert.equal(csv.data.find(row => row.name === 'Egon Spengler'), undefined);
         assert.equal(csv.data.find(row => row.name === 'Ray Stantz'), undefined);
         assert.equal(csv.data.find(row => row.email === 'member2@test.com'), undefined);
         // note that this member doesn't have tiers
-        should.exist(csv.data.find(row => row.labels.length > 0));
+        assertExists(csv.data.find(row => row.labels.length > 0));
     });
 
     it('Can delete a member without cancelling Stripe Subscription', async function () {

--- a/ghost/core/test/e2e-api/admin/oembed.test.js
+++ b/ghost/core/test/e2e-api/admin/oembed.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../utils/assertions');
 const nock = require('nock');
 const sinon = require('sinon');
 const should = require('should');
@@ -67,7 +68,7 @@ describe('Oembed API', function () {
             .expect(200);
 
         assert.equal(requestMock.isDone(), true);
-        should.exist(res.body.html);
+        assertExists(res.body.html);
     });
 
     it('does not use http preferentially to https', async function () {
@@ -92,7 +93,7 @@ describe('Oembed API', function () {
 
         assert.equal(httpMock.isDone(), false);
         assert.equal(httpsMock.isDone(), true);
-        should.exist(res.body.html);
+        assertExists(res.body.html);
     });
 
     it('errors with a useful message when embedding is disabled', async function () {
@@ -122,7 +123,7 @@ describe('Oembed API', function () {
             .expect(422);
 
         assert.equal(requestMock.isDone(), true);
-        should.exist(res.body.errors);
+        assertExists(res.body.errors);
         assert.match(res.body.errors[0].context, /URL contains a private resource/i);
     });
 
@@ -189,7 +190,7 @@ describe('Oembed API', function () {
                 .expect(422);
 
             assert.equal(pageMock.isDone(), true);
-            should.exist(res.body.errors);
+            assertExists(res.body.errors);
             assert.match(res.body.errors[0].context, /insufficient metadata/i);
         });
 
@@ -220,7 +221,7 @@ describe('Oembed API', function () {
                 .expect(422);
 
             assert.equal(pageMock.isDone(), false); // we shouldn't hit this; blocked by externalRequest
-            should.exist(res.body.errors);
+            assertExists(res.body.errors);
         });
 
         it('errors when fetched url is incorrect', async function () {
@@ -231,7 +232,7 @@ describe('Oembed API', function () {
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(422);
 
-            should.exist(res.body.errors);
+            assertExists(res.body.errors);
         });
 
         it('should replace icon URL when it returns 404', async function () {

--- a/ghost/core/test/e2e-api/admin/pages-legacy.test.js
+++ b/ghost/core/test/e2e-api/admin/pages-legacy.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../utils/assertions');
 const should = require('should');
 const supertest = require('supertest');
 const moment = require('moment');
@@ -26,7 +27,7 @@ describe('Pages API', function () {
 
         assert.equal(res.headers['x-cache-invalidate'], undefined);
         const jsonResponse = res.body;
-        should.exist(jsonResponse.pages);
+        assertExists(jsonResponse.pages);
         localUtils.API.checkResponse(jsonResponse, 'pages');
         assert.equal(jsonResponse.pages.length, 6);
 
@@ -48,7 +49,7 @@ describe('Pages API', function () {
 
         assert.equal(res.headers['x-cache-invalidate'], undefined);
         const jsonResponse = res.body;
-        should.exist(jsonResponse.pages);
+        assertExists(jsonResponse.pages);
         localUtils.API.checkResponse(jsonResponse, 'pages');
         assert.equal(jsonResponse.pages.length, 6);
 
@@ -76,9 +77,9 @@ describe('Pages API', function () {
         assert.equal(res.body.pages.length, 1);
 
         localUtils.API.checkResponse(res.body.pages[0], 'page');
-        should.exist(res.headers['x-cache-invalidate']);
+        assertExists(res.headers['x-cache-invalidate']);
 
-        should.exist(res.headers.location);
+        assertExists(res.headers.location);
         res.headers.location.should.equal(`http://127.0.0.1:2369${localUtils.API.getApiQuery('pages/')}${res.body.pages[0].id}/`);
 
         const model = await models.Post.findOne({
@@ -346,7 +347,7 @@ describe('Pages API', function () {
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(200);
 
-        should.exist(res2.headers['x-cache-invalidate']);
+        assertExists(res2.headers['x-cache-invalidate']);
         localUtils.API.checkResponse(res2.body.pages[0], 'page', ['reading_time']);
 
         const model = await models.Post.findOne({
@@ -389,7 +390,7 @@ describe('Pages API', function () {
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(200);
 
-        should.exist(res2.headers['x-cache-invalidate']);
+        assertExists(res2.headers['x-cache-invalidate']);
         localUtils.API.checkResponse(res2.body.pages[0], 'page', ['reading_time']);
         res2.body.pages[0].tiers.length.should.eql(paidTiers.length);
 

--- a/ghost/core/test/e2e-api/admin/posts-legacy.test.js
+++ b/ghost/core/test/e2e-api/admin/posts-legacy.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../utils/assertions');
 const should = require('should');
 const nock = require('nock');
 const path = require('path');
@@ -52,7 +53,7 @@ describe('Posts API', function () {
 
         assert.equal(res.headers['x-cache-invalidate'], undefined);
         const jsonResponse = res.body;
-        should.exist(jsonResponse.posts);
+        assertExists(jsonResponse.posts);
         localUtils.API.checkResponse(jsonResponse, 'posts');
         assert.equal(jsonResponse.posts.length, 15);
         localUtils.API.checkResponse(jsonResponse.posts[0], 'post');
@@ -94,7 +95,7 @@ describe('Posts API', function () {
 
         assert.equal(res.headers['x-cache-invalidate'], undefined);
         const jsonResponse = res.body;
-        should.exist(jsonResponse.posts);
+        assertExists(jsonResponse.posts);
         localUtils.API.checkResponse(jsonResponse, 'posts');
         assert.equal(jsonResponse.posts.length, 3);
         localUtils.API.checkResponse(jsonResponse.posts[0], 'post', ['plaintext']);
@@ -114,7 +115,7 @@ describe('Posts API', function () {
 
         assert.equal(res.headers['x-cache-invalidate'], undefined);
         const jsonResponse = res.body;
-        should.exist(jsonResponse.posts);
+        assertExists(jsonResponse.posts);
         localUtils.API.checkResponse(jsonResponse, 'posts');
         assert.equal(jsonResponse.posts.length, 15);
         localUtils.API.checkResponse(
@@ -136,7 +137,7 @@ describe('Posts API', function () {
 
         assert.equal(res.headers['x-cache-invalidate'], undefined);
         const jsonResponse = res.body;
-        should.exist(jsonResponse.posts);
+        assertExists(jsonResponse.posts);
         localUtils.API.checkResponse(jsonResponse, 'posts');
         assert.equal(jsonResponse.posts.length, 2);
         localUtils.API.checkResponse(jsonResponse.posts[0], 'post');
@@ -173,8 +174,8 @@ describe('Posts API', function () {
 
         assert.equal(res.headers['x-cache-invalidate'], undefined);
         const jsonResponse = res.body;
-        should.exist(jsonResponse);
-        should.exist(jsonResponse.posts);
+        assertExists(jsonResponse);
+        assertExists(jsonResponse.posts);
         localUtils.API.checkResponse(jsonResponse.posts[0], 'post');
         jsonResponse.posts[0].id.should.equal(testUtils.DataGenerator.Content.posts[0].id);
 
@@ -196,8 +197,8 @@ describe('Posts API', function () {
 
         assert.equal(res.headers['x-cache-invalidate'], undefined);
         const jsonResponse = res.body;
-        should.exist(jsonResponse);
-        should.exist(jsonResponse.posts);
+        assertExists(jsonResponse);
+        assertExists(jsonResponse.posts);
         localUtils.API.checkResponse(jsonResponse.posts[0], 'post');
         jsonResponse.posts[0].id.should.equal(testUtils.DataGenerator.Content.posts[1].id);
 
@@ -219,8 +220,8 @@ describe('Posts API', function () {
 
         assert.equal(res.headers['x-cache-invalidate'], undefined);
         const jsonResponse = res.body;
-        should.exist(jsonResponse);
-        should.exist(jsonResponse.posts);
+        assertExists(jsonResponse);
+        assertExists(jsonResponse.posts);
         localUtils.API.checkResponse(jsonResponse.posts[0], 'post');
         assert.equal(jsonResponse.posts[0].slug, 'welcome');
 
@@ -241,8 +242,8 @@ describe('Posts API', function () {
 
         assert.equal(res.headers['x-cache-invalidate'], undefined);
         const jsonResponse = res.body;
-        should.exist(jsonResponse);
-        should.exist(jsonResponse.posts);
+        assertExists(jsonResponse);
+        assertExists(jsonResponse.posts);
 
         localUtils.API.checkResponse(jsonResponse.posts[0], 'post', null, ['count', 'post_revisions']);
 
@@ -283,7 +284,7 @@ describe('Posts API', function () {
         assert.match(res.body.posts[0].url, new RegExp(`${config.get('url')}/p/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}`));
         assert.equal(res.headers['x-cache-invalidate'], undefined);
 
-        should.exist(res.headers.location);
+        assertExists(res.headers.location);
         res.headers.location.should.equal(`http://127.0.0.1:2369${localUtils.API.getApiQuery('posts/')}${res.body.posts[0].id}/`);
 
         // Newsletter should be returned as null
@@ -832,7 +833,7 @@ describe('Posts API', function () {
         }, testUtils.context.internal);
 
         assert.equal(model.get('newsletter_id'), null);
-        should.exist(model.get('published_by'));
+        assertExists(model.get('published_by'));
 
         // Check email
         // Note: we only create an email if we have members susbcribed to the newsletter
@@ -898,7 +899,7 @@ describe('Posts API', function () {
         }, testUtils.context.internal);
 
         should(model.get('newsletter_id')).eql(newsletterId);
-        should.exist(model.get('published_by'));
+        assertExists(model.get('published_by'));
 
         // Check email
         // Note: we only create an email if we have members susbcribed to the newsletter
@@ -906,7 +907,7 @@ describe('Posts API', function () {
             post_id: id
         }, testUtils.context.internal);
 
-        should.exist(email);
+        assertExists(email);
         should(email.get('newsletter_id')).eql(newsletterId);
         should(email.get('status')).equalOneOf('pending', 'submitted', 'submitting');
     });
@@ -969,7 +970,7 @@ describe('Posts API', function () {
         }, testUtils.context.internal);
 
         should(model.get('newsletter_id')).eql(newsletterId);
-        should.exist(model.get('published_by'));
+        assertExists(model.get('published_by'));
 
         // Check email
         // Note: we only create an email if we have members susbcribed to the newsletter
@@ -977,7 +978,7 @@ describe('Posts API', function () {
             post_id: id
         }, testUtils.context.internal);
 
-        should.exist(email);
+        assertExists(email);
         should(email.get('newsletter_id')).eql(newsletterId);
         should(email.get('status')).equalOneOf('pending', 'submitted', 'submitting');
     });
@@ -1040,7 +1041,7 @@ describe('Posts API', function () {
         assert.equal(model.get('status'), 'sent');
         should(model.get('newsletter_id')).eql(newsletterId);
         assert.equal(model.get('email_recipient_filter'), 'all');
-        should.exist(model.get('published_by'));
+        assertExists(model.get('published_by'));
 
         // We should have an email
         const email = await models.Email.findOne({
@@ -1109,7 +1110,7 @@ describe('Posts API', function () {
         assert.equal(model.get('status'), 'sent');
         should(model.get('newsletter_id')).eql(newsletterId);
         assert.equal(model.get('email_recipient_filter'), 'status:free');
-        should.exist(model.get('published_by'));
+        assertExists(model.get('published_by'));
 
         // We should have an email
         const email = await models.Email.findOne({
@@ -1178,7 +1179,7 @@ describe('Posts API', function () {
         assert.equal(model.get('status'), 'sent');
         should(model.get('newsletter_id')).eql(newsletterId);
         assert.equal(model.get('email_recipient_filter'), 'status:free');
-        should.exist(model.get('published_by'));
+        assertExists(model.get('published_by'));
 
         // We should have an email
         const email = await models.Email.findOne({
@@ -1268,7 +1269,7 @@ describe('Posts API', function () {
 
         should(model.get('newsletter_id')).eql(newsletterId);
         assert.equal(model.get('email_recipient_filter'), 'all');
-        should.exist(model.get('published_by'));
+        assertExists(model.get('published_by'));
 
         publishedPost.newsletter.id.should.eql(newsletterId);
         assert.equal(publishedPost.newsletter_id, undefined);
@@ -1651,7 +1652,7 @@ describe('Posts API', function () {
             post_id: id
         }, testUtils.context.internal);
 
-        should.exist(email);
+        assertExists(email);
         should(email.get('newsletter_id')).eql(newsletterId);
 
         const republished = {
@@ -1795,7 +1796,7 @@ describe('Posts API', function () {
                 post_id: id
             }, testUtils.context.internal);
 
-            should.exist(email);
+            assertExists(email);
             should(email.get('newsletter_id')).eql(newsletterId);
             should(email.get('status')).equalOneOf('pending', 'submitted', 'submitting');
         });

--- a/ghost/core/test/e2e-api/admin/storage-adapter-switching.test.js
+++ b/ghost/core/test/e2e-api/admin/storage-adapter-switching.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../utils/assertions');
 const should = require('should');
 const sinon = require('sinon');
 const {agentProvider, fixtureManager} = require('../../utils/e2e-framework');
@@ -96,7 +97,7 @@ describe('Ghost Admin - Storage Adapter Switching', function () {
 
     it('Snippets also switch URLs correctly', async function () {
         const snippet = await models.Snippet.findOne({name: 'Snippet with all media types - Mobiledoc'});
-        should.exist(snippet, 'Snippet should exist');
+        assertExists(snippet, 'Snippet should exist');
 
         let res = await agent
             .get(`snippets/${snippet.id}/`)

--- a/ghost/core/test/e2e-api/admin/tags.test.js
+++ b/ghost/core/test/e2e-api/admin/tags.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../utils/assertions');
 const should = require('should');
 const sinon = require('sinon');
 const supertest = require('supertest');
@@ -26,8 +27,8 @@ describe('Tag API', function () {
 
         assert.equal(res.headers['x-cache-invalidate'], undefined);
         const jsonResponse = res.body;
-        should.exist(jsonResponse);
-        should.exist(jsonResponse.tags);
+        assertExists(jsonResponse);
+        assertExists(jsonResponse.tags);
         assert.equal(jsonResponse.tags.length, 7);
         localUtils.API.checkResponse(jsonResponse.tags[0], 'tag', ['count', 'url']);
 
@@ -49,7 +50,7 @@ describe('Tag API', function () {
 
         // kitchen-sink has published posts, so it should have a valid URL
         kitchenSinkTag.url.should.eql(`${config.get('url')}/tag/kitchen-sink/`);
-        should.exist(kitchenSinkTag.count.posts);
+        assertExists(kitchenSinkTag.count.posts);
         assert.equal(kitchenSinkTag.count.posts, 2);
     });
 
@@ -74,11 +75,11 @@ describe('Tag API', function () {
 
         assert.equal(res.headers['x-cache-invalidate'], undefined);
         const jsonResponse = res.body;
-        should.exist(jsonResponse);
-        should.exist(jsonResponse.tags);
+        assertExists(jsonResponse);
+        assertExists(jsonResponse.tags);
         assert.equal(jsonResponse.tags.length, 1);
         localUtils.API.checkResponse(jsonResponse.tags[0], 'tag', ['count', 'url']);
-        should.exist(jsonResponse.tags[0].count.posts);
+        assertExists(jsonResponse.tags[0].count.posts);
         assert.equal(jsonResponse.tags[0].count.posts, 7);
 
         jsonResponse.tags[0].url.should.eql(`${config.get('url')}/tag/getting-started/`);
@@ -97,16 +98,16 @@ describe('Tag API', function () {
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(201);
 
-        should.exist(res.headers['x-cache-invalidate']);
+        assertExists(res.headers['x-cache-invalidate']);
         const jsonResponse = res.body;
-        should.exist(jsonResponse);
-        should.exist(jsonResponse.tags);
+        assertExists(jsonResponse);
+        assertExists(jsonResponse.tags);
         assert.equal(jsonResponse.tags.length, 1);
 
         localUtils.API.checkResponse(jsonResponse.tags[0], 'tag', ['url']);
         assert.equal(testUtils.API.isISO8601(jsonResponse.tags[0].created_at), true);
 
-        should.exist(res.headers.location);
+        assertExists(res.headers.location);
         res.headers.location.should.equal(`http://127.0.0.1:2369${localUtils.API.getApiQuery('tags/')}${res.body.tags[0].id}/`);
     });
 
@@ -126,14 +127,14 @@ describe('Tag API', function () {
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(201);
 
-        should.exist(res.headers['x-cache-invalidate']);
+        assertExists(res.headers['x-cache-invalidate']);
         const jsonResponse = res.body;
-        should.exist(jsonResponse);
+        assertExists(jsonResponse);
         assert.equal(jsonResponse.tags[0].visibility, 'internal');
         assert.equal(jsonResponse.tags[0].name, '#test');
         assert.equal(jsonResponse.tags[0].slug, 'hash-test');
 
-        should.exist(res.headers.location);
+        assertExists(res.headers.location);
         res.headers.location.should.equal(`http://127.0.0.1:2369${localUtils.API.getApiQuery('tags/')}${res.body.tags[0].id}/`);
     });
 
@@ -148,10 +149,10 @@ describe('Tag API', function () {
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(200);
 
-        should.exist(res.headers['x-cache-invalidate']);
+        assertExists(res.headers['x-cache-invalidate']);
         const jsonResponse = res.body;
-        should.exist(jsonResponse);
-        should.exist(jsonResponse.tags);
+        assertExists(jsonResponse);
+        assertExists(jsonResponse.tags);
         assert.equal(jsonResponse.tags.length, 1);
         localUtils.API.checkResponse(jsonResponse.tags[0], 'tag', ['url']);
         assert.equal(jsonResponse.tags[0].description, 'hey ho ab ins klo');
@@ -164,7 +165,7 @@ describe('Tag API', function () {
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(204);
 
-        should.exist(res.headers['x-cache-invalidate']);
+        assertExists(res.headers['x-cache-invalidate']);
         res.body.should.eql({});
     });
 

--- a/ghost/core/test/e2e-api/admin/themes.test.js
+++ b/ghost/core/test/e2e-api/admin/themes.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../utils/assertions');
 const should = require('should');
 const sinon = require('sinon');
 const path = require('path');
@@ -49,7 +50,7 @@ describe('Themes API', function () {
             .expect(200);
 
         const jsonResponse = res.body;
-        should.exist(jsonResponse.themes);
+        assertExists(jsonResponse.themes);
         localUtils.API.checkResponse(jsonResponse, 'themes');
         assert.equal(jsonResponse.themes.length, 7);
 
@@ -111,7 +112,7 @@ describe('Themes API', function () {
 
         assert.equal(res.headers['x-cache-invalidate'], undefined);
 
-        should.exist(jsonResponse.themes);
+        assertExists(jsonResponse.themes);
         localUtils.API.checkResponse(jsonResponse, 'themes');
         assert.equal(jsonResponse.themes.length, 1);
         localUtils.API.checkResponse(jsonResponse.themes[0], 'theme');
@@ -138,19 +139,19 @@ describe('Themes API', function () {
 
         const jsonResponse3 = res3.body;
 
-        should.exist(jsonResponse3.themes);
+        assertExists(jsonResponse3.themes);
         localUtils.API.checkResponse(jsonResponse3, 'themes');
         assert.equal(jsonResponse3.themes.length, 8);
 
         // Source should be present and still active
         const sourceTheme = _.find(jsonResponse3.themes, {name: 'source'});
-        should.exist(sourceTheme);
+        assertExists(sourceTheme);
         localUtils.API.checkResponse(sourceTheme, 'theme', 'templates');
         assert.equal(sourceTheme.active, true);
 
         // The added theme should be here
         const addedTheme = _.find(jsonResponse3.themes, {name: 'valid'});
-        should.exist(addedTheme);
+        assertExists(addedTheme);
         localUtils.API.checkResponse(addedTheme, 'theme');
         assert.equal(addedTheme.active, false);
 
@@ -208,13 +209,13 @@ describe('Themes API', function () {
 
         const jsonResponse2 = res2.body;
 
-        should.exist(jsonResponse2.themes);
+        assertExists(jsonResponse2.themes);
         localUtils.API.checkResponse(jsonResponse2, 'themes');
         assert.equal(jsonResponse2.themes.length, 7);
 
         // Source should be present and still active
         const sourceTheme = _.find(jsonResponse2.themes, {name: 'source'});
-        should.exist(sourceTheme);
+        assertExists(sourceTheme);
         localUtils.API.checkResponse(sourceTheme, 'theme', 'templates');
         assert.equal(sourceTheme.active, true);
 
@@ -227,7 +228,7 @@ describe('Themes API', function () {
         const res = await uploadTheme({themePath: path.join(__dirname, '/../../utils/fixtures/themes/warnings.zip')});
         const jsonResponse = res.body;
 
-        should.exist(jsonResponse.themes);
+        assertExists(jsonResponse.themes);
         localUtils.API.checkResponse(jsonResponse, 'themes');
         assert.equal(jsonResponse.themes.length, 1);
         localUtils.API.checkResponse(jsonResponse.themes[0], 'theme', ['warnings']);
@@ -250,17 +251,17 @@ describe('Themes API', function () {
 
         const jsonResponse = res.body;
 
-        should.exist(jsonResponse.themes);
+        assertExists(jsonResponse.themes);
         localUtils.API.checkResponse(jsonResponse, 'themes');
         assert.equal(jsonResponse.themes.length, 7);
 
         const sourceTheme = _.find(jsonResponse.themes, {name: 'source'});
-        should.exist(sourceTheme);
+        assertExists(sourceTheme);
         localUtils.API.checkResponse(sourceTheme, 'theme', 'templates');
         assert.equal(sourceTheme.active, true);
 
         const testTheme = _.find(jsonResponse.themes, {name: 'test-theme'});
-        should.exist(testTheme);
+        assertExists(testTheme);
         localUtils.API.checkResponse(testTheme, 'theme');
         assert.equal(testTheme.active, false);
 
@@ -272,8 +273,8 @@ describe('Themes API', function () {
 
         const jsonResponse2 = res2.body;
 
-        should.exist(res2.headers['x-cache-invalidate']);
-        should.exist(jsonResponse2.themes);
+        assertExists(res2.headers['x-cache-invalidate']);
+        assertExists(jsonResponse2.themes);
         localUtils.API.checkResponse(jsonResponse2, 'themes');
         assert.equal(jsonResponse2.themes.length, 1);
 
@@ -281,7 +282,7 @@ describe('Themes API', function () {
         assert.equal(sourceTheme2, undefined);
 
         const testTheme2 = _.find(jsonResponse2.themes, {name: 'test-theme'});
-        should.exist(testTheme2);
+        assertExists(testTheme2);
         localUtils.API.checkResponse(testTheme2, 'theme', ['warnings', 'templates']);
         assert.equal(testTheme2.active, true);
         testTheme2.warnings.should.be.an.Array();
@@ -316,7 +317,7 @@ describe('Themes API', function () {
 
         const jsonResponse = res.body;
 
-        should.exist(jsonResponse.themes);
+        assertExists(jsonResponse.themes);
         localUtils.API.checkResponse(jsonResponse, 'themes');
         assert.equal(jsonResponse.themes.length, 1);
         localUtils.API.checkResponse(jsonResponse.themes[0], 'theme', ['warnings']);
@@ -359,7 +360,7 @@ describe('Themes API', function () {
 
         const jsonResponse = res.body;
 
-        should.exist(jsonResponse.themes);
+        assertExists(jsonResponse.themes);
         localUtils.API.checkResponse(jsonResponse, 'themes');
         assert.equal(jsonResponse.themes.length, 1);
         localUtils.API.checkResponse(jsonResponse.themes[0], 'theme', ['warnings']);
@@ -407,7 +408,7 @@ describe('Themes API', function () {
 
         const jsonResponse = res.body;
 
-        should.exist(jsonResponse.errors);
+        assertExists(jsonResponse.errors);
         assert.equal(jsonResponse.errors[0].type, 'HostLimitError');
         assert.match(jsonResponse.errors[0].message, /Upgrade to use customThemes feature\./);
 
@@ -430,9 +431,9 @@ describe('Themes API', function () {
         const res = await uploadTheme({themePath: path.join(__dirname, '..', '..', 'utils', 'fixtures', 'themes', 'valid.zip')});
         const jsonResponse = res.body;
 
-        should.exist(res.headers['x-cache-invalidate']);
+        assertExists(res.headers['x-cache-invalidate']);
 
-        should.exist(jsonResponse.themes);
+        assertExists(jsonResponse.themes);
         localUtils.API.checkResponse(jsonResponse, 'themes');
         assert.equal(jsonResponse.themes.length, 1);
         localUtils.API.checkResponse(jsonResponse.themes[0], 'theme', 'templates');

--- a/ghost/core/test/e2e-api/content/tags.test.js
+++ b/ghost/core/test/e2e-api/content/tags.test.js
@@ -1,4 +1,5 @@
 const assert = require('assert/strict');
+const {assertExists} = require('../../utils/assertions');
 const should = require('should');
 const supertest = require('supertest');
 const _ = require('lodash');
@@ -33,7 +34,7 @@ describe('Tags Content API', function () {
 
         assert.equal(res.headers['x-cache-invalidate'], undefined);
         const jsonResponse = res.body;
-        should.exist(jsonResponse.tags);
+        assertExists(jsonResponse.tags);
         localUtils.API.checkResponse(jsonResponse, 'tags');
         assert.equal(jsonResponse.tags.length, 5);
         localUtils.API.checkResponse(jsonResponse.tags[0], 'tag', ['url']);
@@ -50,9 +51,9 @@ describe('Tags Content API', function () {
             assert.equal(jsonResponse.tags[4].name, 'kitchen sink');
         }
 
-        should.exist(res.body.tags[0].url);
-        should.exist(url.parse(res.body.tags[0].url).protocol);
-        should.exist(url.parse(res.body.tags[0].url).host);
+        assertExists(res.body.tags[0].url);
+        assertExists(url.parse(res.body.tags[0].url).protocol);
+        assertExists(url.parse(res.body.tags[0].url).host);
     });
 
     it('Can request tags with limit=all', async function () {
@@ -64,7 +65,7 @@ describe('Tags Content API', function () {
 
         assert.equal(res.headers['x-cache-invalidate'], undefined);
         const jsonResponse = res.body;
-        should.exist(jsonResponse.tags);
+        assertExists(jsonResponse.tags);
         localUtils.API.checkResponse(jsonResponse, 'tags');
         assert.equal(jsonResponse.tags.length, 5);
         localUtils.API.checkResponse(jsonResponse.tags[0], 'tag', ['url']);
@@ -80,7 +81,7 @@ describe('Tags Content API', function () {
 
         assert.equal(res.headers['x-cache-invalidate'], undefined);
         const jsonResponse = res.body;
-        should.exist(jsonResponse.tags);
+        assertExists(jsonResponse.tags);
         localUtils.API.checkResponse(jsonResponse, 'tags');
         assert.equal(jsonResponse.tags.length, 3);
         localUtils.API.checkResponse(jsonResponse.tags[0], 'tag', ['url']);
@@ -96,7 +97,7 @@ describe('Tags Content API', function () {
 
         const jsonResponse = res.body;
 
-        should.exist(jsonResponse.tags);
+        assertExists(jsonResponse.tags);
         jsonResponse.tags.should.be.an.Array().with.lengthOf(5);
 
         // Each tag should have the correct count

--- a/ghost/core/test/e2e-api/members/middleware.test.js
+++ b/ghost/core/test/e2e-api/members/middleware.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../utils/assertions');
 const crypto = require('crypto');
 const {agentProvider, mockManager, fixtureManager, matchers, configUtils} = require('../../utils/e2e-framework');
 const {anyEtag, anyObjectId, anyUuid, anyISODateTime, stringMatching} = matchers;
@@ -285,7 +286,7 @@ describe('Comments API', function () {
             await membersAgent
                 .get('/api/member/')
                 .expect(({headers}) => {
-                    should.exist(headers['set-cookie']);
+                    assertExists(headers['set-cookie']);
                     headers['set-cookie'].should.matchAny(/ghost-access=null;/);
                 })
                 .expectStatus(204)

--- a/ghost/core/test/e2e-frontend/custom-routes.test.js
+++ b/ghost/core/test/e2e-frontend/custom-routes.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../utils/assertions');
 const should = require('should');
 const supertest = require('supertest');
 const path = require('path');
@@ -10,7 +11,7 @@ function assertCorrectFrontendHeaders(res) {
     assert.equal(res.headers['x-cache-invalidate'], undefined);
     assert.equal(res.headers['X-CSRF-Token'], undefined);
     assert.equal(res.headers['set-cookie'], undefined);
-    should.exist(res.headers.date);
+    assertExists(res.headers.date);
 }
 
 describe('Custom Frontend routing', function () {

--- a/ghost/core/test/e2e-frontend/default-routes.test.js
+++ b/ghost/core/test/e2e-frontend/default-routes.test.js
@@ -6,6 +6,7 @@
 // Mocking out the models to not touch the DB would turn these into unit tests, and should probably be done in future,
 // But then again testing real code, rather than mock code, might be more useful...
 const assert = require('node:assert/strict');
+const {assertExists} = require('../utils/assertions');
 const should = require('should');
 const sinon = require('sinon');
 const supertest = require('supertest');
@@ -21,7 +22,7 @@ function assertCorrectFrontendHeaders(res) {
     assert.equal(res.headers['x-cache-invalidate'], undefined);
     assert.equal(res.headers['X-CSRF-Token'], undefined);
     assert.equal(res.headers['set-cookie'], undefined);
-    should.exist(res.headers.date);
+    assertExists(res.headers.date);
 }
 
 describe('Default Frontend routing', function () {

--- a/ghost/core/test/e2e-frontend/email-routes.test.js
+++ b/ghost/core/test/e2e-frontend/email-routes.test.js
@@ -3,6 +3,7 @@
 // Mocking out the models to not touch the DB would turn these into unit tests, and should probably be done in future,
 // But then again testing real code, rather than mock code, might be more useful...
 const assert = require('node:assert/strict');
+const {assertExists} = require('../utils/assertions');
 const should = require('should');
 const sinon = require('sinon');
 const supertest = require('supertest');
@@ -51,7 +52,7 @@ describe('Frontend Routing: Email Routes', function () {
         assert.equal(res.headers['x-cache-invalidate'], undefined);
         assert.equal(res.headers['X-CSRF-Token'], undefined);
         assert.equal(res.headers['set-cookie'], undefined);
-        should.exist(res.headers.date);
+        assertExists(res.headers.date);
     });
 
     it('404s for draft email only post', function () {

--- a/ghost/core/test/e2e-frontend/helpers/get.test.js
+++ b/ghost/core/test/e2e-frontend/helpers/get.test.js
@@ -1,4 +1,5 @@
 const assert = require('assert/strict');
+const {assertExists} = require('../../utils/assertions');
 const should = require('should');
 const sinon = require('sinon');
 const testUtils = require('../../utils');
@@ -37,7 +38,7 @@ function testPosts(posts, map) {
         const expectData = map[postID];
 
         const post = posts.find(p => p.id === postID);
-        should.exist(post);
+        assertExists(post);
 
         post.should.match(expectData);
     }

--- a/ghost/core/test/e2e-frontend/member-stats.test.js
+++ b/ghost/core/test/e2e-frontend/member-stats.test.js
@@ -1,3 +1,4 @@
+const {assertExists} = require('../utils/assertions');
 const should = require('should');
 const {getMemberStats} = require('../../core/frontend/utils/member-count.js');
 
@@ -5,24 +6,24 @@ describe('Front-end member stats ', function () {
     it('should return free', async function () {
         const members = await getMemberStats();
         const {free} = members;
-        should.exist(free);
+        assertExists(free);
     });
 
     it('should return paid', async function () {
         const members = await getMemberStats();
         const {paid} = members;
-        should.exist(paid);
+        assertExists(paid);
     });
 
     it('should return comped', async function () {
         const members = await getMemberStats();
         const {comped} = members;
-        should.exist(comped);
+        assertExists(comped);
     });
 
     it('should return total', async function () {
         const members = await getMemberStats();
         const {total} = members;
-        should.exist(total);
+        assertExists(total);
     });
 });

--- a/ghost/core/test/e2e-frontend/members.test.js
+++ b/ghost/core/test/e2e-frontend/members.test.js
@@ -1,4 +1,5 @@
 const assert = require('assert/strict');
+const {assertExists} = require('../utils/assertions');
 const should = require('should');
 const sinon = require('sinon');
 const supertest = require('supertest');
@@ -57,7 +58,7 @@ describe('Front-end members behavior', function () {
             .expect(302)
             .expect((res) => {
                 const redirectUrl = new URL(res.headers.location, testUtils.API.getURL());
-                should.exist(redirectUrl.searchParams.get('success'));
+                assertExists(redirectUrl.searchParams.get('success'));
                 assert.equal(redirectUrl.searchParams.get('success'), 'true');
             });
 
@@ -229,7 +230,7 @@ describe('Front-end members behavior', function () {
                     .expect(200);
                 const getJsonResponse = getRes.body;
 
-                should.exist(getJsonResponse);
+                assertExists(getJsonResponse);
                 getJsonResponse.should.have.properties(['email', 'uuid', 'status', 'name', 'newsletters']);
                 getJsonResponse.should.not.have.property('id');
                 assert.equal(getJsonResponse.newsletters.length, 1);
@@ -256,7 +257,7 @@ describe('Front-end members behavior', function () {
                     .expect(200);
                 const jsonResponse = res.body;
 
-                should.exist(jsonResponse);
+                assertExists(jsonResponse);
                 jsonResponse.should.have.properties(['email', 'uuid', 'status', 'name', 'newsletters']);
                 jsonResponse.should.not.have.property('id');
                 assert.equal(jsonResponse.newsletters.length, 0);
@@ -268,7 +269,7 @@ describe('Front-end members behavior', function () {
                     .expect(200);
 
                 const restoreJsonResponse = resRestored.body;
-                should.exist(restoreJsonResponse);
+                assertExists(restoreJsonResponse);
                 restoreJsonResponse.should.have.properties(['email', 'uuid', 'status', 'name', 'newsletters']);
                 restoreJsonResponse.should.not.have.property('id');
                 assert.equal(restoreJsonResponse.newsletters.length, 1);
@@ -860,7 +861,7 @@ describe('Front-end members behavior', function () {
                     .expect(302)
                     .then((res) => {
                         const redirectUrl = new URL(res.headers.location, testUtils.API.getURL());
-                        should.exist(redirectUrl.searchParams.get('success'));
+                        assertExists(redirectUrl.searchParams.get('success'));
                         assert.equal(redirectUrl.searchParams.get('success'), 'true');
                     });
             });
@@ -870,7 +871,7 @@ describe('Front-end members behavior', function () {
                     .expect(200);
 
                 const memberData = res.body;
-                should.exist(memberData);
+                assertExists(memberData);
 
                 // @NOTE: this should be a snapshot test not code
                 memberData.should.have.properties([

--- a/ghost/core/test/e2e-frontend/preview-routes.test.js
+++ b/ghost/core/test/e2e-frontend/preview-routes.test.js
@@ -3,6 +3,7 @@
 // Mocking out the models to not touch the DB would turn these into unit tests, and should probably be done in future,
 // But then again testing real code, rather than mock code, might be more useful...
 const assert = require('node:assert/strict');
+const {assertExists} = require('../utils/assertions');
 const should = require('should');
 
 const sinon = require('sinon');
@@ -17,7 +18,7 @@ function assertCorrectFrontendHeaders(res) {
     assert.equal(res.headers['x-cache-invalidate'], undefined);
     assert.equal(res.headers['X-CSRF-Token'], undefined);
     assert.equal(res.headers['set-cookie'], undefined);
-    should.exist(res.headers.date);
+    assertExists(res.headers.date);
 }
 
 function assertPaywallRendered(res) {
@@ -67,7 +68,7 @@ describe('Frontend Routing: Preview Routes', function () {
                 assert.equal(res.headers['x-cache-invalidate'], undefined);
                 assert.equal(res.headers['X-CSRF-Token'], undefined);
                 assert.equal(res.headers['set-cookie'], undefined);
-                should.exist(res.headers.date);
+                assertExists(res.headers.date);
 
                 assert.equal($('title').text(), 'Not finished yet');
                 assert.equal($('meta[name="description"]').attr('content'), 'meta description for draft post');

--- a/ghost/core/test/e2e-server/admin.test.js
+++ b/ghost/core/test/e2e-server/admin.test.js
@@ -4,6 +4,7 @@
 // But then again testing real code, rather than mock code, might be more useful...
 
 const assert = require('node:assert/strict');
+const {assertExists} = require('../utils/assertions');
 const should = require('should');
 const path = require('path');
 const fs = require('fs');
@@ -18,7 +19,7 @@ let request;
 
 function assertCorrectHeaders(res) {
     assert.equal(res.headers['x-cache-invalidate'], undefined);
-    should.exist(res.headers.date);
+    assertExists(res.headers.date);
 }
 
 describe('Admin Routing', function () {
@@ -147,7 +148,7 @@ describe('Admin Routing', function () {
                 .set('X-Forwarded-Proto', 'https')
                 .expect(200);
 
-            should.exist(res.headers.etag);
+            assertExists(res.headers.etag);
             assert.equal(res.headers.etag, '8793333e8e91cde411b1336c58ec6ef3');
         });
     });

--- a/ghost/core/test/integration/exporter/exporter.test.js
+++ b/ghost/core/test/integration/exporter/exporter.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../utils/assertions');
 const should = require('should');
 const sinon = require('sinon');
 const testUtils = require('../../utils');
@@ -18,7 +19,7 @@ describe('Exporter', function () {
     });
     beforeEach(testUtils.setup('default', 'settings'));
 
-    should.exist(exporter);
+    assertExists(exporter);
 
     it('exports expected table data', function (done) {
         exporter.doExport().then(function (exportData) {
@@ -102,9 +103,9 @@ describe('Exporter', function () {
                 'webhooks'
             ];
 
-            should.exist(exportData);
-            should.exist(exportData.meta);
-            should.exist(exportData.data);
+            assertExists(exportData);
+            assertExists(exportData.meta);
+            assertExists(exportData.data);
 
             // NOTE: using `Object.keys` here instead of `should.have.only.keys` assertion
             //       because when `have.only.keys` fails there's no useful diff

--- a/ghost/core/test/integration/importer/v2.test.js
+++ b/ghost/core/test/integration/importer/v2.test.js
@@ -4,6 +4,7 @@ const testUtils = require('../../utils');
 const moment = require('moment-timezone');
 const ObjectId = require('bson-objectid').default;
 const assert = require('assert/strict');
+const {assertExists} = require('../../utils/assertions');
 const _ = require('lodash');
 const validator = require('@tryghost/validator');
 
@@ -43,7 +44,7 @@ describe('Importer', function () {
         it('ensure return structure', function () {
             return dataImporter.doImport(exportedBodyV2().db[0], importOptions)
                 .then(function (importResult) {
-                    should.exist(importResult);
+                    assertExists(importResult);
                     assert.equal(importResult.hasOwnProperty('data'), true);
                     assert.equal(importResult.hasOwnProperty('problems'), true);
                 });
@@ -78,7 +79,7 @@ describe('Importer', function () {
 
             return dataImporter.doImport(exportData, importOptions)
                 .then(function (importResult) {
-                    should.exist(importResult.data.posts);
+                    assertExists(importResult.data.posts);
                     assert.equal(importResult.data.posts.length, 2);
                     assert.equal(importResult.problems.length, 1);
 
@@ -131,7 +132,7 @@ describe('Importer', function () {
 
             return dataImporter.doImport(exportData, importOptions)
                 .then(function (importResult) {
-                    should.exist(importResult.data.users);
+                    assertExists(importResult.data.users);
                     assert.equal(importResult.data.users.length, 1);
                     assert.equal(importResult.problems.length, 1);
 
@@ -153,7 +154,7 @@ describe('Importer', function () {
 
             return dataImporter.doImport(exportData, importOptions)
                 .then(function (importResult) {
-                    should.exist(importResult.data.posts);
+                    assertExists(importResult.data.posts);
                     assert.equal(importResult.data.posts.length, 1);
                     assert.equal(importResult.problems.length, 1);
 
@@ -175,7 +176,7 @@ describe('Importer', function () {
 
             return dataImporter.doImport(exportData, importOptions)
                 .then(function (importResult) {
-                    should.exist(importResult.data.posts);
+                    assertExists(importResult.data.posts);
                     assert.equal(importResult.data.posts.length, 2);
                     assert.equal(importResult.problems.length, 0);
 
@@ -225,8 +226,8 @@ describe('Importer', function () {
 
             return dataImporter.doImport(exportData, importOptions)
                 .then(function (importResult) {
-                    should.exist(importResult.data.tags);
-                    should.exist(importResult.originalData.posts_tags);
+                    assertExists(importResult.data.tags);
+                    assertExists(importResult.originalData.posts_tags);
 
                     assert.equal(importResult.data.tags.length, 1);
 
@@ -299,7 +300,7 @@ describe('Importer', function () {
                     ]);
                 })
                 .then(function (importedData) {
-                    should.exist(importedData);
+                    assertExists(importedData);
 
                     assert.equal(importedData.length, 4, 'Did not get data successfully');
 
@@ -432,7 +433,7 @@ describe('Importer', function () {
                     ]);
                 })
                 .then(function (importedData) {
-                    should.exist(importedData);
+                    assertExists(importedData);
 
                     assert.equal(importedData.length, 2, 'Did not get data successfully');
 

--- a/ghost/core/test/legacy/api/admin/db.test.js
+++ b/ghost/core/test/legacy/api/admin/db.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../utils/assertions');
 const path = require('path');
 const os = require('os');
 const fs = require('fs-extra');
@@ -48,7 +49,7 @@ describe('DB API', function () {
             .expect(200)
             .then((res) => {
                 const jsonResponse = res.body;
-                should.exist(jsonResponse.db);
+                assertExists(jsonResponse.db);
                 assert.equal(jsonResponse.db.length, 1);
 
                 // NOTE: default tables + 1 from include parameters
@@ -81,7 +82,7 @@ describe('DB API', function () {
             })
             .then((res) => {
                 const jsonResponse = res.body;
-                should.exist(jsonResponse.db);
+                assertExists(jsonResponse.db);
 
                 fs.ensureDirSync(exportFolder);
                 fs.writeJSONSync(exportPath, jsonResponse);
@@ -149,8 +150,8 @@ describe('DB API', function () {
             .expect(200);
 
         const jsonResponse = res.body;
-        should.exist(jsonResponse.db);
-        should.exist(jsonResponse.problems);
+        assertExists(jsonResponse.db);
+        assertExists(jsonResponse.problems);
         assert.equal(jsonResponse.problems.length, 2);
 
         const postsResponse = await request.get(localUtils.API.getApiQuery('posts/'))
@@ -196,8 +197,8 @@ describe('DB API', function () {
             .expect(200);
 
         const jsonResponse = res.body;
-        should.exist(jsonResponse.db);
-        should.exist(jsonResponse.problems);
+        assertExists(jsonResponse.db);
+        assertExists(jsonResponse.problems);
         assert.equal(jsonResponse.problems.length, 2);
 
         const res2 = await request.get(localUtils.API.getApiQuery('posts/'))
@@ -243,8 +244,8 @@ describe('DB API', function () {
             .expect(200);
 
         const jsonResponse = res.body;
-        should.exist(jsonResponse.db);
-        should.exist(jsonResponse.problems);
+        assertExists(jsonResponse.db);
+        assertExists(jsonResponse.problems);
         assert.equal(jsonResponse.problems.length, 2);
 
         const res2 = await request.get(localUtils.API.getApiQuery('posts/'))
@@ -290,8 +291,8 @@ describe('DB API', function () {
             .expect(200);
 
         const jsonResponse = res.body;
-        should.exist(jsonResponse.db);
-        should.exist(jsonResponse.problems);
+        assertExists(jsonResponse.db);
+        assertExists(jsonResponse.problems);
 
         // 2 expected problems:
         // - Theme not imported
@@ -339,7 +340,7 @@ describe('DB API', function () {
 
         // Check if we have a product
         const product = await models.Product.findOne({slug: 'ghost-inc'});
-        should.exist(product);
+        assertExists(product);
 
         assert.equal(product.get('name'), 'Ghost Inc.');
         assert.equal(product.get('description'), 'Our daily newsletter');
@@ -347,25 +348,25 @@ describe('DB API', function () {
 
         // Check settings
         const portalProducts = await models.Settings.findOne({key: 'portal_products'});
-        should.exist(portalProducts);
+        assertExists(portalProducts);
         JSON.parse(portalProducts.get('value')).should.deepEqual([]);
 
         // Check stripe products
         const stripeProduct = await models.StripeProduct.findOne({product_id: product.id});
-        should.exist(stripeProduct);
+        assertExists(stripeProduct);
         assert.equal(stripeProduct.get('stripe_product_id'), 'prod_d2c1708c21');
         assert.notEqual(stripeProduct.id, '60be1fc9bd3af33564cfb337');
 
         // Check newsletters
         const newsletter = await models.Newsletter.findOne({slug: 'test'});
-        should.exist(newsletter);
+        assertExists(newsletter);
         assert.equal(newsletter.get('name'), 'Ghost Inc.');
         // Make sure sender_email is not set
         assert.equal(newsletter.get('sender_email'), null);
 
         // Check posts
         const post = await models.Post.findOne({slug: 'test-newsletter'}, {withRelated: ['tiers']});
-        should.exist(post);
+        assertExists(post);
 
         post.get('newsletter_id').should.equal(newsletter.id);
         assert.equal(post.get('visibility'), 'public');
@@ -376,10 +377,10 @@ describe('DB API', function () {
 
         // Check stripe prices
         const monthlyPrice = await models.StripePrice.findOne({id: product.get('monthly_price_id')});
-        should.exist(monthlyPrice);
+        assertExists(monthlyPrice);
 
         const yearlyPrice = await models.StripePrice.findOne({id: product.get('yearly_price_id')});
-        should.exist(yearlyPrice);
+        assertExists(yearlyPrice);
 
         assert.equal(monthlyPrice.get('amount'), 500);
         assert.equal(monthlyPrice.get('currency'), 'usd');
@@ -441,7 +442,7 @@ describe('DB API (cleaned)', function () {
 
         // Check if we have a product
         const product = await models.Product.findOne({slug: 'ghost-inc'});
-        should.exist(product);
+        assertExists(product);
         product.id.should.equal(existingProduct.id);
         assert.equal(product.get('slug'), 'ghost-inc');
         assert.equal(product.get('name'), 'Ghost Inc.');
@@ -449,25 +450,25 @@ describe('DB API (cleaned)', function () {
 
         // Check settings
         const portalProducts = await models.Settings.findOne({key: 'portal_products'});
-        should.exist(portalProducts);
+        assertExists(portalProducts);
         JSON.parse(portalProducts.get('value')).should.deepEqual([]);
 
         // Check stripe products
         const stripeProduct = await models.StripeProduct.findOne({product_id: product.id});
-        should.exist(stripeProduct);
+        assertExists(stripeProduct);
         assert.equal(stripeProduct.get('stripe_product_id'), 'prod_d2c1708c21');
         assert.notEqual(stripeProduct.id, '60be1fc9bd3af33564cfb337');
 
         // Check newsletters
         const newsletter = await models.Newsletter.findOne({slug: 'test'});
-        should.exist(newsletter);
+        assertExists(newsletter);
         assert.equal(newsletter.get('name'), 'Ghost Inc.');
         // Make sure sender_email is not set
         assert.equal(newsletter.get('sender_email'), null);
 
         // Check posts
         const post = await models.Post.findOne({slug: 'test-newsletter'}, {withRelated: ['tiers']});
-        should.exist(post);
+        assertExists(post);
 
         post.get('newsletter_id').should.equal(newsletter.id);
         assert.equal(post.get('visibility'), 'public');
@@ -478,10 +479,10 @@ describe('DB API (cleaned)', function () {
 
         // Check stripe prices
         const monthlyPrice = await models.StripePrice.findOne({stripe_price_id: 'price_a425520db0'});
-        should.exist(monthlyPrice);
+        assertExists(monthlyPrice);
 
         const yearlyPrice = await models.StripePrice.findOne({stripe_price_id: 'price_d04baebb73'});
-        should.exist(yearlyPrice);
+        assertExists(yearlyPrice);
 
         assert.equal(monthlyPrice.get('amount'), 500);
         assert.equal(monthlyPrice.get('currency'), 'usd');

--- a/ghost/core/test/legacy/api/admin/identities.test.js
+++ b/ghost/core/test/legacy/api/admin/identities.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../utils/assertions');
 const should = require('should');
 const supertest = require('supertest');
 const jwt = require('jsonwebtoken');
@@ -51,8 +52,8 @@ describe('Identities API', function () {
                 .then((res) => {
                     assert.equal(res.headers['x-cache-invalidate'], undefined);
                     const jsonResponse = res.body;
-                    should.exist(jsonResponse);
-                    should.exist(jsonResponse.identities);
+                    assertExists(jsonResponse);
+                    assertExists(jsonResponse.identities);
 
                     identity = jsonResponse.identities[0];
                 })
@@ -97,8 +98,8 @@ describe('Identities API', function () {
                 .then((res) => {
                     assert.equal(res.headers['x-cache-invalidate'], undefined);
                     const jsonResponse = res.body;
-                    should.exist(jsonResponse);
-                    should.exist(jsonResponse.identities);
+                    assertExists(jsonResponse);
+                    assertExists(jsonResponse.identities);
 
                     identity = jsonResponse.identities[0];
                 })

--- a/ghost/core/test/legacy/api/admin/members-importer.test.js
+++ b/ghost/core/test/legacy/api/admin/members-importer.test.js
@@ -11,6 +11,7 @@ const jobManager = require('../../../../core/server/services/jobs/job-service');
 
 const {mockManager} = require('../../../utils/e2e-framework');
 const assert = require('assert/strict');
+const {assertExists} = require('../../../utils/assertions');
 
 let request;
 let emailMockReceiver;
@@ -45,11 +46,11 @@ describe('Members Importer API', function () {
                 assert.equal(res.headers['x-cache-invalidate'], undefined);
                 const jsonResponse = res.body;
 
-                should.exist(jsonResponse);
-                should.exist(jsonResponse.meta);
-                should.exist(jsonResponse.meta.stats);
+                assertExists(jsonResponse);
+                assertExists(jsonResponse.meta);
+                assertExists(jsonResponse.meta.stats);
 
-                should.exist(jsonResponse.meta.import_label);
+                assertExists(jsonResponse.meta.import_label);
                 assert.match(jsonResponse.meta.import_label.slug, /^import-/);
                 assert.equal(jsonResponse.meta.stats.imported, 2);
                 assert.equal(jsonResponse.meta.stats.invalid.length, 0);
@@ -66,12 +67,12 @@ describe('Members Importer API', function () {
                 assert.equal(res.headers['x-cache-invalidate'], undefined);
                 const jsonResponse = res.body;
 
-                should.exist(jsonResponse);
-                should.exist(jsonResponse.members);
+                assertExists(jsonResponse);
+                assertExists(jsonResponse.members);
                 assert.equal(jsonResponse.members.length, 2);
 
                 const importedMember1 = jsonResponse.members.find(m => m.email === 'member+labels_1@example.com');
-                should.exist(importedMember1);
+                assertExists(importedMember1);
                 assert.equal(importedMember1.name, null);
                 assert.equal(importedMember1.note, null);
                 assert.equal(importedMember1.subscribed, true);
@@ -82,18 +83,18 @@ describe('Members Importer API', function () {
                 // check label order
                 // 1 unique global + 1 record labels + 1 auto generated label
                 assert.equal(importedMember1.labels.length, 3);
-                should.exist(importedMember1.labels.find(({slug}) => slug === 'label'));
-                should.exist(importedMember1.labels.find(({slug}) => slug === 'global-label-1'));
-                should.exist(importedMember1.labels.find(({slug}) => slug.match(/^import-/)));
+                assertExists(importedMember1.labels.find(({slug}) => slug === 'label'));
+                assertExists(importedMember1.labels.find(({slug}) => slug === 'global-label-1'));
+                assertExists(importedMember1.labels.find(({slug}) => slug.match(/^import-/)));
 
                 const importedMember2 = jsonResponse.members.find(m => m.email === 'member+labels_2@example.com');
-                should.exist(importedMember2);
+                assertExists(importedMember2);
                 // 1 unique global + 2 record labels
                 assert.equal(importedMember2.labels.length, 4);
-                should.exist(importedMember2.labels.find(({slug}) => slug === 'another-label'));
-                should.exist(importedMember2.labels.find(({slug}) => slug === 'and-one-more'));
-                should.exist(importedMember2.labels.find(({slug}) => slug === 'global-label-1'));
-                should.exist(importedMember2.labels.find(({slug}) => slug.match(/^import-/)));
+                assertExists(importedMember2.labels.find(({slug}) => slug === 'another-label'));
+                assertExists(importedMember2.labels.find(({slug}) => slug === 'and-one-more'));
+                assertExists(importedMember2.labels.find(({slug}) => slug === 'global-label-1'));
+                assertExists(importedMember2.labels.find(({slug}) => slug.match(/^import-/)));
             });
     });
 
@@ -112,14 +113,14 @@ describe('Members Importer API', function () {
                 assert.equal(res.headers['x-cache-invalidate'], undefined);
                 const jsonResponse = res.body;
 
-                should.exist(jsonResponse);
-                should.exist(jsonResponse.meta);
-                should.exist(jsonResponse.meta.stats);
+                assertExists(jsonResponse);
+                assertExists(jsonResponse.meta);
+                assertExists(jsonResponse.meta.stats);
 
                 assert.equal(jsonResponse.meta.stats.imported, 1);
                 assert.equal(jsonResponse.meta.stats.invalid.length, 0);
 
-                should.exist(jsonResponse.meta.import_label);
+                assertExists(jsonResponse.meta.import_label);
                 assert.match(jsonResponse.meta.import_label.slug, /^import-/);
             })
             .then(() => {
@@ -134,9 +135,9 @@ describe('Members Importer API', function () {
                 assert.equal(res.headers['x-cache-invalidate'], undefined);
                 const jsonResponse = res.body;
 
-                should.exist(jsonResponse);
-                should.exist(jsonResponse.members);
-                should.exist(jsonResponse.members[0]);
+                assertExists(jsonResponse);
+                assertExists(jsonResponse.members);
+                assertExists(jsonResponse.members[0]);
 
                 const importedMember1 = jsonResponse.members[0];
                 assert.equal(importedMember1.email, 'member+mapped_1@example.com');
@@ -162,9 +163,9 @@ describe('Members Importer API', function () {
                 assert.equal(res.headers['x-cache-invalidate'], undefined);
                 const jsonResponse = res.body;
 
-                should.exist(jsonResponse);
-                should.exist(jsonResponse.meta);
-                should.exist(jsonResponse.meta.stats);
+                assertExists(jsonResponse);
+                assertExists(jsonResponse.meta);
+                assertExists(jsonResponse.meta.stats);
 
                 assert.equal(jsonResponse.meta.stats.imported, 2);
                 assert.equal(jsonResponse.meta.stats.invalid.length, 0);
@@ -181,8 +182,8 @@ describe('Members Importer API', function () {
                 assert.equal(res.headers['x-cache-invalidate'], undefined);
                 const jsonResponse = res.body;
 
-                should.exist(jsonResponse);
-                should.exist(jsonResponse.members);
+                assertExists(jsonResponse);
+                assertExists(jsonResponse.members);
 
                 const defaultMember1 = jsonResponse.members.find(member => (member.email === 'member+defaults_1@example.com'));
                 assert.equal(defaultMember1.name, null);
@@ -210,8 +211,8 @@ describe('Members Importer API', function () {
                 assert.equal(res.headers['x-cache-invalidate'], undefined);
                 const jsonResponse = res.body;
 
-                should.exist(jsonResponse);
-                should.exist(jsonResponse.meta);
+                assertExists(jsonResponse);
+                assertExists(jsonResponse.meta);
                 assert.equal(jsonResponse.meta.stats, undefined);
             });
     });
@@ -229,9 +230,9 @@ describe('Members Importer API', function () {
                 assert.equal(res.headers['x-cache-invalidate'], undefined);
                 const jsonResponse = res.body;
 
-                should.exist(jsonResponse);
-                should.exist(jsonResponse.meta);
-                should.exist(jsonResponse.meta.stats);
+                assertExists(jsonResponse);
+                assertExists(jsonResponse.meta);
+                assertExists(jsonResponse.meta.stats);
 
                 assert.equal(jsonResponse.meta.stats.imported, 1);
                 assert.equal(jsonResponse.meta.stats.invalid.length, 2);
@@ -239,7 +240,7 @@ describe('Members Importer API', function () {
                 assert.match(jsonResponse.meta.stats.invalid[0].error, /Invalid Email/);
                 assert.match(jsonResponse.meta.stats.invalid[1].error, /Invalid Email/);
 
-                should.exist(jsonResponse.meta.import_label);
+                assertExists(jsonResponse.meta.import_label);
                 assert.match(jsonResponse.meta.import_label.slug, /^import-/);
             });
     });
@@ -265,9 +266,9 @@ describe('Members Importer API', function () {
         assert.equal(res.headers['x-cache-invalidate'], undefined);
         const jsonResponse = res.body;
 
-        should.exist(jsonResponse);
-        should.exist(jsonResponse.meta);
-        should.exist(jsonResponse.meta.stats);
+        assertExists(jsonResponse);
+        assertExists(jsonResponse.meta);
+        assertExists(jsonResponse.meta.stats);
 
         assert.equal(jsonResponse.meta.stats.imported, 10);
         assert.equal(jsonResponse.meta.stats.invalid.length, 0);
@@ -291,9 +292,9 @@ describe('Members Importer API', function () {
         assert.equal(res.headers['x-cache-invalidate'], undefined);
         const jsonResponse = res.body;
 
-        should.exist(jsonResponse);
-        should.exist(jsonResponse.meta);
-        should.exist(jsonResponse.meta.stats);
+        assertExists(jsonResponse);
+        assertExists(jsonResponse.meta);
+        assertExists(jsonResponse.meta.stats);
 
         assert.equal(jsonResponse.meta.stats.imported, 10);
         assert.equal(jsonResponse.meta.stats.invalid.length, 0);
@@ -334,8 +335,8 @@ describe('Members Importer API', function () {
         assert.equal(res.headers['x-cache-invalidate'], undefined);
         const jsonResponse = res.body;
 
-        should.exist(jsonResponse);
-        should.exist(jsonResponse.meta);
+        assertExists(jsonResponse);
+        assertExists(jsonResponse.meta);
 
         // Wait for the job to finish
         await awaitCompletion;

--- a/ghost/core/test/legacy/api/admin/members-signin-url.test.js
+++ b/ghost/core/test/legacy/api/admin/members-signin-url.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../utils/assertions');
 const should = require('should');
 const supertest = require('supertest');
 const testUtils = require('../../../utils');
@@ -31,8 +32,8 @@ describe('Members Sigin URL API', function () {
                 .then((res) => {
                     assert.equal(res.headers['x-cache-invalidate'], undefined);
                     const jsonResponse = res.body;
-                    should.exist(jsonResponse);
-                    should.exist(jsonResponse.member_signin_urls);
+                    assertExists(jsonResponse);
+                    assertExists(jsonResponse.member_signin_urls);
                     assert.equal(jsonResponse.member_signin_urls.length, 1);
                     localUtils.API.checkResponse(jsonResponse.member_signin_urls[0], 'member_signin_url');
                 });
@@ -62,8 +63,8 @@ describe('Members Sigin URL API', function () {
                 .then((res) => {
                     assert.equal(res.headers['x-cache-invalidate'], undefined);
                     const jsonResponse = res.body;
-                    should.exist(jsonResponse);
-                    should.exist(jsonResponse.member_signin_urls);
+                    assertExists(jsonResponse);
+                    assertExists(jsonResponse.member_signin_urls);
                     assert.equal(jsonResponse.member_signin_urls.length, 1);
                     localUtils.API.checkResponse(jsonResponse.member_signin_urls[0], 'member_signin_url');
                 });
@@ -129,8 +130,8 @@ describe('Members Sigin URL API', function () {
                 .then((res) => {
                     assert.equal(res.headers['x-cache-invalidate'], undefined);
                     const jsonResponse = res.body;
-                    should.exist(jsonResponse);
-                    should.exist(jsonResponse.member_signin_urls);
+                    assertExists(jsonResponse);
+                    assertExists(jsonResponse.member_signin_urls);
                     assert.equal(jsonResponse.member_signin_urls.length, 1);
                     localUtils.API.checkResponse(jsonResponse.member_signin_urls[0], 'member_signin_url');
                 });

--- a/ghost/core/test/legacy/api/admin/posts.test.js
+++ b/ghost/core/test/legacy/api/admin/posts.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../utils/assertions');
 const _ = require('lodash');
 const should = require('should');
 const supertest = require('supertest');
@@ -45,7 +46,7 @@ describe('Posts API', function () {
 
                     assert.equal(res.headers['x-cache-invalidate'], undefined);
                     const jsonResponse = res.body;
-                    should.exist(jsonResponse.posts);
+                    assertExists(jsonResponse.posts);
                     localUtils.API.checkResponse(jsonResponse, 'posts');
                     assert.equal(jsonResponse.posts.length, 15);
 
@@ -76,7 +77,7 @@ describe('Posts API', function () {
 
                     assert.equal(res.headers['x-cache-invalidate'], undefined);
                     const jsonResponse = res.body;
-                    should.exist(jsonResponse.posts);
+                    assertExists(jsonResponse.posts);
                     localUtils.API.checkResponse(jsonResponse, 'posts');
                     assert.equal(jsonResponse.posts.length, 15);
 
@@ -107,7 +108,7 @@ describe('Posts API', function () {
 
                     assert.equal(res.headers['x-cache-invalidate'], undefined);
                     const jsonResponse = res.body;
-                    should.exist(jsonResponse.posts);
+                    assertExists(jsonResponse.posts);
                     localUtils.API.checkResponse(jsonResponse, 'posts');
                     assert.equal(jsonResponse.posts.length, 2);
                     jsonResponse.posts.forEach((post) => {
@@ -138,7 +139,7 @@ describe('Posts API', function () {
 
                     assert.equal(res.headers['x-cache-invalidate'], undefined);
                     const jsonResponse = res.body;
-                    should.exist(jsonResponse.posts);
+                    assertExists(jsonResponse.posts);
                     localUtils.API.checkResponse(jsonResponse, 'posts');
                     assert.equal(jsonResponse.posts.length, 1);
                     jsonResponse.posts[0].id.should.equal(testUtils.DataGenerator.Content.posts[2].id);
@@ -168,7 +169,7 @@ describe('Posts API', function () {
 
                     assert.equal(res.headers['x-cache-invalidate'], undefined);
                     const jsonResponse = res.body;
-                    should.exist(jsonResponse.posts);
+                    assertExists(jsonResponse.posts);
                     localUtils.API.checkResponse(jsonResponse, 'posts');
                     assert.equal(jsonResponse.posts.length, 15);
 
@@ -233,7 +234,7 @@ describe('Posts API', function () {
                 .then((res) => {
                     assert.equal(res.headers['x-cache-invalidate'], undefined);
                     const jsonResponse = res.body;
-                    should.exist(jsonResponse.posts);
+                    assertExists(jsonResponse.posts);
                     localUtils.API.checkResponse(jsonResponse, 'posts');
                     assert.equal(jsonResponse.posts.length, 15);
 
@@ -271,8 +272,8 @@ describe('Posts API', function () {
 
                     assert.equal(res.headers['x-cache-invalidate'], undefined);
                     const jsonResponse = res.body;
-                    should.exist(jsonResponse);
-                    should.exist(jsonResponse.errors);
+                    assertExists(jsonResponse);
+                    assertExists(jsonResponse.errors);
                     testUtils.API.checkResponseValue(jsonResponse.errors[0], [
                         'message',
                         'context',
@@ -311,11 +312,11 @@ describe('Posts API', function () {
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(201)
                 .then((res) => {
-                    should.exist(res.body.posts);
-                    should.exist(res.body.posts[0].title);
+                    assertExists(res.body.posts);
+                    assertExists(res.body.posts[0].title);
                     assert.equal(res.body.posts[0].title, '(Untitled)');
 
-                    should.exist(res.headers.location);
+                    assertExists(res.headers.location);
                     res.headers.location.should.equal(`http://127.0.0.1:2369${localUtils.API.getApiQuery('posts/')}${res.body.posts[0].id}/`);
                 });
         });
@@ -334,8 +335,8 @@ describe('Posts API', function () {
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(201)
                 .then((res) => {
-                    should.exist(res.body.posts);
-                    should.exist(res.body.posts[0].title);
+                    assertExists(res.body.posts);
+                    assertExists(res.body.posts[0].title);
                     assert.equal(res.body.posts[0].title, 'Tags test 1');
                     assert.equal(res.body.posts[0].tags.length, 2);
                     assert.equal(res.body.posts[0].tags[0].slug, 'one');
@@ -357,8 +358,8 @@ describe('Posts API', function () {
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(201)
                 .then((res) => {
-                    should.exist(res.body.posts);
-                    should.exist(res.body.posts[0].title);
+                    assertExists(res.body.posts);
+                    assertExists(res.body.posts[0].title);
                     assert.equal(res.body.posts[0].title, 'Tags test 2');
                     assert.equal(res.body.posts[0].tags.length, 2);
                     assert.equal(res.body.posts[0].tags[0].slug, 'one');
@@ -380,8 +381,8 @@ describe('Posts API', function () {
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(201)
                 .then((res) => {
-                    should.exist(res.body.posts);
-                    should.exist(res.body.posts[0].title);
+                    assertExists(res.body.posts);
+                    assertExists(res.body.posts[0].title);
                     assert.equal(res.body.posts[0].title, 'Tags test 3');
                     assert.equal(res.body.posts[0].tags.length, 2);
                     assert.equal(res.body.posts[0].tags[0].slug, 'one');
@@ -403,8 +404,8 @@ describe('Posts API', function () {
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(201)
                 .then((res) => {
-                    should.exist(res.body.posts);
-                    should.exist(res.body.posts[0].title);
+                    assertExists(res.body.posts);
+                    assertExists(res.body.posts[0].title);
                     assert.equal(res.body.posts[0].title, 'Tags test 4');
                     assert.equal(res.body.posts[0].tags.length, 2);
                     assert.equal(res.body.posts[0].tags[0].slug, 'three');
@@ -426,8 +427,8 @@ describe('Posts API', function () {
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(201);
 
-            should.exist(res.body.posts);
-            should.exist(res.body.posts[0].title);
+            assertExists(res.body.posts);
+            assertExists(res.body.posts[0].title);
             assert.equal(res.body.posts[0].title, 'Tags test 5');
             assert.equal(res.body.posts[0].tags.length, 1);
             assert.equal(res.body.posts[0].tags[0].slug, 'five-spaces');
@@ -451,8 +452,8 @@ describe('Posts API', function () {
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(201);
 
-            should.exist(res2.body.posts);
-            should.exist(res2.body.posts[0].title);
+            assertExists(res2.body.posts);
+            assertExists(res2.body.posts[0].title);
             assert.equal(res2.body.posts[0].title, 'Tags test 6');
             assert.equal(res2.body.posts[0].tags.length, 1);
             res2.body.posts[0].tags[0].id.should.equal(res.body.posts[0].tags[0].id);
@@ -474,8 +475,8 @@ describe('Posts API', function () {
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(201);
 
-            should.exist(res.body.posts);
-            should.exist(res.body.posts[0].title);
+            assertExists(res.body.posts);
+            assertExists(res.body.posts[0].title);
             assert.equal(res.body.posts[0].title, 'Tags test 7');
             assert.equal(res.body.posts[0].tags.length, 1);
             assert.equal(res.body.posts[0].tags[0].slug, 'six-spaces');
@@ -497,8 +498,8 @@ describe('Posts API', function () {
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(201);
 
-            should.exist(res2.body.posts);
-            should.exist(res2.body.posts[0].title);
+            assertExists(res2.body.posts);
+            assertExists(res2.body.posts[0].title);
             assert.equal(res2.body.posts[0].title, 'Tags test 8');
             assert.equal(res2.body.posts[0].tags.length, 1);
             res2.body.posts[0].tags[0].id.should.equal(res.body.posts[0].tags[0].id);
@@ -520,8 +521,8 @@ describe('Posts API', function () {
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(201);
 
-            should.exist(res.body.posts);
-            should.exist(res.body.posts[0].title);
+            assertExists(res.body.posts);
+            assertExists(res.body.posts[0].title);
             assert.equal(res.body.posts[0].title, 'Tags test 9');
             assert.equal(res.body.posts[0].tags.length, 1);
             res.body.posts[0].tags[0].slug.should.equal(tooLongSlug.substring(0, 185));
@@ -542,8 +543,8 @@ describe('Posts API', function () {
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(201);
 
-            should.exist(res2.body.posts);
-            should.exist(res2.body.posts[0].title);
+            assertExists(res2.body.posts);
+            assertExists(res2.body.posts[0].title);
             assert.equal(res2.body.posts[0].title, 'Tags test 10');
             assert.equal(res2.body.posts[0].tags.length, 1);
             res2.body.posts[0].tags[0].id.should.equal(res.body.posts[0].tags[0].id);
@@ -572,9 +573,9 @@ describe('Posts API', function () {
                 })
                 .then((res) => {
                     // @NOTE: if you set published_at to null and the post is published, we set it to NOW in model layer
-                    should.exist(res.headers['x-cache-invalidate']);
-                    should.exist(res.body.posts);
-                    should.exist(res.body.posts[0].published_at);
+                    assertExists(res.headers['x-cache-invalidate']);
+                    assertExists(res.body.posts);
+                    assertExists(res.body.posts[0].published_at);
                 });
         });
 
@@ -592,13 +593,13 @@ describe('Posts API', function () {
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(201);
 
-            should.exist(res.body.posts);
-            should.exist(res.body.posts[0].title);
+            assertExists(res.body.posts);
+            assertExists(res.body.posts[0].title);
             assert.equal(res.body.posts[0].title, 'Email me');
             assert.equal(res.body.posts[0].email_only, true);
             assert.equal(res.body.posts[0].status, 'draft');
 
-            should.exist(res.headers.location);
+            assertExists(res.headers.location);
             res.headers.location.should.equal(`http://127.0.0.1:2369${localUtils.API.getApiQuery('posts/')}${res.body.posts[0].id}/`);
 
             const publishedRes = await request
@@ -614,11 +615,11 @@ describe('Posts API', function () {
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(200);
 
-            should.exist(publishedRes.body.posts);
+            assertExists(publishedRes.body.posts);
             assert.equal(res.body.posts[0].email_only, true);
             assert.equal(publishedRes.body.posts[0].status, 'sent');
 
-            should.exist(publishedRes.body.posts[0].email);
+            assertExists(publishedRes.body.posts[0].email);
             assert.equal(publishedRes.body.posts[0].email.email_count, 4);
         });
 
@@ -635,13 +636,13 @@ describe('Posts API', function () {
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(201);
 
-            should.exist(res.body.posts);
-            should.exist(res.body.posts[0].title);
+            assertExists(res.body.posts);
+            assertExists(res.body.posts[0].title);
             assert.equal(res.body.posts[0].title, 'Email me');
             assert.equal(res.body.posts[0].email_only, false);
             assert.equal(res.body.posts[0].status, 'draft');
 
-            should.exist(res.headers.location);
+            assertExists(res.headers.location);
             res.headers.location.should.equal(`http://127.0.0.1:2369${localUtils.API.getApiQuery('posts/')}${res.body.posts[0].id}/`);
 
             const publishedRes = await request
@@ -658,10 +659,10 @@ describe('Posts API', function () {
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(200);
 
-            should.exist(publishedRes.body.posts);
+            assertExists(publishedRes.body.posts);
             assert.equal(publishedRes.body.posts[0].status, 'sent');
 
-            should.exist(publishedRes.body.posts[0].email);
+            assertExists(publishedRes.body.posts[0].email);
             assert.equal(publishedRes.body.posts[0].email.email_count, 2);
         });
 
@@ -678,13 +679,13 @@ describe('Posts API', function () {
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(201);
 
-            should.exist(res.body.posts);
-            should.exist(res.body.posts[0].title);
+            assertExists(res.body.posts);
+            assertExists(res.body.posts[0].title);
             assert.equal(res.body.posts[0].title, 'Email me');
             assert.equal(res.body.posts[0].email_only, false);
             assert.equal(res.body.posts[0].status, 'draft');
 
-            should.exist(res.headers.location);
+            assertExists(res.headers.location);
             res.headers.location.should.equal(`http://127.0.0.1:2369${localUtils.API.getApiQuery('posts/')}${res.body.posts[0].id}/`);
 
             const publishedRes = await request
@@ -701,10 +702,10 @@ describe('Posts API', function () {
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(200);
 
-            should.exist(publishedRes.body.posts);
+            assertExists(publishedRes.body.posts);
             assert.equal(publishedRes.body.posts[0].status, 'sent');
 
-            should.exist(publishedRes.body.posts[0].email);
+            assertExists(publishedRes.body.posts[0].email);
             assert.equal(publishedRes.body.posts[0].email.email_count, 2);
         });
 
@@ -732,8 +733,8 @@ describe('Posts API', function () {
                     // NOTE: when ONLY ignored fields are posted they should not change a thing, thus cache stays untouched
                     assert.equal(res.headers['x-cache-invalidate'], undefined);
 
-                    should.exist(res.body.posts);
-                    should.exist(res.body.posts[0].published_at);
+                    assertExists(res.body.posts);
+                    assertExists(res.body.posts[0].published_at);
                     assert.equal(res.body.posts[0].frontmatter, null);
                     assert.equal(res.body.posts[0].plaintext, testUtils.DataGenerator.Content.posts[0].plaintext);
                 });
@@ -788,8 +789,8 @@ describe('Posts API', function () {
                         .expect(200);
                 })
                 .then((res) => {
-                    should.exist(res.body.posts);
-                    should.exist(res.body.posts[0].canonical_url);
+                    assertExists(res.body.posts);
+                    assertExists(res.body.posts[0].canonical_url);
                     res.body.posts[0].canonical_url.should.equal(`${config.get('url')}/canonical/url`);
                 });
         });
@@ -846,7 +847,7 @@ describe('Posts API', function () {
                         .expect(200);
                 })
                 .then((res) => {
-                    should.exist(res.headers['x-cache-invalidate']);
+                    assertExists(res.headers['x-cache-invalidate']);
                 });
         });
 
@@ -872,8 +873,8 @@ describe('Posts API', function () {
                         .expect(200);
                 })
                 .then((res) => {
-                    should.exist(res.body.posts);
-                    should.exist(res.body.posts[0].title);
+                    assertExists(res.body.posts);
+                    assertExists(res.body.posts[0].title);
                     res.body.posts[0].title.should.equal(untrimmedTitle.trim());
                 });
         });
@@ -900,8 +901,8 @@ describe('Posts API', function () {
                         .expect(200);
                 })
                 .then((res) => {
-                    should.exist(res.body.posts);
-                    should.exist(res.body.posts[0].slug);
+                    assertExists(res.body.posts);
+                    assertExists(res.body.posts[0].slug);
                     assert.equal(res.body.posts[0].slug, 'this-is-invisible');
                 });
         });
@@ -926,8 +927,8 @@ describe('Posts API', function () {
                         .expect(200);
                 })
                 .then((res) => {
-                    should.exist(res.body.posts);
-                    should.exist(res.body.posts[0].visibility);
+                    assertExists(res.body.posts);
+                    assertExists(res.body.posts[0].visibility);
                     assert.equal(res.body.posts[0].visibility, 'members');
                 });
         });
@@ -952,9 +953,9 @@ describe('Posts API', function () {
                         .expect(200);
                 })
                 .then((res) => {
-                    should.exist(res.headers['x-cache-invalidate']);
+                    assertExists(res.headers['x-cache-invalidate']);
 
-                    should.exist(res.body.posts);
+                    assertExists(res.body.posts);
                     assert.equal(res.body.posts[0].meta_title, 'changed meta title');
                 });
         });
@@ -981,9 +982,9 @@ describe('Posts API', function () {
                         .expect(200);
                 })
                 .then((res) => {
-                    should.exist(res.headers['x-cache-invalidate']);
+                    assertExists(res.headers['x-cache-invalidate']);
 
-                    should.exist(res.body.posts);
+                    assertExists(res.body.posts);
                     assert.equal(res.body.posts[0].email_only, true);
                     assert.equal(res.body.posts[0].url, 'http://127.0.0.1:2369/email/d52c42ae-2755-455c-80ec-70b2ec55c903/');
                 });
@@ -1003,8 +1004,8 @@ describe('Posts API', function () {
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(201)
                 .then((res) => {
-                    should.exist(res.body.posts);
-                    should.exist(res.body.posts[0].title);
+                    assertExists(res.body.posts);
+                    assertExists(res.body.posts[0].title);
                     assert.equal(res.body.posts[0].title, 'Has a title by no other content');
                     assert.equal(res.body.posts[0].html, undefined);
                     assert.equal(res.body.posts[0].plaintext, undefined);
@@ -1026,7 +1027,7 @@ describe('Posts API', function () {
                 .then((res) => {
                     assert.equal(res.headers['x-cache-invalidate'], undefined);
 
-                    should.exist(res.body.posts);
+                    assertExists(res.body.posts);
                     assert.equal(res.body.posts[0].title, 'Has a title by no other content');
                     assert.equal(res.body.posts[0].html, undefined);
                     assert.equal(res.body.posts[0].plaintext, undefined);
@@ -1079,8 +1080,8 @@ describe('Posts API', function () {
                 .expect(404)
                 .then((res) => {
                     assert.equal(res.headers['x-cache-invalidate'], undefined);
-                    should.exist(res.body);
-                    should.exist(res.body.errors);
+                    assertExists(res.body);
+                    assertExists(res.body.errors);
                     testUtils.API.checkResponseValue(res.body.errors[0], [
                         'message',
                         'context',

--- a/ghost/core/test/legacy/api/admin/schedules.test.js
+++ b/ghost/core/test/legacy/api/admin/schedules.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../utils/assertions');
 const _ = require('lodash');
 const should = require('should');
 const supertest = require('supertest');
@@ -106,9 +107,9 @@ describe('Schedules API', function () {
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(200);
 
-            should.exist(res.headers['x-cache-invalidate']);
+            assertExists(res.headers['x-cache-invalidate']);
             const jsonResponse = res.body;
-            should.exist(jsonResponse);
+            assertExists(jsonResponse);
             jsonResponse.posts[0].id.should.eql(resources[0].id);
             assert.equal(jsonResponse.posts[0].status, 'published');
         });
@@ -120,9 +121,9 @@ describe('Schedules API', function () {
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(200);
 
-            should.exist(res.headers['x-cache-invalidate']);
+            assertExists(res.headers['x-cache-invalidate']);
             const jsonResponse = res.body;
-            should.exist(jsonResponse);
+            assertExists(jsonResponse);
             jsonResponse.pages[0].id.should.eql(resources[4].id);
             assert.equal(jsonResponse.pages[0].status, 'published');
         });

--- a/ghost/core/test/legacy/api/admin/settings.test.js
+++ b/ghost/core/test/legacy/api/admin/settings.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../utils/assertions');
 const should = require('should');
 const supertest = require('supertest');
 const config = require('../../../../core/shared/config');
@@ -26,7 +27,7 @@ describe('Settings API', function () {
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(200)
             .expect((response) => {
-                should.exist(response.headers['x-cache-invalidate']);
+                assertExists(response.headers['x-cache-invalidate']);
                 assert.equal(response.headers['x-cache-invalidate'], '/*');
             });
 
@@ -125,7 +126,7 @@ describe('Settings API', function () {
 
             const putBody = body;
             assert.equal(headers['x-cache-invalidate'], '/*');
-            should.exist(putBody);
+            assertExists(putBody);
 
             let setting = putBody.settings.find(s => s.key === 'unsplash');
             assert.equal(setting.value, true);
@@ -155,7 +156,7 @@ describe('Settings API', function () {
 
             const putBody = body;
             assert.equal(headers['x-cache-invalidate'], '/*');
-            should.exist(putBody);
+            assertExists(putBody);
 
             localUtils.API.checkResponse(putBody, 'settings');
             const setting = putBody.settings.find(s => s.key === 'slack_username');
@@ -285,8 +286,8 @@ describe('Settings API', function () {
                 .then(function (res) {
                     let jsonResponse = res.body;
 
-                    should.exist(jsonResponse);
-                    should.exist(jsonResponse.settings);
+                    assertExists(jsonResponse);
+                    assertExists(jsonResponse.settings);
                     jsonResponse.settings = [{key: 'visibility', value: 'public'}];
 
                     return request.put(localUtils.API.getApiQuery('settings/'))
@@ -298,7 +299,7 @@ describe('Settings API', function () {
                         .then(function ({body, headers}) {
                             jsonResponse = body;
                             assert.equal(headers['x-cache-invalidate'], undefined);
-                            should.exist(jsonResponse.errors);
+                            assertExists(jsonResponse.errors);
                             testUtils.API.checkResponseValue(jsonResponse.errors[0], [
                                 'message',
                                 'context',
@@ -338,8 +339,8 @@ describe('Settings API', function () {
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .then(function (res) {
                     let jsonResponse = res.body;
-                    should.exist(jsonResponse);
-                    should.exist(jsonResponse.settings);
+                    assertExists(jsonResponse);
+                    assertExists(jsonResponse.settings);
                     jsonResponse.settings = [{key: 'visibility', value: 'public'}];
 
                     return request.put(localUtils.API.getApiQuery('settings/'))
@@ -351,7 +352,7 @@ describe('Settings API', function () {
                         .then(function ({body, headers}) {
                             jsonResponse = body;
                             assert.equal(headers['x-cache-invalidate'], undefined);
-                            should.exist(jsonResponse.errors);
+                            assertExists(jsonResponse.errors);
                             testUtils.API.checkResponseValue(jsonResponse.errors[0], [
                                 'message',
                                 'context',
@@ -391,7 +392,7 @@ describe('Settings API', function () {
             }, testUtils.context.internal);
 
             const setting = jsonResponse.settings.find(s => s.key === 'email_verification_required');
-            should.exist(setting);
+            assertExists(setting);
             assert.equal(setting.value, true);
         });
     });

--- a/ghost/core/test/legacy/api/admin/update-user-last-seen.test.js
+++ b/ghost/core/test/legacy/api/admin/update-user-last-seen.test.js
@@ -1,3 +1,4 @@
+const {assertExists} = require('../../../utils/assertions');
 const sinon = require('sinon');
 const should = require('should');
 
@@ -45,9 +46,9 @@ describe('Update User Last Seen', function () {
             .expectStatus(200);
 
         const user = await models.User.findOne({id: userId});
-        should.exist(user);
+        assertExists(user);
         const lastSeen = user.get('last_seen');
-        should.exist(lastSeen);
+        assertExists(lastSeen);
 
         clock.tick(1000 * 60 * 60 * 24);
 
@@ -56,14 +57,14 @@ describe('Update User Last Seen', function () {
             .expectStatus(200);
 
         const ownerAfter = await models.User.findOne({id: userId});
-        should.exist(ownerAfter);
+        assertExists(ownerAfter);
         should(ownerAfter.get('last_seen')).not.eql(lastSeen);
     });
 
     it('Should only update last seen after 1 hour', async function () {
         const user = await models.User.findOne({id: userId});
         const lastSeen = user.get('last_seen');
-        should.exist(lastSeen);
+        assertExists(lastSeen);
 
         clock.tick(1000 * 60 * 30);
 
@@ -73,19 +74,19 @@ describe('Update User Last Seen', function () {
             .expectStatus(200);
 
         const ownerAfter = await models.User.findOne({id: userId});
-        should.exist(ownerAfter);
+        assertExists(ownerAfter);
         should(ownerAfter.get('last_seen')).eql(lastSeen);
     });
 
     it('Should always update last seen after login', async function () {
         const user = await models.User.findOne({id: userId});
         const lastSeen = user.get('last_seen');
-        should.exist(lastSeen);
+        assertExists(lastSeen);
 
         await agent.loginAsOwner();
 
         const ownerAfter = await models.User.findOne({id: userId});
-        should.exist(ownerAfter);
+        assertExists(ownerAfter);
         should(ownerAfter.get('last_seen')).not.eql(lastSeen);
     });
 
@@ -97,11 +98,11 @@ describe('Update User Last Seen', function () {
 
         // Suspend the user
         const user = await models.User.findOne({id: userId});
-        should.exist(user);
+        assertExists(user);
 
         await models.User.edit({status: 'inactive'}, {id: userId});
         const lastSeen = user.get('last_seen');
-        should.exist(lastSeen);
+        assertExists(lastSeen);
 
         clock.tick(1000 * 60 * 60 * 24);
 
@@ -110,7 +111,7 @@ describe('Update User Last Seen', function () {
             .expectStatus(403);
 
         const ownerAfter = await models.User.findOne({id: userId});
-        should.exist(ownerAfter);
+        assertExists(ownerAfter);
         should(ownerAfter.get('last_seen')).eql(lastSeen);
     });
 });

--- a/ghost/core/test/legacy/api/admin/users.test.js
+++ b/ghost/core/test/legacy/api/admin/users.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../utils/assertions');
 const should = require('should');
 const supertest = require('supertest');
 const ObjectId = require('bson-objectid').default;
@@ -41,8 +42,8 @@ describe('User API', function () {
 
                         assert.equal(res.headers['x-cache-invalidate'], undefined);
                         const jsonResponse = res.body;
-                        should.exist(jsonResponse);
-                        should.exist(jsonResponse.errors);
+                        assertExists(jsonResponse);
+                        assertExists(jsonResponse.errors);
                         testUtils.API.checkResponseValue(jsonResponse.errors[0], [
                             'message',
                             'context',
@@ -72,8 +73,8 @@ describe('User API', function () {
 
                         assert.equal(res.headers['x-cache-invalidate'], undefined);
                         const jsonResponse = res.body;
-                        should.exist(jsonResponse);
-                        should.exist(jsonResponse.errors);
+                        assertExists(jsonResponse);
+                        assertExists(jsonResponse.errors);
                         testUtils.API.checkResponseValue(jsonResponse.errors[0], [
                             'message',
                             'context',

--- a/ghost/core/test/legacy/api/admin/webhooks.test.js
+++ b/ghost/core/test/legacy/api/admin/webhooks.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../utils/assertions');
 const should = require('should');
 const supertest = require('supertest');
 const testUtils = require('../../../utils');
@@ -37,10 +38,10 @@ describe('Webhooks API', function () {
                 assert.equal(res.headers['x-cache-invalidate'], undefined);
                 const jsonResponse = res.body;
 
-                should.exist(jsonResponse);
-                should.exist(jsonResponse.webhooks);
-                should.exist(jsonResponse.webhooks[0].event);
-                should.exist(jsonResponse.webhooks[0].target_url);
+                assertExists(jsonResponse);
+                assertExists(jsonResponse.webhooks);
+                assertExists(jsonResponse.webhooks[0].event);
+                assertExists(jsonResponse.webhooks[0].target_url);
 
                 assert.equal(jsonResponse.webhooks[0].event, 'test.create');
                 assert.equal(jsonResponse.webhooks[0].target_url, 'http://example.com/webhooks/test/extra/canary');

--- a/ghost/core/test/legacy/api/content/posts.test.js
+++ b/ghost/core/test/legacy/api/content/posts.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../utils/assertions');
 const should = require('should');
 const supertest = require('supertest');
 const _ = require('lodash');
@@ -113,11 +114,11 @@ describe('api/endpoints/content/posts', function () {
                 }
 
                 assert.equal(res.headers.vary, 'Accept-Version, Accept-Encoding');
-                should.exist(res.headers['access-control-allow-origin']);
+                assertExists(res.headers['access-control-allow-origin']);
                 assert.equal(res.headers['x-cache-invalidate'], undefined);
 
                 const jsonResponse = res.body;
-                should.exist(jsonResponse.posts);
+                assertExists(jsonResponse.posts);
                 localUtils.API.checkResponse(jsonResponse, 'posts');
                 assert.equal(jsonResponse.posts.length, 13);
                 localUtils.API.checkResponse(jsonResponse.posts[0], 'post');
@@ -154,11 +155,11 @@ describe('api/endpoints/content/posts', function () {
                 }
 
                 assert.equal(res.headers.vary, 'Accept-Version, Accept-Encoding');
-                should.exist(res.headers['access-control-allow-origin']);
+                assertExists(res.headers['access-control-allow-origin']);
                 assert.equal(res.headers['x-cache-invalidate'], undefined);
 
                 const jsonResponse = res.body;
-                should.exist(jsonResponse.posts);
+                assertExists(jsonResponse.posts);
                 localUtils.API.checkResponse(jsonResponse, 'posts');
                 assert.equal(jsonResponse.posts.length, 13);
                 localUtils.API.checkResponse(
@@ -260,7 +261,7 @@ describe('api/endpoints/content/posts', function () {
 
                 assert.equal(res.headers.vary, 'Accept-Version, Accept, Accept-Encoding');
                 res.headers.location.should.eql(`http://localhost:9999/ghost/api/content/posts/?key=${validKey}`);
-                should.exist(res.headers['access-control-allow-origin']);
+                assertExists(res.headers['access-control-allow-origin']);
                 assert.equal(res.headers['x-cache-invalidate'], undefined);
                 done();
             });
@@ -342,7 +343,7 @@ describe('api/endpoints/content/posts', function () {
                 .expect(200)
                 .then((res) => {
                     const jsonResponse = res.body;
-                    should.exist(jsonResponse.posts);
+                    assertExists(jsonResponse.posts);
                     const post = jsonResponse.posts[0];
 
                     localUtils.API.checkResponse(post, 'post', null, null, ['id', 'slug', 'html', 'plaintext']);
@@ -361,7 +362,7 @@ describe('api/endpoints/content/posts', function () {
                 .expect(200)
                 .then((res) => {
                     const jsonResponse = res.body;
-                    should.exist(jsonResponse.posts);
+                    assertExists(jsonResponse.posts);
                     const post = jsonResponse.posts[0];
 
                     localUtils.API.checkResponse(post, 'post', null, null);
@@ -380,7 +381,7 @@ describe('api/endpoints/content/posts', function () {
                 .expect(200)
                 .then((res) => {
                     const jsonResponse = res.body;
-                    should.exist(jsonResponse.posts);
+                    assertExists(jsonResponse.posts);
                     const post = jsonResponse.posts[0];
 
                     localUtils.API.checkResponse(post, 'post', null, null);
@@ -399,7 +400,7 @@ describe('api/endpoints/content/posts', function () {
                 .expect(200)
                 .then((res) => {
                     const jsonResponse = res.body;
-                    should.exist(jsonResponse.posts);
+                    assertExists(jsonResponse.posts);
                     const post = jsonResponse.posts[0];
 
                     localUtils.API.checkResponse(post, 'post', null, null, ['id', 'html', 'plaintext']);
@@ -417,7 +418,7 @@ describe('api/endpoints/content/posts', function () {
                 .expect(200)
                 .then((res) => {
                     const jsonResponse = res.body;
-                    should.exist(jsonResponse.posts);
+                    assertExists(jsonResponse.posts);
                     const post = jsonResponse.posts[0];
 
                     localUtils.API.checkResponse(post, 'post', ['plaintext']);
@@ -435,11 +436,11 @@ describe('api/endpoints/content/posts', function () {
                 .expect(200)
                 .then((res) => {
                     assert.equal(res.headers.vary, 'Accept-Version, Accept-Encoding');
-                    should.exist(res.headers['access-control-allow-origin']);
+                    assertExists(res.headers['access-control-allow-origin']);
                     assert.equal(res.headers['x-cache-invalidate'], undefined);
 
                     const jsonResponse = res.body;
-                    should.exist(jsonResponse.posts);
+                    assertExists(jsonResponse.posts);
                     localUtils.API.checkResponse(jsonResponse, 'posts');
                     assert.equal(jsonResponse.posts.length, 15);
                     localUtils.API.checkResponse(jsonResponse.posts[0], 'post', null, null);

--- a/ghost/core/test/legacy/api/content/tags.test.js
+++ b/ghost/core/test/legacy/api/content/tags.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../utils/assertions');
 const should = require('should');
 const supertest = require('supertest');
 const _ = require('lodash');
@@ -45,8 +46,8 @@ describe('api/endpoints/content/tags', function () {
             .then((res) => {
                 assert.equal(res.headers['x-cache-invalidate'], undefined);
                 const jsonResponse = res.body;
-                should.exist(jsonResponse);
-                should.exist(jsonResponse.tags);
+                assertExists(jsonResponse);
+                assertExists(jsonResponse.tags);
                 assert.equal(jsonResponse.tags.length, 5);
                 localUtils.API.checkResponse(jsonResponse.tags[0], 'tag', ['count', 'url']);
 
@@ -57,7 +58,7 @@ describe('api/endpoints/content/tags', function () {
                 jsonResponse.meta.pagination.should.have.property('next', 2);
                 jsonResponse.meta.pagination.should.have.property('prev', null);
 
-                should.exist(jsonResponse.tags[0].count.posts);
+                assertExists(jsonResponse.tags[0].count.posts);
                 // Each tag should have the correct count
                 assert.equal(_.find(jsonResponse.tags, {name: 'Getting Started'}).count.posts, 7);
                 assert.equal(_.find(jsonResponse.tags, {name: 'kitchen sink'}).count.posts, 2);

--- a/ghost/core/test/legacy/mock-express-style/api-vs-frontend.test.js
+++ b/ghost/core/test/legacy/mock-express-style/api-vs-frontend.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../utils/assertions');
 const should = require('should');
 const sinon = require('sinon');
 const cheerio = require('cheerio');
@@ -155,12 +156,12 @@ describe('Frontend behavior tests', function () {
 
                         assert.equal($('.post-card').length, 2);
 
-                        should.exist(response.res.locals.context);
-                        should.exist(response.res.locals.version);
-                        should.exist(response.res.locals.safeVersion);
-                        should.exist(response.res.locals.safeVersion);
-                        should.exist(response.res.locals.relativeUrl);
-                        should.exist(response.res.routerOptions);
+                        assertExists(response.res.locals.context);
+                        assertExists(response.res.locals.version);
+                        assertExists(response.res.locals.safeVersion);
+                        assertExists(response.res.locals.safeVersion);
+                        assertExists(response.res.locals.relativeUrl);
+                        assertExists(response.res.routerOptions);
                     });
             });
 

--- a/ghost/core/test/legacy/models/model-member-stripe-customer.test.js
+++ b/ghost/core/test/legacy/models/model-member-stripe-customer.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../utils/assertions');
 const should = require('should');
 const {Member} = require('../../../core/server/models/member');
 const {MemberStripeCustomer} = require('../../../core/server/models/member-stripe-customer');
@@ -71,7 +72,7 @@ describe('MemberStripeCustomer Model', function run() {
                 withRelated: ['subscriptions']
             }));
 
-            should.exist(customer.related('subscriptions'), 'MemberStripeCustomer should have been fetched with subscriptions');
+            assertExists(customer.related('subscriptions'), 'MemberStripeCustomer should have been fetched with subscriptions');
 
             const subscriptions = customer.related('subscriptions');
 
@@ -102,7 +103,7 @@ describe('MemberStripeCustomer Model', function run() {
 
             const memberFromRelation = customer.related('member');
 
-            should.exist(memberFromRelation, 'MemberStripeCustomer should have been fetched with member');
+            assertExists(memberFromRelation, 'MemberStripeCustomer should have been fetched with member');
 
             assert.equal(memberFromRelation.get('id'), member.get('id'));
             assert.equal(memberFromRelation.get('email'), 'test@test.member');
@@ -126,7 +127,7 @@ describe('MemberStripeCustomer Model', function run() {
                 customer_id: 'fake_customer_id'
             }, context);
 
-            should.exist(customer, 'Customer should have been created');
+            assertExists(customer, 'Customer should have been created');
 
             const product = await Product.add({
                 name: 'Ghost Product',
@@ -169,7 +170,7 @@ describe('MemberStripeCustomer Model', function run() {
                 customer_id: customer.get('customer_id')
             }, context);
 
-            should.exist(subscription, 'Subscription should have been created');
+            assertExists(subscription, 'Subscription should have been created');
 
             await MemberStripeCustomer.destroy(Object.assign({
                 id: customer.get('id')

--- a/ghost/core/test/legacy/models/model-members.test.js
+++ b/ghost/core/test/legacy/models/model-members.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../utils/assertions');
 const should = require('should');
 const BaseModel = require('../../../core/server/models/base');
 const {Label} = require('../../../core/server/models/label');
@@ -30,7 +31,7 @@ describe('Member Model', function run() {
                 email: 'test@test.member'
             }, context);
 
-            should.exist(member, 'Member should have been created');
+            assertExists(member, 'Member should have been created');
 
             const product = await Product.add({
                 name: 'Ghost Product',
@@ -108,8 +109,8 @@ describe('Member Model', function run() {
             const subscription1 = subscriptions.find(({id}) => id === 'fake_subscription_id1');
             const subscription2 = subscriptions.find(({id}) => id === 'fake_subscription_id2');
 
-            should.exist(subscription1);
-            should.exist(subscription2);
+            assertExists(subscription1);
+            assertExists(subscription2);
         });
     });
 
@@ -130,7 +131,7 @@ describe('Member Model', function run() {
                 customer_id: 'fake_customer_id1'
             }, context);
 
-            should.exist(customer1, 'MemberStripeCustomer should have been created');
+            assertExists(customer1, 'MemberStripeCustomer should have been created');
 
             await MemberStripeCustomer.add({
                 member_id: customer1.get('member_id'),
@@ -143,7 +144,7 @@ describe('Member Model', function run() {
                 withRelated: ['stripeCustomers']
             }));
 
-            should.exist(member.related('stripeCustomers'), 'Member should have been fetched with stripeCustomers');
+            assertExists(member.related('stripeCustomers'), 'Member should have been fetched with stripeCustomers');
 
             const stripeCustomers = member.related('stripeCustomers');
 
@@ -169,20 +170,20 @@ describe('Member Model', function run() {
                 email: 'test@test.member'
             }, context);
 
-            should.exist(member, 'Member should have been created');
+            assertExists(member, 'Member should have been created');
 
             const label = await Label.findOne({
                 slug: 'a-unique-slug-for-testing-members-model'
             }, context);
 
-            should.exist(label, 'Label should have been created');
+            assertExists(label, 'Label should have been created');
 
             const memberLabel = await BaseModel.knex('members_labels').where({
                 label_id: label.get('id'),
                 member_id: member.get('id')
             }).select().first();
 
-            should.exist(memberLabel, 'Label should have been attached to member');
+            assertExists(memberLabel, 'Label should have been attached to member');
 
             await MemberStripeCustomer.add({
                 member_id: member.get('id'),
@@ -193,7 +194,7 @@ describe('Member Model', function run() {
                 member_id: member.get('id')
             }, context);
 
-            should.exist(customer, 'Customer should have been created');
+            assertExists(customer, 'Customer should have been created');
 
             const product = await Product.add({
                 name: 'Ghost Product',
@@ -236,7 +237,7 @@ describe('Member Model', function run() {
                 customer_id: customer.get('customer_id')
             }, context);
 
-            should.exist(subscription, 'Subscription should have been created');
+            assertExists(subscription, 'Subscription should have been created');
 
             await Member.destroy(Object.assign({
                 id: member.get('id')
@@ -299,11 +300,11 @@ describe('Member Model', function run() {
                 name: 'Product-Add-Test'
             }, context);
 
-            should.exist(createdProduct, 'Product should have been created');
+            assertExists(createdProduct, 'Product should have been created');
 
             const products = member.related('products').toJSON();
 
-            should.exist(
+            assertExists(
                 products.find(model => model.name === 'Product-Add-Test')
             );
         });
@@ -330,25 +331,25 @@ describe('Member Model', function run() {
                 email: 'filter-test@test.member'
             }, context);
 
-            should.exist(member, 'Member should have been created');
+            assertExists(member, 'Member should have been created');
 
             const product = await Product.findOne({
                 slug: 'vip'
             }, context);
 
-            should.exist(product, 'Product should have been created');
+            assertExists(product, 'Product should have been created');
 
             const memberProduct = await BaseModel.knex('members_products').where({
                 product_id: product.get('id'),
                 member_id: member.get('id')
             }).select().first();
 
-            should.exist(memberProduct, 'Product should have been attached to member');
+            assertExists(memberProduct, 'Product should have been attached to member');
 
             const vipProductMembers = await Member.findPage({filter: 'products:vip'});
             const foundMemberInVIP = vipProductMembers.data.find(model => model.id === member.id);
 
-            should.exist(foundMemberInVIP, 'Member should have been included in products filter');
+            assertExists(foundMemberInVIP, 'Member should have been included in products filter');
 
             const podcastProductMembers = await Member.findPage({filter: 'products:podcast'});
             const foundMemberInPodcast = podcastProductMembers.data.find(model => model.id === member.id);
@@ -376,12 +377,12 @@ describe('Member Model', function run() {
                 email: 'name-filter-test@test.member'
             }, context);
 
-            should.exist(member, 'Member should have been created');
+            assertExists(member, 'Member should have been created');
 
             const membersByName = await Member.findPage({filter: `name:'Name Filter Test'`});
             const foundMember = membersByName.data.find(model => model.id === member.id);
 
-            should.exist(foundMember, 'Member should have been included in name filter');
+            assertExists(foundMember, 'Member should have been included in name filter');
         });
 
         it('Should allow filtering on email', async function () {
@@ -401,12 +402,12 @@ describe('Member Model', function run() {
                 email: 'email-filter-test@test.member'
             }, context);
 
-            should.exist(member, 'Member should have been created');
+            assertExists(member, 'Member should have been created');
 
             const membersByName = await Member.findPage({filter: `email:email-filter-test@test.member`});
             const foundMember = membersByName.data.find(model => model.id === member.id);
 
-            should.exist(foundMember, 'Member should have been included in name filter');
+            assertExists(foundMember, 'Member should have been included in name filter');
         });
 
         it('Should allow filtering on subscriptions', async function () {

--- a/ghost/core/test/legacy/models/model-newsletters.test.js
+++ b/ghost/core/test/legacy/models/model-newsletters.test.js
@@ -1,3 +1,4 @@
+const {assertExists} = require('../../utils/assertions');
 const should = require('should');
 const sinon = require('sinon');
 const testUtils = require('../../utils');
@@ -27,7 +28,7 @@ describe('Newsletter Model', function () {
     describe('URL transformations without CDN config', function () {
         it('transforms header_image to absolute site URL', async function () {
             const newsletter = await models.Newsletter.findOne({slug: 'new-newsletter'});
-            should.exist(newsletter, 'New newsletter should exist');
+            assertExists(newsletter, 'New newsletter should exist');
             newsletter.get('header_image').should.equal(`${siteUrl}/content/images/newsletter-header.jpg`);
         });
     });
@@ -46,7 +47,7 @@ describe('Newsletter Model', function () {
 
         it('transforms header_image to absolute site URL(NOT CDN)', async function () {
             const newsletter = await models.Newsletter.findOne({slug: 'new-newsletter'});
-            should.exist(newsletter, 'New newsletter should exist');
+            assertExists(newsletter, 'New newsletter should exist');
             newsletter.get('header_image').should.equal(`${siteUrl}/content/images/newsletter-header.jpg`);
         });
     });

--- a/ghost/core/test/legacy/models/model-posts.test.js
+++ b/ghost/core/test/legacy/models/model-posts.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../utils/assertions');
 const errors = require('@tryghost/errors');
 const should = require('should');
 const sinon = require('sinon');
@@ -253,19 +254,19 @@ describe('Post Model', function () {
 
                 models.Post.findOne({id: postId}).then(function (results) {
                     let post;
-                    should.exist(results);
+                    assertExists(results);
                     post = results.toJSON();
                     post.id.should.equal(postId);
                     assert.notEqual(post.title, 'new title');
 
                     return models.Post.edit({title: 'new title'}, _.extend({}, context, {id: postId}));
                 }).then(function (edited) {
-                    should.exist(edited);
+                    assertExists(edited);
                     assert.equal(edited.attributes.title, 'new title');
 
                     assert.equal(Object.keys(eventsTriggered).length, 2);
-                    should.exist(eventsTriggered['post.published.edited']);
-                    should.exist(eventsTriggered['post.edited']);
+                    assertExists(eventsTriggered['post.published.edited']);
+                    assertExists(eventsTriggered['post.edited']);
 
                     done();
                 }).catch(done);
@@ -276,7 +277,7 @@ describe('Post Model', function () {
 
                 models.Post.findOne({id: postId}).then(function (results) {
                     let post;
-                    should.exist(results);
+                    assertExists(results);
                     post = results.toJSON();
                     post.id.should.equal(postId);
 
@@ -296,21 +297,21 @@ describe('Post Model', function () {
 
                 models.Post.findOne({id: postId, status: 'draft'}).then(function (results) {
                     let post;
-                    should.exist(results);
+                    assertExists(results);
                     post = results.toJSON();
                     post.id.should.equal(postId);
                     assert.equal(post.status, 'draft');
 
                     return models.Post.edit({status: 'published'}, _.extend({}, context, {id: postId}));
                 }).then(function (edited) {
-                    should.exist(edited);
+                    assertExists(edited);
                     assert.equal(edited.attributes.status, 'published');
 
                     assert.equal(Object.keys(eventsTriggered).length, 4);
-                    should.exist(eventsTriggered['post.published']);
-                    should.exist(eventsTriggered['post.edited']);
-                    should.exist(eventsTriggered['tag.attached']);
-                    should.exist(eventsTriggered['user.attached']);
+                    assertExists(eventsTriggered['post.published']);
+                    assertExists(eventsTriggered['post.edited']);
+                    assertExists(eventsTriggered['tag.attached']);
+                    assertExists(eventsTriggered['user.attached']);
 
                     done();
                 }).catch(done);
@@ -321,19 +322,19 @@ describe('Post Model', function () {
 
                 models.Post.findOne({id: postId}).then(function (results) {
                     let post;
-                    should.exist(results);
+                    assertExists(results);
                     post = results.toJSON();
                     post.id.should.equal(postId);
                     assert.equal(post.status, 'published');
 
                     return models.Post.edit({status: 'draft'}, _.extend({}, context, {id: postId}));
                 }).then(function (edited) {
-                    should.exist(edited);
+                    assertExists(edited);
                     assert.equal(edited.attributes.status, 'draft');
 
                     assert.equal(Object.keys(eventsTriggered).length, 4);
-                    should.exist(eventsTriggered['post.unpublished']);
-                    should.exist(eventsTriggered['post.edited']);
+                    assertExists(eventsTriggered['post.unpublished']);
+                    assertExists(eventsTriggered['post.edited']);
 
                     done();
                 }).catch(done);
@@ -343,7 +344,7 @@ describe('Post Model', function () {
                 let post;
 
                 models.Post.findOne({status: 'draft'}).then(function (results) {
-                    should.exist(results);
+                    assertExists(results);
                     post = results.toJSON();
                     assert.equal(post.status, 'draft');
 
@@ -356,7 +357,7 @@ describe('Post Model', function () {
                 }).then(function () {
                     done(new Error('expected error'));
                 }).catch(function (err) {
-                    should.exist(err);
+                    assertExists(err);
                     assert.equal((err instanceof errors.ValidationError), true);
                     done();
                 });
@@ -368,7 +369,7 @@ describe('Post Model', function () {
                 models.Post.findOne({status: 'draft'}).then(function (results) {
                     let post;
 
-                    should.exist(results);
+                    assertExists(results);
                     post = results.toJSON();
                     assert.equal(post.status, 'draft');
 
@@ -377,15 +378,15 @@ describe('Post Model', function () {
                         published_at: newPublishedAt
                     }, _.extend({}, context, {id: post.id}));
                 }).then(function (edited) {
-                    should.exist(edited);
+                    assertExists(edited);
                     assert.equal(edited.attributes.status, 'scheduled');
 
                     // mysql does not store ms
                     assert.equal(moment(edited.attributes.published_at).startOf('seconds').diff(moment(newPublishedAt).startOf('seconds')), 0);
 
                     assert.equal(Object.keys(eventsTriggered).length, 2);
-                    should.exist(eventsTriggered['post.scheduled']);
-                    should.exist(eventsTriggered['post.edited']);
+                    assertExists(eventsTriggered['post.scheduled']);
+                    assertExists(eventsTriggered['post.edited']);
 
                     done();
                 }).catch(done);
@@ -395,7 +396,7 @@ describe('Post Model', function () {
                 models.Post.findOne({status: 'scheduled'}).then(function (results) {
                     let post;
 
-                    should.exist(results);
+                    assertExists(results);
                     post = results.toJSON();
                     assert.equal(post.status, 'scheduled');
 
@@ -403,12 +404,12 @@ describe('Post Model', function () {
                         status: 'draft'
                     }, _.extend({}, context, {id: post.id}));
                 }).then(function (edited) {
-                    should.exist(edited);
+                    assertExists(edited);
                     assert.equal(edited.attributes.status, 'draft');
 
                     assert.equal(Object.keys(eventsTriggered).length, 2);
-                    should.exist(eventsTriggered['post.unscheduled']);
-                    should.exist(eventsTriggered['post.edited']);
+                    assertExists(eventsTriggered['post.unscheduled']);
+                    assertExists(eventsTriggered['post.edited']);
 
                     done();
                 }).catch(done);
@@ -418,7 +419,7 @@ describe('Post Model', function () {
                 models.Post.findOne({status: 'scheduled'}).then(function (results) {
                     let post;
 
-                    should.exist(results);
+                    assertExists(results);
                     post = results.toJSON();
                     assert.equal(post.status, 'scheduled');
 
@@ -427,12 +428,12 @@ describe('Post Model', function () {
                         published_at: moment().add(20, 'days').toDate()
                     }, _.extend({}, context, {id: post.id}));
                 }).then(function (edited) {
-                    should.exist(edited);
+                    assertExists(edited);
                     assert.equal(edited.attributes.status, 'scheduled');
 
                     assert.equal(Object.keys(eventsTriggered).length, 2);
-                    should.exist(eventsTriggered['post.rescheduled']);
-                    should.exist(eventsTriggered['post.edited']);
+                    assertExists(eventsTriggered['post.rescheduled']);
+                    assertExists(eventsTriggered['post.edited']);
 
                     done();
                 }).catch(done);
@@ -442,7 +443,7 @@ describe('Post Model', function () {
                 models.Post.findOne({status: 'scheduled'}).then(function (results) {
                     let post;
 
-                    should.exist(results);
+                    assertExists(results);
                     post = results.toJSON();
                     assert.equal(post.status, 'scheduled');
 
@@ -450,7 +451,7 @@ describe('Post Model', function () {
                         status: 'scheduled'
                     }, _.extend({}, context, {id: post.id}));
                 }).then(function (edited) {
-                    should.exist(edited);
+                    assertExists(edited);
                     assert.equal(edited.attributes.status, 'scheduled');
 
                     // nothing has changed
@@ -464,7 +465,7 @@ describe('Post Model', function () {
                 let post;
 
                 models.Post.findOne({status: 'scheduled'}).then(function (results) {
-                    should.exist(results);
+                    assertExists(results);
                     post = results.toJSON();
                     assert.equal(post.status, 'scheduled');
 
@@ -472,8 +473,8 @@ describe('Post Model', function () {
                     return results.save();
                 }).then(function () {
                     assert.equal(Object.keys(eventsTriggered).length, 2);
-                    should.exist(eventsTriggered['post.edited']);
-                    should.exist(eventsTriggered['post.rescheduled']);
+                    assertExists(eventsTriggered['post.edited']);
+                    assertExists(eventsTriggered['post.rescheduled']);
                     eventsTriggered = {};
 
                     return new Promise((resolve) => {
@@ -484,11 +485,11 @@ describe('Post Model', function () {
                         status: 'scheduled'
                     }, _.extend({}, context, {id: post.id}));
                 }).then(function (edited) {
-                    should.exist(edited);
+                    assertExists(edited);
                     assert.equal(edited.attributes.status, 'scheduled');
 
                     assert.equal(Object.keys(eventsTriggered).length, 1);
-                    should.exist(eventsTriggered['post.edited']);
+                    assertExists(eventsTriggered['post.edited']);
 
                     done();
                 }).catch(done);
@@ -499,7 +500,7 @@ describe('Post Model', function () {
 
                 models.Post.findOne({id: postId}).then(function (results) {
                     let post;
-                    should.exist(results);
+                    assertExists(results);
                     post = results.toJSON();
                     post.id.should.equal(postId);
                     assert.equal(post.status, 'published');
@@ -511,7 +512,7 @@ describe('Post Model', function () {
                 }).then(function () {
                     done(new Error('change status from published to scheduled is not allowed right now!'));
                 }).catch(function (err) {
-                    should.exist(err);
+                    assertExists(err);
                     assert.equal((err instanceof errors.ValidationError), true);
                     done();
                 });
@@ -522,32 +523,32 @@ describe('Post Model', function () {
 
                 models.Post.findOne({id: postId, status: 'draft'}).then(function (results) {
                     let post;
-                    should.exist(results);
+                    assertExists(results);
                     post = results.toJSON();
                     post.id.should.equal(postId);
                     assert.equal(post.status, 'draft');
 
                     return models.Post.edit({type: 'page'}, _.extend({}, context, {id: postId}));
                 }).then(function (edited) {
-                    should.exist(edited);
+                    assertExists(edited);
                     assert.equal(edited.attributes.status, 'draft');
                     assert.equal(edited.attributes.type, 'page');
 
                     assert.equal(Object.keys(eventsTriggered).length, 2);
-                    should.exist(eventsTriggered['post.deleted']);
-                    should.exist(eventsTriggered['page.added']);
+                    assertExists(eventsTriggered['post.deleted']);
+                    assertExists(eventsTriggered['page.added']);
 
                     return models.Post.edit({type: 'post'}, _.extend({}, context, {id: postId}));
                 }).then(function (edited) {
-                    should.exist(edited);
+                    assertExists(edited);
                     assert.equal(edited.attributes.status, 'draft');
                     assert.equal(edited.attributes.type, 'post');
 
                     assert.equal(Object.keys(eventsTriggered).length, 4);
-                    should.exist(eventsTriggered['post.deleted']);
-                    should.exist(eventsTriggered['page.added']);
-                    should.exist(eventsTriggered['post.deleted']);
-                    should.exist(eventsTriggered['post.added']);
+                    assertExists(eventsTriggered['post.deleted']);
+                    assertExists(eventsTriggered['page.added']);
+                    assertExists(eventsTriggered['post.deleted']);
+                    assertExists(eventsTriggered['post.added']);
 
                     done();
                 }).catch(done);
@@ -556,7 +557,7 @@ describe('Post Model', function () {
             it('can convert draft to schedule AND post to page and back', function (done) {
                 models.Post.findOne({status: 'draft'}).then(function (results) {
                     let post;
-                    should.exist(results);
+                    assertExists(results);
                     post = results.toJSON();
                     assert.equal(post.status, 'draft');
 
@@ -566,26 +567,26 @@ describe('Post Model', function () {
                         published_at: moment().add(10, 'days')
                     }, _.extend({}, context, {id: post.id}));
                 }).then(function (edited) {
-                    should.exist(edited);
+                    assertExists(edited);
                     assert.equal(edited.attributes.status, 'scheduled');
                     assert.equal(edited.attributes.type, 'page');
 
                     assert.equal(Object.keys(eventsTriggered).length, 3);
-                    should.exist(eventsTriggered['post.deleted']);
-                    should.exist(eventsTriggered['page.added']);
-                    should.exist(eventsTriggered['page.scheduled']);
+                    assertExists(eventsTriggered['post.deleted']);
+                    assertExists(eventsTriggered['page.added']);
+                    assertExists(eventsTriggered['page.scheduled']);
 
                     return models.Post.edit({type: 'post'}, _.extend({}, context, {id: edited.id}));
                 }).then(function (edited) {
-                    should.exist(edited);
+                    assertExists(edited);
                     assert.equal(edited.attributes.status, 'scheduled');
                     assert.equal(edited.attributes.type, 'post');
 
                     assert.equal(Object.keys(eventsTriggered).length, 7);
-                    should.exist(eventsTriggered['page.unscheduled']);
-                    should.exist(eventsTriggered['page.deleted']);
-                    should.exist(eventsTriggered['post.added']);
-                    should.exist(eventsTriggered['post.scheduled']);
+                    assertExists(eventsTriggered['page.unscheduled']);
+                    assertExists(eventsTriggered['page.deleted']);
+                    assertExists(eventsTriggered['post.added']);
+                    assertExists(eventsTriggered['post.scheduled']);
 
                     done();
                 }).catch(done);
@@ -596,34 +597,34 @@ describe('Post Model', function () {
 
                 models.Post.findOne({id: postId}).then(function (results) {
                     let post;
-                    should.exist(results);
+                    assertExists(results);
                     post = results.toJSON();
                     post.id.should.equal(postId);
                     assert.equal(post.status, 'published');
 
                     return models.Post.edit({type: 'page'}, _.extend({}, context, {id: postId}));
                 }).then(function (edited) {
-                    should.exist(edited);
+                    assertExists(edited);
                     assert.equal(edited.attributes.status, 'published');
                     assert.equal(edited.attributes.type, 'page');
 
                     assert.equal(Object.keys(eventsTriggered).length, 4);
-                    should.exist(eventsTriggered['post.unpublished']);
-                    should.exist(eventsTriggered['post.deleted']);
-                    should.exist(eventsTriggered['page.added']);
-                    should.exist(eventsTriggered['page.published']);
+                    assertExists(eventsTriggered['post.unpublished']);
+                    assertExists(eventsTriggered['post.deleted']);
+                    assertExists(eventsTriggered['page.added']);
+                    assertExists(eventsTriggered['page.published']);
 
                     return models.Post.edit({type: 'post'}, _.extend({}, context, {id: postId}));
                 }).then(function (edited) {
-                    should.exist(edited);
+                    assertExists(edited);
                     assert.equal(edited.attributes.status, 'published');
                     assert.equal(edited.attributes.type, 'post');
 
                     assert.equal(Object.keys(eventsTriggered).length, 8);
-                    should.exist(eventsTriggered['page.unpublished']);
-                    should.exist(eventsTriggered['page.deleted']);
-                    should.exist(eventsTriggered['post.added']);
-                    should.exist(eventsTriggered['post.published']);
+                    assertExists(eventsTriggered['page.unpublished']);
+                    assertExists(eventsTriggered['page.deleted']);
+                    assertExists(eventsTriggered['post.added']);
+                    assertExists(eventsTriggered['post.published']);
 
                     done();
                 }).catch(done);
@@ -634,34 +635,34 @@ describe('Post Model', function () {
 
                 models.Post.findOne({id: postId, status: 'draft'}).then(function (results) {
                     let post;
-                    should.exist(results);
+                    assertExists(results);
                     post = results.toJSON();
                     post.id.should.equal(postId);
                     assert.equal(post.status, 'draft');
 
                     return models.Post.edit({type: 'page', status: 'published'}, _.extend({}, context, {id: postId}));
                 }).then(function (edited) {
-                    should.exist(edited);
+                    assertExists(edited);
                     assert.equal(edited.attributes.status, 'published');
                     assert.equal(edited.attributes.type, 'page');
 
                     assert.equal(Object.keys(eventsTriggered).length, 5);
-                    should.exist(eventsTriggered['post.deleted']);
-                    should.exist(eventsTriggered['page.added']);
-                    should.exist(eventsTriggered['page.published']);
-                    should.exist(eventsTriggered['tag.attached']);
-                    should.exist(eventsTriggered['user.attached']);
+                    assertExists(eventsTriggered['post.deleted']);
+                    assertExists(eventsTriggered['page.added']);
+                    assertExists(eventsTriggered['page.published']);
+                    assertExists(eventsTriggered['tag.attached']);
+                    assertExists(eventsTriggered['user.attached']);
 
                     return models.Post.edit({type: 'post', status: 'draft'}, _.extend({}, context, {id: postId}));
                 }).then(function (edited) {
-                    should.exist(edited);
+                    assertExists(edited);
                     assert.equal(edited.attributes.status, 'draft');
                     assert.equal(edited.attributes.type, 'post');
 
                     assert.equal(Object.keys(eventsTriggered).length, 8);
-                    should.exist(eventsTriggered['page.unpublished']);
-                    should.exist(eventsTriggered['page.deleted']);
-                    should.exist(eventsTriggered['post.added']);
+                    assertExists(eventsTriggered['page.unpublished']);
+                    assertExists(eventsTriggered['page.deleted']);
+                    assertExists(eventsTriggered['post.added']);
 
                     done();
                 }).catch(done);
@@ -672,7 +673,7 @@ describe('Post Model', function () {
 
                 models.Post.findOne({id: postId, status: 'draft'}).then(function (results) {
                     let post;
-                    should.exist(results);
+                    assertExists(results);
                     post = results.toJSON();
                     post.id.should.equal(postId);
                     assert.equal(post.status, 'draft');
@@ -683,14 +684,14 @@ describe('Post Model', function () {
                         published_by: 4
                     }, _.extend({}, context, {id: postId}));
                 }).then(function (edited) {
-                    should.exist(edited);
+                    assertExists(edited);
                     assert.equal(edited.attributes.status, 'published');
                     edited.attributes.published_by.should.equal(context.context.user);
 
                     // Test changing status and published_by on its own
                     return models.Post.edit({published_by: 4}, _.extend({}, context, {id: postId}));
                 }).then(function (edited) {
-                    should.exist(edited);
+                    assertExists(edited);
                     assert.equal(edited.attributes.status, 'published');
                     edited.attributes.published_by.should.equal(context.context.user);
 
@@ -735,7 +736,7 @@ describe('Post Model', function () {
                 models.Post.add(newPost, _.merge({withRelated: ['authors']}, context)).then(function (createdPost) {
                     return models.Post.findOne({id: createdPost.id, status: 'all'}, {withRelated: ['authors']});
                 }).then(function (createdPost) {
-                    should.exist(createdPost);
+                    assertExists(createdPost);
                     assert.equal(createdPost.has('uuid'), true);
                     assert.equal(createdPost.get('status'), 'draft');
                     assert.equal(createdPost.get('title'), newPost.title, 'title is correct');
@@ -763,8 +764,8 @@ describe('Post Model', function () {
                     createdPostUpdatedDate = createdPost.get('updated_at');
 
                     assert.equal(Object.keys(eventsTriggered).length, 2);
-                    should.exist(eventsTriggered['post.added']);
-                    should.exist(eventsTriggered['user.attached']);
+                    assertExists(eventsTriggered['post.added']);
+                    assertExists(eventsTriggered['user.attached']);
 
                     // Set the status to published to check that `published_at` is set.
                     return createdPost.save({status: 'published'}, context);
@@ -775,8 +776,8 @@ describe('Post Model', function () {
                     publishedPost.get('updated_at').should.not.equal(createdPostUpdatedDate);
 
                     assert.equal(Object.keys(eventsTriggered).length, 4);
-                    should.exist(eventsTriggered['post.published']);
-                    should.exist(eventsTriggered['post.edited']);
+                    assertExists(eventsTriggered['post.published']);
+                    assertExists(eventsTriggered['post.edited']);
 
                     done();
                 }).catch(done);
@@ -804,7 +805,7 @@ describe('Post Model', function () {
                 models.Post.add(newPost, _.merge({withRelated: ['authors']}, context)).then(function (createdPost) {
                     return models.Post.findOne({id: createdPost.id, status: 'all'}, {withRelated: ['authors']});
                 }).then(function (createdPost) {
-                    should.exist(createdPost);
+                    assertExists(createdPost);
                     assert.equal(createdPost.has('uuid'), true);
                     assert.equal(createdPost.get('status'), 'draft');
                     assert.equal(createdPost.get('title'), newPost.title, 'title is correct');
@@ -832,8 +833,8 @@ describe('Post Model', function () {
                     createdPostUpdatedDate = createdPost.get('updated_at');
 
                     assert.equal(Object.keys(eventsTriggered).length, 2);
-                    should.exist(eventsTriggered['post.added']);
-                    should.exist(eventsTriggered['user.attached']);
+                    assertExists(eventsTriggered['post.added']);
+                    assertExists(eventsTriggered['user.attached']);
 
                     // Set the status to published to check that `published_at` is set.
                     return createdPost.save({status: 'published'}, context);
@@ -844,8 +845,8 @@ describe('Post Model', function () {
                     publishedPost.get('updated_at').should.not.equal(createdPostUpdatedDate);
 
                     assert.equal(Object.keys(eventsTriggered).length, 4);
-                    should.exist(eventsTriggered['post.published']);
-                    should.exist(eventsTriggered['post.edited']);
+                    assertExists(eventsTriggered['post.published']);
+                    assertExists(eventsTriggered['post.edited']);
 
                     done();
                 }).catch(done);
@@ -860,13 +861,13 @@ describe('Post Model', function () {
                     title: 'published_at test',
                     mobiledoc: markdownToMobiledoc('This is some content')
                 }, context).then(function (newPost) {
-                    should.exist(newPost);
+                    assertExists(newPost);
                     new Date(newPost.get('published_at')).getTime().should.equal(previousPublishedAtDate.getTime());
 
                     assert.equal(Object.keys(eventsTriggered).length, 3);
-                    should.exist(eventsTriggered['post.added']);
-                    should.exist(eventsTriggered['post.published']);
-                    should.exist(eventsTriggered['user.attached']);
+                    assertExists(eventsTriggered['post.added']);
+                    assertExists(eventsTriggered['post.published']);
+                    assertExists(eventsTriggered['user.attached']);
 
                     done();
                 }).catch(done);
@@ -878,12 +879,12 @@ describe('Post Model', function () {
                     title: 'draft 1',
                     mobiledoc: markdownToMobiledoc('This is some content')
                 }, context).then(function (newPost) {
-                    should.exist(newPost);
+                    assertExists(newPost);
                     assert.equal(newPost.get('published_at'), null);
 
                     assert.equal(Object.keys(eventsTriggered).length, 2);
-                    should.exist(eventsTriggered['post.added']);
-                    should.exist(eventsTriggered['user.attached']);
+                    assertExists(eventsTriggered['post.added']);
+                    assertExists(eventsTriggered['user.attached']);
 
                     done();
                 }).catch(done);
@@ -899,7 +900,7 @@ describe('Post Model', function () {
                         name: testUtils.DataGenerator.forKnex.users[0].name
                     }]
                 }, _.merge({withRelated: ['authors']}, context)).then(function (newPost) {
-                    should.exist(newPost);
+                    assertExists(newPost);
                     newPost.toJSON().primary_author.id.should.eql(testUtils.DataGenerator.forKnex.users[0].id);
                     assert.equal(newPost.toJSON().authors.length, 1);
                     newPost.toJSON().authors[0].id.should.eql(testUtils.DataGenerator.forKnex.users[0].id);
@@ -914,12 +915,12 @@ describe('Post Model', function () {
                     title: 'draft 1',
                     mobiledoc: markdownToMobiledoc('This is some content')
                 }, context).then(function (newPost) {
-                    should.exist(newPost);
-                    should.exist(newPost.get('published_at'));
+                    assertExists(newPost);
+                    assertExists(newPost.get('published_at'));
 
                     assert.equal(Object.keys(eventsTriggered).length, 2);
-                    should.exist(eventsTriggered['post.added']);
-                    should.exist(eventsTriggered['user.attached']);
+                    assertExists(eventsTriggered['post.added']);
+                    assertExists(eventsTriggered['user.attached']);
 
                     done();
                 }).catch(done);
@@ -931,7 +932,7 @@ describe('Post Model', function () {
                     title: 'scheduled 1',
                     mobiledoc: markdownToMobiledoc('This is some content')
                 }, context).catch(function (err) {
-                    should.exist(err);
+                    assertExists(err);
                     assert.equal((err instanceof errors.ValidationError), true);
                     assert.equal(Object.keys(eventsTriggered).length, 0);
                     done();
@@ -945,7 +946,7 @@ describe('Post Model', function () {
                     title: 'scheduled 1',
                     mobiledoc: markdownToMobiledoc('This is some content')
                 }, context).catch(function (err) {
-                    should.exist(err);
+                    assertExists(err);
                     assert.equal((err instanceof errors.ValidationError), true);
                     assert.equal(Object.keys(eventsTriggered).length, 0);
                     done();
@@ -959,12 +960,12 @@ describe('Post Model', function () {
                     title: 'scheduled 1',
                     mobiledoc: markdownToMobiledoc('This is some content')
                 }, context);
-                should.exist(post);
+                assertExists(post);
 
                 assert.equal(Object.keys(eventsTriggered).length, 3);
-                should.exist(eventsTriggered['post.added']);
-                should.exist(eventsTriggered['post.scheduled']);
-                should.exist(eventsTriggered['user.attached']);
+                assertExists(eventsTriggered['post.added']);
+                assertExists(eventsTriggered['post.scheduled']);
+                assertExists(eventsTriggered['user.attached']);
             });
 
             it('add scheduled post with published_at 10 minutes in future -> we expect success', function (done) {
@@ -974,12 +975,12 @@ describe('Post Model', function () {
                     title: 'scheduled 1',
                     mobiledoc: markdownToMobiledoc('This is some content')
                 }, context).then(function (post) {
-                    should.exist(post);
+                    assertExists(post);
 
                     assert.equal(Object.keys(eventsTriggered).length, 3);
-                    should.exist(eventsTriggered['post.added']);
-                    should.exist(eventsTriggered['post.scheduled']);
-                    should.exist(eventsTriggered['user.attached']);
+                    assertExists(eventsTriggered['post.added']);
+                    assertExists(eventsTriggered['post.scheduled']);
+                    assertExists(eventsTriggered['user.attached']);
 
                     done();
                 }).catch(done);
@@ -1012,8 +1013,8 @@ describe('Post Model', function () {
                         JSON.parse(post.get('mobiledoc')).cards[0][1].markdown.should.equal('Test Content ' + num);
 
                         assert.equal(Object.keys(eventsTriggered).length, 2);
-                        should.exist(eventsTriggered['post.added']);
-                        should.exist(eventsTriggered['user.attached']);
+                        assertExists(eventsTriggered['post.added']);
+                        assertExists(eventsTriggered['user.attached']);
                         assert.equal(eventsTriggered['post.added'].length, 12);
                     });
 
@@ -1031,8 +1032,8 @@ describe('Post Model', function () {
                     assert.equal(createdPost.get('slug'), 'apprehensive-titles-have-too-many-spaces-and-m-dashes-and-also-n-dashes');
 
                     assert.equal(Object.keys(eventsTriggered).length, 2);
-                    should.exist(eventsTriggered['post.added']);
-                    should.exist(eventsTriggered['user.attached']);
+                    assertExists(eventsTriggered['post.added']);
+                    assertExists(eventsTriggered['user.attached']);
 
                     done();
                 }).catch(done);
@@ -1048,8 +1049,8 @@ describe('Post Model', function () {
                     assert.notEqual(createdPost.get('slug'), 'rss');
 
                     assert.equal(Object.keys(eventsTriggered).length, 2);
-                    should.exist(eventsTriggered['post.added']);
-                    should.exist(eventsTriggered['user.attached']);
+                    assertExists(eventsTriggered['post.added']);
+                    assertExists(eventsTriggered['user.attached']);
 
                     done();
                 });
@@ -1085,8 +1086,8 @@ describe('Post Model', function () {
                         firstPost.slug = createdFirstPost.get('slug');
 
                         assert.equal(Object.keys(eventsTriggered).length, 2);
-                        should.exist(eventsTriggered['post.added']);
-                        should.exist(eventsTriggered['user.attached']);
+                        assertExists(eventsTriggered['post.added']);
+                        assertExists(eventsTriggered['user.attached']);
 
                         // Create the second post
                         return models.Post.add(secondPost, context);
@@ -1095,8 +1096,8 @@ describe('Post Model', function () {
                         secondPost.slug = createdSecondPost.get('slug');
 
                         assert.equal(Object.keys(eventsTriggered).length, 2);
-                        should.exist(eventsTriggered['post.added']);
-                        should.exist(eventsTriggered['user.attached']);
+                        assertExists(eventsTriggered['post.added']);
+                        assertExists(eventsTriggered['user.attached']);
 
                         // Update with a conflicting slug from the first post
                         return createdSecondPost.save({
@@ -1109,7 +1110,7 @@ describe('Post Model', function () {
                         updatedSecondPost.get('slug').should.not.equal(firstPost.slug);
 
                         assert.equal(Object.keys(eventsTriggered).length, 3);
-                        should.exist(eventsTriggered['post.edited']);
+                        assertExists(eventsTriggered['post.edited']);
 
                         return models.Post.findOne({
                             id: updatedSecondPost.id,
@@ -1208,7 +1209,7 @@ describe('Post Model', function () {
                         post = await models.Post.findOne({
                             slug: 'post-with-all-media-types-mobiledoc'
                         }, {withRelated: ['posts_meta']});
-                        should.exist(post, 'Post with all media types (Mobiledoc) should exist');
+                        assertExists(post, 'Post with all media types (Mobiledoc) should exist');
                         postsMeta = post.related('posts_meta');
                         mobiledoc = JSON.parse(post.get('mobiledoc'));
                     });
@@ -1277,7 +1278,7 @@ describe('Post Model', function () {
                         post = await models.Post.findOne({
                             slug: 'post-with-all-media-types-lexical'
                         }, {withRelated: ['posts_meta']});
-                        should.exist(post, 'Post with all media types (Lexical) should exist');
+                        assertExists(post, 'Post with all media types (Lexical) should exist');
                         postsMeta = post.related('posts_meta');
                         lexicalString = post.get('lexical');
                     });
@@ -1473,7 +1474,7 @@ describe('Post Model', function () {
                 // Test that we have the post we expect, with exactly one tag
                 models.Post.findOne(firstItemData, {withRelated: ['tags']}).then(function (results) {
                     let post;
-                    should.exist(results);
+                    assertExists(results);
                     post = results.toJSON();
                     post.id.should.equal(firstItemData.id);
                     assert.equal(post.status, 'published');
@@ -1488,11 +1489,11 @@ describe('Post Model', function () {
                     assert.equal(deleted.author, undefined);
 
                     assert.equal(Object.keys(eventsTriggered).length, 5);
-                    should.exist(eventsTriggered['post.unpublished']);
-                    should.exist(eventsTriggered['post.deleted']);
-                    should.exist(eventsTriggered['user.detached']);
-                    should.exist(eventsTriggered['tag.detached']);
-                    should.exist(eventsTriggered['post.tag.detached']);
+                    assertExists(eventsTriggered['post.unpublished']);
+                    assertExists(eventsTriggered['post.deleted']);
+                    assertExists(eventsTriggered['user.detached']);
+                    assertExists(eventsTriggered['tag.detached']);
+                    assertExists(eventsTriggered['post.tag.detached']);
 
                     // Double check we can't find the post again
                     return models.Post.findOne(firstItemData);
@@ -1515,7 +1516,7 @@ describe('Post Model', function () {
                 // Test that we have the post we expect, with exactly one tag
                 models.Post.findOne(firstItemData, {withRelated: ['tags']}).then(function (results) {
                     let post;
-                    should.exist(results);
+                    assertExists(results);
                     post = results.toJSON();
                     post.id.should.equal(firstItemData.id);
                     assert.equal(post.tags.length, 1);
@@ -1529,10 +1530,10 @@ describe('Post Model', function () {
                     assert.equal(deleted.author, undefined);
 
                     assert.equal(Object.keys(eventsTriggered).length, 4);
-                    should.exist(eventsTriggered['post.deleted']);
-                    should.exist(eventsTriggered['tag.detached']);
-                    should.exist(eventsTriggered['post.tag.detached']);
-                    should.exist(eventsTriggered['user.detached']);
+                    assertExists(eventsTriggered['post.deleted']);
+                    assertExists(eventsTriggered['tag.detached']);
+                    assertExists(eventsTriggered['post.tag.detached']);
+                    assertExists(eventsTriggered['user.detached']);
 
                     // Double check we can't find the post again
                     return models.Post.findOne(firstItemData);
@@ -1555,7 +1556,7 @@ describe('Post Model', function () {
                 // Test that we have the post we expect, with exactly one tag
                 models.Post.findOne(firstItemData, {withRelated: ['tags']}).then(function (results) {
                     let page;
-                    should.exist(results);
+                    assertExists(results);
                     page = results.toJSON();
                     page.id.should.equal(firstItemData.id);
                     assert.equal(page.status, 'published');
@@ -1569,9 +1570,9 @@ describe('Post Model', function () {
                     assert.equal(deleted.author, undefined);
 
                     assert.equal(Object.keys(eventsTriggered).length, 3);
-                    should.exist(eventsTriggered['page.unpublished']);
-                    should.exist(eventsTriggered['page.deleted']);
-                    should.exist(eventsTriggered['user.detached']);
+                    assertExists(eventsTriggered['page.unpublished']);
+                    assertExists(eventsTriggered['page.deleted']);
+                    assertExists(eventsTriggered['user.detached']);
 
                     // Double check we can't find the post again
                     return models.Post.findOne(firstItemData);
@@ -1594,7 +1595,7 @@ describe('Post Model', function () {
                 // Test that we have the post we expect, with exactly one tag
                 models.Post.findOne(firstItemData, {withRelated: ['tags']}).then(function (results) {
                     let page;
-                    should.exist(results);
+                    assertExists(results);
                     page = results.toJSON();
                     page.id.should.equal(firstItemData.id);
 
@@ -1606,8 +1607,8 @@ describe('Post Model', function () {
                     assert.equal(deleted.author, undefined);
 
                     assert.equal(Object.keys(eventsTriggered).length, 2);
-                    should.exist(eventsTriggered['page.deleted']);
-                    should.exist(eventsTriggered['user.detached']);
+                    assertExists(eventsTriggered['page.deleted']);
+                    assertExists(eventsTriggered['user.detached']);
 
                     // Double check we can't find the post again
                     return models.Post.findOne(firstItemData);
@@ -1726,7 +1727,7 @@ describe('Post Model', function () {
                     return models.Post.findOne({id: createdPost.id, status: 'all'});
                 })
                 .then((createdPost) => {
-                    should.exist(createdPost);
+                    assertExists(createdPost);
 
                     return createdPost.save({mobiledoc: markdownToMobiledoc('b')}, context);
                 })
@@ -1757,7 +1758,7 @@ describe('Post Model', function () {
                     return models.Post.findOne({id: createdPost.id, status: 'all'});
                 })
                 .then((createdPost) => {
-                    should.exist(createdPost);
+                    assertExists(createdPost);
                     revisionedPost = createdPost;
 
                     return sequence(_.times(11, (i) => {
@@ -1794,7 +1795,7 @@ describe('Post Model', function () {
 
             return models.Post.add(newPost, options)
                 .then((createdPost) => {
-                    should.exist(createdPost);
+                    assertExists(createdPost);
                     unversionedPost = createdPost;
                     createdPost.get('mobiledoc').should.equal(markdownToMobiledoc('a'));
 
@@ -1811,7 +1812,7 @@ describe('Post Model', function () {
                     }, _.extend({}, context, {id: unversionedPost.id}));
                 })
                 .then((editedPost) => {
-                    should.exist(editedPost);
+                    assertExists(editedPost);
                     editedPost.get('mobiledoc').should.equal(markdownToMobiledoc('b'));
 
                     return models.MobiledocRevision
@@ -2007,7 +2008,7 @@ describe('Post Model', function () {
 
         it('should create the test data correctly', function (done) {
             // creates a test tag
-            should.exist(tagJSON);
+            assertExists(tagJSON);
             tagJSON.should.be.an.Array().with.lengthOf(3);
 
             assert.equal(tagJSON[0].name, 'existing tag a');
@@ -2015,9 +2016,9 @@ describe('Post Model', function () {
             assert.equal(tagJSON[2].name, 'existing_tag_c');
 
             // creates a test post with an array of tags in the correct order
-            should.exist(postJSON);
+            assertExists(postJSON);
             assert.equal(postJSON.title, 'HTML Ipsum');
-            should.exist(postJSON.tags);
+            assertExists(postJSON.tags);
             postJSON.tags.should.be.an.Array().and.have.lengthOf(3);
 
             assert.equal(postJSON.tags[0].name, 'tag1');

--- a/ghost/core/test/legacy/models/model-snippets.test.js
+++ b/ghost/core/test/legacy/models/model-snippets.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../utils/assertions');
 const should = require('should');
 const sinon = require('sinon');
 const testUtils = require('../../utils');
@@ -32,7 +33,7 @@ describe('Snippet Model', function () {
             before(async function () {
                 const snippets = await models.Snippet.findAll();
                 snippet = snippets.models.find(s => s.get('name') === 'Snippet with all media types - Mobiledoc');
-                should.exist(snippet, 'Mobiledoc snippet should exist');
+                assertExists(snippet, 'Mobiledoc snippet should exist');
                 mobiledoc = JSON.parse(snippet.get('mobiledoc'));
             });
 
@@ -75,7 +76,7 @@ describe('Snippet Model', function () {
             before(async function () {
                 const snippets = await models.Snippet.findAll();
                 snippet = snippets.models.find(s => s.get('name') === 'Snippet with all media types - Lexical');
-                should.exist(snippet, 'Lexical snippet should exist');
+                assertExists(snippet, 'Lexical snippet should exist');
                 lexicalString = snippet.get('lexical');
             });
 

--- a/ghost/core/test/legacy/models/model-stripe-customer-subscription.test.js
+++ b/ghost/core/test/legacy/models/model-stripe-customer-subscription.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../utils/assertions');
 const should = require('should');
 const {Member} = require('../../../core/server/models/member');
 const {MemberStripeCustomer} = require('../../../core/server/models/member-stripe-customer');
@@ -71,7 +72,7 @@ describe('StripeCustomerSubscription Model', function run() {
 
             const customer = subscription.related('customer');
 
-            should.exist(customer, 'StripeCustomerSubscription should have been fetched with customer');
+            assertExists(customer, 'StripeCustomerSubscription should have been fetched with customer');
 
             assert.equal(customer.get('customer_id'), 'fake_customer_id');
         });

--- a/ghost/core/test/legacy/models/model-tags.test.js
+++ b/ghost/core/test/legacy/models/model-tags.test.js
@@ -1,3 +1,4 @@
+const {assertExists} = require('../../utils/assertions');
 const should = require('should');
 const sinon = require('sinon');
 const testUtils = require('../../utils');
@@ -27,7 +28,7 @@ describe('Tag Model', function () {
     describe('URL transformations without CDN config', function () {
         it('transforms feature_image, og_image, and twitter_image to absolute site URLs', async function () {
             const tag = await models.Tag.findOne({slug: 'tag-with-images'});
-            should.exist(tag, 'Tag with images should exist');
+            assertExists(tag, 'Tag with images should exist');
             tag.get('feature_image').should.equal(`${siteUrl}/content/images/tag-feature.jpg`);
             tag.get('og_image').should.equal(`${siteUrl}/content/images/tag-og.jpg`);
             tag.get('twitter_image').should.equal(`${siteUrl}/content/images/tag-twitter.jpg`);
@@ -48,7 +49,7 @@ describe('Tag Model', function () {
 
         it('transforms feature_image, og_image, and twitter_image to absolute site URLs(NOT CDN)', async function () {
             const tag = await models.Tag.findOne({slug: 'tag-with-images'});
-            should.exist(tag, 'Tag with images should exist');
+            assertExists(tag, 'Tag with images should exist');
             tag.get('feature_image').should.equal(`${siteUrl}/content/images/tag-feature.jpg`);
             tag.get('og_image').should.equal(`${siteUrl}/content/images/tag-og.jpg`);
             tag.get('twitter_image').should.equal(`${siteUrl}/content/images/tag-twitter.jpg`);

--- a/ghost/core/test/legacy/models/model-users.test.js
+++ b/ghost/core/test/legacy/models/model-users.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../utils/assertions');
 const errors = require('@tryghost/errors');
 const should = require('should');
 const sinon = require('sinon');
@@ -24,7 +25,7 @@ describe('User Model', function run() {
     });
 
     before(function () {
-        should.exist(UserModel);
+        assertExists(UserModel);
     });
 
     describe('Registration', function runRegistration() {
@@ -34,7 +35,7 @@ describe('User Model', function run() {
             const userData = testUtils.DataGenerator.forModel.users[0];
 
             UserModel.add(userData, context).then(function (createdUser) {
-                should.exist(createdUser);
+                assertExists(createdUser);
                 createdUser.attributes.password.should.not.equal(userData.password, 'password was hashed');
                 createdUser.attributes.email.should.eql(userData.email, 'email address correct');
 
@@ -46,7 +47,7 @@ describe('User Model', function run() {
             const userData = testUtils.DataGenerator.forModel.users[2];
 
             UserModel.add(userData, context).then(function (createdUser) {
-                should.exist(createdUser);
+                assertExists(createdUser);
                 assert.equal(createdUser.has('slug'), true);
                 assert.equal(createdUser.attributes.slug, 'jimothy');
                 done();
@@ -57,19 +58,19 @@ describe('User Model', function run() {
             const userData = testUtils.DataGenerator.forModel.users[2];
 
             UserModel.add(userData, context).then(function (createdUser) {
-                should.exist(createdUser);
+                assertExists(createdUser);
                 assert.equal(createdUser.has('slug'), true);
                 assert.equal(createdUser.attributes.slug, 'jimothy');
             }).then(function () {
                 userData.email = 'newmail@mail.com';
                 UserModel.add(userData, context).then(function (createdUser) {
-                    should.exist(createdUser);
+                    assertExists(createdUser);
                     assert.equal(createdUser.has('slug'), true);
                     assert.equal(createdUser.attributes.slug, 'jimothy-bogendath');
                 }).then(function () {
                     userData.email = 'newmail2@mail.com';
                     UserModel.add(userData, context).then(function (createdUser) {
-                        should.exist(createdUser);
+                        assertExists(createdUser);
                         assert.equal(createdUser.has('slug'), true);
                         assert.equal(createdUser.attributes.slug, 'jimothy-bogendath-2');
                         done();
@@ -82,7 +83,7 @@ describe('User Model', function run() {
             const userData = testUtils.DataGenerator.forModel.users[2];
 
             UserModel.add(userData, context).then(function (createdUser) {
-                should.exist(createdUser);
+                assertExists(createdUser);
                 createdUser.attributes.email.should.eql(userData.email, 'email address correct');
                 done();
             }).catch(done);
@@ -97,7 +98,7 @@ describe('User Model', function run() {
             });
 
             UserModel.add(userData, context).then(function (createdUser) {
-                should.exist(createdUser);
+                assertExists(createdUser);
                 assert.equal(createdUser.attributes.profile_image, 'http://www.gravatar.com/avatar/2fab21a4c4ed88e76add10650c73bae1?d=404', 'Gravatar found');
                 done();
             }).catch(done);
@@ -111,7 +112,7 @@ describe('User Model', function run() {
             });
 
             UserModel.add(userData, context).then(function (createdUser) {
-                should.exist(createdUser);
+                assertExists(createdUser);
                 assert.equal(createdUser.image, undefined);
                 done();
             }).catch(done);
@@ -124,25 +125,25 @@ describe('User Model', function run() {
             UserModel.add(userData, context).then(function () {
                 // Test same case
                 return UserModel.getByEmail(email).then(function (user) {
-                    should.exist(user);
+                    assertExists(user);
                     user.attributes.email.should.eql(email);
                 });
             }).then(function () {
                 // Test entered in lowercase
                 return UserModel.getByEmail(email.toLowerCase()).then(function (user) {
-                    should.exist(user);
+                    assertExists(user);
                     user.attributes.email.should.eql(email);
                 });
             }).then(function () {
                 // Test entered in uppercase
                 return UserModel.getByEmail(email.toUpperCase()).then(function (user) {
-                    should.exist(user);
+                    assertExists(user);
                     user.attributes.email.should.eql(email);
                 });
             }).then(function () {
                 // Test incorrect email address - swapped capital O for number 0
                 return UserModel.getByEmail('jb0gendAth@example.com').then(null, function (error) {
-                    should.exist(error);
+                    assertExists(error);
                     assert.equal(error.message, 'NotFound');
                 });
             }).then(function () {
@@ -169,7 +170,7 @@ describe('User Model', function run() {
             const userData = testUtils.DataGenerator.forModel.users[0];
 
             UserModel.check({email: userData.email, password: userData.password}).then(function (activeUser) {
-                should.exist(activeUser.get('last_seen'));
+                assertExists(activeUser.get('last_seen'));
                 done();
             }).catch(done);
         });
@@ -184,7 +185,7 @@ describe('User Model', function run() {
                 let createdAt;
                 let updatedAt;
 
-                should.exist(user);
+                assertExists(user);
 
                 lastLogin = user.get('last_seen');
                 createdAt = user.get('created_at');
@@ -219,14 +220,14 @@ describe('User Model', function run() {
                 let owner = results[0];
                 let editor = results[1];
 
-                should.exist(owner);
-                should.exist(editor);
+                assertExists(owner);
+                assertExists(editor);
 
                 owner = owner.toJSON();
                 editor = editor.toJSON();
 
-                should.exist(owner.roles);
-                should.exist(editor.roles);
+                assertExists(owner.roles);
+                assertExists(editor.roles);
 
                 assert.equal(owner.roles[0].name, 'Owner');
                 assert.equal(editor.roles[0].name, 'Editor');
@@ -241,14 +242,14 @@ describe('User Model', function run() {
 
                 return UserModel.add(userData, _.extend({}, context, {withRelated: ['roles']}));
             }).then(function (createdUser) {
-                should.exist(createdUser);
+                assertExists(createdUser);
                 createdUser.get('password').should.not.equal(userData.password, 'password was hashed');
                 createdUser.get('email').should.eql(userData.email, 'email address correct');
                 assert.equal(createdUser.related('roles').toJSON()[0].name, 'Administrator', 'role set correctly');
 
                 assert.equal(Object.keys(eventsTriggered).length, 2);
-                should.exist(eventsTriggered['user.added']);
-                should.exist(eventsTriggered['user.activated']);
+                assertExists(eventsTriggered['user.added']);
+                assertExists(eventsTriggered['user.activated']);
 
                 done();
             }).catch(done);
@@ -275,19 +276,19 @@ describe('User Model', function run() {
 
             UserModel.findOne({id: firstUser}).then(function (results) {
                 let user;
-                should.exist(results);
+                assertExists(results);
                 user = results.toJSON();
                 user.id.should.equal(firstUser);
                 assert.equal(user.website, null);
 
                 return UserModel.edit({website: 'http://some.newurl.com'}, {id: firstUser});
             }).then(function (edited) {
-                should.exist(edited);
+                assertExists(edited);
                 assert.equal(edited.attributes.website, 'http://some.newurl.com');
 
                 assert.equal(Object.keys(eventsTriggered).length, 2);
-                should.exist(eventsTriggered['user.activated.edited']);
-                should.exist(eventsTriggered['user.edited']);
+                assertExists(eventsTriggered['user.activated.edited']);
+                assertExists(eventsTriggered['user.edited']);
 
                 done();
             }).catch(done);

--- a/ghost/core/test/legacy/site/dynamic-routing.test.js
+++ b/ghost/core/test/legacy/site/dynamic-routing.test.js
@@ -3,6 +3,7 @@
 // These tests are here to cover the headers sent with requests and high-level redirects that can't be
 // tested with the unit tests
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../utils/assertions');
 const should = require('should');
 const supertest = require('supertest');
 const sinon = require('sinon');
@@ -25,7 +26,7 @@ describe('Dynamic Routing', function () {
             assert.equal(res.headers['x-cache-invalidate'], undefined);
             assert.equal(res.headers['X-CSRF-Token'], undefined);
             assert.equal(res.headers['set-cookie'], undefined);
-            should.exist(res.headers.date);
+            assertExists(res.headers.date);
 
             done();
         };
@@ -62,7 +63,7 @@ describe('Dynamic Routing', function () {
                     assert.equal(res.headers['x-cache-invalidate'], undefined);
                     assert.equal(res.headers['X-CSRF-Token'], undefined);
                     assert.equal(res.headers['set-cookie'], undefined);
-                    should.exist(res.headers.date);
+                    assertExists(res.headers.date);
 
                     assert.equal($('title').text(), 'Ghost');
                     assert.equal($('body.home-template').length, 1);
@@ -135,7 +136,7 @@ describe('Dynamic Routing', function () {
                     assert.equal(res.headers['x-cache-invalidate'], undefined);
                     assert.equal(res.headers['X-CSRF-Token'], undefined);
                     assert.equal(res.headers['set-cookie'], undefined);
-                    should.exist(res.headers.date);
+                    assertExists(res.headers.date);
 
                     assert.equal($('body').attr('class'), 'tag-template tag-getting-started has-sans-title has-sans-body');
                     assert.equal($('article.post').length, 5);

--- a/ghost/core/test/legacy/site/frontend.test.js
+++ b/ghost/core/test/legacy/site/frontend.test.js
@@ -3,6 +3,7 @@
 // Mocking out the models to not touch the DB would turn these into unit tests, and should probably be done in future,
 // But then again testing real code, rather than mock code, might be more useful...
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../utils/assertions');
 const should = require('should');
 
 const sinon = require('sinon');
@@ -23,7 +24,7 @@ describe('Frontend Routing', function () {
             assert.equal(res.headers['x-cache-invalidate'], undefined);
             assert.equal(res.headers['X-CSRF-Token'], undefined);
             assert.equal(res.headers['set-cookie'], undefined);
-            should.exist(res.headers.date);
+            assertExists(res.headers.date);
 
             done();
         };
@@ -33,7 +34,7 @@ describe('Frontend Routing', function () {
         assert.equal(res.headers['x-cache-invalidate'], undefined);
         assert.equal(res.headers['X-CSRF-Token'], undefined);
         assert.equal(res.headers['set-cookie'], undefined);
-        should.exist(res.headers.date);
+        assertExists(res.headers.date);
     }
 
     async function addPosts() {
@@ -126,7 +127,7 @@ describe('Frontend Routing', function () {
                         assert.equal(res.headers['x-cache-invalidate'], undefined);
                         assert.equal(res.headers['X-CSRF-Token'], undefined);
                         assert.equal(res.headers['set-cookie'], undefined);
-                        should.exist(res.headers.date);
+                        assertExists(res.headers.date);
 
                         assert.equal($('title').text(), 'This is a static page');
                         assert.equal($('body.page-template').length, 1);

--- a/ghost/core/test/unit/api/canary/utils/serializers/output/all.test.js
+++ b/ghost/core/test/unit/api/canary/utils/serializers/output/all.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../../../../utils/assertions');
 const should = require('should');
 const serializers = require('../../../../../../../core/server/api/endpoints/utils/serializers');
 
@@ -20,7 +21,7 @@ describe('Unit: endpoints/utils/serializers/output/all', function () {
             });
 
             assert.equal(response.posts[0].published_by, undefined);
-            should.exist(response.posts[0].title);
+            assertExists(response.posts[0].title);
 
             response = {
                 post:
@@ -35,7 +36,7 @@ describe('Unit: endpoints/utils/serializers/output/all', function () {
             });
 
             assert.equal(response.post.published_by, undefined);
-            should.exist(response.post.title);
+            assertExists(response.post.title);
 
             response = {
                 pages: [
@@ -59,8 +60,8 @@ describe('Unit: endpoints/utils/serializers/output/all', function () {
 
             assert.equal(response.pages[0].published_by, undefined);
             assert.equal(response.pages[1].published_by, undefined);
-            should.exist(response.pages[0].authors);
-            should.exist(response.pages[0].authors[0].slug);
+            assertExists(response.pages[0].authors);
+            assertExists(response.pages[0].authors[0].slug);
         });
     });
 });

--- a/ghost/core/test/unit/api/canary/utils/serializers/output/mapper.test.js
+++ b/ghost/core/test/unit/api/canary/utils/serializers/output/mapper.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../../../../utils/assertions');
 const should = require('should');
 const sinon = require('sinon');
 const testUtils = require('../../../../../../utils');
@@ -146,16 +147,16 @@ describe('Unit: utils/serializers/output/mappers', function () {
 
             const mapped = mappers.integrations(integration, frame);
 
-            should.exist(mapped.api_keys);
+            assertExists(mapped.api_keys);
 
             mapped.api_keys.forEach((key) => {
                 if (key.type === 'admin') {
                     const [id, secret] = key.secret.split(':');
-                    should.exist(id);
-                    should.exist(secret);
+                    assertExists(id);
+                    assertExists(secret);
                 } else {
                     const [id, secret] = key.secret.split(':');
-                    should.exist(id);
+                    assertExists(id);
                     assert.equal(secret, undefined);
                 }
             });

--- a/ghost/core/test/unit/api/canary/utils/serializers/output/members.test.js
+++ b/ghost/core/test/unit/api/canary/utils/serializers/output/members.test.js
@@ -1,3 +1,4 @@
+const {assertExists} = require('../../../../../../utils/assertions');
 const should = require('should');
 const sinon = require('sinon');
 const testUtils = require('../../../../../../utils');
@@ -30,7 +31,7 @@ describe('Unit: endpoints/utils/serializers/output/members', function () {
             data: [ctrlResponse],
             meta: null
         }, apiConfig, frame);
-        should.exist(frame.response.members[0].newsletters);
+        assertExists(frame.response.members[0].newsletters);
     });
 
     it('browse: includes tiers data', function () {
@@ -47,7 +48,7 @@ describe('Unit: endpoints/utils/serializers/output/members', function () {
             meta: null
         }, apiConfig, frame);
 
-        should.exist(frame.response.members[0].tiers);
+        assertExists(frame.response.members[0].tiers);
     });
 
     it('read: includes newsletter data', function () {
@@ -60,7 +61,7 @@ describe('Unit: endpoints/utils/serializers/output/members', function () {
 
         const ctrlResponse = memberModel(testUtils.DataGenerator.forKnex.createMemberWithNewsletter());
         memberSerializer.read(ctrlResponse, apiConfig, frame);
-        should.exist(frame.response.members[0].newsletters);
+        assertExists(frame.response.members[0].newsletters);
     });
 
     it('read: includes tiers data', function () {
@@ -74,6 +75,6 @@ describe('Unit: endpoints/utils/serializers/output/members', function () {
         const ctrlResponse = memberModel(testUtils.DataGenerator.forKnex.createMemberWithProducts());
         memberSerializer.read(ctrlResponse, apiConfig, frame);
 
-        should.exist(frame.response.members[0].tiers);
+        assertExists(frame.response.members[0].tiers);
     });
 });

--- a/ghost/core/test/unit/frontend/apps/private-blogging/controller.test.js
+++ b/ghost/core/test/unit/frontend/apps/private-blogging/controller.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../../utils/assertions');
 const should = require('should');
 const sinon = require('sinon');
 const path = require('path');
@@ -57,7 +58,7 @@ describe('Private Controller', function () {
     it('Should render default password page when theme has no password template', function (done) {
         res.render = function (view, context) {
             view.should.eql(defaultPath);
-            should.exist(context);
+            assertExists(context);
             done();
         };
 
@@ -69,7 +70,7 @@ describe('Private Controller', function () {
 
         res.render = function (view, context) {
             assert.equal(view, 'private');
-            should.exist(context);
+            assertExists(context);
             done();
         };
 

--- a/ghost/core/test/unit/frontend/apps/private-blogging/input-password.test.js
+++ b/ghost/core/test/unit/frontend/apps/private-blogging/input-password.test.js
@@ -1,3 +1,4 @@
+const {assertExists} = require('../../../../utils/assertions');
 // We use the name input_password to match the helper for consistency:
 const should = require('should');
 
@@ -6,13 +7,13 @@ const input_password = require('../../../../../core/frontend/apps/private-bloggi
 
 describe('{{input_password}} helper', function () {
     it('has input_password helper', function () {
-        should.exist(input_password);
+        assertExists(input_password);
     });
 
     it('returns the correct input when no custom options are specified', function () {
         const markup = '<input class="private-login-password" type="password" name="password" autofocus="autofocus" />';
         const rendered = input_password();
-        should.exist(rendered);
+        assertExists(rendered);
 
         String(rendered).should.equal(markup);
     });
@@ -28,7 +29,7 @@ describe('{{input_password}} helper', function () {
 
         const rendered = input_password(options);
 
-        should.exist(rendered);
+        assertExists(rendered);
 
         String(rendered).should.equal(markup);
     });
@@ -44,7 +45,7 @@ describe('{{input_password}} helper', function () {
 
         const rendered = input_password(options);
 
-        should.exist(rendered);
+        assertExists(rendered);
 
         String(rendered).should.equal(markup);
     });

--- a/ghost/core/test/unit/frontend/helpers/asset.test.js
+++ b/ghost/core/test/unit/frontend/helpers/asset.test.js
@@ -2,6 +2,7 @@
 //       more complicated use cases are tested directly in asset_url.spec
 
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../utils/assertions');
 const should = require('should');
 
 const sinon = require('sinon');
@@ -30,13 +31,13 @@ describe('{{asset}} helper', function () {
     describe('no subdirectory', function () {
         it('handles favicon correctly', function () {
             rendered = asset('favicon.ico');
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(String(rendered), '/favicon.ico');
         });
 
         it('handles ghost.css for default templates correctly', function () {
             rendered = asset('public/ghost.css');
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(String(rendered), '/public/ghost.css?v=abc');
         });
 
@@ -44,25 +45,25 @@ describe('{{asset}} helper', function () {
             // with png
             localSettingsCache.icon = '/content/images/favicon.png';
             rendered = asset('favicon.png');
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(String(rendered), '/content/images/size/w256h256/favicon.png');
 
             // with ico
             localSettingsCache.icon = '/content/images/favicon.ico';
             rendered = asset('favicon.ico');
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(String(rendered), '/content/images/favicon.ico');
 
             // with webp
             localSettingsCache.icon = '/content/images/favicon.webp';
             rendered = asset('favicon.png');
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(String(rendered), '/content/images/size/w256h256/format/png/favicon.webp');
 
             // with svg
             localSettingsCache.icon = '/content/images/favicon.svg';
             rendered = asset('favicon.png');
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(String(rendered), '/content/images/size/w256h256/format/png/favicon.svg');
         });
 
@@ -70,19 +71,19 @@ describe('{{asset}} helper', function () {
             localSettingsCache.icon = '';
 
             rendered = asset('public/asset.js');
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(String(rendered), '/public/asset.js?v=abc');
         });
 
         it('handles theme assets correctly', function () {
             rendered = asset('js/asset.js');
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(String(rendered), '/assets/js/asset.js?v=abc');
         });
 
         it('handles hasMinFile assets correctly', function () {
             rendered = asset('js/asset.js', {hash: {hasMinFile: true}});
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(String(rendered), '/assets/js/asset.min.js?v=abc');
         });
     });
@@ -99,13 +100,13 @@ describe('{{asset}} helper', function () {
 
         it('handles favicon correctly', function () {
             rendered = asset('favicon.ico');
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(String(rendered), 'http://127.0.0.1/favicon.ico');
         });
 
         it('handles ghost.css for default templates correctly', function () {
             rendered = asset('public/ghost.css');
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(String(rendered), 'http://127.0.0.1/public/ghost.css?v=abc');
         });
     });

--- a/ghost/core/test/unit/frontend/helpers/authors.test.js
+++ b/ghost/core/test/unit/frontend/helpers/authors.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../utils/assertions');
 const should = require('should');
 const sinon = require('sinon');
 const urlService = require('../../../../core/server/services/url');
@@ -28,7 +29,7 @@ describe('{{authors}} helper', function () {
         ];
 
         const rendered = authorsHelper.call({authors: authors}, {hash: {autolink: 'false'}});
-        should.exist(rendered);
+        assertExists(rendered);
 
         assert.equal(String(rendered), 'Michael, Thomas');
     });
@@ -40,7 +41,7 @@ describe('{{authors}} helper', function () {
         ];
 
         const rendered = authorsHelper.call({authors: authors}, {hash: {autolink: 'false'}});
-        should.exist(rendered);
+        assertExists(rendered);
 
         assert.equal(String(rendered), 'John O&#x27;Nolan, AB&#x3D;CD&#x60;EF');
     });
@@ -52,7 +53,7 @@ describe('{{authors}} helper', function () {
         ];
 
         const rendered = authorsHelper.call({authors: authors}, {hash: {separator: '|', autolink: 'false'}});
-        should.exist(rendered);
+        assertExists(rendered);
 
         assert.equal(String(rendered), 'haunted|ghost');
     });
@@ -64,7 +65,7 @@ describe('{{authors}} helper', function () {
         ];
 
         const rendered = authorsHelper.call({authors: authors}, {hash: {prefix: 'on ', autolink: 'false'}});
-        should.exist(rendered);
+        assertExists(rendered);
 
         assert.equal(String(rendered), 'on haunted, ghost');
     });
@@ -76,7 +77,7 @@ describe('{{authors}} helper', function () {
         ];
 
         const rendered = authorsHelper.call({authors: authors}, {hash: {suffix: ' forever', autolink: 'false'}});
-        should.exist(rendered);
+        assertExists(rendered);
 
         assert.equal(String(rendered), 'haunted, ghost forever');
     });
@@ -88,7 +89,7 @@ describe('{{authors}} helper', function () {
         ];
 
         const rendered = authorsHelper.call({authors: authors}, {hash: {suffix: ' forever', prefix: 'on ', autolink: 'false'}});
-        should.exist(rendered);
+        assertExists(rendered);
 
         assert.equal(String(rendered), 'on haunted, ghost forever');
     });
@@ -100,14 +101,14 @@ describe('{{authors}} helper', function () {
         ];
 
         const rendered = authorsHelper.call({authors: authors}, {hash: {suffix: ' &bull;', prefix: '&hellip; ', autolink: 'false'}});
-        should.exist(rendered);
+        assertExists(rendered);
 
         assert.equal(String(rendered), '&hellip; haunted, ghost &bull;');
     });
 
     it('does not add prefix or suffix if no authors exist', function () {
         const rendered = authorsHelper.call({}, {hash: {prefix: 'on ', suffix: ' forever', autolink: 'false'}});
-        should.exist(rendered);
+        assertExists(rendered);
 
         assert.equal(String(rendered), '');
     });
@@ -122,7 +123,7 @@ describe('{{authors}} helper', function () {
         urlServiceGetUrlByResourceIdStub.withArgs(authors[1].id).returns('author url 2');
 
         const rendered = authorsHelper.call({authors: authors});
-        should.exist(rendered);
+        assertExists(rendered);
 
         assert.equal(String(rendered), '<a href="author url 1">foo</a>, <a href="author url 2">bar</a>');
     });
@@ -136,7 +137,7 @@ describe('{{authors}} helper', function () {
         urlServiceGetUrlByResourceIdStub.withArgs(authors[0].id).returns('author url 1');
 
         const rendered = authorsHelper.call({authors: authors}, {hash: {limit: '1'}});
-        should.exist(rendered);
+        assertExists(rendered);
 
         assert.equal(String(rendered), '<a href="author url 1">foo</a>');
     });
@@ -150,7 +151,7 @@ describe('{{authors}} helper', function () {
         urlServiceGetUrlByResourceIdStub.withArgs(authors[1].id).returns('author url 2');
 
         const rendered = authorsHelper.call({authors: authors}, {hash: {from: '2'}});
-        should.exist(rendered);
+        assertExists(rendered);
 
         assert.equal(String(rendered), '<a href="author url 2">bar</a>');
     });
@@ -164,7 +165,7 @@ describe('{{authors}} helper', function () {
         urlServiceGetUrlByResourceIdStub.withArgs(authors[0].id).returns('author url');
 
         const rendered = authorsHelper.call({authors: authors}, {hash: {to: '1'}});
-        should.exist(rendered);
+        assertExists(rendered);
 
         assert.equal(String(rendered), '<a href="author url">foo</a>');
     });
@@ -180,7 +181,7 @@ describe('{{authors}} helper', function () {
         urlServiceGetUrlByResourceIdStub.withArgs(authors[2].id).returns('author url 3');
 
         const rendered = authorsHelper.call({authors: authors}, {hash: {from: '2', to: '3'}});
-        should.exist(rendered);
+        assertExists(rendered);
 
         assert.equal(String(rendered), '<a href="author url 2">bar</a>, <a href="author url 3">baz</a>');
     });
@@ -195,7 +196,7 @@ describe('{{authors}} helper', function () {
         urlServiceGetUrlByResourceIdStub.withArgs(authors[1].id).returns('author url x');
 
         const rendered = authorsHelper.call({authors: authors}, {hash: {from: '2', limit: '1'}});
-        should.exist(rendered);
+        assertExists(rendered);
 
         assert.equal(String(rendered), '<a href="author url x">bar</a>');
     });
@@ -212,7 +213,7 @@ describe('{{authors}} helper', function () {
         urlServiceGetUrlByResourceIdStub.withArgs(authors[2].id).returns('author url c');
 
         const rendered = authorsHelper.call({authors: authors}, {hash: {from: '1', to: '3', limit: '2'}});
-        should.exist(rendered);
+        assertExists(rendered);
 
         assert.equal(String(rendered), '<a href="author url a">foo</a>, <a href="author url b">bar</a>, <a href="author url c">baz</a>');
     });

--- a/ghost/core/test/unit/frontend/helpers/body-class.test.js
+++ b/ghost/core/test/unit/frontend/helpers/body-class.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../utils/assertions');
 const should = require('should');
 const themeList = require('../../../../core/server/services/themes/list');
 const sinon = require('sinon');
@@ -45,7 +46,7 @@ describe('{{body_class}} helper', function () {
         options.data.root.context = ['home'];
 
         const rendered = body_class.call({}, options);
-        should.exist(rendered);
+        assertExists(rendered);
 
         assert.equal(rendered.string, 'home-template');
     });

--- a/ghost/core/test/unit/frontend/helpers/cancel-link.test.js
+++ b/ghost/core/test/unit/frontend/helpers/cancel-link.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../utils/assertions');
 const should = require('should');
 const sinon = require('sinon');
 const hbs = require('../../../../core/frontend/services/theme-engine/engine');
@@ -49,7 +50,7 @@ describe('{{cancel_link}} helper', function () {
             id: 'sub_cancel',
             cancel_at_period_end: false
         });
-        should.exist(rendered);
+        assertExists(rendered);
 
         rendered.string.should.match(defaultLinkClass);
         assert.match(rendered.string, /data-members-cancel-subscription="sub_cancel"/);
@@ -63,7 +64,7 @@ describe('{{cancel_link}} helper', function () {
             id: 'sub_continue',
             cancel_at_period_end: true
         });
-        should.exist(rendered);
+        assertExists(rendered);
 
         rendered.string.should.match(defaultLinkClass);
         assert.match(rendered.string, /data-members-continue-subscription="sub_continue"/);
@@ -79,7 +80,7 @@ describe('{{cancel_link}} helper', function () {
                 class: 'custom-link-class'
             }
         });
-        should.exist(rendered);
+        assertExists(rendered);
 
         assert.match(rendered.string, /custom-link-class/);
     });
@@ -93,7 +94,7 @@ describe('{{cancel_link}} helper', function () {
                 errorClass: 'custom-error-class'
             }
         });
-        should.exist(rendered);
+        assertExists(rendered);
 
         assert.match(rendered.string, /custom-error-class/);
     });
@@ -107,7 +108,7 @@ describe('{{cancel_link}} helper', function () {
                 cancelLabel: 'custom cancel link text'
             }
         });
-        should.exist(rendered);
+        assertExists(rendered);
 
         assert.match(rendered.string, /custom cancel link text/);
     });
@@ -121,7 +122,7 @@ describe('{{cancel_link}} helper', function () {
                 continueLabel: 'custom continue link text'
             }
         });
-        should.exist(rendered);
+        assertExists(rendered);
 
         assert.match(rendered.string, /custom continue link text/);
     });
@@ -135,7 +136,7 @@ describe('{{cancel_link}} helper', function () {
             cancel_at_period_end: true
         });
 
-        should.exist(rendered);
+        assertExists(rendered);
 
         assert.match(rendered.string, /^<script/);
         assert.match(rendered.string, /helper is not available/);

--- a/ghost/core/test/unit/frontend/helpers/comments.test.js
+++ b/ghost/core/test/unit/frontend/helpers/comments.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../utils/assertions');
 const should = require('should');
 const sinon = require('sinon');
 const configUtils = require('../../../utils/config-utils');
@@ -56,7 +57,7 @@ describe('{{comments}} helper', function () {
                 site: {}
             }
         });
-        should.exist(rendered);
+        assertExists(rendered);
         assert(rendered.string.includes('<script defer src="https://cdn.jsdelivr.net/ghost/comments-ui'));
         assert(rendered.string.includes('data-ghost-comments="http://127.0.0.1:2369/"'));
         assert(rendered.string.includes('data-api="http://127.0.0.1:2369/ghost/api/content/"'));
@@ -85,7 +86,7 @@ describe('{{comments}} helper', function () {
                 site: {}
             }
         });
-        should.exist(rendered);
+        assertExists(rendered);
         assert(rendered.string.includes('<script defer src="https://cdn.jsdelivr.net/ghost/comments-ui'));
         assert(rendered.string.includes('data-ghost-comments="http://127.0.0.1:2369/"'));
         assert(rendered.string.includes('data-api="http://127.0.0.1:2369/ghost/api/content/"'));

--- a/ghost/core/test/unit/frontend/helpers/content-api-key.test.js
+++ b/ghost/core/test/unit/frontend/helpers/content-api-key.test.js
@@ -1,3 +1,4 @@
+const {assertExists} = require('../../../utils/assertions');
 const proxy = require('../../../../core/frontend/services/proxy');
 const {getFrontendKey} = proxy;
 const should = require('should');
@@ -10,7 +11,7 @@ describe('{{content_api_key}} helper', function () {
         it('returns the content API key', async function () {
             const result = await content_api_key();
             const expected = await getFrontendKey();
-            should.exist(result);
+            assertExists(result);
             String(result).should.equal(expected);
         });
     });

--- a/ghost/core/test/unit/frontend/helpers/content.test.js
+++ b/ghost/core/test/unit/frontend/helpers/content.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../utils/assertions');
 const should = require('should');
 const hbs = require('../../../../core/frontend/services/theme-engine/engine');
 const configUtils = require('../../../utils/config-utils');
@@ -22,7 +23,7 @@ describe('{{content}} helper', function () {
         const html = null;
         const rendered = content.call({html: html});
 
-        should.exist(rendered);
+        assertExists(rendered);
         assert.equal(rendered.string, '');
     });
 
@@ -30,7 +31,7 @@ describe('{{content}} helper', function () {
         const html = 'Hello World';
         const rendered = content.call({html: html});
 
-        should.exist(rendered);
+        assertExists(rendered);
         rendered.string.should.equal(html);
     });
 
@@ -45,7 +46,7 @@ describe('{{content}} helper', function () {
                 )
         );
 
-        should.exist(rendered);
+        assertExists(rendered);
         assert.equal(rendered.string, '<p>Hello <strong>World!</strong></p>');
     });
 
@@ -60,7 +61,7 @@ describe('{{content}} helper', function () {
                 )
         );
 
-        should.exist(rendered);
+        assertExists(rendered);
         assert.equal(rendered.string, '');
     });
 
@@ -75,7 +76,7 @@ describe('{{content}} helper', function () {
                 )
         );
 
-        should.exist(rendered);
+        assertExists(rendered);
         assert.equal(rendered.string, '<p>Hello <strong>Wo</strong></p>');
     });
 });
@@ -111,7 +112,7 @@ describe('{{content}} helper with no access', function () {
         assert(rendered.string.includes('"background-color: #abcdef"'));
         assert(rendered.string.includes('"color:#abcdef"'));
 
-        should.exist(rendered);
+        assertExists(rendered);
     });
 
     it('outputs free content if available via paywall card', function () {
@@ -185,7 +186,7 @@ describe('{{content}} helper with custom template', function () {
         assert(rendered.string.includes('custom-post-upgrade-cta'));
         assert(rendered.string.includes('custom-post-upgrade-cta-content'));
 
-        should.exist(rendered);
+        assertExists(rendered);
     });
 
     it('can correctly render message for page', function () {

--- a/ghost/core/test/unit/frontend/helpers/date.test.js
+++ b/ghost/core/test/unit/frontend/helpers/date.test.js
@@ -1,4 +1,5 @@
 const assert = require('assert/strict');
+const {assertExists} = require('../../../utils/assertions');
 const sinon = require('sinon');
 const should = require('should');
 
@@ -52,18 +53,18 @@ describe('{{date}} helper', function () {
         testDates.forEach(function (d) {
             rendered = date.call({published_at: d}, context);
 
-            should.exist(rendered);
+            assertExists(rendered);
             String(rendered).should.equal(moment(d).tz(timezone).format(format));
 
             rendered = date.call({}, d, context);
 
-            should.exist(rendered);
+            assertExists(rendered);
             String(rendered).should.equal(moment(d).tz(timezone).format(format));
         });
 
         // No date falls back to now
         rendered = date.call({}, context);
-        should.exist(rendered);
+        assertExists(rendered);
         String(rendered).should.equal(moment().tz(timezone).format(format));
     });
 
@@ -100,18 +101,18 @@ describe('{{date}} helper', function () {
             testDates.forEach(function (d) {
                 rendered = date.call({published_at: d}, context);
 
-                should.exist(rendered);
+                assertExists(rendered);
                 String(rendered).should.equal(moment(d).tz(timezone).locale(locale).format(format));
 
                 rendered = date.call({}, d, context);
 
-                should.exist(rendered);
+                assertExists(rendered);
                 String(rendered).should.equal(moment(d).tz(timezone).locale(locale).format(format));
             });
 
             // No date falls back to now
             rendered = date.call({}, context);
-            should.exist(rendered);
+            assertExists(rendered);
             String(rendered).should.equal(moment().tz(timezone).locale(locale).format(format));
         });
     });
@@ -143,18 +144,18 @@ describe('{{date}} helper', function () {
         testDates.forEach(function (d) {
             rendered = date.call({published_at: d}, context);
 
-            should.exist(rendered);
+            assertExists(rendered);
             String(rendered).should.equal(moment(d).tz(timezone).from(timeNow));
 
             rendered = date.call({}, d, context);
 
-            should.exist(rendered);
+            assertExists(rendered);
             String(rendered).should.equal(moment(d).tz(timezone).from(timeNow));
         });
 
         // No date falls back to now
         rendered = date.call({}, context);
-        should.exist(rendered);
+        assertExists(rendered);
         assert.equal(String(rendered), 'a few seconds ago');
     });
 
@@ -177,12 +178,12 @@ describe('{{date}} helper', function () {
 
         rendered = date.call({published_at: invalidDate}, context);
 
-        should.exist(rendered);
+        assertExists(rendered);
         assert.equal(String(rendered), 'a few seconds ago');
 
         rendered = date.call({}, invalidDate, context);
 
-        should.exist(rendered);
+        assertExists(rendered);
         assert.equal(String(rendered), 'a few seconds ago');
     });
 

--- a/ghost/core/test/unit/frontend/helpers/encode.test.js
+++ b/ghost/core/test/unit/frontend/helpers/encode.test.js
@@ -1,3 +1,4 @@
+const {assertExists} = require('../../../utils/assertions');
 const should = require('should');
 
 // Stuff we are testing
@@ -9,7 +10,7 @@ describe('{{encode}} helper', function () {
         const expected = '%24pecial!Charact3r(De%5Biver%5Dy)Foo%20%23Bar';
         const escaped = encode(uri);
 
-        should.exist(escaped);
+        assertExists(escaped);
         String(escaped).should.equal(expected);
     });
 });

--- a/ghost/core/test/unit/frontend/helpers/excerpt.test.js
+++ b/ghost/core/test/unit/frontend/helpers/excerpt.test.js
@@ -1,3 +1,4 @@
+const {assertExists} = require('../../../utils/assertions');
 const should = require('should');
 
 // Stuff we are testing
@@ -6,7 +7,7 @@ const excerptHelper = require('../../../../core/frontend/helpers/excerpt');
 describe('{{excerpt}} Helper', function () {
     function shouldRenderToExpected(data, hash, expected) {
         const rendered = excerptHelper.call(data, hash);
-        should.exist(rendered);
+        assertExists(rendered);
         rendered.string.should.equal(expected);
     }
 

--- a/ghost/core/test/unit/frontend/helpers/ghost-foot.test.js
+++ b/ghost/core/test/unit/frontend/helpers/ghost-foot.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../utils/assertions');
 const should = require('should');
 const sinon = require('sinon');
 const ghost_foot = require('../../../../core/frontend/helpers/ghost_foot');
@@ -19,7 +20,7 @@ describe('{{ghost_foot}} helper', function () {
         settingsCacheStub.withArgs('codeinjection_foot').returns('<script>var test = \'I am a variable!\'</script>');
 
         const rendered = ghost_foot({data: {}});
-        should.exist(rendered);
+        assertExists(rendered);
         assert.match(rendered.string, /<script>var test = 'I am a variable!'<\/script>/);
     });
 
@@ -35,7 +36,7 @@ describe('{{ghost_foot}} helper', function () {
                 }
             }
         });
-        should.exist(rendered);
+        assertExists(rendered);
         assert.match(rendered.string, /<script>var test = 'I am a variable!'<\/script>/);
         assert.match(rendered.string, /post-codeinjection/);
     });
@@ -52,7 +53,7 @@ describe('{{ghost_foot}} helper', function () {
                 }
             }
         });
-        should.exist(rendered);
+        assertExists(rendered);
         assert.match(rendered.string, /<script>var test = 'I am a variable!'<\/script>/);
         assert.doesNotMatch(rendered.string, /post-codeinjection/);
     });
@@ -69,7 +70,7 @@ describe('{{ghost_foot}} helper', function () {
                 }
             }
         });
-        should.exist(rendered);
+        assertExists(rendered);
         assert.match(rendered.string, /<script>var test = 'I am a variable!'<\/script>/);
         assert.doesNotMatch(rendered.string, /post-codeinjection/);
     });
@@ -78,7 +79,7 @@ describe('{{ghost_foot}} helper', function () {
         settingsCacheStub.withArgs('codeinjection_foot').returns('');
 
         const rendered = ghost_foot({data: {}});
-        should.exist(rendered);
+        assertExists(rendered);
         assert.equal(rendered.string, '');
     });
 
@@ -86,7 +87,7 @@ describe('{{ghost_foot}} helper', function () {
         settingsCacheStub.withArgs('codeinjection_foot').returns(undefined);
 
         const rendered = ghost_foot({data: {}});
-        should.exist(rendered);
+        assertExists(rendered);
         assert.equal(rendered.string, '');
     });
 });

--- a/ghost/core/test/unit/frontend/helpers/ghost-head.test.js
+++ b/ghost/core/test/unit/frontend/helpers/ghost-head.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../utils/assertions');
 const should = require('should');
 
 const sinon = require('sinon');
@@ -33,7 +34,7 @@ async function testGhostHead(options) {
     const sodoSearchVersion = /sodo-search@~\d+\.\d+(\.\d+)?\//g;
     rendered = rendered.replace(sodoSearchVersion, 'sodo-search@~[[VERSION]]/');
 
-    should.exist(rendered);
+    assertExists(rendered);
     // Note: we need to convert the string to an object in order to use the snapshot feature
     assertMatchSnapshot({rendered});
     return rendered;

--- a/ghost/core/test/unit/frontend/helpers/img-url.test.js
+++ b/ghost/core/test/unit/frontend/helpers/img-url.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../utils/assertions');
 const should = require('should');
 const sinon = require('sinon');
 const configUtils = require('../../../utils/config-utils');
@@ -30,34 +31,34 @@ describe('{{img_url}} helper', function () {
 
         it('should output relative url of image', function () {
             const rendered = img_url('/content/images/image-relative-url.png', {});
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(rendered, '/content/images/image-relative-url.png');
             assert.equal(logWarnStub.called, false);
         });
 
         it('should output relative url of image if the input is absolute', function () {
             const rendered = img_url('http://localhost:65535/content/images/image-relative-url.png', {});
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(rendered, '/content/images/image-relative-url.png');
             assert.equal(logWarnStub.called, false);
         });
 
         it('should output absolute url of image if the option is present ', function () {
             const rendered = img_url('/content/images/image-relative-url.png', {hash: {absolute: 'true'}});
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(rendered, 'http://localhost:65535/content/images/image-relative-url.png');
             assert.equal(logWarnStub.called, false);
         });
 
         it('should NOT output absolute url of image if the option is "false" ', function () {
             const rendered = img_url('/content/images/image-relative-url.png', {hash: {absolute: 'false'}});
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(rendered, '/content/images/image-relative-url.png');
         });
 
         it('should output author url', function () {
             const rendered = img_url('/content/images/author-image-relative-url.png', {});
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(rendered, '/content/images/author-image-relative-url.png');
             assert.equal(logWarnStub.called, false);
         });
@@ -92,19 +93,19 @@ describe('{{img_url}} helper', function () {
 
         it('should output relative url of image', function () {
             const rendered = img_url('/blog/content/images/image-relative-url.png', {});
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(rendered, '/blog/content/images/image-relative-url.png');
         });
 
         it('should output absolute url of image if the option is present ', function () {
             const rendered = img_url('/blog/content/images/image-relative-url.png', {hash: {absolute: 'true'}});
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(rendered, 'http://localhost:65535/blog/content/images/image-relative-url.png');
         });
 
         it('should not change output for an external url', function () {
             const rendered = img_url('http://example.com/picture.jpg', {});
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(rendered, 'http://example.com/picture.jpg');
         });
     });
@@ -133,7 +134,7 @@ describe('{{img_url}} helper', function () {
                     }
                 }
             });
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(rendered, '/content/images/size/w400/my-coole-img.jpg');
         });
 
@@ -152,7 +153,7 @@ describe('{{img_url}} helper', function () {
                     }
                 }
             });
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(rendered, '//website.com/whatever/my-coole-img.jpg');
         });
 
@@ -171,7 +172,7 @@ describe('{{img_url}} helper', function () {
                     }
                 }
             });
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(rendered, '/content/images/size/w400/my-coole-img.jpg');
         });
 
@@ -190,13 +191,13 @@ describe('{{img_url}} helper', function () {
                     }
                 }
             });
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(rendered, 'content/images/size/w400/my-coole-img.jpg');
         });
 
         it('ignores invalid size options', function () {
             const rendered = img_url('/content/images/author-image-relative-url.png', {hash: {size: 'invalid-size'}});
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(rendered, '/content/images/author-image-relative-url.png');
             assert.equal(logWarnStub.called, false);
         });
@@ -214,7 +215,7 @@ describe('{{img_url}} helper', function () {
                     }
                 }
             });
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(rendered, '/content/images/author-image-relative-url.png');
             assert.equal(logWarnStub.called, false);
         });
@@ -232,7 +233,7 @@ describe('{{img_url}} helper', function () {
                     }
                 }
             });
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(rendered, '/content/images/author-image-relative-url.png');
             assert.equal(logWarnStub.called, false);
         });
@@ -251,7 +252,7 @@ describe('{{img_url}} helper', function () {
                     }
                 }
             });
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(rendered, '/content/images/size/w600/format/webp/author-image-relative-url.png');
             assert.equal(logWarnStub.called, false);
         });
@@ -270,7 +271,7 @@ describe('{{img_url}} helper', function () {
                     }
                 }
             });
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(rendered, '/content/images/size/w600/author-image-relative-url.png');
             assert.equal(logWarnStub.called, false);
         });
@@ -298,7 +299,7 @@ describe('{{img_url}} helper', function () {
                     }
                 }
             });
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(rendered, 'https://images.unsplash.com/photo-1657816793628-191deb91e20f?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=MnwxMTc3M3wwfDF8YWxsfDJ8fHx8fHwyfHwxNjU3ODkzNjU5&ixlib=rb-1.2.1&q=80&w=2000');
         });
 
@@ -317,7 +318,7 @@ describe('{{img_url}} helper', function () {
                     }
                 }
             });
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(rendered, 'https://images.unsplash.com/photo-1657816793628-191deb91e20f?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=MnwxMTc3M3wwfDF8YWxsfDJ8fHx8fHwyfHwxNjU3ODkzNjU5&ixlib=rb-1.2.1&q=80&w=400');
         });
 
@@ -336,7 +337,7 @@ describe('{{img_url}} helper', function () {
                     }
                 }
             });
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(rendered, 'https://images.unsplash.com/photo-1657816793628-191deb91e20f?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=MnwxMTc3M3wwfDF8YWxsfDJ8fHx8fHwyfHwxNjU3ODkzNjU5&ixlib=rb-1.2.1&q=80&h=400');
         });
 
@@ -355,7 +356,7 @@ describe('{{img_url}} helper', function () {
                     }
                 }
             });
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(rendered, 'https://images.unsplash.com/photo-1657816793628-191deb91e20f?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=MnwxMTc3M3wwfDF8YWxsfDJ8fHx8fHwyfHwxNjU3ODkzNjU5&ixlib=rb-1.2.1&q=80');
         });
 
@@ -375,7 +376,7 @@ describe('{{img_url}} helper', function () {
                     }
                 }
             });
-            should.exist(rendered);
+            assertExists(rendered);
             rendered.should.equal(invalid);
         });
 
@@ -394,7 +395,7 @@ describe('{{img_url}} helper', function () {
                     }
                 }
             });
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(rendered, 'https://images.unsplash.com/photo-1657816793628-191deb91e20f?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=MnwxMTc3M3wwfDF8YWxsfDJ8fHx8fHwyfHwxNjU3ODkzNjU5&ixlib=rb-1.2.1&q=80&w=2000');
         });
 
@@ -413,7 +414,7 @@ describe('{{img_url}} helper', function () {
                     }
                 }
             });
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(rendered, 'https://images.unsplash.com/photo-1657816793628-191deb91e20f?crop=entropy&cs=tinysrgb&fit=max&fm=webp&ixid=MnwxMTc3M3wwfDF8YWxsfDJ8fHx8fHwyfHwxNjU3ODkzNjU5&ixlib=rb-1.2.1&q=80&w=2000');
         });
 
@@ -432,7 +433,7 @@ describe('{{img_url}} helper', function () {
                     }
                 }
             });
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(rendered, 'https://images.unsplash.com/photo-1657816793628-191deb91e20f?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=MnwxMTc3M3wwfDF8YWxsfDJ8fHx8fHwyfHwxNjU3ODkzNjU5&ixlib=rb-1.2.1&q=80&w=2000');
         });
 
@@ -451,7 +452,7 @@ describe('{{img_url}} helper', function () {
                     }
                 }
             });
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(rendered, 'https://images.unsplash.com/photo-1657816793628-191deb91e20f?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=MnwxMTc3M3wwfDF8YWxsfDJ8fHx8fHwyfHwxNjU3ODkzNjU5&ixlib=rb-1.2.1&q=80&w=2000');
         });
 
@@ -471,7 +472,7 @@ describe('{{img_url}} helper', function () {
                     }
                 }
             });
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(rendered, 'https://images.unsplash.com/photo-1657816793628-191deb91e20f?crop=entropy&cs=tinysrgb&fit=max&fm=webp&ixid=MnwxMTc3M3wwfDF8YWxsfDJ8fHx8fHwyfHwxNjU3ODkzNjU5&ixlib=rb-1.2.1&q=80&w=400');
         });
     });

--- a/ghost/core/test/unit/frontend/helpers/meta-description.test.js
+++ b/ghost/core/test/unit/frontend/helpers/meta-description.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../utils/assertions');
 const should = require('should');
 const sinon = require('sinon');
 const meta_description = require('../../../../core/frontend/helpers/meta_description');
@@ -28,7 +29,7 @@ describe('{{meta_description}} helper', function () {
                 {data: {root: {context: ['home', 'index']}}}
             );
 
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(String(rendered), 'The professional publishing platform');
         });
 
@@ -38,7 +39,7 @@ describe('{{meta_description}} helper', function () {
                 {data: {root: {context: ['index', 'paged']}}}
             );
 
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(String(rendered), '');
         });
 
@@ -48,7 +49,7 @@ describe('{{meta_description}} helper', function () {
                 {data: {root: {context: ['tag']}}}
             );
 
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(String(rendered), '');
         });
 
@@ -58,7 +59,7 @@ describe('{{meta_description}} helper', function () {
                 {data: {root: {context: ['tag', 'paged']}}}
             );
 
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(String(rendered), '');
         });
 
@@ -68,7 +69,7 @@ describe('{{meta_description}} helper', function () {
                 {data: {root: {context: ['tag']}}}
             );
 
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(String(rendered), 'Rasper is the Cool Red Casper');
         });
 
@@ -78,7 +79,7 @@ describe('{{meta_description}} helper', function () {
                 {data: {root: {context: ['tag', 'paged']}}}
             );
 
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(String(rendered), '');
         });
 
@@ -88,7 +89,7 @@ describe('{{meta_description}} helper', function () {
                 {data: {root: {context: ['author']}}}
             );
 
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(String(rendered), 'I am a Duck.');
         });
 
@@ -98,7 +99,7 @@ describe('{{meta_description}} helper', function () {
                 {data: {root: {context: ['author', 'paged']}}}
             );
 
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(String(rendered), '');
         });
 
@@ -108,7 +109,7 @@ describe('{{meta_description}} helper', function () {
                 {data: {root: {context: ['post']}}}
             );
 
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(String(rendered), '');
         });
 
@@ -118,7 +119,7 @@ describe('{{meta_description}} helper', function () {
                 {data: {root: {context: ['post']}}}
             );
 
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(String(rendered), 'Nice post about stuff.');
         });
 
@@ -128,7 +129,7 @@ describe('{{meta_description}} helper', function () {
                 {data: {root: {context: ['home']}}}
             );
 
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(String(rendered), 'Nice post about stuff.');
         });
     });
@@ -144,7 +145,7 @@ describe('{{meta_description}} helper', function () {
                 {data: {root: {context: ['home', 'index']}}}
             );
 
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(String(rendered), 'Meta description of the professional publishing platform');
         });
 
@@ -154,7 +155,7 @@ describe('{{meta_description}} helper', function () {
                 {data: {root: {context: ['tag']}}}
             );
 
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(String(rendered), 'Rasper is the Cool Red Casper');
         });
     });

--- a/ghost/core/test/unit/frontend/helpers/meta-title.test.js
+++ b/ghost/core/test/unit/frontend/helpers/meta-title.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../utils/assertions');
 const should = require('should');
 const sinon = require('sinon');
 const configUtils = require('../../../utils/config-utils');
@@ -26,7 +27,7 @@ describe('{{meta_title}} helper', function () {
                 {data: {root: {context: ['home']}}}
             );
 
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(String(rendered), 'Ghost');
         });
 
@@ -36,7 +37,7 @@ describe('{{meta_title}} helper', function () {
                 {data: {root: {context: [], pagination: {total: 2, page: 2}}}}
             );
 
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(String(rendered), 'Ghost (Page 2)');
         });
 
@@ -46,7 +47,7 @@ describe('{{meta_title}} helper', function () {
                 {data: {root: {context: ['post']}}}
             );
 
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(String(rendered), 'Post Title');
         });
 
@@ -56,7 +57,7 @@ describe('{{meta_title}} helper', function () {
                 {data: {root: {context: ['post']}}}
             );
 
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(String(rendered), 'Awesome Post');
         });
 
@@ -66,7 +67,7 @@ describe('{{meta_title}} helper', function () {
                 {data: {root: {context: ['page']}}}
             );
 
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(String(rendered), 'All about my awesomeness');
         });
 
@@ -78,7 +79,7 @@ describe('{{meta_title}} helper', function () {
                 {data: {root: {context: ['tag']}}}
             );
 
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(String(rendered), 'Rasper Red - Ghost');
         });
 
@@ -88,7 +89,7 @@ describe('{{meta_title}} helper', function () {
                 {data: {root: {context: ['tag', 'paged'], pagination: {total: 2, page: 2}}}}
             );
 
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(String(rendered), 'Rasper Red - Ghost (Page 2)');
         });
 
@@ -98,7 +99,7 @@ describe('{{meta_title}} helper', function () {
                 {data: {root: {context: ['tag']}}}
             );
 
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(String(rendered), 'Sasper Red');
         });
 
@@ -108,7 +109,7 @@ describe('{{meta_title}} helper', function () {
                 {data: {root: {context: ['tag']}}}
             );
 
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(String(rendered), 'Sasper Red');
         });
 
@@ -118,7 +119,7 @@ describe('{{meta_title}} helper', function () {
                 {data: {root: {context: ['author']}}}
             );
 
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(String(rendered), 'Donald Duck - Ghost');
         });
 
@@ -128,7 +129,7 @@ describe('{{meta_title}} helper', function () {
                 {data: {root: {context: ['author', 'paged'], pagination: {total: 2, page: 2}}}}
             );
 
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(String(rendered), 'Donald Duck - Ghost (Page 2)');
         });
 
@@ -138,7 +139,7 @@ describe('{{meta_title}} helper', function () {
                 {data: {root: {context: ['post']}}}
             );
 
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(String(rendered), 'Post Title "</>');
         });
 
@@ -148,7 +149,7 @@ describe('{{meta_title}} helper', function () {
                 {data: {root: {context: ['home']}}}
             );
 
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(String(rendered), 'Awesome Post');
         });
     });
@@ -167,7 +168,7 @@ describe('{{meta_title}} helper', function () {
                 {data: {root: {context: ['home']}}}
             );
 
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(String(rendered), 'Meta Title Ghost');
         });
 
@@ -177,7 +178,7 @@ describe('{{meta_title}} helper', function () {
                 {data: {root: {context: [], pagination: {total: 2, page: 2}}}}
             );
 
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(String(rendered), 'Ghost (Page 2)');
         });
 
@@ -189,7 +190,7 @@ describe('{{meta_title}} helper', function () {
                 {data: {root: {context: ['tag']}}}
             );
 
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(String(rendered), 'Rasper Red - Ghost');
         });
 
@@ -199,7 +200,7 @@ describe('{{meta_title}} helper', function () {
                 {data: {root: {context: ['author']}}}
             );
 
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(String(rendered), 'Donald Duck - Ghost');
         });
 
@@ -209,7 +210,7 @@ describe('{{meta_title}} helper', function () {
                 {data: {root: {context: ['author', 'paged'], pagination: {total: 2, page: 2}}}}
             );
 
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(String(rendered), 'Donald Duck - Ghost (Page 2)');
         });
     });

--- a/ghost/core/test/unit/frontend/helpers/navigation.test.js
+++ b/ghost/core/test/unit/frontend/helpers/navigation.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../utils/assertions');
 const should = require('should');
 const hbs = require('../../../../core/frontend/services/theme-engine/engine');
 const configUtils = require('../../../utils/config-utils');
@@ -71,7 +72,7 @@ describe('{{navigation}} helper', function () {
     it('can render empty nav', function () {
         const rendered = runHelper(optionsData);
 
-        should.exist(rendered);
+        assertExists(rendered);
         rendered.string.should.be.equal('');
     });
 
@@ -95,7 +96,7 @@ describe('{{navigation}} helper', function () {
         optionsData.data.site.navigation = [singleItem];
         rendered = runHelper(optionsData);
 
-        should.exist(rendered);
+        assertExists(rendered);
         assert(rendered.string.includes('li'));
         assert(rendered.string.includes('nav-foo'));
         assert(rendered.string.includes(testUrl));
@@ -111,7 +112,7 @@ describe('{{navigation}} helper', function () {
         optionsData.data.site.navigation = [firstItem, secondItem];
         rendered = runHelper(optionsData);
 
-        should.exist(rendered);
+        assertExists(rendered);
         assert(rendered.string.includes('nav-foo'));
         assert(rendered.string.includes('nav-bar-baz-qux'));
         assert(rendered.string.includes(testUrl));
@@ -127,7 +128,7 @@ describe('{{navigation}} helper', function () {
         optionsData.data.root.relativeUrl = '/foo';
         rendered = runHelper(optionsData);
 
-        should.exist(rendered);
+        assertExists(rendered);
         assert(rendered.string.includes('nav-foo'));
         assert(rendered.string.includes('nav-current'));
         assert(rendered.string.includes('nav-foo nav-current'));
@@ -143,7 +144,7 @@ describe('{{navigation}} helper', function () {
         optionsData.data.root.relativeUrl = '/foo/';
         rendered = runHelper(optionsData);
 
-        should.exist(rendered);
+        assertExists(rendered);
         assert(rendered.string.includes('nav-foo'));
         assert(rendered.string.includes('nav-current'));
         assert(rendered.string.includes('nav-foo nav-current'));
@@ -157,7 +158,7 @@ describe('{{navigation}} helper', function () {
         optionsData.data.site.navigation = [firstItem];
         rendered = runHelper(optionsData);
 
-        should.exist(rendered);
+        assertExists(rendered);
         assert(!rendered.string.includes('&#x3D;'));
         assert(!rendered.string.includes('&amp;'));
         assert(rendered.string.includes('/?foo=bar&baz=qux'));
@@ -170,7 +171,7 @@ describe('{{navigation}} helper', function () {
         optionsData.data.site.navigation = [firstItem];
         rendered = runHelper(optionsData);
 
-        should.exist(rendered);
+        assertExists(rendered);
         assert(rendered.string.includes('foo=space%20bar'));
         assert(!rendered.string.includes('<script>alert("gotcha")</script>'));
         assert(rendered.string.includes('%3Cscript%3Ealert(%22gotcha%22)%3C/script%3E'));
@@ -183,7 +184,7 @@ describe('{{navigation}} helper', function () {
         optionsData.data.site.navigation = [firstItem];
         rendered = runHelper(optionsData);
 
-        should.exist(rendered);
+        assertExists(rendered);
         assert(!rendered.string.includes('foo=space%2520bar'));
     });
 
@@ -197,7 +198,7 @@ describe('{{navigation}} helper', function () {
             optionsData.hash = {type: 'secondary'};
             rendered = runHelper(optionsData);
 
-            should.exist(rendered);
+            assertExists(rendered);
             assert(rendered.string.includes('li'));
             assert(rendered.string.includes('nav-foo'));
             assert(rendered.string.includes(testUrl));
@@ -214,7 +215,7 @@ describe('{{navigation}} helper', function () {
             optionsData.hash = {type: 'secondary'};
             rendered = runHelper(optionsData);
 
-            should.exist(rendered);
+            assertExists(rendered);
             assert(rendered.string.includes('nav-foo'));
             assert(rendered.string.includes('nav-bar-baz-qux'));
             assert(rendered.string.includes(testUrl));
@@ -257,7 +258,7 @@ describe('{{navigation}} helper with custom template', function () {
 
         rendered = runHelper(optionsData);
 
-        should.exist(rendered);
+        assertExists(rendered);
         assert(rendered.string.includes('Chaos is a ladder'));
         assert(!rendered.string.includes('isHeader is set'));
         assert(!rendered.string.includes('Jeremy Bearimy baby!'));
@@ -274,7 +275,7 @@ describe('{{navigation}} helper with custom template', function () {
 
         rendered = runHelper(optionsData);
 
-        should.exist(rendered);
+        assertExists(rendered);
         assert(!rendered.string.includes('Chaos is a ladder'));
         assert(rendered.string.includes('isHeader is set'));
         assert(!rendered.string.includes('Jeremy Bearimy baby!'));
@@ -291,7 +292,7 @@ describe('{{navigation}} helper with custom template', function () {
 
         rendered = runHelper(optionsData);
 
-        should.exist(rendered);
+        assertExists(rendered);
         assert(!rendered.string.includes('Chaos is a ladder'));
         assert(!rendered.string.includes('isHeader is set'));
         assert(rendered.string.includes('Jeremy Bearimy baby!'));

--- a/ghost/core/test/unit/frontend/helpers/pagination.test.js
+++ b/ghost/core/test/unit/frontend/helpers/pagination.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../utils/assertions');
 const should = require('should');
 const hbs = require('../../../../core/frontend/services/theme-engine/engine');
 const configUtils = require('../../../utils/config-utils');
@@ -43,7 +44,7 @@ describe('{{pagination}} helper', function () {
             pagination: {page: 1, prev: null, next: null, limit: 15, total: 8, pages: 1},
             tag: {slug: 'slug'}
         });
-        should.exist(rendered);
+        assertExists(rendered);
         // strip out carriage returns and compare.
         rendered.string.should.match(paginationRegex);
         rendered.string.should.match(pageRegex);
@@ -56,7 +57,7 @@ describe('{{pagination}} helper', function () {
         const rendered = pagination.call({
             pagination: {page: 1, prev: null, next: 2, limit: 15, total: 8, pages: 3}
         });
-        should.exist(rendered);
+        assertExists(rendered);
 
         rendered.string.should.match(paginationRegex);
         rendered.string.should.match(pageRegex);
@@ -69,7 +70,7 @@ describe('{{pagination}} helper', function () {
         const rendered = pagination.call({
             pagination: {page: 2, prev: 1, next: 3, limit: 15, total: 8, pages: 3}
         });
-        should.exist(rendered);
+        assertExists(rendered);
 
         rendered.string.should.match(paginationRegex);
         rendered.string.should.match(pageRegex);
@@ -82,7 +83,7 @@ describe('{{pagination}} helper', function () {
         const rendered = pagination.call({
             pagination: {page: 3, prev: 2, next: null, limit: 15, total: 8, pages: 3}
         });
-        should.exist(rendered);
+        assertExists(rendered);
 
         rendered.string.should.match(paginationRegex);
         rendered.string.should.match(pageRegex);
@@ -143,7 +144,7 @@ describe('{{pagination}} helper with custom template', function () {
                 }
             }
         });
-        should.exist(rendered);
+        assertExists(rendered);
         // strip out carriage returns and compare.
         assert.match(rendered.string, /Page 1 of 1/);
         assert(rendered.string.includes('Chaos is a ladder'));
@@ -160,7 +161,7 @@ describe('{{pagination}} helper with custom template', function () {
                 site: {}
             }
         });
-        should.exist(rendered);
+        assertExists(rendered);
         // strip out carriage returns and compare.
         assert.match(rendered.string, /Page 1 of 1/);
         assert(!rendered.string.includes('Chaos is a ladder'));

--- a/ghost/core/test/unit/frontend/helpers/plural.test.js
+++ b/ghost/core/test/unit/frontend/helpers/plural.test.js
@@ -1,3 +1,4 @@
+const {assertExists} = require('../../../utils/assertions');
 const should = require('should');
 
 // Stuff we are testing
@@ -15,7 +16,7 @@ describe('{{plural}} helper', function () {
             }
         });
 
-        should.exist(rendered);
+        assertExists(rendered);
         rendered.string.should.equal(expected);
     });
 
@@ -30,7 +31,7 @@ describe('{{plural}} helper', function () {
             }
         });
 
-        should.exist(rendered);
+        assertExists(rendered);
         rendered.string.should.equal(expected);
     });
 
@@ -45,7 +46,7 @@ describe('{{plural}} helper', function () {
             }
         });
 
-        should.exist(rendered);
+        assertExists(rendered);
         rendered.string.should.equal(expected);
     });
 
@@ -60,7 +61,7 @@ describe('{{plural}} helper', function () {
             }
         });
 
-        should.exist(rendered);
+        assertExists(rendered);
         rendered.string.should.equal(expected);
     });
 });

--- a/ghost/core/test/unit/frontend/helpers/post-class.test.js
+++ b/ghost/core/test/unit/frontend/helpers/post-class.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../utils/assertions');
 const should = require('should');
 
 // Stuff we are testing
@@ -8,14 +9,14 @@ describe('{{post_class}} helper', function () {
     it('can render class string', function () {
         const rendered = post_class.call({});
 
-        should.exist(rendered);
+        assertExists(rendered);
         assert.equal(rendered.string, 'post no-image');
     });
 
     it('can render class string without no-image class', function () {
         const rendered = post_class.call({feature_image: 'blah'});
 
-        should.exist(rendered);
+        assertExists(rendered);
         assert.equal(rendered.string, 'post');
     });
 
@@ -23,7 +24,7 @@ describe('{{post_class}} helper', function () {
         const post = {featured: true};
         const rendered = post_class.call(post);
 
-        should.exist(rendered);
+        assertExists(rendered);
         assert.equal(rendered.string, 'post featured no-image');
     });
 
@@ -31,7 +32,7 @@ describe('{{post_class}} helper', function () {
         const post = {featured: true, feature_image: 'asdass'};
         const rendered = post_class.call(post);
 
-        should.exist(rendered);
+        assertExists(rendered);
         assert.equal(rendered.string, 'post featured');
     });
 
@@ -39,7 +40,7 @@ describe('{{post_class}} helper', function () {
         const post = {page: true};
         const rendered = post_class.call(post);
 
-        should.exist(rendered);
+        assertExists(rendered);
         assert.equal(rendered.string, 'post no-image page');
     });
 
@@ -47,7 +48,7 @@ describe('{{post_class}} helper', function () {
         const post = {page: true, feature_image: 'asdasdas'};
         const rendered = post_class.call(post);
 
-        should.exist(rendered);
+        assertExists(rendered);
         assert.equal(rendered.string, 'post page');
     });
 });

--- a/ghost/core/test/unit/frontend/helpers/tags.test.js
+++ b/ghost/core/test/unit/frontend/helpers/tags.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../utils/assertions');
 const should = require('should');
 const sinon = require('sinon');
 const testUtils = require('../../../utils');
@@ -28,7 +29,7 @@ describe('{{tags}} helper', function () {
         ];
 
         const rendered = tagsHelper.call({tags: tags}, {hash: {autolink: 'false'}});
-        should.exist(rendered);
+        assertExists(rendered);
 
         assert.equal(String(rendered), 'foo, bar');
     });
@@ -40,7 +41,7 @@ describe('{{tags}} helper', function () {
         ];
 
         const rendered = tagsHelper.call({tags: tags}, {hash: {separator: '|', autolink: 'false'}});
-        should.exist(rendered);
+        assertExists(rendered);
 
         assert.equal(String(rendered), 'haunted|ghost');
     });
@@ -52,7 +53,7 @@ describe('{{tags}} helper', function () {
         ];
 
         const rendered = tagsHelper.call({tags: tags}, {hash: {prefix: 'on ', autolink: 'false'}});
-        should.exist(rendered);
+        assertExists(rendered);
 
         assert.equal(String(rendered), 'on haunted, ghost');
     });
@@ -64,7 +65,7 @@ describe('{{tags}} helper', function () {
         ];
 
         const rendered = tagsHelper.call({tags: tags}, {hash: {suffix: ' forever', autolink: 'false'}});
-        should.exist(rendered);
+        assertExists(rendered);
 
         assert.equal(String(rendered), 'haunted, ghost forever');
     });
@@ -76,7 +77,7 @@ describe('{{tags}} helper', function () {
         ];
 
         const rendered = tagsHelper.call({tags: tags}, {hash: {suffix: ' forever', prefix: 'on ', autolink: 'false'}});
-        should.exist(rendered);
+        assertExists(rendered);
 
         assert.equal(String(rendered), 'on haunted, ghost forever');
     });
@@ -88,14 +89,14 @@ describe('{{tags}} helper', function () {
         ];
 
         const rendered = tagsHelper.call({tags: tags}, {hash: {suffix: ' &bull;', prefix: '&hellip; ', autolink: 'false'}});
-        should.exist(rendered);
+        assertExists(rendered);
 
         assert.equal(String(rendered), '&hellip; haunted, ghost &bull;');
     });
 
     it('does not add prefix or suffix if no tags exist', function () {
         const rendered = tagsHelper.call({}, {hash: {prefix: 'on ', suffix: ' forever', autolink: 'false'}});
-        should.exist(rendered);
+        assertExists(rendered);
 
         assert.equal(String(rendered), '');
     });
@@ -110,7 +111,7 @@ describe('{{tags}} helper', function () {
         urlServiceGetUrlByResourceIdStub.withArgs(tags[1].id).returns('tag url 2');
 
         const rendered = tagsHelper.call({tags: tags});
-        should.exist(rendered);
+        assertExists(rendered);
 
         assert.equal(String(rendered), '<a href="tag url 1">foo</a>, <a href="tag url 2">bar</a>');
     });
@@ -124,7 +125,7 @@ describe('{{tags}} helper', function () {
         urlServiceGetUrlByResourceIdStub.withArgs(tags[0].id).returns('tag url 1');
 
         const rendered = tagsHelper.call({tags: tags}, {hash: {limit: '1'}});
-        should.exist(rendered);
+        assertExists(rendered);
 
         assert.equal(String(rendered), '<a href="tag url 1">foo</a>');
     });
@@ -138,7 +139,7 @@ describe('{{tags}} helper', function () {
         urlServiceGetUrlByResourceIdStub.withArgs(tags[1].id).returns('tag url 2');
 
         const rendered = tagsHelper.call({tags: tags}, {hash: {from: '2'}});
-        should.exist(rendered);
+        assertExists(rendered);
 
         assert.equal(String(rendered), '<a href="tag url 2">bar</a>');
     });
@@ -152,7 +153,7 @@ describe('{{tags}} helper', function () {
         urlServiceGetUrlByResourceIdStub.withArgs(tags[0].id).returns('tag url x');
 
         const rendered = tagsHelper.call({tags: tags}, {hash: {to: '1'}});
-        should.exist(rendered);
+        assertExists(rendered);
 
         assert.equal(String(rendered), '<a href="tag url x">foo</a>');
     });
@@ -168,7 +169,7 @@ describe('{{tags}} helper', function () {
         urlServiceGetUrlByResourceIdStub.withArgs(tags[2].id).returns('tag url c');
 
         const rendered = tagsHelper.call({tags: tags}, {hash: {from: '2', to: '3'}});
-        should.exist(rendered);
+        assertExists(rendered);
 
         assert.equal(String(rendered), '<a href="tag url b">bar</a>, <a href="tag url c">baz</a>');
     });
@@ -183,7 +184,7 @@ describe('{{tags}} helper', function () {
         urlServiceGetUrlByResourceIdStub.withArgs(tags[1].id).returns('tag url b');
 
         const rendered = tagsHelper.call({tags: tags}, {hash: {from: '2', limit: '1'}});
-        should.exist(rendered);
+        assertExists(rendered);
 
         assert.equal(String(rendered), '<a href="tag url b">bar</a>');
     });
@@ -200,7 +201,7 @@ describe('{{tags}} helper', function () {
         urlServiceGetUrlByResourceIdStub.withArgs(tags[2].id).returns('tag url c');
 
         const rendered = tagsHelper.call({tags: tags}, {hash: {from: '1', to: '3', limit: '2'}});
-        should.exist(rendered);
+        assertExists(rendered);
 
         assert.equal(String(rendered), '<a href="tag url a">foo</a>, <a href="tag url b">bar</a>, <a href="tag url c">baz</a>');
     });
@@ -261,7 +262,7 @@ describe('{{tags}} helper', function () {
 
         it('should output all tags with visibility property set with visibility="public,internal"', function () {
             const rendered = tagsHelper.call({tags: tags}, {hash: {visibility: 'public,internal'}});
-            should.exist(rendered);
+            assertExists(rendered);
 
             String(rendered).should.equal(
                 '<a href="1">foo</a>, ' +
@@ -274,14 +275,14 @@ describe('{{tags}} helper', function () {
 
         it('Should output only internal tags with visibility="internal"', function () {
             const rendered = tagsHelper.call({tags: tags}, {hash: {visibility: 'internal'}});
-            should.exist(rendered);
+            assertExists(rendered);
 
             assert.equal(String(rendered), '<a href="2">#bar</a>');
         });
 
         it('should output nothing if all tags are internal', function () {
             const rendered = tagsHelper.call({tags: tags1}, {hash: {prefix: 'stuff'}});
-            should.exist(rendered);
+            assertExists(rendered);
 
             assert.equal(String(rendered), '');
         });

--- a/ghost/core/test/unit/frontend/helpers/tiers.test.js
+++ b/ghost/core/test/unit/frontend/helpers/tiers.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../utils/assertions');
 const should = require('should');
 const tiersHelper = require('../../../../core/frontend/helpers/tiers');
 
@@ -11,7 +12,7 @@ describe('{{tiers}} helper', function () {
         ];
 
         const rendered = tiersHelper.call({tiers: tiers}, {hash: {}});
-        should.exist(rendered);
+        assertExists(rendered);
 
         assert.equal(String(rendered), 'tier 1, tier 2 and tier 3 tiers');
     });
@@ -24,7 +25,7 @@ describe('{{tiers}} helper', function () {
         ];
 
         const rendered = tiersHelper.call({tiers: tiers}, {hash: {separator: '|'}});
-        should.exist(rendered);
+        assertExists(rendered);
 
         assert.equal(String(rendered), 'tier 1|tier 2 and tier 3 tiers');
     });
@@ -37,7 +38,7 @@ describe('{{tiers}} helper', function () {
         ];
 
         const rendered = tiersHelper.call({tiers: tiers}, {hash: {lastSeparator: ' as well as '}});
-        should.exist(rendered);
+        assertExists(rendered);
 
         assert.equal(String(rendered), 'tier 1, tier 2 as well as tier 3 tiers');
     });
@@ -50,7 +51,7 @@ describe('{{tiers}} helper', function () {
         ];
 
         const rendered = tiersHelper.call({tiers: tiers}, {hash: {prefix: 'on '}});
-        should.exist(rendered);
+        assertExists(rendered);
 
         assert.equal(String(rendered), 'on tier 1, tier 2 and tier 3 tiers');
     });
@@ -63,7 +64,7 @@ describe('{{tiers}} helper', function () {
         ];
 
         const rendered = tiersHelper.call({tiers: tiers}, {hash: {suffix: ' products'}});
-        should.exist(rendered);
+        assertExists(rendered);
 
         assert.equal(String(rendered), 'tier 1, tier 2 and tier 3 products');
     });
@@ -76,7 +77,7 @@ describe('{{tiers}} helper', function () {
         ];
 
         const rendered = tiersHelper.call({tiers: tiers}, {hash: {suffix: ''}});
-        should.exist(rendered);
+        assertExists(rendered);
 
         assert.equal(String(rendered), 'tier 1, tier 2 and tier 3');
     });
@@ -89,7 +90,7 @@ describe('{{tiers}} helper', function () {
         ];
 
         const rendered = tiersHelper.call({tiers: tiers}, {hash: {prefix: 'on ', suffix: ' products'}});
-        should.exist(rendered);
+        assertExists(rendered);
 
         assert.equal(String(rendered), 'on tier 1, tier 2 and tier 3 products');
     });
@@ -102,14 +103,14 @@ describe('{{tiers}} helper', function () {
         ];
 
         const rendered = tiersHelper.call({tiers: tiers}, {hash: {suffix: ' &bull;', prefix: '&hellip; '}});
-        should.exist(rendered);
+        assertExists(rendered);
 
         assert.equal(String(rendered), '&hellip; tier 1, tier 2 and tier 3 &bull;');
     });
 
     it('does not add prefix or suffix if no tiers exist', function () {
         const rendered = tiersHelper.call({}, {hash: {prefix: 'on ', suffix: ' products'}});
-        should.exist(rendered);
+        assertExists(rendered);
 
         assert.equal(String(rendered), '');
     });

--- a/ghost/core/test/unit/frontend/helpers/title.test.js
+++ b/ghost/core/test/unit/frontend/helpers/title.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../utils/assertions');
 const should = require('should');
 
 // Stuff we are testing
@@ -8,7 +9,7 @@ describe('{{title}} Helper', function () {
     it('can render title', function () {
         const rendered = title.call({title: 'Hello World'});
 
-        should.exist(rendered);
+        assertExists(rendered);
         assert.equal(rendered.string, 'Hello World');
     });
 

--- a/ghost/core/test/unit/frontend/helpers/url.test.js
+++ b/ghost/core/test/unit/frontend/helpers/url.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../utils/assertions');
 const should = require('should');
 const sinon = require('sinon');
 const testUtils = require('../../../utils');
@@ -50,7 +51,7 @@ describe('{{url}} helper', function () {
             urlServiceGetUrlByResourceIdStub.withArgs(post.id, {absolute: undefined, withSubdirectory: true}).returns('/slug/');
 
             rendered = url.call(post);
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(rendered.string, '/slug/');
         });
 
@@ -67,7 +68,7 @@ describe('{{url}} helper', function () {
             urlServiceGetUrlByResourceIdStub.withArgs(post.id, {absolute: true, withSubdirectory: true}).returns('http://localhost:65535/slug/');
 
             rendered = url.call(post, {hash: {absolute: 'true'}});
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(rendered.string, 'http://localhost:65535/slug/');
         });
 
@@ -82,7 +83,7 @@ describe('{{url}} helper', function () {
             urlServiceGetUrlByResourceIdStub.withArgs(tag.id, {absolute: undefined, withSubdirectory: true}).returns('/tag/the-tag/');
 
             rendered = url.call(tag);
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(rendered.string, '/tag/the-tag/');
         });
 
@@ -98,20 +99,20 @@ describe('{{url}} helper', function () {
             urlServiceGetUrlByResourceIdStub.withArgs(user.id, {absolute: undefined, withSubdirectory: true}).returns('/author/some-author/');
 
             rendered = url.call(user);
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(rendered.string, '/author/some-author/');
         });
 
         it('should return / if not a post or tag', function () {
             rendered = url.call({something: 'key'});
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(rendered.string, '/');
         });
 
         it('should return a relative url if passed through a nav context', function () {
             rendered = url.call(
                 {url: '/foo', label: 'Foo', slug: 'foo', current: true});
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(rendered.string, '/foo');
         });
 
@@ -119,7 +120,7 @@ describe('{{url}} helper', function () {
             rendered = url.call(
                 {url: '/bar', label: 'Bar', slug: 'bar', current: true},
                 {hash: {absolute: 'true'}});
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(rendered.string, 'http://localhost:65535/bar');
         });
 
@@ -127,7 +128,7 @@ describe('{{url}} helper', function () {
             rendered = url.call(
                 {url: 'http://casper.website/baz', label: 'Baz', slug: 'baz', current: true},
                 {hash: {absolute: 'true'}});
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(rendered.string, 'http://casper.website/baz');
         });
 
@@ -135,7 +136,7 @@ describe('{{url}} helper', function () {
             rendered = url.call(
                 {url: 'http://localhost:65535/qux', label: 'Qux', slug: 'qux', current: true},
                 {hash: {absolute: 'true'}});
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(rendered.string, 'http://localhost:65535/qux');
         });
 
@@ -143,7 +144,7 @@ describe('{{url}} helper', function () {
             rendered = url.call(
                 {url: 'https://localhost:65535/quux', label: 'Quux', slug: 'quux', current: true},
                 {hash: {absolute: 'true'}});
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(rendered.string, 'http://localhost:65535/quux');
         });
 
@@ -151,13 +152,13 @@ describe('{{url}} helper', function () {
             rendered = url.call(
                 {url: '//casper.website/baz', label: 'Baz', slug: 'baz', current: true},
                 {hash: {}});
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(rendered.string, '//casper.website/baz');
 
             rendered = url.call(
                 {url: '//casper.website/baz', label: 'Baz', slug: 'baz', current: true},
                 {hash: {absolute: 'true'}});
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(rendered.string, '//casper.website/baz');
         });
 
@@ -165,25 +166,25 @@ describe('{{url}} helper', function () {
             rendered = url.call(
                 {url: 'tel:01234567890', label: 'Baz', slug: 'baz', current: true},
                 {hash: {}});
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(rendered.string, 'tel:01234567890');
 
             rendered = url.call(
                 {url: 'mailto:example@ghost.org', label: 'Baz', slug: 'baz', current: true},
                 {hash: {}});
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(rendered.string, 'mailto:example@ghost.org');
 
             rendered = url.call(
                 {url: 'tel:01234567890', label: 'Baz', slug: 'baz', current: true},
                 {hash: {absolute: 'true'}});
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(rendered.string, 'tel:01234567890');
 
             rendered = url.call(
                 {url: 'mailto:example@ghost.org', label: 'Baz', slug: 'baz', current: true},
                 {hash: {absolute: 'true'}});
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(rendered.string, 'mailto:example@ghost.org');
         });
 
@@ -191,41 +192,41 @@ describe('{{url}} helper', function () {
             rendered = url.call(
                 {url: '#thatsthegoodstuff', label: 'Baz', slug: 'baz', current: true},
                 {hash: {}});
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(rendered.string, '#thatsthegoodstuff');
 
             rendered = url.call(
                 {url: '#thatsthegoodstuff', label: 'Baz', slug: 'baz', current: true},
                 {hash: {absolute: 'true'}});
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(rendered.string, '#thatsthegoodstuff');
         });
 
         it('should not HTML-escape URLs', function () {
             rendered = url.call(
                 {url: '/foo?foo=bar&baz=qux', label: 'Foo', slug: 'foo', current: true});
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(rendered.string, '/foo?foo=bar&baz=qux');
         });
 
         it('should encode URLs', function () {
             rendered = url.call(
                 {url: '/foo?foo=bar&baz=qux&<script>alert("gotcha")</script>', label: 'Foo', slug: 'foo', current: true});
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(rendered.string, '/foo?foo=bar&baz=qux&%3Cscript%3Ealert(%22gotcha%22)%3C/script%3E');
         });
 
         it('should not double-encode URLs', function () {
             rendered = url.call(
                 {url: '/?foo=space%20bar', label: 'Foo', slug: 'foo', current: true});
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(rendered.string, '/?foo=space%20bar');
         });
 
         it('should return an empty string when we can\'t parse a string', function () {
             const loggingStub = sinon.stub(logging, 'error');
             rendered = url.call({url: '/?foo=space%%bar', label: 'Baz', slug: 'baz', current: true});
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(rendered.string, '');
             sinon.assert.calledOnce(loggingStub);
         });
@@ -234,7 +235,7 @@ describe('{{url}} helper', function () {
             rendered = url.call(
                 {url: 'http://[ffff::]:2368/baz', label: 'Baz', slug: 'baz', current: true},
                 {hash: {absolute: 'true'}});
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(rendered.string, 'http://[ffff::]:2368/baz');
         });
     });
@@ -252,7 +253,7 @@ describe('{{url}} helper', function () {
             rendered = url.call(
                 {url: 'http://casper.website/baz', label: 'Baz', slug: 'baz', current: true},
                 {hash: {absolute: 'true'}});
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(rendered.string, 'http://casper.website/baz');
         });
 
@@ -260,7 +261,7 @@ describe('{{url}} helper', function () {
             rendered = url.call(
                 {url: '/xyzzy', label: 'xyzzy', slug: 'xyzzy', current: true},
                 {hash: {absolute: 'true'}});
-            should.exist(rendered);
+            assertExists(rendered);
             assert.equal(rendered.string, 'http://localhost:65535/blog/xyzzy');
         });
     });

--- a/ghost/core/test/unit/frontend/meta/author-url.test.js
+++ b/ghost/core/test/unit/frontend/meta/author-url.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../utils/assertions');
 const should = require('should');
 const sinon = require('sinon');
 const ObjectId = require('bson-objectid').default;
@@ -28,7 +29,7 @@ describe('getAuthorUrl', function () {
         urlServiceGetUrlByResourceIdStub.withArgs(post.primary_author.id, {absolute: undefined, withSubdirectory: true})
             .returns('author url');
 
-        should.exist(getAuthorUrl({
+        assertExists(getAuthorUrl({
             context: ['post'],
             post: post
         }));
@@ -45,7 +46,7 @@ describe('getAuthorUrl', function () {
         urlServiceGetUrlByResourceIdStub.withArgs(post.primary_author.id, {absolute: true, withSubdirectory: true})
             .returns('absolute author url');
 
-        should.exist(getAuthorUrl({
+        assertExists(getAuthorUrl({
             context: ['post'],
             post: post
         }, true));
@@ -60,7 +61,7 @@ describe('getAuthorUrl', function () {
         urlServiceGetUrlByResourceIdStub.withArgs(author.id, {absolute: undefined, withSubdirectory: true})
             .returns('author url');
 
-        should.exist(getAuthorUrl({
+        assertExists(getAuthorUrl({
             author: author
         }));
     });

--- a/ghost/core/test/unit/frontend/meta/blog-logo.test.js
+++ b/ghost/core/test/unit/frontend/meta/blog-logo.test.js
@@ -1,3 +1,4 @@
+const {assertExists} = require('../../../utils/assertions');
 const should = require('should');
 const getBlogLogo = require('../../../../core/frontend/meta/blog-logo');
 const sinon = require('sinon');
@@ -19,7 +20,7 @@ describe('getBlogLogo', function () {
         });
 
         blogLogo = getBlogLogo();
-        should.exist(blogLogo);
+        assertExists(blogLogo);
         blogLogo.should.have.property('url', 'http://127.0.0.1:2369/content/images/logo.png');
     });
 
@@ -34,7 +35,7 @@ describe('getBlogLogo', function () {
         });
 
         blogLogo = getBlogLogo();
-        should.exist(blogLogo);
+        assertExists(blogLogo);
         blogLogo.should.have.property('url', 'http://127.0.0.1:2369/content/images/size/w256h256/favicon.png');
     });
 });

--- a/ghost/core/test/unit/frontend/meta/context-object.test.js
+++ b/ghost/core/test/unit/frontend/meta/context-object.test.js
@@ -1,3 +1,4 @@
+const {assertExists} = require('../../../utils/assertions');
 const should = require('should');
 const sinon = require('sinon');
 const getContextObject = require('../../../../core/frontend/meta/context-object.js');
@@ -9,7 +10,7 @@ describe('getContextObject', function () {
     let contextObject;
 
     it('should be a function', function () {
-        should.exist(getContextObject);
+        assertExists(getContextObject);
     });
 
     it('should return post context object for a post', function () {
@@ -17,7 +18,7 @@ describe('getContextObject', function () {
         context = ['post'];
         contextObject = getContextObject(data, context);
 
-        should.exist(contextObject);
+        assertExists(contextObject);
         contextObject.should.eql(data.post);
     });
 
@@ -26,7 +27,7 @@ describe('getContextObject', function () {
         context = ['page'];
         contextObject = getContextObject(data, context);
 
-        should.exist(contextObject);
+        assertExists(contextObject);
         contextObject.should.eql(data.post);
     });
 
@@ -35,7 +36,7 @@ describe('getContextObject', function () {
         context = ['news', 'page'];
         contextObject = getContextObject(data, context);
 
-        should.exist(contextObject);
+        assertExists(contextObject);
         contextObject.should.eql(data.page);
     });
 
@@ -57,7 +58,7 @@ describe('getContextObject', function () {
             context = ['unknown'];
             contextObject = getContextObject(data, context);
 
-            should.exist(contextObject);
+            assertExists(contextObject);
             contextObject.should.have.property('cover_image', 'test.png');
         });
     });

--- a/ghost/core/test/unit/frontend/meta/image-dimensions.test.js
+++ b/ghost/core/test/unit/frontend/meta/image-dimensions.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../utils/assertions');
 const _ = require('lodash');
 const should = require('should');
 const sinon = require('sinon');
@@ -45,7 +46,7 @@ describe('getImageDimensions', function () {
         });
 
         getImageDimensions(metaData).then(function (result) {
-            should.exist(result);
+            assertExists(result);
             assert.equal(sizeOfStub.calledWith(metaData.coverImage.url), true);
             assert.equal(sizeOfStub.calledWith(metaData.authorImage.url), true);
             assert.equal(sizeOfStub.calledWith(metaData.ogImage.url), true);
@@ -98,7 +99,7 @@ describe('getImageDimensions', function () {
         });
 
         getImageDimensions(metaData).then(function (result) {
-            should.exist(result);
+            assertExists(result);
             assert.equal(sizeOfStub.calledWith(metaData.coverImage.url), true);
             assert.equal(sizeOfStub.calledWith(metaData.authorImage.url), true);
             assert.equal(sizeOfStub.calledWith(metaData.ogImage.url), true);
@@ -144,7 +145,7 @@ describe('getImageDimensions', function () {
         });
 
         getImageDimensions(metaData).then(function (result) {
-            should.exist(result);
+            assertExists(result);
             assert.equal(sizeOfStub.calledWith(metaData.coverImage.url), true);
             assert.equal(sizeOfStub.calledWith(metaData.authorImage.url), true);
             assert.equal(sizeOfStub.calledWith(metaData.ogImage.url), true);
@@ -198,7 +199,7 @@ describe('getImageDimensions', function () {
         });
 
         getImageDimensions(metaData).then(function (result) {
-            should.exist(result);
+            assertExists(result);
             assert.equal(sizeOfStub.calledWith(metaData.coverImage.url), true);
             assert.equal(sizeOfStub.calledWith(metaData.authorImage.url), true);
             assert.equal(sizeOfStub.calledWith(metaData.ogImage.url), true);
@@ -258,7 +259,7 @@ describe('getImageDimensions', function () {
         });
 
         getImageDimensions(metaData).then(function (result) {
-            should.exist(result);
+            assertExists(result);
             assert.equal(sizeOfStub.calledWith(originalMetaData.coverImage.url), true);
             assert.equal(sizeOfStub.calledWith(originalMetaData.authorImage.url), true);
             assert.equal(sizeOfStub.calledWith(originalMetaData.ogImage.url), true);
@@ -316,7 +317,7 @@ describe('getImageDimensions', function () {
         });
 
         getImageDimensions(metaData).then(function (result) {
-            should.exist(result);
+            assertExists(result);
             result.coverImage.should.have.property('url');
             assert.equal(result.coverImage.url, 'http://anothersite.com/some/storage/mypostcoverimage.jpg');
             result.authorImage.should.have.property('url');

--- a/ghost/core/test/unit/frontend/meta/paginated-url.test.js
+++ b/ghost/core/test/unit/frontend/meta/paginated-url.test.js
@@ -1,3 +1,4 @@
+const {assertExists} = require('../../../utils/assertions');
 const should = require('should');
 const getPaginatedUrl = require('../../../../core/frontend/meta/paginated-url');
 const configUtils = require('../../../utils/config-utils');
@@ -20,7 +21,7 @@ describe('getPaginatedUrl', function () {
     };
 
     it('should be a function', function () {
-        should.exist(getPaginatedUrl);
+        assertExists(getPaginatedUrl);
     });
 
     describe('index', function () {

--- a/ghost/core/test/unit/frontend/meta/schema.test.js
+++ b/ghost/core/test/unit/frontend/meta/schema.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../utils/assertions');
 const should = require('should');
 const {getSchema, SOCIAL_PLATFORMS} = require('../../../../core/frontend/meta/schema');
 const socialUrls = require('@tryghost/social-urls');
@@ -771,7 +772,7 @@ describe('getSchema', function () {
 
         const schema = getSchema(metadata, data);
 
-        should.exist(schema.contributor);
+        assertExists(schema.contributor);
         assert.deepEqual(schema.contributor, [
             {
                 '@type': 'Person',
@@ -826,7 +827,7 @@ describe('getSchema', function () {
 
         const schema = getSchema(metadata, data);
 
-        should.exist(schema.contributor);
+        assertExists(schema.contributor);
         assert.equal(schema.contributor.length, 2);
         assert.deepEqual(schema.contributor[0], {
             '@type': 'Person',
@@ -876,7 +877,7 @@ describe('getSchema', function () {
 
         const schema = getSchema(metadata, data);
 
-        should.exist(schema.contributor);
+        assertExists(schema.contributor);
         assert.deepEqual(schema.contributor[0].sameAs, expectedSameAs);
     });
 
@@ -911,7 +912,7 @@ describe('getSchema', function () {
 
         const schema = getSchema(metadata, data);
 
-        should.exist(schema.contributor);
+        assertExists(schema.contributor);
         assert.deepEqual(schema.contributor[0], {
             '@type': 'Person',
             name: 'Co-Author',
@@ -952,7 +953,7 @@ describe('getSchema', function () {
 
         const schema = getSchema(metadata, data);
 
-        should.exist(schema.contributor);
+        assertExists(schema.contributor);
         assert.deepEqual(schema.contributor[0], {
             '@type': 'Person',
             name: 'Co-Author',
@@ -990,7 +991,7 @@ describe('getSchema', function () {
 
         const schema = getSchema(metadata, data);
 
-        should.exist(schema.contributor);
+        assertExists(schema.contributor);
         assert.deepEqual(schema.contributor[0].sameAs, [
             'http://coauthorsite.com/?user&#x3D;name&amp;param&#x3D;&lt;script&gt;alert(&quot;test&quot;)&lt;/script&gt;',
             'https://www.facebook.com/user&#x3D;name&#x3D;'

--- a/ghost/core/test/unit/frontend/services/apps/proxy.test.js
+++ b/ghost/core/test/unit/frontend/services/apps/proxy.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../../utils/assertions');
 const should = require('should');
 const sinon = require('sinon');
 const helpers = require('../../../../../core/frontend/services/helpers');
@@ -20,10 +21,10 @@ describe('Apps', function () {
         it('creates a ghost proxy', function () {
             const appProxy = AppProxy.getInstance('TestApp');
 
-            should.exist(appProxy.helperService);
-            should.exist(appProxy.helperService.registerAlias);
-            should.exist(appProxy.helperService.registerDir);
-            should.exist(appProxy.helperService.registerHelper);
+            assertExists(appProxy.helperService);
+            assertExists(appProxy.helperService.registerAlias);
+            assertExists(appProxy.helperService.registerDir);
+            assertExists(appProxy.helperService.registerHelper);
         });
 
         it('allows helper registration', function () {

--- a/ghost/core/test/unit/frontend/services/assets-minification/minifier.test.js
+++ b/ghost/core/test/unit/frontend/services/assets-minification/minifier.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../../utils/assertions');
 const should = require('should');
 
 const path = require('path');
@@ -122,7 +123,7 @@ describe('Minifier', function () {
                 });
                 should.fail(minifier, 'Should have errored');
             } catch (err) {
-                should.exist(err);
+                assertExists(err);
                 assert.equal(err.errorType, 'IncorrectUsageError');
                 assert.match(err.message, /Unexpected destination/);
             }
@@ -136,7 +137,7 @@ describe('Minifier', function () {
                 });
                 should.fail(minifier, 'Should have errored');
             } catch (err) {
-                should.exist(err);
+                assertExists(err);
                 assert.equal(err.errorType, 'IncorrectUsageError');
                 assert.match(err.message, /Unable to read/);
             }

--- a/ghost/core/test/unit/frontend/services/data/entry-lookup.test.js
+++ b/ghost/core/test/unit/frontend/services/data/entry-lookup.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../../utils/assertions');
 const should = require('should');
 const sinon = require('sinon');
 
@@ -57,7 +58,7 @@ describe('Unit - frontend/data/entry-lookup', function () {
             return data.entryLookup(testUrl, routerOptions, locals).then(function (lookup) {
                 assert.equal(postsReadStub.called, false);
                 assert.equal(pagesReadStub.calledOnce, true);
-                should.exist(lookup.entry);
+                assertExists(lookup.entry);
                 lookup.entry.should.have.property('url', pages[0].url);
                 assert.equal(lookup.isEditURL, false);
             });
@@ -108,7 +109,7 @@ describe('Unit - frontend/data/entry-lookup', function () {
             return data.entryLookup(testUrl, routerOptions, locals).then(function (lookup) {
                 assert.equal(postsReadStub.calledOnce, true);
                 assert.equal(pagesReadStub.called, false);
-                should.exist(lookup.entry);
+                assertExists(lookup.entry);
                 lookup.entry.should.have.property('url', posts[0].url);
                 assert.equal(lookup.isEditURL, false);
             });
@@ -120,7 +121,7 @@ describe('Unit - frontend/data/entry-lookup', function () {
             return data.entryLookup(testUrl, routerOptions, locals).then(function (lookup) {
                 assert.equal(postsReadStub.calledOnce, true);
                 assert.equal(pagesReadStub.called, false);
-                should.exist(lookup.entry);
+                assertExists(lookup.entry);
                 lookup.entry.should.have.property('url', posts[0].url);
                 assert.equal(lookup.isEditURL, true);
             });

--- a/ghost/core/test/unit/frontend/services/data/fetch-data.test.js
+++ b/ghost/core/test/unit/frontend/services/data/fetch-data.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../../utils/assertions');
 const should = require('should');
 const sinon = require('sinon');
 
@@ -58,7 +59,7 @@ describe('Unit - frontend/data/fetch-data', function () {
 
     it('should handle no options', function (done) {
         data.fetchData(null, null, locals).then(function (result) {
-            should.exist(result);
+            assertExists(result);
             result.should.be.an.Object().with.properties('posts', 'meta');
             result.should.not.have.property('data');
 
@@ -73,7 +74,7 @@ describe('Unit - frontend/data/fetch-data', function () {
 
     it('should handle path options with page/limit', function (done) {
         data.fetchData({page: 2, limit: 10}, null, locals).then(function (result) {
-            should.exist(result);
+            assertExists(result);
             result.should.be.an.Object().with.properties('posts', 'meta');
             result.should.not.have.property('data');
 
@@ -106,7 +107,7 @@ describe('Unit - frontend/data/fetch-data', function () {
         };
 
         data.fetchData(pathOptions, routerOptions, locals).then(function (result) {
-            should.exist(result);
+            assertExists(result);
             result.should.be.an.Object().with.properties('posts', 'meta', 'data');
             result.data.should.be.an.Object().with.properties('featured');
 
@@ -137,7 +138,7 @@ describe('Unit - frontend/data/fetch-data', function () {
         };
 
         data.fetchData(pathOptions, routerOptions, locals).then(function (result) {
-            should.exist(result);
+            assertExists(result);
 
             result.should.be.an.Object().with.properties('posts', 'meta', 'data');
             result.data.should.be.an.Object().with.properties('featured');
@@ -172,7 +173,7 @@ describe('Unit - frontend/data/fetch-data', function () {
         };
 
         data.fetchData(pathOptions, routerOptions, locals).then(function (result) {
-            should.exist(result);
+            assertExists(result);
             result.should.be.an.Object().with.properties('posts', 'meta', 'data');
             result.data.should.be.an.Object().with.properties('tag');
 

--- a/ghost/core/test/unit/frontend/services/rendering/context.test.js
+++ b/ghost/core/test/unit/frontend/services/rendering/context.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../../utils/assertions');
 const should = require('should');
 const sinon = require('sinon');
 const testUtils = require('../../../../utils');
@@ -35,14 +36,14 @@ describe('Contexts', function () {
 
             renderer.context(req, res, data);
 
-            should.exist(res.locals.context);
+            assertExists(res.locals.context);
             res.locals.context.should.be.an.Array().with.lengthOf(0);
         });
 
         it('should return empty array with no error with basic parameters', function () {
             renderer.context(req, res, data);
 
-            should.exist(res.locals.context);
+            assertExists(res.locals.context);
             res.locals.context.should.be.an.Array().with.lengthOf(0);
         });
     });
@@ -54,7 +55,7 @@ describe('Contexts', function () {
 
             renderer.context(req, res, data);
 
-            should.exist(res.locals.context);
+            assertExists(res.locals.context);
             res.locals.context.should.be.an.Array().with.lengthOf(1);
             assert.equal(res.locals.context[0], 'index');
         });
@@ -67,7 +68,7 @@ describe('Contexts', function () {
             renderer.context(req, res, data);
 
             // Check context
-            should.exist(res.locals.context);
+            assertExists(res.locals.context);
             res.locals.context.should.be.an.Array().with.lengthOf(2);
             assert.equal(res.locals.context[0], 'home');
             assert.equal(res.locals.context[1], 'index');
@@ -81,7 +82,7 @@ describe('Contexts', function () {
             renderer.context(req, res, data);
 
             // Check context
-            should.exist(res.locals.context);
+            assertExists(res.locals.context);
             res.locals.context.should.be.an.Array().with.lengthOf(1);
             assert.equal(res.locals.context[0], 'home');
         });
@@ -92,7 +93,7 @@ describe('Contexts', function () {
 
             renderer.context(req, res, data);
 
-            should.exist(res.locals.context);
+            assertExists(res.locals.context);
             res.locals.context.should.be.an.Array().with.lengthOf(1);
             assert.equal(res.locals.context[0], 'index');
         });
@@ -104,7 +105,7 @@ describe('Contexts', function () {
 
             renderer.context(req, res, data);
 
-            should.exist(res.locals.context);
+            assertExists(res.locals.context);
             res.locals.context.should.be.an.Array().with.lengthOf(2);
             assert.equal(res.locals.context[0], 'paged');
             assert.equal(res.locals.context[1], 'index');
@@ -118,7 +119,7 @@ describe('Contexts', function () {
 
             renderer.context(req, res, data);
 
-            should.exist(res.locals.context);
+            assertExists(res.locals.context);
             res.locals.context.should.be.an.Array().with.lengthOf(1);
             assert.equal(res.locals.context[0], 'tag');
         });
@@ -129,7 +130,7 @@ describe('Contexts', function () {
 
             renderer.context(req, res, data);
 
-            should.exist(res.locals.context);
+            assertExists(res.locals.context);
             res.locals.context.should.be.an.Array().with.lengthOf(0);
         });
 
@@ -139,7 +140,7 @@ describe('Contexts', function () {
 
             renderer.context(req, res, data);
 
-            should.exist(res.locals.context);
+            assertExists(res.locals.context);
             res.locals.context.should.be.an.Array().with.lengthOf(1);
             assert.equal(res.locals.context[0], 'tag');
         });
@@ -151,7 +152,7 @@ describe('Contexts', function () {
 
             renderer.context(req, res, data);
 
-            should.exist(res.locals.context);
+            assertExists(res.locals.context);
             res.locals.context.should.be.an.Array().with.lengthOf(2);
             assert.equal(res.locals.context[0], 'paged');
             assert.equal(res.locals.context[1], 'tag');
@@ -165,7 +166,7 @@ describe('Contexts', function () {
 
             renderer.context(req, res, data);
 
-            should.exist(res.locals.context);
+            assertExists(res.locals.context);
             res.locals.context.should.be.an.Array().with.lengthOf(1);
             assert.equal(res.locals.context[0], 'author');
         });
@@ -176,7 +177,7 @@ describe('Contexts', function () {
 
             renderer.context(req, res, data);
 
-            should.exist(res.locals.context);
+            assertExists(res.locals.context);
             res.locals.context.should.be.an.Array().with.lengthOf(0);
         });
 
@@ -186,7 +187,7 @@ describe('Contexts', function () {
 
             renderer.context(req, res, data);
 
-            should.exist(res.locals.context);
+            assertExists(res.locals.context);
             res.locals.context.should.be.an.Array().with.lengthOf(1);
             assert.equal(res.locals.context[0], 'author');
         });
@@ -198,7 +199,7 @@ describe('Contexts', function () {
 
             renderer.context(req, res, data);
 
-            should.exist(res.locals.context);
+            assertExists(res.locals.context);
             res.locals.context.should.be.an.Array().with.lengthOf(2);
             assert.equal(res.locals.context[0], 'paged');
             assert.equal(res.locals.context[1], 'author');
@@ -212,7 +213,7 @@ describe('Contexts', function () {
 
             renderer.context(req, res, data);
 
-            should.exist(res.locals.context);
+            assertExists(res.locals.context);
             res.locals.context.should.be.an.Array().with.lengthOf(2);
             assert.equal(res.locals.context[0], 'custom-context');
             assert.equal(res.locals.context[1], 'test');
@@ -226,7 +227,7 @@ describe('Contexts', function () {
 
             renderer.context(req, res, data);
 
-            should.exist(res.locals.context);
+            assertExists(res.locals.context);
             res.locals.context.should.be.an.Array().with.lengthOf(1);
             assert.equal(res.locals.context[0], 'post');
         });
@@ -239,7 +240,7 @@ describe('Contexts', function () {
 
             renderer.context(req, res, data);
 
-            should.exist(res.locals.context);
+            assertExists(res.locals.context);
             res.locals.context.should.be.an.Array().with.lengthOf(1);
             assert.equal(res.locals.context[0], 'private');
         });
@@ -254,7 +255,7 @@ describe('Contexts', function () {
             delete res.routerOptions;
             renderer.context(req, res, data);
 
-            should.exist(res.locals.context);
+            assertExists(res.locals.context);
             res.locals.context.should.be.an.Array().with.lengthOf(1);
             assert.equal(res.locals.context[0], 'post');
         });

--- a/ghost/core/test/unit/frontend/services/rendering/templates.test.js
+++ b/ghost/core/test/unit/frontend/services/rendering/templates.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../../utils/assertions');
 const should = require('should');
 const sinon = require('sinon');
 const rewire = require('rewire');
@@ -130,7 +131,7 @@ describe('templates', function () {
             hasTemplateStub.returns(false);
 
             const view = _private.getTemplateForEntry({title: 'hey'}, 'page');
-            should.exist(view);
+            assertExists(view);
             assert.equal(view, 'post');
         });
 
@@ -149,7 +150,7 @@ describe('templates', function () {
                     page: 0,
                     slug: 'test-post'
                 });
-                should.exist(view);
+                assertExists(view);
                 assert.equal(view, 'post');
             });
 
@@ -159,7 +160,7 @@ describe('templates', function () {
                     page: 0,
                     slug: 'welcome-to-ghost'
                 });
-                should.exist(view);
+                assertExists(view);
                 assert.equal(view, 'post-welcome-to-ghost');
             });
 
@@ -167,7 +168,7 @@ describe('templates', function () {
                 const view = _private.getTemplateForEntry({
                     slug: 'contact'
                 }, 'page');
-                should.exist(view);
+                assertExists(view);
                 assert.equal(view, 'page');
             });
 
@@ -175,7 +176,7 @@ describe('templates', function () {
                 const view = _private.getTemplateForEntry({
                     slug: 'about'
                 }, 'page');
-                should.exist(view);
+                assertExists(view);
                 assert.equal(view, 'page-about');
             });
 
@@ -186,7 +187,7 @@ describe('templates', function () {
                     page: 0,
                     custom_template: 'custom-about'
                 });
-                should.exist(view);
+                assertExists(view);
                 assert.equal(view, 'custom-about');
             });
 
@@ -197,7 +198,7 @@ describe('templates', function () {
                     page: 1,
                     custom_template: 'custom-about'
                 });
-                should.exist(view);
+                assertExists(view);
                 assert.equal(view, 'custom-about');
             });
 
@@ -208,7 +209,7 @@ describe('templates', function () {
                     page: 0,
                     custom_template: 'custom-about'
                 });
-                should.exist(view);
+                assertExists(view);
                 assert.equal(view, 'post');
             });
 
@@ -218,7 +219,7 @@ describe('templates', function () {
                 const view = _private.getTemplateForEntry({
                     custom_template: 'custom-about'
                 }, 'page');
-                should.exist(view);
+                assertExists(view);
                 assert.equal(view, 'page');
             });
 
@@ -231,7 +232,7 @@ describe('templates', function () {
                     slug: 'about',
                     custom_template: 'custom-about'
                 });
-                should.exist(view);
+                assertExists(view);
                 assert.equal(view, 'post-about');
             });
 
@@ -244,7 +245,7 @@ describe('templates', function () {
                     slug: 'about',
                     custom_template: 'custom-about'
                 });
-                should.exist(view);
+                assertExists(view);
                 assert.equal(view, 'post');
             });
         });
@@ -267,7 +268,7 @@ describe('templates', function () {
 
             it('will return correct view for a tag', function () {
                 const view = _private.getTemplateForEntries({name: 'tag', slugTemplate: true}, {slugParam: 'development'});
-                should.exist(view);
+                assertExists(view);
                 assert.equal(view, 'index');
             });
         });
@@ -282,20 +283,20 @@ describe('templates', function () {
 
             it('will return correct view for a tag when template exists', function () {
                 const view = _private.getTemplateForEntries({name: 'tag', slugTemplate: true}, {slugParam: 'design'});
-                should.exist(view);
+                assertExists(view);
                 assert.equal(view, 'tag-design');
             });
 
             it('will return correct view for a tag', function () {
                 const view = _private.getTemplateForEntries({name: 'tag', slugTemplate: true}, {slugParam: 'development'});
-                should.exist(view);
+                assertExists(view);
                 assert.equal(view, 'tag');
             });
         });
 
         it('will fall back to index even if no index.hbs', function () {
             const view = _private.getTemplateForEntries({name: 'tag', slugTemplate: true}, {slugParam: 'development'});
-            should.exist(view);
+            assertExists(view);
             assert.equal(view, 'index');
         });
     });

--- a/ghost/core/test/unit/frontend/services/routing/collection-router.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/collection-router.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../../utils/assertions');
 const should = require('should');
 const sinon = require('sinon');
 const express = require('../../../../../core/shared/express')._express;
@@ -40,7 +41,7 @@ describe('UNIT - services/routing/CollectionRouter', function () {
         it('default', function () {
             const collectionRouter = new CollectionRouter('/', {permalink: '/:slug/'}, RESOURCE_CONFIG, routerCreatedSpy);
 
-            should.exist(collectionRouter.router);
+            assertExists(collectionRouter.router);
 
             assert.equal(collectionRouter.filter, undefined);
             assert.equal(collectionRouter.getResourceType(), 'posts');
@@ -87,7 +88,7 @@ describe('UNIT - services/routing/CollectionRouter', function () {
         it('collection lives under /blog/', function () {
             const collectionRouter = new CollectionRouter('/blog/', {permalink: '/blog/:year/:slug/'}, RESOURCE_CONFIG, routerCreatedSpy);
 
-            should.exist(collectionRouter.router);
+            assertExists(collectionRouter.router);
 
             assert.equal(collectionRouter.filter, undefined);
             assert.equal(collectionRouter.getResourceType(), 'posts');

--- a/ghost/core/test/unit/frontend/services/routing/controllers/channel.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/controllers/channel.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../../../utils/assertions');
 const errors = require('@tryghost/errors');
 const should = require('should');
 const sinon = require('sinon');
@@ -11,7 +12,7 @@ const dataService = require('../../../../../../core/frontend/services/data');
 
 function failTest(done) {
     return function (err) {
-        should.exist(err);
+        assertExists(err);
         done(err);
     };
 }

--- a/ghost/core/test/unit/frontend/services/routing/controllers/collection.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/controllers/collection.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../../../utils/assertions');
 const errors = require('@tryghost/errors');
 const should = require('should');
 const sinon = require('sinon');
@@ -12,7 +13,7 @@ const dataService = require('../../../../../../core/frontend/services/data');
 
 function failTest(done) {
     return function (err) {
-        should.exist(err);
+        assertExists(err);
         done(err);
     };
 }

--- a/ghost/core/test/unit/frontend/services/routing/controllers/entry.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/controllers/entry.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../../../utils/assertions');
 const should = require('should');
 const sinon = require('sinon');
 const testUtils = require('../../../../../utils');
@@ -198,7 +199,7 @@ describe('Unit - services/routing/controllers/entry', function () {
             });
 
             controllers.entry(req, res, function (err) {
-                should.exist(err);
+                assertExists(err);
                 done(err);
             });
         });

--- a/ghost/core/test/unit/frontend/services/routing/controllers/previews.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/controllers/previews.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../../../utils/assertions');
 const should = require('should');
 const sinon = require('sinon');
 const testUtils = require('../../../../../utils');
@@ -18,7 +19,7 @@ describe('Unit - services/routing/controllers/previews', function () {
 
     function failTest(done) {
         return function (err) {
-            should.exist(err);
+            assertExists(err);
             done(err);
         };
     }

--- a/ghost/core/test/unit/frontend/services/routing/controllers/static.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/controllers/static.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../../../utils/assertions');
 const should = require('should');
 const sinon = require('sinon');
 
@@ -9,7 +10,7 @@ const controllers = require('../../../../../../core/frontend/services/routing/co
 
 function failTest(done) {
     return function (err) {
-        should.exist(err);
+        assertExists(err);
         done(err);
     };
 }

--- a/ghost/core/test/unit/frontend/services/routing/parent-router.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/parent-router.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../../utils/assertions');
 const should = require('should');
 const sinon = require('sinon');
 const configUtils = require('../../../../utils/config-utils');
@@ -44,7 +45,7 @@ describe('UNIT - services/routing/ParentRouter', function () {
                 }
             };
 
-            should.exist(parentRouter._getSiteRouter(req));
+            assertExists(parentRouter._getSiteRouter(req));
         });
     });
 
@@ -343,7 +344,7 @@ describe('UNIT - services/routing/ParentRouter', function () {
                 }
             };
 
-            should.exist(parentRouter.isRedirectEnabled('tags', 'bacon'));
+            assertExists(parentRouter.isRedirectEnabled('tags', 'bacon'));
         });
 
         it('redirect (pages)', function () {
@@ -356,7 +357,7 @@ describe('UNIT - services/routing/ParentRouter', function () {
                 }
             };
 
-            should.exist(parentRouter.isRedirectEnabled('pages', 'home'));
+            assertExists(parentRouter.isRedirectEnabled('pages', 'home'));
         });
     });
 });

--- a/ghost/core/test/unit/frontend/services/routing/rss-router.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/rss-router.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../../utils/assertions');
 const should = require('should');
 const sinon = require('sinon');
 const configUtils = require('../../../../utils/config-utils');
@@ -23,7 +24,7 @@ describe('UNIT - services/routing/RSSRouter', function () {
         it('default', function () {
             const rssRouter = new RSSRouter();
 
-            should.exist(rssRouter.router);
+            assertExists(rssRouter.router);
             assert.equal(rssRouter.route.value, '/rss/');
 
             assert.equal(rssRouter.mountRoute.callCount, 2);
@@ -38,7 +39,7 @@ describe('UNIT - services/routing/RSSRouter', function () {
             configUtils.set('url', 'http://localhost:22222/blog/');
             const rssRouter = new RSSRouter();
 
-            should.exist(rssRouter.router);
+            assertExists(rssRouter.router);
             assert.equal(rssRouter.route.value, '/rss/');
 
             assert.equal(rssRouter.mountRoute.callCount, 2);

--- a/ghost/core/test/unit/frontend/services/routing/static-routes-router.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/static-routes-router.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../../utils/assertions');
 const should = require('should');
 const sinon = require('sinon');
 const controllers = require('../../../../../core/frontend/services/routing/controllers');
@@ -36,7 +37,7 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
     describe('static routes', function () {
         it('instantiate: default', function () {
             const staticRoutesRouter = new StaticRoutesRouter('/about/', {templates: ['test']}, routerCreatedSpy);
-            should.exist(staticRoutesRouter.router);
+            assertExists(staticRoutesRouter.router);
 
             assert.equal(staticRoutesRouter.filter, undefined);
             assert.equal(staticRoutesRouter.getPermalinks(), undefined);
@@ -59,7 +60,7 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
                 filter: 'tag:test'
             }, routerCreatedSpy);
 
-            should.exist(staticRoutesRouter.router);
+            assertExists(staticRoutesRouter.router);
 
             assert.equal(staticRoutesRouter.getPermalinks(), undefined);
             assert.equal(staticRoutesRouter.filter, undefined);
@@ -118,12 +119,12 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
                     filter: 'tag:test'
                 }, routerCreatedSpy);
 
-                should.exist(staticRoutesRouter.router);
+                assertExists(staticRoutesRouter.router);
 
                 assert.equal(staticRoutesRouter.getPermalinks(), undefined);
                 assert.equal(staticRoutesRouter.filter, 'tag:test');
                 staticRoutesRouter.templates.should.eql([]);
-                should.exist(staticRoutesRouter.data);
+                assertExists(staticRoutesRouter.data);
 
                 assert.equal(routerCreatedSpy.calledOnce, true);
                 assert.equal(routerCreatedSpy.calledWith(staticRoutesRouter), true);
@@ -145,7 +146,7 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
                     filter: 'tag:test'
                 }, routerCreatedSpy);
 
-                should.exist(staticRoutesRouter.router);
+                assertExists(staticRoutesRouter.router);
 
                 assert.equal(staticRoutesRouter.getPermalinks(), undefined);
                 assert.equal(staticRoutesRouter.filter, 'tag:test');

--- a/ghost/core/test/unit/frontend/services/routing/taxonomy-router.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/taxonomy-router.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../../utils/assertions');
 const should = require('should');
 const sinon = require('sinon');
 const settingsCache = require('../../../../../core/shared/settings-cache');
@@ -35,8 +36,8 @@ describe('UNIT - services/routing/TaxonomyRouter', function () {
     it('instantiate', function () {
         const taxonomyRouter = new TaxonomyRouter('tag', '/tag/:slug/', {}, routerCreatedSpy);
 
-        should.exist(taxonomyRouter.router);
-        should.exist(taxonomyRouter.rssRouter);
+        assertExists(taxonomyRouter.router);
+        assertExists(taxonomyRouter.rssRouter);
 
         assert.equal(taxonomyRouter.taxonomyKey, 'tag');
         assert.equal(taxonomyRouter.getPermalinks().getValue(), '/tag/:slug/');

--- a/ghost/core/test/unit/frontend/services/rss/generate-feed.test.js
+++ b/ghost/core/test/unit/frontend/services/rss/generate-feed.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../../utils/assertions');
 const should = require('should');
 const sinon = require('sinon');
 const _ = require('lodash');
@@ -64,7 +65,7 @@ describe('RSS: Generate Feed', function () {
             data.posts = [];
 
             generateFeed(baseUrl, data).then(function (xmlData) {
-                should.exist(xmlData);
+                assertExists(xmlData);
 
                 // xml & rss tags
                 assert.match(xmlData, /^<\?xml version="1.0" encoding="UTF-8"\?>/);
@@ -98,7 +99,7 @@ describe('RSS: Generate Feed', function () {
             });
 
             generateFeed(baseUrl, data).then(function (xmlData) {
-                should.exist(xmlData);
+                assertExists(xmlData);
 
                 // item tags
                 assert.match(xmlData, /<item><title><!\[CDATA\[HTML Ipsum\]\]><\/title>/);
@@ -136,7 +137,7 @@ describe('RSS: Generate Feed', function () {
             data.posts = [postWithTags];
 
             generateFeed(baseUrl, data).then(function (xmlData) {
-                should.exist(xmlData);
+                assertExists(xmlData);
                 // item tags
                 assert.match(xmlData, /<title><!\[CDATA\[Short and Sweet\]\]>/);
                 assert.match(xmlData, /<description><!\[CDATA\[test stuff/);
@@ -154,7 +155,7 @@ describe('RSS: Generate Feed', function () {
             data.posts = [_.omit(posts[2], 'primary_author')];
 
             generateFeed(baseUrl, data).then(function (xmlData) {
-                should.exist(xmlData);
+                assertExists(xmlData);
 
                 // special/optional tags
                 assert.match(xmlData, /<title><!\[CDATA\[Short and Sweet\]\]>/);
@@ -172,7 +173,7 @@ describe('RSS: Generate Feed', function () {
             data.posts = [Object.assign({}, posts[2], {html: null})];
 
             generateFeed(baseUrl, data).then(function (xmlData) {
-                should.exist(xmlData);
+                assertExists(xmlData);
 
                 // special/optional tags
                 assert.match(xmlData, /<title><!\[CDATA\[Short and Sweet\]\]>/);
@@ -189,7 +190,7 @@ describe('RSS: Generate Feed', function () {
             data.posts = [posts[2]];
 
             generateFeed(baseUrl, data).then(function (xmlData) {
-                should.exist(xmlData);
+                assertExists(xmlData);
 
                 // special/optional tags
                 assert.match(xmlData, /<title><!\[CDATA\[Short and Sweet\]\]>/);
@@ -210,7 +211,7 @@ describe('RSS: Generate Feed', function () {
             });
 
             generateFeed(baseUrl, data).then(function (xmlData) {
-                should.exist(xmlData);
+                assertExists(xmlData);
 
                 // special/optional tags
                 assert.match(xmlData, /<title><!\[CDATA\[HTML Ipsum\]\]>/);
@@ -224,7 +225,7 @@ describe('RSS: Generate Feed', function () {
             data.posts = [posts[3]];
 
             generateFeed(baseUrl, data).then(function (xmlData) {
-                should.exist(xmlData);
+                assertExists(xmlData);
 
                 // anchor URL - <a href="#nowhere" title="Anchor URL">
                 assert.match(xmlData, /<a href="#nowhere" title="Anchor URL">/);

--- a/ghost/core/test/unit/frontend/services/sitemap/manager.test.js
+++ b/ghost/core/test/unit/frontend/services/sitemap/manager.test.js
@@ -1,6 +1,7 @@
 const should = require('should');
 const sinon = require('sinon');
 const assert = require('assert/strict');
+const {assertExists} = require('../../../../utils/assertions');
 
 // Stuff we are testing
 const DomainEvents = require('@tryghost/domain-events');
@@ -59,12 +60,12 @@ describe('Unit: sitemap/manager', function () {
         });
 
         it('can create a SiteMapManager instance', function () {
-            should.exist(manager);
+            assertExists(manager);
             assert.equal(Object.keys(eventsToRemember).length, 4);
-            should.exist(eventsToRemember['url.added']);
-            should.exist(eventsToRemember['url.removed']);
-            should.exist(eventsToRemember['router.created']);
-            should.exist(eventsToRemember['routers.reset']);
+            assertExists(eventsToRemember['url.added']);
+            assertExists(eventsToRemember['url.removed']);
+            assertExists(eventsToRemember['router.created']);
+            assertExists(eventsToRemember['routers.reset']);
         });
 
         describe('trigger url events', function () {

--- a/ghost/core/test/unit/frontend/services/theme-engine/handlebars/template.test.js
+++ b/ghost/core/test/unit/frontend/services/theme-engine/handlebars/template.test.js
@@ -1,3 +1,4 @@
+const {assertExists} = require('../../../../../utils/assertions');
 const should = require('should');
 const errors = require('@tryghost/errors');
 const {hbs, templates} = require('../../../../../../core/frontend/services/handlebars');
@@ -8,7 +9,7 @@ describe('Helpers Template', function () {
 
         const safeString = templates.execute('test', {name: 'world'});
 
-        should.exist(safeString);
+        assertExists(safeString);
         safeString.should.have.property('string').and.equal('<h1>Hello world</h1>');
     });
 

--- a/ghost/core/test/unit/frontend/services/theme-engine/middleware.test.js
+++ b/ghost/core/test/unit/frontend/services/theme-engine/middleware.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../../utils/assertions');
 const should = require('should');
 const sinon = require('sinon');
 const hbs = require('../../../../../core/frontend/services/theme-engine/engine');
@@ -129,7 +130,7 @@ describe('Themes middleware', function () {
         executeMiddleware(middleware, req, res, function next(err) {
             try {
                 // Did throw an error
-                should.exist(err);
+                assertExists(err);
                 assert.equal(err.message, 'The currently active theme "bacon-sensation" is missing.');
 
                 assert.equal(activeThemeGetStub.called, true);
@@ -194,7 +195,7 @@ describe('Themes middleware', function () {
                     const templateOptions = hbsUpdateTemplateOptionsStub.firstCall.args[0];
                     const data = templateOptions.data;
 
-                    should.exist(data.site.signup_url);
+                    assertExists(data.site.signup_url);
                     assert.equal(data.site.signup_url, 'https://feedly.com/i/subscription/feed/http%3A%2F%2F127.0.0.1%3A2369%2Frss%2F');
 
                     done();

--- a/ghost/core/test/unit/frontend/src/url-attribution.test.js
+++ b/ghost/core/test/unit/frontend/src/url-attribution.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../utils/assertions');
 const should = require('should');
 const sinon = require('sinon');
 const {JSDOM} = require('jsdom');
@@ -48,37 +49,37 @@ describe('URL Attribution Utils', function () {
     describe('parseReferrerData', function () {
         it('should extract ref parameter correctly', function () {
             const result = parseReferrerData('https://example.com/?ref=newsletter');
-            should.exist(result);
+            assertExists(result);
             assert.equal(result.source, 'newsletter');
         });
         
         it('should extract source parameter correctly', function () {
             const result = parseReferrerData('https://example.com/?source=twitter');
-            should.exist(result);
+            assertExists(result);
             assert.equal(result.source, 'twitter');
         });
         
         it('should extract utm_source parameter correctly', function () {
             const result = parseReferrerData('https://example.com/?utm_source=facebook');
-            should.exist(result);
+            assertExists(result);
             assert.equal(result.source, 'facebook');
         });
         
         it('should handle portal hash URLs', function () {
             const result = parseReferrerData('https://example.com/#/portal/signup?ref=portal-hash');
-            should.exist(result);
+            assertExists(result);
             assert.equal(result.source, 'portal-hash');
         });
         
         it('should return document.referrer when no source params are present', function () {
             const result = parseReferrerData('https://example.com/');
-            should.exist(result);
+            assertExists(result);
             assert.equal(result.url, 'https://external-site.com/');
         });
         
         it('should extract all UTM parameters', function () {
             const result = parseReferrerData('https://example.com/?utm_source=google&utm_medium=cpc&utm_campaign=summer&utm_term=ghost&utm_content=banner');
-            should.exist(result);
+            assertExists(result);
             assert.equal(result.utmSource, 'google');
             assert.equal(result.utmMedium, 'cpc');
             assert.equal(result.utmCampaign, 'summer');
@@ -91,20 +92,20 @@ describe('URL Attribution Utils', function () {
     describe('parseReferrerData with portal hash', function () {
         it('should extract parameters from portal hash URL', function () {
             const result = parseReferrerData('https://example.com/#/portal/signup?ref=newsletter');
-            should.exist(result);
+            assertExists(result);
             assert.equal(result.source, 'newsletter');
         });
         
         it('should handle multiple parameters in portal hash', function () {
             const result = parseReferrerData('https://example.com/#/portal/signup?ref=newsletter&utm_medium=email');
-            should.exist(result);
+            assertExists(result);
             assert.equal(result.source, 'newsletter');
             assert.equal(result.medium, 'email');
         });
         
         it('should extract all UTM parameters from portal hash', function () {
             const result = parseReferrerData('https://example.com/#/portal/signup?utm_source=google&utm_medium=cpc&utm_campaign=summer&utm_term=ghost&utm_content=banner');
-            should.exist(result);
+            assertExists(result);
             assert.equal(result.utmSource, 'google');
             assert.equal(result.utmMedium, 'cpc');
             assert.equal(result.utmCampaign, 'summer');

--- a/ghost/core/test/unit/frontend/web/middleware/static-theme.test.js
+++ b/ghost/core/test/unit/frontend/web/middleware/static-theme.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../../utils/assertions');
 const should = require('should');
 const sinon = require('sinon');
 
@@ -106,7 +107,7 @@ describe('staticTheme', function () {
             assert.equal(expressStaticStub.called, true);
 
             // Check that express static gets called with the theme path + maxAge
-            should.exist(expressStaticStub.firstCall.args);
+            assertExists(expressStaticStub.firstCall.args);
             assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
             expressStaticStub.firstCall.args[1].should.be.an.Object().with.property('maxAge');
 
@@ -123,7 +124,7 @@ describe('staticTheme', function () {
             assert.equal(expressStaticStub.called, true);
 
             // Check that express static gets called with the theme path + maxAge
-            should.exist(expressStaticStub.firstCall.args);
+            assertExists(expressStaticStub.firstCall.args);
             assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
             expressStaticStub.firstCall.args[1].should.be.an.Object().with.property('maxAge');
 
@@ -154,7 +155,7 @@ describe('staticTheme', function () {
             assert.equal(expressStaticStub.called, true);
 
             // Check that express static gets called with the theme path + maxAge
-            should.exist(expressStaticStub.firstCall.args);
+            assertExists(expressStaticStub.firstCall.args);
             assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
             expressStaticStub.firstCall.args[1].should.be.an.Object().with.property('maxAge');
 
@@ -171,7 +172,7 @@ describe('staticTheme', function () {
             assert.equal(expressStaticStub.called, true);
 
             // Check that express static gets called with the theme path + maxAge
-            should.exist(expressStaticStub.firstCall.args);
+            assertExists(expressStaticStub.firstCall.args);
             assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
             expressStaticStub.firstCall.args[1].should.be.an.Object().with.property('maxAge');
 
@@ -188,7 +189,7 @@ describe('staticTheme', function () {
             assert.equal(expressStaticStub.called, true);
 
             // Check that express static gets called with the theme path + maxAge
-            should.exist(expressStaticStub.firstCall.args);
+            assertExists(expressStaticStub.firstCall.args);
             assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
             expressStaticStub.firstCall.args[1].should.be.an.Object().with.property('maxAge');
 
@@ -285,7 +286,7 @@ describe('staticTheme', function () {
                 assert.equal(expressStaticStub.called, true);
 
                 // Check that express static gets called with the theme path + maxAge
-                should.exist(expressStaticStub.firstCall.args);
+                assertExists(expressStaticStub.firstCall.args);
                 assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
                 expressStaticStub.firstCall.args[1].should.be.an.Object().with.property('maxAge');
 
@@ -302,7 +303,7 @@ describe('staticTheme', function () {
                 assert.equal(expressStaticStub.called, true);
 
                 // Check that express static gets called with the theme path + maxAge
-                should.exist(expressStaticStub.firstCall.args);
+                assertExists(expressStaticStub.firstCall.args);
                 assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
                 expressStaticStub.firstCall.args[1].should.be.an.Object().with.property('maxAge');
 
@@ -319,7 +320,7 @@ describe('staticTheme', function () {
                 assert.equal(expressStaticStub.called, true);
 
                 // Check that express static gets called with the theme path + maxAge
-                should.exist(expressStaticStub.firstCall.args);
+                assertExists(expressStaticStub.firstCall.args);
                 assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
                 expressStaticStub.firstCall.args[1].should.be.an.Object().with.property('maxAge');
 
@@ -343,7 +344,7 @@ describe('staticTheme', function () {
                 assert.equal(expressStaticStub.called, true);
 
                 const options = expressStaticStub.firstCall.args[1];
-                should.exist(options.setHeaders);
+                assertExists(options.setHeaders);
 
                 const setHeaderStub = sinon.stub();
                 options.setHeaders({setHeader: setHeaderStub});
@@ -373,7 +374,7 @@ describe('staticTheme', function () {
                 assert.equal(expressStaticStub.called, true);
 
                 // Check that express static gets called with correct options
-                should.exist(expressStaticStub.firstCall.args);
+                assertExists(expressStaticStub.firstCall.args);
                 assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
 
                 const options = expressStaticStub.firstCall.args[1];
@@ -394,7 +395,7 @@ describe('staticTheme', function () {
                 assert.equal(expressStaticStub.called, true);
 
                 // Check that express static gets called with correct options
-                should.exist(expressStaticStub.firstCall.args);
+                assertExists(expressStaticStub.firstCall.args);
                 assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
 
                 const options = expressStaticStub.firstCall.args[1];
@@ -415,7 +416,7 @@ describe('staticTheme', function () {
                 assert.equal(expressStaticStub.called, true);
 
                 // Check that express static gets called with correct options
-                should.exist(expressStaticStub.firstCall.args);
+                assertExists(expressStaticStub.firstCall.args);
                 assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
 
                 const options = expressStaticStub.firstCall.args[1];
@@ -434,7 +435,7 @@ describe('staticTheme', function () {
                 assert.equal(activeThemeStub.calledTwice, true);
                 assert.equal(expressStaticStub.called, true);
 
-                should.exist(expressStaticStub.firstCall.args);
+                assertExists(expressStaticStub.firstCall.args);
                 assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
 
                 const options = expressStaticStub.firstCall.args[1];
@@ -497,7 +498,7 @@ describe('staticTheme', function () {
                 assert.equal(expressStaticStub.called, true);
 
                 // Check that express static gets called with correct options
-                should.exist(expressStaticStub.firstCall.args);
+                assertExists(expressStaticStub.firstCall.args);
                 assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
 
                 const options = expressStaticStub.firstCall.args[1];
@@ -518,7 +519,7 @@ describe('staticTheme', function () {
                 assert.equal(expressStaticStub.called, true);
 
                 // Check that express static gets called with correct options
-                should.exist(expressStaticStub.firstCall.args);
+                assertExists(expressStaticStub.firstCall.args);
                 assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
 
                 const options = expressStaticStub.firstCall.args[1];
@@ -539,7 +540,7 @@ describe('staticTheme', function () {
                 assert.equal(expressStaticStub.called, true);
 
                 // Check that express static gets called with correct options
-                should.exist(expressStaticStub.firstCall.args);
+                assertExists(expressStaticStub.firstCall.args);
                 assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
 
                 const options = expressStaticStub.firstCall.args[1];

--- a/ghost/core/test/unit/server/adapters/scheduling/utils.test.js
+++ b/ghost/core/test/unit/server/adapters/scheduling/utils.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../../utils/assertions');
 const should = require('should');
 const fs = require('fs-extra');
 const configUtils = require('../../../../utils/config-utils');
@@ -26,7 +27,7 @@ describe('Scheduling: utils', function () {
     describe('success', function () {
         it('create good adapter', function (done) {
             schedulingUtils.createAdapter().then(function (adapter) {
-                should.exist(adapter);
+                assertExists(adapter);
                 done();
             }).catch(done);
         });
@@ -54,7 +55,7 @@ describe('Scheduling: utils', function () {
             fs.writeFileSync(scope.adapter, jsFile);
 
             schedulingUtils.createAdapter().then(function (adapter) {
-                should.exist(adapter);
+                assertExists(adapter);
                 done();
             }).catch(done);
         });
@@ -79,7 +80,7 @@ describe('Scheduling: utils', function () {
                 }
             });
             schedulingUtils.createAdapter().catch(function (err) {
-                should.exist(err);
+                assertExists(err);
                 assert.equal(err.errorType, 'IncorrectUsageError');
                 done();
             });

--- a/ghost/core/test/unit/server/adapters/storage/index.test.js
+++ b/ghost/core/test/unit/server/adapters/storage/index.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../../utils/assertions');
 const should = require('should');
 const fs = require('fs-extra');
 const StorageBase = require('ghost-storage-base');
@@ -90,7 +91,7 @@ describe('storage: index_spec', function () {
         try {
             storage.getStorage();
         } catch (err) {
-            should.exist(err);
+            assertExists(err);
             assert.equal(err.errorType, 'IncorrectUsageError');
         }
     });

--- a/ghost/core/test/unit/server/adapters/storage/local-images-storage.test.js
+++ b/ghost/core/test/unit/server/adapters/storage/local-images-storage.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../../utils/assertions');
 const errors = require('@tryghost/errors');
 const should = require('should');
 const sinon = require('sinon');
@@ -183,7 +184,7 @@ describe('Local Images Storage', function () {
             localFileStore.save({
                 name: 'test-1.1.1'
             }).then(function (url) {
-                should.exist(url.match(/test-1.1.1/));
+                assertExists(url.match(/test-1.1.1/));
                 done();
             }).catch(done);
         });
@@ -192,7 +193,7 @@ describe('Local Images Storage', function () {
             localFileStore.save({
                 name: 'test-1.1.1.zip'
             }).then(function (url) {
-                should.exist(url.match(/test-1.1.1.zip/));
+                assertExists(url.match(/test-1.1.1.zip/));
                 done();
             }).catch(done);
         });
@@ -201,7 +202,7 @@ describe('Local Images Storage', function () {
             localFileStore.save({
                 name: 'test-1.1.1.jpeg'
             }).then(function (url) {
-                should.exist(url.match(/test-1.1.1.jpeg/));
+                assertExists(url.match(/test-1.1.1.jpeg/));
                 done();
             }).catch(done);
         });

--- a/ghost/core/test/unit/server/adapters/storage/utils.test.js
+++ b/ghost/core/test/unit/server/adapters/storage/utils.test.js
@@ -1,3 +1,4 @@
+const {assertExists} = require('../../../../utils/assertions');
 const should = require('should');
 const sinon = require('sinon');
 const urlUtils = require('../../../../../core/shared/url-utils');
@@ -28,7 +29,7 @@ describe('storage utils', function () {
             urlGetSubdirStub.returns('');
 
             result = storageUtils.getLocalImagesStoragePath(url);
-            should.exist(result);
+            assertExists(result);
             result.should.be.equal('/2017/07/ghost-logo.png');
         });
 
@@ -42,7 +43,7 @@ describe('storage utils', function () {
             urlGetSubdirStub.returns('/blog');
 
             result = storageUtils.getLocalImagesStoragePath(url);
-            should.exist(result);
+            assertExists(result);
             result.should.be.equal('/2017/07/ghost-logo.png');
         });
 
@@ -56,7 +57,7 @@ describe('storage utils', function () {
             urlGetSubdirStub.returns('');
 
             result = storageUtils.getLocalImagesStoragePath(filePath);
-            should.exist(result);
+            assertExists(result);
             result.should.be.equal('/2017/07/ghost-logo.png');
         });
 
@@ -70,7 +71,7 @@ describe('storage utils', function () {
             urlGetSubdirStub.returns('/blog');
 
             result = storageUtils.getLocalImagesStoragePath(filePath);
-            should.exist(result);
+            assertExists(result);
             result.should.be.equal('/2017/07/ghost-logo.png');
         });
 
@@ -84,7 +85,7 @@ describe('storage utils', function () {
             urlGetSubdirStub.returns('');
 
             result = storageUtils.getLocalImagesStoragePath(url);
-            should.exist(result);
+            assertExists(result);
             result.should.be.equal('http://example-blog.com/ghost-logo.png');
         });
     });
@@ -100,7 +101,7 @@ describe('storage utils', function () {
             urlGetSubdirStub.returns('');
 
             result = storageUtils.isLocalImage(url);
-            should.exist(result);
+            assertExists(result);
             result.should.be.equal(true);
         });
 
@@ -114,7 +115,7 @@ describe('storage utils', function () {
             urlGetSubdirStub.returns('/blog');
 
             result = storageUtils.isLocalImage(url);
-            should.exist(result);
+            assertExists(result);
             result.should.be.equal(true);
         });
 
@@ -128,7 +129,7 @@ describe('storage utils', function () {
             urlGetSubdirStub.returns('');
 
             result = storageUtils.isLocalImage(url);
-            should.exist(result);
+            assertExists(result);
             result.should.be.equal(true);
         });
 
@@ -142,7 +143,7 @@ describe('storage utils', function () {
             urlGetSubdirStub.returns('/blog');
 
             result = storageUtils.isLocalImage(url);
-            should.exist(result);
+            assertExists(result);
             result.should.be.equal(true);
         });
 
@@ -156,7 +157,7 @@ describe('storage utils', function () {
             urlGetSubdirStub.returns('');
 
             result = storageUtils.isLocalImage(url);
-            should.exist(result);
+            assertExists(result);
             result.should.be.equal(false);
         });
     });

--- a/ghost/core/test/unit/server/data/exporter/index.test.js
+++ b/ghost/core/test/unit/server/data/exporter/index.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../../utils/assertions');
 const should = require('should');
 const sinon = require('sinon');
 const errors = require('@tryghost/errors');
@@ -43,7 +44,7 @@ describe('Exporter', function () {
                 // NOTE: 15 default tables
                 const expectedCallCount = exporter.TABLES_ALLOWLIST.length;
 
-                should.exist(exportData);
+                assertExists(exportData);
 
                 assert.match(exportData.meta.version, /\d+.\d+.\d+/gi);
 
@@ -94,7 +95,7 @@ describe('Exporter', function () {
                 // NOTE: 15 default tables + 2 includes
                 const expectedCallCount = exporter.TABLES_ALLOWLIST.length + 2;
 
-                should.exist(exportData);
+                assertExists(exportData);
 
                 assert.match(exportData.meta.version, /\d+.\d+.\d+/gi);
 
@@ -166,7 +167,7 @@ describe('Exporter', function () {
             );
 
             exporter.fileName().then(function (result) {
-                should.exist(result);
+                assertExists(result);
                 assert.equal(settingsStub.calledOnce, true);
                 assert.match(result, /^testblog\.ghost\.[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{2}-[0-9]{2}-[0-9]{2}\.json$/);
 
@@ -180,7 +181,7 @@ describe('Exporter', function () {
             );
 
             exporter.fileName().then(function (result) {
-                should.exist(result);
+                assertExists(result);
                 assert.equal(settingsStub.calledOnce, true);
                 assert.match(result, /^ghost\.[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{2}-[0-9]{2}-[0-9]{2}\.json$/);
 
@@ -195,7 +196,7 @@ describe('Exporter', function () {
             const loggingStub = sinon.stub(logging, 'error');
 
             exporter.fileName().then(function (result) {
-                should.exist(result);
+                assertExists(result);
                 assert.equal(settingsStub.calledOnce, true);
                 assert.equal(loggingStub.calledOnce, true);
                 assert.match(result, /^ghost\.[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{2}-[0-9]{2}-[0-9]{2}\.json$/);

--- a/ghost/core/test/unit/server/data/importer/importers/data/posts.test.js
+++ b/ghost/core/test/unit/server/data/importer/importers/data/posts.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../../../../utils/assertions');
 const should = require('should');
 const find = require('lodash/find');
 const PostsImporter = require('../../../../../../../core/server/data/importer/importers/data/posts-importer');
@@ -25,27 +26,27 @@ describe('PostsImporter', function () {
             importer.beforeImport();
 
             const pageFalse = find(importer.dataToImport, {slug: 'page-false'});
-            should.exist(pageFalse);
+            assertExists(pageFalse);
             should.not.exist(pageFalse.page, 'pageFalse.page should not exist');
-            should.exist(pageFalse.type, 'pageFalse.type should exist');
+            assertExists(pageFalse.type, 'pageFalse.type should exist');
             assert.equal(pageFalse.type, 'post');
 
             const pageTrue = find(importer.dataToImport, {slug: 'page-true'});
-            should.exist(pageTrue);
+            assertExists(pageTrue);
             should.not.exist(pageTrue.page, 'pageTrue.page should not exist');
-            should.exist(pageTrue.type, 'pageTrue.type should exist');
+            assertExists(pageTrue.type, 'pageTrue.type should exist');
             assert.equal(pageTrue.type, 'page');
 
             const typePost = find(importer.dataToImport, {slug: 'type-post'});
-            should.exist(typePost);
+            assertExists(typePost);
             should.not.exist(typePost.page, 'typePost.page should not exist');
-            should.exist(typePost.type, 'typePost.type should exist');
+            assertExists(typePost.type, 'typePost.type should exist');
             assert.equal(typePost.type, 'post');
 
             const typePage = find(importer.dataToImport, {slug: 'type-page'});
-            should.exist(typePage);
+            assertExists(typePage);
             should.not.exist(typePage.page, 'typePage.page should not exist');
-            should.exist(typePage.type, 'typePage.type should exist');
+            assertExists(typePage.type, 'typePage.type should exist');
             assert.equal(typePage.type, 'page');
         });
 
@@ -73,19 +74,19 @@ describe('PostsImporter', function () {
             importer.beforeImport();
 
             const pageFalseTypePage = find(importer.dataToImport, {slug: 'page-false-type-page'});
-            should.exist(pageFalseTypePage);
+            assertExists(pageFalseTypePage);
             assert.equal(pageFalseTypePage.type, 'page', 'pageFalseTypePage.type');
 
             const pageTrueTypePage = find(importer.dataToImport, {slug: 'page-true-type-page'});
-            should.exist(pageTrueTypePage);
+            assertExists(pageTrueTypePage);
             assert.equal(pageTrueTypePage.type, 'page', 'pageTrueTypePage.type');
 
             const pageFalseTypePost = find(importer.dataToImport, {slug: 'page-false-type-post'});
-            should.exist(pageFalseTypePost);
+            assertExists(pageFalseTypePost);
             assert.equal(pageFalseTypePost.type, 'post', 'pageFalseTypePost.type');
 
             const pageTrueTypePost = find(importer.dataToImport, {slug: 'page-true-type-post'});
-            should.exist(pageTrueTypePost);
+            assertExists(pageTrueTypePost);
             assert.equal(pageTrueTypePost.type, 'post', 'pageTrueTypePost.type');
         });
 
@@ -100,8 +101,8 @@ describe('PostsImporter', function () {
             importer.beforeImport();
 
             const postWithoutNewsletter = find(importer.dataToImport, {slug: 'post-with-newsletter'});
-            should.exist(postWithoutNewsletter);
-            should.exist(postWithoutNewsletter.newsletter_id);
+            assertExists(postWithoutNewsletter);
+            assertExists(postWithoutNewsletter.newsletter_id);
         });
 
         it('Maps send_email_when_published', function () {
@@ -115,7 +116,7 @@ describe('PostsImporter', function () {
             importer.beforeImport();
 
             const post = find(importer.dataToImport, {slug: 'post-with-newsletter'});
-            should.exist(post);
+            assertExists(post);
             assert.equal(post.email_recipient_filter, 'all');
             assert.equal(post.send_email_when_published, undefined);
             // @TODO: need to check this mapping
@@ -134,7 +135,7 @@ describe('PostsImporter', function () {
             importer.beforeImport();
 
             const post = find(importer.dataToImport, {slug: 'post-with-newsletter'});
-            should.exist(post);
+            assertExists(post);
             assert.equal(post.mobiledoc, undefined);
         });
     });

--- a/ghost/core/test/unit/server/data/importer/importers/data/settings.test.js
+++ b/ghost/core/test/unit/server/data/importer/importers/data/settings.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../../../../utils/assertions');
 const find = require('lodash/find');
 const should = require('should');
 const SettingsImporter = require('../../../../../../../core/server/data/importer/importers/data/settings-importer');
@@ -126,7 +127,7 @@ describe('SettingsImporter', function () {
                 message: 'IMPORTANT: Content in this import was previously published on a private Ghost install, but the current site is public. Are your privacy settings up to date?'
             });
 
-            should.exist(problem);
+            assertExists(problem);
         });
 
         it('Adds a problem if unable to parse data from slack configuration', function () {
@@ -149,7 +150,7 @@ describe('SettingsImporter', function () {
                 message: 'Failed to parse the value of slack setting value'
             });
 
-            should.exist(problem);
+            assertExists(problem);
         });
 
         it('Ignores slack URL from import files in all forms', function () {

--- a/ghost/core/test/unit/server/data/schema/fixtures/fixture-manager.test.js
+++ b/ghost/core/test/unit/server/data/schema/fixtures/fixture-manager.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../../../utils/assertions');
 const should = require('should');
 const sinon = require('sinon');
 
@@ -183,7 +184,7 @@ describe('Migration Fixture Utils', function () {
 
             assert.equal(processed.models[0].entries[0].id, 'user123');
 
-            should.exist(receivedModels);
+            assertExists(receivedModels);
 
             receivedModels.should.equal(models);
         });
@@ -336,7 +337,7 @@ describe('Migration Fixture Utils', function () {
             });
 
             fixtureManager.addFixturesForModel(postFixtures).then(function (result) {
-                should.exist(result);
+                assertExists(result);
                 result.should.be.an.Object();
                 result.should.have.property('expected', 11);
                 result.should.have.property('done', 11);
@@ -357,7 +358,7 @@ describe('Migration Fixture Utils', function () {
             });
 
             fixtureManager.addFixturesForModel(newsletterFixtures).then(function (result) {
-                should.exist(result);
+                assertExists(result);
                 result.should.be.an.Object();
                 result.should.have.property('expected', 1);
                 result.should.have.property('done', 1);
@@ -378,7 +379,7 @@ describe('Migration Fixture Utils', function () {
             });
 
             fixtureManager.addFixturesForModel(postFixtures).then(function (result) {
-                should.exist(result);
+                assertExists(result);
                 result.should.be.an.Object();
                 result.should.have.property('expected', 11);
                 result.should.have.property('done', 0);
@@ -411,7 +412,7 @@ describe('Migration Fixture Utils', function () {
 
             fixtureManager.addFixturesForRelation(fixtures.relations[0]).then(function (result) {
                 const FIXTURE_COUNT = 137;
-                should.exist(result);
+                assertExists(result);
                 result.should.be.an.Object();
                 result.should.have.property('expected', FIXTURE_COUNT);
                 result.should.have.property('done', FIXTURE_COUNT);
@@ -448,7 +449,7 @@ describe('Migration Fixture Utils', function () {
             const tagsAllStub = sinon.stub(models.Tag, 'findAll').returns(Promise.resolve(dataMethodStub));
 
             fixtureManager.addFixturesForRelation(fixtures.relations[1]).then(function (result) {
-                should.exist(result);
+                assertExists(result);
                 result.should.be.an.Object();
                 result.should.have.property('expected', 7);
                 result.should.have.property('done', 7);
@@ -485,7 +486,7 @@ describe('Migration Fixture Utils', function () {
             const tagsAllStub = sinon.stub(models.Tag, 'findAll').returns(Promise.resolve(dataMethodStub));
 
             fixtureManager.addFixturesForRelation(fixtures.relations[1]).then(function (result) {
-                should.exist(result);
+                assertExists(result);
                 result.should.be.an.Object();
                 result.should.have.property('expected', 7);
                 result.should.have.property('done', 0);

--- a/ghost/core/test/unit/server/data/schema/schema.test.js
+++ b/ghost/core/test/unit/server/data/schema/schema.test.js
@@ -1,3 +1,4 @@
+const {assertExists} = require('../../../../utils/assertions');
 const should = require('should');
 const _ = require('lodash');
 
@@ -60,7 +61,7 @@ describe('schema validations', function () {
                 should(column).be.Object();
 
                 // Ensure the `type` key exists on a column
-                should.exist(column.type, `${tableName}.${columnName}.type should exist`);
+                assertExists(column.type, `${tableName}.${columnName}.type should exist`);
 
                 // Ensure the column type is one of the ones we allow
                 should(column.type).be.equalOneOf(Object.keys(VALID_KEYS));

--- a/ghost/core/test/unit/server/lib/image/blog-icon.test.js
+++ b/ghost/core/test/unit/server/lib/image/blog-icon.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../../utils/assertions');
 const should = require('should');
 const sinon = require('sinon');
 const path = require('path');
@@ -176,7 +177,7 @@ describe('lib/image: blog icon', function () {
             const blogIcon = new BlogIcon({config: {}, storageUtils: {}, urlUtils: {}, settingsCache: {}});
             blogIcon.getIconDimensions(path.join(__dirname, '../../../../utils/fixtures/images/favicon.ico'))
                 .then(function (result) {
-                    should.exist(result);
+                    assertExists(result);
                     result.should.eql({
                         width: 48,
                         height: 48
@@ -189,7 +190,7 @@ describe('lib/image: blog icon', function () {
             const blogIcon = new BlogIcon({config: {}, storageUtils: {}, urlUtils: {}, settingsCache: {}});
             blogIcon.getIconDimensions(path.join(__dirname, '../../../../utils/fixtures/images/favicon.png'))
                 .then(function (result) {
-                    should.exist(result);
+                    assertExists(result);
                     result.should.eql({
                         width: 100,
                         height: 100
@@ -202,7 +203,7 @@ describe('lib/image: blog icon', function () {
             const blogIcon = new BlogIcon({config: {}, storageUtils: {}, urlUtils: {}, settingsCache: {}});
             blogIcon.getIconDimensions(path.join(__dirname, '../../../../utils/fixtures/images/favicon_multi_sizes.ico'))
                 .then(function (result) {
-                    should.exist(result);
+                    assertExists(result);
                     result.should.eql({
                         width: 64,
                         height: 64
@@ -217,7 +218,7 @@ describe('lib/image: blog icon', function () {
 
             blogIcon.getIconDimensions(path.join(__dirname, '../../../../utils/fixtures/images/favicon_multi_sizes_FILE_DOES_NOT_EXIST.ico'))
                 .catch(function (error) {
-                    should.exist(error);
+                    assertExists(error);
                     assert.equal(error.message, 'Could not fetch icon dimensions.');
                     done();
                 });

--- a/ghost/core/test/unit/server/lib/image/cached-image-size-from-url.test.js
+++ b/ghost/core/test/unit/server/lib/image/cached-image-size-from-url.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../../utils/assertions');
 const errors = require('@tryghost/errors');
 const should = require('should');
 const sinon = require('sinon');
@@ -39,12 +40,12 @@ describe('lib/image: image size cache', function () {
 
         // first call to get result from `getImageSizeFromUrl`
 
-        should.exist(cacheStore);
+        assertExists(cacheStore);
         cacheStore.get(url).should.not.be.undefined;
         const image = cacheStore.get(url);
-        should.exist(image.width);
+        assertExists(image.width);
         image.width.should.be.equal(50);
-        should.exist(image.height);
+        assertExists(image.height);
         image.height.should.be.equal(50);
 
         // second call to check if values get returned from cache
@@ -55,9 +56,9 @@ describe('lib/image: image size cache', function () {
 
         cacheStore.get(url).should.not.be.undefined;
         const image2 = cacheStore.get(url);
-        should.exist(image2.width);
+        assertExists(image2.width);
         image2.width.should.be.equal(50);
-        should.exist(image2.height);
+        assertExists(image2.height);
         image2.height.should.be.equal(50);
     });
 

--- a/ghost/core/test/unit/server/lib/image/gravatar.test.js
+++ b/ghost/core/test/unit/server/lib/image/gravatar.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../../utils/assertions');
 const should = require('should');
 const Gravatar = require('../../../../../core/server/lib/image/gravatar');
 
@@ -32,8 +33,8 @@ describe('lib/image: gravatar', function () {
         }, request: () => {}});
 
         gravatar.lookup({email: 'exists@example.com'}).then(function (result) {
-            should.exist(result);
-            should.exist(result.image);
+            assertExists(result);
+            assertExists(result.image);
             assert.equal(result.image, 'https://www.gravatar.com/avatar/ef6dcde5c99bb8f685dd451ccc3e050a?s=250&r=x&d=mp');
 
             done();
@@ -53,7 +54,7 @@ describe('lib/image: gravatar', function () {
         }});
 
         gravatar.lookup({email: 'invalid@example.com'}).then(function (result) {
-            should.exist(result);
+            assertExists(result);
             assert.equal(result.image, undefined);
 
             done();

--- a/ghost/core/test/unit/server/lib/image/image-size.test.js
+++ b/ghost/core/test/unit/server/lib/image/image-size.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../../utils/assertions');
 const should = require('should');
 const sinon = require('sinon');
 const nock = require('nock');
@@ -21,8 +22,8 @@ describe('lib/image: image size', function () {
         const imageSize = new ImageSize({config: {
             get: () => {}
         }, tpl: {}, storage: {}, storageUtils: {}, validator: {}, urlUtils: {}, request: {}, probe});
-        should.exist(imageSize.getImageSizeFromUrl);
-        should.exist(imageSize.getImageSizeFromStoragePath);
+        assertExists(imageSize.getImageSizeFromUrl);
+        assertExists(imageSize.getImageSizeFromStoragePath);
     });
 
     describe('getImageSizeFromUrl', function () {
@@ -48,7 +49,7 @@ describe('lib/image: image size', function () {
 
             imageSize.getImageSizeFromUrl(url).then(function (res) {
                 assert.equal(requestMock.isDone(), true);
-                should.exist(res);
+                assertExists(res);
                 res.width.should.be.equal(expectedImageObject.width);
                 res.height.should.be.equal(expectedImageObject.height);
                 res.url.should.be.equal(expectedImageObject.url);
@@ -83,7 +84,7 @@ describe('lib/image: image size', function () {
 
             imageSize.getImageSizeFromUrl(url).then(function (res) {
                 assert.equal(requestMock.isDone(), false);
-                should.exist(res);
+                assertExists(res);
                 res.width.should.be.equal(expectedImageObject.width);
                 res.height.should.be.equal(expectedImageObject.height);
                 res.url.should.be.equal(expectedImageObject.url);
@@ -113,7 +114,7 @@ describe('lib/image: image size', function () {
 
             imageSize.getImageSizeFromUrl(url).then(function (res) {
                 assert.equal(requestMock.isDone(), true);
-                should.exist(res);
+                assertExists(res);
                 res.width.should.be.equal(expectedImageObject.width);
                 res.height.should.be.equal(expectedImageObject.height);
                 res.url.should.be.equal(expectedImageObject.url);
@@ -145,7 +146,7 @@ describe('lib/image: image size', function () {
             imageSize.getImageSizeFromUrl(url).then(function (res) {
                 assert.equal(requestMockNotFound.isDone(), false);
                 assert.equal(requestMock.isDone(), true);
-                should.exist(res);
+                assertExists(res);
                 res.width.should.be.equal(expectedImageObject.width);
                 res.height.should.be.equal(expectedImageObject.height);
                 res.url.should.be.equal(expectedImageObject.url);
@@ -194,7 +195,7 @@ describe('lib/image: image size', function () {
 
             imageSize.getImageSizeFromUrl(url).then(function (res) {
                 assert.equal(requestMock.isDone(), true);
-                should.exist(res);
+                assertExists(res);
                 res.width.should.be.equal(expectedImageObject.width);
                 res.height.should.be.equal(expectedImageObject.height);
                 res.url.should.be.equal(expectedImageObject.url);
@@ -224,7 +225,7 @@ describe('lib/image: image size', function () {
 
             imageSize.getImageSizeFromUrl(url).then(function (res) {
                 assert.equal(requestMock.isDone(), true);
-                should.exist(res);
+                assertExists(res);
                 res.width.should.be.equal(expectedImageObject.width);
                 res.height.should.be.equal(expectedImageObject.height);
                 res.url.should.be.equal(expectedImageObject.url);
@@ -261,7 +262,7 @@ describe('lib/image: image size', function () {
             imageSize.getImageSizeFromUrl(url).then(function (res) {
                 assert.equal(requestMock.isDone(), true);
                 assert.equal(secondRequestMock.isDone(), true);
-                should.exist(res);
+                assertExists(res);
                 res.width.should.be.equal(expectedImageObject.width);
                 res.height.should.be.equal(expectedImageObject.height);
                 res.url.should.be.equal(expectedImageObject.url);
@@ -306,12 +307,12 @@ describe('lib/image: image size', function () {
 
             imageSize.getImageSizeFromUrl(url).then(function (res) {
                 assert.equal(requestMock.isDone(), false);
-                should.exist(res);
-                should.exist(res.width);
+                assertExists(res);
+                assertExists(res.width);
                 res.width.should.be.equal(expectedImageObject.width);
-                should.exist(res.height);
+                assertExists(res.height);
                 res.height.should.be.equal(expectedImageObject.height);
-                should.exist(res.url);
+                assertExists(res.url);
                 res.url.should.be.equal(expectedImageObject.url);
                 done();
             }).catch(done);
@@ -335,7 +336,7 @@ describe('lib/image: image size', function () {
             imageSize.getImageSizeFromUrl(url)
                 .catch(function (err) {
                     assert.equal(requestMock.isDone(), true);
-                    should.exist(err);
+                    assertExists(err);
                     err.errorType.should.be.equal('NotFoundError');
                     err.message.should.be.equal('Image not found.');
                     done();
@@ -373,7 +374,7 @@ describe('lib/image: image size', function () {
             imageSize.getImageSizeFromUrl(url)
                 .catch(function (err) {
                     assert.equal(requestMock.isDone(), false);
-                    should.exist(err);
+                    assertExists(err);
                     err.errorType.should.be.equal('NotFoundError');
                     err.message.should.be.equal('Image not found.');
                     done();
@@ -393,7 +394,7 @@ describe('lib/image: image size', function () {
 
             imageSize.getImageSizeFromUrl(url)
                 .catch(function (err) {
-                    should.exist(err);
+                    assertExists(err);
                     err.errorType.should.be.equal('InternalServerError');
                     err.message.should.be.equal('URL empty or invalid.');
                     done();
@@ -427,7 +428,7 @@ describe('lib/image: image size', function () {
             imageSize.getImageSizeFromUrl(url)
                 .catch(function (err) {
                     assert.equal(requestMock.isDone(), true);
-                    should.exist(err);
+                    assertExists(err);
                     err.errorType.should.be.equal('InternalServerError');
                     err.message.should.be.equal('Request timed out.');
                     done();
@@ -455,7 +456,7 @@ describe('lib/image: image size', function () {
                 })
                 .catch(function (err) {
                     assert.equal(requestMock.isDone(), true);
-                    should.exist(err);
+                    assertExists(err);
                     err.errorType.should.be.equal('InternalServerError');
                     done();
                 }).catch(done);
@@ -489,7 +490,7 @@ describe('lib/image: image size', function () {
                 })
                 .catch(function (err) {
                     assert.equal(requestMock.isDone(), false);
-                    should.exist(err);
+                    assertExists(err);
                     err.errorType.should.be.equal('InternalServerError');
                     done();
                 }).catch(done);
@@ -510,7 +511,7 @@ describe('lib/image: image size', function () {
 
             imageSize.getImageSizeFromUrl(url)
                 .catch(function (err) {
-                    should.exist(err);
+                    assertExists(err);
                     err.errorType.should.be.equal('InternalServerError');
                     err.message.should.be.equal('Unknown Request error.');
                     done();
@@ -542,7 +543,7 @@ describe('lib/image: image size', function () {
             imageSize.getImageSizeFromUrl(url)
                 .catch(function (err) {
                     assert.equal(requestMock.isDone(), true);
-                    should.exist(err);
+                    assertExists(err);
                     err.errorType.should.be.equal('InternalServerError');
                     err.message.should.be.equal('Probe unresponsive.');
                     done();
@@ -583,12 +584,12 @@ describe('lib/image: image size', function () {
             }, probe});
 
             imageSize.getImageSizeFromStoragePath(url).then(function (res) {
-                should.exist(res);
-                should.exist(res.width);
+                assertExists(res);
+                assertExists(res.width);
                 res.width.should.be.equal(expectedImageObject.width);
-                should.exist(res.height);
+                assertExists(res.height);
                 res.height.should.be.equal(expectedImageObject.height);
-                should.exist(res.url);
+                assertExists(res.url);
                 res.url.should.be.equal(expectedImageObject.url);
                 done();
             }).catch(done);
@@ -626,12 +627,12 @@ describe('lib/image: image size', function () {
             }, probe});
 
             imageSize.getImageSizeFromStoragePath(url).then(function (res) {
-                should.exist(res);
-                should.exist(res.width);
+                assertExists(res);
+                assertExists(res.width);
                 res.width.should.be.equal(expectedImageObject.width);
-                should.exist(res.height);
+                assertExists(res.height);
                 res.height.should.be.equal(expectedImageObject.height);
-                should.exist(res.url);
+                assertExists(res.url);
                 res.url.should.be.equal(expectedImageObject.url);
                 done();
             }).catch(done);
@@ -669,12 +670,12 @@ describe('lib/image: image size', function () {
             }, probe});
 
             imageSize.getImageSizeFromStoragePath(url).then(function (res) {
-                should.exist(res);
-                should.exist(res.width);
+                assertExists(res);
+                assertExists(res.width);
                 res.width.should.be.equal(expectedImageObject.width);
-                should.exist(res.height);
+                assertExists(res.height);
                 res.height.should.be.equal(expectedImageObject.height);
-                should.exist(res.url);
+                assertExists(res.url);
                 res.url.should.be.equal(expectedImageObject.url);
                 done();
             }).catch(done);
@@ -712,12 +713,12 @@ describe('lib/image: image size', function () {
             }, probe});
 
             imageSize.getImageSizeFromStoragePath(url).then(function (res) {
-                should.exist(res);
-                should.exist(res.width);
+                assertExists(res);
+                assertExists(res.width);
                 res.width.should.be.equal(expectedImageObject.width);
-                should.exist(res.height);
+                assertExists(res.height);
                 res.height.should.be.equal(expectedImageObject.height);
-                should.exist(res.url);
+                assertExists(res.url);
                 res.url.should.be.equal(expectedImageObject.url);
                 done();
             }).catch(done);
@@ -753,7 +754,7 @@ describe('lib/image: image size', function () {
 
             imageSize.getImageSizeFromStoragePath(url)
                 .catch(function (err) {
-                    should.exist(err);
+                    assertExists(err);
                     assert.equal((err instanceof errors.NotFoundError), true);
                     done();
                 }).catch(done);
@@ -788,7 +789,7 @@ describe('lib/image: image size', function () {
 
             imageSize.getImageSizeFromStoragePath(url)
                 .catch(function (err) {
-                    should.exist(err);
+                    assertExists(err);
                     done();
                 }).catch(done);
         });

--- a/ghost/core/test/unit/server/lib/mobiledoc.test.js
+++ b/ghost/core/test/unit/server/lib/mobiledoc.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../utils/assertions');
 const path = require('path');
 const should = require('should');
 const sinon = require('sinon');
@@ -351,14 +352,14 @@ describe('lib/mobiledoc', function () {
 
             assert.equal(transformed.cards.length, 2);
 
-            should.exist(transformed.cards[0][1].width);
+            assertExists(transformed.cards[0][1].width);
             assert.equal(transformed.cards[0][1].width, 800);
-            should.exist(transformed.cards[0][1].height);
+            assertExists(transformed.cards[0][1].height);
             assert.equal(transformed.cards[0][1].height, 257);
 
-            should.exist(transformed.cards[1][1].width);
+            assertExists(transformed.cards[1][1].width);
             assert.equal(transformed.cards[1][1].width, 800);
-            should.exist(transformed.cards[1][1].height);
+            assertExists(transformed.cards[1][1].height);
             assert.equal(transformed.cards[1][1].height, 257);
         });
     });

--- a/ghost/core/test/unit/server/lib/request-external.test.js
+++ b/ghost/core/test/unit/server/lib/request-external.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../utils/assertions');
 const sinon = require('sinon');
 const should = require('should');
 const nock = require('nock');
@@ -46,12 +47,12 @@ describe('External Request', function () {
 
             return externalRequest(url, options).then(function (res) {
                 assert.equal(requestMock.isDone(), true);
-                should.exist(res);
-                should.exist(res.body);
+                assertExists(res);
+                assertExists(res.body);
                 res.body.should.be.equal(expectedResponse.body);
-                should.exist(res.url);
+                assertExists(res.url);
                 res.statusCode.should.be.equal(expectedResponse.statusCode);
-                should.exist(res.statusCode);
+                assertExists(res.statusCode);
                 res.url.should.be.equal(expectedResponse.url);
             });
         });
@@ -77,12 +78,12 @@ describe('External Request', function () {
 
             return externalRequest(url, options).then(function (res) {
                 assert.equal(requestMock.isDone(), true);
-                should.exist(res);
-                should.exist(res.body);
+                assertExists(res);
+                assertExists(res.body);
                 res.body.should.be.equal(expectedResponse.body);
-                should.exist(res.url);
+                assertExists(res.url);
                 res.statusCode.should.be.equal(expectedResponse.statusCode);
-                should.exist(res.statusCode);
+                assertExists(res.statusCode);
                 res.url.should.be.equal(expectedResponse.url);
             });
         });
@@ -100,7 +101,7 @@ describe('External Request', function () {
             return externalRequest(url, options).then(() => {
                 throw new Error('Request should have rejected with non-permitted IP message');
             }, (err) => {
-                should.exist(err);
+                assertExists(err);
                 err.message.should.be.equal('URL resolves to a non-permitted private IP block');
             });
         });
@@ -118,7 +119,7 @@ describe('External Request', function () {
             return externalRequest(url, options).then(() => {
                 throw new Error('Request should have rejected with non-permitted IP message');
             }, (err) => {
-                should.exist(err);
+                assertExists(err);
                 err.message.should.be.equal('URL resolves to a non-permitted private IP block');
             });
         });
@@ -138,7 +139,7 @@ describe('External Request', function () {
             return externalRequest(url, options).then(function () {
                 throw new Error('Request should have rejected with non-permitted IP message');
             }, (err) => {
-                should.exist(err);
+                assertExists(err);
                 err.message.should.be.equal('URL resolves to a non-permitted private IP block');
                 assert.equal(requestMock.isDone(), false);
             });
@@ -168,7 +169,7 @@ describe('External Request', function () {
             return externalRequest(url, options).then(function () {
                 throw new Error('Request should have rejected with non-permitted IP message');
             }, (err) => {
-                should.exist(err);
+                assertExists(err);
                 err.message.should.be.equal('URL resolves to a non-permitted private IP block');
                 assert.equal(requestMock.isDone(), true);
                 assert.equal(secondRequestMock.isDone(), false);
@@ -208,12 +209,12 @@ describe('External Request', function () {
 
             return externalRequest(url, options).then(function (res) {
                 assert.equal(requestMock.isDone(), true);
-                should.exist(res);
-                should.exist(res.body);
+                assertExists(res);
+                assertExists(res.body);
                 res.body.should.be.equal(expectedResponse.body);
-                should.exist(res.url);
+                assertExists(res.url);
                 res.statusCode.should.be.equal(expectedResponse.statusCode);
-                should.exist(res.statusCode);
+                assertExists(res.statusCode);
                 res.url.should.be.equal(expectedResponse.url);
             });
         });
@@ -245,12 +246,12 @@ describe('External Request', function () {
             return externalRequest(url, options).then(function (res) {
                 assert.equal(requestMock.isDone(), true);
                 assert.equal(secondRequestMock.isDone(), true);
-                should.exist(res);
-                should.exist(res.body);
+                assertExists(res);
+                assertExists(res.body);
                 res.body.should.be.equal(expectedResponse.body);
-                should.exist(res.url);
+                assertExists(res.url);
                 res.statusCode.should.be.equal(expectedResponse.statusCode);
-                should.exist(res.statusCode);
+                assertExists(res.statusCode);
                 res.url.should.be.equal(expectedResponse.url);
             });
         });
@@ -266,7 +267,7 @@ describe('External Request', function () {
             return externalRequest(url, options).then(() => {
                 throw new Error('Request should have rejected with invalid url message');
             }, (err) => {
-                should.exist(err);
+                assertExists(err);
                 err.code.should.be.equal('ERR_INVALID_URL');
             });
         });
@@ -282,7 +283,7 @@ describe('External Request', function () {
             return externalRequest(url, options).then(() => {
                 throw new Error('Request should have rejected with invalid url message');
             }, (err) => {
-                should.exist(err);
+                assertExists(err);
                 // got v11+ throws an error instead of the external requests lib
                 err.message.should.be.equal('No URL protocol specified');
             });
@@ -304,7 +305,7 @@ describe('External Request', function () {
                 throw new Error('Request should have errored');
             }, (err) => {
                 assert.equal(requestMock.isDone(), true);
-                should.exist(err);
+                assertExists(err);
                 err.response.statusMessage.should.be.equal('Not Found');
             });
         });
@@ -326,7 +327,7 @@ describe('External Request', function () {
                 throw new Error('Request should have errored with an awful error');
             }, (err) => {
                 assert.equal(requestMock.isDone(), true);
-                should.exist(err);
+                assertExists(err);
                 err.response.statusMessage.should.be.equal(`Internal Server Error`);
             });
         });

--- a/ghost/core/test/unit/server/models/post.test.js
+++ b/ghost/core/test/unit/server/models/post.test.js
@@ -1,5 +1,6 @@
 /* eslint no-invalid-this:0 */
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../utils/assertions');
 const errors = require('@tryghost/errors');
 const should = require('should');
 const sinon = require('sinon');
@@ -249,7 +250,7 @@ describe('Unit: models/post', function () {
             const json = toJSON(post, {formats: ['mobiledoc']});
 
             assert.equal(json.mobiledoc_revisions, undefined);
-            should.exist(json.mobiledoc);
+            assertExists(json.mobiledoc);
         });
 
         it('ensure post revisions are exposed', function () {
@@ -260,8 +261,8 @@ describe('Unit: models/post', function () {
 
             const json = toJSON(post, {formats: ['lexical']});
 
-            should.exist(json.post_revisions);
-            should.exist(json.lexical);
+            assertExists(json.post_revisions);
+            assertExists(json.lexical);
         });
     });
 
@@ -482,7 +483,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         true,
                         false
                     ).then((result) => {
-                        should.exist(result);
+                        assertExists(result);
                         assert.deepEqual(result.excludedAttrs, ['authors', 'tags']);
                         assert.equal(mockPostObj.get.callCount, 2);
                         assert.equal(mockPostObj.related.callCount, 2);
@@ -569,7 +570,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         true,
                         false
                     ).then((result) => {
-                        should.exist(result);
+                        assertExists(result);
                         assert.deepEqual(result.excludedAttrs, ['authors', 'tags']);
                         assert.equal(mockPostObj.get.callCount, 2);
                         assert.equal(mockPostObj.related.callCount, 1);
@@ -670,7 +671,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         true,
                         true
                     ).then((result) => {
-                        should.exist(result);
+                        assertExists(result);
                         assert.deepEqual(result.excludedAttrs, ['authors', 'tags']);
                         assert.equal(mockPostObj.get.called, false);
                         done();
@@ -756,7 +757,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         true,
                         true
                     ).then((result) => {
-                        should.exist(result);
+                        assertExists(result);
                         assert.deepEqual(result.excludedAttrs, ['authors', 'tags']);
                         assert.equal(mockPostObj.get.calledOnce, true);
                         assert.equal(mockPostObj.related.calledOnce, true);

--- a/ghost/core/test/unit/server/models/set-is-roles.test.js
+++ b/ghost/core/test/unit/server/models/set-is-roles.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../utils/assertions');
 const should = require('should');
 const {setIsRoles} = require('../../../../core/server/models/role-utils');
 
@@ -60,7 +61,7 @@ describe('setIsRoles function behavior', function () {
 
     it('returns an object', function () {
         let result = setIsRoles(loadedPermissionsEditor);
-        should.exist(result);
+        assertExists(result);
         result.should.be.an.Object();
     });
 

--- a/ghost/core/test/unit/server/models/settings.test.js
+++ b/ghost/core/test/unit/server/models/settings.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../utils/assertions');
 const should = require('should');
 const sinon = require('sinon');
 const mockDb = require('mock-knex');
@@ -161,7 +162,7 @@ describe('Unit: models/settings', function () {
             } catch (err) {
                 error = err;
             } finally {
-                should.exist(error, `Setting Model should throw when saving invalid ${key}`);
+                assertExists(error, `Setting Model should throw when saving invalid ${key}`);
                 should.ok(error instanceof errors.ValidationError, 'Setting Model should throw ValidationError');
             }
         }

--- a/ghost/core/test/unit/server/models/single-use-token.test.js
+++ b/ghost/core/test/unit/server/models/single-use-token.test.js
@@ -2,6 +2,7 @@ const models = require('../../../../core/server/models');
 const should = require('should');
 const sinon = require('sinon');
 const assert = require('assert/strict');
+const {assertExists} = require('../../../utils/assertions');
 const validator = require('validator');
 
 let clock;
@@ -30,7 +31,7 @@ describe('Unit: models/single-use-token', function () {
             const model = new models.SingleUseToken();
             const defaults = model.defaults();
             
-            should.exist(defaults.uuid);
+            assertExists(defaults.uuid);
             assert.equal(validator.isUUID(defaults.uuid, 4), true, 'Generated UUID should be a valid v4 UUID');
         });
 
@@ -41,8 +42,8 @@ describe('Unit: models/single-use-token', function () {
             const defaults1 = model1.defaults();
             const defaults2 = model2.defaults();
             
-            should.exist(defaults1.uuid);
-            should.exist(defaults2.uuid);
+            assertExists(defaults1.uuid);
+            assertExists(defaults2.uuid);
             assert.notEqual(defaults1.uuid, defaults2.uuid, 'Each instance should generate a unique UUID');
         });
     });

--- a/ghost/core/test/unit/server/models/stripe-customer-subscription.test.js
+++ b/ghost/core/test/unit/server/models/stripe-customer-subscription.test.js
@@ -1,3 +1,4 @@
+const {assertExists} = require('../../../utils/assertions');
 const sinon = require('sinon');
 const should = require('should');
 const models = require('../../../../core/server/models');
@@ -45,10 +46,10 @@ describe('Unit: models/stripe-customer-subscription', function () {
             };
 
             const json = serialize(stripeSubscription);
-            should.exist(json.plan);
-            should.exist(json.customer);
-            should.exist(json.trial_start_at);
-            should.exist(json.trial_end_at);
+            assertExists(json.plan);
+            assertExists(json.customer);
+            assertExists(json.trial_start_at);
+            assertExists(json.trial_end_at);
         });
     });
 });

--- a/ghost/core/test/unit/server/services/auth/api-key/admin.test.js
+++ b/ghost/core/test/unit/server/services/auth/api-key/admin.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../../../utils/assertions');
 const errors = require('@tryghost/errors');
 const jwt = require('jsonwebtoken');
 const should = require('should');
@@ -127,7 +128,7 @@ describe('Admin API Key Auth', function () {
         const res = {};
 
         apiKeyAuth.admin.authenticate(req, res, (err) => {
-            should.exist(err);
+            assertExists(err);
             assert.equal(err instanceof errors.UnauthorizedError, true);
             assert.equal(err.code, 'INVALID_JWT');
             assert.equal(req.api_key, undefined);
@@ -145,7 +146,7 @@ describe('Admin API Key Auth', function () {
         const res = {};
 
         apiKeyAuth.admin.authenticate(req, res, function next(err) {
-            should.exist(err);
+            assertExists(err);
             assert.equal(err instanceof errors.UnauthorizedError, true);
             assert.equal(err.code, 'INVALID_AUTH_HEADER');
             assert.equal(req.api_key, undefined);
@@ -163,7 +164,7 @@ describe('Admin API Key Auth', function () {
         const res = {};
 
         apiKeyAuth.admin.authenticate(req, res, function next(err) {
-            should.exist(err);
+            assertExists(err);
             assert.equal(err instanceof errors.BadRequestError, true);
             assert.equal(err.code, 'INVALID_JWT');
             assert.equal(req.api_key, undefined);
@@ -190,7 +191,7 @@ describe('Admin API Key Auth', function () {
         const res = {};
 
         apiKeyAuth.admin.authenticate(req, res, function next(err) {
-            should.exist(err);
+            assertExists(err);
             assert.equal(err instanceof errors.UnauthorizedError, true);
             assert.equal(err.code, 'UNKNOWN_ADMIN_API_KEY');
             assert.equal(req.api_key, undefined);
@@ -219,7 +220,7 @@ describe('Admin API Key Auth', function () {
         const res = {};
 
         apiKeyAuth.admin.authenticate(req, res, function next(err) {
-            should.exist(err);
+            assertExists(err);
             assert.equal(err instanceof errors.UnauthorizedError, true);
             assert.equal(err.code, 'INVALID_JWT');
             assert.match(err.message, /jwt expired/);
@@ -249,7 +250,7 @@ describe('Admin API Key Auth', function () {
         const res = {};
 
         apiKeyAuth.admin.authenticate(req, res, function next(err) {
-            should.exist(err);
+            assertExists(err);
             assert.equal(err instanceof errors.UnauthorizedError, true);
             assert.equal(err.code, 'INVALID_JWT');
             assert.match(err.message, /maxAge exceeded/);
@@ -279,7 +280,7 @@ describe('Admin API Key Auth', function () {
         this.fakeApiKey.type = 'content';
 
         apiKeyAuth.admin.authenticate(req, res, function next(err) {
-            should.exist(err);
+            assertExists(err);
             assert.equal(err instanceof errors.UnauthorizedError, true);
             assert.equal(err.code, 'INVALID_API_KEY_TYPE');
             assert.equal(req.api_key, undefined);

--- a/ghost/core/test/unit/server/services/auth/api-key/content.test.js
+++ b/ghost/core/test/unit/server/services/auth/api-key/content.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../../../utils/assertions');
 const errors = require('@tryghost/errors');
 const {authenticateContentApiKey} = require('../../../../../../core/server/services/auth/api-key/content');
 const models = require('../../../../../../core/server/models');
@@ -52,7 +53,7 @@ describe('Content API Key Auth', function () {
         const res = {};
 
         authenticateContentApiKey(req, res, function next(err) {
-            should.exist(err);
+            assertExists(err);
             assert.equal(err instanceof errors.UnauthorizedError, true);
             assert.equal(err.code, 'UNKNOWN_CONTENT_API_KEY');
             assert.equal(req.api_key, undefined);
@@ -71,7 +72,7 @@ describe('Content API Key Auth', function () {
         this.fakeApiKey.type = 'admin';
 
         authenticateContentApiKey(req, res, function next(err) {
-            should.exist(err);
+            assertExists(err);
             assert.equal(err instanceof errors.UnauthorizedError, true);
             assert.equal(err.code, 'INVALID_API_KEY_TYPE');
             assert.equal(req.api_key, undefined);
@@ -88,7 +89,7 @@ describe('Content API Key Auth', function () {
         const res = {};
 
         authenticateContentApiKey(req, res, function next(err) {
-            should.exist(err);
+            assertExists(err);
             assert.equal(err instanceof errors.BadRequestError, true);
             assert.equal(err.code, 'INVALID_REQUEST');
             assert.equal(req.api_key, undefined);

--- a/ghost/core/test/unit/server/services/auth/session/session-service.test.js
+++ b/ghost/core/test/unit/server/services/auth/session/session-service.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../../../utils/assertions');
 const should = require('should');
 const sinon = require('sinon');
 const express = require('express');
@@ -345,7 +346,7 @@ describe('SessionService', function () {
 
         // Generate the auth code
         const authCode = await sessionService.generateAuthCodeForUser(req, res);
-        should.exist(authCode);
+        assertExists(authCode);
 
         req.body = {
             token: authCode
@@ -394,7 +395,7 @@ describe('SessionService', function () {
 
         // Generate the auth code
         const authCode = await sessionService.generateAuthCodeForUser(req, res);
-        should.exist(authCode);
+        assertExists(authCode);
 
         req.body = {
             token: 'wrong-code'

--- a/ghost/core/test/unit/server/services/mail/ghost-mailer.test.js
+++ b/ghost/core/test/unit/server/services/mail/ghost-mailer.test.js
@@ -7,6 +7,7 @@ const configUtils = require('../../../../utils/config-utils');
 const urlUtils = require('../../../../../core/shared/url-utils');
 let mailer;
 const assert = require('assert/strict');
+const {assertExists} = require('../../../../utils/assertions');
 const emailAddress = require('../../../../../core/server/services/email-address');
 
 // Mock SMTP config
@@ -56,7 +57,7 @@ describe('Mail: Ghostmailer', function () {
     it('should attach mail provider to ghost instance', function () {
         mailer = new mail.GhostMailer();
 
-        should.exist(mailer);
+        assertExists(mailer);
         mailer.should.have.property('send').and.be.a.Function();
     });
 
@@ -86,8 +87,8 @@ describe('Mail: Ghostmailer', function () {
         assert.equal(mailer.transport.transporter.name, 'Stub');
 
         mailer.send(mailDataNoServer).then(function (response) {
-            should.exist(response.response);
-            should.exist(response.envelope);
+            assertExists(response.response);
+            assertExists(response.envelope);
             assert(response.envelope.to.includes('joe@example.com'));
 
             done();

--- a/ghost/core/test/unit/server/services/members/importer/members-csv-importer.test.js
+++ b/ghost/core/test/unit/server/services/members/importer/members-csv-importer.test.js
@@ -3,6 +3,7 @@ const should = require('should');
 const Tier = require('../../../../../../core/server/services/tiers/tier');
 const ObjectID = require('bson-objectid').default;
 const assert = require('assert/strict');
+const {assertExists} = require('../../../../../utils/assertions');
 const fs = require('fs-extra');
 const path = require('path');
 const sinon = require('sinon');
@@ -118,15 +119,15 @@ describe('MembersCSVImporter', function () {
                 }
             });
 
-            should.exist(result.meta);
-            should.exist(result.meta.stats);
-            should.exist(result.meta.stats.imported);
+            assertExists(result.meta);
+            assertExists(result.meta.stats);
+            assertExists(result.meta.stats.imported);
             assert.equal(result.meta.stats.imported, 2);
 
-            should.exist(result.meta.stats.invalid);
+            assertExists(result.meta.stats.invalid);
             assert.equal(result.meta.import_label, null);
 
-            should.exist(result.meta.originalImportSize);
+            assertExists(result.meta.originalImportSize);
             assert.equal(result.meta.originalImportSize, 2);
 
             assert.equal(fsWriteSpy.calledOnce, true);
@@ -167,15 +168,15 @@ describe('MembersCSVImporter', function () {
                 }
             });
 
-            should.exist(result.meta);
-            should.exist(result.meta.stats);
-            should.exist(result.meta.stats.imported);
+            assertExists(result.meta);
+            assertExists(result.meta.stats);
+            assertExists(result.meta.stats.imported);
             assert.equal(result.meta.stats.imported, 2);
 
-            should.exist(result.meta.stats.invalid);
+            assertExists(result.meta.stats.invalid);
             assert.deepEqual(result.meta.import_label, internalLabel);
 
-            should.exist(result.meta.originalImportSize);
+            assertExists(result.meta.originalImportSize);
             assert.equal(result.meta.originalImportSize, 2);
 
             assert.equal(fsWriteSpy.calledOnce, true);
@@ -313,15 +314,15 @@ describe('MembersCSVImporter', function () {
                 }
             });
 
-            should.exist(result.meta);
-            should.exist(result.meta.stats);
-            should.exist(result.meta.stats.imported);
+            assertExists(result.meta);
+            assertExists(result.meta.stats);
+            assertExists(result.meta.stats.imported);
             assert.equal(result.meta.stats.imported, 5);
 
-            should.exist(result.meta.stats.invalid);
+            assertExists(result.meta.stats.invalid);
             assert.deepEqual(result.meta.import_label, internalLabel);
 
-            should.exist(result.meta.originalImportSize);
+            assertExists(result.meta.originalImportSize);
             assert.equal(result.meta.originalImportSize, 15);
 
             assert.equal(fsWriteSpy.calledOnce, true);
@@ -473,11 +474,11 @@ describe('MembersCSVImporter', function () {
 
             const result = await membersImporter.prepare(`${csvPath}/single-column-with-header.csv`, defaultAllowedFields);
 
-            should.exist(result.filePath);
+            assertExists(result.filePath);
             assert.match(result.filePath, /\/members\/importer\/fixtures\/Members Import/);
 
             assert.equal(result.batches, 2);
-            should.exist(result.metadata);
+            assertExists(result.metadata);
             assert.equal(result.metadata.hasStripeData, false);
             assert.equal(fsWriteSpy.calledOnce, true);
         });
@@ -507,7 +508,7 @@ describe('MembersCSVImporter', function () {
 
             const result = await membersImporter.prepare(`${csvPath}/member-csv-export.csv`);
 
-            should.exist(result.metadata);
+            assertExists(result.metadata);
             assert.equal(result.metadata.hasStripeData, true);
         });
     });

--- a/ghost/core/test/unit/server/services/members/members-api/services/geolocation-service.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/services/geolocation-service.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../../../../utils/assertions');
 const nock = require('nock');
 const should = require('should');
 const GeolocationService = require('../../../../../../../core/server/services/members/members-api/services/geolocation-service');
@@ -38,7 +39,7 @@ describe('lib/geolocation', function () {
             const result = await service.getGeolocationFromIP('188.39.113.90');
 
             assert.equal(scope.isDone(), true, 'request was not made');
-            should.exist(result, 'nothing was returned');
+            assertExists(result, 'nothing was returned');
             result.should.deepEqual(RESPONSE, 'result didn\'t match expected response');
         });
 
@@ -50,7 +51,7 @@ describe('lib/geolocation', function () {
             const result = await service.getGeolocationFromIP('2a01:4c8:43a:13c9:8d6:128e:1fd5:6aad');
 
             assert.equal(scope.isDone(), true, 'request was not made');
-            should.exist(result, 'nothing was returned');
+            assertExists(result, 'nothing was returned');
             result.should.deepEqual(RESPONSE, 'result didn\'t match expected response');
         });
 

--- a/ghost/core/test/unit/server/services/members/stripe-connect.test.js
+++ b/ghost/core/test/unit/server/services/members/stripe-connect.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../../utils/assertions');
 const should = require('should');
 const stripeConnect = require('../../../../../core/server/services/members/stripe-connect');
 
@@ -12,7 +13,7 @@ describe('Members - Stripe Connect', function () {
 
         should.ok(url instanceof URL, 'getStripeConnectOAuthUrl should return an instance of URL');
 
-        should.exist(session.get(stripeConnect.STATE_PROP), 'The session should have a state set');
+        assertExists(session.get(stripeConnect.STATE_PROP), 'The session should have a state set');
 
         assert.equal(url.origin, 'https://connect.stripe.com');
         assert.equal(url.pathname, '/oauth/authorize');

--- a/ghost/core/test/unit/server/services/notifications/notifications.test.js
+++ b/ghost/core/test/unit/server/services/notifications/notifications.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../../utils/assertions');
 const should = require('should');
 const sinon = require('sinon');
 
@@ -69,7 +70,7 @@ describe('Notifications Service', function () {
 
             const notifications = notificationSvc.browse({user: owner});
 
-            should.exist(notifications);
+            assertExists(notifications);
             assert.equal(notifications.length, 1);
         });
 
@@ -98,7 +99,7 @@ describe('Notifications Service', function () {
 
             const notifications = notificationSvc.browse({user: owner});
 
-            should.exist(notifications);
+            assertExists(notifications);
             assert.equal(notifications.length, 1);
         });
 
@@ -127,7 +128,7 @@ describe('Notifications Service', function () {
 
             const notifications = notificationSvc.browse({user: owner});
 
-            should.exist(notifications);
+            assertExists(notifications);
             assert.equal(notifications.length, 0);
         });
 
@@ -156,7 +157,7 @@ describe('Notifications Service', function () {
 
             const notifications = notificationSvc.browse({user: owner});
 
-            should.exist(notifications);
+            assertExists(notifications);
             assert.equal(notifications.length, 0);
         });
 
@@ -185,7 +186,7 @@ describe('Notifications Service', function () {
 
             const notifications = notificationSvc.browse({user: owner});
 
-            should.exist(notifications);
+            assertExists(notifications);
             assert.equal(notifications.length, 0);
         });
 
@@ -227,7 +228,7 @@ describe('Notifications Service', function () {
 
             const notifications = notificationSvc.browse({user: owner});
 
-            should.exist(notifications);
+            assertExists(notifications);
             assert.equal(notifications.length, 2);
             assert.equal(notifications[0].message, 'should be visible');
             assert.equal(notifications[1].message, 'visible even though without a created at property');
@@ -252,7 +253,7 @@ describe('Notifications Service', function () {
 
             const notifications = notificationSvc.browse({user: owner});
 
-            should.exist(notifications);
+            assertExists(notifications);
             assert.equal(notifications.length, 0);
 
             assert.equal(settingsModelStub.called, true);
@@ -280,7 +281,7 @@ describe('Notifications Service', function () {
 
             const notifications = notificationSvc.browse({user: owner});
 
-            should.exist(notifications);
+            assertExists(notifications);
             assert.equal(notifications.length, 1);
 
             assert.equal(settingsModelStub.called, false);

--- a/ghost/core/test/unit/server/services/offers/domain/models/offer.test.js
+++ b/ghost/core/test/unit/server/services/offers/domain/models/offer.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../../../../utils/assertions');
 const should = require('should');
 const ObjectID = require('bson-objectid').default;
 const errors = require('../../../../../../../core/server/services/offers/domain/errors');
@@ -415,20 +416,20 @@ describe('Offer', function () {
 
             const offer = await Offer.create(data, mockUniqueChecker);
 
-            should.exist(offer.id);
-            should.exist(offer.name);
-            should.exist(offer.code);
-            should.exist(offer.currency);
-            should.exist(offer.duration);
-            should.exist(offer.status);
-            should.exist(offer.redemptionCount);
-            should.exist(offer.displayTitle);
-            should.exist(offer.displayDescription);
-            should.exist(offer.tier);
-            should.exist(offer.cadence);
-            should.exist(offer.type);
-            should.exist(offer.amount);
-            should.exist(offer.isNew);
+            assertExists(offer.id);
+            assertExists(offer.name);
+            assertExists(offer.code);
+            assertExists(offer.currency);
+            assertExists(offer.duration);
+            assertExists(offer.status);
+            assertExists(offer.redemptionCount);
+            assertExists(offer.displayTitle);
+            assertExists(offer.displayDescription);
+            assertExists(offer.tier);
+            assertExists(offer.cadence);
+            assertExists(offer.type);
+            assertExists(offer.amount);
+            assertExists(offer.isNew);
         });
     });
 

--- a/ghost/core/test/unit/server/services/permissions/index.test.js
+++ b/ghost/core/test/unit/server/services/permissions/index.test.js
@@ -1,3 +1,4 @@
+const {assertExists} = require('../../../../utils/assertions');
 const should = require('should');
 const sinon = require('sinon');
 const testUtils = require('../../../../utils');
@@ -76,7 +77,7 @@ describe('Permissions', function () {
             fakePermissions = loadFakePermissions();
 
             permissions.init().then(function (actions) {
-                should.exist(actions);
+                assertExists(actions);
 
                 permissions.canThis.should.not.throwError();
 
@@ -95,7 +96,7 @@ describe('Permissions', function () {
             fakePermissions = loadFakePermissions({extra: true});
 
             permissions.init().then(function (actions) {
-                should.exist(actions);
+                assertExists(actions);
 
                 permissions.canThis.should.not.throwError();
 

--- a/ghost/core/test/unit/server/services/route-settings/settings-loader.test.js
+++ b/ghost/core/test/unit/server/services/route-settings/settings-loader.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../../utils/assertions');
 const sinon = require('sinon');
 const should = require('should');
 const rewire = require('rewire');
@@ -53,7 +54,7 @@ describe('UNIT > SettingsLoader:', function () {
             const fsReadFileStub = sinon.stub(fs, 'readFile').returns(settingsStubFile);
 
             const result = await settingsLoader.loadSettings();
-            should.exist(result);
+            assertExists(result);
             result.should.be.an.Object().with.properties('routes', 'collections', 'taxonomies');
             assert.equal(fsReadFileStub.calledOnce, true);
         });
@@ -73,7 +74,7 @@ describe('UNIT > SettingsLoader:', function () {
                 settingFilePath: expectedSettingsFile
             });
             const setting = await settingsLoader.loadSettings();
-            should.exist(setting);
+            assertExists(setting);
             setting.should.be.an.Object().with.properties('routes', 'collections', 'taxonomies');
 
             assert.equal(fsReadFileSpy.calledOnce, true);
@@ -96,7 +97,7 @@ describe('UNIT > SettingsLoader:', function () {
                 await settingsLoader.loadSettings();
                 throw new Error('Should have failed already');
             } catch (err) {
-                should.exist(err);
+                assertExists(err);
                 err.message.should.be.eql('could not parse yaml file');
                 err.context.should.be.eql('bad indentation of a mapping entry at line 5, column 10');
                 assert.equal(yamlParserStub.calledOnce, true);

--- a/ghost/core/test/unit/server/services/route-settings/settings-path-manager.test.js
+++ b/ghost/core/test/unit/server/services/route-settings/settings-path-manager.test.js
@@ -1,5 +1,6 @@
 // Switch these lines once there are useful utils
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../../utils/assertions');
 // const testUtils = require('./utils');
 const should = require('should');
 const SettingsPathManager = require('../../../../../core/server/services/route-settings/settings-path-manager');
@@ -14,7 +15,7 @@ describe('Settings Path Manager', function () {
 
             should.fail(settingsPathManager, 'Should have errored');
         } catch (err) {
-            should.exist(err);
+            assertExists(err);
             assert.match(err.message, /paths values/g);
         }
     });

--- a/ghost/core/test/unit/server/services/route-settings/yaml-parser.test.js
+++ b/ghost/core/test/unit/server/services/route-settings/yaml-parser.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../../utils/assertions');
 const sinon = require('sinon');
 const should = require('should');
 const fs = require('fs-extra');
@@ -22,7 +23,7 @@ describe('UNIT > Settings Service yaml parser:', function () {
             const file = fs.readFileSync(path.join(__dirname, '../../../../utils/fixtures/settings/', 'goodroutes.yaml'), 'utf8');
 
             const result = yamlParser(file);
-            should.exist(result);
+            assertExists(result);
             result.should.be.an.Object().with.properties('routes', 'collections', 'taxonomies');
             assert.equal(yamlSpy.calledOnce, true);
         });
@@ -34,7 +35,7 @@ describe('UNIT > Settings Service yaml parser:', function () {
                 const result = yamlParser(file);
                 assert.equal(result, undefined);
             } catch (error) {
-                should.exist(error);
+                assertExists(error);
                 assert.equal(error.message, 'Could not parse provided YAML file: bad indentation of a mapping entry.');
                 assert(error.context.includes('bad indentation of a mapping entry (5:14)'));
                 assert.equal(error.help, 'Check provided file for typos and fix the named issues.');

--- a/ghost/core/test/unit/server/services/settings/default-settings-manager.test.js
+++ b/ghost/core/test/unit/server/services/settings/default-settings-manager.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../../utils/assertions');
 const sinon = require('sinon');
 const should = require('should');
 const fs = require('fs-extra');
@@ -78,7 +79,7 @@ describe('UNIT > Settings Service DefaultSettingsManager:', function () {
                 await defaultSettingsManager.ensureSettingsFileExists();
                 throw new Error('Expected test to fail');
             } catch (error) {
-                should.exist(error);
+                assertExists(error);
                 error.message.should.be.eql(`Error trying to access settings files in ${destinationFolderPath}.`);
                 assert.equal(fsReadFileStub.calledOnce, true);
                 assert.equal(fsCopyStub.called, false);

--- a/ghost/core/test/unit/server/services/stats/content.test.js
+++ b/ghost/core/test/unit/server/services/stats/content.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../../utils/assertions');
 const sinon = require('sinon');
 const should = require('should');
 const ContentStatsService = require('../../../../../core/server/services/stats/content-stats-service');
@@ -69,7 +70,7 @@ describe('ContentStatsService', function () {
 
             const result = mockTinybirdClient.buildRequest('api_top_pages', options);
 
-            should.exist(result.url);
+            assertExists(result.url);
             result.url.should.startWith('https://api.tinybird.co/v0/pipes/api_top_pages.json?');
             assert(result.url.includes('site_uuid=site-id'));
             assert(result.url.includes('date_from=2023-01-01'));
@@ -77,8 +78,8 @@ describe('ContentStatsService', function () {
             assert(result.url.includes('timezone=UTC'));
             assert(result.url.includes('member_status=all'));
 
-            should.exist(result.options);
-            should.exist(result.options.headers);
+            assertExists(result.options);
+            assertExists(result.options.headers);
             assert.equal(result.options.headers.Authorization, 'Bearer tb-token');
 
             assert.equal(mockTinybirdClient.buildRequest.calledWith('api_top_pages', options), true);
@@ -100,7 +101,7 @@ describe('ContentStatsService', function () {
             ]);
 
             const result = mockTinybirdClient.parseResponse(mockResponse);
-            should.exist(result);
+            assertExists(result);
             result.should.be.an.Array().with.lengthOf(2);
 
             assert.equal(mockTinybirdClient.parseResponse.calledWith(mockResponse), true);
@@ -115,7 +116,7 @@ describe('ContentStatsService', function () {
             ];
 
             const result = service.extractPostUuids(data);
-            should.exist(result);
+            assertExists(result);
             result.should.be.an.Array().with.lengthOf(2);
             assert(result.includes('post-1'));
             assert(result.includes('post-2'));
@@ -129,7 +130,7 @@ describe('ContentStatsService', function () {
             ];
 
             const result = service.extractPostUuids(data);
-            should.exist(result);
+            assertExists(result);
             result.should.be.an.Array().with.lengthOf(0);
         });
     });
@@ -137,14 +138,14 @@ describe('ContentStatsService', function () {
     describe('lookupPostTitles', function () {
         it('returns empty object for empty UUIDs array', async function () {
             const result = await service.lookupPostTitles([]);
-            should.exist(result);
+            assertExists(result);
             assert.equal(Object.keys(result).length, 0);
         });
 
         it('queries database and builds title map', async function () {
             const result = await service.lookupPostTitles(['post-1', 'post-2']);
 
-            should.exist(result);
+            assertExists(result);
             result.should.have.properties(['post-1', 'post-2']);
             result['post-1'].should.have.property('title', 'Test Post 1');
             result['post-1'].should.have.property('id', 'post-id-1');
@@ -179,7 +180,7 @@ describe('ContentStatsService', function () {
             });
 
             const result = service.getResourceTitle('/about/');
-            should.exist(result);
+            assertExists(result);
             result.should.have.properties(['title', 'resourceType']);
             assert.equal(result.title, 'About Us');
             assert.equal(result.resourceType, 'page');
@@ -194,7 +195,7 @@ describe('ContentStatsService', function () {
             });
 
             const result = service.getResourceTitle('/tag/news/');
-            should.exist(result);
+            assertExists(result);
             result.should.have.properties(['title', 'resourceType']);
             assert.equal(result.title, 'News');
             assert.equal(result.resourceType, 'tag');
@@ -225,7 +226,7 @@ describe('ContentStatsService', function () {
 
         it('returns empty array for empty input', async function () {
             const result = await service.enrichTopContentData([]);
-            should.exist(result);
+            assertExists(result);
             result.should.be.an.Array().with.lengthOf(0);
 
             assert.equal(service.extractPostUuids.called, false);
@@ -244,7 +245,7 @@ describe('ContentStatsService', function () {
 
             const result = await service.enrichTopContentData(data);
 
-            should.exist(result);
+            assertExists(result);
             result.should.be.an.Array().with.lengthOf(2);
             assert.equal(result[0].title, 'Test Post 1');
             assert.equal(result[0].post_id, 'post-id-1');
@@ -271,7 +272,7 @@ describe('ContentStatsService', function () {
 
             const result = await service.enrichTopContentData(data);
 
-            should.exist(result);
+            assertExists(result);
             result.should.be.an.Array().with.lengthOf(1);
             assert.equal(result[0].title, 'About Us');
             assert.equal(result[0].resourceType, 'page');
@@ -289,7 +290,7 @@ describe('ContentStatsService', function () {
 
             const result = await service.enrichTopContentData(data);
 
-            should.exist(result);
+            assertExists(result);
             result.should.be.an.Array().with.lengthOf(1);
             assert.equal(result[0].title, 'unknown-page');
             assert.equal(result[0].url_exists, false);
@@ -306,7 +307,7 @@ describe('ContentStatsService', function () {
 
             const result = await service.enrichTopContentData(data);
 
-            should.exist(result);
+            assertExists(result);
             result.should.be.an.Array().with.lengthOf(1);
             assert.equal(result[0].title, 'Homepage');
             assert.equal(result[0].url_exists, false);
@@ -329,7 +330,7 @@ describe('ContentStatsService', function () {
 
             const result = await service.fetchRawTopContentData(options);
 
-            should.exist(result);
+            assertExists(result);
             result.should.be.an.Array().with.lengthOf(1);
             assert.equal(result[0].pathname, '/test/');
             assert.equal(result[0].visits, 100);
@@ -386,8 +387,8 @@ describe('ContentStatsService', function () {
                 date_to: '2023-01-31'
             });
 
-            should.exist(result);
-            should.exist(result.data);
+            assertExists(result);
+            assertExists(result.data);
             result.data.should.be.an.Array().with.lengthOf(2);
             result.data[0].should.have.property('title');
             result.data[0].should.have.property('post_id');
@@ -410,8 +411,8 @@ describe('ContentStatsService', function () {
                 date_to: '2023-01-31'
             });
 
-            should.exist(result);
-            should.exist(result.data);
+            assertExists(result);
+            assertExists(result.data);
             result.data.should.be.an.Array().with.lengthOf(0);
 
             assert.equal(service.fetchRawTopContentData.calledOnce, true);
@@ -425,8 +426,8 @@ describe('ContentStatsService', function () {
                 date_to: '2023-01-31'
             });
 
-            should.exist(result);
-            should.exist(result.data);
+            assertExists(result);
+            assertExists(result.data);
             result.data.should.be.an.Array().with.lengthOf(0);
         });
 
@@ -442,8 +443,8 @@ describe('ContentStatsService', function () {
                 date_to: '2023-01-31'
             });
 
-            should.exist(result);
-            should.exist(result.data);
+            assertExists(result);
+            assertExists(result.data);
             result.data.should.be.an.Array().with.lengthOf(0);
         });
     });
@@ -466,7 +467,7 @@ describe('ContentStatsService', function () {
             const result = await service.fetchRawTopContentData(options);
 
             // Verify result is correct
-            should.exist(result);
+            assertExists(result);
             result.should.be.an.Array().with.lengthOf(2);
 
             // Verify tinybird client was called with correct parameters
@@ -485,7 +486,7 @@ describe('ContentStatsService', function () {
 
             const result = await service.getTopContent({});
 
-            should.exist(result);
+            assertExists(result);
             result.should.have.property('data').which.is.an.Array().with.lengthOf(0);
         });
 

--- a/ghost/core/test/unit/server/services/stats/utils/tinybird.test.js
+++ b/ghost/core/test/unit/server/services/stats/utils/tinybird.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../../../utils/assertions');
 const sinon = require('sinon');
 const should = require('should');
 const tinybird = require('../../../../../../core/server/services/stats/utils/tinybird');
@@ -58,7 +59,7 @@ describe('Tinybird Client', function () {
                 dateTo: '2023-01-31'
             });
 
-            should.exist(url);
+            assertExists(url);
             url.should.startWith('https://api.tinybird.co/v0/pipes/test_pipe.json?');
             assert(url.includes('site_uuid=931ade9e-a4f1-4217-8625-34bd34250c16'));
             assert(url.includes('date_from=2023-01-01'));
@@ -66,8 +67,8 @@ describe('Tinybird Client', function () {
             // assert(url.includes('timezone=UTC'));
             // assert(url.includes('member_status=all'));
 
-            should.exist(options);
-            should.exist(options.headers);
+            assertExists(options);
+            assertExists(options.headers);
             assert.equal(options.headers.Authorization, 'Bearer mock-jwt-token');
         });
 
@@ -131,7 +132,7 @@ describe('Tinybird Client', function () {
             };
 
             const result = tinybirdClient.parseResponse(mockResponse);
-            should.exist(result);
+            assertExists(result);
             result.should.be.an.Array().with.lengthOf(2);
             assert.equal(result[0].pathname, '/test-1/');
             assert.equal(result[0].visits, 100);
@@ -148,7 +149,7 @@ describe('Tinybird Client', function () {
             };
 
             const result = tinybirdClient.parseResponse(mockResponse);
-            should.exist(result);
+            assertExists(result);
             result.should.be.an.Array().with.lengthOf(2);
         });
 
@@ -160,7 +161,7 @@ describe('Tinybird Client', function () {
             });
 
             const result = tinybirdClient.parseResponse(mockResponse);
-            should.exist(result);
+            assertExists(result);
             result.should.be.an.Array().with.lengthOf(1);
         });
 
@@ -172,7 +173,7 @@ describe('Tinybird Client', function () {
             };
 
             const result = tinybirdClient.parseResponse(mockResponse);
-            should.exist(result);
+            assertExists(result);
             result.should.be.an.Array().with.lengthOf(1);
         });
 
@@ -182,7 +183,7 @@ describe('Tinybird Client', function () {
             };
 
             const result = tinybirdClient.parseResponse(mockResponse);
-            should.exist(result);
+            assertExists(result);
             result.should.be.an.Array().with.lengthOf(0);
         });
 
@@ -213,7 +214,7 @@ describe('Tinybird Client', function () {
                 dateTo: '2023-01-31'
             });
 
-            should.exist(result);
+            assertExists(result);
             result.should.be.an.Array().with.lengthOf(2);
             assert.equal(result[0].pathname, '/test-1/');
             assert.equal(result[0].visits, 100);

--- a/ghost/core/test/unit/server/services/stripe/config.test.js
+++ b/ghost/core/test/unit/server/services/stripe/config.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../../utils/assertions');
 const should = require('should');
 const sinon = require('sinon');
 const UrlUtils = require('@tryghost/url-utils');
@@ -65,10 +66,10 @@ describe('Stripe - config', function () {
         assert.equal(config.publicKey, 'direct_publishable');
         assert.equal(config.webhookHandlerUrl, 'http://site.com/subdir/members/webhooks/stripe/');
 
-        should.exist(config.checkoutSessionSuccessUrl);
-        should.exist(config.checkoutSessionCancelUrl);
-        should.exist(config.checkoutSetupSessionSuccessUrl);
-        should.exist(config.checkoutSetupSessionCancelUrl);
-        should.exist(config.billingPortalReturnUrl);
+        assertExists(config.checkoutSessionSuccessUrl);
+        assertExists(config.checkoutSessionCancelUrl);
+        assertExists(config.checkoutSetupSessionSuccessUrl);
+        assertExists(config.checkoutSetupSessionCancelUrl);
+        assertExists(config.billingPortalReturnUrl);
     });
 });

--- a/ghost/core/test/unit/server/services/stripe/stripe-api.test.js
+++ b/ghost/core/test/unit/server/services/stripe/stripe-api.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../../utils/assertions');
 const sinon = require('sinon');
 const should = require('should');
 const rewire = require('rewire');
@@ -60,8 +61,8 @@ describe('StripeAPI', function () {
         it('sends success_url and cancel_url', async function () {
             await api.createCheckoutSession('priceId', null, {});
 
-            should.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.success_url);
-            should.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.cancel_url);
+            assertExists(mockStripe.checkout.sessions.create.firstCall.firstArg.success_url);
+            assertExists(mockStripe.checkout.sessions.create.firstCall.firstArg.cancel_url);
         });
 
         it('sets valid trialDays', async function () {
@@ -70,14 +71,14 @@ describe('StripeAPI', function () {
             });
 
             assert.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.subscription_data.trial_from_plan, undefined);
-            should.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.subscription_data.trial_period_days);
+            assertExists(mockStripe.checkout.sessions.create.firstCall.firstArg.subscription_data.trial_period_days);
             assert.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.subscription_data.trial_period_days, 12);
         });
 
         it('uses trial_from_plan without trialDays', async function () {
             await api.createCheckoutSession('priceId', null, {});
 
-            should.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.subscription_data.trial_from_plan);
+            assertExists(mockStripe.checkout.sessions.create.firstCall.firstArg.subscription_data.trial_from_plan);
             assert.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.subscription_data.trial_from_plan, true);
             assert.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.subscription_data.trial_period_days, undefined);
         });
@@ -87,7 +88,7 @@ describe('StripeAPI', function () {
                 trialDays: 0
             });
 
-            should.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.subscription_data.trial_from_plan);
+            assertExists(mockStripe.checkout.sessions.create.firstCall.firstArg.subscription_data.trial_from_plan);
             assert.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.subscription_data.trial_from_plan, true);
             assert.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.subscription_data.trial_period_days, undefined);
         });
@@ -97,7 +98,7 @@ describe('StripeAPI', function () {
                 trialDays: null
             });
 
-            should.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.subscription_data.trial_from_plan);
+            assertExists(mockStripe.checkout.sessions.create.firstCall.firstArg.subscription_data.trial_from_plan);
             assert.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.subscription_data.trial_from_plan, true);
             assert.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.subscription_data.trial_period_days, undefined);
         });
@@ -113,7 +114,7 @@ describe('StripeAPI', function () {
                 trialDays: null
             });
 
-            should.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.customer);
+            assertExists(mockStripe.checkout.sessions.create.firstCall.firstArg.customer);
             assert.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.customer, 'cust_mock_123456');
         });
 
@@ -123,7 +124,7 @@ describe('StripeAPI', function () {
                 trialDays: null
             });
 
-            should.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.customer_email);
+            assertExists(mockStripe.checkout.sessions.create.firstCall.firstArg.customer_email);
             assert.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.customer_email, 'foo@example.com');
         });
 
@@ -137,7 +138,7 @@ describe('StripeAPI', function () {
                 trialDays: null
             });
 
-            should.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.customer_email);
+            assertExists(mockStripe.checkout.sessions.create.firstCall.firstArg.customer_email);
             assert.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.customer_email, 'foo@example.com');
         });
 
@@ -153,7 +154,7 @@ describe('StripeAPI', function () {
             });
 
             assert.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.customer_email, undefined);
-            should.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.customer);
+            assertExists(mockStripe.checkout.sessions.create.firstCall.firstArg.customer);
             assert.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.customer, 'cust_mock_123456');
         });
 
@@ -224,8 +225,8 @@ describe('StripeAPI', function () {
         it('createCheckoutSetupSession sends success_url and cancel_url', async function () {
             await api.createCheckoutSetupSession('priceId', {});
 
-            should.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.success_url);
-            should.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.cancel_url);
+            assertExists(mockStripe.checkout.sessions.create.firstCall.firstArg.success_url);
+            assertExists(mockStripe.checkout.sessions.create.firstCall.firstArg.cancel_url);
         });
 
         it('createCheckoutSetupSession does not send currency if additionalPaymentMethods flag is off', async function () {
@@ -463,7 +464,7 @@ describe('StripeAPI', function () {
             await api.createCheckoutSession('priceId', mockCustomer, {
                 trialDays: null
             });
-            should.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.customer_update);
+            assertExists(mockStripe.checkout.sessions.create.firstCall.firstArg.customer_update);
         });
 
         it('createCheckoutSession does not add customer_update if automatic tax flag is enabled and customer is undefined', async function () {
@@ -523,8 +524,8 @@ describe('StripeAPI', function () {
         it('createDonationCheckoutSession sends success_url and cancel_url', async function () {
             await api.createDonationCheckoutSession('priceId', {});
 
-            should.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.success_url);
-            should.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.cancel_url);
+            assertExists(mockStripe.checkout.sessions.create.firstCall.firstArg.success_url);
+            assertExists(mockStripe.checkout.sessions.create.firstCall.firstArg.cancel_url);
         });
 
         it('createDonationCheckoutSession does not send currency if additionalPaymentMethods flag is off', async function () {
@@ -549,7 +550,7 @@ describe('StripeAPI', function () {
                 customer: mockCustomer
             });
 
-            should.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.customer);
+            assertExists(mockStripe.checkout.sessions.create.firstCall.firstArg.customer);
             assert.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.customer, mockCustomerId);
         });
 
@@ -562,7 +563,7 @@ describe('StripeAPI', function () {
                 customerEmail: mockCustomerEmail
             });
 
-            should.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.customer_email);
+            assertExists(mockStripe.checkout.sessions.create.firstCall.firstArg.customer_email);
             assert.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.customer_email, mockCustomerEmail);
         });
 
@@ -582,7 +583,7 @@ describe('StripeAPI', function () {
                 customerEmail: 'another_email@example.com'
             });
 
-            should.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.customer);
+            assertExists(mockStripe.checkout.sessions.create.firstCall.firstArg.customer);
             assert.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.customer, mockCustomerId);
             assert.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.customer_email, undefined);
         });
@@ -601,7 +602,7 @@ describe('StripeAPI', function () {
                 customerEmail: mockCustomerEmail
             });
 
-            should.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.metadata);
+            assertExists(mockStripe.checkout.sessions.create.firstCall.firstArg.metadata);
             assert.deepEqual(mockStripe.checkout.sessions.create.firstCall.firstArg.metadata, metadata);
         });
 
@@ -615,7 +616,7 @@ describe('StripeAPI', function () {
                 customerEmail: mockCustomerEmail
             });
 
-            should.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.custom_fields);
+            assertExists(mockStripe.checkout.sessions.create.firstCall.firstArg.custom_fields);
             const customFields = mockStripe.checkout.sessions.create.firstCall.firstArg.custom_fields;
             assert.equal(customFields.length, 1);
         });

--- a/ghost/core/test/unit/server/services/themes/list.test.js
+++ b/ghost/core/test/unit/server/services/themes/list.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../../utils/assertions');
 const should = require('should');
 const sinon = require('sinon');
 const _ = require('lodash');
@@ -44,19 +45,19 @@ describe('Themes', function () {
         });
 
         it('del() removes a key from the list', function () {
-            should.exist(themeList.get('casper'));
-            should.exist(themeList.get('not-casper'));
+            assertExists(themeList.get('casper'));
+            assertExists(themeList.get('not-casper'));
             themeList.del('casper');
             assert.equal(themeList.get('casper'), undefined);
-            should.exist(themeList.get('not-casper'));
+            assertExists(themeList.get('not-casper'));
         });
 
         it('del() with no argument does nothing', function () {
-            should.exist(themeList.get('casper'));
-            should.exist(themeList.get('not-casper'));
+            assertExists(themeList.get('casper'));
+            assertExists(themeList.get('not-casper'));
             themeList.del();
-            should.exist(themeList.get('casper'));
-            should.exist(themeList.get('not-casper'));
+            assertExists(themeList.get('casper'));
+            assertExists(themeList.get('not-casper'));
         });
 
         it('init() calls set for each theme', function () {
@@ -71,7 +72,7 @@ describe('Themes', function () {
         it('init() with empty object resets the list', function () {
             themeList.init();
             const result = themeList.getAll();
-            should.exist(result);
+            assertExists(result);
             result.should.be.an.Object();
             result.should.eql({});
             assert.equal(Object.keys(result).length, 0);

--- a/ghost/core/test/unit/server/services/url/queue.test.js
+++ b/ghost/core/test/unit/server/services/url/queue.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../../utils/assertions');
 const _ = require('lodash');
 const should = require('should');
 const sinon = require('sinon');
@@ -28,7 +29,7 @@ describe('Unit: services/url/Queue', function () {
             event: 'chocolate'
         }, null);
 
-        should.exist(queue.queue.chocolate);
+        assertExists(queue.queue.chocolate);
         assert.equal(queue.queue.chocolate.subscribers.length, 1);
 
         queue.register({
@@ -41,8 +42,8 @@ describe('Unit: services/url/Queue', function () {
             event: 'nachos'
         }, null);
 
-        should.exist(queue.queue.chocolate);
-        should.exist(queue.queue.nachos);
+        assertExists(queue.queue.chocolate);
+        assertExists(queue.queue.nachos);
 
         assert.equal(queue.queue.chocolate.subscribers.length, 2);
         assert.equal(queue.queue.nachos.subscribers.length, 1);

--- a/ghost/core/test/unit/server/services/url/url-service.test.js
+++ b/ghost/core/test/unit/server/services/url/url-service.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../../utils/assertions');
 const errors = require('@tryghost/errors');
 const rewire = require('rewire');
 const should = require('should');
@@ -42,10 +43,10 @@ describe('Unit: services/url/UrlService', function () {
     });
 
     it('instantiate', function () {
-        should.exist(urlService.utils);
-        should.exist(urlService.urls);
-        should.exist(urlService.resources);
-        should.exist(urlService.queue);
+        assertExists(urlService.utils);
+        assertExists(urlService.urls);
+        assertExists(urlService.resources);
+        assertExists(urlService.queue);
 
         urlService.urlGenerators.should.eql([]);
         assert.equal(urlService.hasFinished(), false);
@@ -80,7 +81,7 @@ describe('Unit: services/url/UrlService', function () {
             assert.equal(urlService.getResourceById('id12345'), true);
             done(new Error('expected error'));
         } catch (err) {
-            should.exist(err);
+            assertExists(err);
             assert.equal(err.code, 'URLSERVICE_RESOURCE_NOT_FOUND');
             done();
         }

--- a/ghost/core/test/unit/server/services/url/urls.test.js
+++ b/ghost/core/test/unit/server/services/url/urls.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../../utils/assertions');
 const should = require('should');
 const sinon = require('sinon');
 const events = require('../../../../../core/server/lib/common/events');
@@ -64,11 +65,11 @@ describe('Unit: services/url/Urls', function () {
             generatorId: 1
         });
 
-        should.exist(eventsToRemember['url.added']);
+        assertExists(eventsToRemember['url.added']);
         assert.equal(eventsToRemember['url.added'].url.absolute, 'http://127.0.0.1:2369/test/');
         assert.equal(eventsToRemember['url.added'].url.relative, '/test/');
-        should.exist(eventsToRemember['url.added'].resource);
-        should.exist(eventsToRemember['url.added'].resource.data);
+        assertExists(eventsToRemember['url.added'].resource);
+        assertExists(eventsToRemember['url.added'].resource.data);
 
         assert.equal(urls.getByResourceId('object-id-x').resource.data.slug, 'a');
 
@@ -85,14 +86,14 @@ describe('Unit: services/url/Urls', function () {
             generatorId: 1
         });
 
-        should.exist(eventsToRemember['url.added']);
+        assertExists(eventsToRemember['url.added']);
 
         assert.equal(urls.getByResourceId('object-id-x').resource.data.slug, 'b');
     });
 
     it('fn: getByResourceId', function () {
         assert.equal(urls.getByResourceId('object-id-2').url, '/something/');
-        should.exist(urls.getByResourceId('object-id-2').generatorId);
+        assertExists(urls.getByResourceId('object-id-2').generatorId);
         assert.equal(urls.getByResourceId('object-id-2').generatorId, 1);
     });
 

--- a/ghost/core/test/unit/server/web/api/canary/content/middleware.test.js
+++ b/ghost/core/test/unit/server/web/api/canary/content/middleware.test.js
@@ -1,10 +1,11 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../../../../utils/assertions');
 const should = require('should');
 const middleware = require('../../../../../../../core/server/web/api/endpoints/content/middleware');
 
 describe('Content API middleware', function () {
     it('exports an authenticatePublic middleware', function () {
-        should.exist(middleware.authenticatePublic);
+        assertExists(middleware.authenticatePublic);
     });
 
     describe('authenticatePublic', function () {

--- a/ghost/core/test/unit/server/web/parent/middleware/ghost-locals.test.js
+++ b/ghost/core/test/unit/server/web/parent/middleware/ghost-locals.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../../../utils/assertions');
 const should = require('should');
 const sinon = require('sinon');
 const ghostLocals = require('../../../../../../core/server/web/parent/middleware/ghost-locals');
@@ -25,8 +26,8 @@ describe('Theme Handler', function () {
             ghostLocals(req, res, next);
 
             res.locals.should.be.an.Object();
-            should.exist(res.locals.version);
-            should.exist(res.locals.safeVersion);
+            assertExists(res.locals.version);
+            assertExists(res.locals.safeVersion);
             res.locals.relativeUrl.should.equal(req.path);
             assert.equal(next.called, true);
         });

--- a/ghost/core/test/unit/server/web/parent/middleware/request-id.test.js
+++ b/ghost/core/test/unit/server/web/parent/middleware/request-id.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {assertExists} = require('../../../../../utils/assertions');
 const should = require('should');
 const sinon = require('sinon');
 const validator = require('@tryghost/validator');
@@ -31,7 +32,7 @@ describe('Request ID middleware', function () {
 
         requestId(req, res, next);
 
-        should.exist(req.requestId);
+        assertExists(req.requestId);
         assert.equal(validator.isUUID(req.requestId), true);
         assert.equal(res.set.calledOnce, false);
     });
@@ -42,7 +43,7 @@ describe('Request ID middleware', function () {
 
         requestId(req, res, next);
 
-        should.exist(req.requestId);
+        assertExists(req.requestId);
         assert.equal(req.requestId, 'abcd');
         assert.equal(res.set.calledOnce, true);
         assert.equal(res.set.calledWith('X-Request-ID', 'abcd'), true);

--- a/ghost/core/test/utils/assertions.js
+++ b/ghost/core/test/utils/assertions.js
@@ -1,6 +1,19 @@
 const assert = require('node:assert/strict');
 const {snapshotManager} = require('@tryghost/express-test').snapshot;
 
+/**
+ * @template T
+ * @param {T} value
+ * @param {string} [message]
+ * @returns {asserts value is NonNullable<T>}
+ */
+function assertExists(value, message = 'Value should exist') {
+    assert(
+        (value !== undefined) && (value !== null),
+        message
+    );
+}
+
 function assertMatchSnapshot(obj, properties) {
     const result = snapshotManager.match(obj, properties);
     assert(result.pass, result.message());
@@ -24,6 +37,7 @@ function assertObjectMatches(obj, properties, message) {
 }
 
 module.exports = {
+    assertExists,
     assertMatchSnapshot,
     assertObjectMatches
 };


### PR DESCRIPTION
no ref

*This test-only change should have no user impact.*

This replaces `should.exist(value)` with a new assertion helper, `assertExists(value)`.
