### PR TITLE
Removed welcomeEmails feature flag usage from e2e tests

### DIFF
--- a/e2e/tests/admin/members/member-activity-events.test.ts
+++ b/e2e/tests/admin/members/member-activity-events.test.ts
@@ -21,8 +21,6 @@ async function waitForWelcomeEmailReceivedEvent(request: APIRequestContext, memb
 test.describe('Ghost Admin - Member Activity Events', () => {
     let emailClient: EmailClient;
 
-    test.use({labs: {welcomeEmails: true}});
-
     test.beforeEach(async () => {
         emailClient = new MailPit();
     });

--- a/e2e/tests/admin/settings/member-welcome-emails.test.ts
+++ b/e2e/tests/admin/settings/member-welcome-emails.test.ts
@@ -15,8 +15,6 @@ interface AutomatedEmailsResponse {
 }
 
 test.describe('Ghost Admin - Member Welcome Emails', () => {
-    test.use({labs: {welcomeEmails: true}});
-
     test('can enable free welcome emails', async ({page}) => {
         const welcomeEmailsSection = new MemberWelcomeEmailsSection(page);
 
@@ -109,7 +107,7 @@ test.describe('Ghost Admin - Member Welcome Emails', () => {
 });
 
 test.describe('Ghost Admin - Paid Member Welcome Emails', () => {
-    test.use({labs: {welcomeEmails: true}, stripeConnected: true});
+    test.use({stripeConnected: true});
 
     test('can enable paid welcome emails', async ({page}) => {
         const welcomeEmailsSection = new MemberWelcomeEmailsSection(page);

--- a/e2e/tests/public/member-signup.test.ts
+++ b/e2e/tests/public/member-signup.test.ts
@@ -8,8 +8,6 @@ import {signupViaPortal} from '@/helpers/playwright/flows/signup';
 test.describe('Ghost Public - Member Signup', () => {
     let emailClient: EmailClient;
 
-    test.use({labs: {welcomeEmails: true}});
-
     test.beforeEach(async () => {
         emailClient = new MailPit();
     });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/NY-971/post-ga-cleanup-remove-the-welcomeemails-labs-flag-from-admin

There should be no behavioral changes in this commit, since the `welcomeEmails` flag has already been promoted to GA. This is also a test only change.

Now that welcome emails are in GA, we want to remove the flag completely. This commit removes any conditional behavior in Ghost's E2E tests that depends on the `welcomeEmails` flag.