### PR TITLE
🐛 Fix offer description length/save validation handling

### DIFF
--- a/apps/admin-x-settings/src/components/settings/growth/offers/add-offer-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/offers/add-offer-modal.tsx
@@ -11,11 +11,8 @@ import {getTiersCadences} from '../../../../utils/get-tiers-cadences';
 import {useAddOffer} from '@tryghost/admin-x-framework/api/offers';
 import {useBrowseOffers} from '@tryghost/admin-x-framework/api/offers';
 import {useEffect, useMemo, useState} from 'react';
-
 import {useGlobalData} from '../../../providers/global-data-provider';
 import {useRouting} from '@tryghost/admin-x-framework/routing';
-
-const OFFER_DESCRIPTION_LIMIT = 2000;
 
 // we should replace this with a library
 function slugify(text: string): string {
@@ -191,8 +188,7 @@ const Sidebar: React.FC<SidebarProps> = ({tierOptions,
                             onKeyDown={() => clearError('displayTitle')}
                         />
                         <TextArea
-                            hint={<div className='flex justify-between'><span>Visible to members in Portal</span><strong>{overrides.displayDescription.length} / {OFFER_DESCRIPTION_LIMIT}</strong></div>}
-                            maxLength={OFFER_DESCRIPTION_LIMIT}
+                            maxLength={2000}
                             placeholder='Take advantage of this limited-time offer.'
                             title='Display description'
                             value={overrides.displayDescription}
@@ -646,7 +642,7 @@ const AddOfferModal = () => {
             if (!isErrorsEmpty) {
                 toast.remove();
                 showToast({
-                    title: 'Can\'t save offer',
+                    title: 'Failed to save offer',
                     type: 'info',
                     message: 'Make sure you filled all required fields'
                 });
@@ -665,13 +661,11 @@ const AddOfferModal = () => {
                 }
 
                 toast.remove();
-                if (message) {
-                    showToast({
-                        title: 'Can\'t save offer',
-                        type: 'error',
-                        message: message || 'Please try again later'
-                    });
-                }
+                showToast({
+                    title: 'Failed to save offer',
+                    type: 'error',
+                    message: message || 'Something went wrong, please try again later'
+                });
             }
         }}
     />;

--- a/apps/admin-x-settings/src/components/settings/growth/offers/add-offer-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/offers/add-offer-modal.tsx
@@ -11,8 +11,11 @@ import {getTiersCadences} from '../../../../utils/get-tiers-cadences';
 import {useAddOffer} from '@tryghost/admin-x-framework/api/offers';
 import {useBrowseOffers} from '@tryghost/admin-x-framework/api/offers';
 import {useEffect, useMemo, useState} from 'react';
+
 import {useGlobalData} from '../../../providers/global-data-provider';
 import {useRouting} from '@tryghost/admin-x-framework/routing';
+
+const OFFER_DESCRIPTION_LIMIT = 2000;
 
 // we should replace this with a library
 function slugify(text: string): string {
@@ -188,6 +191,8 @@ const Sidebar: React.FC<SidebarProps> = ({tierOptions,
                             onKeyDown={() => clearError('displayTitle')}
                         />
                         <TextArea
+                            hint={<div className='flex justify-between'><span>Visible to members in Portal</span><strong>{overrides.displayDescription.length} / {OFFER_DESCRIPTION_LIMIT}</strong></div>}
+                            maxLength={OFFER_DESCRIPTION_LIMIT}
                             placeholder='Take advantage of this limited-time offer.'
                             title='Display description'
                             value={overrides.displayDescription}

--- a/apps/admin-x-settings/src/components/settings/growth/offers/edit-offer-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/offers/edit-offer-modal.tsx
@@ -9,11 +9,8 @@ import {createRedemptionFilterUrl} from './offers-index';
 import {getHomepageUrl} from '@tryghost/admin-x-framework/api/site';
 import {getOfferPortalPreviewUrl, type offerPortalPreviewUrlTypes} from '../../../../utils/get-offers-portal-preview-url';
 import {useEffect, useState} from 'react';
-
 import {useGlobalData} from '../../../providers/global-data-provider';
 import {useRouting} from '@tryghost/admin-x-framework/routing';
-
-const OFFER_DESCRIPTION_LIMIT = 2000;
 
 function formatTimestamp(timestamp: string): string {
     const date = new Date(timestamp);
@@ -155,8 +152,7 @@ const Sidebar: React.FC<{
                                     onKeyDown={() => clearError('displayTitle')}
                                 />
                                 <TextArea
-                                    hint={<div className='flex justify-between'><span>Visible to members in Portal</span><strong>{offer?.display_description?.length || 0} / {OFFER_DESCRIPTION_LIMIT}</strong></div>}
-                                    maxLength={OFFER_DESCRIPTION_LIMIT}
+                                    maxLength={2000}
                                     placeholder='Take advantage of this limited-time offer.'
                                     title='Display description'
                                     value={offer?.display_description}
@@ -299,9 +295,9 @@ const EditOfferModal: React.FC<{id: string}> = ({id}) => {
 
                 toast.remove();
                 showToast({
-                    title: 'Can\'t save offer',
+                    title: 'Failed to save offer',
                     type: 'error',
-                    message: message || 'Please try again later'
+                    message: message || 'Something went wrong, please try again later'
                 });
             }
         }} /> : null;

--- a/apps/admin-x-settings/src/components/settings/growth/offers/edit-offer-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/offers/edit-offer-modal.tsx
@@ -9,8 +9,11 @@ import {createRedemptionFilterUrl} from './offers-index';
 import {getHomepageUrl} from '@tryghost/admin-x-framework/api/site';
 import {getOfferPortalPreviewUrl, type offerPortalPreviewUrlTypes} from '../../../../utils/get-offers-portal-preview-url';
 import {useEffect, useState} from 'react';
+
 import {useGlobalData} from '../../../providers/global-data-provider';
 import {useRouting} from '@tryghost/admin-x-framework/routing';
+
+const OFFER_DESCRIPTION_LIMIT = 2000;
 
 function formatTimestamp(timestamp: string): string {
     const date = new Date(timestamp);
@@ -152,6 +155,8 @@ const Sidebar: React.FC<{
                                     onKeyDown={() => clearError('displayTitle')}
                                 />
                                 <TextArea
+                                    hint={<div className='flex justify-between'><span>Visible to members in Portal</span><strong>{offer?.display_description?.length || 0} / {OFFER_DESCRIPTION_LIMIT}</strong></div>}
+                                    maxLength={OFFER_DESCRIPTION_LIMIT}
                                     placeholder='Take advantage of this limited-time offer.'
                                     title='Display description'
                                     value={offer?.display_description}
@@ -293,13 +298,11 @@ const EditOfferModal: React.FC<{id: string}> = ({id}) => {
                 }
 
                 toast.remove();
-                if (message) {
-                    showToast({
-                        title: 'Can\'t save offer',
-                        type: 'error',
-                        message: 'Please try again later'
-                    });
-                }
+                showToast({
+                    title: 'Can\'t save offer',
+                    type: 'error',
+                    message: message || 'Please try again later'
+                });
             }
         }} /> : null;
 };

--- a/ghost/core/core/server/services/offers/domain/models/offer-description.js
+++ b/ghost/core/core/server/services/offers/domain/models/offer-description.js
@@ -1,6 +1,8 @@
 const ValueObject = require('./shared/value-object');
 const InvalidOfferDescription = require('../errors').InvalidOfferDescription;
 
+const MAX_OFFER_DESCRIPTION_LENGTH = 2000;
+
 /** @extends ValueObject<string> */
 class OfferDescription extends ValueObject {
     /** @param {unknown} description */
@@ -15,9 +17,9 @@ class OfferDescription extends ValueObject {
             });
         }
 
-        if (description.length > 191) {
+        if (description.length > MAX_OFFER_DESCRIPTION_LENGTH) {
             throw new InvalidOfferDescription({
-                message: 'Offer `display_description` can be a maximum of 191 characters.'
+                message: `Offer \`display_description\` can be a maximum of ${MAX_OFFER_DESCRIPTION_LENGTH} characters.`
             });
         }
 

--- a/ghost/core/test/unit/server/services/offers/domain/models/offer-description.test.js
+++ b/ghost/core/test/unit/server/services/offers/domain/models/offer-description.test.js
@@ -33,16 +33,16 @@ describe('OfferDescription', function () {
             }
         });
 
-        it('Requires the string to be a maximum of 191 characters', function () {
-            const maxLengthInput = Array.from({length: 191}).map(() => 'a').join('');
+        it('Requires the string to be a maximum of 2000 characters', function () {
+            const maxLengthInput = Array.from({length: 2000}).map(() => 'a').join('');
 
-            assert.equal(maxLengthInput.length, 191);
+            assert.equal(maxLengthInput.length, 2000);
 
             OfferDescription.create(maxLengthInput);
 
             const tooLong = maxLengthInput + 'a';
 
-            assert.equal(tooLong.length, 192);
+            assert.equal(tooLong.length, 2001);
 
             try {
                 OfferDescription.create(tooLong);
@@ -62,4 +62,3 @@ describe('OfferDescription', function () {
         });
     });
 });
-


### PR DESCRIPTION
### Motivation
- Saving an offer with a long `display_description` failed silently because model validation capped the value at 191 chars while the DB schema allows ~2000 chars.  
- Admin UX didn't surface API validation context, showing a generic error instead of a helpful validation message or the character limit.

### Description
- Increased the offers domain `display_description` validation limit from 191 to `2000` characters and made the error message include the configured limit in `ghost/core/core/server/services/offers/domain/models/offer-description.js`.  
- Updated the unit test to assert the new 2000-character maximum in `ghost/core/test/unit/server/services/offers/domain/models/offer-description.test.js`.  
- Added a visible character counter and `maxLength={2000}` to the Display description `TextArea` in both Add and Edit Offer modals to show `X / 2000` in `apps/admin-x-settings/src/components/settings/growth/offers/{add-offer-modal,edit-offer-modal}.tsx`.  
- Improved Edit Offer save error handling to surface API validation messages in the toast instead of always showing a generic message (Edit modal `onOk` error handler).

### Testing
- Attempted to run the targeted unit test with `yarn test:single test/unit/server/services/offers/domain/models/offer-description.test.js`, but the environment failed to run Yarn v1 workspace commands (current environment uses Yarn v4 and the lockfile resolution failed), so tests could not be executed here.  
- Attempted a small Node runtime check to exercise `OfferDescription.create(...)`, but it failed due to missing runtime dependencies in this environment (e.g. `lodash`), so dynamic validation could not be completed locally.  
- Attempted a Playwright page check to capture the Admin UI, but there was no local server running (`http://localhost:2368` returned empty), so browser verification could not be performed.  

Notes: changes were verified via focused code inspection and diffs; CI/unit tests should be run in the project's normal CI environment (or locally after `yarn install` with Yarn v1) to validate everything end-to-end.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990574c83288320891890528a3412e3)