### PR TITLE
Fixed missing Nx dependency for parse-email-address in unit tests

### DIFF
--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -319,7 +319,13 @@
       },
       "test:unit": {
         "dependsOn": [
-          "build:assets"
+          "build:assets",
+          {
+            "projects": [
+              "@tryghost/parse-email-address"
+            ],
+            "target": "build"
+          }
         ]
       },
       "test:browser": {


### PR DESCRIPTION
## Summary
- Added `@tryghost/parse-email-address:build` as a dependency of `ghost:test:unit` in the Nx target config
- This dependency was already declared for `build:tsc` and `lint` but was missing for `test:unit`
- The gap was exposed after #26404 reduced the CI prebuild scope — Nx no longer built everything upfront, so `parse-email-address` wasn't compiled before tests ran