### PR TITLE
Fixed welcome emails ignoring default newsletter sender settings

### DIFF
--- a/ghost/core/core/server/services/member-welcome-emails/service.js
+++ b/ghost/core/core/server/services/member-welcome-emails/service.js
@@ -3,9 +3,11 @@ const errors = require('@tryghost/errors');
 const urlUtils = require('../../../shared/url-utils');
 const settingsCache = require('../../../shared/settings-cache');
 const emailAddressService = require('../email-address');
+const settingsHelpers = require('../settings-helpers');
+const EmailAddressParser = require('../email-address/email-address-parser');
 const mail = require('../mail');
 // @ts-expect-error type checker has trouble with the dynamic exporting in models
-const {AutomatedEmail} = require('../../models');
+const {AutomatedEmail, Newsletter} = require('../../models');
 const MemberWelcomeEmailRenderer = require('./member-welcome-email-renderer');
 const {MEMBER_WELCOME_EMAIL_LOG_KEY, MEMBER_WELCOME_EMAIL_SLUGS, MESSAGES} = require('./constants');
 
@@ -25,6 +27,59 @@ class MemberWelcomeEmailService {
             title: settingsCache.get('title') || 'Ghost',
             url: urlUtils.urlFor('home', true),
             accentColor: settingsCache.get('accent_color') || '#15212A'
+        };
+    }
+
+    async #getDefaultNewsletterSenderOptions() {
+        const newsletter = await Newsletter.getDefaultNewsletter();
+        if (!newsletter) {
+            return {};
+        }
+
+        let senderName = settingsCache.get('title') ? settingsCache.get('title').replace(/"/g, '\\"') : '';
+        if (newsletter.get('sender_name')) {
+            senderName = newsletter.get('sender_name');
+        }
+
+        let fromAddress = settingsHelpers.getNoReplyAddress();
+        if (newsletter.get('sender_email')) {
+            fromAddress = newsletter.get('sender_email');
+        }
+
+        const fromAddresses = emailAddressService.service.getAddress({
+            from: {
+                address: fromAddress,
+                name: senderName || undefined
+            }
+        });
+
+        const from = EmailAddressParser.stringify(fromAddresses.from);
+        const replyToSetting = newsletter.get('sender_reply_to');
+        let replyTo = null;
+
+        if (replyToSetting === 'support') {
+            replyTo = settingsHelpers.getMembersSupportAddress();
+        } else if (replyToSetting === 'newsletter' && !emailAddressService.service.managedEmailEnabled) {
+            replyTo = from;
+        } else {
+            const addresses = emailAddressService.service.getAddress({
+                from: {
+                    address: fromAddress,
+                    name: senderName || undefined
+                },
+                replyTo: replyToSetting === 'newsletter' ? undefined : {address: replyToSetting}
+            });
+
+            if (addresses.replyTo) {
+                replyTo = EmailAddressParser.stringify(addresses.replyTo);
+            }
+        }
+
+        return {
+            from,
+            ...(replyTo ? {
+                replyTo
+            } : {})
         };
     }
 
@@ -82,12 +137,15 @@ class MemberWelcomeEmailService {
             siteSettings: this.#getSiteSettings()
         });
 
+        const senderOptions = await this.#getDefaultNewsletterSenderOptions();
+
         await this.#mailer.send({
             to: member.email,
             subject,
             html,
             text,
-            forceTextContent: true
+            forceTextContent: true,
+            ...senderOptions
         });
     }
 
@@ -136,12 +194,15 @@ class MemberWelcomeEmailService {
             siteSettings: this.#getSiteSettings()
         });
 
+        const senderOptions = await this.#getDefaultNewsletterSenderOptions();
+
         await this.#mailer.send({
             to: email,
             subject: `[Test] ${renderedSubject}`,
             html,
             text,
-            forceTextContent: true
+            forceTextContent: true,
+            ...senderOptions
         });
     }
 }
@@ -156,4 +217,3 @@ class MemberWelcomeEmailServiceWrapper {
 }
 
 module.exports = new MemberWelcomeEmailServiceWrapper();
-

--- a/ghost/core/test/integration/services/member-welcome-emails.test.js
+++ b/ghost/core/test/integration/services/member-welcome-emails.test.js
@@ -349,6 +349,37 @@ describe('Member Welcome Emails Integration', function () {
             const sendCall = mailService.GhostMailer.prototype.send.firstCall;
             assert.equal(sendCall.args[0].to, memberEmail);
         });
+
+        it('uses configured sender and reply-to when sending member welcome email [NY-1028]', async function () {
+            const senderEmail = 'scott@sagittura.com';
+            const senderReplyTo = 'support@sagittura.com';
+            const defaultNewsletter = await models.Newsletter.getDefaultNewsletter();
+
+            await db.knex('newsletters')
+                .where('id', defaultNewsletter.id)
+                .update({
+                    sender_name: 'Scott',
+                    sender_email: senderEmail,
+                    sender_reply_to: senderReplyTo
+                });
+
+            await models.Outbox.add({
+                event_type: 'MemberCreatedEvent',
+                payload: JSON.stringify({
+                    memberId: ObjectId().toHexString(),
+                    email: 'sender-test@example.com',
+                    name: 'Sender Test',
+                    status: 'free'
+                }),
+                status: OUTBOX_STATUSES.PENDING
+            });
+
+            await scheduleInlineJob();
+
+            assert.equal(mailService.GhostMailer.prototype.send.callCount, 1);
+            const sendCall = mailService.GhostMailer.prototype.send.firstCall;
+            assert.equal(sendCall.args[0].replyTo, senderReplyTo);
+            assert.ok(sendCall.args[0].from.includes(senderEmail));
+        });
     });
 });
-


### PR DESCRIPTION
ref https://linear.app/ghost/issue/NY-1028/welcome-email-uses-noreply-instead-of-configured-sender

