### PR TITLE
Updated copy for welcome emails settings UI

### DIFF
--- a/apps/admin-x-settings/src/components/settings/membership/member-emails.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails.tsx
@@ -207,8 +207,8 @@ const MemberEmails: React.FC<{ keywords: string[] }> = ({keywords}) => {
             <SettingGroupContent className="!gap-y-0" columns={1}>
                 <Separator />
                 <EmailSettingRow
-                    description='Email new free members receive when they join your site.'
-                    title='Free members welcome email'
+                    description='Sent to new free members right after they join your site.'
+                    title='Free members'
                 />
                 <EmailPreview
                     automatedEmail={freeEmailForDisplay}
@@ -221,8 +221,8 @@ const MemberEmails: React.FC<{ keywords: string[] }> = ({keywords}) => {
                 {checkStripeEnabled(settings, config) && (
                     <div className='mt-4'>
                         <EmailSettingRow
-                            description='Sent to new paid members as soon as they start their subscription.'
-                            title='Paid members welcome email'
+                            description='Sent to new paid members right after they start their subscription.'
+                            title='Paid members'
                         />
                         <EmailPreview
                             automatedEmail={paidEmailForDisplay}


### PR DESCRIPTION
Closes [NY-1011: Investigate why merged copy change isn’t on main](https://linear.app/ghost/issue/NY-1011/investigate-why-merged-copy-change-isnt-on-main)

- updates some of the copy of the member welcome emails settings
- this was done in https://github.com/TryGhost/Ghost/pull/26118 but mistakenly overwritten in https://github.com/TryGhost/Ghost/pull/26035

<img width="686" height="490" alt="Screenshot 2026-02-06 at 2 03 59 PM" src="https://github.com/user-attachments/assets/d1cf8f4c-5c63-426c-81a0-40d0b14c25f9" />
