### PR TITLE
Improved Stripe CLI resilience in browser tests

### DIFF
--- a/ghost/core/playwright.config.js
+++ b/ghost/core/playwright.config.js
@@ -21,6 +21,7 @@ const getWorkerCount = () => {
 };
 
 const config = {
+    globalSetup: require.resolve('./test/e2e-browser/global-setup.js'),
     timeout: 75 * 1000,
     expect: {
         timeout: 10000

--- a/ghost/core/test/e2e-browser/global-setup.js
+++ b/ghost/core/test/e2e-browser/global-setup.js
@@ -1,0 +1,36 @@
+/* eslint-disable no-console */
+const {promisify} = require('util');
+const {exec} = require('child_process');
+const {buildStripeCommand} = require('./utils/stripe-cli');
+
+module.exports = async function globalSetup() {
+    const command = buildStripeCommand('listen', '--print-secret');
+
+    let lastError;
+    for (let attempt = 1; attempt <= 3; attempt++) {
+        try {
+            const {stdout, stderr} = await promisify(exec)(command, {timeout: 15000});
+            if (stderr) {
+                console.error(`[stripe] ${stderr.toString().trimEnd()}`);
+            }
+            const secret = stdout.toString().trim();
+            if (!secret.startsWith('whsec_')) {
+                throw new Error(`Unexpected webhook secret format: "${secret}"`);
+            }
+            console.log('[stripe] Webhook secret obtained');
+            process.env.WEBHOOK_SECRET = secret;
+            return;
+        } catch (error) {
+            lastError = error;
+            const stderr = error.stderr ? `\n  stderr: ${error.stderr.toString().trimEnd()}` : '';
+            const stdout = error.stdout ? `\n  stdout: ${error.stdout.toString().trimEnd()}` : '';
+            console.error(`[stripe] Attempt ${attempt}/3 failed: ${error.message}${stderr}${stdout}`);
+            if (attempt < 3) {
+                await new Promise((resolve) => {
+                    setTimeout(resolve, 1000 * Math.pow(2, attempt - 1));
+                });
+            }
+        }
+    }
+    throw lastError;
+};

--- a/ghost/core/test/e2e-browser/utils/stripe-cli.js
+++ b/ghost/core/test/e2e-browser/utils/stripe-cli.js
@@ -1,0 +1,19 @@
+/**
+ * Builds a Stripe CLI command string with the correct flags for the current environment.
+ * Used by both globalSetup (--print-secret) and the per-worker webhook forwarder.
+ *
+ * @param {...string} args - Stripe CLI subcommand and flags (e.g. 'listen', '--print-secret')
+ * @returns {string} The full command string
+ */
+function buildStripeCommand(...args) {
+    const parts = ['stripe', ...args];
+
+    const needsApiKey = process.env.CI || process.env.GHOST_DEV_IS_DOCKER === 'true';
+    if (needsApiKey && process.env.STRIPE_SECRET_KEY) {
+        parts.push('--api-key', process.env.STRIPE_SECRET_KEY);
+    }
+
+    return parts.join(' ');
+}
+
+module.exports = {buildStripeCommand};


### PR DESCRIPTION
## Summary

- Moved `stripe listen --print-secret` (webhook signing secret) into a Playwright `globalSetup` so it runs once before any workers start, instead of once per worker
- Added retry logic (3 attempts, exponential backoff, 15s timeout) with full stderr/stdout in error messages — previously failures were opaque
- Added `[stripe-listen:<port>]` stderr logging to the per-worker webhook forwarders so forwarding issues are visible in CI
- Added a "Ready!" readiness check so tests don't start before the webhook forwarder has connected

## Context

The browser tests have been experiencing flaky Stripe-related failures in CI, most recently in [this run on main](https://github.com/TryGhost/Ghost/actions/runs/21945658998/job/63382819960) where 5 tests flaked and 1 hard-failed — all due to `stripe listen --print-secret` failing transiently.

Each Playwright worker is a separate Node.js process, so the module-level `getWebhookSecret()` call ran once per worker — meaning N concurrent `stripe listen --print-secret` invocations for a secret that is deterministic per API key. Moving it to `globalSetup` eliminates that redundancy.

The per-worker `stripe listen --forward-connect-to` forwarders are still per-worker by design — each worker runs Ghost on a different port, so each needs its own forwarder.
