### PR TITLE
Removed labeled and unlabeled triggers from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened]
   push:
     # Ref: GHA Filter pattern syntax: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#filter-pattern-cheat-sheet
     # Run on pushes to main, release branches, and previous/future major version branches
@@ -30,14 +30,6 @@ jobs:
   job_setup:
     name: Setup
     runs-on: ubuntu-latest
-    # Having certain parts of our huge CI workflow run on a specific label is an anti-pattern.
-    # Long term, we want to get away from this by having all of our tests run on every PR, and have the staging deploy either be automatic or a different workflow
-    # This logic skips the entire workflow if triggered by a label that doesn't contain "test" or "deploy" - there's nothing new to do in that case
-    if: |
-      github.event_name != 'pull_request' ||
-      (github.event.action == 'labeled' && (contains(github.event.label.name, 'test') || contains(github.event.label.name, 'deploy'))) ||
-      (github.event.action == 'unlabeled' && (contains(github.event.label.name, 'test') || contains(github.event.label.name, 'deploy'))) ||
-      (github.event.action != 'labeled' && github.event.action != 'unlabeled')
     timeout-minutes: 15
     env:
       IS_MAIN: ${{ github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
refs https://ghost.slack.com/archives/C02G9E68C/p1770769239070299

## Problem

Currently, adding or removing any label to a PR triggers the CI workflow to run again. For _most_ labels, this isn't desired and results in CI _failing every time_ just because you added an innocent label.

For example, if you have a PR with all checks passing, if you add the "ok to merge for me" label, CI will re-run and the "Merge Reports" job will fail every time. In order to actually merge the PR, you'd need to re-run all the checks again, which is a waste of time.

## Context

Labels that include "test" or "deploy" can trigger additional jobs to run in CI. This is the historical reason that we added the `labeled`/`unlabeled` trigger on PRs for the CI workflow in the first place. These labels include:
- `browser-tests` - to run the browser tests
- `test` - simply used to trigger a full CI re-run
- `perf-tests` - to run the performance tests (Ghost boot time) to run
- `deploy-to-staging` - to trigger a staging build based on the PR branch

Applying any of these labels would trigger all of CI to run again, plus whatever additional jobs they are intended to trigger.

## Fix

This fix removes the `labeled` and `unlabeled` events as triggers for CI entirely. This fixes the "adding a label causes CI to fail on my PR" problem. There are only a few valid use-cases for these triggers, and the costs now outweigh the benefits.

With this change, applying or removing a label from a PR shouldn't trigger CI to run at all. The `label-actions.yml` workflow will still run — this is fine since it's a completely separate workflow and doesn't impact CI checks.

## Breaking changes to CI

With this change, the following labels will no longer trigger any action in the CI workflow simply by adding/removing the label:
- `browser-tests` - this label is no longer necessary
- `deploy-to-staging` - 0/300 open PRs have this label currently
- `test` - 0/300 open PRs have this label
- `perf-tests` - 0/300 open PRs have this label