### PR TITLE
Ported Ember theme error notification banner to React sidebar

### DIFF
--- a/apps/admin-x-framework/src/api/themes.ts
+++ b/apps/admin-x-framework/src/api/themes.ts
@@ -18,7 +18,7 @@ export type Theme = {
 }
 
 export type InstalledTheme = Theme & {
-    gscan_errors?: ThemeProblem<'error'>[];
+    errors?: ThemeProblem<'error'>[];
     warnings?: ThemeProblem<'warning'>[];
 }
 

--- a/apps/admin-x-settings/src/components/settings/site/theme-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/theme-modal.tsx
@@ -188,8 +188,8 @@ const ThemeToolbar: React.FC<ThemeToolbarProps> = ({
             </>;
         }
 
-        if (uploadedTheme?.gscan_errors?.length || uploadedTheme.warnings?.length) {
-            const hasErrors = uploadedTheme?.gscan_errors?.length;
+        if (uploadedTheme?.errors?.length || uploadedTheme.warnings?.length) {
+            const hasErrors = uploadedTheme?.errors?.length;
 
             title = `Upload successful with ${hasErrors ? 'errors' : 'warnings'}`;
             prompt = <>
@@ -482,8 +482,8 @@ const ChangeThemeModal: React.FC<ChangeThemeModalProps> = ({source, themeRef}) =
                     </>;
                 }
 
-                if (newlyInstalledTheme.gscan_errors?.length || newlyInstalledTheme.warnings?.length) {
-                    const hasErrors = newlyInstalledTheme.gscan_errors?.length;
+                if (newlyInstalledTheme.errors?.length || newlyInstalledTheme.warnings?.length) {
+                    const hasErrors = newlyInstalledTheme.errors?.length;
 
                     title = `Installed with ${hasErrors ? 'errors' : 'warnings'}`;
                     prompt = <>

--- a/apps/admin-x-settings/src/components/settings/site/theme/theme-installed-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/theme/theme-installed-modal.tsx
@@ -24,7 +24,7 @@ export const ThemeProblemView = ({problem}:{problem: ThemeProblem}) => {
                             <div dangerouslySetInnerHTML={{__html: problem.details}} className='mb-4' />
                             <Heading level={6}>Affected files:</Heading>
                             <ul className='mt-1'>
-                                {problem.failures.map(failure => <li><code>{failure.ref}</code>{failure.message ? `: ${failure.message}` : ''}</li>)}
+                                {problem.failures.map(failure => <li key={failure.ref}><code>{failure.ref}</code>{failure.message ? `: ${failure.message}` : ''}</li>)}
                             </ul>
                         </div> :
                         null
@@ -47,10 +47,10 @@ const ThemeInstalledModal: React.FC<{
     const handleError = useHandleError();
 
     let errorPrompt = null;
-    if (installedTheme && installedTheme.gscan_errors) {
+    if (installedTheme && installedTheme.errors) {
         errorPrompt = <div className="mt-6">
             <List hint={<>Highly recommended to fix, functionality <strong>could</strong> be restricted</>} title="Errors">
-                {installedTheme.gscan_errors?.map(error => <ThemeProblemView problem={error} />)}
+                {installedTheme.errors?.map((error, index) => <ThemeProblemView key={error.code || index} problem={error} />)}
             </List>
         </div>;
     }
@@ -59,12 +59,12 @@ const ThemeInstalledModal: React.FC<{
     if (installedTheme && installedTheme.warnings) {
         warningPrompt = <div className="mt-10">
             <List title="Warnings">
-                {installedTheme.warnings?.map(warning => <ThemeProblemView problem={warning} />)}
+                {installedTheme.warnings?.map((warning, index) => <ThemeProblemView key={warning.code || index} problem={warning} />)}
             </List>
         </div>;
     }
 
-    let okLabel = `Activate${installedTheme.gscan_errors?.length ? ' with errors' : ''}`;
+    let okLabel = `Activate${installedTheme.errors?.length ? ' with errors' : ''}`;
 
     if (installedTheme.active) {
         okLabel = 'OK';

--- a/apps/admin/src/layout/app-sidebar/app-sidebar-content.tsx
+++ b/apps/admin/src/layout/app-sidebar/app-sidebar-content.tsx
@@ -8,6 +8,7 @@ import NavMain from "./nav-main";
 import NavContent from "./nav-content";
 import NavGhostPro from "./nav-ghost-pro";
 import NavSettings from "./nav-settings";
+import ThemeErrorsBanner from "./theme-errors-banner";
 import UpgradeBanner from "./upgrade-banner";
 import { useUpgradeStatus } from "./hooks/use-upgrade-status";
 
@@ -22,6 +23,7 @@ function AppSidebarContent() {
                 <NavGhostPro />
             </div>
             <div className="flex flex-col gap-2 sidebar:gap-4">
+                <ThemeErrorsBanner />
                 {showUpgradeBanner ? <UpgradeBanner trialDaysRemaining={trialDaysRemaining} /> : <WhatsNewBanner />}
                 <NavSettings className="pb-0" />
             </div>

--- a/apps/admin/src/layout/app-sidebar/hooks/use-theme-errors.ts
+++ b/apps/admin/src/layout/app-sidebar/hooks/use-theme-errors.ts
@@ -1,0 +1,27 @@
+import {useActiveTheme} from '@tryghost/admin-x-framework/api/themes';
+import {useCurrentUser} from '@tryghost/admin-x-framework/api/current-user';
+import {isContributorUser} from '@tryghost/admin-x-framework/api/users';
+import type {ThemeProblem} from '@tryghost/admin-x-framework/api/themes';
+
+function isFilteredError(error: ThemeProblem<'error'>): boolean {
+    return error.code === 'GS110-NO-MISSING-PAGE-BUILDER-USAGE'
+        && !!error.failures?.[0]?.message?.includes('show_title_and_feature_image');
+}
+
+export function useThemeErrors() {
+    const {data: currentUser} = useCurrentUser();
+    const isContributor = currentUser && isContributorUser(currentUser);
+
+    const {data: activeThemeData} = useActiveTheme({
+        enabled: !isContributor
+    });
+
+    const activeTheme = activeThemeData?.themes?.[0];
+    const allErrors = activeTheme?.errors ?? [];
+    const warnings = activeTheme?.warnings ?? [];
+
+    const errors = allErrors.filter(error => !isFilteredError(error));
+    const hasErrors = errors.length > 0;
+
+    return {hasErrors, errors, warnings};
+}

--- a/apps/admin/src/layout/app-sidebar/theme-errors-banner.tsx
+++ b/apps/admin/src/layout/app-sidebar/theme-errors-banner.tsx
@@ -1,0 +1,41 @@
+import {useState} from 'react';
+import {Banner, LucideIcon} from '@tryghost/shade';
+import {useThemeErrors} from './hooks/use-theme-errors';
+import ThemeErrorsDialog from './theme-errors-dialog';
+
+function ThemeErrorsBanner() {
+    const {hasErrors, errors, warnings} = useThemeErrors();
+    const [dialogOpen, setDialogOpen] = useState(false);
+
+    if (!hasErrors) {
+        return null;
+    }
+
+    return (
+        <>
+            <Banner
+                className="mx-2 my-5 cursor-pointer"
+                role="status"
+                size="md"
+                variant="destructive"
+                onClick={() => setDialogOpen(true)}
+            >
+                <div className="flex items-start gap-3">
+                    <LucideIcon.AlertTriangle className="mt-0.5 size-4 shrink-0 text-red-600" />
+                    <div>
+                        <div className="text-sm font-semibold text-red-900">Your theme has errors</div>
+                        <div className="text-xs text-red-700">Some functionality on your site may be limited &rarr;</div>
+                    </div>
+                </div>
+            </Banner>
+            <ThemeErrorsDialog
+                errors={errors}
+                open={dialogOpen}
+                warnings={warnings}
+                onOpenChange={setDialogOpen}
+            />
+        </>
+    );
+}
+
+export default ThemeErrorsBanner;

--- a/apps/admin/src/layout/app-sidebar/theme-errors-dialog.tsx
+++ b/apps/admin/src/layout/app-sidebar/theme-errors-dialog.tsx
@@ -1,0 +1,102 @@
+import {useState} from 'react';
+import {
+    Button,
+    Dialog,
+    DialogContent,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    LucideIcon
+} from '@tryghost/shade';
+import type {ThemeProblem} from '@tryghost/admin-x-framework/api/themes';
+
+interface ThemeErrorsDialogProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    errors: ThemeProblem<'error'>[];
+    warnings: ThemeProblem<'warning'>[];
+}
+
+function ThemeErrorItem({error}: {error: ThemeProblem}) {
+    const [expanded, setExpanded] = useState(false);
+
+    return (
+        <li className="border-b border-border last:border-0">
+            <button
+                className="flex w-full items-center gap-2 py-3 text-left text-sm font-medium hover:text-black"
+                type="button"
+                onClick={() => setExpanded(!expanded)}
+            >
+                <LucideIcon.ChevronRight className={`size-4 shrink-0 text-muted-foreground transition-transform duration-200 ${expanded ? 'rotate-90' : ''}`} />
+                <span>{error.rule}</span>
+            </button>
+            {expanded && (
+                <div className="pb-3 pl-6 text-sm text-muted-foreground">
+                    <p dangerouslySetInnerHTML={{__html: error.details}} />
+                    {error.failures?.length > 0 && (
+                        <div className="mt-2">
+                            <h6 className="text-xs font-semibold uppercase text-muted-foreground">Affected files:</h6>
+                            <ul className="mt-1 list-disc pl-4">
+                                {error.failures.map((failure, i) => (
+                                    <li key={i}>
+                                        <code className="text-xs">{failure.ref}</code>
+                                        {failure.message && <>: {failure.message}</>}
+                                    </li>
+                                ))}
+                            </ul>
+                        </div>
+                    )}
+                </div>
+            )}
+        </li>
+    );
+}
+
+function ThemeErrorsDialog({open, onOpenChange, errors, warnings}: ThemeErrorsDialogProps) {
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent className="max-w-lg max-h-[85vh] flex flex-col">
+                <DialogHeader>
+                    <DialogTitle className="text-2xl tracking-tighter">
+                        Theme errors
+                    </DialogTitle>
+                </DialogHeader>
+
+                <section className="flex-1 overflow-y-auto -mx-6 px-6">
+                    {errors.length > 0 && (
+                        <div>
+                            <h2 className="mb-1 text-sm font-semibold">Errors</h2>
+                            <p className="mb-2 text-xs text-muted-foreground">
+                                Highly recommended to fix, functionality could be restricted
+                            </p>
+                            <ul className="border-t border-border">
+                                {errors.map((error, i) => (
+                                    <ThemeErrorItem key={i} error={error} />
+                                ))}
+                            </ul>
+                        </div>
+                    )}
+
+                    {warnings.length > 0 && (
+                        <div className={errors.length > 0 ? 'mt-4' : ''}>
+                            <h2 className="mb-1 text-sm font-semibold">Warnings</h2>
+                            <ul className="border-t border-border">
+                                {warnings.map((warning, i) => (
+                                    <ThemeErrorItem key={i} error={warning} />
+                                ))}
+                            </ul>
+                        </div>
+                    )}
+                </section>
+
+                <DialogFooter>
+                    <Button onClick={() => onOpenChange(false)}>
+                        OK
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}
+
+export default ThemeErrorsDialog;

--- a/e2e/helpers/pages/admin/sidebar/sidebar-page.ts
+++ b/e2e/helpers/pages/admin/sidebar/sidebar-page.ts
@@ -43,6 +43,8 @@ export class SidebarPage extends AdminPage {
     public readonly networkNotificationBadge: Locator;
     public readonly ghostProLink: Locator;
     public readonly upgradeNowLink: Locator;
+    public readonly themeErrorBanner: Locator;
+    public readonly themeErrorDialog: Locator;
 
     constructor(page: Page) {
         super(page);
@@ -59,6 +61,8 @@ export class SidebarPage extends AdminPage {
             .locator('[data-sidebar="menu-badge"]');
         this.ghostProLink = this.sidebar.getByRole('link', {name: 'Ghost(Pro)'});
         this.upgradeNowLink = this.sidebar.getByRole('link', {name: /upgrade/i});
+        this.themeErrorBanner = page.getByRole('status').filter({hasText: /your theme has errors/i});
+        this.themeErrorDialog = page.getByRole('dialog').filter({hasText: /theme errors/i});
     }
 
     getNavLink(name: string): Locator {

--- a/e2e/tests/admin/sidebar/theme-error-notification.test.ts
+++ b/e2e/tests/admin/sidebar/theme-error-notification.test.ts
@@ -1,0 +1,94 @@
+import {Page} from '@playwright/test';
+import {SidebarPage} from '@/admin-pages';
+import {expect, test} from '@/helpers/playwright/fixture';
+
+function mockActiveThemeWithErrors(page: Page, errors: object[] = [{
+    code: 'GS001-DEPR-PURL',
+    rule: 'Replace deprecated helper',
+    details: 'The <code>{{pageUrl}}</code> helper has been deprecated.',
+    failures: [{ref: 'default.hbs', message: 'deprecated usage'}],
+    fatal: false,
+    level: 'error'
+}]) {
+    return page.route('**/ghost/api/admin/themes/active/**', async (route) => {
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({
+                themes: [{
+                    name: 'casper',
+                    active: true,
+                    package: {name: 'Casper', version: '1.0.0'},
+                    errors: errors,
+                    warnings: []
+                }]
+            })
+        });
+    });
+}
+
+function mockActiveThemeWithoutErrors(page: Page) {
+    return page.route('**/ghost/api/admin/themes/active/**', async (route) => {
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({
+                themes: [{
+                    name: 'casper',
+                    active: true,
+                    package: {name: 'Casper', version: '1.0.0'},
+                    errors: [],
+                    warnings: []
+                }]
+            })
+        });
+    });
+}
+
+test.describe('Ghost Admin - Theme Error Notification', () => {
+    test('shows banner when theme has errors', async ({page}) => {
+        const sidebar = new SidebarPage(page);
+        await mockActiveThemeWithErrors(page);
+
+        await sidebar.goto('/ghost');
+
+        await expect(sidebar.themeErrorBanner).toBeVisible();
+        await expect(sidebar.themeErrorBanner).toContainText('Your theme has errors');
+    });
+
+    test('opens dialog when clicking banner', async ({page}) => {
+        const sidebar = new SidebarPage(page);
+        await mockActiveThemeWithErrors(page);
+
+        await sidebar.goto('/ghost');
+        await sidebar.themeErrorBanner.click();
+
+        await expect(sidebar.themeErrorDialog).toBeVisible();
+        await expect(sidebar.themeErrorDialog).toContainText('Replace deprecated helper');
+    });
+
+    test('does not show banner when theme has no errors', async ({page}) => {
+        const sidebar = new SidebarPage(page);
+        await mockActiveThemeWithoutErrors(page);
+
+        await sidebar.goto('/ghost');
+
+        await expect(sidebar.themeErrorBanner).toBeHidden();
+    });
+
+    test('filters out GS110 show_title_and_feature_image errors', async ({page}) => {
+        const sidebar = new SidebarPage(page);
+        await mockActiveThemeWithErrors(page, [{
+            code: 'GS110-NO-MISSING-PAGE-BUILDER-USAGE',
+            rule: 'Check page builder usage',
+            details: 'Missing page builder helper usage.',
+            failures: [{ref: 'post.hbs', message: 'show_title_and_feature_image'}],
+            fatal: false,
+            level: 'error'
+        }]);
+
+        await sidebar.goto('/ghost');
+
+        await expect(sidebar.themeErrorBanner).toBeHidden();
+    });
+});


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3275

The banner that highlights an active theme with errors was missing in the React sidebar.

- added hook for reading errors from active theme
- added missing banner and errors/warnings list modal

Note: The modal duplicates some UI from `admin-x-settings` but we don't yet have any patterns for sharing components across apps or the Shade / Admin-X-Design-System boundary
