### PR TITLE
Replaced calls to `should()` function with assert

### DIFF
--- a/ghost/core/test/e2e-api/admin/members-exporter.test.js
+++ b/ghost/core/test/e2e-api/admin/members-exporter.test.js
@@ -4,7 +4,6 @@ const {agentProvider, mockManager, fixtureManager, matchers} = require('../../ut
 const {anyContentVersion, anyString} = matchers;
 
 const crypto = require('crypto');
-const should = require('should');
 const Papa = require('papaparse');
 const models = require('../../../core/server/models');
 const moment = require('moment');
@@ -25,12 +24,12 @@ let tiers, labels, newsletters;
 
 function basicAsserts(member, row) {
     // Basic checks
-    should(row.email).eql(member.get('email'));
-    should(row.name).eql(member.get('name'));
-    should(row.note).eql(member.get('note') || '');
+    assert.equal(row.email, member.get('email'));
+    assert.equal(row.name, member.get('name'));
+    assert.equal(row.note, member.get('note') || '');
 
     assert.equal(row.deleted_at, '');
-    should(row.created_at).eql(moment(member.get('created_at')).toISOString());
+    assert.equal(row.created_at, moment(member.get('created_at')).toISOString());
 }
 
 /**
@@ -120,7 +119,7 @@ describe('Members API — exportCSV', function () {
             basicAsserts(member, row);
             assert.equal(row.subscribed_to_emails, 'false');
             assert.equal(row.complimentary_plan, '');
-            should(row.tiers.split(',').sort().join(',')).eql(tiersList);
+            assert.equal(row.tiers.split(',').sort().join(','), tiersList);
         }, [`filter=tier:[${tiers[0].get('slug')}]`, 'filter=subscribed:false']);
     });
 
@@ -157,7 +156,7 @@ describe('Members API — exportCSV', function () {
             basicAsserts(member, row);
             assert.equal(row.subscribed_to_emails, 'false');
             assert.equal(row.complimentary_plan, '');
-            should(row.labels.split(',').sort().join(',')).eql(labelsList);
+            assert.equal(row.labels.split(',').sort().join(','), labelsList);
             assert.equal(row.tiers, '');
         }, [`filter=label:${labels[0].get('slug')}`, 'filter=subscribed:false']);
     });

--- a/ghost/core/test/e2e-api/admin/members.test.js
+++ b/ghost/core/test/e2e-api/admin/members.test.js
@@ -4,7 +4,7 @@ const {queryStringToken} = regexes;
 const ObjectId = require('bson-objectid').default;
 
 const assert = require('node:assert/strict');
-const {assertExists, assertObjectMatches} = require('../../utils/assertions');
+const {assertExists, assertArrayContainsDeep, assertObjectMatches} = require('../../utils/assertions');
 const nock = require('nock');
 const sinon = require('sinon');
 const should = require('should');
@@ -480,7 +480,7 @@ describe('Members API - member attribution', function () {
             })
             .expect(({body}) => {
                 assert.equal(body.events.find(e => e.type !== 'signup_event'), undefined);
-                should(body.events.map(e => e.data.attribution)).containDeep(signupAttributions);
+                assertArrayContainsDeep(body.events.map(e => e.data.attribution), signupAttributions);
             });
     });
 });
@@ -1860,7 +1860,7 @@ describe('Members API', function () {
         // Check that the product that we are going to add is not the same as the existing one
         const product = await getOtherPaidProduct();
         assert.equal(memberWithPaidSubscription.tiers.length, 1);
-        should(memberWithPaidSubscription.tiers[0].id).not.eql(product.id);
+        assert.notEqual(memberWithPaidSubscription.tiers[0].id, product.id);
 
         // Add it manually
         await models.Member.edit({

--- a/ghost/core/test/e2e-api/admin/offers.test.js
+++ b/ghost/core/test/e2e-api/admin/offers.test.js
@@ -2,7 +2,6 @@ const assert = require('node:assert/strict');
 const {assertObjectMatches} = require('../../utils/assertions');
 const {agentProvider, fixtureManager, matchers} = require('../../utils/e2e-framework');
 const {anyContentVersion, anyEtag, anyObjectId, anyLocationFor, anyErrorId, anyISODateTime} = matchers;
-const should = require('should');
 const models = require('../../../core/server/models');
 const sinon = require('sinon');
 const logging = require('@tryghost/logging');
@@ -297,8 +296,8 @@ describe('Offers API', function () {
                 }]
             })
             .expect(({body}) => {
-                body.offers[0].redemption_type.should.eql('retention');
-                should(body.offers[0].tier).be.null();
+                assert.equal(body.offers[0].redemption_type, 'retention');
+                assert.equal(body.offers[0].tier, null);
             });
     });
 
@@ -646,7 +645,7 @@ describe('Offers API', function () {
                 })
             })
             .expect(({body}) => {
-                body.offers[0].should.match(updatedOffer);
+                assertObjectMatches(body.offers[0], updatedOffer);
             });
     });
 
@@ -809,7 +808,7 @@ describe('Offers API', function () {
                 })
             })
             .expect(({body}) => {
-                body.offers[0].tier.id.should.eql(defaultTier.id);
+                assert.equal(body.offers[0].tier.id, defaultTier.id);
             });
     });
 });

--- a/ghost/core/test/e2e-api/members-comments/comments.test.js
+++ b/ghost/core/test/e2e-api/members-comments/comments.test.js
@@ -435,7 +435,7 @@ describe('Comments API', function () {
 
                 // go through all comments and check if the deleted comment is not there
                 data2.body.comments.forEach((comment) => {
-                    should(comment.html).not.eql('This is a deleted comment');
+                    assert.notEqual(comment.html, 'This is a deleted comment');
                 });
 
                 assert.equal(data2.body.comments.length, 0);
@@ -845,7 +845,7 @@ describe('Comments API', function () {
                 // get the LAST comment from data2
                 let lastComment = data2.body.comments[data2.body.comments.length - 1];
 
-                should(lastComment.id).eql(oldestComment.id);
+                assert.equal(lastComment.id, oldestComment.id);
             });
 
             it('Can reply to your own comment', async function () {
@@ -1107,7 +1107,7 @@ describe('Comments API', function () {
                         assert.equal(body.meta.pagination.next, null);
 
                         // Check liked + likes working for replies too
-                        should(body.comments[2].id).eql(replies[2].get('id'));
+                        assert.equal(body.comments[2].id, replies[2].get('id'));
                         assert.equal(body.comments[2].count.likes, 1);
                         assert.equal(body.comments[2].liked, true);
                     });
@@ -1170,7 +1170,7 @@ describe('Comments API', function () {
                 assert.equal(reports.models.length, 1);
 
                 const report = reports.models[0];
-                report.get('member_id').should.eql(loggedInMember.id);
+                assert.equal(report.get('member_id'), loggedInMember.id);
 
                 mockManager.assert.sentEmail({
                     subject: '🚩 A comment has been reported on your post',
@@ -1196,7 +1196,7 @@ describe('Comments API', function () {
                 assert.equal(reports.models.length, 1);
 
                 const report = reports.models[0];
-                report.get('member_id').should.eql(loggedInMember.id);
+                assert.equal(report.get('member_id'), loggedInMember.id);
 
                 emailMockReceiver.assertSentEmailCount(0);
             });
@@ -1481,7 +1481,7 @@ describe('Comments API', function () {
                     });
 
                     // in_reply_to is set
-                    newComment.in_reply_to_id.should.eql(reply.get('id'));
+                    assert.equal(newComment.in_reply_to_id, reply.get('id'));
                     assert.equal(newComment.in_reply_to_snippet, 'This is a reply');
 
                     // replied-to comment author is notified

--- a/ghost/core/test/e2e-api/members/create-stripe-checkout-session.test.js
+++ b/ghost/core/test/e2e-api/members/create-stripe-checkout-session.test.js
@@ -405,9 +405,9 @@ describe('Create Stripe Checkout Session', function () {
                 .reply((uri, body) => {
                     if (uri === '/v1/checkout/sessions') {
                         const parsed = new URLSearchParams(body);
-                        should(parsed.get('metadata[attribution_url]')).eql(url);
+                        assert.equal(parsed.get('metadata[attribution_url]'), url);
                         assert.equal(parsed.get('metadata[attribution_type]'), 'post');
-                        should(parsed.get('metadata[attribution_id]')).eql(post.id);
+                        assert.equal(parsed.get('metadata[attribution_id]'), post.id);
 
                         return [200, {id: 'cs_123', url: 'https://site.com'}];
                     }

--- a/ghost/core/test/legacy/api/admin/update-user-last-seen.test.js
+++ b/ghost/core/test/legacy/api/admin/update-user-last-seen.test.js
@@ -1,6 +1,6 @@
+const assert = require('assert/strict');
 const {assertExists} = require('../../../utils/assertions');
 const sinon = require('sinon');
-const should = require('should');
 
 const {DataGenerator} = require('../../../utils');
 const {agentProvider, fixtureManager} = require('../../../utils/e2e-framework');
@@ -58,7 +58,7 @@ describe('Update User Last Seen', function () {
 
         const ownerAfter = await models.User.findOne({id: userId});
         assertExists(ownerAfter);
-        should(ownerAfter.get('last_seen')).not.eql(lastSeen);
+        assert.notDeepEqual(ownerAfter.get('last_seen'), lastSeen);
     });
 
     it('Should only update last seen after 1 hour', async function () {
@@ -75,7 +75,7 @@ describe('Update User Last Seen', function () {
 
         const ownerAfter = await models.User.findOne({id: userId});
         assertExists(ownerAfter);
-        should(ownerAfter.get('last_seen')).eql(lastSeen);
+        assert.deepEqual(ownerAfter.get('last_seen'), lastSeen);
     });
 
     it('Should always update last seen after login', async function () {
@@ -87,7 +87,7 @@ describe('Update User Last Seen', function () {
 
         const ownerAfter = await models.User.findOne({id: userId});
         assertExists(ownerAfter);
-        should(ownerAfter.get('last_seen')).not.eql(lastSeen);
+        assert.notDeepEqual(ownerAfter.get('last_seen'), lastSeen);
     });
 
     it('Should not update last seen for suspended users', async function () {
@@ -112,6 +112,6 @@ describe('Update User Last Seen', function () {
 
         const ownerAfter = await models.User.findOne({id: userId});
         assertExists(ownerAfter);
-        should(ownerAfter.get('last_seen')).eql(lastSeen);
+        assert.deepEqual(ownerAfter.get('last_seen'), lastSeen);
     });
 });

--- a/ghost/core/test/unit/server/data/importer/index.test.js
+++ b/ghost/core/test/unit/server/data/importer/index.test.js
@@ -1,7 +1,6 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../utils/assertions');
 const errors = require('@tryghost/errors');
-const should = require('should');
 const sinon = require('sinon');
 const rewire = require('rewire');
 const _ = require('lodash');
@@ -235,7 +234,7 @@ describe('Importer', function () {
                         // They should both have data keys, and they should be equivalent
                         assert('data' in zipResult);
                         assert('data' in fileResult);
-                        zipResult.should.eql(fileResult);
+                        assert.deepEqual(zipResult, fileResult);
                         done();
                     });
                 }).catch(done);
@@ -398,7 +397,7 @@ describe('Importer', function () {
                 it('throws invalidZipFileBaseDirectory', function () {
                     const testDir = path.resolve('test/utils/fixtures/import/zips/zip-empty');
 
-                    should(() => ImportManager.getBaseDirectory(testDir)).throwError(/invalid zip file/i);
+                    assert.throws(() => ImportManager.getBaseDirectory(testDir), /invalid zip file/i);
                 });
             });
 
@@ -445,7 +444,7 @@ describe('Importer', function () {
                     assert.equal(imageSpy.calledWith(inputCopy), true);
                     // eql checks for equality
                     // equal checks the references are for the same object
-                    output.should.not.equal(input);
+                    assert.notEqual(output, input);
                     assert.equal(output.preProcessedByData, true);
                     assert.equal(output.preProcessedByImage, true);
                     assert.equal(output.preProcessedByMedia, true);
@@ -483,8 +482,8 @@ describe('Importer', function () {
                     // equal checks the references are for the same object
                     assert.equal(dataSpy.calledOnce, true);
                     assert.equal(imageSpy.calledOnce, true);
-                    dataSpy.getCall(0).args[0].should.eql(expectedData);
-                    imageSpy.getCall(0).args[0].should.eql(expectedImages);
+                    assert.deepEqual(dataSpy.getCall(0).args[0], expectedData);
+                    assert.deepEqual(imageSpy.getCall(0).args[0], expectedImages);
 
                     // we stubbed this as a noop but ImportManager calls with sequence, so we should get an array
                     assert.deepEqual(output, {images: expectedImages, data: expectedData});
@@ -671,7 +670,7 @@ describe('Importer', function () {
             }];
 
             MarkdownHandler.loadFile(file).then(function (result) {
-                result.data.posts.should.be.empty();
+                assert.equal(result.data.posts.length, 0);
 
                 done();
             }).catch(done);
@@ -732,9 +731,9 @@ describe('Importer', function () {
             const outputData = DataImporter.preProcess(_.cloneDeep(inputData));
 
             // Data preprocess is a noop
-            inputData.data.data.posts[0].should.eql(outputData.data.data.posts[0]);
-            inputData.data.data.tags[0].should.eql(outputData.data.data.tags[0]);
-            inputData.data.data.users[0].should.eql(outputData.data.data.users[0]);
+            assert.deepEqual(inputData.data.data.posts[0], outputData.data.data.posts[0]);
+            assert.deepEqual(inputData.data.data.tags[0], outputData.data.data.tags[0]);
+            assert.deepEqual(inputData.data.data.users[0], outputData.data.data.users[0]);
         });
     });
 });

--- a/ghost/core/test/unit/server/services/link-tracking/link-click-tracking-service.test.js
+++ b/ghost/core/test/unit/server/services/link-tracking/link-click-tracking-service.test.js
@@ -1,6 +1,5 @@
 const LinkClickTrackingService = require('../../../../../core/server/services/link-tracking/link-click-tracking-service');
 const sinon = require('sinon');
-const should = require('should');
 const assert = require('node:assert/strict');
 const ObjectID = require('bson-objectid').default;
 const PostLink = require('../../../../../core/server/services/link-tracking/post-link');
@@ -343,7 +342,10 @@ describe('LinkClickTrackingService', function () {
                 }
             };
 
-            await should(service.bulkEdit(data, options)).be.rejectedWith(errors.BadRequestError);
+            await assert.rejects(
+                service.bulkEdit(data, options),
+                errors.BadRequestError
+            );
         });
     });
 });

--- a/ghost/core/test/unit/server/services/member-attribution/history.test.js
+++ b/ghost/core/test/unit/server/services/member-attribution/history.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 
 const UrlHistory = require('../../../../../core/server/services/member-attribution/url-history');
 
@@ -95,7 +94,7 @@ describe('UrlHistory', function () {
         ];
         for (const input of inputs) {
             const history = UrlHistory.create(input);
-            should(history.history).eql(input);
+            assert.deepEqual(history.history, input);
         }
     });
 

--- a/ghost/core/test/unit/server/services/member-attribution/service.test.js
+++ b/ghost/core/test/unit/server/services/member-attribution/service.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 
 const MemberAttributionService = require('../../../../../core/server/services/member-attribution/member-attribution-service');
 
@@ -216,7 +215,7 @@ describe('MemberAttributionService', function () {
             const service = new MemberAttributionService({
                 attributionBuilder: {
                     getAttribution: async function (history) {
-                        should(history).have.property('length');
+                        assert('length' in history);
                         return {success: true};
                     }
                 },


### PR DESCRIPTION
This test-only change should have no user impact.

We had various calls like `should(actual).eql(expected)` and similar. This replaces all of them with calls to `node:assert`, or wrappers around that.

`git grep -F 'should('` returns no results after this change.
