### PR TITLE
Routed custom cancel button through Portal when retention offers exist

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.62.2",
+  "version": "2.62.3",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/portal/src/app.js
+++ b/apps/portal/src/app.js
@@ -109,6 +109,7 @@ export default class App extends React.Component {
                 siteUrl,
                 site: contextState.site,
                 member: contextState.member,
+                offers: contextState.offers,
                 doAction: contextState.doAction,
                 captureException: Sentry.captureException
             });

--- a/apps/portal/src/components/pages/account-plan-page.js
+++ b/apps/portal/src/components/pages/account-plan-page.js
@@ -452,11 +452,19 @@ export default class AccountPlanPage extends React.Component {
     }
 
     componentDidMount() {
-        const {member} = this.context;
+        const {member, pageData} = this.context;
         if (!member) {
             this.context.doAction('switchPage', {
                 page: 'signin'
             });
+            return;
+        }
+
+        // If opened from a custom cancel button with a subscription ID, trigger the cancellation flow
+        if (pageData?.action === 'cancel' && pageData?.subscriptionId) {
+            this.onCancelSubscription({subscriptionId: pageData.subscriptionId});
+            // Clear the action so it doesn't re-trigger if the user dismisses and reopens Portal
+            pageData.action = null;
         }
     }
 
@@ -563,6 +571,9 @@ export default class AccountPlanPage extends React.Component {
     onCancelSubscription({subscriptionId}) {
         const {member, offers} = this.context;
         const subscription = getSubscriptionFromId({subscriptionId, member});
+        if (!subscription) {
+            return;
+        }
         const subscriptionPlan = getPriceFromSubscription({subscription});
         const retentionOffers = (offers || []).filter(o => o.redemption_type === 'retention');
 

--- a/apps/portal/src/data-attributes.js
+++ b/apps/portal/src/data-attributes.js
@@ -205,7 +205,7 @@ export function planClickHandler({event, el, errorEl, siteUrl, site, member, cli
     });
 }
 
-export function handleDataAttributes({siteUrl, site = {}, member, doAction, captureException} = {}) {
+export function handleDataAttributes({siteUrl, site = {}, member, offers = [], doAction, captureException} = {}) {
     if (!siteUrl) {
         return;
     }
@@ -372,15 +372,31 @@ export function handleDataAttributes({siteUrl, site = {}, member, doAction, capt
         el.addEventListener('click', clickHandler);
     });
 
+    const hasRetentionOffers = (offers || []).some(offer => offer.redemption_type === 'retention');
+
     Array.prototype.forEach.call(document.querySelectorAll('[data-members-cancel-subscription]'), function (el) {
         let errorEl = el.parentElement.querySelector('[data-members-error]');
         function clickHandler(event) {
-            el.removeEventListener('click', clickHandler);
             event.preventDefault();
-            el.classList.remove('error');
-            el.classList.add('loading');
 
             let subscriptionId = el.dataset.membersCancelSubscription;
+
+            // If retention offer is available, open Portal to show the offer
+            if (hasRetentionOffers) {
+                doAction('openPopup', {
+                    page: 'accountPlan',
+                    pageData: {
+                        subscriptionId,
+                        action: 'cancel'
+                    }
+                });
+
+                return;
+            }
+
+            el.removeEventListener('click', clickHandler);
+            el.classList.remove('error');
+            el.classList.add('loading');
 
             if (errorEl) {
                 errorEl.innerText = '';

--- a/apps/portal/test/data-attributes.test.js
+++ b/apps/portal/test/data-attributes.test.js
@@ -1,9 +1,10 @@
 import App from '../src/app';
 import {site as FixturesSite, member as FixtureMember} from './utils/test-fixtures';
-import {fireEvent, appRender, within} from './utils/test-utils';
+import {fireEvent, appRender, within, waitFor} from './utils/test-utils';
 import setupGhostApi from '../src/utils/api';
 import * as helpers from '../src/utils/helpers';
 import {formSubmitHandler, planClickHandler, handleDataAttributes} from '../src/data-attributes';
+import {getOfferData} from '../src/utils/fixtures-generator';
 import {vi} from 'vitest';
 
 // Mock data
@@ -650,6 +651,78 @@ describe('Member Data attributes:', () => {
                 integrityToken: 'testtoken'
             });
             expect(window.fetch).toHaveBeenLastCalledWith('https://portal.localhost/members/api/send-magic-link/', {body: expectedBody, headers: {'Content-Type': 'application/json'}, method: 'POST'});
+        });
+    });
+
+    describe('data-members-cancel-subscription', () => {
+        test('opens Portal when retention offers exist', () => {
+            const siteUrl = 'https://portal.localhost';
+            const doAction = vi.fn();
+            const retentionOffer = getOfferData({redemptionType: 'retention'});
+
+            document.body.innerHTML = `
+                <a data-members-cancel-subscription="sub_123">Cancel</a>
+            `;
+
+            handleDataAttributes({siteUrl, offers: [retentionOffer], doAction});
+
+            const button = document.querySelector('[data-members-cancel-subscription]');
+            button.click();
+
+            expect(doAction).toHaveBeenCalledWith('openPopup', {
+                page: 'accountPlan',
+                pageData: {
+                    subscriptionId: 'sub_123',
+                    action: 'cancel'
+                }
+            });
+            expect(window.fetch).not.toHaveBeenCalled();
+        });
+
+        test('falls back to direct API call when no retention offers exist', async () => {
+            const siteUrl = 'https://portal.localhost';
+            const doAction = vi.fn();
+
+            document.body.innerHTML = `
+                <a data-members-cancel-subscription="sub_123">Cancel</a>
+            `;
+
+            handleDataAttributes({siteUrl, offers: [], doAction});
+
+            const button = document.querySelector('[data-members-cancel-subscription]');
+            button.click();
+
+            await waitFor(() => {
+                expect(window.fetch).toHaveBeenCalled();
+            });
+
+            expect(doAction).not.toHaveBeenCalled();
+            expect(window.fetch).toHaveBeenCalledWith(
+                'https://portal.localhost/members/api/session',
+                {credentials: 'same-origin'}
+            );
+        });
+
+        test('ignores non-retention offers and uses direct API call', async () => {
+            const siteUrl = 'https://portal.localhost';
+            const doAction = vi.fn();
+            const signupOffer = getOfferData({redemptionType: 'signup'});
+
+            document.body.innerHTML = `
+                <a data-members-cancel-subscription="sub_123">Cancel</a>
+            `;
+
+            handleDataAttributes({siteUrl, offers: [signupOffer], doAction});
+
+            const button = document.querySelector('[data-members-cancel-subscription]');
+            button.click();
+
+            await waitFor(() => {
+                expect(window.fetch).toHaveBeenCalled();
+            });
+
+            expect(doAction).not.toHaveBeenCalled();
+            expect(window.fetch).toHaveBeenCalled();
         });
     });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3280

The `data-members-cancel-subscription` data attribute previously bypassed Portal entirely, making a direct API call to cancel the subscription. This meant retention offers were never shown to members cancelling via custom theme buttons. Now, when retention offers are configured, clicking the custom cancel button opens Portal's cancellation flow instead, allowing the retention offer to be presented