### PR TITLE
Added dynamic URLs for author slugs

### DIFF
--- a/apps/admin-x-settings/src/components/settings/general/users/profile-tab.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/users/profile-tab.tsx
@@ -3,11 +3,13 @@ import RoleSelector from './role-selector';
 import StaffToken from './staff-token';
 import {SettingGroup, SettingGroupContent, TextArea, TextField} from '@tryghost/admin-x-design-system';
 import {type UserDetailProps} from '../user-detail-modal';
+import {getHomepageUrl} from '@tryghost/admin-x-framework/api/site';
 import {hasAdminAccess} from '@tryghost/admin-x-framework/api/users';
 import {useGlobalData} from '../../../providers/global-data-provider';
 
 const BasicInputs: React.FC<UserDetailProps> = ({errors, clearError, user, setUserData}) => {
-    const {currentUser} = useGlobalData();
+    const {currentUser, siteData} = useGlobalData();
+    const homepageUrl = getHomepageUrl(siteData!);
 
     return (
         <SettingGroupContent>
@@ -36,7 +38,7 @@ const BasicInputs: React.FC<UserDetailProps> = ({errors, clearError, user, setUs
                 onKeyDown={() => clearError('name')}
             />
             <TextField
-                hint={`https://example.com/author/${user.slug}`}
+                hint={`${homepageUrl}author/${user.slug}`}
                 maxLength={191}
                 title="Slug"
                 value={user.slug}

--- a/apps/admin-x-settings/test/acceptance/general/users/profile.test.ts
+++ b/apps/admin-x-settings/test/acceptance/general/users/profile.test.ts
@@ -165,7 +165,7 @@ test.describe('User profile', async () => {
         await modal.getByLabel('Full name').fill('New Admin');
         await modal.getByLabel('Email').fill('newadmin@test.com');
         await modal.getByLabel('Slug').fill('newadmin');
-        await expect(modal.getByText('https://example.com/author/newadmin')).toBeVisible();
+        await expect(modal.getByText('http://test.com/author/newadmin')).toBeVisible();
         await modal.getByLabel('Location').fill('some location');
         await modal.getByLabel('Bio').fill('some bio');
 


### PR DESCRIPTION
Ref https://linear.app/ghost/issue/DES-1289/slack-domain-name-in-staff-settings-is-hardcoded-to-examplecom

We'd previously just use example.com to create the slug. Updated that to use the site's URL instead.

| Before | After |
|--------|--------|
| <img width="288" height="120" alt="Screenshot 2026-02-16 at 15 14 45" src="https://github.com/user-attachments/assets/13721575-fffa-4667-ad20-36a27e4c29aa" /> | <img width="275" height="115" alt="Screenshot 2026-02-16 at 15 14 23" src="https://github.com/user-attachments/assets/b38488d4-c74f-4e9f-957c-385ca6d40ee2" /> | 