### PR TITLE
Updated Stripe test card expiry to far-future date

### DIFF
--- a/ghost/core/test/e2e-browser/utils/e2e-browser-utils.js
+++ b/ghost/core/test/e2e-browser/utils/e2e-browser-utils.js
@@ -333,7 +333,7 @@ const fillInputIfExists = async (page, selector, value) => {
  */
 const submitStripePayment = async (page) => {
     await page.locator('#cardNumber').fill('4242 4242 4242 4242');
-    await page.locator('#cardExpiry').fill('04 / 26');
+    await page.locator('#cardExpiry').fill('12 / 30');
     await page.locator('#cardCvc').fill('424');
     await page.locator('#billingName').fill('Testy McTesterson');
     await page.getByRole('combobox', {name: 'Country or region'}).selectOption('US');


### PR DESCRIPTION
## Summary
- Updated the hardcoded Stripe test card expiry from `04 / 26` to `12 / 30` in browser test utils
- The old date (April 2026) is about to expire, which would cause Stripe to reject the test card and fail CI browser tests