### PR TITLE
Match small portal popover's X to large version

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.69.3",
+  "version": "2.69.4",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/portal/src/components/frame.styles.js
+++ b/apps/portal/src/components/frame.styles.js
@@ -534,7 +534,7 @@ html[dir="rtl"] .gh-portal-closeicon-container {
 }
 
 .gh-portal-closeicon {
-    color: var(--grey10);
+    color: var(--grey6);
     cursor: pointer;
     width: 20px;
     height: 20px;


### PR DESCRIPTION
Currently, the colors used in portal for the gh-portal-close (X) button are inconsistent.  the small popover uses --grey10 (which has poor contrast), while the larger popover (when showing tiers) uses --grey6.  This PR changes gh-portal-close to consistently use --grey6, matching the current visual styling of the large popover's close button.