### PR TITLE
Moved isAdmin and adminUrl to CommentApiProvider context

### DIFF
--- a/apps/comments-ui/src/actions.ts
+++ b/apps/comments-ui/src/actions.ts
@@ -1,19 +1,13 @@
 import {AddComment, Comment, CommentsOptions, DispatchActionType, EditableAppContext, OpenCommentForm} from './app-context';
-import {AdminApi} from './utils/admin-api';
-import {GhostApi} from './utils/api';
+import {CommentApi} from './components/comment-api-provider';
 import {Page} from './pages';
 
-async function loadMoreComments({state, api, options, order}: {state: EditableAppContext, api: GhostApi, options: CommentsOptions, order?:string}): Promise<Partial<EditableAppContext>> {
+async function loadMoreComments({state, commentApi, options, order}: {state: EditableAppContext, commentApi: CommentApi, options: CommentsOptions, order?: string}): Promise<Partial<EditableAppContext>> {
     let page = 1;
     if (state.pagination && state.pagination.page) {
         page = state.pagination.page + 1;
     }
-    let data;
-    if (state.admin && state.adminApi) {
-        data = await state.adminApi.browse({page, postId: options.postId, order: order || state.order, memberUuid: state.member?.uuid});
-    } else {
-        data = await api.comments.browse({page, postId: options.postId, order: order || state.order});
-    }
+    const data = await commentApi.browse({page, postId: options.postId, order: order || state.order});
 
     const updatedComments = [...state.comments, ...data.comments];
     const dedupedComments = updatedComments.filter((comment, index, self) => self.findIndex(c => c.id === comment.id) === index);
@@ -31,16 +25,11 @@ function setCommentsIsLoading({data: isLoading}: {data: boolean | null}) {
     };
 }
 
-async function setOrder({state, data: {order}, options, api, dispatchAction}: {state: EditableAppContext, data: {order: string}, options: CommentsOptions, api: GhostApi, dispatchAction: DispatchActionType}) {
+async function setOrder({state, data: {order}, options, commentApi, dispatchAction}: {state: EditableAppContext, data: {order: string}, options: CommentsOptions, commentApi: CommentApi, dispatchAction: DispatchActionType}) {
     dispatchAction('setCommentsIsLoading', true);
 
     try {
-        let data;
-        if (state.admin && state.adminApi) {
-            data = await state.adminApi.browse({page: 1, postId: options.postId, order, memberUuid: state.member?.uuid});
-        } else {
-            data = await api.comments.browse({page: 1, postId: options.postId, order});
-        }
+        const data = await commentApi.browse({page: 1, postId: options.postId, order});
 
         return {
             comments: [...data.comments],
@@ -55,13 +44,9 @@ async function setOrder({state, data: {order}, options, api, dispatchAction}: {s
     }
 }
 
-async function loadMoreReplies({state, api, data: {comment, limit}, isReply}: {state: EditableAppContext, api: GhostApi, data: {comment: Comment, limit?: number | 'all'}, isReply: boolean}): Promise<Partial<EditableAppContext>> {
+async function loadMoreReplies({state, commentApi, data: {comment, limit}}: {state: EditableAppContext, commentApi: CommentApi, data: {comment: Comment, limit?: number | 'all'}}): Promise<Partial<EditableAppContext>> {
     const fetchReplies = async (afterReplyId: string | undefined, requestLimit: number) => {
-        if (state.admin && state.adminApi && !isReply) { // we don't want the admin api to load reply data for replying to a reply, so we pass isReply: true
-            return await state.adminApi.replies({commentId: comment.id, afterReplyId, limit: requestLimit, memberUuid: state.member?.uuid});
-        } else {
-            return await api.comments.replies({commentId: comment.id, afterReplyId, limit: requestLimit});
-        }
+        return await commentApi.replies({commentId: comment.id, afterReplyId, limit: requestLimit});
     };
 
     let afterReplyId: string | undefined = comment.replies && comment.replies.length > 0
@@ -104,8 +89,8 @@ async function loadMoreReplies({state, api, data: {comment, limit}, isReply}: {s
     };
 }
 
-async function addComment({state, api, data: comment}: {state: EditableAppContext, api: GhostApi, data: AddComment}) {
-    const data = await api.comments.add({comment});
+async function addComment({state, commentApi, data: comment}: {state: EditableAppContext, commentApi: CommentApi, data: AddComment}) {
+    const data = await commentApi.add({comment});
     comment = data.comments[0];
 
     return {
@@ -114,11 +99,11 @@ async function addComment({state, api, data: comment}: {state: EditableAppContex
     };
 }
 
-async function addReply({state, api, data: {reply, parent}}: {state: EditableAppContext, api: GhostApi, data: {reply: any, parent: any}}) {
+async function addReply({state, commentApi, data: {reply, parent}}: {state: EditableAppContext, commentApi: CommentApi, data: {reply: any, parent: any}}) {
     let comment = reply;
     comment.parent_id = parent.id;
 
-    const data = await api.comments.add({comment});
+    const data = await commentApi.add({comment});
     comment = data.comments[0];
 
     // When we add a reply,
@@ -144,9 +129,9 @@ async function addReply({state, api, data: {reply, parent}}: {state: EditableApp
     };
 }
 
-async function hideComment({state, data: comment}: {state: EditableAppContext, adminApi: any, data: {id: string}}) {
-    if (state.adminApi) {
-        await state.adminApi.hideComment(comment.id);
+async function hideComment({state, commentApi, data: comment}: {state: EditableAppContext, commentApi: CommentApi, data: {id: string}}) {
+    if (commentApi.isAdmin) {
+        await commentApi.hideComment(comment.id);
     }
     return {
         comments: state.comments.map((c) => {
@@ -178,18 +163,13 @@ async function hideComment({state, data: comment}: {state: EditableAppContext, a
     };
 }
 
-async function showComment({state, api, data: comment}: {state: EditableAppContext, api: GhostApi, adminApi: any, data: {id: string}}) {
-    if (state.adminApi) {
-        await state.adminApi.showComment({id: comment.id});
+async function showComment({state, commentApi, data: comment}: {state: EditableAppContext, commentApi: CommentApi, data: {id: string}}) {
+    if (commentApi.isAdmin) {
+        await commentApi.showComment({id: comment.id});
     }
     // We need to refetch the comment, to make sure we have an up to date HTML content
     // + all relations are loaded as the current member (not the admin)
-    let data;
-    if (state.admin && state.adminApi) {
-        data = await state.adminApi.read({commentId: comment.id, memberUuid: state.member?.uuid});
-    } else {
-        data = await api.comments.read(comment.id);
-    }
+    const data = await commentApi.read(comment.id);
 
     const updatedComment = data.comments[0];
 
@@ -254,35 +234,35 @@ async function updateCommentLikeState({state, data: comment}: {state: EditableAp
     };
 }
 
-async function likeComment({api, data: comment, dispatchAction}: {state: EditableAppContext, api: GhostApi, data: {id: string}, dispatchAction: DispatchActionType}) {
+async function likeComment({commentApi, data: comment, dispatchAction}: {state: EditableAppContext, commentApi: CommentApi, data: {id: string}, dispatchAction: DispatchActionType}) {
     dispatchAction('updateCommentLikeState', {id: comment.id, liked: true});
     try {
-        await api.comments.like({comment});
+        await commentApi.like({comment});
         return {};
     } catch {
         dispatchAction('updateCommentLikeState', {id: comment.id, liked: false});
     }
 }
 
-async function unlikeComment({api, data: comment, dispatchAction}: {state: EditableAppContext, api: GhostApi, data: {id: string}, dispatchAction: DispatchActionType}) {
+async function unlikeComment({commentApi, data: comment, dispatchAction}: {state: EditableAppContext, commentApi: CommentApi, data: {id: string}, dispatchAction: DispatchActionType}) {
     dispatchAction('updateCommentLikeState', {id: comment.id, liked: false});
 
     try {
-        await api.comments.unlike({comment});
+        await commentApi.unlike({comment});
         return {};
     } catch {
         dispatchAction('updateCommentLikeState', {id: comment.id, liked: true});
     }
 }
 
-async function reportComment({api, data: comment}: {api: GhostApi, data: {id: string}}) {
-    await api.comments.report({comment});
+async function reportComment({commentApi, data: comment}: {commentApi: CommentApi, data: {id: string}}) {
+    await commentApi.report({comment});
 
     return {};
 }
 
-async function deleteComment({state, api, data: comment, dispatchAction}: {state: EditableAppContext, api: GhostApi, data: {id: string}, dispatchAction: DispatchActionType}) {
-    await api.comments.edit({
+async function deleteComment({state, commentApi, data: comment, dispatchAction}: {state: EditableAppContext, commentApi: CommentApi, data: {id: string}, dispatchAction: DispatchActionType}) {
+    await commentApi.edit({
         comment: {
             id: comment.id,
             status: 'deleted'
@@ -333,8 +313,8 @@ async function deleteComment({state, api, data: comment, dispatchAction}: {state
     };
 }
 
-async function editComment({state, api, data: {comment, parent}}: {state: EditableAppContext, api: GhostApi, data: {comment: Partial<Comment> & {id: string}, parent?: Comment}}) {
-    const data = await api.comments.edit({
+async function editComment({state, commentApi, data: {comment, parent}}: {state: EditableAppContext, commentApi: CommentApi, data: {comment: Partial<Comment> & {id: string}, parent?: Comment}}) {
+    const data = await commentApi.edit({
         comment
     });
     comment = data.comments[0];
@@ -361,7 +341,7 @@ async function editComment({state, api, data: {comment, parent}}: {state: Editab
     };
 }
 
-async function updateMember({data, state, api}: {data: {name: string, expertise: string}, state: EditableAppContext, api: GhostApi}) {
+async function updateMember({data, state, commentApi}: {data: {name: string, expertise: string}, state: EditableAppContext, commentApi: CommentApi}) {
     const {name, expertise} = data;
     const patchData: {name?: string, expertise?: string} = {};
 
@@ -379,7 +359,7 @@ async function updateMember({data, state, api}: {data: {name: string, expertise:
 
     if (Object.keys(patchData).length > 0) {
         try {
-            const member = await api.member.update(patchData);
+            const member = await commentApi.updateMember(patchData);
             if (!member) {
                 throw new Error('Failed to update member');
             }
@@ -409,7 +389,7 @@ function closePopup() {
     };
 }
 
-async function openCommentForm({data: newForm, api, state}: {data: OpenCommentForm, api: GhostApi, state: EditableAppContext}) {
+async function openCommentForm({data: newForm, commentApi, state}: {data: OpenCommentForm, commentApi: CommentApi, state: EditableAppContext}) {
     let otherStateChanges = {};
 
     // When opening a reply form, we load in all of the replies for the parent comment so that
@@ -419,9 +399,7 @@ async function openCommentForm({data: newForm, api, state}: {data: OpenCommentFo
         const comment = state.comments.find(c => c.id === topLevelCommentId);
 
         if (comment) {
-            // we don't want the admin api to load reply data for replying to a reply, so we pass isReply: true
-            // TODO: why don't we want the admin api to load reply data for replying to a reply?
-            const newCommentsState = await loadMoreReplies({state, api, data: {comment, limit: 'all'}, isReply: true});
+            const newCommentsState = await loadMoreReplies({state, commentApi, data: {comment, limit: 'all'}});
             otherStateChanges = {...otherStateChanges, ...newCommentsState};
         }
     }
@@ -525,20 +503,20 @@ export function isSyncAction(action: string): action is SyncActionType {
 }
 
 /** Handle actions in the App, returns updated state */
-export async function ActionHandler({action, data, state, api, adminApi, options, dispatchAction}: {action: ActionType, data: any, state: EditableAppContext, options: CommentsOptions, api: GhostApi, adminApi: AdminApi, dispatchAction: DispatchActionType}): Promise<Partial<EditableAppContext>> {
+export async function ActionHandler({action, data, state, commentApi, options, dispatchAction}: {action: ActionType, data: any, state: EditableAppContext, options: CommentsOptions, commentApi: CommentApi, dispatchAction: DispatchActionType}): Promise<Partial<EditableAppContext>> {
     const handler = Actions[action];
     if (handler) {
-        return await handler({data, state, api, adminApi, options, dispatchAction} as any) || {};
+        return await handler({data, state, commentApi, options, dispatchAction} as any) || {};
     }
     return {};
 }
 
 /** Handle actions in the App, returns updated state */
-export function SyncActionHandler({action, data, state, api, adminApi, options}: {action: SyncActionType, data: any, state: EditableAppContext, options: CommentsOptions, api: GhostApi, adminApi: AdminApi}): Partial<EditableAppContext> {
+export function SyncActionHandler({action, data, state, options}: {action: SyncActionType, data: any, state: EditableAppContext, options: CommentsOptions}): Partial<EditableAppContext> {
     const handler = SyncActions[action];
     if (handler) {
         // Do not await here
-        return handler({data, state, api, adminApi, options} as any) || {};
+        return handler({data, state, options} as any) || {};
     }
     return {};
 }

--- a/apps/comments-ui/src/app-context.ts
+++ b/apps/comments-ui/src/app-context.ts
@@ -1,7 +1,6 @@
 // Ref: https://reactjs.org/docs/context.html
 import React, {useContext} from 'react';
 import {ActionType, Actions, SyncActionType, SyncActions} from './actions';
-import {AdminApi} from './utils/admin-api';
 import {Page} from './pages';
 
 export type Member = {
@@ -70,7 +69,6 @@ export type CommentsOptions = {
 export type EditableAppContext = {
     initStatus: string,
     member: null | any,
-    admin: null | any,
     comments: Comment[],
     pagination: {
         page: number,
@@ -83,7 +81,6 @@ export type EditableAppContext = {
     popup: Page | null,
     labs: LabsContextType,
     order: string,
-    adminApi: AdminApi | null,
     commentsIsLoading?: boolean,
     commentIdToHighlight: string | null,
     commentIdToScrollTo: string | null,

--- a/apps/comments-ui/src/app.tsx
+++ b/apps/comments-ui/src/app.tsx
@@ -9,6 +9,7 @@ import setupGhostApi from './utils/api';
 import {ActionHandler, SyncActionHandler, isSyncAction} from './actions';
 import {AppContext, Comment, DispatchActionType, EditableAppContext} from './app-context';
 import {CommentsFrame} from './components/frame';
+import {createCommentApi} from './components/comment-api-provider';
 import {setupAdminAPI} from './utils/admin-api';
 import {useOptions} from './utils/options';
 
@@ -81,7 +82,7 @@ const App: React.FC<AppProps> = ({scriptTag, initialCommentId, pageUrl}) => {
             // because updates to state may be asynchronous
             // so calling dispatchAction('counterUp') multiple times, may yield unexpected results if we don't use a callback function
             setState((state) => {
-                return SyncActionHandler({action, data, state, api, adminApi: state.adminApi!, options});
+                return SyncActionHandler({action, data, state, options});
             });
             return;
         }
@@ -94,7 +95,8 @@ const App: React.FC<AppProps> = ({scriptTag, initialCommentId, pageUrl}) => {
         // allow for async actions within it's updater function so this is the best option.
         return new Promise((resolve) => {
             setState((state) => {
-                ActionHandler({action, data, state, api, adminApi: state.adminApi!, options, dispatchAction: dispatchAction as DispatchActionType}).then((updatedState) => {
+                const commentApi = createCommentApi(api, state.adminApi ?? null, state.member?.uuid);
+                ActionHandler({action, data, state, commentApi, options, dispatchAction: dispatchAction as DispatchActionType}).then((updatedState) => {
                     const newState = {...updatedState};
                     resolve(newState);
                     setState(newState);

--- a/apps/comments-ui/src/components/comment-api-provider.tsx
+++ b/apps/comments-ui/src/components/comment-api-provider.tsx
@@ -66,10 +66,12 @@ const ALLOWED_MODERATORS = ['Owner', 'Administrator', 'Super Editor'];
 
 type CommentApiContextType = {
     commentApi: CommentApi;
+    isAdmin: boolean;
+    adminUrl: string | undefined;
     initAdminAuth: (memberUuid?: string) => Promise<void>;
 };
 
-const CommentApiContext = createContext<CommentApiContextType | null>(null);
+export const CommentApiContext = createContext<CommentApiContextType | null>(null);
 
 export function useCommentApi(): CommentApiContextType {
     const context = useContext(CommentApiContext);
@@ -125,8 +127,10 @@ export function CommentApiProvider({
 
     const contextValue = useMemo(() => ({
         commentApi,
+        isAdmin: commentApi.isAdmin,
+        adminUrl,
         initAdminAuth
-    }), [commentApi, initAdminAuth]);
+    }), [commentApi, adminUrl, initAdminAuth]);
 
     return (
         <CommentApiContext.Provider value={contextValue}>

--- a/apps/comments-ui/src/components/comment-api-provider.tsx
+++ b/apps/comments-ui/src/components/comment-api-provider.tsx
@@ -1,0 +1,62 @@
+import {AddComment, Comment, Member} from '../app-context';
+import {AdminApi} from '../utils/admin-api';
+import {GhostApi} from '../utils/api';
+
+type BaseCommentApi = {
+    browse(params: {page: number; postId: string; order?: string}): Promise<{comments: Comment[]; meta: {pagination: any}}>;
+    replies(params: {commentId: string; afterReplyId?: string; limit?: number | 'all'}): Promise<{comments: Comment[]; meta: {pagination: any}}>;
+    read(commentId: string): Promise<{comments: Comment[]}>;
+    count(params: {postId: string | null}): Promise<any>;
+
+    add(params: {comment: AddComment}): Promise<{comments: Comment[]}>;
+    edit(params: {comment: Partial<Comment> & {id: string}}): Promise<{comments: Comment[]}>;
+    like(params: {comment: {id: string}}): Promise<string>;
+    unlike(params: {comment: {id: string}}): Promise<string>;
+    report(params: {comment: {id: string}}): Promise<string>;
+
+    updateMember(data: {name?: string; expertise?: string}): Promise<Member | null>;
+};
+
+export type MemberCommentApi = BaseCommentApi & {isAdmin: false};
+
+export type AdminCommentApi = BaseCommentApi & {
+    isAdmin: true;
+    hideComment(id: string): Promise<any>;
+    showComment(params: {id: string}): Promise<any>;
+};
+
+export type CommentApi = MemberCommentApi | AdminCommentApi;
+
+export function createCommentApi(api: GhostApi, adminApi: AdminApi | null, memberUuid?: string): CommentApi {
+    if (adminApi) {
+        return {
+            isAdmin: true,
+            browse: p => adminApi.browse({...p, memberUuid}),
+            replies: p => adminApi.replies({...p, memberUuid}),
+            read: id => adminApi.read({commentId: id, memberUuid}),
+            count: p => api.comments.count(p),
+            add: p => api.comments.add(p),
+            edit: p => api.comments.edit(p),
+            like: p => api.comments.like(p),
+            unlike: p => api.comments.unlike(p),
+            report: p => api.comments.report(p),
+            updateMember: data => api.member.update(data),
+            hideComment: id => adminApi.hideComment(id),
+            showComment: p => adminApi.showComment(p)
+        };
+    }
+
+    return {
+        isAdmin: false,
+        browse: p => api.comments.browse(p),
+        replies: p => api.comments.replies(p),
+        read: id => api.comments.read(id),
+        count: p => api.comments.count(p),
+        add: p => api.comments.add(p),
+        edit: p => api.comments.edit(p),
+        like: p => api.comments.like(p),
+        unlike: p => api.comments.unlike(p),
+        report: p => api.comments.report(p),
+        updateMember: data => api.member.update(data)
+    };
+}

--- a/apps/comments-ui/src/components/content/comment.tsx
+++ b/apps/comments-ui/src/components/content/comment.tsx
@@ -10,6 +10,7 @@ import {Avatar, BlankAvatar} from './avatar';
 import {Comment, OpenCommentForm, useAppContext, useLabs} from '../../app-context';
 import {Transition} from '@headlessui/react';
 import {buildCommentPermalink, findCommentById, formatExplicitTime, getCommentInReplyToSnippet, getMemberNameFromComment} from '../../utils/helpers';
+import {useCommentApi} from '../comment-api-provider';
 import {useRelativeTime} from '../../utils/hooks';
 
 type AnimatedCommentProps = {
@@ -40,7 +41,8 @@ const AnimatedComment: React.FC<AnimatedCommentProps> = ({comment, parent}) => {
 };
 
 export const CommentComponent: React.FC<CommentProps> = ({comment, parent}) => {
-    const {dispatchAction, isAdmin} = useAppContext();
+    const {dispatchAction} = useAppContext();
+    const {isAdmin} = useCommentApi();
     const {showDeletedMessage, showHiddenMessage, showCommentContent} = useCommentVisibility(comment, isAdmin);
 
     const openEditMode = useCallback(() => {
@@ -83,7 +85,8 @@ type PublishedCommentProps = CommentProps & {
     openEditMode: () => void;
 }
 const PublishedComment: React.FC<PublishedCommentProps> = ({comment, parent, openEditMode}) => {
-    const {dispatchAction, openCommentForms, isAdmin, commentIdToHighlight} = useAppContext();
+    const {dispatchAction, openCommentForms, commentIdToHighlight} = useAppContext();
+    const {isAdmin} = useCommentApi();
 
     // Determine if the comment should be displayed with reduced opacity
     const isHidden = isAdmin && comment.status === 'hidden';
@@ -160,7 +163,8 @@ type UnpublishedCommentProps = {
     openEditMode: () => void;
 }
 const UnpublishedComment: React.FC<UnpublishedCommentProps> = ({comment, openEditMode}) => {
-    const {isAdmin, openCommentForms, t} = useAppContext();
+    const {openCommentForms, t} = useAppContext();
+    const {isAdmin} = useCommentApi();
 
     const avatar = (isAdmin && comment.status !== 'deleted')
         ? <Avatar member={comment.member} />
@@ -406,7 +410,8 @@ type CommentMenuProps = {
     className?: string;
 };
 const CommentMenu: React.FC<CommentMenuProps> = ({comment, openReplyForm, highlightReplyButton, openEditMode, className = ''}) => {
-    const {member, t, isMember, isAdmin, isCommentingDisabled} = useAppContext();
+    const {member, t, isMember, isCommentingDisabled} = useAppContext();
+    const {isAdmin} = useCommentApi();
 
     const isPublished = comment.status === 'published';
     const isOwnComment = member && comment.member?.uuid === member?.uuid;

--- a/apps/comments-ui/src/components/content/context-menus/admin-context-menu.tsx
+++ b/apps/comments-ui/src/components/content/context-menus/admin-context-menu.tsx
@@ -1,11 +1,13 @@
 import {Comment, useAppContext, useLabs} from '../../../app-context';
+import {useCommentApi} from '../../comment-api-provider';
 
 type Props = {
     comment: Comment;
     close: () => void;
 };
 const AdminContextMenu: React.FC<Props> = ({comment, close}) => {
-    const {dispatchAction, t, adminUrl} = useAppContext();
+    const {dispatchAction, t} = useAppContext();
+    const {adminUrl} = useCommentApi();
     const labs = useLabs();
 
     const hideComment = () => {

--- a/apps/comments-ui/src/components/content/context-menus/comment-context-menu.tsx
+++ b/apps/comments-ui/src/components/content/context-menus/comment-context-menu.tsx
@@ -2,6 +2,7 @@ import AdminContextMenu from './admin-context-menu';
 import AuthorContextMenu from './author-context-menu';
 import NotAuthorContextMenu from './not-author-context-menu';
 import {Comment, useAppContext} from '../../../app-context';
+import {useCommentApi} from '../../comment-api-provider';
 import {useEffect, useRef} from 'react';
 import {useOutOfViewportClasses} from '../../../utils/hooks';
 
@@ -11,7 +12,8 @@ type Props = {
     toggleEdit: () => void;
 };
 const CommentContextMenu: React.FC<Props> = ({comment, close, toggleEdit}) => {
-    const {member, isAdmin} = useAppContext();
+    const {member} = useAppContext();
+    const {isAdmin} = useCommentApi();
     const isAuthor = member && comment.member?.uuid === member?.uuid;
     const element = useRef<HTMLDivElement>(null);
     const innerElement = useRef<HTMLDivElement>(null);

--- a/apps/comments-ui/test/unit/actions.test.js
+++ b/apps/comments-ui/test/unit/actions.test.js
@@ -10,21 +10,19 @@ describe('Actions', function () {
                     {id: '3'}
                 ]
             };
-            const api = {
-                comments: {
-                    browse: () => Promise.resolve({
-                        comments: [
-                            {id: '2'},
-                            {id: '3'},
-                            {id: '4'}
-                        ],
-                        meta: {
-                            pagination: {}
-                        }
-                    })
-                }
+            const commentApi = {
+                browse: () => Promise.resolve({
+                    comments: [
+                        {id: '2'},
+                        {id: '3'},
+                        {id: '4'}
+                    ],
+                    meta: {
+                        pagination: {}
+                    }
+                })
             };
-            const newState = await Actions.loadMoreComments({state, api, options: {postId: '1'}, order: 'desc'});
+            const newState = await Actions.loadMoreComments({state, commentApi, options: {postId: '1'}, order: 'desc'});
             expect(newState.comments).toEqual([
                 {id: '1'},
                 {id: '2'},

--- a/apps/comments-ui/test/unit/components/content/comment.test.jsx
+++ b/apps/comments-ui/test/unit/components/content/comment.test.jsx
@@ -1,9 +1,10 @@
 import {AppContext} from '../../../../src/app-context';
+import {CommentApiContext} from '../../../../src/components/comment-api-provider';
 import {CommentComponent, RepliedToSnippet} from '../../../../src/components/content/comment';
 import {buildComment} from '../../../utils/fixtures';
 import {render, screen} from '@testing-library/react';
 
-const contextualRender = (ui, {appContext, ...renderOptions}) => {
+const contextualRender = (ui, {appContext, commentApiContext, ...renderOptions} = {}) => {
     const contextWithDefaults = {
         commentsEnabled: 'all',
         comments: [],
@@ -15,8 +16,21 @@ const contextualRender = (ui, {appContext, ...renderOptions}) => {
         ...appContext
     };
 
+    const commentApiWithDefaults = {
+        commentApi: {isAdmin: false},
+        admin: null,
+        adminComments: null,
+        isAdmin: false,
+        adminUrl: undefined,
+        initAdminAuth: async () => {},
+        setMember: () => {},
+        ...commentApiContext
+    };
+
     return render(
-        <AppContext.Provider value={contextWithDefaults}>{ui}</AppContext.Provider>,
+        <CommentApiContext.Provider value={commentApiWithDefaults}>
+            <AppContext.Provider value={contextWithDefaults}>{ui}</AppContext.Provider>
+        </CommentApiContext.Provider>,
         renderOptions
     );
 };

--- a/apps/comments-ui/test/unit/components/content/context-menus/comment-context-menu.test.jsx
+++ b/apps/comments-ui/test/unit/components/content/context-menus/comment-context-menu.test.jsx
@@ -2,10 +2,11 @@ import CommentContextMenu from '../../../../../src/components/content/context-me
 import React from 'react';
 import sinon from 'sinon';
 import {AppContext} from '../../../../../src/app-context';
+import {CommentApiContext} from '../../../../../src/components/comment-api-provider';
 import {buildComment} from '../../../../utils/fixtures';
 import {render, screen} from '@testing-library/react';
 
-const contextualRender = (ui, {appContext, ...renderOptions}) => {
+const contextualRender = (ui, {appContext, commentApiContext, ...renderOptions} = {}) => {
     const contextWithDefaults = {
         member: null,
         dispatchAction: () => {},
@@ -13,8 +14,21 @@ const contextualRender = (ui, {appContext, ...renderOptions}) => {
         ...appContext
     };
 
+    const commentApiWithDefaults = {
+        commentApi: {isAdmin: false},
+        admin: null,
+        adminComments: null,
+        isAdmin: false,
+        adminUrl: undefined,
+        initAdminAuth: async () => {},
+        setMember: () => {},
+        ...commentApiContext
+    };
+
     return render(
-        <AppContext.Provider value={contextWithDefaults}>{ui}</AppContext.Provider>,
+        <CommentApiContext.Provider value={commentApiWithDefaults}>
+            <AppContext.Provider value={contextWithDefaults}>{ui}</AppContext.Provider>
+        </CommentApiContext.Provider>,
         renderOptions
     );
 };
@@ -26,7 +40,7 @@ describe('<CommentContextMenu>', () => {
 
     it('has display-below classes when in viewport', () => {
         const comment = buildComment();
-        contextualRender(<CommentContextMenu comment={comment} />, {appContext: {admin: true}});
+        contextualRender(<CommentContextMenu comment={comment} />, {commentApiContext: {isAdmin: true}});
         expect(screen.getByTestId('comment-context-menu-inner')).toHaveClass('top-0');
     });
 
@@ -34,7 +48,7 @@ describe('<CommentContextMenu>', () => {
         sinon.stub(HTMLElement.prototype, 'getBoundingClientRect').returns({bottom: 2000});
 
         const comment = buildComment();
-        contextualRender(<CommentContextMenu comment={comment} />, {appContext: {admin: true}});
+        contextualRender(<CommentContextMenu comment={comment} />, {commentApiContext: {isAdmin: true}});
         expect(screen.getByTestId('comment-context-menu-inner')).toHaveClass('bottom-full', 'mb-6');
     });
 });


### PR DESCRIPTION
This PR moves `isAdmin` and `adminUrl` from `useAppContext()` to `useCommentApi()`, keeping derived API state collocated with the provider that manages the API lifecycle.

Components like `CommentComponent`, `CommentContextMenu`, and `AdminContextMenu` now read these values from `useCommentApi()` instead of `useAppContext()`. This is a small cleanup that reduces the surface area of `AppContext` and makes the data flow clearer—admin-related state lives with the admin API provider.

Note: `isAdmin` intentionally remains in `EditableAppContext` as well, with a sync `useEffect` that updates it when the provider's `admin` state changes. This is necessary because React's batching behavior requires a state update to trigger the re-render cycle needed for `adminComments` synchronization. The dual storage is a workaround for this timing issue, but consumers should read from `useCommentApi()` for consistency.