### PR TITLE
Replace more Should.js calls with `node:assert`

### DIFF
--- a/ghost/core/test/e2e-api/admin/integrations.test.js
+++ b/ghost/core/test/e2e-api/admin/integrations.test.js
@@ -85,7 +85,7 @@ describe('Integrations API', function () {
         assert.equal(secret.length, 64);
 
         assertExists(res.headers.location);
-        res.headers.location.should.equal(`http://127.0.0.1:2369${localUtils.API.getApiQuery('integrations/')}${res.body.integrations[0].id}/`);
+        assert.equal(res.headers.location, `http://127.0.0.1:2369${localUtils.API.getApiQuery('integrations/')}${res.body.integrations[0].id}/`);
     });
 
     it('Can successfully create a single integration with a webhook', async function () {
@@ -115,7 +115,7 @@ describe('Integrations API', function () {
         assert.equal(webhook.integration_id, integration.id);
 
         assertExists(res.headers.location);
-        res.headers.location.should.equal(`http://127.0.0.1:2369${localUtils.API.getApiQuery('integrations/')}${res.body.integrations[0].id}/`);
+        assert.equal(res.headers.location, `http://127.0.0.1:2369${localUtils.API.getApiQuery('integrations/')}${res.body.integrations[0].id}/`);
     });
 
     it('Can successfully get a created integration', async function () {

--- a/ghost/core/test/e2e-api/admin/invites.test.js
+++ b/ghost/core/test/e2e-api/admin/invites.test.js
@@ -94,7 +94,7 @@ describe('Invites API', function () {
             assert.equal(mailService.GhostMailer.prototype.send.called, true);
 
             assertExists(res.headers.location);
-            res.headers.location.should.equal(`http://127.0.0.1:2369${localUtils.API.getApiQuery('invites/')}${res.body.invites[0].id}/`);
+            assert.equal(res.headers.location, `http://127.0.0.1:2369${localUtils.API.getApiQuery('invites/')}${res.body.invites[0].id}/`);
         });
 
         it('Can destroy an existing invite', async function () {
@@ -158,7 +158,7 @@ describe('Invites API', function () {
             assert.equal(mailService.GhostMailer.prototype.send.called, true);
 
             assertExists(res.headers.location);
-            res.headers.location.should.equal(`http://127.0.0.1:2369${localUtils.API.getApiQuery('invites/')}${res.body.invites[0].id}/`);
+            assert.equal(res.headers.location, `http://127.0.0.1:2369${localUtils.API.getApiQuery('invites/')}${res.body.invites[0].id}/`);
         });
 
         it('Can add a new invite by API Key with the Editor Role', async function () {
@@ -185,7 +185,7 @@ describe('Invites API', function () {
             assert.equal(mailService.GhostMailer.prototype.send.called, true);
 
             assertExists(res.headers.location);
-            res.headers.location.should.equal(`http://127.0.0.1:2369${localUtils.API.getApiQuery('invites/')}${res.body.invites[0].id}/`);
+            assert.equal(res.headers.location, `http://127.0.0.1:2369${localUtils.API.getApiQuery('invites/')}${res.body.invites[0].id}/`);
         });
 
         it('Can add a new invite by API Key with the Contributor Role', async function () {
@@ -212,7 +212,7 @@ describe('Invites API', function () {
             assert.equal(mailService.GhostMailer.prototype.send.called, true);
 
             assertExists(res.headers.location);
-            res.headers.location.should.equal(`http://127.0.0.1:2369${localUtils.API.getApiQuery('invites/')}${res.body.invites[0].id}/`);
+            assert.equal(res.headers.location, `http://127.0.0.1:2369${localUtils.API.getApiQuery('invites/')}${res.body.invites[0].id}/`);
         });
 
         it('Can add a new invite by API Key with the Super Editor Role', async function () {
@@ -239,7 +239,7 @@ describe('Invites API', function () {
             assert.equal(mailService.GhostMailer.prototype.send.called, true);
 
             assertExists(res.headers.location);
-            res.headers.location.should.equal(`http://127.0.0.1:2369${localUtils.API.getApiQuery('invites/')}${res.body.invites[0].id}/`);
+            assert.equal(res.headers.location, `http://127.0.0.1:2369${localUtils.API.getApiQuery('invites/')}${res.body.invites[0].id}/`);
         });
 
         it('Can not add a new invite by API Key with the Administrator Role', async function () {

--- a/ghost/core/test/e2e-api/admin/max-limit-cap.test.js
+++ b/ghost/core/test/e2e-api/admin/max-limit-cap.test.js
@@ -188,8 +188,8 @@ describe('Admin API - Max Limit Cap', function () {
                 .expectStatus(200);
 
             // Even though we requested 10, we should only get max 5
-            body.posts.length.should.equal(MAX_LIMIT);
-            body.meta.pagination.limit.should.equal(MAX_LIMIT);
+            assert.equal(body.posts.length, MAX_LIMIT);
+            assert.equal(body.meta.pagination.limit, MAX_LIMIT);
         });
 
         it(`should cap limit to ${MAX_LIMIT} when limit is "all"`, async function () {
@@ -197,8 +197,8 @@ describe('Admin API - Max Limit Cap', function () {
                 .expectStatus(200);
 
             // "all" should be capped to 5
-            body.posts.length.should.equal(MAX_LIMIT);
-            body.meta.pagination.limit.should.equal(MAX_LIMIT);
+            assert.equal(body.posts.length, MAX_LIMIT);
+            assert.equal(body.meta.pagination.limit, MAX_LIMIT);
         });
 
         it('should respect smaller limits', async function () {
@@ -227,7 +227,7 @@ describe('Admin API - Max Limit Cap', function () {
 
             // Even though we requested 10, we should only get max 5
             body.members.length.should.be.lessThanOrEqual(MAX_LIMIT);
-            body.meta.pagination.limit.should.equal(MAX_LIMIT);
+            assert.equal(body.meta.pagination.limit, MAX_LIMIT);
         });
 
         it('should cap limit to 5 when limit is "all"', async function () {
@@ -236,7 +236,7 @@ describe('Admin API - Max Limit Cap', function () {
 
             // "all" should be capped to 5
             body.members.length.should.be.lessThanOrEqual(MAX_LIMIT);
-            body.meta.pagination.limit.should.equal(MAX_LIMIT);
+            assert.equal(body.meta.pagination.limit, MAX_LIMIT);
         });
     });
 
@@ -246,8 +246,8 @@ describe('Admin API - Max Limit Cap', function () {
                 .expectStatus(200);
 
             // Even though we requested 10, we should only get max 5
-            body.tags.length.should.equal(MAX_LIMIT);
-            body.meta.pagination.limit.should.equal(MAX_LIMIT);
+            assert.equal(body.tags.length, MAX_LIMIT);
+            assert.equal(body.meta.pagination.limit, MAX_LIMIT);
         });
     });
 
@@ -258,7 +258,7 @@ describe('Admin API - Max Limit Cap', function () {
 
             // Even though we requested 10, we should only get max 5
             body.pages.length.should.be.lessThanOrEqual(MAX_LIMIT);
-            body.meta.pagination.limit.should.equal(MAX_LIMIT);
+            assert.equal(body.meta.pagination.limit, MAX_LIMIT);
         });
     });
 
@@ -320,8 +320,8 @@ describe('Admin API - Max Limit Cap', function () {
                 .expectStatus(200);
 
             // Invalid limit should be capped to 5
-            body.posts.length.should.equal(MAX_LIMIT);
-            body.meta.pagination.limit.should.equal(MAX_LIMIT);
+            assert.equal(body.posts.length, MAX_LIMIT);
+            assert.equal(body.meta.pagination.limit, MAX_LIMIT);
         });
 
         it('should handle limit=0', async function () {

--- a/ghost/core/test/e2e-api/admin/media.test.js
+++ b/ghost/core/test/e2e-api/admin/media.test.js
@@ -203,7 +203,7 @@ describe('Media API', function () {
                 .expect(200);
 
             const thumbnailUrl = res.body.media[0].url.replace('.mp4', '_thumb.jpg');
-            thumbnailRes.body.media[0].url.should.equal(thumbnailUrl);
+            assert.equal(thumbnailRes.body.media[0].url, thumbnailUrl);
             assert.equal(thumbnailRes.body.media[0].ref, 'updated_thumbnail');
             media.push(thumbnailRes.body.media[0].url.replace(config.get('url'), ''));
         });
@@ -227,7 +227,7 @@ describe('Media API', function () {
                 .expect(200);
 
             const thumbnailUrl = res.body.media[0].url.replace('.mp4', '_thumb.jpg');
-            thumbnailRes.body.media[0].url.should.equal(thumbnailUrl);
+            assert.equal(thumbnailRes.body.media[0].url, thumbnailUrl);
             assert.equal(thumbnailRes.body.media[0].ref, 'updated_thumbnail_2');
 
             media.push(thumbnailRes.body.media[0].url.replace(config.get('url'), ''));

--- a/ghost/core/test/e2e-api/admin/members-importer.test.js
+++ b/ghost/core/test/e2e-api/admin/members-importer.test.js
@@ -73,7 +73,7 @@ describe('Members Importer API', function () {
         assert.equal(importedMember1.name, 'joe');
         assert.equal(importedMember1.note, null);
         assert.equal(importedMember1.subscribed, true);
-        importedMember1.newsletters.length.should.equal(filteredNewsletters.length);
+        assert.equal(importedMember1.newsletters.length, filteredNewsletters.length);
         assert.equal(importedMember1.labels.length, 1);
         assert.equal(testUtils.API.isISO8601(importedMember1.created_at), true);
         assert.equal(importedMember1.comped, false);

--- a/ghost/core/test/e2e-api/admin/members.test.js
+++ b/ghost/core/test/e2e-api/admin/members.test.js
@@ -277,7 +277,7 @@ describe('Members API - member attribution', function () {
                 etag: anyEtag
             })
             .expect(({body}) => {
-                should(body.members[0].attribution).eql({
+                assert.deepEqual(body.members[0].attribution, {
                     id: post.id,
                     url: absoluteUrl,
                     type: 'post',
@@ -320,7 +320,7 @@ describe('Members API - member attribution', function () {
                 etag: anyEtag
             })
             .expect(({body}) => {
-                should(body.members[0].attribution).eql({
+                assert.deepEqual(body.members[0].attribution, {
                     id: post.id,
                     url: absoluteUrl,
                     type: 'page',
@@ -363,7 +363,7 @@ describe('Members API - member attribution', function () {
                 etag: anyEtag
             })
             .expect(({body}) => {
-                should(body.members[0].attribution).eql({
+                assert.deepEqual(body.members[0].attribution, {
                     id: tag.id,
                     url: absoluteUrl,
                     type: 'tag',
@@ -406,7 +406,7 @@ describe('Members API - member attribution', function () {
                 etag: anyEtag
             })
             .expect(({body}) => {
-                should(body.members[0].attribution).eql({
+                assert.deepEqual(body.members[0].attribution, {
                     id: author.id,
                     url: absoluteUrl,
                     type: 'author',
@@ -446,7 +446,7 @@ describe('Members API - member attribution', function () {
                 etag: anyEtag
             })
             .expect(({body}) => {
-                should(body.members[0].attribution).eql({
+                assert.deepEqual(body.members[0].attribution, {
                     id: null,
                     url: absoluteUrl,
                     type: 'url',

--- a/ghost/core/test/e2e-api/admin/pages-legacy.test.js
+++ b/ghost/core/test/e2e-api/admin/pages-legacy.test.js
@@ -80,7 +80,7 @@ describe('Pages API', function () {
         assertExists(res.headers['x-cache-invalidate']);
 
         assertExists(res.headers.location);
-        res.headers.location.should.equal(`http://127.0.0.1:2369${localUtils.API.getApiQuery('pages/')}${res.body.pages[0].id}/`);
+        assert.equal(res.headers.location, `http://127.0.0.1:2369${localUtils.API.getApiQuery('pages/')}${res.body.pages[0].id}/`);
 
         const model = await models.Post.findOne({
             id: res.body.pages[0].id

--- a/ghost/core/test/e2e-api/admin/posts-legacy.test.js
+++ b/ghost/core/test/e2e-api/admin/posts-legacy.test.js
@@ -1028,7 +1028,7 @@ describe('Posts API', function () {
 
         const publishedPost = publishedRes.body.posts[0];
 
-        publishedPost.newsletter.id.should.eql(newsletterId);
+        assert.equal(publishedPost.newsletter.id, newsletterId);
         assert.equal(publishedPost.email_segment, 'all');
         assert.equal(publishedPost.status, 'sent');
         assert.equal(publishedPost.newsletter_id, undefined);
@@ -1097,7 +1097,7 @@ describe('Posts API', function () {
 
         const publishedPost = publishedRes.body.posts[0];
 
-        publishedPost.newsletter.id.should.eql(newsletterId);
+        assert.equal(publishedPost.newsletter.id, newsletterId);
         assert.equal(publishedPost.email_segment, 'status:free');
         assert.equal(publishedPost.status, 'sent');
         assert.equal(publishedPost.newsletter_id, undefined);
@@ -1166,7 +1166,7 @@ describe('Posts API', function () {
 
         const publishedPost = publishedRes.body.posts[0];
 
-        publishedPost.newsletter.id.should.eql(newsletterId);
+        assert.equal(publishedPost.newsletter.id, newsletterId);
         assert.equal(publishedPost.email_segment, 'status:free');
         assert.equal(publishedPost.status, 'sent');
         assert.equal(publishedPost.newsletter_id, undefined);
@@ -1229,7 +1229,7 @@ describe('Posts API', function () {
 
         const scheduledPost = scheduledRes.body.posts[0];
 
-        scheduledPost.newsletter.id.should.eql(newsletterId);
+        assert.equal(scheduledPost.newsletter.id, newsletterId);
         assert.equal(scheduledPost.email_segment, 'all');
         assert.equal(scheduledPost.newsletter_id, undefined);
 
@@ -1271,7 +1271,7 @@ describe('Posts API', function () {
         assert.equal(model.get('email_recipient_filter'), 'all');
         assertExists(model.get('published_by'));
 
-        publishedPost.newsletter.id.should.eql(newsletterId);
+        assert.equal(publishedPost.newsletter.id, newsletterId);
         assert.equal(publishedPost.newsletter_id, undefined);
 
         // Check email is sent to the correct newsletter
@@ -1322,7 +1322,7 @@ describe('Posts API', function () {
 
         const scheduledPost = scheduledRes.body.posts[0];
 
-        scheduledPost.newsletter.id.should.eql(newsletterId);
+        assert.equal(scheduledPost.newsletter.id, newsletterId);
         assert.equal(scheduledPost.email_segment, 'status:free');
         assert.equal(scheduledPost.newsletter_id, undefined);
 
@@ -1362,7 +1362,7 @@ describe('Posts API', function () {
         should(model.get('newsletter_id')).eql(newsletterId);
         assert.equal(model.get('email_recipient_filter'), 'status:free');
 
-        publishedPost.newsletter.id.should.eql(newsletterId);
+        assert.equal(publishedPost.newsletter.id, newsletterId);
         assert.equal(publishedPost.newsletter_id, undefined);
 
         // Check email is sent to the correct newsletter
@@ -1501,7 +1501,7 @@ describe('Posts API', function () {
 
         const scheduledPost = scheduledRes.body.posts[0];
 
-        scheduledPost.newsletter.id.should.eql(newsletterId);
+        assert.equal(scheduledPost.newsletter.id, newsletterId);
         assert.equal(scheduledPost.email_segment, 'all');
         assert.equal(scheduledPost.status, 'scheduled');
         assert.equal(scheduledPost.email_only, true);
@@ -1545,7 +1545,7 @@ describe('Posts API', function () {
         assert.equal(model.get('status'), 'sent');
         assert.equal(model.get('email_recipient_filter'), 'all');
 
-        publishedPost.newsletter.id.should.eql(newsletterId);
+        assert.equal(publishedPost.newsletter.id, newsletterId);
         assert.equal(publishedPost.newsletter_id, undefined);
 
         // Check email is sent to the correct newsletter
@@ -1841,7 +1841,7 @@ describe('Posts API', function () {
 
             const publishedPost = publishedRes.body.posts[0];
 
-            publishedPost.newsletter.id.should.eql(newsletterId);
+            assert.equal(publishedPost.newsletter.id, newsletterId);
             assert.equal(publishedPost.email_segment, 'all');
             assert.equal(publishedPost.status, 'sent');
             assert.equal(publishedPost.newsletter_id, undefined);

--- a/ghost/core/test/e2e-api/admin/posts-legacy.test.js
+++ b/ghost/core/test/e2e-api/admin/posts-legacy.test.js
@@ -247,13 +247,13 @@ describe('Posts API', function () {
 
         localUtils.API.checkResponse(jsonResponse.posts[0], 'post', null, ['count', 'post_revisions']);
 
-        jsonResponse.posts[0].authors[0].should.be.an.Object();
+        assert(_.isPlainObject(jsonResponse.posts[0].authors[0]));
         localUtils.API.checkResponse(jsonResponse.posts[0].authors[0], 'user');
 
-        jsonResponse.posts[0].tags[0].should.be.an.Object();
+        assert(_.isPlainObject(jsonResponse.posts[0].tags[0]));
         localUtils.API.checkResponse(jsonResponse.posts[0].tags[0], 'tag', ['url']);
 
-        jsonResponse.posts[0].email.should.be.an.Object();
+        assert(_.isPlainObject(jsonResponse.posts[0].email));
         localUtils.API.checkResponse(jsonResponse.posts[0].email, 'email');
 
         jsonResponse.posts[0].newsletter.id.should.eql(testUtils.DataGenerator.Content.newsletters[0].id);

--- a/ghost/core/test/e2e-api/admin/posts-legacy.test.js
+++ b/ghost/core/test/e2e-api/admin/posts-legacy.test.js
@@ -890,7 +890,7 @@ describe('Posts API', function () {
             .expect(200);
 
         // Check newsletter relation is loaded in response
-        should(finalPost.body.posts[0].newsletter.id).eql(newsletterId);
+        assert.equal(finalPost.body.posts[0].newsletter.id, newsletterId);
         assert.equal(finalPost.body.posts[0].email_segment, 'all');
         assert.equal(finalPost.body.posts[0].newsletter_id, undefined);
 
@@ -898,7 +898,7 @@ describe('Posts API', function () {
             id
         }, testUtils.context.internal);
 
-        should(model.get('newsletter_id')).eql(newsletterId);
+        assert.equal(model.get('newsletter_id'), newsletterId);
         assertExists(model.get('published_by'));
 
         // Check email
@@ -908,7 +908,7 @@ describe('Posts API', function () {
         }, testUtils.context.internal);
 
         assertExists(email);
-        should(email.get('newsletter_id')).eql(newsletterId);
+        assert.equal(email.get('newsletter_id'), newsletterId);
         assert(['pending', 'submitted', 'submitting'].includes(email.get('status')));
     });
 
@@ -958,7 +958,7 @@ describe('Posts API', function () {
             .expect(200);
 
         // Check newsletter relation is loaded in response
-        should(finalPost.body.posts[0].newsletter.id).eql(newsletterId);
+        assert.equal(finalPost.body.posts[0].newsletter.id, newsletterId);
         assert.equal(finalPost.body.posts[0].email_segment, 'all');
         assert.equal(finalPost.body.posts[0].newsletter_id, undefined);
 
@@ -969,7 +969,7 @@ describe('Posts API', function () {
             id
         }, testUtils.context.internal);
 
-        should(model.get('newsletter_id')).eql(newsletterId);
+        assert.equal(model.get('newsletter_id'), newsletterId);
         assertExists(model.get('published_by'));
 
         // Check email
@@ -979,7 +979,7 @@ describe('Posts API', function () {
         }, testUtils.context.internal);
 
         assertExists(email);
-        should(email.get('newsletter_id')).eql(newsletterId);
+        assert.equal(email.get('newsletter_id'), newsletterId);
         assert(['pending', 'submitted', 'submitting'].includes(email.get('status')));
     });
 
@@ -1039,7 +1039,7 @@ describe('Posts API', function () {
         }, testUtils.context.internal);
 
         assert.equal(model.get('status'), 'sent');
-        should(model.get('newsletter_id')).eql(newsletterId);
+        assert.equal(model.get('newsletter_id'), newsletterId);
         assert.equal(model.get('email_recipient_filter'), 'all');
         assertExists(model.get('published_by'));
 
@@ -1048,7 +1048,7 @@ describe('Posts API', function () {
             post_id: id
         }, testUtils.context.internal);
 
-        should(email.get('newsletter_id')).eql(newsletterId);
+        assert.equal(email.get('newsletter_id'), newsletterId);
         assert.equal(email.get('recipient_filter'), 'all');
         assert(['pending', 'submitted', 'submitting'].includes(email.get('status')));
     });
@@ -1108,7 +1108,7 @@ describe('Posts API', function () {
         }, testUtils.context.internal);
 
         assert.equal(model.get('status'), 'sent');
-        should(model.get('newsletter_id')).eql(newsletterId);
+        assert.equal(model.get('newsletter_id'), newsletterId);
         assert.equal(model.get('email_recipient_filter'), 'status:free');
         assertExists(model.get('published_by'));
 
@@ -1117,7 +1117,7 @@ describe('Posts API', function () {
             post_id: id
         }, testUtils.context.internal);
 
-        should(email.get('newsletter_id')).eql(newsletterId);
+        assert.equal(email.get('newsletter_id'), newsletterId);
         assert.equal(email.get('recipient_filter'), 'status:free');
         assert(['pending', 'submitted', 'submitting'].includes(email.get('status')));
     });
@@ -1177,7 +1177,7 @@ describe('Posts API', function () {
         }, testUtils.context.internal);
 
         assert.equal(model.get('status'), 'sent');
-        should(model.get('newsletter_id')).eql(newsletterId);
+        assert.equal(model.get('newsletter_id'), newsletterId);
         assert.equal(model.get('email_recipient_filter'), 'status:free');
         assertExists(model.get('published_by'));
 
@@ -1186,7 +1186,7 @@ describe('Posts API', function () {
             post_id: id
         }, testUtils.context.internal);
 
-        should(email.get('newsletter_id')).eql(newsletterId);
+        assert.equal(email.get('newsletter_id'), newsletterId);
         assert.equal(email.get('recipient_filter'), 'status:free');
         assert(['pending', 'submitted', 'submitting'].includes(email.get('status')));
     });
@@ -1238,7 +1238,7 @@ describe('Posts API', function () {
             status: 'scheduled'
         }, testUtils.context.internal);
 
-        should(model.get('newsletter_id')).eql(newsletterId);
+        assert.equal(model.get('newsletter_id'), newsletterId);
         assert.equal(model.get('email_recipient_filter'), 'all');
         assert.equal(model.get('published_by'), null);
 
@@ -1267,7 +1267,7 @@ describe('Posts API', function () {
             id
         }, testUtils.context.internal);
 
-        should(model.get('newsletter_id')).eql(newsletterId);
+        assert.equal(model.get('newsletter_id'), newsletterId);
         assert.equal(model.get('email_recipient_filter'), 'all');
         assertExists(model.get('published_by'));
 
@@ -1279,7 +1279,7 @@ describe('Posts API', function () {
             post_id: id
         }, testUtils.context.internal);
 
-        should(email.get('newsletter_id')).eql(newsletterId);
+        assert.equal(email.get('newsletter_id'), newsletterId);
         assert.equal(email.get('recipient_filter'), 'all');
         assert(['pending', 'submitted', 'submitting'].includes(email.get('status')));
     });
@@ -1331,7 +1331,7 @@ describe('Posts API', function () {
             status: 'scheduled'
         }, testUtils.context.internal);
 
-        should(model.get('newsletter_id')).eql(newsletterId);
+        assert.equal(model.get('newsletter_id'), newsletterId);
         assert.equal(model.get('email_recipient_filter'), 'status:free');
 
         // We should not have an email
@@ -1359,7 +1359,7 @@ describe('Posts API', function () {
             id
         }, testUtils.context.internal);
 
-        should(model.get('newsletter_id')).eql(newsletterId);
+        assert.equal(model.get('newsletter_id'), newsletterId);
         assert.equal(model.get('email_recipient_filter'), 'status:free');
 
         assert.equal(publishedPost.newsletter.id, newsletterId);
@@ -1370,7 +1370,7 @@ describe('Posts API', function () {
             post_id: id
         }, testUtils.context.internal);
 
-        should(email.get('newsletter_id')).eql(newsletterId);
+        assert.equal(email.get('newsletter_id'), newsletterId);
         assert.equal(email.get('recipient_filter'), 'status:free');
         assert(['pending', 'submitted', 'submitting'].includes(email.get('status')));
     });
@@ -1512,7 +1512,7 @@ describe('Posts API', function () {
             status: 'scheduled'
         }, testUtils.context.internal);
 
-        should(model.get('newsletter_id')).eql(newsletterId);
+        assert.equal(model.get('newsletter_id'), newsletterId);
         assert.equal(model.get('status'), 'scheduled');
         assert.equal(model.get('email_recipient_filter'), 'all');
 
@@ -1541,7 +1541,7 @@ describe('Posts API', function () {
             status: 'all'
         }, testUtils.context.internal);
 
-        should(model.get('newsletter_id')).eql(newsletterId);
+        assert.equal(model.get('newsletter_id'), newsletterId);
         assert.equal(model.get('status'), 'sent');
         assert.equal(model.get('email_recipient_filter'), 'all');
 
@@ -1553,7 +1553,7 @@ describe('Posts API', function () {
             post_id: id
         }, testUtils.context.internal);
 
-        should(email.get('newsletter_id')).eql(newsletterId);
+        assert.equal(email.get('newsletter_id'), newsletterId);
         assert.equal(email.get('recipient_filter'), 'all');
         assert(['pending', 'submitted', 'submitting'].includes(email.get('status')));
     });
@@ -1599,7 +1599,7 @@ describe('Posts API', function () {
             .expect(200);
 
         // Check newsletter relation is loaded in response
-        should(res2.body.posts[0].newsletter.id).eql(newsletterId);
+        assert.equal(res2.body.posts[0].newsletter.id, newsletterId);
         assert.equal(res2.body.posts[0].email_segment, 'status:-free');
 
         assert.equal(res2.body.posts[0].newsletter_id, undefined);
@@ -1608,7 +1608,7 @@ describe('Posts API', function () {
             id: id,
             status: 'published'
         }, testUtils.context.internal);
-        should(model.get('newsletter_id')).eql(newsletterId);
+        assert.equal(model.get('newsletter_id'), newsletterId);
         assert.equal(model.get('email_recipient_filter'), 'status:-free');
 
         // Check email is sent to the correct newsletter
@@ -1616,7 +1616,7 @@ describe('Posts API', function () {
             post_id: id
         }, testUtils.context.internal);
 
-        should(email.get('newsletter_id')).eql(newsletterId);
+        assert.equal(email.get('newsletter_id'), newsletterId);
         assert.equal(email.get('recipient_filter'), 'status:-free');
         assert(['pending', 'submitted', 'submitting'].includes(email.get('status')));
 
@@ -1635,7 +1635,7 @@ describe('Posts API', function () {
 
         // Check newsletter relation is loaded in response
         // We should keep it, because we already sent an email
-        should(res3.body.posts[0].newsletter.id).eql(newsletterId);
+        assert.equal(res3.body.posts[0].newsletter.id, newsletterId);
         assert.equal(res2.body.posts[0].email_segment, 'status:-free');
         assert.equal(res3.body.posts[0].newsletter_id, undefined);
 
@@ -1644,7 +1644,7 @@ describe('Posts API', function () {
             status: 'draft'
         }, testUtils.context.internal);
 
-        should(model.get('newsletter_id')).eql(newsletterId);
+        assert.equal(model.get('newsletter_id'), newsletterId);
 
         // Check email
         // Note: we only create an email if we have members susbcribed to the newsletter
@@ -1653,7 +1653,7 @@ describe('Posts API', function () {
         }, testUtils.context.internal);
 
         assertExists(email);
-        should(email.get('newsletter_id')).eql(newsletterId);
+        assert.equal(email.get('newsletter_id'), newsletterId);
 
         const republished = {
             status: 'published',
@@ -1670,7 +1670,7 @@ describe('Posts API', function () {
 
         // Check newsletter relation is loaded in response
         // + did update the newsletter id
-        should(res4.body.posts[0].newsletter.id).eql(newsletterId);
+        assert.equal(res4.body.posts[0].newsletter.id, newsletterId);
         assert.equal(res4.body.posts[0].email_segment, 'status:-free');
         assert.equal(res4.body.posts[0].newsletter_id, undefined);
 
@@ -1678,7 +1678,7 @@ describe('Posts API', function () {
             id: id,
             status: 'published'
         }, testUtils.context.internal);
-        should(model.get('newsletter_id')).eql(newsletterId);
+        assert.equal(model.get('newsletter_id'), newsletterId);
 
         // Should not change if status remains published
         const res5 = await request
@@ -1691,7 +1691,7 @@ describe('Posts API', function () {
 
         // Check newsletter relation is loaded in response
         // + did not update the newsletter id
-        should(res5.body.posts[0].newsletter.id).eql(newsletterId);
+        assert.equal(res5.body.posts[0].newsletter.id, newsletterId);
         assert.equal(res5.body.posts[0].email_segment, 'status:-free');
         assert.equal(res5.body.posts[0].newsletter_id, undefined);
 
@@ -1701,7 +1701,7 @@ describe('Posts API', function () {
         }, testUtils.context.internal);
 
         // Test if the newsletter_id option was ignored
-        should(model.get('newsletter_id')).eql(newsletterId);
+        assert.equal(model.get('newsletter_id'), newsletterId);
     });
 
     it('Cannot get post via pages endpoint', async function () {
@@ -1780,7 +1780,7 @@ describe('Posts API', function () {
                 .expect(200);
 
             // Check newsletter relation is loaded in response
-            should(finalPost.body.posts[0].newsletter.id).eql(newsletterId);
+            assert.equal(finalPost.body.posts[0].newsletter.id, newsletterId);
             assert.equal(finalPost.body.posts[0].email_segment, 'all');
             assert.equal(finalPost.body.posts[0].newsletter_id, undefined);
 
@@ -1788,7 +1788,7 @@ describe('Posts API', function () {
                 id
             }, testUtils.context.internal);
 
-            should(model.get('newsletter_id')).eql(newsletterId);
+            assert.equal(model.get('newsletter_id'), newsletterId);
 
             // Check email
             // Note: we only create an email if we have members susbcribed to the newsletter
@@ -1797,7 +1797,7 @@ describe('Posts API', function () {
             }, testUtils.context.internal);
 
             assertExists(email);
-            should(email.get('newsletter_id')).eql(newsletterId);
+            assert.equal(email.get('newsletter_id'), newsletterId);
             assert(['pending', 'submitted', 'submitting'].includes(email.get('status')));
         });
 
@@ -1852,7 +1852,7 @@ describe('Posts API', function () {
             }, testUtils.context.internal);
 
             assert.equal(model.get('status'), 'sent');
-            should(model.get('newsletter_id')).eql(newsletterId);
+            assert.equal(model.get('newsletter_id'), newsletterId);
             assert.equal(model.get('email_recipient_filter'), 'all');
 
             // We should have an email
@@ -1860,7 +1860,7 @@ describe('Posts API', function () {
                 post_id: id
             }, testUtils.context.internal);
 
-            should(email.get('newsletter_id')).eql(newsletterId);
+            assert.equal(email.get('newsletter_id'), newsletterId);
             assert.equal(email.get('recipient_filter'), 'all');
             assert(['pending', 'submitted', 'submitting'].includes(email.get('status')));
         });

--- a/ghost/core/test/e2e-api/admin/posts-legacy.test.js
+++ b/ghost/core/test/e2e-api/admin/posts-legacy.test.js
@@ -177,7 +177,7 @@ describe('Posts API', function () {
         assertExists(jsonResponse);
         assertExists(jsonResponse.posts);
         localUtils.API.checkResponse(jsonResponse.posts[0], 'post');
-        jsonResponse.posts[0].id.should.equal(testUtils.DataGenerator.Content.posts[0].id);
+        assert.equal(jsonResponse.posts[0].id, testUtils.DataGenerator.Content.posts[0].id);
 
         assert.equal(_.isBoolean(jsonResponse.posts[0].featured), true);
 
@@ -200,7 +200,7 @@ describe('Posts API', function () {
         assertExists(jsonResponse);
         assertExists(jsonResponse.posts);
         localUtils.API.checkResponse(jsonResponse.posts[0], 'post');
-        jsonResponse.posts[0].id.should.equal(testUtils.DataGenerator.Content.posts[1].id);
+        assert.equal(jsonResponse.posts[0].id, testUtils.DataGenerator.Content.posts[1].id);
 
         assert.equal(_.isBoolean(jsonResponse.posts[0].featured), true);
 
@@ -285,7 +285,7 @@ describe('Posts API', function () {
         assert.equal(res.headers['x-cache-invalidate'], undefined);
 
         assertExists(res.headers.location);
-        res.headers.location.should.equal(`http://127.0.0.1:2369${localUtils.API.getApiQuery('posts/')}${res.body.posts[0].id}/`);
+        assert.equal(res.headers.location, `http://127.0.0.1:2369${localUtils.API.getApiQuery('posts/')}${res.body.posts[0].id}/`);
 
         // Newsletter should be returned as null
         assert.equal(res.body.posts[0].newsletter, null);

--- a/ghost/core/test/e2e-api/admin/posts-legacy.test.js
+++ b/ghost/core/test/e2e-api/admin/posts-legacy.test.js
@@ -909,7 +909,7 @@ describe('Posts API', function () {
 
         assertExists(email);
         should(email.get('newsletter_id')).eql(newsletterId);
-        should(email.get('status')).equalOneOf('pending', 'submitted', 'submitting');
+        assert(['pending', 'submitted', 'submitting'].includes(email.get('status')));
     });
 
     it('Interprets sent as published for a post with email', async function () {
@@ -980,7 +980,7 @@ describe('Posts API', function () {
 
         assertExists(email);
         should(email.get('newsletter_id')).eql(newsletterId);
-        should(email.get('status')).equalOneOf('pending', 'submitted', 'submitting');
+        assert(['pending', 'submitted', 'submitting'].includes(email.get('status')));
     });
 
     it('Can publish an email_only post by setting status to published', async function () {
@@ -1050,7 +1050,7 @@ describe('Posts API', function () {
 
         should(email.get('newsletter_id')).eql(newsletterId);
         assert.equal(email.get('recipient_filter'), 'all');
-        should(email.get('status')).equalOneOf('pending', 'submitted', 'submitting');
+        assert(['pending', 'submitted', 'submitting'].includes(email.get('status')));
     });
 
     it('Can publish an email_only post with free filter', async function () {
@@ -1119,7 +1119,7 @@ describe('Posts API', function () {
 
         should(email.get('newsletter_id')).eql(newsletterId);
         assert.equal(email.get('recipient_filter'), 'status:free');
-        should(email.get('status')).equalOneOf('pending', 'submitted', 'submitting');
+        assert(['pending', 'submitted', 'submitting'].includes(email.get('status')));
     });
 
     it('Can publish an email_only post by setting the status to sent', async function () {
@@ -1188,7 +1188,7 @@ describe('Posts API', function () {
 
         should(email.get('newsletter_id')).eql(newsletterId);
         assert.equal(email.get('recipient_filter'), 'status:free');
-        should(email.get('status')).equalOneOf('pending', 'submitted', 'submitting');
+        assert(['pending', 'submitted', 'submitting'].includes(email.get('status')));
     });
 
     it('Can publish a scheduled post', async function () {
@@ -1281,7 +1281,7 @@ describe('Posts API', function () {
 
         should(email.get('newsletter_id')).eql(newsletterId);
         assert.equal(email.get('recipient_filter'), 'all');
-        should(email.get('status')).equalOneOf('pending', 'submitted', 'submitting');
+        assert(['pending', 'submitted', 'submitting'].includes(email.get('status')));
     });
 
     it('Can publish a scheduled post with custom email segment', async function () {
@@ -1372,7 +1372,7 @@ describe('Posts API', function () {
 
         should(email.get('newsletter_id')).eql(newsletterId);
         assert.equal(email.get('recipient_filter'), 'status:free');
-        should(email.get('status')).equalOneOf('pending', 'submitted', 'submitting');
+        assert(['pending', 'submitted', 'submitting'].includes(email.get('status')));
     });
 
     it('Can publish a scheduled post without newsletter', async function () {
@@ -1555,7 +1555,7 @@ describe('Posts API', function () {
 
         should(email.get('newsletter_id')).eql(newsletterId);
         assert.equal(email.get('recipient_filter'), 'all');
-        should(email.get('status')).equalOneOf('pending', 'submitted', 'submitting');
+        assert(['pending', 'submitted', 'submitting'].includes(email.get('status')));
     });
 
     it('Can\'t change the newsletter once it has been sent', async function () {
@@ -1618,7 +1618,7 @@ describe('Posts API', function () {
 
         should(email.get('newsletter_id')).eql(newsletterId);
         assert.equal(email.get('recipient_filter'), 'status:-free');
-        should(email.get('status')).equalOneOf('pending', 'submitted', 'submitting');
+        assert(['pending', 'submitted', 'submitting'].includes(email.get('status')));
 
         const unpublished = {
             status: 'draft',
@@ -1798,7 +1798,7 @@ describe('Posts API', function () {
 
             assertExists(email);
             should(email.get('newsletter_id')).eql(newsletterId);
-            should(email.get('status')).equalOneOf('pending', 'submitted', 'submitting');
+            assert(['pending', 'submitted', 'submitting'].includes(email.get('status')));
         });
 
         it('Can publish an email_only post', async function () {
@@ -1862,7 +1862,7 @@ describe('Posts API', function () {
 
             should(email.get('newsletter_id')).eql(newsletterId);
             assert.equal(email.get('recipient_filter'), 'all');
-            should(email.get('status')).equalOneOf('pending', 'submitted', 'submitting');
+            assert(['pending', 'submitted', 'submitting'].includes(email.get('status')));
         });
     });
 

--- a/ghost/core/test/e2e-api/admin/posts.test.js
+++ b/ghost/core/test/e2e-api/admin/posts.test.js
@@ -266,7 +266,7 @@ describe('Posts API', function () {
                 .fetchAll();
 
             assert.equal(postRevisions.length, 1);
-            postRevisions.at(0).get('lexical').should.equal(lexical);
+            assert.equal(postRevisions.at(0).get('lexical'), lexical);
 
             // mobiledoc revision is not created
             const mobiledocRevisions = await models.MobiledocRevision
@@ -434,8 +434,8 @@ describe('Posts API', function () {
                 .fetchAll();
 
             assert.equal(mobiledocRevisions.length, 2);
-            mobiledocRevisions.at(0).get('mobiledoc').should.equal(updatedMobiledoc);
-            mobiledocRevisions.at(1).get('mobiledoc').should.equal(originalMobiledoc);
+            assert.equal(mobiledocRevisions.at(0).get('mobiledoc'), updatedMobiledoc);
+            assert.equal(mobiledocRevisions.at(1).get('mobiledoc'), originalMobiledoc);
 
             // post revisions are not created
             const postRevisions = await models.PostRevision
@@ -488,8 +488,8 @@ describe('Posts API', function () {
                 .fetchAll();
 
             assert.equal(postRevisions.length, 2);
-            postRevisions.at(0).get('lexical').should.equal(updatedLexical);
-            postRevisions.at(1).get('lexical').should.equal(originalLexical);
+            assert.equal(postRevisions.at(0).get('lexical'), updatedLexical);
+            assert.equal(postRevisions.at(1).get('lexical'), originalLexical);
 
             // mobiledoc revisions are not created
             const mobiledocRevisions = await models.MobiledocRevision
@@ -692,7 +692,7 @@ describe('Posts API', function () {
             const [postResponse] = body.posts;
             assert.equal(postResponse.title, 'Integration Auth Test Post');
             assert.equal(postResponse.status, 'published');
-            postResponse.lexical.should.equal(lexical);
+            assert.equal(postResponse.lexical, lexical);
 
             // Verify the post revision was created with owner user as author
             const ownerUser = await models.User.getOwnerUser();
@@ -702,8 +702,8 @@ describe('Posts API', function () {
 
             assert.equal(postRevisions.length, 1);
             const revision = postRevisions.at(0);
-            revision.get('lexical').should.equal(lexical);
-            revision.get('author_id').should.equal(ownerUser.get('id'));
+            assert.equal(revision.get('lexical'), lexical);
+            assert.equal(revision.get('author_id'), ownerUser.get('id'));
 
             // Update the post to ensure revision creation works properly
             const updatedLexical = createLexical('Updated content for revision testing.');
@@ -723,8 +723,8 @@ describe('Posts API', function () {
 
             assert.equal(updatedRevisions.length, 2);
             const latestRevision = updatedRevisions.at(0);
-            latestRevision.get('lexical').should.equal(updatedLexical);
-            latestRevision.get('author_id').should.equal(ownerUser.get('id'));
+            assert.equal(latestRevision.get('lexical'), updatedLexical);
+            assert.equal(latestRevision.get('author_id'), ownerUser.get('id'));
 
             // Verify the post was updated successfully
             await agent
@@ -754,11 +754,11 @@ describe('Posts API', function () {
             const post = res.body.posts[0];
             const mobiledoc = JSON.parse(post.mobiledoc);
 
-            post.feature_image.should.equal(`${siteUrl}/content/images/feature.jpg`);
-            mobiledoc.cards.find(c => c[0] === 'image')[1].src.should.equal(`${siteUrl}/content/images/inline.jpg`);
-            mobiledoc.cards.find(c => c[0] === 'file')[1].src.should.equal(`${siteUrl}/content/files/document.pdf`);
-            mobiledoc.cards.find(c => c[0] === 'video')[1].src.should.equal(`${siteUrl}/content/media/video.mp4`);
-            mobiledoc.cards.find(c => c[0] === 'audio')[1].src.should.equal(`${siteUrl}/content/media/audio.mp3`);
+            assert.equal(post.feature_image, `${siteUrl}/content/images/feature.jpg`);
+            assert.equal(mobiledoc.cards.find(c => c[0] === 'image')[1].src, `${siteUrl}/content/images/inline.jpg`);
+            assert.equal(mobiledoc.cards.find(c => c[0] === 'file')[1].src, `${siteUrl}/content/files/document.pdf`);
+            assert.equal(mobiledoc.cards.find(c => c[0] === 'video')[1].src, `${siteUrl}/content/media/video.mp4`);
+            assert.equal(mobiledoc.cards.find(c => c[0] === 'audio')[1].src, `${siteUrl}/content/media/audio.mp3`);
             assert(post.mobiledoc.includes(`${siteUrl}/content/images/snippet-inline.jpg`));
             assert(post.mobiledoc.includes(`${siteUrl}/content/files/snippet-document.pdf`));
             assert(post.mobiledoc.includes(`${siteUrl}/content/media/snippet-video.mp4`));
@@ -773,7 +773,7 @@ describe('Posts API', function () {
 
             const post = res.body.posts[0];
 
-            post.feature_image.should.equal(`${siteUrl}/content/images/feature.jpg`);
+            assert.equal(post.feature_image, `${siteUrl}/content/images/feature.jpg`);
             assert(post.lexical.includes(`${siteUrl}/content/images/inline.jpg`));
             assert(post.lexical.includes(`${siteUrl}/content/files/document.pdf`));
             assert(post.lexical.includes(`${siteUrl}/content/media/video.mp4`));
@@ -798,12 +798,12 @@ describe('Posts API', function () {
             const mobiledoc = JSON.parse(post.mobiledoc);
 
             // Images stay on site URL
-            post.feature_image.should.equal(`${siteUrl}/content/images/feature.jpg`);
-            mobiledoc.cards.find(c => c[0] === 'image')[1].src.should.equal(`${siteUrl}/content/images/inline.jpg`);
+            assert.equal(post.feature_image, `${siteUrl}/content/images/feature.jpg`);
+            assert.equal(mobiledoc.cards.find(c => c[0] === 'image')[1].src, `${siteUrl}/content/images/inline.jpg`);
             // Media/files use CDN URL
-            mobiledoc.cards.find(c => c[0] === 'file')[1].src.should.equal(`${cdnUrl}/content/files/document.pdf`);
-            mobiledoc.cards.find(c => c[0] === 'video')[1].src.should.equal(`${cdnUrl}/content/media/video.mp4`);
-            mobiledoc.cards.find(c => c[0] === 'audio')[1].src.should.equal(`${cdnUrl}/content/media/audio.mp3`);
+            assert.equal(mobiledoc.cards.find(c => c[0] === 'file')[1].src, `${cdnUrl}/content/files/document.pdf`);
+            assert.equal(mobiledoc.cards.find(c => c[0] === 'video')[1].src, `${cdnUrl}/content/media/video.mp4`);
+            assert.equal(mobiledoc.cards.find(c => c[0] === 'audio')[1].src, `${cdnUrl}/content/media/audio.mp3`);
             // Inserted snippet images stay on site URL
             assert(post.mobiledoc.includes(`${siteUrl}/content/images/snippet-inline.jpg`));
             // Inserted snippet media/files use CDN URL
@@ -825,7 +825,7 @@ describe('Posts API', function () {
             const post = res.body.posts[0];
 
             // Images stay on site URL
-            post.feature_image.should.equal(`${siteUrl}/content/images/feature.jpg`);
+            assert.equal(post.feature_image, `${siteUrl}/content/images/feature.jpg`);
             assert(post.lexical.includes(`${siteUrl}/content/images/inline.jpg`));
             // Media/files use CDN URL
             assert(post.lexical.includes(`${cdnUrl}/content/files/document.pdf`));

--- a/ghost/core/test/e2e-api/admin/redirects.test.js
+++ b/ghost/core/test/e2e-api/admin/redirects.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const supertest = require('supertest');
 const fs = require('fs-extra');
@@ -24,7 +25,7 @@ describe('Redirects API', function () {
             .expect('Content-Disposition', 'Attachment; filename="redirects.json"')
             .expect(200)
             .expect((res) => {
-                res.body.should.eql([
+                assert.deepEqual(res.body, [
                     {from: '^/post/[0-9]+/([a-z0-9\\-]+)', to: '/$1'},
                     {permanent: true, from: '/my-old-blog-post/', to: '/revamped-url/'},
                     {permanent: true, from: '/test-params', to: '/result?q=abc'},

--- a/ghost/core/test/e2e-api/admin/snippets.test.js
+++ b/ghost/core/test/e2e-api/admin/snippets.test.js
@@ -269,10 +269,10 @@ describe('Snippets API', function () {
             const snippet = res.body.snippets[0];
             const mobiledoc = JSON.parse(snippet.mobiledoc);
 
-            mobiledoc.cards.find(c => c[0] === 'image')[1].src.should.equal(`${siteUrl}/content/images/snippet-inline.jpg`);
-            mobiledoc.cards.find(c => c[0] === 'file')[1].src.should.equal(`${siteUrl}/content/files/snippet-document.pdf`);
-            mobiledoc.cards.find(c => c[0] === 'video')[1].src.should.equal(`${siteUrl}/content/media/snippet-video.mp4`);
-            mobiledoc.cards.find(c => c[0] === 'audio')[1].src.should.equal(`${siteUrl}/content/media/snippet-audio.mp3`);
+            assert.equal(mobiledoc.cards.find(c => c[0] === 'image')[1].src, `${siteUrl}/content/images/snippet-inline.jpg`);
+            assert.equal(mobiledoc.cards.find(c => c[0] === 'file')[1].src, `${siteUrl}/content/files/snippet-document.pdf`);
+            assert.equal(mobiledoc.cards.find(c => c[0] === 'video')[1].src, `${siteUrl}/content/media/snippet-video.mp4`);
+            assert.equal(mobiledoc.cards.find(c => c[0] === 'audio')[1].src, `${siteUrl}/content/media/snippet-audio.mp3`);
             assert(!snippet.mobiledoc.includes('__GHOST_URL__'));
         });
 
@@ -303,11 +303,11 @@ describe('Snippets API', function () {
             const mobiledoc = JSON.parse(snippet.mobiledoc);
 
             // Images stay on site URL
-            mobiledoc.cards.find(c => c[0] === 'image')[1].src.should.equal(`${siteUrl}/content/images/snippet-inline.jpg`);
+            assert.equal(mobiledoc.cards.find(c => c[0] === 'image')[1].src, `${siteUrl}/content/images/snippet-inline.jpg`);
             // Media/files use CDN URL
-            mobiledoc.cards.find(c => c[0] === 'file')[1].src.should.equal(`${cdnUrl}/content/files/snippet-document.pdf`);
-            mobiledoc.cards.find(c => c[0] === 'video')[1].src.should.equal(`${cdnUrl}/content/media/snippet-video.mp4`);
-            mobiledoc.cards.find(c => c[0] === 'audio')[1].src.should.equal(`${cdnUrl}/content/media/snippet-audio.mp3`);
+            assert.equal(mobiledoc.cards.find(c => c[0] === 'file')[1].src, `${cdnUrl}/content/files/snippet-document.pdf`);
+            assert.equal(mobiledoc.cards.find(c => c[0] === 'video')[1].src, `${cdnUrl}/content/media/snippet-video.mp4`);
+            assert.equal(mobiledoc.cards.find(c => c[0] === 'audio')[1].src, `${cdnUrl}/content/media/snippet-audio.mp3`);
             assert(!snippet.mobiledoc.includes('__GHOST_URL__'));
         });
 

--- a/ghost/core/test/e2e-api/admin/storage-adapter-switching.test.js
+++ b/ghost/core/test/e2e-api/admin/storage-adapter-switching.test.js
@@ -30,7 +30,7 @@ describe('Ghost Admin - Storage Adapter Switching', function () {
             .expectStatus(200);
 
         let post = res.body.posts[0];
-        post.feature_image.should.equal(`${siteUrl}/content/images/feature.jpg`);
+        assert.equal(post.feature_image, `${siteUrl}/content/images/feature.jpg`);
         assert(post.lexical.includes(`${siteUrl}/content/files/document.pdf`));
         assert(post.lexical.includes(`${siteUrl}/content/media/video.mp4`));
 
@@ -43,7 +43,7 @@ describe('Ghost Admin - Storage Adapter Switching', function () {
             .expectStatus(200);
 
         post = res.body.posts[0];
-        post.feature_image.should.equal(`${siteUrl}/content/images/feature.jpg`);
+        assert.equal(post.feature_image, `${siteUrl}/content/images/feature.jpg`);
         assert(post.lexical.includes(`${cdnUrl}/content/files/document.pdf`));
         assert(post.lexical.includes(`${cdnUrl}/content/media/video.mp4`));
 
@@ -54,7 +54,7 @@ describe('Ghost Admin - Storage Adapter Switching', function () {
             .expectStatus(200);
 
         post = res.body.posts[0];
-        post.feature_image.should.equal(`${siteUrl}/content/images/feature.jpg`);
+        assert.equal(post.feature_image, `${siteUrl}/content/images/feature.jpg`);
         assert(post.lexical.includes(`${siteUrl}/content/files/document.pdf`));
         assert(post.lexical.includes(`${siteUrl}/content/media/video.mp4`));
 
@@ -67,7 +67,7 @@ describe('Ghost Admin - Storage Adapter Switching', function () {
             .expectStatus(200);
 
         post = res.body.posts[0];
-        post.feature_image.should.equal(`${siteUrl}/content/images/feature.jpg`);
+        assert.equal(post.feature_image, `${siteUrl}/content/images/feature.jpg`);
         assert(post.lexical.includes(`${newCdnUrl}/content/files/document.pdf`));
         assert(post.lexical.includes(`${newCdnUrl}/content/media/video.mp4`));
     });
@@ -79,7 +79,7 @@ describe('Ghost Admin - Storage Adapter Switching', function () {
 
         let post = res.body.posts[0];
         let mobiledoc = JSON.parse(post.mobiledoc);
-        mobiledoc.cards.find(c => c[0] === 'file')[1].src.should.equal(`${siteUrl}/content/files/document.pdf`);
+        assert.equal(mobiledoc.cards.find(c => c[0] === 'file')[1].src, `${siteUrl}/content/files/document.pdf`);
 
         urlUtilsHelper.stubUrlUtilsWithCdn({
             assetBaseUrls: {media: cdnUrl, files: cdnUrl}
@@ -91,8 +91,8 @@ describe('Ghost Admin - Storage Adapter Switching', function () {
 
         post = res.body.posts[0];
         mobiledoc = JSON.parse(post.mobiledoc);
-        mobiledoc.cards.find(c => c[0] === 'file')[1].src.should.equal(`${cdnUrl}/content/files/document.pdf`);
-        post.feature_image.should.equal(`${siteUrl}/content/images/feature.jpg`);
+        assert.equal(mobiledoc.cards.find(c => c[0] === 'file')[1].src, `${cdnUrl}/content/files/document.pdf`);
+        assert.equal(post.feature_image, `${siteUrl}/content/images/feature.jpg`);
     });
 
     it('Snippets also switch URLs correctly', async function () {

--- a/ghost/core/test/e2e-api/admin/tags.test.js
+++ b/ghost/core/test/e2e-api/admin/tags.test.js
@@ -166,7 +166,7 @@ describe('Tag API', function () {
             .expect(204);
 
         assertExists(res.headers['x-cache-invalidate']);
-        res.body.should.eql({});
+        assert.deepEqual(res.body, {});
     });
 
     it('Can destroy a non-existent tag', async function () {

--- a/ghost/core/test/e2e-api/admin/tags.test.js
+++ b/ghost/core/test/e2e-api/admin/tags.test.js
@@ -108,7 +108,7 @@ describe('Tag API', function () {
         assert.equal(testUtils.API.isISO8601(jsonResponse.tags[0].created_at), true);
 
         assertExists(res.headers.location);
-        res.headers.location.should.equal(`http://127.0.0.1:2369${localUtils.API.getApiQuery('tags/')}${res.body.tags[0].id}/`);
+        assert.equal(res.headers.location, `http://127.0.0.1:2369${localUtils.API.getApiQuery('tags/')}${res.body.tags[0].id}/`);
     });
 
     it('Can add an internal tag', async function () {
@@ -135,7 +135,7 @@ describe('Tag API', function () {
         assert.equal(jsonResponse.tags[0].slug, 'hash-test');
 
         assertExists(res.headers.location);
-        res.headers.location.should.equal(`http://127.0.0.1:2369${localUtils.API.getApiQuery('tags/')}${res.body.tags[0].id}/`);
+        assert.equal(res.headers.location, `http://127.0.0.1:2369${localUtils.API.getApiQuery('tags/')}${res.body.tags[0].id}/`);
     });
 
     it('Can edit a tag', async function () {
@@ -196,9 +196,9 @@ describe('Tag API', function () {
 
             const tag = res.body.tags[0];
 
-            tag.feature_image.should.equal(`${siteUrl}/content/images/tag-feature.jpg`);
-            tag.og_image.should.equal(`${siteUrl}/content/images/tag-og.jpg`);
-            tag.twitter_image.should.equal(`${siteUrl}/content/images/tag-twitter.jpg`);
+            assert.equal(tag.feature_image, `${siteUrl}/content/images/tag-feature.jpg`);
+            assert.equal(tag.og_image, `${siteUrl}/content/images/tag-og.jpg`);
+            assert.equal(tag.twitter_image, `${siteUrl}/content/images/tag-twitter.jpg`);
         });
 
         it('Transforms image URLs to absolute site URLs even when CDN is configured', async function () {
@@ -215,9 +215,9 @@ describe('Tag API', function () {
 
             const tag = res.body.tags[0];
 
-            tag.feature_image.should.equal(`${siteUrl}/content/images/tag-feature.jpg`);
-            tag.og_image.should.equal(`${siteUrl}/content/images/tag-og.jpg`);
-            tag.twitter_image.should.equal(`${siteUrl}/content/images/tag-twitter.jpg`);
+            assert.equal(tag.feature_image, `${siteUrl}/content/images/tag-feature.jpg`);
+            assert.equal(tag.og_image, `${siteUrl}/content/images/tag-og.jpg`);
+            assert.equal(tag.twitter_image, `${siteUrl}/content/images/tag-twitter.jpg`);
         });
     });
 });

--- a/ghost/core/test/e2e-api/admin/themes.test.js
+++ b/ghost/core/test/e2e-api/admin/themes.test.js
@@ -156,7 +156,7 @@ describe('Themes API', function () {
         assert.equal(addedTheme.active, false);
 
         // Note: at this point, the API should not return a valid_34324324 backup folder as a theme
-        _.map(jsonResponse3.themes, 'name').should.eql([
+        assert.deepEqual(_.map(jsonResponse3.themes, 'name'), [
             'broken-theme',
             'casper',
             'locale-theme',
@@ -186,7 +186,7 @@ describe('Themes API', function () {
         }
         tmpFolderContents.should.be.an.Array().with.lengthOf(12);
 
-        tmpFolderContents.should.eql([
+        assert.deepEqual(tmpFolderContents, [
             'broken-theme',
             'casper',
             'casper.zip',

--- a/ghost/core/test/e2e-frontend/default-routes.test.js
+++ b/ghost/core/test/e2e-frontend/default-routes.test.js
@@ -345,15 +345,13 @@ describe('Default Frontend routing', function () {
                 .expect(200)
                 .expect(assertCorrectFrontendHeaders);
 
-            res.text.should.equal(
-                'User-agent: *\n' +
-                'Sitemap: http://127.0.0.1:2369/sitemap.xml\nDisallow: /ghost/\n' +
-                'Disallow: /email/\n' +
-                'Disallow: /members/api/comments/counts/\n' +
-                'Disallow: /r/\n' +
-                'Disallow: /webmentions/receive/\n' +
-                'Disallow: /.ghost/analytics/api/\n'
-            );
+            assert.equal(res.text, 'User-agent: *\n' +
+            'Sitemap: http://127.0.0.1:2369/sitemap.xml\nDisallow: /ghost/\n' +
+            'Disallow: /email/\n' +
+            'Disallow: /members/api/comments/counts/\n' +
+            'Disallow: /r/\n' +
+            'Disallow: /webmentions/receive/\n' +
+            'Disallow: /.ghost/analytics/api/\n');
         });
 
         it('should retrieve default favicon.ico', async function () {

--- a/ghost/core/test/e2e-frontend/theme-i18n.test.js
+++ b/ghost/core/test/e2e-frontend/theme-i18n.test.js
@@ -2,6 +2,7 @@
 // Tests theme translations using the {{t}} helper
 // Uses the Admin API to change locale and labs settings
 
+const assert = require('node:assert/strict');
 const cheerio = require('cheerio');
 const {agentProvider, fixtureManager} = require('../utils/e2e-framework');
 const config = require('../../core/shared/config');
@@ -39,13 +40,13 @@ describe('Theme i18n', function () {
             .expect((res) => {
                 const $ = cheerio.load(res.text);
                 if (translated) {
-                    $('.translation-test .translated').text().should.equal(translated);
+                    assert.equal($('.translation-test .translated').text(), translated);
                 }
                 if (untranslated) {
-                    $('.translation-test .untranslated').text().should.equal(untranslated);
+                    assert.equal($('.translation-test .untranslated').text(), untranslated);
                 }
                 if (interpolated) {
-                    $('.translation-test .interpolated').text().should.equal(interpolated);
+                    assert.equal($('.translation-test .interpolated').text(), interpolated);
                 }
             });
     }

--- a/ghost/core/test/e2e-server/admin.test.js
+++ b/ghost/core/test/e2e-server/admin.test.js
@@ -130,7 +130,7 @@ describe('Admin Routing', function () {
                 .set('X-Forwarded-Proto', 'https')
                 .expect(200);
 
-            res.text.should.equal(prodTemplate);
+            assert.equal(res.text, prodTemplate);
         });
 
         it('serves assets when not in production', async function () {
@@ -140,7 +140,7 @@ describe('Admin Routing', function () {
                 .set('X-Forwarded-Proto', 'https')
                 .expect(200);
 
-            res.text.should.equal(devTemplate);
+            assert.equal(res.text, devTemplate);
         });
 
         it('generates it\'s own ETag header from file contents', async function () {

--- a/ghost/core/test/e2e-server/services/stats/mrr-stats-service.test.js
+++ b/ghost/core/test/e2e-server/services/stats/mrr-stats-service.test.js
@@ -55,7 +55,7 @@ describe('MRR Stats Service', function () {
     describe('getCurrentMrr', function () {
         it('Always returns at least one currency', async function () {
             const result = await statsService.api.mrr.getCurrentMrr();
-            result.should.eql([
+            assert.deepEqual(result, [
                 {
                     currency: 'usd', // need to check capital usage here!
                     mrr: 0
@@ -66,7 +66,7 @@ describe('MRR Stats Service', function () {
         it('Can handle multiple currencies', async function () {
             await createMemberWithSubscription('month', 500, 'eur', '2000-01-10');
             const result = await statsService.api.mrr.getCurrentMrr();
-            result.should.eql([
+            assert.deepEqual(result, [
                 {
                     currency: 'EUR',
                     mrr: 500
@@ -77,7 +77,7 @@ describe('MRR Stats Service', function () {
         it('Increases MRR by 1 / 12 of yearly subscriptions', async function () {
             await createMemberWithSubscription('year', 12, 'usd', '2000-01-10');
             const result = await statsService.api.mrr.getCurrentMrr();
-            result.should.eql([
+            assert.deepEqual(result, [
                 {
                     currency: 'EUR',
                     mrr: 500
@@ -92,7 +92,7 @@ describe('MRR Stats Service', function () {
         it('Increases MRR with monthly subscriptions', async function () {
             await createMemberWithSubscription('month', 1, 'usd', '2000-01-11');
             const result = await statsService.api.mrr.getCurrentMrr();
-            result.should.eql([
+            assert.deepEqual(result, [
                 {
                     currency: 'EUR',
                     mrr: 500
@@ -107,7 +107,7 @@ describe('MRR Stats Service', function () {
         it('Floors results', async function () {
             await createMemberWithSubscription('year', 17, 'usd', '2000-01-12');
             let result = await statsService.api.mrr.getCurrentMrr();
-            result.should.eql([
+            assert.deepEqual(result, [
                 {
                     currency: 'EUR',
                     mrr: 500
@@ -121,7 +121,7 @@ describe('MRR Stats Service', function () {
             // Floor 11/12 to 0 (same as getMRRDelta method)
             await createMemberWithSubscription('year', 11, 'usd', '2000-01-12');
             result = await statsService.api.mrr.getCurrentMrr();
-            result.should.eql([
+            assert.deepEqual(result, [
                 {
                     currency: 'EUR',
                     mrr: 500
@@ -135,7 +135,7 @@ describe('MRR Stats Service', function () {
             // Floor 11/12 to 0, don't combine with previous addition
             await createMemberWithSubscription('year', 11, 'usd', '2000-01-12');
             result = await statsService.api.mrr.getCurrentMrr();
-            result.should.eql([
+            assert.deepEqual(result, [
                 {
                     currency: 'EUR',
                     mrr: 500
@@ -149,7 +149,7 @@ describe('MRR Stats Service', function () {
             // Floor 13/12 to 1
             await createMemberWithSubscription('year', 13, 'usd', '2000-01-12');
             result = await statsService.api.mrr.getCurrentMrr();
-            result.should.eql([
+            assert.deepEqual(result, [
                 {
                     currency: 'EUR',
                     mrr: 500

--- a/ghost/core/test/integration/exporter/exporter.test.js
+++ b/ghost/core/test/integration/exporter/exporter.test.js
@@ -111,7 +111,7 @@ describe('Exporter', function () {
             //       because when `have.only.keys` fails there's no useful diff
             Object.keys(exportData.data).sort().should.eql(tables.sort());
             Object.keys(exportData.data).sort().should.containDeep(Object.keys(exportedBodyLatest().db[0].data));
-            exportData.meta.version.should.equal(ghostVersion.full);
+            assert.equal(exportData.meta.version, ghostVersion.full);
 
             // excludes table should contain no data
             const excludedTables = [

--- a/ghost/core/test/integration/importer/v2.test.js
+++ b/ghost/core/test/integration/importer/v2.test.js
@@ -333,13 +333,13 @@ describe('Importer', function () {
                 .then(function (result) {
                     assert.equal(result.models.length, 2);
 
-                    result.models[0].get('email').should.equal(testUtils.DataGenerator.Content.users[0].email);
-                    result.models[0].get('slug').should.equal(testUtils.DataGenerator.Content.users[0].slug);
-                    result.models[0].get('name').should.equal(testUtils.DataGenerator.Content.users[0].name);
+                    assert.equal(result.models[0].get('email'), testUtils.DataGenerator.Content.users[0].email);
+                    assert.equal(result.models[0].get('slug'), testUtils.DataGenerator.Content.users[0].slug);
+                    assert.equal(result.models[0].get('name'), testUtils.DataGenerator.Content.users[0].name);
 
-                    result.models[1].get('email').should.equal(exportData.data.users[0].email);
-                    result.models[1].get('slug').should.equal(exportData.data.users[0].slug);
-                    result.models[1].get('name').should.equal(exportData.data.users[0].name);
+                    assert.equal(result.models[1].get('email'), exportData.data.users[0].email);
+                    assert.equal(result.models[1].get('slug'), exportData.data.users[0].slug);
+                    assert.equal(result.models[1].get('name'), exportData.data.users[0].name);
 
                     return models.User.isPasswordCorrect({
                         hashedPassword: result.models[0].get('password'),
@@ -604,32 +604,32 @@ describe('Importer', function () {
                     assert.equal(posts.length, exportData.data.posts.length, 'Wrong number of posts');
 
                     // findPage returns the posts in correct order (latest created post is the first)
-                    posts[0].title.should.equal(exportData.data.posts[2].title);
-                    posts[1].title.should.equal(exportData.data.posts[1].title);
-                    posts[2].title.should.equal(exportData.data.posts[0].title);
+                    assert.equal(posts[0].title, exportData.data.posts[2].title);
+                    assert.equal(posts[1].title, exportData.data.posts[1].title);
+                    assert.equal(posts[2].title, exportData.data.posts[0].title);
 
-                    posts[0].slug.should.equal(exportData.data.posts[2].slug);
-                    posts[1].slug.should.equal(exportData.data.posts[1].slug);
-                    posts[2].slug.should.equal(exportData.data.posts[0].slug);
+                    assert.equal(posts[0].slug, exportData.data.posts[2].slug);
+                    assert.equal(posts[1].slug, exportData.data.posts[1].slug);
+                    assert.equal(posts[2].slug, exportData.data.posts[0].slug);
 
-                    posts[0].primary_author.id.should.equal(users[1].id);
-                    posts[1].primary_author.id.should.equal(users[4].id);
-                    posts[2].primary_author.id.should.equal(users[1].id);
+                    assert.equal(posts[0].primary_author.id, users[1].id);
+                    assert.equal(posts[1].primary_author.id, users[4].id);
+                    assert.equal(posts[2].primary_author.id, users[1].id);
 
-                    posts[0].published_by.should.equal(users[4].id);
-                    posts[1].published_by.should.equal(users[2].id);
-                    posts[2].published_by.should.equal(users[2].id);
+                    assert.equal(posts[0].published_by, users[4].id);
+                    assert.equal(posts[1].published_by, users[2].id);
+                    assert.equal(posts[2].published_by, users[2].id);
 
                     assert.equal(tags.length, exportData.data.tags.length, 'Wrong number of tags');
 
                     // 4 imported users + 1 owner user
                     assert.equal(users.length, exportData.data.users.length + 1, 'Wrong number of users');
 
-                    users[0].email.should.equal(testUtils.DataGenerator.Content.users[0].email);
-                    users[1].email.should.equal(exportData.data.users[0].email);
-                    users[2].email.should.equal(exportData.data.users[1].email);
-                    users[3].email.should.equal(exportData.data.users[2].email);
-                    users[4].email.should.equal(exportData.data.users[3].email);
+                    assert.equal(users[0].email, testUtils.DataGenerator.Content.users[0].email);
+                    assert.equal(users[1].email, exportData.data.users[0].email);
+                    assert.equal(users[2].email, exportData.data.users[1].email);
+                    assert.equal(users[3].email, exportData.data.users[2].email);
+                    assert.equal(users[4].email, exportData.data.users[3].email);
 
                     assert.equal(users[0].status, 'active');
                     assert.equal(users[1].status, 'locked');
@@ -637,15 +637,15 @@ describe('Importer', function () {
                     assert.equal(users[3].status, 'locked');
                     assert.equal(users[4].status, 'locked');
 
-                    users[1].created_at.toISOString().should.equal(moment(exportData.data.users[0].created_at).startOf('seconds').toISOString());
-                    users[2].created_at.toISOString().should.equal(moment(exportData.data.users[1].created_at).startOf('seconds').toISOString());
-                    users[3].created_at.toISOString().should.equal(moment(exportData.data.users[2].created_at).startOf('seconds').toISOString());
-                    users[4].created_at.toISOString().should.equal(moment(exportData.data.users[3].created_at).startOf('seconds').toISOString());
+                    assert.equal(users[1].created_at.toISOString(), moment(exportData.data.users[0].created_at).startOf('seconds').toISOString());
+                    assert.equal(users[2].created_at.toISOString(), moment(exportData.data.users[1].created_at).startOf('seconds').toISOString());
+                    assert.equal(users[3].created_at.toISOString(), moment(exportData.data.users[2].created_at).startOf('seconds').toISOString());
+                    assert.equal(users[4].created_at.toISOString(), moment(exportData.data.users[3].created_at).startOf('seconds').toISOString());
 
-                    users[1].updated_at.toISOString().should.equal(moment(exportData.data.users[0].updated_at).startOf('seconds').toISOString());
-                    users[2].updated_at.toISOString().should.equal(moment(exportData.data.users[1].updated_at).startOf('seconds').toISOString());
-                    users[3].updated_at.toISOString().should.equal(moment(exportData.data.users[2].updated_at).startOf('seconds').toISOString());
-                    users[4].updated_at.toISOString().should.equal(moment(exportData.data.users[3].updated_at).startOf('seconds').toISOString());
+                    assert.equal(users[1].updated_at.toISOString(), moment(exportData.data.users[0].updated_at).startOf('seconds').toISOString());
+                    assert.equal(users[2].updated_at.toISOString(), moment(exportData.data.users[1].updated_at).startOf('seconds').toISOString());
+                    assert.equal(users[3].updated_at.toISOString(), moment(exportData.data.users[2].updated_at).startOf('seconds').toISOString());
+                    assert.equal(users[4].updated_at.toISOString(), moment(exportData.data.users[3].updated_at).startOf('seconds').toISOString());
 
                     users[0].roles[0].id.should.eql(testUtils.DataGenerator.Content.roles[3].id);
                     users[1].roles[0].id.should.eql(testUtils.DataGenerator.Content.roles[0].id);

--- a/ghost/core/test/integration/importer/v5.js
+++ b/ghost/core/test/integration/importer/v5.js
@@ -80,7 +80,7 @@ describe('Importing 5.x export', function () {
         const post1 = posts.data[0].toJSON();
         const post2 = posts.data[1].toJSON();
 
-        post1.authors[0].id.should.equal(user2.id);
-        post2.authors[0].id.should.equal(user2.id);
+        assert.equal(post1.authors[0].id, user2.id);
+        assert.equal(post2.authors[0].id, user2.id);
     });
 });

--- a/ghost/core/test/legacy/api/admin/db.test.js
+++ b/ghost/core/test/legacy/api/admin/db.test.js
@@ -368,7 +368,7 @@ describe('DB API', function () {
         const post = await models.Post.findOne({slug: 'test-newsletter'}, {withRelated: ['tiers']});
         assertExists(post);
 
-        post.get('newsletter_id').should.equal(newsletter.id);
+        assert.equal(post.get('newsletter_id'), newsletter.id);
         assert.equal(post.get('visibility'), 'public');
         assert.equal(post.get('email_recipient_filter'), 'status:-free');
 
@@ -443,7 +443,7 @@ describe('DB API (cleaned)', function () {
         // Check if we have a product
         const product = await models.Product.findOne({slug: 'ghost-inc'});
         assertExists(product);
-        product.id.should.equal(existingProduct.id);
+        assert.equal(product.id, existingProduct.id);
         assert.equal(product.get('slug'), 'ghost-inc');
         assert.equal(product.get('name'), 'Ghost Inc.');
         assert.equal(product.get('description'), 'Our daily newsletter');
@@ -470,7 +470,7 @@ describe('DB API (cleaned)', function () {
         const post = await models.Post.findOne({slug: 'test-newsletter'}, {withRelated: ['tiers']});
         assertExists(post);
 
-        post.get('newsletter_id').should.equal(newsletter.id);
+        assert.equal(post.get('newsletter_id'), newsletter.id);
         assert.equal(post.get('visibility'), 'public');
         assert.equal(post.get('email_recipient_filter'), 'status:-free');
 

--- a/ghost/core/test/legacy/api/admin/members-importer.test.js
+++ b/ghost/core/test/legacy/api/admin/members-importer.test.js
@@ -195,7 +195,7 @@ describe('Members Importer API', function () {
                 assert.equal(defaultMember1.labels.length, 1); // auto-generated import label
 
                 const defaultMember2 = jsonResponse.members.find(member => (member.email === 'member+defaults_2@example.com'));
-                should(defaultMember2).not.be.undefined();
+                assertExists(defaultMember2);
             });
     });
 

--- a/ghost/core/test/legacy/api/admin/posts.test.js
+++ b/ghost/core/test/legacy/api/admin/posts.test.js
@@ -142,7 +142,7 @@ describe('Posts API', function () {
                     assertExists(jsonResponse.posts);
                     localUtils.API.checkResponse(jsonResponse, 'posts');
                     assert.equal(jsonResponse.posts.length, 1);
-                    jsonResponse.posts[0].id.should.equal(testUtils.DataGenerator.Content.posts[2].id);
+                    assert.equal(jsonResponse.posts[0].id, testUtils.DataGenerator.Content.posts[2].id);
                     assert.equal(jsonResponse.posts[0].meta_description, 'meta description for short and sweet');
 
                     localUtils.API.checkResponse(
@@ -317,7 +317,7 @@ describe('Posts API', function () {
                     assert.equal(res.body.posts[0].title, '(Untitled)');
 
                     assertExists(res.headers.location);
-                    res.headers.location.should.equal(`http://127.0.0.1:2369${localUtils.API.getApiQuery('posts/')}${res.body.posts[0].id}/`);
+                    assert.equal(res.headers.location, `http://127.0.0.1:2369${localUtils.API.getApiQuery('posts/')}${res.body.posts[0].id}/`);
                 });
         });
 
@@ -456,7 +456,7 @@ describe('Posts API', function () {
             assertExists(res2.body.posts[0].title);
             assert.equal(res2.body.posts[0].title, 'Tags test 6');
             assert.equal(res2.body.posts[0].tags.length, 1);
-            res2.body.posts[0].tags[0].id.should.equal(res.body.posts[0].tags[0].id);
+            assert.equal(res2.body.posts[0].tags[0].id, res.body.posts[0].tags[0].id);
         });
 
         it('can add with tags - slug with spaces not automated', async function () {
@@ -502,7 +502,7 @@ describe('Posts API', function () {
             assertExists(res2.body.posts[0].title);
             assert.equal(res2.body.posts[0].title, 'Tags test 8');
             assert.equal(res2.body.posts[0].tags.length, 1);
-            res2.body.posts[0].tags[0].id.should.equal(res.body.posts[0].tags[0].id);
+            assert.equal(res2.body.posts[0].tags[0].id, res.body.posts[0].tags[0].id);
         });
 
         it('can add with tags - too long slug', async function () {
@@ -525,7 +525,7 @@ describe('Posts API', function () {
             assertExists(res.body.posts[0].title);
             assert.equal(res.body.posts[0].title, 'Tags test 9');
             assert.equal(res.body.posts[0].tags.length, 1);
-            res.body.posts[0].tags[0].slug.should.equal(tooLongSlug.substring(0, 185));
+            assert.equal(res.body.posts[0].tags[0].slug, tooLongSlug.substring(0, 185));
 
             // If we create another post again now that the very long tag exists,
             // we need to make sure it matches correctly and doesn't create a new tag again
@@ -547,7 +547,7 @@ describe('Posts API', function () {
             assertExists(res2.body.posts[0].title);
             assert.equal(res2.body.posts[0].title, 'Tags test 10');
             assert.equal(res2.body.posts[0].tags.length, 1);
-            res2.body.posts[0].tags[0].id.should.equal(res.body.posts[0].tags[0].id);
+            assert.equal(res2.body.posts[0].tags[0].id, res.body.posts[0].tags[0].id);
         });
     });
 
@@ -600,7 +600,7 @@ describe('Posts API', function () {
             assert.equal(res.body.posts[0].status, 'draft');
 
             assertExists(res.headers.location);
-            res.headers.location.should.equal(`http://127.0.0.1:2369${localUtils.API.getApiQuery('posts/')}${res.body.posts[0].id}/`);
+            assert.equal(res.headers.location, `http://127.0.0.1:2369${localUtils.API.getApiQuery('posts/')}${res.body.posts[0].id}/`);
 
             const publishedRes = await request
                 .put(localUtils.API.getApiQuery(`posts/${res.body.posts[0].id}/?newsletter=${defaultNewsletterSlug}`))
@@ -643,7 +643,7 @@ describe('Posts API', function () {
             assert.equal(res.body.posts[0].status, 'draft');
 
             assertExists(res.headers.location);
-            res.headers.location.should.equal(`http://127.0.0.1:2369${localUtils.API.getApiQuery('posts/')}${res.body.posts[0].id}/`);
+            assert.equal(res.headers.location, `http://127.0.0.1:2369${localUtils.API.getApiQuery('posts/')}${res.body.posts[0].id}/`);
 
             const publishedRes = await request
                 .put(localUtils.API.getApiQuery(`posts/${res.body.posts[0].id}/?email_segment=status:-free&newsletter=${defaultNewsletterSlug}`))
@@ -686,7 +686,7 @@ describe('Posts API', function () {
             assert.equal(res.body.posts[0].status, 'draft');
 
             assertExists(res.headers.location);
-            res.headers.location.should.equal(`http://127.0.0.1:2369${localUtils.API.getApiQuery('posts/')}${res.body.posts[0].id}/`);
+            assert.equal(res.headers.location, `http://127.0.0.1:2369${localUtils.API.getApiQuery('posts/')}${res.body.posts[0].id}/`);
 
             const publishedRes = await request
                 .put(localUtils.API.getApiQuery(`posts/${res.body.posts[0].id}/?email_segment=status:-free&newsletter=${secondNewsletterSlug}`))
@@ -791,7 +791,7 @@ describe('Posts API', function () {
                 .then((res) => {
                     assertExists(res.body.posts);
                     assertExists(res.body.posts[0].canonical_url);
-                    res.body.posts[0].canonical_url.should.equal(`${config.get('url')}/canonical/url`);
+                    assert.equal(res.body.posts[0].canonical_url, `${config.get('url')}/canonical/url`);
                 });
         });
 
@@ -875,7 +875,7 @@ describe('Posts API', function () {
                 .then((res) => {
                     assertExists(res.body.posts);
                     assertExists(res.body.posts[0].title);
-                    res.body.posts[0].title.should.equal(untrimmedTitle.trim());
+                    assert.equal(res.body.posts[0].title, untrimmedTitle.trim());
                 });
         });
 

--- a/ghost/core/test/legacy/models/model-newsletters.test.js
+++ b/ghost/core/test/legacy/models/model-newsletters.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const {assertExists} = require('../../utils/assertions');
 const should = require('should');
 const sinon = require('sinon');
@@ -29,7 +30,7 @@ describe('Newsletter Model', function () {
         it('transforms header_image to absolute site URL', async function () {
             const newsletter = await models.Newsletter.findOne({slug: 'new-newsletter'});
             assertExists(newsletter, 'New newsletter should exist');
-            newsletter.get('header_image').should.equal(`${siteUrl}/content/images/newsletter-header.jpg`);
+            assert.equal(newsletter.get('header_image'), `${siteUrl}/content/images/newsletter-header.jpg`);
         });
     });
 
@@ -48,7 +49,7 @@ describe('Newsletter Model', function () {
         it('transforms header_image to absolute site URL(NOT CDN)', async function () {
             const newsletter = await models.Newsletter.findOne({slug: 'new-newsletter'});
             assertExists(newsletter, 'New newsletter should exist');
-            newsletter.get('header_image').should.equal(`${siteUrl}/content/images/newsletter-header.jpg`);
+            assert.equal(newsletter.get('header_image'), `${siteUrl}/content/images/newsletter-header.jpg`);
         });
     });
 });

--- a/ghost/core/test/legacy/models/model-posts.test.js
+++ b/ghost/core/test/legacy/models/model-posts.test.js
@@ -256,7 +256,7 @@ describe('Post Model', function () {
                     let post;
                     assertExists(results);
                     post = results.toJSON();
-                    post.id.should.equal(postId);
+                    assert.equal(post.id, postId);
                     assert.notEqual(post.title, 'new title');
 
                     return models.Post.edit({title: 'new title'}, _.extend({}, context, {id: postId}));
@@ -279,7 +279,7 @@ describe('Post Model', function () {
                     let post;
                     assertExists(results);
                     post = results.toJSON();
-                    post.id.should.equal(postId);
+                    assert.equal(post.id, postId);
 
                     return models.Post.edit({
                         custom_excerpt: new Array(302).join('a')
@@ -299,7 +299,7 @@ describe('Post Model', function () {
                     let post;
                     assertExists(results);
                     post = results.toJSON();
-                    post.id.should.equal(postId);
+                    assert.equal(post.id, postId);
                     assert.equal(post.status, 'draft');
 
                     return models.Post.edit({status: 'published'}, _.extend({}, context, {id: postId}));
@@ -324,7 +324,7 @@ describe('Post Model', function () {
                     let post;
                     assertExists(results);
                     post = results.toJSON();
-                    post.id.should.equal(postId);
+                    assert.equal(post.id, postId);
                     assert.equal(post.status, 'published');
 
                     return models.Post.edit({status: 'draft'}, _.extend({}, context, {id: postId}));
@@ -502,7 +502,7 @@ describe('Post Model', function () {
                     let post;
                     assertExists(results);
                     post = results.toJSON();
-                    post.id.should.equal(postId);
+                    assert.equal(post.id, postId);
                     assert.equal(post.status, 'published');
 
                     return models.Post.edit({
@@ -525,7 +525,7 @@ describe('Post Model', function () {
                     let post;
                     assertExists(results);
                     post = results.toJSON();
-                    post.id.should.equal(postId);
+                    assert.equal(post.id, postId);
                     assert.equal(post.status, 'draft');
 
                     return models.Post.edit({type: 'page'}, _.extend({}, context, {id: postId}));
@@ -599,7 +599,7 @@ describe('Post Model', function () {
                     let post;
                     assertExists(results);
                     post = results.toJSON();
-                    post.id.should.equal(postId);
+                    assert.equal(post.id, postId);
                     assert.equal(post.status, 'published');
 
                     return models.Post.edit({type: 'page'}, _.extend({}, context, {id: postId}));
@@ -637,7 +637,7 @@ describe('Post Model', function () {
                     let post;
                     assertExists(results);
                     post = results.toJSON();
-                    post.id.should.equal(postId);
+                    assert.equal(post.id, postId);
                     assert.equal(post.status, 'draft');
 
                     return models.Post.edit({type: 'page', status: 'published'}, _.extend({}, context, {id: postId}));
@@ -675,7 +675,7 @@ describe('Post Model', function () {
                     let post;
                     assertExists(results);
                     post = results.toJSON();
-                    post.id.should.equal(postId);
+                    assert.equal(post.id, postId);
                     assert.equal(post.status, 'draft');
 
                     // Test changing status and published_by at the same time
@@ -686,14 +686,14 @@ describe('Post Model', function () {
                 }).then(function (edited) {
                     assertExists(edited);
                     assert.equal(edited.attributes.status, 'published');
-                    edited.attributes.published_by.should.equal(context.context.user);
+                    assert.equal(edited.attributes.published_by, context.context.user);
 
                     // Test changing status and published_by on its own
                     return models.Post.edit({published_by: 4}, _.extend({}, context, {id: postId}));
                 }).then(function (edited) {
                     assertExists(edited);
                     assert.equal(edited.attributes.status, 'published');
-                    edited.attributes.published_by.should.equal(context.context.user);
+                    assert.equal(edited.attributes.published_by, context.context.user);
 
                     done();
                 }).catch(done);
@@ -742,10 +742,10 @@ describe('Post Model', function () {
                     assert.equal(createdPost.get('title'), newPost.title, 'title is correct');
                     assert.equal(createdPost.get('mobiledoc'), newPost.mobiledoc, 'mobiledoc is correct');
                     assert.equal(createdPost.has('html'), true);
-                    createdPost.get('html').should.equal(newPostDB.html);
+                    assert.equal(createdPost.get('html'), newPostDB.html);
                     assert.equal(createdPost.has('plaintext'), true);
                     assert.match(createdPost.get('plaintext'), /^testing/);
-                    createdPost.get('slug').should.equal(newPostDB.slug + '-2');
+                    assert.equal(createdPost.get('slug'), newPostDB.slug + '-2');
                     assert.equal((!!createdPost.get('featured')), false);
                     assert.equal((!!createdPost.get('page')), false);
 
@@ -756,7 +756,7 @@ describe('Post Model', function () {
                     assert.equal((createdPost.get('feature_image') === null), true);
 
                     createdPost.get('created_at').should.be.above(new Date(0).getTime());
-                    createdPost.relations.authors.models[0].id.should.equal(testUtils.DataGenerator.Content.users[0].id);
+                    assert.equal(createdPost.relations.authors.models[0].id, testUtils.DataGenerator.Content.users[0].id);
                     createdPost.get('updated_at').should.be.above(new Date(0).getTime());
                     assert.equal(createdPost.get('published_at'), null);
                     assert.equal(createdPost.get('published_by'), null);
@@ -771,7 +771,7 @@ describe('Post Model', function () {
                     return createdPost.save({status: 'published'}, context);
                 }).then(function (publishedPost) {
                     publishedPost.get('published_at').should.be.instanceOf(Date);
-                    publishedPost.get('published_by').should.equal(testUtils.DataGenerator.Content.users[0].id);
+                    assert.equal(publishedPost.get('published_by'), testUtils.DataGenerator.Content.users[0].id);
                     publishedPost.get('updated_at').should.be.instanceOf(Date);
                     publishedPost.get('updated_at').should.not.equal(createdPostUpdatedDate);
 
@@ -811,7 +811,7 @@ describe('Post Model', function () {
                     assert.equal(createdPost.get('title'), newPost.title, 'title is correct');
                     assert.equal(createdPost.get('mobiledoc'), newPost.mobiledoc, 'mobiledoc is correct');
                     assert.equal(createdPost.has('html'), true);
-                    createdPost.get('html').should.equal(newPostDB.html);
+                    assert.equal(createdPost.get('html'), newPostDB.html);
                     assert.equal(createdPost.has('plaintext'), true);
                     assert.match(createdPost.get('plaintext'), /^testing/);
                     // createdPost.get('slug').should.equal(newPostDB.slug + '-3');
@@ -825,7 +825,7 @@ describe('Post Model', function () {
                     assert.equal((createdPost.get('feature_image') === null), true);
 
                     createdPost.get('created_at').should.be.above(new Date(0).getTime());
-                    createdPost.relations.authors.models[0].id.should.equal(testUtils.DataGenerator.Content.users[0].id);
+                    assert.equal(createdPost.relations.authors.models[0].id, testUtils.DataGenerator.Content.users[0].id);
                     createdPost.get('updated_at').should.be.above(new Date(0).getTime());
                     assert.equal(createdPost.get('published_at'), null);
                     assert.equal(createdPost.get('published_by'), null);
@@ -840,7 +840,7 @@ describe('Post Model', function () {
                     return createdPost.save({status: 'published'}, context);
                 }).then(function (publishedPost) {
                     publishedPost.get('published_at').should.be.instanceOf(Date);
-                    publishedPost.get('published_by').should.equal(testUtils.DataGenerator.Content.users[0].id);
+                    assert.equal(publishedPost.get('published_by'), testUtils.DataGenerator.Content.users[0].id);
                     publishedPost.get('updated_at').should.be.instanceOf(Date);
                     publishedPost.get('updated_at').should.not.equal(createdPostUpdatedDate);
 
@@ -862,7 +862,7 @@ describe('Post Model', function () {
                     mobiledoc: markdownToMobiledoc('This is some content')
                 }, context).then(function (newPost) {
                     assertExists(newPost);
-                    new Date(newPost.get('published_at')).getTime().should.equal(previousPublishedAtDate.getTime());
+                    assert.equal(new Date(newPost.get('published_at')).getTime(), previousPublishedAtDate.getTime());
 
                     assert.equal(Object.keys(eventsTriggered).length, 3);
                     assertExists(eventsTriggered['post.added']);
@@ -1009,8 +1009,8 @@ describe('Post Model', function () {
                             return;
                         }
 
-                        post.get('slug').should.equal('test-title-' + num);
-                        JSON.parse(post.get('mobiledoc')).cards[0][1].markdown.should.equal('Test Content ' + num);
+                        assert.equal(post.get('slug'), 'test-title-' + num);
+                        assert.equal(JSON.parse(post.get('mobiledoc')).cards[0][1].markdown, 'Test Content ' + num);
 
                         assert.equal(Object.keys(eventsTriggered).length, 2);
                         assertExists(eventsTriggered['post.added']);
@@ -1215,59 +1215,59 @@ describe('Post Model', function () {
                     });
 
                     it('transforms feature_image, og_image, and twitter_image to absolute site URLs', function () {
-                        post.get('feature_image').should.equal(`${siteUrl}/content/images/feature.jpg`);
-                        postsMeta.get('og_image').should.equal(`${siteUrl}/content/images/og.jpg`);
-                        postsMeta.get('twitter_image').should.equal(`${siteUrl}/content/images/twitter.jpg`);
+                        assert.equal(post.get('feature_image'), `${siteUrl}/content/images/feature.jpg`);
+                        assert.equal(postsMeta.get('og_image'), `${siteUrl}/content/images/og.jpg`);
+                        assert.equal(postsMeta.get('twitter_image'), `${siteUrl}/content/images/twitter.jpg`);
                     });
 
                     it('transforms all media card URLs to absolute site URLs', function () {
                         // Image card
                         const imageCard = mobiledoc.cards.find(card => card[0] === 'image' && card[1].src.includes('inline.jpg'));
-                        imageCard[1].src.should.equal(`${siteUrl}/content/images/inline.jpg`);
+                        assert.equal(imageCard[1].src, `${siteUrl}/content/images/inline.jpg`);
 
                         // Gallery card
                         const galleryCard = mobiledoc.cards.find(card => card[0] === 'gallery');
-                        galleryCard[1].images[0].src.should.equal(`${siteUrl}/content/images/gallery-1.jpg`);
-                        galleryCard[1].images[1].src.should.equal(`${siteUrl}/content/images/gallery-2.jpg`);
-                        galleryCard[1].images[2].src.should.equal(`${siteUrl}/content/images/gallery-3.jpg`);
+                        assert.equal(galleryCard[1].images[0].src, `${siteUrl}/content/images/gallery-1.jpg`);
+                        assert.equal(galleryCard[1].images[1].src, `${siteUrl}/content/images/gallery-2.jpg`);
+                        assert.equal(galleryCard[1].images[2].src, `${siteUrl}/content/images/gallery-3.jpg`);
 
                         // File card
                         const fileCard = mobiledoc.cards.find(card => card[0] === 'file' && card[1].src.includes('document.pdf'));
-                        fileCard[1].src.should.equal(`${siteUrl}/content/files/document.pdf`);
+                        assert.equal(fileCard[1].src, `${siteUrl}/content/files/document.pdf`);
 
                         // Video card
                         const videoCard = mobiledoc.cards.find(card => card[0] === 'video' && card[1].src.includes('video.mp4') && !card[1].src.includes('snippet'));
-                        videoCard[1].src.should.equal(`${siteUrl}/content/media/video.mp4`);
-                        videoCard[1].thumbnailSrc.should.equal(`${siteUrl}/content/images/video-thumb.jpg`);
+                        assert.equal(videoCard[1].src, `${siteUrl}/content/media/video.mp4`);
+                        assert.equal(videoCard[1].thumbnailSrc, `${siteUrl}/content/images/video-thumb.jpg`);
 
                         // Audio card
                         const audioCard = mobiledoc.cards.find(card => card[0] === 'audio' && card[1].src.includes('audio.mp3') && !card[1].src.includes('snippet'));
-                        audioCard[1].src.should.equal(`${siteUrl}/content/media/audio.mp3`);
-                        audioCard[1].thumbnailSrc.should.equal(`${siteUrl}/content/images/audio-thumb.jpg`);
+                        assert.equal(audioCard[1].src, `${siteUrl}/content/media/audio.mp3`);
+                        assert.equal(audioCard[1].thumbnailSrc, `${siteUrl}/content/images/audio-thumb.jpg`);
 
                         // Link markup
                         const linkMarkup = mobiledoc.markups.find(markup => markup[0] === 'a');
-                        linkMarkup[1][1].should.equal(`${siteUrl}/snippet-link`);
+                        assert.equal(linkMarkup[1][1], `${siteUrl}/snippet-link`);
                     });
 
                     it('transforms inserted snippet URLs to absolute site URLs', function () {
                         // Snippet image
                         const snippetImage = mobiledoc.cards.find(card => card[0] === 'image' && card[1].src.includes('snippet-inline'));
-                        snippetImage[1].src.should.equal(`${siteUrl}/content/images/snippet-inline.jpg`);
+                        assert.equal(snippetImage[1].src, `${siteUrl}/content/images/snippet-inline.jpg`);
 
                         // Snippet file
                         const snippetFile = mobiledoc.cards.find(card => card[0] === 'file' && card[1].src.includes('snippet-document'));
-                        snippetFile[1].src.should.equal(`${siteUrl}/content/files/snippet-document.pdf`);
+                        assert.equal(snippetFile[1].src, `${siteUrl}/content/files/snippet-document.pdf`);
 
                         // Snippet video
                         const snippetVideo = mobiledoc.cards.find(card => card[0] === 'video' && card[1].src.includes('snippet-video'));
-                        snippetVideo[1].src.should.equal(`${siteUrl}/content/media/snippet-video.mp4`);
-                        snippetVideo[1].thumbnailSrc.should.equal(`${siteUrl}/content/images/snippet-video-thumb.jpg`);
+                        assert.equal(snippetVideo[1].src, `${siteUrl}/content/media/snippet-video.mp4`);
+                        assert.equal(snippetVideo[1].thumbnailSrc, `${siteUrl}/content/images/snippet-video-thumb.jpg`);
 
                         // Snippet audio
                         const snippetAudio = mobiledoc.cards.find(card => card[0] === 'audio' && card[1].src.includes('snippet-audio'));
-                        snippetAudio[1].src.should.equal(`${siteUrl}/content/media/snippet-audio.mp3`);
-                        snippetAudio[1].thumbnailSrc.should.equal(`${siteUrl}/content/images/snippet-audio-thumb.jpg`);
+                        assert.equal(snippetAudio[1].src, `${siteUrl}/content/media/snippet-audio.mp3`);
+                        assert.equal(snippetAudio[1].thumbnailSrc, `${siteUrl}/content/images/snippet-audio-thumb.jpg`);
                     });
                 });
 
@@ -1284,9 +1284,9 @@ describe('Post Model', function () {
                     });
 
                     it('transforms feature_image, og_image, and twitter_image to absolute site URLs', function () {
-                        post.get('feature_image').should.equal(`${siteUrl}/content/images/feature.jpg`);
-                        postsMeta.get('og_image').should.equal(`${siteUrl}/content/images/og.jpg`);
-                        postsMeta.get('twitter_image').should.equal(`${siteUrl}/content/images/twitter.jpg`);
+                        assert.equal(post.get('feature_image'), `${siteUrl}/content/images/feature.jpg`);
+                        assert.equal(postsMeta.get('og_image'), `${siteUrl}/content/images/og.jpg`);
+                        assert.equal(postsMeta.get('twitter_image'), `${siteUrl}/content/images/twitter.jpg`);
                     });
 
                     it('transforms all media URLs to absolute site URLs', function () {
@@ -1335,21 +1335,21 @@ describe('Post Model', function () {
                         const post = await models.Post.findOne({slug: 'post-with-all-media-types-mobiledoc'}, {withRelated: ['tags']});
                         const mobiledoc = JSON.parse(post.get('mobiledoc'));
                         const fileCard = mobiledoc.cards.find(card => card[0] === 'file');
-                        fileCard[1].src.should.equal(`${cdnUrl}/content/files/document.pdf`);
+                        assert.equal(fileCard[1].src, `${cdnUrl}/content/files/document.pdf`);
                     });
 
                     it('transforms video card src to media CDN URL', async function () {
                         const post = await models.Post.findOne({slug: 'post-with-all-media-types-mobiledoc'}, {withRelated: ['tags']});
                         const mobiledoc = JSON.parse(post.get('mobiledoc'));
                         const videoCard = mobiledoc.cards.find(card => card[0] === 'video');
-                        videoCard[1].src.should.equal(`${cdnUrl}/content/media/video.mp4`);
+                        assert.equal(videoCard[1].src, `${cdnUrl}/content/media/video.mp4`);
                     });
 
                     it('transforms audio card src to media CDN URL', async function () {
                         const post = await models.Post.findOne({slug: 'post-with-all-media-types-mobiledoc'}, {withRelated: ['tags']});
                         const mobiledoc = JSON.parse(post.get('mobiledoc'));
                         const audioCard = mobiledoc.cards.find(card => card[0] === 'audio');
-                        audioCard[1].src.should.equal(`${cdnUrl}/content/media/audio.mp3`);
+                        assert.equal(audioCard[1].src, `${cdnUrl}/content/media/audio.mp3`);
                     });
 
                     it('transforms inserted snippet file/media URLs to CDN URLs', async function () {
@@ -1362,7 +1362,7 @@ describe('Post Model', function () {
 
                     it('transforms feature_image to absolute site URL(NOT CDN)', async function () {
                         const post = await models.Post.findOne({slug: 'post-with-all-media-types-mobiledoc'}, {withRelated: ['tags']});
-                        post.get('feature_image').should.equal(`${siteUrl}/content/images/feature.jpg`);
+                        assert.equal(post.get('feature_image'), `${siteUrl}/content/images/feature.jpg`);
                     });
 
                     it('transforms gallery images to absolute site URL(NOT CDN)', async function () {
@@ -1379,14 +1379,14 @@ describe('Post Model', function () {
                         const post = await models.Post.findOne({slug: 'post-with-all-media-types-mobiledoc'}, {withRelated: ['tags']});
                         const mobiledoc = JSON.parse(post.get('mobiledoc'));
                         const imageCard = mobiledoc.cards.find(card => card[0] === 'image');
-                        imageCard[1].src.should.equal(`${siteUrl}/content/images/inline.jpg`);
+                        assert.equal(imageCard[1].src, `${siteUrl}/content/images/inline.jpg`);
                     });
 
                     it('transforms video thumbnailSrc to absolute site URL(NOT CDN)', async function () {
                         const post = await models.Post.findOne({slug: 'post-with-all-media-types-mobiledoc'}, {withRelated: ['tags']});
                         const mobiledoc = JSON.parse(post.get('mobiledoc'));
                         const videoCard = mobiledoc.cards.find(card => card[0] === 'video');
-                        videoCard[1].thumbnailSrc.should.equal(`${siteUrl}/content/images/video-thumb.jpg`);
+                        assert.equal(videoCard[1].thumbnailSrc, `${siteUrl}/content/images/video-thumb.jpg`);
                     });
                 });
 
@@ -1414,7 +1414,7 @@ describe('Post Model', function () {
 
                     it('transforms feature_image to absolute site URL(NOT CDN)', async function () {
                         const post = await models.Post.findOne({slug: 'post-with-all-media-types-lexical'}, {withRelated: ['tags']});
-                        post.get('feature_image').should.equal(`${siteUrl}/content/images/feature.jpg`);
+                        assert.equal(post.get('feature_image'), `${siteUrl}/content/images/feature.jpg`);
                     });
 
                     it('transforms gallery images to absolute site URL(NOT CDN)', async function () {
@@ -1476,10 +1476,10 @@ describe('Post Model', function () {
                     let post;
                     assertExists(results);
                     post = results.toJSON();
-                    post.id.should.equal(firstItemData.id);
+                    assert.equal(post.id, firstItemData.id);
                     assert.equal(post.status, 'published');
                     assert.equal(post.tags.length, 2);
-                    post.tags[0].id.should.equal(testUtils.DataGenerator.Content.tags[0].id);
+                    assert.equal(post.tags[0].id, testUtils.DataGenerator.Content.tags[0].id);
 
                     // Destroy the post
                     return results.destroy();
@@ -1518,9 +1518,9 @@ describe('Post Model', function () {
                     let post;
                     assertExists(results);
                     post = results.toJSON();
-                    post.id.should.equal(firstItemData.id);
+                    assert.equal(post.id, firstItemData.id);
                     assert.equal(post.tags.length, 1);
-                    post.tags[0].id.should.equal(testUtils.DataGenerator.Content.tags[3].id);
+                    assert.equal(post.tags[0].id, testUtils.DataGenerator.Content.tags[3].id);
 
                     // Destroy the post
                     return results.destroy(firstItemData);
@@ -1558,7 +1558,7 @@ describe('Post Model', function () {
                     let page;
                     assertExists(results);
                     page = results.toJSON();
-                    page.id.should.equal(firstItemData.id);
+                    assert.equal(page.id, firstItemData.id);
                     assert.equal(page.status, 'published');
                     assert.equal(page.type, 'page');
 
@@ -1597,7 +1597,7 @@ describe('Post Model', function () {
                     let page;
                     assertExists(results);
                     page = results.toJSON();
-                    page.id.should.equal(firstItemData.id);
+                    assert.equal(page.id, firstItemData.id);
 
                     // Destroy the page
                     return results.destroy(firstItemData);
@@ -1732,7 +1732,7 @@ describe('Post Model', function () {
                     return createdPost.save({mobiledoc: markdownToMobiledoc('b')}, context);
                 })
                 .then((updatedPost) => {
-                    updatedPost.get('mobiledoc').should.equal(markdownToMobiledoc('b'));
+                    assert.equal(updatedPost.get('mobiledoc'), markdownToMobiledoc('b'));
 
                     return models.MobiledocRevision
                         .findAll({
@@ -1742,8 +1742,8 @@ describe('Post Model', function () {
                 .then((mobiledocRevisions) => {
                     assert.equal(mobiledocRevisions.length, 2);
 
-                    mobiledocRevisions.toJSON()[0].mobiledoc.should.equal(markdownToMobiledoc('b'));
-                    mobiledocRevisions.toJSON()[1].mobiledoc.should.equal(markdownToMobiledoc('a'));
+                    assert.equal(mobiledocRevisions.toJSON()[0].mobiledoc, markdownToMobiledoc('b'));
+                    assert.equal(mobiledocRevisions.toJSON()[1].mobiledoc, markdownToMobiledoc('a'));
                 });
         });
 
@@ -1777,8 +1777,8 @@ describe('Post Model', function () {
                 .then((mobiledocRevisions) => {
                     assert.equal(mobiledocRevisions.length, 10);
 
-                    mobiledocRevisions.toJSON()[0].mobiledoc.should.equal(markdownToMobiledoc('revision: 11'));
-                    mobiledocRevisions.toJSON()[9].mobiledoc.should.equal(markdownToMobiledoc('revision: 2'));
+                    assert.equal(mobiledocRevisions.toJSON()[0].mobiledoc, markdownToMobiledoc('revision: 11'));
+                    assert.equal(mobiledocRevisions.toJSON()[9].mobiledoc, markdownToMobiledoc('revision: 2'));
                 });
         });
 
@@ -1797,7 +1797,7 @@ describe('Post Model', function () {
                 .then((createdPost) => {
                     assertExists(createdPost);
                     unversionedPost = createdPost;
-                    createdPost.get('mobiledoc').should.equal(markdownToMobiledoc('a'));
+                    assert.equal(createdPost.get('mobiledoc'), markdownToMobiledoc('a'));
 
                     return models.MobiledocRevision
                         .findAll({
@@ -1813,7 +1813,7 @@ describe('Post Model', function () {
                 })
                 .then((editedPost) => {
                     assertExists(editedPost);
-                    editedPost.get('mobiledoc').should.equal(markdownToMobiledoc('b'));
+                    assert.equal(editedPost.get('mobiledoc'), markdownToMobiledoc('b'));
 
                     return models.MobiledocRevision
                         .findAll({
@@ -1823,8 +1823,8 @@ describe('Post Model', function () {
                 .then((mobiledocRevisions) => {
                     assert.equal(mobiledocRevisions.length, 2);
 
-                    mobiledocRevisions.toJSON()[0].mobiledoc.should.equal(markdownToMobiledoc('b'));
-                    mobiledocRevisions.toJSON()[1].mobiledoc.should.equal(markdownToMobiledoc('a'));
+                    assert.equal(mobiledocRevisions.toJSON()[0].mobiledoc, markdownToMobiledoc('b'));
+                    assert.equal(mobiledocRevisions.toJSON()[1].mobiledoc, markdownToMobiledoc('a'));
                 });
         });
     });
@@ -1850,7 +1850,7 @@ describe('Post Model', function () {
 
             const preReassignPosts = await models.Post.findAll({context: {internal: true}});
             // The posts:mu fixture creates two posts per staff member.
-            preReassignPosts.length.should.equal(2 * staffCount);
+            assert.equal(preReassignPosts.length, 2 * staffCount);
 
             const preReassignOwnerWithPosts = await models.Post.findAll({
                 filter: `authors:${ownerData.slug}`,
@@ -1862,7 +1862,7 @@ describe('Post Model', function () {
 
             const postReassignPosts = await models.Post.findAll({context: {internal: true}});
             // All posts should remain
-            postReassignPosts.length.should.equal(2 * staffCount);
+            assert.equal(postReassignPosts.length, 2 * staffCount);
 
             const postReassignOwnerWithPosts = await models.Post.findAll({
                 filter: `authors:${ownerData.slug}`,

--- a/ghost/core/test/legacy/models/model-settings.test.js
+++ b/ghost/core/test/legacy/models/model-settings.test.js
@@ -20,7 +20,7 @@ describe('Settings Model', function () {
             await models.Settings.populateDefaults();
 
             const settingsPopulated = await models.Settings.findAll();
-            settingsPopulated.length.should.equal(SETTINGS_LENGTH);
+            assert.equal(settingsPopulated.length, SETTINGS_LENGTH);
         });
 
         it('doesn\'t overwrite any existing settings', async function () {
@@ -43,7 +43,7 @@ describe('Settings Model', function () {
             await models.Settings.populateDefaults();
 
             const settingsPopulated = await models.Settings.findAll();
-            settingsPopulated.length.should.equal(SETTINGS_LENGTH);
+            assert.equal(settingsPopulated.length, SETTINGS_LENGTH);
 
             const titleSetting = settingsPopulated.models.find(s => s.get('key') === 'title');
             assert.equal(titleSetting.get('value'), 'Testing Defaults');

--- a/ghost/core/test/legacy/models/model-snippets.test.js
+++ b/ghost/core/test/legacy/models/model-snippets.test.js
@@ -40,33 +40,33 @@ describe('Snippet Model', function () {
             it('transforms image card src to absolute site URL', function () {
                 const imageCard = mobiledoc.cards.find(card => card[0] === 'image');
 
-                imageCard[1].src.should.equal(`${siteUrl}/content/images/snippet-inline.jpg`);
+                assert.equal(imageCard[1].src, `${siteUrl}/content/images/snippet-inline.jpg`);
             });
 
             it('transforms file card src to absolute site URL', function () {
                 const fileCard = mobiledoc.cards.find(card => card[0] === 'file');
 
-                fileCard[1].src.should.equal(`${siteUrl}/content/files/snippet-document.pdf`);
+                assert.equal(fileCard[1].src, `${siteUrl}/content/files/snippet-document.pdf`);
             });
 
             it('transforms video card src and thumbnailSrc to absolute site URLs', function () {
                 const videoCard = mobiledoc.cards.find(card => card[0] === 'video');
 
-                videoCard[1].src.should.equal(`${siteUrl}/content/media/snippet-video.mp4`);
-                videoCard[1].thumbnailSrc.should.equal(`${siteUrl}/content/images/snippet-video-thumb.jpg`);
+                assert.equal(videoCard[1].src, `${siteUrl}/content/media/snippet-video.mp4`);
+                assert.equal(videoCard[1].thumbnailSrc, `${siteUrl}/content/images/snippet-video-thumb.jpg`);
             });
 
             it('transforms audio card src and thumbnailSrc to absolute site URLs', function () {
                 const audioCard = mobiledoc.cards.find(card => card[0] === 'audio');
 
-                audioCard[1].src.should.equal(`${siteUrl}/content/media/snippet-audio.mp3`);
-                audioCard[1].thumbnailSrc.should.equal(`${siteUrl}/content/images/snippet-audio-thumb.jpg`);
+                assert.equal(audioCard[1].src, `${siteUrl}/content/media/snippet-audio.mp3`);
+                assert.equal(audioCard[1].thumbnailSrc, `${siteUrl}/content/images/snippet-audio-thumb.jpg`);
             });
 
             it('transforms link markup href to absolute site URL', function () {
                 const linkMarkup = mobiledoc.markups.find(markup => markup[0] === 'a');
 
-                linkMarkup[1][1].should.equal(`${siteUrl}/snippet-link`);
+                assert.equal(linkMarkup[1][1], `${siteUrl}/snippet-link`);
             });
         });
 
@@ -114,7 +114,7 @@ describe('Snippet Model', function () {
                 const mobiledoc = JSON.parse(snippet.get('mobiledoc'));
 
                 const fileCard = mobiledoc.cards.find(card => card[0] === 'file');
-                fileCard[1].src.should.equal(`${cdnUrl}/content/files/snippet-document.pdf`);
+                assert.equal(fileCard[1].src, `${cdnUrl}/content/files/snippet-document.pdf`);
             });
 
             it('transforms video card src to media CDN URL', async function () {
@@ -123,7 +123,7 @@ describe('Snippet Model', function () {
                 const mobiledoc = JSON.parse(snippet.get('mobiledoc'));
 
                 const videoCard = mobiledoc.cards.find(card => card[0] === 'video');
-                videoCard[1].src.should.equal(`${cdnUrl}/content/media/snippet-video.mp4`);
+                assert.equal(videoCard[1].src, `${cdnUrl}/content/media/snippet-video.mp4`);
             });
 
             it('transforms audio card src to media CDN URL', async function () {
@@ -132,7 +132,7 @@ describe('Snippet Model', function () {
                 const mobiledoc = JSON.parse(snippet.get('mobiledoc'));
 
                 const audioCard = mobiledoc.cards.find(card => card[0] === 'audio');
-                audioCard[1].src.should.equal(`${cdnUrl}/content/media/snippet-audio.mp3`);
+                assert.equal(audioCard[1].src, `${cdnUrl}/content/media/snippet-audio.mp3`);
             });
 
             it('transforms image card src to absolute site URL(NOT CDN)', async function () {
@@ -141,7 +141,7 @@ describe('Snippet Model', function () {
                 const mobiledoc = JSON.parse(snippet.get('mobiledoc'));
 
                 const imageCard = mobiledoc.cards.find(card => card[0] === 'image');
-                imageCard[1].src.should.equal(`${siteUrl}/content/images/snippet-inline.jpg`);
+                assert.equal(imageCard[1].src, `${siteUrl}/content/images/snippet-inline.jpg`);
             });
 
             it('transforms video thumbnailSrc to absolute site URL(NOT CDN)', async function () {
@@ -150,7 +150,7 @@ describe('Snippet Model', function () {
                 const mobiledoc = JSON.parse(snippet.get('mobiledoc'));
 
                 const videoCard = mobiledoc.cards.find(card => card[0] === 'video');
-                videoCard[1].thumbnailSrc.should.equal(`${siteUrl}/content/images/snippet-video-thumb.jpg`);
+                assert.equal(videoCard[1].thumbnailSrc, `${siteUrl}/content/images/snippet-video-thumb.jpg`);
             });
         });
 

--- a/ghost/core/test/legacy/models/model-tags.test.js
+++ b/ghost/core/test/legacy/models/model-tags.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const {assertExists} = require('../../utils/assertions');
 const should = require('should');
 const sinon = require('sinon');
@@ -29,9 +30,9 @@ describe('Tag Model', function () {
         it('transforms feature_image, og_image, and twitter_image to absolute site URLs', async function () {
             const tag = await models.Tag.findOne({slug: 'tag-with-images'});
             assertExists(tag, 'Tag with images should exist');
-            tag.get('feature_image').should.equal(`${siteUrl}/content/images/tag-feature.jpg`);
-            tag.get('og_image').should.equal(`${siteUrl}/content/images/tag-og.jpg`);
-            tag.get('twitter_image').should.equal(`${siteUrl}/content/images/tag-twitter.jpg`);
+            assert.equal(tag.get('feature_image'), `${siteUrl}/content/images/tag-feature.jpg`);
+            assert.equal(tag.get('og_image'), `${siteUrl}/content/images/tag-og.jpg`);
+            assert.equal(tag.get('twitter_image'), `${siteUrl}/content/images/tag-twitter.jpg`);
         });
     });
 
@@ -50,9 +51,9 @@ describe('Tag Model', function () {
         it('transforms feature_image, og_image, and twitter_image to absolute site URLs(NOT CDN)', async function () {
             const tag = await models.Tag.findOne({slug: 'tag-with-images'});
             assertExists(tag, 'Tag with images should exist');
-            tag.get('feature_image').should.equal(`${siteUrl}/content/images/tag-feature.jpg`);
-            tag.get('og_image').should.equal(`${siteUrl}/content/images/tag-og.jpg`);
-            tag.get('twitter_image').should.equal(`${siteUrl}/content/images/tag-twitter.jpg`);
+            assert.equal(tag.get('feature_image'), `${siteUrl}/content/images/tag-feature.jpg`);
+            assert.equal(tag.get('og_image'), `${siteUrl}/content/images/tag-og.jpg`);
+            assert.equal(tag.get('twitter_image'), `${siteUrl}/content/images/tag-twitter.jpg`);
         });
     });
 });

--- a/ghost/core/test/legacy/models/model-users.test.js
+++ b/ghost/core/test/legacy/models/model-users.test.js
@@ -278,7 +278,7 @@ describe('User Model', function run() {
                 let user;
                 assertExists(results);
                 user = results.toJSON();
-                user.id.should.equal(firstUser);
+                assert.equal(user.id, firstUser);
                 assert.equal(user.website, null);
 
                 return UserModel.edit({website: 'http://some.newurl.com'}, {id: firstUser});

--- a/ghost/core/test/unit/api/canary/utils/serializers/output/mapper.test.js
+++ b/ghost/core/test/unit/api/canary/utils/serializers/output/mapper.test.js
@@ -79,8 +79,8 @@ describe('Unit: utils/serializers/output/mappers', function () {
             assert.equal(urlUtil.forTag.callCount, 1);
             assert.equal(urlUtil.forUser.callCount, 1);
 
-            urlUtil.forTag.getCall(0).args.should.eql(['id3', {id: 'id3', feature_image: 'value'}, frame.options]);
-            urlUtil.forUser.getCall(0).args.should.eql(['id4', {name: 'Ghosty', id: 'id4'}, frame.options]);
+            assert.deepEqual(urlUtil.forTag.getCall(0).args, ['id3', {id: 'id3', feature_image: 'value'}, frame.options]);
+            assert.deepEqual(urlUtil.forUser.getCall(0).args, ['id4', {name: 'Ghosty', id: 'id4'}, frame.options]);
         });
     });
 
@@ -105,7 +105,7 @@ describe('Unit: utils/serializers/output/mappers', function () {
             mappers.users(user, frame);
 
             assert.equal(urlUtil.forUser.callCount, 1);
-            urlUtil.forUser.getCall(0).args.should.eql(['id1', user, frame.options]);
+            assert.deepEqual(urlUtil.forUser.getCall(0).args, ['id1', user, frame.options]);
             assert.equal(cleanUtil.author.callCount, 1);
         });
     });
@@ -131,7 +131,7 @@ describe('Unit: utils/serializers/output/mappers', function () {
             mappers.tags(tag, frame);
 
             assert.equal(urlUtil.forTag.callCount, 1);
-            urlUtil.forTag.getCall(0).args.should.eql(['id3', tag, frame.options]);
+            assert.deepEqual(urlUtil.forTag.getCall(0).args, ['id3', tag, frame.options]);
             assert.equal(cleanUtil.tag.callCount, 1);
         });
     });
@@ -176,7 +176,7 @@ describe('Unit: utils/serializers/output/mappers', function () {
 
             const mapped = mappers.snippets(snippet, frame);
 
-            mapped.should.eql({
+            assert.deepEqual(mapped, {
                 id: snippet.id,
                 name: snippet.name,
                 mobiledoc: snippet.mobiledoc,
@@ -200,7 +200,7 @@ describe('Unit: utils/serializers/output/mappers', function () {
 
             const mapped = mappers.newsletters(newsletter, frame);
 
-            mapped.should.eql({
+            assert.deepEqual(mapped, {
                 id: newsletter.id,
                 uuid: newsletter.uuid,
                 name: newsletter.name,
@@ -252,7 +252,7 @@ describe('Unit: utils/serializers/output/mappers', function () {
             });
 
             const mapped = mappers.emailBatches(model, frame);
-            mapped.should.eql({
+            assert.deepEqual(mapped, {
                 id: 'id1',
                 provider_id: 'provider_id1',
                 status: 'status1',
@@ -305,7 +305,7 @@ describe('Unit: utils/serializers/output/mappers', function () {
             });
 
             const mapped = mappers.emailFailures(model, frame);
-            mapped.should.eql({
+            assert.deepEqual(mapped, {
                 id: 'id1',
                 code: 'code1',
                 enhanced_code: 'enhanced_code1',
@@ -349,7 +349,7 @@ describe('Unit: utils/serializers/output/mappers', function () {
             });
 
             const mapped = mappers.emailFailures(model, frame);
-            mapped.should.eql({
+            assert.deepEqual(mapped, {
                 id: 'id1',
                 code: 'code1',
                 enhanced_code: 'enhanced_code1',
@@ -410,7 +410,7 @@ describe('Unit: utils/serializers/output/mappers', function () {
             };
 
             const mapped = mappers.activityFeedEvents(model, frame);
-            mapped.should.eql({
+            assert.deepEqual(mapped, {
                 foo: 'bar',
                 type: 'comment_event',
                 data: {
@@ -483,7 +483,7 @@ describe('Unit: utils/serializers/output/mappers', function () {
             };
 
             const mapped = mappers.activityFeedEvents(model, frame);
-            mapped.should.eql({
+            assert.deepEqual(mapped, {
                 foo: 'bar',
                 type: 'click_event',
                 data: {
@@ -535,7 +535,7 @@ describe('Unit: utils/serializers/output/mappers', function () {
             };
 
             const mapped = mappers.activityFeedEvents(model, frame);
-            mapped.should.eql({
+            assert.deepEqual(mapped, {
                 foo: 'bar',
                 type: 'aggregated_click_event',
                 data: {
@@ -584,7 +584,7 @@ describe('Unit: utils/serializers/output/mappers', function () {
             };
 
             const mapped = mappers.activityFeedEvents(model, frame);
-            mapped.should.eql({
+            assert.deepEqual(mapped, {
                 foo: 'bar',
                 type: 'feedback_event',
                 data: {
@@ -608,7 +608,7 @@ describe('Unit: utils/serializers/output/mappers', function () {
             });
 
             const mapped2 = mappers.activityFeedEvents({...model, data: {...model.data, member: undefined, post: undefined}}, frame);
-            mapped2.should.eql({
+            assert.deepEqual(mapped2, {
                 foo: 'bar',
                 type: 'feedback_event',
                 data: {
@@ -656,7 +656,7 @@ describe('Unit: utils/serializers/output/mappers', function () {
 
             const mapped = mappers.comments(model, frame);
 
-            mapped.should.eql({
+            assert.deepEqual(mapped, {
                 id: 'comment3',
                 html: '<p>comment 3</p>',
                 member: {
@@ -704,7 +704,7 @@ describe('Unit: utils/serializers/output/mappers', function () {
 
             assert.equal(converterSpy.calledOnce, true, 'htmlToPlaintext.commentSnippet was not called');
 
-            mapped.should.eql({
+            assert.deepEqual(mapped, {
                 in_reply_to_snippet: 'First paragraph with link, and new line. Second paragraph',
                 member: null
             });
@@ -721,7 +721,7 @@ describe('Unit: utils/serializers/output/mappers', function () {
 
             const mapped = mappers.comments(model, frame);
 
-            mapped.should.eql({
+            assert.deepEqual(mapped, {
                 id: 'comment1',
                 html: '<p>comment 1</p>',
                 member: null,

--- a/ghost/core/test/unit/frontend/apps/private-blogging/controller.test.js
+++ b/ghost/core/test/unit/frontend/apps/private-blogging/controller.test.js
@@ -82,7 +82,7 @@ describe('Private Controller', function () {
 
         res.render = function (view, context) {
             view.should.eql(defaultPath);
-            context.should.eql({error: 'Test Error'});
+            assert.deepEqual(context, {error: 'Test Error'});
             done();
         };
 

--- a/ghost/core/test/unit/frontend/apps/private-blogging/input-password.test.js
+++ b/ghost/core/test/unit/frontend/apps/private-blogging/input-password.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../utils/assertions');
 // We use the name input_password to match the helper for consistency:
 const should = require('should');
@@ -15,7 +16,7 @@ describe('{{input_password}} helper', function () {
         const rendered = input_password();
         assertExists(rendered);
 
-        String(rendered).should.equal(markup);
+        assert.equal(String(rendered), markup);
     });
 
     it('returns the correct input when a custom class is specified', function () {
@@ -31,7 +32,7 @@ describe('{{input_password}} helper', function () {
 
         assertExists(rendered);
 
-        String(rendered).should.equal(markup);
+        assert.equal(String(rendered), markup);
     });
 
     it('returns the correct input when a custom placeholder is specified', function () {
@@ -47,6 +48,6 @@ describe('{{input_password}} helper', function () {
 
         assertExists(rendered);
 
-        String(rendered).should.equal(markup);
+        assert.equal(String(rendered), markup);
     });
 });

--- a/ghost/core/test/unit/frontend/apps/private-blogging/middleware.test.js
+++ b/ghost/core/test/unit/frontend/apps/private-blogging/middleware.test.js
@@ -265,7 +265,7 @@ describe('Private Blogging', function () {
 
                 privateBlogging.doLoginToPrivateSite(req, res, next);
                 assert.equal(res.redirect.called, true);
-                res.redirect.args[0][0].should.be.equal('/');
+                assert.equal(res.redirect.args[0][0], '/');
             });
 
             it('doLoginToPrivateSite should redirect to the relative path if r param is there', function () {
@@ -278,7 +278,7 @@ describe('Private Blogging', function () {
 
                 privateBlogging.doLoginToPrivateSite(req, res, next);
                 assert.equal(res.redirect.called, true);
-                res.redirect.args[0][0].should.be.equal('/test');
+                assert.equal(res.redirect.args[0][0], '/test');
             });
 
             it('doLoginToPrivateSite should preserve query string including UTM parameters', function () {
@@ -291,7 +291,7 @@ describe('Private Blogging', function () {
 
                 privateBlogging.doLoginToPrivateSite(req, res, next);
                 assert.equal(res.redirect.called, true);
-                res.redirect.args[0][0].should.be.equal('/?utm_source=twitter&utm_campaign=test');
+                assert.equal(res.redirect.args[0][0], '/?utm_source=twitter&utm_campaign=test');
             });
 
             it('doLoginToPrivateSite should preserve query string on paths', function () {
@@ -304,7 +304,7 @@ describe('Private Blogging', function () {
 
                 privateBlogging.doLoginToPrivateSite(req, res, next);
                 assert.equal(res.redirect.called, true);
-                res.redirect.args[0][0].should.be.equal('/welcome/?ref=newsletter&utm_medium=email');
+                assert.equal(res.redirect.args[0][0], '/welcome/?ref=newsletter&utm_medium=email');
             });
 
             it('doLoginToPrivateSite should redirect to "/" if r param is redirecting to another domain than the current instance', function () {
@@ -317,7 +317,7 @@ describe('Private Blogging', function () {
 
                 privateBlogging.doLoginToPrivateSite(req, res, next);
                 assert.equal(res.redirect.called, true);
-                res.redirect.args[0][0].should.be.equal('/');
+                assert.equal(res.redirect.args[0][0], '/');
             });
 
             describe('Bad Password', function () {

--- a/ghost/core/test/unit/frontend/helpers/cancel-link.test.js
+++ b/ghost/core/test/unit/frontend/helpers/cancel-link.test.js
@@ -38,11 +38,11 @@ describe('{{cancel_link}} helper', function () {
             };
         };
 
-        runHelper('not an object').should.throw();
-        runHelper(function () { }).should.throw();
-        runHelper({}).should.throw();
-        runHelper({id: ''}).should.throw();
-        runHelper({cancel_at_period_end: ''}).should.throw();
+        assert.throws(runHelper('not an object'));
+        assert.throws(runHelper(function () { }));
+        assert.throws(runHelper({}));
+        assert.throws(runHelper({id: ''}));
+        assert.throws(runHelper({cancel_at_period_end: ''}));
     });
 
     it('can render cancel subscription link', function () {

--- a/ghost/core/test/unit/frontend/helpers/content-api-key.test.js
+++ b/ghost/core/test/unit/frontend/helpers/content-api-key.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const {assertExists} = require('../../../utils/assertions');
 const proxy = require('../../../../core/frontend/services/proxy');
 const {getFrontendKey} = proxy;
@@ -12,7 +13,7 @@ describe('{{content_api_key}} helper', function () {
             const result = await content_api_key();
             const expected = await getFrontendKey();
             assertExists(result);
-            String(result).should.equal(expected);
+            assert.equal(String(result), expected);
         });
     });
 });

--- a/ghost/core/test/unit/frontend/helpers/content.test.js
+++ b/ghost/core/test/unit/frontend/helpers/content.test.js
@@ -32,7 +32,7 @@ describe('{{content}} helper', function () {
         const rendered = content.call({html: html});
 
         assertExists(rendered);
-        rendered.string.should.equal(html);
+        assert.equal(rendered.string, html);
     });
 
     it('can truncate html by word', function () {

--- a/ghost/core/test/unit/frontend/helpers/date.test.js
+++ b/ghost/core/test/unit/frontend/helpers/date.test.js
@@ -54,18 +54,18 @@ describe('{{date}} helper', function () {
             rendered = date.call({published_at: d}, context);
 
             assertExists(rendered);
-            String(rendered).should.equal(moment(d).tz(timezone).format(format));
+            assert.equal(String(rendered), moment(d).tz(timezone).format(format));
 
             rendered = date.call({}, d, context);
 
             assertExists(rendered);
-            String(rendered).should.equal(moment(d).tz(timezone).format(format));
+            assert.equal(String(rendered), moment(d).tz(timezone).format(format));
         });
 
         // No date falls back to now
         rendered = date.call({}, context);
         assertExists(rendered);
-        String(rendered).should.equal(moment().tz(timezone).format(format));
+        assert.equal(String(rendered), moment().tz(timezone).format(format));
     });
 
     it('creates properly localised date strings', function () {
@@ -102,18 +102,18 @@ describe('{{date}} helper', function () {
                 rendered = date.call({published_at: d}, context);
 
                 assertExists(rendered);
-                String(rendered).should.equal(moment(d).tz(timezone).locale(locale).format(format));
+                assert.equal(String(rendered), moment(d).tz(timezone).locale(locale).format(format));
 
                 rendered = date.call({}, d, context);
 
                 assertExists(rendered);
-                String(rendered).should.equal(moment(d).tz(timezone).locale(locale).format(format));
+                assert.equal(String(rendered), moment(d).tz(timezone).locale(locale).format(format));
             });
 
             // No date falls back to now
             rendered = date.call({}, context);
             assertExists(rendered);
-            String(rendered).should.equal(moment().tz(timezone).locale(locale).format(format));
+            assert.equal(String(rendered), moment().tz(timezone).locale(locale).format(format));
         });
     });
 
@@ -145,12 +145,12 @@ describe('{{date}} helper', function () {
             rendered = date.call({published_at: d}, context);
 
             assertExists(rendered);
-            String(rendered).should.equal(moment(d).tz(timezone).from(timeNow));
+            assert.equal(String(rendered), moment(d).tz(timezone).from(timeNow));
 
             rendered = date.call({}, d, context);
 
             assertExists(rendered);
-            String(rendered).should.equal(moment(d).tz(timezone).from(timeNow));
+            assert.equal(String(rendered), moment(d).tz(timezone).from(timeNow));
         });
 
         // No date falls back to now

--- a/ghost/core/test/unit/frontend/helpers/encode.test.js
+++ b/ghost/core/test/unit/frontend/helpers/encode.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const {assertExists} = require('../../../utils/assertions');
 const should = require('should');
 
@@ -11,6 +12,6 @@ describe('{{encode}} helper', function () {
         const escaped = encode(uri);
 
         assertExists(escaped);
-        String(escaped).should.equal(expected);
+        assert.equal(String(escaped), expected);
     });
 });

--- a/ghost/core/test/unit/frontend/helpers/excerpt.test.js
+++ b/ghost/core/test/unit/frontend/helpers/excerpt.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const {assertExists} = require('../../../utils/assertions');
 const should = require('should');
 
@@ -8,7 +9,7 @@ describe('{{excerpt}} Helper', function () {
     function shouldRenderToExpected(data, hash, expected) {
         const rendered = excerptHelper.call(data, hash);
         assertExists(rendered);
-        rendered.string.should.equal(expected);
+        assert.equal(rendered.string, expected);
     }
 
     it('renders empty string when html, excerpt, and custom_excerpt are null', function () {

--- a/ghost/core/test/unit/frontend/helpers/foreach.test.js
+++ b/ghost/core/test/unit/frontend/helpers/foreach.test.js
@@ -49,7 +49,7 @@ describe('{{#foreach}} helper', function () {
             runTest(_this, context, options);
 
             assert.equal(options.fn.called, true);
-            options.fn.getCalls().length.should.eql(_.size(context));
+            sinon.assert.callCount(options.fn, _.size(context));
 
             _.each(context, function (value, index) {
                 options.fn.getCall(index).args[0].should.eql(value);
@@ -74,7 +74,7 @@ describe('{{#foreach}} helper', function () {
             runTest(_this, context, options);
 
             assert.equal(options.fn.called, true);
-            options.fn.getCalls().length.should.eql(_.size(context));
+            sinon.assert.callCount(options.fn, _.size(context));
 
             _.each(_.keys(context), function (value, index) {
                 options.fn.getCall(index).args[0].should.eql(context[value]);
@@ -100,7 +100,7 @@ describe('{{#foreach}} helper', function () {
             runTest(_this, context, options);
 
             assert.equal(options.fn.called, true);
-            options.fn.getCalls().length.should.eql(_.size(context));
+            sinon.assert.callCount(options.fn, _.size(context));
 
             _.each(context, function (value, index) {
                 options.fn.getCall(index).args[0].should.eql(value);
@@ -142,7 +142,7 @@ describe('{{#foreach}} helper', function () {
             runTest(_this, context, options);
 
             assert.equal(options.fn.called, true);
-            options.fn.getCalls().length.should.eql(_.size(context));
+            sinon.assert.callCount(options.fn, _.size(context));
 
             _.each(_.keys(context), function (value, index) {
                 options.fn.getCall(index).args[0].should.eql(context[value]);
@@ -177,7 +177,7 @@ describe('{{#foreach}} helper', function () {
             runTest(_this, context, options);
 
             assert.equal(options.fn.called, true);
-            options.fn.getCalls().length.should.eql(_.size(context));
+            sinon.assert.callCount(options.fn, _.size(context));
 
             _.each(context, function (value, index) {
                 options.fn.getCall(index).args[0].should.eql(value);
@@ -219,7 +219,7 @@ describe('{{#foreach}} helper', function () {
             runTest(_this, context, options);
 
             assert.equal(options.fn.called, true);
-            options.fn.getCalls().length.should.eql(_.size(context));
+            sinon.assert.callCount(options.fn, _.size(context));
 
             _.each(_.keys(context), function (value, index) {
                 options.fn.getCall(index).args[0].should.eql(context[value]);

--- a/ghost/core/test/unit/frontend/helpers/foreach.test.js
+++ b/ghost/core/test/unit/frontend/helpers/foreach.test.js
@@ -3,7 +3,7 @@ const should = require('should');
 const sinon = require('sinon');
 const _ = require('lodash');
 const foreach = require('../../../../core/frontend/helpers/foreach');
-const {assertObjectMatches} = require('../../../utils/assertions');
+const {assertExists, assertObjectMatches} = require('../../../utils/assertions');
 const {registerHelper, shouldCompileToExpected} = require('./utils/handlebars');
 
 describe('{{#foreach}} helper', function () {
@@ -104,7 +104,7 @@ describe('{{#foreach}} helper', function () {
 
             _.each(context, function (value, index) {
                 options.fn.getCall(index).args[0].should.eql(value);
-                should(options.fn.getCall(index).args[1].data).not.be.undefined();
+                assertExists(options.fn.getCall(index).args[1].data);
 
                 // Expected properties
                 assertObjectMatches(resultData[index].data, expected[index]);
@@ -146,7 +146,7 @@ describe('{{#foreach}} helper', function () {
 
             _.each(_.keys(context), function (value, index) {
                 options.fn.getCall(index).args[0].should.eql(context[value]);
-                should(options.fn.getCall(index).args[1].data).not.be.undefined();
+                assertExists(options.fn.getCall(index).args[1].data);
 
                 // Expected properties
                 assertObjectMatches(resultData[index].data, expected[index]);
@@ -181,7 +181,7 @@ describe('{{#foreach}} helper', function () {
 
             _.each(context, function (value, index) {
                 options.fn.getCall(index).args[0].should.eql(value);
-                should(options.fn.getCall(index).args[1].data).not.be.undefined();
+                assertExists(options.fn.getCall(index).args[1].data);
 
                 // Expected properties
                 assertObjectMatches(resultData[index].data, expected[index]);
@@ -223,7 +223,7 @@ describe('{{#foreach}} helper', function () {
 
             _.each(_.keys(context), function (value, index) {
                 options.fn.getCall(index).args[0].should.eql(context[value]);
-                should(options.fn.getCall(index).args[1].data).not.be.undefined();
+                assertExists(options.fn.getCall(index).args[1].data);
 
                 // Expected properties
                 assertObjectMatches(resultData[index].data, expected[index]);

--- a/ghost/core/test/unit/frontend/helpers/get.test.js
+++ b/ghost/core/test/unit/frontend/helpers/get.test.js
@@ -128,7 +128,7 @@ describe('{{#get}} helper', function () {
             ).then(function () {
                 assert.equal(fn.called, true);
                 fn.firstCall.args[0].should.be.an.Object().with.property('authors');
-                fn.firstCall.args[0].authors.should.eql([]);
+                assert.deepEqual(fn.firstCall.args[0].authors, []);
                 assert.equal(inverse.called, false);
 
                 done();
@@ -157,7 +157,7 @@ describe('{{#get}} helper', function () {
             ).then(function () {
                 assert.equal(fn.called, true);
                 fn.firstCall.args[0].should.be.an.Object().with.property('newsletters');
-                fn.firstCall.args[0].newsletters.should.eql([]);
+                assert.deepEqual(fn.firstCall.args[0].newsletters, []);
                 assert.equal(inverse.called, false);
 
                 done();

--- a/ghost/core/test/unit/frontend/helpers/img-url.test.js
+++ b/ghost/core/test/unit/frontend/helpers/img-url.test.js
@@ -377,7 +377,7 @@ describe('{{img_url}} helper', function () {
                 }
             });
             assertExists(rendered);
-            rendered.should.equal(invalid);
+            assert.equal(rendered, invalid);
         });
 
         it('ignores invalid sizes', function () {

--- a/ghost/core/test/unit/frontend/helpers/link-class.test.js
+++ b/ghost/core/test/unit/frontend/helpers/link-class.test.js
@@ -38,10 +38,10 @@ describe('{{link_class}} helper', function () {
     });
 
     it('throws an error for missing for=""', function () {
-        (function compileWith() {
+        assert.throws((function compileWith() {
             compile('{{link_class}}')
                 .with({});
-        }).should.throw();
+        }));
     });
 
     it('silently accepts an empty for...', function () {

--- a/ghost/core/test/unit/frontend/helpers/link.test.js
+++ b/ghost/core/test/unit/frontend/helpers/link.test.js
@@ -41,10 +41,10 @@ describe('{{link}} helper', function () {
 
     describe('basic behavior: simple links without context', function () {
         it('throws an error for missing href=""', function () {
-            (function compileWith() {
+            assert.throws((function compileWith() {
                 compile('{{#link}}text{{/link}}')
                     .with({});
-            }).should.throw();
+            }));
         });
 
         it('silently accepts an empty href...', function () {

--- a/ghost/core/test/unit/frontend/helpers/navigation.test.js
+++ b/ghost/core/test/unit/frontend/helpers/navigation.test.js
@@ -73,7 +73,7 @@ describe('{{navigation}} helper', function () {
         const rendered = runHelper(optionsData);
 
         assertExists(rendered);
-        rendered.string.should.be.equal('');
+        assert.equal(rendered.string, '');
     });
 
     it('can handle relativeUrl not being set (e.g. for images/assets)', function () {

--- a/ghost/core/test/unit/frontend/helpers/page-url.test.js
+++ b/ghost/core/test/unit/frontend/helpers/page-url.test.js
@@ -40,6 +40,6 @@ describe('{{page_url}} helper', function () {
         options.data.root.pagination.next = 10;
         options.data.root.pagination.prev = 2;
 
-        page_url(options).should.equal(page_url(1, options));
+        assert.equal(page_url(options), page_url(1, options));
     });
 });

--- a/ghost/core/test/unit/frontend/helpers/plural.test.js
+++ b/ghost/core/test/unit/frontend/helpers/plural.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const {assertExists} = require('../../../utils/assertions');
 const should = require('should');
 
@@ -17,7 +18,7 @@ describe('{{plural}} helper', function () {
         });
 
         assertExists(rendered);
-        rendered.string.should.equal(expected);
+        assert.equal(rendered.string, expected);
     });
 
     it('will show no-value string with placement', function () {
@@ -32,7 +33,7 @@ describe('{{plural}} helper', function () {
         });
 
         assertExists(rendered);
-        rendered.string.should.equal(expected);
+        assert.equal(rendered.string, expected);
     });
 
     it('will show singular string', function () {
@@ -47,7 +48,7 @@ describe('{{plural}} helper', function () {
         });
 
         assertExists(rendered);
-        rendered.string.should.equal(expected);
+        assert.equal(rendered.string, expected);
     });
 
     it('will show plural string', function () {
@@ -62,6 +63,6 @@ describe('{{plural}} helper', function () {
         });
 
         assertExists(rendered);
-        rendered.string.should.equal(expected);
+        assert.equal(rendered.string, expected);
     });
 });

--- a/ghost/core/test/unit/frontend/helpers/recommendations.test.js
+++ b/ghost/core/test/unit/frontend/helpers/recommendations.test.js
@@ -100,7 +100,7 @@ describe('{{#recommendations}} helper', function () {
         // console.log('Actual:');
         // console.log(actual);
 
-        trimSpaces(actual).should.equal(trimSpaces(expected));
+        assert.equal(trimSpaces(actual), trimSpaces(expected));
     });
 
     describe('when there are no recommendations', function () {

--- a/ghost/core/test/unit/frontend/helpers/social-url.test.js
+++ b/ghost/core/test/unit/frontend/helpers/social-url.test.js
@@ -60,9 +60,8 @@ describe('{{social_url}} helper', function () {
 
     platforms.forEach((platform) => {
         it(`should output the ${platform.name} url when 'type="${platform.name}"' is provided`, function () {
-            compile(`{{social_url type="${platform.name}"}}`)
-                .with(socialData)
-                .should.equal(platform.expectedUrl);
+            assert.equal(compile(`{{social_url type="${platform.name}"}}`)
+                .with(socialData), platform.expectedUrl);
         });
     });
 

--- a/ghost/core/test/unit/frontend/helpers/tags.test.js
+++ b/ghost/core/test/unit/frontend/helpers/tags.test.js
@@ -231,46 +231,38 @@ describe('{{tags}} helper', function () {
         it('will not output internal tags by default', function () {
             const rendered = tagsHelper.call({tags: tags});
 
-            String(rendered).should.equal(
-                '<a href="1">foo</a>, ' +
-                '<a href="3">bar</a>, ' +
-                '<a href="4">baz</a>, ' +
-                '<a href="5">buzz</a>'
-            );
+            assert.equal(String(rendered), '<a href="1">foo</a>, ' +
+            '<a href="3">bar</a>, ' +
+            '<a href="4">baz</a>, ' +
+            '<a href="5">buzz</a>');
         });
 
         it('should still correctly apply from & limit tags', function () {
             const rendered = tagsHelper.call({tags: tags}, {hash: {from: '2', limit: '2'}});
 
-            String(rendered).should.equal(
-                '<a href="3">bar</a>, ' +
-                '<a href="4">baz</a>'
-            );
+            assert.equal(String(rendered), '<a href="3">bar</a>, ' +
+            '<a href="4">baz</a>');
         });
 
         it('should output all tags with visibility="all"', function () {
             const rendered = tagsHelper.call({tags: tags}, {hash: {visibility: 'all'}});
 
-            String(rendered).should.equal(
-                '<a href="1">foo</a>, ' +
-                '<a href="2">#bar</a>, ' +
-                '<a href="3">bar</a>, ' +
-                '<a href="4">baz</a>, ' +
-                '<a href="5">buzz</a>'
-            );
+            assert.equal(String(rendered), '<a href="1">foo</a>, ' +
+            '<a href="2">#bar</a>, ' +
+            '<a href="3">bar</a>, ' +
+            '<a href="4">baz</a>, ' +
+            '<a href="5">buzz</a>');
         });
 
         it('should output all tags with visibility property set with visibility="public,internal"', function () {
             const rendered = tagsHelper.call({tags: tags}, {hash: {visibility: 'public,internal'}});
             assertExists(rendered);
 
-            String(rendered).should.equal(
-                '<a href="1">foo</a>, ' +
-                '<a href="2">#bar</a>, ' +
-                '<a href="3">bar</a>, ' +
-                '<a href="4">baz</a>, ' +
-                '<a href="5">buzz</a>'
-            );
+            assert.equal(String(rendered), '<a href="1">foo</a>, ' +
+            '<a href="2">#bar</a>, ' +
+            '<a href="3">bar</a>, ' +
+            '<a href="4">baz</a>, ' +
+            '<a href="5">buzz</a>');
         });
 
         it('Should output only internal tags with visibility="internal"', function () {

--- a/ghost/core/test/unit/frontend/meta/asset-url.test.js
+++ b/ghost/core/test/unit/frontend/meta/asset-url.test.js
@@ -17,32 +17,32 @@ describe('getAssetUrl', function () {
 
     it('should return asset url with just context', function () {
         const testUrl = getAssetUrl('myfile.js');
-        testUrl.should.equal('/assets/myfile.js?v=' + config.get('assetHash'));
+        assert.equal(testUrl, '/assets/myfile.js?v=' + config.get('assetHash'));
     });
 
     it('should return asset url with just context even with leading /', function () {
         const testUrl = getAssetUrl('/myfile.js');
-        testUrl.should.equal('/assets/myfile.js?v=' + config.get('assetHash'));
+        assert.equal(testUrl, '/assets/myfile.js?v=' + config.get('assetHash'));
     });
 
     it('should not add asset to url if ghost.css for default templates', function () {
         const testUrl = getAssetUrl('public/ghost.css');
-        testUrl.should.equal('/public/ghost.css?v=' + config.get('assetHash'));
+        assert.equal(testUrl, '/public/ghost.css?v=' + config.get('assetHash'));
     });
 
     it('should not add asset to url has public in it', function () {
         const testUrl = getAssetUrl('public/myfile.js');
-        testUrl.should.equal('/public/myfile.js?v=' + config.get('assetHash'));
+        assert.equal(testUrl, '/public/myfile.js?v=' + config.get('assetHash'));
     });
 
     it('should return hash before #', function () {
         const testUrl = getAssetUrl('myfile.svg#arrow-up');
-        testUrl.should.equal(`/assets/myfile.svg?v=${config.get('assetHash')}#arrow-up`);
+        assert.equal(testUrl, `/assets/myfile.svg?v=${config.get('assetHash')}#arrow-up`);
     });
 
     it('should handle Handlebars’ SafeString', function () {
         const testUrl = getAssetUrl(new SafeString('myfile.js'));
-        testUrl.should.equal('/assets/myfile.js?v=' + config.get('assetHash'));
+        assert.equal(testUrl, '/assets/myfile.js?v=' + config.get('assetHash'));
     });
 
     describe('favicon', function () {
@@ -73,25 +73,25 @@ describe('getAssetUrl', function () {
         it('should return asset minified url when hasMinFile & useMinFiles are both set to true', function () {
             configUtils.set('useMinFiles', true);
             const testUrl = getAssetUrl('myfile.js', true);
-            testUrl.should.equal('/assets/myfile.min.js?v=' + config.get('assetHash'));
+            assert.equal(testUrl, '/assets/myfile.min.js?v=' + config.get('assetHash'));
         });
 
         it('should NOT return asset minified url when hasMinFile true but useMinFiles is false', function () {
             configUtils.set('useMinFiles', false);
             const testUrl = getAssetUrl('myfile.js', true);
-            testUrl.should.equal('/assets/myfile.js?v=' + config.get('assetHash'));
+            assert.equal(testUrl, '/assets/myfile.js?v=' + config.get('assetHash'));
         });
 
         it('should NOT return asset minified url when hasMinFile false but useMinFiles is true', function () {
             configUtils.set('useMinFiles', true);
             const testUrl = getAssetUrl('myfile.js', false);
-            testUrl.should.equal('/assets/myfile.js?v=' + config.get('assetHash'));
+            assert.equal(testUrl, '/assets/myfile.js?v=' + config.get('assetHash'));
         });
 
         it('should not add min to anything besides the last .', function () {
             configUtils.set('useMinFiles', true);
             const testUrl = getAssetUrl('test.page/myfile.js', true);
-            testUrl.should.equal('/assets/test.page/myfile.min.js?v=' + config.get('assetHash'));
+            assert.equal(testUrl, '/assets/test.page/myfile.min.js?v=' + config.get('assetHash'));
         });
     });
 
@@ -106,22 +106,22 @@ describe('getAssetUrl', function () {
 
         it('should return asset url with just context', function () {
             const testUrl = getAssetUrl('myfile.js');
-            testUrl.should.equal('/blog/assets/myfile.js?v=' + config.get('assetHash'));
+            assert.equal(testUrl, '/blog/assets/myfile.js?v=' + config.get('assetHash'));
         });
 
         it('should return asset url with just context even with leading /', function () {
             const testUrl = getAssetUrl('/myfile.js');
-            testUrl.should.equal('/blog/assets/myfile.js?v=' + config.get('assetHash'));
+            assert.equal(testUrl, '/blog/assets/myfile.js?v=' + config.get('assetHash'));
         });
 
         it('should not add asset to url if ghost.css for default templates', function () {
             const testUrl = getAssetUrl('public/ghost.css');
-            testUrl.should.equal('/blog/public/ghost.css?v=' + config.get('assetHash'));
+            assert.equal(testUrl, '/blog/public/ghost.css?v=' + config.get('assetHash'));
         });
 
         it('should not add asset to url has public in it', function () {
             const testUrl = getAssetUrl('public/myfile.js');
-            testUrl.should.equal('/blog/public/myfile.js?v=' + config.get('assetHash'));
+            assert.equal(testUrl, '/blog/public/myfile.js?v=' + config.get('assetHash'));
         });
 
         describe('favicon', function () {
@@ -149,25 +149,25 @@ describe('getAssetUrl', function () {
             it('should return asset minified url when hasMinFile & useMinFiles are both set to true', function () {
                 configUtils.set('useMinFiles', true);
                 const testUrl = getAssetUrl('myfile.js', true);
-                testUrl.should.equal('/blog/assets/myfile.min.js?v=' + config.get('assetHash'));
+                assert.equal(testUrl, '/blog/assets/myfile.min.js?v=' + config.get('assetHash'));
             });
 
             it('should NOT return asset minified url when hasMinFile true but useMinFiles is false', function () {
                 configUtils.set('useMinFiles', false);
                 const testUrl = getAssetUrl('myfile.js', true);
-                testUrl.should.equal('/blog/assets/myfile.js?v=' + config.get('assetHash'));
+                assert.equal(testUrl, '/blog/assets/myfile.js?v=' + config.get('assetHash'));
             });
 
             it('should NOT return asset minified url when hasMinFile false but useMinFiles is true', function () {
                 configUtils.set('useMinFiles', true);
                 const testUrl = getAssetUrl('myfile.js', false);
-                testUrl.should.equal('/blog/assets/myfile.js?v=' + config.get('assetHash'));
+                assert.equal(testUrl, '/blog/assets/myfile.js?v=' + config.get('assetHash'));
             });
 
             it('should not add min to anything besides the last .', function () {
                 configUtils.set('useMinFiles', true);
                 const testUrl = getAssetUrl('test.page/myfile.js', true);
-                testUrl.should.equal('/blog/assets/test.page/myfile.min.js?v=' + config.get('assetHash'));
+                assert.equal(testUrl, '/blog/assets/test.page/myfile.min.js?v=' + config.get('assetHash'));
             });
         });
     });

--- a/ghost/core/test/unit/frontend/services/assets-minification/minifier.test.js
+++ b/ghost/core/test/unit/frontend/services/assets-minification/minifier.test.js
@@ -99,21 +99,21 @@ describe('Minifier', function () {
 
     describe('Bad inputs', function () {
         it('cannot create a minifier without src and dest', function () {
-            (function noObject(){
+            assert.throws((function noObject(){
                 new Minifier();
-            }).should.throw();
+            }));
 
-            (function emptyObject() {
+            assert.throws((function emptyObject() {
                 new Minifier({});
-            }).should.throw();
+            }));
 
-            (function missingSrc() {
+            assert.throws((function missingSrc() {
                 new Minifier({dest: 'a'});
-            }).should.throw();
+            }));
 
-            (function missingDest() {
+            assert.throws((function missingDest() {
                 new Minifier({src: 'a'});
-            }).should.throw();
+            }));
         });
 
         it('can only handle css and js files', async function () {

--- a/ghost/core/test/unit/frontend/services/card-assets.test.js
+++ b/ghost/core/test/unit/frontend/services/card-assets.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 
 const path = require('path');
@@ -36,7 +37,7 @@ describe('Card Asset Service', function () {
 
         await cardAssets.load();
 
-        cardAssets.files.should.eql([]);
+        assert.deepEqual(cardAssets.files, []);
     });
 
     it('can load a single css file', async function () {
@@ -62,14 +63,14 @@ describe('Card Asset Service', function () {
 
         await cardAssets.load(false);
 
-        cardAssets.files.should.eql([]);
+        assert.deepEqual(cardAssets.files, []);
     });
 
     describe('Generate the correct glob strings', function () {
         it('CARD ASSET SERVICE DEFAULT CASE: do nothing', function () {
             const cardAssets = new CardAssetService();
 
-            cardAssets.generateGlobs().should.eql({});
+            assert.deepEqual(cardAssets.generateGlobs(), {});
         });
 
         it('GHOST DEFAULT CASE: exclude bookmark and gallery', function () {
@@ -99,7 +100,7 @@ describe('Card Asset Service', function () {
                 config: false
             });
 
-            cardAssets.generateGlobs().should.eql({});
+            assert.deepEqual(cardAssets.generateGlobs(), {});
         });
 
         it('CASE: card_assets is an object with an exclude property, generate inverse match strings', function () {

--- a/ghost/core/test/unit/frontend/services/card-assets.test.js
+++ b/ghost/core/test/unit/frontend/services/card-assets.test.js
@@ -50,7 +50,7 @@ describe('Card Asset Service', function () {
 
         await cardAssets.load(true);
 
-        cardAssets.files.should.eql(['cards.min.css']);
+        assert.deepEqual(cardAssets.files, ['cards.min.css']);
     });
 
     it('can correctly load nothing when config is false', async function () {
@@ -78,7 +78,7 @@ describe('Card Asset Service', function () {
                 config: themeDefaults.card_assets
             });
 
-            cardAssets.generateGlobs().should.eql({
+            assert.deepEqual(cardAssets.generateGlobs(), {
                 'cards.min.css': 'css/*.css',
                 'cards.min.js': 'js/*.js'
             });
@@ -89,7 +89,7 @@ describe('Card Asset Service', function () {
                 config: true
             });
 
-            cardAssets.generateGlobs().should.eql({
+            assert.deepEqual(cardAssets.generateGlobs(), {
                 'cards.min.css': 'css/*.css',
                 'cards.min.js': 'js/*.js'
             });
@@ -110,7 +110,7 @@ describe('Card Asset Service', function () {
                 }
             });
 
-            cardAssets.generateGlobs().should.eql({
+            assert.deepEqual(cardAssets.generateGlobs(), {
                 'cards.min.css': 'css/!(bookmarks).css',
                 'cards.min.js': 'js/!(bookmarks).js'
             });
@@ -123,7 +123,7 @@ describe('Card Asset Service', function () {
                 }
             });
 
-            cardAssets.generateGlobs().should.eql({
+            assert.deepEqual(cardAssets.generateGlobs(), {
                 'cards.min.css': 'css/@(gallery).css',
                 'cards.min.js': 'js/@(gallery).js'
             });
@@ -137,7 +137,7 @@ describe('Card Asset Service', function () {
                 }
             });
 
-            cardAssets.generateGlobs().should.eql({
+            assert.deepEqual(cardAssets.generateGlobs(), {
                 'cards.min.css': 'css/@(gallery).css',
                 'cards.min.js': 'js/@(gallery).js'
             });

--- a/ghost/core/test/unit/frontend/services/data/checks.test.js
+++ b/ghost/core/test/unit/frontend/services/data/checks.test.js
@@ -4,7 +4,7 @@ const {checks} = require('../../../../../core/frontend/services/data');
 
 describe('Checks', function () {
     it('methods', function () {
-        Object.keys(checks).should.eql([
+        assert.deepEqual(Object.keys(checks), [
             'isPost',
             'isNewsletter',
             'isPage',

--- a/ghost/core/test/unit/frontend/services/data/fetch-data.test.js
+++ b/ghost/core/test/unit/frontend/services/data/fetch-data.test.js
@@ -2,6 +2,7 @@ const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../utils/assertions');
 const should = require('should');
 const sinon = require('sinon');
+const _ = require('lodash');
 
 const api = require('../../../../../core/frontend/services/proxy').api;
 const data = require('../../../../../core/frontend/services/data');
@@ -64,7 +65,7 @@ describe('Unit - frontend/data/fetch-data', function () {
             result.should.not.have.property('data');
 
             assert.equal(browsePostsStub.calledOnce, true);
-            browsePostsStub.firstCall.args[0].should.be.an.Object();
+            assert(_.isPlainObject(browsePostsStub.firstCall.args[0]));
             browsePostsStub.firstCall.args[0].should.have.property('include');
             browsePostsStub.firstCall.args[0].should.not.have.property('filter');
 
@@ -81,7 +82,7 @@ describe('Unit - frontend/data/fetch-data', function () {
             result.posts.length.should.eql(posts.length);
 
             assert.equal(browsePostsStub.calledOnce, true);
-            browsePostsStub.firstCall.args[0].should.be.an.Object();
+            assert(_.isPlainObject(browsePostsStub.firstCall.args[0]));
             browsePostsStub.firstCall.args[0].should.have.property('include');
             browsePostsStub.firstCall.args[0].should.have.property('limit', 10);
             browsePostsStub.firstCall.args[0].should.have.property('page', 2);

--- a/ghost/core/test/unit/frontend/services/rendering/error.test.js
+++ b/ghost/core/test/unit/frontend/services/rendering/error.test.js
@@ -1,5 +1,3 @@
-const assert = require('node:assert/strict');
-const should = require('should');
 const sinon = require('sinon');
 const errors = require('@tryghost/errors');
 const helpers = require('../../../../../core/frontend/services/rendering');
@@ -19,8 +17,7 @@ describe('handleError', function () {
         const notFoundError = new errors.NotFoundError({message: 'Something wasn\'t found'});
         helpers.handleError(next)(notFoundError);
 
-        assert.equal(next.calledOnce, true);
-        next.firstCall.args.should.be.empty();
+        sinon.assert.calledOnceWithExactly(next);
     });
 
     it('should call next with error for other errors', function () {
@@ -29,9 +26,6 @@ describe('handleError', function () {
 
         helpers.handleError(next)(otherError);
 
-        assert.equal(next.calledOnce, true);
-        assert.equal(next.firstCall.args.length, 1);
-        next.firstCall.args[0].should.be.an.Object();
-        next.firstCall.args[0].should.be.instanceof(Error);
+        sinon.assert.calledOnceWithExactly(next, sinon.match(Error));
     });
 });

--- a/ghost/core/test/unit/frontend/services/rendering/templates.test.js
+++ b/ghost/core/test/unit/frontend/services/rendering/templates.test.js
@@ -17,60 +17,60 @@ describe('templates', function () {
 
     describe('[private fn] getEntriesTemplateHierarchy', function () {
         it('should return just index for empty options', function () {
-            _private.getEntriesTemplateHierarchy({}).should.eql(['index']);
+            assert.deepEqual(_private.getEntriesTemplateHierarchy({}), ['index']);
         });
 
         it('should return just index if collection name is index', function () {
-            _private.getEntriesTemplateHierarchy({name: 'index'}).should.eql(['index']);
+            assert.deepEqual(_private.getEntriesTemplateHierarchy({name: 'index'}), ['index']);
         });
 
         it('should return custom templates even if the collection is index', function () {
-            _private.getEntriesTemplateHierarchy({name: 'index', templates: ['something']}).should.eql(['something', 'index']);
+            assert.deepEqual(_private.getEntriesTemplateHierarchy({name: 'index', templates: ['something']}), ['something', 'index']);
         });
 
         it('should return collection name', function () {
-            _private.getEntriesTemplateHierarchy({name: 'podcast'}).should.eql(['podcast', 'index']);
+            assert.deepEqual(_private.getEntriesTemplateHierarchy({name: 'podcast'}), ['podcast', 'index']);
         });
 
         it('should return custom templates', function () {
-            _private.getEntriesTemplateHierarchy({name: 'podcast', templates: ['mozart']}).should.eql(['mozart', 'podcast', 'index']);
+            assert.deepEqual(_private.getEntriesTemplateHierarchy({name: 'podcast', templates: ['mozart']}), ['mozart', 'podcast', 'index']);
         });
 
         it('should return just index if collection name is index even if slug is set', function () {
-            _private.getEntriesTemplateHierarchy({name: 'index', slugTemplate: true}, {slugParam: 'test'}).should.eql(['index']);
+            assert.deepEqual(_private.getEntriesTemplateHierarchy({name: 'index', slugTemplate: true}, {slugParam: 'test'}), ['index']);
         });
 
         it('should return collection, index if collection has name', function () {
-            _private.getEntriesTemplateHierarchy({name: 'tag'}).should.eql(['tag', 'index']);
+            assert.deepEqual(_private.getEntriesTemplateHierarchy({name: 'tag'}), ['tag', 'index']);
         });
 
         it('should return collection-slug, collection, index if collection has name & slug + slugTemplate set', function () {
-            _private.getEntriesTemplateHierarchy({
+            assert.deepEqual(_private.getEntriesTemplateHierarchy({
                 name: 'tag',
                 slugTemplate: true
-            }, {slugParam: 'test'}).should.eql(['tag-test', 'tag', 'index']);
+            }, {slugParam: 'test'}), ['tag-test', 'tag', 'index']);
         });
 
         it('should return front, collection-slug, collection, index if name, slugParam+slugTemplate & frontPageTemplate+pageParam=1 is set', function () {
-            _private.getEntriesTemplateHierarchy({
+            assert.deepEqual(_private.getEntriesTemplateHierarchy({
                 name: 'tag',
                 slugTemplate: true,
                 frontPageTemplate: 'front-tag'
-            }, {page: 1, path: '/', slugParam: 'test'}).should.eql(['front-tag', 'tag-test', 'tag', 'index']);
+            }, {page: 1, path: '/', slugParam: 'test'}), ['front-tag', 'tag-test', 'tag', 'index']);
         });
 
         it('should return home, index for index collection if front is set and pageParam = 1', function () {
-            _private.getEntriesTemplateHierarchy({
+            assert.deepEqual(_private.getEntriesTemplateHierarchy({
                 name: 'index',
                 frontPageTemplate: 'home'
-            }, {path: '/'}).should.eql(['home', 'index']);
+            }, {path: '/'}), ['home', 'index']);
         });
 
         it('should not use frontPageTemplate if not / collection', function () {
-            _private.getEntriesTemplateHierarchy({
+            assert.deepEqual(_private.getEntriesTemplateHierarchy({
                 name: 'index',
                 frontPageTemplate: 'home'
-            }, {path: '/magic/'}).should.eql(['index']);
+            }, {path: '/magic/'}), ['index']);
         });
     });
 

--- a/ghost/core/test/unit/frontend/services/routing/collection-router.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/collection-router.test.js
@@ -45,7 +45,7 @@ describe('UNIT - services/routing/CollectionRouter', function () {
 
             assert.equal(collectionRouter.filter, undefined);
             assert.equal(collectionRouter.getResourceType(), 'posts');
-            collectionRouter.templates.should.eql([]);
+            assert.deepEqual(collectionRouter.templates, []);
             assert.equal(collectionRouter.getPermalinks().getValue(), '/:slug/');
 
             assert.equal(routerCreatedSpy.calledOnce, true);
@@ -92,7 +92,7 @@ describe('UNIT - services/routing/CollectionRouter', function () {
 
             assert.equal(collectionRouter.filter, undefined);
             assert.equal(collectionRouter.getResourceType(), 'posts');
-            collectionRouter.templates.should.eql([]);
+            assert.deepEqual(collectionRouter.templates, []);
             assert.equal(collectionRouter.getPermalinks().getValue(), '/blog/:year/:slug/');
 
             assert.equal(routerCreatedSpy.calledOnce, true);

--- a/ghost/core/test/unit/frontend/services/routing/collection-router.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/collection-router.test.js
@@ -80,9 +80,9 @@ describe('UNIT - services/routing/CollectionRouter', function () {
             assert.equal(collectionRouter2.routerName, 'podcast');
             assert.equal(collectionRouter3.routerName, 'helloworld');
 
-            collectionRouter1.context.should.eql(['index']);
-            collectionRouter2.context.should.eql(['podcast']);
-            collectionRouter3.context.should.eql(['helloworld']);
+            assert.deepEqual(collectionRouter1.context, ['index']);
+            assert.deepEqual(collectionRouter2.context, ['podcast']);
+            assert.deepEqual(collectionRouter3.context, ['helloworld']);
         });
 
         it('collection lives under /blog/', function () {
@@ -127,7 +127,7 @@ describe('UNIT - services/routing/CollectionRouter', function () {
             const collectionRouter = new CollectionRouter('/magic/', {permalink: '/:slug/', templates: ['home', 'index']}, RESOURCE_CONFIG, routerCreatedSpy);
 
             // they are getting reversed because we unshift the templates in the helper
-            collectionRouter.templates.should.eql(['index', 'home']);
+            assert.deepEqual(collectionRouter.templates, ['index', 'home']);
         });
     });
 
@@ -138,7 +138,7 @@ describe('UNIT - services/routing/CollectionRouter', function () {
             collectionRouter._prepareEntriesContext(req, res, next);
 
             assert.equal(next.calledOnce, true);
-            res.routerOptions.should.eql({
+            assert.deepEqual(res.routerOptions, {
                 type: 'collection',
                 filter: undefined,
                 permalinks: '/:slug/:options(edit)?/',
@@ -166,7 +166,7 @@ describe('UNIT - services/routing/CollectionRouter', function () {
             collectionRouter._prepareEntriesContext(req, res, next);
 
             assert.equal(next.calledOnce, true);
-            res.routerOptions.should.eql({
+            assert.deepEqual(res.routerOptions, {
                 type: 'collection',
                 filter: undefined,
                 permalinks: '/:slug/:options(edit)?/',

--- a/ghost/core/test/unit/frontend/services/routing/static-routes-router.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/static-routes-router.test.js
@@ -64,7 +64,7 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
 
             assert.equal(staticRoutesRouter.getPermalinks(), undefined);
             assert.equal(staticRoutesRouter.filter, undefined);
-            staticRoutesRouter.templates.should.eql([]);
+            assert.deepEqual(staticRoutesRouter.templates, []);
 
             assert.equal(routerCreatedSpy.calledOnce, true);
             assert.equal(routerCreatedSpy.calledWith(staticRoutesRouter), true);
@@ -84,10 +84,10 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
 
             res.routerOptions.should.have.properties('type', 'templates', 'defaultTemplate', 'context', 'data', 'contentType');
             assert.equal(res.routerOptions.type, 'custom');
-            res.routerOptions.templates.should.eql([]);
+            assert.deepEqual(res.routerOptions.templates, []);
             res.routerOptions.defaultTemplate.should.be.a.Function();
             res.routerOptions.context.should.eql(['about']);
-            res.routerOptions.data.should.eql({});
+            assert.deepEqual(res.routerOptions.data, {});
 
             assert.equal(res.routerOptions.contentType, undefined);
             assert.equal(res.locals.slug, undefined);
@@ -101,10 +101,10 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
 
             res.routerOptions.should.have.properties('type', 'templates', 'defaultTemplate', 'context', 'data', 'contentType');
             assert.equal(res.routerOptions.type, 'custom');
-            res.routerOptions.templates.should.eql([]);
+            assert.deepEqual(res.routerOptions.templates, []);
             res.routerOptions.defaultTemplate.should.be.a.Function();
             res.routerOptions.context.should.eql(['index']);
-            res.routerOptions.data.should.eql({});
+            assert.deepEqual(res.routerOptions.data, {});
 
             assert.equal(res.locals.slug, undefined);
         });
@@ -123,7 +123,7 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
 
                 assert.equal(staticRoutesRouter.getPermalinks(), undefined);
                 assert.equal(staticRoutesRouter.filter, 'tag:test');
-                staticRoutesRouter.templates.should.eql([]);
+                assert.deepEqual(staticRoutesRouter.templates, []);
                 assertExists(staticRoutesRouter.data);
 
                 assert.equal(routerCreatedSpy.calledOnce, true);
@@ -151,7 +151,7 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
                 assert.equal(staticRoutesRouter.getPermalinks(), undefined);
                 assert.equal(staticRoutesRouter.filter, 'tag:test');
 
-                staticRoutesRouter.templates.should.eql([]);
+                assert.deepEqual(staticRoutesRouter.templates, []);
 
                 assert.equal(routerCreatedSpy.calledOnce, true);
                 assert.equal(routerCreatedSpy.calledWith(staticRoutesRouter), true);

--- a/ghost/core/test/unit/frontend/services/routing/static-routes-router.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/static-routes-router.test.js
@@ -42,7 +42,7 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
             assert.equal(staticRoutesRouter.filter, undefined);
             assert.equal(staticRoutesRouter.getPermalinks(), undefined);
 
-            staticRoutesRouter.templates.should.eql(['test']);
+            assert.deepEqual(staticRoutesRouter.templates, ['test']);
 
             assert.equal(routerCreatedSpy.calledOnce, true);
             assert.equal(routerCreatedSpy.calledWith(staticRoutesRouter), true);
@@ -86,7 +86,7 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
             assert.equal(res.routerOptions.type, 'custom');
             assert.deepEqual(res.routerOptions.templates, []);
             res.routerOptions.defaultTemplate.should.be.a.Function();
-            res.routerOptions.context.should.eql(['about']);
+            assert.deepEqual(res.routerOptions.context, ['about']);
             assert.deepEqual(res.routerOptions.data, {});
 
             assert.equal(res.routerOptions.contentType, undefined);
@@ -103,7 +103,7 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
             assert.equal(res.routerOptions.type, 'custom');
             assert.deepEqual(res.routerOptions.templates, []);
             res.routerOptions.defaultTemplate.should.be.a.Function();
-            res.routerOptions.context.should.eql(['index']);
+            assert.deepEqual(res.routerOptions.context, ['index']);
             assert.deepEqual(res.routerOptions.data, {});
 
             assert.equal(res.locals.slug, undefined);
@@ -207,7 +207,7 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
 
                 staticRoutesRouter._prepareChannelContext(req, res, next);
                 assert.equal(next.calledOnce, true);
-                res.routerOptions.should.eql({
+                assert.deepEqual(res.routerOptions, {
                     type: 'channel',
                     context: ['channel'],
                     filter: 'tag:test',
@@ -227,7 +227,7 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
 
                 staticRoutesRouter._prepareChannelContext(req, res, next);
                 assert.equal(next.calledOnce, true);
-                res.routerOptions.should.eql({
+                assert.deepEqual(res.routerOptions, {
                     type: 'channel',
                     context: ['nothingcomparestoyou'],
                     name: 'nothingcomparestoyou',
@@ -247,7 +247,7 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
 
                 staticRoutesRouter._prepareChannelContext(req, res, next);
                 assert.equal(next.calledOnce, true);
-                res.routerOptions.should.eql({
+                assert.deepEqual(res.routerOptions, {
                     type: 'channel',
                     context: ['channel'],
                     filter: 'tag:test',
@@ -269,7 +269,7 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
 
                 staticRoutesRouter._prepareChannelContext(req, res, next);
                 assert.equal(next.calledOnce, true);
-                res.routerOptions.should.eql({
+                assert.deepEqual(res.routerOptions, {
                     type: 'channel',
                     context: ['channel'],
                     filter: 'tag:test',

--- a/ghost/core/test/unit/frontend/services/routing/taxonomy-router.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/taxonomy-router.test.js
@@ -69,7 +69,7 @@ describe('UNIT - services/routing/TaxonomyRouter', function () {
         taxonomyRouter._prepareContext(req, res, next);
         assert.equal(next.calledOnce, true);
 
-        res.routerOptions.should.eql({
+        assert.deepEqual(res.routerOptions, {
             type: 'channel',
             name: 'tag',
             permalinks: '/tag/:slug/',

--- a/ghost/core/test/unit/frontend/services/rss/cache.test.js
+++ b/ghost/core/test/unit/frontend/services/rss/cache.test.js
@@ -48,7 +48,7 @@ describe('RSS: Cache', function () {
                 assert.equal(generateSpy.callCount, 1);
 
                 // The data should be identical, no changing lastBuildDate
-                xmlData1.should.equal(xmlData2);
+                assert.equal(xmlData1, xmlData2);
 
                 done();
             })

--- a/ghost/core/test/unit/frontend/services/rss/renderer.test.js
+++ b/ghost/core/test/unit/frontend/services/rss/renderer.test.js
@@ -30,7 +30,7 @@ describe('RSS: Renderer', function () {
 
         renderer.render(res, baseUrl).then(function () {
             assert.equal(rssCacheStub.calledOnce, true);
-            rssCacheStub.firstCall.args.should.eql(['/rss/', {}]);
+            assert.deepEqual(rssCacheStub.firstCall.args, ['/rss/', {}]);
 
             assert.equal(res.set.calledOnce, true);
             assert.equal(res.set.calledWith('Content-Type', 'application/rss+xml; charset=UTF-8'), true);
@@ -49,7 +49,7 @@ describe('RSS: Renderer', function () {
 
         renderer.render(res, baseUrl).then(function () {
             assert.equal(rssCacheStub.calledOnce, true);
-            rssCacheStub.firstCall.args.should.eql(['/rss/', {foo: 'bar'}]);
+            assert.deepEqual(rssCacheStub.firstCall.args, ['/rss/', {foo: 'bar'}]);
 
             assert.equal(res.set.calledOnce, true);
             assert.equal(res.set.calledWith('Content-Type', 'application/rss+xml; charset=UTF-8'), true);
@@ -69,7 +69,7 @@ describe('RSS: Renderer', function () {
 
         renderer.render(res, baseUrl, data).then(function () {
             assert.equal(rssCacheStub.calledOnce, true);
-            rssCacheStub.firstCall.args.should.eql(['/rss/', {foo: 'baz', fizz: 'buzz'}]);
+            assert.deepEqual(rssCacheStub.firstCall.args, ['/rss/', {foo: 'baz', fizz: 'buzz'}]);
 
             assert.equal(res.set.calledOnce, true);
             assert.equal(res.set.calledWith('Content-Type', 'application/rss+xml; charset=UTF-8'), true);
@@ -90,7 +90,7 @@ describe('RSS: Renderer', function () {
             assert.equal(err.message, 'Fake Error');
 
             assert.equal(rssCacheStub.calledOnce, true);
-            rssCacheStub.firstCall.args.should.eql(['/rss/', {}]);
+            assert.deepEqual(rssCacheStub.firstCall.args, ['/rss/', {}]);
 
             assert.equal(res.set.called, false);
             assert.equal(res.send.called, false);

--- a/ghost/core/test/unit/frontend/services/theme-engine/active.test.js
+++ b/ghost/core/test/unit/frontend/services/theme-engine/active.test.js
@@ -64,7 +64,7 @@ describe('Themes', function () {
                 assert.equal(configStub.calledWith('assetHash', null), true);
 
                 // Check te view cache was cleared
-                fakeBlogApp.cache.should.eql({});
+                assert.deepEqual(fakeBlogApp.cache, {});
 
                 // Check the views were set correctly
                 assert.equal(fakeBlogApp.set.calledOnce, true);
@@ -95,7 +95,7 @@ describe('Themes', function () {
                 assert.equal(configStub.calledWith('assetHash', null), true);
 
                 // Check te view cache was cleared
-                fakeBlogApp.cache.should.eql({});
+                assert.deepEqual(fakeBlogApp.cache, {});
 
                 // Check the views were set correctly
                 assert.equal(fakeBlogApp.set.calledOnce, true);

--- a/ghost/core/test/unit/frontend/services/theme-engine/config.test.js
+++ b/ghost/core/test/unit/frontend/services/theme-engine/config.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 const themeConfig = require('../../../../../core/frontend/services/theme-engine/config');
@@ -11,7 +12,7 @@ describe('Themes', function () {
         it('handles no package.json', function () {
             const config = themeConfig.create();
 
-            config.should.eql({
+            assert.deepEqual(config, {
                 posts_per_page: 5,
                 card_assets: true
             });
@@ -20,7 +21,7 @@ describe('Themes', function () {
         it('handles package.json without config', function () {
             const config = themeConfig.create({name: 'casper'});
 
-            config.should.eql({
+            assert.deepEqual(config, {
                 posts_per_page: 5,
                 card_assets: true
             });
@@ -29,7 +30,7 @@ describe('Themes', function () {
         it('handles allows package.json to override default', function () {
             const config = themeConfig.create({name: 'casper', config: {posts_per_page: 3, card_assets: true}});
 
-            config.should.eql({
+            assert.deepEqual(config, {
                 posts_per_page: 3,
                 card_assets: true
             });
@@ -38,7 +39,7 @@ describe('Themes', function () {
         it('handles ignores non-allowed config', function () {
             const config = themeConfig.create({name: 'casper', config: {magic: 'roundabout'}});
 
-            config.should.eql({
+            assert.deepEqual(config, {
                 posts_per_page: 5,
                 card_assets: true
             });

--- a/ghost/core/test/unit/frontend/services/theme-engine/i18n.test.js
+++ b/ghost/core/test/unit/frontend/services/theme-engine/i18n.test.js
@@ -59,9 +59,10 @@ describe('I18n Class behavior', function () {
         });
 
         it('errors for invalid strings', function () {
-            should(function () {
-                i18n.t('unknown string');
-            }).throw('i18n.t() called with an invalid key: unknown string');
+            assert.throws(
+                () => i18n.t('unknown string'),
+                {message: 'i18n.t() called with an invalid key: unknown string'}
+            );
         });
     });
 

--- a/ghost/core/test/unit/frontend/services/theme-engine/i18next.test.js
+++ b/ghost/core/test/unit/frontend/services/theme-engine/i18next.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const sinon = require('sinon');
 const ThemeI18n = require('../../../../../core/frontend/services/theme-engine/i18next/theme-i18n');
 const path = require('path');
@@ -50,9 +49,10 @@ describe('NEW i18nextThemeI18n Class behavior', function () {
     });
 
     it('throws error if used before initialization', function () {
-        should(function () {
-            i18n.t('some key');
-        }).throw('Theme translation was used before it was initialised with key some key');
+        assert.throws(
+            () => i18n.t('some key'),
+            {message: 'Theme translation was used before it was initialised with key some key'}
+        );
     });
 
     it('uses key fallback correctly', function () {

--- a/ghost/core/test/unit/frontend/services/theme-engine/middleware.test.js
+++ b/ghost/core/test/unit/frontend/services/theme-engine/middleware.test.js
@@ -2,6 +2,7 @@ const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../utils/assertions');
 const should = require('should');
 const sinon = require('sinon');
+const _ = require('lodash');
 const hbs = require('../../../../../core/frontend/services/theme-engine/engine');
 const middleware = require('../../../../../core/frontend/services/theme-engine').middleware;
 // is only exposed via themeEngine.getActive()
@@ -334,7 +335,7 @@ describe('Themes middleware', function () {
 
                     data.should.be.an.Object().with.properties('site', 'custom');
 
-                    data.custom.should.be.an.Object();
+                    assert(_.isPlainObject(data.custom));
                     data.custom.should.be.empty();
 
                     done();
@@ -360,7 +361,7 @@ describe('Themes middleware', function () {
 
                     data.should.be.an.Object().with.properties('site', 'custom');
 
-                    data.custom.should.be.an.Object();
+                    assert(_.isPlainObject(data.custom));
                     data.custom.should.be.empty();
 
                     done();

--- a/ghost/core/test/unit/frontend/web/middleware/error-handler.test.js
+++ b/ghost/core/test/unit/frontend/web/middleware/error-handler.test.js
@@ -44,7 +44,7 @@ describe('Frontend Error Handler', function () {
         assert.equal(response.status.calledOnceWithExactly(statusCode), true);
         assert.equal(response.type.calledOnceWithExactly('text/plain'), true);
         assert.equal(response.send.calledOnce, true);
-        response.send.firstCall.args[0].should.equal(message);
+        assert.equal(response.send.firstCall.args[0], message);
         assert.equal(response.render.called, false);
     }
 

--- a/ghost/core/test/unit/frontend/web/middleware/static-theme.test.js
+++ b/ghost/core/test/unit/frontend/web/middleware/static-theme.test.js
@@ -2,6 +2,7 @@ const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../utils/assertions');
 const should = require('should');
 const sinon = require('sinon');
+const _ = require('lodash');
 
 const express = require('../../../../../core/shared/express');
 const themeEngine = require('../../../../../core/frontend/services/theme-engine');
@@ -378,7 +379,7 @@ describe('staticTheme', function () {
                 assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
 
                 const options = expressStaticStub.firstCall.args[1];
-                options.should.be.an.Object();
+                assert(_.isPlainObject(options));
                 options.should.have.property('maxAge');
                 options.should.have.property('fallthrough', true);
 
@@ -399,7 +400,7 @@ describe('staticTheme', function () {
                 assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
 
                 const options = expressStaticStub.firstCall.args[1];
-                options.should.be.an.Object();
+                assert(_.isPlainObject(options));
                 options.should.have.property('maxAge');
                 options.should.have.property('fallthrough', true);
 
@@ -420,7 +421,7 @@ describe('staticTheme', function () {
                 assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
 
                 const options = expressStaticStub.firstCall.args[1];
-                options.should.be.an.Object();
+                assert(_.isPlainObject(options));
                 options.should.have.property('maxAge');
                 options.should.have.property('fallthrough', true);
 
@@ -439,7 +440,7 @@ describe('staticTheme', function () {
                 assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
 
                 const options = expressStaticStub.firstCall.args[1];
-                options.should.be.an.Object();
+                assert(_.isPlainObject(options));
                 options.should.have.property('maxAge');
                 options.should.have.property('fallthrough', true);
 
@@ -502,7 +503,7 @@ describe('staticTheme', function () {
                 assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
 
                 const options = expressStaticStub.firstCall.args[1];
-                options.should.be.an.Object();
+                assert(_.isPlainObject(options));
                 options.should.have.property('maxAge');
                 options.should.have.property('fallthrough', false);
 
@@ -523,7 +524,7 @@ describe('staticTheme', function () {
                 assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
 
                 const options = expressStaticStub.firstCall.args[1];
-                options.should.be.an.Object();
+                assert(_.isPlainObject(options));
                 options.should.have.property('maxAge');
                 options.should.have.property('fallthrough', false);
 
@@ -544,7 +545,7 @@ describe('staticTheme', function () {
                 assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
 
                 const options = expressStaticStub.firstCall.args[1];
-                options.should.be.an.Object();
+                assert(_.isPlainObject(options));
                 options.should.have.property('maxAge');
                 options.should.have.property('fallthrough', false);
 

--- a/ghost/core/test/unit/server/adapters/scheduling/post-scheduling/post-scheduler.test.js
+++ b/ghost/core/test/unit/server/adapters/scheduling/post-scheduling/post-scheduler.test.js
@@ -78,7 +78,7 @@ describe('Scheduling: Post Scheduler', function () {
 
                 assert.equal(adapter.schedule.calledOnce, true);
 
-                adapter.schedule.args[0][0].time.should.equal(moment(post.get('published_at')).valueOf());
+                assert.equal(adapter.schedule.args[0][0].time, moment(post.get('published_at')).valueOf());
                 adapter.schedule.args[0][0].url.should.startWith(urlUtils.urlJoin('http://scheduler.local:1111/', 'schedules', 'posts', post.get('id'), '?token='));
                 assert.equal(adapter.schedule.args[0][0].extra.httpMethod, 'PUT');
                 assert.equal(null, adapter.schedule.args[0][0].extra.oldTime);

--- a/ghost/core/test/unit/server/adapters/scheduling/scheduling-default.test.js
+++ b/ghost/core/test/unit/server/adapters/scheduling/scheduling-default.test.js
@@ -53,7 +53,7 @@ describe('Scheduling Default Adapter', function () {
             assert.equal(scope.adapter._execute.calledTwice, true);
 
             Object.keys(scope.adapter.allJobs).length.should.eql(dates.length - 2);
-            Object.keys(scope.adapter.allJobs).should.eql([
+            assert.deepEqual(Object.keys(scope.adapter.allJobs), [
                 moment(dates[2]).valueOf().toString(),
                 moment(dates[6]).valueOf().toString(),
                 moment(dates[4]).valueOf().toString(),

--- a/ghost/core/test/unit/server/adapters/storage/local-images-storage.test.js
+++ b/ghost/core/test/unit/server/adapters/storage/local-images-storage.test.js
@@ -91,7 +91,7 @@ describe('Local Images Storage', function () {
     it('should create month and year directory', function (done) {
         localFileStore.save(image).then(function () {
             assert.equal(fsMkdirsStub.calledOnce, true);
-            fsMkdirsStub.args[0][0].should.equal(path.resolve('./content/images/2013/09'));
+            assert.equal(fsMkdirsStub.args[0][0], path.resolve('./content/images/2013/09'));
 
             done();
         }).catch(done);
@@ -101,7 +101,7 @@ describe('Local Images Storage', function () {
         localFileStore.save(image).then(function () {
             assert.equal(fsCopyStub.calledOnce, true);
             assert.equal(fsCopyStub.args[0][0], 'tmp/123456.jpg');
-            fsCopyStub.args[0][1].should.equal(path.resolve('./content/images/2013/09/IMAGE.jpg'));
+            assert.equal(fsCopyStub.args[0][1], path.resolve('./content/images/2013/09/IMAGE.jpg'));
 
             done();
         }).catch(done);

--- a/ghost/core/test/unit/server/adapters/storage/utils.test.js
+++ b/ghost/core/test/unit/server/adapters/storage/utils.test.js
@@ -1,5 +1,5 @@
+const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../utils/assertions');
-const should = require('should');
 const sinon = require('sinon');
 const urlUtils = require('../../../../../core/shared/url-utils');
 
@@ -30,7 +30,7 @@ describe('storage utils', function () {
 
             result = storageUtils.getLocalImagesStoragePath(url);
             assertExists(result);
-            result.should.be.equal('/2017/07/ghost-logo.png');
+            assert.equal(result, '/2017/07/ghost-logo.png');
         });
 
         it('should return local file storage path for absolute URL with subdirectory', function () {
@@ -44,7 +44,7 @@ describe('storage utils', function () {
 
             result = storageUtils.getLocalImagesStoragePath(url);
             assertExists(result);
-            result.should.be.equal('/2017/07/ghost-logo.png');
+            assert.equal(result, '/2017/07/ghost-logo.png');
         });
 
         it('should return local file storage path for relative URL', function () {
@@ -58,7 +58,7 @@ describe('storage utils', function () {
 
             result = storageUtils.getLocalImagesStoragePath(filePath);
             assertExists(result);
-            result.should.be.equal('/2017/07/ghost-logo.png');
+            assert.equal(result, '/2017/07/ghost-logo.png');
         });
 
         it('should return local file storage path for relative URL with subdirectory', function () {
@@ -72,7 +72,7 @@ describe('storage utils', function () {
 
             result = storageUtils.getLocalImagesStoragePath(filePath);
             assertExists(result);
-            result.should.be.equal('/2017/07/ghost-logo.png');
+            assert.equal(result, '/2017/07/ghost-logo.png');
         });
 
         it('should not sanitize URL if not local file storage', function () {
@@ -86,7 +86,7 @@ describe('storage utils', function () {
 
             result = storageUtils.getLocalImagesStoragePath(url);
             assertExists(result);
-            result.should.be.equal('http://example-blog.com/ghost-logo.png');
+            assert.equal(result, 'http://example-blog.com/ghost-logo.png');
         });
     });
 
@@ -102,7 +102,7 @@ describe('storage utils', function () {
 
             result = storageUtils.isLocalImage(url);
             assertExists(result);
-            result.should.be.equal(true);
+            assert.equal(result, true);
         });
 
         it('should return true when absolute URL with subdirectory and local file', function () {
@@ -116,7 +116,7 @@ describe('storage utils', function () {
 
             result = storageUtils.isLocalImage(url);
             assertExists(result);
-            result.should.be.equal(true);
+            assert.equal(result, true);
         });
 
         it('should return true when relative URL and local file', function () {
@@ -130,7 +130,7 @@ describe('storage utils', function () {
 
             result = storageUtils.isLocalImage(url);
             assertExists(result);
-            result.should.be.equal(true);
+            assert.equal(result, true);
         });
 
         it('should return true when relative URL and local file (blog subdir)', function () {
@@ -144,7 +144,7 @@ describe('storage utils', function () {
 
             result = storageUtils.isLocalImage(url);
             assertExists(result);
-            result.should.be.equal(true);
+            assert.equal(result, true);
         });
 
         it('should return false when no local file', function () {
@@ -158,7 +158,7 @@ describe('storage utils', function () {
 
             result = storageUtils.isLocalImage(url);
             assertExists(result);
-            result.should.be.equal(false);
+            assert.equal(result, false);
         });
     });
 });

--- a/ghost/core/test/unit/server/data/exporter/index.test.js
+++ b/ghost/core/test/unit/server/data/exporter/index.test.js
@@ -79,7 +79,7 @@ describe('Exporter', function () {
 
                 for (let call = 0; call < expectedCallCount; call++) {
                     const arg = knexMock.getCall(call).args[0];
-                    arg.should.be.equalOneOf(expectedTables);
+                    assert(expectedTables.includes(arg));
                     expectedTables = expectedTables.filter(item => item !== arg);
                 }
                 expectedTables.should.be.empty();
@@ -131,7 +131,7 @@ describe('Exporter', function () {
 
                 for (let call = 0; call < expectedCallCount; call++) {
                     const arg = knexMock.getCall(call).args[0];
-                    arg.should.be.equalOneOf(expectedTables);
+                    assert(expectedTables.includes(arg));
                     expectedTables = expectedTables.filter(item => item !== arg);
                 }
                 expectedTables.should.be.empty();

--- a/ghost/core/test/unit/server/data/importer/importers/data/newsletters.test.js
+++ b/ghost/core/test/unit/server/data/importer/importers/data/newsletters.test.js
@@ -47,10 +47,10 @@ describe('NewslettersImporter', function () {
             const newsletter1 = importer.dataToImport[0];
             const newsletter2 = importer.dataToImport[1];
 
-            newsletter1.name.should.be.eql('Daily newsletter');
+            assert.equal(newsletter1.name, 'Daily newsletter');
             assert.equal(newsletter1.sender_email, undefined);
 
-            newsletter2.name.should.be.eql('Weekly roundup');
+            assert.equal(newsletter2.name, 'Weekly roundup');
             assert.equal(newsletter2.sender_email, undefined);
         });
     });

--- a/ghost/core/test/unit/server/data/importer/index.test.js
+++ b/ghost/core/test/unit/server/data/importer/index.test.js
@@ -351,7 +351,7 @@ describe('Importer', function () {
                     const testDir = path.resolve('test/utils/fixtures/import/zips/zip-multiple-data-formats');
                     const extractSpy = sinon.stub(ImportManager, 'extractZip').returns(Promise.resolve(testDir));
 
-                    await should(ImportManager.processZip(testZip)).rejectedWith(/multiple data formats/);
+                    await assert.rejects(ImportManager.processZip(testZip), /multiple data formats/);
                     assert.equal(extractSpy.calledOnce, true);
                 });
 
@@ -359,7 +359,7 @@ describe('Importer', function () {
                     const testDir = path.resolve('test/utils/fixtures/import/zips/zip-empty');
                     const extractSpy = sinon.stub(ImportManager, 'extractZip').returns(Promise.resolve(testDir));
 
-                    await should(ImportManager.processZip(testZip)).rejectedWith(/not include any content/);
+                    await assert.rejects(ImportManager.processZip(testZip), /not include any content/);
                     assert.equal(extractSpy.calledOnce, true);
                 });
             });

--- a/ghost/core/test/unit/server/data/importer/index.test.js
+++ b/ghost/core/test/unit/server/data/importer/index.test.js
@@ -481,7 +481,7 @@ describe('Importer', function () {
                     imageSpy.getCall(0).args[0].should.eql(expectedImages);
 
                     // we stubbed this as a noop but ImportManager calls with sequence, so we should get an array
-                    output.should.eql({images: expectedImages, data: expectedData});
+                    assert.deepEqual(output, {images: expectedImages, data: expectedData});
                     done();
                 }).catch(done);
             });

--- a/ghost/core/test/unit/server/data/importer/index.test.js
+++ b/ghost/core/test/unit/server/data/importer/index.test.js
@@ -494,7 +494,7 @@ describe('Importer', function () {
             it('is currently a noop', function (done) {
                 const input = [{data: {}, images: []}];
                 ImportManager.generateReport(input).then(function (output) {
-                    output.should.equal(input);
+                    assert.equal(output, input);
                     done();
                 }).catch(done);
             });

--- a/ghost/core/test/unit/server/data/schema/fixtures/fixture-manager.test.js
+++ b/ghost/core/test/unit/server/data/schema/fixtures/fixture-manager.test.js
@@ -513,7 +513,7 @@ describe('Migration Fixture Utils', function () {
         it('should fetch a single fixture entry', function () {
             const foundFixture = fixtureManager.findModelFixtureEntry('Integration', {slug: 'zapier'});
             assert(_.isPlainObject(foundFixture));
-            foundFixture.should.eql({
+            assert.deepEqual(foundFixture, {
                 slug: 'zapier',
                 name: 'Zapier',
                 description: 'Built-in Zapier integration',
@@ -528,12 +528,12 @@ describe('Migration Fixture Utils', function () {
             const foundFixture = fixtureManager.findModelFixtures('Permission', {object_type: 'db'});
             assert(_.isPlainObject(foundFixture));
             foundFixture.entries.should.be.an.Array().with.lengthOf(4);
-            foundFixture.entries[0].should.eql({
+            assert.deepEqual(foundFixture.entries[0], {
                 name: 'Export database',
                 action_type: 'exportContent',
                 object_type: 'db'
             });
-            foundFixture.entries[3].should.eql({
+            assert.deepEqual(foundFixture.entries[3], {
                 name: 'Backup database',
                 action_type: 'backupContent',
                 object_type: 'db'

--- a/ghost/core/test/unit/server/data/schema/fixtures/fixture-manager.test.js
+++ b/ghost/core/test/unit/server/data/schema/fixtures/fixture-manager.test.js
@@ -2,6 +2,7 @@ const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../../utils/assertions');
 const should = require('should');
 const sinon = require('sinon');
+const _ = require('lodash');
 
 const models = require('../../../../../../core/server/models');
 const baseUtils = require('../../../../../../core/server/models/base/utils');
@@ -338,7 +339,7 @@ describe('Migration Fixture Utils', function () {
 
             fixtureManager.addFixturesForModel(postFixtures).then(function (result) {
                 assertExists(result);
-                result.should.be.an.Object();
+                assert(_.isPlainObject(result));
                 result.should.have.property('expected', 11);
                 result.should.have.property('done', 11);
 
@@ -359,7 +360,7 @@ describe('Migration Fixture Utils', function () {
 
             fixtureManager.addFixturesForModel(newsletterFixtures).then(function (result) {
                 assertExists(result);
-                result.should.be.an.Object();
+                assert(_.isPlainObject(result));
                 result.should.have.property('expected', 1);
                 result.should.have.property('done', 1);
 
@@ -380,7 +381,7 @@ describe('Migration Fixture Utils', function () {
 
             fixtureManager.addFixturesForModel(postFixtures).then(function (result) {
                 assertExists(result);
-                result.should.be.an.Object();
+                assert(_.isPlainObject(result));
                 result.should.have.property('expected', 11);
                 result.should.have.property('done', 0);
 
@@ -413,7 +414,7 @@ describe('Migration Fixture Utils', function () {
             fixtureManager.addFixturesForRelation(fixtures.relations[0]).then(function (result) {
                 const FIXTURE_COUNT = 137;
                 assertExists(result);
-                result.should.be.an.Object();
+                assert(_.isPlainObject(result));
                 result.should.have.property('expected', FIXTURE_COUNT);
                 result.should.have.property('done', FIXTURE_COUNT);
 
@@ -450,7 +451,7 @@ describe('Migration Fixture Utils', function () {
 
             fixtureManager.addFixturesForRelation(fixtures.relations[1]).then(function (result) {
                 assertExists(result);
-                result.should.be.an.Object();
+                assert(_.isPlainObject(result));
                 result.should.have.property('expected', 7);
                 result.should.have.property('done', 7);
 
@@ -487,7 +488,7 @@ describe('Migration Fixture Utils', function () {
 
             fixtureManager.addFixturesForRelation(fixtures.relations[1]).then(function (result) {
                 assertExists(result);
-                result.should.be.an.Object();
+                assert(_.isPlainObject(result));
                 result.should.have.property('expected', 7);
                 result.should.have.property('done', 0);
 
@@ -511,7 +512,7 @@ describe('Migration Fixture Utils', function () {
     describe('findModelFixtureEntry', function () {
         it('should fetch a single fixture entry', function () {
             const foundFixture = fixtureManager.findModelFixtureEntry('Integration', {slug: 'zapier'});
-            foundFixture.should.be.an.Object();
+            assert(_.isPlainObject(foundFixture));
             foundFixture.should.eql({
                 slug: 'zapier',
                 name: 'Zapier',
@@ -525,7 +526,7 @@ describe('Migration Fixture Utils', function () {
     describe('findModelFixtures', function () {
         it('should fetch a fixture with multiple entries', function () {
             const foundFixture = fixtureManager.findModelFixtures('Permission', {object_type: 'db'});
-            foundFixture.should.be.an.Object();
+            assert(_.isPlainObject(foundFixture));
             foundFixture.entries.should.be.an.Array().with.lengthOf(4);
             foundFixture.entries[0].should.eql({
                 name: 'Export database',
@@ -543,8 +544,8 @@ describe('Migration Fixture Utils', function () {
     describe('findPermissionRelationsForObject', function () {
         it('should fetch a fixture with multiple entries', function () {
             const foundFixture = fixtureManager.findPermissionRelationsForObject('db');
-            foundFixture.should.be.an.Object();
-            foundFixture.entries.should.be.an.Object();
+            assert(_.isPlainObject(foundFixture));
+            assert(_.isPlainObject(foundFixture.entries));
             foundFixture.entries.should.have.property('Administrator', {db: 'all'});
         });
     });

--- a/ghost/core/test/unit/server/data/schema/fixtures/fixture-manager.test.js
+++ b/ghost/core/test/unit/server/data/schema/fixtures/fixture-manager.test.js
@@ -135,8 +135,8 @@ describe('Migration Fixture Utils', function () {
             const third = manager.fixtures;
 
             assert.equal(callCount, 1);
-            first.should.equal(second);
-            second.should.equal(third);
+            assert.equal(first, second);
+            assert.equal(second, third);
         });
 
         it('should handle no placeholders gracefully', function () {
@@ -187,7 +187,7 @@ describe('Migration Fixture Utils', function () {
 
             assertExists(receivedModels);
 
-            receivedModels.should.equal(models);
+            assert.equal(receivedModels, models);
         });
 
         it('should handle missing placeholder handlers', function () {

--- a/ghost/core/test/unit/server/data/schema/schema.test.js
+++ b/ghost/core/test/unit/server/data/schema/schema.test.js
@@ -67,7 +67,7 @@ describe('schema validations', function () {
                 // Ensure the column type is one of the ones we allow
                 assert(Object.keys(VALID_KEYS).includes(column.type));
 
-                should(_.difference(Object.keys(column), [...VALID_KEYS[column.type], 'type'])).be.Array().with.length(0);
+                assert.deepEqual(_.difference(Object.keys(column), [...VALID_KEYS[column.type], 'type']), []);
             });
         });
     });
@@ -80,8 +80,9 @@ describe('schema validations', function () {
                 const columnIsInValidation = _.get(column, 'validations.isIn');
                 // Check column's isIn validation is in correct format
                 if (columnIsInValidation) {
-                    should(columnIsInValidation).be.Array().with.length(1);
-                    should(columnIsInValidation[0]).be.Array();
+                    assert(Array.isArray(columnIsInValidation));
+                    assert.equal(columnIsInValidation.length, 1);
+                    assert(Array.isArray(columnIsInValidation[0]));
                 }
             });
         });

--- a/ghost/core/test/unit/server/data/schema/schema.test.js
+++ b/ghost/core/test/unit/server/data/schema/schema.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../utils/assertions');
 const should = require('should');
 const _ = require('lodash');
@@ -64,7 +65,7 @@ describe('schema validations', function () {
                 assertExists(column.type, `${tableName}.${columnName}.type should exist`);
 
                 // Ensure the column type is one of the ones we allow
-                should(column.type).be.equalOneOf(Object.keys(VALID_KEYS));
+                assert(Object.keys(VALID_KEYS).includes(column.type));
 
                 should(_.difference(Object.keys(column), [...VALID_KEYS[column.type], 'type'])).be.Array().with.length(0);
             });

--- a/ghost/core/test/unit/server/data/schema/schema.test.js
+++ b/ghost/core/test/unit/server/data/schema/schema.test.js
@@ -47,11 +47,11 @@ const VALID_KEYS = {
 describe('schema validations', function () {
     it('matches the required format', function () {
         // The top-level export should be an object of table names to definitions
-        should(schema).be.Object();
+        assert(_.isPlainObject(schema));
 
         // Each table should be an object, and each column should be an object
         _.each(schema, function (table, tableName) {
-            should(table).be.Object();
+            assert(_.isPlainObject(table));
 
             _.each(table, function (column, columnName) {
                 if (['@@INDEXES@@', '@@UNIQUE_CONSTRAINTS@@'].includes(columnName)) {
@@ -59,7 +59,7 @@ describe('schema validations', function () {
                 }
 
                 // Ensure the column is an object
-                should(column).be.Object();
+                assert(_.isPlainObject(column));
 
                 // Ensure the `type` key exists on a column
                 assertExists(column.type, `${tableName}.${columnName}.type should exist`);

--- a/ghost/core/test/unit/server/lib/image/blog-icon.test.js
+++ b/ghost/core/test/unit/server/lib/image/blog-icon.test.js
@@ -178,7 +178,7 @@ describe('lib/image: blog icon', function () {
             blogIcon.getIconDimensions(path.join(__dirname, '../../../../utils/fixtures/images/favicon.ico'))
                 .then(function (result) {
                     assertExists(result);
-                    result.should.eql({
+                    assert.deepEqual(result, {
                         width: 48,
                         height: 48
                     });
@@ -191,7 +191,7 @@ describe('lib/image: blog icon', function () {
             blogIcon.getIconDimensions(path.join(__dirname, '../../../../utils/fixtures/images/favicon.png'))
                 .then(function (result) {
                     assertExists(result);
-                    result.should.eql({
+                    assert.deepEqual(result, {
                         width: 100,
                         height: 100
                     });
@@ -204,7 +204,7 @@ describe('lib/image: blog icon', function () {
             blogIcon.getIconDimensions(path.join(__dirname, '../../../../utils/fixtures/images/favicon_multi_sizes.ico'))
                 .then(function (result) {
                     assertExists(result);
-                    result.should.eql({
+                    assert.deepEqual(result, {
                         width: 64,
                         height: 64
                     });

--- a/ghost/core/test/unit/server/lib/image/cached-image-size-from-url.test.js
+++ b/ghost/core/test/unit/server/lib/image/cached-image-size-from-url.test.js
@@ -44,9 +44,9 @@ describe('lib/image: image size cache', function () {
         cacheStore.get(url).should.not.be.undefined;
         const image = cacheStore.get(url);
         assertExists(image.width);
-        image.width.should.be.equal(50);
+        assert.equal(image.width, 50);
         assertExists(image.height);
-        image.height.should.be.equal(50);
+        assert.equal(image.height, 50);
 
         // second call to check if values get returned from cache
         await cachedImageSizeFromUrl.getCachedImageSizeFromUrl(url);
@@ -57,9 +57,9 @@ describe('lib/image: image size cache', function () {
         cacheStore.get(url).should.not.be.undefined;
         const image2 = cacheStore.get(url);
         assertExists(image2.width);
-        image2.width.should.be.equal(50);
+        assert.equal(image2.width, 50);
         assertExists(image2.height);
-        image2.height.should.be.equal(50);
+        assert.equal(image2.height, 50);
     });
 
     it('can handle generic image-size errors', async function () {

--- a/ghost/core/test/unit/server/lib/image/image-size.test.js
+++ b/ghost/core/test/unit/server/lib/image/image-size.test.js
@@ -50,9 +50,9 @@ describe('lib/image: image size', function () {
             imageSize.getImageSizeFromUrl(url).then(function (res) {
                 assert.equal(requestMock.isDone(), true);
                 assertExists(res);
-                res.width.should.be.equal(expectedImageObject.width);
-                res.height.should.be.equal(expectedImageObject.height);
-                res.url.should.be.equal(expectedImageObject.url);
+                assert.equal(res.width, expectedImageObject.width);
+                assert.equal(res.height, expectedImageObject.height);
+                assert.equal(res.url, expectedImageObject.url);
                 done();
             }).catch(done);
         });
@@ -85,9 +85,9 @@ describe('lib/image: image size', function () {
             imageSize.getImageSizeFromUrl(url).then(function (res) {
                 assert.equal(requestMock.isDone(), false);
                 assertExists(res);
-                res.width.should.be.equal(expectedImageObject.width);
-                res.height.should.be.equal(expectedImageObject.height);
-                res.url.should.be.equal(expectedImageObject.url);
+                assert.equal(res.width, expectedImageObject.width);
+                assert.equal(res.height, expectedImageObject.height);
+                assert.equal(res.url, expectedImageObject.url);
                 done();
             }).catch(done);
         });
@@ -115,9 +115,9 @@ describe('lib/image: image size', function () {
             imageSize.getImageSizeFromUrl(url).then(function (res) {
                 assert.equal(requestMock.isDone(), true);
                 assertExists(res);
-                res.width.should.be.equal(expectedImageObject.width);
-                res.height.should.be.equal(expectedImageObject.height);
-                res.url.should.be.equal(expectedImageObject.url);
+                assert.equal(res.width, expectedImageObject.width);
+                assert.equal(res.height, expectedImageObject.height);
+                assert.equal(res.url, expectedImageObject.url);
                 done();
             }).catch(done);
         });
@@ -147,9 +147,9 @@ describe('lib/image: image size', function () {
                 assert.equal(requestMockNotFound.isDone(), false);
                 assert.equal(requestMock.isDone(), true);
                 assertExists(res);
-                res.width.should.be.equal(expectedImageObject.width);
-                res.height.should.be.equal(expectedImageObject.height);
-                res.url.should.be.equal(expectedImageObject.url);
+                assert.equal(res.width, expectedImageObject.width);
+                assert.equal(res.height, expectedImageObject.height);
+                assert.equal(res.url, expectedImageObject.url);
                 done();
             }).catch(done);
         });
@@ -196,9 +196,9 @@ describe('lib/image: image size', function () {
             imageSize.getImageSizeFromUrl(url).then(function (res) {
                 assert.equal(requestMock.isDone(), true);
                 assertExists(res);
-                res.width.should.be.equal(expectedImageObject.width);
-                res.height.should.be.equal(expectedImageObject.height);
-                res.url.should.be.equal(expectedImageObject.url);
+                assert.equal(res.width, expectedImageObject.width);
+                assert.equal(res.height, expectedImageObject.height);
+                assert.equal(res.url, expectedImageObject.url);
                 done();
             }).catch(done);
         });
@@ -226,9 +226,9 @@ describe('lib/image: image size', function () {
             imageSize.getImageSizeFromUrl(url).then(function (res) {
                 assert.equal(requestMock.isDone(), true);
                 assertExists(res);
-                res.width.should.be.equal(expectedImageObject.width);
-                res.height.should.be.equal(expectedImageObject.height);
-                res.url.should.be.equal(expectedImageObject.url);
+                assert.equal(res.width, expectedImageObject.width);
+                assert.equal(res.height, expectedImageObject.height);
+                assert.equal(res.url, expectedImageObject.url);
                 done();
             }).catch(done);
         });
@@ -263,9 +263,9 @@ describe('lib/image: image size', function () {
                 assert.equal(requestMock.isDone(), true);
                 assert.equal(secondRequestMock.isDone(), true);
                 assertExists(res);
-                res.width.should.be.equal(expectedImageObject.width);
-                res.height.should.be.equal(expectedImageObject.height);
-                res.url.should.be.equal(expectedImageObject.url);
+                assert.equal(res.width, expectedImageObject.width);
+                assert.equal(res.height, expectedImageObject.height);
+                assert.equal(res.url, expectedImageObject.url);
                 done();
             }).catch(done);
         });
@@ -309,11 +309,11 @@ describe('lib/image: image size', function () {
                 assert.equal(requestMock.isDone(), false);
                 assertExists(res);
                 assertExists(res.width);
-                res.width.should.be.equal(expectedImageObject.width);
+                assert.equal(res.width, expectedImageObject.width);
                 assertExists(res.height);
-                res.height.should.be.equal(expectedImageObject.height);
+                assert.equal(res.height, expectedImageObject.height);
                 assertExists(res.url);
-                res.url.should.be.equal(expectedImageObject.url);
+                assert.equal(res.url, expectedImageObject.url);
                 done();
             }).catch(done);
         });
@@ -337,8 +337,8 @@ describe('lib/image: image size', function () {
                 .catch(function (err) {
                     assert.equal(requestMock.isDone(), true);
                     assertExists(err);
-                    err.errorType.should.be.equal('NotFoundError');
-                    err.message.should.be.equal('Image not found.');
+                    assert.equal(err.errorType, 'NotFoundError');
+                    assert.equal(err.message, 'Image not found.');
                     done();
                 }).catch(done);
         });
@@ -375,8 +375,8 @@ describe('lib/image: image size', function () {
                 .catch(function (err) {
                     assert.equal(requestMock.isDone(), false);
                     assertExists(err);
-                    err.errorType.should.be.equal('NotFoundError');
-                    err.message.should.be.equal('Image not found.');
+                    assert.equal(err.errorType, 'NotFoundError');
+                    assert.equal(err.message, 'Image not found.');
                     done();
                 }).catch(done);
         });
@@ -395,8 +395,8 @@ describe('lib/image: image size', function () {
             imageSize.getImageSizeFromUrl(url)
                 .catch(function (err) {
                     assertExists(err);
-                    err.errorType.should.be.equal('InternalServerError');
-                    err.message.should.be.equal('URL empty or invalid.');
+                    assert.equal(err.errorType, 'InternalServerError');
+                    assert.equal(err.message, 'URL empty or invalid.');
                     done();
                 }).catch(done);
         });
@@ -429,8 +429,8 @@ describe('lib/image: image size', function () {
                 .catch(function (err) {
                     assert.equal(requestMock.isDone(), true);
                     assertExists(err);
-                    err.errorType.should.be.equal('InternalServerError');
-                    err.message.should.be.equal('Request timed out.');
+                    assert.equal(err.errorType, 'InternalServerError');
+                    assert.equal(err.message, 'Request timed out.');
                     done();
                 }).catch(done);
         });
@@ -457,7 +457,7 @@ describe('lib/image: image size', function () {
                 .catch(function (err) {
                     assert.equal(requestMock.isDone(), true);
                     assertExists(err);
-                    err.errorType.should.be.equal('InternalServerError');
+                    assert.equal(err.errorType, 'InternalServerError');
                     done();
                 }).catch(done);
         });
@@ -491,7 +491,7 @@ describe('lib/image: image size', function () {
                 .catch(function (err) {
                     assert.equal(requestMock.isDone(), false);
                     assertExists(err);
-                    err.errorType.should.be.equal('InternalServerError');
+                    assert.equal(err.errorType, 'InternalServerError');
                     done();
                 }).catch(done);
         });
@@ -512,8 +512,8 @@ describe('lib/image: image size', function () {
             imageSize.getImageSizeFromUrl(url)
                 .catch(function (err) {
                     assertExists(err);
-                    err.errorType.should.be.equal('InternalServerError');
-                    err.message.should.be.equal('Unknown Request error.');
+                    assert.equal(err.errorType, 'InternalServerError');
+                    assert.equal(err.message, 'Unknown Request error.');
                     done();
                 }).catch(done);
         });
@@ -544,8 +544,8 @@ describe('lib/image: image size', function () {
                 .catch(function (err) {
                     assert.equal(requestMock.isDone(), true);
                     assertExists(err);
-                    err.errorType.should.be.equal('InternalServerError');
-                    err.message.should.be.equal('Probe unresponsive.');
+                    assert.equal(err.errorType, 'InternalServerError');
+                    assert.equal(err.message, 'Probe unresponsive.');
                     done();
                 }).catch(done);
         });
@@ -586,11 +586,11 @@ describe('lib/image: image size', function () {
             imageSize.getImageSizeFromStoragePath(url).then(function (res) {
                 assertExists(res);
                 assertExists(res.width);
-                res.width.should.be.equal(expectedImageObject.width);
+                assert.equal(res.width, expectedImageObject.width);
                 assertExists(res.height);
-                res.height.should.be.equal(expectedImageObject.height);
+                assert.equal(res.height, expectedImageObject.height);
                 assertExists(res.url);
-                res.url.should.be.equal(expectedImageObject.url);
+                assert.equal(res.url, expectedImageObject.url);
                 done();
             }).catch(done);
         });
@@ -629,11 +629,11 @@ describe('lib/image: image size', function () {
             imageSize.getImageSizeFromStoragePath(url).then(function (res) {
                 assertExists(res);
                 assertExists(res.width);
-                res.width.should.be.equal(expectedImageObject.width);
+                assert.equal(res.width, expectedImageObject.width);
                 assertExists(res.height);
-                res.height.should.be.equal(expectedImageObject.height);
+                assert.equal(res.height, expectedImageObject.height);
                 assertExists(res.url);
-                res.url.should.be.equal(expectedImageObject.url);
+                assert.equal(res.url, expectedImageObject.url);
                 done();
             }).catch(done);
         });
@@ -672,11 +672,11 @@ describe('lib/image: image size', function () {
             imageSize.getImageSizeFromStoragePath(url).then(function (res) {
                 assertExists(res);
                 assertExists(res.width);
-                res.width.should.be.equal(expectedImageObject.width);
+                assert.equal(res.width, expectedImageObject.width);
                 assertExists(res.height);
-                res.height.should.be.equal(expectedImageObject.height);
+                assert.equal(res.height, expectedImageObject.height);
                 assertExists(res.url);
-                res.url.should.be.equal(expectedImageObject.url);
+                assert.equal(res.url, expectedImageObject.url);
                 done();
             }).catch(done);
         });
@@ -715,11 +715,11 @@ describe('lib/image: image size', function () {
             imageSize.getImageSizeFromStoragePath(url).then(function (res) {
                 assertExists(res);
                 assertExists(res.width);
-                res.width.should.be.equal(expectedImageObject.width);
+                assert.equal(res.width, expectedImageObject.width);
                 assertExists(res.height);
-                res.height.should.be.equal(expectedImageObject.height);
+                assert.equal(res.height, expectedImageObject.height);
                 assertExists(res.url);
-                res.url.should.be.equal(expectedImageObject.url);
+                assert.equal(res.url, expectedImageObject.url);
                 done();
             }).catch(done);
         });

--- a/ghost/core/test/unit/server/lib/package-json/parse.test.js
+++ b/ghost/core/test/unit/server/lib/package-json/parse.test.js
@@ -48,7 +48,7 @@ describe('package-json parse', function () {
             })
             .catch(function (err) {
                 assert.equal(err.message, '"name" or "version" is missing from theme package.json file.');
-                err.context.should.equal(tmpFile.name);
+                assert.equal(err.context, tmpFile.name);
                 assert.equal(err.help, 'This will be required in future. Please see https://ghost.org/docs/themes/');
 
                 done();
@@ -74,7 +74,7 @@ describe('package-json parse', function () {
             })
             .catch(function (err) {
                 assert.equal(err.message, '"name" or "version" is missing from theme package.json file.');
-                err.context.should.equal(tmpFile.name);
+                assert.equal(err.context, tmpFile.name);
                 assert.equal(err.help, 'This will be required in future. Please see https://ghost.org/docs/themes/');
 
                 done();
@@ -98,7 +98,7 @@ describe('package-json parse', function () {
             })
             .catch(function (err) {
                 assert.equal(err.message, 'Theme package.json file is malformed');
-                err.context.should.equal(tmpFile.name);
+                assert.equal(err.context, tmpFile.name);
                 assert.equal(err.help, 'This will be required in future. Please see https://ghost.org/docs/themes/');
 
                 done();
@@ -117,7 +117,7 @@ describe('package-json parse', function () {
             })
             .catch(function (err) {
                 assert.equal(err.message, 'Could not read package.json file');
-                err.context.should.equal(tmpFile.name);
+                assert.equal(err.context, tmpFile.name);
 
                 done();
             })

--- a/ghost/core/test/unit/server/lib/package-json/parse.test.js
+++ b/ghost/core/test/unit/server/lib/package-json/parse.test.js
@@ -20,7 +20,7 @@ describe('package-json parse', function () {
 
         parse(tmpFile.name)
             .then(function (pkg) {
-                pkg.should.eql({
+                assert.deepEqual(pkg, {
                     name: 'test',
                     version: '0.0.0'
                 });

--- a/ghost/core/test/unit/server/lib/package-json/read.test.js
+++ b/ghost/core/test/unit/server/lib/package-json/read.test.js
@@ -320,7 +320,7 @@ describe('package-json read', function () {
 
             packageJSON.readPackage(packagePath.name, 'casper.zip')
                 .then(function (pkg) {
-                    pkg.should.eql({});
+                    assert.deepEqual(pkg, {});
 
                     done();
                 })

--- a/ghost/core/test/unit/server/lib/package-json/read.test.js
+++ b/ghost/core/test/unit/server/lib/package-json/read.test.js
@@ -23,7 +23,7 @@ describe('package-json read', function () {
 
             packageJSON.readPackages(packagePath.name)
                 .then(function (pkgs) {
-                    pkgs.should.eql({
+                    assert.deepEqual(pkgs, {
                         casper: {
                             name: 'casper',
                             path: join(packagePath.name, 'casper'),
@@ -54,7 +54,7 @@ describe('package-json read', function () {
 
             packageJSON.readPackages(packagePath.name)
                 .then(function (pkgs) {
-                    pkgs.should.eql({
+                    assert.deepEqual(pkgs, {
                         testtheme: {
                             name: 'testtheme',
                             path: join(packagePath.name, 'testtheme'),
@@ -87,7 +87,7 @@ describe('package-json read', function () {
 
             packageJSON.readPackages(packagePath.name)
                 .then(function (pkgs) {
-                    pkgs.should.eql({
+                    assert.deepEqual(pkgs, {
                         testtheme: {
                             name: 'testtheme',
                             path: join(packagePath.name, 'testtheme'),
@@ -120,7 +120,7 @@ describe('package-json read', function () {
 
             packageJSON.readPackages(packagePath.name)
                 .then(function (pkgs) {
-                    pkgs.should.eql({
+                    assert.deepEqual(pkgs, {
                         testtheme: {
                             name: 'testtheme',
                             path: join(packagePath.name, 'testtheme'),
@@ -155,7 +155,7 @@ describe('package-json read', function () {
 
             try {
                 const pkgs = await packageJSON.readPackages(packagePath.name);
-                pkgs.should.eql({
+                assert.deepEqual(pkgs, {
                     testtheme: {
                         name: 'testtheme',
                         path: join(packagePath.name, 'testtheme'),
@@ -184,7 +184,7 @@ describe('package-json read', function () {
 
             packageJSON.readPackage(packagePath.name, 'casper')
                 .then(function (pkgs) {
-                    pkgs.should.eql({
+                    assert.deepEqual(pkgs, {
                         casper: {
                             name: 'casper',
                             path: join(packagePath.name, 'casper'),
@@ -215,7 +215,7 @@ describe('package-json read', function () {
 
             packageJSON.readPackage(packagePath.name, 'testtheme')
                 .then(function (pkgs) {
-                    pkgs.should.eql({
+                    assert.deepEqual(pkgs, {
                         testtheme: {
                             name: 'testtheme',
                             path: join(packagePath.name, 'testtheme'),
@@ -248,7 +248,7 @@ describe('package-json read', function () {
 
             packageJSON.readPackage(packagePath.name, 'testtheme')
                 .then(function (pkgs) {
-                    pkgs.should.eql({
+                    assert.deepEqual(pkgs, {
                         testtheme: {
                             name: 'testtheme',
                             path: join(packagePath.name, 'testtheme'),
@@ -279,7 +279,7 @@ describe('package-json read', function () {
 
             packageJSON.readPackage(packagePath.name, 'casper')
                 .then(function (pkgs) {
-                    pkgs.should.eql({
+                    assert.deepEqual(pkgs, {
                         casper: {
                             name: 'casper',
                             path: join(packagePath.name, 'casper'),

--- a/ghost/core/test/unit/server/lib/request-external.test.js
+++ b/ghost/core/test/unit/server/lib/request-external.test.js
@@ -49,11 +49,11 @@ describe('External Request', function () {
                 assert.equal(requestMock.isDone(), true);
                 assertExists(res);
                 assertExists(res.body);
-                res.body.should.be.equal(expectedResponse.body);
+                assert.equal(res.body, expectedResponse.body);
                 assertExists(res.url);
-                res.statusCode.should.be.equal(expectedResponse.statusCode);
+                assert.equal(res.statusCode, expectedResponse.statusCode);
                 assertExists(res.statusCode);
-                res.url.should.be.equal(expectedResponse.url);
+                assert.equal(res.url, expectedResponse.url);
             });
         });
 
@@ -80,11 +80,11 @@ describe('External Request', function () {
                 assert.equal(requestMock.isDone(), true);
                 assertExists(res);
                 assertExists(res.body);
-                res.body.should.be.equal(expectedResponse.body);
+                assert.equal(res.body, expectedResponse.body);
                 assertExists(res.url);
-                res.statusCode.should.be.equal(expectedResponse.statusCode);
+                assert.equal(res.statusCode, expectedResponse.statusCode);
                 assertExists(res.statusCode);
-                res.url.should.be.equal(expectedResponse.url);
+                assert.equal(res.url, expectedResponse.url);
             });
         });
 
@@ -102,7 +102,7 @@ describe('External Request', function () {
                 throw new Error('Request should have rejected with non-permitted IP message');
             }, (err) => {
                 assertExists(err);
-                err.message.should.be.equal('URL resolves to a non-permitted private IP block');
+                assert.equal(err.message, 'URL resolves to a non-permitted private IP block');
             });
         });
 
@@ -120,7 +120,7 @@ describe('External Request', function () {
                 throw new Error('Request should have rejected with non-permitted IP message');
             }, (err) => {
                 assertExists(err);
-                err.message.should.be.equal('URL resolves to a non-permitted private IP block');
+                assert.equal(err.message, 'URL resolves to a non-permitted private IP block');
             });
         });
 
@@ -140,7 +140,7 @@ describe('External Request', function () {
                 throw new Error('Request should have rejected with non-permitted IP message');
             }, (err) => {
                 assertExists(err);
-                err.message.should.be.equal('URL resolves to a non-permitted private IP block');
+                assert.equal(err.message, 'URL resolves to a non-permitted private IP block');
                 assert.equal(requestMock.isDone(), false);
             });
         });
@@ -170,7 +170,7 @@ describe('External Request', function () {
                 throw new Error('Request should have rejected with non-permitted IP message');
             }, (err) => {
                 assertExists(err);
-                err.message.should.be.equal('URL resolves to a non-permitted private IP block');
+                assert.equal(err.message, 'URL resolves to a non-permitted private IP block');
                 assert.equal(requestMock.isDone(), true);
                 assert.equal(secondRequestMock.isDone(), false);
             });
@@ -211,11 +211,11 @@ describe('External Request', function () {
                 assert.equal(requestMock.isDone(), true);
                 assertExists(res);
                 assertExists(res.body);
-                res.body.should.be.equal(expectedResponse.body);
+                assert.equal(res.body, expectedResponse.body);
                 assertExists(res.url);
-                res.statusCode.should.be.equal(expectedResponse.statusCode);
+                assert.equal(res.statusCode, expectedResponse.statusCode);
                 assertExists(res.statusCode);
-                res.url.should.be.equal(expectedResponse.url);
+                assert.equal(res.url, expectedResponse.url);
             });
         });
 
@@ -248,11 +248,11 @@ describe('External Request', function () {
                 assert.equal(secondRequestMock.isDone(), true);
                 assertExists(res);
                 assertExists(res.body);
-                res.body.should.be.equal(expectedResponse.body);
+                assert.equal(res.body, expectedResponse.body);
                 assertExists(res.url);
-                res.statusCode.should.be.equal(expectedResponse.statusCode);
+                assert.equal(res.statusCode, expectedResponse.statusCode);
                 assertExists(res.statusCode);
-                res.url.should.be.equal(expectedResponse.url);
+                assert.equal(res.url, expectedResponse.url);
             });
         });
 
@@ -268,7 +268,7 @@ describe('External Request', function () {
                 throw new Error('Request should have rejected with invalid url message');
             }, (err) => {
                 assertExists(err);
-                err.code.should.be.equal('ERR_INVALID_URL');
+                assert.equal(err.code, 'ERR_INVALID_URL');
             });
         });
 
@@ -285,7 +285,7 @@ describe('External Request', function () {
             }, (err) => {
                 assertExists(err);
                 // got v11+ throws an error instead of the external requests lib
-                err.message.should.be.equal('No URL protocol specified');
+                assert.equal(err.message, 'No URL protocol specified');
             });
         });
 
@@ -306,7 +306,7 @@ describe('External Request', function () {
             }, (err) => {
                 assert.equal(requestMock.isDone(), true);
                 assertExists(err);
-                err.response.statusMessage.should.be.equal('Not Found');
+                assert.equal(err.response.statusMessage, 'Not Found');
             });
         });
 
@@ -328,7 +328,7 @@ describe('External Request', function () {
             }, (err) => {
                 assert.equal(requestMock.isDone(), true);
                 assertExists(err);
-                err.response.statusMessage.should.be.equal(`Internal Server Error`);
+                assert.equal(err.response.statusMessage, `Internal Server Error`);
             });
         });
     });

--- a/ghost/core/test/unit/server/models/base/relations.test.js
+++ b/ghost/core/test/unit/server/models/base/relations.test.js
@@ -42,7 +42,7 @@ describe('Models: getLazyRelation', function () {
         assert.equal(fetchStub.calledOnceWithExactly(options), true);
 
         // Check if we can force reload
-        await should(modelA.getLazyRelation('tiers', {forceRefresh: true})).rejectedWith(/Called twice/);
+        await assert.rejects(modelA.getLazyRelation('tiers', {forceRefresh: true}), /Called twice/);
         assert.equal(fetchStub.calledTwice, true);
     });
 
@@ -77,7 +77,7 @@ describe('Models: getLazyRelation', function () {
         assert.equal(fetchStub.calledOnceWithExactly(options), true);
 
         // Check if we can force reload
-        await should(modelA.getLazyRelation('other', {forceRefresh: true})).rejectedWith(/Called twice/);
+        await assert.rejects(modelA.getLazyRelation('other', {forceRefresh: true}), /Called twice/);
         assert.equal(fetchStub.calledTwice, true);
     });
 

--- a/ghost/core/test/unit/server/models/integration.test.js
+++ b/ghost/core/test/unit/server/models/integration.test.js
@@ -62,7 +62,7 @@ describe('Unit: models/integration', function () {
             }).then(() => {
                 assert.equal(queries.length, 1);
                 assert.equal(queries[0].sql, 'select `integrations`.* from `integrations` where `integrations`.`type` in (?, ?, ?) and `integrations`.`id` = ? limit ?');
-                queries[0].bindings.should.eql(['custom', 'builtin', 'core', '123', 1]);
+                assert.deepEqual(queries[0].bindings, ['custom', 'builtin', 'core', '123', 1]);
             });
         });
     });
@@ -92,7 +92,7 @@ describe('Unit: models/integration', function () {
             return models.Integration.getInternalFrontendKey().then(() => {
                 assert.equal(queries.length, 1);
                 assert.equal(queries[0].sql, 'select `integrations`.* from `integrations` where `integrations`.`slug` = ? limit ?');
-                queries[0].bindings.should.eql(['ghost-internal-frontend', 1]);
+                assert.deepEqual(queries[0].bindings, ['ghost-internal-frontend', 1]);
             });
         });
     });

--- a/ghost/core/test/unit/server/models/post.test.js
+++ b/ghost/core/test/unit/server/models/post.test.js
@@ -45,7 +45,7 @@ describe('Unit: models/post', function () {
             }).then(() => {
                 assert.equal(queries.length, 2);
                 assert.equal(queries[0].sql, 'select count(distinct posts.id) as aggregate from `posts` where ((`posts`.`id` != ? and `posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` inner join `tags` on `tags`.`id` = `posts_tags`.`tag_id` where `tags`.`slug` in (?, ?))) and (`posts`.`type` = ? and `posts`.`status` = ?))');
-                queries[0].bindings.should.eql([
+                assert.deepEqual(queries[0].bindings, [
                     testUtils.filterData.data.posts[3].id,
                     'photo',
                     'video',
@@ -54,7 +54,7 @@ describe('Unit: models/post', function () {
                 ]);
 
                 assert.equal(queries[1].sql, 'select `posts`.* from `posts` where ((`posts`.`id` != ? and `posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` inner join `tags` on `tags`.`id` = `posts_tags`.`tag_id` where `tags`.`slug` in (?, ?))) and (`posts`.`type` = ? and `posts`.`status` = ?)) order by (SELECT count(*) FROM posts_tags WHERE post_id = posts.id) DESC, CASE WHEN posts.status = \'scheduled\' THEN 1 WHEN posts.status = \'draft\' THEN 2 ELSE 3 END ASC,CASE WHEN posts.status != \'draft\' THEN posts.published_at END DESC,posts.updated_at DESC,posts.id DESC limit ?');
-                queries[1].bindings.should.eql([
+                assert.deepEqual(queries[1].bindings, [
                     testUtils.filterData.data.posts[3].id,
                     'photo',
                     'video',
@@ -80,7 +80,7 @@ describe('Unit: models/post', function () {
             }).then(() => {
                 assert.equal(queries.length, 2);
                 assert.equal(queries[0].sql, 'select count(distinct posts.id) as aggregate from `posts` where (((`posts`.`feature_image` is not null or `posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` inner join `tags` on `tags`.`id` = `posts_tags`.`tag_id` where `tags`.`slug` = ?)) and `posts`.`id` in (select `posts_authors`.`post_id` from `posts_authors` inner join `users` as `authors` on `authors`.`id` = `posts_authors`.`author_id` where `authors`.`slug` in (?, ?))) and (`posts`.`type` = ? and `posts`.`status` = ?))');
-                queries[0].bindings.should.eql([
+                assert.deepEqual(queries[0].bindings, [
                     'hash-audio',
                     'leslie',
                     'pat',
@@ -89,7 +89,7 @@ describe('Unit: models/post', function () {
                 ]);
 
                 assert.equal(queries[1].sql, 'select `posts`.* from `posts` where (((`posts`.`feature_image` is not null or `posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` inner join `tags` on `tags`.`id` = `posts_tags`.`tag_id` where `tags`.`slug` = ?)) and `posts`.`id` in (select `posts_authors`.`post_id` from `posts_authors` inner join `users` as `authors` on `authors`.`id` = `posts_authors`.`author_id` where `authors`.`slug` in (?, ?))) and (`posts`.`type` = ? and `posts`.`status` = ?)) order by (SELECT count(*) FROM posts_authors WHERE post_id = posts.id) DESC, CASE WHEN posts.status = \'scheduled\' THEN 1 WHEN posts.status = \'draft\' THEN 2 ELSE 3 END ASC,CASE WHEN posts.status != \'draft\' THEN posts.published_at END DESC,posts.updated_at DESC,posts.id DESC limit ?');
-                queries[1].bindings.should.eql([
+                assert.deepEqual(queries[1].bindings, [
                     'hash-audio',
                     'leslie',
                     'pat',
@@ -116,14 +116,14 @@ describe('Unit: models/post', function () {
             }).then(() => {
                 assert.equal(queries.length, 2);
                 assert.equal(queries[0].sql, 'select count(distinct posts.id) as aggregate from `posts` where (`posts`.`published_at` > ? and (`posts`.`type` = ? and `posts`.`status` = ?))');
-                queries[0].bindings.should.eql([
+                assert.deepEqual(queries[0].bindings, [
                     '2015-07-20',
                     'post',
                     'published'
                 ]);
 
                 assert.equal(queries[1].sql, 'select `posts`.* from `posts` where (`posts`.`published_at` > ? and (`posts`.`type` = ? and `posts`.`status` = ?)) order by CASE WHEN posts.status = \'scheduled\' THEN 1 WHEN posts.status = \'draft\' THEN 2 ELSE 3 END ASC,CASE WHEN posts.status != \'draft\' THEN posts.published_at END DESC,posts.updated_at DESC,posts.id DESC limit ?');
-                queries[1].bindings.should.eql([
+                assert.deepEqual(queries[1].bindings, [
                     '2015-07-20',
                     'post',
                     'published',
@@ -148,7 +148,7 @@ describe('Unit: models/post', function () {
                 }).then(() => {
                     assert.equal(queries.length, 2);
                     assert.equal(queries[0].sql, 'select count(distinct posts.id) as aggregate from `posts` where ((`posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` inner join `tags` on `tags`.`id` = `posts_tags`.`tag_id` and `posts_tags`.`sort_order` = 0 where `tags`.`slug` = ? and `tags`.`visibility` = ?)) and (`posts`.`type` = ? and `posts`.`status` = ?))');
-                    queries[0].bindings.should.eql([
+                    assert.deepEqual(queries[0].bindings, [
                         'photo',
                         'public',
                         'post',
@@ -156,7 +156,7 @@ describe('Unit: models/post', function () {
                     ]);
 
                     assert.equal(queries[1].sql, 'select `posts`.* from `posts` where ((`posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` inner join `tags` on `tags`.`id` = `posts_tags`.`tag_id` and `posts_tags`.`sort_order` = 0 where `tags`.`slug` = ? and `tags`.`visibility` = ?)) and (`posts`.`type` = ? and `posts`.`status` = ?)) order by CASE WHEN posts.status = \'scheduled\' THEN 1 WHEN posts.status = \'draft\' THEN 2 ELSE 3 END ASC,CASE WHEN posts.status != \'draft\' THEN posts.published_at END DESC,posts.updated_at DESC,posts.id DESC limit ?');
-                    queries[1].bindings.should.eql([
+                    assert.deepEqual(queries[1].bindings, [
                         'photo',
                         'public',
                         'post',
@@ -181,7 +181,7 @@ describe('Unit: models/post', function () {
                 }).then(() => {
                     assert.equal(queries.length, 2);
                     assert.equal(queries[0].sql, 'select count(distinct posts.id) as aggregate from `posts` where ((`posts`.`id` in (select `posts_authors`.`post_id` from `posts_authors` inner join `users` as `authors` on `authors`.`id` = `posts_authors`.`author_id` and `posts_authors`.`sort_order` = 0 where `authors`.`slug` = ? and `authors`.`visibility` = ?)) and (`posts`.`type` = ? and `posts`.`status` = ?))');
-                    queries[0].bindings.should.eql([
+                    assert.deepEqual(queries[0].bindings, [
                         'leslie',
                         'public',
                         'post',
@@ -189,7 +189,7 @@ describe('Unit: models/post', function () {
                     ]);
 
                     assert.equal(queries[1].sql, 'select `posts`.* from `posts` where ((`posts`.`id` in (select `posts_authors`.`post_id` from `posts_authors` inner join `users` as `authors` on `authors`.`id` = `posts_authors`.`author_id` and `posts_authors`.`sort_order` = 0 where `authors`.`slug` = ? and `authors`.`visibility` = ?)) and (`posts`.`type` = ? and `posts`.`status` = ?)) order by CASE WHEN posts.status = \'scheduled\' THEN 1 WHEN posts.status = \'draft\' THEN 2 ELSE 3 END ASC,CASE WHEN posts.status != \'draft\' THEN posts.published_at END DESC,posts.updated_at DESC,posts.id DESC limit ?');
-                    queries[1].bindings.should.eql([
+                    assert.deepEqual(queries[1].bindings, [
                         'leslie',
                         'public',
                         'post',
@@ -225,7 +225,7 @@ describe('Unit: models/post', function () {
                     assert.equal(queries.length, 1);
 
                     assert.equal(queries[0].sql, 'select `posts`.* from `posts` where ((`posts`.`status` in (?, ?) and `posts`.`status` = ?) and (`posts`.`type` = ?)) order by CASE WHEN posts.status = \'scheduled\' THEN 1 WHEN posts.status = \'draft\' THEN 2 ELSE 3 END ASC,CASE WHEN posts.status != \'draft\' THEN posts.published_at END DESC,posts.updated_at DESC,posts.id DESC');
-                    queries[0].bindings.should.eql([
+                    assert.deepEqual(queries[0].bindings, [
                         'published',
                         'draft',
                         'published',

--- a/ghost/core/test/unit/server/models/set-is-roles.test.js
+++ b/ghost/core/test/unit/server/models/set-is-roles.test.js
@@ -2,6 +2,7 @@ const assert = require('node:assert/strict');
 const {assertExists} = require('../../../utils/assertions');
 const should = require('should');
 const {setIsRoles} = require('../../../../core/server/models/role-utils');
+const _ = require('lodash');
 
 describe('setIsRoles function behavior', function () {
     // create a fake 'loadedpermissions' object and then confirm the behavior of setIsRoles with it
@@ -62,12 +63,12 @@ describe('setIsRoles function behavior', function () {
     it('returns an object', function () {
         let result = setIsRoles(loadedPermissionsEditor);
         assertExists(result);
-        result.should.be.an.Object();
+        assert(_.isPlainObject(result));
     });
 
     it('returns the correct object for Editor', function () {
         let result = setIsRoles(loadedPermissionsEditor);
-        result.should.be.an.Object();
+        assert(_.isPlainObject(result));
         assert.equal(result.isOwner, false);
         assert.equal(result.isAdmin, false);
         assert.equal(result.isEditor, true);
@@ -79,7 +80,7 @@ describe('setIsRoles function behavior', function () {
 
     it('returns the correct object for Administrator', function () {
         let result = setIsRoles(loadedPermissionsAdmin);
-        result.should.be.an.Object();
+        assert(_.isPlainObject(result));
         assert.equal(result.isOwner, false);
         assert.equal(result.isAdmin, true);
         assert.equal(result.isEditor, false);
@@ -91,7 +92,7 @@ describe('setIsRoles function behavior', function () {
 
     it('returns the correct object for Author', function () {
         let result = setIsRoles(loadedPermissionsAuthor);
-        result.should.be.an.Object();
+        assert(_.isPlainObject(result));
         assert.equal(result.isOwner, false);
         assert.equal(result.isAdmin, false);
         assert.equal(result.isEditor, false);
@@ -103,7 +104,7 @@ describe('setIsRoles function behavior', function () {
 
     it('returns the correct object for Super Editor', function () {
         let result = setIsRoles(loadedPermissionsSuperEditor);
-        result.should.be.an.Object();
+        assert(_.isPlainObject(result));
         assert.equal(result.isOwner, false);
         assert.equal(result.isAdmin, false);
         assert.equal(result.isEditor, false);
@@ -115,7 +116,7 @@ describe('setIsRoles function behavior', function () {
 
     it('returns the correct object for multiple roles', function () {
         let result = setIsRoles(loadedPermissionsWithMultipleRoles);
-        result.should.be.an.Object();
+        assert(_.isPlainObject(result));
         assert.equal(result.isOwner, false);
         assert.equal(result.isAdmin, false);
         assert.equal(result.isEditor, true);
@@ -126,7 +127,7 @@ describe('setIsRoles function behavior', function () {
     });
     it('returns the correct object for no roles', function () {
         let result = setIsRoles(loadedPermissionsWithNoRoles);
-        result.should.be.an.Object();
+        assert(_.isPlainObject(result));
         assert.equal(result.isOwner, false);
         assert.equal(result.isAdmin, false);
         assert.equal(result.isEditor, false);
@@ -137,7 +138,7 @@ describe('setIsRoles function behavior', function () {
     });
     it('returns the correct object for no user', function () {
         let result = setIsRoles(loadedPermissionsWithNoUser);
-        result.should.be.an.Object();
+        assert(_.isPlainObject(result));
         assert.equal(result.isOwner, false);
         assert.equal(result.isAdmin, false);
         assert.equal(result.isEditor, false);
@@ -148,7 +149,7 @@ describe('setIsRoles function behavior', function () {
     });
     it('returns the correct object for permissions without role', function () {
         let result = setIsRoles(loadedPermissionswithPermissions);
-        result.should.be.an.Object();
+        assert(_.isPlainObject(result));
         assert.equal(result.isOwner, false);
         assert.equal(result.isAdmin, false);
         assert.equal(result.isEditor, false);

--- a/ghost/core/test/unit/server/models/tag.test.js
+++ b/ghost/core/test/unit/server/models/tag.test.js
@@ -48,7 +48,7 @@ describe('Unit: models/tag', function () {
                 assert.equal(queries.length, 1);
 
                 assert.equal(queries[0].sql, 'select `tags`.*, (select count(`posts`.`id`) from `posts` left outer join `posts_tags` on `posts`.`id` = `posts_tags`.`post_id` where posts_tags.tag_id = tags.id) as `count__posts` from `tags` where `count`.`posts` >= ? order by `count__posts` DESC');
-                queries[0].bindings.should.eql([
+                assert.deepEqual(queries[0].bindings, [
                     1
                 ]);
             });

--- a/ghost/core/test/unit/server/services/auth/session/session-service.test.js
+++ b/ghost/core/test/unit/server/services/auth/session/session-service.test.js
@@ -106,9 +106,10 @@ describe('SessionService', function () {
         });
         const res = Object.create(express.response);
 
-        const error = `Request made from incorrect origin. Expected 'origin' received 'other-origin'.`;
-
-        await sessionService.getUserForSession(req, res).should.be.rejectedWith(error);
+        await assert.rejects(
+            sessionService.getUserForSession(req, res),
+            {message: `Request made from incorrect origin. Expected 'origin' received 'other-origin'.`}
+        );
     });
 
     it('Doesn\'t throw an error when the csrf verification fails when bypassed', async function () {

--- a/ghost/core/test/unit/server/services/auth/session/session-service.test.js
+++ b/ghost/core/test/unit/server/services/auth/session/session-service.test.js
@@ -551,10 +551,9 @@ describe('SessionService', function () {
         const req = Object.create(express.request);
         const res = Object.create(express.response);
 
-        await should(sessionService.sendAuthCodeToUser(req, res))
-            .rejectedWith({
-                message: 'Failed to send email. Please check your site configuration and try again.'
-            });
+        await assert.rejects(sessionService.sendAuthCodeToUser(req, res), {
+            message: 'Failed to send email. Please check your site configuration and try again.'
+        });
     });
 
     it('Can create a verified session for SSO', async function () {
@@ -640,10 +639,9 @@ describe('SessionService', function () {
         const req = Object.create(express.request);
         const res = Object.create(express.response);
 
-        await should(sessionService.sendAuthCodeToUser(req, res))
-            .rejectedWith({
-                message: 'Could not fetch user from the session.'
-            });
+        await assert.rejects(sessionService.sendAuthCodeToUser(req, res), {
+            message: 'Could not fetch user from the session.'
+        });
     });
 
     it('Can remove verified session', async function () {

--- a/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
+++ b/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
@@ -1159,7 +1159,7 @@ describe('Email renderer', function () {
                 }
             };
             let response = await emailRenderer.getSegments(post);
-            response.should.eql([null]);
+            assert.deepEqual(response, [null]);
 
             post = {
                 get: (key) => {
@@ -1169,7 +1169,7 @@ describe('Email renderer', function () {
                 }
             };
             response = await emailRenderer.getSegments(post);
-            response.should.eql([null]);
+            assert.deepEqual(response, [null]);
         });
 
         it('returns correct segments for post with members only card', async function () {
@@ -1197,7 +1197,7 @@ describe('Email renderer', function () {
                 }
             };
             let response = await emailRenderer.getSegments(post);
-            response.should.eql(['status:free', 'status:-free']);
+            assert.deepEqual(response, ['status:free', 'status:-free']);
         });
 
         it('returns correct segments for post with email card', async function () {
@@ -1225,7 +1225,7 @@ describe('Email renderer', function () {
                 }
             };
             let response = await emailRenderer.getSegments(post);
-            response.should.eql(['status:free', 'status:-free']);
+            assert.deepEqual(response, ['status:free', 'status:-free']);
         });
     });
 

--- a/ghost/core/test/unit/server/services/indexnow.test.js
+++ b/ghost/core/test/unit/server/services/indexnow.test.js
@@ -391,7 +391,7 @@ describe('IndexNow', function () {
             settingsCacheStub.withArgs('indexnow_api_key').returns(expectedKey);
 
             const key = indexnow.getApiKey();
-            key.should.equal(expectedKey);
+            assert.equal(key, expectedKey);
         });
 
         it('should return null when no key is set', function () {

--- a/ghost/core/test/unit/server/services/link-redirection/link-redirect-repository.test.js
+++ b/ghost/core/test/unit/server/services/link-redirection/link-redirect-repository.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const sinon = require('sinon');
 const ObjectID = require('bson-objectid').default;
 const EventEmitter = require('events').EventEmitter;
@@ -150,7 +149,6 @@ describe('UNIT: LinkRedirectRepository class', function () {
             const url = new URL('https://example.com/r/1234abcd');
             linkRedirectRepository = createLinkRedirectRepository();
             const result = await linkRedirectRepository.getByURL(url);
-            should(result).be.an.Object();
             assert.equal(result.from.href, url.href);
             assert.equal(result.to.href, 'https://google.com/');
         });
@@ -170,7 +168,6 @@ describe('UNIT: LinkRedirectRepository class', function () {
                 cacheAdapter: cacheAdapterStub
             });
             const result = await linkRedirectRepository.getByURL(url);
-            should(result).be.an.Object();
             assert.equal(result.from.href, 'https://example.com/r/1234abcd');
             assert.equal(result.to.href, 'https://google.com/');
             assert.equal(result.edited, true);
@@ -188,7 +185,6 @@ describe('UNIT: LinkRedirectRepository class', function () {
                 cacheAdapter: cacheAdapterStub
             });
             const result = await linkRedirectRepository.getByURL(url);
-            should(result).be.an.Object();
             assert.equal(result.from.href, 'https://example.com/r/1234abcd');
             assert.equal(result.to.href, 'https://google.com/');
             assert.equal(result.edited, true);

--- a/ghost/core/test/unit/server/services/link-tracking/link-click-tracking-service.test.js
+++ b/ghost/core/test/unit/server/services/link-tracking/link-click-tracking-service.test.js
@@ -202,7 +202,7 @@ describe('LinkClickTrackingService', function () {
                     link: {to: 'https://example.com'}
                 }
             }, options);
-            should(result).eql({
+            assert.deepEqual(result, {
                 successful: 0,
                 unsuccessful: 0,
                 errors: [],
@@ -248,7 +248,7 @@ describe('LinkClickTrackingService', function () {
             const result = await service.bulkEdit(data, options);
 
             assert.equal(postLinkRepositoryStub.updateLinks.calledOnce, true);
-            should(result).eql({
+            assert.deepEqual(result, {
                 successful: 0,
                 unsuccessful: 0,
                 errors: [],
@@ -297,7 +297,7 @@ describe('LinkClickTrackingService', function () {
             const result = await service.bulkEdit(data, options);
 
             assert.equal(postLinkRepositoryStub.updateLinks.calledOnce, true);
-            should(result).eql({
+            assert.deepEqual(result, {
                 successful: 0,
                 unsuccessful: 0,
                 errors: [],

--- a/ghost/core/test/unit/server/services/link-tracking/post-link-repository.test.js
+++ b/ghost/core/test/unit/server/services/link-tracking/post-link-repository.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const sinon = require('sinon');
 
@@ -38,7 +39,7 @@ describe('UNIT: PostLinkRepository class', function () {
                 to: 'https://example.com',
                 updated_at: new Date('2022-10-20T00:00:00.000Z')
             }, {});
-            should(links).eql({
+            assert.deepEqual(links, {
                 bulk: {
                     action: 'updateLink',
                     meta: {

--- a/ghost/core/test/unit/server/services/mail/ghost-mailer.test.js
+++ b/ghost/core/test/unit/server/services/mail/ghost-mailer.test.js
@@ -113,9 +113,9 @@ describe('Mail: Ghostmailer', function () {
     it('should fail to send messages when given insufficient data', async function () {
         mailer = new mail.GhostMailer();
 
-        await mailer.send().should.be.rejectedWith('Incomplete message data.');
-        await mailer.send({subject: '123'}).should.be.rejectedWith('Incomplete message data.');
-        await mailer.send({subject: '', html: '123'}).should.be.rejectedWith('Incomplete message data.');
+        await assert.rejects(mailer.send(), {message: 'Incomplete message data.'});
+        await assert.rejects(mailer.send({subject: '123'}), {message: 'Incomplete message data.'});
+        await assert.rejects(mailer.send({subject: '', html: '123'}), {message: 'Incomplete message data.'});
     });
 
     describe('Direct', function () {

--- a/ghost/core/test/unit/server/services/member-attribution/history.test.js
+++ b/ghost/core/test/unit/server/services/member-attribution/history.test.js
@@ -112,6 +112,6 @@ describe('UrlHistory', function () {
             id: 'old'
         }];
         const history = UrlHistory.create(input);
-        should(history.history).eql([input[1]]);
+        assert.deepEqual(history.history, [input[1]]);
     });
 });

--- a/ghost/core/test/unit/server/services/member-attribution/history.test.js
+++ b/ghost/core/test/unit/server/services/member-attribution/history.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 
 const UrlHistory = require('../../../../../core/server/services/member-attribution/url-history');
@@ -61,7 +62,7 @@ describe('UrlHistory', function () {
 
         for (const input of inputs) {
             const history = UrlHistory.create(input);
-            should(history.history).eql([]);
+            assert.deepEqual(history.history, []);
         }
     });
 

--- a/ghost/core/test/unit/server/services/member-attribution/referrer-translator.test.js
+++ b/ghost/core/test/unit/server/services/member-attribution/referrer-translator.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 
 const ReferrerTranslator = require('../../../../../core/server/services/member-attribution/referrer-translator');
@@ -19,7 +20,7 @@ describe('ReferrerTranslator', function () {
         });
 
         it('returns ghost explore from source ref for valid history', async function () {
-            should(translator.getReferrerDetails([
+            assert.deepEqual(translator.getReferrerDetails([
                 {
                     referrerSource: 'ghost-explore',
                     referrerMedium: null,
@@ -35,7 +36,7 @@ describe('ReferrerTranslator', function () {
                     referrerMedium: null,
                     referrerUrl: 'https://t.co'
                 }
-            ])).eql({
+            ]), {
                 referrerSource: 'Ghost Explore',
                 referrerMedium: 'Ghost Network',
                 referrerUrl: null,
@@ -48,7 +49,7 @@ describe('ReferrerTranslator', function () {
         });
 
         it('returns ghost explore from url for valid history', async function () {
-            should(translator.getReferrerDetails([
+            assert.deepEqual(translator.getReferrerDetails([
                 {
                     referrerSource: null,
                     referrerMedium: null,
@@ -64,7 +65,7 @@ describe('ReferrerTranslator', function () {
                     referrerMedium: null,
                     referrerUrl: 'https://t.co'
                 }
-            ])).eql({
+            ]), {
                 referrerSource: 'Ghost Explore',
                 referrerMedium: 'Ghost Network',
                 referrerUrl: 'ghost.org',
@@ -77,7 +78,7 @@ describe('ReferrerTranslator', function () {
         });
 
         it('returns ghost explore from admin url for valid history', async function () {
-            should(translator.getReferrerDetails([
+            assert.deepEqual(translator.getReferrerDetails([
                 {
                     referrerSource: null,
                     referrerMedium: null,
@@ -93,7 +94,7 @@ describe('ReferrerTranslator', function () {
                     referrerMedium: null,
                     referrerUrl: 'https://t.co'
                 }
-            ])).eql({
+            ]), {
                 referrerSource: 'Ghost Explore',
                 referrerMedium: 'Ghost Network',
                 referrerUrl: 'admin.example.com',
@@ -106,7 +107,7 @@ describe('ReferrerTranslator', function () {
         });
 
         it('returns ghost newsletter ref for valid history', async function () {
-            should(translator.getReferrerDetails([
+            assert.deepEqual(translator.getReferrerDetails([
                 {
                     referrerSource: 'publisher-weekly-newsletter',
                     referrerMedium: null,
@@ -122,7 +123,7 @@ describe('ReferrerTranslator', function () {
                     referrerMedium: null,
                     referrerUrl: 'https://t.co'
                 }
-            ])).eql({
+            ]), {
                 referrerSource: 'publisher weekly newsletter',
                 referrerMedium: 'Email',
                 referrerUrl: null,
@@ -135,7 +136,7 @@ describe('ReferrerTranslator', function () {
         });
 
         it('returns ghost.org ref for valid history', async function () {
-            should(translator.getReferrerDetails([
+            assert.deepEqual(translator.getReferrerDetails([
                 {
                     referrerSource: null,
                     referrerMedium: null,
@@ -151,7 +152,7 @@ describe('ReferrerTranslator', function () {
                     referrerMedium: null,
                     referrerUrl: null
                 }
-            ])).eql({
+            ]), {
                 referrerSource: 'Ghost.org',
                 referrerMedium: 'Ghost Network',
                 referrerUrl: 'ghost.org',
@@ -164,7 +165,7 @@ describe('ReferrerTranslator', function () {
         });
 
         it('returns ref source for valid history', async function () {
-            should(translator.getReferrerDetails([
+            assert.deepEqual(translator.getReferrerDetails([
                 {
                     referrerSource: 'twitter',
                     referrerMedium: null,
@@ -180,7 +181,7 @@ describe('ReferrerTranslator', function () {
                     referrerMedium: null,
                     referrerUrl: null
                 }
-            ])).eql({
+            ]), {
                 referrerSource: 'Twitter',
                 referrerMedium: 'social',
                 referrerUrl: null,
@@ -193,13 +194,13 @@ describe('ReferrerTranslator', function () {
         });
 
         it('returns known source for ref source if exists', async function () {
-            should(translator.getReferrerDetails([
+            assert.deepEqual(translator.getReferrerDetails([
                 {
                     referrerSource: 'facebook',
                     referrerMedium: null,
                     referrerUrl: null
                 }
-            ])).eql({
+            ]), {
                 referrerSource: 'Facebook',
                 referrerMedium: 'social',
                 referrerUrl: null,
@@ -213,7 +214,7 @@ describe('ReferrerTranslator', function () {
 
         describe('returns source and medium for', function () {
             it('known external url with path', async function () {
-                should(translator.getReferrerDetails([
+                assert.deepEqual(translator.getReferrerDetails([
                     {
                         referrerSource: null,
                         referrerMedium: null,
@@ -234,7 +235,7 @@ describe('ReferrerTranslator', function () {
                         referrerMedium: null,
                         referrerUrl: null
                     }
-                ])).eql({
+                ]), {
                     referrerSource: 'Google Product Search',
                     referrerMedium: 'search',
                     referrerUrl: 'google.ac',
@@ -247,7 +248,7 @@ describe('ReferrerTranslator', function () {
             });
 
             it('known external url without path', async function () {
-                should(translator.getReferrerDetails([
+                assert.deepEqual(translator.getReferrerDetails([
                     {
                         referrerSource: null,
                         referrerMedium: null,
@@ -263,7 +264,7 @@ describe('ReferrerTranslator', function () {
                         referrerMedium: null,
                         referrerUrl: null
                     }
-                ])).eql({
+                ]), {
                     referrerSource: 'Twitter',
                     referrerMedium: 'social',
                     referrerUrl: 't.co',
@@ -277,7 +278,7 @@ describe('ReferrerTranslator', function () {
         });
 
         it('returns external ref url as source', async function () {
-            should(translator.getReferrerDetails([
+            assert.deepEqual(translator.getReferrerDetails([
                 {
                     referrerSource: null,
                     referrerMedium: null,
@@ -293,7 +294,7 @@ describe('ReferrerTranslator', function () {
                     referrerMedium: null,
                     referrerUrl: null
                 }
-            ])).eql({
+            ]), {
                 referrerSource: 'sample.com',
                 referrerMedium: null,
                 referrerUrl: 'sample.com',
@@ -306,7 +307,7 @@ describe('ReferrerTranslator', function () {
         });
 
         it('returns null for empty history', async function () {
-            should(translator.getReferrerDetails([])).eql({
+            assert.deepEqual(translator.getReferrerDetails([]), {
                 referrerSource: null,
                 referrerMedium: null,
                 referrerUrl: null,
@@ -319,13 +320,13 @@ describe('ReferrerTranslator', function () {
         });
 
         it('returns null for history with only site url', async function () {
-            should(translator.getReferrerDetails([
+            assert.deepEqual(translator.getReferrerDetails([
                 {
                     referrerSource: null,
                     referrerMedium: null,
                     referrerUrl: 'https://example.com'
                 }
-            ])).eql({
+            ]), {
                 referrerSource: 'Direct',
                 referrerMedium: null,
                 referrerUrl: null,
@@ -339,7 +340,7 @@ describe('ReferrerTranslator', function () {
 
         describe('UTM parameter extraction', function () {
             it('extracts all UTM parameters', async function () {
-                should(translator.getReferrerDetails([
+                assert.deepEqual(translator.getReferrerDetails([
                     {
                         referrerSource: 'google',
                         referrerMedium: null,
@@ -355,7 +356,7 @@ describe('ReferrerTranslator', function () {
                         referrerMedium: null,
                         referrerUrl: null
                     }
-                ])).eql({
+                ]), {
                     referrerSource: 'Google',
                     referrerMedium: 'unknown',
                     referrerUrl: null,
@@ -368,14 +369,14 @@ describe('ReferrerTranslator', function () {
             });
 
             it('extracts partial UTM parameters (only utmSource)', async function () {
-                should(translator.getReferrerDetails([
+                assert.deepEqual(translator.getReferrerDetails([
                     {
                         referrerSource: 'facebook',
                         referrerMedium: null,
                         referrerUrl: null,
                         utmSource: 'twitter_campaign'
                     }
-                ])).eql({
+                ]), {
                     referrerSource: 'Facebook',
                     referrerMedium: 'social',
                     referrerUrl: null,
@@ -388,7 +389,7 @@ describe('ReferrerTranslator', function () {
             });
 
             it('extracts partial UTM parameters (source and campaign)', async function () {
-                should(translator.getReferrerDetails([
+                assert.deepEqual(translator.getReferrerDetails([
                     {
                         referrerSource: null,
                         referrerMedium: null,
@@ -396,7 +397,7 @@ describe('ReferrerTranslator', function () {
                         utmSource: 'instagram',
                         utmCampaign: 'summer_promo'
                     }
-                ])).eql({
+                ]), {
                     referrerSource: 'Twitter',
                     referrerMedium: 'social',
                     referrerUrl: 't.co',
@@ -409,7 +410,7 @@ describe('ReferrerTranslator', function () {
             });
 
             it('uses earliest entry with UTM data when multiple entries have UTM', async function () {
-                should(translator.getReferrerDetails([
+                assert.deepEqual(translator.getReferrerDetails([
                     {
                         referrerSource: 'google',
                         referrerMedium: null,
@@ -424,7 +425,7 @@ describe('ReferrerTranslator', function () {
                         utmSource: 'earliest_source',
                         utmCampaign: 'earliest_campaign'
                     }
-                ])).eql({
+                ]), {
                     referrerSource: 'Google',
                     referrerMedium: 'unknown',
                     referrerUrl: null,
@@ -437,7 +438,7 @@ describe('ReferrerTranslator', function () {
             });
 
             it('returns null UTM values when no history entries contain UTM data', async function () {
-                should(translator.getReferrerDetails([
+                assert.deepEqual(translator.getReferrerDetails([
                     {
                         referrerSource: 'twitter',
                         referrerMedium: null,
@@ -448,7 +449,7 @@ describe('ReferrerTranslator', function () {
                         referrerMedium: null,
                         referrerUrl: null
                     }
-                ])).eql({
+                ]), {
                     referrerSource: 'Twitter',
                     referrerMedium: 'social',
                     referrerUrl: null,
@@ -461,7 +462,7 @@ describe('ReferrerTranslator', function () {
             });
 
             it('extracts UTM from earliest entry when more recent entries have no UTM', async function () {
-                should(translator.getReferrerDetails([
+                assert.deepEqual(translator.getReferrerDetails([
                     {
                         referrerSource: 'twitter',
                         referrerMedium: null,
@@ -474,7 +475,7 @@ describe('ReferrerTranslator', function () {
                         utmSource: 'delayed_utm',
                         utmMedium: 'social_media'
                     }
-                ])).eql({
+                ]), {
                     referrerSource: 'Twitter',
                     referrerMedium: 'social',
                     referrerUrl: null,
@@ -487,7 +488,7 @@ describe('ReferrerTranslator', function () {
             });
 
             it('combines Ghost referrer with UTM parameters', async function () {
-                should(translator.getReferrerDetails([
+                assert.deepEqual(translator.getReferrerDetails([
                     {
                         referrerSource: 'ghost-explore',
                         referrerMedium: null,
@@ -495,7 +496,7 @@ describe('ReferrerTranslator', function () {
                         utmSource: 'partner_site',
                         utmCampaign: 'q1_2024'
                     }
-                ])).eql({
+                ]), {
                     referrerSource: 'Ghost Explore',
                     referrerMedium: 'Ghost Network',
                     referrerUrl: null,

--- a/ghost/core/test/unit/server/services/member-attribution/service.test.js
+++ b/ghost/core/test/unit/server/services/member-attribution/service.test.js
@@ -108,7 +108,7 @@ describe('MemberAttributionService', function () {
                     return null;
                 }
             };
-            should(service.getEventAttribution(model)).eql({
+            assert.deepEqual(service.getEventAttribution(model), {
                 id: null,
                 url: null,
                 title: 'added',
@@ -148,7 +148,7 @@ describe('MemberAttributionService', function () {
                     return null;
                 }
             };
-            should(service.getEventAttribution(model)).eql({
+            assert.deepEqual(service.getEventAttribution(model), {
                 id: null,
                 type: 'url',
                 url: '/my/url/',
@@ -199,7 +199,7 @@ describe('MemberAttributionService', function () {
                     return {};
                 }
             };
-            should(service.getEventAttribution(model)).eql({
+            assert.deepEqual(service.getEventAttribution(model), {
                 id: 'test_user_id',
                 type: 'user',
                 url: '/my/url/',

--- a/ghost/core/test/unit/server/services/member-welcome-emails/member-welcome-email-renderer.test.js
+++ b/ghost/core/test/unit/server/services/member-welcome-emails/member-welcome-email-renderer.test.js
@@ -248,12 +248,12 @@ describe('MemberWelcomeEmailRenderer', function () {
             lexicalRenderStub.rejects(new Error('Invalid JSON'));
             const renderer = new MemberWelcomeEmailRenderer();
 
-            await renderer.render({
+            await assert.rejects(renderer.render({
                 lexical: 'invalid',
                 subject: 'Welcome!',
                 member: {name: 'John', email: 'john@example.com'},
                 siteSettings: defaultSiteSettings
-            }).should.be.rejectedWith(errors.IncorrectUsageError);
+            }), errors.IncorrectUsageError);
         });
 
         it('includes error context in IncorrectUsageError', async function () {

--- a/ghost/core/test/unit/server/services/members/content-gating.test.js
+++ b/ghost/core/test/unit/server/services/members/content-gating.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const {checkPostAccess, checkGatedBlockAccess} = require('../../../../../core/server/services/members/content-gating');
 
 describe('Members Service - Content gating', function () {
@@ -51,7 +50,7 @@ describe('Members Service - Content gating', function () {
                 slug: 'x'
             }]};
 
-            (() => checkPostAccess(post, member)).should.not.throw();
+            assert.doesNotThrow(() => checkPostAccess(post, member));
         });
 
         it('should block access to members only post without member', async function () {

--- a/ghost/core/test/unit/server/services/members/content-gating.test.js
+++ b/ghost/core/test/unit/server/services/members/content-gating.test.js
@@ -95,7 +95,7 @@ describe('Members Service - Content gating', function () {
     describe('checkGatedBlockAccess', function () {
         function testCheckGatedBlockAccess({params, member, expectedAccess}) {
             const access = checkGatedBlockAccess(params, member);
-            should(access).be.exactly(expectedAccess);
+            assert.equal(access, expectedAccess);
         }
 
         it('nonMember:true permits access when not logged in', function () {

--- a/ghost/core/test/unit/server/services/members/importer/members-csv-importer-stripe-utils.test.js
+++ b/ghost/core/test/unit/server/services/members/importer/members-csv-importer-stripe-utils.test.js
@@ -278,7 +278,7 @@ describe('MembersCSVImporterStripeUtils', function () {
                 product_id: PRODUCT_ID
             }, OPTIONS);
 
-            result.stripePriceId.should.equal(stripeCustomerSubscriptionItem.price.id);
+            assert.equal(result.stripePriceId, stripeCustomerSubscriptionItem.price.id);
             assert.equal(result.isNewStripePrice, false);
 
             assert.equal(stripeAPIServiceStub.updateSubscriptionItemPrice.calledOnce, false);
@@ -299,7 +299,7 @@ describe('MembersCSVImporterStripeUtils', function () {
                 product_id: PRODUCT_ID
             }, OPTIONS);
 
-            result.stripePriceId.should.equal(GHOST_PRODUCT_STRIPE_PRICE_ID);
+            assert.equal(result.stripePriceId, GHOST_PRODUCT_STRIPE_PRICE_ID);
             assert.equal(result.isNewStripePrice, false);
 
             assert.equal(stripeAPIServiceStub.updateSubscriptionItemPrice.calledOnce, true);
@@ -341,7 +341,7 @@ describe('MembersCSVImporterStripeUtils', function () {
             }, OPTIONS);
 
             // Assert new price was created
-            result.stripePriceId.should.equal(NEW_STRIPE_PRICE_ID);
+            assert.equal(result.stripePriceId, NEW_STRIPE_PRICE_ID);
             assert.equal(result.isNewStripePrice, true);
 
             // Assert subscription was updated

--- a/ghost/core/test/unit/server/services/members/members-api/controllers/router-controller.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/controllers/router-controller.test.js
@@ -786,7 +786,10 @@ describe('RouterController', function () {
                     newslettersService: newslettersServiceStub
                 });
 
-                await controller.sendMagicLink(req, res).should.be.rejectedWith(`Cannot subscribe to invalid newsletters ${INVALID_NEWSLETTER_NAME}`);
+                await assert.rejects(
+                    controller.sendMagicLink(req, res),
+                    {message: `Cannot subscribe to invalid newsletters ${INVALID_NEWSLETTER_NAME}`}
+                );
             });
 
             it('validates archived newsletters', async function () {
@@ -826,7 +829,10 @@ describe('RouterController', function () {
                     newslettersService: newslettersServiceStub
                 });
 
-                await controller.sendMagicLink(req, res).should.be.rejectedWith(`Cannot subscribe to archived newsletters Newsletter 2`);
+                await assert.rejects(
+                    controller.sendMagicLink(req, res),
+                    {message: `Cannot subscribe to archived newsletters Newsletter 2`}
+                );
             });
         });
 

--- a/ghost/core/test/unit/server/services/members/members-api/controllers/router-controller.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/controllers/router-controller.test.js
@@ -757,7 +757,7 @@ describe('RouterController', function () {
                 assert.equal(res.end.calledOnceWith('{}'), true);
 
                 assert.equal(sendEmailWithMagicLinkStub.calledOnce, true);
-                sendEmailWithMagicLinkStub.args[0][0].tokenData.newsletters.should.eql([
+                assert.deepEqual(sendEmailWithMagicLinkStub.args[0][0].tokenData.newsletters, [
                     {id: newsletters[0].id},
                     {id: newsletters[1].id},
                     {id: newsletters[2].id}
@@ -1046,7 +1046,7 @@ describe('RouterController', function () {
                 {name: 'Newsletter 3'}
             ];
             const result = await routerController._validateNewsletters(requestedNewsletters);
-            result.should.eql([
+            assert.deepEqual(result, [
                 {id: 'abc123'},
                 {id: 'def456'},
                 {id: 'ghi789'}

--- a/ghost/core/test/unit/server/services/members/members-api/repositories/member-repository.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/repositories/member-repository.test.js
@@ -533,7 +533,7 @@ describe('MemberRepository', function () {
             offersAPI.ensureOfferForStripeCoupon.firstCall.args[0].should.deepEqual(stripeCoupon);
             assert.equal(offersAPI.ensureOfferForStripeCoupon.firstCall.args[1], 'month');
             offersAPI.ensureOfferForStripeCoupon.firstCall.args[2].should.deepEqual({id: 'tier_1', name: 'Tier One'});
-            offersAPI.ensureOfferForStripeCoupon.firstCall.args[3].transacting.should.equal(transacting);
+            assert.equal(offersAPI.ensureOfferForStripeCoupon.firstCall.args[3].transacting, transacting);
             assert.equal(StripeCustomerSubscription.add.firstCall.args[0].offer_id, 'offer_new');
         });
 

--- a/ghost/core/test/unit/server/services/members/request-integrity-token-provider.test.js
+++ b/ghost/core/test/unit/server/services/members/request-integrity-token-provider.test.js
@@ -26,7 +26,7 @@ describe('RequestIntegrityTokenProvider', function () {
             token.split(':').should.be.an.Array().with.lengthOf(3);
             const [timestamp, nonce, digest] = token.split(':');
 
-            timestamp.should.equal((new Date('2021-01-01').valueOf() + 100).toString());
+            assert.equal(timestamp, (new Date('2021-01-01').valueOf() + 100).toString());
 
             assert.match(nonce, /[0-9a-f]{16}/);
 

--- a/ghost/core/test/unit/server/services/notifications/notifications.test.js
+++ b/ghost/core/test/unit/server/services/notifications/notifications.test.js
@@ -257,7 +257,7 @@ describe('Notifications Service', function () {
             assert.equal(notifications.length, 0);
 
             assert.equal(settingsModelStub.called, true);
-            settingsModelStub.args[0][0].should.eql([{
+            assert.deepEqual(settingsModelStub.args[0][0], [{
                 key: 'notifications',
                 value: '[]'
             }]);

--- a/ghost/core/test/unit/server/services/permissions/can-this.test.js
+++ b/ghost/core/test/unit/server/services/permissions/can-this.test.js
@@ -81,21 +81,21 @@ describe('Permissions', function () {
         it('canThisResult gets build properly', function () {
             const canThisResult = permissions.canThis();
 
-            canThisResult.browse.should.be.an.Object();
+            assert(_.isPlainObject(canThisResult.browse));
             canThisResult.browse.post.should.be.a.Function();
 
-            canThisResult.edit.should.be.an.Object();
+            assert(_.isPlainObject(canThisResult.edit));
             canThisResult.edit.post.should.be.a.Function();
             canThisResult.edit.tag.should.be.a.Function();
             canThisResult.edit.user.should.be.a.Function();
             canThisResult.edit.page.should.be.a.Function();
 
-            canThisResult.add.should.be.an.Object();
+            assert(_.isPlainObject(canThisResult.add));
             canThisResult.add.post.should.be.a.Function();
             canThisResult.add.user.should.be.a.Function();
             canThisResult.add.page.should.be.a.Function();
 
-            canThisResult.destroy.should.be.an.Object();
+            assert(_.isPlainObject(canThisResult.destroy));
             canThisResult.destroy.post.should.be.a.Function();
             canThisResult.destroy.user.should.be.a.Function();
         });

--- a/ghost/core/test/unit/server/services/permissions/can-this.test.js
+++ b/ghost/core/test/unit/server/services/permissions/can-this.test.js
@@ -133,7 +133,7 @@ describe('Permissions', function () {
                             assert.equal(err.errorType, 'NoPermissionError');
 
                             assert.equal(findPostSpy.callCount, 1);
-                            findPostSpy.firstCall.args[0].should.eql({id: 1, status: 'all'});
+                            assert.deepEqual(findPostSpy.firstCall.args[0], {id: 1, status: 'all'});
                             done();
                         });
                 });
@@ -150,7 +150,7 @@ describe('Permissions', function () {
                             assert.equal(err.errorType, 'NoPermissionError');
 
                             assert.equal(findPostSpy.callCount, 1);
-                            findPostSpy.firstCall.args[0].should.eql({id: 1, status: 'all'});
+                            assert.deepEqual(findPostSpy.firstCall.args[0], {id: 1, status: 'all'});
                             done();
                         });
                 });
@@ -182,7 +182,7 @@ describe('Permissions', function () {
                             assert.equal(err.errorType, 'NoPermissionError');
 
                             assert.equal(findPostSpy.callCount, 1);
-                            findPostSpy.firstCall.args[0].should.eql({id: 1, status: 'all'});
+                            assert.deepEqual(findPostSpy.firstCall.args[0], {id: 1, status: 'all'});
                             done();
                         });
                 });

--- a/ghost/core/test/unit/server/services/permissions/index.test.js
+++ b/ghost/core/test/unit/server/services/permissions/index.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../utils/assertions');
 const should = require('should');
 const sinon = require('sinon');
@@ -81,12 +82,12 @@ describe('Permissions', function () {
 
                 permissions.canThis.should.not.throwError();
 
-                _.keys(actions).should.eql(['browse', 'edit', 'add', 'destroy']);
+                assert.deepEqual(_.keys(actions), ['browse', 'edit', 'add', 'destroy']);
 
-                actions.browse.should.eql(['post']);
-                actions.edit.should.eql(['post', 'tag', 'user', 'page']);
-                actions.add.should.eql(['post', 'user', 'page']);
-                actions.destroy.should.eql(['post', 'user']);
+                assert.deepEqual(actions.browse, ['post']);
+                assert.deepEqual(actions.edit, ['post', 'tag', 'user', 'page']);
+                assert.deepEqual(actions.add, ['post', 'user', 'page']);
+                assert.deepEqual(actions.destroy, ['post', 'user']);
 
                 done();
             }).catch(done);
@@ -100,12 +101,12 @@ describe('Permissions', function () {
 
                 permissions.canThis.should.not.throwError();
 
-                _.keys(actions).should.eql(['browse', 'edit', 'add', 'destroy']);
+                assert.deepEqual(_.keys(actions), ['browse', 'edit', 'add', 'destroy']);
 
-                actions.browse.should.eql(['post']);
-                actions.edit.should.eql(['post', 'tag', 'user', 'page']);
-                actions.add.should.eql(['post', 'user', 'page']);
-                actions.destroy.should.eql(['post', 'user']);
+                assert.deepEqual(actions.browse, ['post']);
+                assert.deepEqual(actions.edit, ['post', 'tag', 'user', 'page']);
+                assert.deepEqual(actions.add, ['post', 'user', 'page']);
+                assert.deepEqual(actions.destroy, ['post', 'user']);
 
                 done();
             }).catch(done);

--- a/ghost/core/test/unit/server/services/permissions/parse-context.test.js
+++ b/ghost/core/test/unit/server/services/permissions/parse-context.test.js
@@ -1,10 +1,11 @@
+const assert = require('node:assert/strict');
 const should = require('should');
 const parseContext = require('../../../../../core/server/services/permissions/parse-context');
 
 describe('Permissions', function () {
     describe('parseContext', function () {
         it('should return public for no context', function () {
-            parseContext().should.eql({
+            assert.deepEqual(parseContext(), {
                 internal: false,
                 user: null,
                 api_key: null,
@@ -12,7 +13,7 @@ describe('Permissions', function () {
                 public: true,
                 integration: null
             });
-            parseContext({}).should.eql({
+            assert.deepEqual(parseContext({}), {
                 internal: false,
                 user: null,
                 api_key: null,
@@ -23,7 +24,7 @@ describe('Permissions', function () {
         });
 
         it('should return public for random context', function () {
-            parseContext('public').should.eql({
+            assert.deepEqual(parseContext('public'), {
                 internal: false,
                 user: null,
                 api_key: null,
@@ -31,7 +32,7 @@ describe('Permissions', function () {
                 public: true,
                 integration: null
             });
-            parseContext({client: 'thing'}).should.eql({
+            assert.deepEqual(parseContext({client: 'thing'}), {
                 internal: false,
                 user: null,
                 api_key: null,
@@ -42,7 +43,7 @@ describe('Permissions', function () {
         });
 
         it('should return user if user populated', function () {
-            parseContext({user: 1}).should.eql({
+            assert.deepEqual(parseContext({user: 1}), {
                 internal: false,
                 user: 1,
                 api_key: null,
@@ -53,10 +54,10 @@ describe('Permissions', function () {
         });
 
         it('should return api_key and public context if content api_key provided', function () {
-            parseContext({api_key: {
+            assert.deepEqual(parseContext({api_key: {
                 id: 1,
                 type: 'content'
-            }, integration: {id: 2}}).should.eql({
+            }, integration: {id: 2}}), {
                 internal: false,
                 user: null,
                 api_key: {
@@ -70,10 +71,10 @@ describe('Permissions', function () {
         });
 
         it('should return api_key and non public context if admin api_key provided', function () {
-            parseContext({api_key: {
+            assert.deepEqual(parseContext({api_key: {
                 id: 1,
                 type: 'admin'
-            }, integration: {id: 3}}).should.eql({
+            }, integration: {id: 3}}), {
                 internal: false,
                 user: null,
                 api_key: {
@@ -87,14 +88,14 @@ describe('Permissions', function () {
         });
 
         it('should return both user and api_key when both provided (staff API key scenario)', function () {
-            parseContext({
+            assert.deepEqual(parseContext({
                 user: {id: 1},
                 api_key: {
                     id: 2,
                     type: 'admin'
                 },
                 integration: {id: 3}
-            }).should.eql({
+            }), {
                 internal: false,
                 user: {id: 1},
                 api_key: {
@@ -108,7 +109,7 @@ describe('Permissions', function () {
         });
 
         it('should return internal if internal provided', function () {
-            parseContext({internal: true}).should.eql({
+            assert.deepEqual(parseContext({internal: true}), {
                 internal: true,
                 user: null,
                 api_key: null,
@@ -117,7 +118,7 @@ describe('Permissions', function () {
                 integration: null
             });
 
-            parseContext('internal').should.eql({
+            assert.deepEqual(parseContext('internal'), {
                 internal: true,
                 user: null,
                 api_key: null,

--- a/ghost/core/test/unit/server/services/route-settings/settings-loader.test.js
+++ b/ghost/core/test/unit/server/services/route-settings/settings-loader.test.js
@@ -79,7 +79,7 @@ describe('UNIT > SettingsLoader:', function () {
 
             assert.equal(fsReadFileSpy.calledOnce, true);
             assert.equal(fsReadFileSpy.calledWith(expectedSettingsFile), true);
-            yamlParserStub.callCount.should.be.eql(1);
+            sinon.assert.calledOnce(yamlParserStub);
         });
 
         it('can handle errors from YAML parser', async function () {
@@ -98,9 +98,9 @@ describe('UNIT > SettingsLoader:', function () {
                 throw new Error('Should have failed already');
             } catch (err) {
                 assertExists(err);
-                err.message.should.be.eql('could not parse yaml file');
-                err.context.should.be.eql('bad indentation of a mapping entry at line 5, column 10');
-                assert.equal(yamlParserStub.calledOnce, true);
+                assert.equal(err.message, 'could not parse yaml file');
+                assert.equal(err.context, 'bad indentation of a mapping entry at line 5, column 10');
+                sinon.assert.calledOnce(yamlParserStub);
             }
         });
 

--- a/ghost/core/test/unit/server/services/route-settings/validate.test.js
+++ b/ghost/core/test/unit/server/services/route-settings/validate.test.js
@@ -9,7 +9,7 @@ describe('UNIT: services/settings/validate', function () {
     it('no type definitions / empty yaml file', function () {
         const object = validate({});
 
-        object.should.eql({collections: {}, routes: {}, taxonomies: {}});
+        assert.deepEqual(object, {collections: {}, routes: {}, taxonomies: {}});
     });
 
     it('throws error when using :\w+ notiation in collection', function () {
@@ -241,7 +241,7 @@ describe('UNIT: services/settings/validate', function () {
             }
         });
 
-        object.should.eql({
+        assert.deepEqual(object, {
             routes: {},
             taxonomies: {
                 tag: '/tags/:slug/',
@@ -277,7 +277,7 @@ describe('UNIT: services/settings/validate', function () {
                 }
             });
 
-            object.should.eql({
+            assert.deepEqual(object, {
                 taxonomies: {},
                 routes: {
                     '/about/': {
@@ -312,7 +312,7 @@ describe('UNIT: services/settings/validate', function () {
                 }
             });
 
-            object.should.eql({
+            assert.deepEqual(object, {
                 taxonomies: {},
                 routes: {
                     '/about/': {
@@ -375,7 +375,7 @@ describe('UNIT: services/settings/validate', function () {
                 }
             });
 
-            object.should.eql({
+            assert.deepEqual(object, {
                 taxonomies: {},
                 routes: {
                     '/food/': {
@@ -591,7 +591,7 @@ describe('UNIT: services/settings/validate', function () {
                 }
             });
 
-            object.should.eql({
+            assert.deepEqual(object, {
                 taxonomies: {},
                 routes: {
                     '/food/': {

--- a/ghost/core/test/unit/server/services/settings/default-settings-manager.test.js
+++ b/ghost/core/test/unit/server/services/settings/default-settings-manager.test.js
@@ -80,7 +80,7 @@ describe('UNIT > Settings Service DefaultSettingsManager:', function () {
                 throw new Error('Expected test to fail');
             } catch (error) {
                 assertExists(error);
-                error.message.should.be.eql(`Error trying to access settings files in ${destinationFolderPath}.`);
+                assert.equal(error.message, `Error trying to access settings files in ${destinationFolderPath}.`);
                 assert.equal(fsReadFileStub.calledOnce, true);
                 assert.equal(fsCopyStub.called, false);
             }

--- a/ghost/core/test/unit/server/services/settings/settings-bread-service.test.js
+++ b/ghost/core/test/unit/server/services/settings/settings-bread-service.test.js
@@ -272,7 +272,7 @@ describe('UNIT > Settings BREAD Service:', function () {
                 labsService: {}
             });
 
-            await should(defaultSettingsManager.verifyKeyUpdate('test')).rejectedWith(/Not allowed to update this setting key via tokens/);
+            await assert.rejects(defaultSettingsManager.verifyKeyUpdate('test'), /Not allowed to update this setting key via tokens/);
         });
     });
 });

--- a/ghost/core/test/unit/server/services/settings/settings-utils.test.js
+++ b/ghost/core/test/unit/server/services/settings/settings-utils.test.js
@@ -30,7 +30,7 @@ describe('Unit: services/settings/settings-utils', function () {
 
             const result = getOrGenerateSiteUuid();
 
-            result.should.equal(testUuid.toLowerCase());
+            assert.equal(result, testUuid.toLowerCase());
             assert.equal(configGetStub.calledOnce, true);
             assert.equal(loggingInfoStub.calledOnce, true);
         });
@@ -86,7 +86,7 @@ describe('Unit: services/settings/settings-utils', function () {
 
             const result = getOrGenerateSiteUuid();
 
-            result.should.equal(testUuid.toLowerCase());
+            assert.equal(result, testUuid.toLowerCase());
             assert.equal(result, '550e8400-e29b-41d4-a716-446655440000');
         });
 
@@ -96,7 +96,7 @@ describe('Unit: services/settings/settings-utils', function () {
 
             const result = getOrGenerateSiteUuid();
 
-            result.should.equal(testUuid.toLowerCase());
+            assert.equal(result, testUuid.toLowerCase());
             assert.equal(result, '550e8400-e29b-41d4-a716-446655440000');
         });
 
@@ -107,8 +107,8 @@ describe('Unit: services/settings/settings-utils', function () {
             const result1 = getOrGenerateSiteUuid();
             const result2 = getOrGenerateSiteUuid();
 
-            result1.should.equal(result2);
-            result1.should.equal(testUuid.toLowerCase());
+            assert.equal(result1, result2);
+            assert.equal(result1, testUuid.toLowerCase());
             // Config should only be called once due to caching
             assert.equal(configGetStub.calledOnce, true);
         });

--- a/ghost/core/test/unit/server/services/stats/mrr.test.js
+++ b/ghost/core/test/unit/server/services/stats/mrr.test.js
@@ -63,7 +63,7 @@ describe('MrrStatsService', function () {
          * @param {string} currency - Expected currency
          */
         function assertMrrEntry(result, date, mrr, currency = 'usd') {
-            result.should.eql({
+            assert.deepEqual(result, {
                 date: date,
                 mrr: mrr,
                 currency: currency

--- a/ghost/core/test/unit/server/services/themes/list.test.js
+++ b/ghost/core/test/unit/server/services/themes/list.test.js
@@ -19,7 +19,7 @@ describe('Themes', function () {
         });
 
         it('get() allows getting a single theme', function () {
-            themeList.get('casper').should.eql({foo: 'bar'});
+            assert.deepEqual(themeList.get('casper'), {foo: 'bar'});
         });
 
         it('get() with no args should do nothing', function () {
@@ -36,12 +36,12 @@ describe('Themes', function () {
             themeList.set('casper', {magic: 'update'});
 
             themeList.get('casper').should.not.eql(origCasper);
-            themeList.get('casper').should.eql({magic: 'update'});
+            assert.deepEqual(themeList.get('casper'), {magic: 'update'});
         });
 
         it('set() can add a new theme', function () {
             themeList.set('rasper', {color: 'red'});
-            themeList.get('rasper').should.eql({color: 'red'});
+            assert.deepEqual(themeList.get('rasper'), {color: 'red'});
         });
 
         it('del() removes a key from the list', function () {

--- a/ghost/core/test/unit/server/services/themes/list.test.js
+++ b/ghost/core/test/unit/server/services/themes/list.test.js
@@ -73,7 +73,7 @@ describe('Themes', function () {
             themeList.init();
             const result = themeList.getAll();
             assertExists(result);
-            result.should.be.an.Object();
+            assert(_.isPlainObject(result));
             result.should.eql({});
             assert.equal(Object.keys(result).length, 0);
         });

--- a/ghost/core/test/unit/server/services/themes/list.test.js
+++ b/ghost/core/test/unit/server/services/themes/list.test.js
@@ -74,7 +74,7 @@ describe('Themes', function () {
             const result = themeList.getAll();
             assertExists(result);
             assert(_.isPlainObject(result));
-            result.should.eql({});
+            assert.deepEqual(result, {});
             assert.equal(Object.keys(result).length, 0);
         });
     });

--- a/ghost/core/test/unit/server/services/themes/loader.test.js
+++ b/ghost/core/test/unit/server/services/themes/loader.test.js
@@ -44,7 +44,7 @@ describe('Themes', function () {
                         // Loader doesn't return anything
                         assert.equal(result, undefined);
 
-                        themeResult.should.eql({
+                        assert.deepEqual(themeResult, {
                             casper: {
                                 name: 'casper',
                                 path: join(themePath.name, 'casper'),
@@ -77,7 +77,7 @@ describe('Themes', function () {
                         // Loader doesn't return anything
                         assert.equal(result, undefined);
 
-                        themeResult.should.eql({
+                        assert.deepEqual(themeResult, {
                             casper: {
                                 name: 'casper',
                                 path: join(themePath.name, 'casper'),
@@ -114,7 +114,7 @@ describe('Themes', function () {
 
                 loader.loadOneTheme('casper')
                     .then(function (themeResult) {
-                        themeResult.should.eql({
+                        assert.deepEqual(themeResult, {
                             name: 'casper',
                             path: join(themePath.name, 'casper'),
                             'package.json': {name: 'casper', version: '0.1.2'}

--- a/ghost/core/test/unit/server/services/themes/validate.test.js
+++ b/ghost/core/test/unit/server/services/themes/validate.test.js
@@ -141,7 +141,7 @@ describe('Themes', function () {
                     checkedTheme.should.not.exist();
                 }).catch((error) => {
                     assert(error instanceof Error);
-                    error.message.should.be.equal('invalid zip file');
+                    assert.equal(error.message, 'invalid zip file');
                     assert.equal(checkZipStub.calledOnce, true);
                     assert.equal(checkZipStub.calledWith(testTheme), true);
                     sinon.assert.notCalled(checkStub);

--- a/ghost/core/test/unit/server/services/themes/validate.test.js
+++ b/ghost/core/test/unit/server/services/themes/validate.test.js
@@ -7,6 +7,7 @@ const assert = require('assert/strict');
 const adapterManager = require('../../../../../core/server/services/adapter-manager');
 const InMemoryCache = require('../../../../../core/server/adapters/cache/MemoryCache');
 const logging = require('@tryghost/logging');
+const _ = require('lodash');
 
 describe('Themes', function () {
     let checkZipStub;
@@ -51,7 +52,7 @@ describe('Themes', function () {
                     assert.equal(checkZipStub.calledWith(testTheme), true);
                     checkStub.callCount.should.be.equal(0);
                     assert.equal(formatStub.calledOnce, true);
-                    checkedTheme.should.be.an.Object();
+                    assert(_.isPlainObject(checkedTheme));
 
                     assert.equal(validate.canActivate(checkedTheme), true);
                 });
@@ -67,7 +68,7 @@ describe('Themes', function () {
                     assert.equal(checkStub.calledOnce, true);
                     assert.equal(checkStub.calledWith(testTheme.path), true);
                     assert.equal(formatStub.calledOnce, true);
-                    checkedTheme.should.be.an.Object();
+                    assert(_.isPlainObject(checkedTheme));
 
                     assert.equal(validate.canActivate(checkedTheme), true);
                 });
@@ -139,7 +140,7 @@ describe('Themes', function () {
                 .then((checkedTheme) => {
                     checkedTheme.should.not.exist();
                 }).catch((error) => {
-                    error.should.be.an.Object();
+                    assert(error instanceof Error);
                     error.message.should.be.equal('invalid zip file');
                     assert.equal(checkZipStub.calledOnce, true);
                     assert.equal(checkZipStub.calledWith(testTheme), true);

--- a/ghost/core/test/unit/server/services/themes/validate.test.js
+++ b/ghost/core/test/unit/server/services/themes/validate.test.js
@@ -50,7 +50,7 @@ describe('Themes', function () {
                 .then((checkedTheme) => {
                     assert.equal(checkZipStub.calledOnce, true);
                     assert.equal(checkZipStub.calledWith(testTheme), true);
-                    checkStub.callCount.should.be.equal(0);
+                    sinon.assert.notCalled(checkStub);
                     assert.equal(formatStub.calledOnce, true);
                     assert(_.isPlainObject(checkedTheme));
 
@@ -64,7 +64,7 @@ describe('Themes', function () {
 
             return validate.check(testTheme.name, testTheme, {isZip: false})
                 .then((checkedTheme) => {
-                    checkZipStub.callCount.should.be.equal(0);
+                    sinon.assert.notCalled(checkZipStub);
                     assert.equal(checkStub.calledOnce, true);
                     assert.equal(checkStub.calledWith(testTheme.path), true);
                     assert.equal(formatStub.calledOnce, true);
@@ -96,7 +96,7 @@ describe('Themes', function () {
                 .then((checkedTheme) => {
                     assert.equal(checkZipStub.calledOnce, true);
                     assert.equal(checkZipStub.calledWith(testTheme), true);
-                    checkStub.callCount.should.be.equal(0);
+                    sinon.assert.notCalled(checkStub);
                     assert.equal(formatStub.calledOnce, true);
 
                     assert.equal(validate.canActivate(checkedTheme), false);
@@ -125,7 +125,7 @@ describe('Themes', function () {
                 .then((checkedTheme) => {
                     assert.equal(checkStub.calledOnce, true);
                     assert.equal(checkStub.calledWith(testTheme.path), true);
-                    checkZipStub.callCount.should.be.equal(0);
+                    sinon.assert.notCalled(checkZipStub);
                     assert.equal(formatStub.calledOnce, true);
 
                     assert.equal(validate.canActivate(checkedTheme), false);
@@ -144,7 +144,7 @@ describe('Themes', function () {
                     error.message.should.be.equal('invalid zip file');
                     assert.equal(checkZipStub.calledOnce, true);
                     assert.equal(checkZipStub.calledWith(testTheme), true);
-                    checkStub.callCount.should.be.equal(0);
+                    sinon.assert.notCalled(checkStub);
                     assert.equal(formatStub.calledOnce, false);
                 });
         });

--- a/ghost/core/test/unit/server/services/update-check.test.js
+++ b/ghost/core/test/unit/server/services/update-check.test.js
@@ -294,7 +294,7 @@ describe('Update Check', function () {
             assert.equal(usersBrowseStub.calledTwice, true);
 
             // Second (non statistical) call should be looking for admin users with an 'active' status only
-            usersBrowseStub.args[1][0].should.eql({
+            assert.deepEqual(usersBrowseStub.args[1][0], {
                 limit: 'all',
                 include: ['roles'],
                 filter: 'status:active',

--- a/ghost/core/test/unit/server/services/update-check.test.js
+++ b/ghost/core/test/unit/server/services/update-check.test.js
@@ -209,8 +209,8 @@ describe('Update Check', function () {
             assert.equal(scope.isDone(), true);
 
             assert.equal(capturedData.ghost_version, '4.0.0');
-            capturedData.node_version.should.equal(process.versions.node);
-            capturedData.env.should.equal(process.env.NODE_ENV);
+            assert.equal(capturedData.node_version, process.versions.node);
+            assert.equal(capturedData.env, process.env.NODE_ENV);
             assert.match(capturedData.database_type, /sqlite3|mysql/);
             capturedData.blog_id.should.be.a.String();
             capturedData.blog_id.should.not.be.empty();

--- a/ghost/core/test/unit/server/services/update-check.test.js
+++ b/ghost/core/test/unit/server/services/update-check.test.js
@@ -214,11 +214,11 @@ describe('Update Check', function () {
             assert.match(capturedData.database_type, /sqlite3|mysql/);
             capturedData.blog_id.should.be.a.String();
             capturedData.blog_id.should.not.be.empty();
-            capturedData.theme.should.be.equal('casperito');
+            assert.equal(capturedData.theme, 'casperito');
             assert.equal(capturedData.blog_created_at, 819846900);
-            capturedData.user_count.should.be.equal(2);
-            capturedData.post_count.should.be.equal(13);
-            capturedData.npm_version.should.be.equal('10.8.2');
+            assert.equal(capturedData.user_count, 2);
+            assert.equal(capturedData.post_count, 13);
+            assert.equal(capturedData.npm_version, '10.8.2');
         });
     });
 

--- a/ghost/core/test/unit/server/services/url/queue.test.js
+++ b/ghost/core/test/unit/server/services/url/queue.test.js
@@ -49,7 +49,7 @@ describe('Unit: services/url/Queue', function () {
         assert.equal(queue.queue.nachos.subscribers.length, 1);
 
         // events have not been triggered yet
-        queue.toNotify.should.eql({});
+        assert.deepEqual(queue.toNotify, {});
     });
 
     describe('fn: start (no tolerance)', function () {

--- a/ghost/core/test/unit/server/services/url/queue.test.js
+++ b/ghost/core/test/unit/server/services/url/queue.test.js
@@ -96,7 +96,7 @@ describe('Unit: services/url/Queue', function () {
                 // 9 subscribers + start triggers run
                 assert.equal(queueRunSpy.callCount, 10);
                 assert.equal(notified, 9);
-                order.should.eql([0, 1, 2, 3, 4, 5, 6, 7, 8]);
+                assert.deepEqual(order, [0, 1, 2, 3, 4, 5, 6, 7, 8]);
                 done();
             });
 

--- a/ghost/core/test/unit/server/services/url/url-service.test.js
+++ b/ghost/core/test/unit/server/services/url/url-service.test.js
@@ -48,7 +48,7 @@ describe('Unit: services/url/UrlService', function () {
         assertExists(urlService.resources);
         assertExists(urlService.queue);
 
-        urlService.urlGenerators.should.eql([]);
+        assert.deepEqual(urlService.urlGenerators, []);
         assert.equal(urlService.hasFinished(), false);
 
         assert.equal(urlService.queue.addListener.calledTwice, true);

--- a/ghost/core/test/unit/server/services/verification-trigger.test.js
+++ b/ghost/core/test/unit/server/services/verification-trigger.test.js
@@ -158,10 +158,12 @@ describe('Email verification flow', function () {
             sendVerificationEmail: emailStub
         });
 
-        await trigger._startVerificationProcess({
-            amount: 10,
-            throwOnTrigger: true
-        }).should.be.rejected();
+        await assert.rejects(
+            trigger._startVerificationProcess({
+                amount: 10,
+                throwOnTrigger: true
+            })
+        );
     });
 
     it('Sends a message containing the number of members imported', async function () {

--- a/ghost/core/test/unit/server/services/verification-trigger.test.js
+++ b/ghost/core/test/unit/server/services/verification-trigger.test.js
@@ -183,7 +183,7 @@ describe('Email verification flow', function () {
             throwOnTrigger: false
         });
 
-        emailStub.lastCall.firstArg.should.eql({
+        assert.deepEqual(emailStub.lastCall.firstArg, {
             subject: 'Email needs verification',
             message: 'Email verification needed for site: {siteUrl}, has imported: {amountTriggered} members in the last 30 days.',
             amountTriggered: 10
@@ -315,7 +315,7 @@ describe('Email verification flow', function () {
         assert.match(eventStub.firstCall.lastArg.created_at.$gt, /\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/);
 
         assert.equal(emailStub.callCount, 1);
-        emailStub.lastCall.firstArg.should.eql({
+        assert.deepEqual(emailStub.lastCall.firstArg, {
             subject: 'Email needs verification',
             message: 'Email verification needed for site: {siteUrl}, has imported: {amountTriggered} members in the last 30 days.',
             amountTriggered: 10
@@ -438,7 +438,7 @@ describe('Email verification flow', function () {
         assert.match(eventStub.firstCall.lastArg.created_at.$gt, /\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/);
 
         assert.equal(emailStub.callCount, 1);
-        emailStub.lastCall.firstArg.should.eql({
+        assert.deepEqual(emailStub.lastCall.firstArg, {
             subject: 'Email needs verification',
             message: 'Email verification needed for site: {siteUrl} has added: {amountTriggered} members through the Admin client in the last 30 days.',
             amountTriggered: 10
@@ -496,7 +496,7 @@ describe('Email verification flow', function () {
         assert.match(eventStub.firstCall.lastArg.created_at.$gt, /\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/);
 
         assert.equal(emailStub.callCount, 1);
-        emailStub.lastCall.firstArg.should.eql({
+        assert.deepEqual(emailStub.lastCall.firstArg, {
             subject: 'Email needs verification',
             message: 'Email verification needed for site: {siteUrl} has added: {amountTriggered} members through the API in the last 30 days.',
             amountTriggered: 10

--- a/ghost/core/test/unit/server/web/api/middleware/cors.test.js
+++ b/ghost/core/test/unit/server/web/api/middleware/cors.test.js
@@ -62,7 +62,7 @@ describe('cors', function () {
         cors(req, res, next);
 
         sinon.assert.calledOnce(res.end);
-        res.headers['Access-Control-Allow-Origin'].should.equal(origin);
+        assert.equal(res.headers['Access-Control-Allow-Origin'], origin);
 
         done();
     });
@@ -77,7 +77,7 @@ describe('cors', function () {
         cors(req, res, next);
 
         sinon.assert.calledOnce(res.end);
-        res.headers['Access-Control-Allow-Origin'].should.equal(origin);
+        assert.equal(res.headers['Access-Control-Allow-Origin'], origin);
 
         done();
     });
@@ -109,7 +109,7 @@ describe('cors', function () {
         cors(req, res, next);
 
         sinon.assert.calledOnce(res.end);
-        res.headers['Access-Control-Allow-Origin'].should.equal(origin);
+        assert.equal(res.headers['Access-Control-Allow-Origin'], origin);
 
         done();
     });
@@ -131,7 +131,7 @@ describe('cors', function () {
         cors(req, res, next);
 
         sinon.assert.called(res.end);
-        res.headers['Access-Control-Allow-Origin'].should.equal(origin);
+        assert.equal(res.headers['Access-Control-Allow-Origin'], origin);
 
         done();
     });

--- a/ghost/core/test/unit/server/web/parent/middleware/ghost-locals.test.js
+++ b/ghost/core/test/unit/server/web/parent/middleware/ghost-locals.test.js
@@ -29,7 +29,7 @@ describe('Theme Handler', function () {
             assert(_.isPlainObject(res.locals));
             assertExists(res.locals.version);
             assertExists(res.locals.safeVersion);
-            res.locals.relativeUrl.should.equal(req.path);
+            assert.equal(res.locals.relativeUrl, req.path);
             assert.equal(next.called, true);
         });
     });

--- a/ghost/core/test/unit/server/web/parent/middleware/ghost-locals.test.js
+++ b/ghost/core/test/unit/server/web/parent/middleware/ghost-locals.test.js
@@ -1,5 +1,6 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../../utils/assertions');
+const _ = require('lodash');
 const should = require('should');
 const sinon = require('sinon');
 const ghostLocals = require('../../../../../../core/server/web/parent/middleware/ghost-locals');
@@ -25,7 +26,7 @@ describe('Theme Handler', function () {
 
             ghostLocals(req, res, next);
 
-            res.locals.should.be.an.Object();
+            assert(_.isPlainObject(res.locals));
             assertExists(res.locals.version);
             assertExists(res.locals.safeVersion);
             res.locals.relativeUrl.should.equal(req.path);

--- a/ghost/core/test/unit/shared/config/loader.test.js
+++ b/ghost/core/test/unit/shared/config/loader.test.js
@@ -85,7 +85,7 @@ describe('Config Loader', function () {
             assert.equal(customConfig.get('database:debug'), true);
             assert.equal(customConfig.get('url'), 'http://localhost:2368');
             assert.equal(customConfig.get('logging:level'), 'error');
-            customConfig.get('logging:transports').should.eql(['stdout']);
+            assert.deepEqual(customConfig.get('logging:transports'), ['stdout']);
         });
 
         it('should load JSONC files', function () {
@@ -108,7 +108,7 @@ describe('Config Loader', function () {
             // NOTE: using `Object.keys` here instead of `should.have.keys` assertion
             //       because when `have.keys` fails there's no useful diff
             //       and it doesn't make sure to check for "extra" keys
-            Object.keys(pathConfig).should.eql([
+            assert.deepEqual(Object.keys(pathConfig), [
                 'contentPath',
                 'fixtures',
                 'defaultSettings',


### PR DESCRIPTION
Replaced various Should.js usages. The majority of them:

| Before | After |
|---|---|
| `a.should.equal(b)` | `assert.equal(a, b)` |
| `should(a).be.exactly(b)` | `assert.equal(a, b)` |
| `should(value).be.Array()` | `assert(Array.isArray(value))` |
| `should(fn).throw()` | `assert.throws()` |
| `should(fn).rejectedWith(err)` | `assert.rejects(fn, err)` |
| `should(value).eql([])` | `assert.deepEqual(value, [])` |
| `should(value).eql({})` | `assert.deepEqual(value, {})` |
| `should(value).not.be.undefined()` | `assertExists` |

I also converted several `.eql()` calls, but those can't be done automatically because there isn't an obvious analog in `assert`-land.
