### PR TITLE
Fixed mysql services in CI for PRs raised from forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -511,11 +511,24 @@ jobs:
     needs: [job_setup]
     if: needs.job_setup.outputs.changed_core == 'true'
     services:
-      mysql:
-        image: ${{ matrix.env.DB == 'mysql8' && 'mysql:8.0' || '' }}
+      mysql_auth:
+        image: ${{ matrix.env.DB == 'mysql8' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'mysql:8.0' || '' }}
         credentials:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && secrets.DOCKERHUB_USERNAME || 'unused' }}
+          password: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && secrets.DOCKERHUB_TOKEN || 'unused' }}
+        env:
+          MYSQL_DATABASE: ghost_testing
+          MYSQL_ROOT_PASSWORD: root
+        ports:
+          - 3306
+        options: >-
+          --tmpfs /var/lib/mysql
+          --health-cmd "mysqladmin ping -h 127.0.0.1 -uroot -proot"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=12
+      mysql_anon:
+        image: ${{ matrix.env.DB == 'mysql8' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'mysql:8.0' || '' }}
         env:
           MYSQL_DATABASE: ghost_testing
           MYSQL_ROOT_PASSWORD: root
@@ -568,10 +581,17 @@ jobs:
         run: echo "database__connection__filename=/dev/shm/ghost-test.db" >> $GITHUB_ENV
 
       - name: Set env vars (MySQL)
-        if: contains(matrix.env.DB, 'mysql')
+        if: contains(matrix.env.DB, 'mysql') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         run: |
           echo "database__connection__host=127.0.0.1" >> $GITHUB_ENV
-          echo "database__connection__port=${{ job.services.mysql.ports['3306'] }}" >> $GITHUB_ENV
+          echo "database__connection__port=${{ job.services.mysql_auth.ports['3306'] }}" >> $GITHUB_ENV
+          echo "database__connection__password=root" >> $GITHUB_ENV
+
+      - name: Set env vars (MySQL, fork PR)
+        if: contains(matrix.env.DB, 'mysql') && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+        run: |
+          echo "database__connection__host=127.0.0.1" >> $GITHUB_ENV
+          echo "database__connection__port=${{ job.services.mysql_anon.ports['3306'] }}" >> $GITHUB_ENV
           echo "database__connection__password=root" >> $GITHUB_ENV
 
       - name: E2E tests
@@ -602,11 +622,24 @@ jobs:
     needs: [job_setup]
     if: needs.job_setup.outputs.changed_core == 'true'
     services:
-      mysql:
-        image: ${{ matrix.env.DB == 'mysql8' && 'mysql:8.0' || '' }}
+      mysql_auth:
+        image: ${{ matrix.env.DB == 'mysql8' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'mysql:8.0' || '' }}
         credentials:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && secrets.DOCKERHUB_USERNAME || 'unused' }}
+          password: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && secrets.DOCKERHUB_TOKEN || 'unused' }}
+        env:
+          MYSQL_DATABASE: ghost_testing
+          MYSQL_ROOT_PASSWORD: root
+        ports:
+          - 3306
+        options: >-
+          --tmpfs /var/lib/mysql
+          --health-cmd "mysqladmin ping -h 127.0.0.1 -uroot -proot"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=12
+      mysql_anon:
+        image: ${{ matrix.env.DB == 'mysql8' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'mysql:8.0' || '' }}
         env:
           MYSQL_DATABASE: ghost_testing
           MYSQL_ROOT_PASSWORD: root
@@ -656,10 +689,17 @@ jobs:
         run: echo "database__connection__filename=/dev/shm/ghost-test.db" >> $GITHUB_ENV
 
       - name: Set env vars (MySQL)
-        if: contains(matrix.env.DB, 'mysql')
+        if: contains(matrix.env.DB, 'mysql') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         run: |
           echo "database__connection__host=127.0.0.1" >> $GITHUB_ENV
-          echo "database__connection__port=${{ job.services.mysql.ports['3306'] }}" >> $GITHUB_ENV
+          echo "database__connection__port=${{ job.services.mysql_auth.ports['3306'] }}" >> $GITHUB_ENV
+          echo "database__connection__password=root" >> $GITHUB_ENV
+
+      - name: Set env vars (MySQL, fork PR)
+        if: contains(matrix.env.DB, 'mysql') && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+        run: |
+          echo "database__connection__host=127.0.0.1" >> $GITHUB_ENV
+          echo "database__connection__port=${{ job.services.mysql_anon.ports['3306'] }}" >> $GITHUB_ENV
           echo "database__connection__password=root" >> $GITHUB_ENV
 
       - name: Legacy tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -511,24 +511,8 @@ jobs:
     needs: [job_setup]
     if: needs.job_setup.outputs.changed_core == 'true'
     services:
-      mysql_auth:
-        image: ${{ matrix.env.DB == 'mysql8' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'mysql:8.0' || '' }}
-        credentials:
-          username: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && secrets.DOCKERHUB_USERNAME || 'unused' }}
-          password: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && secrets.DOCKERHUB_TOKEN || 'unused' }}
-        env:
-          MYSQL_DATABASE: ghost_testing
-          MYSQL_ROOT_PASSWORD: root
-        ports:
-          - 3306
-        options: >-
-          --tmpfs /var/lib/mysql
-          --health-cmd "mysqladmin ping -h 127.0.0.1 -uroot -proot"
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=12
-      mysql_anon:
-        image: ${{ matrix.env.DB == 'mysql8' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'mysql:8.0' || '' }}
+      mysql:
+        image: ${{ matrix.env.DB == 'mysql8' && 'mysql:8.0' || '' }}
         env:
           MYSQL_DATABASE: ghost_testing
           MYSQL_ROOT_PASSWORD: root
@@ -581,17 +565,10 @@ jobs:
         run: echo "database__connection__filename=/dev/shm/ghost-test.db" >> $GITHUB_ENV
 
       - name: Set env vars (MySQL)
-        if: contains(matrix.env.DB, 'mysql') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        if: contains(matrix.env.DB, 'mysql')
         run: |
           echo "database__connection__host=127.0.0.1" >> $GITHUB_ENV
-          echo "database__connection__port=${{ job.services.mysql_auth.ports['3306'] }}" >> $GITHUB_ENV
-          echo "database__connection__password=root" >> $GITHUB_ENV
-
-      - name: Set env vars (MySQL, fork PR)
-        if: contains(matrix.env.DB, 'mysql') && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
-        run: |
-          echo "database__connection__host=127.0.0.1" >> $GITHUB_ENV
-          echo "database__connection__port=${{ job.services.mysql_anon.ports['3306'] }}" >> $GITHUB_ENV
+          echo "database__connection__port=${{ job.services.mysql.ports['3306'] }}" >> $GITHUB_ENV
           echo "database__connection__password=root" >> $GITHUB_ENV
 
       - name: E2E tests
@@ -622,24 +599,8 @@ jobs:
     needs: [job_setup]
     if: needs.job_setup.outputs.changed_core == 'true'
     services:
-      mysql_auth:
-        image: ${{ matrix.env.DB == 'mysql8' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'mysql:8.0' || '' }}
-        credentials:
-          username: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && secrets.DOCKERHUB_USERNAME || 'unused' }}
-          password: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && secrets.DOCKERHUB_TOKEN || 'unused' }}
-        env:
-          MYSQL_DATABASE: ghost_testing
-          MYSQL_ROOT_PASSWORD: root
-        ports:
-          - 3306
-        options: >-
-          --tmpfs /var/lib/mysql
-          --health-cmd "mysqladmin ping -h 127.0.0.1 -uroot -proot"
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=12
-      mysql_anon:
-        image: ${{ matrix.env.DB == 'mysql8' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'mysql:8.0' || '' }}
+      mysql:
+        image: ${{ matrix.env.DB == 'mysql8' && 'mysql:8.0' || '' }}
         env:
           MYSQL_DATABASE: ghost_testing
           MYSQL_ROOT_PASSWORD: root
@@ -689,17 +650,10 @@ jobs:
         run: echo "database__connection__filename=/dev/shm/ghost-test.db" >> $GITHUB_ENV
 
       - name: Set env vars (MySQL)
-        if: contains(matrix.env.DB, 'mysql') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        if: contains(matrix.env.DB, 'mysql')
         run: |
           echo "database__connection__host=127.0.0.1" >> $GITHUB_ENV
-          echo "database__connection__port=${{ job.services.mysql_auth.ports['3306'] }}" >> $GITHUB_ENV
-          echo "database__connection__password=root" >> $GITHUB_ENV
-
-      - name: Set env vars (MySQL, fork PR)
-        if: contains(matrix.env.DB, 'mysql') && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
-        run: |
-          echo "database__connection__host=127.0.0.1" >> $GITHUB_ENV
-          echo "database__connection__port=${{ job.services.mysql_anon.ports['3306'] }}" >> $GITHUB_ENV
+          echo "database__connection__port=${{ job.services.mysql.ports['3306'] }}" >> $GITHUB_ENV
           echo "database__connection__password=root" >> $GITHUB_ENV
 
       - name: Legacy tests


### PR DESCRIPTION
## What this changes
- Removes Docker Hub credentials from MySQL service containers in CI.

## Why
Fork PRs do not receive repository secrets, so requiring Docker Hub credentials in the service definition broke external contributor PRs.

For GitHub-hosted runners, GitHub documents that Docker Hub pull rate limits are not applied when pulling public images, so credentials are not needed for this case.

Docs:
- https://docs.github.com/en/actions/reference/actions-limits#docker-hubs-rate-limit-for-github-actions