### PR TITLE
Removed welcome email test inbox override

### DIFF
--- a/ghost/core/core/server/services/member-welcome-emails/service.js
+++ b/ghost/core/core/server/services/member-welcome-emails/service.js
@@ -49,8 +49,14 @@ class MemberWelcomeEmailService {
     }
 
     async send({member, memberStatus}) {
+        if (!member.email) {
+            throw new errors.IncorrectUsageError({
+                message: MESSAGES.MISSING_RECIPIENT_EMAIL
+            });
+        }
+
         const name = member?.name ? `${member.name} at ` : '';
-        logging.info(`${MEMBER_WELCOME_EMAIL_LOG_KEY} Sending welcome email to ${name}${member?.email}`);
+        logging.info(`${MEMBER_WELCOME_EMAIL_LOG_KEY} Sending welcome email to ${name}${member.email}`);
 
         const memberWelcomeEmail = this.#memberWelcomeEmails[memberStatus];
 
@@ -75,12 +81,6 @@ class MemberWelcomeEmailService {
             },
             siteSettings: this.#getSiteSettings()
         });
-
-        if (!member.email) {
-            throw new errors.IncorrectUsageError({
-                message: MESSAGES.MISSING_RECIPIENT_EMAIL
-            });
-        }
 
         await this.#mailer.send({
             to: member.email,

--- a/ghost/core/core/server/services/member-welcome-emails/service.js
+++ b/ghost/core/core/server/services/member-welcome-emails/service.js
@@ -2,7 +2,6 @@ const logging = require('@tryghost/logging');
 const errors = require('@tryghost/errors');
 const urlUtils = require('../../../shared/url-utils');
 const settingsCache = require('../../../shared/settings-cache');
-const config = require('../../../shared/config');
 const emailAddressService = require('../email-address');
 const mail = require('../mail');
 // @ts-expect-error type checker has trouble with the dynamic exporting in models
@@ -77,17 +76,14 @@ class MemberWelcomeEmailService {
             siteSettings: this.#getSiteSettings()
         });
 
-        const testInbox = config.get('memberWelcomeEmailTestInbox');
-        const toEmail = testInbox || member.email;
-
-        if (!toEmail) {
+        if (!member.email) {
             throw new errors.IncorrectUsageError({
                 message: MESSAGES.MISSING_RECIPIENT_EMAIL
             });
         }
 
         await this.#mailer.send({
-            to: toEmail,
+            to: member.email,
             subject,
             html,
             text,


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1021

- The memberWelcomeEmailTestInbox config was used for QA routing of welcome emails to a Slack channel. This is no longer needed as the feature has been validated.