### PR TITLE
Trimmed leading empty entries in all time data for traffic api data

### DIFF
--- a/apps/stats/src/utils/chart-helpers.ts
+++ b/apps/stats/src/utils/chart-helpers.ts
@@ -18,6 +18,20 @@ export const getPeriodText = (range: number): string => {
     return '';
 };
 
+/**
+ * Truncates leading empty data points from the beginning of a dataset,
+ * keeping one zero entry before the first real data for a smooth chart transition.
+ * Ultimately, we should fix the API to return only what we want to see.
+ */
+export function truncateLeadingEmptyData<T extends {value?: number}>(data: T[]): T[] {
+    const firstNonEmptyIndex = data.findIndex(item => Number(item.value) > 0);
+    if (firstNonEmptyIndex > 1) {
+        // Keep one zero entry before the first real data
+        return data.slice(firstNonEmptyIndex - 1);
+    }
+    return data;
+}
+
 type AggregationType = 'sum' | 'avg' | 'exact';
 
 type AggregationStrategy = 'none' | 'weekly' | 'monthly' | 'monthly-exact';

--- a/apps/stats/src/utils/chart-helpers.ts
+++ b/apps/stats/src/utils/chart-helpers.ts
@@ -22,6 +22,7 @@ export const getPeriodText = (range: number): string => {
  * Truncates leading empty data points from the beginning of a dataset,
  * keeping one zero entry before the first real data for a smooth chart transition.
  * Ultimately, we should fix the API to return only what we want to see.
+ * https://linear.app/ghost/issue/NY-1035/
  */
 export function truncateLeadingEmptyData<T extends {value?: number}>(data: T[]): T[] {
     const firstNonEmptyIndex = data.findIndex(item => Number(item.value) > 0);

--- a/apps/stats/test/unit/utils/chart-helpers.test.ts
+++ b/apps/stats/test/unit/utils/chart-helpers.test.ts
@@ -7,7 +7,8 @@ import {
     determineAggregationStrategy,
     getMonthKey,
     getPeriodText,
-    sanitizeChartData
+    sanitizeChartData,
+    truncateLeadingEmptyData
 } from '@src/utils/chart-helpers';
 import {describe, expect, it} from 'vitest';
 
@@ -48,6 +49,87 @@ describe('chart-helpers', () => {
             STATS_RANGE_OPTIONS.push(customRange);
             expect(getPeriodText(customRange.value)).toBe('custom range');
             STATS_RANGE_OPTIONS.pop(); // Clean up
+        });
+    });
+
+    describe('truncateLeadingEmptyData', () => {
+        it('removes leading zero entries, keeping one before first real data', () => {
+            const data = [
+                {date: '2024-01-01', value: 0},
+                {date: '2024-02-01', value: 0},
+                {date: '2024-03-01', value: 0},
+                {date: '2024-04-01', value: 0},
+                {date: '2024-05-01', value: 0},
+                {date: '2024-06-01', value: 0}, // Should be kept (one before first real data)
+                {date: '2024-07-01', value: 10}, // First real data
+                {date: '2024-08-01', value: 20}
+            ];
+
+            const result = truncateLeadingEmptyData(data);
+
+            expect(result.length).toBe(3);
+            expect(result[0].date).toBe('2024-06-01');
+            expect(result[0].value).toBe(0);
+            expect(result[1].date).toBe('2024-07-01');
+            expect(result[1].value).toBe(10);
+            expect(result[2].date).toBe('2024-08-01');
+            expect(result[2].value).toBe(20);
+        });
+
+        it('returns data unchanged if first entry has data', () => {
+            const data = [
+                {date: '2024-01-01', value: 10},
+                {date: '2024-02-01', value: 20}
+            ];
+
+            const result = truncateLeadingEmptyData(data);
+
+            expect(result).toEqual(data);
+        });
+
+        it('returns data unchanged if only one leading zero', () => {
+            const data = [
+                {date: '2024-01-01', value: 0},
+                {date: '2024-02-01', value: 10}
+            ];
+
+            const result = truncateLeadingEmptyData(data);
+
+            expect(result).toEqual(data);
+        });
+
+        it('handles empty array', () => {
+            const result = truncateLeadingEmptyData([]);
+            expect(result).toEqual([]);
+        });
+
+        it('handles all zero values', () => {
+            const data = [
+                {date: '2024-01-01', value: 0},
+                {date: '2024-02-01', value: 0},
+                {date: '2024-03-01', value: 0}
+            ];
+
+            const result = truncateLeadingEmptyData(data);
+
+            // No non-empty data found, returns original
+            expect(result).toEqual(data);
+        });
+
+        it('preserves trailing zeros after real data', () => {
+            const data = [
+                {date: '2024-01-01', value: 0},
+                {date: '2024-02-01', value: 0},
+                {date: '2024-03-01', value: 10},
+                {date: '2024-04-01', value: 0}, // Trailing zero should be kept
+                {date: '2024-05-01', value: 0} // Trailing zero should be kept
+            ];
+
+            const result = truncateLeadingEmptyData(data);
+
+            expect(result.length).toBe(4);
+            expect(result[0].date).toBe('2024-02-01'); // One zero before first real data
+            expect(result[3].date).toBe('2024-05-01'); // Trailing zeros preserved
         });
     });
 

--- a/apps/stats/test/unit/utils/chart-helpers.test.ts
+++ b/apps/stats/test/unit/utils/chart-helpers.test.ts
@@ -111,8 +111,6 @@ describe('chart-helpers', () => {
             ];
 
             const result = truncateLeadingEmptyData(data);
-
-            // No non-empty data found, returns original
             expect(result).toEqual(data);
         });
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ONC-1457/

Added util to strip leading zeroes in the api_kpis response for 'all time'. Previously, this would show 1000 days of data, regardless of when the data started for a given site.

Ultimately we'll want to fix this in the api - this is a short term and easier fix for now.