### PR TITLE
Bumped Portal to 2.64.5

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.64.4",
+  "version": "2.64.5",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/pull/26449/

This PR was intended to bump Portal, however the CI job that ran to validate the Portal bump ran before the bump happened, leading to a false pass.