### PR TITLE
Added React Query for comment/reply submission

### DIFF
--- a/apps/comments-ui/package.json
+++ b/apps/comments-ui/package.json
@@ -44,6 +44,7 @@
   },
   "dependencies": {
     "@headlessui/react": "1.7.19",
+    "@tanstack/react-query": "^4",
     "@tiptap/core": "2.26.3",
     "@tiptap/extension-blockquote": "2.26.3",
     "@tiptap/extension-document": "2.26.3",

--- a/apps/comments-ui/src/app-context.ts
+++ b/apps/comments-ui/src/app-context.ts
@@ -2,6 +2,7 @@
 import React, {useContext} from 'react';
 import {ActionType, Actions, SyncActionType, SyncActions} from './actions';
 import {AdminApi} from './utils/admin-api';
+import {GhostApi} from './utils/api';
 import {Page} from './pages';
 
 export type Member = {
@@ -71,13 +72,6 @@ export type EditableAppContext = {
     initStatus: string,
     member: null | any,
     admin: null | any,
-    comments: Comment[],
-    pagination: {
-        page: number,
-        limit: number,
-        pages: number,
-        total: number
-    } | null,
     commentCount: number,
     openCommentForms: OpenCommentForm[],
     popup: Page | null,
@@ -102,7 +96,8 @@ export type AppContextType = EditableAppContext & CommentsOptions & {
     // This part makes sure we can add automatic data and return types to the actions when using context.dispatchAction('actionName', data)
     t: TranslationFunction,
     dispatchAction: <T extends ActionType | SyncActionType>(action: T, data: Parameters<(typeof Actions & typeof SyncActions)[T]>[0] extends { data: any } ? Parameters<(typeof Actions & typeof SyncActions)[T]>[0]['data'] : any) => T extends ActionType ? Promise<void> : void,
-    openFormCount: number
+    openFormCount: number,
+    api: GhostApi
 }
 
 // Copy time from AppContextType

--- a/apps/comments-ui/src/components/content/comment.tsx
+++ b/apps/comments-ui/src/components/content/comment.tsx
@@ -10,6 +10,7 @@ import {Avatar, BlankAvatar} from './avatar';
 import {Comment, OpenCommentForm, useAppContext, useLabs} from '../../app-context';
 import {Transition} from '@headlessui/react';
 import {buildCommentPermalink, findCommentById, formatExplicitTime, getCommentInReplyToSnippet, getMemberNameFromComment} from '../../utils/helpers';
+import {useComments} from '../../utils/query';
 import {useRelativeTime} from '../../utils/hooks';
 
 type AnimatedCommentProps = {
@@ -269,7 +270,9 @@ const AuthorName: React.FC<{comment: Comment}> = ({comment}) => {
 };
 
 export const RepliedToSnippet: React.FC<{comment: Comment}> = ({comment}) => {
-    const {comments, dispatchAction, t, pageUrl} = useAppContext();
+    const {dispatchAction, t, pageUrl} = useAppContext();
+    const commentsQuery = useComments();
+    const comments = commentsQuery.data?.comments ?? [];
     const labs = useLabs();
     const inReplyToComment = findCommentById(comments, comment.in_reply_to_id);
 

--- a/apps/comments-ui/src/components/content/content.tsx
+++ b/apps/comments-ui/src/components/content/content.tsx
@@ -9,6 +9,7 @@ import {SortingForm} from './forms/sorting-form';
 import {parseCommentIdFromHash} from '../../utils/helpers';
 import {useAppContext, useLabs} from '../../app-context';
 import {useCallback, useEffect, useRef} from 'react';
+import {useComments} from '../../utils/query';
 
 /**
  * Find the iframe element that contains the current window, if any.
@@ -73,8 +74,15 @@ function onIframeResize(
 
 const Content = () => {
     const labs = useLabs();
-    const {pagination, comments, commentCount, title, showCount, commentsIsLoading, t, dispatchAction, commentIdToScrollTo, isMember, isPaidOnly, hasRequiredTier, isCommentingDisabled} = useAppContext();
+    const {commentCount, title, showCount, t, dispatchAction, commentIdToScrollTo, isMember, isPaidOnly, hasRequiredTier, isCommentingDisabled, initStatus, commentsIsLoading: contextLoading} = useAppContext();
     const containerRef = useRef<HTMLDivElement>(null);
+
+    // Fetch comments via React Query - enabled only after init completes
+    const commentsQuery = useComments();
+    const comments = commentsQuery.data?.comments ?? [];
+    const pagination = commentsQuery.data?.pagination ?? null;
+    // Show loading: initial fetch, during refetch, or when action sets loading state (e.g., sorting)
+    const commentsIsLoading = commentsQuery.isLoading || commentsQuery.isFetching || contextLoading || initStatus !== 'success';
 
     const scrollToComment = useCallback((element: HTMLElement, commentId: string) => {
         element.scrollIntoView({behavior: 'smooth', block: 'center'});

--- a/apps/comments-ui/src/components/content/forms/main-form.tsx
+++ b/apps/comments-ui/src/components/content/forms/main-form.tsx
@@ -1,6 +1,7 @@
 import React, {useCallback, useEffect, useMemo, useRef} from 'react';
 import {Form, FormWrapper} from './form';
 import {scrollToElement} from '../../../utils/helpers';
+import {useAddComment} from '../../../utils/query';
 import {useAppContext} from '../../../app-context';
 import {useEditor} from '../../../utils/hooks';
 
@@ -9,7 +10,8 @@ type Props = {
 };
 
 const MainForm: React.FC<Props> = ({commentsCount}) => {
-    const {postId, dispatchAction, t} = useAppContext();
+    const {postId, t} = useAppContext();
+    const addCommentMutation = useAddComment();
 
     const editorConfig = useMemo(() => ({
         placeholder: (commentsCount === 0 ? t('Start the conversation') : t('Join the discussion')),
@@ -19,15 +21,16 @@ const MainForm: React.FC<Props> = ({commentsCount}) => {
     const {editor, hasContent} = useEditor(editorConfig);
 
     const submit = useCallback(async ({html}) => {
-        // Send comment to server
-        await dispatchAction('addComment', {
+        // Send comment using React Query mutation
+        // Mutation handles invalidation, useComments subscribers auto-refetch
+        await addCommentMutation.mutateAsync({
             post_id: postId,
             status: 'published',
             html
         });
 
         editor?.commands.clearContent();
-    }, [postId, dispatchAction, editor]);
+    }, [postId, addCommentMutation, editor]);
 
     // C keyboard shortcut to focus main form
     const formEl = useRef(null);

--- a/apps/comments-ui/src/components/content/pagination.tsx
+++ b/apps/comments-ui/src/components/content/pagination.tsx
@@ -1,8 +1,11 @@
 import {formatNumber} from '../../utils/helpers';
 import {useAppContext} from '../../app-context';
+import {useComments} from '../../utils/query';
 
 const Pagination = () => {
-    const {pagination, dispatchAction, t} = useAppContext();
+    const {dispatchAction, t} = useAppContext();
+    const commentsQuery = useComments();
+    const pagination = commentsQuery.data?.pagination;
 
     const loadMore = () => {
         dispatchAction('loadMoreComments', {});

--- a/apps/comments-ui/src/utils/query.ts
+++ b/apps/comments-ui/src/utils/query.ts
@@ -1,0 +1,147 @@
+import {QueryClient, queryOptions, useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
+import {Comment, useAppContext} from '../app-context';
+import {GhostApi} from './api';
+
+// Query client with sensible defaults
+export const queryClient = new QueryClient({
+    defaultOptions: {
+        queries: {
+            // Comments are relatively stable - 30 second stale time
+            // reduces refetches while keeping data reasonably fresh
+            staleTime: 30 * 1000,
+            // Retry once on failure
+            retry: 1
+        }
+    }
+});
+
+// Query key factory - hierarchical structure for selective invalidation
+export const commentKeys = {
+    all: ['comments'] as const,
+    lists: () => [...commentKeys.all, 'list'] as const,
+    list: (postId: string, order: string) => [...commentKeys.lists(), postId, order] as const,
+    replies: () => [...commentKeys.all, 'replies'] as const,
+    reply: (commentId: string) => [...commentKeys.replies(), commentId] as const
+};
+
+// Query options factory for comments list
+export function commentsQuery(api: GhostApi, postId: string, order: string, page = 1) {
+    return queryOptions({
+        queryKey: commentKeys.list(postId, order),
+        queryFn: async () => {
+            const data = await api.comments.browse({page, postId, order});
+            return {
+                comments: data.comments as Comment[],
+                pagination: data.meta.pagination
+            };
+        }
+    });
+}
+
+// Query options factory for replies
+export function repliesQuery(api: GhostApi, commentId: string) {
+    return queryOptions({
+        queryKey: commentKeys.reply(commentId),
+        queryFn: async () => {
+            const data = await api.comments.replies({commentId, limit: 10000});
+            return data.comments as Comment[];
+        }
+    });
+}
+
+/**
+ * Hook to fetch comments for a post.
+ * Components consume this instead of context state.
+ * Only fetches after initialization is complete.
+ */
+export function useComments() {
+    const {api, postId, order, initStatus} = useAppContext();
+    return useQuery({
+        ...commentsQuery(api, postId, order),
+        // Only fetch after app initialization completes (member auth, etc.)
+        enabled: initStatus === 'success'
+    });
+}
+
+/**
+ * Hook to fetch all replies for a specific comment.
+ * Use when you need fresh reply data (e.g., after posting).
+ */
+export function useReplies(commentId: string, enabled = true) {
+    const {api} = useAppContext();
+    return useQuery({
+        ...repliesQuery(api, commentId),
+        enabled
+    });
+}
+
+/**
+ * Hook to add a reply.
+ * Just POSTs, then invalidates - useQuery subscribers auto-refetch.
+ */
+export function useAddReply() {
+    const {api, postId, order, dispatchAction} = useAppContext();
+    const queryClientInstance = useQueryClient();
+
+    return useMutation({
+        mutationFn: async ({reply, parentId}: {
+            reply: {post_id: string; in_reply_to_id?: string; status: string; html: string};
+            parentId: string;
+        }) => {
+            const data = await api.comments.add({
+                comment: {...reply, parent_id: parentId}
+            });
+            return data.comments[0] as Comment;
+        },
+        onSuccess: (newComment, {parentId}) => {
+            // Invalidate replies for this parent - any useReplies subscribers will refetch
+            queryClientInstance.invalidateQueries({queryKey: commentKeys.reply(parentId)});
+
+            // Also invalidate the comments list since it contains nested replies
+            queryClientInstance.invalidateQueries({queryKey: commentKeys.list(postId, order)});
+
+            // Update comment count in state
+            dispatchAction('incrementCommentCount', null);
+
+            // Scroll to the new comment
+            dispatchAction('setScrollTarget', newComment.id);
+        }
+    });
+}
+
+/**
+ * Hook to add a top-level comment.
+ * Just POSTs, then invalidates - useQuery subscribers auto-refetch.
+ */
+export function useAddComment() {
+    const {api, postId, order, dispatchAction} = useAppContext();
+    const queryClientInstance = useQueryClient();
+
+    return useMutation({
+        mutationFn: async (comment: {post_id: string; status: string; html: string}) => {
+            const data = await api.comments.add({comment});
+            return data.comments[0] as Comment;
+        },
+        onSuccess: (newComment) => {
+            // Invalidate comments list - any useComments subscribers will refetch
+            queryClientInstance.invalidateQueries({queryKey: commentKeys.list(postId, order)});
+
+            // Update comment count in state
+            dispatchAction('incrementCommentCount', null);
+
+            // Scroll to the new comment
+            dispatchAction('setScrollTarget', newComment.id);
+        }
+    });
+}
+
+/**
+ * Hook to get comment count.
+ */
+export function useCommentCount() {
+    const {api, postId} = useAppContext();
+    return useQuery({
+        queryKey: [...commentKeys.all, 'count', postId],
+        queryFn: () => api.comments.count({postId})
+    });
+}

--- a/apps/comments-ui/test/unit/components/content/content.test.jsx
+++ b/apps/comments-ui/test/unit/components/content/content.test.jsx
@@ -1,6 +1,13 @@
 import Content from '../../../../src/components/content/content';
 import {AppContext} from '../../../../src/app-context';
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
 import {render, screen} from '@testing-library/react';
+
+const testQueryClient = new QueryClient({
+    defaultOptions: {
+        queries: {staleTime: Infinity}
+    }
+});
 
 const contextualRender = (ui, {appContext, ...renderOptions}) => {
     const member = appContext?.member ?? null;
@@ -23,11 +30,14 @@ const contextualRender = (ui, {appContext, ...renderOptions}) => {
         hasRequiredTier,
         isCommentingDisabled,
         t: str => str,
+        api: {comments: {}},
         ...appContext
     };
 
     return render(
-        <AppContext.Provider value={contextWithDefaults}>{ui}</AppContext.Provider>,
+        <QueryClientProvider client={testQueryClient}>
+            <AppContext.Provider value={contextWithDefaults}>{ui}</AppContext.Provider>
+        </QueryClientProvider>,
         renderOptions
     );
 };

--- a/apps/comments-ui/test/unit/components/content/pagination.test.jsx
+++ b/apps/comments-ui/test/unit/components/content/pagination.test.jsx
@@ -1,30 +1,51 @@
 import Pagination from '../../../../src/components/content/pagination';
 import i18nLib from '@tryghost/i18n';
 import {AppContext} from '../../../../src/app-context';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {commentKeys, queryClient} from '../../../../src/utils/query';
 import {render, screen} from '@testing-library/react';
 
 const i18n = i18nLib('en', 'comments');
 
-const contextualRender = (ui, {appContext, ...renderOptions}) => {
+const contextualRender = (ui, {appContext, pagination, ...renderOptions}) => {
+    const postId = 'test-post';
+    const order = 'desc';
+
+    // Pre-populate React Query cache with pagination data
+    queryClient.setQueryData(commentKeys.list(postId, order), {
+        comments: [],
+        pagination
+    });
+
     const contextWithDefaults = {
+        postId,
+        order,
+        initStatus: 'success',
+        api: {},
         ...appContext,
         t: i18n.t
     };
 
     return render(
-        <AppContext.Provider value={contextWithDefaults}>{ui}</AppContext.Provider>,
+        <QueryClientProvider client={queryClient}>
+            <AppContext.Provider value={contextWithDefaults}>{ui}</AppContext.Provider>
+        </QueryClientProvider>,
         renderOptions
     );
 };
 
 describe('<Pagination>', function () {
+    beforeEach(() => {
+        queryClient.clear();
+    });
+
     it('has correct text for 1 more', function () {
-        contextualRender(<Pagination />, {appContext: {pagination: {total: 4, page: 1, limit: 3}}});
+        contextualRender(<Pagination />, {pagination: {total: 4, page: 1, limit: 3}});
         expect(screen.getByText('Load more (1)')).toBeInTheDocument();
     });
 
     it('has correct text for x more', function () {
-        contextualRender(<Pagination />, {appContext: {pagination: {total: 6, page: 1, limit: 3}}});
+        contextualRender(<Pagination />, {pagination: {total: 6, page: 1, limit: 3}});
         expect(screen.getByText('Load more (3)')).toBeInTheDocument();
     });
 });

--- a/apps/comments-ui/test/utils/mocked-api.ts
+++ b/apps/comments-ui/test/utils/mocked-api.ts
@@ -67,12 +67,13 @@ export class MockedApi {
             post_id: this.postId
         });
 
-        // If this is a reply, add it to the parent's replies array
+        // If this is a reply, add it to the parent's replies array (not to top-level comments)
         if (overrides.parent_id) {
             const parent = this.comments.find(c => c.id === overrides.parent_id);
             if (parent) {
                 parent.replies.push(fixture);
                 parent.count.replies = parent.replies.length;
+                return; // Don't add replies to top-level comments array
             }
         }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8425,6 +8425,11 @@
   resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-4.36.1.tgz#79f8c1a539d47c83104210be2388813a7af2e524"
   integrity sha512-DJSilV5+ytBP1FbFcEJovv4rnnm/CokuVvrBEtW/Va9DvuJ3HksbXUJEpI0aV1KtuL4ZoO9AVE6PyNLzF7tLeA==
 
+"@tanstack/query-core@4.43.0":
+  version "4.43.0"
+  resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-4.43.0.tgz#e72d9dbab4b1207efe740363b68375b4bdaff1c2"
+  integrity sha512-m1QeUUIpNXDYxmfuuWNFZLky0EwVmbE0hj8ulZ2nIGA1183raJgDCn0IKlxug80NotRqzodxAaoYTKHbE1/P/Q==
+
 "@tanstack/react-query@4.36.1":
   version "4.36.1"
   resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-4.36.1.tgz#acb589fab4085060e2e78013164868c9c785e5d2"
@@ -8432,6 +8437,14 @@
   dependencies:
     "@tanstack/query-core" "4.36.1"
     use-sync-external-store "^1.2.0"
+
+"@tanstack/react-query@^4":
+  version "4.43.0"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-4.43.0.tgz#f993211864c2070ba7f764971901bd3e60c886d1"
+  integrity sha512-Lj8luFKHQL27oZbw5T8xdTbsfAPp2+bCtSCa2bAVvIwnvNfRP0hpB1GxfKFgCktat8lPcYBHAu8eMTXzz2sQtQ==
+  dependencies:
+    "@tanstack/query-core" "4.43.0"
+    use-sync-external-store "^1.6.0"
 
 "@tanstack/react-virtual@3.13.12", "@tanstack/react-virtual@^3.0.0-beta.60":
   version "3.13.12"
@@ -8853,7 +8866,7 @@
   resolved "https://registry.yarnpkg.com/@tryghost/domain-events/-/domain-events-1.0.2.tgz#0d4b134a997802946f3615385a09b82c4904d8c7"
   integrity sha512-y2sam/cOhCDViWLzLFmGn7ZIwNpz7dTOK1zygxwVrojhwrORWPtbA9MSoVrT6zUF9IplOx53/MAgnE1CYXSfng==
 
-"@tryghost/elasticsearch@^3.0.24":
+"@tryghost/elasticsearch@^3.0.22", "@tryghost/elasticsearch@^3.0.24":
   version "3.0.24"
   resolved "https://registry.yarnpkg.com/@tryghost/elasticsearch/-/elasticsearch-3.0.24.tgz#291d51d6a6cc607fa860612dfc37098c4ebdedc4"
   integrity sha512-/ocoCYS74+Dc1qH9yJCgqHtOyxQMvwmY71MPAqhfLHAfa4vpsd8VJNa2EsO/rkLRsw+cmf8p/8ZILUXXnBOheg==
@@ -8883,7 +8896,15 @@
     focus-trap "^6.7.2"
     postcss-preset-env "^7.3.1"
 
-"@tryghost/errors@1.3.6", "@tryghost/errors@1.3.8", "@tryghost/errors@^1.2.26", "@tryghost/errors@^1.2.3", "@tryghost/errors@^1.3.7", "@tryghost/errors@^1.3.8":
+"@tryghost/errors@1.3.6":
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/@tryghost/errors/-/errors-1.3.6.tgz#b34993d03122a59f29bf7050a3c0bc90a23a7254"
+  integrity sha512-qxl6wF5tlhr646Earjmfcz3km6d+B0tzUmocyVu3tY8StI4pH8mLgzHDtkiTAls9ABPichBxZQe6a8PDcVJbFw==
+  dependencies:
+    "@stdlib/utils-copy" "^0.2.0"
+    uuid "^9.0.0"
+
+"@tryghost/errors@1.3.8", "@tryghost/errors@^1.2.26", "@tryghost/errors@^1.2.3", "@tryghost/errors@^1.3.8":
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/@tryghost/errors/-/errors-1.3.8.tgz#d4212b52e876360b4fa8e303ae13ef86f3e95846"
   integrity sha512-2+4ExAAWM0rFWC7FlzxQMzIvIEQKt/vQLxLyqJqCmAcJa4i2uqUPJHqd/X5BBRuSTuftgca7EAo7adESbHEkZw==
@@ -8931,7 +8952,7 @@
   resolved "https://registry.yarnpkg.com/@tryghost/http-cache-utils/-/http-cache-utils-0.1.20.tgz#5a513593a2d5d944389a88eb56a8614cd0599350"
   integrity sha512-8+GbDQ/xo97orv5UUYv2x92e3RovVurYoFcBY+e0IJlExgSxP7oOqskqgFfZVs5Hhwi+SpZs6gFw2cv1OlUY9g==
 
-"@tryghost/http-stream@^0.1.37":
+"@tryghost/http-stream@^0.1.34", "@tryghost/http-stream@^0.1.37":
   version "0.1.37"
   resolved "https://registry.yarnpkg.com/@tryghost/http-stream/-/http-stream-0.1.37.tgz#319f0c8691b75fc5949a1a9c866bd410f6c52f05"
   integrity sha512-QY9UhDrjHEdrlnnQaJ49kshdAU2pDCBHg6+QzyRVOIqvq+UHpydhhkxy3QDN1b+EII2DjpDMlOK1SSL9q6fXew==
@@ -9148,7 +9169,41 @@
     lodash "^4.17.21"
     luxon "^1.26.0"
 
-"@tryghost/logging@2.4.19", "@tryghost/logging@2.4.23", "@tryghost/logging@2.5.0", "@tryghost/logging@^2.4.23", "@tryghost/logging@^2.4.7":
+"@tryghost/logging@2.4.19":
+  version "2.4.19"
+  resolved "https://registry.yarnpkg.com/@tryghost/logging/-/logging-2.4.19.tgz#8aab372486268b6fc8e31615b6e79d59b299a44f"
+  integrity sha512-NCCElue4AqvfhLnJLjDDR1uXBXQwfDOuGZTSI9/relqj+cfxwezQuPGG66EkPEB29ZAdtnHLOqMJTF2k6/s/hw==
+  dependencies:
+    "@tryghost/bunyan-rotating-filestream" "^0.0.7"
+    "@tryghost/elasticsearch" "^3.0.22"
+    "@tryghost/http-stream" "^0.1.34"
+    "@tryghost/pretty-stream" "^0.1.27"
+    "@tryghost/root-utils" "^0.3.31"
+    bunyan "^1.8.15"
+    bunyan-loggly "^1.4.2"
+    fs-extra "^11.0.0"
+    gelf-stream "^1.1.1"
+    json-stringify-safe "^5.0.1"
+    lodash "^4.17.21"
+
+"@tryghost/logging@2.4.23":
+  version "2.4.23"
+  resolved "https://registry.yarnpkg.com/@tryghost/logging/-/logging-2.4.23.tgz#a2351b55c0d413e3f06ee41cbcfe7bbdff785972"
+  integrity sha512-xmindrXwW0zKvuxdTNkyK3TM1exPvgkqqSRXOdf8G1SDZpuvemWGlrllAFQuj2J/K4dy9CWcYl9GpM1wYaG1CQ==
+  dependencies:
+    "@tryghost/bunyan-rotating-filestream" "^0.0.7"
+    "@tryghost/elasticsearch" "^3.0.24"
+    "@tryghost/http-stream" "^0.1.37"
+    "@tryghost/pretty-stream" "^0.2.0"
+    "@tryghost/root-utils" "^0.3.33"
+    bunyan "^1.8.15"
+    bunyan-loggly "^1.4.2"
+    fs-extra "^11.0.0"
+    gelf-stream "^1.1.1"
+    json-stringify-safe "^5.0.1"
+    lodash "^4.17.21"
+
+"@tryghost/logging@2.5.0", "@tryghost/logging@^2.4.23", "@tryghost/logging@^2.4.7":
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/@tryghost/logging/-/logging-2.5.0.tgz#239fc3518cba48ff18794dfa24be44c5d2ba7a45"
   integrity sha512-fLPWNbghbdsUIH/7+CPmhT8l1MhZPI6za1Zm65rcwjGpaX+1Cr1ehcj22rMm91sl4A8AVe8vpYofRKM3UL8GIQ==
@@ -9272,6 +9327,15 @@
     chalk "^4.1.0"
     sywac "^1.3.0"
 
+"@tryghost/pretty-stream@^0.1.27":
+  version "0.1.29"
+  resolved "https://registry.yarnpkg.com/@tryghost/pretty-stream/-/pretty-stream-0.1.29.tgz#e0bbab7333a6cac38fdfa19d3da86aeaaded7f02"
+  integrity sha512-HByPoCd5R63bRg34wZ4D7bfCeBsLTP3gLCi5xVsOnETxB4GiHHo31/vm+kI8pZd7mnWMre3nnDdVR0Sf72U0eQ==
+  dependencies:
+    date-format "^4.0.14"
+    lodash "^4.17.21"
+    prettyjson "^1.2.5"
+
 "@tryghost/pretty-stream@^0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@tryghost/pretty-stream/-/pretty-stream-0.2.0.tgz#622e6c37a6a8f3f724e10e2980f51ec8efae96bc"
@@ -9318,7 +9382,7 @@
     got "13.0.0"
     lodash "^4.17.21"
 
-"@tryghost/root-utils@0.3.33", "@tryghost/root-utils@^0.3.24", "@tryghost/root-utils@^0.3.33":
+"@tryghost/root-utils@0.3.33", "@tryghost/root-utils@^0.3.24", "@tryghost/root-utils@^0.3.31", "@tryghost/root-utils@^0.3.33":
   version "0.3.33"
   resolved "https://registry.yarnpkg.com/@tryghost/root-utils/-/root-utils-0.3.33.tgz#208e3d15520131c2d4157c7e62fe74771a7a110f"
   integrity sha512-Gmc/TrKtiRT7PV9JOPoSZ7jAOl/jJDWJFKNaLZbDQaiJIBP5C6PucqEfRqGb2Ko/S9j73HzEEBu6B7+qZMvbBg==
@@ -22633,10 +22697,10 @@ iterator.prototype@^1.1.4:
     has-symbols "^1.1.0"
     set-function-name "^2.0.2"
 
-jackspeak@2.3.6, jackspeak@^3.1.2:
-  version "2.3.6"
-  resolved "https://registry.yarnpkg.com/jackspeak/-/jackspeak-2.3.6.tgz#647ecc472238aee4b06ac0e461acc21a8c505ca8"
-  integrity sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==
+jackspeak@^3.1.2:
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/jackspeak/-/jackspeak-3.4.3.tgz#8833a9d89ab4acde6188942bd1c53b6390ed5a8a"
+  integrity sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==
   dependencies:
     "@isaacs/cliui" "^8.0.2"
   optionalDependencies:
@@ -25686,17 +25750,34 @@ module-details-from-path@^1.0.3:
   resolved "https://registry.yarnpkg.com/module-details-from-path/-/module-details-from-path-1.0.4.tgz#b662fdcd93f6c83d3f25289da0ce81c8d9685b94"
   integrity sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==
 
-moment-timezone@0.5.45, moment-timezone@^0.5.23, moment-timezone@^0.5.31, moment-timezone@^0.5.33, moment-timezone@^0.5.48:
+moment-timezone@0.5.45, moment-timezone@^0.5.23, moment-timezone@^0.5.31, moment-timezone@^0.5.33:
   version "0.5.45"
   resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.45.tgz#cb685acd56bac10e69d93c536366eb65aa6bcf5c"
   integrity sha512-HIWmqA86KcmCAhnMAN0wuDOARV/525R2+lOLotuGFzn4HO+FH+/645z2wx0Dt3iDv6/p61SIvKnDstISainhLQ==
   dependencies:
     moment "^2.29.4"
 
-moment@2.24.0, moment@2.27.0, moment@2.30.1, moment@^2.10.2, moment@^2.18.1, moment@^2.19.3, moment@^2.27.0, moment@^2.29.4:
+moment-timezone@^0.5.48:
+  version "0.5.48"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.48.tgz#111727bb274734a518ae154b5ca589283f058967"
+  integrity sha512-f22b8LV1gbTO2ms2j2z13MuPogNoh5UzxL3nzNAYKGraILnbGc9NEE6dyiiiLv46DGRb8A4kg8UKWLjPthxBHw==
+  dependencies:
+    moment "^2.29.4"
+
+moment@2.24.0, moment@^2.10.2, moment@^2.18.1, moment@^2.19.3:
   version "2.24.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
   integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
+
+moment@2.27.0:
+  version "2.27.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.27.0.tgz#8bff4e3e26a236220dfe3e36de756b6ebaa0105d"
+  integrity sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ==
+
+moment@2.30.1, moment@^2.27.0, moment@^2.29.4:
+  version "2.30.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.30.1.tgz#f8c91c07b7a786e30c59926df530b4eac96974ae"
+  integrity sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==
 
 moo@^0.5.0, moo@^0.5.1:
   version "0.5.2"
@@ -26411,7 +26492,7 @@ numbered@^1.1.0:
   resolved "https://registry.yarnpkg.com/numbered/-/numbered-1.1.0.tgz#9fcd79564c73a84b9574e8370c3d8e58fe3c133c"
   integrity sha512-pv/ue2Odr7IfYOO0byC1KgBI10wo5YDauLhxY6/saNzAdAs0r1SotGCPzzCLNPL0xtrAwWRialLu23AAu9xO1g==
 
-nwsapi@2.2.12, nwsapi@^2.2.0, nwsapi@^2.2.10, nwsapi@^2.2.12:
+nwsapi@^2.2.0, nwsapi@^2.2.10, nwsapi@^2.2.12:
   version "2.2.12"
   resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.12.tgz#fb6af5c0ec35b27b4581eb3bbad34ec9e5c696f8"
   integrity sha512-qXDmcVlZV4XRtKFzddidpfVP4oMSGhga+xdMc25mv8kaLUHtgzCDhUxkrN8exkGdTlLNaXj7CV3GtON7zuGZ+w==
@@ -33482,6 +33563,11 @@ use-sync-external-store@^1, use-sync-external-store@^1.2.0, use-sync-external-st
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz#55122e2a3edd2a6c106174c27485e0fd59bcfca0"
   integrity sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==
+
+use-sync-external-store@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz#b174bfa65cb2b526732d9f2ac0a408027876f32d"
+  integrity sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
This branch reimplements the comment/reply submission using React Query instead of manual fetch calls. The base branch already refactored submission to refetch from the server after posting, which ensures concurrent replies from other users become visible. This branch takes the same approach but uses React Query's mutation primitives.

Components now call `useAddReply()` and `useAddComment()` hooks directly rather than dispatching actions. The mutations handle the API call and refetch, then invoke sync actions to update app state. This adds `@tanstack/react-query` as a dependency (~15KB gzipped) and introduces a new `utils/query.ts` file with the mutation hooks.

Both branches pass the same tests and achieve identical behavior. This PR exists to compare the two approaches and decide whether React Query's declarative pattern justifies the added dependency and complexity for this use case.