### PR TITLE
Enabled caching for CDN/Object Storage images

### DIFF
--- a/ghost/core/core/server/adapters/storage/utils.js
+++ b/ghost/core/core/server/adapters/storage/utils.js
@@ -51,3 +51,18 @@ exports.isLocalImage = function isLocalImage(imagePath) {
         return false;
     }
 };
+
+/**
+ * @description checks if an image URL belongs to configured image base URL (e.g. CDN/S3)
+ * @param {String} imagePath as URL
+ * @param {String} imageBaseUrl configured image base URL
+ * @returns {Boolean}
+ */
+exports.isCDNImage = function isCDNImage(imagePath, imageBaseUrl) {
+    if (!imageBaseUrl || !imagePath) {
+        return false;
+    }
+
+    const normalizedImageBaseUrl = imageBaseUrl.replace(/\/+$/, '');
+    return imagePath.startsWith(`${normalizedImageBaseUrl}/`);
+};

--- a/ghost/core/core/server/lib/image/image-size.js
+++ b/ghost/core/core/server/lib/image/image-size.js
@@ -158,7 +158,9 @@ class ImageSize {
      * @returns {Promise<Object>} imageObject or error
      */
     getImageSizeFromUrl(imagePath) {
-        if (this.storageUtils.isLocalImage(imagePath)) {
+        const imageAssetBaseUrl = this.config.get('urls:image');
+
+        if (this.storageUtils.isLocalImage(imagePath) && !this.storageUtils.isCDNImage(imagePath, imageAssetBaseUrl)) {
             // don't make a request for a locally stored image
             return this.getImageSizeFromStoragePath(imagePath);
         }

--- a/ghost/core/test/unit/server/adapters/storage/utils.test.js
+++ b/ghost/core/test/unit/server/adapters/storage/utils.test.js
@@ -161,4 +161,60 @@ describe('storage utils', function () {
             assert.equal(result, false);
         });
     });
+
+    describe('fn: isCDNImage', function () {
+        it('should return true when image URL matches configured image base URL', function () {
+            const imagePath = 'https://cdn.example.com/c/site-uuid/content/images/2026/02/photo.jpg';
+            const imageBaseUrl = 'https://cdn.example.com/c/site-uuid';
+            const result = storageUtils.isCDNImage(imagePath, imageBaseUrl);
+            assert.equal(result, true);
+        });
+
+        it('should return true when image base URL has trailing slash', function () {
+            const imagePath = 'https://cdn.example.com/c/site-uuid/content/images/2026/02/photo.jpg';
+            const imageBaseUrl = 'https://cdn.example.com/c/site-uuid/';
+            const result = storageUtils.isCDNImage(imagePath, imageBaseUrl);
+            assert.equal(result, true);
+        });
+
+        it('should return false when image URL does not match configured image base URL', function () {
+            const imagePath = 'https://other.example.com/content/images/2026/02/photo.jpg';
+            const imageBaseUrl = 'https://cdn.example.com/c/site-uuid';
+            const result = storageUtils.isCDNImage(imagePath, imageBaseUrl);
+            assert.equal(result, false);
+        });
+
+        it('should return false for relative image path', function () {
+            const imagePath = '/content/images/2026/02/photo.jpg';
+            const imageBaseUrl = 'https://cdn.example.com/c/site-uuid';
+            const result = storageUtils.isCDNImage(imagePath, imageBaseUrl);
+            assert.equal(result, false);
+        });
+
+        it('should return false when image base URL is missing', function () {
+            const imagePath = 'https://cdn.example.com/c/site-uuid/content/images/2026/02/photo.jpg';
+            const result = storageUtils.isCDNImage(imagePath, '');
+            assert.equal(result, false);
+        });
+
+        it('should return false when image path is null', function () {
+            const imagePath = null;
+            const imageBaseUrl = 'https://cdn.example.com/c/site-uuid';
+            const result = storageUtils.isCDNImage(imagePath, imageBaseUrl);
+            assert.equal(result, false);
+        });
+
+        it('should return false when image path is undefined', function () {
+            const imageBaseUrl = 'https://cdn.example.com/c/site-uuid';
+            const result = storageUtils.isCDNImage(undefined, imageBaseUrl);
+            assert.equal(result, false);
+        });
+
+        it('should return false when image path is an empty string', function () {
+            const imagePath = '';
+            const imageBaseUrl = 'https://cdn.example.com/c/site-uuid';
+            const result = storageUtils.isCDNImage(imagePath, imageBaseUrl);
+            assert.equal(result, false);
+        });
+    });
 });

--- a/ghost/core/test/unit/server/lib/image/image-size.test.js
+++ b/ghost/core/test/unit/server/lib/image/image-size.test.js
@@ -42,7 +42,8 @@ describe('lib/image: image size', function () {
             const imageSize = new ImageSize({config: {
                 get: () => {}
             }, tpl: {}, storage: {}, storageUtils: {
-                isLocalImage: () => false
+                isLocalImage: () => false,
+                isCDNImage: () => false
             }, validator: {
                 isURL: () => true
             }, urlUtils: {}, request: {}, probe});
@@ -70,7 +71,8 @@ describe('lib/image: image size', function () {
             const imageSize = new ImageSize({config: {
                 get: () => {}
             }, tpl: {}, storage: {}, storageUtils: {
-                isLocalImage: () => false
+                isLocalImage: () => false,
+                isCDNImage: () => false
             }, validator: {
                 isURL: () => true
             }, urlUtils: {}, request: (requestUrl) => {
@@ -107,7 +109,8 @@ describe('lib/image: image size', function () {
             const imageSize = new ImageSize({config: {
                 get: () => {}
             }, tpl: {}, storage: {}, storageUtils: {
-                isLocalImage: () => false
+                isLocalImage: () => false,
+                isCDNImage: () => false
             }, validator: {
                 isURL: () => true
             }, urlUtils: {}, request: {}, probe});
@@ -138,7 +141,8 @@ describe('lib/image: image size', function () {
             const imageSize = new ImageSize({config: {
                 get: () => {}
             }, tpl: {}, storage: {}, storageUtils: {
-                isLocalImage: () => false
+                isLocalImage: () => false,
+                isCDNImage: () => false
             }, validator: {
                 isURL: () => true
             }, urlUtils: {}, request: {}, probe});
@@ -172,7 +176,8 @@ describe('lib/image: image size', function () {
             const imageSize = new ImageSize({config: {
                 get: () => {}
             }, tpl: {}, storage: {}, storageUtils: {
-                isLocalImage: () => false
+                isLocalImage: () => false,
+                isCDNImage: () => false
             }, validator: {
                 isURL: () => true
             }, urlUtils: {
@@ -218,7 +223,8 @@ describe('lib/image: image size', function () {
             const imageSize = new ImageSize({config: {
                 get: () => {}
             }, tpl: {}, storage: {}, storageUtils: {
-                isLocalImage: () => false
+                isLocalImage: () => false,
+                isCDNImage: () => false
             }, validator: {
                 isURL: () => true
             }, urlUtils: {}, request: {}, probe});
@@ -254,7 +260,8 @@ describe('lib/image: image size', function () {
             const imageSize = new ImageSize({config: {
                 get: () => {}
             }, tpl: {}, storage: {}, storageUtils: {
-                isLocalImage: () => false
+                isLocalImage: () => false,
+                isCDNImage: () => false
             }, validator: {
                 isURL: () => true
             }, urlUtils: {}, request: {}, probe});
@@ -299,6 +306,7 @@ describe('lib/image: image size', function () {
                 })
             }, storageUtils: {
                 isLocalImage: () => true,
+                isCDNImage: () => false,
                 getLocalImagesStoragePath: imageUrl => path.join(storagePath, imageUrl.replace(/.*\//, ''))
             }, validator: {}, urlUtils: {
                 urlFor: urlForStub,
@@ -318,6 +326,53 @@ describe('lib/image: image size', function () {
             }).catch(done);
         });
 
+        it('should fetch dimensions via URL for CDN image URL even if local-image check matches', function (done) {
+            const cdnUrl = 'https://cdn.example.com/c/site-uuid';
+            const imageUrl = `${cdnUrl}/content/images/2026/02/photo.jpg`;
+
+            const requestMock = nock('https://cdn.example.com')
+                .get('/c/site-uuid/content/images/2026/02/photo.jpg')
+                .reply(200, GIF1x1);
+
+            const storageReadSpy = sinon.spy(() => Promise.resolve(Buffer.from('')));
+
+            const imageSize = new ImageSize({
+                config: {
+                    get: (key) => {
+                        if (key === 'urls:image') {
+                            return cdnUrl;
+                        }
+                        return undefined;
+                    }
+                },
+                tpl: {},
+                storage: {
+                    getStorage: () => ({
+                        read: storageReadSpy
+                    })
+                },
+                storageUtils: {
+                    isLocalImage: () => true,
+                    isCDNImage: () => true
+                },
+                validator: {
+                    isURL: () => true
+                },
+                urlUtils: {},
+                request: {},
+                probe
+            });
+
+            imageSize.getImageSizeFromUrl(imageUrl).then(function (res) {
+                assert.equal(requestMock.isDone(), true);
+                assert.equal(storageReadSpy.called, false);
+                assert.equal(res.width, 1);
+                assert.equal(res.height, 1);
+                assert.equal(res.url, imageUrl);
+                done();
+            }).catch(done);
+        });
+
         it('[failure] can handle an error with statuscode not 200 (probe-image-size)', function (done) {
             const url = 'http://noimagehere.com/files/f/feedough/x/11/1540353_20925115.jpg';
 
@@ -328,7 +383,8 @@ describe('lib/image: image size', function () {
             const imageSize = new ImageSize({config: {
                 get: () => {}
             }, tpl: {}, storage: {}, storageUtils: {
-                isLocalImage: () => false
+                isLocalImage: () => false,
+                isCDNImage: () => false
             }, validator: {
                 isURL: () => true
             }, urlUtils: {}, request: {}, probe});
@@ -361,7 +417,8 @@ describe('lib/image: image size', function () {
             const imageSize = new ImageSize({config: {
                 get: () => {}
             }, tpl: {}, storage: {}, storageUtils: {
-                isLocalImage: () => false
+                isLocalImage: () => false,
+                isCDNImage: () => false
             }, validator: {
                 isURL: () => true
             }, urlUtils: {}, request: (requestUrl) => {
@@ -387,7 +444,8 @@ describe('lib/image: image size', function () {
             const imageSize = new ImageSize({config: {
                 get: () => {}
             }, tpl: {}, storage: {}, storageUtils: {
-                isLocalImage: () => false
+                isLocalImage: () => false,
+                isCDNImage: () => false
             }, validator: {
                 isURL: () => false
             }, urlUtils: {}, request: {}, probe});
@@ -416,7 +474,8 @@ describe('lib/image: image size', function () {
                     }
                 }
             }, tpl: {}, storage: {}, storageUtils: {
-                isLocalImage: () => false
+                isLocalImage: () => false,
+                isCDNImage: () => false
             }, validator: {
                 isURL: () => true
             }, urlUtils: {}, request: {},
@@ -445,7 +504,8 @@ describe('lib/image: image size', function () {
             const imageSize = new ImageSize({config: {
                 get: () => {}
             }, tpl: {}, storage: {}, storageUtils: {
-                isLocalImage: () => false
+                isLocalImage: () => false,
+                isCDNImage: () => false
             }, validator: {
                 isURL: () => true
             }, urlUtils: {}, request: {}, probe});
@@ -472,7 +532,8 @@ describe('lib/image: image size', function () {
             const imageSize = new ImageSize({config: {
                 get: () => {}
             }, tpl: {}, storage: {}, storageUtils: {
-                isLocalImage: () => false
+                isLocalImage: () => false,
+                isCDNImage: () => false
             }, validator: {
                 isURL: () => true
             }, urlUtils: {}, request: (requestUrl) => {
@@ -502,7 +563,8 @@ describe('lib/image: image size', function () {
             const imageSize = new ImageSize({config: {
                 get: () => {}
             }, tpl: {}, storage: {}, storageUtils: {
-                isLocalImage: () => false
+                isLocalImage: () => false,
+                isCDNImage: () => false
             }, validator: {
                 isURL: () => true
             }, urlUtils: {}, request: () => {
@@ -531,7 +593,8 @@ describe('lib/image: image size', function () {
                     }
                 }
             }, tpl: {}, storage: {}, storageUtils: {
-                isLocalImage: () => false
+                isLocalImage: () => false,
+                isCDNImage: () => false
             }, validator: {
                 isURL: () => true
             }, urlUtils: {}, request: {},
@@ -575,6 +638,7 @@ describe('lib/image: image size', function () {
                 })
             }, storageUtils: {
                 isLocalImage: () => true,
+                isCDNImage: () => false,
                 getLocalImagesStoragePath: imageUrl => path.join(storagePath, imageUrl.replace(/.*\//, ''))
             }, validator: {}, urlUtils: {
                 urlFor: urlForStub,
@@ -618,6 +682,7 @@ describe('lib/image: image size', function () {
                 })
             }, storageUtils: {
                 isLocalImage: () => true,
+                isCDNImage: () => false,
                 getLocalImagesStoragePath: imageUrl => path.join(storagePath, imageUrl.replace(/.*\//, ''))
             }, validator: {}, urlUtils: {
                 urlFor: urlForStub,
@@ -661,6 +726,7 @@ describe('lib/image: image size', function () {
                 })
             }, storageUtils: {
                 isLocalImage: () => true,
+                isCDNImage: () => false,
                 getLocalImagesStoragePath: imageUrl => path.join(storagePath, imageUrl.replace(/.*\//, ''))
             }, validator: {}, urlUtils: {
                 urlFor: urlForStub,
@@ -704,6 +770,7 @@ describe('lib/image: image size', function () {
                 })
             }, storageUtils: {
                 isLocalImage: () => true,
+                isCDNImage: () => false,
                 getLocalImagesStoragePath: imageUrl => path.join(storagePath, imageUrl.replace(/.*\//, ''))
             }, validator: {}, urlUtils: {
                 urlFor: urlForStub,
@@ -744,6 +811,7 @@ describe('lib/image: image size', function () {
                 })
             }, storageUtils: {
                 isLocalImage: () => true,
+                isCDNImage: () => false,
                 getLocalImagesStoragePath: imageUrl => path.join(storagePath, imageUrl.replace(/.*\//, ''))
             }, validator: {}, urlUtils: {
                 urlFor: urlForStub,
@@ -779,6 +847,7 @@ describe('lib/image: image size', function () {
                 })
             }, storageUtils: {
                 isLocalImage: () => true,
+                isCDNImage: () => false,
                 getLocalImagesStoragePath: () => ''
             }, validator: {}, urlUtils: {
                 urlFor: urlForStub,


### PR DESCRIPTION
ref https://linear.app/ghost/issue/HKG-1582/

This PR adds support for S3/CDN images in the image-size cache flow, so Ghost can cache and reuse their dimensions just like local images.

- We want to cache the CDN/S3 images
- Added a new helper to detect S3/CDN images.
- Added a guard in `getImageSizeFromUrl` so S3/CDN images do not go through the local-image read path.
- This ensures CDN images follow the existing URL-based dimension lookup flow, which fetches dimensions over HTTP using the public S3/CDN URL.
- Added test for the new detection helper and the updated image-size behavior.
