### PR TITLE
Fixed paid signup welcome email race condition

### DIFF
--- a/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
+++ b/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
@@ -491,7 +491,7 @@ module.exports = class RouterController {
                         url: options.metadata.attribution_url ?? null
                     }
                 },
-                type: 'signup',
+                type: 'signup-paid',
                 // Redirect to the original success url after sign up
                 referrer: options.successUrl
             });

--- a/ghost/core/core/server/services/members/members-api/members-api.js
+++ b/ghost/core/core/server/services/members/members-api/members-api.js
@@ -274,7 +274,7 @@ module.exports = function MembersAPI({
         }
 
         // Note: old tokens can still have a missing type (we can remove this after a couple of weeks)
-        if (type && !['signup', 'subscribe'].includes(type)) {
+        if (type && !['signup', 'signup-paid', 'subscribe'].includes(type)) {
             // Don't allow sign up
             // Note that we use the type from inside the magic token so this behaviour can't be changed
             return null;
@@ -291,7 +291,15 @@ module.exports = function MembersAPI({
             }
         }
 
-        const newMember = await users.create({name, email, labels, newsletters, attribution, geolocation});
+        const newMember = await users.create({
+            name,
+            email,
+            labels,
+            newsletters,
+            attribution,
+            geolocation,
+            signupIntent: type === 'signup-paid' ? 'paid' : null
+        });
 
         await MemberLoginEvent.add({member_id: newMember.id});
         return getMemberIdentityData(email);

--- a/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
@@ -277,6 +277,7 @@ module.exports = class MemberRepository {
      * @param {string} [data.offerId]
      * @param {import('@tryghost/member-attribution/lib/Attribution').AttributionResource} [data.attribution]
      * @param {boolean} [data.email_disabled]
+     * @param {'paid'|null} [data.signupIntent]
      * @param {*} options
      * @returns
      */
@@ -290,7 +291,7 @@ module.exports = class MemberRepository {
             options.batch_id = ObjectId().toHexString();
         }
 
-        const {labels, stripeCustomer, offerId, attribution} = data;
+        const {labels, stripeCustomer, offerId, attribution, signupIntent} = data;
 
         if (labels) {
             labels.forEach((label, index) => {
@@ -361,7 +362,7 @@ module.exports = class MemberRepository {
         if (welcomeEmailsEnabled && WELCOME_EMAIL_SOURCES.includes(source)) {
             const freeWelcomeEmail = this._AutomatedEmail ? await this._AutomatedEmail.findOne({slug: MEMBER_WELCOME_EMAIL_SLUGS.free}) : null;
             const isFreeWelcomeEmailActive = freeWelcomeEmail && freeWelcomeEmail.get('lexical') && freeWelcomeEmail.get('status') === 'active';
-            const isFreeSignup = !stripeCustomer;
+            const isFreeSignup = !stripeCustomer && signupIntent !== 'paid';
 
             const runMemberCreation = async (transacting) => {
                 const newMember = await this._Member.add({

--- a/ghost/core/test/e2e-api/members/send-magic-link.test.js
+++ b/ghost/core/test/e2e-api/members/send-magic-link.test.js
@@ -77,6 +77,20 @@ describe('sendMagicLink', function () {
         assert.equal(member.email, email);
     });
 
+    it('Allows member creation from signup-paid magic link token', async function () {
+        const email = 'new-paid-signup-token@test.com';
+        const magicLink = await membersService.api.getMagicLink(email, 'signup-paid');
+        const magicLinkUrl = new URL(magicLink);
+        const token = magicLinkUrl.searchParams.get('token');
+
+        const tokenData = await membersService.api.getTokenDataFromMagicLinkToken(token);
+        assert.equal(tokenData.email, email);
+        assert.equal(tokenData.type, 'signup-paid');
+
+        const member = await membersService.api.getMemberDataFromMagicLinkToken(token);
+        assert.equal(member.email, email);
+    });
+
     it('Does not send email when logging in to email that does not exist on invite-only site', async function () {
         settingsCache.set('members_signup_access', {value: 'invite'});
 

--- a/ghost/core/test/unit/server/services/members/members-api/controllers/router-controller.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/controllers/router-controller.test.js
@@ -183,7 +183,8 @@ describe('RouterController', function () {
                 settingsCache,
                 settingsHelpers,
                 magicLinkService,
-                memberRepository
+                memberRepository,
+                emailAddressService
             });
 
             await routerController.createCheckoutSession({
@@ -206,6 +207,9 @@ describe('RouterController', function () {
                 metadata: {
                     ghostSignupContext: 'has_precheckout_magic_link'
                 }
+            })), true);
+            assert.equal(magicLinkService.getMagicLink.calledWith(sinon.match({
+                type: 'signup-paid'
             })), true);
         });
 

--- a/ghost/core/test/unit/server/services/members/members-api/repositories/member-repository.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/repositories/member-repository.test.js
@@ -1329,6 +1329,27 @@ describe('MemberRepository', function () {
             // The free welcome email should NOT be sent when stripeCustomer is present
             sinon.assert.notCalled(Outbox.add);
         });
+
+        it('does NOT create outbox entry when member signup intent is paid', async function () {
+            const repo = new MemberRepository({
+                Member,
+                Outbox,
+                MemberStatusEvent,
+                MemberSubscribeEventModel: MemberSubscribeEvent,
+                newslettersService,
+                AutomatedEmail,
+                labsService,
+                OfferRedemption: mockOfferRedemption
+            });
+
+            await repo.create({
+                email: 'test@example.com',
+                name: 'Test Member',
+                signupIntent: 'paid'
+            }, {});
+
+            sinon.assert.notCalled(Outbox.add);
+        });
     });
 
     describe('linkSubscription - outbox integration', function () {


### PR DESCRIPTION
## Summary

  - added paid-signup intent handling to pre-checkout magic-link flow
  - prevented free welcome emails from being sent for paid-intent signups even when webhook processing is delayed
  - added unit and e2e coverage for paid signup magic-link intent and welcome-email gating