### PR TITLE
Improved (fixed?) flaky migration tools test timing out on CI

### DIFF
--- a/apps/admin-x-settings/test/acceptance/advanced/migration-tools.test.ts
+++ b/apps/admin-x-settings/test/acceptance/advanced/migration-tools.test.ts
@@ -8,14 +8,16 @@ test.describe('Migration tools', async () => {
         }});
 
         const openMigrator = async (name: string, route: string) => {
-            await page.goto('/');
-
             const migrationSection = page.getByTestId('migrationtools');
             await expect(migrationSection).toBeVisible();
 
             await migrationSection.getByRole('button', {name}).click();
             await expectExternalNavigate(page, {route});
+
+            await page.goBack();
         };
+
+        await page.goto('/');
 
         await openMigrator('Substack', '/migrate/substack');
         await openMigrator('WordPress', '/migrate/wordpress');


### PR DESCRIPTION
no issue

The "Built-in migrators" test was doing 4 full page.goto('/') reloads within a single 30s test timeout. Each reload requires API fetches and a full React render, which on CI runners easily exceeds the budget. Replaced with a single page load and page.goBack() between assertions.
