### PR TITLE
Fixed truncated unit test failure logs in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -492,6 +492,9 @@ jobs:
         run: yarn nx run-many -t build --exclude=ghost-admin
 
       - run: yarn nx affected -t test:unit --base=${{ needs.job_setup.outputs.BASE_COMMIT }}
+        env:
+          FORCE_COLOR: 0
+          NX_SKIP_LOG_GROUPING: true
 
       - uses: actions/upload-artifact@v4
         if: matrix.node == env.NODE_VERSION


### PR DESCRIPTION
## What this does
Disables forced ANSI color and Nx GitHub log grouping for the CI unit-test step so failure output remains readable.

## Why
In GitHub Actions, forced color output from Yarn includes ANSI clear-line sequences that can overwrite parts of stack traces and error lines. This made unit test failures hard to inspect in CI.

## Changes
- Set FORCE_COLOR=0 for the `yarn nx affected -t test:unit` step
- Set NX_SKIP_LOG_GROUPING=true for the same step

## Reference
- https://github.com/TryGhost/Ghost/actions/runs/21972538338/job/63477243630
