### PR TITLE
Added better debug logging to e2e tests when the environment setup fails

### DIFF
--- a/e2e/helpers/environment/docker-compose.ts
+++ b/e2e/helpers/environment/docker-compose.ts
@@ -32,7 +32,7 @@ export class DockerCompose {
 
         try {
             logging.info('Starting docker compose services...');
-            execSync(command, {stdio: 'inherit'});
+            execSync(command, {encoding: 'utf-8', maxBuffer: 1024 * 1024 * 10});
             logging.info('Docker compose services are up');
         } catch (error) {
             this.logCommandFailure(command, error);
@@ -50,7 +50,7 @@ export class DockerCompose {
         const command = this.composeCommand('down -v');
 
         try {
-            execSync(command, {stdio: 'inherit'});
+            execSync(command, {encoding: 'utf-8', maxBuffer: 1024 * 1024 * 10});
         } catch (error) {
             this.logCommandFailure(command, error);
             logging.error('Failed to stop docker compose services:', error);
@@ -158,7 +158,7 @@ export class DockerCompose {
             logging.error('\n=== Docker compose logs ===');
 
             const logs = execSync(
-                `docker compose -f ${this.composeFilePath} -p ${this.projectName} logs`,
+                this.composeCommand('logs'),
                 {encoding: 'utf-8', maxBuffer: 1024 * 1024 * 10} // 10MB buffer for logs
             );
 
@@ -218,7 +218,7 @@ export class DockerCompose {
     }
 
     private async getContainers(): Promise<ContainerStatusItem[] | null> {
-        const command = `docker compose -f ${this.composeFilePath} -p ${this.projectName} ps -a --format json`;
+        const command = this.composeCommand('ps -a --format json');
         const output = execSync(command, {encoding: 'utf-8'}).trim();
 
         if (!output) {

--- a/e2e/helpers/environment/docker-compose.ts
+++ b/e2e/helpers/environment/docker-compose.ts
@@ -59,18 +59,18 @@ export class DockerCompose {
     }
 
     execShellInService(service: string, shellCommand: string): string {
-        const command = `docker compose -f ${this.composeFilePath} -p ${this.projectName} run --rm -T --entrypoint sh ${service} -c "${shellCommand}"`;
+        const command = this.composeCommand(`run --rm -T --entrypoint sh ${service} -c "${shellCommand}"`);
         debug('readFileFromService running:', command);
 
-        return execSync(command, {encoding: 'utf-8'}).toString();
+        return execSync(command, {encoding: 'utf-8'});
     }
 
     execInService(service: string, command: string[]): string {
         const cmdArgs = command.map(arg => `"${arg}"`).join(' ');
-        const cmd = `docker compose -f ${this.composeFilePath} -p ${this.projectName} run --rm -T ${service} ${cmdArgs}`;
+        const cmd = this.composeCommand(`run --rm -T ${service} ${cmdArgs}`);
 
         debug('execInService running:', cmd);
-        return execSync(cmd, {encoding: 'utf-8'}).toString();
+        return execSync(cmd, {encoding: 'utf-8'});
     }
 
     async getContainerForService(serviceLabel: string): Promise<Container> {

--- a/e2e/helpers/environment/docker-compose.ts
+++ b/e2e/helpers/environment/docker-compose.ts
@@ -28,12 +28,16 @@ export class DockerCompose {
     }
 
     async up(): Promise<void> {
+        const command = this.composeCommand('up -d');
+
         try {
             logging.info('Starting docker compose services...');
-            execSync(`docker compose -f ${this.composeFilePath} -p ${this.projectName} up -d`, {stdio: 'inherit'});
+            execSync(command, {stdio: 'inherit'});
             logging.info('Docker compose services are up');
         } catch (error) {
+            this.logCommandFailure(command, error);
             logging.error('Failed to start docker compose services:', error);
+            this.ps();
             this.logs();
             throw error;
         }
@@ -43,12 +47,12 @@ export class DockerCompose {
 
     // Stop and remove all services for the project including volumes
     down(): void {
+        const command = this.composeCommand('down -v');
+
         try {
-            execSync(
-                `docker compose -f ${this.composeFilePath} -p ${this.projectName} down -v`,
-                {stdio: 'inherit'}
-            );
+            execSync(command, {stdio: 'inherit'});
         } catch (error) {
+            this.logCommandFailure(command, error);
             logging.error('Failed to stop docker compose services:', error);
             throw error;
         }
@@ -162,6 +166,54 @@ export class DockerCompose {
             logging.error('=== End docker compose logs ===\n');
         } catch (logError) {
             debug('Could not get docker compose logs:', logError);
+        }
+    }
+
+    private ps(): void {
+        try {
+            logging.error('\n=== Docker compose ps -a ===');
+
+            const ps = execSync(this.composeCommand('ps -a'), {
+                encoding: 'utf-8',
+                maxBuffer: 1024 * 1024 * 10
+            });
+
+            logging.error(ps);
+            logging.error('=== End docker compose ps -a ===\n');
+        } catch (psError) {
+            debug('Could not get docker compose ps -a:', psError);
+        }
+    }
+
+    private composeCommand(args: string): string {
+        return `docker compose -f ${this.composeFilePath} -p ${this.projectName} ${args}`;
+    }
+
+    private logCommandFailure(command: string, error: unknown): void {
+        if (!(error instanceof Error)) {
+            return;
+        }
+
+        const commandError = error as Error & {
+            stdout?: Buffer | string;
+            stderr?: Buffer | string;
+        };
+
+        const stdout = commandError.stdout?.toString().trim();
+        const stderr = commandError.stderr?.toString().trim();
+
+        logging.error(`Command failed: ${command}`);
+
+        if (stdout) {
+            logging.error('\n=== docker compose command stdout ===');
+            logging.error(stdout);
+            logging.error('=== End docker compose command stdout ===\n');
+        }
+
+        if (stderr) {
+            logging.error('\n=== docker compose command stderr ===');
+            logging.error(stderr);
+            logging.error('=== End docker compose command stderr ===\n');
         }
     }
 


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/actions/runs/22108351018/job/63898093273

This is a test only change, and doesn't impact any user-facing Ghost functionality.

The E2E test suite sometimes fails in CI at the `docker compose up ...` step during environment setup. Currently it's practically impossible to debug this with the logs that are output. This change doesn't fix the problem, but adds more detailed logs that should hopefully make it easier to debug next time we see the same failure.