### PR TITLE
Added Playwright report download command to browser tests CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -398,6 +398,11 @@ jobs:
         path: ghost/core/playwright-report
         retention-days: 30
 
+    - name: View Test Report command
+      if: failure()
+      run: |
+        echo -e "::notice::To view the Playwright report locally, run:\n\nREPORT_DIR=\$(mktemp -d) && gh run download ${{ github.run_id }} -n browser-tests-playwright-report -D \"\$REPORT_DIR\" && npx playwright show-report \"\$REPORT_DIR\""
+
   job_perf-tests:
     runs-on:
       labels: ubuntu-latest-4-cores


### PR DESCRIPTION
## Summary

- Added a "View Test Report command" step to the browser tests CI job, matching the existing pattern in the e2e test merge reports job
- On failure, outputs a `::notice` with a single-line command to download and view the Playwright report locally
- Uses the `browser-tests-playwright-report` artifact name