### PR TITLE
Reverted --outputStyle=stream for CI unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -499,7 +499,7 @@ jobs:
         run: yarn nx run-many -t build --projects="${{ steps.affected_unit_projects.outputs.projects }}"
 
       - name: Run unit tests
-        run: ./node_modules/.bin/nx affected -t test:unit --outputStyle=stream --base=${{ needs.job_setup.outputs.BASE_COMMIT }}
+        run: yarn nx affected -t test:unit --base=${{ needs.job_setup.outputs.BASE_COMMIT }}
         env:
           FORCE_COLOR: 0
           GHOST_UNIT_TEST_VARIANT: ci


### PR DESCRIPTION
## Summary
- Removed `--outputStyle=stream` from the CI unit test Nx command and switched back to `yarn nx`
- Stream output was mixing parallel project logs together, making failures harder to reason about
- Nx default batched output keeps each project's logs cleanly grouped
- Truncated Ghost unit test failures should still be fixed by using the `min` reporter in CI