### PR TITLE
🐛 Fixed last_seen being modifiable via User API

### DIFF
--- a/ghost/core/core/server/api/endpoints/utils/serializers/input/users.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/input/users.js
@@ -21,6 +21,8 @@ module.exports = {
             delete frame.data.users[0].password;
         }
 
+        delete frame.data.users[0].last_seen;
+
         frame.data.users[0] = url.forUser(Object.assign({}, frame.data.users[0]));
     }
 };

--- a/ghost/core/core/server/api/endpoints/utils/serializers/input/users.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/input/users.js
@@ -17,10 +17,7 @@ module.exports = {
             frame.options.id = frame.options.context.user;
         }
 
-        if (frame.data.users[0].password) {
-            delete frame.data.users[0].password;
-        }
-
+        delete frame.data.users[0].password;
         delete frame.data.users[0].last_seen;
 
         frame.data.users[0] = url.forUser(Object.assign({}, frame.data.users[0]));

--- a/ghost/core/test/e2e-api/admin/users.test.js
+++ b/ghost/core/test/e2e-api/admin/users.test.js
@@ -197,6 +197,27 @@ describe('User API', function () {
         }
     });
 
+    it('cannot modify last_seen via the API', async function () {
+        const userId = fixtureManager.get('users', 0).id;
+
+        // Set a known last_seen value directly in the database
+        const before = await models.User.findOne({id: userId});
+        const originalLastSeen = before.get('last_seen');
+
+        // Attempt to reset last_seen via the API
+        await agent.put('users/me/')
+            .body({
+                users: [{
+                    last_seen: null
+                }]
+            })
+            .expectStatus(200);
+
+        // Verify last_seen was not changed
+        const after = await models.User.findOne({id: userId});
+        assert.deepEqual(after.get('last_seen'), originalLastSeen);
+    });
+
     it('can edit a user fetched from the API', async function () {
         const userToEditId = fixtureManager.get('users', 1).id;
         


### PR DESCRIPTION
## Summary
- The `last_seen` field on the `users` table was not stripped in the user edit input serializer, allowing any authenticated staff user to reset or tamper with it via `PUT /users/{id}`
- Added `delete frame.data.users[0].last_seen` to the input serializer, matching the existing pattern used for `password`
- Added an e2e test verifying `last_seen` cannot be modified through the API

## Test plan
- [ ] Verify the new e2e test passes: `yarn test:e2e --grep "cannot modify last_seen" test/e2e-api/admin/users.test.js`
- [ ] Confirm existing user edit tests still pass
- [ ] Manually verify `PUT /users/me/` with `last_seen: null` in the body no longer changes the value

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to request input sanitization with an added regression test; minimal impact beyond disallowing unintended updates to `last_seen`.
> 
> **Overview**
> Prevents clients from tampering with user activity metadata by stripping `last_seen` (and always stripping `password`) from the `users` edit input serializer before updates are applied.
> 
> Adds an admin API e2e regression test that attempts to set `last_seen: null` via `PUT /users/me/` and asserts the value in the database is unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c49b7d52ebe6df7735f3828e470962ca086efb10. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->