### PR TITLE
Replaced more Should.js assertions

### DIFF
--- a/ghost/core/test/integration/exporter/exporter.test.js
+++ b/ghost/core/test/integration/exporter/exporter.test.js
@@ -110,7 +110,11 @@ describe('Exporter', function () {
             // NOTE: using `Object.keys` here instead of `should.have.only.keys` assertion
             //       because when `have.only.keys` fails there's no useful diff
             assert.deepEqual(Object.keys(exportData.data).sort(), tables.sort());
-            Object.keys(exportData.data).sort().should.containDeep(Object.keys(exportedBodyLatest().db[0].data));
+            assert(
+                Object.keys(exportedBodyLatest().db[0].data).every(key => (
+                    Object.hasOwnProperty.call(exportData.data, key)
+                ))
+            );
             assert.equal(exportData.meta.version, ghostVersion.full);
 
             // excludes table should contain no data

--- a/ghost/core/test/integration/importer/v5.js
+++ b/ghost/core/test/integration/importer/v5.js
@@ -73,7 +73,7 @@ describe('Importing 5.x export', function () {
 
         // Imported user
         assert.equal(user2.email, 'import-test-user@ghost.org');
-        user2.id.should.not.equal(LEGACY_HARDCODED_USER_ID);
+        assert.notEqual(user2.id, LEGACY_HARDCODED_USER_ID);
 
         assert.equal(posts.data.length, 2);
 

--- a/ghost/core/test/legacy/api/admin/db.test.js
+++ b/ghost/core/test/legacy/api/admin/db.test.js
@@ -308,8 +308,8 @@ describe('DB API', function () {
         assert.equal(res2.body.posts.length, 1);
 
         // Ensure the author is not imported with the legacy hardcoded user id
-        res2.body.posts[0].authors[0].id.should.not.equal(LEGACY_HARDCODED_USER_ID);
-        res2.body.posts[0].primary_author.id.should.not.equal(LEGACY_HARDCODED_USER_ID);
+        assert.notEqual(res2.body.posts[0].authors[0].id, LEGACY_HARDCODED_USER_ID);
+        assert.notEqual(res2.body.posts[0].primary_author.id, LEGACY_HARDCODED_USER_ID);
 
         const usersResponse = await request.get(localUtils.API.getApiQuery('users/'))
             .set('Origin', config.get('url'))
@@ -320,9 +320,9 @@ describe('DB API', function () {
         assert.equal(usersResponse.body.users.length, 3);
 
         // Ensure user is not imported with the legacy hardcoded user id
-        usersResponse.body.users[0].id.should.not.equal(LEGACY_HARDCODED_USER_ID);
-        usersResponse.body.users[1].id.should.not.equal(LEGACY_HARDCODED_USER_ID);
-        usersResponse.body.users[2].id.should.not.equal(LEGACY_HARDCODED_USER_ID);
+        assert.notEqual(usersResponse.body.users[0].id, LEGACY_HARDCODED_USER_ID);
+        assert.notEqual(usersResponse.body.users[1].id, LEGACY_HARDCODED_USER_ID);
+        assert.notEqual(usersResponse.body.users[2].id, LEGACY_HARDCODED_USER_ID);
     });
 
     it('Can import a JSON database with products', async function () {

--- a/ghost/core/test/legacy/models/model-posts.test.js
+++ b/ghost/core/test/legacy/models/model-posts.test.js
@@ -773,7 +773,7 @@ describe('Post Model', function () {
                     assert(publishedPost.get('published_at') instanceof Date);
                     assert.equal(publishedPost.get('published_by'), testUtils.DataGenerator.Content.users[0].id);
                     assert(publishedPost.get('updated_at') instanceof Date);
-                    publishedPost.get('updated_at').should.not.equal(createdPostUpdatedDate);
+                    assert.notEqual(publishedPost.get('updated_at'), createdPostUpdatedDate);
 
                     assert.equal(Object.keys(eventsTriggered).length, 4);
                     assertExists(eventsTriggered['post.published']);
@@ -842,7 +842,7 @@ describe('Post Model', function () {
                     assert(publishedPost.get('published_at') instanceof Date);
                     assert.equal(publishedPost.get('published_by'), testUtils.DataGenerator.Content.users[0].id);
                     assert(publishedPost.get('updated_at') instanceof Date);
-                    publishedPost.get('updated_at').should.not.equal(createdPostUpdatedDate);
+                    assert.notEqual(publishedPost.get('updated_at'), createdPostUpdatedDate);
 
                     assert.equal(Object.keys(eventsTriggered).length, 4);
                     assertExists(eventsTriggered['post.published']);
@@ -1105,9 +1105,9 @@ describe('Post Model', function () {
                         }, context);
                     }).then(function (updatedSecondPost) {
                     // Should have updated from original
-                        updatedSecondPost.get('slug').should.not.equal(secondPost.slug);
+                        assert.notEqual(updatedSecondPost.get('slug'), secondPost.slug);
                         // Should not have a conflicted slug from the first
-                        updatedSecondPost.get('slug').should.not.equal(firstPost.slug);
+                        assert.notEqual(updatedSecondPost.get('slug'), firstPost.slug);
 
                         assert.equal(Object.keys(eventsTriggered).length, 3);
                         assertExists(eventsTriggered['post.edited']);
@@ -1118,9 +1118,9 @@ describe('Post Model', function () {
                         });
                     }).then(function (foundPost) {
                     // Should have updated from original
-                        foundPost.get('slug').should.not.equal(secondPost.slug);
+                        assert.notEqual(foundPost.get('slug'), secondPost.slug);
                         // Should not have a conflicted slug from the first
-                        foundPost.get('slug').should.not.equal(firstPost.slug);
+                        assert.notEqual(foundPost.get('slug'), firstPost.slug);
 
                         done();
                     }).catch(done);

--- a/ghost/core/test/legacy/models/model-users.test.js
+++ b/ghost/core/test/legacy/models/model-users.test.js
@@ -37,7 +37,7 @@ describe('User Model', function run() {
 
             UserModel.add(userData, context).then(function (createdUser) {
                 assertExists(createdUser);
-                createdUser.attributes.password.should.not.equal(userData.password, 'password was hashed');
+                assert.notEqual(createdUser.attributes.password, userData.password, 'password was hashed');
                 assert.equal(createdUser.attributes.email, userData.email, 'email address correct');
 
                 done();
@@ -244,7 +244,7 @@ describe('User Model', function run() {
                 return UserModel.add(userData, _.extend({}, context, {withRelated: ['roles']}));
             }).then(function (createdUser) {
                 assertExists(createdUser);
-                createdUser.get('password').should.not.equal(userData.password, 'password was hashed');
+                assert.notEqual(createdUser.get('password'), userData.password, 'password was hashed');
                 assert.equal(createdUser.get('email'), userData.email, 'email address correct');
                 assert.equal(createdUser.related('roles').toJSON()[0].name, 'Administrator', 'role set correctly');
 

--- a/ghost/core/test/unit/frontend/helpers/get.test.js
+++ b/ghost/core/test/unit/frontend/helpers/get.test.js
@@ -389,7 +389,7 @@ describe('{{#get}} helper', function () {
 
         it('handles Date values', function () {
             const result = querySimplePath(data, 'post.published_at');
-            result.should.have.length(1);
+            assert.equal(result.length, 1);
             assert(result[0] instanceof Date);
         });
 

--- a/ghost/core/test/unit/frontend/helpers/get.test.js
+++ b/ghost/core/test/unit/frontend/helpers/get.test.js
@@ -390,7 +390,7 @@ describe('{{#get}} helper', function () {
         it('handles Date values', function () {
             const result = querySimplePath(data, 'post.published_at');
             result.should.have.length(1);
-            result[0].should.be.a.Date();
+            assert(result[0] instanceof Date);
         });
 
         it('throws on recursive descent syntax', function () {

--- a/ghost/core/test/unit/frontend/meta/og-image.test.js
+++ b/ghost/core/test/unit/frontend/meta/og-image.test.js
@@ -22,13 +22,11 @@ describe('getOgImage', function () {
         localSettingsCache.og_image = '/content/images/settings-og.jpg';
         localSettingsCache.cover_image = '/content/images/settings-cover.jpg';
 
-        getOgImage({context: ['home'], home: {}})
-            .should.endWith('/content/images/settings-og.jpg');
+        assert(getOgImage({context: ['home'], home: {}}).endsWith('/content/images/settings-og.jpg'));
 
         localSettingsCache.og_image = '';
 
-        getOgImage({context: ['home'], home: {}})
-            .should.endWith('/content/images/settings-cover.jpg');
+        assert(getOgImage({context: ['home'], home: {}}).endsWith('/content/images/settings-cover.jpg'));
 
         localSettingsCache.cover_image = '';
 
@@ -44,13 +42,11 @@ describe('getOgImage', function () {
             feature_image: '/content/images/post-feature.jpg'
         };
 
-        getOgImage({context: ['post'], post})
-            .should.endWith('post-og.jpg');
+        assert(getOgImage({context: ['post'], post}).endsWith('post-og.jpg'));
 
         post.og_image = '';
 
-        getOgImage({context: ['post'], post})
-            .should.endWith('post-feature.jpg');
+        assert(getOgImage({context: ['post'], post}).endsWith('post-feature.jpg'));
 
         post.feature_image = '';
 
@@ -74,13 +70,11 @@ describe('getOgImage', function () {
             feature_image: '/content/images/page-feature.jpg'
         };
 
-        getOgImage({context: ['page'], page})
-            .should.endWith('page-og.jpg');
+        assert(getOgImage({context: ['page'], page}).endsWith('page-og.jpg'));
 
         page.og_image = '';
 
-        getOgImage({context: ['page'], page})
-            .should.endWith('page-feature.jpg');
+        assert(getOgImage({context: ['page'], page}).endsWith('page-feature.jpg'));
 
         page.feature_image = '';
 
@@ -104,13 +98,11 @@ describe('getOgImage', function () {
             feature_image: '/content/images/page-feature.jpg'
         };
 
-        getOgImage({context: ['page'], post})
-            .should.endWith('page-og.jpg');
+        assert(getOgImage({context: ['page'], post}).endsWith('page-og.jpg'));
 
         post.og_image = '';
 
-        getOgImage({context: ['page'], post})
-            .should.endWith('page-feature.jpg');
+        assert(getOgImage({context: ['page'], post}).endsWith('page-feature.jpg'));
 
         post.feature_image = '';
 
@@ -133,8 +125,7 @@ describe('getOgImage', function () {
             cover_image: '/content/images/author-cover.jpg'
         };
 
-        getOgImage({context: ['author'], author})
-            .should.endWith('author-cover.jpg');
+        assert(getOgImage({context: ['author'], author}).endsWith('author-cover.jpg'));
 
         author.cover_image = '';
 
@@ -149,8 +140,7 @@ describe('getOgImage', function () {
             cover_image: '/content/images/author-cover.jpg'
         };
 
-        getOgImage({context: ['author', 'paged'], author})
-            .should.endWith('author-cover.jpg');
+        assert(getOgImage({context: ['author', 'paged'], author}).endsWith('author-cover.jpg'));
 
         author.cover_image = '';
 
@@ -165,13 +155,11 @@ describe('getOgImage', function () {
             feature_image: '/content/images/tag-feature.jpg'
         };
 
-        getOgImage({context: ['tag'], tag})
-            .should.endWith('tag-feature.jpg');
+        assert(getOgImage({context: ['tag'], tag}).endsWith('tag-feature.jpg'));
 
         tag.feature_image = '';
 
-        getOgImage({context: ['tag'], tag})
-            .should.endWith('settings-cover.jpg');
+        assert(getOgImage({context: ['tag'], tag}).endsWith('settings-cover.jpg'));
 
         localSettingsCache.cover_image = '';
 
@@ -186,13 +174,11 @@ describe('getOgImage', function () {
             feature_image: '/content/images/tag-feature.jpg'
         };
 
-        getOgImage({context: ['tag', 'paged'], tag})
-            .should.endWith('tag-feature.jpg');
+        assert(getOgImage({context: ['tag', 'paged'], tag}).endsWith('tag-feature.jpg'));
 
         tag.feature_image = '';
 
-        getOgImage({context: ['tag', 'paged'], tag})
-            .should.endWith('settings-cover.jpg');
+        assert(getOgImage({context: ['tag', 'paged'], tag}).endsWith('settings-cover.jpg'));
 
         localSettingsCache.cover_image = '';
 

--- a/ghost/core/test/unit/frontend/meta/twitter-image.test.js
+++ b/ghost/core/test/unit/frontend/meta/twitter-image.test.js
@@ -22,13 +22,11 @@ describe('getTwitterImage', function () {
         localSettingsCache.twitter_image = '/content/images/settings-twitter.jpg';
         localSettingsCache.cover_image = '/content/images/settings-cover.jpg';
 
-        getTwitterImage({context: ['home'], home: {}})
-            .should.endWith('/content/images/settings-twitter.jpg');
+        assert(getTwitterImage({context: ['home'], home: {}}).endsWith('/content/images/settings-twitter.jpg'));
 
         localSettingsCache.twitter_image = '';
 
-        getTwitterImage({context: ['home'], home: {}})
-            .should.endWith('/content/images/settings-cover.jpg');
+        assert(getTwitterImage({context: ['home'], home: {}}).endsWith('/content/images/settings-cover.jpg'));
 
         localSettingsCache.cover_image = '';
 
@@ -44,13 +42,11 @@ describe('getTwitterImage', function () {
             feature_image: '/content/images/post-feature.jpg'
         };
 
-        getTwitterImage({context: ['post'], post})
-            .should.endWith('post-twitter.jpg');
+        assert(getTwitterImage({context: ['post'], post}).endsWith('post-twitter.jpg'));
 
         post.twitter_image = '';
 
-        getTwitterImage({context: ['post'], post})
-            .should.endWith('post-feature.jpg');
+        assert(getTwitterImage({context: ['post'], post}).endsWith('post-feature.jpg'));
 
         post.feature_image = '';
 
@@ -74,13 +70,11 @@ describe('getTwitterImage', function () {
             feature_image: '/content/images/page-feature.jpg'
         };
 
-        getTwitterImage({context: ['page'], page})
-            .should.endWith('page-twitter.jpg');
+        assert(getTwitterImage({context: ['page'], page}).endsWith('page-twitter.jpg'));
 
         page.twitter_image = '';
 
-        getTwitterImage({context: ['page'], page})
-            .should.endWith('page-feature.jpg');
+        assert(getTwitterImage({context: ['page'], page}).endsWith('page-feature.jpg'));
 
         page.feature_image = '';
 
@@ -104,13 +98,11 @@ describe('getTwitterImage', function () {
             feature_image: '/content/images/page-feature.jpg'
         };
 
-        getTwitterImage({context: ['page'], post})
-            .should.endWith('page-twitter.jpg');
+        assert(getTwitterImage({context: ['page'], post}).endsWith('page-twitter.jpg'));
 
         post.twitter_image = '';
 
-        getTwitterImage({context: ['page'], post})
-            .should.endWith('page-feature.jpg');
+        assert(getTwitterImage({context: ['page'], post}).endsWith('page-feature.jpg'));
 
         post.feature_image = '';
 
@@ -133,8 +125,7 @@ describe('getTwitterImage', function () {
             cover_image: '/content/images/author-cover.jpg'
         };
 
-        getTwitterImage({context: ['author'], author})
-            .should.endWith('author-cover.jpg');
+        assert(getTwitterImage({context: ['author'], author}).endsWith('author-cover.jpg'));
 
         author.cover_image = '';
 
@@ -149,8 +140,7 @@ describe('getTwitterImage', function () {
             cover_image: '/content/images/author-cover.jpg'
         };
 
-        getTwitterImage({context: ['author', 'paged'], author})
-            .should.endWith('author-cover.jpg');
+        assert(getTwitterImage({context: ['author', 'paged'], author}).endsWith('author-cover.jpg'));
 
         author.cover_image = '';
 
@@ -165,13 +155,11 @@ describe('getTwitterImage', function () {
             feature_image: '/content/images/tag-feature.jpg'
         };
 
-        getTwitterImage({context: ['tag'], tag})
-            .should.endWith('tag-feature.jpg');
+        assert(getTwitterImage({context: ['tag'], tag}).endsWith('tag-feature.jpg'));
 
         tag.feature_image = '';
 
-        getTwitterImage({context: ['tag'], tag})
-            .should.endWith('settings-cover.jpg');
+        assert(getTwitterImage({context: ['tag'], tag}).endsWith('settings-cover.jpg'));
 
         localSettingsCache.cover_image = '';
 
@@ -186,13 +174,11 @@ describe('getTwitterImage', function () {
             feature_image: '/content/images/tag-feature.jpg'
         };
 
-        getTwitterImage({context: ['tag', 'paged'], tag})
-            .should.endWith('tag-feature.jpg');
+        assert(getTwitterImage({context: ['tag', 'paged'], tag}).endsWith('tag-feature.jpg'));
 
         tag.feature_image = '';
 
-        getTwitterImage({context: ['tag', 'paged'], tag})
-            .should.endWith('settings-cover.jpg');
+        assert(getTwitterImage({context: ['tag', 'paged'], tag}).endsWith('settings-cover.jpg'));
 
         localSettingsCache.cover_image = '';
 

--- a/ghost/core/test/unit/frontend/services/routing/static-routes-router.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/static-routes-router.test.js
@@ -85,7 +85,7 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
             res.routerOptions.should.have.properties('type', 'templates', 'defaultTemplate', 'context', 'data', 'contentType');
             assert.equal(res.routerOptions.type, 'custom');
             assert.deepEqual(res.routerOptions.templates, []);
-            res.routerOptions.defaultTemplate.should.be.a.Function();
+            assert.equal(typeof res.routerOptions.defaultTemplate, 'function');
             assert.deepEqual(res.routerOptions.context, ['about']);
             assert.deepEqual(res.routerOptions.data, {});
 
@@ -102,7 +102,7 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
             res.routerOptions.should.have.properties('type', 'templates', 'defaultTemplate', 'context', 'data', 'contentType');
             assert.equal(res.routerOptions.type, 'custom');
             assert.deepEqual(res.routerOptions.templates, []);
-            res.routerOptions.defaultTemplate.should.be.a.Function();
+            assert.equal(typeof res.routerOptions.defaultTemplate, 'function');
             assert.deepEqual(res.routerOptions.context, ['index']);
             assert.deepEqual(res.routerOptions.data, {});
 

--- a/ghost/core/test/unit/frontend/services/theme-engine/active.test.js
+++ b/ghost/core/test/unit/frontend/services/theme-engine/active.test.js
@@ -68,7 +68,7 @@ describe('Themes', function () {
                 assert.equal(configStub.calledWith('assetHash', null), true);
 
                 // Check the file-based asset hash cache is cleared
-                clearCacheSpy.calledOnce.should.be.true();
+                sinon.assert.calledOnce(clearCacheSpy);
 
                 // Check te view cache was cleared
                 assert.deepEqual(fakeBlogApp.cache, {});
@@ -105,7 +105,7 @@ describe('Themes', function () {
                 assert.equal(configStub.calledWith('assetHash', null), true);
 
                 // Check the file-based asset hash cache is cleared
-                clearCacheSpy.calledOnce.should.be.true();
+                sinon.assert.calledOnce(clearCacheSpy);
 
                 // Check te view cache was cleared
                 assert.deepEqual(fakeBlogApp.cache, {});

--- a/ghost/core/test/unit/frontend/web/middleware/serve-public-file.test.js
+++ b/ghost/core/test/unit/frontend/web/middleware/serve-public-file.test.js
@@ -50,7 +50,7 @@ describe('servePublicFile', function () {
         middleware(req, res, next);
 
         assert.equal(next.called, false);
-        fileStub.firstCall.args[0].should.endWith('core/frontend/public/robots.txt');
+        assert(fileStub.firstCall.args[0].endsWith('core/frontend/public/robots.txt'));
         assert.equal(res.writeHead.called, true);
         assert.equal(res.writeHead.args[0][0], 200);
         assert.equal(res.writeHead.calledWith(200, sinon.match.has('Content-Type')), true);
@@ -80,7 +80,7 @@ describe('servePublicFile', function () {
 
         // File only gets read onece
         assert.equal(fileStub.calledOnce, true);
-        fileStub.firstCall.args[0].should.endWith('core/frontend/public/robots.txt');
+        assert(fileStub.firstCall.args[0].endsWith('core/frontend/public/robots.txt'));
 
         // File gets served twice
         assert.equal(res.writeHead.calledTwice, true);
@@ -116,8 +116,8 @@ describe('servePublicFile', function () {
         assert.equal(fileStub.calledTwice, true);
 
         assert.equal(next.called, false);
-        fileStub.firstCall.args[0].should.endWith('core/frontend/public/robots.txt');
-        fileStub.secondCall.args[0].should.endWith('core/frontend/public/robots.txt');
+        assert(fileStub.firstCall.args[0].endsWith('core/frontend/public/robots.txt'));
+        assert(fileStub.secondCall.args[0].endsWith('core/frontend/public/robots.txt'));
 
         assert.equal(res.writeHead.calledThrice, true);
         assert.equal(res.writeHead.args[0][0], 200);
@@ -189,6 +189,6 @@ describe('servePublicFile', function () {
         assert.equal(res.writeHead.called, true);
         assert.equal(res.writeHead.args[0][0], 200);
 
-        fileStub.firstCall.args[0].should.endWith('/public/something.css');
+        assert(fileStub.firstCall.args[0].endsWith('/public/something.css'));
     });
 });

--- a/ghost/core/test/unit/frontend/web/middleware/serve-public-file.test.js
+++ b/ghost/core/test/unit/frontend/web/middleware/serve-public-file.test.js
@@ -23,7 +23,7 @@ describe('servePublicFile', function () {
     it('should return a middleware', function () {
         const result = servePublicFile('static', 'robots.txt', 'text/plain', 3600);
 
-        result.should.be.a.Function();
+        assert.equal(typeof result, 'function');
     });
 
     it('should skip if the request does NOT match the file', function () {

--- a/ghost/core/test/unit/server/lib/image/cached-image-size-from-url.test.js
+++ b/ghost/core/test/unit/server/lib/image/cached-image-size-from-url.test.js
@@ -41,7 +41,7 @@ describe('lib/image: image size cache', function () {
         // first call to get result from `getImageSizeFromUrl`
 
         assertExists(cacheStore);
-        cacheStore.get(url).should.not.be.undefined;
+        assertExists(cacheStore.get(url));
         const image = cacheStore.get(url);
         assertExists(image.width);
         assert.equal(image.width, 50);
@@ -54,7 +54,7 @@ describe('lib/image: image size cache', function () {
         assert.equal(imageSizeSpy.calledOnce, true);
         assert.equal(imageSizeSpy.calledTwice, false);
 
-        cacheStore.get(url).should.not.be.undefined;
+        assertExists(cacheStore.get(url));
         const image2 = cacheStore.get(url);
         assertExists(image2.width);
         assert.equal(image2.width, 50);
@@ -108,7 +108,7 @@ describe('lib/image: image size cache', function () {
         assert.equal(result, null);
 
         // Verify 404 was cached with notFound marker
-        cacheStore.get(url).should.not.be.undefined;
+        assertExists(cacheStore.get(url));
         const image = cacheStore.get(url);
         assert.equal(image.url, url);
         assert.equal(image.notFound, true);

--- a/ghost/core/test/unit/server/models/base/bulk-filters.test.js
+++ b/ghost/core/test/unit/server/models/base/bulk-filters.test.js
@@ -14,7 +14,7 @@ describe('Models: bulk-filters', function () {
             const results = [...strategy];
 
             assert.equal(results.length, 1);
-            results[0].should.be.a.Function();
+            assert.equal(typeof results[0], 'function');
         });
     });
 

--- a/ghost/core/test/unit/server/models/base/index.test.js
+++ b/ghost/core/test/unit/server/models/base/index.test.js
@@ -165,18 +165,18 @@ describe('Models: base', function () {
             models.Base.Model.sanitizeData
                 .bind({prototype: {tableName: 'posts'}})(data);
 
-            data.updated_at.should.be.a.Date();
+            assert(data.updated_at instanceof Date);
         });
 
         it('date is JS date, ignore', function () {
             const data = testUtils.DataGenerator.forKnex.createPost({updated_at: new Date()});
 
-            data.updated_at.should.be.a.Date();
+            assert(data.updated_at instanceof Date);
 
             models.Base.Model.sanitizeData
                 .bind({prototype: {tableName: 'posts'}})(data);
 
-            data.updated_at.should.be.a.Date();
+            assert(data.updated_at instanceof Date);
         });
 
         it('expect date transformation for nested relations', function () {
@@ -199,7 +199,7 @@ describe('Models: base', function () {
                 })(data);
 
             assert.equal(data.authors[0].name, 'Thomas');
-            data.authors[0].updated_at.should.be.a.Date();
+            assert(data.authors[0].updated_at instanceof Date);
         });
     });
 

--- a/ghost/core/test/unit/server/models/base/index.test.js
+++ b/ghost/core/test/unit/server/models/base/index.test.js
@@ -160,7 +160,7 @@ describe('Models: base', function () {
         it('expect date transformation', function () {
             const data = testUtils.DataGenerator.forKnex.createPost({updated_at: '2018-04-01 07:53:07'});
 
-            data.updated_at.should.be.a.String();
+            assert.equal(typeof data.updated_at, 'string');
 
             models.Base.Model.sanitizeData
                 .bind({prototype: {tableName: 'posts'}})(data);
@@ -187,7 +187,7 @@ describe('Models: base', function () {
                 }]
             });
 
-            data.authors[0].updated_at.should.be.a.String();
+            assert.equal(typeof data.authors[0].updated_at, 'string');
 
             models.Base.Model.sanitizeData
                 .bind({

--- a/ghost/core/test/unit/server/models/user.test.js
+++ b/ghost/core/test/unit/server/models/user.test.js
@@ -496,8 +496,7 @@ describe('Unit: models/user', function () {
                 .then(Promise.reject)
                 .catch((err) => {
                     assert(err instanceof errors.ValidationError);
-                    err.message.indexOf('Only administrators can')
-                        .should.be.aboveOrEqual(0, 'contains correct error message');
+                    assert(err.message.includes('Only administrators can'), 'contains correct error message');
                 });
         });
 
@@ -527,8 +526,7 @@ describe('Unit: models/user', function () {
                 .then(Promise.reject)
                 .catch((err) => {
                     assert(err instanceof errors.ValidationError);
-                    err.message.indexOf('Only active administrators can')
-                        .should.be.aboveOrEqual(0, 'contains correct error message');
+                    assert(err.message.includes('Only active administrators can'), 'contains correct error message');
                 });
         });
 

--- a/ghost/core/test/unit/server/services/email-analytics/email-analytics-service.test.js
+++ b/ghost/core/test/unit/server/services/email-analytics/email-analytics-service.test.js
@@ -870,8 +870,8 @@ describe('EmailAnalyticsService', function () {
 
             await service.aggregateEmailStats('memberId');
 
-            assert.equal(service.queries.aggregateEmailStats.calledOnce, true);
-            service.queries.aggregateEmailStats.calledWith('memberId').should.be.true;
+            sinon.assert.calledOnce(service.queries.aggregateEmailStats);
+            sinon.assert.calledWith(service.queries.aggregateEmailStats, 'memberId');
         });
     });
 
@@ -886,8 +886,8 @@ describe('EmailAnalyticsService', function () {
 
             await service.aggregateMemberStats('memberId');
 
-            assert.equal(service.queries.aggregateMemberStats.calledOnce, true);
-            service.queries.aggregateMemberStats.calledWith('memberId').should.be.true;
+            sinon.assert.calledOnce(service.queries.aggregateMemberStats);
+            sinon.assert.calledWith(service.queries.aggregateMemberStats, 'memberId');
         });
     });
 });

--- a/ghost/core/test/unit/server/services/mail/ghost-mailer.test.js
+++ b/ghost/core/test/unit/server/services/mail/ghost-mailer.test.js
@@ -67,7 +67,7 @@ describe('Mail: Ghostmailer', function () {
 
         assert('transport' in mailer);
         assert.equal(mailer.transport.transporter.name, 'SMTP');
-        mailer.transport.sendMail.should.be.a.Function();
+        assert.equal(typeof mailer.transport.sendMail, 'function');
     });
 
     it('should fallback to direct if config is empty', function () {

--- a/ghost/core/test/unit/server/services/member-welcome-emails/member-welcome-email-renderer.test.js
+++ b/ghost/core/test/unit/server/services/member-welcome-emails/member-welcome-email-renderer.test.js
@@ -240,7 +240,7 @@ describe('MemberWelcomeEmailRenderer', function () {
                 siteSettings: defaultSiteSettings
             });
 
-            result.text.should.be.a.String();
+            assert.equal(typeof result.text, 'string');
             assert(result.text.includes('Hello World'));
         });
 

--- a/ghost/core/test/unit/server/services/members/importer/members-csv-importer-stripe-utils.test.js
+++ b/ghost/core/test/unit/server/services/members/importer/members-csv-importer-stripe-utils.test.js
@@ -1,7 +1,6 @@
 const assert = require('node:assert/strict');
 require('should');
 const sinon = require('sinon');
-const {DataImportError} = require('@tryghost/errors');
 const MembersCSVImporterStripeUtils = require('../../../../../../core/server/services/members/importer/members-csv-importer-stripe-utils');
 
 describe('MembersCSVImporterStripeUtils', function () {

--- a/ghost/core/test/unit/server/services/members/importer/members-csv-importer-stripe-utils.test.js
+++ b/ghost/core/test/unit/server/services/members/importer/members-csv-importer-stripe-utils.test.js
@@ -130,9 +130,12 @@ describe('MembersCSVImporterStripeUtils', function () {
                 stripeAPIService: stripeAPIServiceStub
             });
 
-            await membersCSVImporterStripeUtils.forceStripeSubscriptionToProduct({}, OPTIONS).should.be.rejectedWith(
-                DataImportError,
-                {message: 'Cannot force subscription to product without a Stripe Connection'}
+            await assert.rejects(
+                membersCSVImporterStripeUtils.forceStripeSubscriptionToProduct({}, OPTIONS),
+                {
+                    name: 'DataImportError',
+                    message: 'Cannot force subscription to product without a Stripe Connection'
+                }
             );
         });
 
@@ -142,11 +145,12 @@ describe('MembersCSVImporterStripeUtils', function () {
                 stripeAPIService: stripeAPIServiceStub
             });
 
-            await membersCSVImporterStripeUtils.forceStripeSubscriptionToProduct({
-                customer_id: CUSTOMER_ID
-            }, OPTIONS).should.be.rejectedWith(
-                DataImportError,
-                {message: 'Cannot find Stripe customer to update subscription'}
+            await assert.rejects(
+                membersCSVImporterStripeUtils.forceStripeSubscriptionToProduct({customer_id: CUSTOMER_ID}, OPTIONS),
+                {
+                    name: 'DataImportError',
+                    message: 'Cannot find Stripe customer to update subscription'
+                }
             );
         });
 
@@ -159,11 +163,12 @@ describe('MembersCSVImporterStripeUtils', function () {
                 stripeAPIService: stripeAPIServiceStub
             });
 
-            await membersCSVImporterStripeUtils.forceStripeSubscriptionToProduct({
-                customer_id: CUSTOMER_ID
-            }, OPTIONS).should.be.rejectedWith(
-                DataImportError,
-                {message: 'Cannot update subscription when customer does not have an existing subscription'}
+            await assert.rejects(
+                membersCSVImporterStripeUtils.forceStripeSubscriptionToProduct({customer_id: CUSTOMER_ID}, OPTIONS),
+                {
+                    name: 'DataImportError',
+                    message: 'Cannot update subscription when customer does not have an existing subscription'
+                }
             );
         });
 
@@ -191,11 +196,12 @@ describe('MembersCSVImporterStripeUtils', function () {
                 stripeAPIService: stripeAPIServiceStub
             });
 
-            await membersCSVImporterStripeUtils.forceStripeSubscriptionToProduct({
-                customer_id: CUSTOMER_ID
-            }, OPTIONS).should.be.rejectedWith(
-                DataImportError,
-                {message: 'Cannot update subscription when customer has multiple subscriptions'}
+            await assert.rejects(
+                membersCSVImporterStripeUtils.forceStripeSubscriptionToProduct({customer_id: CUSTOMER_ID}, OPTIONS),
+                {
+                    name: 'DataImportError',
+                    message: 'Cannot update subscription when customer has multiple subscriptions'
+                }
             );
         });
 
@@ -216,11 +222,12 @@ describe('MembersCSVImporterStripeUtils', function () {
                 stripeAPIService: stripeAPIServiceStub
             });
 
-            await membersCSVImporterStripeUtils.forceStripeSubscriptionToProduct({
-                customer_id: CUSTOMER_ID
-            }, OPTIONS).should.be.rejectedWith(
-                DataImportError,
-                {message: 'Cannot update subscription when existing subscription has multiple items'}
+            await assert.rejects(
+                membersCSVImporterStripeUtils.forceStripeSubscriptionToProduct({customer_id: CUSTOMER_ID}, OPTIONS),
+                {
+                    name: 'DataImportError',
+                    message: 'Cannot update subscription when existing subscription has multiple items'
+                }
             );
         });
 
@@ -233,11 +240,12 @@ describe('MembersCSVImporterStripeUtils', function () {
                 stripeAPIService: stripeAPIServiceStub
             });
 
-            await membersCSVImporterStripeUtils.forceStripeSubscriptionToProduct({
-                customer_id: CUSTOMER_ID
-            }, OPTIONS).should.be.rejectedWith(
-                DataImportError,
-                {message: 'Cannot update subscription when existing subscription is not recurring'}
+            await assert.rejects(
+                membersCSVImporterStripeUtils.forceStripeSubscriptionToProduct({customer_id: CUSTOMER_ID}, OPTIONS),
+                {
+                    name: 'DataImportError',
+                    message: 'Cannot update subscription when existing subscription is not recurring'
+                }
             );
         });
 
@@ -257,12 +265,15 @@ describe('MembersCSVImporterStripeUtils', function () {
                 productRepository: productRepositoryStub
             });
 
-            await membersCSVImporterStripeUtils.forceStripeSubscriptionToProduct({
-                customer_id: CUSTOMER_ID,
-                product_id: PRODUCT_ID
-            }, OPTIONS).should.be.rejectedWith(
-                DataImportError,
-                {message: `Cannot find Product ${PRODUCT_ID}`}
+            await assert.rejects(
+                membersCSVImporterStripeUtils.forceStripeSubscriptionToProduct({
+                    customer_id: CUSTOMER_ID,
+                    product_id: PRODUCT_ID
+                }, OPTIONS),
+                {
+                    name: 'DataImportError',
+                    message: `Cannot find Product ${PRODUCT_ID}`
+                }
             );
         });
 

--- a/ghost/core/test/unit/server/services/members/members-api/repositories/member-repository.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/repositories/member-repository.test.js
@@ -886,7 +886,7 @@ describe('MemberRepository', function () {
                 context: {}
             });
 
-            StripeCustomerSubscription.add.calledOnce.should.be.true();
+            sinon.assert.calledOnce(StripeCustomerSubscription.add);
             const addedData = StripeCustomerSubscription.add.firstCall.args[0];
             assert.equal(addedData.default_payment_card_last4, '8888');
         });
@@ -927,7 +927,7 @@ describe('MemberRepository', function () {
                 context: {}
             });
 
-            StripeCustomerSubscription.add.calledOnce.should.be.true();
+            sinon.assert.calledOnce(StripeCustomerSubscription.add);
             const addedData = StripeCustomerSubscription.add.firstCall.args[0];
             assert.equal(addedData.default_payment_card_last4, null);
         });
@@ -968,7 +968,7 @@ describe('MemberRepository', function () {
                 context: {}
             });
 
-            StripeCustomerSubscription.add.calledOnce.should.be.true();
+            sinon.assert.calledOnce(StripeCustomerSubscription.add);
             const addedData = StripeCustomerSubscription.add.firstCall.args[0];
             assert.equal(addedData.default_payment_card_last4, '4242');
         });
@@ -1017,7 +1017,7 @@ describe('MemberRepository', function () {
                 context: {}
             });
 
-            StripeCustomerSubscription.add.calledOnce.should.be.true();
+            sinon.assert.calledOnce(StripeCustomerSubscription.add);
             const addedData = StripeCustomerSubscription.add.firstCall.args[0];
             assert.equal(addedData.default_payment_card_last4, '1234');
         });

--- a/ghost/core/test/unit/server/services/members/request-integrity-token-provider.test.js
+++ b/ghost/core/test/unit/server/services/members/request-integrity-token-provider.test.js
@@ -22,7 +22,7 @@ describe('RequestIntegrityTokenProvider', function () {
         it('should create a HMAC digest from the secret', function () {
             const token = tokenProvider.create();
 
-            token.should.be.a.String();
+            assert.equal(typeof token, 'string');
             assert(Array.isArray(token.split(':')));
             assert.equal(token.split(':').length, 3);
             const [timestamp, nonce, digest] = token.split(':');
@@ -31,7 +31,8 @@ describe('RequestIntegrityTokenProvider', function () {
 
             assert.match(nonce, /[0-9a-f]{16}/);
 
-            digest.should.be.a.String().with.lengthOf(64);
+            assert.equal(typeof digest, 'string');
+            assert.equal(digest.length, 64);
         });
     });
 

--- a/ghost/core/test/unit/server/services/permissions/can-this.test.js
+++ b/ghost/core/test/unit/server/services/permissions/can-this.test.js
@@ -82,22 +82,22 @@ describe('Permissions', function () {
             const canThisResult = permissions.canThis();
 
             assert(_.isPlainObject(canThisResult.browse));
-            canThisResult.browse.post.should.be.a.Function();
+            assert.equal(typeof canThisResult.browse.post, 'function');
 
             assert(_.isPlainObject(canThisResult.edit));
-            canThisResult.edit.post.should.be.a.Function();
-            canThisResult.edit.tag.should.be.a.Function();
-            canThisResult.edit.user.should.be.a.Function();
-            canThisResult.edit.page.should.be.a.Function();
+            assert.equal(typeof canThisResult.edit.post, 'function');
+            assert.equal(typeof canThisResult.edit.tag, 'function');
+            assert.equal(typeof canThisResult.edit.user, 'function');
+            assert.equal(typeof canThisResult.edit.page, 'function');
 
             assert(_.isPlainObject(canThisResult.add));
-            canThisResult.add.post.should.be.a.Function();
-            canThisResult.add.user.should.be.a.Function();
-            canThisResult.add.page.should.be.a.Function();
+            assert.equal(typeof canThisResult.add.post, 'function');
+            assert.equal(typeof canThisResult.add.user, 'function');
+            assert.equal(typeof canThisResult.add.page, 'function');
 
             assert(_.isPlainObject(canThisResult.destroy));
-            canThisResult.destroy.post.should.be.a.Function();
-            canThisResult.destroy.user.should.be.a.Function();
+            assert.equal(typeof canThisResult.destroy.post, 'function');
+            assert.equal(typeof canThisResult.destroy.user, 'function');
         });
 
         describe('Non user permissions', function () {

--- a/ghost/core/test/unit/server/services/permissions/index.test.js
+++ b/ghost/core/test/unit/server/services/permissions/index.test.js
@@ -80,7 +80,7 @@ describe('Permissions', function () {
             permissions.init().then(function (actions) {
                 assertExists(actions);
 
-                permissions.canThis.should.not.throwError();
+                assert.doesNotThrow(permissions.canThis);
 
                 assert.deepEqual(_.keys(actions), ['browse', 'edit', 'add', 'destroy']);
 
@@ -99,7 +99,7 @@ describe('Permissions', function () {
             permissions.init().then(function (actions) {
                 assertExists(actions);
 
-                permissions.canThis.should.not.throwError();
+                assert.doesNotThrow(permissions.canThis);
 
                 assert.deepEqual(_.keys(actions), ['browse', 'edit', 'add', 'destroy']);
 

--- a/ghost/core/test/unit/server/web/api/middleware/upload.test.js
+++ b/ghost/core/test/unit/server/web/api/middleware/upload.test.js
@@ -8,7 +8,7 @@ const assert = require('node:assert/strict');
 describe('web utils', function () {
     describe('checkFileExists', function () {
         it('should return true if file exists in input', function () {
-            validation.checkFileExists({mimetype: 'file', path: 'path'}).should.be.true;
+            assert.equal(validation.checkFileExists({mimetype: 'file', path: 'path'}), true);
         });
 
         it('should return false if file does not exist in input', function () {
@@ -22,17 +22,17 @@ describe('web utils', function () {
 
     describe('checkFileIsValid', function () {
         it('returns true if file has valid extension and type', function () {
-            validation.checkFileIsValid({
+            assert.equal(validation.checkFileIsValid({
                 name: 'test.txt',
                 mimetype: 'text',
                 ext: '.txt'
-            }, ['text'], ['.txt']).should.be.true;
+            }, ['text'], ['.txt']), true);
 
-            validation.checkFileIsValid({
+            assert.equal(validation.checkFileIsValid({
                 name: 'test.jpg',
                 mimetype: 'jpeg',
                 ext: '.jpg'
-            }, ['text', 'jpeg'], ['.txt', '.jpg']).should.be.true;
+            }, ['text', 'jpeg'], ['.txt', '.jpg']), true);
         });
 
         it('returns false if file has invalid extension', function () {

--- a/ghost/core/test/unit/shared/custom-theme-settings-cache/cache.test.js
+++ b/ghost/core/test/unit/shared/custom-theme-settings-cache/cache.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 
 const Cache = require('../../../../core/shared/custom-theme-settings-cache/custom-theme-settings-cache');
 
@@ -16,7 +15,6 @@ describe('Cache', function () {
 
             const getAll = cache.getAll();
 
-            getAll.should.have.size(2);
             assert.deepEqual(getAll, {
                 one: 1,
                 two: 2
@@ -43,8 +41,6 @@ describe('Cache', function () {
 
             const getAll = cache.getAll();
 
-            getAll.should.have.size(1);
-            getAll.should.not.have.keys('one', 'two');
             assert.deepEqual(getAll, {
                 three: 3
             });
@@ -108,7 +104,6 @@ describe('Cache', function () {
 
             const returned = cache.getAll();
 
-            returned.should.have.size(2);
             assert.deepEqual(returned, {
                 one: 1,
                 two: 2


### PR DESCRIPTION
This test-only change should have no user impact.

This replaces the following Should.js assertions with `node:assert`:

- `.should.be.a.Date`
- `.should.be.a.Function`
- `.should.be.a.String`
- `.should.be.aboveOrEqual`
- `.should.be.rejectedWith`
- `.should.be.true`
- `.should.containDeep`
- `.should.endWith`
- `.should.have.length`
- `.should.have.size`
- `.should.not.be.undefined`
- `.should.not.equal`
- `.should.not.have.keys`
- `.should.not.throwError`
