### PR TITLE
Removed welcomeEmails feature flag checks in the members repository

### DIFF
--- a/ghost/core/core/server/services/members/members-api/members-api.js
+++ b/ghost/core/core/server/services/members/members-api/members-api.js
@@ -100,7 +100,6 @@ module.exports = function MembersAPI({
         stripeAPIService,
         tokenService,
         newslettersService,
-        labsService,
         productRepository,
         AutomatedEmail,
         Member,

--- a/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
@@ -359,8 +359,7 @@ module.exports = class MemberRepository {
         const memberAddOptions = {...(options || {}), withRelated};
         let member;
 
-        const welcomeEmailsEnabled = this._labsService.isSet('welcomeEmails');
-        if (welcomeEmailsEnabled && WELCOME_EMAIL_SOURCES.includes(source)) {
+        if (WELCOME_EMAIL_SOURCES.includes(source)) {
             const freeWelcomeEmail = this._AutomatedEmail ? await this._AutomatedEmail.findOne({slug: MEMBER_WELCOME_EMAIL_SLUGS.free}) : null;
             const isFreeWelcomeEmailActive = freeWelcomeEmail && freeWelcomeEmail.get('lexical') && freeWelcomeEmail.get('status') === 'active';
             const isFreeSignup = !stripeCustomer;
@@ -1472,7 +1471,7 @@ module.exports = class MemberRepository {
 
             const context = options?.context || {};
             const source = this._resolveContextSource(context);
-            const shouldSendPaidWelcomeEmail = this._labsService.isSet('welcomeEmails') && WELCOME_EMAIL_SOURCES.includes(source);
+            const shouldSendPaidWelcomeEmail = WELCOME_EMAIL_SOURCES.includes(source);
             let isPaidWelcomeEmailActive = false;
             if (shouldSendPaidWelcomeEmail && this._AutomatedEmail) {
                 const paidWelcomeEmail = await this._AutomatedEmail.findOne({slug: MEMBER_WELCOME_EMAIL_SLUGS.paid}, options);

--- a/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
@@ -61,7 +61,6 @@ module.exports = class MemberRepository {
      * @param {any} deps.OfferRedemption
      * @param {any} deps.Outbox
      * @param {import('../../services/stripe-api')} deps.stripeAPIService
-     * @param {any} deps.labsService
      * @param {any} deps.productRepository
      * @param {any} deps.offersAPI
      * @param {ITokenService} deps.tokenService
@@ -82,7 +81,6 @@ module.exports = class MemberRepository {
         OfferRedemption,
         Outbox,
         stripeAPIService,
-        labsService,
         productRepository,
         offersAPI,
         tokenService,
@@ -106,7 +104,6 @@ module.exports = class MemberRepository {
         this._offersAPI = offersAPI;
         this.tokenService = tokenService;
         this._newslettersService = newslettersService;
-        this._labsService = labsService;
         this._AutomatedEmail = AutomatedEmail;
 
         DomainEvents.subscribe(OfferRedemptionEvent, async function (event) {

--- a/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
@@ -356,11 +356,16 @@ module.exports = class MemberRepository {
         const memberAddOptions = {...(options || {}), withRelated};
         let member;
 
-        if (WELCOME_EMAIL_SOURCES.includes(source)) {
-            const freeWelcomeEmail = this._AutomatedEmail ? await this._AutomatedEmail.findOne({slug: MEMBER_WELCOME_EMAIL_SLUGS.free}) : null;
-            const isFreeWelcomeEmailActive = freeWelcomeEmail && freeWelcomeEmail.get('lexical') && freeWelcomeEmail.get('status') === 'active';
-            const isFreeSignup = !stripeCustomer;
+        const isFreeSignup = !stripeCustomer;
+        const shouldCheckFreeWelcomeEmail = WELCOME_EMAIL_SOURCES.includes(source) && isFreeSignup;
+        let isFreeWelcomeEmailActive = false;
 
+        if (shouldCheckFreeWelcomeEmail) {
+            const freeWelcomeEmail = this._AutomatedEmail ? await this._AutomatedEmail.findOne({slug: MEMBER_WELCOME_EMAIL_SLUGS.free}) : null;
+            isFreeWelcomeEmailActive = freeWelcomeEmail && freeWelcomeEmail.get('lexical') && freeWelcomeEmail.get('status') === 'active';
+        }
+
+        if (isFreeWelcomeEmailActive && isFreeSignup) {
             const runMemberCreation = async (transacting) => {
                 const newMember = await this._Member.add({
                     ...memberData,
@@ -368,26 +373,21 @@ module.exports = class MemberRepository {
                     labels
                 }, {...memberAddOptions, transacting});
 
-                // Only send the free welcome email if:
-                // 1. The free welcome email is active
-                // 2. The member is not signing up for a paid subscription (no stripeCustomer)
-                if (isFreeWelcomeEmailActive && isFreeSignup) {
-                    const timestamp = eventData.created_at || newMember.get('created_at');
+                const timestamp = eventData.created_at || newMember.get('created_at');
 
-                    await this._Outbox.add({
-                        id: ObjectId().toHexString(),
-                        event_type: MemberCreatedEvent.name,
-                        payload: JSON.stringify({
-                            memberId: newMember.id,
-                            uuid: newMember.get('uuid'),
-                            email: newMember.get('email'),
-                            name: newMember.get('name'),
-                            source,
-                            timestamp,
-                            status: 'free'
-                        })
-                    }, {transacting});
-                }
+                await this._Outbox.add({
+                    id: ObjectId().toHexString(),
+                    event_type: MemberCreatedEvent.name,
+                    payload: JSON.stringify({
+                        memberId: newMember.id,
+                        uuid: newMember.get('uuid'),
+                        email: newMember.get('email'),
+                        name: newMember.get('name'),
+                        source,
+                        timestamp,
+                        status: 'free'
+                    })
+                }, {transacting});
 
                 return newMember;
             };
@@ -398,9 +398,7 @@ module.exports = class MemberRepository {
                 member = await this._Member.transaction(runMemberCreation);
             }
 
-            if (isFreeWelcomeEmailActive && isFreeSignup) {
-                this.dispatchEvent(StartOutboxProcessingEvent.create({memberId: member.id}), memberAddOptions);
-            }
+            this.dispatchEvent(StartOutboxProcessingEvent.create({memberId: member.id}), memberAddOptions);
         } else {
             member = await this._Member.add({
                 ...memberData,

--- a/ghost/core/test/integration/services/member-welcome-emails.test.js
+++ b/ghost/core/test/integration/services/member-welcome-emails.test.js
@@ -5,7 +5,6 @@ const testUtils = require('../../utils');
 const models = require('../../../core/server/models');
 const {OUTBOX_STATUSES} = require('../../../core/server/models/outbox');
 const db = require('../../../core/server/data/db');
-const mockManager = require('../../utils/e2e-framework-mock-manager');
 const mailService = require('../../../core/server/services/mail');
 const {MEMBER_WELCOME_EMAIL_SLUGS} = require('../../../core/server/services/member-welcome-emails/constants');
 const processOutbox = require('../../../core/server/services/outbox/jobs/lib/process-outbox');
@@ -86,13 +85,10 @@ describe('Member Welcome Emails Integration', function () {
         await db.knex('members').del();
         await db.knex('automated_emails').where('slug', MEMBER_WELCOME_EMAIL_SLUGS.free).del();
         await db.knex('automated_emails').where('slug', MEMBER_WELCOME_EMAIL_SLUGS.paid).del();
-        mockManager.restore();
     });
 
-    describe('Member creation with welcome emails enabled', function () {
+    describe('Member creation with welcome emails', function () {
         it('creates outbox entry when member source is "member"', async function () {
-            mockManager.mockLabsEnabled('welcomeEmails');
-
             const member = await membersService.api.members.create({
                 email: 'welcome-test@example.com',
                 name: 'Welcome Test Member'
@@ -116,8 +112,6 @@ describe('Member Welcome Emails Integration', function () {
         });
 
         it('does NOT create outbox entry when member is imported', async function () {
-            mockManager.mockLabsEnabled('welcomeEmails');
-
             await membersService.api.members.create({
                 email: 'imported@example.com',
                 name: 'Imported Member'
@@ -131,8 +125,6 @@ describe('Member Welcome Emails Integration', function () {
         });
 
         it('does NOT create outbox entry when member is created by admin', async function () {
-            mockManager.mockLabsEnabled('welcomeEmails');
-
             await membersService.api.members.create({
                 email: 'admin-created@example.com',
                 name: 'Admin Created Member'
@@ -146,8 +138,6 @@ describe('Member Welcome Emails Integration', function () {
         });
 
         it('creates outbox entry with correct timestamp', async function () {
-            mockManager.mockLabsEnabled('welcomeEmails');
-
             const beforeCreation = new Date(Date.now() - 1000);
 
             await membersService.api.members.create({
@@ -181,7 +171,6 @@ describe('Member Welcome Emails Integration', function () {
 
         beforeEach(function () {
             sinon.stub(mailService.GhostMailer.prototype, 'send').resolves('Mail sent');
-            mockManager.mockLabsEnabled('welcomeEmails');
         });
 
         afterEach(async function () {

--- a/ghost/core/test/integration/services/member-welcome-emails.test.js
+++ b/ghost/core/test/integration/services/member-welcome-emails.test.js
@@ -115,21 +115,6 @@ describe('Member Welcome Emails Integration', function () {
             assert.equal(payload.status, 'free');
         });
 
-        it('does NOT create outbox entry when welcomeEmails labs flag is off', async function () {
-            mockManager.mockLabsDisabled('welcomeEmails');
-
-            await membersService.api.members.create({
-                email: 'no-welcome@example.com',
-                name: 'No Welcome Member'
-            }, {});
-
-            const outboxEntries = await models.Outbox.findAll({
-                filter: 'event_type:MemberCreatedEvent'
-            });
-
-            assert.equal(outboxEntries.length, 0);
-        });
-
         it('does NOT create outbox entry when member is imported', async function () {
             mockManager.mockLabsEnabled('welcomeEmails');
 

--- a/ghost/core/test/unit/server/services/members/members-api/repositories/member-repository.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/repositories/member-repository.test.js
@@ -1062,7 +1062,6 @@ describe('MemberRepository', function () {
                 MemberPaidSubscriptionEvent,
                 MemberProductEvent,
                 productRepository,
-                labsService,
                 Member,
                 OfferRedemption: mockOfferRedemption
             });
@@ -1110,7 +1109,6 @@ describe('MemberRepository', function () {
                 MemberPaidSubscriptionEvent,
                 MemberProductEvent,
                 productRepository,
-                labsService,
                 Member,
                 OfferRedemption: mockOfferRedemption
             });
@@ -1157,7 +1155,6 @@ describe('MemberRepository', function () {
                 MemberPaidSubscriptionEvent,
                 MemberProductEvent,
                 productRepository,
-                labsService,
                 Member,
                 OfferRedemption: mockOfferRedemption
             });
@@ -1222,7 +1219,6 @@ describe('MemberRepository', function () {
                 MemberProductEvent,
                 productRepository,
                 offersAPI,
-                labsService,
                 Member,
                 OfferRedemption: mockOfferRedemption
             });
@@ -1285,7 +1281,6 @@ describe('MemberRepository', function () {
                 MemberPaidSubscriptionEvent,
                 MemberProductEvent,
                 productRepository,
-                labsService,
                 Member,
                 OfferRedemption: mockOfferRedemption
             });
@@ -1354,7 +1349,6 @@ describe('MemberRepository', function () {
                 MemberProductEvent,
                 productRepository,
                 offersAPI,
-                labsService,
                 Member,
                 OfferRedemption: mockOfferRedemption
             });
@@ -1422,7 +1416,6 @@ describe('MemberRepository', function () {
                 MemberProductEvent,
                 productRepository,
                 offersAPI,
-                labsService,
                 Member,
                 OfferRedemption: mockOfferRedemption
             });

--- a/ghost/core/test/unit/server/services/members/members-api/repositories/member-repository.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/repositories/member-repository.test.js
@@ -1674,6 +1674,8 @@ describe('MemberRepository', function () {
 
             // The free welcome email should NOT be sent when stripeCustomer is present
             sinon.assert.notCalled(Outbox.add);
+            sinon.assert.notCalled(AutomatedEmail.findOne);
+            sinon.assert.notCalled(Member.transaction);
         });
     });
 

--- a/ghost/core/test/unit/server/services/members/members-api/repositories/member-repository.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/repositories/member-repository.test.js
@@ -1545,12 +1545,7 @@ describe('MemberRepository', function () {
             };
 
             labsService = {
-                isSet: sinon.stub().callsFake((flag) => {
-                    if (flag === 'welcomeEmails') {
-                        return true;
-                    }
-                    return false;
-                })
+                isSet: sinon.stub()
             };
         });
 
@@ -1581,25 +1576,6 @@ describe('MemberRepository', function () {
             assert.equal(payload.email, 'test@example.com');
             assert.equal(payload.name, 'Test Member');
             assert.equal(payload.source, 'member');
-        });
-
-        it('does NOT create outbox entry when welcomeEmails labs flag is off', async function () {
-            labsService.isSet.withArgs('welcomeEmails').returns(false);
-
-            const repo = new MemberRepository({
-                Member,
-                Outbox,
-                MemberStatusEvent,
-                MemberSubscribeEventModel: MemberSubscribeEvent,
-                newslettersService,
-                AutomatedEmail,
-                labsService,
-                OfferRedemption: mockOfferRedemption
-            });
-
-            await repo.create({email: 'test@example.com', name: 'Test Member'}, {});
-
-            sinon.assert.notCalled(Outbox.add);
         });
 
         it('does not create outbox entry for disallowed sources', async function () {
@@ -1873,12 +1849,7 @@ describe('MemberRepository', function () {
             };
 
             labsService = {
-                isSet: sinon.stub().callsFake((flag) => {
-                    if (flag === 'welcomeEmails') {
-                        return true;
-                    }
-                    return false;
-                })
+                isSet: sinon.stub()
             };
         });
 
@@ -1930,47 +1901,6 @@ describe('MemberRepository', function () {
             assert.equal(payload.name, 'Test Member');
             assert.equal(payload.source, 'member');
             assert.ok(payload.timestamp);
-        });
-
-        it('does NOT create outbox entry when welcomeEmails labs flag is off', async function () {
-            labsService.isSet.withArgs('welcomeEmails').returns(false);
-
-            Member.edit.resolves({
-                attributes: {status: 'paid'},
-                _previousAttributes: {status: 'free'},
-                get: sinon.stub().callsFake((key) => {
-                    const data = {status: 'paid'};
-                    return data[key];
-                })
-            });
-
-            const repo = new MemberRepository({
-                Member,
-                Outbox,
-                MemberPaidSubscriptionEvent,
-                StripeCustomerSubscription,
-                MemberProductEvent,
-                MemberStatusEvent,
-                stripeAPIService,
-                productRepository,
-                AutomatedEmail,
-                labsService,
-                OfferRedemption: mockOfferRedemption
-            });
-
-            sinon.stub(repo, 'getSubscriptionByStripeID').resolves(null);
-
-            await repo.linkSubscription({
-                id: 'member_id_123',
-                subscription: subscriptionData
-            }, {
-                transacting: {
-                    executionPromise: Promise.resolve()
-                },
-                context: {}
-            });
-
-            sinon.assert.notCalled(Outbox.add);
         });
 
         it('does NOT create outbox entry for disallowed sources', async function () {

--- a/ghost/core/test/unit/server/services/members/members-api/repositories/member-repository.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/repositories/member-repository.test.js
@@ -238,7 +238,6 @@ describe('MemberRepository', function () {
         let stripeAPIService;
         let productRepository;
         let offersAPI;
-        let labsService;
         let subscriptionData;
         let subscriptionCreatedNotifySpy;
         let offerRedemptionNotifySpy;
@@ -334,10 +333,6 @@ describe('MemberRepository', function () {
                 update: sinon.stub().resolves({})
             };
 
-            labsService = {
-                isSet: sinon.stub().returns(true)
-            };
-
             offersAPI = {
                 ensureOfferForStripeCoupon: sinon.stub().resolves({
                     id: 'offer_new'
@@ -352,7 +347,6 @@ describe('MemberRepository', function () {
                 MemberPaidSubscriptionEvent,
                 MemberProductEvent,
                 productRepository,
-                labsService,
                 Member,
                 OfferRedemption: mockOfferRedemption
             });
@@ -384,7 +378,6 @@ describe('MemberRepository', function () {
                 MemberProductEvent,
                 productRepository,
                 offersAPI,
-                labsService,
                 Member,
                 OfferRedemption: mockOfferRedemption
             });
@@ -432,7 +425,6 @@ describe('MemberRepository', function () {
                 MemberPaidSubscriptionEvent,
                 MemberProductEvent,
                 productRepository,
-                labsService,
                 Member,
                 OfferRedemption: mockOfferRedemption
             });
@@ -508,7 +500,6 @@ describe('MemberRepository', function () {
                 MemberProductEvent,
                 productRepository: productRepositoryWithTier,
                 offersAPI,
-                labsService,
                 Member,
                 OfferRedemption: mockOfferRedemption
             });
@@ -584,7 +575,6 @@ describe('MemberRepository', function () {
                 MemberProductEvent,
                 productRepository: productRepositoryWithTier,
                 offersAPI,
-                labsService,
                 Member,
                 OfferRedemption: mockOfferRedemption
             });
@@ -658,7 +648,6 @@ describe('MemberRepository', function () {
                 MemberProductEvent,
                 productRepository: productRepositoryWithTier,
                 offersAPI,
-                labsService,
                 Member,
                 OfferRedemption: mockOfferRedemption
             });
@@ -720,7 +709,6 @@ describe('MemberRepository', function () {
                 MemberProductEvent,
                 productRepository,
                 offersAPI,
-                labsService,
                 Member,
                 OfferRedemption: mockOfferRedemption
             });
@@ -776,7 +764,6 @@ describe('MemberRepository', function () {
                 MemberProductEvent,
                 productRepository,
                 offersAPI,
-                labsService,
                 Member,
                 OfferRedemption: mockOfferRedemption
             });
@@ -814,7 +801,6 @@ describe('MemberRepository', function () {
                 MemberPaidSubscriptionEvent,
                 MemberProductEvent,
                 productRepository,
-                labsService,
                 Member,
                 OfferRedemption: mockOfferRedemption
             });
@@ -869,7 +855,6 @@ describe('MemberRepository', function () {
                 MemberPaidSubscriptionEvent,
                 MemberProductEvent,
                 productRepository,
-                labsService,
                 Member,
                 OfferRedemption: mockOfferRedemption
             });
@@ -910,7 +895,6 @@ describe('MemberRepository', function () {
                 MemberPaidSubscriptionEvent,
                 MemberProductEvent,
                 productRepository,
-                labsService,
                 Member,
                 OfferRedemption: mockOfferRedemption
             });
@@ -951,7 +935,6 @@ describe('MemberRepository', function () {
                 MemberPaidSubscriptionEvent,
                 MemberProductEvent,
                 productRepository,
-                labsService,
                 Member,
                 OfferRedemption: mockOfferRedemption
             });
@@ -1000,7 +983,6 @@ describe('MemberRepository', function () {
                 MemberPaidSubscriptionEvent,
                 MemberProductEvent,
                 productRepository,
-                labsService,
                 Member,
                 OfferRedemption: mockOfferRedemption
             });
@@ -1048,7 +1030,6 @@ describe('MemberRepository', function () {
                 MemberProductEvent,
                 productRepository,
                 offersAPI,
-                labsService,
                 Member,
                 OfferRedemption: mockOfferRedemption
             });
@@ -1481,7 +1462,6 @@ describe('MemberRepository', function () {
         let MemberSubscribeEvent;
         let newslettersService;
         let AutomatedEmail;
-        let labsService;
         const oldNodeEnv = process.env.NODE_ENV;
 
         beforeEach(function () {
@@ -1543,10 +1523,6 @@ describe('MemberRepository', function () {
                     })
                 })
             };
-
-            labsService = {
-                isSet: sinon.stub()
-            };
         });
 
         afterEach(function () {
@@ -1561,7 +1537,6 @@ describe('MemberRepository', function () {
                 MemberSubscribeEventModel: MemberSubscribeEvent,
                 newslettersService,
                 AutomatedEmail,
-                labsService,
                 OfferRedemption: mockOfferRedemption
             });
 
@@ -1586,7 +1561,6 @@ describe('MemberRepository', function () {
                 MemberSubscribeEventModel: MemberSubscribeEvent,
                 newslettersService,
                 AutomatedEmail,
-                labsService,
                 OfferRedemption: mockOfferRedemption
             });
 
@@ -1611,7 +1585,6 @@ describe('MemberRepository', function () {
                 MemberSubscribeEventModel: MemberSubscribeEvent,
                 newslettersService,
                 AutomatedEmail,
-                labsService,
                 OfferRedemption: mockOfferRedemption
             });
 
@@ -1630,7 +1603,6 @@ describe('MemberRepository', function () {
                 MemberSubscribeEventModel: MemberSubscribeEvent,
                 newslettersService,
                 AutomatedEmail,
-                labsService,
                 OfferRedemption: mockOfferRedemption
             });
 
@@ -1655,7 +1627,6 @@ describe('MemberRepository', function () {
                 MemberSubscribeEventModel: MemberSubscribeEvent,
                 newslettersService,
                 AutomatedEmail,
-                labsService,
                 OfferRedemption: mockOfferRedemption
             });
 
@@ -1676,7 +1647,6 @@ describe('MemberRepository', function () {
                 newslettersService,
                 AutomatedEmail,
                 StripeCustomer,
-                labsService,
                 OfferRedemption: mockOfferRedemption
             });
 
@@ -1717,7 +1687,6 @@ describe('MemberRepository', function () {
         let stripeAPIService;
         let productRepository;
         let AutomatedEmail;
-        let labsService;
         let subscriptionData;
 
         beforeEach(function () {
@@ -1847,10 +1816,6 @@ describe('MemberRepository', function () {
                     })
                 })
             };
-
-            labsService = {
-                isSet: sinon.stub()
-            };
         });
 
         afterEach(function () {
@@ -1877,7 +1842,6 @@ describe('MemberRepository', function () {
                 stripeAPIService,
                 productRepository,
                 AutomatedEmail,
-                labsService,
                 OfferRedemption: mockOfferRedemption
             });
 
@@ -1923,7 +1887,6 @@ describe('MemberRepository', function () {
                 stripeAPIService,
                 productRepository,
                 AutomatedEmail,
-                labsService,
                 OfferRedemption: mockOfferRedemption
             });
 
@@ -1977,7 +1940,6 @@ describe('MemberRepository', function () {
                 stripeAPIService,
                 productRepository,
                 AutomatedEmail,
-                labsService,
                 OfferRedemption: mockOfferRedemption
             });
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/NY-971/post-ga-cleanup-remove-the-welcomeemails-labs-flag-from-admin
closes https://linear.app/ghost/issue/NY-965/post-ga-cleanup-remove-labsservice-from-memberrepository

There should be no behavioral changes in this commit, since the `welcomeEmails` flag has already been promoted to GA.

Now that welcome emails are in GA, we want to remove the flag completely. This commit removes any conditional behavior in Ghost/core's Member Repository that depends on the `welcomeEmails` flag.

Note: this also removes the labsService dependency from the MembersRepository entirely.


I've manually tested the following:
- Free welcome email disabled, free signup does not receive welcome email
- Free welcome email enabled, free signup does receive welcome email
- Paid welcome email disabled, paid signup does not receive welcome email
- Paid welcome email enabled, paid signup does receive welcome email