### PR TITLE
Fixed browser tests not testing React admin

### DIFF
--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -324,19 +324,19 @@
       "test:browser": {
         "dependsOn": [
           "build:assets",
-          "ghost-admin:build"
+          "@tryghost/admin:build"
         ]
       },
       "test:browser:admin": {
         "dependsOn": [
           "build:assets",
-          "ghost-admin:build"
+          "@tryghost/admin:build"
         ]
       },
       "test:browser:portal": {
         "dependsOn": [
           "build:assets",
-          "ghost-admin:build"
+          "@tryghost/admin:build"
         ]
       }
     }

--- a/ghost/core/test/e2e-browser/admin/announcement-bar-settings.spec.js
+++ b/ghost/core/test/e2e-browser/admin/announcement-bar-settings.spec.js
@@ -49,7 +49,7 @@ test.describe('Announcement Bar Settings', () => {
 
 async function goToAnnouncementBarSettings(sharedPage) {
     await test.step('Navigate to the announcement bar settings', async () => {
-        await sharedPage.locator('[data-test-nav="settings"]').click();
+        await sharedPage.locator('[data-sidebar="sidebar"]').getByRole('link', {name: 'Settings'}).click();
         await sharedPage.getByTestId('announcement-bar').getByRole('button', {name: 'Customize'}).click();
         // Wait for the preview to load
         await getPreviewFrame(sharedPage).locator('body *:visible').first().waitFor();

--- a/ghost/core/test/e2e-browser/admin/membership-settings.spec.js
+++ b/ghost/core/test/e2e-browser/admin/membership-settings.spec.js
@@ -11,7 +11,7 @@ test.describe('Membership Settings', () => {
 
             // Open Portal settings
             await sharedPage.goto('/ghost');
-            await sharedPage.locator('.gh-nav a[href="#/settings/"]').click();
+            await sharedPage.locator('[data-sidebar="sidebar"]').getByRole('link', {name: 'Settings'}).click();
             await sharedPage.getByTestId('portal').getByRole('button', {name: 'Customize'}).click();
 
             const modal = sharedPage.getByTestId('portal-modal');

--- a/ghost/core/test/e2e-browser/admin/portal-settings.spec.js
+++ b/ghost/core/test/e2e-browser/admin/portal-settings.spec.js
@@ -5,7 +5,7 @@ test.describe('Portal Settings', () => {
     test.describe('Links', () => {
         const openPortalLinks = async (sharedPage) => {
             await sharedPage.goto('/ghost');
-            await sharedPage.locator('[data-test-nav="settings"]').click();
+            await sharedPage.locator('[data-sidebar="sidebar"]').getByRole('link', {name: 'Settings'}).click();
 
             await sharedPage.getByTestId('portal').getByRole('button', {name: 'Customize'}).click();
 

--- a/ghost/core/test/e2e-browser/admin/private-site.spec.js
+++ b/ghost/core/test/e2e-browser/admin/private-site.spec.js
@@ -7,7 +7,7 @@ test.describe('Site Settings', () => {
             // set private mode in admin "on"
             await sharedPage.goto('/ghost');
 
-            await sharedPage.locator('[data-test-nav="settings"]').click();
+            await sharedPage.locator('[data-sidebar="sidebar"]').getByRole('link', {name: 'Settings'}).click();
 
             const section = sharedPage.getByTestId('locksite');
 

--- a/ghost/core/test/e2e-browser/admin/publishing.spec.js
+++ b/ghost/core/test/e2e-browser/admin/publishing.spec.js
@@ -68,7 +68,7 @@ const checkPostPublished = async (page, {slug, title, body}) => {
  * @param {String} [options.body]
  */
 const createPage = async (page, {title = 'Hello world', body = 'This is my post body.'} = {}) => {
-    await page.locator('.gh-nav a[href="#/pages/"]').click();
+    await page.locator('[data-sidebar="sidebar"]').getByRole('link', {name: 'Pages'}).click();
 
     // Create a new post
     await page.locator('[data-test-new-page-button]').click();
@@ -620,7 +620,7 @@ test.describe('Updating post access', () => {
         await closePublishFlow(page);
 
         // go to settings and change the timezone
-        await page.locator('[data-test-nav="settings"]').click();
+        await page.locator('[data-sidebar="sidebar"]').getByRole('link', {name: 'Settings'}).click();
         await expect(page.getByTestId('timezone')).toContainText('UTC');
 
         await page.getByTestId('timezone-select').click();
@@ -630,7 +630,7 @@ test.describe('Updating post access', () => {
         await expect(page.getByTestId('timezone')).toContainText('(GMT +9:00) Osaka, Sapporo, Tokyo');
 
         await page.getByTestId('exit-settings').click();
-        await page.locator('[data-test-nav="posts"]').click();
+        await page.locator('[data-sidebar="sidebar"]').getByRole('link', {name: 'Posts'}).click();
         await page.locator('[data-test-post-id]', {hasText: /Published in timezones/}).click();
 
         await openPostSettingsMenu(page);

--- a/ghost/core/test/e2e-browser/admin/site-settings.spec.js
+++ b/ghost/core/test/e2e-browser/admin/site-settings.spec.js
@@ -3,7 +3,7 @@ const test = require('../fixtures/ghost-test');
 const {createPostDraft, createTier, disconnectStripe, generateStripeIntegrationToken, setupStripe, getStripeAccountId} = require('../utils');
 
 const changeSubscriptionAccess = async (page, access) => {
-    await page.locator('[data-test-nav="settings"]').click();
+    await page.locator('[data-sidebar="sidebar"]').getByRole('link', {name: 'Settings'}).click();
 
     const section = page.getByTestId('access');
     const select = section.getByTestId('subscription-access-select');

--- a/ghost/core/test/e2e-browser/portal/invites.spec.js
+++ b/ghost/core/test/e2e-browser/portal/invites.spec.js
@@ -11,7 +11,6 @@ test.describe('Portal', () => {
             // Navigate to settings
             await sharedPage.goto('/ghost');
             await sharedPage.locator('[data-sidebar="sidebar"]').getByRole('link', {name: 'Settings'}).click();
-            await sharedPage.waitForLoadState('networkidle');
 
             const testEmail = `test-${Date.now()}@gmail.com`;
 
@@ -51,7 +50,6 @@ test.describe('Portal', () => {
             await sharedPage.goto(inviteUrl);
 
             // Verify we're on the signup page
-            await sharedPage.waitForLoadState('networkidle');
             await expect(sharedPage.locator('text=Create your account.')).toBeVisible();
 
             //Signup using the invite Link
@@ -75,7 +73,6 @@ test.describe('Portal', () => {
                 // Navigate to settings
                 await sharedPage.goto('/ghost');
                 await sharedPage.locator('[data-sidebar="sidebar"]').getByRole('link', {name: 'Settings'}).click();
-                await sharedPage.waitForLoadState('networkidle');
 
                 const testEmail = `test-${Date.now()}@gmail.com`;
 
@@ -117,7 +114,6 @@ test.describe('Portal', () => {
                 await sharedPage.goto(inviteUrl);
 
                 // Verify we're on the signup page
-                await sharedPage.waitForLoadState('networkidle');
                 await expect(sharedPage.locator('text=Create your account.')).toBeVisible();
 
                 //Signup using the invite Link

--- a/ghost/core/test/e2e-browser/portal/invites.spec.js
+++ b/ghost/core/test/e2e-browser/portal/invites.spec.js
@@ -105,8 +105,6 @@ test.describe('Portal', () => {
                 const encodedToken = security.url.encodeBase64(token);
                 const adminUrl = new URL(sharedPage.url()).origin + '/ghost';
                 const inviteUrl = `${adminUrl}/signup/${encodedToken}/`;
-                const context = await sharedPage.context();
-                await context.clearCookies();
 
                 await signOutCurrentUser(sharedPage);
 
@@ -122,11 +120,9 @@ test.describe('Portal', () => {
                 await sharedPage.getByPlaceholder('At least 10 characters').fill('test123456');
                 await sharedPage.getByRole('button', {name: 'Create Account →'}).click();
                 await expect(sharedPage).toHaveURL(/\/ghost\/#\/.*/, {timeout: 30000});
-                // Reload so the React admin picks up the newly authenticated session
-                await sharedPage.goto('/ghost');
 
                 // Invited users are Contributors, which get a floating user menu instead of the sidebar
-                await sharedPage.getByRole('button', {name: 'Open user menu'}).click({timeout: 30000});
+                await sharedPage.getByRole('button', {name: 'Open user menu'}).click();
                 await expect(sharedPage.locator(`text=${testEmail}`)).toBeVisible();
 
                 await signOutCurrentUser(sharedPage);

--- a/ghost/core/test/e2e-browser/portal/invites.spec.js
+++ b/ghost/core/test/e2e-browser/portal/invites.spec.js
@@ -10,7 +10,7 @@ test.describe('Portal', () => {
         test('New staff member can signup using an invite link', async ({sharedPage}) => {
             // Navigate to settings
             await sharedPage.goto('/ghost');
-            await sharedPage.locator('[data-test-nav="settings"]').click();
+            await sharedPage.locator('[data-sidebar="sidebar"]').getByRole('link', {name: 'Settings'}).click();
             await sharedPage.waitForLoadState('networkidle');
 
             const testEmail = `test-${Date.now()}@gmail.com`;
@@ -59,10 +59,10 @@ test.describe('Portal', () => {
             await sharedPage.getByPlaceholder('jamie@example.com').fill(testEmail);
             await sharedPage.getByPlaceholder('At least 10 characters').fill('test123456');
             await sharedPage.getByRole('button', {name: 'Create Account →'}).click();
-            await sharedPage.waitForLoadState('networkidle');
-            await expect(sharedPage).toHaveURL(/\/ghost\/#\/.*/);
+            await expect(sharedPage).toHaveURL(/\/ghost\/#\/.*/, {timeout: 30000});
 
-            await sharedPage.locator('[data-test-nav="arrow-down"]').click();
+            // Invited users are Contributors, which get a floating user menu instead of the sidebar
+            await sharedPage.getByRole('button', {name: 'Open user menu'}).click();
             await expect(sharedPage.locator(`text=${testEmail}`)).toBeVisible();
 
             await signOutCurrentUser(sharedPage);
@@ -74,7 +74,7 @@ test.describe('Portal', () => {
             test('New staff member can signup using an invite link with 2FA enabled', async ({sharedPage}) => {
                 // Navigate to settings
                 await sharedPage.goto('/ghost');
-                await sharedPage.locator('[data-test-nav="settings"]').click();
+                await sharedPage.locator('[data-sidebar="sidebar"]').getByRole('link', {name: 'Settings'}).click();
                 await sharedPage.waitForLoadState('networkidle');
 
                 const testEmail = `test-${Date.now()}@gmail.com`;
@@ -125,11 +125,12 @@ test.describe('Portal', () => {
                 await sharedPage.getByPlaceholder('jamie@example.com').fill(testEmail);
                 await sharedPage.getByPlaceholder('At least 10 characters').fill('test123456');
                 await sharedPage.getByRole('button', {name: 'Create Account →'}).click();
-                await sharedPage.waitForLoadState('networkidle');
+                await expect(sharedPage).toHaveURL(/\/ghost\/#\/.*/, {timeout: 30000});
+                // Reload so the React admin picks up the newly authenticated session
+                await sharedPage.goto('/ghost');
 
-                await expect(sharedPage).toHaveURL(/\/ghost\/#\/.*/);
-
-                await sharedPage.locator('[data-test-nav="arrow-down"]').click();
+                // Invited users are Contributors, which get a floating user menu instead of the sidebar
+                await sharedPage.getByRole('button', {name: 'Open user menu'}).click({timeout: 30000});
                 await expect(sharedPage.locator(`text=${testEmail}`)).toBeVisible();
 
                 await signOutCurrentUser(sharedPage);

--- a/ghost/core/test/e2e-browser/portal/member-actions.spec.js
+++ b/ghost/core/test/e2e-browser/portal/member-actions.spec.js
@@ -7,7 +7,7 @@ const {createMember, impersonateMember} = require('../utils');
  */
 const addNewsletter = async (page) => {
     await page.goto('/ghost');
-    await page.locator('[data-test-nav="settings"]').click();
+    await page.locator('[data-sidebar="sidebar"]').getByRole('link', {name: 'Settings'}).click();
 
     // create newsletter
     const section = page.getByTestId('newsletters');

--- a/ghost/core/test/e2e-browser/portal/offers.spec.js
+++ b/ghost/core/test/e2e-browser/portal/offers.spec.js
@@ -30,7 +30,7 @@ test.describe('Portal', () => {
 
             // check that offer was added in the offer list screen
             await sharedPage.goto('/ghost');
-            await sharedPage.locator('[data-test-nav="settings"]').click();
+            await sharedPage.locator('[data-sidebar="sidebar"]').getByRole('link', {name: 'Settings'}).click();
             await expect(await sharedPage.getByTestId('offers')).toContainText(offerName);
 
             await sharedPage.goto(offerLink);
@@ -71,7 +71,7 @@ test.describe('Portal', () => {
 
             // go to member list on admin
             await sharedPage.goto('/ghost');
-            await sharedPage.locator('.gh-nav a[href="#/members/"]').click();
+            await sharedPage.locator('[data-sidebar="sidebar"]').getByRole('link', {name: 'Members'}).click();
 
             // // 1 member, should be Testy, on Portal Tier
             await expect(await sharedPage.getByRole('link', {name: 'Testy McTesterson testy+trial@example.com'}), 'Should have 1 paid member').toBeVisible();
@@ -107,7 +107,7 @@ test.describe('Portal', () => {
 
             // check that offer was added in the offer list screen
             await sharedPage.goto('/ghost');
-            await sharedPage.locator('[data-test-nav="settings"]').click();
+            await sharedPage.locator('[data-sidebar="sidebar"]').getByRole('link', {name: 'Settings'}).click();
             await expect(sharedPage.getByTestId('offers')).toContainText(offerName);
             // open offer details page
             // await sharedPage.locator(`[data-test-offer="${offerName}"] a`).first().click();
@@ -153,7 +153,7 @@ test.describe('Portal', () => {
 
             // go to members list on admin
             await sharedPage.goto('/ghost');
-            await sharedPage.locator('.gh-nav a[href="#/members/"]').click();
+            await sharedPage.locator('[data-sidebar="sidebar"]').getByRole('link', {name: 'Members'}).click();
 
             // 1 member, should be Testy, on Portal Tier
             await expect(await sharedPage.getByRole('link', {name: 'Testy McTesterson testy+oneoff@example.com'}), 'Should have 1 paid member').toBeVisible();
@@ -184,7 +184,7 @@ test.describe('Portal', () => {
             });
 
             await sharedPage.goto('/ghost');
-            await sharedPage.locator('[data-test-nav="settings"]').click();
+            await sharedPage.locator('[data-sidebar="sidebar"]').getByRole('link', {name: 'Settings'}).click();
             await expect(await sharedPage.getByTestId('offers')).toContainText(offerName);
 
             await sharedPage.goto(offerLink);
@@ -228,7 +228,7 @@ test.describe('Portal', () => {
             // Discounted price should not be visible for member for one-time offers
             await expect(portalFrameLocator.locator('text=$5.40/month'), 'Portal should show discounted price').toBeVisible();
             await sharedPage.goto('/ghost');
-            await sharedPage.locator('.gh-nav a[href="#/members/"]').click();
+            await sharedPage.locator('[data-sidebar="sidebar"]').getByRole('link', {name: 'Members'}).click();
 
             // 1 member, should be Testy, on Portal Tier
             await expect(await sharedPage.getByRole('link', {name: 'Testy McTesterson testy+multi@example.com'}), 'Should have 1 paid member').toBeVisible();
@@ -259,7 +259,7 @@ test.describe('Portal', () => {
 
             // check that offer was added in the offer list screen
             await sharedPage.goto('/ghost');
-            await sharedPage.locator('[data-test-nav="settings"]').click();
+            await sharedPage.locator('[data-sidebar="sidebar"]').getByRole('link', {name: 'Settings'}).click();
             await expect(sharedPage.getByTestId('offers')).toContainText(offerName);
 
             await sharedPage.goto(offerLink);
@@ -301,7 +301,7 @@ test.describe('Portal', () => {
             // Discounted price should be visible for member for forever offers
             await expect(portalFrameLocator.locator('text=$5.40/month'), 'Portal should show discounted price').toBeVisible();
             await sharedPage.goto('/ghost');
-            await sharedPage.locator('.gh-nav a[href="#/members/"]').click();
+            await sharedPage.locator('[data-sidebar="sidebar"]').getByRole('link', {name: 'Members'}).click();
 
             // 1 member, should be Testy, on Portal Tier
             await expect(await sharedPage.getByRole('link', {name: 'Testy McTesterson testy+forever@example.com'}), 'Should have 1 paid member').toBeVisible();

--- a/ghost/core/test/e2e-browser/utils/e2e-browser-utils.js
+++ b/ghost/core/test/e2e-browser/utils/e2e-browser-utils.js
@@ -36,7 +36,7 @@ const setupGhost = async (page) => {
     const action = await Promise.race([
         page.locator('.gh-signin').waitFor(options).then(() => actions.signin).catch(() => {}),
         page.locator('.gh-setup').waitFor(options).then(() => actions.setup).catch(() => {}),
-        page.locator('.gh-nav').waitFor(options).then(() => actions.noAction).catch(() => {})
+        page.locator('[data-sidebar="sidebar"]').waitFor(options).then(() => actions.noAction).catch(() => {})
     ]);
 
     // Add owner user data from usual fixture
@@ -56,7 +56,7 @@ const setupGhost = async (page) => {
 
         await page.getByPlaceholder('At least 10 characters').press('Enter');
 
-        await page.locator('.gh-nav').waitFor(options);
+        await page.locator('[data-sidebar="sidebar"]').waitFor(options);
     }
 };
 
@@ -70,7 +70,7 @@ const signInAsUserById = async (page, userId) => {
     await page.locator('#password').fill(user.password);
     await page.getByRole('button', {name: 'Sign in'}).click();
     // Confirm we have reached Ghost Admin
-    await page.locator('.gh-nav').waitFor({state: 'visible', timeout: 10000});
+    await page.locator('[data-sidebar="sidebar"]').waitFor({state: 'visible', timeout: 10000});
 };
 
 const signOutCurrentUser = async (page) => {
@@ -81,7 +81,7 @@ const signOutCurrentUser = async (page) => {
 
 const disconnectStripe = async (page) => {
     await deleteAllMembers(page);
-    await page.locator('.gh-nav a[href="#/settings/"]').click();
+    await page.locator('[data-sidebar="sidebar"]').getByRole('link', {name: 'Settings'}).click();
     await page.getByTestId('tiers').waitFor();
     if (await page.isVisible('[data-testid="stripe-connected"]')) {
         await page.getByTestId('stripe-connected').first().click();
@@ -92,7 +92,7 @@ const disconnectStripe = async (page) => {
 
 const setupStripe = async (page, stripConnectIntegrationToken) => {
     await deleteAllMembers(page);
-    await page.locator('.gh-nav a[href="#/settings/"]').click();
+    await page.locator('[data-sidebar="sidebar"]').getByRole('link', {name: 'Settings'}).click();
     await page.getByTestId('tiers').waitFor();
     if (await page.isVisible('[data-testid="stripe-connected"]')) {
         // Disconnect if already connected
@@ -115,7 +115,7 @@ const setupStripe = async (page, stripConnectIntegrationToken) => {
 
 // Setup Mailgun with fake data for Ghost Admin to allow bulk sending
 const setupMailgun = async (page) => {
-    await page.locator('.gh-nav a[href="#/settings/"]').click();
+    await page.locator('[data-sidebar="sidebar"]').getByRole('link', {name: 'Settings'}).click();
     const section = page.getByTestId('mailgun');
 
     await section.getByRole('button', {name: 'Edit'}).click();
@@ -181,7 +181,7 @@ const impersonateMember = async (page) => {
 const createTier = async (page, {name, monthlyPrice, yearlyPrice, trialDays}, enableInPortal = true) => {
     await test.step('Create a tier', async () => {
         // Navigate to the member settings
-        await page.locator('[data-test-nav="settings"]').click();
+        await page.locator('[data-sidebar="sidebar"]').getByRole('link', {name: 'Settings'}).click();
 
         // Tiers request can take time, so waiting until there is no connections before interacting with them
         await page.waitForLoadState('networkidle');
@@ -253,7 +253,7 @@ const createOffer = async (page, {name, tierName, offerType, amount, discountTyp
     let offerLink;
     await test.step('Create an offer', async () => {
         await page.goto('/ghost');
-        await page.locator('[data-test-nav="settings"]').click();
+        await page.locator('[data-sidebar="sidebar"]').getByRole('link', {name: 'Settings'}).click();
 
         // Keep offer names unique & <= 40 characters
         offerName = `${name} (${new ObjectID().toHexString().slice(0, 40 - name.length - 3)})`;
@@ -372,7 +372,7 @@ const completeStripeSubscription = async (page, {awaitNetworkIdle = true} = {}) 
  */
 const createMember = async (page, {email, name, note, label = '', compedPlan}) => {
     await page.goto('/ghost');
-    await page.locator('.gh-nav a[href="#/members/"]').click();
+    await page.locator('[data-sidebar="sidebar"]').getByRole('link', {name: 'Members'}).click();
     await page.waitForSelector('a[href="#/members/new/"] span');
     await page.locator('a[href="#/members/new/"] span:has-text("New member")').click();
     await page.waitForSelector('input[name="name"]');
@@ -412,7 +412,7 @@ const createMember = async (page, {email, name, note, label = '', compedPlan}) =
  * @param {String} [options.body]
  */
 const createPostDraft = async (page, {title = 'Hello world', body = 'This is my post body.'} = {}) => {
-    await page.locator('.gh-nav a[href="#/posts/"]').click();
+    await page.locator('[data-sidebar="sidebar"]').getByRole('link', {name: 'Posts'}).click();
 
     // Create a new post
     await page.locator('[data-test-new-post-button]').click();
@@ -439,7 +439,7 @@ const createPostDraft = async (page, {title = 'Hello world', body = 'This is my 
 const goToMembershipPage = async (page) => {
     return await test.step('Open Membership settings', async () => {
         await page.goto('/ghost');
-        await page.locator('[data-test-nav="settings"]').click();
+        await page.locator('[data-sidebar="sidebar"]').getByRole('link', {name: 'Settings'}).click();
         // Tiers request can take time, so waiting until there is no connections before interacting with UI
         await page.waitForLoadState('networkidle');
     });

--- a/ghost/core/test/e2e-browser/utils/e2e-browser-utils.js
+++ b/ghost/core/test/e2e-browser/utils/e2e-browser-utils.js
@@ -75,7 +75,6 @@ const signInAsUserById = async (page, userId) => {
 
 const signOutCurrentUser = async (page) => {
     await page.goto('/ghost/#/signout');
-    await page.waitForLoadState('networkidle');
     await page.locator('.gh-signin').waitFor({state: 'visible', timeout: 10000});
 };
 
@@ -183,8 +182,8 @@ const createTier = async (page, {name, monthlyPrice, yearlyPrice, trialDays}, en
         // Navigate to the member settings
         await page.locator('[data-sidebar="sidebar"]').getByRole('link', {name: 'Settings'}).click();
 
-        // Tiers request can take time, so waiting until there is no connections before interacting with them
-        await page.waitForLoadState('networkidle');
+        // Tiers request can take time, so waiting until the Add tier button is visible before interacting
+        await page.getByTestId('tiers').getByRole('button', {name: 'Add tier'}).waitFor();
 
         // Archive if already exists
         while (await page.getByTestId('tier-card').filter({hasText: name}).first().isVisible()) {
@@ -257,9 +256,7 @@ const createOffer = async (page, {name, tierName, offerType, amount, discountTyp
 
         // Keep offer names unique & <= 40 characters
         offerName = `${name} (${new ObjectID().toHexString().slice(0, 40 - name.length - 3)})`;
-        // Tiers request can take time, so waiting until there is no connections before interacting with them
-        await page.waitForLoadState('networkidle');
-        // ... and even so, the component updates can take a bit to trickle down, so we should verify that the Tier is fully loaded before proceeding
+        // Verify that the Tier is fully loaded before proceeding
         await page.getByTestId('tiers').getByText('No active tiers found').waitFor({state: 'hidden'});
         await page.getByTestId('offers').getByRole('button', {name: 'Manage tiers'}).waitFor({state: 'hidden'});
 
@@ -314,7 +311,6 @@ const createOffer = async (page, {name, tierName, offerType, amount, discountTyp
 
         await chooseOptionInSelect(page.getByTestId('tier-cadence-select-offers'), `${tierName} - Monthly`);
         await page.getByRole('button', {name: 'Publish'}).click();
-        await page.waitForLoadState('networkidle');
 
         const offerLinkInput = await page.locator('input[name="offer-url"]');
         // sometimes offer link is not generated, and if so the rest of the test will fail
@@ -440,8 +436,8 @@ const goToMembershipPage = async (page) => {
     return await test.step('Open Membership settings', async () => {
         await page.goto('/ghost');
         await page.locator('[data-sidebar="sidebar"]').getByRole('link', {name: 'Settings'}).click();
-        // Tiers request can take time, so waiting until there is no connections before interacting with UI
-        await page.waitForLoadState('networkidle');
+        // Tiers request can take time, so waiting until the tiers section is loaded before interacting with UI
+        await page.getByTestId('tiers').waitFor();
     });
 };
 


### PR DESCRIPTION
no issue

- browser tests were depending on the Ember build of Admin but that no longer matches reality since `adminForward` was made GA meaning the tests aren't testing what our users are seeing
- swapped the ember build for the react build in the nx dependency graph for browser builds so we render the real-world React+Ember mix and Ember's `inAdminForward` feature flag correctly matches
