### PR TITLE
🐛 Fixed from address for gmail inbox links

### DIFF
--- a/ghost/core/core/server/services/email-address/email-address-service-wrapper.js
+++ b/ghost/core/core/server/services/email-address/email-address-service-wrapper.js
@@ -33,6 +33,9 @@ class EmailAddressServiceWrapper {
             getFallbackEmail: () => {
                 return config.get('hostSettings:managedEmail:fallbackAddress') || null;
             },
+            getMembersSupportAddress: () => {
+                return settingsHelpers.getMembersSupportAddress();
+            },
             isValidEmailAddress: (emailAddress) => {
                 return validator.isEmail(emailAddress);
             }

--- a/ghost/core/core/server/services/email-address/email-address-service.ts
+++ b/ghost/core/core/server/services/email-address/email-address-service.ts
@@ -24,6 +24,7 @@ export class EmailAddressService {
     #getDefaultEmail: () => EmailAddress;
     #getFallbackDomain: () => string | null;
     #getFallbackEmail: () => EmailAddress | null;
+    #getMembersSupportAddress: () => string;
     #isValidEmailAddress: (email: string) => boolean;
 
     constructor(dependencies: {
@@ -32,12 +33,14 @@ export class EmailAddressService {
         getFallbackDomain: () => string | null,
         getDefaultEmail: () => EmailAddress,
         getFallbackEmail: () => string | null,
+        getMembersSupportAddress: () => string,
         isValidEmailAddress: (email: string) => boolean
     }) {
         this.#getManagedEmailEnabled = dependencies.getManagedEmailEnabled;
         this.#getSendingDomain = dependencies.getSendingDomain;
         this.#getFallbackDomain = dependencies.getFallbackDomain;
         this.#getDefaultEmail = dependencies.getDefaultEmail;
+        this.#getMembersSupportAddress = dependencies.getMembersSupportAddress;
         this.#getFallbackEmail = () => {
             const fallbackAddress = dependencies.getFallbackEmail();
             if (!fallbackAddress) {
@@ -66,6 +69,16 @@ export class EmailAddressService {
 
     get fallbackEmail(): EmailAddress | null {
         return this.#getFallbackEmail();
+    }
+
+    /**
+     * Get the actual sender address for member emails after DMARC transformation.
+     * On managed platforms, this may differ from the configured support address to ensure DMARC compliance.
+     */
+    getMembersSupportAddress(): string {
+        const configuredAddress = this.#getMembersSupportAddress();
+        const transformed = this.getAddressFromString(configuredAddress);
+        return transformed.from.address;
     }
 
     getAddressFromString(from: string, replyTo?: string): EmailAddresses {

--- a/ghost/core/core/server/services/members/api.js
+++ b/ghost/core/core/server/services/members/api.js
@@ -19,6 +19,7 @@ const newslettersService = require('../newsletters');
 const memberAttributionService = require('../member-attribution');
 const emailSuppressionList = require('../email-suppression-list');
 const commentsService = require('../comments');
+const emailAddressService = require('../email-address');
 const {t} = require('../i18n');
 const sentry = require('../../../shared/sentry');
 
@@ -254,7 +255,8 @@ function createApiInstance(config) {
         sentry,
         settingsHelpers,
         urlUtils,
-        commentsService
+        commentsService,
+        emailAddressService: emailAddressService.service
     });
 
     return membersApiInstance;

--- a/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
+++ b/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
@@ -75,6 +75,7 @@ module.exports = class RouterController {
      * @param {any} deps.settingsCache
      * @param {any} deps.settingsHelpers
      * @param {any} deps.urlUtils
+     * @param {any} deps.emailAddressService
      */
     constructor({
         offersAPI,
@@ -93,7 +94,8 @@ module.exports = class RouterController {
         sentry,
         settingsCache,
         settingsHelpers,
-        urlUtils
+        urlUtils,
+        emailAddressService
     }) {
         this._offersAPI = offersAPI;
         this._paymentsService = paymentsService;
@@ -112,6 +114,7 @@ module.exports = class RouterController {
         this._settingsCache = settingsCache;
         this._settingsHelpers = settingsHelpers;
         this._urlUtils = urlUtils;
+        this._emailAddressService = emailAddressService;
     }
 
     async ensureStripe(_req, res, next) {
@@ -733,7 +736,7 @@ module.exports = class RouterController {
 
             const inboxLinks = await getInboxLinks({
                 recipient: normalizedEmail,
-                sender: this._settingsHelpers.getMembersSupportAddress(),
+                sender: this._emailAddressService.getMembersSupportAddress(),
                 dnsResolver: this.#inboxLinksDnsResolver
             });
             if (inboxLinks) {

--- a/ghost/core/core/server/services/members/members-api/members-api.js
+++ b/ghost/core/core/server/services/members/members-api/members-api.js
@@ -79,7 +79,8 @@ module.exports = function MembersAPI({
     sentry,
     settingsHelpers,
     urlUtils,
-    commentsService
+    commentsService,
+    emailAddressService
 }) {
     const tokenService = new TokenService({
         privateKey,
@@ -213,7 +214,8 @@ module.exports = function MembersAPI({
         settingsCache,
         settingsHelpers,
         sentry,
-        urlUtils
+        urlUtils,
+        emailAddressService
     });
 
     const wellKnownController = new WellKnownController({

--- a/ghost/core/test/unit/server/services/members/members-api/controllers/router-controller.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/controllers/router-controller.test.js
@@ -16,8 +16,14 @@ describe('RouterController', function () {
     let getDonationLinkSpy;
     let settingsCache;
     let settingsHelpers;
+    let emailAddressService;
 
     beforeEach(async function () {
+        // Mock emailAddressService for inbox links sender address transformation
+        emailAddressService = {
+            getMembersSupportAddress: sinon.stub().returns('noreply@example.com')
+        };
+
         getPaymentLinkSpy = sinon.spy();
         getDonationLinkSpy = sinon.spy();
         tiersService = {
@@ -90,7 +96,8 @@ describe('RouterController', function () {
                 stripeAPIService,
                 labsService,
                 settingsCache,
-                settingsHelpers
+                settingsHelpers,
+                emailAddressService
             });
 
             await routerController.createCheckoutSession({
@@ -126,7 +133,8 @@ describe('RouterController', function () {
                 labsService,
                 settingsCache,
                 settingsHelpers,
-                newslettersService: newslettersServiceStub
+                newslettersService: newslettersServiceStub,
+                emailAddressService
             });
             const newsletters = [
                 {id: 'abc123', name: 'Newsletter 1'},
@@ -693,6 +701,7 @@ describe('RouterController', function () {
                     sendEmailWithMagicLink: sendEmailWithMagicLinkStub,
                     settingsCache,
                     settingsHelpers,
+                    emailAddressService,
                     ...deps
                 });
             };
@@ -848,6 +857,7 @@ describe('RouterController', function () {
                     sendEmailWithMagicLink: sendEmailWithMagicLinkStub,
                     settingsCache,
                     settingsHelpers,
+                    emailAddressService,
                     ...deps
                 });
             };
@@ -923,7 +933,8 @@ describe('RouterController', function () {
                     settingsHelpers,
                     newslettersService: {},
                     sentry: {},
-                    urlUtils: {}
+                    urlUtils: {},
+                    emailAddressService
                 });
 
                 routerController._handleSignin = handleSigninStub;
@@ -1035,7 +1046,8 @@ describe('RouterController', function () {
                 stripeAPIService,
                 labsService,
                 settingsCache,
-                newslettersService: newslettersServiceStub
+                newslettersService: newslettersServiceStub,
+                emailAddressService
             });
         });
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/NY-1012/

Inbox links used the support address (reply) instead of the specified from address. Gmail allows us to pass params to automatically filter to a message, and in this case we're filtering to the wrong one, making it look like the email never got sent.