### PR TITLE
Added error message on private sites embedded in Admin iframes with cross-origin setups if cookies are blocked

### DIFF
--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -119,6 +119,7 @@ services:
     ports:
       - "2368:80"
       - "80:80"
+      - "443:443"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     volumes:

--- a/docker/dev-gateway/Caddyfile
+++ b/docker/dev-gateway/Caddyfile
@@ -2,7 +2,8 @@
     admin off
 }
 
-:80 {
+# Shared handlers snippet - used by both HTTP and HTTPS
+(shared_handlers) {
     # Compact log format for development
     log {
         output stdout
@@ -216,4 +217,15 @@
         # Default error response
         respond "{err.status_code} {err.status_text}"
     }
+}
+
+# HTTPS - for testing cookie behavior in Chrome (requires accepting self-signed cert)
+localhost {
+    tls internal
+    import shared_handlers
+}
+
+# HTTP - standard development
+:80 {
+    import shared_handlers
 }

--- a/ghost/core/core/frontend/apps/private-blogging/lib/middleware.js
+++ b/ghost/core/core/frontend/apps/private-blogging/lib/middleware.js
@@ -60,7 +60,8 @@ const privateBlogging = {
             name: 'ghost-private',
             maxAge: (30 * 24 * 60 * 60 * 1000), // 30 days in ms
             signed: false,
-            sameSite: 'none'
+            sameSite: urlUtils.isSSL(config.get('url')) ? 'none' : 'lax',
+            secure: urlUtils.isSSL(config.get('url'))
         })(req, res, next);
     },
 

--- a/ghost/core/core/frontend/apps/private-blogging/lib/views/private.hbs
+++ b/ghost/core/core/frontend/apps/private-blogging/lib/views/private.hbs
@@ -48,6 +48,13 @@
                                 <header>
                                     <h1>This site is private.</h1>
                                 </header>
+                                <div id="cookie-warning" style="display: none;">
+                                    <p>Your browser is blocking the cookies needed to view this site. To preview your private site, try one of the following:</p>
+                                    <ul>
+                                        <li>Open the site directly in a new tab</li>
+                                        <li>Disable third-party cookie blocking in your browser settings</li>
+                                    </ul>
+                                </div>
                                 <form class="gh-signin" method="post" novalidate="novalidate">
                                     <div class="form-group{{#if error}} error{{/if}}">
                                             {{input_password class="gh-input" placeholder="Password"}}
@@ -63,5 +70,22 @@
                 </main>
             </div>
         </div>
+        <script>
+            (function() {
+                if (window.self === window.top) return;
+
+                try {
+                    document.cookie = 'ghost_cookie_test=1; SameSite=Lax; path=/';
+                    var cookiesWork = document.cookie.indexOf('ghost_cookie_test') !== -1;
+                    document.cookie = 'ghost_cookie_test=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/';
+                    if (cookiesWork) return;
+                } catch (e) {
+                    // Cookie access threw - cookies are blocked
+                }
+
+                var warning = document.getElementById('cookie-warning');
+                if (warning) warning.style.display = 'block';
+            })();
+        </script>
     </body>
 </html>

--- a/ghost/core/core/frontend/public/ghost.css
+++ b/ghost/core/core/frontend/public/ghost.css
@@ -712,6 +712,30 @@ h2 {
     box-shadow: none;
 }
 
+#cookie-warning {
+    margin-bottom: 24px;
+    padding: 16px 20px;
+    background: #FFF4E5;
+    border: 1px solid #FFD699;
+    border-radius: 8px;
+    font-size: 1.5rem;
+    line-height: 1.5;
+    color: #6E4600;
+}
+
+#cookie-warning p {
+    margin: 0 0 8px;
+}
+
+#cookie-warning ul {
+    margin: 0;
+    padding-left: 20px;
+}
+
+#cookie-warning li {
+    margin-bottom: 4px;
+}
+
 @media (max-width: 500px) {
     .gh-flow-content {
         padding: 0;


### PR DESCRIPTION
refs https://linear.app/ghost/issue/ONC-1444

## Summary

- Fixed the `ghost-private` session cookie to use `SameSite=None; Secure` on HTTPS sites so it works for cross-origin admin/site setups
- Added HTTPS support to the local Caddy dev gateway for reproducing the issue locally
- Added a cookie warning banner on the private site password page that detects when the page is loaded inside an iframe (Ghost Admin's "View Site" tab) and cookies are being blocked by the browser (Safari, Chrome Incognito)
- The warning advises users to either open the site directly in a new tab or disable third-party cookie blocking

