### PR TITLE
Expanded browser tests to always run in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,8 +145,6 @@ jobs:
             tinybird:
               - 'ghost/core/core/server/data/tinybird/**'
               - '!ghost/core/core/server/data/tinybird/**/*.md'
-            browser-tests:
-              - 'ghost/core/test/e2e-browser/**'
             any-code:
               - '!**/*.md'
 
@@ -212,7 +210,6 @@ jobs:
       changed_sodo_search: ${{ steps.changed.outputs.sodo-search }}
       changed_tinybird: ${{ steps.changed.outputs.tinybird }}
       changed_any_code: ${{ steps.changed.outputs.any-code }}
-      changed_browser_tests: ${{ steps.changed.outputs.browser-tests }}
       changed_new_package: ${{ steps.added.outputs.new-package }}
       base_commit: ${{ env.BASE_COMMIT }}
       is_main: ${{ env.IS_MAIN }}
@@ -221,7 +218,6 @@ jobs:
       is_six_pr: ${{ env.IS_SIX_PR }}
       is_five: ${{ env.IS_FIVE }}
       member_is_in_org: ${{ steps.check_user_org_membership.outputs.is_member }}
-      has_browser_tests_label: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'browser-tests') }}
       has_perf_tests_label: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'perf-tests') }}
       dependency_cache_key: ${{ env.cachekey }}
       node_version: ${{ env.NODE_VERSION }}
@@ -332,7 +328,6 @@ jobs:
     runs-on:
       labels: ubuntu-latest
     needs: [job_setup]
-    if: needs.job_setup.outputs.changed_any_code == 'true' && (needs.job_setup.outputs.is_six_pr == 'true' || needs.job_setup.outputs.is_development == 'true' || needs.job_setup.outputs.has_browser_tests_label == 'true' || needs.job_setup.outputs.changed_browser_tests == 'true')
     steps:
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/commit/31c7bf0a42efe5141da65f0f8e3dcb9dbf830792

Browser tests have been fairly stable since expanding their use and adding parallelization across CI runs. This expands to always run.

Arguably, we could limit this to renovate, Portal, and Ghost changes.