### PR TITLE
Fixed app version bump check false positives on stale PR branches

### DIFF
--- a/.github/scripts/check-app-version-bump.js
+++ b/.github/scripts/check-app-version-bump.js
@@ -159,7 +159,15 @@ function compareSemver(a, b) {
 }
 
 function getChangedFiles(baseSha, compareSha) {
-    return runGit(['diff', '--name-only', baseSha, compareSha, '--', ...MONITORED_APP_PATHS])
+    let mergeBaseSha;
+
+    try {
+        mergeBaseSha = runGit(['merge-base', baseSha, compareSha]);
+    } catch (error) {
+        throw new Error(`Unable to determine merge-base for ${baseSha} and ${compareSha}. Ensure the base branch history is available in the checkout.\n${error.message}`);
+    }
+
+    return runGit(['diff', '--name-only', mergeBaseSha, compareSha, '--', ...MONITORED_APP_PATHS])
         .split('\n')
         .map(file => file.trim())
         .filter(Boolean);

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,7 +228,7 @@ jobs:
           fetch-depth: 0
 
       - name: Fetch main branch
-        run: git fetch --no-tags --depth=1 origin main
+        run: git fetch --no-tags origin main
 
       - name: Check app version bump
         env:


### PR DESCRIPTION
## What this fixes
- Uses merge-base to detect monitored app file changes instead of directly diffing base SHA to head SHA.
- Fetches main without shallow depth in CI so merge-base can always be resolved.

## Why
The old diff strategy could include unrelated changes from main when a PR branch was behind, causing false-positive failures in the app version bump job.

Example failure:
https://github.com/TryGhost/Ghost/actions/runs/21980583293/job/63501979159

## Testing
Ran the script with PR_BASE_SHA=2171ae59932382033c8384398a30af7017198008 and PR_COMPARE_SHA=9d946fb7c099f7c0c2c898aa5916dcd74e5bfb32.
Result: No app changes detected. Skipping version bump check.