### PR TITLE
Used package.json version instead of git describe in bump-version

### DIFF
--- a/.github/scripts/bump-version.js
+++ b/.github/scripts/bump-version.js
@@ -23,8 +23,7 @@ const semver = require('semver');
         const bumpedVersion = semver.inc(current_version, 'minor');
         newVersion = `${bumpedVersion}-pre-g${buildString}`;
     } else {
-        const gitVersion = await exec('git describe --long HEAD').then(({stdout}) => stdout.trim().replace(/^v/, ''));
-        newVersion = gitVersion;
+        newVersion = `${current_version}-0-g${buildString}`;
     }
 
     newVersion += '+moya';


### PR DESCRIPTION
## Summary
- Replaced `git describe --long HEAD` with the version from `package.json` in the non-canary code path
- `git describe` relies on tags being available locally, which can produce wrong versions on clones without recent tags
- The package.json version is the source of truth and doesn't depend on tag state