### PR TITLE
Added delay to dev script

### DIFF
--- a/.github/scripts/dev.js
+++ b/.github/scripts/dev.js
@@ -286,6 +286,12 @@ async function handleStripe() {
     await exec("yarn nx daemon --start");
     debug('nx daemon started');
 
+    // Wait for daemon to be fully ready by verifying it responds
+    debug('verifying daemon is ready');
+    await new Promise(resolve => setTimeout(resolve, 200));
+    await exec("yarn nx daemon --version");
+    debug('daemon verified ready');
+
     console.log(`Running projects: ${commands.map(c => chalk.green(c.name)).join(', ')}`);
 
     debug('creating concurrently promise');


### PR DESCRIPTION
no ref

On particularly fast systems, nx can trip over itself. This delay helps add resiliency.