### PR TITLE
Removed welcomeEmails feature flag checks from admin-x-settings

### DIFF
--- a/apps/admin-x-settings/src/components/settings/membership/membership-settings.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/membership-settings.tsx
@@ -6,7 +6,6 @@ import SearchableSection from '../../searchable-section';
 import SpamFilters from '../advanced/spam-filters';
 import Tiers from './tiers';
 import TipsAndDonations from '../growth/tips-and-donations';
-import useFeatureFlag from '../../../hooks/use-feature-flag';
 import {checkStripeEnabled, getSettingValues} from '@tryghost/admin-x-framework/api/settings';
 import {useGlobalData} from '../../providers/global-data-provider';
 
@@ -22,7 +21,6 @@ const MembershipSettings: React.FC = () => {
     const {config, settings} = useGlobalData();
     const [hasTipsAndDonations] = getSettingValues(settings, ['donations_enabled']) as [boolean];
     const hasStripeEnabled = checkStripeEnabled(settings || [], config || {});
-    const hasWelcomeEmails = useFeatureFlag('welcomeEmails');
 
     return (
         <SearchableSection keywords={Object.values(searchKeywords).flat()} title='Membership'>
@@ -30,7 +28,7 @@ const MembershipSettings: React.FC = () => {
             <SpamFilters keywords={searchKeywords.access} />
             <Tiers keywords={searchKeywords.tiers} />
             <Portal keywords={searchKeywords.portal} />
-            {hasWelcomeEmails && <MemberEmails keywords={searchKeywords.memberEmails} />}
+            <MemberEmails keywords={searchKeywords.memberEmails} />
             {hasTipsAndDonations && hasStripeEnabled && <TipsAndDonations keywords={searchKeywords.tips} />}
         </SearchableSection>
     );

--- a/apps/admin-x-settings/src/components/sidebar.tsx
+++ b/apps/admin-x-settings/src/components/sidebar.tsx
@@ -1,7 +1,6 @@
 import GhostLogo from '../assets/images/orb-pink.png';
 import React, {useEffect, useRef} from 'react';
 import clsx from 'clsx';
-import useFeatureFlag from '../hooks/use-feature-flag';
 import {Button, Icon, SettingNavItem, type SettingNavItemProps, SettingNavSection, TextField, useFocusContext} from '@tryghost/admin-x-design-system';
 
 import {checkStripeEnabled, getSettingValues} from '@tryghost/admin-x-framework/api/settings';
@@ -109,7 +108,6 @@ const Sidebar: React.FC = () => {
     const {settings, config} = useGlobalData();
     const [hasTipsAndDonations] = getSettingValues(settings, ['donations_enabled']) as [string];
     const hasStripeEnabled = checkStripeEnabled(settings || [], config || {});
-    const hasWelcomeEmails = useFeatureFlag('welcomeEmails');
 
     const handleSectionClick = (e?: React.MouseEvent<HTMLAnchorElement>) => {
         if (e) {
@@ -191,7 +189,7 @@ const Sidebar: React.FC = () => {
                     <NavItem icon='key' keywords={membershipSearchKeywords.access} navid={['members', 'spam-filters']} title="Access" onClick={handleSectionClick} />
                     <NavItem icon='bills' keywords={membershipSearchKeywords.tiers} navid='tiers' title="Tiers" onClick={handleSectionClick} />
                     <NavItem icon='portal' keywords={membershipSearchKeywords.portal} navid='portal' title="Signup portal" onClick={handleSectionClick} />
-                    {hasWelcomeEmails && <NavItem icon='mailplus' keywords={membershipSearchKeywords.memberEmails} navid='memberemails' title="Welcome emails" onClick={handleSectionClick} />}
+                    <NavItem icon='mailplus' keywords={membershipSearchKeywords.memberEmails} navid='memberemails' title="Welcome emails" onClick={handleSectionClick} />
                     {hasTipsAndDonations && hasStripeEnabled && <NavItem icon='piggybank' keywords={membershipSearchKeywords.tips} navid='tips-and-donations' title="Tips & donations" onClick={handleSectionClick} />}
                     <NavItem icon='email' keywords={emailSearchKeywords.newslettersNavMenu} navid={['enable-newsletters', 'default-recipients', 'newsletters', 'mailgun']} title="Newsletters" onClick={handleSectionClick} />
                 </SettingNavSection>

--- a/apps/admin-x-settings/test/acceptance/membership/member-welcome-emails.test.ts
+++ b/apps/admin-x-settings/test/acceptance/membership/member-welcome-emails.test.ts
@@ -25,16 +25,10 @@ const newslettersRequest = {
 test.describe('Member emails settings', async () => {
     test.describe('Welcome email modal', async () => {
         test('Escape key closes test email dropdown without closing modal', async ({page}) => {
-            const configResponse = {
-                config: {
-                    ...responseFixtures.config.config
-                }
-            };
-
             await mockApi({page, requests: {
                 ...globalDataRequests,
                 ...newslettersRequest,
-                browseConfig: {method: 'GET', path: '/config/', response: configResponse},
+                browseConfig: {method: 'GET', path: '/config/', response: responseFixtures.config},
                 browseAutomatedEmails: {method: 'GET', path: '/automated_emails/', response: automatedEmailsFixture}
             }});
 
@@ -71,16 +65,10 @@ test.describe('Member emails settings', async () => {
         });
 
         test('Escape key closes modal when test email dropdown is not open', async ({page}) => {
-            const configResponse = {
-                config: {
-                    ...responseFixtures.config.config
-                }
-            };
-
             await mockApi({page, requests: {
                 ...globalDataRequests,
                 ...newslettersRequest,
-                browseConfig: {method: 'GET', path: '/config/', response: configResponse},
+                browseConfig: {method: 'GET', path: '/config/', response: responseFixtures.config},
                 browseAutomatedEmails: {method: 'GET', path: '/automated_emails/', response: automatedEmailsFixture}
             }});
 
@@ -107,16 +95,10 @@ test.describe('Member emails settings', async () => {
         });
 
         test('Welcome email modal does not start dirty but becomes dirty after edit', async ({page}) => {
-            const configResponse = {
-                config: {
-                    ...responseFixtures.config.config
-                }
-            };
-
             await mockApi({page, requests: {
                 ...globalDataRequests,
                 ...newslettersRequest,
-                browseConfig: {method: 'GET', path: '/config/', response: configResponse},
+                browseConfig: {method: 'GET', path: '/config/', response: responseFixtures.config},
                 browseAutomatedEmails: {method: 'GET', path: '/automated_emails/', response: automatedEmailsFixture}
             }});
 
@@ -161,16 +143,10 @@ test.describe('Member emails settings', async () => {
         });
 
         test('Escape key does not close modal or navigate away when pressed from Koenig link input', async ({page}) => {
-            const configResponse = {
-                config: {
-                    ...responseFixtures.config.config
-                }
-            };
-
             await mockApi({page, requests: {
                 ...globalDataRequests,
                 ...newslettersRequest,
-                browseConfig: {method: 'GET', path: '/config/', response: configResponse},
+                browseConfig: {method: 'GET', path: '/config/', response: responseFixtures.config},
                 browseAutomatedEmails: {method: 'GET', path: '/automated_emails/', response: automatedEmailsFixture}
             }});
 
@@ -221,12 +197,6 @@ test.describe('Member emails settings', async () => {
         });
 
         test('uses automated email sender fields when populated, even if newsletter differs', async ({page}) => {
-            const configResponse = {
-                config: {
-                    ...responseFixtures.config.config
-                }
-            };
-
             const populatedAutomatedEmailsFixture = {
                 automated_emails: [{
                     ...automatedEmailsFixture.automated_emails[0],
@@ -248,7 +218,7 @@ test.describe('Member emails settings', async () => {
 
             await mockApi({page, requests: {
                 ...globalDataRequests,
-                browseConfig: {method: 'GET', path: '/config/', response: configResponse},
+                browseConfig: {method: 'GET', path: '/config/', response: responseFixtures.config},
                 browseAutomatedEmails: {method: 'GET', path: '/automated_emails/', response: populatedAutomatedEmailsFixture},
                 browseNewslettersLimit: {method: 'GET', path: '/newsletters/?filter=status%3Aactive&limit=1', response: defaultNewsletterResponse}
             }});
@@ -269,12 +239,6 @@ test.describe('Member emails settings', async () => {
         });
 
         test('falls back to default newsletter sender values when automated fields are empty', async ({page}) => {
-            const configResponse = {
-                config: {
-                    ...responseFixtures.config.config
-                }
-            };
-
             const emptyAutomatedSenderFixture = {
                 automated_emails: [{
                     ...automatedEmailsFixture.automated_emails[0],
@@ -296,7 +260,7 @@ test.describe('Member emails settings', async () => {
 
             await mockApi({page, requests: {
                 ...globalDataRequests,
-                browseConfig: {method: 'GET', path: '/config/', response: configResponse},
+                browseConfig: {method: 'GET', path: '/config/', response: responseFixtures.config},
                 browseAutomatedEmails: {method: 'GET', path: '/automated_emails/', response: emptyAutomatedSenderFixture},
                 browseNewslettersLimit: {method: 'GET', path: '/newsletters/?filter=status%3Aactive&limit=1', response: defaultNewsletterResponse}
             }});
@@ -317,12 +281,6 @@ test.describe('Member emails settings', async () => {
         });
 
         test('preview card uses newsletter sender name when automated sender name is empty', async ({page}) => {
-            const configResponse = {
-                config: {
-                    ...responseFixtures.config.config
-                }
-            };
-
             const emptyAutomatedSenderFixture = {
                 automated_emails: [{
                     ...automatedEmailsFixture.automated_emails[0],
@@ -340,7 +298,7 @@ test.describe('Member emails settings', async () => {
 
             await mockApi({page, requests: {
                 ...globalDataRequests,
-                browseConfig: {method: 'GET', path: '/config/', response: configResponse},
+                browseConfig: {method: 'GET', path: '/config/', response: responseFixtures.config},
                 browseAutomatedEmails: {method: 'GET', path: '/automated_emails/', response: emptyAutomatedSenderFixture},
                 browseNewslettersLimit: {method: 'GET', path: '/newsletters/?filter=status%3Aactive&limit=1', response: defaultNewsletterResponse}
             }});
@@ -359,12 +317,6 @@ test.describe('Member emails settings', async () => {
     // NY-842: Tests for editing/viewing welcome emails before activation
     test.describe('Email preview visibility and edit-before-activation', async () => {
         test('Email preview card is visible with default subject when no DB row exists', async ({page}) => {
-            const configResponse = {
-                config: {
-                    ...responseFixtures.config.config
-                }
-            };
-
             // Empty automated_emails response - no DB rows exist
             const emptyAutomatedEmailsFixture = {
                 automated_emails: []
@@ -373,7 +325,7 @@ test.describe('Member emails settings', async () => {
             await mockApi({page, requests: {
                 ...globalDataRequests,
                 ...newslettersRequest,
-                browseConfig: {method: 'GET', path: '/config/', response: configResponse},
+                browseConfig: {method: 'GET', path: '/config/', response: responseFixtures.config},
                 browseAutomatedEmails: {method: 'GET', path: '/automated_emails/', response: emptyAutomatedEmailsFixture}
             }});
 
@@ -397,12 +349,6 @@ test.describe('Member emails settings', async () => {
         });
 
         test('Clicking Edit when no row exists creates inactive row then opens modal', async ({page}) => {
-            const configResponse = {
-                config: {
-                    ...responseFixtures.config.config
-                }
-            };
-
             const emptyAutomatedEmailsFixture = {
                 automated_emails: []
             };
@@ -427,7 +373,7 @@ test.describe('Member emails settings', async () => {
             const {lastApiRequests} = await mockApi({page, requests: {
                 ...globalDataRequests,
                 ...newslettersRequest,
-                browseConfig: {method: 'GET', path: '/config/', response: configResponse},
+                browseConfig: {method: 'GET', path: '/config/', response: responseFixtures.config},
                 browseAutomatedEmails: {method: 'GET', path: '/automated_emails/', response: emptyAutomatedEmailsFixture},
                 addAutomatedEmail: {method: 'POST', path: '/automated_emails/', response: createdAutomatedEmailResponse}
             }});
@@ -456,12 +402,6 @@ test.describe('Member emails settings', async () => {
         });
 
         test('Clicking Edit when row exists does NOT create new row, just opens modal', async ({page}) => {
-            const configResponse = {
-                config: {
-                    ...responseFixtures.config.config
-                }
-            };
-
             const existingAutomatedEmailsFixture = {
                 automated_emails: [{
                     id: 'free-welcome-email-id',
@@ -481,7 +421,7 @@ test.describe('Member emails settings', async () => {
             const {lastApiRequests} = await mockApi({page, requests: {
                 ...globalDataRequests,
                 ...newslettersRequest,
-                browseConfig: {method: 'GET', path: '/config/', response: configResponse},
+                browseConfig: {method: 'GET', path: '/config/', response: responseFixtures.config},
                 browseAutomatedEmails: {method: 'GET', path: '/automated_emails/', response: existingAutomatedEmailsFixture},
                 addAutomatedEmail: {method: 'POST', path: '/automated_emails/', response: existingAutomatedEmailsFixture}
             }});
@@ -505,12 +445,6 @@ test.describe('Member emails settings', async () => {
         });
 
         test('Toggle ON when no row exists creates active row', async ({page}) => {
-            const configResponse = {
-                config: {
-                    ...responseFixtures.config.config
-                }
-            };
-
             const emptyAutomatedEmailsFixture = {
                 automated_emails: []
             };
@@ -534,7 +468,7 @@ test.describe('Member emails settings', async () => {
             const {lastApiRequests} = await mockApi({page, requests: {
                 ...globalDataRequests,
                 ...newslettersRequest,
-                browseConfig: {method: 'GET', path: '/config/', response: configResponse},
+                browseConfig: {method: 'GET', path: '/config/', response: responseFixtures.config},
                 browseAutomatedEmails: {method: 'GET', path: '/automated_emails/', response: emptyAutomatedEmailsFixture},
                 addAutomatedEmail: {method: 'POST', path: '/automated_emails/', response: createdActiveResponse}
             }});
@@ -559,12 +493,6 @@ test.describe('Member emails settings', async () => {
         });
 
         test('Toggle ON when inactive row exists updates to active', async ({page}) => {
-            const configResponse = {
-                config: {
-                    ...responseFixtures.config.config
-                }
-            };
-
             const inactiveAutomatedEmailsFixture = {
                 automated_emails: [{
                     id: 'free-welcome-email-id',
@@ -591,7 +519,7 @@ test.describe('Member emails settings', async () => {
             const {lastApiRequests} = await mockApi({page, requests: {
                 ...globalDataRequests,
                 ...newslettersRequest,
-                browseConfig: {method: 'GET', path: '/config/', response: configResponse},
+                browseConfig: {method: 'GET', path: '/config/', response: responseFixtures.config},
                 browseAutomatedEmails: {method: 'GET', path: '/automated_emails/', response: inactiveAutomatedEmailsFixture},
                 editAutomatedEmail: {method: 'PUT', path: '/automated_emails/free-welcome-email-id/', response: updatedActiveResponse}
             }});
@@ -616,12 +544,6 @@ test.describe('Member emails settings', async () => {
         });
 
         test('Toggle OFF when active row exists updates to inactive', async ({page}) => {
-            const configResponse = {
-                config: {
-                    ...responseFixtures.config.config
-                }
-            };
-
             const activeAutomatedEmailsFixture = {
                 automated_emails: [{
                     id: 'free-welcome-email-id',
@@ -648,7 +570,7 @@ test.describe('Member emails settings', async () => {
             const {lastApiRequests} = await mockApi({page, requests: {
                 ...globalDataRequests,
                 ...newslettersRequest,
-                browseConfig: {method: 'GET', path: '/config/', response: configResponse},
+                browseConfig: {method: 'GET', path: '/config/', response: responseFixtures.config},
                 browseAutomatedEmails: {method: 'GET', path: '/automated_emails/', response: activeAutomatedEmailsFixture},
                 editAutomatedEmail: {method: 'PUT', path: '/automated_emails/free-welcome-email-id/', response: updatedInactiveResponse}
             }});

--- a/apps/admin-x-settings/test/acceptance/membership/member-welcome-emails.test.ts
+++ b/apps/admin-x-settings/test/acceptance/membership/member-welcome-emails.test.ts
@@ -25,13 +25,9 @@ const newslettersRequest = {
 test.describe('Member emails settings', async () => {
     test.describe('Welcome email modal', async () => {
         test('Escape key closes test email dropdown without closing modal', async ({page}) => {
-            // Config with welcomeEmails feature flag enabled
             const configResponse = {
                 config: {
                     ...responseFixtures.config.config,
-                    labs: {
-                        welcomeEmails: true
-                    }
                 }
             };
 
@@ -75,13 +71,9 @@ test.describe('Member emails settings', async () => {
         });
 
         test('Escape key closes modal when test email dropdown is not open', async ({page}) => {
-            // Config with welcomeEmails feature flag enabled
             const configResponse = {
                 config: {
                     ...responseFixtures.config.config,
-                    labs: {
-                        welcomeEmails: true
-                    }
                 }
             };
 
@@ -115,13 +107,9 @@ test.describe('Member emails settings', async () => {
         });
 
         test('Welcome email modal does not start dirty but becomes dirty after edit', async ({page}) => {
-            // Config with welcomeEmails feature flag enabled
             const configResponse = {
                 config: {
                     ...responseFixtures.config.config,
-                    labs: {
-                        welcomeEmails: true
-                    }
                 }
             };
 
@@ -173,13 +161,9 @@ test.describe('Member emails settings', async () => {
         });
 
         test('Escape key does not close modal or navigate away when pressed from Koenig link input', async ({page}) => {
-            // Config with welcomeEmails feature flag enabled
             const configResponse = {
                 config: {
                     ...responseFixtures.config.config,
-                    labs: {
-                        welcomeEmails: true
-                    }
                 }
             };
 
@@ -240,9 +224,6 @@ test.describe('Member emails settings', async () => {
             const configResponse = {
                 config: {
                     ...responseFixtures.config.config,
-                    labs: {
-                        welcomeEmails: true
-                    }
                 }
             };
 
@@ -291,9 +272,6 @@ test.describe('Member emails settings', async () => {
             const configResponse = {
                 config: {
                     ...responseFixtures.config.config,
-                    labs: {
-                        welcomeEmails: true
-                    }
                 }
             };
 
@@ -342,9 +320,6 @@ test.describe('Member emails settings', async () => {
             const configResponse = {
                 config: {
                     ...responseFixtures.config.config,
-                    labs: {
-                        welcomeEmails: true
-                    }
                 }
             };
 
@@ -384,13 +359,9 @@ test.describe('Member emails settings', async () => {
     // NY-842: Tests for editing/viewing welcome emails before activation
     test.describe('Email preview visibility and edit-before-activation', async () => {
         test('Email preview card is visible with default subject when no DB row exists', async ({page}) => {
-            // Config with welcomeEmails feature flag enabled
             const configResponse = {
                 config: {
                     ...responseFixtures.config.config,
-                    labs: {
-                        welcomeEmails: true
-                    }
                 }
             };
 
@@ -429,9 +400,6 @@ test.describe('Member emails settings', async () => {
             const configResponse = {
                 config: {
                     ...responseFixtures.config.config,
-                    labs: {
-                        welcomeEmails: true
-                    }
                 }
             };
 
@@ -491,9 +459,6 @@ test.describe('Member emails settings', async () => {
             const configResponse = {
                 config: {
                     ...responseFixtures.config.config,
-                    labs: {
-                        welcomeEmails: true
-                    }
                 }
             };
 
@@ -543,9 +508,6 @@ test.describe('Member emails settings', async () => {
             const configResponse = {
                 config: {
                     ...responseFixtures.config.config,
-                    labs: {
-                        welcomeEmails: true
-                    }
                 }
             };
 
@@ -600,9 +562,6 @@ test.describe('Member emails settings', async () => {
             const configResponse = {
                 config: {
                     ...responseFixtures.config.config,
-                    labs: {
-                        welcomeEmails: true
-                    }
                 }
             };
 
@@ -660,9 +619,6 @@ test.describe('Member emails settings', async () => {
             const configResponse = {
                 config: {
                     ...responseFixtures.config.config,
-                    labs: {
-                        welcomeEmails: true
-                    }
                 }
             };
 

--- a/apps/admin-x-settings/test/acceptance/membership/member-welcome-emails.test.ts
+++ b/apps/admin-x-settings/test/acceptance/membership/member-welcome-emails.test.ts
@@ -27,7 +27,7 @@ test.describe('Member emails settings', async () => {
         test('Escape key closes test email dropdown without closing modal', async ({page}) => {
             const configResponse = {
                 config: {
-                    ...responseFixtures.config.config,
+                    ...responseFixtures.config.config
                 }
             };
 
@@ -73,7 +73,7 @@ test.describe('Member emails settings', async () => {
         test('Escape key closes modal when test email dropdown is not open', async ({page}) => {
             const configResponse = {
                 config: {
-                    ...responseFixtures.config.config,
+                    ...responseFixtures.config.config
                 }
             };
 
@@ -109,7 +109,7 @@ test.describe('Member emails settings', async () => {
         test('Welcome email modal does not start dirty but becomes dirty after edit', async ({page}) => {
             const configResponse = {
                 config: {
-                    ...responseFixtures.config.config,
+                    ...responseFixtures.config.config
                 }
             };
 
@@ -163,7 +163,7 @@ test.describe('Member emails settings', async () => {
         test('Escape key does not close modal or navigate away when pressed from Koenig link input', async ({page}) => {
             const configResponse = {
                 config: {
-                    ...responseFixtures.config.config,
+                    ...responseFixtures.config.config
                 }
             };
 
@@ -223,7 +223,7 @@ test.describe('Member emails settings', async () => {
         test('uses automated email sender fields when populated, even if newsletter differs', async ({page}) => {
             const configResponse = {
                 config: {
-                    ...responseFixtures.config.config,
+                    ...responseFixtures.config.config
                 }
             };
 
@@ -271,7 +271,7 @@ test.describe('Member emails settings', async () => {
         test('falls back to default newsletter sender values when automated fields are empty', async ({page}) => {
             const configResponse = {
                 config: {
-                    ...responseFixtures.config.config,
+                    ...responseFixtures.config.config
                 }
             };
 
@@ -319,7 +319,7 @@ test.describe('Member emails settings', async () => {
         test('preview card uses newsletter sender name when automated sender name is empty', async ({page}) => {
             const configResponse = {
                 config: {
-                    ...responseFixtures.config.config,
+                    ...responseFixtures.config.config
                 }
             };
 
@@ -361,7 +361,7 @@ test.describe('Member emails settings', async () => {
         test('Email preview card is visible with default subject when no DB row exists', async ({page}) => {
             const configResponse = {
                 config: {
-                    ...responseFixtures.config.config,
+                    ...responseFixtures.config.config
                 }
             };
 
@@ -399,7 +399,7 @@ test.describe('Member emails settings', async () => {
         test('Clicking Edit when no row exists creates inactive row then opens modal', async ({page}) => {
             const configResponse = {
                 config: {
-                    ...responseFixtures.config.config,
+                    ...responseFixtures.config.config
                 }
             };
 
@@ -458,7 +458,7 @@ test.describe('Member emails settings', async () => {
         test('Clicking Edit when row exists does NOT create new row, just opens modal', async ({page}) => {
             const configResponse = {
                 config: {
-                    ...responseFixtures.config.config,
+                    ...responseFixtures.config.config
                 }
             };
 
@@ -507,7 +507,7 @@ test.describe('Member emails settings', async () => {
         test('Toggle ON when no row exists creates active row', async ({page}) => {
             const configResponse = {
                 config: {
-                    ...responseFixtures.config.config,
+                    ...responseFixtures.config.config
                 }
             };
 
@@ -561,7 +561,7 @@ test.describe('Member emails settings', async () => {
         test('Toggle ON when inactive row exists updates to active', async ({page}) => {
             const configResponse = {
                 config: {
-                    ...responseFixtures.config.config,
+                    ...responseFixtures.config.config
                 }
             };
 
@@ -618,7 +618,7 @@ test.describe('Member emails settings', async () => {
         test('Toggle OFF when active row exists updates to inactive', async ({page}) => {
             const configResponse = {
                 config: {
-                    ...responseFixtures.config.config,
+                    ...responseFixtures.config.config
                 }
             };
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/NY-971/post-ga-cleanup-remove-the-welcomeemails-labs-flag-from-admin

There should be no behavioral changes in this commit, since the `welcomeEmails` flag has already been promoted to GA.

Now that welcome emails are in GA, we want to remove the flag completely. This commit removes any conditional behavior in the admin-x-settings app that depends on the `welcomeEmails` flag.