### PR TITLE
Added unit test to detect orphaned migration folders

### DIFF
--- a/ghost/core/test/unit/server/data/migrations/version-consistency.test.js
+++ b/ghost/core/test/unit/server/data/migrations/version-consistency.test.js
@@ -1,0 +1,33 @@
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const semver = require('semver');
+
+describe('Migration version consistency', function () {
+    it('all migration folders should be runnable at current package.json version', function () {
+        const pkg = require('../../../../../package.json');
+        const safeVersion = pkg.version.match(/^(\d+\.)?(\d+)/)[0];
+
+        const migrationsDir = path.join(
+            __dirname, '../../../../../core/server/data/migrations/versions'
+        );
+
+        const folders = fs.readdirSync(migrationsDir)
+            .filter(f => fs.statSync(path.join(migrationsDir, f)).isDirectory())
+            .filter(f => /^\d+\.\d+$/.test(f));
+
+        const orphaned = folders.filter((folder) => {
+            // Same comparison knex-migrator uses: folder > currentVersion
+            return semver.gt(semver.coerce(folder), semver.coerce(safeVersion));
+        });
+
+        assert.equal(
+            orphaned.length,
+            0,
+            `Migration folders exceed package.json version (${pkg.version}, safe: ${safeVersion}): ` +
+            `${orphaned.join(', ')}\n` +
+            `Run \`slimer migration\` which handles the version bump automatically, ` +
+            `or manually bump package.json to the next minor rc.`
+        );
+    });
+});


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3318/

knex-migrator silently skips migration folders where the folder version exceeds `ghostVersion.safe` (the `major.minor` extracted from `package.json`). If a developer creates a migration folder for the next minor version without bumping `package.json` to an rc, those migrations will never run.

This adds a unit test that scans all version folders under `migrations/versions/` and fails when any folder exceeds the current safe version. It uses the same regex as `@tryghost/version` and the same `semver.gt`/`semver.coerce` comparison that knex-migrator uses internally. The error message tells the developer exactly what to do: run `slimer migration` (which handles the bump automatically) or manually bump `package.json` to the next minor rc.

This is part 3 of 3 for the rc version bump initiative (BER-3315). Part 2 (BER-3317, super-slimer auto-bump) ensures `slimer migration` bumps `package.json` to an rc automatically when creating a migration. This test is the safety net that catches cases where someone bypasses slimer and creates a migration folder manually.