### PR TITLE
🐛 Fixed email rendering to use cached image dimensions

### DIFF
--- a/ghost/core/core/server/services/email-service/email-renderer.js
+++ b/ghost/core/core/server/services/email-service/email-renderer.js
@@ -148,7 +148,7 @@ class EmailRenderer {
      * @param {object} dependencies.renderers
      * @param {{render(object, options): string}} dependencies.renderers.lexical
      * @param {{render(object, options): string}} dependencies.renderers.mobiledoc
-     * @param {{getImageSizeFromUrl(url: string): Promise<{width: number, height: number}>}} dependencies.imageSize
+     * @param {{getCachedImageSizeFromUrl(url: string): Promise<{url: string, width: number, height: number} | {url: string}>}} dependencies.imageSize
      * @param {{urlFor(type: string, optionsOrAbsolute, absolute): string, isSiteUrl(url, context): boolean}} dependencies.urlUtils
      * @param {{isLocalImage(url: string): boolean}} dependencies.storageUtils
      * @param {(post: Post) => string} dependencies.getPostUrl
@@ -1402,7 +1402,11 @@ class EmailRenderer {
             };
         } else {
             try {
-                const size = await this.#imageSize.getImageSizeFromUrl(href);
+                const size = await this.#imageSize.getCachedImageSizeFromUrl(href);
+
+                if (!size || !size.width) {
+                    return {href, width: 0, height: null};
+                }
 
                 if (size.width >= visibleWidth) {
                     if (!visibleHeight) {

--- a/ghost/core/core/server/services/email-service/email-service-wrapper.js
+++ b/ghost/core/core/server/services/email-service/email-service-wrapper.js
@@ -47,7 +47,7 @@ class EmailServiceWrapper {
         const audienceFeedback = require('../audience-feedback');
         const storageUtils = require('../../adapters/storage/utils');
         const emailAnalyticsJobs = require('../email-analytics/jobs');
-        const {imageSize} = require('../../lib/image');
+        const {cachedImageSizeFromUrl} = require('../../lib/image');
 
         // capture errors from mailgun client and log them in sentry
         const errorHandler = (error) => {
@@ -79,7 +79,7 @@ class EmailServiceWrapper {
                 mobiledoc: mobiledocLib,
                 lexical: lexicalLib
             },
-            imageSize,
+            imageSize: cachedImageSizeFromUrl,
             urlUtils,
             storageUtils,
             getPostUrl: this.getPostUrl,

--- a/ghost/core/test/unit/frontend/helpers/ghost-head.test.js
+++ b/ghost/core/test/unit/frontend/helpers/ghost-head.test.js
@@ -377,7 +377,7 @@ describe('{{ghost_head}} helper', function () {
 
         // @TODO: this is a LOT of mocking :/
         routingRegistryGetRssUrlStub = sinon.stub(routing.registry, 'getRssUrl').returns('http://localhost:65530/rss/');
-        sinon.stub(imageLib.imageSize, 'getImageSizeFromUrl').resolves();
+        sinon.stub(imageLib.cachedImageSizeFromUrl, 'getCachedImageSizeFromUrl').resolves();
         getStub = sinon.stub(settingsCache, 'get');
 
         getStub.withArgs('title').returns('Ghost');
@@ -415,7 +415,7 @@ describe('{{ghost_head}} helper', function () {
                     safeVersion: '0.3'
                 }
             }));
-            sinon.assert.calledOnce(loggingErrorStub);
+            sinon.assert.notCalled(loggingErrorStub);
         });
 
         it('returns structured data on first index page', async function () {

--- a/ghost/core/test/unit/server/lib/image/cached-image-size-from-url.test.js
+++ b/ghost/core/test/unit/server/lib/image/cached-image-size-from-url.test.js
@@ -62,7 +62,7 @@ describe('lib/image: image size cache', function () {
         assert.equal(image2.height, 50);
     });
 
-    it('can handle generic image-size errors', async function () {
+    it('should not cache transient errors, allowing retry on next call', async function () {
         const url = 'http://mysite.com/content/image/mypostcoverimage.jpg';
 
         sizeOfStub.rejects('error');
@@ -74,17 +74,30 @@ describe('lib/image: image size cache', function () {
         });
 
         const loggingStub = sinon.stub(logging, 'error');
-        await cachedImageSizeFromUrl.getCachedImageSizeFromUrl(url);
+        const result = await cachedImageSizeFromUrl.getCachedImageSizeFromUrl(url);
 
-        cacheStore.get(url).should.not.be.undefined;
-        const image = cacheStore.get(url);
-        assert.equal(image.url, 'http://mysite.com/content/image/mypostcoverimage.jpg');
-        assert.equal(image.width, undefined);
-        assert.equal(image.height, undefined);
+        assert.equal(result.url, url);
+        assert.equal(result.width, undefined);
+        assert.equal(result.height, undefined);
+
+        // Transient errors should NOT be cached
+        assert.equal(cacheStore.get(url), undefined);
         sinon.assert.calledOnce(loggingStub);
+        assert.equal(sizeOfStub.calledOnce, true);
+
+        // Second call should retry the fetch since nothing was cached
+        const result2 = await cachedImageSizeFromUrl.getCachedImageSizeFromUrl(url);
+
+        assert.equal(result2.url, url);
+        assert.equal(result2.width, undefined);
+        assert.equal(result2.height, undefined);
+
+        // Cache should still be empty after the second transient error
+        assert.equal(cacheStore.get(url), undefined);
+        assert.equal(sizeOfStub.calledTwice, true);
     });
 
-    it('can handle NotFoundError error', async function () {
+    it('should cache NotFoundError permanently and not refetch on subsequent calls', async function () {
         const url = 'http://mysite.com/content/image/mypostcoverimage.jpg';
 
         sizeOfStub.rejects(new errors.NotFoundError('it iz gone mate!'));
@@ -95,13 +108,73 @@ describe('lib/image: image size cache', function () {
             cache: cacheStore
         });
 
-        await cachedImageSizeFromUrl.getCachedImageSizeFromUrl(url);
+        const result = await cachedImageSizeFromUrl.getCachedImageSizeFromUrl(url);
+        assert.equal(result.url, url);
+        assert.equal(result.width, undefined);
+        assert.equal(result.height, undefined);
 
         cacheStore.get(url).should.not.be.undefined;
         const image = cacheStore.get(url);
-        assert.equal(image.url, 'http://mysite.com/content/image/mypostcoverimage.jpg');
-        assert.equal(image.width, undefined);
-        assert.equal(image.height, undefined);
+        assert.equal(image.url, url);
+        assert.equal(image.notFound, true);
+
+        // Second call should NOT refetch — 404 is permanent
+        const secondResult = await cachedImageSizeFromUrl.getCachedImageSizeFromUrl(url);
+        assert.equal(secondResult.url, url);
+        assert.equal(secondResult.width, undefined);
+        assert.equal(sizeOfStub.calledOnce, true);
+    });
+
+    it('should retry fetch when cache has a stale error entry (no dimensions)', async function () {
+        const url = 'http://mysite.com/content/image/photo.jpg';
+
+        sizeOfStub.resolves({width: 500, height: 400, type: 'jpg'});
+
+        const cacheStore = new InMemoryCache();
+        // Pre-populate cache with an error entry (no width/height)
+        cacheStore.set(url, {url});
+
+        const cachedImageSizeFromUrl = new CachedImageSizeFromUrl({
+            getImageSizeFromUrl: sizeOfStub,
+            cache: cacheStore
+        });
+
+        const result = await cachedImageSizeFromUrl.getCachedImageSizeFromUrl(url);
+
+        assert.equal(result.width, 500);
+        assert.equal(result.height, 400);
+        assert.equal(sizeOfStub.calledOnce, true);
+
+        // Verify cache was overwritten with valid dimensions
+        const cached = cacheStore.get(url);
+        assert.equal(cached.width, 500);
+        assert.equal(cached.height, 400);
+    });
+
+    it('should not corrupt cache when caller mutates the returned object', async function () {
+        const url = 'http://mysite.com/content/image/mypostcoverimage.jpg';
+
+        sizeOfStub.resolves({width: 2000, height: 1000, type: 'jpg'});
+
+        const cacheStore = new InMemoryCache();
+        const cachedImageSizeFromUrl = new CachedImageSizeFromUrl({
+            getImageSizeFromUrl: sizeOfStub,
+            cache: cacheStore
+        });
+
+        const result = await cachedImageSizeFromUrl.getCachedImageSizeFromUrl(url);
+        result.width = 1200;
+        result.height = 600;
+
+        // Cache should still hold the original dimensions
+        const cached = cacheStore.get(url);
+        assert.equal(cached.width, 2000);
+        assert.equal(cached.height, 1000);
+
+        // A subsequent call should also return original dimensions
+        const secondResult = await cachedImageSizeFromUrl.getCachedImageSizeFromUrl(url);
+        assert.equal(secondResult.width, 2000);
+        assert.equal(secondResult.height, 1000);
     });
 
     it('should return null if url is null', async function () {

--- a/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
+++ b/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
@@ -9,6 +9,8 @@ const sinon = require('sinon');
 const logging = require('@tryghost/logging');
 const {HtmlValidate} = require('html-validate');
 const crypto = require('crypto');
+const CachedImageSizeFromUrl = require('../../../../../core/server/lib/image/cached-image-size-from-url');
+const InMemoryCache = require('../../../../../core/server/adapters/cache/MemoryCache');
 
 async function validateHtml(html) {
     const htmlvalidate = new HtmlValidate({
@@ -87,10 +89,8 @@ const tFr = (key, options) => {
 };
 
 describe('Email renderer', function () {
-    let logStub;
-
     beforeEach(function () {
-        logStub = sinon.stub(logging, 'error');
+        sinon.stub(logging, 'error');
     });
 
     afterEach(function () {
@@ -2991,7 +2991,7 @@ describe('Email renderer', function () {
         it('Limits width of local images', async function () {
             const emailRenderer = new EmailRenderer({
                 imageSize: {
-                    getImageSizeFromUrl() {
+                    getCachedImageSizeFromUrl() {
                         return {
                             width: 2000,
                             height: 1000
@@ -3013,7 +3013,7 @@ describe('Email renderer', function () {
         it('Limits width and height of local images', async function () {
             const emailRenderer = new EmailRenderer({
                 imageSize: {
-                    getImageSizeFromUrl() {
+                    getCachedImageSizeFromUrl() {
                         return {
                             width: 2000,
                             height: 1000
@@ -3032,11 +3032,11 @@ describe('Email renderer', function () {
             assert.equal(response.href, 'http://your-blog.com/content/images/size/w1200h1200/2017/01/02/example.png');
         });
 
-        it('Ignores and logs errors', async function () {
+        it('Returns default dimensions when getCachedImageSizeFromUrl returns no dimensions', async function () {
             const emailRenderer = new EmailRenderer({
                 imageSize: {
-                    getImageSizeFromUrl() {
-                        throw new Error('Oops, this is a test.');
+                    getCachedImageSizeFromUrl() {
+                        return {url: 'http://your-blog.com/content/images/2017/01/02/example.png'};
                     }
                 },
                 storageUtils: {
@@ -3047,14 +3047,14 @@ describe('Email renderer', function () {
             });
             const response = await emailRenderer.limitImageWidth('http://your-blog.com/content/images/2017/01/02/example.png');
             assert.equal(response.width, 0);
+            assert.equal(response.height, null);
             assert.equal(response.href, 'http://your-blog.com/content/images/2017/01/02/example.png');
-            sinon.assert.calledOnce(logStub);
         });
 
         it('Limits width of unsplash images', async function () {
             const emailRenderer = new EmailRenderer({
                 imageSize: {
-                    getImageSizeFromUrl() {
+                    getCachedImageSizeFromUrl() {
                         return {
                             width: 2000
                         };
@@ -3075,7 +3075,7 @@ describe('Email renderer', function () {
         it('Limits width and height of unsplash images', async function () {
             const emailRenderer = new EmailRenderer({
                 imageSize: {
-                    getImageSizeFromUrl() {
+                    getCachedImageSizeFromUrl() {
                         return {
                             width: 2000,
                             height: 1000
@@ -3097,7 +3097,7 @@ describe('Email renderer', function () {
         it('Does not increase width of images', async function () {
             const emailRenderer = new EmailRenderer({
                 imageSize: {
-                    getImageSizeFromUrl() {
+                    getCachedImageSizeFromUrl() {
                         return {
                             width: 300
                         };
@@ -3112,6 +3112,119 @@ describe('Email renderer', function () {
             const response = await emailRenderer.limitImageWidth('https://example.com/image.png');
             assert.equal(response.width, 300);
             assert.equal(response.href, 'https://example.com/image.png');
+        });
+
+        it('Uses cached image dimensions on cache hit', async function () {
+            const underlyingFetch = sinon.stub().callsFake(() => Promise.resolve({width: 2000, height: 1000}));
+            const cacheStore = new InMemoryCache();
+            // Pre-populate cache
+            cacheStore.set('https://example.com/image.png', {url: 'https://example.com/image.png', width: 2000, height: 1000});
+
+            const cachedImageSize = new CachedImageSizeFromUrl({
+                getImageSizeFromUrl: underlyingFetch,
+                cache: cacheStore
+            });
+
+            const emailRenderer = new EmailRenderer({
+                imageSize: cachedImageSize,
+                storageUtils: {
+                    isLocalImage() {
+                        return false;
+                    }
+                }
+            });
+
+            const response = await emailRenderer.limitImageWidth('https://example.com/image.png');
+            assert.equal(response.width, 600);
+            assert.equal(response.height, 300);
+            // Underlying fetch should not be called when cache has the data
+            sinon.assert.notCalled(underlyingFetch);
+        });
+
+        it('Falls back to fetching image dimensions on cache miss and writes back to cache', async function () {
+            const underlyingFetch = sinon.stub().callsFake(() => Promise.resolve({width: 2000, height: 1000}));
+            const cacheStore = new InMemoryCache();
+
+            const cachedImageSize = new CachedImageSizeFromUrl({
+                getImageSizeFromUrl: underlyingFetch,
+                cache: cacheStore
+            });
+
+            const emailRenderer = new EmailRenderer({
+                imageSize: cachedImageSize,
+                storageUtils: {
+                    isLocalImage() {
+                        return false;
+                    }
+                }
+            });
+
+            const response = await emailRenderer.limitImageWidth('https://example.com/image.png');
+            assert.equal(response.width, 600);
+            assert.equal(response.height, 300);
+            // Underlying fetch SHOULD be called on cache miss
+            sinon.assert.calledOnce(underlyingFetch);
+            // Result should be written back to cache
+            const cached = cacheStore.get('https://example.com/image.png');
+            assert.ok(cached);
+            assert.equal(cached.width, 2000);
+            assert.equal(cached.height, 1000);
+        });
+
+        it('Falls back to fetching when cache has an error entry (no dimensions)', async function () {
+            const underlyingFetch = sinon.stub().callsFake(() => Promise.resolve({width: 2000, height: 1000}));
+            const cacheStore = new InMemoryCache();
+            // Pre-populate cache with an error entry (no width/height)
+            cacheStore.set('https://example.com/image.png', {url: 'https://example.com/image.png'});
+
+            const cachedImageSize = new CachedImageSizeFromUrl({
+                getImageSizeFromUrl: underlyingFetch,
+                cache: cacheStore
+            });
+
+            const emailRenderer = new EmailRenderer({
+                imageSize: cachedImageSize,
+                storageUtils: {
+                    isLocalImage() {
+                        return false;
+                    }
+                }
+            });
+
+            const response = await emailRenderer.limitImageWidth('https://example.com/image.png');
+            assert.equal(response.width, 600);
+            assert.equal(response.height, 300);
+            // Should retry the underlying fetch when cache has an error entry
+            sinon.assert.calledOnce(underlyingFetch);
+        });
+
+        it('Returns default dimensions when fetch fails', async function () {
+            const ghosterrors = require('@tryghost/errors');
+            const underlyingFetch = sinon.stub().rejects(new ghosterrors.InternalServerError({
+                message: 'Request timed out.',
+                code: 'IMAGE_SIZE_URL'
+            }));
+            const cacheStore = new InMemoryCache();
+
+            const cachedImageSize = new CachedImageSizeFromUrl({
+                getImageSizeFromUrl: underlyingFetch,
+                cache: cacheStore
+            });
+
+            const emailRenderer = new EmailRenderer({
+                imageSize: cachedImageSize,
+                storageUtils: {
+                    isLocalImage() {
+                        return false;
+                    }
+                }
+            });
+
+            const response = await emailRenderer.limitImageWidth('https://example.com/broken.png');
+            // getCachedImageSizeFromUrl returns {url} without dimensions, limitImageWidth returns fallback
+            assert.equal(response.href, 'https://example.com/broken.png');
+            assert.equal(response.width, 0);
+            assert.equal(response.height, null);
         });
     });
     describe('additional i18n tests', function () {


### PR DESCRIPTION
## Summary
- Email rendering was bypassing the image dimension cache — it used the raw `ImageSize.getImageSizeFromUrl()` which makes a fresh HTTP request/probe on every call, even though the frontend metadata path already cached these via `CachedImageSizeFromUrl`
- Updated the caching logic into the existing `getCachedImageSizeFromUrl()` — it now returns shallow copies to prevent cache corruption when consumers mutate dimensions in-place, only caches 404s permanently with a `notFound` marker so they can be distinguished from stale transient errors (transient errors are not cached, allowing retry), and retries fetch when the cache holds a stale error entry without dimensions
- Wired the email renderer to use `cachedImageSizeFromUrl` directly as the `imageSize` dependency, replacing the uncached `ImageSize` instance
- Added a guard in `limitImageWidth` for missing dimensions — since `getCachedImageSizeFromUrl` never throws (returns `{url}` on error), it checks `!size.width` and returns defaults, so the renderer gracefully handles failed fetches without a behavior change
- The other consumer — `image-dimensions.js` (frontend metadata) — did not need any changes since it already calls `getCachedImageSizeFromUrl` and handles missing dimensions gracefully. The shallow copy fix and improved caching strategy benefit it automatically
- Updated unit tests for `getCachedImageSizeFromUrl` (transient errors not cached, 404s cached, stale entry retry, cache corruption prevention) and added integration tests verifying the email renderer wiring end-to-end (cache hit, cache miss with write-back, stale error entry retry, fetch failure fallback)

ref HKG-1583

🤖 Generated with [Claude Code](https://claude.com/claude-code)
