### PR TITLE
🐛 Fixed welcome emails using noreply address instead of default newsletter reply-to address

### DIFF
--- a/ghost/core/core/server/services/member-welcome-emails/service.js
+++ b/ghost/core/core/server/services/member-welcome-emails/service.js
@@ -3,9 +3,11 @@ const errors = require('@tryghost/errors');
 const urlUtils = require('../../../shared/url-utils');
 const settingsCache = require('../../../shared/settings-cache');
 const emailAddressService = require('../email-address');
+const settingsHelpers = require('../settings-helpers');
+const EmailAddressParser = require('../email-address/email-address-parser');
 const mail = require('../mail');
 // @ts-expect-error type checker has trouble with the dynamic exporting in models
-const {AutomatedEmail} = require('../../models');
+const {AutomatedEmail, Newsletter} = require('../../models');
 const MemberWelcomeEmailRenderer = require('./member-welcome-email-renderer');
 const {MEMBER_WELCOME_EMAIL_LOG_KEY, MEMBER_WELCOME_EMAIL_SLUGS, MESSAGES} = require('./constants');
 
@@ -25,6 +27,59 @@ class MemberWelcomeEmailService {
             title: settingsCache.get('title') || 'Ghost',
             url: urlUtils.urlFor('home', true),
             accentColor: settingsCache.get('accent_color') || '#15212A'
+        };
+    }
+
+    async #getDefaultNewsletterSenderOptions() {
+        const newsletter = await Newsletter.getDefaultNewsletter();
+        if (!newsletter) {
+            return {};
+        }
+
+        let senderName = settingsCache.get('title') ? settingsCache.get('title').replace(/"/g, '\\"') : '';
+        if (newsletter.get('sender_name')) {
+            senderName = newsletter.get('sender_name');
+        }
+
+        let fromAddress = settingsHelpers.getNoReplyAddress();
+        if (newsletter.get('sender_email')) {
+            fromAddress = newsletter.get('sender_email');
+        }
+
+        const fromAddresses = emailAddressService.service.getAddress({
+            from: {
+                address: fromAddress,
+                name: senderName || undefined
+            }
+        });
+
+        const from = EmailAddressParser.stringify(fromAddresses.from);
+        const replyToSetting = newsletter.get('sender_reply_to');
+        let replyTo = null;
+
+        if (replyToSetting === 'support') {
+            replyTo = settingsHelpers.getMembersSupportAddress();
+        } else if (replyToSetting === 'newsletter' && !emailAddressService.service.managedEmailEnabled) {
+            replyTo = from;
+        } else {
+            const addresses = emailAddressService.service.getAddress({
+                from: {
+                    address: fromAddress,
+                    name: senderName || undefined
+                },
+                replyTo: replyToSetting === 'newsletter' ? undefined : {address: replyToSetting}
+            });
+
+            if (addresses.replyTo) {
+                replyTo = EmailAddressParser.stringify(addresses.replyTo);
+            }
+        }
+
+        return {
+            from,
+            ...(replyTo ? {
+                replyTo
+            } : {})
         };
     }
 
@@ -82,12 +137,15 @@ class MemberWelcomeEmailService {
             siteSettings: this.#getSiteSettings()
         });
 
+        const senderOptions = await this.#getDefaultNewsletterSenderOptions();
+
         await this.#mailer.send({
             to: member.email,
             subject,
             html,
             text,
-            forceTextContent: true
+            forceTextContent: true,
+            ...senderOptions
         });
     }
 
@@ -136,12 +194,15 @@ class MemberWelcomeEmailService {
             siteSettings: this.#getSiteSettings()
         });
 
+        const senderOptions = await this.#getDefaultNewsletterSenderOptions();
+
         await this.#mailer.send({
             to: email,
             subject: `[Test] ${renderedSubject}`,
             html,
             text,
-            forceTextContent: true
+            forceTextContent: true,
+            ...senderOptions
         });
     }
 }
@@ -156,4 +217,3 @@ class MemberWelcomeEmailServiceWrapper {
 }
 
 module.exports = new MemberWelcomeEmailServiceWrapper();
-

--- a/ghost/core/core/server/services/member-welcome-emails/service.js
+++ b/ghost/core/core/server/services/member-welcome-emails/service.js
@@ -15,6 +15,7 @@ class MemberWelcomeEmailService {
     #mailer;
     #renderer;
     #memberWelcomeEmails = {free: null, paid: null};
+    #defaultNewsletterSenderOptions = null;
 
     constructor() {
         emailAddressService.init();
@@ -83,7 +84,18 @@ class MemberWelcomeEmailService {
         };
     }
 
+    async #getSenderOptions() {
+        if (this.#defaultNewsletterSenderOptions) {
+            return this.#defaultNewsletterSenderOptions;
+        }
+
+        this.#defaultNewsletterSenderOptions = await this.#getDefaultNewsletterSenderOptions();
+        return this.#defaultNewsletterSenderOptions;
+    }
+
     async loadMemberWelcomeEmails() {
+        this.#defaultNewsletterSenderOptions = await this.#getDefaultNewsletterSenderOptions();
+
         for (const [memberStatus, slug] of Object.entries(MEMBER_WELCOME_EMAIL_SLUGS)) {
             const row = await AutomatedEmail.findOne({slug});
 
@@ -137,7 +149,7 @@ class MemberWelcomeEmailService {
             siteSettings: this.#getSiteSettings()
         });
 
-        const senderOptions = await this.#getDefaultNewsletterSenderOptions();
+        const senderOptions = await this.#getSenderOptions();
 
         await this.#mailer.send({
             to: member.email,
@@ -194,7 +206,7 @@ class MemberWelcomeEmailService {
             siteSettings: this.#getSiteSettings()
         });
 
-        const senderOptions = await this.#getDefaultNewsletterSenderOptions();
+        const senderOptions = await this.#getSenderOptions();
 
         await this.#mailer.send({
             to: email,

--- a/ghost/core/core/server/services/member-welcome-emails/service.js
+++ b/ghost/core/core/server/services/member-welcome-emails/service.js
@@ -206,7 +206,8 @@ class MemberWelcomeEmailService {
             siteSettings: this.#getSiteSettings()
         });
 
-        const senderOptions = await this.#getSenderOptions();
+        // Test sends should always reflect the latest newsletter sender settings.
+        const senderOptions = await this.#getDefaultNewsletterSenderOptions();
 
         await this.#mailer.send({
             to: email,

--- a/ghost/core/core/server/services/member-welcome-emails/service.js
+++ b/ghost/core/core/server/services/member-welcome-emails/service.js
@@ -37,7 +37,7 @@ class MemberWelcomeEmailService {
             return {};
         }
 
-        let senderName = settingsCache.get('title') ? settingsCache.get('title').replace(/"/g, '\\"') : '';
+        let senderName = settingsCache.get('title') || '';
         if (newsletter.get('sender_name')) {
             senderName = newsletter.get('sender_name');
         }

--- a/ghost/core/test/e2e-api/admin/automated-emails.test.js
+++ b/ghost/core/test/e2e-api/admin/automated-emails.test.js
@@ -502,6 +502,36 @@ describe('Automated Emails API', function () {
                 });
         });
 
+        it('Uses configured sender and reply-to for test email', async function () {
+            const senderEmail = 'editor@example.com';
+            const senderReplyTo = 'reply@example.com';
+            const {body: newslettersBody} = await agent.get('newsletters/?limit=1').expectStatus(200);
+            const defaultNewsletterId = newslettersBody.newsletters[0].id;
+
+            await agent
+                .put(`newsletters/${defaultNewsletterId}`)
+                .body({newsletters: [{
+                    sender_email: senderEmail,
+                    sender_reply_to: senderReplyTo
+                }]})
+                .expectStatus(200);
+
+            await agent
+                .post(`automated_emails/${automatedEmailId}/test/`)
+                .body({
+                    email: 'test@ghost.org',
+                    subject: 'Test Subject',
+                    lexical: validLexical
+                })
+                .expectStatus(204);
+
+            sinon.assert.calledOnce(mailService.GhostMailer.prototype.send);
+            sinon.assert.calledWithMatch(mailService.GhostMailer.prototype.send, {
+                from: sinon.match(new RegExp(senderEmail)),
+                replyTo: senderReplyTo
+            });
+        });
+
         it('Cannot send test email for non-existent automated email', async function () {
             await agent
                 .post('automated_emails/abcd1234abcd1234abcd1234/test/')


### PR DESCRIPTION
ref https://linear.app/ghost/issue/NY-1028/welcome-email-uses-noreply-instead-of-configured-sender

## Problem

Welcome emails aren't currently respecting the sender info of the default newsletter as intended. Instead, they are being sent with a fallback `sender_name` and `sender_reply_to` address:
- For a site with custom sending domain, this is `noreply@example.com`
- For a site without a custom sending domain, this is `subdomain@ghost.io`

## Fix

Welcome emails should use the sender info from the default newsletter's settings, so that new members can reply directly to the welcome email and the publisher will receive that email. This fix gets the settings from the default newsletter, and passes this through to mailgun when sending welcome emails (real ones and test emails).