### PR TITLE
Added `offer_redemptions` to subscription API response

### DIFF
--- a/ghost/admin/app/components/gh-member-settings-form.hbs
+++ b/ghost/admin/app/components/gh-member-settings-form.hbs
@@ -115,11 +115,17 @@
                         <div class="gh-main-content-card gh-cp-membertier gh-cp-membertier-attribution gh-membertier-subscription">
                             {{#each this.tiers as |tier|}}
                                 {{#each tier.subscriptions as |sub index|}}
-                                    <div class="gh-tier-card-header flex items-center" data-test-tier={{tier.id}}>
+                                    <div class="gh-tier-card-header flex items-start" data-test-tier={{tier.id}}>
                                         <div class="gh-tier-card-price">
                                             <div class="flex items-start">
-                                                <span class="currency-symbol">{{sub.price.currencySymbol}}</span>
-                                                <span class="amount">{{format-number sub.price.nonDecimalAmount}}</span>
+                                                {{#if sub.hasActiveDiscount}}
+                                                    <span class="currency-symbol">{{sub.discountedPrice.currencySymbol}}</span>
+                                                    <span class="amount">{{format-number sub.discountedPrice.nonDecimalAmount}}</span>
+                                                    <span class="gh-membertier-original-price">{{sub.originalPrice.currencySymbol}}{{format-number sub.originalPrice.nonDecimalAmount}}</span>
+                                                {{else}}
+                                                    <span class="currency-symbol">{{sub.price.currencySymbol}}</span>
+                                                    <span class="amount">{{format-number sub.price.nonDecimalAmount}}</span>
+                                                {{/if}}
                                             </div>
                                             <div class="period">{{if (eq sub.price.interval "year") "yearly" "monthly"}}</div>
                                         </div>

--- a/ghost/admin/app/components/member/subscription-detail-box.hbs
+++ b/ghost/admin/app/components/member/subscription-detail-box.hbs
@@ -20,7 +20,7 @@
             </p>
             {{/if}}
         </div>
-        {{#if (or @sub.cancellationReason @sub.offer)}}
+        {{#if (or @sub.cancellationReason @sub.offer_redemptions.length)}}
         <div class="gh-membertier-offer-cancellation">
             {{#if @sub.cancellationReason}}
             <div>
@@ -28,32 +28,32 @@
                 <div class="gh-membertier-cancelreason">{{@sub.cancellationReason}}</div>
             </div>
             {{/if}}
-            {{#if @sub.offer}}
-                {{#if (eq @sub.offer.type "trial")}}
+            {{#each @sub.offer_redemptions as |offer|}}
+                {{#if (eq offer.type "trial")}}
                 <div>
                     <h4>Offer</h4>
-                    <span class="gh-cp-membertier-pricelabel"> {{@sub.offer.name}} </span>
-                    &ndash; {{@sub.offer.amount}} days free
+                    <span class="gh-cp-membertier-pricelabel"> {{offer.name}} </span>
+                    &ndash; {{offer.amount}} days free
                 </div>
-                {{else if (eq @sub.offer.type "free_months")}}
+                {{else if (eq offer.type "free_months")}}
                 <div>
                     <h4>Offer</h4>
-                    <span class="gh-cp-membertier-pricelabel"> {{@sub.offer.name}} </span>
-                    &ndash; {{@sub.offer.amount}} {{if (eq @sub.offer.amount 1) "month" "months"}} free
+                    <span class="gh-cp-membertier-pricelabel"> {{offer.name}} </span>
+                    &ndash; {{offer.amount}} {{if (eq offer.amount 1) "month" "months"}} free
                 </div>
                 {{else}}
                 <div>
                     <h4>Offer</h4>
-                    <span class="gh-cp-membertier-pricelabel"> {{@sub.offer.name}}
-                    {{#if (eq @sub.offer.type 'fixed')}}
-                    &ndash; {{currency-symbol @sub.offer.currency}}{{gh-price-amount @sub.offer.amount}} off
+                    <span class="gh-cp-membertier-pricelabel"> {{offer.name}}
+                    {{#if (eq offer.type 'fixed')}}
+                    &ndash; {{currency-symbol offer.currency}}{{gh-price-amount offer.amount}} off
                     {{else}}
-                    &ndash; {{@sub.offer.amount}}% off
+                    &ndash; {{offer.amount}}% off
                     {{/if}}
                     </span>
                 </div>
                 {{/if}}
-            {{/if}}
+            {{/each}}
         </div>
         {{/if}}
     </div>

--- a/ghost/admin/app/components/member/subscription-detail-box.hbs
+++ b/ghost/admin/app/components/member/subscription-detail-box.hbs
@@ -20,41 +20,23 @@
             </p>
             {{/if}}
         </div>
-        {{!-- TODO: replace this.offerRedemptions with @sub.offer_redemptions once available on all environments --}}
-        {{#if (or @sub.cancellationReason this.offerRedemptions.length)}}
+        {{#if this.formattedOffers.length}}
+        <div class="gh-membertier-offers">
+            <div class="gh-membertier-details">
+                {{#each this.formattedOffers as |offer|}}
+                <p>
+                    {{offer.label}}&nbsp;&mdash;&nbsp;<span>{{offer.detail}}</span>
+                </p>
+                {{/each}}
+            </div>
+        </div>
+        {{/if}}
+        {{#if @sub.cancellationReason}}
         <div class="gh-membertier-offer-cancellation">
-            {{#if @sub.cancellationReason}}
             <div>
                 <h4>Cancellation reason</h4>
                 <div class="gh-membertier-cancelreason">{{@sub.cancellationReason}}</div>
             </div>
-            {{/if}}
-            {{#each this.offerRedemptions as |offer|}}
-                {{#if (eq offer.type "trial")}}
-                <div>
-                    <h4>Offer</h4>
-                    <span class="gh-cp-membertier-pricelabel"> {{offer.name}} </span>
-                    &ndash; {{offer.amount}} days free
-                </div>
-                {{else if (eq offer.type "free_months")}}
-                <div>
-                    <h4>Offer</h4>
-                    <span class="gh-cp-membertier-pricelabel"> {{offer.name}} </span>
-                    &ndash; {{offer.amount}} {{if (eq offer.amount 1) "month" "months"}} free
-                </div>
-                {{else}}
-                <div>
-                    <h4>Offer</h4>
-                    <span class="gh-cp-membertier-pricelabel"> {{offer.name}}
-                    {{#if (eq offer.type 'fixed')}}
-                    &ndash; {{currency-symbol offer.currency}}{{gh-price-amount offer.amount}} off
-                    {{else}}
-                    &ndash; {{offer.amount}}% off
-                    {{/if}}
-                    </span>
-                </div>
-                {{/if}}
-            {{/each}}
         </div>
         {{/if}}
     </div>

--- a/ghost/admin/app/components/member/subscription-detail-box.hbs
+++ b/ghost/admin/app/components/member/subscription-detail-box.hbs
@@ -20,7 +20,8 @@
             </p>
             {{/if}}
         </div>
-        {{#if (or @sub.cancellationReason @sub.offer_redemptions.length)}}
+        {{!-- TODO: replace this.offerRedemptions with @sub.offer_redemptions once available on all environments --}}
+        {{#if (or @sub.cancellationReason this.offerRedemptions.length)}}
         <div class="gh-membertier-offer-cancellation">
             {{#if @sub.cancellationReason}}
             <div>
@@ -28,7 +29,7 @@
                 <div class="gh-membertier-cancelreason">{{@sub.cancellationReason}}</div>
             </div>
             {{/if}}
-            {{#each @sub.offer_redemptions as |offer|}}
+            {{#each this.offerRedemptions as |offer|}}
                 {{#if (eq offer.type "trial")}}
                 <div>
                     <h4>Offer</h4>

--- a/ghost/admin/app/components/member/subscription-detail-box.js
+++ b/ghost/admin/app/components/member/subscription-detail-box.js
@@ -5,6 +5,18 @@ import {tracked} from '@glimmer/tracking';
 export default class SubscriptionDetailBox extends Component {
     @tracked showDetails = false;
 
+    // TODO: remove this fallback once offer_redemptions is available on all environments
+    get offerRedemptions() {
+        const sub = this.args.sub;
+        if (sub.offer_redemptions) {
+            return sub.offer_redemptions;
+        }
+        if (sub.offer) {
+            return [sub.offer];
+        }
+        return [];
+    }
+
     @action
     toggleSubscriptionExpanded() {
         this.showDetails = !this.showDetails;

--- a/ghost/admin/app/components/member/subscription-detail-box.js
+++ b/ghost/admin/app/components/member/subscription-detail-box.js
@@ -1,5 +1,6 @@
 import Component from '@glimmer/component';
 import {action} from '@ember/object';
+import {getOfferDisplayData} from 'ghost-admin/utils/subscription-data';
 import {tracked} from '@glimmer/tracking';
 
 export default class SubscriptionDetailBox extends Component {
@@ -15,6 +16,10 @@ export default class SubscriptionDetailBox extends Component {
             return [sub.offer];
         }
         return [];
+    }
+
+    get formattedOffers() {
+        return this.offerRedemptions.map(offer => getOfferDisplayData(offer, this.args.sub));
     }
 
     @action

--- a/ghost/admin/app/components/members/filters/offers.js
+++ b/ghost/admin/app/components/members/filters/offers.js
@@ -10,7 +10,9 @@ export const OFFERS_FILTER = {
     getColumnValue: (member) => {
         return {
             class: 'gh-members-list-labels',
-            text: (member.subscriptions ?? []).map(label => label.offer?.name).join(', ')
+            text: (member.subscriptions ?? [])
+                .flatMap(sub => (sub.offer_redemptions ?? []).map(o => o.name))
+                .join(', ')
         };
     }
 };

--- a/ghost/admin/app/components/members/filters/offers.js
+++ b/ghost/admin/app/components/members/filters/offers.js
@@ -10,8 +10,11 @@ export const OFFERS_FILTER = {
     getColumnValue: (member) => {
         return {
             class: 'gh-members-list-labels',
+            // TODO: remove sub.offer fallback once offer_redemptions is available on all environments
             text: (member.subscriptions ?? [])
-                .flatMap(sub => (sub.offer_redemptions ?? []).map(o => o.name))
+                .flatMap(sub => (sub.offer_redemptions
+                    ? sub.offer_redemptions.map(o => o.name)
+                    : (sub.offer?.name ? [sub.offer.name] : [])))
                 .join(', ')
         };
     }

--- a/ghost/admin/app/styles/layouts/members.css
+++ b/ghost/admin/app/styles/layouts/members.css
@@ -3042,7 +3042,8 @@ a.gh-members-emailpreview-subscription-link {
     font-weight: 500;
 }
 
-.gh-membertier-offer-cancellation {
+.gh-membertier-offer-cancellation,
+.gh-membertier-offers {
     margin-top: 16px;
     padding-top: 16px;
     border-top:1px solid #ECEEF0;

--- a/ghost/admin/app/styles/layouts/members.css
+++ b/ghost/admin/app/styles/layouts/members.css
@@ -2965,6 +2965,15 @@ a.gh-members-emailpreview-subscription-link {
     border-radius: 6px;
 }
 
+.gh-membertier-original-price {
+    margin-left: 4px;
+    font-size: 1.4rem;
+    font-weight: 500;
+    color: var(--midgrey);
+    text-decoration: line-through;
+    align-self: center;
+}
+
 .gh-cp-membertier-attribution .amount {
     font-weight: bold !important;
     font-size: 2.4rem !important;
@@ -3036,10 +3045,6 @@ a.gh-members-emailpreview-subscription-link {
     font-size: 1.3rem;
     font-weight: 500;
     color: var(--darkgrey);
-}
-
-.gh-membertier-offer-cancellation .gh-cp-membertier-pricelabel {
-    font-weight: 500;
 }
 
 .gh-membertier-offer-cancellation,

--- a/ghost/admin/app/utils/subscription-data.js
+++ b/ghost/admin/app/utils/subscription-data.js
@@ -142,8 +142,9 @@ export function getOfferDisplayData(offer, sub = {}) {
 
     let detail;
     if (isRetention) {
-        const discountEnd = offer.id && sub.next_payment?.discount?.offer_id === offer.id
-            ? sub.next_payment.discount.end
+        const isActiveDiscount = offer.id && sub.next_payment?.discount?.offer_id === offer.id;
+        const discountEnd = isActiveDiscount
+            ? (offer.type === 'free_months' ? sub.current_period_end : sub.next_payment.discount.end)
             : null;
 
         if (discountEnd) {

--- a/ghost/admin/app/utils/subscription-data.js
+++ b/ghost/admin/app/utils/subscription-data.js
@@ -117,3 +117,40 @@ export function priceLabel(data) {
         return data.price.nickname;
     }
 }
+
+export function getOfferDisplayData(offer, sub = {}) {
+    const isRetention = offer.redemption_type === 'retention';
+    const label = isRetention ? 'Retention offer' : 'Signup offer';
+
+    let discount;
+    if (offer.type === 'trial') {
+        discount = `${offer.amount} days free`;
+    } else if (offer.type === 'free_months') {
+        discount = `${offer.amount} ${offer.amount === 1 ? 'month' : 'months'} free`;
+    } else if (offer.type === 'fixed') {
+        discount = `${getSymbol(offer.currency)}${getNonDecimal(offer.amount)} off`;
+    } else {
+        discount = `${offer.amount}% off`;
+    }
+
+    let detail;
+    if (isRetention) {
+        const discountEnd = offer.id && sub.next_payment?.discount?.offer_id === offer.id
+            ? sub.next_payment.discount.end
+            : null;
+
+        if (discountEnd) {
+            detail = `${discount} until ${moment(discountEnd).format('D MMM YYYY')}`;
+        } else if (offer.duration === 'repeating' && offer.duration_in_months) {
+            detail = `${discount} for ${offer.duration_in_months} ${offer.duration_in_months === 1 ? 'month' : 'months'}`;
+        } else if (offer.duration === 'forever') {
+            detail = `${discount} forever`;
+        } else {
+            detail = discount;
+        }
+    } else {
+        detail = `${offer.name} (${discount})`;
+    }
+
+    return {label, detail};
+}

--- a/ghost/admin/app/utils/subscription-data.js
+++ b/ghost/admin/app/utils/subscription-data.js
@@ -27,6 +27,13 @@ export function getSubscriptionData(sub) {
     data.priceLabel = priceLabel(data);
     data.validityDetails = validityDetails(data, !!data.priceLabel);
 
+    const discount = getDiscountPrice(sub);
+    if (discount) {
+        data.hasActiveDiscount = true;
+        data.discountedPrice = discount.discountedPrice;
+        data.originalPrice = discount.originalPrice;
+    }
+
     return data;
 }
 
@@ -140,7 +147,7 @@ export function getOfferDisplayData(offer, sub = {}) {
             : null;
 
         if (discountEnd) {
-            detail = `${discount} until ${moment(discountEnd).format('D MMM YYYY')}`;
+            detail = `${discount} until ${moment(discountEnd).format('MMM YYYY')}`;
         } else if (offer.duration === 'repeating' && offer.duration_in_months) {
             detail = `${discount} for ${offer.duration_in_months} ${offer.duration_in_months === 1 ? 'month' : 'months'}`;
         } else if (offer.duration === 'forever') {
@@ -153,4 +160,25 @@ export function getOfferDisplayData(offer, sub = {}) {
     }
 
     return {label, detail};
+}
+
+export function getDiscountPrice(sub) {
+    if (!sub.next_payment || !sub.next_payment.discount) {
+        return null;
+    }
+
+    if (sub.next_payment.amount === sub.next_payment.original_amount) {
+        return null;
+    }
+
+    return {
+        discountedPrice: {
+            currencySymbol: getSymbol(sub.next_payment.currency),
+            nonDecimalAmount: getNonDecimal(sub.next_payment.amount)
+        },
+        originalPrice: {
+            currencySymbol: getSymbol(sub.next_payment.currency),
+            nonDecimalAmount: getNonDecimal(sub.next_payment.original_amount)
+        }
+    };
 }

--- a/ghost/admin/app/utils/subscription-data.js
+++ b/ghost/admin/app/utils/subscription-data.js
@@ -142,9 +142,8 @@ export function getOfferDisplayData(offer, sub = {}) {
 
     let detail;
     if (isRetention) {
-        const isActiveDiscount = offer.id && sub.next_payment?.discount?.offer_id === offer.id;
-        const discountEnd = isActiveDiscount
-            ? (offer.type === 'free_months' ? sub.current_period_end : sub.next_payment.discount.end)
+        const discountEnd = offer.id && sub.next_payment?.discount?.offer_id === offer.id
+            ? sub.next_payment.discount.end
             : null;
 
         if (discountEnd) {

--- a/ghost/admin/tests/unit/utils/subscription-data-test.js
+++ b/ghost/admin/tests/unit/utils/subscription-data-test.js
@@ -1,5 +1,5 @@
 import moment from 'moment-timezone';
-import {compExpiry, getOfferDisplayData, getSubscriptionData, isActive, isCanceled, isComplimentary, isSetToCancel, priceLabel, trialUntil, validUntil, validityDetails} from 'ghost-admin/utils/subscription-data';
+import {compExpiry, getDiscountPrice, getOfferDisplayData, getSubscriptionData, isActive, isCanceled, isComplimentary, isSetToCancel, priceLabel, trialUntil, validUntil, validityDetails} from 'ghost-admin/utils/subscription-data';
 import {describe, it} from 'mocha';
 import {expect} from 'chai';
 
@@ -442,6 +442,42 @@ describe('Unit: Util: subscription-data', function () {
                 validityDetails: ' – Expires 31 May 2021'
             });
         });
+
+        it('sets hasActiveDiscount with discounted and original prices', function () {
+            const sub = {
+                id: 'sub_1',
+                status: 'active',
+                cancel_at_period_end: false,
+                current_period_end: '2026-05-31',
+                price: {currency: 'usd', amount: 5000},
+                next_payment: {
+                    amount: 2500,
+                    original_amount: 5000,
+                    currency: 'usd',
+                    discount: {offer_id: 'offer_1', end: '2026-09-01'}
+                }
+            };
+
+            const data = getSubscriptionData(sub);
+
+            expect(data.hasActiveDiscount).to.be.true;
+            expect(data.discountedPrice).to.deep.equal({currencySymbol: '$', nonDecimalAmount: 25});
+            expect(data.originalPrice).to.deep.equal({currencySymbol: '$', nonDecimalAmount: 50});
+        });
+
+        it('does not set hasActiveDiscount when no discount', function () {
+            const sub = {
+                id: 'sub_1',
+                status: 'active',
+                cancel_at_period_end: false,
+                current_period_end: '2026-05-31',
+                price: {currency: 'usd', amount: 5000}
+            };
+
+            const data = getSubscriptionData(sub);
+
+            expect(data.hasActiveDiscount).to.be.undefined;
+        });
     });
 
     describe('getOfferDisplayData', function () {
@@ -485,7 +521,7 @@ describe('Unit: Util: subscription-data', function () {
                 name: 'retention + percent + repeating (with discount end)',
                 offer: {id: 'offer_1', redemption_type: 'retention', type: 'percent', amount: 50, duration: 'repeating', duration_in_months: 3},
                 sub: {next_payment: {discount: {offer_id: 'offer_1', end: '2026-02-17T00:00:00.000Z'}}},
-                expected: {label: 'Retention offer', detail: '50% off until 17 Feb 2026'}
+                expected: {label: 'Retention offer', detail: '50% off until Feb 2026'}
             },
             {
                 name: 'retention + percent + forever',
@@ -501,7 +537,7 @@ describe('Unit: Util: subscription-data', function () {
                 name: 'retention + free_months (with discount end)',
                 offer: {id: 'offer_2', redemption_type: 'retention', type: 'free_months', amount: 1, duration: 'free_months'},
                 sub: {next_payment: {discount: {offer_id: 'offer_2', end: '2026-02-17T00:00:00.000Z'}}},
-                expected: {label: 'Retention offer', detail: '1 month free until 17 Feb 2026'}
+                expected: {label: 'Retention offer', detail: '1 month free until Feb 2026'}
             },
             {
                 name: 'retention + discount end does not match offer id',
@@ -520,6 +556,63 @@ describe('Unit: Util: subscription-data', function () {
             it(name, function () {
                 const result = getOfferDisplayData(offer, sub);
                 expect(result).to.deep.equal(expected);
+            });
+        });
+    });
+
+    describe('getDiscountPrice', function () {
+        it('returns null when there is no next_payment', function () {
+            expect(getDiscountPrice({price: {currency: 'usd', amount: 5000}})).to.be.null;
+        });
+
+        it('returns null when there is no discount on next_payment', function () {
+            expect(getDiscountPrice({
+                price: {currency: 'usd', amount: 5000},
+                next_payment: {amount: 5000, original_amount: 5000, currency: 'usd'}
+            })).to.be.null;
+        });
+
+        it('returns null when discounted amount equals original amount', function () {
+            expect(getDiscountPrice({
+                price: {currency: 'usd', amount: 5000},
+                next_payment: {
+                    amount: 5000,
+                    original_amount: 5000,
+                    currency: 'usd',
+                    discount: {offer_id: 'offer_1', end: '2026-09-01'}
+                }
+            })).to.be.null;
+        });
+
+        it('returns discounted and original prices for USD', function () {
+            const result = getDiscountPrice({
+                price: {currency: 'usd', amount: 5000},
+                next_payment: {
+                    amount: 2500,
+                    original_amount: 5000,
+                    currency: 'usd',
+                    discount: {offer_id: 'offer_1', end: '2026-09-01'}
+                }
+            });
+            expect(result).to.deep.equal({
+                discountedPrice: {currencySymbol: '$', nonDecimalAmount: 25},
+                originalPrice: {currencySymbol: '$', nonDecimalAmount: 50}
+            });
+        });
+
+        it('returns discounted and original prices for EUR', function () {
+            const result = getDiscountPrice({
+                price: {currency: 'eur', amount: 10000},
+                next_payment: {
+                    amount: 7000,
+                    original_amount: 10000,
+                    currency: 'eur',
+                    discount: {offer_id: 'offer_1', end: '2026-09-01'}
+                }
+            });
+            expect(result).to.deep.equal({
+                discountedPrice: {currencySymbol: '€', nonDecimalAmount: 70},
+                originalPrice: {currencySymbol: '€', nonDecimalAmount: 100}
             });
         });
     });

--- a/ghost/admin/tests/unit/utils/subscription-data-test.js
+++ b/ghost/admin/tests/unit/utils/subscription-data-test.js
@@ -536,8 +536,8 @@ describe('Unit: Util: subscription-data', function () {
             {
                 name: 'retention + free_months (with discount end)',
                 offer: {id: 'offer_2', redemption_type: 'retention', type: 'free_months', amount: 1, duration: 'free_months'},
-                sub: {current_period_end: '2026-03-17T00:00:00.000Z', next_payment: {discount: {offer_id: 'offer_2', end: '2026-02-17T00:00:00.000Z'}}},
-                expected: {label: 'Retention offer', detail: '1 month free until Mar 2026'}
+                sub: {next_payment: {discount: {offer_id: 'offer_2', end: '2026-02-17T00:00:00.000Z'}}},
+                expected: {label: 'Retention offer', detail: '1 month free until Feb 2026'}
             },
             {
                 name: 'retention + discount end does not match offer id',

--- a/ghost/admin/tests/unit/utils/subscription-data-test.js
+++ b/ghost/admin/tests/unit/utils/subscription-data-test.js
@@ -536,8 +536,8 @@ describe('Unit: Util: subscription-data', function () {
             {
                 name: 'retention + free_months (with discount end)',
                 offer: {id: 'offer_2', redemption_type: 'retention', type: 'free_months', amount: 1, duration: 'free_months'},
-                sub: {next_payment: {discount: {offer_id: 'offer_2', end: '2026-02-17T00:00:00.000Z'}}},
-                expected: {label: 'Retention offer', detail: '1 month free until Feb 2026'}
+                sub: {current_period_end: '2026-03-17T00:00:00.000Z', next_payment: {discount: {offer_id: 'offer_2', end: '2026-02-17T00:00:00.000Z'}}},
+                expected: {label: 'Retention offer', detail: '1 month free until Mar 2026'}
             },
             {
                 name: 'retention + discount end does not match offer id',

--- a/ghost/admin/tests/unit/utils/subscription-data-test.js
+++ b/ghost/admin/tests/unit/utils/subscription-data-test.js
@@ -1,5 +1,5 @@
 import moment from 'moment-timezone';
-import {compExpiry, getSubscriptionData, isActive, isCanceled, isComplimentary, isSetToCancel, priceLabel, trialUntil, validUntil, validityDetails} from 'ghost-admin/utils/subscription-data';
+import {compExpiry, getOfferDisplayData, getSubscriptionData, isActive, isCanceled, isComplimentary, isSetToCancel, priceLabel, trialUntil, validUntil, validityDetails} from 'ghost-admin/utils/subscription-data';
 import {describe, it} from 'mocha';
 import {expect} from 'chai';
 
@@ -440,6 +440,86 @@ describe('Unit: Util: subscription-data', function () {
                 trialUntil: undefined,
                 priceLabel: 'Complimentary',
                 validityDetails: ' – Expires 31 May 2021'
+            });
+        });
+    });
+
+    describe('getOfferDisplayData', function () {
+        const cases = [
+            {
+                name: 'signup + percent',
+                offer: {redemption_type: 'signup', type: 'percent', name: 'Black Friday', amount: 30},
+                expected: {label: 'Signup offer', detail: 'Black Friday (30% off)'}
+            },
+            {
+                name: 'signup + fixed (USD)',
+                offer: {redemption_type: 'signup', type: 'fixed', name: 'Welcome Deal', amount: 500, currency: 'USD'},
+                expected: {label: 'Signup offer', detail: 'Welcome Deal ($5 off)'}
+            },
+            {
+                name: 'signup + fixed (EUR)',
+                offer: {redemption_type: 'signup', type: 'fixed', name: 'Euro Deal', amount: 1000, currency: 'EUR'},
+                expected: {label: 'Signup offer', detail: 'Euro Deal (€10 off)'}
+            },
+            {
+                name: 'signup + trial',
+                offer: {redemption_type: 'signup', type: 'trial', name: 'Try It', amount: 7},
+                expected: {label: 'Signup offer', detail: 'Try It (7 days free)'}
+            },
+            {
+                name: 'retention + percent + once',
+                offer: {redemption_type: 'retention', type: 'percent', amount: 50, duration: 'once'},
+                expected: {label: 'Retention offer', detail: '50% off'}
+            },
+            {
+                name: 'retention + percent + repeating (no discount end)',
+                offer: {redemption_type: 'retention', type: 'percent', amount: 50, duration: 'repeating', duration_in_months: 3},
+                expected: {label: 'Retention offer', detail: '50% off for 3 months'}
+            },
+            {
+                name: 'retention + percent + repeating (1 month, no discount end)',
+                offer: {redemption_type: 'retention', type: 'percent', amount: 50, duration: 'repeating', duration_in_months: 1},
+                expected: {label: 'Retention offer', detail: '50% off for 1 month'}
+            },
+            {
+                name: 'retention + percent + repeating (with discount end)',
+                offer: {id: 'offer_1', redemption_type: 'retention', type: 'percent', amount: 50, duration: 'repeating', duration_in_months: 3},
+                sub: {next_payment: {discount: {offer_id: 'offer_1', end: '2026-02-17T00:00:00.000Z'}}},
+                expected: {label: 'Retention offer', detail: '50% off until 17 Feb 2026'}
+            },
+            {
+                name: 'retention + percent + forever',
+                offer: {redemption_type: 'retention', type: 'percent', amount: 25, duration: 'forever'},
+                expected: {label: 'Retention offer', detail: '25% off forever'}
+            },
+            {
+                name: 'retention + free_months (no discount end)',
+                offer: {redemption_type: 'retention', type: 'free_months', amount: 1, duration: 'free_months'},
+                expected: {label: 'Retention offer', detail: '1 month free'}
+            },
+            {
+                name: 'retention + free_months (with discount end)',
+                offer: {id: 'offer_2', redemption_type: 'retention', type: 'free_months', amount: 1, duration: 'free_months'},
+                sub: {next_payment: {discount: {offer_id: 'offer_2', end: '2026-02-17T00:00:00.000Z'}}},
+                expected: {label: 'Retention offer', detail: '1 month free until 17 Feb 2026'}
+            },
+            {
+                name: 'retention + discount end does not match offer id',
+                offer: {id: 'offer_1', redemption_type: 'retention', type: 'percent', amount: 50, duration: 'repeating', duration_in_months: 3},
+                sub: {next_payment: {discount: {offer_id: 'offer_other', end: '2026-02-17T00:00:00.000Z'}}},
+                expected: {label: 'Retention offer', detail: '50% off for 3 months'}
+            },
+            {
+                name: 'missing redemption_type defaults to signup label',
+                offer: {type: 'percent', name: 'Legacy Offer', amount: 15},
+                expected: {label: 'Signup offer', detail: 'Legacy Offer (15% off)'}
+            }
+        ];
+
+        cases.forEach(({name, offer, sub, expected}) => {
+            it(name, function () {
+                const result = getOfferDisplayData(offer, sub);
+                expect(result).to.deep.equal(expected);
             });
         });
     });

--- a/ghost/core/core/server/services/offers/application/offers-api.js
+++ b/ghost/core/core/server/services/offers/application/offers-api.js
@@ -251,6 +251,24 @@ class OffersAPI {
     }
 
     /**
+     * @param {object} options
+     * @param {string[]} options.subscriptionIds
+     * @returns {Promise<Array<{subscription_id: string, offer_id: string}>>}
+     */
+    async getRedeemedOfferIdsForSubscriptions({subscriptionIds}) {
+        if (subscriptionIds.length === 0) {
+            return [];
+        }
+
+        return await this.repository.createTransaction(async (transaction) => {
+            return await this.repository.getRedeemedOfferIdsForSubscriptions({
+                subscriptionIds,
+                transacting: transaction
+            });
+        });
+    }
+
+    /**
      * @param {object} coupon
      * @param {string} coupon.id
      * @param {number} [coupon.percent_off]

--- a/ghost/core/core/server/services/offers/application/offers-api.js
+++ b/ghost/core/core/server/services/offers/application/offers-api.js
@@ -233,10 +233,10 @@ class OffersAPI {
             }
 
             // Filter out offers already redeemed on this subscription
-            const redeemedOfferIds = await this.repository.getRedeemedOfferIdsForSubscription({
+            const redeemedOfferIds = await this.repository.getRedeemedOfferIdsForSubscription(
                 subscriptionId,
-                transacting: transaction
-            });
+                {transacting: transaction}
+            );
 
             const beforeRedeemedFilter = available.length;
             available = available.filter(offer => !redeemedOfferIds.includes(offer.id));
@@ -261,10 +261,10 @@ class OffersAPI {
         }
 
         return await this.repository.createTransaction(async (transaction) => {
-            return await this.repository.getRedeemedOfferIdsForSubscriptions({
+            return await this.repository.getRedeemedOfferIdsForSubscriptions(
                 subscriptionIds,
-                transacting: transaction
-            });
+                {transacting: transaction}
+            );
         });
     }
 

--- a/ghost/core/core/server/services/offers/offer-bookshelf-repository.js
+++ b/ghost/core/core/server/services/offers/offer-bookshelf-repository.js
@@ -209,6 +209,27 @@ class OfferBookshelfRepository {
     }
 
     /**
+     * @param {object} options
+     * @param {string[]} options.subscriptionIds
+     * @param {import('knex').Knex.Transaction} [options.transacting]
+     * @returns {Promise<Array<{subscription_id: string, offer_id: string}>>}
+     */
+    async getRedeemedOfferIdsForSubscriptions({subscriptionIds, transacting}) {
+        if (subscriptionIds.length === 0) {
+            return [];
+        }
+
+        const redemptions = await this.OfferRedemptionModel
+            .query(qb => qb.whereIn('subscription_id', subscriptionIds))
+            .fetchAll({transacting, columns: ['subscription_id', 'offer_id']});
+
+        return redemptions.map(r => ({
+            subscription_id: r.get('subscription_id'),
+            offer_id: r.get('offer_id')
+        }));
+    }
+
+    /**
      * @param {import('./domain/models/offer')} offer
      * @param {BaseOptions} [options]
      * @returns {Promise<void>}

--- a/ghost/core/core/server/services/offers/offer-bookshelf-repository.js
+++ b/ghost/core/core/server/services/offers/offer-bookshelf-repository.js
@@ -195,33 +195,31 @@ class OfferBookshelfRepository {
     }
 
     /**
-     * @param {object} options
-     * @param {string} options.subscriptionId
-     * @param {import('knex').Knex.Transaction} [options.transacting]
+     * @param {string} subscriptionId
+     * @param {BaseOptions} [options]
      * @returns {Promise<string[]>}
      */
-    async getRedeemedOfferIdsForSubscription({subscriptionId, transacting}) {
+    async getRedeemedOfferIdsForSubscription(subscriptionId, options = {}) {
         const redemptions = await this.OfferRedemptionModel.where({
             subscription_id: subscriptionId
-        }).fetchAll({transacting, columns: ['offer_id']});
+        }).fetchAll({transacting: options.transacting, columns: ['offer_id']});
 
         return redemptions.map(r => r.get('offer_id'));
     }
 
     /**
-     * @param {object} options
-     * @param {string[]} options.subscriptionIds
-     * @param {import('knex').Knex.Transaction} [options.transacting]
+     * @param {string[]} subscriptionIds
+     * @param {BaseOptions} [options]
      * @returns {Promise<Array<{subscription_id: string, offer_id: string}>>}
      */
-    async getRedeemedOfferIdsForSubscriptions({subscriptionIds, transacting}) {
+    async getRedeemedOfferIdsForSubscriptions(subscriptionIds, options = {}) {
         if (subscriptionIds.length === 0) {
             return [];
         }
 
         const redemptions = await this.OfferRedemptionModel
             .query(qb => qb.whereIn('subscription_id', subscriptionIds))
-            .fetchAll({transacting, columns: ['subscription_id', 'offer_id']});
+            .fetchAll({transacting: options.transacting, columns: ['subscription_id', 'offer_id']});
 
         return redemptions.map(r => ({
             subscription_id: r.get('subscription_id'),

--- a/ghost/core/test/e2e-api/admin/__snapshots__/members-edit-subscriptions.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/members-edit-subscriptions.test.js.snap
@@ -70,6 +70,7 @@ Object {
             "original_amount": 5000,
           },
           "offer": null,
+          "offer_redemptions": Array [],
           "plan": Object {
             "amount": 5000,
             "currency": "USD",
@@ -149,7 +150,7 @@ exports[`Members API: edit subscriptions Can cancel a subscription 2: [headers] 
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "2816",
+  "content-length": "2839",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -222,6 +223,7 @@ Object {
           "id": Any<String>,
           "next_payment": null,
           "offer": null,
+          "offer_redemptions": Array [],
           "plan": Object {
             "amount": 5000,
             "currency": "USD",
@@ -262,7 +264,7 @@ exports[`Members API: edit subscriptions Can cancel a subscription 4: [headers] 
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "1831",
+  "content-length": "1854",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -432,7 +434,7 @@ exports[`Members API: edit subscriptions Can cancel a subscription for a member 
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "3818",
+  "content-length": "3864",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -494,7 +496,7 @@ exports[`Members API: edit subscriptions Can cancel a subscription for a member 
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "2834",
+  "content-length": "2880",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -556,7 +558,7 @@ exports[`Members API: edit subscriptions Can cancel a subscription for a member 
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "3827",
+  "content-length": "3873",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -618,7 +620,7 @@ exports[`Members API: edit subscriptions Can cancel a subscription for a member 
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "2843",
+  "content-length": "2889",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -680,7 +682,7 @@ exports[`Members API: edit subscriptions Can recover member products when we can
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "3860",
+  "content-length": "3906",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -742,7 +744,7 @@ exports[`Members API: edit subscriptions Can recover member products when we can
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "2876",
+  "content-length": "2922",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -804,7 +806,7 @@ exports[`Members API: edit subscriptions Can recover member products when we upd
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "4700",
+  "content-length": "4746",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -866,7 +868,7 @@ exports[`Members API: edit subscriptions Can update a subscription for a member 
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "4679",
+  "content-length": "4725",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -928,7 +930,7 @@ exports[`Members API: edit subscriptions Can update a subscription for a member 
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "4678",
+  "content-length": "4724",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -982,7 +984,7 @@ exports[`Members API: edit subscriptions Comp product is removed when a comped m
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "2665",
+  "content-length": "2688",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -1036,7 +1038,7 @@ exports[`Members API: edit subscriptions Comp product is removed when a comped m
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "1681",
+  "content-length": "1704",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/e2e-api/admin/__snapshots__/members-newsletters.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/members-newsletters.test.js.snap
@@ -85,7 +85,7 @@ exports[`Members API - With Newsletters - compat mode Can fetch members who are 
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "2698",
+  "content-length": "2721",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -307,7 +307,7 @@ exports[`Members API - With Newsletters - compat mode Can fetch members who are 
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "9519",
+  "content-length": "9588",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -401,7 +401,7 @@ exports[`Members API - With Newsletters Can fetch members who are NOT subscribed
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "2698",
+  "content-length": "2721",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -623,7 +623,7 @@ exports[`Members API - With Newsletters Can fetch members who are subscribed 2: 
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "9519",
+  "content-length": "9588",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/e2e-api/admin/__snapshots__/members.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/members.test.js.snap
@@ -1279,6 +1279,7 @@ Object {
             "original_amount": 500,
           },
           "offer": null,
+          "offer_redemptions": Array [],
           "plan": Object {
             "amount": 500,
             "currency": "USD",
@@ -1358,7 +1359,7 @@ exports[`Members API Can add a subscription 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "3067",
+  "content-length": "3090",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -1444,6 +1445,7 @@ Object {
             "original_amount": 500,
           },
           "offer": null,
+          "offer_redemptions": Array [],
           "plan": Object {
             "amount": 500,
             "currency": "USD",
@@ -1523,7 +1525,7 @@ exports[`Members API Can add a subscription 4: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "3067",
+  "content-length": "3090",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -2205,7 +2207,7 @@ exports[`Members API Can add complimentary subscription (out of date) 4: [header
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "2845",
+  "content-length": "2868",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -2539,7 +2541,7 @@ exports[`Members API Can browse 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "12116",
+  "content-length": "12208",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -2741,7 +2743,7 @@ exports[`Members API Can browse with limit 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "3608",
+  "content-length": "3631",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -3075,7 +3077,7 @@ exports[`Members API Can browse with limit=all 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "12117",
+  "content-length": "12209",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -3409,7 +3411,7 @@ exports[`Members API Can browse with more than maximum allowed limit 2: [headers
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "12117",
+  "content-length": "12209",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -3567,7 +3569,7 @@ exports[`Members API Can create a member with an existing complimentary subscrip
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "2896",
+  "content-length": "2919",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -3657,7 +3659,7 @@ exports[`Members API Can create a member with an existing paid subscription 2: [
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "2888",
+  "content-length": "2911",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -3747,7 +3749,7 @@ exports[`Members API Can create a new member with a product (complimentary) 2: [
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "2480",
+  "content-length": "2503",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -4358,7 +4360,7 @@ exports[`Members API Can filter by paid status 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "9527",
+  "content-length": "9619",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -4498,7 +4500,7 @@ exports[`Members API Can filter by signup attribution 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "4082",
+  "content-length": "4105",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -4683,7 +4685,7 @@ exports[`Members API Can filter by tier id 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "8708",
+  "content-length": "8800",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -4842,7 +4844,7 @@ exports[`Members API Can filter on newsletter slug 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "4229",
+  "content-length": "4252",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -5351,7 +5353,7 @@ exports[`Members API Can filter on tier slug 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "20209",
+  "content-length": "20393",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -5630,7 +5632,7 @@ exports[`Members API Can ignore any unknown includes 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "9527",
+  "content-length": "9619",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -7406,7 +7408,7 @@ exports[`Members API Search for paid members retrieves member with email paid@te
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "2344",
+  "content-length": "2367",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/e2e-api/members/__snapshots__/webhooks.test.js.snap
+++ b/ghost/core/test/e2e-api/members/__snapshots__/webhooks.test.js.snap
@@ -45,7 +45,7 @@ exports[`Members API Member attribution Creates a SubscriptionCreatedEvent with 
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "2863",
+  "content-length": "2886",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -99,7 +99,7 @@ exports[`Members API Member attribution Creates a SubscriptionCreatedEvent with 
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "2927",
+  "content-length": "2950",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -153,7 +153,7 @@ exports[`Members API Member attribution Creates a SubscriptionCreatedEvent with 
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "2895",
+  "content-length": "2918",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -207,7 +207,7 @@ exports[`Members API Member attribution Creates a SubscriptionCreatedEvent with 
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "2783",
+  "content-length": "2806",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -261,7 +261,7 @@ exports[`Members API Member attribution Creates a SubscriptionCreatedEvent with 
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "2943",
+  "content-length": "2966",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -315,7 +315,7 @@ exports[`Members API Member attribution Creates a SubscriptionCreatedEvent with 
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "2909",
+  "content-length": "2932",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -369,7 +369,7 @@ exports[`Members API Member attribution Creates a SubscriptionCreatedEvent with 
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "2923",
+  "content-length": "2946",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -423,7 +423,7 @@ exports[`Members API Member attribution Creates a SubscriptionCreatedEvent with 
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "2837",
+  "content-length": "2860",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -477,7 +477,7 @@ exports[`Members API Member attribution Creates a SubscriptionCreatedEvent witho
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "2783",
+  "content-length": "2806",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3295

Adds `subscription.offer_redemptions` (sourced from offer_redemptions table) to the member API response, and updates admin to display all historical offers on the member page instead of only the current active offer. This is to support retention offers where the system now has to account for multiple offer redemptions potentially occurring on the same sub