### PR TITLE
Added srcset support for CDN images

### DIFF
--- a/ghost/core/core/server/lib/lexical.js
+++ b/ghost/core/core/server/lib/lexical.js
@@ -81,6 +81,7 @@ module.exports = {
 
         const options = Object.assign({
             siteUrl: config.get('url'),
+            imageBaseUrl: config.get('urls:image') || '',
             imageOptimization: config.get('imageOptimization'),
             canTransformImage(storagePath) {
                 const imageTransform = require('@tryghost/image-transform');

--- a/ghost/core/core/server/lib/mobiledoc.js
+++ b/ghost/core/core/server/lib/mobiledoc.js
@@ -31,6 +31,7 @@ module.exports = {
 
             cardFactory = new CardFactory({
                 siteUrl: config.get('url'),
+                imageBaseUrl: config.get('urls:image') || '',
                 imageOptimization: config.get('imageOptimization'),
                 canTransformImage(storagePath) {
                     const imageTransform = require('@tryghost/image-transform');

--- a/ghost/core/core/server/services/koenig/node-renderers/call-to-action-renderer.js
+++ b/ghost/core/core/server/services/koenig/node-renderers/call-to-action-renderer.js
@@ -2,7 +2,7 @@ const {renderEmailButton} = require('../render-partials/email-button');
 const {addCreateDocumentOption} = require('../render-utils/add-create-document-option');
 const {renderWithVisibility} = require('../render-utils/visibility');
 const {getResizedImageDimensions} = require('../render-utils/get-resized-image-dimensions');
-const {isLocalContentImage} = require('../render-utils/is-local-content-image');
+const {isContentImage} = require('../render-utils/is-content-image');
 const {buildCleanBasicHtmlForElement} = require('../render-utils/build-clean-basic-html-for-element');
 
 const showButton = dataset => dataset.showButton && dataset.buttonUrl && dataset.buttonText;
@@ -74,7 +74,7 @@ function emailCTATemplate(dataset, options = {}) {
     }
 
     if (dataset.layout === 'minimal' && dataset.imageUrl) {
-        if (isLocalContentImage(dataset.imageUrl, options.siteUrl) && options.canTransformImage?.(dataset.imageUrl)) {
+        if (isContentImage(dataset.imageUrl, options.siteUrl, options.imageBaseUrl) && options.canTransformImage?.(dataset.imageUrl)) {
             const [, imagesPath, filename] = dataset.imageUrl.match(/(.*\/content\/images)\/(.*)/);
             const iconSize = options?.imageOptimization?.internalImageSizes?.['email-cta-minimal-image'] || {width: 256, height: 256}; // default to 256 since we know the image is a square
             dataset.imageUrl = `${imagesPath}/size/w${iconSize.width}h${iconSize.height}/${filename}`;

--- a/ghost/core/core/server/services/koenig/node-renderers/gallery-renderer.js
+++ b/ghost/core/core/server/services/koenig/node-renderers/gallery-renderer.js
@@ -1,6 +1,6 @@
 const {addCreateDocumentOption} = require('../render-utils/add-create-document-option');
 const {getAvailableImageWidths} = require('../render-utils/get-available-image-widths');
-const {isLocalContentImage} = require('../render-utils/is-local-content-image');
+const {isContentImage} = require('../render-utils/is-content-image');
 const {isUnsplashImage} = require('../render-utils/is-unsplash-image');
 const {getResizedImageDimensions} = require('../render-utils/get-resized-image-dimensions');
 const {setSrcsetAttribute} = require('../render-utils/srcset-attribute');
@@ -79,7 +79,7 @@ function renderGalleryNode(node, options = {}) {
             if (
                 defaultMaxWidth &&
                 image.width > defaultMaxWidth &&
-                isLocalContentImage(image.src, options.siteUrl) &&
+                isContentImage(image.src, options.siteUrl, options.imageBaseUrl) &&
                 canTransformImage &&
                 canTransformImage(image.src)
             ) {
@@ -112,7 +112,7 @@ function renderGalleryNode(node, options = {}) {
                     img.setAttribute('height', newImageDimensions.height);
                 }
 
-                if (isLocalContentImage(image.src, options.siteUrl) && options.canTransformImage && options.canTransformImage(image.src)) {
+                if (isContentImage(image.src, options.siteUrl, options.imageBaseUrl) && options.canTransformImage && options.canTransformImage(image.src)) {
                     // find available image size next up from 2x600 so we can use it for the "retina" src
                     const availableImageWidths = getAvailableImageWidths(image, options.imageOptimization.contentImageSizes);
                     const srcWidth = availableImageWidths.find(width => width >= 1200);

--- a/ghost/core/core/server/services/koenig/node-renderers/image-renderer.js
+++ b/ghost/core/core/server/services/koenig/node-renderers/image-renderer.js
@@ -1,5 +1,5 @@
 const {getAvailableImageWidths} = require('../render-utils/get-available-image-widths');
-const {isLocalContentImage} = require('../render-utils/is-local-content-image');
+const {isContentImage} = require('../render-utils/is-content-image');
 const {setSrcsetAttribute} = require('../render-utils/srcset-attribute');
 const {getResizedImageDimensions} = require('../render-utils/get-resized-image-dimensions');
 const {addCreateDocumentOption} = require('../render-utils/add-create-document-option');
@@ -49,7 +49,7 @@ function renderImageNode(node, options = {}) {
     if (
         defaultMaxWidth &&
             node.width > defaultMaxWidth &&
-            isLocalContentImage(node.src, options.siteUrl) &&
+            isContentImage(node.src, options.siteUrl, options.imageBaseUrl) &&
             canTransformImage &&
             canTransformImage(node.src)
     ) {
@@ -96,7 +96,7 @@ function renderImageNode(node, options = {}) {
         img.setAttribute('width', imageDimensions.width);
         img.setAttribute('height', imageDimensions.height);
 
-        if (isLocalContentImage(node.src, options.siteUrl) && options.canTransformImage?.(node.src)) {
+        if (isContentImage(node.src, options.siteUrl, options.imageBaseUrl) && options.canTransformImage?.(node.src)) {
             // find available image size next up from 2x600 so we can use it for the "retina" src
             const availableImageWidths = getAvailableImageWidths(node, options.imageOptimization.contentImageSizes);
             const srcWidth = availableImageWidths.find(width => width >= 1200);

--- a/ghost/core/core/server/services/koenig/render-utils/is-content-image.js
+++ b/ghost/core/core/server/services/koenig/render-utils/is-content-image.js
@@ -1,0 +1,22 @@
+const isLocalContentImage = function (url, siteUrl = '') {
+    const normalizedSiteUrl = siteUrl.replace(/\/$/, '');
+    const imagePath = url.replace(normalizedSiteUrl, '');
+    return /^(\/.*|__GHOST_URL__)\/?content\/images\//.test(imagePath);
+};
+
+const isContentImage = function (url, siteUrl = '', imageBaseUrl = '') {
+    if (isLocalContentImage(url, siteUrl)) {
+        return true;
+    }
+    if (imageBaseUrl) {
+        const normalizedBaseUrl = imageBaseUrl.replace(/\/$/, '');
+        const imagePath = url.replace(normalizedBaseUrl, '');
+        return /^\/?content\/images\//.test(imagePath);
+    }
+    return false;
+};
+
+module.exports = {
+    isLocalContentImage,
+    isContentImage
+};

--- a/ghost/core/core/server/services/koenig/render-utils/is-content-image.js
+++ b/ghost/core/core/server/services/koenig/render-utils/is-content-image.js
@@ -1,19 +1,15 @@
+const matchesContentImagePath = function (url, baseUrl = '', pattern = /^\/?content\/images\//) {
+    const normalized = baseUrl.replace(/\/$/, '');
+    const path = url.replace(normalized, '');
+    return pattern.test(path);
+};
+
 const isLocalContentImage = function (url, siteUrl = '') {
-    const normalizedSiteUrl = siteUrl.replace(/\/$/, '');
-    const imagePath = url.replace(normalizedSiteUrl, '');
-    return /^(\/.*|__GHOST_URL__)\/?content\/images\//.test(imagePath);
+    return matchesContentImagePath(url, siteUrl, /^(\/.*|__GHOST_URL__)\/?content\/images\//);
 };
 
 const isContentImage = function (url, siteUrl = '', imageBaseUrl = '') {
-    if (isLocalContentImage(url, siteUrl)) {
-        return true;
-    }
-    if (imageBaseUrl) {
-        const normalizedBaseUrl = imageBaseUrl.replace(/\/$/, '');
-        const imagePath = url.replace(normalizedBaseUrl, '');
-        return /^\/?content\/images\//.test(imagePath);
-    }
-    return false;
+    return isLocalContentImage(url, siteUrl) || Boolean(imageBaseUrl && matchesContentImagePath(url, imageBaseUrl));
 };
 
 module.exports = {

--- a/ghost/core/core/server/services/koenig/render-utils/is-local-content-image.js
+++ b/ghost/core/core/server/services/koenig/render-utils/is-local-content-image.js
@@ -1,9 +1,0 @@
-const isLocalContentImage = function (url, siteUrl = '') {
-    const normalizedSiteUrl = siteUrl.replace(/\/$/, '');
-    const imagePath = url.replace(normalizedSiteUrl, '');
-    return /^(\/.*|__GHOST_URL__)\/?content\/images\//.test(imagePath);
-};
-
-module.exports = {
-    isLocalContentImage
-};

--- a/ghost/core/core/server/services/koenig/render-utils/srcset-attribute.js
+++ b/ghost/core/core/server/services/koenig/render-utils/srcset-attribute.js
@@ -1,4 +1,4 @@
-const {isLocalContentImage} = require('./is-local-content-image');
+const {isContentImage} = require('./is-content-image');
 const {getAvailableImageWidths} = require('./get-available-image-widths');
 const {isUnsplashImage} = require('./is-unsplash-image');
 
@@ -9,14 +9,14 @@ const getSrcsetAttribute = function ({src, width, options}) {
         return;
     }
 
-    if (isLocalContentImage(src, options.siteUrl) && options.canTransformImage && !options.canTransformImage(src)) {
+    if (isContentImage(src, options.siteUrl, options.imageBaseUrl) && options.canTransformImage && !options.canTransformImage(src)) {
         return;
     }
 
     const srcsetWidths = getAvailableImageWidths({width}, options.imageOptimization.contentImageSizes);
 
-    // apply srcset if this is a relative image that matches Ghost's image url structure
-    if (isLocalContentImage(src, options.siteUrl)) {
+    // apply srcset if this is a local or CDN image that matches Ghost's image url structure
+    if (isContentImage(src, options.siteUrl, options.imageBaseUrl)) {
         const [, imagesPath, filename] = src.match(/(.*\/content\/images)\/(.*)/);
         const srcs = [];
 

--- a/ghost/core/test/e2e-frontend/rendered-content.test.js
+++ b/ghost/core/test/e2e-frontend/rendered-content.test.js
@@ -4,6 +4,7 @@ const supertest = require('supertest');
 
 const testUtils = require('../utils');
 const config = require('../../core/shared/config');
+const configUtils = require('../utils/config-utils');
 const urlUtilsHelper = require('../utils/url-utils');
 
 describe('Post Rendering', function () {
@@ -20,8 +21,9 @@ describe('Post Rendering', function () {
         await testUtils.initFixtures('posts');
     });
 
-    afterEach(function () {
+    afterEach(async function () {
         sinon.restore();
+        await configUtils.restore();
     });
 
     describe('HTML', function () {
@@ -122,6 +124,23 @@ describe('Post Rendering', function () {
                     assert(res.text.includes(`${cdnUrl}/content/files/snippet-document.pdf`));
                     assert(res.text.includes(`${cdnUrl}/content/media/snippet-video.mp4`));
                     assert(res.text.includes(`${cdnUrl}/content/media/snippet-audio.mp3`));
+                    assert(!res.text.includes('__GHOST_URL__'));
+                });
+        });
+
+        it('Lexical post renders CDN images with srcset when urls:image is configured', async function () {
+            const cdnUrl = 'https://cdn.example.com/c/site-uuid';
+            configUtils.set('urls:image', cdnUrl);
+            urlUtilsHelper.stubUrlUtilsWithCdn({
+                assetBaseUrls: {media: cdnUrl, files: cdnUrl, image: cdnUrl}
+            }, sinon);
+
+            await request.get('/post-with-all-media-types-lexical/')
+                .expect('Content-Type', /html/)
+                .expect(200)
+                .expect((res) => {
+                    // CDN images should get srcset attributes with /size/w{width}/ pattern
+                    assert(res.text.includes(`${cdnUrl}/content/images/size/w`), 'CDN images should have srcset with /size/w pattern');
                     assert(!res.text.includes('__GHOST_URL__'));
                 });
         });

--- a/ghost/core/test/unit/server/services/koenig/node-renderers/gallery-renderer.test.js
+++ b/ghost/core/test/unit/server/services/koenig/node-renderers/gallery-renderer.test.js
@@ -170,6 +170,45 @@ describe('services/koenig/node-renderers/gallery-renderer', function () {
             const result = renderForWeb(getTestData({images: []}));
             assert.equal(result.html, '');
         });
+
+        it('generates srcset for CDN gallery images when imageBaseUrl is configured', function () {
+            const cdnUrl = 'https://cdn.example.com/c/uuid';
+            const result = renderForWeb(getTestData({
+                images: [
+                    {
+                        row: 0,
+                        fileName: 'NatGeo01.jpg',
+                        src: `${cdnUrl}/content/images/2018/08/NatGeo01-9.jpg`,
+                        width: 3200,
+                        height: 1600
+                    }
+                ],
+                caption: ''
+            }), {imageBaseUrl: cdnUrl});
+
+            assert.ok(result.html);
+            assert.ok(result.html.includes(`${cdnUrl}/content/images/size/w600/2018/08/NatGeo01-9.jpg`));
+            assert.ok(result.html.includes('srcset'));
+        });
+
+        it('does not generate srcset for CDN gallery images when imageBaseUrl is not configured', function () {
+            const cdnUrl = 'https://cdn.example.com/c/uuid';
+            const result = renderForWeb(getTestData({
+                images: [
+                    {
+                        row: 0,
+                        fileName: 'NatGeo01.jpg',
+                        src: `${cdnUrl}/content/images/2018/08/NatGeo01-9.jpg`,
+                        width: 3200,
+                        height: 1600
+                    }
+                ],
+                caption: ''
+            }));
+
+            assert.ok(result.html);
+            assert.ok(!result.html.includes('srcset'));
+        });
     });
 
     describe('email', function () {

--- a/ghost/core/test/unit/server/services/koenig/node-renderers/image-renderer.test.js
+++ b/ghost/core/test/unit/server/services/koenig/node-renderers/image-renderer.test.js
@@ -69,6 +69,47 @@ describe('services/koenig/node-renderers/image-renderer', function () {
             const result = renderForWeb(getTestData({href: 'https://example.com'}));
             assert.ok(result.html.includes('<a href="https://example.com"'));
         });
+
+        it('generates srcset for CDN image URLs when imageBaseUrl is configured', function () {
+            const cdnUrl = 'https://cdn.example.com/c/uuid';
+            const result = renderForWeb(
+                getTestData({src: `${cdnUrl}/content/images/2022/11/koenig-lexical.jpg`}),
+                {imageBaseUrl: cdnUrl}
+            );
+
+            assert.ok(result.html);
+
+            assertPrettifiesTo(result.html, html`
+                <figure class="kg-card kg-image-card kg-width-undefined kg-card-hascaption">
+                    <img
+                        src="${cdnUrl}/content/images/2022/11/koenig-lexical.jpg"
+                        class="kg-image"
+                        alt="This is some alt text"
+                        loading="lazy"
+                        title="This is a title"
+                        width="3840"
+                        height="2160"
+                        srcset="
+                            ${cdnUrl}/content/images/size/w600/2022/11/koenig-lexical.jpg   600w,
+                            ${cdnUrl}/content/images/size/w1000/2022/11/koenig-lexical.jpg 1000w,
+                            ${cdnUrl}/content/images/size/w1600/2022/11/koenig-lexical.jpg 1600w,
+                            ${cdnUrl}/content/images/size/w2400/2022/11/koenig-lexical.jpg 2400w
+                        "
+                        sizes="(min-width: 720px) 720px" />
+                    <figcaption>This is a<b>caption</b></figcaption>
+                </figure>
+            `);
+        });
+
+        it('does not generate srcset for CDN image URLs when imageBaseUrl is not configured', function () {
+            const cdnUrl = 'https://cdn.example.com/c/uuid';
+            const result = renderForWeb(
+                getTestData({src: `${cdnUrl}/content/images/2022/11/koenig-lexical.jpg`})
+            );
+
+            assert.ok(result.html);
+            assert.ok(!result.html.includes('srcset'));
+        });
     });
 
     describe('email', function () {
@@ -95,6 +136,17 @@ describe('services/koenig/node-renderers/image-renderer', function () {
         it('renders with href', function () {
             const result = renderForEmail(getTestData({href: 'https://example.com'}));
             assert.ok(result.html.includes('<a href="https://example.com"'));
+        });
+
+        it('uses retina src for CDN images in email', function () {
+            const cdnUrl = 'https://cdn.example.com/c/uuid';
+            const result = renderForEmail(
+                getTestData({src: `${cdnUrl}/content/images/2022/11/koenig-lexical.jpg`}),
+                {imageBaseUrl: cdnUrl}
+            );
+
+            assert.ok(result.html);
+            assert.ok(result.html.includes(`${cdnUrl}/content/images/size/w1600/2022/11/koenig-lexical.jpg`));
         });
     });
 });

--- a/ghost/core/test/unit/server/services/koenig/render-utils/is-content-image.test.js
+++ b/ghost/core/test/unit/server/services/koenig/render-utils/is-content-image.test.js
@@ -1,7 +1,7 @@
 const assert = require('assert/strict');
 const {isLocalContentImage, isContentImage} = require('../../../../../../core/server/services/koenig/render-utils/is-content-image');
 
-describe('services/koenig/render-utils/is-local-content-image', function () {
+describe('services/koenig/render-utils/is-content-image', function () {
     describe('isLocalContentImage', function () {
         it('returns true for relative content image paths', function () {
             assert.ok(isLocalContentImage('/content/images/2024/01/photo.jpg'));

--- a/ghost/core/test/unit/server/services/koenig/render-utils/is-content-image.test.js
+++ b/ghost/core/test/unit/server/services/koenig/render-utils/is-content-image.test.js
@@ -1,0 +1,113 @@
+const assert = require('assert/strict');
+const {isLocalContentImage, isContentImage} = require('../../../../../../core/server/services/koenig/render-utils/is-content-image');
+
+describe('services/koenig/render-utils/is-local-content-image', function () {
+    describe('isLocalContentImage', function () {
+        it('returns true for relative content image paths', function () {
+            assert.ok(isLocalContentImage('/content/images/2024/01/photo.jpg'));
+        });
+
+        it('returns true for relative content image paths with subdirectory', function () {
+            assert.ok(isLocalContentImage('/blog/content/images/2024/01/photo.jpg'));
+        });
+
+        it('returns true for __GHOST_URL__ prefixed paths', function () {
+            assert.ok(isLocalContentImage('__GHOST_URL__/content/images/2024/01/photo.jpg'));
+        });
+
+        it('returns true for absolute URLs matching siteUrl', function () {
+            assert.ok(isLocalContentImage('https://example.com/content/images/2024/01/photo.jpg', 'https://example.com'));
+        });
+
+        it('returns true for absolute URLs matching siteUrl with trailing slash', function () {
+            assert.ok(isLocalContentImage('https://example.com/content/images/2024/01/photo.jpg', 'https://example.com/'));
+        });
+
+        it('returns false for external image URLs', function () {
+            assert.ok(!isLocalContentImage('https://external.com/images/photo.jpg'));
+        });
+
+        it('returns false for CDN image URLs', function () {
+            assert.ok(!isLocalContentImage('https://cdn.example.com/c/uuid/content/images/2024/01/photo.jpg'));
+        });
+
+        it('returns false for Unsplash images', function () {
+            assert.ok(!isLocalContentImage('https://images.unsplash.com/photo-abc123'));
+        });
+    });
+
+    describe('isContentImage', function () {
+        it('returns true for local content images (delegates to isLocalContentImage)', function () {
+            assert.ok(isContentImage('/content/images/2024/01/photo.jpg'));
+        });
+
+        it('returns true for __GHOST_URL__ prefixed paths', function () {
+            assert.ok(isContentImage('__GHOST_URL__/content/images/2024/01/photo.jpg', '', ''));
+        });
+
+        it('returns true for absolute URLs matching siteUrl', function () {
+            assert.ok(isContentImage('https://example.com/content/images/2024/01/photo.jpg', 'https://example.com'));
+        });
+
+        it('returns true for CDN image URLs when imageBaseUrl is configured', function () {
+            assert.ok(isContentImage(
+                'https://cdn.example.com/c/uuid/content/images/2024/01/photo.jpg',
+                'https://example.com',
+                'https://cdn.example.com/c/uuid'
+            ));
+        });
+
+        it('returns true for CDN image URLs with trailing slash in imageBaseUrl', function () {
+            assert.ok(isContentImage(
+                'https://cdn.example.com/c/uuid/content/images/2024/01/photo.jpg',
+                'https://example.com',
+                'https://cdn.example.com/c/uuid/'
+            ));
+        });
+
+        it('returns false for CDN image URLs when imageBaseUrl is not configured', function () {
+            assert.ok(!isContentImage(
+                'https://cdn.example.com/c/uuid/content/images/2024/01/photo.jpg',
+                'https://example.com',
+                ''
+            ));
+        });
+
+        it('returns false for external image URLs', function () {
+            assert.ok(!isContentImage(
+                'https://external.com/images/photo.jpg',
+                'https://example.com',
+                'https://cdn.example.com/c/uuid'
+            ));
+        });
+
+        it('returns false for Unsplash images', function () {
+            assert.ok(!isContentImage(
+                'https://images.unsplash.com/photo-abc123',
+                'https://example.com',
+                'https://cdn.example.com/c/uuid'
+            ));
+        });
+
+        it('returns false for CDN URL without content/images path', function () {
+            assert.ok(!isContentImage(
+                'https://cdn.example.com/c/uuid/other/path/photo.jpg',
+                'https://example.com',
+                'https://cdn.example.com/c/uuid'
+            ));
+        });
+
+        it('returns false when imageBaseUrl does not match the URL', function () {
+            assert.ok(!isContentImage(
+                'https://other-cdn.example.com/content/images/2024/01/photo.jpg',
+                'https://example.com',
+                'https://cdn.example.com/c/uuid'
+            ));
+        });
+
+        it('handles missing siteUrl and imageBaseUrl gracefully', function () {
+            assert.ok(isContentImage('/content/images/2024/01/photo.jpg'));
+            assert.ok(!isContentImage('https://cdn.example.com/content/images/2024/01/photo.jpg'));
+        });
+    });
+});


### PR DESCRIPTION
ref [HKG-1581](https://linear.app/ghost/issue/HKG-1581)

- Ghost generates responsive image `srcset` for local `/content/images/` URLs, but CDN/Object Storage URLs were not recognized as content images. As sites move image delivery to CDN, those images should also have `srcset` for responsive loading.
- This PR supports CDN-hosted Ghost images while keeping existing local-image and Unsplash behavior unchanged.
- The updated renderer paths are safe for CDN URLs because they only do URL/HTML string transformations (e.g. inserting `/size/w{width}/`), not file reads.
- If `urls:image` is not configured, behavior falls back to local-content-image detection.
- Existing local-image and Unsplash flows continue to work.