### PR TITLE
🐛 Fixed settings page not scrollable on mobile

### DIFF
--- a/apps/admin-x-settings/src/main-content.tsx
+++ b/apps/admin-x-settings/src/main-content.tsx
@@ -14,7 +14,7 @@ const Page: React.FC<{children: ReactNode}> = ({children}) => {
         <div className='fixed right-0 top-2 z-50 flex justify-end bg-transparent p-8 tablet:fixed tablet:top-0 tablet:px-8' id="done-button-container">
             <ExitSettingsButton />
         </div>
-        <div className="w-full tablet:fixed tablet:left-0 tablet:top-0 tablet:flex tablet:h-full dark:bg-grey-975" id="admin-x-settings-content">
+        <div className="fixed left-0 top-0 flex h-full w-full dark:bg-grey-975" id="admin-x-settings-content">
             {children}
         </div>
     </>;


### PR DESCRIPTION
closes https://linear.app/ghost/issue/BER-3350/
closes https://github.com/TryGhost/Ghost/issues/26473

## Summary
- Fixed the settings page not being scrollable at mobile sizes (below 860px) when the sidebar is hidden
- The page wrapper only applied `fixed` positioning and `h-full` at the `tablet` breakpoint, so on smaller screens the content area had no height constraint and `overflow-y-scroll` had no effect
- Applied `fixed left-0 top-0 flex h-full` at all sizes so the content scroller works on mobile too