### PR TITLE
Added playwright report command to browser tests job in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -398,6 +398,11 @@ jobs:
         path: ghost/core/playwright-report
         retention-days: 30
 
+    - name: View Test Report command
+      if: failure()
+      run: |
+        echo -e "::notice::To view the Playwright report locally, run:\n\nREPORT_DIR=\$(mktemp -d) && gh run download ${{ github.run_id }} -n browser-tests-playwright-report -D \"\$REPORT_DIR\" && npx playwright show-report \"\$REPORT_DIR\""
+
   job_perf-tests:
     runs-on:
       labels: ubuntu-latest-4-cores

--- a/ghost/core/test/e2e-browser/admin/site-settings.spec.js
+++ b/ghost/core/test/e2e-browser/admin/site-settings.spec.js
@@ -88,8 +88,8 @@ test.describe('Site Settings', () => {
             // Go to the signup page
             await sharedPage.goto('/#/portal/signup');
 
-            // Intentional CI failure for verification: this should be 1
-            await expect(sharedPage.locator('#ghost-portal-root div iframe')).toHaveCount(0);
+            // Portal should load
+            await expect(sharedPage.locator('#ghost-portal-root div iframe')).toHaveCount(1);
             await checkPortalScriptLoaded(sharedPage, true);
         });
 

--- a/ghost/core/test/e2e-browser/admin/site-settings.spec.js
+++ b/ghost/core/test/e2e-browser/admin/site-settings.spec.js
@@ -88,8 +88,8 @@ test.describe('Site Settings', () => {
             // Go to the signup page
             await sharedPage.goto('/#/portal/signup');
 
-            // Portal should load
-            await expect(sharedPage.locator('#ghost-portal-root div iframe')).toHaveCount(1);
+            // Intentional CI failure for verification: this should be 1
+            await expect(sharedPage.locator('#ghost-portal-root div iframe')).toHaveCount(0);
             await checkPortalScriptLoaded(sharedPage, true);
         });
 


### PR DESCRIPTION
In the e2e test suite, there's a convenient one-liner command posted to the PR that you can copy and run locally to download and view the playwright test report if any tests fail. This is way more convenient than manually downloading, unzipping, and running the playwright command to see what went wrong in the tests. 

This PR adds the same one-liner to the browser tests to make it easier to debug when things go wrong.