### PR TITLE
🐛 Fixed automatic Medium.com bookmark creation

### DIFF
--- a/ghost/core/core/server/services/oembed/oembed-service.js
+++ b/ghost/core/core/server/services/oembed/oembed-service.js
@@ -10,7 +10,7 @@ const iconv = require('iconv-lite');
 const path = require('path');
 
 // Some sites block non-standard user agents so we need to mimic a typical browser
-const USER_AGENT = 'Mozilla/5.0 (compatible; Ghost/5.0; +https://ghost.org/)';
+const USER_AGENT = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/144.0.0.0 Safari/537.36';
 
 const messages = {
     noUrlProvided: 'No url provided.',


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ONC-1429/
ref https://linear.app/ghost/issue/ONC-1451/

- Medium.com and Itch.com have added Cloudflare bot protection (or CF bot protection has changed) on their oEmbed endpoint that was preventing our oEmbed service from using it to create embeds when pasting links
- Changed the user-agent our oEmbed service uses to match latest Chrome which appears to bypass the current Cloudflare restrictions
  - the effectiveness of this technique for bypassing itch.com restrictions hasn't been consistent in testing but has shown improvement in some cases