### PR TITLE
Cleaned up GA `audienceFeedback` labs flag

### DIFF
--- a/apps/admin-x-framework/src/test/acceptance.ts
+++ b/apps/admin-x-framework/src/test/acceptance.ts
@@ -81,7 +81,6 @@ export const responseFixtures = {
 };
 
 const defaultLabFlags = {
-    audienceFeedback: false,
     collections: false,
     outboundLinkTagging: false,
     announcementBar: false,

--- a/apps/admin-x-settings/src/components/settings/email/newsletters/newsletter-preview.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/newsletters/newsletter-preview.tsx
@@ -20,7 +20,7 @@ const NewsletterPreview: React.FC<{newsletter: Newsletter}> = ({newsletter}) => 
     const headerSubtitle = (newsletter.show_header_title && newsletter.show_header_name) ? newsletter.name : undefined;
 
     const showCommentCta = newsletter.show_comment_cta && commentsEnabled !== 'off';
-    const showFeedback = newsletter.feedback_enabled && config.labs.audienceFeedback;
+    const showFeedback = newsletter.feedback_enabled;
 
     const backgroundColor = () => {
         const value = newsletter.background_color;

--- a/ghost/admin/app/components/members/filters/audience-feedback.js
+++ b/ghost/admin/app/components/members/filters/audience-feedback.js
@@ -9,7 +9,6 @@ export const AUDIENCE_FEEDBACK_FILTER = {
     valueType: 'string',
     resource: 'email',
     relationOptions: FEEDBACK_RELATION_OPTIONS,
-    feature: 'audienceFeedback',
     buildNqlFilter: (filter) => {
         // Added brackets to make sure we can parse as a single AND filter
         return `(feedback.post_id:'${filter.value}'+feedback.score:${filter.relation})`;

--- a/ghost/admin/app/models/post.js
+++ b/ghost/admin/app/models/post.js
@@ -187,7 +187,7 @@ export default Model.extend(Comparable, ValidationEngine, {
     }),
 
     showAudienceFeedback: computed('sentiment', function () {
-        return this.feature.get('audienceFeedback') && this.sentiment !== undefined;
+        return this.sentiment !== undefined;
     }),
 
     showEmailOpenAnalytics: computed('hasBeenEmailed', 'isSent', 'isPublished', function () {

--- a/ghost/admin/app/services/feature.js
+++ b/ghost/admin/app/services/feature.js
@@ -60,7 +60,6 @@ export default class FeatureService extends Service {
     @feature('referralInviteDismissed', {user: true}) referralInviteDismissed;
 
     // labs flags
-    @feature('audienceFeedback') audienceFeedback;
     @feature('welcomeEmails') welcomeEmails;
     @feature('webmentions') webmentions;
     @feature('stripeAutomaticTax') stripeAutomaticTax;

--- a/ghost/admin/app/utils/member-event-types.js
+++ b/ghost/admin/app/utils/member-event-types.js
@@ -20,9 +20,7 @@ export function getAvailableEventTypes(settings, feature, hiddenEvents = []) {
     if (settings.commentsEnabled !== 'off') {
         extended.push({event: 'comment_event', icon: 'filter-dropdown-comments', name: 'Comments', group: 'others'});
     }
-    if (feature.audienceFeedback) {
-        extended.push({event: 'feedback_event', icon: 'filter-dropdown-feedback', name: 'Feedback', group: 'others'});
-    }
+    extended.push({event: 'feedback_event', icon: 'filter-dropdown-feedback', name: 'Feedback', group: 'others'});
     if (settings.emailTrackClicks) {
         extended.push({event: 'click_event', icon: 'filter-dropdown-clicked-in-email', name: 'Clicked link in email', group: 'others'});
     }

--- a/ghost/admin/tests/unit/utils/member-event-types-test.js
+++ b/ghost/admin/tests/unit/utils/member-event-types-test.js
@@ -8,9 +8,7 @@ describe('Unit | Utility | event-type-utils', function () {
             commentsEnabled: 'on',
             emailTrackClicks: true
         };
-        const feature = {
-            audienceFeedback: true
-        };
+        const feature = {};
         const hiddenEvents = [];
 
         const eventTypes = getAvailableEventTypes(settings, feature, hiddenEvents);
@@ -54,13 +52,16 @@ describe('Unit | Utility | event-type-utils', function () {
             commentsEnabled: 'off',
             emailTrackClicks: false
         };
-        const feature = {
-            audienceFeedback: false
-        };
+        const feature = {};
         const hiddenEvents = [];
 
         const eventTypes = getAvailableEventTypes(settings, feature, hiddenEvents);
 
-        expect(eventTypes).to.deep.equal(ALL_EVENT_TYPES);
+        // Feedback is always included now (audienceFeedback is GA)
+        const expectedTypes = [
+            ...ALL_EVENT_TYPES,
+            {event: 'feedback_event', icon: 'filter-dropdown-feedback', name: 'Feedback', group: 'others'}
+        ];
+        expect(eventTypes).to.deep.equal(expectedTypes);
     });
 });

--- a/ghost/core/core/server/services/members/members-api/repositories/event-repository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/event-repository.js
@@ -99,9 +99,7 @@ module.exports = class EventRepository {
 
         pageActions.push({type: 'email_complained_event', action: 'getEmailSpamComplaintEvents'});
 
-        if (this._labsService.isSet('audienceFeedback')) {
-            pageActions.push({type: 'feedback_event', action: 'getFeedbackEvents'});
-        }
+        pageActions.push({type: 'feedback_event', action: 'getFeedbackEvents'});
 
         //Filter events to query
         let filteredPages = pageActions;

--- a/ghost/core/core/server/services/newsletters/newsletters-service.js
+++ b/ghost/core/core/server/services/newsletters/newsletters-service.js
@@ -303,13 +303,6 @@ class NewslettersService {
             }
         }
 
-        if (cleanedAttrs.feedback_enabled) {
-            if (!this.labs.isSet('audienceFeedback')) {
-                // Not allowed to set to true
-                cleanedAttrs.feedback_enabled = false;
-            }
-        }
-
         // If one of the properties was changed, we need to reset sender_email in case it was not changed but is invalid in the database
         // which can happen after a config change (= auto correcting behaviour)
         const didChangeReplyTo = newsletter && attrs.sender_reply_to !== undefined && newsletter.get('sender_reply_to') !== attrs.sender_reply_to;

--- a/ghost/core/core/server/web/members/app.js
+++ b/ghost/core/core/server/web/members/app.js
@@ -123,7 +123,6 @@ module.exports = function setupMembersApp() {
     // Feedback
     membersApp.post(
         '/api/feedback',
-        labs.enabledMiddleware('audienceFeedback'),
         bodyParser.json({limit: '50mb'}),
         middleware.loadMemberSession,
         middleware.authMemberByUuid,

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -21,7 +21,6 @@ const messages = {
 
 // flags in this list always return `true`, allows quick global enable prior to full flag removal
 const GA_FEATURES = [
-    'audienceFeedback',
     'announcementBar',
     'customFonts',
     'explore',

--- a/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
@@ -11,7 +11,6 @@ Object {
     "labs": Object {
       "additionalPaymentMethods": true,
       "announcementBar": true,
-      "audienceFeedback": true,
       "commentModeration": true,
       "customFonts": true,
       "editorExcerpt": true,

--- a/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
@@ -1675,7 +1675,7 @@ exports[`Settings API Edit can edit Stripe settings when Stripe Connect limit is
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "5217",
+  "content-length": "5191",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/unit/shared/labs.test.js
+++ b/ghost/core/test/unit/shared/labs.test.js
@@ -67,15 +67,15 @@ describe('Labs Service', function () {
 
     it('respects the value in config over GA keys', function () {
         configUtils.set('labs', {
-            audienceFeedback: false
+            announcementBar: false
         });
 
         assert.deepEqual(labs.getAll(), expectedLabsObject({
-            audienceFeedback: false,
+            announcementBar: false,
             members: true
         }));
 
-        assert.equal(labs.isSet('audienceFeedback'), false);
+        assert.equal(labs.isSet('announcementBar'), false);
     });
 
     it('members flag is true when members_signup_access setting is "all"', function () {


### PR DESCRIPTION
## Summary
- Removed the `audienceFeedback` labs flag that was already in the GA_FEATURES list
- Audience feedback functionality (newsletter feedback, feedback events, feedback API endpoint) is now unconditionally enabled
- Updated tests to reflect the flag removal