### PR TITLE
🐛 Fixed comment permalinks not scrolling to selected comment

### DIFF
--- a/apps/comments-ui/package.json
+++ b/apps/comments-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/comments-ui",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/comments-ui/src/app.tsx
+++ b/apps/comments-ui/src/app.tsx
@@ -304,7 +304,7 @@ const App: React.FC<AppProps> = ({scriptTag, initialCommentId, pageUrl}) => {
             let pagination = initialPagination;
             let scrollTargetFound = false;
 
-            const shouldFindScrollTarget = labs?.commentPermalinks && initialCommentId && pagination;
+            const shouldFindScrollTarget = initialCommentId && pagination;
             if (shouldFindScrollTarget) {
                 const targetComment = await fetchScrollTarget(initialCommentId);
                 if (targetComment) {

--- a/apps/comments-ui/src/components/content/comment.tsx
+++ b/apps/comments-ui/src/components/content/comment.tsx
@@ -7,7 +7,7 @@ import Replies, {RepliesProps} from './replies';
 import ReplyButton from './buttons/reply-button';
 import ReplyForm from './forms/reply-form';
 import {Avatar, BlankAvatar} from './avatar';
-import {Comment, OpenCommentForm, useAppContext, useLabs} from '../../app-context';
+import {Comment, OpenCommentForm, useAppContext} from '../../app-context';
 import {Transition} from '@headlessui/react';
 import {buildCommentPermalink, findCommentById, formatExplicitTime, getCommentInReplyToSnippet, getMemberNameFromComment} from '../../utils/helpers';
 import {useRelativeTime} from '../../utils/hooks';
@@ -269,23 +269,8 @@ const AuthorName: React.FC<{comment: Comment}> = ({comment}) => {
 };
 
 export const RepliedToSnippet: React.FC<{comment: Comment}> = ({comment}) => {
-    const {comments, dispatchAction, t, pageUrl} = useAppContext();
-    const labs = useLabs();
+    const {comments, t, pageUrl} = useAppContext();
     const inReplyToComment = findCommentById(comments, comment.in_reply_to_id);
-
-    const scrollRepliedToCommentIntoView = (e: React.MouseEvent<HTMLAnchorElement>) => {
-        e.preventDefault();
-
-        if (!e.target) {
-            return;
-        }
-
-        const element = (e.target as HTMLElement).ownerDocument.getElementById(comment.in_reply_to_id);
-        if (element) {
-            dispatchAction('highlightComment', {commentId: comment.in_reply_to_id});
-            element.scrollIntoView({behavior: 'smooth', block: 'center'});
-        }
-    };
 
     let inReplyToSnippet = comment.in_reply_to_snippet;
     // For public API requests hidden/deleted comments won't exist in the comments array
@@ -302,12 +287,8 @@ export const RepliedToSnippet: React.FC<{comment: Comment}> = ({comment}) => {
         return <span className={className} data-testid="comment-in-reply-to">{inReplyToSnippet}</span>;
     }
 
-    // With labs flag: use permalink URL, let hashchange listener handle scroll
-    // Without labs flag: use onClick handler for direct scroll behavior
-    return labs?.commentPermalinks ? (
+    return (
         <a className={linkClassName} data-testid="comment-in-reply-to" href={buildCommentPermalink(pageUrl, comment.in_reply_to_id)} target="_parent">{inReplyToSnippet}</a>
-    ) : (
-        <a className={linkClassName} data-testid="comment-in-reply-to" href={`#${comment.in_reply_to_id}`} onClick={scrollRepliedToCommentIntoView}>{inReplyToSnippet}</a>
     );
 };
 
@@ -318,12 +299,11 @@ type CommentHeaderProps = {
 
 const CommentHeader: React.FC<CommentHeaderProps> = ({comment, className = ''}) => {
     const {member, t, pageUrl} = useAppContext();
-    const labs = useLabs();
     const createdAtRelative = useRelativeTime(comment.created_at);
     const memberExpertise = member && comment.member && comment.member.uuid === member.uuid ? member.expertise : comment?.member?.expertise;
     const isReplyToReply = comment.in_reply_to_id && comment.in_reply_to_snippet;
 
-    const timestampElement = labs?.commentPermalinks ? (
+    const timestampElement = (
         <a
             className="hover:underline"
             href={buildCommentPermalink(pageUrl, comment.id)}
@@ -332,10 +312,6 @@ const CommentHeader: React.FC<CommentHeaderProps> = ({comment, className = ''}) 
         >
             <span className="mx-[0.3em]">·</span>{createdAtRelative}
         </a>
-    ) : (
-        <span title={formatExplicitTime(comment.created_at)}>
-            <span className="mx-[0.3em]">·</span>{createdAtRelative}
-        </span>
     );
 
     return (

--- a/apps/comments-ui/src/components/content/content.tsx
+++ b/apps/comments-ui/src/components/content/content.tsx
@@ -101,10 +101,6 @@ const Content = () => {
     }, []);
 
     useEffect(() => {
-        if (!labs?.commentPermalinks) {
-            return;
-        }
-
         const handleHashChange = () => {
             const commentId = parseCommentIdFromHash(window.parent.location.hash);
             if (commentId && containerRef.current) {
@@ -118,7 +114,7 @@ const Content = () => {
 
         window.parent.addEventListener('hashchange', handleHashChange);
         return () => window.parent.removeEventListener('hashchange', handleHashChange);
-    }, [labs?.commentPermalinks, scrollToComment]);
+    }, [scrollToComment]);
 
     useEffect(() => {
         if (!commentIdToScrollTo || commentsIsLoading || !containerRef.current) {

--- a/apps/comments-ui/test/e2e/permalink.test.ts
+++ b/apps/comments-ui/test/e2e/permalink.test.ts
@@ -15,14 +15,6 @@ async function setupPermalinkTest(
 ): Promise<FrameLocator> {
     const sitePath = MOCKED_SITE_URL;
 
-    mockedApi.setSettings({
-        settings: {
-            labs: {
-                commentPermalinks: true
-            }
-        }
-    });
-
     await page.route(sitePath, async (route) => {
         await route.fulfill({status: 200, body: bodyHtml});
     });
@@ -68,8 +60,7 @@ test.describe('Comment Permalinks', async () => {
         const {frame} = await initialize({
             mockedApi,
             page,
-            publication: 'Publisher Weekly',
-            labs: {commentPermalinks: true}
+            publication: 'Publisher Weekly'
         });
 
         // Check that the timestamp is an anchor with the correct href
@@ -89,8 +80,7 @@ test.describe('Comment Permalinks', async () => {
         const {frame} = await initialize({
             mockedApi,
             page,
-            publication: 'Publisher Weekly',
-            labs: {commentPermalinks: true}
+            publication: 'Publisher Weekly'
         });
 
         // Find timestamp link and verify it has the hover:underline class
@@ -410,14 +400,6 @@ test.describe('Comment Permalinks', async () => {
         // Set up permalink test with admin URL in the script tag options
         const sitePath = MOCKED_SITE_URL;
 
-        mockedApi.setSettings({
-            settings: {
-                labs: {
-                    commentPermalinks: true
-                }
-            }
-        });
-
         await page.route(sitePath, async (route) => {
             await route.fulfill({status: 200, body: '<html><head><meta charset="UTF-8" /></head><body></body></html>'});
         });
@@ -496,14 +478,6 @@ test.describe('Comment Permalinks', async () => {
         mockedApi.addComment(parentComment);
 
         const sitePath = MOCKED_SITE_URL;
-
-        mockedApi.setSettings({
-            settings: {
-                labs: {
-                    commentPermalinks: true
-                }
-            }
-        });
 
         await page.route(sitePath, async (route) => {
             await route.fulfill({status: 200, body: '<html><head><meta charset="UTF-8" /></head><body></body></html>'});


### PR DESCRIPTION
no issue

The Content API settings endpoint doesn't include `GA_FEATURES` labs flags so Comments-UI was never triggering any of the comment permalinks behaviour that was gated by the labs flag.

- removed all `commentPermalinks` labs flag gating in Comments-UI so it becomes the default behaviour