### PR TITLE
Improved the domain warming tests to run faster

### DIFF
--- a/ghost/core/test/integration/services/email-service/domain-warming.test.js
+++ b/ghost/core/test/integration/services/email-service/domain-warming.test.js
@@ -5,7 +5,7 @@ const assert = require('assert/strict');
 const jobManager = require('../../../../core/server/services/jobs/job-service');
 const configUtils = require('../../../utils/config-utils');
 const ObjectId = require('bson-objectid').default;
-const {v4: uuidv4} = require('uuid');
+const crypto = require('crypto');
 const db = require('../../../../core/server/data/db');
 
 describe('Domain Warming Integration Tests', function () {
@@ -33,8 +33,8 @@ describe('Domain Warming Integration Tests', function () {
             const memberId = ObjectId().toHexString();
             memberRows.push({
                 id: memberId,
-                uuid: uuidv4(),
-                transient_id: uuidv4(),
+                uuid: crypto.randomUUID(),
+                transient_id: crypto.randomUUID(),
                 email: `member-${prefix}-${i}@example.com`,
                 name: `Member ${prefix} ${i}`,
                 status: 'free',


### PR DESCRIPTION
no issue

This should prevent the flakiness we've seen where the domain tests take too long to run. Instead of using the ORM layer, we're bulk inserting / deleting using the knex layer. I wouldn't want to do this in the source, but in tests this feels like a suitable optimisation to check bulk cases quickly.
