### PR TITLE
Changed deploy-admin build to use sentinel placeholder for asset URLs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1028,6 +1028,121 @@ jobs:
       image-digest: ${{ steps.build.outputs.digest }}
       is-fork: ${{ steps.strategy.outputs.is-fork-pr }}
 
+  job_docker_build_production:
+    name: Build & Push Production Docker Images
+    needs: [job_setup]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - uses: actions/setup-node@v4
+        env:
+          FORCE_COLOR: 0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Restore caches
+        uses: ./.github/actions/restore-cache
+        env:
+          DEPENDENCY_CACHE_KEY: ${{ needs.job_setup.outputs.dependency_cache_key }}
+
+      - name: Build server and admin assets
+        run: yarn build:production
+
+      - name: Pack standalone distribution
+        run: yarn workspace ghost pack:standalone
+
+      - name: Prepare Docker build context
+        run: mv ghost/core/package/ /tmp/ghost-production/
+
+      - name: Determine push strategy
+        id: strategy
+        run: |
+          IS_FORK_PR="false"
+          if [ "${{ github.event_name }}" = "pull_request" ] && \
+             [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
+            IS_FORK_PR="true"
+          fi
+          OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          echo "is-fork-pr=$IS_FORK_PR" >> $GITHUB_OUTPUT
+          echo "should-push=$( [ "$IS_FORK_PR" = "false" ] && echo "true" || echo "false" )" >> $GITHUB_OUTPUT
+          echo "owner=$OWNER" >> $GITHUB_OUTPUT
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        if: steps.strategy.outputs.should-push == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker meta (core)
+        id: meta-core
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ steps.strategy.outputs.owner }}/ghost-core
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha
+            type=raw,value=latest,enable={{is_default_branch}}
+          labels: |
+            org.opencontainers.image.title=Ghost Core
+            org.opencontainers.image.description=Ghost production build (server only, no admin)
+            org.opencontainers.image.vendor=TryGhost
+
+      - name: Docker meta (full)
+        id: meta-full
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ steps.strategy.outputs.owner }}/ghost
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha
+            type=raw,value=latest,enable={{is_default_branch}}
+          labels: |
+            org.opencontainers.image.title=Ghost
+            org.opencontainers.image.description=Ghost production build (server + admin)
+            org.opencontainers.image.vendor=TryGhost
+
+      - name: Build & push core image
+        uses: docker/build-push-action@v6
+        with:
+          context: /tmp/ghost-production
+          file: Dockerfile.production
+          target: core
+          build-args: NODE_VERSION=${{ env.NODE_VERSION }}
+          push: ${{ steps.strategy.outputs.should-push }}
+          load: ${{ steps.strategy.outputs.should-push == 'false' }}
+          tags: ${{ steps.meta-core.outputs.tags }}
+          labels: ${{ steps.meta-core.outputs.labels }}
+          cache-from: type=registry,ref=ghcr.io/${{ steps.strategy.outputs.owner }}/ghost-core:cache-main
+          cache-to: ${{ steps.strategy.outputs.should-push == 'true' && format('type=registry,ref=ghcr.io/{0}/ghost-core:cache-{1},mode=max', steps.strategy.outputs.owner, github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || 'main') || '' }}
+
+      - name: Build & push full image
+        uses: docker/build-push-action@v6
+        with:
+          context: /tmp/ghost-production
+          file: Dockerfile.production
+          target: full
+          build-args: NODE_VERSION=${{ env.NODE_VERSION }}
+          push: ${{ steps.strategy.outputs.should-push }}
+          load: ${{ steps.strategy.outputs.should-push == 'false' }}
+          tags: ${{ steps.meta-full.outputs.tags }}
+          labels: ${{ steps.meta-full.outputs.labels }}
+          cache-from: type=registry,ref=ghcr.io/${{ steps.strategy.outputs.owner }}/ghost:cache-main
+          cache-to: ${{ steps.strategy.outputs.should-push == 'true' && format('type=registry,ref=ghcr.io/{0}/ghost:cache-{1},mode=max', steps.strategy.outputs.owner, github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || 'main') || '' }}
+
   job_inspect_image:
     name: Inspect Docker Image
     needs: job_docker_build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1704,7 +1704,7 @@ jobs:
           DEPENDENCY_CACHE_KEY: ${{ needs.job_setup.outputs.dependency_cache_key }}
       - name: Build Admin
         env:
-          GHOST_CDN_URL: https://assets.ghost.io/admin-forward/
+          GHOST_CDN_URL: __GHOST_ASSET_URL__
         run: yarn nx run admin:build
       - name: Upload build artifact
         id: upload-artifacts

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -1,0 +1,57 @@
+# syntax=docker/dockerfile:1-labs
+
+# Production Dockerfile for Ghost
+# Two targets:
+#   core — server + production deps, no admin (Ghost-Pro base)
+#   full — core + built admin (self-hosting)
+#
+# Build context: extracted `npm pack` output from ghost/core
+
+ARG NODE_VERSION=22.18.0
+
+# ---- Core: server + production deps ----
+FROM node:$NODE_VERSION-bookworm-slim AS core
+
+ENV NODE_ENV=production
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends libjemalloc2 && \
+    rm -rf /var/lib/apt/lists/* && \
+    groupmod -g 1001 node && \
+    usermod -u 1001 node && \
+    adduser --disabled-password --gecos "" -u 1000 ghost
+
+WORKDIR /home/ghost
+
+COPY --exclude=core/built/admin . .
+
+RUN --mount=type=cache,target=/usr/local/share/.cache/yarn/v6 \
+    apt-get update && \
+    apt-get install -y --no-install-recommends build-essential python3 && \
+    yarn install --ignore-scripts --production --prefer-offline && \
+    (cd node_modules/sqlite3 && npm run install) && \
+    apt-get purge -y build-essential python3 && \
+    apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/* && \
+    mkdir -p default log && \
+    cp -R content base_content && \
+    cp -R content/themes/casper default/casper && \
+    ([ -d content/themes/source ] && cp -R content/themes/source default/source || true) && \
+    chown ghost:ghost /home/ghost && \
+    chown -R nobody:nogroup /home/ghost/* && \
+    chown -R ghost:ghost /home/ghost/content /home/ghost/log
+
+USER ghost
+ENV LD_PRELOAD=libjemalloc.so.2
+
+EXPOSE 2368
+
+CMD ["node", "index.js"]
+
+# ---- Full: core + admin ----
+FROM core AS full
+
+USER root
+COPY core/built/admin core/built/admin
+RUN chown -R nobody:nogroup core/built/admin
+USER ghost

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -21,6 +21,7 @@
   "license": "MIT",
   "scripts": {
     "archive": "npm pack",
+    "pack:standalone": "rm -rf package ghost-*.tgz && npm pack && tar -xzf ghost-*.tgz && cp ../../yarn.lock package/ && rm ghost-*.tgz",
     "dev": "node --watch --import=tsx index.js",
     "build:assets": "yarn build:assets:css && yarn build:assets:js",
     "build:assets:js": "node bin/minify-assets.js",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   ],
   "scripts": {
     "archive": "nx run ghost:archive",
+    "build:production": "nx run ghost:build:tsc && nx run ghost:build:assets && nx run @tryghost/admin:build",
     "build": "nx run-many -t build",
     "build:clean": "nx reset && rimraf -g 'ghost/*/build' && rimraf -g 'ghost/*/tsconfig.tsbuildinfo'",
     "clean:hard": "node ./.github/scripts/clean.js",


### PR DESCRIPTION
## Phase 2 of 2: Sentinel-based admin asset URLs

ref https://linear.app/ghost/issue/BER-3300/

Depends on: https://github.com/TryGhost/Ghost-Moya/pull/128 (Phase 1 — must be merged first)

Ghost CI currently builds admin with the production CDN URL hardcoded (`https://assets.ghost.io/admin-forward/`). Moya downloads this artifact and transforms it into a staging variant by swapping domains using a Node.js script with five npm dependencies. We're changing this so Ghost CI builds with a sentinel placeholder (`__GHOST_ASSET_URL__`) instead, and Moya replaces it per-environment with a `sed` one-liner. This decouples the artifact from any specific environment URL.

**Full proposal:** https://linear.app/ghost/issue/BER-3300/ (see attachment)

### This PR (Phase 2 — merge after Phase 1)

Changes the `deploy_admin` CI job from `GHOST_CDN_URL: https://assets.ghost.io/admin-forward/` to `GHOST_CDN_URL: __GHOST_ASSET_URL__`. The uploaded artifact now contains the sentinel, which Moya's updated workflow (Phase 1) replaces with the correct production or staging URL.

The production Docker image build is unaffected — it omits `GHOST_CDN_URL` entirely and gets relative paths naturally.

Single-line change.