### PR TITLE
Removed all top-level `should` invocations

### DIFF
--- a/ghost/core/test/e2e-api/admin/members-importer.test.js
+++ b/ghost/core/test/e2e-api/admin/members-importer.test.js
@@ -109,7 +109,7 @@ describe('Members Importer API', function () {
     //         .expect('Content-Type', /json/)
     //         .expect('Cache-Control', testUtils.cacheRules.private)
     //         .then((res) => {
-    //             should.not.exist(res.headers['x-cache-invalidate']);
+    //             assert(!res.headers['x-cache-invalidate']);
 
     //             const jsonResponse = res.body;
 
@@ -130,7 +130,7 @@ describe('Members Importer API', function () {
     //                 .expect('Cache-Control', testUtils.cacheRules.private)
     //                 .expect(200)
     //                 .then((res) => {
-    //                     should.not.exist(res.headers['x-cache-invalidate']);
+    //                     assert(!res.headers['x-cache-invalidate']);
     //                     const jsonResponse = res.body;
     //                     assertExists(jsonResponse);
     //                     assertExists(jsonResponse.members);
@@ -147,7 +147,7 @@ describe('Members Importer API', function () {
     //                 .expect('Cache-Control', testUtils.cacheRules.private)
     //                 .expect(200)
     //                 .then((res) => {
-    //                     should.not.exist(res.headers['x-cache-invalidate']);
+    //                     assert(!res.headers['x-cache-invalidate']);
     //                     const jsonResponse = res.body;
     //                     assertExists(jsonResponse);
     //                     assertExists(jsonResponse.meta);

--- a/ghost/core/test/e2e-api/members-comments/comments.test.js
+++ b/ghost/core/test/e2e-api/members-comments/comments.test.js
@@ -260,10 +260,10 @@ async function testCanCommentOnPost(member) {
 
     // Check last_updated_at changed?
     member = await models.Member.findOne({id: member.id});
-    should.notEqual(member.get('last_seen_at'), null, 'The member should have a `last_seen_at` property after posting a comment.');
+    assert.notEqual(member.get('last_seen_at'), null, 'The member should have a `last_seen_at` property after posting a comment.');
 
     // Check last_commented_at changed?
-    should.notEqual(member.get('last_commented_at'), null, 'The member should have a `last_commented_at` property after posting a comment.');
+    assert.notEqual(member.get('last_commented_at'), null, 'The member should have a `last_commented_at` property after posting a comment.');
 }
 
 async function testCanReply(member, emailMatchers = {}) {
@@ -294,10 +294,10 @@ async function testCanReply(member, emailMatchers = {}) {
 
     // Check last_updated_at changed?
     member = await models.Member.findOne({id: member.id});
-    should.notEqual(member.get('last_seen_at').getTime(), date.getTime(), 'Should update `last_seen_at` property after posting a comment.');
+    assert.notEqual(member.get('last_seen_at').getTime(), date.getTime(), 'Should update `last_seen_at` property after posting a comment.');
 
     // Check last_commented_at changed?
-    should.notEqual(member.get('last_commented_at').getTime(), date.getTime(), 'Should update `last_commented_at` property after posting a comment.');
+    assert.notEqual(member.get('last_commented_at').getTime(), date.getTime(), 'Should update `last_commented_at` property after posting a comment.');
 }
 
 async function testCannotCommentOnPost(status = 403) {
@@ -477,8 +477,8 @@ describe('Comments API', function () {
 
                 // check if hidden and deleted comments have their html removed
                 data2.body.comments.forEach((comment) => {
-                    should.notEqual(comment.html, 'This is a hidden comment');
-                    should.notEqual(comment.html, 'This is a deleted comment');
+                    assert.notEqual(comment.html, 'This is a hidden comment');
+                    assert.notEqual(comment.html, 'This is a deleted comment');
                 });
 
                 // check if hiddenComment.id and deletedComment.id are in the response

--- a/ghost/core/test/integration/migrations/nullable-utils.test.js
+++ b/ghost/core/test/integration/migrations/nullable-utils.test.js
@@ -159,7 +159,7 @@ describe('Migrations - schema utils', function () {
             await migration.up({transacting});
             await transacting.commit();
 
-            should.ok(logSpy.calledWith(sinon.match('skipping as column is already nullable')), 'Should log skip message');
+            assert(logSpy.calledWith(sinon.match('skipping as column is already nullable')), 'Should log skip message');
 
             // Column should still be nullable
             const isNullableAfter = await isColumnNullable(tableName, 'nullable_col');
@@ -235,7 +235,7 @@ describe('Migrations - schema utils', function () {
             await migration.up({transacting});
             await transacting.commit();
 
-            should.ok(logSpy.calledWith(sinon.match('skipping as column is already not nullable')), 'Should log skip message');
+            assert(logSpy.calledWith(sinon.match('skipping as column is already not nullable')), 'Should log skip message');
 
             // Column should still be not nullable
             const isNotNullableAfter = await isColumnNotNullable(tableName, 'not_nullable_col');
@@ -321,12 +321,11 @@ describe('Migrations - schema utils', function () {
             
             if (dbUtils.isMySQL()) {
                 // MySQL should log a warning when checking nullable status fails
-                should.ok(logWarnSpy.calledWith(sinon.match('Could not check nullable status')), 
-                    'MySQL should log warning about checking nullable status');
+                assert(logWarnSpy.calledWith(sinon.match('Could not check nullable status')), 'MySQL should log warning about checking nullable status');
             }
             
             // Both databases should eventually fail when trying to ALTER the non-existent table
-            should.ok(errorThrown, 'Should throw an error when trying to alter non-existent table');
+            assert(errorThrown, 'Should throw an error when trying to alter non-existent table');
             
             // The error message varies between databases and Knex versions
             // SQLite might give a Knex internal error or a 'no such table' error
@@ -335,7 +334,7 @@ describe('Migrations - schema utils', function () {
                                   errorMessage.includes('Cannot read properties of undefined') ||
                                   errorMessage.includes('SQLITE_ERROR');
             
-            should.ok(isExpectedError, `Error should be related to missing table, but was: ${errorMessage}`);
+            assert(isExpectedError, `Error should be related to missing table, but was: ${errorMessage}`);
         });
     });
 });

--- a/ghost/core/test/legacy/api/admin/posts.test.js
+++ b/ghost/core/test/legacy/api/admin/posts.test.js
@@ -112,7 +112,7 @@ describe('Posts API', function () {
                     localUtils.API.checkResponse(jsonResponse, 'posts');
                     assert.equal(jsonResponse.posts.length, 2);
                     jsonResponse.posts.forEach((post) => {
-                        should.notEqual(post.meta_description, null);
+                        assert.notEqual(post.meta_description, null);
                     });
 
                     localUtils.API.checkResponse(

--- a/ghost/core/test/legacy/models/model-member-stripe-customer.test.js
+++ b/ghost/core/test/legacy/models/model-member-stripe-customer.test.js
@@ -179,12 +179,12 @@ describe('MemberStripeCustomer Model', function run() {
             const customerAfterDestroy = await MemberStripeCustomer.findOne({
                 customer_id: 'fake_customer_id'
             });
-            should.not.exist(customerAfterDestroy, 'MemberStripeCustomer should have been destroyed');
+            assert.equal(customerAfterDestroy, null, 'MemberStripeCustomer should have been destroyed');
 
             const subscriptionAfterDestroy = await StripeCustomerSubscription.findOne({
                 customer_id: 'fake_customer_id'
             });
-            should.not.exist(subscriptionAfterDestroy, 'StripeCustomerSubscription should have been destroyed');
+            assert.equal(subscriptionAfterDestroy, null, 'StripeCustomerSubscription should have been destroyed');
         });
     });
 });

--- a/ghost/core/test/legacy/models/model-members.test.js
+++ b/ghost/core/test/legacy/models/model-members.test.js
@@ -246,23 +246,23 @@ describe('Member Model', function run() {
             const memberAfterDestroy = await Member.findOne({
                 email: 'test@test.member'
             });
-            should.not.exist(memberAfterDestroy, 'Member should have been destroyed');
+            assert.equal(memberAfterDestroy, null, 'Member should have been destroyed');
 
-            const memberLabelAfterDestroy = await BaseModel.knex('members_labels').where({
+            const memberLabelsAfterDestroy = await BaseModel.knex('members_labels').where({
                 label_id: label.get('id'),
                 member_id: member.get('id')
-            }).select().first();
-            should.not.exist(memberLabelAfterDestroy, 'Label should have been removed from member');
+            }).select();
+            assert.deepEqual(memberLabelsAfterDestroy, [], 'Label should have been removed from member');
 
             const customerAfterDestroy = await MemberStripeCustomer.findOne({
                 member_id: member.get('id')
             });
-            should.not.exist(customerAfterDestroy, 'MemberStripeCustomer should have been destroyed');
+            assert.equal(customerAfterDestroy, null, 'MemberStripeCustomer should have been destroyed');
 
             const subscriptionAfterDestroy = await StripeCustomerSubscription.findOne({
                 customer_id: customer.get('customer_id')
             });
-            should.not.exist(subscriptionAfterDestroy, 'StripeCustomerSubscription should have been destroyed');
+            assert.equal(subscriptionAfterDestroy, null, 'StripeCustomerSubscription should have been destroyed');
         });
     });
 
@@ -354,7 +354,7 @@ describe('Member Model', function run() {
             const podcastProductMembers = await Member.findPage({filter: 'products:podcast'});
             const foundMemberInPodcast = podcastProductMembers.data.find(model => model.id === member.id);
 
-            should.not.exist(foundMemberInPodcast, 'Member should not have been included in products filter');
+            assert.equal(foundMemberInPodcast, undefined, 'Member should not have been included in products filter');
         });
     });
 

--- a/ghost/core/test/unit/frontend/services/assets-minification/minifier.test.js
+++ b/ghost/core/test/unit/frontend/services/assets-minification/minifier.test.js
@@ -129,7 +129,7 @@ describe('Minifier', function () {
                 await minifier.minify({
                     'card.min.ts': 'js/*.ts'
                 });
-                should.fail(minifier, 'Should have errored');
+                assert.fail('Should have errored');
             } catch (err) {
                 assertExists(err);
                 assert.equal(err.errorType, 'IncorrectUsageError');
@@ -143,7 +143,7 @@ describe('Minifier', function () {
                     'card.min.ts': 'ts/*.ts',
                     'card.min.js': 'js/fake.js'
                 });
-                should.fail(minifier, 'Should have errored');
+                assert.fail('Should have errored');
             } catch (err) {
                 assertExists(err);
                 assert.equal(err.errorType, 'IncorrectUsageError');

--- a/ghost/core/test/unit/server/data/importer/importers/data/posts.test.js
+++ b/ghost/core/test/unit/server/data/importer/importers/data/posts.test.js
@@ -27,25 +27,25 @@ describe('PostsImporter', function () {
 
             const pageFalse = find(importer.dataToImport, {slug: 'page-false'});
             assertExists(pageFalse);
-            should.not.exist(pageFalse.page, 'pageFalse.page should not exist');
+            assert.equal(pageFalse.page, undefined, 'pageFalse.page should not exist');
             assertExists(pageFalse.type, 'pageFalse.type should exist');
             assert.equal(pageFalse.type, 'post');
 
             const pageTrue = find(importer.dataToImport, {slug: 'page-true'});
             assertExists(pageTrue);
-            should.not.exist(pageTrue.page, 'pageTrue.page should not exist');
+            assert.equal(pageTrue.page, undefined, 'pageTrue.page should not exist');
             assertExists(pageTrue.type, 'pageTrue.type should exist');
             assert.equal(pageTrue.type, 'page');
 
             const typePost = find(importer.dataToImport, {slug: 'type-post'});
             assertExists(typePost);
-            should.not.exist(typePost.page, 'typePost.page should not exist');
+            assert.equal(typePost.page, undefined, 'typePost.page should not exist');
             assertExists(typePost.type, 'typePost.type should exist');
             assert.equal(typePost.type, 'post');
 
             const typePage = find(importer.dataToImport, {slug: 'type-page'});
             assertExists(typePage);
-            should.not.exist(typePage.page, 'typePage.page should not exist');
+            assert.equal(typePage.page, undefined, 'typePage.page should not exist');
             assertExists(typePage.type, 'typePage.type should exist');
             assert.equal(typePage.type, 'page');
         });

--- a/ghost/core/test/unit/server/data/migrations/utils.test.js
+++ b/ghost/core/test/unit/server/data/migrations/utils.test.js
@@ -34,13 +34,13 @@ describe('migrations/utils', function () {
             const upResult = migration.up(config);
             const downResult = migration.down(config);
 
-            should.ok(migration.config.transaction, 'Migration config should set transaction to true');
+            assert(migration.config.transaction, 'Migration config should set transaction to true');
 
-            should.ok(upResult instanceof Promise, 'Migration up method should return a Promise');
-            should.ok(downResult instanceof Promise, 'Migration down method should return a Promise');
+            assert(upResult instanceof Promise, 'Migration up method should return a Promise');
+            assert(downResult instanceof Promise, 'Migration down method should return a Promise');
 
-            should.ok(up.calledOnceWith(config.transacting), 'up function should be called with transacting');
-            should.ok(down.calledOnceWith(config.transacting), 'down function should be called with transacting');
+            assert(up.calledOnceWith(config.transacting), 'up function should be called with transacting');
+            assert(down.calledOnceWith(config.transacting), 'down function should be called with transacting');
         });
     });
 
@@ -58,23 +58,23 @@ describe('migrations/utils', function () {
             const migrationB = utils.createTransactionalMigration(upB, downB);
             const combinedMigration = utils.combineTransactionalMigrations(migrationA, migrationB);
 
-            should.ok(combinedMigration.config.transaction, 'Migration config should set transaction to true');
+            assert(combinedMigration.config.transaction, 'Migration config should set transaction to true');
 
             const upResult = combinedMigration.up(config);
-            should.ok(upResult instanceof Promise, 'Migration up method should return a Promise');
+            assert(upResult instanceof Promise, 'Migration up method should return a Promise');
 
             await upResult;
-            should.ok(upA.calledOnceWith(config.transacting), 'first up fn should be called with transacting');
-            should.ok(upB.calledOnceWith(config.transacting), 'second up fn should be called with transacting');
-            should.ok(upA.calledBefore(upB), 'Migration up method should call child up methods in order');
+            assert(upA.calledOnceWith(config.transacting), 'first up fn should be called with transacting');
+            assert(upB.calledOnceWith(config.transacting), 'second up fn should be called with transacting');
+            assert(upA.calledBefore(upB), 'Migration up method should call child up methods in order');
 
             const downResult = combinedMigration.down(config);
-            should.ok(downResult instanceof Promise, 'Migration down method should return a Promise');
+            assert(downResult instanceof Promise, 'Migration down method should return a Promise');
 
             await downResult;
-            should.ok(downA.calledOnceWith(config.transacting), 'first down fn should be called with transacting');
-            should.ok(downB.calledOnceWith(config.transacting), 'second down fn should be called with transacting');
-            should.ok(downB.calledBefore(downA), 'Migration down method should call child down methods in reverse order');
+            assert(downA.calledOnceWith(config.transacting), 'first down fn should be called with transacting');
+            assert(downB.calledOnceWith(config.transacting), 'second down fn should be called with transacting');
+            assert(downB.calledBefore(downA), 'Migration down method should call child down methods in reverse order');
         });
 
         it('Waits for each migration to finish before executing the next', async function () {
@@ -97,15 +97,15 @@ describe('migrations/utils', function () {
 
             combinedMigration.up(config);
 
-            should.ok(!upB.called, 'second up fn should not be called until first up fn has resolved');
+            assert(!upB.called, 'second up fn should not be called until first up fn has resolved');
             await upDeferredA.resolve();
-            should.ok(upB.calledOnce, 'second up fn should be called once first up fn has resolved');
+            assert(upB.calledOnce, 'second up fn should be called once first up fn has resolved');
 
             combinedMigration.down(config);
 
-            should.ok(!downA.called, 'penultimate down fn should not be called until last down fn has resolved');
+            assert(!downA.called, 'penultimate down fn should not be called until last down fn has resolved');
             await downDeferredB.resolve();
-            should.ok(downA.calledOnce, 'penultimate down fn should be called once last down fn has resolved');
+            assert(downA.calledOnce, 'penultimate down fn should be called once last down fn has resolved');
         });
 
         it('Stops execution if a migration errors, and propagates error', async function () {
@@ -128,13 +128,13 @@ describe('migrations/utils', function () {
 
             const upResult = combinedMigration.up(config);
 
-            should.ok(!upB.called, 'second up fn should not be called until first up fn has resolved');
+            assert(!upB.called, 'second up fn should not be called until first up fn has resolved');
             try {
                 await upDeferredA.reject(new Error('some reason'));
             } catch (err) {
                 //
             } finally {
-                should.ok(!upB.called, 'second up fn should not be called if first up fn has rejected');
+                assert(!upB.called, 'second up fn should not be called if first up fn has rejected');
             }
 
             let upError = null;
@@ -143,18 +143,18 @@ describe('migrations/utils', function () {
             } catch (err) {
                 upError = true;
             } finally {
-                should.ok(upError, 'Migration up should error if child errors');
+                assert(upError, 'Migration up should error if child errors');
             }
 
             const downResult = combinedMigration.down(config);
 
-            should.ok(!downA.called, 'penultimate down fn should not be called until last down fn has resolved');
+            assert(!downA.called, 'penultimate down fn should not be called until last down fn has resolved');
             try {
                 await downDeferredB.reject(new Error('some reason'));
             } catch (err) {
                 //
             } finally {
-                should.ok(!downA.called, 'penultimate down fn should not be called if last down fn has rejected');
+                assert(!downA.called, 'penultimate down fn should not be called if last down fn has rejected');
             }
 
             let downErr = null;
@@ -163,7 +163,7 @@ describe('migrations/utils', function () {
             } catch (err) {
                 downErr = err;
             } finally {
-                should.ok(downErr, 'Migration down should error if child errors');
+                assert(downErr, 'Migration down should error if child errors');
             }
         });
     });
@@ -299,7 +299,7 @@ describe('migrations/utils/permissions', function () {
                 action: 'say hello'
             });
 
-            should.ok(migration.config.transaction, 'addPermission creates a transactional migration');
+            assert(migration.config.transaction, 'addPermission creates a transactional migration');
 
             const runDownMigration = await runUpMigration(knex, migration);
 
@@ -308,7 +308,7 @@ describe('migrations/utils/permissions', function () {
                 return row.name === 'scarface';
             });
 
-            should.ok(insertedPermissionsAfterUp.length === 1, 'The permission was inserted into the database');
+            assert(insertedPermissionsAfterUp.length === 1, 'The permission was inserted into the database');
 
             await runDownMigration();
 
@@ -317,7 +317,7 @@ describe('migrations/utils/permissions', function () {
                 return row.name === 'scarface';
             });
 
-            should.ok(insertedPermissionsAfterDown.length === 0, 'The permission was removed');
+            assert(insertedPermissionsAfterDown.length === 0, 'The permission was removed');
         });
     });
 
@@ -353,7 +353,7 @@ describe('migrations/utils/permissions', function () {
                 return row.name === 'Permission Name';
             });
 
-            should.ok(attachedPermissionAfterUp, 'The permission was attached to the role.');
+            assert(attachedPermissionAfterUp, 'The permission was attached to the role.');
 
             await runDownMigration();
 
@@ -378,7 +378,7 @@ describe('migrations/utils/permissions', function () {
                 return row.name === 'Permission Name';
             });
 
-            should.ok(!attachedPermissionAfterDown, 'The permission was removed from the role.');
+            assert(!attachedPermissionAfterDown, 'The permission was removed from the role.');
         });
 
         describe('Throws errors', function () {
@@ -470,7 +470,7 @@ describe('migrations/utils/permissions', function () {
                 return row.name === 'scarface';
             });
 
-            should.ok(insertedPermissionsAfterUp.length === 1, 'The permission was inserted into the database');
+            assert(insertedPermissionsAfterUp.length === 1, 'The permission was inserted into the database');
 
             const allPermissionsForRoleAfterUp = await knex.raw(`
                 SELECT
@@ -493,7 +493,7 @@ describe('migrations/utils/permissions', function () {
                 return row.name === 'scarface';
             });
 
-            should.ok(permissionAttachedToRoleAfterUp, 'The permission was attached to the role.');
+            assert(permissionAttachedToRoleAfterUp, 'The permission was attached to the role.');
 
             await knex.raw(`
                 SELECT
@@ -516,7 +516,7 @@ describe('migrations/utils/permissions', function () {
                 return row.name === 'scarface';
             });
 
-            should.ok(permissionAttachedToOtherRoleAfterUp, 'The permission was attached to the other role.');
+            assert(permissionAttachedToOtherRoleAfterUp, 'The permission was attached to the other role.');
 
             await runDownMigration();
 
@@ -525,7 +525,7 @@ describe('migrations/utils/permissions', function () {
                 return row.name === 'scarface';
             });
 
-            should.ok(insertedPermissionsAfterDown.length === 0, 'The permission was removed from the database');
+            assert(insertedPermissionsAfterDown.length === 0, 'The permission was removed from the database');
 
             const allPermissionsForRoleAfterDown = await knex.raw(`
                 SELECT
@@ -548,7 +548,7 @@ describe('migrations/utils/permissions', function () {
                 return row.name === 'scarface';
             });
 
-            should.ok(!permissionAttachedToRoleAfterDown, 'The permission was removed from the role.');
+            assert(!permissionAttachedToRoleAfterDown, 'The permission was removed from the role.');
 
             const allPermissionsForOtherRoleAfterDown = await knex.raw(`
                 SELECT
@@ -571,7 +571,7 @@ describe('migrations/utils/permissions', function () {
                 return row.name === 'scarface';
             });
 
-            should.ok(!permissionAttachedToOtherRoleAfterDown, 'The permission was removed from the other role.');
+            assert(!permissionAttachedToOtherRoleAfterDown, 'The permission was removed from the other role.');
         });
     });
 });
@@ -749,7 +749,7 @@ describe('migrations/utils/schema nullable functions', function () {
 
             const migration = utils.createSetNullableMigration('test_nullable_migration', 'not_nullable_col');
 
-            should.ok(migration.config.transaction, 'createSetNullableMigration creates a transactional migration');
+            assert(migration.config.transaction, 'createSetNullableMigration creates a transactional migration');
 
             // Verify initial state - column should be not nullable
             const isNullableInitial = await checkColumnNullable('test_nullable_migration', 'not_nullable_col', knex);
@@ -784,7 +784,7 @@ describe('migrations/utils/schema nullable functions', function () {
             try {
                 const runDownMigration = await runUpMigration(knex, migration);
 
-                should.ok(logSpy.calledWith(sinon.match('skipping as column is already nullable')), 'Should log skip message');
+                assert(logSpy.calledWith(sinon.match('skipping as column is already nullable')), 'Should log skip message');
 
                 // Column should still be nullable
                 const isNullableAfter = await checkColumnNullable('test_nullable_migration', 'nullable_col', knex);
@@ -805,7 +805,7 @@ describe('migrations/utils/schema nullable functions', function () {
 
             const migration = utils.createDropNullableMigration('test_nullable_migration', 'nullable_col');
 
-            should.ok(migration.config.transaction, 'createDropNullableMigration creates a transactional migration');
+            assert(migration.config.transaction, 'createDropNullableMigration creates a transactional migration');
 
             // Verify initial state - column should be nullable
             const isNullableInitial = await checkColumnNullable('test_nullable_migration', 'nullable_col', knex);
@@ -840,7 +840,7 @@ describe('migrations/utils/schema nullable functions', function () {
             try {
                 const runDownMigration = await runUpMigration(knex, migration);
 
-                should.ok(logSpy.calledWith(sinon.match('skipping as column is already not nullable')), 'Should log skip message');
+                assert(logSpy.calledWith(sinon.match('skipping as column is already not nullable')), 'Should log skip message');
 
                 // Column should still be not nullable
                 const isNotNullableAfter = await checkColumnNullable('test_nullable_migration', 'not_nullable_col', knex);

--- a/ghost/core/test/unit/server/models/settings.test.js
+++ b/ghost/core/test/unit/server/models/settings.test.js
@@ -166,7 +166,7 @@ describe('Unit: models/settings', function () {
                 error = err;
             } finally {
                 assertExists(error, `Setting Model should throw when saving invalid ${key}`);
-                should.ok(error instanceof errors.ValidationError, 'Setting Model should throw ValidationError');
+                assert(error instanceof errors.ValidationError, 'Setting Model should throw ValidationError');
             }
         }
 
@@ -181,17 +181,11 @@ describe('Unit: models/settings', function () {
 
             const setting = models.Settings.forge({key, value, type, group});
 
-            let error;
-            try {
-                await setting.save();
-                error = null;
-            } catch (err) {
-                error = err;
-            } finally {
-                tracker.uninstall();
-                mockDb.unmock(knex);
-                should.not.exist(error, `Setting Model should not throw when saving valid ${key}`);
-            }
+            // This should not reject.
+            await setting.save();
+
+            tracker.uninstall();
+            mockDb.unmock(knex);
         }
 
         it('throws when stripe_secret_key is invalid', async function () {

--- a/ghost/core/test/unit/server/services/auth/session/session-service.test.js
+++ b/ghost/core/test/unit/server/services/auth/session/session-service.test.js
@@ -457,7 +457,7 @@ describe('SessionService', function () {
         });
 
         const authCodeSecond = await sessionServiceSecond.generateAuthCodeForUser(req, res);
-        should.notEqual(authCodeFirst, authCodeSecond);
+        assert.notEqual(authCodeFirst, authCodeSecond);
     });
 
     it('sends an email with the auth code', async function () {

--- a/ghost/core/test/unit/server/services/lib/dynamic-redirect-manager.test.js
+++ b/ghost/core/test/unit/server/services/lib/dynamic-redirect-manager.test.js
@@ -54,7 +54,7 @@ describe('DynamicRedirectManager', function () {
             req.url = '/test-params/?q=123&lang=js';
 
             manager.handleRequest(req, res, function next() {
-                should.fail(true, false, 'next should NOT have been called');
+                assert.fail('next should NOT have been called');
             });
 
             assert.equal(headers['Cache-Control'], 'public, max-age=100');
@@ -69,7 +69,7 @@ describe('DynamicRedirectManager', function () {
             req.url = '/test-params/?q=123&lang=js';
 
             manager.handleRequest(req, res, function next() {
-                should.ok(true, 'next should have been called');
+                assert(true, 'next should have been called');
             });
 
             assert.equal(headers, null);
@@ -85,7 +85,7 @@ describe('DynamicRedirectManager', function () {
             req.url = '/test-params/?q=123&lang=js';
 
             manager.handleRequest(req, res, function next() {
-                should.ok(true, 'next should have been called');
+                assert(true, 'next should have been called');
             });
 
             assert.equal(headers, null);
@@ -104,7 +104,7 @@ describe('DynamicRedirectManager', function () {
             req.url = '/test-params/';
 
             manager.handleRequest(req, res, function next() {
-                should.ok(true, 'next should have been called');
+                assert(true, 'next should have been called');
             });
 
             assert.equal(headers, null);
@@ -123,7 +123,7 @@ describe('DynamicRedirectManager', function () {
 
             try {
                 manager.addRedirect(from , to);
-                should.fail(false, 'Should have thrown an error');
+                assert.fail('Should have thrown an error');
             } catch (e) {
                 assert.equal(e.message, 'Unknown error');
             }
@@ -141,7 +141,7 @@ describe('DynamicRedirectManager', function () {
             manager.redirects.should.be.empty();
 
             manager.handleRequest(req, res, function next() {
-                should.ok(true, 'next should have been called');
+                assert(true, 'next should have been called');
             });
         });
 
@@ -155,7 +155,7 @@ describe('DynamicRedirectManager', function () {
                 req.url = '/post/10/a-nice-blog-post';
 
                 manager.handleRequest(req, res, function next() {
-                    should.fail(true, 'next should NOT have been called');
+                    assert.fail('next should NOT have been called');
                 });
 
                 // NOTE: max-age is "0" because it's not a permanent redirect
@@ -173,7 +173,7 @@ describe('DynamicRedirectManager', function () {
                 req.url = '/post/10/a-nice-blog-post/';
 
                 manager.handleRequest(req, res, function next() {
-                    should.fail(true, 'next should NOT have been called');
+                    assert.fail('next should NOT have been called');
                 });
 
                 // NOTE: max-age is "0" because it's not a permanent redirect
@@ -191,7 +191,7 @@ describe('DynamicRedirectManager', function () {
                 req.url = '/post/10/a-nice-blog-post?a=b';
 
                 manager.handleRequest(req, res, function next() {
-                    should.fail(true, 'next should NOT have been called');
+                    assert.fail('next should NOT have been called');
                 });
 
                 // NOTE: max-age is "0" because it's not a permanent redirect
@@ -209,7 +209,7 @@ describe('DynamicRedirectManager', function () {
                 req.url = '/topic?something=good';
 
                 manager.handleRequest(req, res, function next() {
-                    should.fail(true, 'next should NOT have been called');
+                    assert.fail('next should NOT have been called');
                 });
 
                 // NOTE: max-age is "0" because it's not a permanent redirect
@@ -229,7 +229,7 @@ describe('DynamicRedirectManager', function () {
                 req.url = '/CaSe-InSeNsItIvE';
 
                 manager.handleRequest(req, res, function next() {
-                    should.fail(true, 'next should NOT have been called');
+                    assert.fail('next should NOT have been called');
                 });
 
                 // NOTE: max-age is "0" because it's not a permanent redirect
@@ -247,7 +247,7 @@ describe('DynamicRedirectManager', function () {
                 req.url = '/Case-Sensitive';
 
                 manager.handleRequest(req, res, function next() {
-                    should.fail(true, 'next should NOT have been called');
+                    assert.fail('next should NOT have been called');
                 });
 
                 // NOTE: max-age is "0" because it's not a permanent redirect
@@ -265,7 +265,7 @@ describe('DynamicRedirectManager', function () {
                 req.url = '/Default-Sensitive';
 
                 manager.handleRequest(req, res, function next() {
-                    should.fail(true, 'next should NOT have been called');
+                    assert.fail('next should NOT have been called');
                 });
 
                 assert.equal(headers['Cache-Control'], 'public, max-age=0');
@@ -282,7 +282,7 @@ describe('DynamicRedirectManager', function () {
                 req.url = '/casE-sensitivE';
 
                 manager.handleRequest(req, res, function next() {
-                    should.ok(true, 'next should have been called');
+                    assert(true, 'next should have been called');
                 });
 
                 assert.equal(headers, null);
@@ -299,7 +299,7 @@ describe('DynamicRedirectManager', function () {
                 req.url = '/defaulT-sensitivE';
 
                 manager.handleRequest(req, res, function next() {
-                    should.ok(true, 'next should have been called');
+                    assert(true, 'next should have been called');
                 });
 
                 assert.equal(headers, null);
@@ -318,7 +318,7 @@ describe('DynamicRedirectManager', function () {
                 req.url = '/external-url/';
 
                 manager.handleRequest(req, res, function next() {
-                    should.fail(true, 'next should NOT have been called');
+                    assert.fail('next should NOT have been called');
                 });
 
                 // NOTE: max-age is "0" because it's not a permanent redirect
@@ -336,7 +336,7 @@ describe('DynamicRedirectManager', function () {
                 req.url = '/external-url';
 
                 manager.handleRequest(req, res, function next() {
-                    should.fail(true, 'next should NOT have been called');
+                    assert.fail('next should NOT have been called');
                 });
 
                 // NOTE: max-age is "0" because it's not a permanent redirect
@@ -354,7 +354,7 @@ describe('DynamicRedirectManager', function () {
                 req.url = '/external-url/docs';
 
                 manager.handleRequest(req, res, function next() {
-                    should.fail(true, 'next should NOT have been called');
+                    assert.fail('next should NOT have been called');
                 });
 
                 // NOTE: max-age is "0" because it's not a permanent redirect
@@ -374,7 +374,7 @@ describe('DynamicRedirectManager', function () {
                 req.url = from;
 
                 manager.handleRequest(req, res, function next() {
-                    should.fail(true, false, 'next should NOT have been called');
+                    assert.fail('next should NOT have been called');
                 });
 
                 // NOTE: max-age is "0" because it's not a permanent redirect
@@ -406,7 +406,7 @@ describe('DynamicRedirectManager', function () {
             req.url = '/blog/my-old-blog-post/';
 
             manager.handleRequest(req, res, function next() {
-                should.fail(true, 'next should NOT have been called');
+                assert.fail('next should NOT have been called');
             });
 
             assert.equal(headers['Cache-Control'], 'public, max-age=100');

--- a/ghost/core/test/unit/server/services/members/stripe-connect.test.js
+++ b/ghost/core/test/unit/server/services/members/stripe-connect.test.js
@@ -11,7 +11,7 @@ describe('Members - Stripe Connect', function () {
         /** @type URL */
         const url = await stripeConnect.getStripeConnectOAuthUrl(setSessionProp);
 
-        should.ok(url instanceof URL, 'getStripeConnectOAuthUrl should return an instance of URL');
+        assert(url instanceof URL, 'getStripeConnectOAuthUrl should return an instance of URL');
 
         assertExists(session.get(stripeConnect.STATE_PROP), 'The session should have a state set');
 

--- a/ghost/core/test/unit/server/services/offers/domain/models/offer-amount.test.js
+++ b/ghost/core/test/unit/server/services/offers/domain/models/offer-amount.test.js
@@ -11,50 +11,35 @@ describe('OfferAmount', function () {
                     OfferPercentageAmount.create();
                     assert.fail();
                 } catch (err) {
-                    should.ok(
-                        err instanceof OfferPercentageAmount.InvalidOfferAmount,
-                        'expected an InvalidOfferAmount error'
-                    );
+                    assert(err instanceof OfferPercentageAmount.InvalidOfferAmount, 'expected an InvalidOfferAmount error');
                 }
 
                 try {
                     OfferPercentageAmount.create('1');
                     assert.fail();
                 } catch (err) {
-                    should.ok(
-                        err instanceof OfferPercentageAmount.InvalidOfferAmount,
-                        'expected an InvalidOfferAmount error'
-                    );
+                    assert(err instanceof OfferPercentageAmount.InvalidOfferAmount, 'expected an InvalidOfferAmount error');
                 }
 
                 try {
                     OfferPercentageAmount.create(-1);
                     assert.fail();
                 } catch (err) {
-                    should.ok(
-                        err instanceof OfferPercentageAmount.InvalidOfferAmount,
-                        'expected an InvalidOfferAmount error'
-                    );
+                    assert(err instanceof OfferPercentageAmount.InvalidOfferAmount, 'expected an InvalidOfferAmount error');
                 }
 
                 try {
                     OfferPercentageAmount.create(200);
                     assert.fail();
                 } catch (err) {
-                    should.ok(
-                        err instanceof OfferPercentageAmount.InvalidOfferAmount,
-                        'expected an InvalidOfferAmount error'
-                    );
+                    assert(err instanceof OfferPercentageAmount.InvalidOfferAmount, 'expected an InvalidOfferAmount error');
                 }
 
                 try {
                     OfferPercentageAmount.create(3.14);
                     assert.fail();
                 } catch (err) {
-                    should.ok(
-                        err instanceof OfferPercentageAmount.InvalidOfferAmount,
-                        'expected an InvalidOfferAmount error'
-                    );
+                    assert(err instanceof OfferPercentageAmount.InvalidOfferAmount, 'expected an InvalidOfferAmount error');
                 }
 
                 OfferPercentageAmount.create(69); // nice
@@ -75,40 +60,28 @@ describe('OfferAmount', function () {
                     OfferFixedAmount.create();
                     assert.fail();
                 } catch (err) {
-                    should.ok(
-                        err instanceof OfferFixedAmount.InvalidOfferAmount,
-                        'expected an InvalidOfferAmount error'
-                    );
+                    assert(err instanceof OfferFixedAmount.InvalidOfferAmount, 'expected an InvalidOfferAmount error');
                 }
 
                 try {
                     OfferFixedAmount.create('1');
                     assert.fail();
                 } catch (err) {
-                    should.ok(
-                        err instanceof OfferFixedAmount.InvalidOfferAmount,
-                        'expected an InvalidOfferAmount error'
-                    );
+                    assert(err instanceof OfferFixedAmount.InvalidOfferAmount, 'expected an InvalidOfferAmount error');
                 }
 
                 try {
                     OfferFixedAmount.create(-1);
                     assert.fail();
                 } catch (err) {
-                    should.ok(
-                        err instanceof OfferFixedAmount.InvalidOfferAmount,
-                        'expected an InvalidOfferAmount error'
-                    );
+                    assert(err instanceof OfferFixedAmount.InvalidOfferAmount, 'expected an InvalidOfferAmount error');
                 }
 
                 try {
                     OfferFixedAmount.create(3.14);
                     assert.fail();
                 } catch (err) {
-                    should.ok(
-                        err instanceof OfferFixedAmount.InvalidOfferAmount,
-                        'expected an InvalidOfferAmount error'
-                    );
+                    assert(err instanceof OfferFixedAmount.InvalidOfferAmount, 'expected an InvalidOfferAmount error');
                 }
 
                 OfferFixedAmount.create(200);
@@ -129,40 +102,28 @@ describe('OfferAmount', function () {
                     OfferTrialAmount.create();
                     assert.fail();
                 } catch (err) {
-                    should.ok(
-                        err instanceof OfferTrialAmount.InvalidOfferAmount,
-                        'expected an InvalidOfferAmount error'
-                    );
+                    assert(err instanceof OfferTrialAmount.InvalidOfferAmount, 'expected an InvalidOfferAmount error');
                 }
 
                 try {
                     OfferTrialAmount.create('1');
                     assert.fail();
                 } catch (err) {
-                    should.ok(
-                        err instanceof OfferTrialAmount.InvalidOfferAmount,
-                        'expected an InvalidOfferAmount error'
-                    );
+                    assert(err instanceof OfferTrialAmount.InvalidOfferAmount, 'expected an InvalidOfferAmount error');
                 }
 
                 try {
                     OfferTrialAmount.create(-1);
                     assert.fail();
                 } catch (err) {
-                    should.ok(
-                        err instanceof OfferTrialAmount.InvalidOfferAmount,
-                        'expected an InvalidOfferAmount error'
-                    );
+                    assert(err instanceof OfferTrialAmount.InvalidOfferAmount, 'expected an InvalidOfferAmount error');
                 }
 
                 try {
                     OfferTrialAmount.create(3.14);
                     assert.fail();
                 } catch (err) {
-                    should.ok(
-                        err instanceof OfferTrialAmount.InvalidOfferAmount,
-                        'expected an InvalidOfferAmount error'
-                    );
+                    assert(err instanceof OfferTrialAmount.InvalidOfferAmount, 'expected an InvalidOfferAmount error');
                 }
 
                 OfferTrialAmount.create(200);
@@ -181,52 +142,37 @@ describe('OfferAmount', function () {
             it('Will only create an OfferFreeMonthsAmount containing an integer greater than 0', function () {
                 try {
                     OfferFreeMonthsAmount.create();
-                    should.fail();
+                    assert.fail();
                 } catch (err) {
-                    should.ok(
-                        err instanceof OfferFreeMonthsAmount.InvalidOfferAmount,
-                        'expected an InvalidOfferAmount error'
-                    );
+                    assert(err instanceof OfferFreeMonthsAmount.InvalidOfferAmount, 'expected an InvalidOfferAmount error');
                 }
 
                 try {
                     OfferFreeMonthsAmount.create('1');
-                    should.fail();
+                    assert.fail();
                 } catch (err) {
-                    should.ok(
-                        err instanceof OfferFreeMonthsAmount.InvalidOfferAmount,
-                        'expected an InvalidOfferAmount error'
-                    );
+                    assert(err instanceof OfferFreeMonthsAmount.InvalidOfferAmount, 'expected an InvalidOfferAmount error');
                 }
 
                 try {
                     OfferFreeMonthsAmount.create(0);
-                    should.fail();
+                    assert.fail();
                 } catch (err) {
-                    should.ok(
-                        err instanceof OfferFreeMonthsAmount.InvalidOfferAmount,
-                        'expected an InvalidOfferAmount error'
-                    );
+                    assert(err instanceof OfferFreeMonthsAmount.InvalidOfferAmount, 'expected an InvalidOfferAmount error');
                 }
 
                 try {
                     OfferFreeMonthsAmount.create(-1);
-                    should.fail();
+                    assert.fail();
                 } catch (err) {
-                    should.ok(
-                        err instanceof OfferFreeMonthsAmount.InvalidOfferAmount,
-                        'expected an InvalidOfferAmount error'
-                    );
+                    assert(err instanceof OfferFreeMonthsAmount.InvalidOfferAmount, 'expected an InvalidOfferAmount error');
                 }
 
                 try {
                     OfferFreeMonthsAmount.create(3.14);
-                    should.fail();
+                    assert.fail();
                 } catch (err) {
-                    should.ok(
-                        err instanceof OfferFreeMonthsAmount.InvalidOfferAmount,
-                        'expected an InvalidOfferAmount error'
-                    );
+                    assert(err instanceof OfferFreeMonthsAmount.InvalidOfferAmount, 'expected an InvalidOfferAmount error');
                 }
 
                 OfferFreeMonthsAmount.create(1);
@@ -236,7 +182,7 @@ describe('OfferAmount', function () {
         it('Exposes a number on the value property', function () {
             const cadence = OfferFreeMonthsAmount.create(2);
 
-            should.ok(typeof cadence.value === 'number');
+            assert.equal(typeof cadence.value, 'number');
         });
     });
 });

--- a/ghost/core/test/unit/server/services/offers/domain/models/offer-cadence.test.js
+++ b/ghost/core/test/unit/server/services/offers/domain/models/offer-cadence.test.js
@@ -13,30 +13,21 @@ describe('OfferCadence', function () {
                 OfferCadence.create();
                 assert.fail();
             } catch (err) {
-                should.ok(
-                    err instanceof OfferCadence.InvalidOfferCadence,
-                    'expected an InvalidOfferCadence error'
-                );
+                assert(err instanceof OfferCadence.InvalidOfferCadence, 'expected an InvalidOfferCadence error');
             }
 
             try {
                 OfferCadence.create(12);
                 assert.fail();
             } catch (err) {
-                should.ok(
-                    err instanceof OfferCadence.InvalidOfferCadence,
-                    'expected an InvalidOfferCadence error'
-                );
+                assert(err instanceof OfferCadence.InvalidOfferCadence, 'expected an InvalidOfferCadence error');
             }
 
             try {
                 OfferCadence.create('daily');
                 assert.fail();
             } catch (err) {
-                should.ok(
-                    err instanceof OfferCadence.InvalidOfferCadence,
-                    'expected an InvalidOfferCadence error'
-                );
+                assert(err instanceof OfferCadence.InvalidOfferCadence, 'expected an InvalidOfferCadence error');
             }
         });
     });

--- a/ghost/core/test/unit/server/services/offers/domain/models/offer-code.test.js
+++ b/ghost/core/test/unit/server/services/offers/domain/models/offer-code.test.js
@@ -12,20 +12,14 @@ describe('OfferCode', function () {
                 OfferCode.create();
                 assert.fail();
             } catch (err) {
-                should.ok(
-                    err instanceof OfferCode.InvalidOfferCode,
-                    'expected an InvalidOfferCode error'
-                );
+                assert(err instanceof OfferCode.InvalidOfferCode, 'expected an InvalidOfferCode error');
             }
 
             try {
                 OfferCode.create(1234);
                 assert.fail();
             } catch (err) {
-                should.ok(
-                    err instanceof OfferCode.InvalidOfferCode,
-                    'expected an InvalidOfferCode error'
-                );
+                assert(err instanceof OfferCode.InvalidOfferCode, 'expected an InvalidOfferCode error');
             }
 
             const code = OfferCode.create('Hello, world');
@@ -48,10 +42,7 @@ describe('OfferCode', function () {
                 OfferCode.create(tooLong);
                 assert.fail();
             } catch (err) {
-                should.ok(
-                    err instanceof OfferCode.InvalidOfferCode,
-                    'expected an InvalidOfferCode error'
-                );
+                assert(err instanceof OfferCode.InvalidOfferCode, 'expected an InvalidOfferCode error');
             }
         });
     });

--- a/ghost/core/test/unit/server/services/offers/domain/models/offer-currency.test.js
+++ b/ghost/core/test/unit/server/services/offers/domain/models/offer-currency.test.js
@@ -13,50 +13,35 @@ describe('OfferCurrency', function () {
                 OfferCurrency.create();
                 assert.fail();
             } catch (err) {
-                should.ok(
-                    err instanceof OfferCurrency.InvalidOfferCurrency,
-                    'expected an InvalidOfferCurrency error'
-                );
+                assert(err instanceof OfferCurrency.InvalidOfferCurrency, 'expected an InvalidOfferCurrency error');
             }
 
             try {
                 OfferCurrency.create('US Dollars');
                 assert.fail();
             } catch (err) {
-                should.ok(
-                    err instanceof OfferCurrency.InvalidOfferCurrency,
-                    'expected an InvalidOfferCurrency error'
-                );
+                assert(err instanceof OfferCurrency.InvalidOfferCurrency, 'expected an InvalidOfferCurrency error');
             }
 
             try {
                 OfferCurrency.create('$');
                 assert.fail();
             } catch (err) {
-                should.ok(
-                    err instanceof OfferCurrency.InvalidOfferCurrency,
-                    'expected an InvalidOfferCurrency error'
-                );
+                assert(err instanceof OfferCurrency.InvalidOfferCurrency, 'expected an InvalidOfferCurrency error');
             }
 
             try {
                 OfferCurrency.create('USDC');
                 assert.fail();
             } catch (err) {
-                should.ok(
-                    err instanceof OfferCurrency.InvalidOfferCurrency,
-                    'expected an InvalidOfferCurrency error'
-                );
+                assert(err instanceof OfferCurrency.InvalidOfferCurrency, 'expected an InvalidOfferCurrency error');
             }
 
             try {
                 OfferCurrency.create(2);
                 assert.fail();
             } catch (err) {
-                should.ok(
-                    err instanceof OfferCurrency.InvalidOfferCurrency,
-                    'expected an InvalidOfferCurrency error'
-                );
+                assert(err instanceof OfferCurrency.InvalidOfferCurrency, 'expected an InvalidOfferCurrency error');
             }
         });
     });

--- a/ghost/core/test/unit/server/services/offers/domain/models/offer-description.test.js
+++ b/ghost/core/test/unit/server/services/offers/domain/models/offer-description.test.js
@@ -16,20 +16,14 @@ describe('OfferDescription', function () {
                 OfferDescription.create(12);
                 assert.fail();
             } catch (err) {
-                should.ok(
-                    err instanceof OfferDescription.InvalidOfferDescription,
-                    'expected an InvalidOfferDescription error'
-                );
+                assert(err instanceof OfferDescription.InvalidOfferDescription, 'expected an InvalidOfferDescription error');
             }
 
             try {
                 OfferDescription.create({});
                 assert.fail();
             } catch (err) {
-                should.ok(
-                    err instanceof OfferDescription.InvalidOfferDescription,
-                    'expected an InvalidOfferDescription error'
-                );
+                assert(err instanceof OfferDescription.InvalidOfferDescription, 'expected an InvalidOfferDescription error');
             }
         });
 
@@ -48,10 +42,7 @@ describe('OfferDescription', function () {
                 OfferDescription.create(tooLong);
                 assert.fail();
             } catch (err) {
-                should.ok(
-                    err instanceof OfferDescription.InvalidOfferDescription,
-                    'expected an InvalidOfferDescription error'
-                );
+                assert(err instanceof OfferDescription.InvalidOfferDescription, 'expected an InvalidOfferDescription error');
             }
         });
 

--- a/ghost/core/test/unit/server/services/offers/domain/models/offer-duration.test.js
+++ b/ghost/core/test/unit/server/services/offers/domain/models/offer-duration.test.js
@@ -16,60 +16,42 @@ describe('OfferDuration', function () {
                 OfferDuration.create();
                 assert.fail();
             } catch (err) {
-                should.ok(
-                    err instanceof OfferDuration.InvalidOfferDuration,
-                    'expected an InvalidOfferDuration error'
-                );
+                assert(err instanceof OfferDuration.InvalidOfferDuration, 'expected an InvalidOfferDuration error');
             }
 
             try {
                 OfferDuration.create('other');
                 assert.fail();
             } catch (err) {
-                should.ok(
-                    err instanceof OfferDuration.InvalidOfferDuration,
-                    'expected an InvalidOfferDuration error'
-                );
+                assert(err instanceof OfferDuration.InvalidOfferDuration, 'expected an InvalidOfferDuration error');
             }
 
             try {
                 OfferDuration.create('repeating');
                 assert.fail();
             } catch (err) {
-                should.ok(
-                    err instanceof OfferDuration.InvalidOfferDuration,
-                    'expected an InvalidOfferDuration error'
-                );
+                assert(err instanceof OfferDuration.InvalidOfferDuration, 'expected an InvalidOfferDuration error');
             }
 
             try {
                 OfferDuration.create('repeating', 1.5);
                 assert.fail();
             } catch (err) {
-                should.ok(
-                    err instanceof OfferDuration.InvalidOfferDuration,
-                    'expected an InvalidOfferDuration error'
-                );
+                assert(err instanceof OfferDuration.InvalidOfferDuration, 'expected an InvalidOfferDuration error');
             }
 
             try {
                 OfferDuration.create('repeating', -12);
                 assert.fail();
             } catch (err) {
-                should.ok(
-                    err instanceof OfferDuration.InvalidOfferDuration,
-                    'expected an InvalidOfferDuration error'
-                );
+                assert(err instanceof OfferDuration.InvalidOfferDuration, 'expected an InvalidOfferDuration error');
             }
 
             try {
                 OfferDuration.create('repeating', '2');
                 assert.fail();
             } catch (err) {
-                should.ok(
-                    err instanceof OfferDuration.InvalidOfferDuration,
-                    'expected an InvalidOfferDuration error'
-                );
+                assert(err instanceof OfferDuration.InvalidOfferDuration, 'expected an InvalidOfferDuration error');
             }
         });
     });

--- a/ghost/core/test/unit/server/services/offers/domain/models/offer-name.test.js
+++ b/ghost/core/test/unit/server/services/offers/domain/models/offer-name.test.js
@@ -12,40 +12,28 @@ describe('OfferName', function () {
                 OfferName.create();
                 assert.fail();
             } catch (err) {
-                should.ok(
-                    err instanceof OfferName.InvalidOfferName,
-                    'expected an InvalidOfferName error'
-                );
+                assert(err instanceof OfferName.InvalidOfferName, 'expected an InvalidOfferName error');
             }
 
             try {
                 OfferName.create(null);
                 assert.fail();
             } catch (err) {
-                should.ok(
-                    err instanceof OfferName.InvalidOfferName,
-                    'expected an InvalidOfferName error'
-                );
+                assert(err instanceof OfferName.InvalidOfferName, 'expected an InvalidOfferName error');
             }
 
             try {
                 OfferName.create(12);
                 assert.fail();
             } catch (err) {
-                should.ok(
-                    err instanceof OfferName.InvalidOfferName,
-                    'expected an InvalidOfferName error'
-                );
+                assert(err instanceof OfferName.InvalidOfferName, 'expected an InvalidOfferName error');
             }
 
             try {
                 OfferName.create({});
                 assert.fail();
             } catch (err) {
-                should.ok(
-                    err instanceof OfferName.InvalidOfferName,
-                    'expected an InvalidOfferName error'
-                );
+                assert(err instanceof OfferName.InvalidOfferName, 'expected an InvalidOfferName error');
             }
         });
 
@@ -64,10 +52,7 @@ describe('OfferName', function () {
                 OfferName.create(tooLong);
                 assert.fail();
             } catch (err) {
-                should.ok(
-                    err instanceof OfferName.InvalidOfferName,
-                    'expected an InvalidOfferName error'
-                );
+                assert(err instanceof OfferName.InvalidOfferName, 'expected an InvalidOfferName error');
             }
         });
 

--- a/ghost/core/test/unit/server/services/offers/domain/models/offer-redemption-type.test.js
+++ b/ghost/core/test/unit/server/services/offers/domain/models/offer-redemption-type.test.js
@@ -13,20 +13,14 @@ describe('OfferRedemptionType', function () {
                 OfferRedemptionType.create('other');
                 assert.fail();
             } catch (err) {
-                should.ok(
-                    err instanceof OfferRedemptionType.InvalidOfferRedemptionType,
-                    'expected an InvalidOfferRedemptionType error'
-                );
+                assert(err instanceof OfferRedemptionType.InvalidOfferRedemptionType, 'expected an InvalidOfferRedemptionType error');
             }
 
             try {
                 OfferRedemptionType.create();
                 assert.fail();
             } catch (err) {
-                should.ok(
-                    err instanceof OfferRedemptionType.InvalidOfferRedemptionType,
-                    'expected an InvalidOfferRedemptionType error'
-                );
+                assert(err instanceof OfferRedemptionType.InvalidOfferRedemptionType, 'expected an InvalidOfferRedemptionType error');
             }
         });
     });

--- a/ghost/core/test/unit/server/services/offers/domain/models/offer-status.test.js
+++ b/ghost/core/test/unit/server/services/offers/domain/models/offer-status.test.js
@@ -13,20 +13,14 @@ describe('OfferStatus', function () {
                 OfferStatus.create('other');
                 assert.fail();
             } catch (err) {
-                should.ok(
-                    err instanceof OfferStatus.InvalidOfferStatus,
-                    'expected an InvalidOfferStatus error'
-                );
+                assert(err instanceof OfferStatus.InvalidOfferStatus, 'expected an InvalidOfferStatus error');
             }
 
             try {
                 OfferStatus.create();
                 assert.fail();
             } catch (err) {
-                should.ok(
-                    err instanceof OfferStatus.InvalidOfferStatus,
-                    'expected an InvalidOfferStatus error'
-                );
+                assert(err instanceof OfferStatus.InvalidOfferStatus, 'expected an InvalidOfferStatus error');
             }
         });
     });

--- a/ghost/core/test/unit/server/services/offers/domain/models/offer-title.test.js
+++ b/ghost/core/test/unit/server/services/offers/domain/models/offer-title.test.js
@@ -16,20 +16,14 @@ describe('OfferTitle', function () {
                 OfferTitle.create(12);
                 assert.fail();
             } catch (err) {
-                should.ok(
-                    err instanceof OfferTitle.InvalidOfferTitle,
-                    'expected an InvalidOfferTitle error'
-                );
+                assert(err instanceof OfferTitle.InvalidOfferTitle, 'expected an InvalidOfferTitle error');
             }
 
             try {
                 OfferTitle.create({});
                 assert.fail();
             } catch (err) {
-                should.ok(
-                    err instanceof OfferTitle.InvalidOfferTitle,
-                    'expected an InvalidOfferTitle error'
-                );
+                assert(err instanceof OfferTitle.InvalidOfferTitle, 'expected an InvalidOfferTitle error');
             }
         });
 
@@ -48,10 +42,7 @@ describe('OfferTitle', function () {
                 OfferTitle.create(tooLong);
                 assert.fail();
             } catch (err) {
-                should.ok(
-                    err instanceof OfferTitle.InvalidOfferTitle,
-                    'expected an InvalidOfferTitle error'
-                );
+                assert(err instanceof OfferTitle.InvalidOfferTitle, 'expected an InvalidOfferTitle error');
             }
         });
 

--- a/ghost/core/test/unit/server/services/offers/domain/models/offer-type.test.js
+++ b/ghost/core/test/unit/server/services/offers/domain/models/offer-type.test.js
@@ -15,20 +15,14 @@ describe('OfferType', function () {
                 OfferType.create('other');
                 assert.fail();
             } catch (err) {
-                should.ok(
-                    err instanceof OfferType.InvalidOfferType,
-                    'expected an InvalidOfferType error'
-                );
+                assert(err instanceof OfferType.InvalidOfferType, 'expected an InvalidOfferType error');
             }
 
             try {
                 OfferType.create();
                 assert.fail();
             } catch (err) {
-                should.ok(
-                    err instanceof OfferType.InvalidOfferType,
-                    'expected an InvalidOfferType error'
-                );
+                assert(err instanceof OfferType.InvalidOfferType, 'expected an InvalidOfferType error');
             }
         });
     });
@@ -57,7 +51,7 @@ describe('OfferType', function () {
     describe('OfferType.FreeMonths', function () {
         it('Is an OfferType with a value of "free_months"', function () {
             assert.equal(OfferType.FreeMonths.value, 'free_months');
-            should.ok(OfferType.FreeMonths.equals(OfferType.create('free_months')));
+            assert(OfferType.FreeMonths.equals(OfferType.create('free_months')));
         });
     });
 });

--- a/ghost/core/test/unit/server/services/offers/domain/models/offer.test.js
+++ b/ghost/core/test/unit/server/services/offers/domain/models/offer.test.js
@@ -37,10 +37,7 @@ describe('Offer', function () {
                     id: ObjectID()
                 }
             }, mockUniqueChecker);
-            should.ok(
-                offer instanceof Offer,
-                'Offer.create should return an instance of Offer'
-            );
+            assert(offer instanceof Offer, 'Offer.create should return an instance of Offer');
         });
 
         it('Stores stripe_coupon_id when provided', async function () {
@@ -77,10 +74,7 @@ describe('Offer', function () {
                     id: ObjectID()
                 }
             }, mockUniqueChecker);
-            should.ok(
-                offer instanceof Offer,
-                'Offer.create should return an instance of Offer'
-            );
+            assert(offer instanceof Offer, 'Offer.create should return an instance of Offer');
         });
 
         it('Can create a free-months offer on monthly cadence', async function () {
@@ -99,10 +93,7 @@ describe('Offer', function () {
                     id: ObjectID()
                 }
             }, mockUniqueChecker);
-            should.ok(
-                offer instanceof Offer,
-                'Should create a free months offer on monthly cadence'
-            );
+            assert(offer instanceof Offer, 'Should create a free months offer on monthly cadence');
         });
 
         it('Can create a free-months offer on yearly cadence', async function () {
@@ -121,10 +112,7 @@ describe('Offer', function () {
                     id: ObjectID()
                 }
             }, mockUniqueChecker);
-            should.ok(
-                offer instanceof Offer,
-                'Should create a free months offer on yearly cadence'
-            );
+            assert(offer instanceof Offer, 'Should create a free months offer on yearly cadence');
         });
 
         it('Throws an error if the duration for trial offer is not right', async function () {
@@ -163,9 +151,9 @@ describe('Offer', function () {
                     id: ObjectID()
                 }
             }, mockUniqueChecker).then(() => {
-                should.fail('Expected an error');
+                assert.fail('Expected an error');
             }, (err) => {
-                should.ok(err);
+                assert(err);
             });
         });
 
@@ -405,7 +393,7 @@ describe('Offer', function () {
                 tier: null
             }, mockUniqueChecker);
 
-            should.ok(offer instanceof Offer);
+            assert(offer instanceof Offer);
             assert.equal(offer.tier, null);
             assert.equal(offer.redemptionType.value, 'retention');
         });
@@ -427,9 +415,9 @@ describe('Offer', function () {
                         id: ObjectID()
                     }
                 }, mockUniqueChecker);
-                should.fail('Expected an error');
+                assert.fail('Expected an error');
             } catch (err) {
-                should.ok(err instanceof errors.InvalidOfferTier);
+                assert(err instanceof errors.InvalidOfferTier);
             }
         });
 
@@ -448,9 +436,9 @@ describe('Offer', function () {
                     redemption_type: 'signup',
                     tier: null
                 }, mockUniqueChecker);
-                should.fail('Expected an error');
+                assert.fail('Expected an error');
             } catch (err) {
-                should.ok(err instanceof errors.InvalidOfferTier);
+                assert(err instanceof errors.InvalidOfferTier);
             }
         });
 
@@ -468,9 +456,9 @@ describe('Offer', function () {
                     duration: 'forever',
                     tier: null
                 }, mockUniqueChecker);
-                should.fail('Expected an error');
+                assert.fail('Expected an error');
             } catch (err) {
-                should.ok(err instanceof errors.InvalidOfferTier);
+                assert(err instanceof errors.InvalidOfferTier);
             }
         });
     });

--- a/ghost/core/test/unit/server/services/route-settings/route-settings.test.js
+++ b/ghost/core/test/unit/server/services/route-settings/route-settings.test.js
@@ -43,7 +43,7 @@ describe('UNIT > Settings Service DefaultSettingsManager:', function () {
 
             try {
                 await defaultSettingsManager.setFromFilePath(incomingSettingsPath);
-                assert.fail('should.fail');
+                assert.fail();
             } catch (error) {
                 assert.match(error.message, /YAMLException: bad indentation of a mapping entry/);
             }

--- a/ghost/core/test/unit/server/services/route-settings/settings-path-manager.test.js
+++ b/ghost/core/test/unit/server/services/route-settings/settings-path-manager.test.js
@@ -1,23 +1,14 @@
-// Switch these lines once there are useful utils
 const assert = require('node:assert/strict');
-const {assertExists} = require('../../../../utils/assertions');
-// const testUtils = require('./utils');
-const should = require('should');
 const SettingsPathManager = require('../../../../../core/server/services/route-settings/settings-path-manager');
 
 describe('Settings Path Manager', function () {
     it('throws when paths parameter is not provided', function () {
-        try {
-            const settingsPathManager = new SettingsPathManager({
+        assert.throws(() => {
+            new SettingsPathManager({
                 paths: [],
                 type: 'routes'
             });
-
-            should.fail(settingsPathManager, 'Should have errored');
-        } catch (err) {
-            assertExists(err);
-            assert.match(err.message, /paths values/g);
-        }
+        }, /paths values/g);
     });
 
     describe('getDefaultFilePath', function () {

--- a/ghost/core/test/unit/server/services/themes/validate.test.js
+++ b/ghost/core/test/unit/server/services/themes/validate.test.js
@@ -132,21 +132,18 @@ describe('Themes', function () {
                 });
         });
 
-        it('[failure] can handle a corrupt zip file', function () {
+        it('[failure] can handle a corrupt zip file', async function () {
             checkZipStub.rejects(new Error('invalid zip file'));
             formatStub.returns({results: {error: []}});
 
-            return validate.check(testTheme.name, testTheme, {isZip: true})
-                .then((checkedTheme) => {
-                    checkedTheme.should.not.exist();
-                }).catch((error) => {
-                    assert(error instanceof Error);
-                    assert.equal(error.message, 'invalid zip file');
-                    assert.equal(checkZipStub.calledOnce, true);
-                    assert.equal(checkZipStub.calledWith(testTheme), true);
-                    sinon.assert.notCalled(checkStub);
-                    assert.equal(formatStub.calledOnce, false);
-                });
+            await assert.rejects(() => (
+                validate.check(testTheme.name, testTheme, {isZip: true})
+            ), {message: 'invalid zip file'});
+
+            sinon.assert.calledOnce(checkZipStub);
+            sinon.assert.calledWith(checkZipStub, testTheme);
+            sinon.assert.notCalled(checkStub);
+            sinon.assert.notCalled(formatStub);
         });
     });
 


### PR DESCRIPTION
This test-only change should have no user impact. It removes:

- `should.ok`
- `should.fail`
- `should.notEqual`
- `should.not.exist`

`git grep -F ' should.'` returns no results after this change.
