### PR TITLE
Handle deleted comments with [removed] placeholder

### DIFF
--- a/apps/posts/src/views/comments/components/comment-content.tsx
+++ b/apps/posts/src/views/comments/components/comment-content.tsx
@@ -20,6 +20,8 @@ function CommentContent({item}: {item: Comment}) {
     const [isClamped, setIsClamped] = useState(false);
     const [isExpanded, setIsExpanded] = useState(false);
 
+    const isDeleted = item.status === 'deleted';
+
     useEffect(() => {
         // Don't recalculate clamping while expanded, as the content won't be clamped
         // and we'd incorrectly hide the ExpandButton
@@ -39,6 +41,16 @@ function CommentContent({item}: {item: Comment}) {
         window.addEventListener('resize', checkIfClamped);
         return () => window.removeEventListener('resize', checkIfClamped);
     }, [item.html, isExpanded]);
+
+    if (isDeleted) {
+        return (
+            <div className="mt-1 flex flex-col gap-2">
+                <div className="flex max-w-full flex-col items-start opacity-50">
+                    <p className="text-base italic text-muted-foreground">[removed]</p>
+                </div>
+            </div>
+        );
+    }
 
     return (
         <div className={`mt-1 flex flex-col gap-2`}>


### PR DESCRIPTION
## Why are you making it?

Comments with a `deleted` status should be displayed differently to indicate they've been removed, rather than showing their original content or treating them the same as hidden comments.

## What does it do?

This change adds explicit handling for deleted comments in the `CommentContent` component. When a comment has `status === 'deleted'`, it now displays a `[removed]` placeholder with reduced opacity instead of rendering the comment's HTML content.

The deleted state is checked early in the component lifecycle, allowing it to return a simplified UI before any content rendering logic executes.

## Why is this something Ghost users or developers need?

This improves the user experience by clearly indicating when a comment has been removed, distinguishing it from hidden comments and providing transparency about moderation actions.