### PR TITLE
Added i18n for welcome email preferences link

### DIFF
--- a/ghost/core/core/server/services/member-welcome-emails/email-templates/wrapper.hbs
+++ b/ghost/core/core/server/services/member-welcome-emails/email-templates/wrapper.hbs
@@ -338,7 +338,7 @@
               </tr>
               <tr>
                 <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 11px; color: #738A94; font-weight: normal; line-height: 16px; vertical-align: top; padding-top: 12px; text-align: center;">
-                  {{siteTitle}} &copy; {{year}} &mdash; <a class="small" href="{{managePreferencesUrl}}" style="text-decoration: underline; text-underline-offset: 2px; color: #738A94; font-size: 11px;">Manage your preferences</a>
+                  {{siteTitle}} &copy; {{year}} &mdash; <a class="small" href="{{managePreferencesUrl}}" style="text-decoration: underline; text-underline-offset: 2px; color: #738A94; font-size: 11px;">{{t "Manage your preferences"}}</a>
                 </td>
               </tr>
             </table>

--- a/ghost/core/core/server/services/member-welcome-emails/member-welcome-email-renderer.js
+++ b/ghost/core/core/server/services/member-welcome-emails/member-welcome-email-renderer.js
@@ -13,8 +13,12 @@ const UNMATCHED_TOKEN_REGEX = /%%\{.*?\}%%/g;
 class MemberWelcomeEmailRenderer {
     #wrapperTemplate;
 
-    constructor() {
+    constructor({t}) {
         this.Handlebars = require('handlebars').create();
+        this.Handlebars.registerHelper('t', function (key, options) {
+            let hash = options?.hash;
+            return t(key, hash || options || {});
+        });
         const wrapperSource = fs.readFileSync(
             path.join(__dirname, './email-templates/wrapper.hbs'),
             'utf8'

--- a/ghost/core/core/server/services/member-welcome-emails/service.js
+++ b/ghost/core/core/server/services/member-welcome-emails/service.js
@@ -17,10 +17,10 @@ class MemberWelcomeEmailService {
     #memberWelcomeEmails = {free: null, paid: null};
     #defaultNewsletterSenderOptions = null;
 
-    constructor() {
+    constructor({t}) {
         emailAddressService.init();
         this.#mailer = new mail.GhostMailer();
-        this.#renderer = new MemberWelcomeEmailRenderer();
+        this.#renderer = new MemberWelcomeEmailRenderer({t});
     }
 
     #getSiteSettings() {
@@ -225,7 +225,17 @@ class MemberWelcomeEmailServiceWrapper {
         if (this.api) {
             return;
         }
-        this.api = new MemberWelcomeEmailService();
+
+        const i18nLib = require('@tryghost/i18n');
+        const events = require('../../lib/common/events');
+
+        const i18n = i18nLib(settingsCache.get('locale') || 'en', 'ghost');
+
+        events.on('settings.locale.edited', (model) => {
+            i18n.changeLanguage(model.get('value'));
+        });
+
+        this.api = new MemberWelcomeEmailService({t: i18n.t});
     }
 }
 

--- a/ghost/core/test/unit/server/services/member-welcome-emails/member-welcome-email-renderer.test.js
+++ b/ghost/core/test/unit/server/services/member-welcome-emails/member-welcome-email-renderer.test.js
@@ -29,7 +29,7 @@ describe('MemberWelcomeEmailRenderer', function () {
 
     describe('render', function () {
         it('renders Lexical content to HTML via lexicalLib.render', async function () {
-            const renderer = new MemberWelcomeEmailRenderer();
+            const renderer = new MemberWelcomeEmailRenderer({t: key => key});
             const lexicalJson = '{"root":{"children":[]}}';
 
             await renderer.render({
@@ -45,7 +45,7 @@ describe('MemberWelcomeEmailRenderer', function () {
 
         it('substitutes member template variables', async function () {
             lexicalRenderStub.resolves('<p>Hello {name}, or {first_name}! Contact: {email}</p>');
-            const renderer = new MemberWelcomeEmailRenderer();
+            const renderer = new MemberWelcomeEmailRenderer({t: key => key});
 
             const result = await renderer.render({
                 lexical: '{}',
@@ -61,7 +61,7 @@ describe('MemberWelcomeEmailRenderer', function () {
 
         it('substitutes site template variables', async function () {
             lexicalRenderStub.resolves('<p>Welcome to {site_title} at {site_url}</p>');
-            const renderer = new MemberWelcomeEmailRenderer();
+            const renderer = new MemberWelcomeEmailRenderer({t: key => key});
 
             const result = await renderer.render({
                 lexical: '{}',
@@ -76,7 +76,7 @@ describe('MemberWelcomeEmailRenderer', function () {
 
         it('inlines accentColor into link styles', async function () {
             lexicalRenderStub.resolves('<p><a href="https://example.com">Click here</a></p>');
-            const renderer = new MemberWelcomeEmailRenderer();
+            const renderer = new MemberWelcomeEmailRenderer({t: key => key});
 
             const result = await renderer.render({
                 lexical: '{}',
@@ -89,7 +89,7 @@ describe('MemberWelcomeEmailRenderer', function () {
         });
 
         it('substitutes template variables in subject', async function () {
-            const renderer = new MemberWelcomeEmailRenderer();
+            const renderer = new MemberWelcomeEmailRenderer({t: key => key});
 
             const result = await renderer.render({
                 lexical: '{}',
@@ -103,7 +103,7 @@ describe('MemberWelcomeEmailRenderer', function () {
 
         it('renders empty when member name is missing and no fallback specified', async function () {
             lexicalRenderStub.resolves('<p>Hello {name}!</p>');
-            const renderer = new MemberWelcomeEmailRenderer();
+            const renderer = new MemberWelcomeEmailRenderer({t: key => key});
 
             const result = await renderer.render({
                 lexical: '{}',
@@ -118,7 +118,7 @@ describe('MemberWelcomeEmailRenderer', function () {
 
         it('uses custom fallback when member name is missing', async function () {
             lexicalRenderStub.resolves('<p>Hello {name, "there"}</p>');
-            const renderer = new MemberWelcomeEmailRenderer();
+            const renderer = new MemberWelcomeEmailRenderer({t: key => key});
 
             const result = await renderer.render({
                 lexical: '{}',
@@ -132,7 +132,7 @@ describe('MemberWelcomeEmailRenderer', function () {
 
         it('uses custom fallback for first_name when missing', async function () {
             lexicalRenderStub.resolves('<p>Hey {first_name, "friend"}</p>');
-            const renderer = new MemberWelcomeEmailRenderer();
+            const renderer = new MemberWelcomeEmailRenderer({t: key => key});
 
             const result = await renderer.render({
                 lexical: '{}',
@@ -146,7 +146,7 @@ describe('MemberWelcomeEmailRenderer', function () {
 
         it('ignores fallback when member name is present', async function () {
             lexicalRenderStub.resolves('<p>Hello {name, "there"}</p>');
-            const renderer = new MemberWelcomeEmailRenderer();
+            const renderer = new MemberWelcomeEmailRenderer({t: key => key});
 
             const result = await renderer.render({
                 lexical: '{}',
@@ -160,7 +160,7 @@ describe('MemberWelcomeEmailRenderer', function () {
 
         it('renders empty when member email is missing', async function () {
             lexicalRenderStub.resolves('<p>Email: {email}!</p>');
-            const renderer = new MemberWelcomeEmailRenderer();
+            const renderer = new MemberWelcomeEmailRenderer({t: key => key});
 
             const result = await renderer.render({
                 lexical: '{}',
@@ -175,7 +175,7 @@ describe('MemberWelcomeEmailRenderer', function () {
 
         it('extracts first name correctly from full name', async function () {
             lexicalRenderStub.resolves('<p>Hi {first_name}</p>');
-            const renderer = new MemberWelcomeEmailRenderer();
+            const renderer = new MemberWelcomeEmailRenderer({t: key => key});
 
             const result = await renderer.render({
                 lexical: '{}',
@@ -189,7 +189,7 @@ describe('MemberWelcomeEmailRenderer', function () {
 
         it('handles whitespace in name when extracting first_name', async function () {
             lexicalRenderStub.resolves('<p>Hi {first_name, "friend"}</p>');
-            const renderer = new MemberWelcomeEmailRenderer();
+            const renderer = new MemberWelcomeEmailRenderer({t: key => key});
 
             const paddedResult = await renderer.render({
                 lexical: '{}',
@@ -210,7 +210,7 @@ describe('MemberWelcomeEmailRenderer', function () {
 
         it('wraps content in wrapper.hbs template', async function () {
             lexicalRenderStub.resolves('<p>Content</p>');
-            const renderer = new MemberWelcomeEmailRenderer();
+            const renderer = new MemberWelcomeEmailRenderer({t: key => key});
             const year = new Date().getFullYear();
 
             const result = await renderer.render({
@@ -231,7 +231,7 @@ describe('MemberWelcomeEmailRenderer', function () {
 
         it('generates plain text from HTML', async function () {
             lexicalRenderStub.resolves('<p>Hello World</p>');
-            const renderer = new MemberWelcomeEmailRenderer();
+            const renderer = new MemberWelcomeEmailRenderer({t: key => key});
 
             const result = await renderer.render({
                 lexical: '{}',
@@ -246,7 +246,7 @@ describe('MemberWelcomeEmailRenderer', function () {
 
         it('throws IncorrectUsageError for invalid Lexical', async function () {
             lexicalRenderStub.rejects(new Error('Invalid JSON'));
-            const renderer = new MemberWelcomeEmailRenderer();
+            const renderer = new MemberWelcomeEmailRenderer({t: key => key});
 
             await assert.rejects(renderer.render({
                 lexical: 'invalid',
@@ -258,7 +258,7 @@ describe('MemberWelcomeEmailRenderer', function () {
 
         it('includes error context in IncorrectUsageError', async function () {
             lexicalRenderStub.rejects(new Error('Parse error'));
-            const renderer = new MemberWelcomeEmailRenderer();
+            const renderer = new MemberWelcomeEmailRenderer({t: key => key});
 
             await assert.rejects(
                 renderer.render({
@@ -277,7 +277,7 @@ describe('MemberWelcomeEmailRenderer', function () {
 
         it('escapes HTML in member values for body but not subject', async function () {
             lexicalRenderStub.resolves('<p>Hello {name}</p>');
-            const renderer = new MemberWelcomeEmailRenderer();
+            const renderer = new MemberWelcomeEmailRenderer({t: key => key});
 
             const result = await renderer.render({
                 lexical: '{}',
@@ -293,7 +293,7 @@ describe('MemberWelcomeEmailRenderer', function () {
 
         it('removes unknown tokens from output', async function () {
             lexicalRenderStub.resolves('<p>Hello {unknown_token} and {another}</p>');
-            const renderer = new MemberWelcomeEmailRenderer();
+            const renderer = new MemberWelcomeEmailRenderer({t: key => key});
 
             const result = await renderer.render({
                 lexical: '{}',
@@ -309,7 +309,7 @@ describe('MemberWelcomeEmailRenderer', function () {
 
         it('removes code wrappers around replacement strings', async function () {
             lexicalRenderStub.resolves('<p>Hello <code>{first_name}</code></p>');
-            const renderer = new MemberWelcomeEmailRenderer();
+            const renderer = new MemberWelcomeEmailRenderer({t: key => key});
 
             const result = await renderer.render({
                 lexical: '{}',
@@ -324,7 +324,7 @@ describe('MemberWelcomeEmailRenderer', function () {
 
         it('preserves code blocks that are not replacement strings', async function () {
             lexicalRenderStub.resolves('<p>Here is some code: <code>if (x) { return y; }</code> and a greeting for <code>{first_name}</code></p>');
-            const renderer = new MemberWelcomeEmailRenderer();
+            const renderer = new MemberWelcomeEmailRenderer({t: key => key});
 
             const result = await renderer.render({
                 lexical: '{}',
@@ -342,7 +342,7 @@ describe('MemberWelcomeEmailRenderer', function () {
 
         it('removes code wrappers around replacement strings with fallback', async function () {
             lexicalRenderStub.resolves('<p>Hey <code>{first_name, "friend"}</code></p>');
-            const renderer = new MemberWelcomeEmailRenderer();
+            const renderer = new MemberWelcomeEmailRenderer({t: key => key});
 
             const result = await renderer.render({
                 lexical: '{}',
@@ -357,7 +357,7 @@ describe('MemberWelcomeEmailRenderer', function () {
 
         it('removes code wrappers around replacement strings with fallback (no comma)', async function () {
             lexicalRenderStub.resolves('<p>Hey <code>{first_name "friend"}</code></p>');
-            const renderer = new MemberWelcomeEmailRenderer();
+            const renderer = new MemberWelcomeEmailRenderer({t: key => key});
 
             const result = await renderer.render({
                 lexical: '{}',
@@ -368,6 +368,26 @@ describe('MemberWelcomeEmailRenderer', function () {
 
             assert(!result.html.includes('<code>{first_name "friend"}</code>'));
             assert(result.html.includes('Hey friend'));
+        });
+
+        it('translates footer text using the t helper', async function () {
+            lexicalRenderStub.resolves('<p>Content</p>');
+            const renderer = new MemberWelcomeEmailRenderer({t: (key) => {
+                if (key === 'Manage your preferences') {
+                    return 'Gérer vos préférences';
+                }
+                return key;
+            }});
+
+            const result = await renderer.render({
+                lexical: '{}',
+                subject: 'Welcome!',
+                member: {name: 'John', email: 'john@example.com'},
+                siteSettings: defaultSiteSettings
+            });
+
+            assert(result.html.includes('Gérer vos préférences'));
+            assert(!result.html.includes('Manage your preferences'));
         });
     });
 });

--- a/ghost/i18n/locales/af/ghost.json
+++ b/ghost/i18n/locales/af/ghost.json
@@ -26,6 +26,7 @@
     "Keep reading": "",
     "Less like this": "",
     "Manage subscription": "",
+    "Manage your preferences": "",
     "Member since": "",
     "More like this": "",
     "Name": "",

--- a/ghost/i18n/locales/ar/ghost.json
+++ b/ghost/i18n/locales/ar/ghost.json
@@ -26,6 +26,7 @@
     "Keep reading": "تابع القراءة",
     "Less like this": "أقل مثل هذا",
     "Manage subscription": "ادارة الاشتراك",
+    "Manage your preferences": "",
     "Member since": "عضو منذ",
     "More like this": "المزيد مثل هذا",
     "Name": "الاسم",

--- a/ghost/i18n/locales/bg/ghost.json
+++ b/ghost/i18n/locales/bg/ghost.json
@@ -26,6 +26,7 @@
     "Keep reading": "Продължете четенето",
     "Less like this": "По-малко такива",
     "Manage subscription": "Управление на абонамента",
+    "Manage your preferences": "",
     "Member since": "Абонат от",
     "More like this": "Повече такива",
     "Name": "Име",

--- a/ghost/i18n/locales/bn/ghost.json
+++ b/ghost/i18n/locales/bn/ghost.json
@@ -26,6 +26,7 @@
     "Keep reading": "",
     "Less like this": "",
     "Manage subscription": "",
+    "Manage your preferences": "",
     "Member since": "",
     "More like this": "",
     "Name": "",

--- a/ghost/i18n/locales/bs/ghost.json
+++ b/ghost/i18n/locales/bs/ghost.json
@@ -26,6 +26,7 @@
     "Keep reading": "",
     "Less like this": "",
     "Manage subscription": "",
+    "Manage your preferences": "",
     "Member since": "",
     "More like this": "",
     "Name": "",

--- a/ghost/i18n/locales/ca/ghost.json
+++ b/ghost/i18n/locales/ca/ghost.json
@@ -26,6 +26,7 @@
     "Keep reading": "Seguir llegint",
     "Less like this": "Menys d'aquest tipus",
     "Manage subscription": "Gestiona subscripció",
+    "Manage your preferences": "",
     "Member since": "Membre des de",
     "More like this": "Més d'aquest tipus",
     "Name": "Nom",

--- a/ghost/i18n/locales/context.json
+++ b/ghost/i18n/locales/context.json
@@ -153,6 +153,7 @@
     "Make sure emails aren't accidentally ending up in the Spam or Promotions folders of your inbox. If they are, click on \"Mark as not spam\" and/or \"Move to inbox\".": "Paragraph in the email receiving FAQ",
     "Manage": "A button for managing settings",
     "Manage subscription": "Header in Portal for the subscription management screen",
+    "Manage your preferences": "Link text in the member welcome email footer for managing communication preferences",
     "Maybe later": "An informal phrase to dismiss or close a popup",
     "Member discussion": "Default title for the comments section on a post",
     "Member since": "Shown in the 'subscription status' section of the newsletter, will be followed by a date",

--- a/ghost/i18n/locales/cs/ghost.json
+++ b/ghost/i18n/locales/cs/ghost.json
@@ -26,6 +26,7 @@
     "Keep reading": "Pokračovat ve čtení",
     "Less like this": "Méně podobných",
     "Manage subscription": "Spravovat předplatné",
+    "Manage your preferences": "",
     "Member since": "Členem od",
     "More like this": "Více podobných",
     "Name": "Jméno",

--- a/ghost/i18n/locales/da/ghost.json
+++ b/ghost/i18n/locales/da/ghost.json
@@ -26,6 +26,7 @@
     "Keep reading": "Fortsæt med at læse",
     "Less like this": "Mindre af dette",
     "Manage subscription": "Administrer abonnement",
+    "Manage your preferences": "",
     "Member since": "Medlem siden",
     "More like this": "Mere af dette",
     "Name": "Navn",

--- a/ghost/i18n/locales/de-CH/ghost.json
+++ b/ghost/i18n/locales/de-CH/ghost.json
@@ -26,6 +26,7 @@
     "Keep reading": "Weiterlesen",
     "Less like this": "Weniger hiervon",
     "Manage subscription": "Abos verwalten",
+    "Manage your preferences": "",
     "Member since": "Mitglied seit",
     "More like this": "Mehr davon",
     "Name": "Name",

--- a/ghost/i18n/locales/de/ghost.json
+++ b/ghost/i18n/locales/de/ghost.json
@@ -26,6 +26,7 @@
     "Keep reading": "Weiterlesen",
     "Less like this": "Weniger hiervon",
     "Manage subscription": "Abos verwalten",
+    "Manage your preferences": "",
     "Member since": "Mitglied seit",
     "More like this": "Mehr hiervon",
     "Name": "Name",

--- a/ghost/i18n/locales/el/ghost.json
+++ b/ghost/i18n/locales/el/ghost.json
@@ -26,6 +26,7 @@
     "Keep reading": "",
     "Less like this": "",
     "Manage subscription": "",
+    "Manage your preferences": "",
     "Member since": "",
     "More like this": "",
     "Name": "",

--- a/ghost/i18n/locales/en/ghost.json
+++ b/ghost/i18n/locales/en/ghost.json
@@ -26,6 +26,7 @@
     "Keep reading": "",
     "Less like this": "",
     "Manage subscription": "",
+    "Manage your preferences": "",
     "Member since": "",
     "More like this": "",
     "Name": "",

--- a/ghost/i18n/locales/eo/ghost.json
+++ b/ghost/i18n/locales/eo/ghost.json
@@ -26,6 +26,7 @@
     "Keep reading": "",
     "Less like this": "",
     "Manage subscription": "",
+    "Manage your preferences": "",
     "Member since": "",
     "More like this": "",
     "Name": "",

--- a/ghost/i18n/locales/es/ghost.json
+++ b/ghost/i18n/locales/es/ghost.json
@@ -26,6 +26,7 @@
     "Keep reading": "Seguir leyendo",
     "Less like this": "Menos como esto",
     "Manage subscription": "Gestionar suscripción",
+    "Manage your preferences": "",
     "Member since": "Miembro desde",
     "More like this": "Más como esto",
     "Name": "Nombre",

--- a/ghost/i18n/locales/et/ghost.json
+++ b/ghost/i18n/locales/et/ghost.json
@@ -26,6 +26,7 @@
     "Keep reading": "",
     "Less like this": "",
     "Manage subscription": "",
+    "Manage your preferences": "",
     "Member since": "",
     "More like this": "",
     "Name": "",

--- a/ghost/i18n/locales/eu/ghost.json
+++ b/ghost/i18n/locales/eu/ghost.json
@@ -26,6 +26,7 @@
     "Keep reading": "Segi irakurtzen",
     "Less like this": "Honelako gutxiago",
     "Manage subscription": "Kudeatu harpidetza",
+    "Manage your preferences": "",
     "Member since": "Kide egin zeneko data:",
     "More like this": "Honelako gehiago",
     "Name": "Izena",

--- a/ghost/i18n/locales/fa/ghost.json
+++ b/ghost/i18n/locales/fa/ghost.json
@@ -26,6 +26,7 @@
     "Keep reading": "",
     "Less like this": "",
     "Manage subscription": "",
+    "Manage your preferences": "",
     "Member since": "",
     "More like this": "",
     "Name": "",

--- a/ghost/i18n/locales/fi/ghost.json
+++ b/ghost/i18n/locales/fi/ghost.json
@@ -26,6 +26,7 @@
     "Keep reading": "Jatka lukemista",
     "Less like this": "Vähemmän tämän kaltaisia",
     "Manage subscription": "Hallitse tilausta",
+    "Manage your preferences": "",
     "Member since": "Jäsenyyden alku",
     "More like this": "Enemmän tämän kaltaisia",
     "Name": "Nimi",

--- a/ghost/i18n/locales/fr/ghost.json
+++ b/ghost/i18n/locales/fr/ghost.json
@@ -26,6 +26,7 @@
     "Keep reading": "Continuer la lecture",
     "Less like this": "Contenu à éviter",
     "Manage subscription": "Gérer l'abonnement",
+    "Manage your preferences": "",
     "Member since": "Abonné depuis",
     "More like this": "Contenu apprécié",
     "Name": "Nom",

--- a/ghost/i18n/locales/gd/ghost.json
+++ b/ghost/i18n/locales/gd/ghost.json
@@ -26,6 +26,7 @@
     "Keep reading": "Leugh barrachd",
     "Less like this": "Nas lugha mar seo",
     "Manage subscription": "Stiùirich am fo-sgrìobhadh",
+    "Manage your preferences": "",
     "Member since": "Nad bhall o chionn",
     "More like this": "Barrachd mar seo",
     "Name": "Ainm",

--- a/ghost/i18n/locales/he/ghost.json
+++ b/ghost/i18n/locales/he/ghost.json
@@ -26,6 +26,7 @@
     "Keep reading": "המשיכו לקרוא",
     "Less like this": "פחות כזה",
     "Manage subscription": "ניהול מינוי",
+    "Manage your preferences": "",
     "Member since": "רשום מאז",
     "More like this": "עוד כזה",
     "Name": "שם",

--- a/ghost/i18n/locales/hi/ghost.json
+++ b/ghost/i18n/locales/hi/ghost.json
@@ -26,6 +26,7 @@
     "Keep reading": "पढ़ते रहें",
     "Less like this": "ऐसे कम दिखाएं",
     "Manage subscription": "सदस्यता प्रबंधित करें",
+    "Manage your preferences": "",
     "Member since": "सदस्यता प्रारंभ",
     "More like this": "ऐसे और दिखाएं",
     "Name": "नाम",

--- a/ghost/i18n/locales/hr/ghost.json
+++ b/ghost/i18n/locales/hr/ghost.json
@@ -26,6 +26,7 @@
     "Keep reading": "Nastavi čitati",
     "Less like this": "Manje ovakvih",
     "Manage subscription": "Upravljaj pretplatom",
+    "Manage your preferences": "",
     "Member since": "Član od",
     "More like this": "Više ovakvih",
     "Name": "Ime",

--- a/ghost/i18n/locales/hu/ghost.json
+++ b/ghost/i18n/locales/hu/ghost.json
@@ -26,6 +26,7 @@
     "Keep reading": "Olvasd tovább",
     "Less like this": "Kevesebb hasonló",
     "Manage subscription": "Előfizetés kezelése",
+    "Manage your preferences": "",
     "Member since": "Tag vagy ekkortól",
     "More like this": "Több hasonló",
     "Name": "Név",

--- a/ghost/i18n/locales/id/ghost.json
+++ b/ghost/i18n/locales/id/ghost.json
@@ -26,6 +26,7 @@
     "Keep reading": "",
     "Less like this": "",
     "Manage subscription": "",
+    "Manage your preferences": "",
     "Member since": "",
     "More like this": "",
     "Name": "",

--- a/ghost/i18n/locales/is/ghost.json
+++ b/ghost/i18n/locales/is/ghost.json
@@ -26,6 +26,7 @@
     "Keep reading": "",
     "Less like this": "",
     "Manage subscription": "",
+    "Manage your preferences": "",
     "Member since": "",
     "More like this": "",
     "Name": "",

--- a/ghost/i18n/locales/it/ghost.json
+++ b/ghost/i18n/locales/it/ghost.json
@@ -26,6 +26,7 @@
     "Keep reading": "Continua a leggere",
     "Less like this": "Non mi piace",
     "Manage subscription": "Gestisci l’abbonamento",
+    "Manage your preferences": "",
     "Member since": "Abbonato dal",
     "More like this": "Mi piace",
     "Name": "Nome",

--- a/ghost/i18n/locales/ja/ghost.json
+++ b/ghost/i18n/locales/ja/ghost.json
@@ -26,6 +26,7 @@
     "Keep reading": "",
     "Less like this": "",
     "Manage subscription": "",
+    "Manage your preferences": "",
     "Member since": "",
     "More like this": "",
     "Name": "",

--- a/ghost/i18n/locales/ko/ghost.json
+++ b/ghost/i18n/locales/ko/ghost.json
@@ -26,6 +26,7 @@
     "Keep reading": "계속 읽기",
     "Less like this": "이런 콘텐츠 줄이기",
     "Manage subscription": "구독 관리",
+    "Manage your preferences": "",
     "Member since": "가입일",
     "More like this": "이런 콘텐츠 더보기",
     "Name": "이름",

--- a/ghost/i18n/locales/kz/ghost.json
+++ b/ghost/i18n/locales/kz/ghost.json
@@ -26,6 +26,7 @@
     "Keep reading": "",
     "Less like this": "",
     "Manage subscription": "",
+    "Manage your preferences": "",
     "Member since": "",
     "More like this": "",
     "Name": "",

--- a/ghost/i18n/locales/lt/ghost.json
+++ b/ghost/i18n/locales/lt/ghost.json
@@ -26,6 +26,7 @@
     "Keep reading": "",
     "Less like this": "",
     "Manage subscription": "",
+    "Manage your preferences": "",
     "Member since": "",
     "More like this": "",
     "Name": "",

--- a/ghost/i18n/locales/lv/ghost.json
+++ b/ghost/i18n/locales/lv/ghost.json
@@ -26,6 +26,7 @@
     "Keep reading": "Turpiniet lasīt",
     "Less like this": "Mazāk kā šis",
     "Manage subscription": "Pārvaldīt abonementu",
+    "Manage your preferences": "",
     "Member since": "Dalībnieks kopš",
     "More like this": "Vairāk kā šis",
     "Name": "Vārds",

--- a/ghost/i18n/locales/mk/ghost.json
+++ b/ghost/i18n/locales/mk/ghost.json
@@ -26,6 +26,7 @@
     "Keep reading": "",
     "Less like this": "",
     "Manage subscription": "",
+    "Manage your preferences": "",
     "Member since": "",
     "More like this": "",
     "Name": "",

--- a/ghost/i18n/locales/mn/ghost.json
+++ b/ghost/i18n/locales/mn/ghost.json
@@ -26,6 +26,7 @@
     "Keep reading": "Үргэлжлүүлэн унших",
     "Less like this": "Таалагдсангүй",
     "Manage subscription": "Захиалгаа удирдах",
+    "Manage your preferences": "",
     "Member since": "Гишүүн болсон огноо",
     "More like this": "Үүнтэй ижилхэн",
     "Name": "Нэр",

--- a/ghost/i18n/locales/ms/ghost.json
+++ b/ghost/i18n/locales/ms/ghost.json
@@ -26,6 +26,7 @@
     "Keep reading": "",
     "Less like this": "",
     "Manage subscription": "",
+    "Manage your preferences": "",
     "Member since": "",
     "More like this": "",
     "Name": "",

--- a/ghost/i18n/locales/nb/ghost.json
+++ b/ghost/i18n/locales/nb/ghost.json
@@ -26,6 +26,7 @@
     "Keep reading": "Fortsett å lese",
     "Less like this": "Mindre som dette",
     "Manage subscription": "Administrer abonnement",
+    "Manage your preferences": "",
     "Member since": "Medlem siden",
     "More like this": "Mer som dette",
     "Name": "Navn",

--- a/ghost/i18n/locales/ne/ghost.json
+++ b/ghost/i18n/locales/ne/ghost.json
@@ -26,6 +26,7 @@
     "Keep reading": "पढिरहनुहोस्",
     "Less like this": "यो जस्तो कम",
     "Manage subscription": "सदस्यता व्यवस्थापन गर्नुहोस्",
+    "Manage your preferences": "",
     "Member since": "देखि सदस्य",
     "More like this": "यो जस्तै थप",
     "Name": "नाम",

--- a/ghost/i18n/locales/nl/ghost.json
+++ b/ghost/i18n/locales/nl/ghost.json
@@ -26,6 +26,7 @@
     "Keep reading": "Blijf lezen",
     "Less like this": "Minder van dit",
     "Manage subscription": "Abonnement beheren",
+    "Manage your preferences": "",
     "Member since": "Lid sinds",
     "More like this": "Meer van dit",
     "Name": "Naam",

--- a/ghost/i18n/locales/nn/ghost.json
+++ b/ghost/i18n/locales/nn/ghost.json
@@ -26,6 +26,7 @@
     "Keep reading": "",
     "Less like this": "",
     "Manage subscription": "",
+    "Manage your preferences": "",
     "Member since": "",
     "More like this": "",
     "Name": "",

--- a/ghost/i18n/locales/pa/ghost.json
+++ b/ghost/i18n/locales/pa/ghost.json
@@ -26,6 +26,7 @@
     "Keep reading": "ਪੜਦੇ ਰਹੋ",
     "Less like this": "ਇਸ ਵਰਗੇ ਘੱਟ",
     "Manage subscription": "ਸਦੱਸਤਾ ਦਾ ਪ੍ਰਬੰਧਨ ਕਰੋ",
+    "Manage your preferences": "",
     "Member since": "ਤੋਂ ਮੈਂਬਰ",
     "More like this": "ਇਸ ਵਰਗੇ ਹੋਰ",
     "Name": "ਨਾਮ",

--- a/ghost/i18n/locales/pl/ghost.json
+++ b/ghost/i18n/locales/pl/ghost.json
@@ -26,6 +26,7 @@
     "Keep reading": "Czytaj dalej",
     "Less like this": "Mniej w tym stylu",
     "Manage subscription": "Zarządzaj subskrypcją",
+    "Manage your preferences": "",
     "Member since": "Członek od",
     "More like this": "Więcej w tym stylu",
     "Name": "Imię",

--- a/ghost/i18n/locales/pt-BR/ghost.json
+++ b/ghost/i18n/locales/pt-BR/ghost.json
@@ -26,6 +26,7 @@
     "Keep reading": "Continue lendo",
     "Less like this": "Não gostei",
     "Manage subscription": "Gerenciar assinatura",
+    "Manage your preferences": "",
     "Member since": "Membro desde",
     "More like this": "Gostei",
     "Name": "Nome",

--- a/ghost/i18n/locales/pt/ghost.json
+++ b/ghost/i18n/locales/pt/ghost.json
@@ -26,6 +26,7 @@
     "Keep reading": "Continuar a ler",
     "Less like this": "Não gostei",
     "Manage subscription": "Gerir subscrição",
+    "Manage your preferences": "",
     "Member since": "Membro desde",
     "More like this": "Gostei",
     "Name": "Nome",

--- a/ghost/i18n/locales/ro/ghost.json
+++ b/ghost/i18n/locales/ro/ghost.json
@@ -26,6 +26,7 @@
     "Keep reading": "Continuă să citești",
     "Less like this": "Mai puțin de acest fel",
     "Manage subscription": "Gestionează abonamentul",
+    "Manage your preferences": "",
     "Member since": "Membru din",
     "More like this": "Mai mult de acest fel",
     "Name": "Nume",

--- a/ghost/i18n/locales/ru/ghost.json
+++ b/ghost/i18n/locales/ru/ghost.json
@@ -26,6 +26,7 @@
     "Keep reading": "Читать далее",
     "Less like this": "Меньше такого",
     "Manage subscription": "Управление подпиской",
+    "Manage your preferences": "",
     "Member since": "Участник с",
     "More like this": "Больше такого",
     "Name": "Имя",

--- a/ghost/i18n/locales/si/ghost.json
+++ b/ghost/i18n/locales/si/ghost.json
@@ -26,6 +26,7 @@
     "Keep reading": "",
     "Less like this": "",
     "Manage subscription": "",
+    "Manage your preferences": "",
     "Member since": "",
     "More like this": "",
     "Name": "",

--- a/ghost/i18n/locales/sk/ghost.json
+++ b/ghost/i18n/locales/sk/ghost.json
@@ -26,6 +26,7 @@
     "Keep reading": "Prečítať celé",
     "Less like this": "Chcem menej takýchto",
     "Manage subscription": "Spravovať odber",
+    "Manage your preferences": "",
     "Member since": "Členom od",
     "More like this": "Chcem viac takýchto",
     "Name": "Meno",

--- a/ghost/i18n/locales/sl/ghost.json
+++ b/ghost/i18n/locales/sl/ghost.json
@@ -26,6 +26,7 @@
     "Keep reading": "Beri naprej",
     "Less like this": "Manj takšnih vsebin",
     "Manage subscription": "Upravljanje naročnine",
+    "Manage your preferences": "",
     "Member since": "Član od",
     "More like this": "Več takšnih vsebin",
     "Name": "Ime",

--- a/ghost/i18n/locales/sq/ghost.json
+++ b/ghost/i18n/locales/sq/ghost.json
@@ -26,6 +26,7 @@
     "Keep reading": "",
     "Less like this": "",
     "Manage subscription": "",
+    "Manage your preferences": "",
     "Member since": "",
     "More like this": "",
     "Name": "",

--- a/ghost/i18n/locales/sr-Cyrl/ghost.json
+++ b/ghost/i18n/locales/sr-Cyrl/ghost.json
@@ -26,6 +26,7 @@
     "Keep reading": "Наставите са читањем",
     "Less like this": "Мање налик на ово",
     "Manage subscription": "Управљајте претплатом",
+    "Manage your preferences": "",
     "Member since": "Члан од",
     "More like this": "Више налик на ово",
     "Name": "Име",

--- a/ghost/i18n/locales/sr/ghost.json
+++ b/ghost/i18n/locales/sr/ghost.json
@@ -26,6 +26,7 @@
     "Keep reading": "Nastavite sa čitanjem",
     "Less like this": "Manje nalik na ovo",
     "Manage subscription": "Upravljajte pretplatom",
+    "Manage your preferences": "",
     "Member since": "Član od",
     "More like this": "Više nalik na ovo",
     "Name": "Ime",

--- a/ghost/i18n/locales/sv/ghost.json
+++ b/ghost/i18n/locales/sv/ghost.json
@@ -26,6 +26,7 @@
     "Keep reading": "Fortsätt läsa",
     "Less like this": "Mindre av det här",
     "Manage subscription": "Hantera prenumeration",
+    "Manage your preferences": "",
     "Member since": "Medlem sen",
     "More like this": "Mer av det här",
     "Name": "Namn",

--- a/ghost/i18n/locales/sw/ghost.json
+++ b/ghost/i18n/locales/sw/ghost.json
@@ -26,6 +26,7 @@
     "Keep reading": "",
     "Less like this": "",
     "Manage subscription": "",
+    "Manage your preferences": "",
     "Member since": "",
     "More like this": "",
     "Name": "",

--- a/ghost/i18n/locales/ta/ghost.json
+++ b/ghost/i18n/locales/ta/ghost.json
@@ -26,6 +26,7 @@
     "Keep reading": "",
     "Less like this": "",
     "Manage subscription": "",
+    "Manage your preferences": "",
     "Member since": "",
     "More like this": "",
     "Name": "",

--- a/ghost/i18n/locales/th/ghost.json
+++ b/ghost/i18n/locales/th/ghost.json
@@ -26,6 +26,7 @@
     "Keep reading": "",
     "Less like this": "",
     "Manage subscription": "",
+    "Manage your preferences": "",
     "Member since": "",
     "More like this": "",
     "Name": "",

--- a/ghost/i18n/locales/tr/ghost.json
+++ b/ghost/i18n/locales/tr/ghost.json
@@ -26,6 +26,7 @@
     "Keep reading": "Okumaya devam et",
     "Less like this": "Buna benzer daha az",
     "Manage subscription": "Aboneliği yönet",
+    "Manage your preferences": "",
     "Member since": "Üyelik tarihi",
     "More like this": "Daha fazlası için oku",
     "Name": "Ad",

--- a/ghost/i18n/locales/uk/ghost.json
+++ b/ghost/i18n/locales/uk/ghost.json
@@ -26,6 +26,7 @@
     "Keep reading": "",
     "Less like this": "",
     "Manage subscription": "",
+    "Manage your preferences": "",
     "Member since": "",
     "More like this": "",
     "Name": "",

--- a/ghost/i18n/locales/ur/ghost.json
+++ b/ghost/i18n/locales/ur/ghost.json
@@ -26,6 +26,7 @@
     "Keep reading": "",
     "Less like this": "",
     "Manage subscription": "",
+    "Manage your preferences": "",
     "Member since": "",
     "More like this": "",
     "Name": "",

--- a/ghost/i18n/locales/uz/ghost.json
+++ b/ghost/i18n/locales/uz/ghost.json
@@ -26,6 +26,7 @@
     "Keep reading": "",
     "Less like this": "",
     "Manage subscription": "",
+    "Manage your preferences": "",
     "Member since": "",
     "More like this": "",
     "Name": "",

--- a/ghost/i18n/locales/vi/ghost.json
+++ b/ghost/i18n/locales/vi/ghost.json
@@ -26,6 +26,7 @@
     "Keep reading": "Đọc tiếp",
     "Less like this": "Gửi ít hơn",
     "Manage subscription": "Quản lý tài khoản",
+    "Manage your preferences": "",
     "Member since": "Thành viên từ",
     "More like this": "Gửi nhiều hơn",
     "Name": "Tên",

--- a/ghost/i18n/locales/zh-Hant/ghost.json
+++ b/ghost/i18n/locales/zh-Hant/ghost.json
@@ -26,6 +26,7 @@
     "Keep reading": "繼續閱讀",
     "Less like this": "減少相似內容",
     "Manage subscription": "管理訂閱",
+    "Manage your preferences": "",
     "Member since": "成為會員自",
     "More like this": "更多類似內容",
     "Name": "名字",

--- a/ghost/i18n/locales/zh/ghost.json
+++ b/ghost/i18n/locales/zh/ghost.json
@@ -26,6 +26,7 @@
     "Keep reading": "继续阅读",
     "Less like this": "减少此类内容",
     "Manage subscription": "管理订阅",
+    "Manage your preferences": "",
     "Member since": "成为会员的时间",
     "More like this": "更多类似内容",
     "Name": "姓名",

--- a/ghost/i18n/package.json
+++ b/ghost/i18n/package.json
@@ -19,7 +19,7 @@
     "lint:test": "eslint -c test/.eslintrc.js test/ --ext .js --cache",
     "lint:translations": "node ./test/i18n.lint.js",
     "translate": "yarn translate:ghost && yarn translate:portal && yarn translate:signup-form && yarn translate:comments && yarn translate:search && node generate-context.js",
-    "translate:ghost": "NAMESPACE=ghost i18next '../core/core/{frontend,server,shared}/**/*.{js,jsx}' '../core/core/server/services/email-service/email-templates/**/*.hbs' '../core/core/server/services/comments/email-templates/**/*.hbs'",
+    "translate:ghost": "NAMESPACE=ghost i18next '../core/core/{frontend,server,shared}/**/*.{js,jsx}' '../core/core/server/services/email-service/email-templates/**/*.hbs' '../core/core/server/services/comments/email-templates/**/*.hbs' '../core/core/server/services/member-welcome-emails/email-templates/**/*.hbs'",
     "translate:portal": "NAMESPACE=portal i18next '../../apps/portal/src/**/*.{js,jsx}'",
     "translate:signup-form": "NAMESPACE=signup-form i18next '../../apps/signup-form/src/**/*.{ts,tsx}'",
     "translate:comments": "NAMESPACE=comments i18next '../../apps/comments-ui/src/**/*.{ts,tsx}'",


### PR DESCRIPTION
closes [NY-1001](https://linear.app/ghost/issue/NY-1001/use-i18n-t-for-member-welcome-email-footer-text)

- Added i18n support for the "Manage your preferences" link in the member welcome email footer
  using {{t}} Handlebars helper
- Wired @tryghost/i18n through MemberWelcomeEmailService → MemberWelcomeEmailRenderer with locale
   change listener
- Added "Manage your preferences" key to all 60+ locale JSON files
- Updated translate:ghost script to scan member-welcome-emails/email-templates/
- Added test for translation in the email footer

Site set to `en`:
<img width="302" height="80" alt="Screenshot 2026-02-17 at 4 40 45 PM" src="https://github.com/user-attachments/assets/9747a631-1c57-4a9f-aac6-1520cc1328ab" />

Site set to `es` (note - i didn't actually add this translation in the code, because it was just Google Translate. i just did it locally so i could spot check. Please forgive me if it's technically incorrect):
<img width="359" height="113" alt="Screenshot 2026-02-17 at 4 40 40 PM" src="https://github.com/user-attachments/assets/a05ec659-1c9c-4af2-8afc-fc7fb326f6dc" />
