### PR TITLE
Fixed contributor dropdown menu width

### DIFF
--- a/apps/admin/src/layout/app-sidebar/user-menu.tsx
+++ b/apps/admin/src/layout/app-sidebar/user-menu.tsx
@@ -210,7 +210,7 @@ function ContributorUserMenu() {
                 align="start"
                 side="top"
                 sideOffset={10}
-                className="w-[var(--radix-dropdown-menu-trigger-width)] mb-2"
+                className="min-w-56 mb-2"
             >
                 <UserMenuHeader
                     name={currentUser.data?.name}


### PR DESCRIPTION
Ref https://ghost.slack.com/archives/C072AHLF4AE/p1770890848203219

When I made [updates to the sidebar menu](https://github.com/TryGhost/Ghost/pull/25984) I broke the contributor menu by making its width the same size as the parent. This fixes that.

| Before | After |
|--------|--------|
| <img width="314" height="463" alt="Screenshot 2026-02-12 at 13 27 16" src="https://github.com/user-attachments/assets/07ea0063-52ab-4678-9929-127ed48f0024" /> | <img width="323" height="384" alt="Screenshot 2026-02-12 at 13 26 56" src="https://github.com/user-attachments/assets/65f7c479-c86b-4ff5-b581-7a0322be50cb" /> | 
