### PR TITLE
Prevented docker build from running when a label is applied

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1201,7 +1201,7 @@ jobs:
 
   job_merge_e2e_reports:
     name: Merge Reports
-    if: always()
+    if: needs.job_setup.result == 'success' && needs.job_e2e_tests.result == 'failure'
     needs: [job_e2e_tests, job_setup]
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -942,6 +942,11 @@ jobs:
 
   job_docker_build:
     name: Build & Push Docker Image
+    if: |
+      github.event_name != 'pull_request' ||
+      (github.event.action == 'labeled' && (contains(github.event.label.name, 'test') || contains(github.event.label.name, 'deploy'))) ||
+      (github.event.action == 'unlabeled' && (contains(github.event.label.name, 'test') || contains(github.event.label.name, 'deploy'))) ||
+      (github.event.action != 'labeled' && github.event.action != 'unlabeled')
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
ref https://ghost.slack.com/archives/C02G9E68C/p1770769239070299

## Problem

Applying any label that doesn't include "test" or "deploy" would kick-off a new CI run, and it would always fail, because the "Merge Reports" job would always run even though the E2E tests did not.

## Diagnosis

When applying labels to a PR, this will kick off CI again. The `job_setup` has a complex conditional to only re-run if the label includes "test" or "deploy", i.e. for the `browser-tests` and `deploy-to-staging` labels. All the other jobs that depend on `job_setup` will be skipped if the `job_setup` is skipped for this reason.

The `job_docker_build` and `job_inspect_image` didn't include this condition, so these jobs would re-run when _any_ label is applied, like the harmless "ok to merge for me" label. The "Merge Reports" job would also run because it has an `if: always()` applied to it, and since the E2E tests didn't run, there were no reports to merge so the job would fail. 

As a result, adding any label that doesn't include "test" or "deploy" would cause CI to fail 100% of the time.

## Fix

This includes two small tweaks to our CI pipeline:

- replicates the same conditional logic that's on `job_setup` to the `job_docker_build` job. This prevents the docker build and inspect image jobs from running
- removes the `if: always()` from Merge Reports, and changes the conditional so Merge Reports only runs if the e2e tests run and fail. If the e2e tests succeed, are skipped or cancelled, Merge Reports will not run.