### PR TITLE
Fixed Ember theme response mutations leaking into React

### DIFF
--- a/apps/admin-x-framework/src/api/themes.ts
+++ b/apps/admin-x-framework/src/api/themes.ts
@@ -18,7 +18,7 @@ export type Theme = {
 }
 
 export type InstalledTheme = Theme & {
-    gscan_errors?: ThemeProblem<'error'>[];
+    errors?: ThemeProblem<'error'>[];
     warnings?: ThemeProblem<'warning'>[];
 }
 

--- a/apps/admin-x-settings/src/components/settings/site/theme-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/theme-modal.tsx
@@ -188,8 +188,8 @@ const ThemeToolbar: React.FC<ThemeToolbarProps> = ({
             </>;
         }
 
-        if (uploadedTheme?.gscan_errors?.length || uploadedTheme.warnings?.length) {
-            const hasErrors = uploadedTheme?.gscan_errors?.length;
+        if (uploadedTheme?.errors?.length || uploadedTheme.warnings?.length) {
+            const hasErrors = uploadedTheme?.errors?.length;
 
             title = `Upload successful with ${hasErrors ? 'errors' : 'warnings'}`;
             prompt = <>
@@ -482,8 +482,8 @@ const ChangeThemeModal: React.FC<ChangeThemeModalProps> = ({source, themeRef}) =
                     </>;
                 }
 
-                if (newlyInstalledTheme.gscan_errors?.length || newlyInstalledTheme.warnings?.length) {
-                    const hasErrors = newlyInstalledTheme.gscan_errors?.length;
+                if (newlyInstalledTheme.errors?.length || newlyInstalledTheme.warnings?.length) {
+                    const hasErrors = newlyInstalledTheme.errors?.length;
 
                     title = `Installed with ${hasErrors ? 'errors' : 'warnings'}`;
                     prompt = <>

--- a/apps/admin-x-settings/src/components/settings/site/theme/theme-installed-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/theme/theme-installed-modal.tsx
@@ -24,7 +24,7 @@ export const ThemeProblemView = ({problem}:{problem: ThemeProblem}) => {
                             <div dangerouslySetInnerHTML={{__html: problem.details}} className='mb-4' />
                             <Heading level={6}>Affected files:</Heading>
                             <ul className='mt-1'>
-                                {problem.failures.map(failure => <li><code>{failure.ref}</code>{failure.message ? `: ${failure.message}` : ''}</li>)}
+                                {problem.failures.map(failure => <li key={failure.ref}><code>{failure.ref}</code>{failure.message ? `: ${failure.message}` : ''}</li>)}
                             </ul>
                         </div> :
                         null
@@ -46,11 +46,12 @@ const ThemeInstalledModal: React.FC<{
     const {refreshActiveThemeData} = useCustomFonts();
     const handleError = useHandleError();
 
+    /* eslint-disable react/no-array-index-key */
     let errorPrompt = null;
-    if (installedTheme && installedTheme.gscan_errors) {
+    if (installedTheme && installedTheme.errors) {
         errorPrompt = <div className="mt-6">
             <List hint={<>Highly recommended to fix, functionality <strong>could</strong> be restricted</>} title="Errors">
-                {installedTheme.gscan_errors?.map(error => <ThemeProblemView problem={error} />)}
+                {installedTheme.errors?.map((error, index) => <ThemeProblemView key={index} problem={error} />)}
             </List>
         </div>;
     }
@@ -59,12 +60,13 @@ const ThemeInstalledModal: React.FC<{
     if (installedTheme && installedTheme.warnings) {
         warningPrompt = <div className="mt-10">
             <List title="Warnings">
-                {installedTheme.warnings?.map(warning => <ThemeProblemView problem={warning} />)}
+                {installedTheme.warnings?.map((warning, index) => <ThemeProblemView key={index} problem={warning} />)}
             </List>
         </div>;
     }
+    /* eslint-enable react/no-array-index-key */
 
-    let okLabel = `Activate${installedTheme.gscan_errors?.length ? ' with errors' : ''}`;
+    let okLabel = `Activate${installedTheme.errors?.length ? ' with errors' : ''}`;
 
     if (installedTheme.active) {
         okLabel = 'OK';


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3275/

The `InstalledTheme` type used `gscan_errors` as the property name for theme validation errors, but the API returns `errors`.

The `gscan_errors` name came from Ember's serializer which remaps the property internally.
Additionally, Ember's `pushPayload` in the state bridge was mutating the response object in place (renaming `errors` via the serializer attrs), which meant React code holding a reference to the same object could not read the original properties. This is fixed by cloning the response before passing it to Ember's store.

---

The original code was working but relied on a side-effect of the Ember state bridge. With more of Ember being ripped out we would have hit problems with this sooner or later.
