### PR TITLE
Fixed flaky portal browser tests in CI

### DIFF
--- a/ghost/core/test/e2e-browser/portal/upgrade.spec.js
+++ b/ghost/core/test/e2e-browser/portal/upgrade.spec.js
@@ -33,7 +33,7 @@ test.describe('Portal', () => {
                     delay: 500
                 });
 
-                await sharedPage.waitForLoadState('networkidle');
+                await expect(sharedPage.locator('[data-test-tier]').first()).toBeVisible();
                 await impersonateMember(sharedPage);
 
                 const portalTriggerButton = sharedPage.frameLocator('[data-testid="portal-trigger-frame"]').locator('[data-testid="portal-trigger-button"]');
@@ -50,8 +50,9 @@ test.describe('Portal', () => {
                 await completeStripeSubscription(sharedPage);
 
                 // open portal and check that member has been upgraded to paid tier
+                await expect(portalTriggerButton).toBeVisible();
                 await portalTriggerButton.click();
-                await expect(portalFrame.getByText('$50.00/year')).toBeVisible();
+                await expect(portalFrame.getByText('$50.00/year')).toBeVisible({timeout: 30000});
                 await expect(portalFrame.getByRole('heading', {name: 'Billing info'})).toBeVisible();
                 await expect(portalFrame.getByText('**** **** **** 4242')).toBeVisible();
 
@@ -102,10 +103,11 @@ test.describe('Portal', () => {
                 await completeStripeSubscription(sharedPage);
 
                 // open portal and check that member has been upgraded to paid tier
+                await expect(portalTriggerButton).toBeVisible();
                 await portalTriggerButton.click();
                 // verify member's tier, price and card details
                 await expect(portalFrame.getByText(tierName)).toBeVisible();
-                await expect(portalFrame.getByText('$50.00/year')).toBeVisible();
+                await expect(portalFrame.getByText('$50.00/year')).toBeVisible({timeout: 30000});
                 await expect(portalFrame.getByText('**** **** **** 4242')).toBeVisible();
 
                 // verify member's tier on member detail page in admin

--- a/ghost/core/test/e2e-browser/utils/e2e-browser-utils.js
+++ b/ghost/core/test/e2e-browser/utils/e2e-browser-utils.js
@@ -277,15 +277,14 @@ const createOffer = async (page, {name, tierName, offerType, amount, discountTyp
 
             const confirmModal = await page.getByTestId('confirmation-modal');
             await confirmModal.getByRole('button', {name: 'Archive'}).click();
-        }
+            await confirmModal.waitFor({state: 'hidden'});
 
-        if (isCTA) {
+            // Still in the offers modal after archiving — click "New offer" directly
+            await page.getByText('New offer').click();
+        } else if (await page.getByTestId('offers').getByRole('button', {name: 'Add offer'}).isVisible()) {
             await page.getByTestId('offers').getByRole('button', {name: 'Add offer'}).click();
         } else {
-            // ensure the modal is open
-            if (!page.getByTestId('offers-modal').isVisible()) {
-                await page.getByTestId('offers').getByRole('button', {name: 'Manage offers'}).click();
-            }
+            await page.getByTestId('offers').getByRole('button', {name: 'Manage offers'}).click();
             await page.getByText('New offer').click();
         }
 


### PR DESCRIPTION
## Summary
- Fixed `createOffer` helper using stale page state after archiving an offer — the code captured button visibility before archiving but used those values after, causing it to click "Manage offers" when the page had changed to "Add offer". Now re-checks live page state after the archive step.
- Replaced unreliable `waitForLoadState('networkidle')` with a concrete tier visibility assertion in the comped upgrade test — `networkidle` never resolves reliably due to Ghost Admin's background polling
- Added portal trigger visibility waits and increased Stripe webhook timeout to 30s after checkout redirects in both upgrade tests

ref https://github.com/TryGhost/Ghost/actions/runs/22091441492/job/63837799328