### PR TITLE
Remove welcomeEmails labs gating from Admin UI

### DIFF
--- a/apps/admin-x-settings/src/components/settings/membership/membership-settings.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/membership-settings.tsx
@@ -6,7 +6,6 @@ import SearchableSection from '../../searchable-section';
 import SpamFilters from '../advanced/spam-filters';
 import Tiers from './tiers';
 import TipsAndDonations from '../growth/tips-and-donations';
-import useFeatureFlag from '../../../hooks/use-feature-flag';
 import {checkStripeEnabled, getSettingValues} from '@tryghost/admin-x-framework/api/settings';
 import {useGlobalData} from '../../providers/global-data-provider';
 
@@ -22,7 +21,6 @@ const MembershipSettings: React.FC = () => {
     const {config, settings} = useGlobalData();
     const [hasTipsAndDonations] = getSettingValues(settings, ['donations_enabled']) as [boolean];
     const hasStripeEnabled = checkStripeEnabled(settings || [], config || {});
-    const hasWelcomeEmails = useFeatureFlag('welcomeEmails');
 
     return (
         <SearchableSection keywords={Object.values(searchKeywords).flat()} title='Membership'>
@@ -30,7 +28,7 @@ const MembershipSettings: React.FC = () => {
             <SpamFilters keywords={searchKeywords.access} />
             <Tiers keywords={searchKeywords.tiers} />
             <Portal keywords={searchKeywords.portal} />
-            {hasWelcomeEmails && <MemberEmails keywords={searchKeywords.memberEmails} />}
+            <MemberEmails keywords={searchKeywords.memberEmails} />
             {hasTipsAndDonations && hasStripeEnabled && <TipsAndDonations keywords={searchKeywords.tips} />}
         </SearchableSection>
     );

--- a/apps/admin-x-settings/src/components/sidebar.tsx
+++ b/apps/admin-x-settings/src/components/sidebar.tsx
@@ -1,7 +1,6 @@
 import GhostLogo from '../assets/images/orb-pink.png';
 import React, {useEffect, useRef} from 'react';
 import clsx from 'clsx';
-import useFeatureFlag from '../hooks/use-feature-flag';
 import {Button, Icon, SettingNavItem, type SettingNavItemProps, SettingNavSection, TextField, useFocusContext} from '@tryghost/admin-x-design-system';
 
 import {checkStripeEnabled, getSettingValues} from '@tryghost/admin-x-framework/api/settings';
@@ -109,7 +108,6 @@ const Sidebar: React.FC = () => {
     const {settings, config} = useGlobalData();
     const [hasTipsAndDonations] = getSettingValues(settings, ['donations_enabled']) as [string];
     const hasStripeEnabled = checkStripeEnabled(settings || [], config || {});
-    const hasWelcomeEmails = useFeatureFlag('welcomeEmails');
 
     const handleSectionClick = (e?: React.MouseEvent<HTMLAnchorElement>) => {
         if (e) {
@@ -191,7 +189,7 @@ const Sidebar: React.FC = () => {
                     <NavItem icon='key' keywords={membershipSearchKeywords.access} navid={['members', 'spam-filters']} title="Access" onClick={handleSectionClick} />
                     <NavItem icon='bills' keywords={membershipSearchKeywords.tiers} navid='tiers' title="Tiers" onClick={handleSectionClick} />
                     <NavItem icon='portal' keywords={membershipSearchKeywords.portal} navid='portal' title="Signup portal" onClick={handleSectionClick} />
-                    {hasWelcomeEmails && <NavItem icon='mailplus' keywords={membershipSearchKeywords.memberEmails} navid='memberemails' title="Welcome emails" onClick={handleSectionClick} />}
+                    <NavItem icon='mailplus' keywords={membershipSearchKeywords.memberEmails} navid='memberemails' title="Welcome emails" onClick={handleSectionClick} />
                     {hasTipsAndDonations && hasStripeEnabled && <NavItem icon='piggybank' keywords={membershipSearchKeywords.tips} navid='tips-and-donations' title="Tips & donations" onClick={handleSectionClick} />}
                     <NavItem icon='email' keywords={emailSearchKeywords.newslettersNavMenu} navid={['enable-newsletters', 'default-recipients', 'newsletters', 'mailgun']} title="Newsletters" onClick={handleSectionClick} />
                 </SettingNavSection>

--- a/ghost/admin/app/services/feature.js
+++ b/ghost/admin/app/services/feature.js
@@ -60,7 +60,6 @@ export default class FeatureService extends Service {
     @feature('referralInviteDismissed', {user: true}) referralInviteDismissed;
 
     // labs flags
-    @feature('welcomeEmails') welcomeEmails;
     @feature('webmentions') webmentions;
     @feature('stripeAutomaticTax') stripeAutomaticTax;
     @feature('emailCustomization') emailCustomization;

--- a/ghost/admin/app/utils/member-event-types.js
+++ b/ghost/admin/app/utils/member-event-types.js
@@ -14,9 +14,7 @@ export const ALL_EVENT_TYPES = [
 export function getAvailableEventTypes(settings, feature, hiddenEvents = []) {
     const extended = [...ALL_EVENT_TYPES];
 
-    if (feature.welcomeEmails) {
-        extended.push({event: 'automated_email_sent_event', icon: 'filter-dropdown-email-received', name: 'Welcome email received', group: 'emails'});
-    }
+    extended.push({event: 'automated_email_sent_event', icon: 'filter-dropdown-email-received', name: 'Welcome email received', group: 'emails'});
     if (settings.commentsEnabled !== 'off') {
         extended.push({event: 'comment_event', icon: 'filter-dropdown-comments', name: 'Comments', group: 'others'});
     }

--- a/ghost/admin/tests/unit/utils/member-event-types-test.js
+++ b/ghost/admin/tests/unit/utils/member-event-types-test.js
@@ -16,6 +16,7 @@ describe('Unit | Utility | event-type-utils', function () {
         expect(eventTypes).to.deep.include({event: 'comment_event', icon: 'filter-dropdown-comments', name: 'Comments', group: 'others'});
         expect(eventTypes).to.deep.include({event: 'feedback_event', icon: 'filter-dropdown-feedback', name: 'Feedback', group: 'others'});
         expect(eventTypes).to.deep.include({event: 'click_event', icon: 'filter-dropdown-clicked-in-email', name: 'Clicked link in email', group: 'others'});
+        expect(eventTypes).to.deep.include({event: 'automated_email_sent_event', icon: 'filter-dropdown-email-received', name: 'Welcome email received', group: 'emails'});
     });
 
     it('should toggle both payment_event and donation_event when toggling payment_event', function () {
@@ -57,11 +58,6 @@ describe('Unit | Utility | event-type-utils', function () {
 
         const eventTypes = getAvailableEventTypes(settings, feature, hiddenEvents);
 
-        // Feedback is always included now (audienceFeedback is GA)
-        const expectedTypes = [
-            ...ALL_EVENT_TYPES,
-            {event: 'feedback_event', icon: 'filter-dropdown-feedback', name: 'Feedback', group: 'others'}
-        ];
-        expect(eventTypes).to.deep.equal(expectedTypes);
+        expect(eventTypes).to.deep.equal([...ALL_EVENT_TYPES, {event: 'automated_email_sent_event', icon: 'filter-dropdown-email-received', name: 'Welcome email received', group: 'emails'}]);
     });
 });


### PR DESCRIPTION
### Motivation
- Welcome emails are now GA and the Admin UI should always expose the related settings, navigation and event types instead of gating them behind the `welcomeEmails` labs flag.

### Description
- Removed `welcomeEmails` gating in the Admin X Membership settings so the `MemberEmails` component is always rendered (modified `apps/admin-x-settings/src/components/settings/membership/membership-settings.tsx`).
- Removed `welcomeEmails` gating in the Admin X sidebar so the Welcome emails nav item is always shown (modified `apps/admin-x-settings/src/components/sidebar.tsx`).
- Removed the legacy Ember labs property from the feature service by deleting `@feature('welcomeEmails') welcomeEmails` (modified `ghost/admin/app/services/feature.js`).
- Always include the `automated_email_sent_event` member event and updated unit assertions to expect it (modified `ghost/admin/app/utils/member-event-types.js` and `ghost/admin/tests/unit/utils/member-event-types-test.js`).

### Testing
- Ran Admin X lint: `yarn --cwd apps/admin-x-settings lint:js src/components/settings/membership/membership-settings.tsx src/components/sidebar.tsx`, which completed successfully with warnings (no errors).
- Ran Ember admin lint: `yarn --cwd ghost/admin lint:js app/utils/member-event-types.js app/services/feature.js tests/unit/utils/member-event-types-test.js`, which completed successfully with warnings (no errors).
- Attempted a Playwright navigation to `http://localhost:2368` to capture a screenshot, but the local Ghost instance in this environment returned `ERR_EMPTY_RESPONSE` so the browser check could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993a5a2a66483299608f2f126712fa7)