### PR TITLE
Sub-head field tk

### DIFF
--- a/ghost/admin/app/controllers/lexical-editor.js
+++ b/ghost/admin/app/controllers/lexical-editor.js
@@ -291,13 +291,13 @@ export default class LexicalEditorController extends Controller {
         return textHasTk(this.post.titleScratch);
     }
 
-    @computed('post.customExcerpt')
+    @computed('post.customExcerptScratch')
     get excerptHasTk() {
         if (!this.feature.editorExcerpt) {
             return false;
         }
 
-        return textHasTk(this.post.customExcerpt || '');
+        return textHasTk(this.post.customExcerptScratch || '');
     }
 
     @computed('titleHasTk', 'excerptHasTk', 'postTkCount', 'featureImageTkCount')
@@ -340,7 +340,7 @@ export default class LexicalEditorController extends Controller {
 
     @action
     async updateExcerpt(excerpt) {
-        this.post.customExcerpt = excerpt;
+        this.post.customExcerptScratch = excerpt;
         try {
             await this.post.validate({property: 'customExcerpt'});
             this.excerptErrorMessage = '';

--- a/ghost/admin/app/controllers/lexical-editor.js
+++ b/ghost/admin/app/controllers/lexical-editor.js
@@ -341,6 +341,8 @@ export default class LexicalEditorController extends Controller {
     @action
     async updateExcerpt(excerpt) {
         this.post.customExcerptScratch = excerpt;
+        // Temporarily set customExcerpt for validation, it will be properly set in beforeSaveTask
+        this.post.customExcerpt = excerpt;
         try {
             await this.post.validate({property: 'customExcerpt'});
             this.excerptErrorMessage = '';

--- a/ghost/admin/app/templates/lexical-editor.hbs
+++ b/ghost/admin/app/templates/lexical-editor.hbs
@@ -67,7 +67,7 @@
                 @titleHasTk={{this.titleHasTk}}
                 @onTitleChange={{this.updateTitleScratch}}
                 @onTitleBlur={{perform this.saveTitleTask}}
-                @excerpt={{readonly this.post.customExcerpt}}
+                @excerpt={{readonly this.post.customExcerptScratch}}
                 @excerptHasTk={{this.excerptHasTk}}
                 @setExcerpt={{this.updateExcerpt}}
                 @onExcerptBlur={{perform this.saveExcerptTask}}


### PR DESCRIPTION
Got some code for us? Awesome 🎊!

Please take a minute to explain the change you're making:
- **Why are you making it?**
  The "TK" (To Come) indicator in the sub-head (custom excerpt) field was not updating in real-time as users typed, leading to an inconsistent and unresponsive editing experience compared to the post title field.

- **What does it do?**
  This change modifies the editor to use a `customExcerptScratch` property for the excerpt field, mirroring the existing `titleScratch` pattern used for the post title. The `excerptHasTk` computed property now watches `post.customExcerptScratch`, ensuring the TK indicator updates instantly as the user types. The `updateExcerpt` action and the template binding have been updated accordingly.

- **Why is this something Ghost users or developers need?**
  Ghost users will now experience a consistent and real-time TK indicator in both the post title and sub-head fields, improving the overall responsiveness and usability of the editor. For developers, this aligns the excerpt field's behavior with the established pattern for the title field, promoting consistency in the codebase.

Please check your PR against these items:

- [ ] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [ ] I've written an automated test to prove my change works

We appreciate your contribution! 🙏

---
Linear Issue: [BER-2237](https://linear.app/ghost/issue/BER-2237/apply-tk-functionality-in-the-sub-head-field-when-turned-on-in-the)

<p><a href="https://cursor.com/background-agent?bcId=bc-d7d6d262-9d1b-4ed1-9e11-125e99a9c3ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d7d6d262-9d1b-4ed1-9e11-125e99a9c3ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

