### PR TITLE
Stabilize resend verification acceptance test timeouts

### DIFF
--- a/ghost/admin/tests/acceptance/authentication-test.js
+++ b/ghost/admin/tests/acceptance/authentication-test.js
@@ -304,17 +304,17 @@ describe('Acceptance: Authentication', function () {
 
         it('can resend verification code', async function () {
             setupVerificationRequired(this.server);
-            setupResendSuccess(this.server, {timing: 100});
+            setupResendSuccess(this.server, {timing: 300});
             await completeSignIn();
 
             // no await so we can test for intermediary state
             click(resendButton);
 
             // await this.pauseTest();
-            await waitFor(`${resendButton}[disabled]`, {timeout: 10});
-            await waitUntil(() => find(resendButton).textContent.includes('Sending'), {timeout: 30, timeoutMessage: 'Check for "Sending" timed out'});
-            await waitUntil(() => find(resendButton).textContent.includes('Sent'), {timeout: 150, timeoutMessage: 'Check for "Sent" timed out'});
-            await waitFor(`${resendButton}:not([disabled])`, {timeout: 200});
+            await waitFor(`${resendButton}[disabled]`, {timeout: 1000});
+            await waitUntil(() => find(resendButton).textContent.includes('Sending'), {timeout: 2000, timeoutMessage: 'Check for "Sending" timed out'});
+            await waitUntil(() => find(resendButton).textContent.includes('Sent'), {timeout: 3000, timeoutMessage: 'Check for "Sent" timed out'});
+            await waitFor(`${resendButton}:not([disabled])`, {timeout: 4000});
             expect(find(resendButton)).to.have.trimmed.text('Resend');
         });
 


### PR DESCRIPTION
### Motivation
- The admin acceptance test for the sign-in 2FA resend flow was intermittently failing due to overly tight timing assertions around transient UI states (`disabled` → `Sending` → `Sent` → enabled). 
- CI scheduling and Mirage response timing can exceed tiny time windows (10–200ms), making the assertions brittle and causing unrelated flakes.

### Description
- Updated `ghost/admin/tests/acceptance/authentication-test.js` to increase the Mirage resend stub delay from `100ms` to `300ms` to make the intermediate states observable. 
- Relaxed the test's timing windows by increasing the `waitFor`/`waitUntil` timeouts from `10/30/150/200ms` to `1000/2000/3000/4000ms` respectively while keeping the same behavioral assertions and selectors. 
- No change to application code or locators; the test logic and asserted outcomes remain unchanged.

### Testing
- Ran the filtered acceptance test with `cd ghost/admin && CI=true yarn test -- --filter "Authentication / signin / can resend verification code"` and observed the test build start but the process did not complete within the run window in this environment. 
- Ran lint for the file with `cd ghost/admin && yarn lint:js tests/acceptance/authentication-test.js` and the lint step failed in this environment due to ESLint v9 configuration expectations (environment-specific), not related to the test changes. 
- Verified the updated test assertions and Mirage timing locally in the code (no functional changes to behavior), and expect these larger timeouts to reduce CI flakes caused by scheduling jitter.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bac3667548322beacd4ad4d7d1dd3)