### PR TITLE
Replaced `value.should.be.an.Array()` with `node:assert`

### DIFF
--- a/ghost/core/test/e2e-api/admin/themes.test.js
+++ b/ghost/core/test/e2e-api/admin/themes.test.js
@@ -184,8 +184,6 @@ describe('Themes API', function () {
                 tmpFolderContents.splice(i, 1);
             }
         }
-        tmpFolderContents.should.be.an.Array().with.lengthOf(12);
-
         assert.deepEqual(tmpFolderContents, [
             'broken-theme',
             'casper',

--- a/ghost/core/test/e2e-api/admin/themes.test.js
+++ b/ghost/core/test/e2e-api/admin/themes.test.js
@@ -234,7 +234,7 @@ describe('Themes API', function () {
         localUtils.API.checkResponse(jsonResponse.themes[0], 'theme', ['warnings']);
         assert.equal(jsonResponse.themes[0].name, 'warnings');
         assert.equal(jsonResponse.themes[0].active, false);
-        jsonResponse.themes[0].warnings.should.be.an.Array();
+        assert(Array.isArray(jsonResponse.themes[0].warnings));
 
         // Delete the theme to clean up after the test
         await ownerRequest
@@ -285,7 +285,7 @@ describe('Themes API', function () {
         assertExists(testTheme2);
         localUtils.API.checkResponse(testTheme2, 'theme', ['warnings', 'templates']);
         assert.equal(testTheme2.active, true);
-        testTheme2.warnings.should.be.an.Array();
+        assert(Array.isArray(testTheme2.warnings));
 
         // Result should be the same
         const activeThemeResult = await ownerRequest
@@ -323,7 +323,7 @@ describe('Themes API', function () {
         localUtils.API.checkResponse(jsonResponse.themes[0], 'theme', ['warnings']);
         assert.equal(jsonResponse.themes[0].name, 'test');
         assert.equal(jsonResponse.themes[0].active, false);
-        jsonResponse.themes[0].warnings.should.be.an.Array();
+        assert(Array.isArray(jsonResponse.themes[0].warnings));
 
         // Delete the theme to clean up after the test
         await ownerRequest
@@ -366,7 +366,7 @@ describe('Themes API', function () {
         localUtils.API.checkResponse(jsonResponse.themes[0], 'theme', ['warnings']);
         assert.equal(jsonResponse.themes[0].name, 'starter');
         assert.equal(jsonResponse.themes[0].active, false);
-        jsonResponse.themes[0].warnings.should.be.an.Array();
+        assert(Array.isArray(jsonResponse.themes[0].warnings));
 
         // Delete the theme to clean up after the test
         await ownerRequest

--- a/ghost/core/test/e2e-api/content/tags.test.js
+++ b/ghost/core/test/e2e-api/content/tags.test.js
@@ -97,8 +97,8 @@ describe('Tags Content API', function () {
 
         const jsonResponse = res.body;
 
-        assertExists(jsonResponse.tags);
-        jsonResponse.tags.should.be.an.Array().with.lengthOf(5);
+        assert(Array.isArray(jsonResponse.tags));
+        assert.equal(jsonResponse.tags.length, 5);
 
         // Each tag should have the correct count
         assert.equal(_.find(jsonResponse.tags, {name: 'Getting Started'}).count.posts, 7);

--- a/ghost/core/test/e2e-frontend/helpers/get.test.js
+++ b/ghost/core/test/e2e-frontend/helpers/get.test.js
@@ -30,7 +30,7 @@ function buildMember(status, products = []) {
 }
 
 function testPosts(posts, map) {
-    posts.should.be.an.Array();
+    assert(Array.isArray(posts));
     posts.length.should.eql(DEFAULT_POST_FIXTURE_COUNT + Object.keys(map).length);
 
     // Free post

--- a/ghost/core/test/legacy/api/content/authors.test.js
+++ b/ghost/core/test/legacy/api/content/authors.test.js
@@ -120,7 +120,8 @@ describe('Authors Content API', function () {
             .then((res) => {
                 const jsonResponse = res.body;
 
-                jsonResponse.authors.should.be.an.Array().with.lengthOf(3);
+                assert(Array.isArray(jsonResponse.authors));
+                assert.equal(jsonResponse.authors.length, 3);
                 assert.equal(jsonResponse.authors[0].slug, 'joe-bloggs');
                 assert.equal(jsonResponse.authors[1].slug, 'ghost');
                 assert.equal(jsonResponse.authors[2].slug, 'slimer-mcectoplasm');

--- a/ghost/core/test/legacy/api/content/pages.test.js
+++ b/ghost/core/test/legacy/api/content/pages.test.js
@@ -114,7 +114,8 @@ describe('api/endpoints/content/pages', function () {
             .then((res) => {
                 const jsonResponse = res.body;
 
-                jsonResponse.pages.should.be.an.Array().with.lengthOf(1);
+                assert(Array.isArray(jsonResponse.pages));
+                assert.equal(jsonResponse.pages.length, 1);
                 assert.equal(jsonResponse.pages[0].slug, 'static-page-test');
             });
     });

--- a/ghost/core/test/legacy/api/content/posts.test.js
+++ b/ghost/core/test/legacy/api/content/posts.test.js
@@ -208,7 +208,8 @@ describe('api/endpoints/content/posts', function () {
                 }
                 const jsonResponse = res.body;
 
-                jsonResponse.posts.should.be.an.Array().with.lengthOf(13);
+                assert(Array.isArray(jsonResponse.posts));
+                assert.equal(jsonResponse.posts.length, 13);
 
                 done();
             });
@@ -222,7 +223,8 @@ describe('api/endpoints/content/posts', function () {
             .then((res) => {
                 const jsonResponse = res.body;
 
-                jsonResponse.posts.should.be.an.Array().with.lengthOf(3);
+                assert(Array.isArray(jsonResponse.posts));
+                assert.equal(jsonResponse.posts.length, 3);
                 assert.equal(jsonResponse.posts[0].slug, 'write');
                 assert.equal(jsonResponse.posts[1].slug, 'ghostly-kitchen-sink');
                 assert.equal(jsonResponse.posts[2].slug, 'grow');
@@ -237,7 +239,8 @@ describe('api/endpoints/content/posts', function () {
             .then((res) => {
                 const jsonResponse = res.body;
 
-                jsonResponse.posts.should.be.an.Array().with.lengthOf(3);
+                assert(Array.isArray(jsonResponse.posts));
+                assert.equal(jsonResponse.posts.length, 3);
                 assert.equal(jsonResponse.posts[0].slug, 'write');
                 assert.equal(jsonResponse.posts[1].slug, 'grow');
                 assert.equal(jsonResponse.posts[2].slug, 'ghostly-kitchen-sink');

--- a/ghost/core/test/legacy/api/content/tags.test.js
+++ b/ghost/core/test/legacy/api/content/tags.test.js
@@ -75,7 +75,8 @@ describe('api/endpoints/content/tags', function () {
             .then((res) => {
                 const jsonResponse = res.body;
 
-                jsonResponse.tags.should.be.an.Array().with.lengthOf(3);
+                assert(Array.isArray(jsonResponse.tags));
+                assert.equal(jsonResponse.tags.length, 3);
                 assert.equal(jsonResponse.tags[0].slug, 'kitchen-sink');
                 assert.equal(jsonResponse.tags[1].slug, 'bacon');
                 assert.equal(jsonResponse.tags[2].slug, 'chorizo');

--- a/ghost/core/test/legacy/models/model-posts.test.js
+++ b/ghost/core/test/legacy/models/model-posts.test.js
@@ -2011,7 +2011,8 @@ describe('Post Model', function () {
         it('should create the test data correctly', function (done) {
             // creates a test tag
             assertExists(tagJSON);
-            tagJSON.should.be.an.Array().with.lengthOf(3);
+            assert(Array.isArray(tagJSON));
+            assert.equal(tagJSON.length, 3);
 
             assert.equal(tagJSON[0].name, 'existing tag a');
             assert.equal(tagJSON[1].name, 'existing-tag-b');
@@ -2020,8 +2021,8 @@ describe('Post Model', function () {
             // creates a test post with an array of tags in the correct order
             assertExists(postJSON);
             assert.equal(postJSON.title, 'HTML Ipsum');
-            assertExists(postJSON.tags);
-            postJSON.tags.should.be.an.Array().and.have.lengthOf(3);
+            assert(Array.isArray(postJSON.tags));
+            assert.equal(postJSON.tags.length, 3);
 
             assert.equal(postJSON.tags[0].name, 'tag1');
             assert.equal(postJSON.tags[1].name, 'tag2');

--- a/ghost/core/test/unit/frontend/helpers/get.test.js
+++ b/ghost/core/test/unit/frontend/helpers/get.test.js
@@ -239,7 +239,8 @@ describe('{{#get}} helper', function () {
                 'posts',
                 {hash: {filter: 'tags:[{{post.tags}}]'}, data: locals, fn: fn, inverse: inverse}
             ).then(function () {
-                browseStub.firstCall.args.should.be.an.Array().with.lengthOf(1);
+                assert(Array.isArray(browseStub.firstCall.args));
+                assert.equal(browseStub.firstCall.args.length, 1);
                 browseStub.firstCall.args[0].should.be.an.Object().with.property('filter');
                 assert.equal(browseStub.firstCall.args[0].filter, 'tags:[test,magic]');
 
@@ -253,7 +254,8 @@ describe('{{#get}} helper', function () {
                 'posts',
                 {hash: {filter: 'author:{{post.author}}'}, data: locals, fn: fn, inverse: inverse}
             ).then(function () {
-                browseStub.firstCall.args.should.be.an.Array().with.lengthOf(1);
+                assert(Array.isArray(browseStub.firstCall.args));
+                assert.equal(browseStub.firstCall.args.length, 1);
                 browseStub.firstCall.args[0].should.be.an.Object().with.property('filter');
                 assert.equal(browseStub.firstCall.args[0].filter, 'author:cameron');
 
@@ -267,7 +269,8 @@ describe('{{#get}} helper', function () {
                 'posts',
                 {hash: {filter: 'id:-{{post.id}}'}, data: locals, fn: fn, inverse: inverse}
             ).then(function () {
-                browseStub.firstCall.args.should.be.an.Array().with.lengthOf(1);
+                assert(Array.isArray(browseStub.firstCall.args));
+                assert.equal(browseStub.firstCall.args.length, 1);
                 browseStub.firstCall.args[0].should.be.an.Object().with.property('filter');
                 assert.equal(browseStub.firstCall.args[0].filter, 'id:-3');
 
@@ -281,7 +284,8 @@ describe('{{#get}} helper', function () {
                 'posts',
                 {hash: {filter: 'tags:{{post.tags.[0].slug}}'}, data: locals, fn: fn, inverse: inverse}
             ).then(function () {
-                browseStub.firstCall.args.should.be.an.Array().with.lengthOf(1);
+                assert(Array.isArray(browseStub.firstCall.args));
+                assert.equal(browseStub.firstCall.args.length, 1);
                 browseStub.firstCall.args[0].should.be.an.Object().with.property('filter');
                 assert.equal(browseStub.firstCall.args[0].filter, 'tags:test');
 
@@ -295,7 +299,8 @@ describe('{{#get}} helper', function () {
                 'posts',
                 {hash: {filter: 'published_at:<=\'{{post.published_at}}\''}, data: locals, fn: fn, inverse: inverse}
             ).then(function () {
-                browseStub.firstCall.args.should.be.an.Array().with.lengthOf(1);
+                assert(Array.isArray(browseStub.firstCall.args));
+                assert.equal(browseStub.firstCall.args.length, 1);
                 browseStub.firstCall.args[0].should.be.an.Object().with.property('filter');
                 browseStub.firstCall.args[0].filter.should.eql(`published_at:<='${pubDate.toISOString()}'`);
 
@@ -309,7 +314,8 @@ describe('{{#get}} helper', function () {
                 'posts',
                 {hash: {filter: 'id:{{post.thing}}'}, data: locals, fn: fn, inverse: inverse}
             ).then(function () {
-                browseStub.firstCall.args.should.be.an.Array().with.lengthOf(1);
+                assert(Array.isArray(browseStub.firstCall.args));
+                assert.equal(browseStub.firstCall.args.length, 1);
                 browseStub.firstCall.args[0].should.be.an.Object().with.property('filter');
                 assert.equal(browseStub.firstCall.args[0].filter, 'id:');
 
@@ -323,7 +329,8 @@ describe('{{#get}} helper', function () {
                 'posts',
                 {hash: {filter: 'slug:{{@globalProp.foo}}'}, data: locals, fn: fn, inverse: inverse}
             ).then(function () {
-                browseStub.firstCall.args.should.be.an.Array().with.lengthOf(1);
+                assert(Array.isArray(browseStub.firstCall.args));
+                assert.equal(browseStub.firstCall.args.length, 1);
                 browseStub.firstCall.args[0].should.be.an.Object().with.property('filter');
                 assert.equal(browseStub.firstCall.args[0].filter, 'slug:bar');
 
@@ -554,7 +561,8 @@ describe('{{#get}} helper', function () {
             // The get helper will return as per usual
             assert.equal(fn.calledOnce, true);
             fn.firstCall.args[0].should.be.an.Object().with.property('posts');
-            fn.firstCall.args[0].posts.should.be.an.Array().with.lengthOf(1);
+            assert(Array.isArray(fn.firstCall.args[0].posts));
+            assert.equal(fn.firstCall.args[0].posts.length, 1);
         });
 
         it('should log an error and return safely if it hits the timeout threshold', async function () {

--- a/ghost/core/test/unit/frontend/helpers/get.test.js
+++ b/ghost/core/test/unit/frontend/helpers/get.test.js
@@ -572,7 +572,7 @@ describe('{{#get}} helper', function () {
             // The get helper gets called with an empty array of results
             assert.equal(fn.calledOnce, true);
             fn.firstCall.args[0].should.be.an.Object().with.property('posts');
-            fn.firstCall.args[0].posts.should.be.an.Array().with.lengthOf(0);
+            assert.deepEqual(fn.firstCall.args[0].posts, []);
         });
     });
 });

--- a/ghost/core/test/unit/frontend/services/assets-minification/minifier.test.js
+++ b/ghost/core/test/unit/frontend/services/assets-minification/minifier.test.js
@@ -28,7 +28,8 @@ describe('Minifier', function () {
         it('star glob e.g. css/*.css', async function () {
             let result = await minifier.getMatchingFiles('css/*.css');
 
-            result.should.be.an.Array().with.lengthOf(3);
+            assert(Array.isArray(result));
+            assert.equal(result.length, 3);
             result[0].should.eql(path.join('test','unit','frontend','services','assets-minification','fixtures','basic-cards','css','bookmark.css'));
             result[1].should.eql(path.join('test','unit','frontend','services','assets-minification','fixtures','basic-cards','css','empty.css'));
             result[2].should.eql(path.join('test','unit','frontend','services','assets-minification','fixtures','basic-cards','css','gallery.css'));
@@ -37,7 +38,8 @@ describe('Minifier', function () {
         it('match glob range e.g. css/bookmark.css and css/empty.css (css/@(bookmark|empty).css)', async function () {
             let result = await minifier.getMatchingFiles('css/@(bookmark|empty).css');
 
-            result.should.be.an.Array().with.lengthOf(2);
+            assert(Array.isArray(result));
+            assert.equal(result.length, 2);
             result[0].should.eql(path.join('test','unit','frontend','services','assets-minification','fixtures','basic-cards','css','bookmark.css'));
             result[1].should.eql(path.join('test','unit','frontend','services','assets-minification','fixtures','basic-cards','css','empty.css'));
         });
@@ -45,14 +47,16 @@ describe('Minifier', function () {
         it('reverse match glob e.g. css/!(bookmark).css', async function () {
             let result = await minifier.getMatchingFiles('css/!(bookmark).css');
 
-            result.should.be.an.Array().with.lengthOf(2);
+            assert(Array.isArray(result));
+            assert.equal(result.length, 2);
             result[0].should.eql(path.join('test','unit','frontend','services','assets-minification','fixtures','basic-cards','css','empty.css'));
             result[1].should.eql(path.join('test','unit','frontend','services','assets-minification','fixtures','basic-cards','css','gallery.css'));
         });
         it('reverse match glob e.g. css/!(bookmark|gallery).css', async function () {
             let result = await minifier.getMatchingFiles('css/!(bookmark|gallery).css');
 
-            result.should.be.an.Array().with.lengthOf(1);
+            assert(Array.isArray(result));
+            assert.equal(result.length, 1);
             result[0].should.eql(path.join('test','unit','frontend','services','assets-minification','fixtures','basic-cards','css','empty.css'));
         });
     });
@@ -62,14 +66,16 @@ describe('Minifier', function () {
             let result = await minifier.minify({
                 'card.min.js': 'js/*.js'
             });
-            result.should.be.an.Array().with.lengthOf(1);
+            assert(Array.isArray(result));
+            assert.equal(result.length, 1);
         });
 
         it('single type, multi file', async function () {
             let result = await minifier.minify({
                 'card.min.css': 'css/*.css'
             });
-            result.should.be.an.Array().with.lengthOf(1);
+            assert(Array.isArray(result));
+            assert.equal(result.length, 1);
         });
 
         it('both css and js types + multiple files', async function () {
@@ -78,7 +84,8 @@ describe('Minifier', function () {
                 'card.min.css': 'css/*.css'
             });
 
-            result.should.be.an.Array().with.lengthOf(2);
+            assert(Array.isArray(result));
+            assert.equal(result.length, 2);
         });
 
         it('can replace the content', async function () {
@@ -89,7 +96,8 @@ describe('Minifier', function () {
                     '.kg-gallery-image': 'randomword'
                 }
             });
-            result.should.be.an.Array().with.lengthOf(1);
+            assert(Array.isArray(result));
+            assert.equal(result.length, 1);
 
             const outputPath = minifier.getFullDest(result[0]);
             const content = await fs.readFile(outputPath, {encoding: 'utf8'});

--- a/ghost/core/test/unit/frontend/services/assets-minification/minifier.test.js
+++ b/ghost/core/test/unit/frontend/services/assets-minification/minifier.test.js
@@ -148,7 +148,7 @@ describe('Minifier', function () {
                 'card.min.js': 'js/empty.js'
             });
 
-            result.should.be.an.Array().with.lengthOf(0);
+            assert.deepEqual(result, []);
         });
 
         it('can minify empty css correctly to no result', async function () {
@@ -156,7 +156,7 @@ describe('Minifier', function () {
                 'card.min.css': 'css/empty.css'
             });
 
-            result.should.be.an.Array().with.lengthOf(0);
+            assert.deepEqual(result, []);
         });
     });
 });

--- a/ghost/core/test/unit/frontend/services/rendering/context.test.js
+++ b/ghost/core/test/unit/frontend/services/rendering/context.test.js
@@ -37,14 +37,14 @@ describe('Contexts', function () {
             renderer.context(req, res, data);
 
             assertExists(res.locals.context);
-            res.locals.context.should.be.an.Array().with.lengthOf(0);
+            assert.deepEqual(res.locals.context, []);
         });
 
         it('should return empty array with no error with basic parameters', function () {
             renderer.context(req, res, data);
 
             assertExists(res.locals.context);
-            res.locals.context.should.be.an.Array().with.lengthOf(0);
+            assert.deepEqual(res.locals.context, []);
         });
     });
 
@@ -131,7 +131,7 @@ describe('Contexts', function () {
             renderer.context(req, res, data);
 
             assertExists(res.locals.context);
-            res.locals.context.should.be.an.Array().with.lengthOf(0);
+            assert.deepEqual(res.locals.context, []);
         });
 
         it('will not identify /page/2/ as paged without page param', function () {
@@ -178,7 +178,7 @@ describe('Contexts', function () {
             renderer.context(req, res, data);
 
             assertExists(res.locals.context);
-            res.locals.context.should.be.an.Array().with.lengthOf(0);
+            assert.deepEqual(res.locals.context, []);
         });
 
         it('will not identify /page/2/ as paged without page param', function () {

--- a/ghost/core/test/unit/frontend/services/rendering/context.test.js
+++ b/ghost/core/test/unit/frontend/services/rendering/context.test.js
@@ -56,7 +56,8 @@ describe('Contexts', function () {
             renderer.context(req, res, data);
 
             assertExists(res.locals.context);
-            res.locals.context.should.be.an.Array().with.lengthOf(1);
+            assert(Array.isArray(res.locals.context));
+            assert.equal(res.locals.context.length, 1);
             assert.equal(res.locals.context[0], 'index');
         });
 
@@ -69,7 +70,8 @@ describe('Contexts', function () {
 
             // Check context
             assertExists(res.locals.context);
-            res.locals.context.should.be.an.Array().with.lengthOf(2);
+            assert(Array.isArray(res.locals.context));
+            assert.equal(res.locals.context.length, 2);
             assert.equal(res.locals.context[0], 'home');
             assert.equal(res.locals.context[1], 'index');
         });
@@ -83,7 +85,8 @@ describe('Contexts', function () {
 
             // Check context
             assertExists(res.locals.context);
-            res.locals.context.should.be.an.Array().with.lengthOf(1);
+            assert(Array.isArray(res.locals.context));
+            assert.equal(res.locals.context.length, 1);
             assert.equal(res.locals.context[0], 'home');
         });
 
@@ -94,7 +97,8 @@ describe('Contexts', function () {
             renderer.context(req, res, data);
 
             assertExists(res.locals.context);
-            res.locals.context.should.be.an.Array().with.lengthOf(1);
+            assert(Array.isArray(res.locals.context));
+            assert.equal(res.locals.context.length, 1);
             assert.equal(res.locals.context[0], 'index');
         });
 
@@ -106,7 +110,8 @@ describe('Contexts', function () {
             renderer.context(req, res, data);
 
             assertExists(res.locals.context);
-            res.locals.context.should.be.an.Array().with.lengthOf(2);
+            assert(Array.isArray(res.locals.context));
+            assert.equal(res.locals.context.length, 2);
             assert.equal(res.locals.context[0], 'paged');
             assert.equal(res.locals.context[1], 'index');
         });
@@ -120,7 +125,8 @@ describe('Contexts', function () {
             renderer.context(req, res, data);
 
             assertExists(res.locals.context);
-            res.locals.context.should.be.an.Array().with.lengthOf(1);
+            assert(Array.isArray(res.locals.context));
+            assert.equal(res.locals.context.length, 1);
             assert.equal(res.locals.context[0], 'tag');
         });
 
@@ -141,7 +147,8 @@ describe('Contexts', function () {
             renderer.context(req, res, data);
 
             assertExists(res.locals.context);
-            res.locals.context.should.be.an.Array().with.lengthOf(1);
+            assert(Array.isArray(res.locals.context));
+            assert.equal(res.locals.context.length, 1);
             assert.equal(res.locals.context[0], 'tag');
         });
 
@@ -153,7 +160,8 @@ describe('Contexts', function () {
             renderer.context(req, res, data);
 
             assertExists(res.locals.context);
-            res.locals.context.should.be.an.Array().with.lengthOf(2);
+            assert(Array.isArray(res.locals.context));
+            assert.equal(res.locals.context.length, 2);
             assert.equal(res.locals.context[0], 'paged');
             assert.equal(res.locals.context[1], 'tag');
         });
@@ -167,7 +175,8 @@ describe('Contexts', function () {
             renderer.context(req, res, data);
 
             assertExists(res.locals.context);
-            res.locals.context.should.be.an.Array().with.lengthOf(1);
+            assert(Array.isArray(res.locals.context));
+            assert.equal(res.locals.context.length, 1);
             assert.equal(res.locals.context[0], 'author');
         });
 
@@ -188,7 +197,8 @@ describe('Contexts', function () {
             renderer.context(req, res, data);
 
             assertExists(res.locals.context);
-            res.locals.context.should.be.an.Array().with.lengthOf(1);
+            assert(Array.isArray(res.locals.context));
+            assert.equal(res.locals.context.length, 1);
             assert.equal(res.locals.context[0], 'author');
         });
 
@@ -200,7 +210,8 @@ describe('Contexts', function () {
             renderer.context(req, res, data);
 
             assertExists(res.locals.context);
-            res.locals.context.should.be.an.Array().with.lengthOf(2);
+            assert(Array.isArray(res.locals.context));
+            assert.equal(res.locals.context.length, 2);
             assert.equal(res.locals.context[0], 'paged');
             assert.equal(res.locals.context[1], 'author');
         });
@@ -214,7 +225,8 @@ describe('Contexts', function () {
             renderer.context(req, res, data);
 
             assertExists(res.locals.context);
-            res.locals.context.should.be.an.Array().with.lengthOf(2);
+            assert(Array.isArray(res.locals.context));
+            assert.equal(res.locals.context.length, 2);
             assert.equal(res.locals.context[0], 'custom-context');
             assert.equal(res.locals.context[1], 'test');
         });
@@ -228,7 +240,8 @@ describe('Contexts', function () {
             renderer.context(req, res, data);
 
             assertExists(res.locals.context);
-            res.locals.context.should.be.an.Array().with.lengthOf(1);
+            assert(Array.isArray(res.locals.context));
+            assert.equal(res.locals.context.length, 1);
             assert.equal(res.locals.context[0], 'post');
         });
     });
@@ -241,7 +254,8 @@ describe('Contexts', function () {
             renderer.context(req, res, data);
 
             assertExists(res.locals.context);
-            res.locals.context.should.be.an.Array().with.lengthOf(1);
+            assert(Array.isArray(res.locals.context));
+            assert.equal(res.locals.context.length, 1);
             assert.equal(res.locals.context[0], 'private');
         });
     });
@@ -256,7 +270,8 @@ describe('Contexts', function () {
             renderer.context(req, res, data);
 
             assertExists(res.locals.context);
-            res.locals.context.should.be.an.Array().with.lengthOf(1);
+            assert(Array.isArray(res.locals.context));
+            assert.equal(res.locals.context.length, 1);
             assert.equal(res.locals.context[0], 'post');
         });
     });

--- a/ghost/core/test/unit/frontend/services/theme-engine/handlebars/helpers.test.js
+++ b/ghost/core/test/unit/frontend/services/theme-engine/handlebars/helpers.test.js
@@ -1,4 +1,4 @@
-const should = require('should');
+const assert = require('node:assert/strict');
 const _ = require('lodash');
 const hbs = require('../../../../../../core/frontend/services/theme-engine/engine');
 

--- a/ghost/core/test/unit/frontend/services/theme-engine/handlebars/helpers.test.js
+++ b/ghost/core/test/unit/frontend/services/theme-engine/handlebars/helpers.test.js
@@ -29,8 +29,8 @@ describe('Helpers', function () {
             const missingHelpers = _.difference(expectedHelpers, foundHelpers);
             const unexpectedHelpers = _.difference(foundHelpers, expectedHelpers);
 
-            missingHelpers.should.be.an.Array().with.lengthOf(0);
-            unexpectedHelpers.should.be.an.Array().with.lengthOf(0);
+            assert.deepEqual(missingHelpers, []);
+            assert.deepEqual(unexpectedHelpers, []);
         });
     });
 });

--- a/ghost/core/test/unit/server/data/schema/fixtures/fixture-manager.test.js
+++ b/ghost/core/test/unit/server/data/schema/fixtures/fixture-manager.test.js
@@ -527,7 +527,8 @@ describe('Migration Fixture Utils', function () {
         it('should fetch a fixture with multiple entries', function () {
             const foundFixture = fixtureManager.findModelFixtures('Permission', {object_type: 'db'});
             assert(_.isPlainObject(foundFixture));
-            foundFixture.entries.should.be.an.Array().with.lengthOf(4);
+            assert(Array.isArray(foundFixture.entries));
+            assert.equal(foundFixture.entries.length, 4);
             assert.deepEqual(foundFixture.entries[0], {
                 name: 'Export database',
                 action_type: 'exportContent',

--- a/ghost/core/test/unit/server/lib/package-json/filter.test.js
+++ b/ghost/core/test/unit/server/lib/package-json/filter.test.js
@@ -124,6 +124,6 @@ describe('package-json filter', function () {
         const result = packageJSON.filter({
             '.git': {}, '.anything': {}, 'README.md': {}, _messages: {}
         });
-        result.should.be.an.Array().with.lengthOf(0);
+        assert.deepEqual(result, []);
     });
 });

--- a/ghost/core/test/unit/server/lib/package-json/filter.test.js
+++ b/ghost/core/test/unit/server/lib/package-json/filter.test.js
@@ -44,11 +44,13 @@ describe('package-json filter', function () {
         const result = packageJSON.filter({casper: casper});
         let package1;
 
-        result.should.be.an.Array().with.lengthOf(1);
+        assert(Array.isArray(result));
+        assert.equal(result.length, 1);
         package1 = result[0];
 
         package1.should.be.an.Object().with.properties('name', 'package', 'active');
-        Object.keys(package1).should.be.an.Array().with.lengthOf(3);
+        assert(Array.isArray(Object.keys(package1)));
+        assert.equal(Object.keys(package1).length, 3);
         assert.equal(package1.name, 'casper');
         package1.package.should.be.an.Object().with.properties('name', 'version');
         assert.equal(package1.active, false);
@@ -59,18 +61,21 @@ describe('package-json filter', function () {
         let package1;
         let package2;
 
-        result.should.be.an.Array().with.lengthOf(2);
+        assert(Array.isArray(result));
+        assert.equal(result.length, 2);
         package1 = result[0];
         package2 = result[1];
 
         package1.should.be.an.Object().with.properties('name', 'package', 'active');
-        Object.keys(package1).should.be.an.Array().with.lengthOf(3);
+        assert(Array.isArray(Object.keys(package1)));
+        assert.equal(Object.keys(package1).length, 3);
         assert.equal(package1.name, 'casper');
         package1.package.should.be.an.Object().with.properties('name', 'version');
         assert.equal(package1.active, true);
 
         package2.should.be.an.Object().with.properties('name', 'package', 'active');
-        Object.keys(package2).should.be.an.Array().with.lengthOf(3);
+        assert(Array.isArray(Object.keys(package2)));
+        assert.equal(Object.keys(package2).length, 3);
         assert.equal(package2.name, 'simple');
         package2.package.should.be.an.Object().with.properties('name', 'version');
         assert.equal(package2.active, false);
@@ -81,18 +86,21 @@ describe('package-json filter', function () {
         let package1;
         let package2;
 
-        result.should.be.an.Array().with.lengthOf(2);
+        assert(Array.isArray(result));
+        assert.equal(result.length, 2);
         package1 = result[0];
         package2 = result[1];
 
         package1.should.be.an.Object().with.properties('name', 'package', 'active');
-        Object.keys(package1).should.be.an.Array().with.lengthOf(3);
+        assert(Array.isArray(Object.keys(package1)));
+        assert.equal(Object.keys(package1).length, 3);
         assert.equal(package1.name, 'casper');
         package1.package.should.be.an.Object().with.properties('name', 'version');
         assert.equal(package1.active, true);
 
         package2.should.be.an.Object().with.properties('name', 'package', 'active');
-        Object.keys(package2).should.be.an.Array().with.lengthOf(3);
+        assert(Array.isArray(Object.keys(package2)));
+        assert.equal(Object.keys(package2).length, 3);
         assert.equal(package2.name, 'simple');
         package2.package.should.be.an.Object().with.properties('name', 'version');
         assert.equal(package2.active, true);
@@ -103,18 +111,21 @@ describe('package-json filter', function () {
         let package1;
         let package2;
 
-        result.should.be.an.Array().with.lengthOf(2);
+        assert(Array.isArray(result));
+        assert.equal(result.length, 2);
         package1 = result[0];
         package2 = result[1];
 
         package1.should.be.an.Object().with.properties('name', 'package', 'active');
-        Object.keys(package1).should.be.an.Array().with.lengthOf(3);
+        assert(Array.isArray(Object.keys(package1)));
+        assert.equal(Object.keys(package1).length, 3);
         assert.equal(package1.name, 'casper');
         package1.package.should.be.an.Object().with.properties('name', 'version');
         assert.equal(package1.active, true);
 
         package2.should.be.an.Object().with.properties('name', 'package', 'active');
-        Object.keys(package2).should.be.an.Array().with.lengthOf(3);
+        assert(Array.isArray(Object.keys(package2)));
+        assert.equal(Object.keys(package2).length, 3);
         assert.equal(package2.name, 'missing');
         assert.equal(package2.package, false);
         assert.equal(package2.active, false);

--- a/ghost/core/test/unit/server/models/user.test.js
+++ b/ghost/core/test/unit/server/models/user.test.js
@@ -69,7 +69,7 @@ describe('Unit: models/user', function () {
                         throw new Error('expected ValidationError');
                     })
                     .catch(function (err) {
-                        err.should.be.an.Array();
+                        assert(Array.isArray(err));
                         assert.equal((err[0] instanceof errors.ValidationError), true);
                         assert.match(err[0].message, /users\.email/);
                     });

--- a/ghost/core/test/unit/server/services/mail/ghost-mailer.test.js
+++ b/ghost/core/test/unit/server/services/mail/ghost-mailer.test.js
@@ -351,7 +351,7 @@ describe('Mail: Ghostmailer', function () {
             });
 
             const sentMessage = sendMailSpy.firstCall.args[0];
-            sentMessage['o:tag'].should.be.an.Array();
+            assert(Array.isArray(sentMessage['o:tag']));
             assert(sentMessage['o:tag'].includes('transactional-email'));
             assert(sentMessage['o:tag'].includes('blog-123123'));
             assert.equal(sentMessage['o:tracking-opens'], true);
@@ -374,7 +374,7 @@ describe('Mail: Ghostmailer', function () {
             });
 
             const sentMessage = sendMailSpy.firstCall.args[0];
-            sentMessage['o:tag'].should.be.an.Array();
+            assert(Array.isArray(sentMessage['o:tag']));
             assert(sentMessage['o:tag'].includes('transactional-email'));
             assert(sentMessage['o:tag'].includes('blog-123123'));
             assert.equal(sentMessage['o:tracking-opens'], undefined);

--- a/ghost/core/test/unit/server/services/members/middleware.test.js
+++ b/ghost/core/test/unit/server/services/members/middleware.test.js
@@ -57,7 +57,7 @@ describe('Members Service Middleware', function () {
 
             // Check behavior
             assert.equal(next.calledOnce, true);
-            next.firstCall.args.should.be.an.Array().with.lengthOf(0);
+            assert.deepEqual(next.firstCall.args, []);
         });
 
         it('redirects correctly on success', async function () {

--- a/ghost/core/test/unit/server/services/members/request-integrity-token-provider.test.js
+++ b/ghost/core/test/unit/server/services/members/request-integrity-token-provider.test.js
@@ -23,7 +23,8 @@ describe('RequestIntegrityTokenProvider', function () {
             const token = tokenProvider.create();
 
             token.should.be.a.String();
-            token.split(':').should.be.an.Array().with.lengthOf(3);
+            assert(Array.isArray(token.split(':')));
+            assert.equal(token.split(':').length, 3);
             const [timestamp, nonce, digest] = token.split(':');
 
             assert.equal(timestamp, (new Date('2021-01-01').valueOf() + 100).toString());

--- a/ghost/core/test/unit/server/services/permissions/providers.test.js
+++ b/ghost/core/test/unit/server/services/permissions/providers.test.js
@@ -63,8 +63,10 @@ describe('Permission Providers', function () {
 
                     res.should.be.an.Object().with.properties('permissions', 'roles');
 
-                    res.permissions.should.be.an.Array().with.lengthOf(10);
-                    res.roles.should.be.an.Array().with.lengthOf(1);
+                    assert(Array.isArray(res.permissions));
+                    assert.equal(res.permissions.length, 10);
+                    assert(Array.isArray(res.roles));
+                    assert.equal(res.roles.length, 1);
 
                     // @TODO fix this!
                     // Permissions is an array of models
@@ -113,8 +115,10 @@ describe('Permission Providers', function () {
 
                     res.should.be.an.Object().with.properties('permissions', 'roles');
 
-                    res.permissions.should.be.an.Array().with.lengthOf(10);
-                    res.roles.should.be.an.Array().with.lengthOf(1);
+                    assert(Array.isArray(res.permissions));
+                    assert.equal(res.permissions.length, 10);
+                    assert(Array.isArray(res.roles));
+                    assert.equal(res.roles.length, 1);
 
                     // @TODO fix this!
                     // Permissions is an array of models
@@ -164,8 +168,10 @@ describe('Permission Providers', function () {
 
                     res.should.be.an.Object().with.properties('permissions', 'roles');
 
-                    res.permissions.should.be.an.Array().with.lengthOf(10);
-                    res.roles.should.be.an.Array().with.lengthOf(1);
+                    assert(Array.isArray(res.permissions));
+                    assert.equal(res.permissions.length, 10);
+                    assert(Array.isArray(res.roles));
+                    assert.equal(res.roles.length, 1);
 
                     // @TODO fix this!
                     // Permissions is an array of models
@@ -234,7 +240,8 @@ describe('Permission Providers', function () {
             providers.apiKey(1).then((res) => {
                 assert.equal(findApiKeySpy.callCount, 1);
                 res.should.be.an.Object().with.properties('permissions', 'roles');
-                res.roles.should.be.an.Array().with.lengthOf(1);
+                assert(Array.isArray(res.roles));
+                assert.equal(res.roles.length, 1);
                 res.permissions[0].should.be.an.Object().with.properties('attributes', 'id');
                 res.roles[0].should.be.an.Object().with.properties('id', 'name', 'description');
                 assert(res.permissions[0] instanceof models.Base.Model);

--- a/ghost/core/test/unit/server/services/stats/content.test.js
+++ b/ghost/core/test/unit/server/services/stats/content.test.js
@@ -131,7 +131,7 @@ describe('ContentStatsService', function () {
 
             const result = service.extractPostUuids(data);
             assertExists(result);
-            result.should.be.an.Array().with.lengthOf(0);
+            assert.deepEqual(result, []);
         });
     });
 
@@ -227,7 +227,7 @@ describe('ContentStatsService', function () {
         it('returns empty array for empty input', async function () {
             const result = await service.enrichTopContentData([]);
             assertExists(result);
-            result.should.be.an.Array().with.lengthOf(0);
+            assert.deepEqual(result, []);
 
             assert.equal(service.extractPostUuids.called, false);
             assert.equal(service.lookupPostTitles.called, false);
@@ -413,7 +413,7 @@ describe('ContentStatsService', function () {
 
             assertExists(result);
             assertExists(result.data);
-            result.data.should.be.an.Array().with.lengthOf(0);
+            assert.deepEqual(result.data, []);
 
             assert.equal(service.fetchRawTopContentData.calledOnce, true);
         });
@@ -428,7 +428,7 @@ describe('ContentStatsService', function () {
 
             assertExists(result);
             assertExists(result.data);
-            result.data.should.be.an.Array().with.lengthOf(0);
+            assert.deepEqual(result.data, []);
         });
 
         it('returns empty data array when tinybirdClient is not available', async function () {
@@ -445,7 +445,7 @@ describe('ContentStatsService', function () {
 
             assertExists(result);
             assertExists(result.data);
-            result.data.should.be.an.Array().with.lengthOf(0);
+            assert.deepEqual(result.data, []);
         });
     });
 

--- a/ghost/core/test/unit/server/services/stats/content.test.js
+++ b/ghost/core/test/unit/server/services/stats/content.test.js
@@ -102,7 +102,8 @@ describe('ContentStatsService', function () {
 
             const result = mockTinybirdClient.parseResponse(mockResponse);
             assertExists(result);
-            result.should.be.an.Array().with.lengthOf(2);
+            assert(Array.isArray(result));
+            assert.equal(result.length, 2);
 
             assert.equal(mockTinybirdClient.parseResponse.calledWith(mockResponse), true);
         });
@@ -117,7 +118,8 @@ describe('ContentStatsService', function () {
 
             const result = service.extractPostUuids(data);
             assertExists(result);
-            result.should.be.an.Array().with.lengthOf(2);
+            assert(Array.isArray(result));
+            assert.equal(result.length, 2);
             assert(result.includes('post-1'));
             assert(result.includes('post-2'));
         });
@@ -246,7 +248,8 @@ describe('ContentStatsService', function () {
             const result = await service.enrichTopContentData(data);
 
             assertExists(result);
-            result.should.be.an.Array().with.lengthOf(2);
+            assert(Array.isArray(result));
+            assert.equal(result.length, 2);
             assert.equal(result[0].title, 'Test Post 1');
             assert.equal(result[0].post_id, 'post-id-1');
             assert.equal(result[0].url_exists, true);
@@ -273,7 +276,8 @@ describe('ContentStatsService', function () {
             const result = await service.enrichTopContentData(data);
 
             assertExists(result);
-            result.should.be.an.Array().with.lengthOf(1);
+            assert(Array.isArray(result));
+            assert.equal(result.length, 1);
             assert.equal(result[0].title, 'About Us');
             assert.equal(result[0].resourceType, 'page');
             assert.equal(result[0].url_exists, true);
@@ -291,7 +295,8 @@ describe('ContentStatsService', function () {
             const result = await service.enrichTopContentData(data);
 
             assertExists(result);
-            result.should.be.an.Array().with.lengthOf(1);
+            assert(Array.isArray(result));
+            assert.equal(result.length, 1);
             assert.equal(result[0].title, 'unknown-page');
             assert.equal(result[0].url_exists, false);
 
@@ -308,7 +313,8 @@ describe('ContentStatsService', function () {
             const result = await service.enrichTopContentData(data);
 
             assertExists(result);
-            result.should.be.an.Array().with.lengthOf(1);
+            assert(Array.isArray(result));
+            assert.equal(result.length, 1);
             assert.equal(result[0].title, 'Homepage');
             assert.equal(result[0].url_exists, false);
         });
@@ -331,7 +337,8 @@ describe('ContentStatsService', function () {
             const result = await service.fetchRawTopContentData(options);
 
             assertExists(result);
-            result.should.be.an.Array().with.lengthOf(1);
+            assert(Array.isArray(result));
+            assert.equal(result.length, 1);
             assert.equal(result[0].pathname, '/test/');
             assert.equal(result[0].visits, 100);
 
@@ -389,7 +396,8 @@ describe('ContentStatsService', function () {
 
             assertExists(result);
             assertExists(result.data);
-            result.data.should.be.an.Array().with.lengthOf(2);
+            assert(Array.isArray(result.data));
+            assert.equal(result.data.length, 2);
             assert('title' in result.data[0]);
             assert('post_id' in result.data[0]);
             assert('title' in result.data[1]);
@@ -468,7 +476,8 @@ describe('ContentStatsService', function () {
 
             // Verify result is correct
             assertExists(result);
-            result.should.be.an.Array().with.lengthOf(2);
+            assert(Array.isArray(result));
+            assert.equal(result.length, 2);
 
             // Verify tinybird client was called with correct parameters
             assert.equal(mockTinybirdClient.fetch.calledOnce, true);
@@ -487,7 +496,7 @@ describe('ContentStatsService', function () {
             const result = await service.getTopContent({});
 
             assertExists(result);
-            result.should.have.property('data').which.is.an.Array().with.lengthOf(0);
+            assert.deepEqual(result.data, []);
         });
 
         it('passes all filter parameters to tinybird client with correct shape', async function () {

--- a/ghost/core/test/unit/server/services/stats/utils/tinybird.test.js
+++ b/ghost/core/test/unit/server/services/stats/utils/tinybird.test.js
@@ -133,7 +133,8 @@ describe('Tinybird Client', function () {
 
             const result = tinybirdClient.parseResponse(mockResponse);
             assertExists(result);
-            result.should.be.an.Array().with.lengthOf(2);
+            assert(Array.isArray(result));
+            assert.equal(result.length, 2);
             assert.equal(result[0].pathname, '/test-1/');
             assert.equal(result[0].visits, 100);
         });
@@ -150,7 +151,8 @@ describe('Tinybird Client', function () {
 
             const result = tinybirdClient.parseResponse(mockResponse);
             assertExists(result);
-            result.should.be.an.Array().with.lengthOf(2);
+            assert(Array.isArray(result));
+            assert.equal(result.length, 2);
         });
 
         it('handles direct JSON string response', function () {
@@ -162,7 +164,8 @@ describe('Tinybird Client', function () {
 
             const result = tinybirdClient.parseResponse(mockResponse);
             assertExists(result);
-            result.should.be.an.Array().with.lengthOf(1);
+            assert(Array.isArray(result));
+            assert.equal(result.length, 1);
         });
 
         it('handles direct object response', function () {
@@ -174,7 +177,8 @@ describe('Tinybird Client', function () {
 
             const result = tinybirdClient.parseResponse(mockResponse);
             assertExists(result);
-            result.should.be.an.Array().with.lengthOf(1);
+            assert(Array.isArray(result));
+            assert.equal(result.length, 1);
         });
 
         it('returns empty array for empty data', function () {
@@ -215,7 +219,8 @@ describe('Tinybird Client', function () {
             });
 
             assertExists(result);
-            result.should.be.an.Array().with.lengthOf(2);
+            assert(Array.isArray(result));
+            assert.equal(result.length, 2);
             assert.equal(result[0].pathname, '/test-1/');
             assert.equal(result[0].visits, 100);
 

--- a/ghost/core/test/unit/server/services/stats/utils/tinybird.test.js
+++ b/ghost/core/test/unit/server/services/stats/utils/tinybird.test.js
@@ -184,7 +184,7 @@ describe('Tinybird Client', function () {
 
             const result = tinybirdClient.parseResponse(mockResponse);
             assertExists(result);
-            result.should.be.an.Array().with.lengthOf(0);
+            assert.deepEqual(result, []);
         });
 
         it('returns null for invalid JSON', function () {


### PR DESCRIPTION
This change should have no user impact.

`value.should.be.an.Array()` has been replaced with `node:assert` in our effort to replace Should.js with `node:assert`.
