### PR TITLE
Add number formatting with thousands separators across apps

### DIFF
--- a/apps/activitypub/src/components/feed/feed-item-stats.tsx
+++ b/apps/activitypub/src/components/feed/feed-item-stats.tsx
@@ -106,6 +106,7 @@ const FeedItemStats: React.FC<FeedItemStatsProps> = ({
                     {layout !== 'inbox' && (
                         <AnimatedNumber
                             className={likeCount === 0 ? '-ml-1.5 w-0 overflow-hidden' : ''}
+                            format={{useGrouping: true}}
                             spinTiming={{duration: 300}}
                             value={likeCount}
                         />
@@ -153,6 +154,7 @@ const FeedItemStats: React.FC<FeedItemStatsProps> = ({
                     {layout !== 'inbox' && (
                         <AnimatedNumber
                             className={repostCount === 0 ? '-ml-1.5 w-0 overflow-hidden' : ''}
+                            format={{useGrouping: true}}
                             spinTiming={{duration: 300}}
                             value={repostCount}
                         />

--- a/apps/activitypub/src/components/global/show-replies-button.tsx
+++ b/apps/activitypub/src/components/global/show-replies-button.tsx
@@ -14,7 +14,7 @@ const ShowRepliesButton: React.FC<ShowRepliesButtonProps> = ({count, onClick, va
 
     const getButtonText = () => {
         if (count && count > 0) {
-            return `Show ${count} more ${count === 1 ? 'reply' : 'replies'}`;
+            return `Show ${count.toLocaleString()} more ${count === 1 ? 'reply' : 'replies'}`;
         }
 
         switch (variant) {

--- a/apps/admin-x-design-system/src/global/pagination.tsx
+++ b/apps/admin-x-design-system/src/global/pagination.tsx
@@ -4,6 +4,8 @@ import Icon from './icon';
 
 export type PaginationProps = PaginationData
 
+const formatNumber = (num: number): string => num.toLocaleString();
+
 const Pagination: React.FC<PaginationProps> = ({page, limit, total, prevPage, nextPage}) => {
     // Detect loading state
     const startIndex = (page - 1) * limit + 1;
@@ -15,7 +17,7 @@ const Pagination: React.FC<PaginationProps> = ({page, limit, total, prevPage, ne
     /* If there is less than X items total, where X is the number of items per page that we want to show */
     if (total && limit < total) {
         return (
-            <div className={`mt-1 flex items-center gap-2 text-xs text-grey-700`}>Showing {startIndex}-{endIndex} of {total}
+            <div className={`mt-1 flex items-center gap-2 text-xs text-grey-700`}>Showing {formatNumber(startIndex)}-{formatNumber(endIndex)} of {formatNumber(total)}
                 <button type='button' onClick={prevPage}><Icon className={`size-[10px] [&>path]:stroke-[3px] ${!hasPrev ? 'cursor-default opacity-50' : 'hover:text-green-700 cursor-pointer'}`} colorClass="text-green" name='chevron-left' />
                 </button>
                 <button type="button" onClick={nextPage}><Icon className={`size-[10px] [&>path]:stroke-[3px] ${!hasNext ? 'cursor-default opacity-50' : 'hover:text-green-700 cursor-pointer'}`} colorClass="text-green" name='chevron-right' /></button>
@@ -25,7 +27,7 @@ const Pagination: React.FC<PaginationProps> = ({page, limit, total, prevPage, ne
     /* If there is more than X items total, where X is the number of items per page that we want to show */
     } else {
         return (
-            <div className={`mt-1 flex items-center gap-2 text-xs text-grey-700`}>Showing {total ?? '?'} in total
+            <div className={`mt-1 flex items-center gap-2 text-xs text-grey-700`}>Showing {total !== undefined ? formatNumber(total) : '?'} in total
             </div>
         );
     }

--- a/apps/admin-x-settings/src/components/settings/advanced/history-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/history-modal.tsx
@@ -237,7 +237,7 @@ const HistoryModal = NiceModal.create<RoutingModalProps>(({params}) => {
                                         <div className='text-sm'>
                                             {getActionTitle(action)}{isBulkAction(action) ? '' : ': '}
                                             {!isBulkAction(action) && <HistoryActionDescription action={action} />}
-                                            {action.count ? <> {action.count} times</> : null}
+                                            {action.count ? <> {action.count.toLocaleString()} times</> : null}
                                             <span> &mdash; by {action.actor?.name || action.actor?.slug}</span>
                                         </div>
                                     }

--- a/apps/comments-ui/src/components/content/buttons/like-count.tsx
+++ b/apps/comments-ui/src/components/content/buttons/like-count.tsx
@@ -1,4 +1,5 @@
 import {ReactComponent as LikeIcon} from '../../../images/icons/like.svg';
+import {formatNumber} from '../../../utils/helpers';
 
 type Props = {
     count: number;
@@ -18,7 +19,7 @@ const LikeCount: React.FC<Props> = ({count, liked}) => {
                     liked ? 'fill-black stroke-black dark:fill-white dark:stroke-white' : 'stroke-black/50 dark:stroke-white/60'
                 }`}
             />
-            {count}
+            {formatNumber(count)}
         </span>
     );
 };

--- a/ghost/admin/app/components/gh-members-filter-count.hbs
+++ b/ghost/admin/app/components/gh-members-filter-count.hbs
@@ -1,1 +1,1 @@
-{{this.memberCount}}
+{{format-number this.memberCount}}

--- a/ghost/admin/app/components/modal-import-members.hbs
+++ b/ghost/admin/app/components/modal-import-members.hbs
@@ -89,7 +89,7 @@
                     <div class="gh-member-import-errorlist">
                         <ul>
                         {{#each this.importResponse.errorList as |error|}}
-                            <li>{{error.message}} ({{error.count}}) </li>
+                            <li>{{error.message}} ({{format-number error.count}}) </li>
                         {{/each}}
                         </ul>
                     </div>


### PR DESCRIPTION
## Why are you making it?

Numbers throughout the Ghost admin and comment UI should be formatted with thousands separators (e.g., "1,234" instead of "1234") for improved readability, especially when displaying large counts like member imports, engagement metrics, and pagination totals.

## What does it do?

This change adds consistent number formatting with thousands separators across multiple applications:

- **ActivityPub feed**: Formats like and repost counts in animated number components
- **Show replies button**: Formats reply count in button text
- **Admin pagination**: Formats page indices and total counts
- **History modal**: Formats action occurrence counts
- **Comments UI**: Formats like counts using a shared helper
- **Admin members**: Formats member count and import error counts in Handlebars templates

The implementation uses native `toLocaleString()` for JavaScript and a `format-number` helper for Handlebars templates, ensuring locale-appropriate formatting.

## Why is this something Ghost users or developers need?

Large numbers are difficult to parse at a glance. Adding thousands separators significantly improves the user experience when viewing statistics, pagination controls, and import results. This is a common UX best practice that makes the interface more professional and easier to use.

## Checklist

- [x] I've explained my change
- [x] Change follows existing code patterns and conventions

https://claude.ai/code/session_01V1QqK2JgvNe5oQHt8st99e