### PR TITLE
Removed `should.eql`

### DIFF
--- a/ghost/core/test/e2e-api/admin/actions.test.js
+++ b/ghost/core/test/e2e-api/admin/actions.test.js
@@ -56,10 +56,10 @@ describe('Actions API', function () {
         assert.equal(res2.body.actions[0].actor_type, 'user');
         assert.equal(res2.body.actions[0].event, 'added');
         assert.equal(Object.keys(res2.body.actions[0].actor).length, 4);
-        res2.body.actions[0].actor.id.should.eql(testUtils.DataGenerator.Content.users[0].id);
-        res2.body.actions[0].actor.image.should.eql(testUtils.DataGenerator.Content.users[0].profile_image);
-        res2.body.actions[0].actor.name.should.eql(testUtils.DataGenerator.Content.users[0].name);
-        res2.body.actions[0].actor.slug.should.eql(testUtils.DataGenerator.Content.users[0].slug);
+        assert.equal(res2.body.actions[0].actor.id, testUtils.DataGenerator.Content.users[0].id);
+        assert.equal(res2.body.actions[0].actor.image, testUtils.DataGenerator.Content.users[0].profile_image);
+        assert.equal(res2.body.actions[0].actor.name, testUtils.DataGenerator.Content.users[0].name);
+        assert.equal(res2.body.actions[0].actor.slug, testUtils.DataGenerator.Content.users[0].slug);
 
         clock.tick(1000);
 
@@ -94,10 +94,10 @@ describe('Actions API', function () {
         assert.equal(res4.body.actions[0].actor_type, 'user');
         assert.equal(res4.body.actions[0].event, 'edited');
         assert.equal(Object.keys(res4.body.actions[0].actor).length, 4);
-        res4.body.actions[0].actor.id.should.eql(testUtils.DataGenerator.Content.users[0].id);
-        res4.body.actions[0].actor.image.should.eql(testUtils.DataGenerator.Content.users[0].profile_image);
-        res4.body.actions[0].actor.name.should.eql(testUtils.DataGenerator.Content.users[0].name);
-        res4.body.actions[0].actor.slug.should.eql(testUtils.DataGenerator.Content.users[0].slug);
+        assert.equal(res4.body.actions[0].actor.id, testUtils.DataGenerator.Content.users[0].id);
+        assert.equal(res4.body.actions[0].actor.image, testUtils.DataGenerator.Content.users[0].profile_image);
+        assert.equal(res4.body.actions[0].actor.name, testUtils.DataGenerator.Content.users[0].name);
+        assert.equal(res4.body.actions[0].actor.slug, testUtils.DataGenerator.Content.users[0].slug);
 
         clock.tick(1000);
 
@@ -132,9 +132,9 @@ describe('Actions API', function () {
         assert.equal(res5.body.actions[0].actor_type, 'integration');
         assert.equal(res5.body.actions[0].event, 'edited');
         assert.equal(Object.keys(res5.body.actions[0].actor).length, 4);
-        res5.body.actions[0].actor.id.should.eql(testUtils.DataGenerator.Content.integrations[0].id);
+        assert.equal(res5.body.actions[0].actor.id, testUtils.DataGenerator.Content.integrations[0].id);
         assert.equal(res5.body.actions[0].actor.image, null);
-        res5.body.actions[0].actor.name.should.eql(testUtils.DataGenerator.Content.integrations[0].name);
-        res5.body.actions[0].actor.slug.should.eql(testUtils.DataGenerator.Content.integrations[0].slug);
+        assert.equal(res5.body.actions[0].actor.name, testUtils.DataGenerator.Content.integrations[0].name);
+        assert.equal(res5.body.actions[0].actor.slug, testUtils.DataGenerator.Content.integrations[0].slug);
     });
 });

--- a/ghost/core/test/e2e-api/admin/invites.test.js
+++ b/ghost/core/test/e2e-api/admin/invites.test.js
@@ -44,11 +44,11 @@ describe('Invites API', function () {
 
             assert.equal(jsonResponse.invites[0].status, 'sent');
             assert.equal(jsonResponse.invites[0].email, 'test1@ghost.org');
-            jsonResponse.invites[0].role_id.should.eql(testUtils.roles.ids.admin);
+            assert.equal(jsonResponse.invites[0].role_id, testUtils.roles.ids.admin);
 
             assert.equal(jsonResponse.invites[1].status, 'sent');
             assert.equal(jsonResponse.invites[1].email, 'test2@ghost.org');
-            jsonResponse.invites[1].role_id.should.eql(testUtils.roles.ids.author);
+            assert.equal(jsonResponse.invites[1].role_id, testUtils.roles.ids.author);
 
             assert.equal(mailService.GhostMailer.prototype.send.called, false);
         });
@@ -89,7 +89,7 @@ describe('Invites API', function () {
             assert.equal(jsonResponse.invites.length, 1);
 
             localUtils.API.checkResponse(jsonResponse.invites[0], 'invite');
-            jsonResponse.invites[0].role_id.should.eql(testUtils.getExistingData().roles[1].id);
+            assert.equal(jsonResponse.invites[0].role_id, testUtils.getExistingData().roles[1].id);
 
             assert.equal(mailService.GhostMailer.prototype.send.called, true);
 
@@ -153,7 +153,7 @@ describe('Invites API', function () {
             assert.equal(jsonResponse.invites.length, 1);
 
             localUtils.API.checkResponse(jsonResponse.invites[0], 'invite');
-            jsonResponse.invites[0].role_id.should.eql(roleId);
+            assert.equal(jsonResponse.invites[0].role_id, roleId);
 
             assert.equal(mailService.GhostMailer.prototype.send.called, true);
 
@@ -180,7 +180,7 @@ describe('Invites API', function () {
             assert.equal(jsonResponse.invites.length, 1);
 
             localUtils.API.checkResponse(jsonResponse.invites[0], 'invite');
-            jsonResponse.invites[0].role_id.should.eql(roleId);
+            assert.equal(jsonResponse.invites[0].role_id, roleId);
 
             assert.equal(mailService.GhostMailer.prototype.send.called, true);
 
@@ -207,7 +207,7 @@ describe('Invites API', function () {
             assert.equal(jsonResponse.invites.length, 1);
 
             localUtils.API.checkResponse(jsonResponse.invites[0], 'invite');
-            jsonResponse.invites[0].role_id.should.eql(roleId);
+            assert.equal(jsonResponse.invites[0].role_id, roleId);
 
             assert.equal(mailService.GhostMailer.prototype.send.called, true);
 
@@ -234,7 +234,7 @@ describe('Invites API', function () {
             assert.equal(jsonResponse.invites.length, 1);
 
             localUtils.API.checkResponse(jsonResponse.invites[0], 'invite');
-            jsonResponse.invites[0].role_id.should.eql(roleId);
+            assert.equal(jsonResponse.invites[0].role_id, roleId);
 
             assert.equal(mailService.GhostMailer.prototype.send.called, true);
 

--- a/ghost/core/test/e2e-api/admin/oembed.test.js
+++ b/ghost/core/test/e2e-api/admin/oembed.test.js
@@ -281,7 +281,7 @@ describe('Oembed API', function () {
         assert.equal(pageMock.isDone(), true);
 
         // Check that the substitute icon URL is returned in place of the original
-        res.body.metadata.icon.should.eql(`${urlUtils.urlFor('home', true)}content/images/icon/image-01.png`);
+        assert.equal(res.body.metadata.icon, `${urlUtils.urlFor('home', true)}content/images/icon/image-01.png`);
     });
 
     it('should fetch and store thumbnails', async function () {
@@ -305,7 +305,7 @@ describe('Oembed API', function () {
         assert.equal(pageMock.isDone(), true);
 
         // Check that the substitute thumbnail URL is returned in place of the original
-        res.body.metadata.thumbnail.should.eql(`${urlUtils.urlFor('home', true)}content/images/thumbnail/image-01.png`);
+        assert.equal(res.body.metadata.thumbnail, `${urlUtils.urlFor('home', true)}content/images/thumbnail/image-01.png`);
     });
 
     it('should prevent SSRF attacks via bookmark image fetching', async function () {
@@ -824,7 +824,7 @@ describe('Oembed API', function () {
             assert.equal(pageMock.isDone(), true);
             assert.equal(res.body.type, 'bookmark');
             assert.equal(res.body.url, 'http://example.com');
-            res.body.metadata.title.should.eql(utfString);
+            assert.equal(res.body.metadata.title, utfString);
         });
 
         it('does not fail on unknown charset', async function () {

--- a/ghost/core/test/e2e-api/admin/pages-legacy.test.js
+++ b/ghost/core/test/e2e-api/admin/pages-legacy.test.js
@@ -88,12 +88,12 @@ describe('Pages API', function () {
 
         const modelJson = model.toJSON();
 
-        modelJson.title.should.eql(page.title);
-        modelJson.status.should.eql(page.status);
+        assert.equal(modelJson.title, page.title);
+        assert.equal(modelJson.status, page.status);
         assert.equal(modelJson.type, 'page');
 
-        modelJson.posts_meta.feature_image_alt.should.eql(page.feature_image_alt);
-        modelJson.posts_meta.feature_image_caption.should.eql(page.feature_image_caption);
+        assert.equal(modelJson.posts_meta.feature_image_alt, page.feature_image_alt);
+        assert.equal(modelJson.posts_meta.feature_image_caption, page.feature_image_caption);
     });
 
     it('Can add a page with mobiledoc', async function () {
@@ -392,7 +392,7 @@ describe('Pages API', function () {
 
         assertExists(res2.headers['x-cache-invalidate']);
         localUtils.API.checkResponse(res2.body.pages[0], 'page', ['reading_time']);
-        res2.body.pages[0].tiers.length.should.eql(paidTiers.length);
+        assert.equal(res2.body.pages[0].tiers.length, paidTiers.length);
 
         const model = await models.Post.findOne({
             id: res2.body.pages[0].id

--- a/ghost/core/test/e2e-api/admin/posts-legacy.test.js
+++ b/ghost/core/test/e2e-api/admin/posts-legacy.test.js
@@ -78,8 +78,8 @@ describe('Posts API', function () {
         assert.equal(new URL(jsonResponse.posts[2].authors[0].url).pathname, '/author/ghost/');
 
         // Check if the newsletter relation is loaded by default and newsletter_id is not returned
-        jsonResponse.posts[14].id.should.eql(testUtils.DataGenerator.Content.posts[0].id);
-        jsonResponse.posts[14].newsletter.id.should.eql(testUtils.DataGenerator.Content.newsletters[0].id);
+        assert.equal(jsonResponse.posts[14].id, testUtils.DataGenerator.Content.posts[0].id);
+        assert.equal(jsonResponse.posts[14].newsletter.id, testUtils.DataGenerator.Content.newsletters[0].id);
         assert.equal(jsonResponse.posts[14].newsletter_id, undefined);
 
         assert.equal(jsonResponse.posts[0].newsletter, null);
@@ -184,7 +184,7 @@ describe('Posts API', function () {
         assert.equal(testUtils.API.isISO8601(jsonResponse.posts[0].created_at), true);
 
         // Check if the newsletter relation is loaded by default and newsletter_id is not returned
-        jsonResponse.posts[0].newsletter.id.should.eql(testUtils.DataGenerator.Content.newsletters[0].id);
+        assert.equal(jsonResponse.posts[0].newsletter.id, testUtils.DataGenerator.Content.newsletters[0].id);
         assert.equal(jsonResponse.posts[0].newsletter_id, undefined);
     });
 
@@ -256,7 +256,7 @@ describe('Posts API', function () {
         assert(_.isPlainObject(jsonResponse.posts[0].email));
         localUtils.API.checkResponse(jsonResponse.posts[0].email, 'email');
 
-        jsonResponse.posts[0].newsletter.id.should.eql(testUtils.DataGenerator.Content.newsletters[0].id);
+        assert.equal(jsonResponse.posts[0].newsletter.id, testUtils.DataGenerator.Content.newsletters[0].id);
         assert.equal(jsonResponse.posts[0].newsletter_id, undefined);
     });
 
@@ -298,14 +298,14 @@ describe('Posts API', function () {
 
         const modelJson = model.toJSON();
 
-        modelJson.title.should.eql(post.title);
-        modelJson.status.should.eql(post.status);
+        assert.equal(modelJson.title, post.title);
+        assert.equal(modelJson.status, post.status);
         assert.equal(modelJson.published_at.toISOString(), '2016-05-30T07:00:00.000Z');
         modelJson.created_at.toISOString().should.not.eql(post.created_at.toISOString());
         modelJson.updated_at.toISOString().should.not.eql(post.updated_at.toISOString());
 
-        modelJson.posts_meta.feature_image_alt.should.eql(post.feature_image_alt);
-        modelJson.posts_meta.feature_image_caption.should.eql(post.feature_image_caption);
+        assert.equal(modelJson.posts_meta.feature_image_alt, post.feature_image_alt);
+        assert.equal(modelJson.posts_meta.feature_image_caption, post.feature_image_caption);
     });
 
     it('Can include free and paid tiers for public post', async function () {
@@ -407,7 +407,7 @@ describe('Posts API', function () {
 
         const uuid = res2.body.posts[0].uuid;
         const expectedPattern = `/p/${uuid}/, /p/${uuid}/?member_status=anonymous, /p/${uuid}/?member_status=free, /p/${uuid}/?member_status=paid`;
-        res2.headers['x-cache-invalidate'].should.eql(expectedPattern);
+        assert.equal(res2.headers['x-cache-invalidate'], expectedPattern);
 
         // Newsletter should be returned as null
         assert.equal(res2.body.posts[0].newsletter, null);
@@ -446,7 +446,7 @@ describe('Posts API', function () {
 
         const uuid = res2.body.posts[0].uuid;
         const expectedPattern = `/p/${uuid}/, /p/${uuid}/?member_status=anonymous, /p/${uuid}/?member_status=free, /p/${uuid}/?member_status=paid`;
-        res2.headers['x-cache-invalidate'].should.eql(expectedPattern);
+        assert.equal(res2.headers['x-cache-invalidate'], expectedPattern);
 
         assert.equal(unsplashMock.isDone(), true);
 

--- a/ghost/core/test/e2e-api/admin/themes.test.js
+++ b/ghost/core/test/e2e-api/admin/themes.test.js
@@ -291,7 +291,7 @@ describe('Themes API', function () {
             .set('Origin', config.get('url'))
             .expect(200);
 
-        res2.body.should.eql(activeThemeResult.body);
+        assert.deepEqual(res2.body, activeThemeResult.body);
     });
 
     it('Can download and install a theme from GitHub', async function () {

--- a/ghost/core/test/e2e-api/members/middleware.test.js
+++ b/ghost/core/test/e2e-api/members/middleware.test.js
@@ -79,7 +79,7 @@ describe('Comments API', function () {
                 })
                 .matchBodySnapshot(buildMemberMatcher(1))
                 .expect(({body}) => {
-                    body.email.should.eql(member.get('email'));
+                    assert.equal(body.email, member.get('email'));
                     assert.equal(body.enable_comment_notifications, false);
                 });
             member = await models.Member.findOne({id: member.id}, {require: true});
@@ -104,7 +104,7 @@ describe('Comments API', function () {
                 })
                 .matchBodySnapshot(memberMatcher(2))
                 .expect(({body}) => {
-                    body.email.should.eql(member.get('email'));
+                    assert.equal(body.email, member.get('email'));
                 });
         });
 
@@ -120,7 +120,7 @@ describe('Comments API', function () {
                 })
                 .matchBodySnapshot(memberMatcher(2))
                 .expect(({body}) => {
-                    body.email.should.eql(member.get('email'));
+                    assert.equal(body.email, member.get('email'));
                     assert.equal(body.expertise, 'Head of Testing');
                 });
             member = await models.Member.findOne({id: member.id}, {require: true});
@@ -139,7 +139,7 @@ describe('Comments API', function () {
                 })
                 .matchBodySnapshot(memberMatcher(2))
                 .expect(({body}) => {
-                    body.email.should.eql(member.get('email'));
+                    assert.equal(body.email, member.get('email'));
                     assert.equal(body.expertise, 'test');
                 });
             member = await models.Member.findOne({id: member.id}, {require: true});
@@ -158,7 +158,7 @@ describe('Comments API', function () {
                 })
                 .matchBodySnapshot(memberMatcher(2))
                 .expect(({body}) => {
-                    body.email.should.eql(member.get('email'));
+                    assert.equal(body.email, member.get('email'));
                     assert.equal(body.name, 'Test User');
                     assert.equal(body.firstname, 'Test');
                 });
@@ -181,7 +181,7 @@ describe('Comments API', function () {
                 })
                 .matchBodySnapshot(memberMatcher(2))
                 .expect(({body}) => {
-                    body.email.should.eql(member.get('email'));
+                    assert.equal(body.email, member.get('email'));
                     assert.equal(body.enable_comment_notifications, false);
                 });
             member = await models.Member.findOne({id: member.id}, {require: true});
@@ -202,7 +202,7 @@ describe('Comments API', function () {
                 })
                 .matchBodySnapshot(buildMemberMatcher(2))
                 .expect(({body}) => {
-                    body.email.should.eql(member.get('email'));
+                    assert.equal(body.email, member.get('email'));
                     assert.equal(body.enable_comment_notifications, true);
                 });
             member = await models.Member.findOne({id: member.id}, {require: true});
@@ -257,7 +257,7 @@ describe('Comments API', function () {
                 })
                 .matchBodySnapshot(memberMatcher(2))
                 .expect(({body}) => {
-                    body.email.should.eql(member.get('email'));
+                    assert.equal(body.email, member.get('email'));
                 });
         });
 

--- a/ghost/core/test/e2e-frontend/helpers/get.test.js
+++ b/ghost/core/test/e2e-frontend/helpers/get.test.js
@@ -31,7 +31,7 @@ function buildMember(status, products = []) {
 
 function testPosts(posts, map) {
     assert(Array.isArray(posts));
-    posts.length.should.eql(DEFAULT_POST_FIXTURE_COUNT + Object.keys(map).length);
+    assert.equal(posts.length, DEFAULT_POST_FIXTURE_COUNT + Object.keys(map).length);
 
     // Free post
     for (const postID in map) {

--- a/ghost/core/test/integration/exporter/exporter.test.js
+++ b/ghost/core/test/integration/exporter/exporter.test.js
@@ -109,7 +109,7 @@ describe('Exporter', function () {
 
             // NOTE: using `Object.keys` here instead of `should.have.only.keys` assertion
             //       because when `have.only.keys` fails there's no useful diff
-            Object.keys(exportData.data).sort().should.eql(tables.sort());
+            assert.deepEqual(Object.keys(exportData.data).sort(), tables.sort());
             Object.keys(exportData.data).sort().should.containDeep(Object.keys(exportedBodyLatest().db[0].data));
             assert.equal(exportData.meta.version, ghostVersion.full);
 

--- a/ghost/core/test/integration/importer/v1.test.js
+++ b/ghost/core/test/integration/importer/v1.test.js
@@ -39,7 +39,7 @@ describe('Importer 1.0', function () {
                 const posts = result[0].data.map(model => model.toJSON());
 
                 assert.equal(posts.length, 2);
-                posts[0].comment_id.should.eql(exportData.data.posts[1].id);
+                assert.equal(posts[0].comment_id, exportData.data.posts[1].id);
                 assert.equal(posts[1].comment_id, '2');
             });
     });
@@ -180,7 +180,7 @@ describe('Importer 1.0', function () {
                     assert.equal(posts[0].html, '<!--kg-card-begin: markdown--><h1 id="thisismypostcontent">This is my post content</h1>\n<!--kg-card-end: markdown-->');
                     const expectedMobiledoc = JSON.parse(exportData.data.posts[0].mobiledoc);
                     expectedMobiledoc.ghostVersion = '3.0';
-                    posts[0].mobiledoc.should.eql(JSON.stringify(expectedMobiledoc));
+                    assert.equal(posts[0].mobiledoc, JSON.stringify(expectedMobiledoc));
                 });
         });
 

--- a/ghost/core/test/integration/importer/v2.test.js
+++ b/ghost/core/test/integration/importer/v2.test.js
@@ -83,7 +83,7 @@ describe('Importer', function () {
                     assert.equal(importResult.data.posts.length, 2);
                     assert.equal(importResult.problems.length, 1);
 
-                    importResult.problems[0].message.should.eql('Date is in a wrong format and invalid. ' +
+                    assert.equal(importResult.problems[0].message, 'Date is in a wrong format and invalid. ' +
                         'It was replaced with the current timestamp.');
                     assert.equal(importResult.problems[0].help, 'Post');
 
@@ -356,7 +356,7 @@ describe('Importer', function () {
             return dataImporter.doImport(exportData, importOptions)
                 .then(function (importResult) {
                     assert.equal(importResult.problems.length, 0);
-                    importResult.data.posts[0].comment_id.should.eql(exportData.data.posts[0].id.toString());
+                    assert.equal(importResult.data.posts[0].comment_id, exportData.data.posts[0].id.toString());
                 });
         });
 
@@ -419,7 +419,7 @@ describe('Importer', function () {
                 .then(function (importedData) {
                     assert.equal(importedData.problems.length, 1);
 
-                    importedData.problems[0].message.should.eql('Entry was imported, but we were not able to ' +
+                    assert.equal(importedData.problems[0].message, 'Entry was imported, but we were not able to ' +
                         'resolve the following user references: author_id, published_by. The user does not exist, fallback to owner user.');
                     assert.equal(importedData.problems[0].help, 'Post');
 
@@ -445,11 +445,11 @@ describe('Importer', function () {
 
                     // NOTE: we fallback to owner user for invalid user references
 
-                    users[1].slug.should.eql(exportData.data.users[0].slug);
+                    assert.equal(users[1].slug, exportData.data.users[0].slug);
 
-                    posts[0].slug.should.eql(exportData.data.posts[0].slug);
-                    posts[0].primary_author.id.should.eql(testUtils.DataGenerator.Content.users[0].id);
-                    posts[0].published_by.should.eql(testUtils.DataGenerator.Content.users[0].id);
+                    assert.equal(posts[0].slug, exportData.data.posts[0].slug);
+                    assert.equal(posts[0].primary_author.id, testUtils.DataGenerator.Content.users[0].id);
+                    assert.equal(posts[0].published_by, testUtils.DataGenerator.Content.users[0].id);
                 });
         });
 
@@ -506,22 +506,22 @@ describe('Importer', function () {
                     assert.equal(posts.length, exportData.data.posts.length, 'Wrong number of posts');
 
                     // post1
-                    posts[0].slug.should.eql(exportData.data.posts[0].slug);
+                    assert.equal(posts[0].slug, exportData.data.posts[0].slug);
                     assert.equal(posts[0].tags.length, 1);
-                    posts[0].tags[0].slug.should.eql(exportData.data.tags[0].slug);
+                    assert.equal(posts[0].tags[0].slug, exportData.data.tags[0].slug);
 
                     // post3, has a specific sort_order
-                    posts[1].slug.should.eql(exportData.data.posts[2].slug);
+                    assert.equal(posts[1].slug, exportData.data.posts[2].slug);
                     assert.equal(posts[1].tags.length, 3);
-                    posts[1].tags[0].slug.should.eql(exportData.data.tags[2].slug);
-                    posts[1].tags[1].slug.should.eql(exportData.data.tags[0].slug);
-                    posts[1].tags[2].slug.should.eql(exportData.data.tags[1].slug);
+                    assert.equal(posts[1].tags[0].slug, exportData.data.tags[2].slug);
+                    assert.equal(posts[1].tags[1].slug, exportData.data.tags[0].slug);
+                    assert.equal(posts[1].tags[2].slug, exportData.data.tags[1].slug);
 
                     // post2, sort_order property is missing (order depends on the posts_tags entries)
-                    posts[2].slug.should.eql(exportData.data.posts[1].slug);
+                    assert.equal(posts[2].slug, exportData.data.posts[1].slug);
                     assert.equal(posts[2].tags.length, 2);
-                    posts[2].tags[0].slug.should.eql(exportData.data.tags[1].slug);
-                    posts[2].tags[1].slug.should.eql(exportData.data.tags[0].slug);
+                    assert.equal(posts[2].tags[0].slug, exportData.data.tags[1].slug);
+                    assert.equal(posts[2].tags[1].slug, exportData.data.tags[0].slug);
 
                     // test tags
                     assert.equal(tags.length, exportData.data.tags.length, 'no new tags');
@@ -647,11 +647,11 @@ describe('Importer', function () {
                     assert.equal(users[3].updated_at.toISOString(), moment(exportData.data.users[2].updated_at).startOf('seconds').toISOString());
                     assert.equal(users[4].updated_at.toISOString(), moment(exportData.data.users[3].updated_at).startOf('seconds').toISOString());
 
-                    users[0].roles[0].id.should.eql(testUtils.DataGenerator.Content.roles[3].id);
-                    users[1].roles[0].id.should.eql(testUtils.DataGenerator.Content.roles[0].id);
-                    users[2].roles[0].id.should.eql(testUtils.DataGenerator.Content.roles[2].id);
-                    users[3].roles[0].id.should.eql(testUtils.DataGenerator.Content.roles[2].id);
-                    users[4].roles[0].id.should.eql(testUtils.DataGenerator.Content.roles[4].id);
+                    assert.equal(users[0].roles[0].id, testUtils.DataGenerator.Content.roles[3].id);
+                    assert.equal(users[1].roles[0].id, testUtils.DataGenerator.Content.roles[0].id);
+                    assert.equal(users[2].roles[0].id, testUtils.DataGenerator.Content.roles[2].id);
+                    assert.equal(users[3].roles[0].id, testUtils.DataGenerator.Content.roles[2].id);
+                    assert.equal(users[4].roles[0].id, testUtils.DataGenerator.Content.roles[4].id);
                 });
         });
 
@@ -685,10 +685,10 @@ describe('Importer', function () {
                     const users = result[0].data.map(model => model.toJSON());
 
                     assert.equal(users.length, 2);
-                    users[1].slug.should.eql(exportData.data.users[0].slug);
-                    users[1].slug.should.eql(exportData.data.users[0].slug);
+                    assert.equal(users[1].slug, exportData.data.users[0].slug);
+                    assert.equal(users[1].slug, exportData.data.users[0].slug);
                     assert.equal(users[1].roles.length, 1);
-                    users[1].roles[0].id.should.eql(testUtils.DataGenerator.Content.roles[4].id);
+                    assert.equal(users[1].roles[0].id, testUtils.DataGenerator.Content.roles[4].id);
                 });
         });
 
@@ -965,8 +965,8 @@ describe('Importer', function () {
                     const posts = result[0].data.map(model => model.toJSON());
 
                     assert.equal(posts.length, 2);
-                    posts[0].comment_id.should.eql(exportData.data.posts[1].id);
-                    posts[1].comment_id.should.eql(exportData.data.posts[0].comment_id);
+                    assert.equal(posts[0].comment_id, exportData.data.posts[1].id);
+                    assert.equal(posts[1].comment_id, exportData.data.posts[0].comment_id);
                 });
         });
 
@@ -1030,28 +1030,28 @@ describe('Importer', function () {
                     const users = result[1].data.map(model => model.toJSON());
 
                     // 2 duplicates, 1 owner, 4 imported users
-                    users.length.should.eql(exportData.data.users.length - 2 + 1);
+                    assert.equal(users.length, exportData.data.users.length - 2 + 1);
                     assert.equal(posts.length, 3);
 
                     // has 4 posts_authors relations, but 3 of them are invalid
-                    posts[0].slug.should.eql(exportData.data.posts[2].slug);
+                    assert.equal(posts[0].slug, exportData.data.posts[2].slug);
                     assert.equal(posts[0].authors.length, 1);
-                    posts[0].authors[0].id.should.eql(users[4].id);
-                    posts[0].primary_author.id.should.eql(users[4].id);
+                    assert.equal(posts[0].authors[0].id, users[4].id);
+                    assert.equal(posts[0].primary_author.id, users[4].id);
 
                     // no valid authors reference, use owner author_id
-                    posts[1].slug.should.eql(exportData.data.posts[1].slug);
+                    assert.equal(posts[1].slug, exportData.data.posts[1].slug);
                     assert.equal(posts[1].authors.length, 1);
-                    posts[1].primary_author.id.should.eql(testUtils.DataGenerator.Content.users[0].id);
-                    posts[1].authors[0].id.should.eql(testUtils.DataGenerator.Content.users[0].id);
+                    assert.equal(posts[1].primary_author.id, testUtils.DataGenerator.Content.users[0].id);
+                    assert.equal(posts[1].authors[0].id, testUtils.DataGenerator.Content.users[0].id);
 
-                    posts[2].slug.should.eql(exportData.data.posts[0].slug);
+                    assert.equal(posts[2].slug, exportData.data.posts[0].slug);
                     assert.equal(posts[2].authors.length, 3);
-                    posts[2].primary_author.id.should.eql(users[2].id);
+                    assert.equal(posts[2].primary_author.id, users[2].id);
                     assert.equal(posts[2].authors.length, 3);
-                    posts[2].authors[0].id.should.eql(users[2].id);
-                    posts[2].authors[1].id.should.eql(users[1].id);
-                    posts[2].authors[2].id.should.eql(users[3].id);
+                    assert.equal(posts[2].authors[0].id, users[2].id);
+                    assert.equal(posts[2].authors[1].id, users[1].id);
+                    assert.equal(posts[2].authors[2].id, users[3].id);
                 });
         });
 

--- a/ghost/core/test/integration/url-service.test.js
+++ b/ghost/core/test/integration/url-service.test.js
@@ -107,7 +107,7 @@ describe('Integration: services/url/UrlService', function () {
 
         it('getResource', function () {
             let resource = urlService.getResource('/html-ipsum/');
-            resource.data.id.should.eql(testUtils.DataGenerator.forKnex.posts[0].id);
+            assert.equal(resource.data.id, testUtils.DataGenerator.forKnex.posts[0].id);
 
             resource = urlService.getResource('/does-not-exist/');
             assert.equal(resource, null);

--- a/ghost/core/test/legacy/api/admin/db.test.js
+++ b/ghost/core/test/legacy/api/admin/db.test.js
@@ -53,7 +53,7 @@ describe('DB API', function () {
                 assert.equal(jsonResponse.db.length, 1);
 
                 // NOTE: default tables + 1 from include parameters
-                Object.keys(jsonResponse.db[0].data).length.should.eql(TABLE_ALLOWLIST_LENGTH + 1);
+                assert.equal(Object.keys(jsonResponse.db[0].data).length, TABLE_ALLOWLIST_LENGTH + 1);
             });
     });
 

--- a/ghost/core/test/legacy/api/admin/redirects.test.js
+++ b/ghost/core/test/legacy/api/admin/redirects.test.js
@@ -68,7 +68,7 @@ describe('Redirects API', function () {
                         assert.equal(dataFiles.join(',').match(/(redirects)/g).length, 2);
 
                         const fileContent = fs.readFileSync(path.join(contentFolder, 'data', 'redirects.json'), 'utf-8');
-                        fileContent.should.eql(JSON.stringify([{
+                        assert.equal(fileContent, JSON.stringify([{
                             from: 'k',
                             to: 'l'
                         }]));

--- a/ghost/core/test/legacy/api/admin/schedules.test.js
+++ b/ghost/core/test/legacy/api/admin/schedules.test.js
@@ -110,7 +110,7 @@ describe('Schedules API', function () {
             assertExists(res.headers['x-cache-invalidate']);
             const jsonResponse = res.body;
             assertExists(jsonResponse);
-            jsonResponse.posts[0].id.should.eql(resources[0].id);
+            assert.equal(jsonResponse.posts[0].id, resources[0].id);
             assert.equal(jsonResponse.posts[0].status, 'published');
         });
 
@@ -124,7 +124,7 @@ describe('Schedules API', function () {
             assertExists(res.headers['x-cache-invalidate']);
             const jsonResponse = res.body;
             assertExists(jsonResponse);
-            jsonResponse.pages[0].id.should.eql(resources[4].id);
+            assert.equal(jsonResponse.pages[0].id, resources[4].id);
             assert.equal(jsonResponse.pages[0].status, 'published');
         });
 

--- a/ghost/core/test/legacy/api/admin/webhooks.test.js
+++ b/ghost/core/test/legacy/api/admin/webhooks.test.js
@@ -45,7 +45,7 @@ describe('Webhooks API', function () {
 
                 assert.equal(jsonResponse.webhooks[0].event, 'test.create');
                 assert.equal(jsonResponse.webhooks[0].target_url, 'http://example.com/webhooks/test/extra/canary');
-                jsonResponse.webhooks[0].integration_id.should.eql(testUtils.DataGenerator.Content.api_keys[0].integration_id);
+                assert.equal(jsonResponse.webhooks[0].integration_id, testUtils.DataGenerator.Content.api_keys[0].integration_id);
                 assert.equal(jsonResponse.webhooks[0].name, 'test');
                 assert.equal(jsonResponse.webhooks[0].secret, 'thisissecret');
                 assert.equal(jsonResponse.webhooks[0].api_version, 'canary');

--- a/ghost/core/test/legacy/api/content/posts.test.js
+++ b/ghost/core/test/legacy/api/content/posts.test.js
@@ -263,7 +263,7 @@ describe('api/endpoints/content/posts', function () {
                 }
 
                 assert.equal(res.headers.vary, 'Accept-Version, Accept, Accept-Encoding');
-                res.headers.location.should.eql(`http://localhost:9999/ghost/api/content/posts/?key=${validKey}`);
+                assert.equal(res.headers.location, `http://localhost:9999/ghost/api/content/posts/?key=${validKey}`);
                 assertExists(res.headers['access-control-allow-origin']);
                 assert.equal(res.headers['x-cache-invalidate'], undefined);
                 done();
@@ -475,7 +475,7 @@ describe('api/endpoints/content/posts', function () {
                         }
                     });
 
-                    seen.should.eql(membersOnlySlugs.length + freeToSeeSlugs.length);
+                    assert.equal(seen, membersOnlySlugs.length + freeToSeeSlugs.length);
 
                     // check meta response for this test
                     assert.equal(jsonResponse.meta.pagination.page, 1);

--- a/ghost/core/test/legacy/mock-express-style/parent-app-vhosts.test.js
+++ b/ghost/core/test/legacy/mock-express-style/parent-app-vhosts.test.js
@@ -203,7 +203,7 @@ describe('Integration - Web - vhosts', function () {
             return localUtils.mockExpress.invoke(app, req)
                 .then(function (response) {
                     assert.equal(response.statusCode, 301);
-                    response.headers.location.should.eql(`https://admin.example.com${ADMIN_API_URL}/site/`);
+                    assert.equal(response.headers.location, `https://admin.example.com${ADMIN_API_URL}/site/`);
                 });
         });
 
@@ -218,7 +218,7 @@ describe('Integration - Web - vhosts', function () {
             return localUtils.mockExpress.invoke(app, req)
                 .then(function (response) {
                     assert.equal(response.statusCode, 301);
-                    response.headers.location.should.eql(`https://admin.example.com${ADMIN_API_URL}/site/`);
+                    assert.equal(response.headers.location, `https://admin.example.com${ADMIN_API_URL}/site/`);
                 });
         });
 
@@ -432,7 +432,7 @@ describe('Integration - Web - vhosts', function () {
             return localUtils.mockExpress.invoke(app, req)
                 .then(function (response) {
                     assert.equal(response.statusCode, 301);
-                    response.headers.location.should.eql(`https://example.com${ADMIN_API_URL}/site/`);
+                    assert.equal(response.headers.location, `https://example.com${ADMIN_API_URL}/site/`);
                 });
         });
 
@@ -490,7 +490,7 @@ describe('Integration - Web - vhosts', function () {
             return localUtils.mockExpress.invoke(app, req)
                 .then(function (response) {
                     assert.equal(response.statusCode, 301);
-                    response.headers.location.should.eql(`https://example.com${ADMIN_API_URL}/site/`);
+                    assert.equal(response.headers.location, `https://example.com${ADMIN_API_URL}/site/`);
                 });
         });
     });

--- a/ghost/core/test/legacy/models/model-posts.test.js
+++ b/ghost/core/test/legacy/models/model-posts.test.js
@@ -901,9 +901,9 @@ describe('Post Model', function () {
                     }]
                 }, _.merge({withRelated: ['authors']}, context)).then(function (newPost) {
                     assertExists(newPost);
-                    newPost.toJSON().primary_author.id.should.eql(testUtils.DataGenerator.forKnex.users[0].id);
+                    assert.equal(newPost.toJSON().primary_author.id, testUtils.DataGenerator.forKnex.users[0].id);
                     assert.equal(newPost.toJSON().authors.length, 1);
-                    newPost.toJSON().authors[0].id.should.eql(testUtils.DataGenerator.forKnex.users[0].id);
+                    assert.equal(newPost.toJSON().authors[0].id, testUtils.DataGenerator.forKnex.users[0].id);
                     done();
                 }).catch(done);
             });
@@ -2042,9 +2042,9 @@ describe('Post Model', function () {
                 updatedPost = updatedPost.toJSON({withRelated: ['tags']});
 
                 assert.equal(updatedPost.tags.length, 1);
-                updatedPost.tags[0].name.should.eql(postJSON.tags[0].name);
+                assert.equal(updatedPost.tags[0].name, postJSON.tags[0].name);
                 assert.equal(updatedPost.tags[0].slug, 'eins');
-                updatedPost.tags[0].id.should.eql(postJSON.tags[0].id);
+                assert.equal(updatedPost.tags[0].id, postJSON.tags[0].id);
             });
         });
 
@@ -2080,11 +2080,11 @@ describe('Post Model', function () {
                     });
 
                     updatedAtFormat = moment(updatedPost.tags[0].updated_at).format('YYYY-MM-DD HH:mm:ss');
-                    updatedAtFormat.should.eql(moment(postJSON.tags[0].updated_at).format('YYYY-MM-DD HH:mm:ss'));
+                    assert.equal(updatedAtFormat, moment(postJSON.tags[0].updated_at).format('YYYY-MM-DD HH:mm:ss'));
                     updatedAtFormat.should.not.eql(moment(newJSON.tags[0].updated_at).format('YYYY-MM-DD HH:mm:ss'));
 
                     createdAtFormat = moment(updatedPost.tags[0].created_at).format('YYYY-MM-DD HH:mm:ss');
-                    createdAtFormat.should.eql(moment(postJSON.tags[0].created_at).format('YYYY-MM-DD HH:mm:ss'));
+                    assert.equal(createdAtFormat, moment(postJSON.tags[0].created_at).format('YYYY-MM-DD HH:mm:ss'));
                     createdAtFormat.should.not.eql(moment(newJSON.tags[0].created_at).format('YYYY-MM-DD HH:mm:ss'));
                 });
         });
@@ -2162,7 +2162,7 @@ describe('Post Model', function () {
     //    new models.Post().fetch().then(function (model) {
     //        return model.set({'title': "</title></head><body><script>alert('blogtitle');</script>"}).save();
     //    }).then(function (saved) {
-    //        saved.get('title').should.eql("&lt;/title&gt;&lt;/head>&lt;body&gt;[removed]alert&#40;'blogtitle'&#41;;[removed]");
+    //        assert.equal(saved.get('title'), "&lt;/title&gt;&lt;/head>&lt;body&gt;[removed]alert&#40;'blogtitle'&#41;;[removed]");
     //        done();
     //    }).catch(done);
     // });

--- a/ghost/core/test/legacy/models/model-users.test.js
+++ b/ghost/core/test/legacy/models/model-users.test.js
@@ -38,7 +38,7 @@ describe('User Model', function run() {
             UserModel.add(userData, context).then(function (createdUser) {
                 assertExists(createdUser);
                 createdUser.attributes.password.should.not.equal(userData.password, 'password was hashed');
-                createdUser.attributes.email.should.eql(userData.email, 'email address correct');
+                assert.equal(createdUser.attributes.email, userData.email, 'email address correct');
 
                 done();
             }).catch(done);
@@ -85,7 +85,7 @@ describe('User Model', function run() {
 
             UserModel.add(userData, context).then(function (createdUser) {
                 assertExists(createdUser);
-                createdUser.attributes.email.should.eql(userData.email, 'email address correct');
+                assert.equal(createdUser.attributes.email, userData.email, 'email address correct');
                 done();
             }).catch(done);
         });
@@ -127,19 +127,19 @@ describe('User Model', function run() {
                 // Test same case
                 return UserModel.getByEmail(email).then(function (user) {
                     assertExists(user);
-                    user.attributes.email.should.eql(email);
+                    assert.equal(user.attributes.email, email);
                 });
             }).then(function () {
                 // Test entered in lowercase
                 return UserModel.getByEmail(email.toLowerCase()).then(function (user) {
                     assertExists(user);
-                    user.attributes.email.should.eql(email);
+                    assert.equal(user.attributes.email, email);
                 });
             }).then(function () {
                 // Test entered in uppercase
                 return UserModel.getByEmail(email.toUpperCase()).then(function (user) {
                     assertExists(user);
-                    user.attributes.email.should.eql(email);
+                    assert.equal(user.attributes.email, email);
                 });
             }).then(function () {
                 // Test incorrect email address - swapped capital O for number 0
@@ -245,7 +245,7 @@ describe('User Model', function run() {
             }).then(function (createdUser) {
                 assertExists(createdUser);
                 createdUser.get('password').should.not.equal(userData.password, 'password was hashed');
-                createdUser.get('email').should.eql(userData.email, 'email address correct');
+                assert.equal(createdUser.get('email'), userData.email, 'email address correct');
                 assert.equal(createdUser.related('roles').toJSON()[0].name, 'Administrator', 'role set correctly');
 
                 assert.equal(Object.keys(eventsTriggered).length, 2);
@@ -454,8 +454,8 @@ describe('User Model', function run() {
 
             UserModel.setup(userData, {id: DataGenerator.Content.users[0].id})
                 .then(function (user) {
-                    user.get('name').should.eql(userData.name);
-                    user.get('email').should.eql(userData.email);
+                    assert.equal(user.get('name'), userData.name);
+                    assert.equal(user.get('email'), userData.email);
                     assert.equal(user.get('slug'), 'max');
 
                     // naive check that password was hashed

--- a/ghost/core/test/unit/api/canary/utils/serializers/output/mapper.test.js
+++ b/ghost/core/test/unit/api/canary/utils/serializers/output/mapper.test.js
@@ -226,7 +226,7 @@ describe('Unit: utils/serializers/output/mappers', function () {
             }));
 
             const mapped = mappers.newsletters(newsletter, frame);
-            assert.equal(mapped, newsletter.toJSON());
+            assert.deepEqual(mapped, newsletter.toJSON());
         });
     });
 

--- a/ghost/core/test/unit/api/canary/utils/serializers/output/mapper.test.js
+++ b/ghost/core/test/unit/api/canary/utils/serializers/output/mapper.test.js
@@ -226,7 +226,7 @@ describe('Unit: utils/serializers/output/mappers', function () {
             }));
 
             const mapped = mappers.newsletters(newsletter, frame);
-            mapped.should.eql(newsletter.toJSON());
+            assert.equal(mapped, newsletter.toJSON());
         });
     });
 

--- a/ghost/core/test/unit/frontend/apps/private-blogging/controller.test.js
+++ b/ghost/core/test/unit/frontend/apps/private-blogging/controller.test.js
@@ -57,7 +57,7 @@ describe('Private Controller', function () {
 
     it('Should render default password page when theme has no password template', function (done) {
         res.render = function (view, context) {
-            view.should.eql(defaultPath);
+            assert.equal(view, defaultPath);
             assertExists(context);
             done();
         };
@@ -81,7 +81,7 @@ describe('Private Controller', function () {
         res.error = 'Test Error';
 
         res.render = function (view, context) {
-            view.should.eql(defaultPath);
+            assert.equal(view, defaultPath);
             assert.deepEqual(context, {error: 'Test Error'});
             done();
         };

--- a/ghost/core/test/unit/frontend/helpers/foreach.test.js
+++ b/ghost/core/test/unit/frontend/helpers/foreach.test.js
@@ -52,7 +52,7 @@ describe('{{#foreach}} helper', function () {
             sinon.assert.callCount(options.fn, _.size(context));
 
             _.each(context, function (value, index) {
-                options.fn.getCall(index).args[0].should.eql(value);
+                assert.equal(options.fn.getCall(index).args[0], value);
                 assert.equal(options.fn.getCall(index).args[1].data, undefined);
             });
         });
@@ -77,7 +77,7 @@ describe('{{#foreach}} helper', function () {
             sinon.assert.callCount(options.fn, _.size(context));
 
             _.each(_.keys(context), function (value, index) {
-                options.fn.getCall(index).args[0].should.eql(context[value]);
+                assert.equal(options.fn.getCall(index).args[0], context[value]);
                 assert.equal(options.fn.getCall(index).args[1].data, undefined);
             });
         });
@@ -103,7 +103,7 @@ describe('{{#foreach}} helper', function () {
             sinon.assert.callCount(options.fn, _.size(context));
 
             _.each(context, function (value, index) {
-                options.fn.getCall(index).args[0].should.eql(value);
+                assert.equal(options.fn.getCall(index).args[0], value);
                 assertExists(options.fn.getCall(index).args[1].data);
 
                 // Expected properties
@@ -115,7 +115,7 @@ describe('{{#foreach}} helper', function () {
                 assert.equal(resultData[index].data.number, index + 1);
             });
 
-            resultData[_.size(context) - 1].data.should.eql(options.fn.lastCall.args[1].data);
+            assert.deepEqual(resultData[_.size(context) - 1].data, options.fn.lastCall.args[1].data);
         });
 
         it('should populate data when private data is supplied (object)', function () {
@@ -145,7 +145,7 @@ describe('{{#foreach}} helper', function () {
             sinon.assert.callCount(options.fn, _.size(context));
 
             _.each(_.keys(context), function (value, index) {
-                options.fn.getCall(index).args[0].should.eql(context[value]);
+                assert.equal(options.fn.getCall(index).args[0], context[value]);
                 assertExists(options.fn.getCall(index).args[1].data);
 
                 // Expected properties
@@ -157,7 +157,7 @@ describe('{{#foreach}} helper', function () {
                 assert.equal(resultData[index].data.number, index + 1);
             });
 
-            resultData[_.size(context) - 1].data.should.eql(options.fn.lastCall.args[1].data);
+            assert.deepEqual(resultData[_.size(context) - 1].data, options.fn.lastCall.args[1].data);
         });
 
         it('should handle rowStart and rowEnd for multiple columns (array)', function () {
@@ -180,7 +180,7 @@ describe('{{#foreach}} helper', function () {
             sinon.assert.callCount(options.fn, _.size(context));
 
             _.each(context, function (value, index) {
-                options.fn.getCall(index).args[0].should.eql(value);
+                assert.equal(options.fn.getCall(index).args[0], value);
                 assertExists(options.fn.getCall(index).args[1].data);
 
                 // Expected properties
@@ -192,7 +192,7 @@ describe('{{#foreach}} helper', function () {
                 assert.equal(resultData[index].data.number, index + 1);
             });
 
-            resultData[_.size(context) - 1].data.should.eql(options.fn.lastCall.args[1].data);
+            assert.deepEqual(resultData[_.size(context) - 1].data, options.fn.lastCall.args[1].data);
         });
 
         it('should handle rowStart and rowEnd for multiple columns (object)', function () {
@@ -222,7 +222,7 @@ describe('{{#foreach}} helper', function () {
             sinon.assert.callCount(options.fn, _.size(context));
 
             _.each(_.keys(context), function (value, index) {
-                options.fn.getCall(index).args[0].should.eql(context[value]);
+                assert.equal(options.fn.getCall(index).args[0], context[value]);
                 assertExists(options.fn.getCall(index).args[1].data);
 
                 // Expected properties
@@ -234,7 +234,7 @@ describe('{{#foreach}} helper', function () {
                 assert.equal(resultData[index].data.number, index + 1);
             });
 
-            resultData[_.size(context) - 1].data.should.eql(options.fn.lastCall.args[1].data);
+            assert.deepEqual(resultData[_.size(context) - 1].data, options.fn.lastCall.args[1].data);
         });
 
         it('should return the correct inverse result if no context is provided', function () {

--- a/ghost/core/test/unit/frontend/helpers/get.test.js
+++ b/ghost/core/test/unit/frontend/helpers/get.test.js
@@ -302,7 +302,7 @@ describe('{{#get}} helper', function () {
                 assert(Array.isArray(browseStub.firstCall.args));
                 assert.equal(browseStub.firstCall.args.length, 1);
                 browseStub.firstCall.args[0].should.be.an.Object().with.property('filter');
-                browseStub.firstCall.args[0].filter.should.eql(`published_at:<='${pubDate.toISOString()}'`);
+                assert.equal(browseStub.firstCall.args[0].filter, `published_at:<='${pubDate.toISOString()}'`);
 
                 done();
             }).catch(done);
@@ -351,40 +351,40 @@ describe('{{#get}} helper', function () {
         };
 
         it('resolves simple dot-notation path', function () {
-            querySimplePath(data, 'post.id').should.eql([3]);
+            assert.deepEqual(querySimplePath(data, 'post.id'), [3]);
         });
 
         it('resolves nested dot-notation path', function () {
-            querySimplePath(data, 'post.author.slug').should.eql(['cameron']);
+            assert.deepEqual(querySimplePath(data, 'post.author.slug'), ['cameron']);
         });
 
         it('resolves array wildcard', function () {
-            querySimplePath(data, 'post.tags[*].slug').should.eql(['test', 'magic']);
+            assert.deepEqual(querySimplePath(data, 'post.tags[*].slug'), ['test', 'magic']);
         });
 
         it('resolves numeric array index', function () {
-            querySimplePath(data, 'post.tags[0].slug').should.eql(['test']);
-            querySimplePath(data, 'post.tags[1].slug').should.eql(['magic']);
+            assert.deepEqual(querySimplePath(data, 'post.tags[0].slug'), ['test']);
+            assert.deepEqual(querySimplePath(data, 'post.tags[1].slug'), ['magic']);
         });
 
         it('returns empty array for non-existent path', function () {
-            querySimplePath(data, 'post.nonexistent').should.eql([]);
+            assert.deepEqual(querySimplePath(data, 'post.nonexistent'), []);
         });
 
         it('returns empty array for non-existent nested path', function () {
-            querySimplePath(data, 'post.foo.bar.baz').should.eql([]);
+            assert.deepEqual(querySimplePath(data, 'post.foo.bar.baz'), []);
         });
 
         it('returns empty array when wildcard applied to non-array', function () {
-            querySimplePath(data, 'post.title[*].slug').should.eql([]);
+            assert.deepEqual(querySimplePath(data, 'post.title[*].slug'), []);
         });
 
         it('returns empty array for out-of-bounds index', function () {
-            querySimplePath(data, 'post.tags[5].slug').should.eql([]);
+            assert.deepEqual(querySimplePath(data, 'post.tags[5].slug'), []);
         });
 
         it('handles null in path gracefully', function () {
-            querySimplePath({a: null}, 'a.b').should.eql([]);
+            assert.deepEqual(querySimplePath({a: null}, 'a.b'), []);
         });
 
         it('handles Date values', function () {
@@ -525,7 +525,7 @@ describe('{{#get}} helper', function () {
                 'posts',
                 {hash: {}, data: locals, fn: fn, inverse: inverse}
             );
-            browseStub.firstCall.args[0].context.member.should.eql(member);
+            assert.equal(browseStub.firstCall.args[0].context.member, member);
         });
     });
 

--- a/ghost/core/test/unit/frontend/helpers/ghost-head.test.js
+++ b/ghost/core/test/unit/frontend/helpers/ghost-head.test.js
@@ -532,7 +532,7 @@ describe('{{ghost_head}} helper', function () {
                     safeVersion: '0.3'
                 }
             }));
-            renderObject.post.should.eql(postBk);
+            assert.deepEqual(renderObject.post, postBk);
         });
 
         it('returns structured data on post page with custom excerpt for description and meta description', async function () {
@@ -550,7 +550,7 @@ describe('{{ghost_head}} helper', function () {
                     safeVersion: '0.3'
                 }
             }));
-            renderObject.post.should.eql(postBk);
+            assert.deepEqual(renderObject.post, postBk);
         });
 
         it('returns structured data on post page with fall back excerpt if no meta description provided', async function () {
@@ -568,7 +568,7 @@ describe('{{ghost_head}} helper', function () {
                     safeVersion: '0.3'
                 }
             }));
-            renderObject.post.should.eql(postBk);
+            assert.deepEqual(renderObject.post, postBk);
         });
 
         it('returns structured data if metaTitle and metaDescription have double quotes', async function () {

--- a/ghost/core/test/unit/frontend/helpers/next-post.test.js
+++ b/ghost/core/test/unit/frontend/helpers/next-post.test.js
@@ -441,7 +441,7 @@ describe('{{next_post}} helper', function () {
             assert.equal(browsePostsStub.firstCall.args[0].include, 'author,authors,tags,tiers');
 
             // Check context passed
-            browsePostsStub.firstCall.args[0].context.member.should.eql(member);
+            assert.equal(browsePostsStub.firstCall.args[0].context.member, member);
         });
     });
 });

--- a/ghost/core/test/unit/frontend/helpers/prev-post.test.js
+++ b/ghost/core/test/unit/frontend/helpers/prev-post.test.js
@@ -445,7 +445,7 @@ describe('{{prev_post}} helper', function () {
             assert.equal(browsePostsStub.firstCall.args[0].include, 'author,authors,tags,tiers');
 
             // Check context passed
-            browsePostsStub.firstCall.args[0].context.member.should.eql(member);
+            assert.equal(browsePostsStub.firstCall.args[0].context.member, member);
         });
     });
 });

--- a/ghost/core/test/unit/frontend/meta/context-object.test.js
+++ b/ghost/core/test/unit/frontend/meta/context-object.test.js
@@ -20,7 +20,7 @@ describe('getContextObject', function () {
         contextObject = getContextObject(data, context);
 
         assertExists(contextObject);
-        contextObject.should.eql(data.post);
+        assert.equal(contextObject, data.post);
     });
 
     it('should return post context object for a static page', function () {
@@ -29,7 +29,7 @@ describe('getContextObject', function () {
         contextObject = getContextObject(data, context);
 
         assertExists(contextObject);
-        contextObject.should.eql(data.post);
+        assert.equal(contextObject, data.post);
     });
 
     it('should return page', function () {
@@ -38,7 +38,7 @@ describe('getContextObject', function () {
         contextObject = getContextObject(data, context);
 
         assertExists(contextObject);
-        contextObject.should.eql(data.page);
+        assert.equal(contextObject, data.page);
     });
 
     describe('override blog', function () {

--- a/ghost/core/test/unit/frontend/services/assets-minification/minifier.test.js
+++ b/ghost/core/test/unit/frontend/services/assets-minification/minifier.test.js
@@ -30,9 +30,9 @@ describe('Minifier', function () {
 
             assert(Array.isArray(result));
             assert.equal(result.length, 3);
-            result[0].should.eql(path.join('test','unit','frontend','services','assets-minification','fixtures','basic-cards','css','bookmark.css'));
-            result[1].should.eql(path.join('test','unit','frontend','services','assets-minification','fixtures','basic-cards','css','empty.css'));
-            result[2].should.eql(path.join('test','unit','frontend','services','assets-minification','fixtures','basic-cards','css','gallery.css'));
+            assert.equal(result[0], path.join('test','unit','frontend','services','assets-minification','fixtures','basic-cards','css','bookmark.css'));
+            assert.equal(result[1], path.join('test','unit','frontend','services','assets-minification','fixtures','basic-cards','css','empty.css'));
+            assert.equal(result[2], path.join('test','unit','frontend','services','assets-minification','fixtures','basic-cards','css','gallery.css'));
         });
 
         it('match glob range e.g. css/bookmark.css and css/empty.css (css/@(bookmark|empty).css)', async function () {
@@ -40,8 +40,8 @@ describe('Minifier', function () {
 
             assert(Array.isArray(result));
             assert.equal(result.length, 2);
-            result[0].should.eql(path.join('test','unit','frontend','services','assets-minification','fixtures','basic-cards','css','bookmark.css'));
-            result[1].should.eql(path.join('test','unit','frontend','services','assets-minification','fixtures','basic-cards','css','empty.css'));
+            assert.equal(result[0], path.join('test','unit','frontend','services','assets-minification','fixtures','basic-cards','css','bookmark.css'));
+            assert.equal(result[1], path.join('test','unit','frontend','services','assets-minification','fixtures','basic-cards','css','empty.css'));
         });
 
         it('reverse match glob e.g. css/!(bookmark).css', async function () {
@@ -49,15 +49,15 @@ describe('Minifier', function () {
 
             assert(Array.isArray(result));
             assert.equal(result.length, 2);
-            result[0].should.eql(path.join('test','unit','frontend','services','assets-minification','fixtures','basic-cards','css','empty.css'));
-            result[1].should.eql(path.join('test','unit','frontend','services','assets-minification','fixtures','basic-cards','css','gallery.css'));
+            assert.equal(result[0], path.join('test','unit','frontend','services','assets-minification','fixtures','basic-cards','css','empty.css'));
+            assert.equal(result[1], path.join('test','unit','frontend','services','assets-minification','fixtures','basic-cards','css','gallery.css'));
         });
         it('reverse match glob e.g. css/!(bookmark|gallery).css', async function () {
             let result = await minifier.getMatchingFiles('css/!(bookmark|gallery).css');
 
             assert(Array.isArray(result));
             assert.equal(result.length, 1);
-            result[0].should.eql(path.join('test','unit','frontend','services','assets-minification','fixtures','basic-cards','css','empty.css'));
+            assert.equal(result[0], path.join('test','unit','frontend','services','assets-minification','fixtures','basic-cards','css','empty.css'));
         });
     });
 

--- a/ghost/core/test/unit/frontend/services/data/fetch-data.test.js
+++ b/ghost/core/test/unit/frontend/services/data/fetch-data.test.js
@@ -79,7 +79,7 @@ describe('Unit - frontend/data/fetch-data', function () {
             result.should.be.an.Object().with.properties('posts', 'meta');
             assert(!('data' in result));
 
-            result.posts.length.should.eql(posts.length);
+            assert.equal(result.posts.length, posts.length);
 
             assert.equal(browsePostsStub.calledOnce, true);
             assert(_.isPlainObject(browsePostsStub.firstCall.args[0]));
@@ -112,8 +112,8 @@ describe('Unit - frontend/data/fetch-data', function () {
             result.should.be.an.Object().with.properties('posts', 'meta', 'data');
             result.data.should.be.an.Object().with.properties('featured');
 
-            result.posts.length.should.eql(posts.length);
-            result.data.featured.length.should.eql(posts.length);
+            assert.equal(result.posts.length, posts.length);
+            assert.equal(result.data.featured.length, posts.length);
 
             assert.equal(browsePostsStub.calledTwice, true);
             assert.equal(browsePostsStub.firstCall.args[0].include, 'authors,tags,tiers');
@@ -144,8 +144,8 @@ describe('Unit - frontend/data/fetch-data', function () {
             result.should.be.an.Object().with.properties('posts', 'meta', 'data');
             result.data.should.be.an.Object().with.properties('featured');
 
-            result.posts.length.should.eql(posts.length);
-            result.data.featured.length.should.eql(posts.length);
+            assert.equal(result.posts.length, posts.length);
+            assert.equal(result.data.featured.length, posts.length);
 
             assert.equal(browsePostsStub.calledTwice, true);
             assert.equal(browsePostsStub.firstCall.args[0].include, 'authors,tags,tiers');
@@ -178,8 +178,8 @@ describe('Unit - frontend/data/fetch-data', function () {
             result.should.be.an.Object().with.properties('posts', 'meta', 'data');
             result.data.should.be.an.Object().with.properties('tag');
 
-            result.posts.length.should.eql(posts.length);
-            result.data.tag.length.should.eql(tags.length);
+            assert.equal(result.posts.length, posts.length);
+            assert.equal(result.data.tag.length, tags.length);
 
             assert.equal(browsePostsStub.calledOnce, true);
             assert('include' in browsePostsStub.firstCall.args[0]);

--- a/ghost/core/test/unit/frontend/services/rendering/format-response.test.js
+++ b/ghost/core/test/unit/frontend/services/rendering/format-response.test.js
@@ -31,7 +31,7 @@ describe('Unit - services/routing/helpers/format-response', function () {
             const formatted = helpers.formatResponse.entry(postObject);
 
             formatted.should.be.an.Object().with.property('post');
-            formatted.post.should.eql(postObject);
+            assert.equal(formatted.post, postObject);
         });
 
         it('should return the post object with html strings converted to SafeString', function () {
@@ -90,8 +90,8 @@ describe('Unit - services/routing/helpers/format-response', function () {
             const formatted = helpers.formatResponse.entries(data);
 
             formatted.should.be.an.Object().with.properties('posts', 'pagination');
-            formatted.posts.should.eql(data.posts);
-            formatted.pagination.should.eql(data.meta.pagination);
+            assert.equal(formatted.posts, data.posts);
+            assert.equal(formatted.pagination, data.meta.pagination);
         });
 
         it('should flatten api read responses which have no pagination data', function () {
@@ -104,7 +104,7 @@ describe('Unit - services/routing/helpers/format-response', function () {
             const formatted = helpers.formatResponse.entries(data);
 
             formatted.should.be.an.Object().with.properties('posts', 'pagination', 'tag');
-            formatted.tag.should.eql(data.data.tag[0]);
+            assert.equal(formatted.tag, data.data.tag[0]);
         });
 
         it('should remove the meta key from api browse responses', function () {

--- a/ghost/core/test/unit/frontend/services/routing/collection-router.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/collection-router.test.js
@@ -56,19 +56,19 @@ describe('UNIT - services/routing/CollectionRouter', function () {
 
             // parent route
             assert.equal(mountRouteSpy.args[0][0], '/');
-            mountRouteSpy.args[0][1].should.eql(controllers.collection);
+            assert.equal(mountRouteSpy.args[0][1], controllers.collection);
 
             // pagination feature
             assert.equal(mountRouteSpy.args[1][0], '/page/:page(\\d+)');
-            mountRouteSpy.args[1][1].should.eql(controllers.collection);
+            assert.equal(mountRouteSpy.args[1][1], controllers.collection);
 
             // permalinks
             assert.equal(mountRouteSpy.args[2][0], '/:slug/:options(edit)?/');
-            mountRouteSpy.args[2][1].should.eql(controllers.entry);
+            assert.equal(mountRouteSpy.args[2][1], controllers.entry);
 
             assert.equal(mountRouterSpy.callCount, 1);
             assert.equal(mountRouterSpy.args[0][0], '/');
-            mountRouterSpy.args[0][1].should.eql(collectionRouter.rssRouter.router());
+            assert.equal(mountRouterSpy.args[0][1], collectionRouter.rssRouter.router());
         });
 
         it('router name', function () {
@@ -102,19 +102,19 @@ describe('UNIT - services/routing/CollectionRouter', function () {
 
             // parent route
             assert.equal(mountRouteSpy.args[0][0], '/blog/');
-            mountRouteSpy.args[0][1].should.eql(controllers.collection);
+            assert.equal(mountRouteSpy.args[0][1], controllers.collection);
 
             // pagination feature
             assert.equal(mountRouteSpy.args[1][0], '/blog/page/:page(\\d+)');
-            mountRouteSpy.args[1][1].should.eql(controllers.collection);
+            assert.equal(mountRouteSpy.args[1][1], controllers.collection);
 
             // permalinks
             assert.equal(mountRouteSpy.args[2][0], '/blog/:year/:slug/:options(edit)?/');
-            mountRouteSpy.args[2][1].should.eql(controllers.entry);
+            assert.equal(mountRouteSpy.args[2][1], controllers.entry);
 
             assert.equal(mountRouterSpy.callCount, 1);
             assert.equal(mountRouterSpy.args[0][0], '/blog/');
-            mountRouterSpy.args[0][1].should.eql(collectionRouter.rssRouter.router());
+            assert.equal(mountRouterSpy.args[0][1], collectionRouter.rssRouter.router());
         });
 
         it('with custom filter', function () {

--- a/ghost/core/test/unit/frontend/services/routing/controllers/entry.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/controllers/entry.test.js
@@ -121,7 +121,7 @@ describe('Unit - services/routing/controllers/entry', function () {
 
             urlUtilsRedirectToAdminStub.callsFake(function (statusCode, _res, editorUrl) {
                 assert.equal(statusCode, 302);
-                editorUrl.should.eql(EDITOR_URL + post.id);
+                assert.equal(editorUrl, EDITOR_URL + post.id);
                 done();
             });
 
@@ -194,7 +194,7 @@ describe('Unit - services/routing/controllers/entry', function () {
                 });
 
             urlUtilsRedirect301Stub.callsFake(function (_res, postUrl) {
-                postUrl.should.eql(post.url);
+                assert.equal(postUrl, post.url);
                 done();
             });
 
@@ -223,7 +223,7 @@ describe('Unit - services/routing/controllers/entry', function () {
                 });
 
             urlUtilsRedirect301Stub.callsFake(function (_res, postUrl) {
-                postUrl.should.eql(post.url + '?query=true');
+                assert.equal(postUrl, post.url + '?query=true');
                 done();
             });
 

--- a/ghost/core/test/unit/frontend/services/routing/controllers/rss.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/controllers/rss.test.js
@@ -67,7 +67,7 @@ describe('Unit - services/routing/controllers/rss', function () {
 
         rssServiceRenderStub.callsFake(function (_res, baseUrl, data) {
             assert.equal(baseUrl, '/rss/');
-            data.posts.should.eql(posts);
+            assert.equal(data.posts, posts);
             assert.equal(data.title, 'Ghost');
             assert.equal(data.description, 'Ghost is cool!');
             done();

--- a/ghost/core/test/unit/frontend/services/routing/rss-router.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/rss-router.test.js
@@ -30,7 +30,7 @@ describe('UNIT - services/routing/RSSRouter', function () {
             assert.equal(rssRouter.mountRoute.callCount, 2);
 
             assert.equal(rssRouter.mountRoute.args[0][0], '/rss/');
-            rssRouter.mountRoute.args[0][1].should.eql(controllers.rss);
+            assert.equal(rssRouter.mountRoute.args[0][1], controllers.rss);
 
             assert.equal(rssRouter.mountRoute.args[1][0], '/feed/');
         });
@@ -45,7 +45,7 @@ describe('UNIT - services/routing/RSSRouter', function () {
             assert.equal(rssRouter.mountRoute.callCount, 2);
 
             assert.equal(rssRouter.mountRoute.args[0][0], '/rss/');
-            rssRouter.mountRoute.args[0][1].should.eql(controllers.rss);
+            assert.equal(rssRouter.mountRoute.args[0][1], controllers.rss);
 
             assert.equal(rssRouter.mountRoute.args[1][0], '/feed/');
         });

--- a/ghost/core/test/unit/frontend/services/routing/static-routes-router.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/static-routes-router.test.js
@@ -51,7 +51,7 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
 
             // parent route
             assert.equal(mountRouteSpy.args[0][0], '/about/');
-            mountRouteSpy.args[0][1].should.eql(controllers.static);
+            assert.equal(mountRouteSpy.args[0][1], controllers.static);
         });
 
         it('initialize with data+filter', function () {
@@ -73,7 +73,7 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
 
             // parent route
             assert.equal(mountRouteSpy.args[0][0], '/about/');
-            mountRouteSpy.args[0][1].should.eql(controllers.static);
+            assert.equal(mountRouteSpy.args[0][1], controllers.static);
         });
 
         it('fn: _prepareStaticRouteContext', function () {
@@ -133,11 +133,11 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
 
                 // parent route
                 assert.equal(mountRouteSpy.args[0][0], '/channel/');
-                mountRouteSpy.args[0][1].should.eql(controllers.channel);
+                assert.equal(mountRouteSpy.args[0][1], controllers.channel);
 
                 // pagination feature
                 assert.equal(mountRouteSpy.args[1][0], '/channel/page/:page(\\d+)');
-                mountRouteSpy.args[1][1].should.eql(controllers.channel);
+                assert.equal(mountRouteSpy.args[1][1], controllers.channel);
             });
 
             it('initialize with controller+filter', function () {
@@ -160,11 +160,11 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
 
                 // parent route
                 assert.equal(mountRouteSpy.args[0][0], '/channel/');
-                mountRouteSpy.args[0][1].should.eql(controllers.channel);
+                assert.equal(mountRouteSpy.args[0][1], controllers.channel);
 
                 // pagination feature
                 assert.equal(mountRouteSpy.args[1][0], '/channel/page/:page(\\d+)');
-                mountRouteSpy.args[1][1].should.eql(controllers.channel);
+                assert.equal(mountRouteSpy.args[1][1], controllers.channel);
             });
 
             it('initialize with controller+data', function () {
@@ -189,11 +189,11 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
 
                 // parent route
                 assert.equal(mountRouteSpy.args[0][0], '/channel/');
-                mountRouteSpy.args[0][1].should.eql(controllers.channel);
+                assert.equal(mountRouteSpy.args[0][1], controllers.channel);
 
                 // pagination feature
                 assert.equal(mountRouteSpy.args[1][0], '/channel/page/:page(\\d+)');
-                mountRouteSpy.args[1][1].should.eql(controllers.channel);
+                assert.equal(mountRouteSpy.args[1][1], controllers.channel);
             });
         });
 

--- a/ghost/core/test/unit/frontend/services/routing/taxonomy-router.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/taxonomy-router.test.js
@@ -47,21 +47,23 @@ describe('UNIT - services/routing/TaxonomyRouter', function () {
 
         assert.equal(taxonomyRouter.mountRouter.callCount, 1);
         assert.equal(taxonomyRouter.mountRouter.args[0][0], '/tag/:slug/');
-        taxonomyRouter.mountRouter.args[0][1].should.eql(taxonomyRouter.rssRouter.router());
+        assert.equal(taxonomyRouter.mountRouter.args[0][1], taxonomyRouter.rssRouter.router());
 
         assert.equal(taxonomyRouter.mountRoute.callCount, 3);
 
         // permalink route
         assert.equal(taxonomyRouter.mountRoute.args[0][0], '/tag/:slug/');
-        taxonomyRouter.mountRoute.args[0][1].should.eql(controllers.channel);
+        assert.equal(taxonomyRouter.mountRoute.args[0][1], controllers.channel);
 
         // pagination feature
         assert.equal(taxonomyRouter.mountRoute.args[1][0], '/tag/:slug/page/:page(\\d+)');
-        taxonomyRouter.mountRoute.args[1][1].should.eql(controllers.channel);
+        assert.equal(taxonomyRouter.mountRoute.args[1][1], controllers.channel);
 
         // edit feature
         assert.equal(taxonomyRouter.mountRoute.args[2][0], '/tag/:slug/edit');
-        taxonomyRouter.mountRoute.args[2][1].should.eql(taxonomyRouter._redirectEditOption.bind(taxonomyRouter));
+        // We'd can't compare to `taxonomyRouter._redirectEditOption.bind(taxonomyRouter)`, so this is the next best thing.
+        assert(typeof taxonomyRouter.mountRoute.args[2][1] === 'function');
+        assert(taxonomyRouter.mountRoute.args[2][1].name.includes('_redirectEditOption'));
     });
 
     it('_prepareContext behaves as expected', function () {

--- a/ghost/core/test/unit/frontend/services/theme-engine/i18n.test.js
+++ b/ghost/core/test/unit/frontend/services/theme-engine/i18n.test.js
@@ -45,7 +45,7 @@ describe('I18n Class behavior', function () {
         });
 
         it('correctly loads strings', function () {
-            i18n._strings.should.eql(fakeStrings);
+            assert.equal(i18n._strings, fakeStrings);
         });
 
         it('correctly uses dot notation', function () {
@@ -81,7 +81,7 @@ describe('I18n Class behavior', function () {
         });
 
         it('correctly loads strings', function () {
-            i18n._strings.should.eql(fakeStrings);
+            assert.equal(i18n._strings, fakeStrings);
         });
 
         it('correctly uses fulltext with bracket notation', function () {

--- a/ghost/core/test/unit/frontend/services/theme-engine/middleware.test.js
+++ b/ghost/core/test/unit/frontend/services/theme-engine/middleware.test.js
@@ -225,7 +225,7 @@ describe('Themes middleware', function () {
                     data.should.be.an.Object().with.properties('site');
 
                     data.site.should.be.an.Object().with.properties('accent_color', '_preview');
-                    data.site._preview.should.eql(previewString);
+                    assert.equal(data.site._preview, previewString);
                     assert.equal(data.site.accent_color, '#000fff');
 
                     done();
@@ -252,7 +252,7 @@ describe('Themes middleware', function () {
                     data.should.be.an.Object().with.properties('site');
 
                     data.site.should.be.an.Object().with.properties('accent_color', 'icon', '_preview');
-                    data.site._preview.should.eql(previewString);
+                    assert.equal(data.site._preview, previewString);
                     assert.equal(data.site.accent_color, '#000fff');
                     assert.equal(data.site.icon, '/content/images/myimg.png');
 

--- a/ghost/core/test/unit/server/adapters/scheduling/scheduling-default.test.js
+++ b/ghost/core/test/unit/server/adapters/scheduling/scheduling-default.test.js
@@ -52,7 +52,7 @@ describe('Scheduling Default Adapter', function () {
             assert.equal(scope.adapter.allJobs[moment(dates[7]).valueOf()], undefined);
             assert.equal(scope.adapter._execute.calledTwice, true);
 
-            Object.keys(scope.adapter.allJobs).length.should.eql(dates.length - 2);
+            assert.equal(Object.keys(scope.adapter.allJobs).length, dates.length - 2);
             assert.deepEqual(Object.keys(scope.adapter.allJobs), [
                 moment(dates[2]).valueOf().toString(),
                 moment(dates[6]).valueOf().toString(),
@@ -139,7 +139,7 @@ describe('Scheduling Default Adapter', function () {
 
             sinon.stub(scope.adapter, '_execute').callsFake(function (nextJobs) {
                 assert.equal(Object.keys(nextJobs).length, 121);
-                Object.keys(scope.adapter.allJobs).length.should.eql(1000 - 121);
+                assert.equal(Object.keys(scope.adapter.allJobs).length, 1000 - 121);
                 done();
             });
 

--- a/ghost/core/test/unit/server/data/exporter/index.test.js
+++ b/ghost/core/test/unit/server/data/exporter/index.test.js
@@ -51,7 +51,7 @@ describe('Exporter', function () {
                 assert.equal(tablesStub.calledOnce, true);
                 assert.equal(db.knex.called, true);
 
-                knexMock.callCount.should.eql(expectedCallCount);
+                assert.equal(knexMock.callCount, expectedCallCount);
                 queryMock.select.callCount.should.have.eql(expectedCallCount);
 
                 const expectedTables = new Set([
@@ -98,7 +98,7 @@ describe('Exporter', function () {
                 assert.equal(db.knex.called, true);
                 assert.equal(queryMock.select.called, true);
 
-                knexMock.callCount.should.eql(expectedCallCount);
+                assert.equal(knexMock.callCount, expectedCallCount);
                 queryMock.select.callCount.should.have.eql(expectedCallCount);
 
                 const expectedTables = new Set([
@@ -230,7 +230,7 @@ describe('Exporter', function () {
             // NOTE: if default settings changed either modify the settings keys blocklist or increase allowedKeysLength
             //       This is a reminder to think about the importer/exporter scenarios ;)
             const allowedKeysLength = 100;
-            totalKeysLength.should.eql(SETTING_KEYS_BLOCKLIST.length + allowedKeysLength);
+            assert.equal(totalKeysLength, SETTING_KEYS_BLOCKLIST.length + allowedKeysLength);
         });
     });
 });

--- a/ghost/core/test/unit/server/data/importer/importers/data/posts.test.js
+++ b/ghost/core/test/unit/server/data/importer/importers/data/posts.test.js
@@ -120,7 +120,7 @@ describe('PostsImporter', function () {
             assert.equal(post.email_recipient_filter, 'all');
             assert.equal(post.send_email_when_published, undefined);
             // @TODO: need to check this mapping
-            //post.newsletter_id.should.eql();
+            // assert.equal(post.newsletter_id, TODO);
         });
 
         it('Doesn\'t populate the mobiledoc column if it is a lexical post', function () {

--- a/ghost/core/test/unit/server/data/schema/fixtures/fixture-manager.test.js
+++ b/ghost/core/test/unit/server/data/schema/fixtures/fixture-manager.test.js
@@ -317,8 +317,8 @@ describe('Migration Fixture Utils', function () {
 
             await fixtureManager.addAllFixtures();
 
-            addFixturesForModelStub.callCount.should.eql(fixtures.models.length);
-            addFixturesForRelationStub.callCount.should.eql(fixtures.relations.length);
+            assert.equal(addFixturesForModelStub.callCount, fixtures.models.length);
+            assert.equal(addFixturesForRelationStub.callCount, fixtures.relations.length);
 
             // NOTE: users and roles have to be initialized first for the post fixtures to work
             assert.equal(addFixturesForModelStub.firstCall.args[0].name, 'Role');
@@ -421,12 +421,12 @@ describe('Migration Fixture Utils', function () {
                 // Permissions & Roles
                 assert.equal(permsAllStub.calledOnce, true);
                 assert.equal(rolesAllStub.calledOnce, true);
-                dataMethodStub.filter.callCount.should.eql(FIXTURE_COUNT);
+                assert.equal(dataMethodStub.filter.callCount, FIXTURE_COUNT);
                 assert.equal(dataMethodStub.find.callCount, 10);
-                baseUtilAttachStub.callCount.should.eql(FIXTURE_COUNT);
+                assert.equal(baseUtilAttachStub.callCount, FIXTURE_COUNT);
 
-                fromItem.related.callCount.should.eql(FIXTURE_COUNT);
-                fromItem.find.callCount.should.eql(FIXTURE_COUNT);
+                assert.equal(fromItem.related.callCount, FIXTURE_COUNT);
+                assert.equal(fromItem.find.callCount, FIXTURE_COUNT);
 
                 done();
             }).catch(done);

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -1,4 +1,4 @@
-const should = require('should');
+const assert = require('node:assert/strict');
 const _ = require('lodash');
 const yaml = require('js-yaml');
 const crypto = require('crypto');
@@ -63,10 +63,10 @@ describe('DB version integrity', function () {
         settingsHash = crypto.createHash('md5').update(JSON.stringify(defaultSettings), 'binary').digest('hex');
         routesHash = crypto.createHash('md5').update(JSON.stringify(defaultRoutes), 'binary').digest('hex');
 
-        schemaHash.should.eql(currentSchemaHash, 'Database schema has changed, please ensure a proper migration has been created if necessary and update the hash in this test.');
-        fixturesHash.should.eql(currentFixturesHash, 'Fixtures have changed, please ensure a proper migration has been created if necessary and update the hash in this test.');
-        settingsHash.should.eql(currentSettingsHash, 'Default settings have changed, please ensure a proper migration has been created if necessary and update the hash in this test.');
-        routesHash.should.eql(currentRoutesHash, 'Default routes have changed, please ensure a proper migration has been created if necessary and update the hash in this test.');
-        routesHash.should.eql(routeSettings.getDefaultHash());
+        assert.equal(schemaHash, currentSchemaHash, 'Database schema has changed, please ensure a proper migration has been created if necessary and update the hash in this test.');
+        assert.equal(fixturesHash, currentFixturesHash, 'Fixtures have changed, please ensure a proper migration has been created if necessary and update the hash in this test.');
+        assert.equal(settingsHash, currentSettingsHash, 'Default settings have changed, please ensure a proper migration has been created if necessary and update the hash in this test.');
+        assert.equal(routesHash, currentRoutesHash, 'Default routes have changed, please ensure a proper migration has been created if necessary and update the hash in this test.');
+        assert.equal(routesHash, routeSettings.getDefaultHash());
     });
 });

--- a/ghost/core/test/unit/server/lib/image/blog-icon.test.js
+++ b/ghost/core/test/unit/server/lib/image/blog-icon.test.js
@@ -134,7 +134,7 @@ describe('lib/image: blog icon', function () {
             }, storageUtils: {}, urlUtils: {}, settingsCache: {
                 get: () => {}
             }});
-            blogIcon.getIconPath().should.eql(path.join(root, 'favicon.ico'));
+            assert.equal(blogIcon.getIconPath(), path.join(root, 'favicon.ico'));
         });
     });
 

--- a/ghost/core/test/unit/server/lib/image/gravatar.test.js
+++ b/ghost/core/test/unit/server/lib/image/gravatar.test.js
@@ -71,7 +71,7 @@ describe('lib/image: gravatar', function () {
                 } : null;
             }
         }, request: (url, options) => {
-            options.timeout.request.should.eql(delay);
+            assert.equal(options.timeout.request, delay);
         }});
 
         gravatar.lookup({email: 'exists@example.com'}, delay);

--- a/ghost/core/test/unit/server/models/base/index.test.js
+++ b/ghost/core/test/unit/server/models/base/index.test.js
@@ -96,13 +96,13 @@ describe('Models: base', function () {
 
         it('too long', function () {
             Model.findOne.resolves(false);
-            const slug = new Array(500).join('a');
+            const slug = 'a'.repeat(500);
 
             securityStringSafeStub.withArgs(slug).returns(slug);
 
             return models.Base.Model.generateSlug(Model, slug, options)
                 .then((generatedSlug) => {
-                    generatedSlug.should.eql(new Array(186).join('a'));
+                    assert.equal(generatedSlug, 'a'.repeat(185));
                 });
         });
 

--- a/ghost/core/test/unit/server/models/base/relations.test.js
+++ b/ghost/core/test/unit/server/models/base/relations.test.js
@@ -34,11 +34,11 @@ describe('Models: getLazyRelation', function () {
 
         const options = {test: true};
         const modelA = TestModel.forge({id: '1'});
-        (await modelA.getLazyRelation('tiers', options)).should.eql(rel);
+        assert.equal((await modelA.getLazyRelation('tiers', options)), rel);
         assert.equal(fetchStub.calledOnceWithExactly(options), true);
 
         // Check if it can reuse it again
-        (await modelA.getLazyRelation('tiers', options)).should.eql(rel);
+        assert.equal((await modelA.getLazyRelation('tiers', options)), rel);
         assert.equal(fetchStub.calledOnceWithExactly(options), true);
 
         // Check if we can force reload
@@ -69,11 +69,11 @@ describe('Models: getLazyRelation', function () {
 
         const options = {test: true};
         const modelA = TestModel.forge({id: '1'});
-        (await modelA.getLazyRelation('other', options)).should.eql(rel);
+        assert.equal((await modelA.getLazyRelation('other', options)), rel);
         assert.equal(fetchStub.calledOnceWithExactly(options), true);
 
         // Check if it can reuse it again
-        (await modelA.getLazyRelation('other', options)).should.eql(rel);
+        assert.equal((await modelA.getLazyRelation('other', options)), rel);
         assert.equal(fetchStub.calledOnceWithExactly(options), true);
 
         // Check if we can force reload

--- a/ghost/core/test/unit/server/models/member.test.js
+++ b/ghost/core/test/unit/server/models/member.test.js
@@ -38,7 +38,7 @@ describe('Unit: models/member', function () {
             config.set('privacy:useGravatar', true);
             const json = toJSON(member);
 
-            json.avatar_image.should.eql(`https://www.gravatar.com/avatar/55502f40dc8b7c769880b10874abc9d0?s=250&r=g&d=blank`);
+            assert.equal(json.avatar_image, `https://www.gravatar.com/avatar/55502f40dc8b7c769880b10874abc9d0?s=250&r=g&d=blank`);
         });
 
         it('avatar_image: skips gravatar when privacy.useGravatar=false', function () {

--- a/ghost/core/test/unit/server/services/auth/api-key/admin.test.js
+++ b/ghost/core/test/unit/server/services/auth/api-key/admin.test.js
@@ -54,7 +54,7 @@ describe('Admin API Key Auth', function () {
 
         apiKeyAuth.admin.authenticate(req, res, (err) => {
             assert.equal(err, undefined);
-            req.api_key.should.eql(this.fakeApiKey);
+            assert.equal(req.api_key, this.fakeApiKey);
             done();
         });
     });
@@ -79,7 +79,7 @@ describe('Admin API Key Auth', function () {
 
         apiKeyAuth.admin.authenticate(req, res, (err) => {
             assert.equal(err, undefined);
-            req.api_key.should.eql(this.fakeApiKey);
+            assert.equal(req.api_key, this.fakeApiKey);
             done();
         });
     });
@@ -104,7 +104,7 @@ describe('Admin API Key Auth', function () {
 
         apiKeyAuth.admin.authenticate(req, res, (err) => {
             assert.equal(err, undefined);
-            req.api_key.should.eql(this.fakeApiKey);
+            assert.equal(req.api_key, this.fakeApiKey);
             done();
         });
     });

--- a/ghost/core/test/unit/server/services/auth/api-key/content.test.js
+++ b/ghost/core/test/unit/server/services/auth/api-key/content.test.js
@@ -39,7 +39,7 @@ describe('Content API Key Auth', function () {
 
         authenticateContentApiKey(req, res, (arg) => {
             assert.equal(arg, undefined);
-            req.api_key.should.eql(this.fakeApiKey);
+            assert.equal(req.api_key, this.fakeApiKey);
             done();
         });
     });

--- a/ghost/core/test/unit/server/services/email-analytics/email-analytics-service.test.js
+++ b/ghost/core/test/unit/server/services/email-analytics/email-analytics-service.test.js
@@ -64,7 +64,7 @@ describe('EmailAnalyticsService', function () {
             });
 
             const result = await service.getLastNonOpenedEventTimestamp();
-            result.should.eql(new Date(1));
+            assert.deepEqual(result, new Date(1));
         });
 
         it('returns the fallback if nothing is found', async function () {
@@ -76,7 +76,7 @@ describe('EmailAnalyticsService', function () {
             });
 
             const result = await service.getLastNonOpenedEventTimestamp();
-            result.should.eql(new Date(Date.now() - 30 * 60 * 1000)); // should be 30 mins prior
+            assert.deepEqual(result, new Date(Date.now() - 30 * 60 * 1000)); // should be 30 mins prior
         });
     });
 
@@ -90,7 +90,7 @@ describe('EmailAnalyticsService', function () {
             });
 
             const result = await service.getLastOpenedEventTimestamp();
-            result.should.eql(new Date(1));
+            assert.deepEqual(result, new Date(1));
         });
 
         it('returns the fallback if nothing is found', async function () {
@@ -102,7 +102,7 @@ describe('EmailAnalyticsService', function () {
             });
 
             const result = await service.getLastOpenedEventTimestamp();
-            result.should.eql(new Date(Date.now() - 30 * 60 * 1000)); // should be 30 mins prior
+            assert.deepEqual(result, new Date(Date.now() - 30 * 60 * 1000)); // should be 30 mins prior
         });
     });
 

--- a/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
+++ b/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
@@ -1765,11 +1765,11 @@ describe('Email renderer', function () {
             // Check uuid in replacements
             assert.equal(response.replacements.length, 4);
             assert.equal(response.replacements[0].id, 'uuid');
-            response.replacements[0].token.should.eql(/%%\{uuid\}%%/g);
+            assert.deepEqual(response.replacements[0].token, /%%\{uuid\}%%/g);
             assert.equal(response.replacements[1].id, 'key');
-            response.replacements[1].token.should.eql(/%%\{key\}%%/g);
+            assert.deepEqual(response.replacements[1].token, /%%\{key\}%%/g);
             assert.equal(response.replacements[2].id, 'unsubscribe_url');
-            response.replacements[2].token.should.eql(/%%\{unsubscribe_url\}%%/g);
+            assert.deepEqual(response.replacements[2].token, /%%\{unsubscribe_url\}%%/g);
             assert.equal(response.replacements[3].id, 'list_unsubscribe');
         });
 
@@ -1875,11 +1875,11 @@ describe('Email renderer', function () {
             // Check uuid in replacements
             assert.equal(response.replacements.length, 4);
             assert.equal(response.replacements[0].id, 'uuid');
-            response.replacements[0].token.should.eql(/%%\{uuid\}%%/g);
+            assert.deepEqual(response.replacements[0].token, /%%\{uuid\}%%/g);
             assert.equal(response.replacements[1].id, 'key');
-            response.replacements[1].token.should.eql(/%%\{key\}%%/g);
+            assert.deepEqual(response.replacements[1].token, /%%\{key\}%%/g);
             assert.equal(response.replacements[2].id, 'unsubscribe_url');
-            response.replacements[2].token.should.eql(/%%\{unsubscribe_url\}%%/g);
+            assert.deepEqual(response.replacements[2].token, /%%\{unsubscribe_url\}%%/g);
             assert.equal(response.replacements[3].id, 'list_unsubscribe');
         });
 

--- a/ghost/core/test/unit/server/services/stats/mrr.test.js
+++ b/ghost/core/test/unit/server/services/stats/mrr.test.js
@@ -80,7 +80,7 @@ describe('MrrStatsService', function () {
                 mrr: item.mrr,
                 currency: item.currency || 'usd'
             }));
-            totals.should.eql(expectedTotals);
+            assert.deepEqual(totals, expectedTotals);
         }
 
         /**

--- a/ghost/core/test/unit/server/services/update-check.test.js
+++ b/ghost/core/test/unit/server/services/update-check.test.js
@@ -285,11 +285,11 @@ describe('Update Check', function () {
             assert.equal(notificationsAPIAddStub.args[0][0].notifications.length, 1);
 
             const targetNotification = notificationsAPIAddStub.args[0][0].notifications[0];
-            targetNotification.dismissible.should.eql(notification.messages[0].dismissible);
-            targetNotification.id.should.eql(notification.messages[0].id);
-            targetNotification.top.should.eql(notification.messages[0].top);
+            assert.equal(targetNotification.dismissible, notification.messages[0].dismissible);
+            assert.equal(targetNotification.id, notification.messages[0].id);
+            assert.equal(targetNotification.top, notification.messages[0].top);
             assert.equal(targetNotification.type, 'info');
-            targetNotification.message.should.eql(notification.messages[0].content);
+            assert.equal(targetNotification.message, notification.messages[0].content);
 
             assert.equal(usersBrowseStub.calledTwice, true);
 

--- a/ghost/core/test/unit/server/services/url/url-service.test.js
+++ b/ghost/core/test/unit/server/services/url/url-service.test.js
@@ -111,7 +111,7 @@ describe('Unit: services/url/UrlService', function () {
 
             urlService.finished = true;
             urlService.urls.getByUrl.withArgs('/blog-post/').returns([{resource: resource}]);
-            urlService.getResource('/blog-post/').should.eql(resource);
+            assert.equal(urlService.getResource('/blog-post/'), resource);
         });
 
         it('two resources for url found', function () {
@@ -129,7 +129,7 @@ describe('Unit: services/url/UrlService', function () {
 
             urlService.finished = true;
             urlService.urls.getByUrl.withArgs('/blog-post/').returns([object1, object2]);
-            urlService.getResource('/blog-post/').should.eql(object2.resource);
+            assert.equal(urlService.getResource('/blog-post/'), object2.resource);
         });
 
         it('two resources for url found (reverse registration order)', function () {
@@ -147,7 +147,7 @@ describe('Unit: services/url/UrlService', function () {
 
             urlService.finished = true;
             urlService.urls.getByUrl.withArgs('/blog-post/').returns([object1, object2]);
-            urlService.getResource('/blog-post/').should.eql(object1.resource);
+            assert.equal(urlService.getResource('/blog-post/'), object1.resource);
         });
     });
 

--- a/ghost/core/test/unit/server/services/verification-trigger.test.js
+++ b/ghost/core/test/unit/server/services/verification-trigger.test.js
@@ -65,7 +65,7 @@ describe('Import threshold', function () {
         });
 
         const result = await trigger.getImportThreshold();
-        result.should.eql(Infinity);
+        assert.equal(result, Infinity);
         assert.equal(membersStub.callCount, 0);
     });
 });

--- a/ghost/core/test/unit/shared/config/helpers.test.js
+++ b/ghost/core/test/unit/shared/config/helpers.test.js
@@ -14,8 +14,8 @@ describe('vhost utils', function () {
     // url = 'https://ghost.blog'
     describe('without separate admin url', function () {
         it('uses the default arg for both backend and frontend', function () {
-            configUtils.config.getBackendMountPath().should.eql(/.*/);
-            configUtils.config.getFrontendMountPath().should.eql(/.*/);
+            assert.deepEqual(configUtils.config.getBackendMountPath(), /.*/);
+            assert.deepEqual(configUtils.config.getFrontendMountPath(), /.*/);
         });
     });
 
@@ -28,7 +28,7 @@ describe('vhost utils', function () {
 
         it('should use admin url and inverse as args', function () {
             assert.equal(configUtils.config.getBackendMountPath(), 'admin.ghost.blog');
-            configUtils.config.getFrontendMountPath().should.eql(/^(?!admin\.ghost\.blog).*/);
+            assert.deepEqual(configUtils.config.getFrontendMountPath(), /^(?!admin\.ghost\.blog).*/);
         });
 
         it('should have regex that excludes admin traffic on front-end', function () {
@@ -48,8 +48,8 @@ describe('vhost utils', function () {
         });
 
         it('should mount and assign correct routes', function () {
-            configUtils.config.getBackendMountPath().should.eql(/.*/);
-            configUtils.config.getFrontendMountPath().should.eql(/.*/);
+            assert.deepEqual(configUtils.config.getBackendMountPath(), /.*/);
+            assert.deepEqual(configUtils.config.getFrontendMountPath(), /.*/);
         });
     });
 });

--- a/ghost/core/test/unit/shared/config/loader.test.js
+++ b/ghost/core/test/unit/shared/config/loader.test.js
@@ -140,7 +140,7 @@ describe('Config Loader', function () {
 
             configUtils.set('paths:contentPath', contentPath);
             assert.equal(configUtils.config.get('paths').contentPath, contentPath);
-            configUtils.config.getContentPath('images').should.eql(contentPath + 'images/');
+            assert.equal(configUtils.config.getContentPath('images'), contentPath + 'images/');
         });
     });
 });

--- a/ghost/core/test/utils/api.js
+++ b/ghost/core/test/utils/api.js
@@ -40,7 +40,7 @@ function checkResponseValue(jsonResponse, expectedProperties) {
         assert(!(prop in jsonResponse));
     });
 
-    providedProperties.length.should.eql(expectedProperties.length, 'provided properties length does not match expected properties length');
+    assert.equal(providedProperties.length, expectedProperties.length, 'provided properties length does not match expected properties length');
 }
 
 // @TODO: support options pattern only, it's annoying to call checkResponse(null, null, null, something)


### PR DESCRIPTION
This test-only change should have no user impact.

This replaces `should.eql` with `assert.equal` and `assert.deepEqual`.
