### PR TITLE
Added yarn dev:local command to run Ghost backend locally

### DIFF
--- a/compose.dev.local.yaml
+++ b/compose.dev.local.yaml
@@ -1,0 +1,23 @@
+# Local backend development mode.
+# Use with: yarn dev:local
+#
+# This keeps infrastructure (MySQL/Redis/Mailpit/Gateway) in Docker,
+# but runs Ghost core on the host machine.
+services:
+  ghost-dev:
+    command:
+      - bash
+      - -lc
+      - |
+        echo "Local backend mode enabled. Ghost backend is running on the host."
+        sleep infinity
+    healthcheck:
+      test: ["CMD", "bash", "-lc", "echo ok"]
+
+  ghost-dev-gateway:
+    environment:
+      GHOST_BACKEND: host.docker.internal:2369
+
+  stripe:
+    environment:
+      - GHOST_URL=http://ghost-dev-gateway

--- a/docker/ghost-dev/README.md
+++ b/docker/ghost-dev/README.md
@@ -29,7 +29,22 @@ This image is used automatically when running:
 
 ```bash
 yarn dev              # Starts Docker backend + frontend dev servers on host
+yarn dev:local        # Starts Docker infra + host Ghost backend + frontend dev servers
 yarn dev:analytics    # Include Tinybird analytics
 yarn dev:storage      # Include MinIO S3-compatible object storage
 yarn dev:all          # Include all optional services
+```
+
+## Local Backend Mode
+
+`yarn dev:local` runs Ghost core on the host machine while keeping MySQL, Redis, Mailpit, and the Caddy gateway in Docker.
+
+- Gateway remains available at `http://localhost:2368`
+- Host Ghost backend runs on `http://localhost:2369`
+- This mode works with standard host-side package linking (`yarn link`)
+
+To combine with optional compose overrides, set `DEV_LOCAL_COMPOSE_FILES`:
+
+```bash
+DEV_LOCAL_COMPOSE_FILES='-f compose.dev.analytics.yaml' yarn dev:local
 ```

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -22,6 +22,7 @@
   "scripts": {
     "archive": "npm pack",
     "dev": "node --watch --import=tsx index.js",
+    "dev:wait-mysql": "bash -lc 'until nc -z 127.0.0.1 \"${database__connection__port:-3306}\"; do echo \"Waiting for MySQL on 127.0.0.1:${database__connection__port:-3306}\"; sleep 1; done; yarn dev'",
     "build:assets": "yarn build:assets:css && yarn build:assets:js",
     "build:assets:js": "node bin/minify-assets.js",
     "build:assets:css": "postcss core/frontend/public/ghost.css --no-map --use cssnano -o core/frontend/public/ghost.min.css",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "dev:analytics": "DEV_COMPOSE_FILES='-f compose.dev.analytics.yaml' nx run ghost-monorepo:docker:dev",
     "dev:storage": "DEV_COMPOSE_FILES='-f compose.dev.storage.yaml' nx run ghost-monorepo:docker:dev",
     "dev:all": "DEV_COMPOSE_FILES='-f compose.dev.analytics.yaml -f compose.dev.storage.yaml' nx run ghost-monorepo:docker:dev",
+    "dev:local": "NODE_TLS_REJECT_UNAUTHORIZED=0 database__client=mysql2 database__connection__host=127.0.0.1 database__connection__user=root database__connection__password=${MYSQL_ROOT_PASSWORD:-root} database__connection__database=${MYSQL_DATABASE:-ghost_dev} server__host=0.0.0.0 server__port=2369 mail__transport=SMTP mail__options__host=127.0.0.1 mail__options__port=1025 adapters__cache__Redis__host=127.0.0.1 adapters__cache__Redis__port=6379 portal__url=/ghost/assets/portal/portal.min.js comments__url=/ghost/assets/comments-ui/comments-ui.min.js sodoSearch__url=/ghost/assets/sodo-search/sodo-search.min.js sodoSearch__styles=/ghost/assets/sodo-search/main.css signupForm__url=/ghost/assets/signup-form/signup-form.min.js announcementBar__url=/ghost/assets/announcement-bar/announcement-bar.min.js DEV_COMPOSE_FILES=\"-f compose.dev.local.yaml ${DEV_LOCAL_COMPOSE_FILES:-}\" nx run ghost-monorepo:docker:dev:local",
     "dev:ghost": "node .github/scripts/dev.js --ghost",
     "dev:legacy": "node .github/scripts/dev.js",
     "dev:legacy:debug": "DEBUG_COLORS=true DEBUG=@tryghost*,ghost:* yarn dev:legacy",
@@ -149,6 +150,43 @@
               "@tryghost/sodo-search",
               "@tryghost/announcement-bar",
               "@tryghost/parse-email-address"
+            ]
+          }
+        ]
+      },
+      "docker:up:local": {
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "docker compose -f compose.dev.yaml ${DEV_COMPOSE_FILES} up -d --force-recreate --wait"
+        },
+        "dependsOn": [
+          "docker:build"
+        ]
+      },
+      "docker:dev:local": {
+        "continuous": true,
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "trap 'docker compose -f compose.dev.yaml ${DEV_COMPOSE_FILES} down' EXIT; docker compose -f compose.dev.yaml ${DEV_COMPOSE_FILES} logs -f"
+        },
+        "dependsOn": [
+          "docker:up:local",
+          {
+            "target": "dev",
+            "projects": [
+              "@tryghost/admin",
+              "@tryghost/portal",
+              "@tryghost/comments-ui",
+              "@tryghost/signup-form",
+              "@tryghost/sodo-search",
+              "@tryghost/announcement-bar",
+              "@tryghost/parse-email-address"
+            ]
+          },
+          {
+            "target": "dev:wait-mysql",
+            "projects": [
+              "ghost"
             ]
           }
         ]


### PR DESCRIPTION
In some circumstances, it can be more convenient to run Ghost's backend locally, rather than in Docker. In particular, when testing Ghost against local versions of dependencies that live in other monorepos with `yarn link`.

This leaves the default `yarn dev` as-is, but adds a new `yarn dev:local` command that runs:
- Docker services like mysql and redis
- Ghost's backend directly on the host
- Dev servers for all the apps