### PR TITLE
Refactored comments-ui to use CommentApiProvider for API abstraction

### DIFF
--- a/apps/comments-ui/src/actions.ts
+++ b/apps/comments-ui/src/actions.ts
@@ -1,19 +1,13 @@
 import {AddComment, Comment, CommentsOptions, DispatchActionType, EditableAppContext, OpenCommentForm} from './app-context';
-import {AdminApi} from './utils/admin-api';
-import {GhostApi} from './utils/api';
+import {CommentApi} from './components/comment-api-provider';
 import {Page} from './pages';
 
-async function loadMoreComments({state, api, options, order}: {state: EditableAppContext, api: GhostApi, options: CommentsOptions, order?:string}): Promise<Partial<EditableAppContext>> {
+async function loadMoreComments({state, commentApi, options, order}: {state: EditableAppContext, commentApi: CommentApi, options: CommentsOptions, order?: string}): Promise<Partial<EditableAppContext>> {
     let page = 1;
     if (state.pagination && state.pagination.page) {
         page = state.pagination.page + 1;
     }
-    let data;
-    if (state.admin && state.adminApi) {
-        data = await state.adminApi.browse({page, postId: options.postId, order: order || state.order, memberUuid: state.member?.uuid});
-    } else {
-        data = await api.comments.browse({page, postId: options.postId, order: order || state.order});
-    }
+    const data = await commentApi.browse({page, postId: options.postId, order: order || state.order});
 
     const updatedComments = [...state.comments, ...data.comments];
     const dedupedComments = updatedComments.filter((comment, index, self) => self.findIndex(c => c.id === comment.id) === index);
@@ -31,16 +25,11 @@ function setCommentsIsLoading({data: isLoading}: {data: boolean | null}) {
     };
 }
 
-async function setOrder({state, data: {order}, options, api, dispatchAction}: {state: EditableAppContext, data: {order: string}, options: CommentsOptions, api: GhostApi, dispatchAction: DispatchActionType}) {
+async function setOrder({state, data: {order}, options, commentApi, dispatchAction}: {state: EditableAppContext, data: {order: string}, options: CommentsOptions, commentApi: CommentApi, dispatchAction: DispatchActionType}) {
     dispatchAction('setCommentsIsLoading', true);
 
     try {
-        let data;
-        if (state.admin && state.adminApi) {
-            data = await state.adminApi.browse({page: 1, postId: options.postId, order, memberUuid: state.member?.uuid});
-        } else {
-            data = await api.comments.browse({page: 1, postId: options.postId, order});
-        }
+        const data = await commentApi.browse({page: 1, postId: options.postId, order});
 
         return {
             comments: [...data.comments],
@@ -55,13 +44,9 @@ async function setOrder({state, data: {order}, options, api, dispatchAction}: {s
     }
 }
 
-async function loadMoreReplies({state, api, data: {comment, limit}, isReply}: {state: EditableAppContext, api: GhostApi, data: {comment: Comment, limit?: number | 'all'}, isReply: boolean}): Promise<Partial<EditableAppContext>> {
+async function loadMoreReplies({state, commentApi, data: {comment, limit}}: {state: EditableAppContext, commentApi: CommentApi, data: {comment: Comment, limit?: number | 'all'}}): Promise<Partial<EditableAppContext>> {
     const fetchReplies = async (afterReplyId: string | undefined, requestLimit: number) => {
-        if (state.admin && state.adminApi && !isReply) { // we don't want the admin api to load reply data for replying to a reply, so we pass isReply: true
-            return await state.adminApi.replies({commentId: comment.id, afterReplyId, limit: requestLimit, memberUuid: state.member?.uuid});
-        } else {
-            return await api.comments.replies({commentId: comment.id, afterReplyId, limit: requestLimit});
-        }
+        return await commentApi.replies({commentId: comment.id, afterReplyId, limit: requestLimit});
     };
 
     let afterReplyId: string | undefined = comment.replies && comment.replies.length > 0
@@ -104,8 +89,8 @@ async function loadMoreReplies({state, api, data: {comment, limit}, isReply}: {s
     };
 }
 
-async function addComment({state, api, data: comment}: {state: EditableAppContext, api: GhostApi, data: AddComment}) {
-    const data = await api.comments.add({comment});
+async function addComment({state, commentApi, data: comment}: {state: EditableAppContext, commentApi: CommentApi, data: AddComment}) {
+    const data = await commentApi.add({comment});
     const newComment = data.comments[0];
 
     return {
@@ -115,13 +100,13 @@ async function addComment({state, api, data: comment}: {state: EditableAppContex
     };
 }
 
-async function addReply({state, api, data: {reply, parent}}: {state: EditableAppContext, api: GhostApi, data: {reply: any, parent: any}}) {
-    const data = await api.comments.add({
+async function addReply({state, commentApi, data: {reply, parent}}: {state: EditableAppContext, commentApi: CommentApi, data: {reply: any, parent: any}}) {
+    const data = await commentApi.add({
         comment: {...reply, parent_id: parent.id}
     });
     const newComment = data.comments[0];
 
-    const allReplies = await api.comments.replies({commentId: parent.id, limit: 'all'});
+    const allReplies = await commentApi.replies({commentId: parent.id, limit: 'all'});
 
     return {
         comments: state.comments.map((c) => {
@@ -142,9 +127,9 @@ async function addReply({state, api, data: {reply, parent}}: {state: EditableApp
     };
 }
 
-async function hideComment({state, data: comment}: {state: EditableAppContext, adminApi: any, data: {id: string}}) {
-    if (state.adminApi) {
-        await state.adminApi.hideComment(comment.id);
+async function hideComment({state, commentApi, data: comment}: {state: EditableAppContext, commentApi: CommentApi, data: {id: string}}) {
+    if (commentApi.isAdmin) {
+        await commentApi.hideComment(comment.id);
     }
     return {
         comments: state.comments.map((c) => {
@@ -176,18 +161,13 @@ async function hideComment({state, data: comment}: {state: EditableAppContext, a
     };
 }
 
-async function showComment({state, api, data: comment}: {state: EditableAppContext, api: GhostApi, adminApi: any, data: {id: string}}) {
-    if (state.adminApi) {
-        await state.adminApi.showComment({id: comment.id});
+async function showComment({state, commentApi, data: comment}: {state: EditableAppContext, commentApi: CommentApi, data: {id: string}}) {
+    if (commentApi.isAdmin) {
+        await commentApi.showComment({id: comment.id});
     }
     // We need to refetch the comment, to make sure we have an up to date HTML content
     // + all relations are loaded as the current member (not the admin)
-    let data;
-    if (state.admin && state.adminApi) {
-        data = await state.adminApi.read({commentId: comment.id, memberUuid: state.member?.uuid});
-    } else {
-        data = await api.comments.read(comment.id);
-    }
+    const data = await commentApi.read(comment.id);
 
     const updatedComment = data.comments[0];
 
@@ -252,35 +232,35 @@ async function updateCommentLikeState({state, data: comment}: {state: EditableAp
     };
 }
 
-async function likeComment({api, data: comment, dispatchAction}: {state: EditableAppContext, api: GhostApi, data: {id: string}, dispatchAction: DispatchActionType}) {
+async function likeComment({commentApi, data: comment, dispatchAction}: {state: EditableAppContext, commentApi: CommentApi, data: {id: string}, dispatchAction: DispatchActionType}) {
     dispatchAction('updateCommentLikeState', {id: comment.id, liked: true});
     try {
-        await api.comments.like({comment});
+        await commentApi.like({comment});
         return {};
     } catch {
         dispatchAction('updateCommentLikeState', {id: comment.id, liked: false});
     }
 }
 
-async function unlikeComment({api, data: comment, dispatchAction}: {state: EditableAppContext, api: GhostApi, data: {id: string}, dispatchAction: DispatchActionType}) {
+async function unlikeComment({commentApi, data: comment, dispatchAction}: {state: EditableAppContext, commentApi: CommentApi, data: {id: string}, dispatchAction: DispatchActionType}) {
     dispatchAction('updateCommentLikeState', {id: comment.id, liked: false});
 
     try {
-        await api.comments.unlike({comment});
+        await commentApi.unlike({comment});
         return {};
     } catch {
         dispatchAction('updateCommentLikeState', {id: comment.id, liked: true});
     }
 }
 
-async function reportComment({api, data: comment}: {api: GhostApi, data: {id: string}}) {
-    await api.comments.report({comment});
+async function reportComment({commentApi, data: comment}: {commentApi: CommentApi, data: {id: string}}) {
+    await commentApi.report({comment});
 
     return {};
 }
 
-async function deleteComment({state, api, data: comment, dispatchAction}: {state: EditableAppContext, api: GhostApi, data: {id: string}, dispatchAction: DispatchActionType}) {
-    await api.comments.edit({
+async function deleteComment({state, commentApi, data: comment, dispatchAction}: {state: EditableAppContext, commentApi: CommentApi, data: {id: string}, dispatchAction: DispatchActionType}) {
+    await commentApi.edit({
         comment: {
             id: comment.id,
             status: 'deleted'
@@ -331,8 +311,8 @@ async function deleteComment({state, api, data: comment, dispatchAction}: {state
     };
 }
 
-async function editComment({state, api, data: {comment, parent}}: {state: EditableAppContext, api: GhostApi, data: {comment: Partial<Comment> & {id: string}, parent?: Comment}}) {
-    const data = await api.comments.edit({
+async function editComment({state, commentApi, data: {comment, parent}}: {state: EditableAppContext, commentApi: CommentApi, data: {comment: Partial<Comment> & {id: string}, parent?: Comment}}) {
+    const data = await commentApi.edit({
         comment
     });
     comment = data.comments[0];
@@ -359,7 +339,7 @@ async function editComment({state, api, data: {comment, parent}}: {state: Editab
     };
 }
 
-async function updateMember({data, state, api}: {data: {name: string, expertise: string}, state: EditableAppContext, api: GhostApi}) {
+async function updateMember({data, state, commentApi}: {data: {name: string, expertise: string}, state: EditableAppContext, commentApi: CommentApi}) {
     const {name, expertise} = data;
     const patchData: {name?: string, expertise?: string} = {};
 
@@ -377,7 +357,7 @@ async function updateMember({data, state, api}: {data: {name: string, expertise:
 
     if (Object.keys(patchData).length > 0) {
         try {
-            const member = await api.member.update(patchData);
+            const member = await commentApi.updateMember(patchData);
             if (!member) {
                 throw new Error('Failed to update member');
             }
@@ -407,7 +387,7 @@ function closePopup() {
     };
 }
 
-async function openCommentForm({data: newForm, api, state}: {data: OpenCommentForm, api: GhostApi, state: EditableAppContext}) {
+async function openCommentForm({data: newForm, commentApi, state}: {data: OpenCommentForm, commentApi: CommentApi, state: EditableAppContext}) {
     let otherStateChanges = {};
 
     // When opening a reply form, load all replies for the parent comment so the
@@ -418,7 +398,7 @@ async function openCommentForm({data: newForm, api, state}: {data: OpenCommentFo
 
         if (comment) {
             try {
-                const newCommentsState = await loadMoreReplies({state, api, data: {comment, limit: 'all'}, isReply: true});
+                const newCommentsState = await loadMoreReplies({state, commentApi, data: {comment, limit: 'all'}});
                 otherStateChanges = {...otherStateChanges, ...newCommentsState};
             } catch (e) {
                 // If loading replies fails, continue anyway - the form should still open
@@ -525,20 +505,20 @@ export function isSyncAction(action: string): action is SyncActionType {
 }
 
 /** Handle actions in the App, returns updated state */
-export async function ActionHandler({action, data, state, api, adminApi, options, dispatchAction}: {action: ActionType, data: any, state: EditableAppContext, options: CommentsOptions, api: GhostApi, adminApi: AdminApi, dispatchAction: DispatchActionType}): Promise<Partial<EditableAppContext>> {
+export async function ActionHandler({action, data, state, commentApi, options, dispatchAction}: {action: ActionType, data: any, state: EditableAppContext, options: CommentsOptions, commentApi: CommentApi, dispatchAction: DispatchActionType}): Promise<Partial<EditableAppContext>> {
     const handler = Actions[action];
     if (handler) {
-        return await handler({data, state, api, adminApi, options, dispatchAction} as any) || {};
+        return await handler({data, state, commentApi, options, dispatchAction} as any) || {};
     }
     return {};
 }
 
 /** Handle actions in the App, returns updated state */
-export function SyncActionHandler({action, data, state, api, adminApi, options}: {action: SyncActionType, data: any, state: EditableAppContext, options: CommentsOptions, api: GhostApi, adminApi: AdminApi}): Partial<EditableAppContext> {
+export function SyncActionHandler({action, data, state, options}: {action: SyncActionType, data: any, state: EditableAppContext, options: CommentsOptions}): Partial<EditableAppContext> {
     const handler = SyncActions[action];
     if (handler) {
         // Do not await here
-        return handler({data, state, api, adminApi, options} as any) || {};
+        return handler({data, state, options} as any) || {};
     }
     return {};
 }

--- a/apps/comments-ui/src/app-context.ts
+++ b/apps/comments-ui/src/app-context.ts
@@ -1,7 +1,6 @@
 // Ref: https://reactjs.org/docs/context.html
 import React, {useContext} from 'react';
 import {ActionType, Actions, SyncActionType, SyncActions} from './actions';
-import {AdminApi} from './utils/admin-api';
 import {Page} from './pages';
 
 export type Member = {
@@ -70,7 +69,6 @@ export type CommentsOptions = {
 export type EditableAppContext = {
     initStatus: string,
     member: null | any,
-    admin: null | any,
     comments: Comment[],
     pagination: {
         page: number,
@@ -83,7 +81,6 @@ export type EditableAppContext = {
     popup: Page | null,
     labs: LabsContextType,
     order: string,
-    adminApi: AdminApi | null,
     commentsIsLoading?: boolean,
     commentIdToHighlight: string | null,
     commentIdToScrollTo: string | null,

--- a/apps/comments-ui/src/app.tsx
+++ b/apps/comments-ui/src/app.tsx
@@ -1,16 +1,14 @@
 /* eslint-disable no-shadow */
 
-import AuthFrame from './auth-frame';
 import ContentBox from './components/content-box';
 import PopupBox from './components/popup-box';
-import React, {useCallback, useEffect, useMemo, useState} from 'react';
+import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import i18nLib from '@tryghost/i18n';
 import setupGhostApi from './utils/api';
 import {ActionHandler, SyncActionHandler, isSyncAction} from './actions';
 import {AppContext, Comment, DispatchActionType, EditableAppContext} from './app-context';
+import {CommentApiProvider, useCommentApi} from './components/comment-api-provider';
 import {CommentsFrame} from './components/frame';
-import {createCommentApi} from './components/comment-api-provider';
-import {setupAdminAPI} from './utils/admin-api';
 import {useOptions} from './utils/options';
 
 type AppProps = {
@@ -19,8 +17,6 @@ type AppProps = {
     pageUrl: string;
 };
 
-const ALLOWED_MODERATORS = ['Owner', 'Administrator', 'Super Editor'];
-
 /**
  * Check if a comment ID exists in the comments array (either as a top-level comment or reply)
  */
@@ -28,12 +24,15 @@ function isCommentLoaded(comments: Comment[], targetId: string): boolean {
     return comments.some(c => c.id === targetId || c.replies?.some(r => r.id === targetId));
 }
 
-const App: React.FC<AppProps> = ({scriptTag, initialCommentId, pageUrl}) => {
-    const options = useOptions(scriptTag);
+const AppContent: React.FC<{
+    options: ReturnType<typeof useOptions>;
+    initialCommentId: string | null;
+    pageUrl: string;
+}> = ({options, initialCommentId, pageUrl}) => {
+    const {commentApi, member, labs, supportEmail} = useCommentApi();
     const [state, setFullState] = useState<EditableAppContext>({
         initStatus: 'running',
         member: null,
-        admin: null,
         comments: [],
         pagination: null,
         commentCount: 0,
@@ -41,7 +40,6 @@ const App: React.FC<AppProps> = ({scriptTag, initialCommentId, pageUrl}) => {
         popup: null,
         labs: {},
         order: 'count__likes desc, created_at desc',
-        adminApi: null,
         commentsIsLoading: false,
         commentIdToHighlight: null,
         commentIdToScrollTo: initialCommentId,
@@ -55,15 +53,7 @@ const App: React.FC<AppProps> = ({scriptTag, initialCommentId, pageUrl}) => {
         isCommentingDisabled: false
     });
 
-    const iframeRef = React.createRef<HTMLIFrameElement>();
-
-    const api = React.useMemo(() => {
-        return setupGhostApi({
-            siteUrl: options.siteUrl,
-            apiUrl: options.apiUrl!,
-            apiKey: options.apiKey!
-        });
-    }, [options]);
+    const iframeRef = useRef<HTMLIFrameElement>(null);
 
     const setState = useCallback((newState: Partial<EditableAppContext> | ((state: EditableAppContext) => Partial<EditableAppContext>)) => {
         setFullState((state) => {
@@ -96,7 +86,6 @@ const App: React.FC<AppProps> = ({scriptTag, initialCommentId, pageUrl}) => {
         // allow for async actions within it's updater function so this is the best option.
         return new Promise((resolve) => {
             setState((state) => {
-                const commentApi = createCommentApi(api, state.adminApi ?? null, state.member?.uuid);
                 ActionHandler({action, data, state, commentApi, options, dispatchAction: dispatchAction as DispatchActionType}).then((updatedState) => {
                     const newState = {...updatedState};
                     resolve(newState);
@@ -107,7 +96,7 @@ const App: React.FC<AppProps> = ({scriptTag, initialCommentId, pageUrl}) => {
                 return {};
             });
         });
-    }, [api, options]); // Do not add state or context as a dependency here -> infinite render loop
+    }, [commentApi, options]); // Do not add state or context as a dependency here -> infinite render loop
 
     const i18n = useMemo(() => {
         return i18nLib(options.locale, 'comments');
@@ -121,68 +110,10 @@ const App: React.FC<AppProps> = ({scriptTag, initialCommentId, pageUrl}) => {
         openFormCount: useMemo(() => state.openCommentForms.length, [state.openCommentForms])
     };
 
-    const initAdminAuth = async () => {
-        if (state.adminApi || !options.adminUrl) {
-            return;
-        }
-
-        try {
-            const adminApi = setupAdminAPI({
-                adminUrl: options.adminUrl
-            });
-
-            let admin = null;
-            try {
-                admin = await adminApi.getUser();
-
-                // remove 'admin' for any roles (author, contributor, editor) who can't moderate comments
-                if (!admin || !(admin.roles.some(role => ALLOWED_MODERATORS.includes(role.name)))) {
-                    admin = null;
-                }
-
-                if (admin) {
-                    // this is a bit of a hack, but we need to fetch the comments fully populated if the user is an admin
-                    const adminComments = await adminApi.browse({page: 1, postId: options.postId, order: state.order, memberUuid: state.member?.uuid});
-                    setState((currentState) => {
-                        // Don't overwrite comments when initSetup loaded extra data
-                        // for permalink scrolling (multiple pages or expanded replies)
-                        if ((currentState.pagination && currentState.pagination.page > 1) || initialCommentId) {
-                            return {
-                                adminApi,
-                                admin,
-                                isAdmin: true
-                            };
-                        }
-                        return {
-                            adminApi,
-                            admin,
-                            isAdmin: true,
-                            comments: adminComments.comments,
-                            pagination: adminComments.meta.pagination
-                        };
-                    });
-                }
-            } catch (e) {
-                // Loading of admin failed. Could be not signed in, or a different error (not important)
-                // eslint-disable-next-line no-console
-                console.warn(`[Comments] Failed to fetch admin endpoint:`, e);
-            }
-
-            setState({
-                adminApi,
-                admin,
-                isAdmin: !!admin
-            });
-        } catch (e) {
-            /* eslint-disable no-console */
-            console.error(`[Comments] Failed to initialize admin authentication:`, e);
-        }
-    };
-
-    /** Fetch first few comments  */
+    /** Fetch first few comments using the resolved commentApi */
     const fetchComments = async () => {
-        const dataPromise = api.comments.browse({page: 1, postId: options.postId, order: state.order});
-        const countPromise = api.comments.count({postId: options.postId});
+        const dataPromise = commentApi.browse({page: 1, postId: options.postId, order: state.order});
+        const countPromise = commentApi.count({postId: options.postId});
 
         const [data, count] = await Promise.all([dataPromise, countPromise]);
 
@@ -199,7 +130,7 @@ const App: React.FC<AppProps> = ({scriptTag, initialCommentId, pageUrl}) => {
      */
     const fetchScrollTarget = async (targetId: string): Promise<Comment | null> => {
         try {
-            const response = await api.comments.read(targetId);
+            const response = await commentApi.read(targetId);
             const comment = response.comments?.[0];
             return (comment && comment.status === 'published') ? comment : null;
         } catch {
@@ -224,7 +155,7 @@ const App: React.FC<AppProps> = ({scriptTag, initialCommentId, pageUrl}) => {
                 break;
             }
 
-            const nextPage = await api.comments.browse({
+            const nextPage = await commentApi.browse({
                 page: pagination.page + 1,
                 postId: options.postId,
                 order: state.order
@@ -237,10 +168,47 @@ const App: React.FC<AppProps> = ({scriptTag, initialCommentId, pageUrl}) => {
     };
 
     /**
-     * Load additional comment pages and/or replies until the scroll
-     * target is found. After paginating to the parent comment, if the
-     * target reply isn't in the inline replies (partial API response),
-     * fetch all replies from the server.
+     * Load all replies for a parent comment if the target reply isn't already loaded.
+     */
+    const loadRepliesForComment = async (
+        parentId: string,
+        comments: Comment[]
+    ): Promise<Comment[]> => {
+        const parent = comments.find(c => c.id === parentId);
+        const hasMoreReplies = parent && parent.count.replies > parent.replies.length;
+
+        if (!hasMoreReplies) {
+            return comments;
+        }
+
+        let allReplies: Comment[] = [];
+        let hasMore = true;
+        let afterReplyId: string | undefined;
+
+        while (hasMore) {
+            const response = await commentApi.replies({
+                commentId: parentId,
+                afterReplyId,
+                limit: 100
+            });
+            allReplies = [...allReplies, ...response.comments];
+            hasMore = !!response.meta?.pagination?.next;
+
+            if (response.comments.length > 0) {
+                afterReplyId = response.comments[response.comments.length - 1]?.id;
+            } else {
+                hasMore = false;
+            }
+        }
+
+        return comments.map(c => (c.id === parentId
+            ? {...c, replies: allReplies}
+            : c
+        ));
+    };
+
+    /**
+     * Load additional comment pages and/or replies until the scroll target is found.
      */
     const loadScrollTarget = async (
         targetId: string,
@@ -261,10 +229,9 @@ const App: React.FC<AppProps> = ({scriptTag, initialCommentId, pageUrl}) => {
         return {comments, pagination, found: isCommentLoaded(comments, targetId)};
     };
 
-    /** Initialize comments setup once in viewport, fetch data and setup state */
+    /** Initialize comments setup - called after provider is resolved */
     const initSetup = async () => {
         try {
-            const {member, labs, supportEmail} = await api.init();
             const {count, comments: initialComments, pagination: initialPagination} = await fetchComments();
 
             let comments = initialComments;
@@ -302,13 +269,14 @@ const App: React.FC<AppProps> = ({scriptTag, initialCommentId, pageUrl}) => {
                 showMissingCommentNotice: !!initialCommentId && !scrollTargetFound,
                 supportEmail,
                 isMember,
+                isAdmin: commentApi.isAdmin,
                 isPaidOnly,
                 hasRequiredTier,
                 isCommentingDisabled: member?.can_comment === false
             });
         } catch (e) {
+            // eslint-disable-next-line no-console
             console.error(`[Comments] Failed to initialize:`, e);
-            /* eslint-enable no-console */
             setState({
                 initStatus: 'failed'
             });
@@ -356,9 +324,33 @@ const App: React.FC<AppProps> = ({scriptTag, initialCommentId, pageUrl}) => {
             <CommentsFrame ref={iframeRef}>
                 <ContentBox done={done} />
             </CommentsFrame>
-            {state.comments.length > 0 ? <AuthFrame adminUrl={options.adminUrl} onLoad={initAdminAuth}/> : null}
             <PopupBox />
         </AppContext.Provider>
+    );
+};
+
+const App: React.FC<AppProps> = ({scriptTag, initialCommentId, pageUrl}) => {
+    const options = useOptions(scriptTag);
+
+    const api = useMemo(() => {
+        return setupGhostApi({
+            siteUrl: options.siteUrl,
+            apiUrl: options.apiUrl!,
+            apiKey: options.apiKey!
+        });
+    }, [options]);
+
+    return (
+        <CommentApiProvider
+            adminUrl={options.adminUrl}
+            api={api}
+        >
+            <AppContent
+                initialCommentId={initialCommentId}
+                options={options}
+                pageUrl={pageUrl}
+            />
+        </CommentApiProvider>
     );
 };
 

--- a/apps/comments-ui/src/app.tsx
+++ b/apps/comments-ui/src/app.tsx
@@ -9,6 +9,7 @@ import setupGhostApi from './utils/api';
 import {ActionHandler, SyncActionHandler, isSyncAction} from './actions';
 import {AppContext, Comment, DispatchActionType, EditableAppContext} from './app-context';
 import {CommentsFrame} from './components/frame';
+import {createCommentApi} from './components/comment-api-provider';
 import {setupAdminAPI} from './utils/admin-api';
 import {useOptions} from './utils/options';
 
@@ -82,7 +83,7 @@ const App: React.FC<AppProps> = ({scriptTag, initialCommentId, pageUrl}) => {
             // because updates to state may be asynchronous
             // so calling dispatchAction('counterUp') multiple times, may yield unexpected results if we don't use a callback function
             setState((state) => {
-                return SyncActionHandler({action, data, state, api, adminApi: state.adminApi!, options});
+                return SyncActionHandler({action, data, state, options});
             });
             return;
         }
@@ -95,7 +96,8 @@ const App: React.FC<AppProps> = ({scriptTag, initialCommentId, pageUrl}) => {
         // allow for async actions within it's updater function so this is the best option.
         return new Promise((resolve) => {
             setState((state) => {
-                ActionHandler({action, data, state, api, adminApi: state.adminApi!, options, dispatchAction: dispatchAction as DispatchActionType}).then((updatedState) => {
+                const commentApi = createCommentApi(api, state.adminApi ?? null, state.member?.uuid);
+                ActionHandler({action, data, state, commentApi, options, dispatchAction: dispatchAction as DispatchActionType}).then((updatedState) => {
                     const newState = {...updatedState};
                     resolve(newState);
                     setState(newState);

--- a/apps/comments-ui/src/auth-frame.tsx
+++ b/apps/comments-ui/src/auth-frame.tsx
@@ -1,14 +1,20 @@
 type Props = {
-    adminUrl: string|undefined;
+    adminUrl: string;
     onLoad: () => void;
+    onError: () => void;
 };
-const AuthFrame: React.FC<Props> = ({adminUrl, onLoad}) => {
-    const iframeStyle = {
-        display: 'none'
-    };
 
+const AuthFrame: React.FC<Props> = ({adminUrl, onLoad, onError}) => {
     return (
-        <iframe data-frame="admin-auth" src={adminUrl + 'auth-frame/'} style={iframeStyle} title="auth-frame" onLoad={onLoad}></iframe>
+        <iframe
+            data-frame="admin-auth"
+            src={adminUrl + 'auth-frame/'}
+            style={{display: 'none'}}
+            title="auth-frame"
+            onError={onError}
+            onLoad={onLoad}
+        />
     );
 };
+
 export default AuthFrame;

--- a/apps/comments-ui/src/components/comment-api-provider.tsx
+++ b/apps/comments-ui/src/components/comment-api-provider.tsx
@@ -1,10 +1,24 @@
-import {AddComment, Comment, Member} from '../app-context';
-import {AdminApi} from '../utils/admin-api';
+import AuthFrame from '../auth-frame';
+import React, {createContext, useContext, useEffect, useMemo, useState} from 'react';
+import {AddComment, Comment, LabsContextType, Member} from '../app-context';
+import {AdminApi, setupAdminAPI} from '../utils/admin-api';
 import {GhostApi} from '../utils/api';
+
+async function checkHasAdminSession(adminUrl: string): Promise<boolean> {
+    try {
+        const response = await fetch(adminUrl + 'auth-frame/', {
+            method: 'HEAD',
+            credentials: 'include'
+        });
+        return response.ok && response.status !== 204;
+    } catch {
+        return false;
+    }
+}
 
 type BaseCommentApi = {
     browse(params: {page: number; postId: string; order?: string}): Promise<{comments: Comment[]; meta: {pagination: any}}>;
-    replies(params: {commentId: string; afterReplyId?: string; limit?: number | 'all'}): Promise<{comments: Comment[]; meta: {pagination: any}}>;
+    replies(params: {commentId: string; afterReplyId?: string; limit?: number}): Promise<{comments: Comment[]; meta: {pagination: any}}>;
     read(commentId: string): Promise<{comments: Comment[]}>;
     count(params: {postId: string | null}): Promise<any>;
 
@@ -27,7 +41,9 @@ export type AdminCommentApi = BaseCommentApi & {
 
 export type CommentApi = MemberCommentApi | AdminCommentApi;
 
-export function createCommentApi(api: GhostApi, adminApi: AdminApi | null, memberUuid?: string): CommentApi {
+const ALLOWED_MODERATORS = ['Owner', 'Administrator', 'Super Editor'];
+
+function createCommentApi(api: GhostApi, adminApi: AdminApi | null, memberUuid?: string): CommentApi {
     if (adminApi) {
         return {
             isAdmin: true,
@@ -59,4 +75,109 @@ export function createCommentApi(api: GhostApi, adminApi: AdminApi | null, membe
         report: p => api.comments.report(p),
         updateMember: data => api.member.update(data)
     };
+}
+
+type MemberData = {
+    member: Member | null;
+    labs: LabsContextType;
+    supportEmail: string | null;
+};
+
+type CommentApiContextType = {
+    commentApi: CommentApi;
+    member: Member | null;
+    labs: LabsContextType;
+    supportEmail: string | null;
+};
+
+const CommentApiContext = createContext<CommentApiContextType | null>(null);
+
+export function useCommentApi(): CommentApiContextType {
+    const context = useContext(CommentApiContext);
+    if (!context) {
+        throw new Error('useCommentApi must be used within a CommentApiProvider');
+    }
+    return context;
+}
+
+type CommentApiProviderProps = {
+    children: React.ReactNode;
+    api: GhostApi;
+    adminUrl: string | undefined;
+};
+
+export function CommentApiProvider({children, api, adminUrl}: CommentApiProviderProps) {
+    // undefined = pending, value = resolved
+    const [memberData, setMemberData] = useState<MemberData | undefined>(undefined);
+    const [adminApi, setAdminApi] = useState<AdminApi | null | undefined>(adminUrl ? undefined : null);
+    const [hasAdminSession, setHasSession] = useState<boolean | undefined>(adminUrl ? undefined : false);
+
+    // Step 1: Initialize member data
+    useEffect(() => {
+        api.init()
+            .then(setMemberData)
+            .catch((e) => {
+                // eslint-disable-next-line no-console
+                console.error(`[Comments] Failed to initialize member:`, e);
+                setMemberData({member: null, labs: {}, supportEmail: null});
+            });
+    }, [api]);
+
+    // Step 2: Preflight check for admin session
+    useEffect(() => {
+        if (!adminUrl) {
+            return;
+        }
+        checkHasAdminSession(adminUrl).then((result) => {
+            setHasSession(result);
+            if (!result) {
+                setAdminApi(null);
+            }
+        });
+    }, [adminUrl]);
+
+    // Step 3: If session exists, verify admin role when iframe loads
+    const onAdminAuthLoad = async () => {
+        try {
+            const newAdminApi = setupAdminAPI({adminUrl: adminUrl!});
+            const admin = await newAdminApi.getUser();
+            const isAllowed = admin?.roles?.some((role: {name: string}) => ALLOWED_MODERATORS.includes(role.name));
+            setAdminApi(isAllowed ? newAdminApi : null);
+        } catch (e) {
+            // eslint-disable-next-line no-console
+            console.warn(`[Comments] Admin auth failed:`, e);
+            setAdminApi(null);
+        }
+    };
+
+    const onAdminAuthError = () => {
+        // eslint-disable-next-line no-console
+        console.warn(`[Comments] Admin auth frame failed to load`);
+        setAdminApi(null);
+    };
+
+    const resolved = memberData !== undefined && adminApi !== undefined;
+
+    const contextValue = useMemo(() => {
+        if (!resolved) {
+            return null;
+        }
+        return {
+            commentApi: createCommentApi(api, adminApi, memberData.member?.uuid),
+            member: memberData.member,
+            labs: memberData.labs,
+            supportEmail: memberData.supportEmail
+        };
+    }, [resolved, api, adminApi, memberData]);
+
+    return (
+        <>
+            {hasAdminSession && <AuthFrame adminUrl={adminUrl!} onError={onAdminAuthError} onLoad={onAdminAuthLoad} />}
+            {contextValue && (
+                <CommentApiContext.Provider value={contextValue}>
+                    {children}
+                </CommentApiContext.Provider>
+            )}
+        </>
+    );
 }

--- a/apps/comments-ui/src/components/comment-api-provider.tsx
+++ b/apps/comments-ui/src/components/comment-api-provider.tsx
@@ -1,0 +1,62 @@
+import {AddComment, Comment, Member} from '../app-context';
+import {AdminApi} from '../utils/admin-api';
+import {GhostApi} from '../utils/api';
+
+type BaseCommentApi = {
+    browse(params: {page: number; postId: string; order?: string}): Promise<{comments: Comment[]; meta: {pagination: any}}>;
+    replies(params: {commentId: string; afterReplyId?: string; limit?: number | 'all'}): Promise<{comments: Comment[]; meta: {pagination: any}}>;
+    read(commentId: string): Promise<{comments: Comment[]}>;
+    count(params: {postId: string | null}): Promise<any>;
+
+    add(params: {comment: AddComment}): Promise<{comments: Comment[]}>;
+    edit(params: {comment: Partial<Comment> & {id: string}}): Promise<{comments: Comment[]}>;
+    like(params: {comment: {id: string}}): Promise<string>;
+    unlike(params: {comment: {id: string}}): Promise<string>;
+    report(params: {comment: {id: string}}): Promise<string>;
+
+    updateMember(data: {name?: string; expertise?: string}): Promise<Member | null>;
+};
+
+export type MemberCommentApi = BaseCommentApi & {isAdmin: false};
+
+export type AdminCommentApi = BaseCommentApi & {
+    isAdmin: true;
+    hideComment(id: string): Promise<any>;
+    showComment(params: {id: string}): Promise<any>;
+};
+
+export type CommentApi = MemberCommentApi | AdminCommentApi;
+
+export function createCommentApi(api: GhostApi, adminApi: AdminApi | null, memberUuid?: string): CommentApi {
+    if (adminApi) {
+        return {
+            isAdmin: true,
+            browse: p => adminApi.browse({...p, memberUuid}),
+            replies: p => adminApi.replies({...p, memberUuid}),
+            read: id => adminApi.read({commentId: id, memberUuid}),
+            count: p => api.comments.count(p),
+            add: p => api.comments.add(p),
+            edit: p => api.comments.edit(p),
+            like: p => api.comments.like(p),
+            unlike: p => api.comments.unlike(p),
+            report: p => api.comments.report(p),
+            updateMember: data => api.member.update(data),
+            hideComment: id => adminApi.hideComment(id),
+            showComment: p => adminApi.showComment(p)
+        };
+    }
+
+    return {
+        isAdmin: false,
+        browse: p => api.comments.browse(p),
+        replies: p => api.comments.replies(p),
+        read: id => api.comments.read(id),
+        count: p => api.comments.count(p),
+        add: p => api.comments.add(p),
+        edit: p => api.comments.edit(p),
+        like: p => api.comments.like(p),
+        unlike: p => api.comments.unlike(p),
+        report: p => api.comments.report(p),
+        updateMember: data => api.member.update(data)
+    };
+}

--- a/apps/comments-ui/test/e2e/admin-moderation.test.ts
+++ b/apps/comments-ui/test/e2e/admin-moderation.test.ts
@@ -44,15 +44,9 @@ test.describe('Admin moderation', async () => {
         });
     }
 
-    test('skips rendering the auth frame with no comments', async ({page}) => {
-        await initializeTest(page);
-
-        const iframeElement = page.locator('iframe[data-frame="admin-auth"]');
-        await expect(iframeElement).toHaveCount(0);
-    });
-
-    test('renders the auth frame when there are comments', async ({page}) => {
-        mockedApi.addComment({html: '<p>This is comment 1</p>'});
+    test('always renders the auth frame', async ({page}) => {
+        // Auth frame should render even with no comments - admin status must be
+        // resolved before fetching comments to use the correct API endpoint
         await initializeTest(page);
 
         const iframeElement = page.locator('iframe[data-frame="admin-auth"]');

--- a/apps/comments-ui/test/e2e/content.test.ts
+++ b/apps/comments-ui/test/e2e/content.test.ts
@@ -31,9 +31,6 @@ test.describe('Deleted and Hidden Content', async () => {
             labs: {}
         });
 
-        const iframeElement = await page.locator('iframe[data-frame="admin-auth"]');
-        await expect(iframeElement).toHaveCount(1);
-
         // Check if more actions button is visible on each comment
         const comments = await frame.getByTestId('comment-component');
         // 3 comments are visible

--- a/apps/comments-ui/test/e2e/lazy-loading.test.ts
+++ b/apps/comments-ui/test/e2e/lazy-loading.test.ts
@@ -63,8 +63,9 @@ test.describe('Lazy loading', async () => {
         const iframeHandle = await page.locator(commentsFrameSelector);
         iframeHandle.scrollIntoViewIfNeeded();
 
-        // loading state should be gone and admin-auth frame should be present
+        // loading state should be gone once comments are fetched
+        // (no admin-auth frame expected since no admin URL was provided)
         await expect(commentsFrame.getByTestId('loading')).toHaveCount(0);
-        await expect(page.locator(adminFrameSelector)).toHaveCount(1);
+        await expect(page.locator(adminFrameSelector)).toHaveCount(0);
     });
 });

--- a/apps/comments-ui/test/unit/actions.test.js
+++ b/apps/comments-ui/test/unit/actions.test.js
@@ -10,21 +10,19 @@ describe('Actions', function () {
                     {id: '3'}
                 ]
             };
-            const api = {
-                comments: {
-                    browse: () => Promise.resolve({
-                        comments: [
-                            {id: '2'},
-                            {id: '3'},
-                            {id: '4'}
-                        ],
-                        meta: {
-                            pagination: {}
-                        }
-                    })
-                }
+            const commentApi = {
+                browse: () => Promise.resolve({
+                    comments: [
+                        {id: '2'},
+                        {id: '3'},
+                        {id: '4'}
+                    ],
+                    meta: {
+                        pagination: {}
+                    }
+                })
             };
-            const newState = await Actions.loadMoreComments({state, api, options: {postId: '1'}, order: 'desc'});
+            const newState = await Actions.loadMoreComments({state, commentApi, options: {postId: '1'}, order: 'desc'});
             expect(newState.comments).toEqual([
                 {id: '1'},
                 {id: '2'},

--- a/apps/comments-ui/test/utils/e2e.ts
+++ b/apps/comments-ui/test/utils/e2e.ts
@@ -87,6 +87,8 @@ export async function mockAdminAuthFrame({admin, page}) {
 }
 
 export async function mockAdminAuthFrame204({admin, page}) {
+    // Return 204 to simulate no admin session cookie (matches production behavior).
+    // The provider handles this via timeout since there's no message handler.
     await page.route(admin + 'auth-frame/', async (route) => {
         await route.fulfill({
             status: 204
@@ -166,7 +168,7 @@ export async function initialize({mockedApi, page, bodyStyle, labs = {}, key = '
 
     const commentsFrameSelector = 'iframe[title="comments-frame"]';
 
-    await page.waitForSelector('iframe');
+    await page.waitForSelector(commentsFrameSelector);
 
     // wait for data to be loaded because our tests expect it
     const iframeElement = await page.locator(commentsFrameSelector).elementHandle();


### PR DESCRIPTION
The comments-ui codebase had a recurring code smell: every action that needed to fetch data contained inline `if (state.admin && state.adminApi) { ... } else { ... }` conditionals to choose between the admin API and the member API. This duplicated branching logic was scattered across `loadMoreComments`, `setOrder`, `loadMoreReplies`, `showComment`, and other functions.

This PR introduces a `CommentApi` polymorphic facade that abstracts away the admin/member distinction. Actions now call methods like `commentApi.browse()` without knowing which underlying API is being used. The facade uses a discriminated union (`MemberCommentApi | AdminCommentApi`) so TypeScript enforces correct usage—admin-only methods like `hideComment` are only available when `commentApi.isAdmin` is true.

The new `CommentApiProvider` centralizes several things that were previously scattered in `app.tsx`:
- Admin authentication via AuthFrame
- Role checking against allowed moderators
- Member initialization via `api.init()`
- Creation of the appropriate CommentApi facade

The provider uses a preflight HEAD request to check if an admin session cookie exists before loading the AuthFrame iframe. If the server returns 204 (no session), we skip the iframe entirely and resolve as non-admin immediately. This avoids the overhead of loading the iframe for non-admin users and eliminates the need for arbitrary timeouts.

`EditableAppContext` is cleaned up by removing `admin` and `adminApi` fields—these are now internal to the provider. The provider exposes `member`, `labs`, and `supportEmail` from the init response, plus the resolved `commentApi`.

## Review notes

A couple of admin-only action instances (`hideComment`, `showComment`) still have `commentApi.isAdmin` guards in `actions.ts`. These are being extracted into a separate `AdminActionsProvider` in the follow-up PR `refactor/comments-admin-actions`, which leverages the discriminated union to remove those guards entirely.