### PR TITLE
🐛 Fixed redirect back to account pages after login

### DIFF
--- a/apps/portal/src/app.js
+++ b/apps/portal/src/app.js
@@ -543,6 +543,19 @@ export default class App extends React.Component {
         if (path && linkRegex.test(path)) {
             const [,pagePath] = path.match(linkRegex);
             const {page, pageQuery, pageData} = this.getPageFromLinkPath(pagePath, site) || {};
+
+            // If user is not logged in and trying to access an account page,
+            // redirect to signin with a redirect URL back to the intended page
+            if (!member && page && isAccountPage({page})) {
+                return {
+                    showPopup: true,
+                    page: 'signin',
+                    pageData: {
+                        redirect: site.url + `#/portal/${pagePath}/`
+                    }
+                };
+            }
+
             const lastPage = ['accountPlan', 'accountProfile'].includes(page) ? 'accountHome' : null;
             const showPopup = (
                 ['monthly', 'yearly'].includes(pageQuery) ||

--- a/apps/portal/test/portal-links.test.js
+++ b/apps/portal/test/portal-links.test.js
@@ -344,4 +344,57 @@ describe('Portal Data links:', () => {
             expect(helpPageTitle).toBeInTheDocument();
         });
     });
+
+    describe('unauthenticated account page access', () => {
+        test('#/portal/account redirects to signin when not logged in', async () => {
+            window.location.hash = '#/portal/account';
+            let {
+                popupFrame, triggerButtonFrame, ...utils
+            } = await setup({
+                site: FixtureSite.singleTier.basic,
+                member: null,
+                showPopup: false
+            });
+            expect(triggerButtonFrame).toBeInTheDocument();
+            popupFrame = await utils.findByTitle(/portal-popup/i);
+            expect(popupFrame).toBeInTheDocument();
+            // Should show signin page instead of account page
+            const signinTitle = within(popupFrame.contentDocument).queryByText(/sign in/i);
+            expect(signinTitle).toBeInTheDocument();
+        });
+
+        test('#/portal/account/plans redirects to signin when not logged in', async () => {
+            window.location.hash = '#/portal/account/plans';
+            let {
+                popupFrame, triggerButtonFrame, ...utils
+            } = await setup({
+                site: FixtureSite.singleTier.basic,
+                member: null,
+                showPopup: false
+            });
+            expect(triggerButtonFrame).toBeInTheDocument();
+            popupFrame = await utils.findByTitle(/portal-popup/i);
+            expect(popupFrame).toBeInTheDocument();
+            // Should show signin page instead of account plan page
+            const signinTitle = within(popupFrame.contentDocument).queryByText(/sign in/i);
+            expect(signinTitle).toBeInTheDocument();
+        });
+
+        test('#/portal/account/profile redirects to signin when not logged in', async () => {
+            window.location.hash = '#/portal/account/profile';
+            let {
+                popupFrame, triggerButtonFrame, ...utils
+            } = await setup({
+                site: FixtureSite.singleTier.basic,
+                member: null,
+                showPopup: false
+            });
+            expect(triggerButtonFrame).toBeInTheDocument();
+            popupFrame = await utils.findByTitle(/portal-popup/i);
+            expect(popupFrame).toBeInTheDocument();
+            // Should show signin page instead of account profile page
+            const signinTitle = within(popupFrame.contentDocument).queryByText(/sign in/i);
+            expect(signinTitle).toBeInTheDocument();
+        });
+    });
 });


### PR DESCRIPTION
fixes https://linear.app/ghost/issue/BER-3314

When users accessed account pages (e.g., #/portal/account/plans) without being logged in, they were redirected to signin but not returned to the intended page after authentication. This change adds a redirect URL to pageData when navigating to signin from an account page, similar to the existing feedback flow pattern.

https://claude.ai/code/session_01GupE4JYFrykw8mV8dgeVT8