### PR TITLE
Removed unnecessary PII from member geolocation data

### DIFF
--- a/ghost/core/core/server/data/seeders/importers/members-importer.js
+++ b/ghost/core/core/server/data/seeders/importers/members-importer.js
@@ -80,21 +80,9 @@ class MembersImporter extends TableImporter {
             name: name,
             expertise: luck(30) ? faker.name.jobTitle() : undefined,
             geolocation: JSON.stringify({
-                organization_name: faker.company.name(),
-                region: faker.address.state(),
-                accuracy: 50,
-                asn: parseInt(faker.random.numeric(4)),
-                organization: `${faker.random.alpha({count: 2, casing: 'upper'})}${faker.random.numeric(4)} ${faker.company.name()}`,
-                timezone: faker.address.timeZone(),
-                longitude: faker.address.longitude(),
-                country_code3: faker.address.countryCode('alpha-3'),
-                area_code: '0',
-                ip: faker.internet.ipv4(),
-                city: faker.address.cityName(),
                 country: faker.address.country(),
-                continent_code: 'EU',
                 country_code: faker.address.countryCode('alpha-2'),
-                latitude: faker.address.latitude()
+                region: faker.address.state()
             }),
             email_count: 0, // Depends on number of emails sent since created_at, the newsletter they're a part of and subscription status
             email_opened_count: 0,

--- a/ghost/core/core/server/services/members/members-api/services/geolocation-service.js
+++ b/ghost/core/core/server/services/members/members-api/services/geolocation-service.js
@@ -18,6 +18,10 @@ module.exports = class GeolocationService {
 
         const geojsUrl = `https://get.geojs.io/v1/ip/geo/${encodeURIComponent(ipAddress)}.json`;
         const response = await got(geojsUrl, gotOpts).json();
-        return response;
+        return {
+            country: response.country,
+            country_code: response.country_code,
+            region: response.region
+        };
     }
 };

--- a/ghost/core/test/unit/server/services/members/members-api/services/geolocation-service.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/services/geolocation-service.test.js
@@ -3,7 +3,7 @@ const {assertExists} = require('../../../../../../utils/assertions');
 const nock = require('nock');
 const GeolocationService = require('../../../../../../../core/server/services/members/members-api/services/geolocation-service');
 
-const RESPONSE = {
+const GEOJS_RESPONSE = {
     longitude: '-2.2417',
     city: 'Kidderminster',
     timezone: 'Europe/London',
@@ -21,6 +21,12 @@ const RESPONSE = {
     country_code3: 'GBR'
 };
 
+const EXPECTED_RESULT = {
+    country: 'United Kingdom',
+    country_code: 'GB',
+    region: 'England'
+};
+
 const service = new GeolocationService();
 
 describe('lib/geolocation', function () {
@@ -33,25 +39,25 @@ describe('lib/geolocation', function () {
         it('fetches from geojs.io with IPv4 address', async function () {
             const scope = nock('https://get.geojs.io')
                 .get('/v1/ip/geo/188.39.113.90.json')
-                .reply(200, RESPONSE);
+                .reply(200, GEOJS_RESPONSE);
 
             const result = await service.getGeolocationFromIP('188.39.113.90');
 
             assert.equal(scope.isDone(), true, 'request was not made');
             assertExists(result, 'nothing was returned');
-            assert.deepEqual(result, RESPONSE, 'result didn\'t match expected response');
+            assert.deepEqual(result, EXPECTED_RESULT, 'result didn\'t match expected response');
         });
 
         it('fetches from geojs.io with IPv6 address', async function () {
             const scope = nock('https://get.geojs.io')
                 .get('/v1/ip/geo/2a01%3A4c8%3A43a%3A13c9%3A8d6%3A128e%3A1fd5%3A6aad.json')
-                .reply(200, RESPONSE);
+                .reply(200, GEOJS_RESPONSE);
 
             const result = await service.getGeolocationFromIP('2a01:4c8:43a:13c9:8d6:128e:1fd5:6aad');
 
             assert.equal(scope.isDone(), true, 'request was not made');
             assertExists(result, 'nothing was returned');
-            assert.deepEqual(result, RESPONSE, 'result didn\'t match expected response');
+            assert.deepEqual(result, EXPECTED_RESULT, 'result didn\'t match expected response');
         });
 
         it('handles non-IP addresses', async function () {


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/26315

The geolocation service stored the full geojs.io response (IP, coordinates, ASN, org, etc.) but only country, country_code, and region are ever used. This strips the response to just those three fields to reduce stored PII.

Got some code for us? Awesome 🎊!

Please take a minute to explain the change you're making:
- Why are you making it?
- What does it do?
- Why is this something Ghost users or developers need?

Please check your PR against these items:

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [x] I've written an automated test to prove my change works

We appreciate your contribution! 🙏

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavioral change that narrows stored data; main risk is any downstream code implicitly relying on removed geojs fields.
> 
> **Overview**
> Member geolocation storage is reduced to only `country`, `country_code`, and `region`, stripping other fields returned by geojs.io (e.g. IP, coordinates, ASN/org data) before persisting.
> 
> Test fixtures and assertions are updated to expect the trimmed geolocation object, and the members seeder now generates only those three geolocation fields.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e3c87f1c3d933e65e841ce5858e8e2e1cfe90049. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->