### PR TITLE
Removed welcomeEmails feature flag checks from Stripe service

### DIFF
--- a/ghost/core/core/server/services/stripe/stripe-service.js
+++ b/ghost/core/core/server/services/stripe/stripe-service.js
@@ -123,9 +123,6 @@ module.exports = class StripeService {
                 });
             },
             async isPaidWelcomeEmailActive() {
-                if (!labs.isSet('welcomeEmails')) {
-                    return false;
-                }
                 memberWelcomeEmailService.init();
                 return memberWelcomeEmailService.api.isMemberWelcomeEmailActive('paid');
             }


### PR DESCRIPTION
ref https://linear.app/ghost/issue/NY-971/post-ga-cleanup-remove-the-welcomeemails-labs-flag-from-admin

There should be no behavioral changes in this commit, since the `welcomeEmails` flag has already been promoted to GA.

Now that welcome emails are in GA, we want to remove the flag completely. This commit removes any conditional behavior in Ghost/core's Stripe service that depends on the `welcomeEmails` flag.