### PR TITLE
Fixed free month offers decreasing MRR

### DIFF
--- a/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
@@ -184,8 +184,8 @@ module.exports = class MemberRepository {
         return source;
     }
 
-    getMRR({interval, amount, status = null, canceled = false, discount = null}) {
-        if (status === 'trialing') {
+    getMRR({interval, amount, status = null, canceled = false, discount = null, offer = null}) {
+        if (status === 'trialing' && (!offer || offer.type === 'trial')) {
             return 0;
         }
         if (status === 'incomplete') {
@@ -1064,6 +1064,7 @@ module.exports = class MemberRepository {
 
         // For trial offers, offer id is passed from metadata as there is no stripe coupon
         let offerId = data.offerId || null;
+        let offer = null;
 
         if (stripeCouponId && !offerId && ghostProduct) {
             const coupon = stripeSubscriptionData.discount.coupon;
@@ -1071,7 +1072,7 @@ module.exports = class MemberRepository {
             const tier = {id: ghostProduct.get('id'), name: ghostProduct.get('name')};
 
             try {
-                const offer = await this._offersAPI.ensureOfferForStripeCoupon(
+                offer = await this._offersAPI.ensureOfferForStripeCoupon(
                     coupon,
                     cadence,
                     tier,
@@ -1090,6 +1091,10 @@ module.exports = class MemberRepository {
                     throw e;
                 }
             }
+        }
+
+        if (offerId && !offer) {
+            offer = await this._offersAPI.getOffer({id: offerId}, options);
         }
 
         const subscriptionData = {
@@ -1119,7 +1124,8 @@ module.exports = class MemberRepository {
                 amount: subscriptionPriceData.unit_amount,
                 status: stripeSubscriptionData.status,
                 canceled: stripeSubscriptionData.cancel_at_period_end,
-                discount: stripeSubscriptionData.discount
+                discount: stripeSubscriptionData.discount,
+                offer: offer
             }),
             offer_id: offerId,
             discount_start: stripeSubscriptionData.discount?.start ? new Date(stripeSubscriptionData.discount.start * 1000) : null,

--- a/ghost/core/test/e2e-api/members/member-offers.test.js
+++ b/ghost/core/test/e2e-api/members/member-offers.test.js
@@ -2,6 +2,7 @@ const {agentProvider, mockManager, fixtureManager} = require('../../utils/e2e-fr
 const models = require('../../../core/server/models');
 const assert = require('node:assert/strict');
 const DomainEvents = require('@tryghost/domain-events');
+const addCalendarMonths = require('../../../core/server/services/members/members-api/utils/add-calendar-months');
 
 let membersAgent;
 let membersService;
@@ -810,11 +811,18 @@ describe('Members API - Member Offers', function () {
             const {subscription} = await getMemberSubscription('paid@test.com');
             const stripePrice = subscription.related('stripePrice');
             const stripeProduct = stripePrice.related('stripeProduct');
-
             const stripeSubscriptionId = subscription.get('subscription_id');
             const cadence = stripePrice.get('interval');
+            const originalCurrentPeriodEnd = subscription.get('current_period_end');
 
-            const currentPeriodEnd = subscription.get('current_period_end');
+            // Make sure the test subscription fixture has an active billing period
+            const currentPeriodEnd = new Date();
+            currentPeriodEnd.setUTCDate(currentPeriodEnd.getUTCDate() + 30);
+            currentPeriodEnd.setUTCMilliseconds(0);
+            await subscription.save({current_period_end: currentPeriodEnd}, {patch: true});
+            await subscription.refresh();
+
+            const expectedMrr = stripePrice.get('amount');
 
             const mockPrice = {
                 id: stripePrice.get('stripe_price_id'),
@@ -891,17 +899,23 @@ describe('Members API - Member Offers', function () {
 
                 await subscription.refresh();
                 assert.equal(subscription.get('offer_id'), retentionOffer.id);
+                assert.equal(subscription.get('mrr'), expectedMrr, 'MRR should not change');
+
+                // Subscription now should have a trialing status
+                assert.equal(subscription.get('status'), 'trialing');
 
                 // Trial period should be set to current period end + 1 month
-                const expectedTrialEnd = new Date(currentPeriodEnd);
-                expectedTrialEnd.setUTCMonth(expectedTrialEnd.getUTCMonth() + 1);
-
+                const expectedTrialEnd = addCalendarMonths(currentPeriodEnd, 1);
                 const trialEndAt = subscription.get('trial_end_at');
 
                 assert.ok(trialEndAt, 'trial_end_at should be set');
-                assert.equal(new Date(trialEndAt).getTime(), expectedTrialEnd.getTime());
+                assert.equal(
+                    trialEndAt.toISOString(),
+                    expectedTrialEnd.toISOString(),
+                    'Trial end date should be set to current period end + 1 month'
+                );
 
-                // Verify offer redemption was recorded
+                // Offer redemption should be recorded
                 const redemption = await models.OfferRedemption.findOne({
                     offer_id: retentionOffer.id,
                     subscription_id: subscription.id
@@ -915,7 +929,11 @@ describe('Members API - Member Offers', function () {
                 if (redemption) {
                     await models.OfferRedemption.destroy({id: redemption.id});
                 }
-                await subscription.save({offer_id: null, trial_end_at: null}, {patch: true});
+                await subscription.save({
+                    offer_id: null,
+                    trial_end_at: null,
+                    current_period_end: originalCurrentPeriodEnd
+                }, {patch: true});
                 await models.Offer.destroy({id: retentionOffer.id});
             }
         });

--- a/ghost/core/test/unit/server/services/members/members-api/repositories/member-repository.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/repositories/member-repository.test.js
@@ -64,6 +64,50 @@ describe('MemberRepository', function () {
         });
     });
 
+    describe('#getMRR', function () {
+        it('trial subscriptions have a MRR of 0', function () {
+            const repo = new MemberRepository({OfferRedemption: mockOfferRedemption});
+
+            const mrr = repo.getMRR({
+                interval: 'month',
+                amount: 500,
+                status: 'trialing'
+            });
+
+            assert.equal(mrr, 0);
+        });
+
+        it('offers of type trial have a MRR of 0', function () {
+            const repo = new MemberRepository({OfferRedemption: mockOfferRedemption});
+
+            const mrr = repo.getMRR({
+                interval: 'month',
+                amount: 500,
+                status: 'trialing',
+                offer: {
+                    type: 'trial'
+                }
+            });
+
+            assert.equal(mrr, 0);
+        });
+
+        it('offers of type free_months have no impact on MRR', function () {
+            const repo = new MemberRepository({OfferRedemption: mockOfferRedemption});
+
+            const mrr = repo.getMRR({
+                interval: 'month',
+                amount: 500,
+                status: 'trialing',
+                offer: {
+                    type: 'free_months'
+                }
+            });
+
+            assert.equal(mrr, 500);
+        });
+    });
+
     describe('setComplimentarySubscription', function () {
         let Member;
         let productRepository;

--- a/ghost/core/test/utils/stripe-mocker.js
+++ b/ghost/core/test/utils/stripe-mocker.js
@@ -241,6 +241,44 @@ class StripeMocker {
     }
 
     /**
+     * Stripe sets subscription status to `trialing` when trial_end is in the future.
+     * The mock emulates this behavior for updates where status is not explicitly provided.
+     *
+     * @param {object} subscription
+     * @param {object} payload
+     */
+    #syncSubscriptionStatusWithTrialEnd(subscription, payload) {
+        if (!Object.prototype.hasOwnProperty.call(payload, 'trial_end')) {
+            return;
+        }
+
+        if (Object.prototype.hasOwnProperty.call(payload, 'status')) {
+            return;
+        }
+
+        const trialEnd = subscription.trial_end;
+        const now = Math.floor(Date.now() / 1000);
+
+        if (trialEnd === 'now' || trialEnd === null) {
+            if (subscription.status === 'trialing') {
+                subscription.status = 'active';
+            }
+            return;
+        }
+
+        const numericTrialEnd = typeof trialEnd === 'string' ? Number.parseFloat(trialEnd) : trialEnd;
+        if (!Number.isFinite(numericTrialEnd)) {
+            return;
+        }
+
+        if (numericTrialEnd > now) {
+            subscription.status = 'trialing';
+        } else if (subscription.status === 'trialing') {
+            subscription.status = 'active';
+        }
+    }
+
+    /**
      * Handles creation and updating of in memory resources.
      *
      * @param {Array} arr - The array to store the processed data.
@@ -349,6 +387,9 @@ class StripeMocker {
         if (!id) {
             // create
             decoded.id = `${resource.substr(0, 4)}_${this.#generateRandomId()}`;
+            if (resource === 'subscriptions') {
+                this.#syncSubscriptionStatusWithTrialEnd(decoded, decoded);
+            }
             arr.push(decoded);
             return [200, decoded];
         }
@@ -359,6 +400,9 @@ class StripeMocker {
             return [404];
         }
         Object.assign(subscription, decoded);
+        if (resource === 'subscriptions') {
+            this.#syncSubscriptionStatusWithTrialEnd(subscription, decoded);
+        }
         return [200, subscription];
     }
 


### PR DESCRIPTION
closes https://linear.app/ghost/issue/BER-3321

- Free month offers work by adding a trial period to an existing Stripe subscription, which puts the subscription to "trialing" status in Stripe
- Changing the status to "trialing" was automatically decreasing MRR, for both trial signups and for free months offers
- MRR should not decrease when a free month retention offer is redeemed, as the paid member has not churned