### PR TITLE
Fixed flaky portal upgrade browser test

### DIFF
--- a/ghost/core/test/e2e-browser/portal/donations.spec.js
+++ b/ghost/core/test/e2e-browser/portal/donations.spec.js
@@ -1,6 +1,6 @@
 const {expect} = require('@playwright/test');
 const test = require('../fixtures/ghost-test');
-const {createMember, impersonateMember, completeStripeSubscription} = require('../utils');
+const {createMember, impersonateMember, submitStripePayment} = require('../utils');
 
 test.describe('Portal', () => {
     test.describe('Donations', () => {
@@ -16,7 +16,7 @@ test.describe('Portal', () => {
             if (await sharedPage.getByTestId('card-tab-button').isVisible()) {
                 await sharedPage.getByTestId('card-tab-button').dispatchEvent('click');
             }
-            await completeStripeSubscription(sharedPage);
+            await submitStripePayment(sharedPage);
             await sharedPage.waitForSelector('[data-testid="portal-popup-frame"]', {state: 'visible'});
             expect(sharedPage.url()).toMatch(/[^\/]\/#\/portal\/support\/success/); // Ensure correct URL and no double-slash
             const portalFrame = sharedPage.frameLocator('[data-testid="portal-popup-frame"]');
@@ -45,7 +45,7 @@ test.describe('Portal', () => {
             if (await sharedPage.getByTestId('card-tab-button').isVisible()) {
                 await sharedPage.getByTestId('card-tab-button').dispatchEvent('click');
             }
-            await completeStripeSubscription(sharedPage);
+            await submitStripePayment(sharedPage);
 
             // Check success notification
             const notificationFrame = sharedPage.frameLocator('[data-testid="portal-notification-frame"]');
@@ -76,7 +76,7 @@ test.describe('Portal', () => {
             if (await sharedPage.getByTestId('card-tab-button').isVisible()) {
                 await sharedPage.getByTestId('card-tab-button').dispatchEvent('click');
             }
-            await completeStripeSubscription(sharedPage);
+            await submitStripePayment(sharedPage);
 
             // Check success message
             await sharedPage.waitForSelector('[data-testid="portal-popup-frame"]', {state: 'visible'});

--- a/ghost/core/test/e2e-browser/portal/upgrade.spec.js
+++ b/ghost/core/test/e2e-browser/portal/upgrade.spec.js
@@ -46,13 +46,13 @@ test.describe('Portal', () => {
                 // select the tier for checkout (yearly)
                 await choseTierByName(portalFrame, tierName);
 
-                // complete stripe checkout
+                // complete stripe checkout and wait for webhook to process
                 await completeStripeSubscription(sharedPage);
 
                 // open portal and check that member has been upgraded to paid tier
                 await expect(portalTriggerButton).toBeVisible();
                 await portalTriggerButton.click();
-                await expect(portalFrame.getByText('$50.00/year')).toBeVisible({timeout: 30000});
+                await expect(portalFrame.getByText('$50.00/year')).toBeVisible();
                 await expect(portalFrame.getByRole('heading', {name: 'Billing info'})).toBeVisible();
                 await expect(portalFrame.getByText('**** **** **** 4242')).toBeVisible();
 
@@ -99,7 +99,7 @@ test.describe('Portal', () => {
                 // select the tier for checkout (yearly)
                 await choseTierByName(portalFrame, tierName);
 
-                // complete stripe checkout
+                // complete stripe checkout and wait for webhook to process
                 await completeStripeSubscription(sharedPage);
 
                 // open portal and check that member has been upgraded to paid tier
@@ -107,7 +107,7 @@ test.describe('Portal', () => {
                 await portalTriggerButton.click();
                 // verify member's tier, price and card details
                 await expect(portalFrame.getByText(tierName)).toBeVisible();
-                await expect(portalFrame.getByText('$50.00/year')).toBeVisible({timeout: 30000});
+                await expect(portalFrame.getByText('$50.00/year')).toBeVisible();
                 await expect(portalFrame.getByText('**** **** **** 4242')).toBeVisible();
 
                 // verify member's tier on member detail page in admin


### PR DESCRIPTION
## Summary
- Refactored `completeStripeSubscription` to poll the Members API (`/members/api/member/`) until the member has `paid` status, replacing the unreliable `waitForLoadState('networkidle')` which returned before the Stripe webhook was processed
- Extracted `submitStripePayment` helper for non-subscription checkouts (donations) where the member won't become paid
- Removed hardcoded `{timeout: 30000}` from upgrade test assertions since the webhook is now confirmed processed before Portal is opened

The "allows comped member to upgrade to paid tier" test was [failing in CI](https://github.com/TryGhost/Ghost/actions/runs/22138287071/job/63996023980?pr=26443) on all 3 attempts because Portal was checking for subscription data before the Stripe webhook had updated the member from comped to paid.