### PR TITLE
Ensured retention offers are not shown post cancellation

### DIFF
--- a/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
+++ b/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
@@ -980,6 +980,10 @@ module.exports = class RouterController {
             return res.end(JSON.stringify({offers}));
         }
 
+        function sendNoOffersAvailable() {
+            return sendOffersResponse([]);
+        }
+
         if (!identity) {
             res.writeHead(401);
             return res.end('Unauthorized');
@@ -1029,50 +1033,50 @@ module.exports = class RouterController {
 
         // No active subscription - return empty offers
         if (activeSubscriptions.length === 0) {
-            return sendOffersResponse();
+            return sendNoOffersAvailable();
         }
 
         // Multiple active subscriptions - edge case, return empty offers to avoid ambiguity
         if (activeSubscriptions.length > 1) {
-            return sendOffersResponse();
+            return sendNoOffersAvailable();
         }
 
         const activeSubscription = activeSubscriptions[0];
 
         // If subscription is already set to cancel, don't show retention offers
         if (activeSubscription.get('cancel_at_period_end')) {
-            return sendOffersResponse();
+            return sendNoOffersAvailable();
         }
 
         // If subscription already has an offer applied (e.g. signup offer), don't show retention offers
         if (activeSubscription.get('offer_id')) {
-            return sendOffersResponse();
+            return sendNoOffersAvailable();
         }
 
         // If subscription is in a trial period (either offer-based or tier-based), don't show retention offers
         const trialEndAt = activeSubscription.get('trial_end_at');
         if (trialEndAt && trialEndAt > new Date()) {
-            return sendOffersResponse();
+            return sendNoOffersAvailable();
         }
 
         // Get tier and cadence from the subscription
         const stripePrice = activeSubscription.related('stripePrice');
         if (!stripePrice || !stripePrice.id) {
-            return sendOffersResponse();
+            return sendNoOffersAvailable();
         }
 
         const stripeProduct = stripePrice.related('stripeProduct');
 
         // If the stripe product is not found, return empty offers
         if (!stripeProduct || !stripeProduct.id) {
-            return sendOffersResponse();
+            return sendNoOffersAvailable();
         }
 
         const product = stripeProduct.related('product');
 
         // If the product is not found, return empty offers
         if (!product || !product.id) {
-            return sendOffersResponse();
+            return sendNoOffersAvailable();
         }
 
         const tierId = product.id;

--- a/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
+++ b/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
@@ -1039,6 +1039,11 @@ module.exports = class RouterController {
 
         const activeSubscription = activeSubscriptions[0];
 
+        // If subscription is already set to cancel, don't show retention offers
+        if (activeSubscription.get('cancel_at_period_end')) {
+            return sendOffersResponse();
+        }
+
         // If subscription already has an offer applied (e.g. signup offer), don't show retention offers
         if (activeSubscription.get('offer_id')) {
             return sendOffersResponse();

--- a/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
@@ -31,7 +31,8 @@ const messages = {
     offerAlreadyRedeemed: 'This offer has already been redeemed on this subscription',
     subscriptionNotActive: 'Cannot apply offer to an inactive subscription',
     subscriptionHasOffer: 'Subscription already has an offer applied',
-    subscriptionInTrial: 'Cannot apply offer to a subscription in a trial period'
+    subscriptionInTrial: 'Cannot apply offer to a subscription in a trial period',
+    subscriptionCancelling: 'Cannot apply retention offer to a subscription that is already cancelling'
 };
 
 const SUBSCRIPTION_STATUS_TRIALING = 'trialing';
@@ -1766,6 +1767,12 @@ module.exports = class MemberRepository {
         if (offer.redemption_type === 'signup') {
             throw new errors.BadRequestError({
                 message: tpl(messages.offerIsSignupOffer)
+            });
+        }
+
+        if (offer.redemption_type === 'retention' && subscriptionModel.get('cancel_at_period_end')) {
+            throw new errors.BadRequestError({
+                message: tpl(messages.subscriptionCancelling)
             });
         }
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3297

With the custom cancellation button, it was possible that after a cancellation had occurred that the button would still trigger the retention offers to be shown. Seeming though the user has already cancelled, there is no need to show the offers. This prevents an issue where the user can take up an offer, but the cancellation period does not get reset.
