### PR TITLE
Made copy link action more prominent in offer edit modal

### DIFF
--- a/apps/admin-x-settings/src/components/settings/growth/offers/edit-offer-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/offers/edit-offer-modal.tsx
@@ -143,6 +143,17 @@ const Sidebar: React.FC<{
                                     onKeyDown={() => clearError('name')}
                                 />
                                 <TextField
+                                    containerClassName='group'
+                                    error={Boolean(errors.code)}
+                                    hint={errors.code || (offer?.code !== '' ? <span className='truncate text-grey-700'>{homepageUrl}<span className='font-bold text-black dark:text-white'>{offer?.code}</span></span> : null)}
+                                    placeholder='black-friday'
+                                    rightPlaceholder={offer?.code !== '' ? <Button className='mt-1 mr-0.5' color='green' label={isCopied ? 'Copied!' : 'Copy link'} size='sm' onClick={handleCopyClick} /> : null}
+                                    title='Offer code'
+                                    value={offer?.code}
+                                    onChange={e => updateOffer({code: e.target.value})}
+                                    onKeyDown={() => clearError('code')}
+                                />
+                                <TextField
                                     error={Boolean(errors.displayTitle)}
                                     hint={errors.displayTitle}
                                     placeholder='Black Friday Special'
@@ -156,15 +167,6 @@ const Sidebar: React.FC<{
                                     title='Display description'
                                     value={offer?.display_description}
                                     onChange={e => updateOffer({display_description: e.target.value})}
-                                />
-                                <TextField
-                                    error={Boolean(errors.code)}
-                                    hint={errors.code || (offer?.code !== '' ? <div className='flex items-center justify-between'><div>{homepageUrl}<span className='font-bold'>{offer?.code}</span></div><span></span><Button className='text-xs' color='green' label={`${isCopied ? 'Copied' : 'Copy'}`} size='sm' link onClick={handleCopyClick} /></div> : null)}
-                                    placeholder='black-friday'
-                                    title='Offer code'
-                                    value={offer?.code}
-                                    onChange={e => updateOffer({code: e.target.value})}
-                                    onKeyDown={() => clearError('code')}
                                 />
                             </div>
                         </section>

--- a/apps/admin-x-settings/src/components/settings/growth/offers/edit-offer-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/offers/edit-offer-modal.tsx
@@ -147,7 +147,7 @@ const Sidebar: React.FC<{
                                     error={Boolean(errors.code)}
                                     hint={errors.code || (offer?.code !== '' ? <span className='truncate text-grey-700'>{homepageUrl}<span className='font-bold text-black dark:text-white'>{offer?.code}</span></span> : null)}
                                     placeholder='black-friday'
-                                    rightPlaceholder={offer?.code !== '' ? <Button className='mt-1 mr-0.5' color='green' label={isCopied ? 'Copied!' : 'Copy link'} size='sm' onClick={handleCopyClick} /> : null}
+                                    rightPlaceholder={offer?.code !== '' ? <Button className='mr-0.5 mt-1' color='green' label={isCopied ? 'Copied!' : 'Copy link'} size='sm' onClick={handleCopyClick} /> : null}
                                     title='Offer code'
                                     value={offer?.code}
                                     onChange={e => updateOffer({code: e.target.value})}


### PR DESCRIPTION
ref https://linear.app/ghost/issue/DES-1292/offer-creation-primary-action-is-a-tiny-non-obvious-link

The copy link is the primary action when editing an offer but was buried as a tiny link below the offer code input at the bottom of the form. Moved the offer code field to sit right below the offer name and added an inline copy link button for better discoverability. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only layout/styling changes in the offer edit modal; no changes to saving logic or API interactions.
> 
> **Overview**
> Makes the *offer link copy* action more prominent when editing an offer by moving the `Offer code` field directly under `Offer name` and rendering a visible inline `Copy link` button within the input when a code is present.
> 
> Updates the `Offer code` field hint styling to show a truncated URL preview and removes the previous small link-style copy control embedded in the hint area.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3ba5367e549ed1fdc8df6c3e1495fad4011ba01d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->