### PR TITLE
🐛 Fixed Content API settings missing GA labs flags

### DIFF
--- a/ghost/core/core/server/api/endpoints/settings-public.js
+++ b/ghost/core/core/server/api/endpoints/settings-public.js
@@ -1,4 +1,5 @@
 const settingsCache = require('../../../shared/settings-cache');
+const labs = require('../../../shared/labs');
 const urlUtils = require('../../../shared/url-utils');
 const ghostVersion = require('@tryghost/version');
 
@@ -17,7 +18,8 @@ const controller = {
             return Object.assign({},
                 settingsCache.getPublic(), {
                     url: urlUtils.urlFor('home', true),
-                    version: ghostVersion.safe
+                    version: ghostVersion.safe,
+                    labs: labs.getAll()
                 }
             );
         }

--- a/ghost/core/test/e2e-api/content/settings.test.js
+++ b/ghost/core/test/e2e-api/content/settings.test.js
@@ -1,5 +1,7 @@
+const assert = require('assert/strict');
 const {agentProvider, fixtureManager, matchers} = require('../../utils/e2e-framework');
 const {anyEtag, anyContentLength, anyContentVersion, anyUuid, anyString, anyObject} = matchers;
+const labs = require('../../../core/shared/labs');
 
 const settingsMatcher = {
     version: anyString,
@@ -27,5 +29,23 @@ describe('Settings Content API', function () {
             .matchBodySnapshot({
                 settings: settingsMatcher
             });
+    });
+
+    it('Includes GA labs flags in settings response', async function () {
+        const {body} = await agent.get('settings/')
+            .expectStatus(200);
+
+        const settingsLabs = body.settings.labs;
+        const allLabs = labs.getAll();
+
+        // GA_FEATURES should be present in the Content API response
+        for (const key of labs.GA_KEYS) {
+            assert.equal(settingsLabs[key], true, `Expected labs.${key} to be true in Content API settings`);
+        }
+
+        // Content API labs should match labs.getAll()
+        for (const [key, value] of Object.entries(allLabs)) {
+            assert.equal(settingsLabs[key], value, `Expected labs.${key} to be ${value} in Content API settings`);
+        }
     });
 });


### PR DESCRIPTION
The Content API `/settings` endpoint was returning an empty `labs` object because it read the raw value from the settings cache via `settingsCache.getPublic()`. Unlike the Admin API — which passes labs through `SettingsBREADService._formatBrowse()` and calls `labs.getAll()` to inject GA_FEATURES — the Content API path bypassed this entirely. The result was that GA flags like `commentPermalinks` were missing from all Content API settings responses.

This broke comment deep-links (e.g. `#ghost-comments-{id}`) for every site. The comments-ui app fetches labs from the Content API settings endpoint, and its permalink scroll logic is gated behind `labs?.commentPermalinks`. With the flag missing, the hash was parsed and comments loaded, but the scroll-to-comment and highlighting never fired. The bug was reported via a site owner whose comment deep-links weren't working.

The fix overrides the `labs` key in the Content API settings response with `labs.getAll()`, matching what the Admin API already does. A regression test verifies that all GA_KEYS are present and `true` in the Content API response going forward.