### PR TITLE
🐛 Fixed Portal crash when navigating via hash links on a page

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.64.2",
+  "version": "2.64.3",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/portal/src/app.js
+++ b/apps/portal/src/app.js
@@ -744,7 +744,7 @@ export default class App extends React.Component {
     /**Handle state update for preview url and Portal Link changes */
     updateStateForPreviewLinks() {
         const {site: previewSite, ...restPreviewData} = this.fetchPreviewData();
-        const {site: linkSite, ...restLinkData} = this.fetchLinkData();
+        const {site: linkSite, ...restLinkData} = this.fetchLinkData(this.state.site, this.state.member);
 
         const updatedState = {
             site: {


### PR DESCRIPTION
## Summary
- Portal's `updateStateForPreviewLinks()` (the `hashchange` event handler) called `fetchLinkData()` without arguments, leaving `site` and `member` as `undefined`
- This caused a crash when clicking portal hash links (e.g. `<a href="#/portal/account/profile">`) on an already-loaded page
- Loading the full URL directly (e.g. `http://localhost:2368/#/portal/account/profile`) worked fine because the initial `fetchData()` code path passed the arguments correctly
- Fixed by passing `this.state.site` and `this.state.member` to `fetchLinkData()` in `updateStateForPreviewLinks()`
- Added tests for both logged-in and logged-out hashchange navigation