### PR TITLE
🐛 Fixed free member creation on paid-only sites during sign-in

### DIFF
--- a/ghost/core/test/e2e-api/members/__snapshots__/send-magic-link.test.js.snap
+++ b/ghost/core/test/e2e-api/members/__snapshots__/send-magic-link.test.js.snap
@@ -54,6 +54,42 @@ Object {
 }
 `;
 
+exports[`sendMagicLink Returns error when logging in to email that does not exist on invite-only site 1: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": null,
+      "context": null,
+      "details": null,
+      "ghostErrorCode": null,
+      "help": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "No member exists with this email address. Please sign up first.",
+      "property": null,
+      "type": "BadRequestError",
+    },
+  ],
+}
+`;
+
+exports[`sendMagicLink Returns error when logging in to email that does not exist when free tier is hidden 1: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": null,
+      "context": null,
+      "details": null,
+      "ghostErrorCode": null,
+      "help": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "No member exists with this email address. Please sign up first.",
+      "property": null,
+      "type": "BadRequestError",
+    },
+  ],
+}
+`;
+
 exports[`sendMagicLink Throws an error when logging in to a email that does not exist (invite only) 1: [body] 1`] = `
 Object {
   "errors": Array [


### PR DESCRIPTION
ref [ONC-1464](https://linear.app/ghost/issue/ONC-1464/eroneous-free-sign-ups)
ref https://github.com/TryGhost/Ghost/pull/26015

The enumeration prevention from #26015 incorrectly sent signup emails for non-existent members on sites with no free tier visible, creating free members. Now returns an error when free signups aren't available, providing better UX without enabling the phishing attack vector (since no email would be sent anyway).
