### PR TITLE
Removed welcomeEmails feature flag checks from Ember Admin

### DIFF
--- a/ghost/admin/app/components/members-activity/event-type-filter.js
+++ b/ghost/admin/app/components/members-activity/event-type-filter.js
@@ -5,10 +5,9 @@ import {inject as service} from '@ember/service';
 
 export default class MembersActivityEventTypeFilter extends Component {
     @service settings;
-    @service feature;
 
     getAvailableEventTypes() {
-        return getAvailableEventTypes(this.settings, this.feature, this.args.hiddenEvents);
+        return getAvailableEventTypes(this.settings, this.args.hiddenEvents);
     }
 
     get eventTypes() {

--- a/ghost/admin/app/services/feature.js
+++ b/ghost/admin/app/services/feature.js
@@ -60,7 +60,6 @@ export default class FeatureService extends Service {
     @feature('referralInviteDismissed', {user: true}) referralInviteDismissed;
 
     // labs flags
-    @feature('welcomeEmails') welcomeEmails;
     @feature('stripeAutomaticTax') stripeAutomaticTax;
     @feature('emailCustomization') emailCustomization;
     @feature('announcementBar') announcementBar;

--- a/ghost/admin/app/utils/member-event-types.js
+++ b/ghost/admin/app/utils/member-event-types.js
@@ -14,9 +14,7 @@ export const ALL_EVENT_TYPES = [
 export function getAvailableEventTypes(settings, feature, hiddenEvents = []) {
     const extended = [...ALL_EVENT_TYPES];
 
-    if (feature.welcomeEmails) {
-        extended.push({event: 'automated_email_sent_event', icon: 'filter-dropdown-email-received', name: 'Welcome email received', group: 'emails'});
-    }
+    extended.push({event: 'automated_email_sent_event', icon: 'filter-dropdown-email-received', name: 'Welcome email received', group: 'emails'});
     if (settings.commentsEnabled !== 'off') {
         extended.push({event: 'comment_event', icon: 'filter-dropdown-comments', name: 'Comments', group: 'others'});
     }

--- a/ghost/admin/app/utils/member-event-types.js
+++ b/ghost/admin/app/utils/member-event-types.js
@@ -8,17 +8,17 @@ export const ALL_EVENT_TYPES = [
     {event: 'email_delivered_event', icon: 'filter-dropdown-email-received', name: 'Email received', group: 'emails'},
     {event: 'email_complaint_event', icon: 'filter-dropdown-email-flagged-as-spam', name: 'Email flagged as spam', group: 'emails'},
     {event: 'email_failed_event', icon: 'filter-dropdown-email-bounced', name: 'Email bounced', group: 'emails'},
-    {event: 'email_change_event', icon: 'filter-dropdown-email-address-changed', name: 'Email address changed', group: 'emails'}
+    {event: 'email_change_event', icon: 'filter-dropdown-email-address-changed', name: 'Email address changed', group: 'emails'},
+    {event: 'automated_email_sent_event', icon: 'filter-dropdown-email-received', name: 'Welcome email received', group: 'emails'},
+    {event: 'feedback_event', icon: 'filter-dropdown-feedback', name: 'Feedback', group: 'others'}
 ];
 
-export function getAvailableEventTypes(settings, feature, hiddenEvents = []) {
+export function getAvailableEventTypes(settings, hiddenEvents = []) {
     const extended = [...ALL_EVENT_TYPES];
 
-    extended.push({event: 'automated_email_sent_event', icon: 'filter-dropdown-email-received', name: 'Welcome email received', group: 'emails'});
     if (settings.commentsEnabled !== 'off') {
         extended.push({event: 'comment_event', icon: 'filter-dropdown-comments', name: 'Comments', group: 'others'});
     }
-    extended.push({event: 'feedback_event', icon: 'filter-dropdown-feedback', name: 'Feedback', group: 'others'});
     if (settings.emailTrackClicks) {
         extended.push({event: 'click_event', icon: 'filter-dropdown-clicked-in-email', name: 'Clicked link in email', group: 'others'});
     }

--- a/ghost/admin/tests/unit/utils/member-event-types-test.js
+++ b/ghost/admin/tests/unit/utils/member-event-types-test.js
@@ -60,6 +60,7 @@ describe('Unit | Utility | event-type-utils', function () {
         // Feedback is always included now (audienceFeedback is GA)
         const expectedTypes = [
             ...ALL_EVENT_TYPES,
+            {event: 'automated_email_sent_event', icon: 'filter-dropdown-email-received', name: 'Welcome email received', group: 'emails'},
             {event: 'feedback_event', icon: 'filter-dropdown-feedback', name: 'Feedback', group: 'others'}
         ];
         expect(eventTypes).to.deep.equal(expectedTypes);

--- a/ghost/admin/tests/unit/utils/member-event-types-test.js
+++ b/ghost/admin/tests/unit/utils/member-event-types-test.js
@@ -3,15 +3,14 @@ import {describe, it} from 'mocha';
 import {expect} from 'chai';
 
 describe('Unit | Utility | event-type-utils', function () {
-    it('should return available event types with settings and features applied', function () {
+    it('should return available event types with settings applied', function () {
         const settings = {
             commentsEnabled: 'on',
             emailTrackClicks: true
         };
-        const feature = {};
         const hiddenEvents = [];
 
-        const eventTypes = getAvailableEventTypes(settings, feature, hiddenEvents);
+        const eventTypes = getAvailableEventTypes(settings, hiddenEvents);
 
         expect(eventTypes).to.deep.include({event: 'comment_event', icon: 'filter-dropdown-comments', name: 'Comments', group: 'others'});
         expect(eventTypes).to.deep.include({event: 'feedback_event', icon: 'filter-dropdown-feedback', name: 'Feedback', group: 'others'});
@@ -47,22 +46,16 @@ describe('Unit | Utility | event-type-utils', function () {
         expect(result).to.be.true;
     });
 
-    it('should return only base event types when no settings or features are enabled', function () {
+    it('should return base event types when no conditional settings are enabled', function () {
         const settings = {
             commentsEnabled: 'off',
             emailTrackClicks: false
         };
-        const feature = {};
         const hiddenEvents = [];
 
-        const eventTypes = getAvailableEventTypes(settings, feature, hiddenEvents);
+        const eventTypes = getAvailableEventTypes(settings, hiddenEvents);
 
-        // Feedback is always included now (audienceFeedback is GA)
-        const expectedTypes = [
-            ...ALL_EVENT_TYPES,
-            {event: 'automated_email_sent_event', icon: 'filter-dropdown-email-received', name: 'Welcome email received', group: 'emails'},
-            {event: 'feedback_event', icon: 'filter-dropdown-feedback', name: 'Feedback', group: 'others'}
-        ];
+        const expectedTypes = [...ALL_EVENT_TYPES];
         expect(eventTypes).to.deep.equal(expectedTypes);
     });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/NY-971/post-ga-cleanup-remove-the-welcomeemails-labs-flag-from-admin

There should be no behavioral changes in this commit, since the `welcomeEmails` flag has already been promoted to GA.

Now that welcome emails are in GA, we want to remove the flag completely. This commit removes any conditional behavior in the Admin ember app that depends on the `welcomeEmails` flag.