### PR TITLE
Fixed template token formatting in welcome emails

### DIFF
--- a/ghost/core/core/server/services/member-welcome-emails/member-welcome-email-renderer.js
+++ b/ghost/core/core/server/services/member-welcome-emails/member-welcome-email-renderer.js
@@ -53,14 +53,12 @@ class MemberWelcomeEmailRenderer {
      * Applies replacement tokens to a string
      * Supports fallback values: {first_name, "friend"} renders "friend" if name is empty
      * @param {Object} options
+     * @param {{id: string, getValue: () => string|undefined}[]} options.definitions - Replacement token definitions
      * @param {string} options.text - The text to process (content body or subject line)
-     * @param {Object} options.member - Member data
-     * @param {Object} options.siteSettings - Site settings
      * @param {boolean} [options.escapeHtml=false] - Whether to HTML-escape replaced values
      * @returns {string}
      */
-    #applyReplacements({text, member, siteSettings, escapeHtml = false}) {
-        const definitions = this.#buildReplacementDefinitions({member, siteSettings});
+    #applyReplacements({definitions, text, escapeHtml = false}) {
         let processed = wrapReplacementStrings(text);
 
         processed = processed.replace(REPLACEMENT_REGEX, (match, property, fallback) => {
@@ -96,8 +94,17 @@ class MemberWelcomeEmailRenderer {
             });
         }
 
-        const contentWithReplacements = this.#applyReplacements({text: content, member, siteSettings, escapeHtml: true});
-        const subjectWithReplacements = this.#applyReplacements({text: subject, member, siteSettings, escapeHtml: false});
+        const definitions = this.#buildReplacementDefinitions({member, siteSettings});
+
+        // Remove <code> wrappers around replacement strings (Lexical treats curly braces as inline code)
+        const tokenIds = definitions.map(d => d.id).join('|');
+        content = content.replace(
+            new RegExp(`<code>(\\{(?:${tokenIds})(?:,\\s*"[^"]*")?\\})<\\/code>`, 'g'),
+            '$1'
+        );
+
+        const contentWithReplacements = this.#applyReplacements({definitions, text: content, escapeHtml: true});
+        const subjectWithReplacements = this.#applyReplacements({definitions, text: subject, escapeHtml: false});
 
         const managePreferencesUrl = new URL('#/portal/account/newsletters', siteSettings.url).href;
         const year = new Date().getFullYear();

--- a/ghost/core/core/server/services/member-welcome-emails/member-welcome-email-renderer.js
+++ b/ghost/core/core/server/services/member-welcome-emails/member-welcome-email-renderer.js
@@ -99,7 +99,7 @@ class MemberWelcomeEmailRenderer {
         // Remove <code> wrappers around replacement strings (Lexical treats curly braces as inline code)
         const tokenIds = definitions.map(d => d.id).join('|');
         content = content.replace(
-            new RegExp(`<code>(\\{(?:${tokenIds})(?:,\\s*"[^"]*")?\\})<\\/code>`, 'g'),
+            new RegExp(`<code>(\\{(?:${tokenIds})(?:\\s*,?\\s*"[^"]*")?\\})<\\/code>`, 'g'),
             '$1'
         );
 
@@ -131,4 +131,3 @@ class MemberWelcomeEmailRenderer {
 }
 
 module.exports = MemberWelcomeEmailRenderer;
-

--- a/ghost/core/test/unit/server/services/member-welcome-emails/member-welcome-email-renderer.test.js
+++ b/ghost/core/test/unit/server/services/member-welcome-emails/member-welcome-email-renderer.test.js
@@ -354,5 +354,20 @@ describe('MemberWelcomeEmailRenderer', function () {
             assert(!result.html.includes('<code>{first_name, "friend"}</code>'));
             assert(result.html.includes('Hey friend'));
         });
+
+        it('removes code wrappers around replacement strings with fallback (no comma)', async function () {
+            lexicalRenderStub.resolves('<p>Hey <code>{first_name "friend"}</code></p>');
+            const renderer = new MemberWelcomeEmailRenderer();
+
+            const result = await renderer.render({
+                lexical: '{}',
+                subject: 'Welcome!',
+                member: {email: 'john@example.com'},
+                siteSettings: defaultSiteSettings
+            });
+
+            assert(!result.html.includes('<code>{first_name "friend"}</code>'));
+            assert(result.html.includes('Hey friend'));
+        });
     });
 });


### PR DESCRIPTION
Closes [NY-995: Fix Mono Font Styling on Welcome Email Template Variables](https://linear.app/ghost/issue/NY-995/fix-mono-font-styling-on-welcome-email-template-variables)

- Replacement strings like `{name}` or `{email}` were showing up with code formatting when the email was sent
- This PR removes the `<code>` html that gets wrapped around those before rendering, while making sure that we still properly format real code blocks


Before:
<img width="300" height="374" alt="Screenshot 2026-02-03 at 3 21 45 PM" src="https://github.com/user-attachments/assets/ce4dc53a-070e-4804-8eec-b96de5e5bb9f" />


After:
<img width="300" height="378" alt="Screenshot 2026-02-03 at 3 20 01 PM" src="https://github.com/user-attachments/assets/a985302c-54c0-4a87-963b-a78aeff99b8d" />

With all the variables plus some code that _should_ still be styled:
<img width="476" height="417" alt="Screenshot 2026-02-10 at 4 52 53 PM" src="https://github.com/user-attachments/assets/cbc7b3f3-1fbd-466d-bcb9-55e20564cef4" />

