### PR TITLE
Replaced more Should.js assertions

### DIFF
--- a/ghost/core/test/e2e-api/admin/email-previews.test.js
+++ b/ghost/core/test/e2e-api/admin/email-previews.test.js
@@ -161,7 +161,11 @@ describe('Email Preview API', function () {
         it('uses the posts newsletter by default', async function () {
             const defaultNewsletter = await models.Newsletter.getDefaultNewsletter();
             const selectedNewsletter = fixtureManager.get('newsletters', 0);
-            defaultNewsletter.id.should.not.eql(selectedNewsletter.id, 'Should use a non-default newsletter for this test');
+            assert.notEqual(
+                defaultNewsletter.id,
+                selectedNewsletter.id,
+                'Should use a non-default newsletter for this test'
+            );
 
             const post = testUtils.DataGenerator.forKnex.createPost({
                 id: ObjectId().toHexString(),
@@ -203,7 +207,11 @@ describe('Email Preview API', function () {
             const defaultNewsletter = await models.Newsletter.getDefaultNewsletter();
             const selectedNewsletter = fixtureManager.get('newsletters', 0);
 
-            selectedNewsletter.id.should.not.eql(defaultNewsletter.id, 'Should use a non-default newsletter for this test');
+            assert.notEqual(
+                selectedNewsletter.id,
+                defaultNewsletter.id,
+                'Should use a non-default newsletter for this test'
+            );
 
             const post = testUtils.DataGenerator.forKnex.createPost({
                 id: ObjectId().toHexString(),

--- a/ghost/core/test/e2e-api/admin/integrations.test.js
+++ b/ghost/core/test/e2e-api/admin/integrations.test.js
@@ -262,7 +262,7 @@ describe('Integrations API', function () {
         const [updatedIntegration] = res2.body.integrations;
         const updatedAdminApiKey = updatedIntegration.api_keys.find(key => key.type === 'admin');
         assert.equal(updatedIntegration.id, createdIntegration.id);
-        updatedAdminApiKey.secret.should.not.eql(adminApiKey.secret);
+        assert.notEqual(updatedAdminApiKey.secret, adminApiKey.secret);
 
         const res3 = await request.get(localUtils.API.getApiQuery(`actions/?filter=resource_id:'${adminApiKey.id}'&include=actor`))
             .set('Origin', config.get('url'))

--- a/ghost/core/test/e2e-api/admin/posts-legacy.test.js
+++ b/ghost/core/test/e2e-api/admin/posts-legacy.test.js
@@ -301,8 +301,8 @@ describe('Posts API', function () {
         assert.equal(modelJson.title, post.title);
         assert.equal(modelJson.status, post.status);
         assert.equal(modelJson.published_at.toISOString(), '2016-05-30T07:00:00.000Z');
-        modelJson.created_at.toISOString().should.not.eql(post.created_at.toISOString());
-        modelJson.updated_at.toISOString().should.not.eql(post.updated_at.toISOString());
+        assert.notEqual(modelJson.created_at.toISOString(), post.created_at.toISOString());
+        assert.notEqual(modelJson.updated_at.toISOString(), post.updated_at.toISOString());
 
         assert.equal(modelJson.posts_meta.feature_image_alt, post.feature_image_alt);
         assert.equal(modelJson.posts_meta.feature_image_caption, post.feature_image_caption);

--- a/ghost/core/test/e2e-api/admin/themes.test.js
+++ b/ghost/core/test/e2e-api/admin/themes.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../utils/assertions');
-const should = require('should');
 const sinon = require('sinon');
 const path = require('path');
 const fs = require('fs');
@@ -56,32 +55,44 @@ describe('Themes API', function () {
 
         localUtils.API.checkResponse(jsonResponse.themes[0], 'theme');
         assert.equal(jsonResponse.themes[0].name, 'broken-theme');
-        jsonResponse.themes[0].package.should.be.an.Object().with.properties('name', 'version');
+        assert(jsonResponse.themes[0].package && typeof jsonResponse.themes[0].package === 'object');
+        assert('name' in jsonResponse.themes[0].package);
+        assert('version' in jsonResponse.themes[0].package);
         assert.equal(jsonResponse.themes[0].active, false);
 
         localUtils.API.checkResponse(jsonResponse.themes[1], 'theme');
         assert.equal(jsonResponse.themes[1].name, 'casper');
-        jsonResponse.themes[1].package.should.be.an.Object().with.properties('name', 'version');
+        assert(jsonResponse.themes[1].package && typeof jsonResponse.themes[1].package === 'object');
+        assert('name' in jsonResponse.themes[1].package);
+        assert('version' in jsonResponse.themes[1].package);
         assert.equal(jsonResponse.themes[1].active, false);
 
         localUtils.API.checkResponse(jsonResponse.themes[2], 'theme');
         assert.equal(jsonResponse.themes[2].name, 'locale-theme');
-        jsonResponse.themes[2].package.should.be.an.Object().with.properties('name', 'version');
+        assert(jsonResponse.themes[2].package && typeof jsonResponse.themes[2].package === 'object');
+        assert('name' in jsonResponse.themes[2].package);
+        assert('version' in jsonResponse.themes[2].package);
         assert.equal(jsonResponse.themes[2].active, false);
 
         localUtils.API.checkResponse(jsonResponse.themes[3], 'theme');
         assert.equal(jsonResponse.themes[3].name, 'members-test-theme');
-        jsonResponse.themes[3].package.should.be.an.Object().with.properties('name', 'version');
+        assert(jsonResponse.themes[3].package && typeof jsonResponse.themes[3].package === 'object');
+        assert('name' in jsonResponse.themes[3].package);
+        assert('version' in jsonResponse.themes[3].package);
         assert.equal(jsonResponse.themes[3].active, false);
 
         localUtils.API.checkResponse(jsonResponse.themes[4], 'theme', 'templates');
         assert.equal(jsonResponse.themes[4].name, 'source');
-        jsonResponse.themes[4].package.should.be.an.Object().with.properties('name', 'version');
+        assert(jsonResponse.themes[4].package && typeof jsonResponse.themes[4].package === 'object');
+        assert('name' in jsonResponse.themes[4].package);
+        assert('version' in jsonResponse.themes[4].package);
         assert.equal(jsonResponse.themes[4].active, true);
 
         localUtils.API.checkResponse(jsonResponse.themes[5], 'theme');
         assert.equal(jsonResponse.themes[5].name, 'test-theme');
-        jsonResponse.themes[5].package.should.be.an.Object().with.properties('name', 'version');
+        assert(jsonResponse.themes[5].package && typeof jsonResponse.themes[5].package === 'object');
+        assert('name' in jsonResponse.themes[5].package);
+        assert('version' in jsonResponse.themes[5].package);
         assert.equal(jsonResponse.themes[5].active, false);
 
         localUtils.API.checkResponse(jsonResponse.themes[6], 'theme');

--- a/ghost/core/test/e2e-api/members/middleware.test.js
+++ b/ghost/core/test/e2e-api/members/middleware.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const {assertExists} = require('../../utils/assertions');
 const crypto = require('crypto');
 const {agentProvider, mockManager, fixtureManager, matchers, configUtils} = require('../../utils/e2e-framework');
 const {anyEtag, anyObjectId, anyUuid, anyISODateTime, stringMatching} = matchers;
@@ -286,8 +285,8 @@ describe('Comments API', function () {
             await membersAgent
                 .get('/api/member/')
                 .expect(({headers}) => {
-                    assertExists(headers['set-cookie']);
-                    headers['set-cookie'].should.matchAny(/ghost-access=null;/);
+                    assert(Array.isArray(headers['set-cookie']));
+                    assert(headers['set-cookie'].some(h => /ghost-access=null;/.test(h)));
                 })
                 .expectStatus(204)
                 .expectEmptyBody();

--- a/ghost/core/test/e2e-api/members/signin.test.js
+++ b/ghost/core/test/e2e-api/members/signin.test.js
@@ -1,7 +1,7 @@
+const {assertArrayMatchesWithoutOrder} = require('../../utils/assertions');
 const {agentProvider, mockManager, fixtureManager} = require('../../utils/e2e-framework');
 const models = require('../../../core/server/models');
 const assert = require('node:assert/strict');
-require('should');
 const sinon = require('sinon');
 const members = require('../../../core/server/services/members');
 
@@ -10,12 +10,7 @@ let membersAgent, membersService;
 async function assertMemberEvents({eventType, memberId, asserts}) {
     const events = await models[eventType].where('member_id', memberId).fetchAll();
     const eventsJSON = events.map(e => e.toJSON());
-
-    // Order shouldn't matter here
-    for (const a of asserts) {
-        eventsJSON.should.matchAny(a);
-    }
-    assert.equal(events.length, asserts.length, `Only ${asserts.length} ${eventType} should have been added.`);
+    assertArrayMatchesWithoutOrder(eventsJSON, asserts);
 }
 
 async function getMemberByEmail(email, require = true) {

--- a/ghost/core/test/legacy/api/admin/posts.test.js
+++ b/ghost/core/test/legacy/api/admin/posts.test.js
@@ -818,10 +818,10 @@ describe('Posts API', function () {
                 })
                 .then((model) => {
                     // We expect that the changed properties aren't changed, they are still the same than before.
-                    model.get('created_at').toISOString().should.not.eql(post.created_at);
+                    assert.notEqual(model.get('created_at').toISOString(), post.created_at);
 
                     // `updated_at` is automatically set, but it's not the date we send to override.
-                    model.get('updated_at').toISOString().should.not.eql(post.updated_at);
+                    assert.notEqual(model.get('updated_at').toISOString(), post.updated_at);
                 });
         });
 

--- a/ghost/core/test/legacy/models/model-posts.test.js
+++ b/ghost/core/test/legacy/models/model-posts.test.js
@@ -2081,11 +2081,11 @@ describe('Post Model', function () {
 
                     updatedAtFormat = moment(updatedPost.tags[0].updated_at).format('YYYY-MM-DD HH:mm:ss');
                     assert.equal(updatedAtFormat, moment(postJSON.tags[0].updated_at).format('YYYY-MM-DD HH:mm:ss'));
-                    updatedAtFormat.should.not.eql(moment(newJSON.tags[0].updated_at).format('YYYY-MM-DD HH:mm:ss'));
+                    assert.notEqual(updatedAtFormat, moment(newJSON.tags[0].updated_at).format('YYYY-MM-DD HH:mm:ss'));
 
                     createdAtFormat = moment(updatedPost.tags[0].created_at).format('YYYY-MM-DD HH:mm:ss');
                     assert.equal(createdAtFormat, moment(postJSON.tags[0].created_at).format('YYYY-MM-DD HH:mm:ss'));
-                    createdAtFormat.should.not.eql(moment(newJSON.tags[0].created_at).format('YYYY-MM-DD HH:mm:ss'));
+                    assert.notEqual(createdAtFormat, moment(newJSON.tags[0].created_at).format('YYYY-MM-DD HH:mm:ss'));
                 });
         });
 

--- a/ghost/core/test/legacy/models/model-users.test.js
+++ b/ghost/core/test/legacy/models/model-users.test.js
@@ -459,7 +459,7 @@ describe('User Model', function run() {
                     assert.equal(user.get('slug'), 'max');
 
                     // naive check that password was hashed
-                    user.get('password').should.not.eql(userData.password);
+                    assert.notEqual(user.get('password'), userData.password);
                     done();
                 })
                 .catch(done);

--- a/ghost/core/test/unit/frontend/helpers/get.test.js
+++ b/ghost/core/test/unit/frontend/helpers/get.test.js
@@ -99,7 +99,9 @@ describe('{{#get}} helper', function () {
                 {hash: {}, data: locals, fn: fn, inverse: inverse}
             ).then(function () {
                 assert.equal(fn.called, true);
-                fn.firstCall.args[0].should.be.an.Object().with.property('posts');
+                const args = fn.firstCall.args[0];
+                assert(args && typeof args === 'object');
+                assert('posts' in args);
 
                 assert(fn.firstCall.args[0].posts[0].feature_image_caption instanceof SafeString);
 
@@ -128,7 +130,9 @@ describe('{{#get}} helper', function () {
                 {hash: {}, data: locals, fn: fn, inverse: inverse}
             ).then(function () {
                 assert.equal(fn.called, true);
-                fn.firstCall.args[0].should.be.an.Object().with.property('authors');
+                const args = fn.firstCall.args[0];
+                assert(args && typeof args === 'object');
+                assert('authors' in args);
                 assert.deepEqual(fn.firstCall.args[0].authors, []);
                 assert.equal(inverse.called, false);
 
@@ -157,7 +161,9 @@ describe('{{#get}} helper', function () {
                 {hash: {}, data: locals, fn: fn, inverse: inverse}
             ).then(function () {
                 assert.equal(fn.called, true);
-                fn.firstCall.args[0].should.be.an.Object().with.property('newsletters');
+                const args = fn.firstCall.args[0];
+                assert(args && typeof args === 'object');
+                assert('newsletters' in args);
                 assert.deepEqual(fn.firstCall.args[0].newsletters, []);
                 assert.equal(inverse.called, false);
 
@@ -175,9 +181,13 @@ describe('{{#get}} helper', function () {
             ).then(function () {
                 assert.equal(fn.called, false);
                 assert.equal(inverse.calledOnce, true);
-                inverse.firstCall.args[1].should.be.an.Object().and.have.property('data');
-                inverse.firstCall.args[1].data.should.be.an.Object().and.have.property('error');
-                assert.equal(inverse.firstCall.args[1].data.error, 'Invalid "magic" resource given to get helper');
+                const args = inverse.firstCall.args[1];
+                assert(args && typeof args === 'object');
+                assert('data' in args);
+                const data = args.data;
+                assert(data && typeof data === 'object');
+                assert('error' in data);
+                assert.equal(data.error, 'Invalid "magic" resource given to get helper');
 
                 done();
             }).catch(done);
@@ -191,9 +201,13 @@ describe('{{#get}} helper', function () {
             ).then(function () {
                 assert.equal(fn.called, false);
                 assert.equal(inverse.calledOnce, true);
-                inverse.firstCall.args[1].should.be.an.Object().and.have.property('data');
-                inverse.firstCall.args[1].data.should.be.an.Object().and.have.property('error');
-                assert.match(inverse.firstCall.args[1].data.error, /^Validation/);
+                const args = inverse.firstCall.args[1];
+                assert(args && typeof args === 'object');
+                assert('data' in args);
+                const data = args.data;
+                assert(data && typeof data === 'object');
+                assert('error' in data);
+                assert.match(data.error, /^Validation/);
 
                 done();
             }).catch(done);
@@ -241,8 +255,10 @@ describe('{{#get}} helper', function () {
             ).then(function () {
                 assert(Array.isArray(browseStub.firstCall.args));
                 assert.equal(browseStub.firstCall.args.length, 1);
-                browseStub.firstCall.args[0].should.be.an.Object().with.property('filter');
-                assert.equal(browseStub.firstCall.args[0].filter, 'tags:[test,magic]');
+                const options = browseStub.firstCall.args[0];
+                assert(options && typeof options === 'object');
+                assert('filter' in options);
+                assert.equal(options.filter, 'tags:[test,magic]');
 
                 done();
             }).catch(done);
@@ -256,8 +272,10 @@ describe('{{#get}} helper', function () {
             ).then(function () {
                 assert(Array.isArray(browseStub.firstCall.args));
                 assert.equal(browseStub.firstCall.args.length, 1);
-                browseStub.firstCall.args[0].should.be.an.Object().with.property('filter');
-                assert.equal(browseStub.firstCall.args[0].filter, 'author:cameron');
+                const options = browseStub.firstCall.args[0];
+                assert(options && typeof options === 'object');
+                assert('filter' in options);
+                assert.equal(options.filter, 'author:cameron');
 
                 done();
             }).catch(done);
@@ -271,8 +289,10 @@ describe('{{#get}} helper', function () {
             ).then(function () {
                 assert(Array.isArray(browseStub.firstCall.args));
                 assert.equal(browseStub.firstCall.args.length, 1);
-                browseStub.firstCall.args[0].should.be.an.Object().with.property('filter');
-                assert.equal(browseStub.firstCall.args[0].filter, 'id:-3');
+                const options = browseStub.firstCall.args[0];
+                assert(options && typeof options === 'object');
+                assert('filter' in options);
+                assert.equal(options.filter, 'id:-3');
 
                 done();
             }).catch(done);
@@ -286,8 +306,10 @@ describe('{{#get}} helper', function () {
             ).then(function () {
                 assert(Array.isArray(browseStub.firstCall.args));
                 assert.equal(browseStub.firstCall.args.length, 1);
-                browseStub.firstCall.args[0].should.be.an.Object().with.property('filter');
-                assert.equal(browseStub.firstCall.args[0].filter, 'tags:test');
+                const options = browseStub.firstCall.args[0];
+                assert(options && typeof options === 'object');
+                assert('filter' in options);
+                assert.equal(options.filter, 'tags:test');
 
                 done();
             }).catch(done);
@@ -301,8 +323,10 @@ describe('{{#get}} helper', function () {
             ).then(function () {
                 assert(Array.isArray(browseStub.firstCall.args));
                 assert.equal(browseStub.firstCall.args.length, 1);
-                browseStub.firstCall.args[0].should.be.an.Object().with.property('filter');
-                assert.equal(browseStub.firstCall.args[0].filter, `published_at:<='${pubDate.toISOString()}'`);
+                const options = browseStub.firstCall.args[0];
+                assert(options && typeof options === 'object');
+                assert('filter' in options);
+                assert.equal(options.filter, `published_at:<='${pubDate.toISOString()}'`);
 
                 done();
             }).catch(done);
@@ -316,8 +340,10 @@ describe('{{#get}} helper', function () {
             ).then(function () {
                 assert(Array.isArray(browseStub.firstCall.args));
                 assert.equal(browseStub.firstCall.args.length, 1);
-                browseStub.firstCall.args[0].should.be.an.Object().with.property('filter');
-                assert.equal(browseStub.firstCall.args[0].filter, 'id:');
+                const options = browseStub.firstCall.args[0];
+                assert(options && typeof options === 'object');
+                assert('filter' in options);
+                assert.equal(options.filter, 'id:');
 
                 done();
             }).catch(done);
@@ -331,8 +357,10 @@ describe('{{#get}} helper', function () {
             ).then(function () {
                 assert(Array.isArray(browseStub.firstCall.args));
                 assert.equal(browseStub.firstCall.args.length, 1);
-                browseStub.firstCall.args[0].should.be.an.Object().with.property('filter');
-                assert.equal(browseStub.firstCall.args[0].filter, 'slug:bar');
+                const options = browseStub.firstCall.args[0];
+                assert(options && typeof options === 'object');
+                assert('filter' in options);
+                assert.equal(options.filter, 'slug:bar');
 
                 done();
             }).catch(done);
@@ -560,9 +588,11 @@ describe('{{#get}} helper', function () {
             assert.equal(logging.warn.calledOnce, true);
             // The get helper will return as per usual
             assert.equal(fn.calledOnce, true);
-            fn.firstCall.args[0].should.be.an.Object().with.property('posts');
-            assert(Array.isArray(fn.firstCall.args[0].posts));
-            assert.equal(fn.firstCall.args[0].posts.length, 1);
+            const args = fn.firstCall.args[0];
+            assert(args && typeof args === 'object');
+            assert('posts' in args);
+            assert(Array.isArray(args.posts));
+            assert.equal(args.posts.length, 1);
         });
 
         it('should log an error and return safely if it hits the timeout threshold', async function () {
@@ -579,8 +609,10 @@ describe('{{#get}} helper', function () {
             assert.equal(logging.error.calledOnce, true);
             // The get helper gets called with an empty array of results
             assert.equal(fn.calledOnce, true);
-            fn.firstCall.args[0].should.be.an.Object().with.property('posts');
-            assert.deepEqual(fn.firstCall.args[0].posts, []);
+            const args = fn.firstCall.args[0];
+            assert(args && typeof args === 'object');
+            assert('posts' in args);
+            assert.deepEqual(args.posts, []);
         });
     });
 });

--- a/ghost/core/test/unit/frontend/helpers/recommendations.test.js
+++ b/ghost/core/test/unit/frontend/helpers/recommendations.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const sinon = require('sinon');
 const models = require('../../../../core/server/models');
 const api = require('../../../../core/server/api').endpoints;
@@ -66,8 +65,6 @@ describe('{{#recommendations}} helper', function () {
             'recommendations'
         );
 
-        response.should.be.an.Object().with.property('string');
-
         const expected = html`
         <ul class="recommendations">
             <li class="recommendation">
@@ -92,6 +89,8 @@ describe('{{#recommendations}} helper', function () {
             </li>
         </ul>
         `;
+
+        assert(response !== null && typeof response === 'object');
         const actual = response.string;
 
         // Uncomment to debug
@@ -124,7 +123,7 @@ describe('{{#recommendations}} helper', function () {
             );
 
             // No HTML is rendered
-            response.should.be.an.Object().with.property('string');
+            assert(response !== null && typeof response === 'object');
             assert.equal(response.string, '');
         });
     });
@@ -141,7 +140,7 @@ describe('{{#recommendations}} helper', function () {
             );
 
             // No HTML is rendered
-            response.should.be.an.Object().with.property('string');
+            assert(response !== null && typeof response === 'object');
             assert.equal(response.string, '');
         });
     });
@@ -175,7 +174,7 @@ describe('{{#recommendations}} helper', function () {
             assert.equal(logging.error.calledOnce, true);
 
             // No HTML is rendered
-            response.should.be.an.Object().with.property('string');
+            assert(response !== null && typeof response === 'object');
             assert.equal(response.string, '');
         });
     });

--- a/ghost/core/test/unit/frontend/services/data/fetch-data.test.js
+++ b/ghost/core/test/unit/frontend/services/data/fetch-data.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../utils/assertions');
-const should = require('should');
 const sinon = require('sinon');
 const _ = require('lodash');
 
@@ -61,7 +60,9 @@ describe('Unit - frontend/data/fetch-data', function () {
     it('should handle no options', function (done) {
         data.fetchData(null, null, locals).then(function (result) {
             assertExists(result);
-            result.should.be.an.Object().with.properties('posts', 'meta');
+            assert(result && typeof result === 'object');
+            assert('posts' in result);
+            assert('meta' in result);
             assert(!('data' in result));
 
             assert.equal(browsePostsStub.calledOnce, true);
@@ -76,7 +77,9 @@ describe('Unit - frontend/data/fetch-data', function () {
     it('should handle path options with page/limit', function (done) {
         data.fetchData({page: 2, limit: 10}, null, locals).then(function (result) {
             assertExists(result);
-            result.should.be.an.Object().with.properties('posts', 'meta');
+            assert(result && typeof result === 'object');
+            assert('posts' in result);
+            assert('meta' in result);
             assert(!('data' in result));
 
             assert.equal(result.posts.length, posts.length);
@@ -109,8 +112,12 @@ describe('Unit - frontend/data/fetch-data', function () {
 
         data.fetchData(pathOptions, routerOptions, locals).then(function (result) {
             assertExists(result);
-            result.should.be.an.Object().with.properties('posts', 'meta', 'data');
-            result.data.should.be.an.Object().with.properties('featured');
+            assert(result && typeof result === 'object');
+            assert('posts' in result);
+            assert('meta' in result);
+            assert('data' in result);
+            assert(result.data && typeof result.data === 'object');
+            assert('featured' in result.data);
 
             assert.equal(result.posts.length, posts.length);
             assert.equal(result.data.featured.length, posts.length);
@@ -141,8 +148,12 @@ describe('Unit - frontend/data/fetch-data', function () {
         data.fetchData(pathOptions, routerOptions, locals).then(function (result) {
             assertExists(result);
 
-            result.should.be.an.Object().with.properties('posts', 'meta', 'data');
-            result.data.should.be.an.Object().with.properties('featured');
+            assert(result && typeof result === 'object');
+            assert('posts' in result);
+            assert('meta' in result);
+            assert('data' in result);
+            assert(result.data && typeof result.data === 'object');
+            assert('featured' in result.data);
 
             assert.equal(result.posts.length, posts.length);
             assert.equal(result.data.featured.length, posts.length);
@@ -175,8 +186,12 @@ describe('Unit - frontend/data/fetch-data', function () {
 
         data.fetchData(pathOptions, routerOptions, locals).then(function (result) {
             assertExists(result);
-            result.should.be.an.Object().with.properties('posts', 'meta', 'data');
-            result.data.should.be.an.Object().with.properties('tag');
+            assert(result && typeof result === 'object');
+            assert('posts' in result);
+            assert('meta' in result);
+            assert('data' in result);
+            assert(result.data && typeof result.data === 'object');
+            assert('tag' in result.data);
 
             assert.equal(result.posts.length, posts.length);
             assert.equal(result.data.tag.length, tags.length);

--- a/ghost/core/test/unit/frontend/services/rendering/format-response.test.js
+++ b/ghost/core/test/unit/frontend/services/rendering/format-response.test.js
@@ -30,7 +30,7 @@ describe('Unit - services/routing/helpers/format-response', function () {
 
             const formatted = helpers.formatResponse.entry(postObject);
 
-            formatted.should.be.an.Object().with.property('post');
+            assert(formatted && typeof formatted === 'object');
             assert.equal(formatted.post, postObject);
         });
 
@@ -48,8 +48,6 @@ describe('Unit - services/routing/helpers/format-response', function () {
 
             helpers.formatResponse.entry(postObject, ['post'], locals);
 
-            locals.should.be.an.Object().with.properties('_templateOptions');
-            locals._templateOptions.data.should.be.an.Object().with.properties('page');
             assert.equal(locals._templateOptions.data.page.show_title_and_feature_image, true);
         });
 
@@ -61,8 +59,6 @@ describe('Unit - services/routing/helpers/format-response', function () {
 
             assert(!('show_title_and_feature_image' in formatted.page));
 
-            locals.should.be.an.Object().with.properties('_templateOptions');
-            locals._templateOptions.data.should.be.an.Object().with.properties('page');
             assert.equal(locals._templateOptions.data.page.show_title_and_feature_image, true);
         });
 
@@ -74,8 +70,6 @@ describe('Unit - services/routing/helpers/format-response', function () {
 
             assert(!('show_title_and_feature_image' in formatted.page));
 
-            locals.should.be.an.Object().with.properties('_templateOptions');
-            locals._templateOptions.data.should.be.an.Object().with.properties('page');
             assert.equal(locals._templateOptions.data.page.show_title_and_feature_image, false);
         });
     });
@@ -89,7 +83,6 @@ describe('Unit - services/routing/helpers/format-response', function () {
 
             const formatted = helpers.formatResponse.entries(data);
 
-            formatted.should.be.an.Object().with.properties('posts', 'pagination');
             assert.equal(formatted.posts, data.posts);
             assert.equal(formatted.pagination, data.meta.pagination);
         });
@@ -103,7 +96,8 @@ describe('Unit - services/routing/helpers/format-response', function () {
 
             const formatted = helpers.formatResponse.entries(data);
 
-            formatted.should.be.an.Object().with.properties('posts', 'pagination', 'tag');
+            assert(formatted && typeof formatted === 'object');
+            assert('posts' in formatted && 'pagination' in formatted && 'tag' in formatted);
             assert.equal(formatted.tag, data.data.tag[0]);
         });
 
@@ -121,8 +115,9 @@ describe('Unit - services/routing/helpers/format-response', function () {
 
             const formatted = helpers.formatResponse.entries(data);
 
-            formatted.should.be.an.Object().with.properties('posts', 'pagination', 'featured');
-            formatted.featured.should.be.an.Object().with.properties('posts', 'pagination');
+            assert(formatted && typeof formatted === 'object');
+            assert('posts' in formatted && 'pagination' in formatted && 'featured' in formatted);
+            assert('posts' in formatted.featured && 'pagination' in formatted.featured);
         });
 
         it('should return post objects with html strings converted to SafeString', function () {
@@ -165,8 +160,6 @@ describe('Unit - services/routing/helpers/format-response', function () {
             const formatted = helpers.formatResponse.entries(data, true, locals);
             assert(!('show_title_and_feature_image' in formatted.page));
 
-            locals.should.be.an.Object().with.properties('_templateOptions');
-            locals._templateOptions.data.should.be.an.Object().with.properties('page');
             assert.equal(locals._templateOptions.data.page.show_title_and_feature_image, false);
         });
     });

--- a/ghost/core/test/unit/frontend/services/theme-engine/middleware.test.js
+++ b/ghost/core/test/unit/frontend/services/theme-engine/middleware.test.js
@@ -156,12 +156,17 @@ describe('Themes middleware', function () {
                     const templateOptions = hbsUpdateTemplateOptionsStub.firstCall.args[0];
                     const data = templateOptions.data;
 
-                    data.should.be.an.Object().with.properties('site', 'labs', 'config', 'custom');
+                    assert(data && typeof data === 'object');
+                    assert('site' in data);
+                    assert('labs' in data);
+                    assert('config' in data);
+                    assert('custom' in data);
 
                     // Check Theme Config
-                    data.config.should.be.an.Object()
-                        .with.properties(themeDataExpectedProps)
-                        .and.size(themeDataExpectedProps.length);
+                    assert(data.config && typeof data.config === 'object');
+                    assert('posts_per_page' in data.config);
+                    assert('image_sizes' in data.config);
+                    assert.equal(Object.keys(data.config).length, themeDataExpectedProps.length);
                     // posts per page should be set according to the stub
                     assert.equal(data.config.posts_per_page, 2);
 
@@ -222,9 +227,6 @@ describe('Themes middleware', function () {
                     const templateOptions = hbsUpdateLocalTemplateOptionsStub.firstCall.args[1];
                     const data = templateOptions.data;
 
-                    data.should.be.an.Object().with.properties('site');
-
-                    data.site.should.be.an.Object().with.properties('accent_color', '_preview');
                     assert.equal(data.site._preview, previewString);
                     assert.equal(data.site.accent_color, '#000fff');
 
@@ -249,9 +251,6 @@ describe('Themes middleware', function () {
                     const templateOptions = hbsUpdateLocalTemplateOptionsStub.firstCall.args[1];
                     const data = templateOptions.data;
 
-                    data.should.be.an.Object().with.properties('site');
-
-                    data.site.should.be.an.Object().with.properties('accent_color', 'icon', '_preview');
                     assert.equal(data.site._preview, previewString);
                     assert.equal(data.site.accent_color, '#000fff');
                     assert.equal(data.site.icon, '/content/images/myimg.png');
@@ -278,9 +277,8 @@ describe('Themes middleware', function () {
                     const templateOptions = hbsUpdateLocalTemplateOptionsStub.firstCall.args[1];
                     const data = templateOptions.data;
 
-                    data.should.be.an.Object().with.properties('site', 'custom');
-
-                    data.custom.should.be.an.Object().with.properties('header_typography');
+                    assert(data && typeof data === 'object');
+                    assert('site' in data);
                     assert.equal(data.custom.header_typography, 'Serif');
 
                     done();
@@ -305,9 +303,10 @@ describe('Themes middleware', function () {
                     const templateOptions = hbsUpdateLocalTemplateOptionsStub.firstCall.args[1];
                     const data = templateOptions.data;
 
-                    data.should.be.an.Object().with.properties('site', 'custom');
+                    assert(data && typeof data === 'object');
+                    assert('site' in data);
+                    assert('custom' in data);
 
-                    data.custom.should.be.an.Object().with.properties('header_typography');
                     assert.equal(data.custom.header_typography, 'Serif');
 
                     assert(!('unknown_setting' in data.custom));
@@ -333,8 +332,8 @@ describe('Themes middleware', function () {
                     const templateOptions = hbsUpdateLocalTemplateOptionsStub.firstCall.args[1];
                     const data = templateOptions.data;
 
-                    data.should.be.an.Object().with.properties('site', 'custom');
-
+                    assert(data && typeof data === 'object');
+                    assert('site' in data);
                     assert.deepEqual(data.custom, {});
 
                     done();
@@ -358,8 +357,8 @@ describe('Themes middleware', function () {
                     const templateOptions = hbsUpdateLocalTemplateOptionsStub.firstCall.args[1];
                     const data = templateOptions.data;
 
-                    data.should.be.an.Object().with.properties('site', 'custom');
-
+                    assert(data && typeof data === 'object');
+                    assert('site' in data);
                     assert.deepEqual(data.custom, {});
 
                     done();

--- a/ghost/core/test/unit/frontend/services/theme-engine/preview.test.js
+++ b/ghost/core/test/unit/frontend/services/theme-engine/preview.test.js
@@ -1,5 +1,5 @@
 const assert = require('node:assert/strict');
-const should = require('should');
+// No need for 'should' anymore
 
 const preview = require('../../../../../core/frontend/services/theme-engine/preview');
 
@@ -19,7 +19,6 @@ describe('Theme Preview', function () {
 
         let siteData = preview.handle(req, {});
 
-        siteData.should.be.an.Object().with.properties('logo');
         assert.equal(siteData.logo, null);
     });
 
@@ -28,7 +27,6 @@ describe('Theme Preview', function () {
 
         let siteData = preview.handle(req, {});
 
-        siteData.should.be.an.Object().with.properties('cover_image');
         assert.equal(siteData.cover_image, null);
     });
 
@@ -37,7 +35,6 @@ describe('Theme Preview', function () {
 
         let siteData = preview.handle(req, {});
 
-        siteData.should.be.an.Object().with.properties('accent_color');
         assert.equal(siteData.accent_color, '#f02d2d');
     });
 
@@ -45,7 +42,6 @@ describe('Theme Preview', function () {
         previewString = 'c=%23f02d2d&icon=&logo=&cover=null';
 
         let siteData = preview.handle(req, {});
-        siteData.should.be.an.Object().with.properties('accent_color', 'icon', 'logo', 'cover_image');
 
         assert.equal(siteData.accent_color, '#f02d2d');
         assert.equal(siteData.icon, null);

--- a/ghost/core/test/unit/frontend/web/middleware/static-theme.test.js
+++ b/ghost/core/test/unit/frontend/web/middleware/static-theme.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../utils/assertions');
-const should = require('should');
 const sinon = require('sinon');
 const _ = require('lodash');
 
@@ -110,7 +109,9 @@ describe('staticTheme', function () {
             // Check that express static gets called with the theme path + maxAge
             assertExists(expressStaticStub.firstCall.args);
             assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
-            expressStaticStub.firstCall.args[1].should.be.an.Object().with.property('maxAge');
+            const options = expressStaticStub.firstCall.args[1];
+            assert(options && typeof options === 'object');
+            assert('maxAge' in options);
 
             done();
         });
@@ -127,7 +128,9 @@ describe('staticTheme', function () {
             // Check that express static gets called with the theme path + maxAge
             assertExists(expressStaticStub.firstCall.args);
             assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
-            expressStaticStub.firstCall.args[1].should.be.an.Object().with.property('maxAge');
+            const options = expressStaticStub.firstCall.args[1];
+            assert(options && typeof options === 'object');
+            assert('maxAge' in options);
 
             done();
         });
@@ -158,7 +161,9 @@ describe('staticTheme', function () {
             // Check that express static gets called with the theme path + maxAge
             assertExists(expressStaticStub.firstCall.args);
             assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
-            expressStaticStub.firstCall.args[1].should.be.an.Object().with.property('maxAge');
+            const options = expressStaticStub.firstCall.args[1];
+            assert(options && typeof options === 'object');
+            assert('maxAge' in options);
 
             done();
         });
@@ -175,7 +180,9 @@ describe('staticTheme', function () {
             // Check that express static gets called with the theme path + maxAge
             assertExists(expressStaticStub.firstCall.args);
             assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
-            expressStaticStub.firstCall.args[1].should.be.an.Object().with.property('maxAge');
+            const options = expressStaticStub.firstCall.args[1];
+            assert(options && typeof options === 'object');
+            assert('maxAge' in options);
 
             done();
         });
@@ -192,7 +199,9 @@ describe('staticTheme', function () {
             // Check that express static gets called with the theme path + maxAge
             assertExists(expressStaticStub.firstCall.args);
             assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
-            expressStaticStub.firstCall.args[1].should.be.an.Object().with.property('maxAge');
+            const options = expressStaticStub.firstCall.args[1];
+            assert(options && typeof options === 'object');
+            assert('maxAge' in options);
 
             done();
         });
@@ -289,7 +298,9 @@ describe('staticTheme', function () {
                 // Check that express static gets called with the theme path + maxAge
                 assertExists(expressStaticStub.firstCall.args);
                 assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
-                expressStaticStub.firstCall.args[1].should.be.an.Object().with.property('maxAge');
+                const options = expressStaticStub.firstCall.args[1];
+                assert(options && typeof options === 'object');
+                assert('maxAge' in options);
 
                 done();
             });
@@ -306,7 +317,9 @@ describe('staticTheme', function () {
                 // Check that express static gets called with the theme path + maxAge
                 assertExists(expressStaticStub.firstCall.args);
                 assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
-                expressStaticStub.firstCall.args[1].should.be.an.Object().with.property('maxAge');
+                const options = expressStaticStub.firstCall.args[1];
+                assert(options && typeof options === 'object');
+                assert('maxAge' in options);
 
                 done();
             });
@@ -323,7 +336,9 @@ describe('staticTheme', function () {
                 // Check that express static gets called with the theme path + maxAge
                 assertExists(expressStaticStub.firstCall.args);
                 assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
-                expressStaticStub.firstCall.args[1].should.be.an.Object().with.property('maxAge');
+                const options = expressStaticStub.firstCall.args[1];
+                assert(options && typeof options === 'object');
+                assert('maxAge' in options);
 
                 done();
             });

--- a/ghost/core/test/unit/server/lib/package-json/filter.test.js
+++ b/ghost/core/test/unit/server/lib/package-json/filter.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-require('should');
 
 const packageJSON = require('../../../../../core/server/lib/package-json');
 
@@ -48,11 +47,16 @@ describe('package-json filter', function () {
         assert.equal(result.length, 1);
         package1 = result[0];
 
-        package1.should.be.an.Object().with.properties('name', 'package', 'active');
+        assert(package1 && typeof package1 === 'object');
+        assert('name' in package1);
+        assert('package' in package1);
+        assert('active' in package1);
         assert(Array.isArray(Object.keys(package1)));
         assert.equal(Object.keys(package1).length, 3);
         assert.equal(package1.name, 'casper');
-        package1.package.should.be.an.Object().with.properties('name', 'version');
+        assert(package1.package && typeof package1.package === 'object');
+        assert('name' in package1.package);
+        assert('version' in package1.package);
         assert.equal(package1.active, false);
     });
 
@@ -66,18 +70,28 @@ describe('package-json filter', function () {
         package1 = result[0];
         package2 = result[1];
 
-        package1.should.be.an.Object().with.properties('name', 'package', 'active');
+        assert(package1 && typeof package1 === 'object');
+        assert('name' in package1);
+        assert('package' in package1);
+        assert('active' in package1);
         assert(Array.isArray(Object.keys(package1)));
         assert.equal(Object.keys(package1).length, 3);
         assert.equal(package1.name, 'casper');
-        package1.package.should.be.an.Object().with.properties('name', 'version');
+        assert(package1.package && typeof package1.package === 'object');
+        assert('name' in package1.package);
+        assert('version' in package1.package);
         assert.equal(package1.active, true);
 
-        package2.should.be.an.Object().with.properties('name', 'package', 'active');
+        assert(package2 && typeof package2 === 'object');
+        assert('name' in package2);
+        assert('package' in package2);
+        assert('active' in package2);
         assert(Array.isArray(Object.keys(package2)));
         assert.equal(Object.keys(package2).length, 3);
         assert.equal(package2.name, 'simple');
-        package2.package.should.be.an.Object().with.properties('name', 'version');
+        assert(package2.package && typeof package2.package === 'object');
+        assert('name' in package2.package);
+        assert('version' in package2.package);
         assert.equal(package2.active, false);
     });
 
@@ -91,18 +105,28 @@ describe('package-json filter', function () {
         package1 = result[0];
         package2 = result[1];
 
-        package1.should.be.an.Object().with.properties('name', 'package', 'active');
+        assert(package1 && typeof package1 === 'object');
+        assert('name' in package1);
+        assert('package' in package1);
+        assert('active' in package1);
         assert(Array.isArray(Object.keys(package1)));
         assert.equal(Object.keys(package1).length, 3);
         assert.equal(package1.name, 'casper');
-        package1.package.should.be.an.Object().with.properties('name', 'version');
+        assert(package1.package && typeof package1.package === 'object');
+        assert('name' in package1.package);
+        assert('version' in package1.package);
         assert.equal(package1.active, true);
 
-        package2.should.be.an.Object().with.properties('name', 'package', 'active');
+        assert(package2 && typeof package2 === 'object');
+        assert('name' in package2);
+        assert('package' in package2);
+        assert('active' in package2);
         assert(Array.isArray(Object.keys(package2)));
         assert.equal(Object.keys(package2).length, 3);
         assert.equal(package2.name, 'simple');
-        package2.package.should.be.an.Object().with.properties('name', 'version');
+        assert(package2.package && typeof package2.package === 'object');
+        assert('name' in package2.package);
+        assert('version' in package2.package);
         assert.equal(package2.active, true);
     });
 
@@ -116,14 +140,22 @@ describe('package-json filter', function () {
         package1 = result[0];
         package2 = result[1];
 
-        package1.should.be.an.Object().with.properties('name', 'package', 'active');
+        assert(package1 && typeof package1 === 'object');
+        assert('name' in package1);
+        assert('package' in package1);
+        assert('active' in package1);
         assert(Array.isArray(Object.keys(package1)));
         assert.equal(Object.keys(package1).length, 3);
         assert.equal(package1.name, 'casper');
-        package1.package.should.be.an.Object().with.properties('name', 'version');
+        assert(package1.package && typeof package1.package === 'object');
+        assert('name' in package1.package);
+        assert('version' in package1.package);
         assert.equal(package1.active, true);
 
-        package2.should.be.an.Object().with.properties('name', 'package', 'active');
+        assert(package2 && typeof package2 === 'object');
+        assert('name' in package2);
+        assert('package' in package2);
+        assert('active' in package2);
         assert(Array.isArray(Object.keys(package2)));
         assert.equal(Object.keys(package2).length, 3);
         assert.equal(package2.name, 'missing');

--- a/ghost/core/test/unit/server/notify.test.js
+++ b/ghost/core/test/unit/server/notify.test.js
@@ -44,7 +44,8 @@ describe('Notify', function () {
             assert.equal(process.send.calledOnce, true);
 
             let message = process.send.firstCall.args[0];
-            message.should.be.an.Object().with.properties('started', 'debug');
+            assert(message && typeof message === 'object');
+            assert('debug' in message);
             assert(!('error' in message));
             assert.equal(message.started, true);
         });
@@ -55,9 +56,9 @@ describe('Notify', function () {
             assert.equal(process.send.calledOnce, true);
 
             let message = process.send.firstCall.args[0];
-            message.should.be.an.Object().with.properties('started', 'debug', 'error');
+            assert(message && typeof message === 'object');
+            assert('debug' in message);
             assert.equal(message.started, false);
-            message.error.should.be.an.Object().with.properties('message');
             assert.equal(message.error.message, 'something went wrong');
         });
 
@@ -70,7 +71,8 @@ describe('Notify', function () {
             assert.equal(socketStub.firstCall.args[0], 'testing');
 
             let message = socketStub.firstCall.args[1];
-            message.should.be.an.Object().with.properties('started', 'debug');
+            assert(message && typeof message === 'object');
+            assert('debug' in message);
             assert(!('error' in message));
             assert.equal(message.started, true);
         });
@@ -84,9 +86,9 @@ describe('Notify', function () {
             assert.equal(socketStub.firstCall.args[0], 'testing');
 
             let message = socketStub.firstCall.args[1];
-            message.should.be.an.Object().with.properties('started', 'debug', 'error');
+            assert(message && typeof message === 'object');
+            assert('debug' in message);
             assert.equal(message.started, false);
-            message.error.should.be.an.Object().with.properties('message');
             assert.equal(message.error.message, 'something went wrong');
         });
 

--- a/ghost/core/test/unit/server/services/permissions/providers.test.js
+++ b/ghost/core/test/unit/server/services/permissions/providers.test.js
@@ -61,7 +61,9 @@ describe('Permission Providers', function () {
                 .then(function (res) {
                     assert.equal(findUserSpy.callCount, 1);
 
-                    res.should.be.an.Object().with.properties('permissions', 'roles');
+                    assert(res && typeof res === 'object');
+                    assert('permissions' in res);
+                    assert('roles' in res);
 
                     assert(Array.isArray(res.permissions));
                     assert.equal(res.permissions.length, 10);
@@ -71,10 +73,15 @@ describe('Permission Providers', function () {
                     // @TODO fix this!
                     // Permissions is an array of models
                     // Roles is a JSON array
-                    res.permissions[0].should.be.an.Object().with.properties('attributes', 'id');
-                    res.roles[0].should.be.an.Object().with.properties('id', 'name', 'description');
+                    assert(res.permissions[0] && typeof res.permissions[0] === 'object');
+                    assert('attributes' in res.permissions[0]);
+                    assert('id' in res.permissions[0]);
+                    assert(res.roles[0] && typeof res.roles[0] === 'object');
+                    assert('id' in res.roles[0]);
+                    assert('name' in res.roles[0]);
+                    assert('description' in res.roles[0]);
                     assert(res.permissions[0] instanceof models.Base.Model);
-                    res.roles[0].should.not.be.instanceOf(models.Base.Model);
+                    assert(!(res.roles[0] instanceof models.Base.Model));
 
                     done();
                 })
@@ -113,7 +120,9 @@ describe('Permission Providers', function () {
                 .then(function (res) {
                     assert.equal(findUserSpy.callCount, 1);
 
-                    res.should.be.an.Object().with.properties('permissions', 'roles');
+                    assert(res && typeof res === 'object');
+                    assert('permissions' in res);
+                    assert('roles' in res);
 
                     assert(Array.isArray(res.permissions));
                     assert.equal(res.permissions.length, 10);
@@ -123,10 +132,15 @@ describe('Permission Providers', function () {
                     // @TODO fix this!
                     // Permissions is an array of models
                     // Roles is a JSON array
-                    res.permissions[0].should.be.an.Object().with.properties('attributes', 'id');
-                    res.roles[0].should.be.an.Object().with.properties('id', 'name', 'description');
+                    assert(res.permissions[0] && typeof res.permissions[0] === 'object');
+                    assert('attributes' in res.permissions[0]);
+                    assert('id' in res.permissions[0]);
+                    assert(res.roles[0] && typeof res.roles[0] === 'object');
+                    assert('id' in res.roles[0]);
+                    assert('name' in res.roles[0]);
+                    assert('description' in res.roles[0]);
                     assert(res.permissions[0] instanceof models.Base.Model);
-                    res.roles[0].should.not.be.instanceOf(models.Base.Model);
+                    assert(!(res.roles[0] instanceof models.Base.Model));
 
                     done();
                 })
@@ -166,7 +180,9 @@ describe('Permission Providers', function () {
                 .then(function (res) {
                     assert.equal(findUserSpy.callCount, 1);
 
-                    res.should.be.an.Object().with.properties('permissions', 'roles');
+                    assert(res && typeof res === 'object');
+                    assert('permissions' in res);
+                    assert('roles' in res);
 
                     assert(Array.isArray(res.permissions));
                     assert.equal(res.permissions.length, 10);
@@ -176,10 +192,15 @@ describe('Permission Providers', function () {
                     // @TODO fix this!
                     // Permissions is an array of models
                     // Roles is a JSON array
-                    res.permissions[0].should.be.an.Object().with.properties('attributes', 'id');
-                    res.roles[0].should.be.an.Object().with.properties('id', 'name', 'description');
+                    assert(res.permissions[0] && typeof res.permissions[0] === 'object');
+                    assert('attributes' in res.permissions[0]);
+                    assert('id' in res.permissions[0]);
+                    assert(res.roles[0] && typeof res.roles[0] === 'object');
+                    assert('id' in res.roles[0]);
+                    assert('name' in res.roles[0]);
+                    assert('description' in res.roles[0]);
                     assert(res.permissions[0] instanceof models.Base.Model);
-                    res.roles[0].should.not.be.instanceOf(models.Base.Model);
+                    assert(!(res.roles[0] instanceof models.Base.Model));
 
                     done();
                 })
@@ -239,13 +260,20 @@ describe('Permission Providers', function () {
             });
             providers.apiKey(1).then((res) => {
                 assert.equal(findApiKeySpy.callCount, 1);
-                res.should.be.an.Object().with.properties('permissions', 'roles');
+                assert(res && typeof res === 'object');
+                assert('permissions' in res);
+                assert('roles' in res);
                 assert(Array.isArray(res.roles));
                 assert.equal(res.roles.length, 1);
-                res.permissions[0].should.be.an.Object().with.properties('attributes', 'id');
-                res.roles[0].should.be.an.Object().with.properties('id', 'name', 'description');
+                assert(res.permissions[0] && typeof res.permissions[0] === 'object');
+                assert('attributes' in res.permissions[0]);
+                assert('id' in res.permissions[0]);
+                assert(res.roles[0] && typeof res.roles[0] === 'object');
+                assert('id' in res.roles[0]);
+                assert('name' in res.roles[0]);
+                assert('description' in res.roles[0]);
                 assert(res.permissions[0] instanceof models.Base.Model);
-                res.roles[0].should.not.be.instanceOf(models.Base.Model);
+                assert(!(res.roles[0] instanceof models.Base.Model));
                 done();
             }).catch(done);
         });

--- a/ghost/core/test/unit/server/services/route-settings/settings-loader.test.js
+++ b/ghost/core/test/unit/server/services/route-settings/settings-loader.test.js
@@ -55,7 +55,8 @@ describe('UNIT > SettingsLoader:', function () {
 
             const result = await settingsLoader.loadSettings();
             assertExists(result);
-            result.should.be.an.Object().with.properties('routes', 'collections', 'taxonomies');
+            assert(typeof result === 'object' && result !== null);
+            assert('routes' in result && 'collections' in result && 'taxonomies' in result);
             assert.equal(fsReadFileStub.calledOnce, true);
         });
 
@@ -75,7 +76,8 @@ describe('UNIT > SettingsLoader:', function () {
             });
             const setting = await settingsLoader.loadSettings();
             assertExists(setting);
-            setting.should.be.an.Object().with.properties('routes', 'collections', 'taxonomies');
+            assert(typeof setting === 'object' && setting !== null);
+            assert('routes' in setting && 'collections' in setting && 'taxonomies' in setting);
 
             assert.equal(fsReadFileSpy.calledOnce, true);
             assert.equal(fsReadFileSpy.calledWith(expectedSettingsFile), true);

--- a/ghost/core/test/unit/server/services/route-settings/yaml-parser.test.js
+++ b/ghost/core/test/unit/server/services/route-settings/yaml-parser.test.js
@@ -1,7 +1,6 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../utils/assertions');
 const sinon = require('sinon');
-const should = require('should');
 const fs = require('fs-extra');
 const yaml = require('js-yaml');
 const path = require('path');
@@ -24,7 +23,10 @@ describe('UNIT > Settings Service yaml parser:', function () {
 
             const result = yamlParser(file);
             assertExists(result);
-            result.should.be.an.Object().with.properties('routes', 'collections', 'taxonomies');
+            assert(result && typeof result === 'object');
+            assert('routes' in result);
+            assert('collections' in result);
+            assert('taxonomies' in result);
             assert.equal(yamlSpy.calledOnce, true);
         });
 

--- a/ghost/core/test/unit/server/services/themes/list.test.js
+++ b/ghost/core/test/unit/server/services/themes/list.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../utils/assertions');
-const should = require('should');
 const sinon = require('sinon');
 const _ = require('lodash');
 const themeList = require('../../../../../core/server/services/themes/list');
@@ -27,8 +26,10 @@ describe('Themes', function () {
         });
 
         it('getAll() returns all themes', function () {
-            themeList.getAll().should.be.an.Object().with.properties('casper', 'not-casper');
-            assert.equal(Object.keys(themeList.getAll()).length, 2);
+            assert.deepEqual(
+                new Set(Object.keys(themeList.getAll())),
+                new Set(['casper', 'not-casper'])
+            );
         });
 
         it('set() updates an existing theme', function () {

--- a/ghost/core/test/unit/server/services/themes/list.test.js
+++ b/ghost/core/test/unit/server/services/themes/list.test.js
@@ -35,7 +35,7 @@ describe('Themes', function () {
             const origCasper = _.cloneDeep(themeList.get('casper'));
             themeList.set('casper', {magic: 'update'});
 
-            themeList.get('casper').should.not.eql(origCasper);
+            assert.notDeepEqual(themeList.get('casper'), origCasper);
             assert.deepEqual(themeList.get('casper'), {magic: 'update'});
         });
 

--- a/ghost/core/test/utils/assertions.js
+++ b/ghost/core/test/utils/assertions.js
@@ -45,12 +45,14 @@ function assertArrayContainsDeep(arr, expectedElements, message) {
  */
 function objectMatches(obj, properties) {
     for (const [key, value] of Object.entries(properties)) {
-        if (isPlainObject(obj[key])) {
-            return objectMatches(obj[key], value);
-        } else {
-            return isDeepStrictEqual(obj[key], value);
+        const matches = isPlainObject(obj[key])
+            ? objectMatches(obj[key], value)
+            : isDeepStrictEqual(obj[key], value);
+        if (!matches) {
+            return false;
         }
     }
+    return true;
 }
 
 /**

--- a/ghost/core/test/utils/assertions.js
+++ b/ghost/core/test/utils/assertions.js
@@ -41,6 +41,49 @@ function assertArrayContainsDeep(arr, expectedElements, message) {
  * @template T
  * @param {T} obj
  * @param {Partial<T>} properties
+ * @returns {boolean}
+ */
+function objectMatches(obj, properties) {
+    for (const [key, value] of Object.entries(properties)) {
+        if (isPlainObject(obj[key])) {
+            return objectMatches(obj[key], value);
+        } else {
+            return isDeepStrictEqual(obj[key], value);
+        }
+    }
+}
+
+/**
+ * @internal
+ * @template T
+ * @typedef {(
+ *     T extends Object
+ *         ? {[P in keyof T]?: DeepPartial<T[P]>}
+ *         : T
+ * )} DeepPartial
+ */
+
+/**
+ * @template {object} T
+ * @param {ReadonlyArray<T>} haystack
+ * @param {ReadonlyArray<DeepPartial<T>>} needles
+ * @returns {void}
+ */
+function assertArrayMatchesWithoutOrder(haystack, needles) {
+    assert.equal(
+        haystack.length,
+        needles.length,
+        `Expected ${needles.length} items, but got ${haystack.length}`
+    );
+    for (const a of needles) {
+        assert(haystack.some(el => objectMatches(el, a)));
+    }
+}
+
+/**
+ * @template {object} T
+ * @param {T} obj
+ * @param {DeepPartial<T>} properties
  * @param {string} [message]
  * @returns {void}
  */
@@ -62,5 +105,6 @@ module.exports = {
     assertExists,
     assertMatchSnapshot,
     assertArrayContainsDeep,
+    assertArrayMatchesWithoutOrder,
     assertObjectMatches
 };


### PR DESCRIPTION
This test-only change should have no user impact.

This replaces the following Should.js assertions with `node:assert`:

- `.should.not.eql`
- `.should.matchAny`
- `.should.be.an.Object()`
