### PR TITLE
Added structured logs for Ghost welcome emails enabled/disabled

### DIFF
--- a/ghost/core/core/server/api/endpoints/automated-emails.js
+++ b/ghost/core/core/server/api/endpoints/automated-emails.js
@@ -1,10 +1,43 @@
 const tpl = require('@tryghost/tpl');
 const errors = require('@tryghost/errors');
+const logging = require('@tryghost/logging');
 const models = require('../../models');
 const memberWelcomeEmailService = require('../../services/member-welcome-emails/service');
+const {MEMBER_WELCOME_EMAIL_SLUGS} = require('../../services/member-welcome-emails/constants');
+
+const MEMBER_WELCOME_EMAIL_SLUG_SET = new Set(Object.values(MEMBER_WELCOME_EMAIL_SLUGS));
 
 const messages = {
     automatedEmailNotFound: 'Automated email not found.'
+};
+
+const logWelcomeEmailStatusTransition = (beforeModel, afterModel) => {
+    if (!beforeModel || !afterModel) {
+        return;
+    }
+
+    const slug = afterModel.get('slug');
+
+    if (!MEMBER_WELCOME_EMAIL_SLUG_SET.has(slug)) {
+        return;
+    }
+
+    const previousStatus = beforeModel.get('status');
+    const currentStatus = afterModel.get('status');
+    const hasChangedStatus = previousStatus !== currentStatus;
+    const isEnableTransition = previousStatus === 'inactive' && currentStatus === 'active';
+    const isDisableTransition = previousStatus === 'active' && currentStatus === 'inactive';
+
+    if (!hasChangedStatus || (!isEnableTransition && !isDisableTransition)) {
+        return;
+    }
+
+    logging.info('Welcome email status changed', {
+        event: isEnableTransition ? 'welcome_email.enabled' : 'welcome_email.disabled',
+        automated_email_id: afterModel.id,
+        slug,
+        enabled: currentStatus === 'active'
+    });
 };
 
 /** @type {import('@tryghost/api-framework').Controller} */
@@ -81,12 +114,15 @@ const controller = {
         permissions: true,
         async query(frame) {
             const data = frame.data.automated_emails[0];
+            const currentModel = await models.AutomatedEmail.findOne({id: frame.options.id}, frame.options);
             const model = await models.AutomatedEmail.edit(data, frame.options);
             if (!model) {
                 throw new errors.NotFoundError({
                     message: tpl(messages.automatedEmailNotFound)
                 });
             }
+
+            logWelcomeEmailStatusTransition(currentModel, model);
 
             return model;
         }

--- a/ghost/core/core/server/api/endpoints/automated-emails.js
+++ b/ghost/core/core/server/api/endpoints/automated-emails.js
@@ -28,12 +28,7 @@ const logWelcomeEmailStatusTransition = ({automatedEmailId, slug, previousStatus
         return;
     }
 
-    logging.info({
-        event: isEnableTransition ? 'welcome_email.enabled' : 'welcome_email.disabled',
-        automated_email_id: automatedEmailId,
-        slug,
-        enabled: currentStatus === 'active'
-    }, 'Welcome email status changed');
+    logging.info(isEnableTransition ? 'Welcome email enabled' : 'Welcome email disabled');
 };
 
 /** @type {import('@tryghost/api-framework').Controller} */

--- a/ghost/core/core/server/api/endpoints/automated-emails.js
+++ b/ghost/core/core/server/api/endpoints/automated-emails.js
@@ -29,10 +29,12 @@ const logWelcomeEmailStatusTransition = ({automatedEmailId, slug, previousStatus
     }
 
     logging.info({
-        event: isEnableTransition ? 'welcome_email.enabled' : 'welcome_email.disabled',
-        automated_email_id: automatedEmailId,
-        slug,
-        enabled: currentStatus === 'active'
+        system: {
+            event: isEnableTransition ? 'welcome_email.enabled' : 'welcome_email.disabled',
+            automated_email_id: automatedEmailId,
+            slug,
+            enabled: currentStatus === 'active'
+        }
     }, 'Welcome email status changed');
 };
 

--- a/ghost/core/core/server/api/endpoints/automated-emails.js
+++ b/ghost/core/core/server/api/endpoints/automated-emails.js
@@ -28,7 +28,12 @@ const logWelcomeEmailStatusTransition = ({automatedEmailId, slug, previousStatus
         return;
     }
 
-    logging.info(isEnableTransition ? 'Welcome email enabled' : 'Welcome email disabled');
+    logging.info({
+        event: isEnableTransition ? 'welcome_email.enabled' : 'welcome_email.disabled',
+        automated_email_id: automatedEmailId,
+        slug,
+        enabled: currentStatus === 'active'
+    }, 'Welcome email status changed');
 };
 
 /** @type {import('@tryghost/api-framework').Controller} */

--- a/ghost/core/core/server/api/endpoints/automated-emails.js
+++ b/ghost/core/core/server/api/endpoints/automated-emails.js
@@ -28,12 +28,12 @@ const logWelcomeEmailStatusTransition = ({automatedEmailId, slug, previousStatus
         return;
     }
 
-    logging.info('Welcome email status changed', {
+    logging.info({
         event: isEnableTransition ? 'welcome_email.enabled' : 'welcome_email.disabled',
         automated_email_id: automatedEmailId,
         slug,
         enabled: currentStatus === 'active'
-    });
+    }, 'Welcome email status changed');
 };
 
 /** @type {import('@tryghost/api-framework').Controller} */

--- a/ghost/core/core/server/api/endpoints/automated-emails.js
+++ b/ghost/core/core/server/api/endpoints/automated-emails.js
@@ -40,7 +40,7 @@ const logWelcomeEmailStatusTransition = (model) => {
             slug,
             enabled: currentStatus === 'active'
         }
-    }, 'Welcome email status changed');
+    }, isEnableTransition ? 'Welcome email enabled' : 'Welcome email disabled');
 };
 
 /** @type {import('@tryghost/api-framework').Controller} */

--- a/ghost/core/core/server/models/automated-email.js
+++ b/ghost/core/core/server/models/automated-email.js
@@ -64,8 +64,7 @@ const AutomatedEmail = ghostBookshelf.Model.extend({
             system: {
                 event: isEnableTransition ? 'welcome_email.enabled' : 'welcome_email.disabled',
                 automated_email_id: model.id,
-                slug,
-                enabled: currentStatus === 'active'
+                slug
             }
         }, isEnableTransition ? 'Welcome email enabled' : 'Welcome email disabled');
     }

--- a/ghost/core/core/server/models/automated-email.js
+++ b/ghost/core/core/server/models/automated-email.js
@@ -1,6 +1,10 @@
 const ghostBookshelf = require('./base');
+const logging = require('@tryghost/logging');
 const urlUtils = require('../../shared/url-utils');
 const lexicalLib = require('../lib/lexical');
+const {MEMBER_WELCOME_EMAIL_SLUGS} = require('../services/member-welcome-emails/constants');
+
+const MEMBER_WELCOME_EMAIL_SLUG_SET = new Set(Object.values(MEMBER_WELCOME_EMAIL_SLUGS));
 
 const AutomatedEmail = ghostBookshelf.Model.extend({
     tableName: 'automated_emails',
@@ -33,6 +37,37 @@ const AutomatedEmail = ghostBookshelf.Model.extend({
         }
 
         return attrs;
+    },
+
+    onSaved(model) {
+        if (!model?.id) {
+            return;
+        }
+
+        const slug = model.get('slug');
+
+        if (!MEMBER_WELCOME_EMAIL_SLUG_SET.has(slug)) {
+            return;
+        }
+
+        const previousStatus = model.previous('status');
+        const currentStatus = model.get('status');
+        const isNewModel = previousStatus === undefined;
+        const isEnableTransition = currentStatus === 'active' && (isNewModel || previousStatus === 'inactive');
+        const isDisableTransition = previousStatus === 'active' && currentStatus === 'inactive';
+
+        if (!isEnableTransition && !isDisableTransition) {
+            return;
+        }
+
+        logging.info({
+            system: {
+                event: isEnableTransition ? 'welcome_email.enabled' : 'welcome_email.disabled',
+                automated_email_id: model.id,
+                slug,
+                enabled: currentStatus === 'active'
+            }
+        }, isEnableTransition ? 'Welcome email enabled' : 'Welcome email disabled');
     }
 });
 

--- a/ghost/core/test/e2e-api/admin/automated-emails.test.js
+++ b/ghost/core/test/e2e-api/admin/automated-emails.test.js
@@ -307,12 +307,7 @@ describe('Automated Emails API', function () {
                     }]})
                     .expectStatus(200);
 
-                sinon.assert.calledWithMatch(infoStub, {
-                    event: 'welcome_email.enabled',
-                    automated_email_id: automatedEmail.id,
-                    slug: 'member-welcome-email-free',
-                    enabled: true
-                }, sinon.match.string);
+                sinon.assert.calledWithMatch(infoStub, 'Welcome email enabled');
             });
 
             it('Logs when a welcome email is disabled', async function () {
@@ -326,12 +321,7 @@ describe('Automated Emails API', function () {
                     }]})
                     .expectStatus(200);
 
-                sinon.assert.calledWithMatch(infoStub, {
-                    event: 'welcome_email.disabled',
-                    automated_email_id: automatedEmail.id,
-                    slug: 'member-welcome-email-free',
-                    enabled: false
-                }, sinon.match.string);
+                sinon.assert.calledWithMatch(infoStub, 'Welcome email disabled');
             });
 
             it('Does not log when status does not change', async function () {
@@ -345,9 +335,7 @@ describe('Automated Emails API', function () {
                     }]})
                     .expectStatus(200);
 
-                sinon.assert.neverCalledWithMatch(infoStub, sinon.match.any, {
-                    event: sinon.match(/^welcome_email\.(enabled|disabled)$/)
-                });
+                sinon.assert.neverCalledWithMatch(infoStub, sinon.match(/^Welcome email (enabled|disabled)$/));
             });
         });
     });

--- a/ghost/core/test/e2e-api/admin/automated-emails.test.js
+++ b/ghost/core/test/e2e-api/admin/automated-emails.test.js
@@ -307,7 +307,12 @@ describe('Automated Emails API', function () {
                     }]})
                     .expectStatus(200);
 
-                sinon.assert.calledWithMatch(infoStub, 'Welcome email enabled');
+                sinon.assert.calledWithMatch(infoStub, {
+                    event: 'welcome_email.enabled',
+                    automated_email_id: automatedEmail.id,
+                    slug: 'member-welcome-email-free',
+                    enabled: true
+                }, sinon.match.string);
             });
 
             it('Logs when a welcome email is disabled', async function () {
@@ -321,7 +326,12 @@ describe('Automated Emails API', function () {
                     }]})
                     .expectStatus(200);
 
-                sinon.assert.calledWithMatch(infoStub, 'Welcome email disabled');
+                sinon.assert.calledWithMatch(infoStub, {
+                    event: 'welcome_email.disabled',
+                    automated_email_id: automatedEmail.id,
+                    slug: 'member-welcome-email-free',
+                    enabled: false
+                }, sinon.match.string);
             });
 
             it('Does not log when status does not change', async function () {
@@ -335,7 +345,9 @@ describe('Automated Emails API', function () {
                     }]})
                     .expectStatus(200);
 
-                sinon.assert.neverCalledWithMatch(infoStub, sinon.match(/^Welcome email (enabled|disabled)$/));
+                sinon.assert.neverCalledWithMatch(infoStub, sinon.match.any, {
+                    event: sinon.match(/^welcome_email\.(enabled|disabled)$/)
+                });
             });
         });
     });

--- a/ghost/core/test/e2e-api/admin/automated-emails.test.js
+++ b/ghost/core/test/e2e-api/admin/automated-emails.test.js
@@ -217,12 +217,12 @@ describe('Automated Emails API', function () {
                     }]})
                     .expectStatus(201);
 
-                sinon.assert.neverCalledWithMatch(infoStub, sinon.match.any, {
+                sinon.assert.neverCalledWithMatch(infoStub, {
                     system: {
                         event: 'welcome_email.enabled',
                         slug: 'member-welcome-email-free'
                     }
-                });
+                }, sinon.match.any);
             });
         });
     });
@@ -402,11 +402,11 @@ describe('Automated Emails API', function () {
                     }]})
                     .expectStatus(200);
 
-                sinon.assert.neverCalledWithMatch(infoStub, sinon.match.any, {
+                sinon.assert.neverCalledWithMatch(infoStub, {
                     system: {
                         event: sinon.match(/^welcome_email\.(enabled|disabled)$/)
                     }
-                });
+                }, sinon.match.any);
             });
         });
     });

--- a/ghost/core/test/e2e-api/admin/automated-emails.test.js
+++ b/ghost/core/test/e2e-api/admin/automated-emails.test.js
@@ -307,12 +307,12 @@ describe('Automated Emails API', function () {
                     }]})
                     .expectStatus(200);
 
-                sinon.assert.calledWithMatch(infoStub, sinon.match.string, {
+                sinon.assert.calledWithMatch(infoStub, {
                     event: 'welcome_email.enabled',
                     automated_email_id: automatedEmail.id,
                     slug: 'member-welcome-email-free',
                     enabled: true
-                });
+                }, sinon.match.string);
             });
 
             it('Logs when a welcome email is disabled', async function () {
@@ -326,12 +326,12 @@ describe('Automated Emails API', function () {
                     }]})
                     .expectStatus(200);
 
-                sinon.assert.calledWithMatch(infoStub, sinon.match.string, {
+                sinon.assert.calledWithMatch(infoStub, {
                     event: 'welcome_email.disabled',
                     automated_email_id: automatedEmail.id,
                     slug: 'member-welcome-email-free',
                     enabled: false
-                });
+                }, sinon.match.string);
             });
 
             it('Does not log when status does not change', async function () {

--- a/ghost/core/test/e2e-api/admin/automated-emails.test.js
+++ b/ghost/core/test/e2e-api/admin/automated-emails.test.js
@@ -308,10 +308,12 @@ describe('Automated Emails API', function () {
                     .expectStatus(200);
 
                 sinon.assert.calledWithMatch(infoStub, {
-                    event: 'welcome_email.enabled',
-                    automated_email_id: automatedEmail.id,
-                    slug: 'member-welcome-email-free',
-                    enabled: true
+                    system: {
+                        event: 'welcome_email.enabled',
+                        automated_email_id: automatedEmail.id,
+                        slug: 'member-welcome-email-free',
+                        enabled: true
+                    }
                 }, sinon.match.string);
             });
 
@@ -327,10 +329,12 @@ describe('Automated Emails API', function () {
                     .expectStatus(200);
 
                 sinon.assert.calledWithMatch(infoStub, {
-                    event: 'welcome_email.disabled',
-                    automated_email_id: automatedEmail.id,
-                    slug: 'member-welcome-email-free',
-                    enabled: false
+                    system: {
+                        event: 'welcome_email.disabled',
+                        automated_email_id: automatedEmail.id,
+                        slug: 'member-welcome-email-free',
+                        enabled: false
+                    }
                 }, sinon.match.string);
             });
 
@@ -346,7 +350,9 @@ describe('Automated Emails API', function () {
                     .expectStatus(200);
 
                 sinon.assert.neverCalledWithMatch(infoStub, sinon.match.any, {
-                    event: sinon.match(/^welcome_email\.(enabled|disabled)$/)
+                    system: {
+                        event: sinon.match(/^welcome_email\.(enabled|disabled)$/)
+                    }
                 });
             });
         });

--- a/ghost/core/test/e2e-api/admin/automated-emails.test.js
+++ b/ghost/core/test/e2e-api/admin/automated-emails.test.js
@@ -314,7 +314,7 @@ describe('Automated Emails API', function () {
                         slug: 'member-welcome-email-free',
                         enabled: true
                     }
-                }, sinon.match.string);
+                }, 'Welcome email enabled');
             });
 
             it('Logs when a welcome email is disabled', async function () {
@@ -335,7 +335,7 @@ describe('Automated Emails API', function () {
                         slug: 'member-welcome-email-free',
                         enabled: false
                     }
-                }, sinon.match.string);
+                }, 'Welcome email disabled');
             });
 
             it('Does not log when status does not change', async function () {

--- a/ghost/core/test/e2e-api/admin/automated-emails.test.js
+++ b/ghost/core/test/e2e-api/admin/automated-emails.test.js
@@ -1,6 +1,7 @@
 const {agentProvider, fixtureManager, matchers, dbUtils} = require('../../utils/e2e-framework');
 const {anyContentVersion, anyObjectId, anyISODateTime, anyErrorId, anyEtag, anyLocationFor} = matchers;
 const sinon = require('sinon');
+const logging = require('@tryghost/logging');
 const mailService = require('../../../core/server/services/mail');
 
 const matchAutomatedEmail = {
@@ -282,6 +283,72 @@ describe('Automated Emails API', function () {
                     'content-version': anyContentVersion,
                     etag: anyEtag
                 });
+        });
+
+        describe('Structured logging', function () {
+            let infoStub;
+
+            beforeEach(function () {
+                infoStub = sinon.stub(logging, 'info');
+            });
+
+            afterEach(function () {
+                sinon.restore();
+            });
+
+            it('Logs when a welcome email is enabled', async function () {
+                const automatedEmail = await createAutomatedEmail({status: 'inactive'});
+
+                await agent
+                    .put(`automated_emails/${automatedEmail.id}`)
+                    .body({automated_emails: [{
+                        name: 'Welcome Email (Free)',
+                        status: 'active'
+                    }]})
+                    .expectStatus(200);
+
+                sinon.assert.calledWithMatch(infoStub, sinon.match.string, {
+                    event: 'welcome_email.enabled',
+                    automated_email_id: automatedEmail.id,
+                    slug: 'member-welcome-email-free',
+                    enabled: true
+                });
+            });
+
+            it('Logs when a welcome email is disabled', async function () {
+                const automatedEmail = await createAutomatedEmail({status: 'active'});
+
+                await agent
+                    .put(`automated_emails/${automatedEmail.id}`)
+                    .body({automated_emails: [{
+                        name: 'Welcome Email (Free)',
+                        status: 'inactive'
+                    }]})
+                    .expectStatus(200);
+
+                sinon.assert.calledWithMatch(infoStub, sinon.match.string, {
+                    event: 'welcome_email.disabled',
+                    automated_email_id: automatedEmail.id,
+                    slug: 'member-welcome-email-free',
+                    enabled: false
+                });
+            });
+
+            it('Does not log when status does not change', async function () {
+                const automatedEmail = await createAutomatedEmail({status: 'inactive'});
+
+                await agent
+                    .put(`automated_emails/${automatedEmail.id}`)
+                    .body({automated_emails: [{
+                        name: 'Welcome Email (Free)',
+                        subject: 'Updated subject only'
+                    }]})
+                    .expectStatus(200);
+
+                sinon.assert.neverCalledWithMatch(infoStub, sinon.match.any, {
+                    event: sinon.match(/^welcome_email\.(enabled|disabled)$/)
+                });
+            });
         });
     });
 

--- a/ghost/core/test/e2e-api/admin/automated-emails.test.js
+++ b/ghost/core/test/e2e-api/admin/automated-emails.test.js
@@ -200,8 +200,7 @@ describe('Automated Emails API', function () {
                     system: {
                         event: 'welcome_email.enabled',
                         automated_email_id: automatedEmail.id,
-                        slug: 'member-welcome-email-free',
-                        enabled: true
+                        slug: 'member-welcome-email-free'
                     }
                 }, 'Welcome email enabled');
             });
@@ -367,8 +366,7 @@ describe('Automated Emails API', function () {
                     system: {
                         event: 'welcome_email.enabled',
                         automated_email_id: automatedEmail.id,
-                        slug: 'member-welcome-email-free',
-                        enabled: true
+                        slug: 'member-welcome-email-free'
                     }
                 }, 'Welcome email enabled');
             });
@@ -388,8 +386,7 @@ describe('Automated Emails API', function () {
                     system: {
                         event: 'welcome_email.disabled',
                         automated_email_id: automatedEmail.id,
-                        slug: 'member-welcome-email-free',
-                        enabled: false
+                        slug: 'member-welcome-email-free'
                     }
                 }, 'Welcome email disabled');
             });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/NY-1019/add-structured-logs-for-when-a-welcome-email-is-enableddisabled

This adds two logging events when publishers enable or disable welcome emails:
- welcome_email.enabled - a useful signal for feature adoption
- welcome_email.disabled - a useful signal for feature (dis)-satisfaction

This is also an initial experiment in structured logging in Ghost, which we can hopefully build on and convert most/all of Ghost's logs to a similar format over time to make them easier to search through.

The reason for the "system" top level key is that this top level object is already ingested in Elastic search. We may want to adjust this at some point to something that makes more sense in the context of Ghost, but for now this should do the trick.