### PR TITLE
Traffic empty state spacing

### DIFF
--- a/apps/stats/src/views/Stats/Web/components/sources-card.tsx
+++ b/apps/stats/src/views/Stats/Web/components/sources-card.tsx
@@ -152,7 +152,7 @@ export const SourcesCard: React.FC<SourcesCardProps> = ({
                             onSourceClick={onSourceClick} />
                     ) : (
                         <EmptyIndicator
-                            className='mt-8 w-full py-20'
+                            className='w-full py-20'
                             title={`No visitors ${getPeriodText(range)}`}
                         >
                             <LucideIcon.Globe strokeWidth={1.5} />


### PR DESCRIPTION
Got some code for us? Awesome 🎊!

Please take a minute to explain the change you're making:
- Why are you making it?
  To resolve the issue (DES-1282) where the empty state spacing differed between the "Top content" and "Top sources" sections on the Web Traffic tab.
- What does it do?
  It removes an unnecessary `mt-8` (margin-top: 2rem) class from the `EmptyIndicator` component in the "Top sources" card.
- Why is this something Ghost users or developers need?
  This ensures a consistent and polished user interface for empty states within the Web Traffic tab, improving the overall user experience.

Please check your PR against these items:

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [ ] I've written an automated test to prove my change works

We appreciate your contribution! 🙏

---
Linear Issue: [DES-1282](https://linear.app/ghost/issue/DES-1282/empty-state-spacing-differs-on-web-traffic-tab)

<p><a href="https://cursor.com/background-agent?bcId=bc-6a17bae7-1215-4cfb-bb4e-899f88f710b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6a17bae7-1215-4cfb-bb4e-899f88f710b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely a small UI spacing tweak with no logic, data, or API behavior changes.
> 
> **Overview**
> Aligns empty-state spacing on the Web Traffic tab by removing the `mt-8` top margin from the `EmptyIndicator` in `sources-card.tsx` ("Top sources").
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 671335d6001d5f26f8e1143915ef11aceeff89a4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->