### PR TITLE
Fixed flaky comments API test ordering

### DIFF
--- a/ghost/core/test/e2e-api/admin/comments.test.js
+++ b/ghost/core/test/e2e-api/admin/comments.test.js
@@ -1675,15 +1675,22 @@ describe(`Admin Comments API`, function () {
                 html: '<p>Reported comment</p>'
             });
 
-            // Add reports from different members
-            await models.CommentReport.add({
-                comment_id: comment.id,
-                member_id: fixtureManager.get('members', 1).id
-            });
-            await models.CommentReport.add({
+            // Add reports from different members with explicit timestamps to ensure deterministic ordering
+            const olderReport = await models.CommentReport.add({
                 comment_id: comment.id,
                 member_id: fixtureManager.get('members', 2).id
             });
+            await db.knex('comment_reports')
+                .where('id', olderReport.id)
+                .update({created_at: new Date('2023-01-01')});
+
+            const newerReport = await models.CommentReport.add({
+                comment_id: comment.id,
+                member_id: fixtureManager.get('members', 1).id
+            });
+            await db.knex('comment_reports')
+                .where('id', newerReport.id)
+                .update({created_at: new Date('2023-06-01')});
 
             await adminApi.get(`/comments/${comment.id}/reports/`)
                 .expectStatus(200)
@@ -1798,15 +1805,22 @@ describe(`Admin Comments API`, function () {
                 html: '<p>Liked comment</p>'
             });
 
-            // Add likes from different members
-            await models.CommentLike.add({
-                comment_id: comment.id,
-                member_id: fixtureManager.get('members', 1).id
-            });
-            await models.CommentLike.add({
+            // Add likes from different members with explicit timestamps to ensure deterministic ordering
+            const olderLike = await models.CommentLike.add({
                 comment_id: comment.id,
                 member_id: fixtureManager.get('members', 2).id
             });
+            await db.knex('comment_likes')
+                .where('id', olderLike.id)
+                .update({created_at: new Date('2023-01-01')});
+
+            const newerLike = await models.CommentLike.add({
+                comment_id: comment.id,
+                member_id: fixtureManager.get('members', 1).id
+            });
+            await db.knex('comment_likes')
+                .where('id', newerLike.id)
+                .update({created_at: new Date('2023-06-01')});
 
             await adminApi.get(`/comments/${comment.id}/likes/`)
                 .expectStatus(200)

--- a/ghost/core/test/e2e-api/admin/comments.test.js
+++ b/ghost/core/test/e2e-api/admin/comments.test.js
@@ -1676,21 +1676,16 @@ describe(`Admin Comments API`, function () {
             });
 
             // Add reports from different members with explicit timestamps to ensure deterministic ordering
-            const olderReport = await models.CommentReport.add({
+            await models.CommentReport.add({
                 comment_id: comment.id,
-                member_id: fixtureManager.get('members', 2).id
+                member_id: fixtureManager.get('members', 1).id,
+                created_at: new Date('2023-06-01')
             });
-            await db.knex('comment_reports')
-                .where('id', olderReport.id)
-                .update({created_at: new Date('2023-01-01')});
-
-            const newerReport = await models.CommentReport.add({
+            await models.CommentReport.add({
                 comment_id: comment.id,
-                member_id: fixtureManager.get('members', 1).id
+                member_id: fixtureManager.get('members', 2).id,
+                created_at: new Date('2023-01-01')
             });
-            await db.knex('comment_reports')
-                .where('id', newerReport.id)
-                .update({created_at: new Date('2023-06-01')});
 
             await adminApi.get(`/comments/${comment.id}/reports/`)
                 .expectStatus(200)
@@ -1806,21 +1801,16 @@ describe(`Admin Comments API`, function () {
             });
 
             // Add likes from different members with explicit timestamps to ensure deterministic ordering
-            const olderLike = await models.CommentLike.add({
+            await models.CommentLike.add({
                 comment_id: comment.id,
-                member_id: fixtureManager.get('members', 2).id
+                member_id: fixtureManager.get('members', 1).id,
+                created_at: new Date('2023-06-01')
             });
-            await db.knex('comment_likes')
-                .where('id', olderLike.id)
-                .update({created_at: new Date('2023-01-01')});
-
-            const newerLike = await models.CommentLike.add({
+            await models.CommentLike.add({
                 comment_id: comment.id,
-                member_id: fixtureManager.get('members', 1).id
+                member_id: fixtureManager.get('members', 2).id,
+                created_at: new Date('2023-01-01')
             });
-            await db.knex('comment_likes')
-                .where('id', newerLike.id)
-                .update({created_at: new Date('2023-06-01')});
 
             await adminApi.get(`/comments/${comment.id}/likes/`)
                 .expectStatus(200)


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/actions/runs/22150423065/job/64040429159
- added timestamps to comment entries in comments tests

The "Can browse reporters for a comment" and "Can browse comment likes" tests were flaky because they created multiple reports/likes without explicit timestamps. When both were created in the same millisecond, the `order: 'created_at desc'` query returned results in non-deterministic order, causing snapshot mismatches.