### PR TITLE
Fixed display of member welcome email sender in modal

### DIFF
--- a/apps/admin-x-settings/src/components/settings/membership/member-emails.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails.tsx
@@ -8,6 +8,7 @@ import {checkStripeEnabled, getSettingValues} from '@tryghost/admin-x-framework/
 import {useAddAutomatedEmail, useBrowseAutomatedEmails, useEditAutomatedEmail} from '@tryghost/admin-x-framework/api/automated-emails';
 import {useGlobalData} from '../../providers/global-data-provider';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
+import {useWelcomeEmailSenderDetails} from '../../../hooks/use-welcome-email-sender-details';
 import type {AutomatedEmail} from '@tryghost/admin-x-framework/api/automated-emails';
 
 // Default welcome email content in Lexical JSON format
@@ -32,10 +33,9 @@ const EmailPreview: React.FC<{
     onToggle
 }) => {
     const {settings} = useGlobalData();
-    const [accentColor, icon, siteTitle] = getSettingValues<string>(settings, ['accent_color', 'icon', 'title']);
+    const [accentColor, icon] = getSettingValues<string>(settings, ['accent_color', 'icon']);
     const color = accentColor || '#F6414E';
-
-    const senderName = automatedEmail.sender_name || siteTitle || 'Your Site';
+    const {resolvedSenderName} = useWelcomeEmailSenderDetails(automatedEmail);
 
     return (
         <div
@@ -60,7 +60,7 @@ const EmailPreview: React.FC<{
                         </div>
                     }
                     <div className='text-left'>
-                        <div className='font-semibold'>{senderName}</div>
+                        <div className='font-semibold'>{resolvedSenderName}</div>
                         <div className='text-sm'>{automatedEmail.subject}</div>
                     </div>
                 </div>

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-modal.tsx
@@ -4,6 +4,7 @@ import {useCallback, useEffect, useRef, useState} from 'react';
 import MemberEmailEditor from './member-email-editor';
 import {Button, Hint, Modal, TextField} from '@tryghost/admin-x-design-system';
 import {useForm, useHandleError} from '@tryghost/admin-x-framework/hooks';
+import {useWelcomeEmailSenderDetails} from '../../../../hooks/use-welcome-email-sender-details';
 
 import TestEmailDropdown from './test-email-dropdown';
 import {getSettingValues} from '@tryghost/admin-x-framework/api/settings';
@@ -51,7 +52,8 @@ const WelcomeEmailModal = NiceModal.create<WelcomeEmailModalProps>(({emailType =
     const hasEditorBeenFocused = useRef(false);
     const handleError = useHandleError();
     const {settings} = useGlobalData();
-    const [siteTitle, defaultEmailAddress] = getSettingValues<string>(settings, ['title', 'default_email_address']);
+    const [siteTitle] = getSettingValues<string>(settings, ['title']);
+    const {resolvedSenderName, resolvedSenderEmail, resolvedReplyToEmail, hasDistinctReplyTo} = useWelcomeEmailSenderDetails(automatedEmail);
 
     const {formState, saveState, updateForm, setFormState, handleSave, okProps, errors, validate} = useForm({
         initialState: {
@@ -135,9 +137,6 @@ const WelcomeEmailModal = NiceModal.create<WelcomeEmailModalProps>(({emailType =
         }
     }, [setFormState, updateForm]);
 
-    const senderEmail = automatedEmail?.sender_email || defaultEmailAddress;
-    const replyToEmail = automatedEmail?.sender_reply_to || defaultEmailAddress;
-
     return (
         <Modal
             afterClose={() => {
@@ -177,15 +176,15 @@ const WelcomeEmailModal = NiceModal.create<WelcomeEmailModalProps>(({emailType =
                     <div className='flex items-center'>
                         <div className='w-20 font-semibold'>From:</div>
                         <div className='flex grow items-center gap-1'>
-                            <span>{automatedEmail?.sender_name || siteTitle}</span>
-                            <span className='text-grey-700 dark:text-grey-400'>{`<${senderEmail}>`}</span>
+                            <span>{resolvedSenderName}</span>
+                            <span className='text-grey-700 dark:text-grey-400'>{`<${resolvedSenderEmail}>`}</span>
                         </div>
                     </div>
-                    {replyToEmail !== senderEmail && (
+                    {hasDistinctReplyTo && (
                         <div className='flex items-center py-0.5'>
                             <div className='w-20 font-semibold'>Reply-to:</div>
                             <div className='grow text-grey-700 dark:text-grey-400'>
-                                {replyToEmail}
+                                {resolvedReplyToEmail}
                             </div>
                         </div>
                     )}

--- a/apps/admin-x-settings/src/hooks/use-welcome-email-sender-details.ts
+++ b/apps/admin-x-settings/src/hooks/use-welcome-email-sender-details.ts
@@ -1,0 +1,54 @@
+import {getSettingValues} from '@tryghost/admin-x-framework/api/settings';
+import {renderReplyToEmail, renderSenderEmail} from '../utils/newsletter-emails';
+import {useBrowseNewsletters} from '@tryghost/admin-x-framework/api/newsletters';
+import {useGlobalData} from '../components/providers/global-data-provider';
+import {useMemo} from 'react';
+import type {AutomatedEmail} from '@tryghost/admin-x-framework/api/automated-emails';
+
+type AutomatedEmailSenderFields = Pick<AutomatedEmail, 'sender_name' | 'sender_email' | 'sender_reply_to'> | null | undefined;
+
+const trimValue = (value: string | null | undefined) => value?.trim() || '';
+
+export const useWelcomeEmailSenderDetails = (automatedEmail: AutomatedEmailSenderFields) => {
+    const {settings, config} = useGlobalData();
+    const [siteTitle, defaultEmailAddress, supportEmailAddress] = getSettingValues<string>(settings, ['title', 'default_email_address', 'support_email_address']);
+    const {data: newslettersData} = useBrowseNewsletters({
+        searchParams: {
+            filter: 'status:active',
+            limit: '1'
+        }
+    });
+    const defaultNewsletter = newslettersData?.newsletters?.[0];
+
+    return useMemo(() => {
+        const automatedSenderName = trimValue(automatedEmail?.sender_name);
+        const automatedSenderEmail = trimValue(automatedEmail?.sender_email);
+        const automatedSenderReplyTo = trimValue(automatedEmail?.sender_reply_to);
+
+        const defaultNewsletterSenderName = trimValue(defaultNewsletter?.sender_name);
+        const defaultNewsletterSenderEmail = defaultNewsletter ? trimValue(renderSenderEmail(defaultNewsletter, config, defaultEmailAddress)) : '';
+        const defaultNewsletterReplyTo = defaultNewsletter ? trimValue(renderReplyToEmail(defaultNewsletter, config, supportEmailAddress, defaultEmailAddress)) : '';
+
+        const resolvedSenderName = automatedSenderName || defaultNewsletterSenderName || trimValue(siteTitle) || 'Your Site';
+        const resolvedSenderEmail = automatedSenderEmail || defaultNewsletterSenderEmail || trimValue(defaultEmailAddress) || '';
+        const resolvedReplyToEmail = automatedSenderReplyTo || defaultNewsletterReplyTo || '';
+        const hasDistinctReplyTo = resolvedReplyToEmail !== '' && resolvedReplyToEmail !== resolvedSenderEmail;
+
+        return {
+            resolvedSenderName,
+            resolvedSenderEmail,
+            resolvedReplyToEmail,
+            defaultNewsletterSenderName,
+            hasDistinctReplyTo
+        };
+    }, [
+        automatedEmail?.sender_email,
+        automatedEmail?.sender_name,
+        automatedEmail?.sender_reply_to,
+        config,
+        defaultEmailAddress,
+        defaultNewsletter,
+        siteTitle,
+        supportEmailAddress
+    ]);
+};


### PR DESCRIPTION
closes [NY-1041](https://linear.app/ghost/issue/NY-1041/oss-issue-welcome-email-sender-still-appears-as-noreply-in-preview) and https://github.com/TryGhost/Ghost/issues/26381

- In https://github.com/TryGhost/Ghost/pull/26358 we made it so that member welcome emails, when sent, would use sender info and reply_to from the default newsletter
- this PR updates the modal to display that information properly as well
- Since this info is used in both the button that opens the modal and the modal itself, added a hook to de-duplicate some of the logic for determining exactly what to display
- No logic yet for updating sender name, email, and reply to specifically for welcome emails, but this code is written in such a way that once that's supported it can easily take precedence over default newsletter values 

### State 1 - defaults
The default values for the newsletter (first screenshot) are what welcome emails use.

<table> <tr> <th>Default Newsletter Settings</th> <th>Welcome Email Buttons</th> <th>Modal</th> </tr> <tr> <td align="center"><img src="https://github.com/user-attachments/assets/b41a23a5-0e0b-42a6-b482-9a872c452780" alt="Screenshot 2026-02-16 at 3 01 30 PM" width="380" /></td> <td align="center"><img src="https://github.com/user-attachments/assets/20258e4e-1d4d-4d3d-880c-a91b311b8aa9" alt="Screenshot 2026-02-16 at 3 02 04 PM" width="380" /></td> <td align="center"><img src="https://github.com/user-attachments/assets/63439fd1-7067-47d7-b000-7a22b7bc4f32" alt="Screenshot 2026-02-16 at 3 01 43 PM" width="620" /></td> </tr> </table>

### State 2 - custom name and sender email
Updated sender name and sender email for the default newsletter. Sender name is updated in the button that opens the modal, and name + sender email are updated in the modal. The test email matches the same values.

<table> <tr> <th>Newsletter Settings</th> <th>Welcome Email Buttons</th> </tr> <tr> <td align="center"><img src="https://github.com/user-attachments/assets/5a971b12-3ff0-4195-8a89-a69638b90b75" alt="Screenshot 2026-02-16 at 3 02 38 PM" width="420" /></td> <td align="center"><img src="https://github.com/user-attachments/assets/c5dd8e08-3b53-4f21-8b2e-7955092f50cc" alt="Screenshot 2026-02-16 at 3 02 48 PM" width="420" /></td> </tr> <tr> <th>Modal</th> <th>Resulting Test Email</th> </tr> <tr> <td align="center"><img src="https://github.com/user-attachments/assets/5eebce17-b11c-40eb-88a7-7edf3a486d0d" alt="Screenshot 2026-02-16 at 3 02 54 PM" width="420" /></td> <td align="center"><img src="https://github.com/user-attachments/assets/20a19864-3a21-4c53-82a0-c521ea7a070e" alt="Screenshot 2026-02-16 at 3 03 08 PM" width="420" /></td> </tr> </table>

### State 3 - custom reply to
Same as above, but with a custom reply-to address. It appears in the modal and in the actual sent email.

<table> <tr> <th>Newsletter Reply-To Setting</th> <th>Modal (w/ Reply-To)</th> <th>Resulting Test Email</th> </tr> <tr> <td align="center"><img src="https://github.com/user-attachments/assets/eab3dded-8e52-461c-8665-0565558cf471" alt="Screenshot 2026-02-16 at 3 03 24 PM" width="380" /></td> <td align="center"><img src="https://github.com/user-attachments/assets/c5f1c741-4aac-4648-a82a-cf477c8a5a9e" alt="Screenshot 2026-02-16 at 3 03 33 PM" width="380" /></td> <td align="center"><img src="https://github.com/user-attachments/assets/1633a176-0625-4ebf-b591-1724be037c6a" alt="Screenshot 2026-02-16 at 3 03 42 PM" width="520" /></td> </tr> </table>
