### PR TITLE
Updated member subscription detail to show offer type and discounted price

### DIFF
--- a/ghost/admin/app/components/gh-member-settings-form.hbs
+++ b/ghost/admin/app/components/gh-member-settings-form.hbs
@@ -115,11 +115,17 @@
                         <div class="gh-main-content-card gh-cp-membertier gh-cp-membertier-attribution gh-membertier-subscription">
                             {{#each this.tiers as |tier|}}
                                 {{#each tier.subscriptions as |sub index|}}
-                                    <div class="gh-tier-card-header flex items-center" data-test-tier={{tier.id}}>
+                                    <div class="gh-tier-card-header flex items-start" data-test-tier={{tier.id}}>
                                         <div class="gh-tier-card-price">
                                             <div class="flex items-start">
-                                                <span class="currency-symbol">{{sub.price.currencySymbol}}</span>
-                                                <span class="amount">{{format-number sub.price.nonDecimalAmount}}</span>
+                                                {{#if sub.hasActiveDiscount}}
+                                                    <span class="currency-symbol">{{sub.discountedPrice.currencySymbol}}</span>
+                                                    <span class="amount">{{format-number sub.discountedPrice.nonDecimalAmount}}</span>
+                                                    <span class="gh-membertier-original-price">{{sub.originalPrice.currencySymbol}}{{format-number sub.originalPrice.nonDecimalAmount}}</span>
+                                                {{else}}
+                                                    <span class="currency-symbol">{{sub.price.currencySymbol}}</span>
+                                                    <span class="amount">{{format-number sub.price.nonDecimalAmount}}</span>
+                                                {{/if}}
                                             </div>
                                             <div class="period">{{if (eq sub.price.interval "year") "yearly" "monthly"}}</div>
                                         </div>

--- a/ghost/admin/app/components/member/subscription-detail-box.hbs
+++ b/ghost/admin/app/components/member/subscription-detail-box.hbs
@@ -22,37 +22,18 @@
         </div>
         {{#if (or @sub.cancellationReason @sub.offer)}}
         <div class="gh-membertier-offer-cancellation">
+            {{#if @sub.offer}}
+            <div class="gh-membertier-details">
+                <p>
+                    {{@sub.offerLabel}}&nbsp;&mdash;&nbsp;<span>{{@sub.offerDetails}}</span>
+                </p>
+            </div>
+            {{/if}}
             {{#if @sub.cancellationReason}}
             <div>
                 <h4>Cancellation reason</h4>
                 <div class="gh-membertier-cancelreason">{{@sub.cancellationReason}}</div>
             </div>
-            {{/if}}
-            {{#if @sub.offer}}
-                {{#if (eq @sub.offer.type "trial")}}
-                <div>
-                    <h4>Offer</h4>
-                    <span class="gh-cp-membertier-pricelabel"> {{@sub.offer.name}} </span>
-                    &ndash; {{@sub.offer.amount}} days free
-                </div>
-                {{else if (eq @sub.offer.type "free_months")}}
-                <div>
-                    <h4>Offer</h4>
-                    <span class="gh-cp-membertier-pricelabel"> {{@sub.offer.name}} </span>
-                    &ndash; {{@sub.offer.amount}} {{if (eq @sub.offer.amount 1) "month" "months"}} free
-                </div>
-                {{else}}
-                <div>
-                    <h4>Offer</h4>
-                    <span class="gh-cp-membertier-pricelabel"> {{@sub.offer.name}}
-                    {{#if (eq @sub.offer.type 'fixed')}}
-                    &ndash; {{currency-symbol @sub.offer.currency}}{{gh-price-amount @sub.offer.amount}} off
-                    {{else}}
-                    &ndash; {{@sub.offer.amount}}% off
-                    {{/if}}
-                    </span>
-                </div>
-                {{/if}}
             {{/if}}
         </div>
         {{/if}}

--- a/ghost/admin/app/styles/layouts/members.css
+++ b/ghost/admin/app/styles/layouts/members.css
@@ -2965,6 +2965,15 @@ a.gh-members-emailpreview-subscription-link {
     border-radius: 6px;
 }
 
+.gh-membertier-original-price {
+    margin-left: 4px;
+    font-size: 1.4rem;
+    font-weight: 500;
+    color: var(--midgrey);
+    text-decoration: line-through;
+    align-self: center;
+}
+
 .gh-cp-membertier-attribution .amount {
     font-weight: bold !important;
     font-size: 2.4rem !important;


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3242/show-discounted-subscription-price-on-admin-member-page

- Distinguished between signup and retention offers in subscription details
- Displayed offer info using attribution-style layout (e.g. "Signup offer — Black Friday (30% off)")
- Added strikethrough original price when an active discount exists

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily UI/data-shaping changes, but relies on `next_payment`/discount fields for pricing display which could misrepresent amounts if upstream data is missing or inconsistent.
> 
> **Overview**
> Updates the member subscriptions UI to surface **active discounts** by showing the discounted next payment amount alongside a struck-through original price.
> 
> Refactors subscription “Offer” details to a single attribution-style line that distinguishes *Signup* vs *Retention* offers, with retention offers optionally showing an “until MMM YYYY” end date derived from `next_payment.discount`.
> 
> Adds supporting subscription data helpers (`offerLabel`, `offerDetails`, `discountPrice`) and related styling for the original-price strike-through.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e2b4a1eeeeee238a9f6bfbc060a532d262f375a6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->