### PR TITLE
Fixed flaky migration tools test by avoiding real page navigations

### DIFF
--- a/apps/admin-x-framework/src/test/acceptance.ts
+++ b/apps/admin-x-framework/src/test/acceptance.ts
@@ -358,5 +358,7 @@ export async function testUrlValidation(input: Locator, textToEnter: string, exp
 };
 
 export async function expectExternalNavigate(page: Page, link: Partial<ExternalLink>) {
-    await page.waitForURL(`/external/${encodeURIComponent(JSON.stringify({isExternal: true, ...link}))}`);
+    const expected = {isExternal: true, ...link};
+    await expect.poll(() => page.locator('body').getAttribute('data-external-navigate').then(v => v && JSON.parse(v))).toEqual(expected);
+    await page.locator('body').evaluate(el => delete el.dataset.externalNavigate);
 };

--- a/apps/admin-x-framework/src/test/render-shade.tsx
+++ b/apps/admin-x-framework/src/test/render-shade.tsx
@@ -40,7 +40,7 @@ export default function renderShadeApp<Props extends object>(
                 framework={{
                     externalNavigate: (link) => {
                         // Use the expectExternalNavigate helper to test this dummy external linking
-                        window.location.href = `/external/${encodeURIComponent(JSON.stringify(link))}`;
+                        document.body.dataset.externalNavigate = JSON.stringify(link);
                     },
                     ghostVersion: '5.x',
                     sentryDSN: null,

--- a/apps/admin-x-framework/src/test/render.tsx
+++ b/apps/admin-x-framework/src/test/render.tsx
@@ -40,7 +40,7 @@ export default function renderStandaloneApp<Props extends object>(
                 framework={{
                     externalNavigate: (link) => {
                         // Use the expectExternalNavigate helper to test this dummy external linking
-                        window.location.href = `/external/${encodeURIComponent(JSON.stringify(link))}`;
+                        document.body.dataset.externalNavigate = JSON.stringify(link);
                     },
                     ghostVersion: '5.x',
                     sentryDSN: null,

--- a/apps/admin-x-settings/test/acceptance/advanced/migration-tools.test.ts
+++ b/apps/admin-x-settings/test/acceptance/advanced/migration-tools.test.ts
@@ -7,22 +7,22 @@ test.describe('Migration tools', async () => {
             ...globalDataRequests
         }});
 
-        const openMigrator = async (name: string, route: string) => {
-            const migrationSection = page.getByTestId('migrationtools');
-            await expect(migrationSection).toBeVisible();
-
-            await migrationSection.getByRole('button', {name}).click();
-            await expectExternalNavigate(page, {route});
-
-            await page.goBack();
-        };
-
         await page.goto('/');
 
-        await openMigrator('Substack', '/migrate/substack');
-        await openMigrator('WordPress', '/migrate/wordpress');
-        await openMigrator('Medium', '/migrate/medium');
-        await openMigrator('Mailchimp', '/migrate/mailchimp');
+        const migrationSection = page.getByTestId('migrationtools');
+        await expect(migrationSection).toBeVisible();
+
+        const migrators = [
+            {name: 'Substack', route: '/migrate/substack'},
+            {name: 'WordPress', route: '/migrate/wordpress'},
+            {name: 'Medium', route: '/migrate/medium'},
+            {name: 'Mailchimp', route: '/migrate/mailchimp'}
+        ];
+
+        for (const {name, route} of migrators) {
+            await migrationSection.getByRole('button', {name}).click();
+            await expectExternalNavigate(page, {route});
+        }
     });
 
     // test('Universal import', async ({page}) => {

--- a/apps/admin-x-settings/test/acceptance/membership/tiers.test.ts
+++ b/apps/admin-x-settings/test/acceptance/membership/tiers.test.ts
@@ -1,5 +1,5 @@
 import {expect, test} from '@playwright/test';
-import {globalDataRequests, limitRequests, mockApi, responseFixtures, settingsWithStripe} from '@tryghost/admin-x-framework/test/acceptance';
+import {expectExternalNavigate, globalDataRequests, limitRequests, mockApi, responseFixtures, settingsWithStripe} from '@tryghost/admin-x-framework/test/acceptance';
 
 test.describe('Tier settings', async () => {
     test('Supports creating a new tier', async ({page}) => {
@@ -252,12 +252,7 @@ test.describe('Tier settings', async () => {
         const limitModal = page.getByTestId('limit-modal');
         await limitModal.getByRole('button', {name: 'Upgrade'}).click();
 
-        // The route should be updated to /pro
-        const newPageUrl = page.url();
-        const newPageUrlObject = new URL(newPageUrl);
-        const decodedUrl = decodeURIComponent(newPageUrlObject.pathname);
-
-        expect(decodedUrl).toMatch(/\/\{\"route\":\"\/pro\",\"isExternal\":true\}$/);
+        await expectExternalNavigate(page, {route: '/pro'});
     });
 
     test('Allows access to Stripe Connect with limitStripeConnect and Stripe already set up', async ({page}) => {
@@ -339,11 +334,6 @@ test.describe('Tier settings', async () => {
         const limitModal = page.getByTestId('limit-modal');
         await limitModal.getByRole('button', {name: 'Upgrade'}).click();
 
-        // The route should be updated to /pro
-        const newPageUrl = page.url();
-        const newPageUrlObject = new URL(newPageUrl);
-        const decodedUrl = decodeURIComponent(newPageUrlObject.pathname);
-
-        expect(decodedUrl).toMatch(/\/\{\"route\":\"\/pro\",\"isExternal\":true\}$/);
+        await expectExternalNavigate(page, {route: '/pro'});
     });
 });

--- a/apps/admin-x-settings/test/acceptance/site/theme.test.ts
+++ b/apps/admin-x-settings/test/acceptance/site/theme.test.ts
@@ -1,5 +1,5 @@
 import {expect, test} from '@playwright/test';
-import {globalDataRequests, limitRequests, mockApi, responseFixtures} from '@tryghost/admin-x-framework/test/acceptance';
+import {expectExternalNavigate, globalDataRequests, limitRequests, mockApi, responseFixtures} from '@tryghost/admin-x-framework/test/acceptance';
 
 test.describe('Theme settings', async () => {
     test('Browsing and installing default themes', async ({page}) => {
@@ -229,13 +229,7 @@ test.describe('Theme settings', async () => {
 
         await limitModal.getByRole('button', {name: 'Upgrade'}).click();
 
-        // The route should be updated
-        const newPageUrl = page.url();
-        const newPageUrlObject = new URL(newPageUrl);
-        const decodedUrl = decodeURIComponent(newPageUrlObject.pathname);
-
-        // expect the route to be updated to /pro
-        expect(decodedUrl).toMatch(/\/\{\"route\":\"\/pro\",\"isExternal\":true\}$/);
+        await expectExternalNavigate(page, {route: '/pro'});
     });
 
     test('Prevents overwriting the default theme', async ({page}) => {
@@ -355,12 +349,7 @@ test.describe('Theme settings', async () => {
         const limitModal = page.getByTestId('limit-modal');
         await limitModal.getByRole('button', {name: 'Upgrade'}).click();
 
-        // The route should be updated to /pro
-        const newPageUrl = page.url();
-        const newPageUrlObject = new URL(newPageUrl);
-        const decodedUrl = decodeURIComponent(newPageUrlObject.pathname);
-
-        expect(decodedUrl).toMatch(/\/\{"route":"\/pro","isExternal":true\}$/);
+        await expectExternalNavigate(page, {route: '/pro'});
     });
 
     test('Allows changing theme when multiple themes are allowed', async ({page}) => {


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/pull/26310

The test's `externalNavigate` stub was setting `window.location.href` which
triggered real browser navigations to non-existent URLs (~3s each) followed
by `page.goBack()` to reload the React app (~3.5s each), repeated 4 times.
This easily exceeded the 30s timeout on CI.

The stub now stores the navigation link as a data attribute on `document.body`
instead of navigating, and the `expectExternalNavigate` helper asserts against
that attribute. This lets the test verify all 4 migrator buttons with a
single page load and zero navigations.
