### PR TITLE
Reduced unit-test prebuild scope to only affected projects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -487,9 +487,16 @@ jobs:
         with:
           timezoneLinux: "America/New_York"
 
-      # Ensure all built packages are built before running tests (admin is built in job_setup)
-      - name: Build remaining assets
-        run: yarn nx run-many -t build --exclude=ghost-admin
+      - name: Determine affected unit-test projects
+        id: affected_unit_projects
+        run: |
+          PROJECTS=$(yarn -s nx show projects --affected --withTarget=test:unit --base=${{ needs.job_setup.outputs.BASE_COMMIT }} --sep=, | tr -d '\n')
+          echo "projects=$PROJECTS" >> "$GITHUB_OUTPUT"
+
+      # Build only projects that will run unit tests
+      - name: Build assets for affected unit tests
+        if: steps.affected_unit_projects.outputs.projects != ''
+        run: yarn nx run-many -t build --projects="${{ steps.affected_unit_projects.outputs.projects }}"
 
       - run: yarn nx affected -t test:unit --base=${{ needs.job_setup.outputs.BASE_COMMIT }}
         env:


### PR DESCRIPTION
## What this changes
- Replaced the unit-test job's broad prebuild step with a targeted prebuild flow.
- Added a step to compute affected projects with a test:unit target.
- Build step now runs nx run-many -t build only for that computed project list.

## Why
- The previous run-many -t build --exclude=ghost-admin prebuilt far more projects than needed.
- Unit-test execution already uses nx affected; this aligns prebuild scope with the same affected set.

## Notes
- No functional test command changes: unit tests still run via yarn nx affected -t test:unit --base=...
- This should reduce unnecessary CI build work when few or no unit-test projects are affected.
