### PR TITLE
Portal settings link navigation

### DIFF
--- a/apps/admin-x-settings/test/acceptance/membership/portal.test.ts
+++ b/apps/admin-x-settings/test/acceptance/membership/portal.test.ts
@@ -185,8 +185,9 @@ test.describe('Portal Settings', async () => {
         const displayNameToggle = modal.getByLabel('Display name in signup form');
         await expect(displayNameToggle).toBeVisible();
 
-        // Click on "Account page" preview tab
-        const accountPreviewTab = modal.getByRole('tab', {name: 'Account page'});
+        // Click on "Account page" preview tab (use ID to disambiguate from sidebar tab)
+        const previewToolbar = modal.getByTestId('design-toolbar');
+        const accountPreviewTab = previewToolbar.getByRole('tab', {name: 'Account page'});
         await accountPreviewTab.click();
 
         // Verify sidebar switched to Account page - support email field should be visible
@@ -194,7 +195,7 @@ test.describe('Portal Settings', async () => {
         await expect(supportEmailField).toBeVisible();
 
         // Click on "Signup" preview tab
-        const signupPreviewTab = modal.getByRole('tab', {name: 'Signup'});
+        const signupPreviewTab = previewToolbar.getByRole('tab', {name: 'Signup'});
         await signupPreviewTab.click();
 
         // Verify sidebar switched back to Signup options

--- a/apps/admin-x-settings/test/acceptance/membership/portal.test.ts
+++ b/apps/admin-x-settings/test/acceptance/membership/portal.test.ts
@@ -161,4 +161,59 @@ test.describe('Portal Settings', async () => {
             ]
         });
     });
+
+    test('synchronizes sidebar and preview tabs', async ({page}) => {
+        await mockApi({page, requests: {
+            ...globalDataRequests,
+            editSettings: {method: 'PUT', path: '/settings/', response: responseFixtures.settings}
+        }});
+
+        await mockSitePreview({
+            page,
+            url: 'http://localhost:2368/?v=modal-portal-settings#/portal/preview?button=true&name=true&isFree=true&isMonthly=true&isYearly=true&page=signup&buttonIcon=icon-1&signupButtonText=Subscribe&membersSignupAccess=all&allowSelfSignup=true&signupTermsHtml=&signupCheckboxRequired=false&portalProducts=6511005e14c14a231e49af15&portalPrices=free%252Cmonthly%252Cyearly&accentColor=%2523FF1A75&buttonStyle=icon-and-text&disableBackground=false',
+            response: '<html><head><style></style></head><body><div>PortalPreview</div></body></html>'
+        });
+
+        await page.goto('/');
+        const section = page.getByTestId('portal');
+        await section.getByRole('button', {name: 'Customize'}).click();
+
+        const modal = page.getByTestId('portal-modal');
+        await expect(modal).toBeVisible();
+
+        // Verify initial state - should be on Signup options tab
+        const displayNameToggle = modal.getByLabel('Display name in signup form');
+        await expect(displayNameToggle).toBeVisible();
+
+        // Click on "Account page" preview tab
+        const accountPreviewTab = modal.getByRole('tab', {name: 'Account page'});
+        await accountPreviewTab.click();
+
+        // Verify sidebar switched to Account page - support email field should be visible
+        const supportEmailField = modal.getByRole('textbox', {name: 'Support email address'});
+        await expect(supportEmailField).toBeVisible();
+
+        // Click on "Signup" preview tab
+        const signupPreviewTab = modal.getByRole('tab', {name: 'Signup'});
+        await signupPreviewTab.click();
+
+        // Verify sidebar switched back to Signup options
+        await expect(displayNameToggle).toBeVisible();
+
+        // Now test the reverse - clicking sidebar tabs should update preview
+        const lookAndFeelSidebarTab = page.locator('#lookAndFeel').first();
+        await lookAndFeelSidebarTab.click();
+
+        // Verify Look & feel content is visible
+        const showPortalButton = modal.getByLabel('Show portal button');
+        await expect(showPortalButton).toBeVisible();
+
+        // Click Account page sidebar tab
+        const accountSidebarTab = page.locator('#accountPage').first();
+        await accountSidebarTab.click();
+
+        // Verify Account page content is visible and preview tab is selected
+        await expect(supportEmailField).toBeVisible();
+        await expect(accountPreviewTab).toHaveAttribute('aria-selected', 'true');
+    });
 });


### PR DESCRIPTION
Got some code for us? Awesome 🎊!

Please take a minute to explain the change you're making:
- **Why are you making it?**
  To resolve a bug (DES-1286) where clicking "Account page" or "Signup options" in the Portal settings did not correctly navigate or synchronize the UI tabs. This led to a confusing user experience where the preview tab and sidebar tab could be out of sync.

- **What does it do?**
  This PR implements bi-directional synchronization between the Portal modal's sidebar tabs ("Signup options", "Account page") and the preview tabs ("Signup", "Account page"). Now, clicking a tab in one area will correctly update the selection in the other.

- **Why is this something Ghost users or developers need?**
  This improves the user experience in Portal settings by ensuring consistent and predictable navigation. Users will no longer encounter a mismatch between the selected preview and the active sidebar tab, making the configuration process smoother and less confusing.

Please check your PR against these items:

- [ ] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [ ] I've written an automated test to prove my change works

We appreciate your contribution! 🙏

---
Linear Issue: [DES-1286](https://linear.app/ghost/issue/DES-1286/portal-settings-link-to-account-page-doesnt-navigate-ui)

<p><a href="https://cursor.com/background-agent?bcId=bc-6d390841-f429-4a16-99fd-6dfe8b5d0c7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6d390841-f429-4a16-99fd-6dfe8b5d0c7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

