### PR TITLE
Added CDN image parity for sizing and dimensions

### DIFF
--- a/ghost/core/core/frontend/utils/images.js
+++ b/ghost/core/core/frontend/utils/images.js
@@ -1,11 +1,14 @@
 const url = require('url');
 const imageTransform = require('@tryghost/image-transform');
+const config = require('../../shared/config');
 const urlUtils = require('../../shared/url-utils');
 
 module.exports.detectInternalImage = function detectInternalImage(requestedImageUrl) {
     const siteUrl = urlUtils.getSiteUrl();
+    const imageBaseUrl = (config.get('urls:image') || '').replace(/\/+$/, '');
     const isAbsoluteImage = /https?:\/\//.test(requestedImageUrl);
-    const isAbsoluteInternalImage = isAbsoluteImage && requestedImageUrl.startsWith(siteUrl);
+    const matchesImageBase = imageBaseUrl && requestedImageUrl.startsWith(imageBaseUrl + '/');
+    const isAbsoluteInternalImage = isAbsoluteImage && (requestedImageUrl.startsWith(siteUrl) || matchesImageBase);
 
     // CASE: imagePath is a "protocol relative" url e.g. "//www.gravatar.com/ava..."
     //       by resolving the the imagePath relative to the blog url, we can then

--- a/ghost/core/core/frontend/utils/images.js
+++ b/ghost/core/core/frontend/utils/images.js
@@ -1,14 +1,12 @@
 const url = require('url');
 const imageTransform = require('@tryghost/image-transform');
-const config = require('../../shared/config');
 const urlUtils = require('../../shared/url-utils');
+const storageUtils = require('../../server/adapters/storage/utils');
 
 module.exports.detectInternalImage = function detectInternalImage(requestedImageUrl) {
     const siteUrl = urlUtils.getSiteUrl();
-    const imageBaseUrl = (config.get('urls:image') || '').replace(/\/+$/, '');
     const isAbsoluteImage = /https?:\/\//.test(requestedImageUrl);
-    const matchesImageBase = imageBaseUrl && requestedImageUrl.startsWith(imageBaseUrl + '/');
-    const isAbsoluteInternalImage = isAbsoluteImage && (requestedImageUrl.startsWith(siteUrl) || matchesImageBase);
+    const isAbsoluteInternalImage = isAbsoluteImage && (requestedImageUrl.startsWith(siteUrl) || storageUtils.isInternalImage(requestedImageUrl));
 
     // CASE: imagePath is a "protocol relative" url e.g. "//www.gravatar.com/ava..."
     //       by resolving the the imagePath relative to the blog url, we can then

--- a/ghost/core/core/server/adapters/storage/utils.js
+++ b/ghost/core/core/server/adapters/storage/utils.js
@@ -64,5 +64,5 @@ exports.isInternalImage = function isInternalImage(imagePath) {
     }
 
     const imageBaseUrl = (config.get('urls:image') || '').replace(/\/+$/, '');
-    return imageBaseUrl && imagePath.startsWith(imageBaseUrl + '/');
+    return !!(imageBaseUrl && imagePath.startsWith(imageBaseUrl + '/'));
 };

--- a/ghost/core/core/server/adapters/storage/utils.js
+++ b/ghost/core/core/server/adapters/storage/utils.js
@@ -1,3 +1,4 @@
+const config = require('../../../shared/config');
 const urlUtils = require('../../../shared/url-utils');
 /**
  * @TODO: move `events.js` to here - e.g. storageUtils.getStorage
@@ -50,4 +51,18 @@ exports.isLocalImage = function isLocalImage(imagePath) {
     } else {
         return false;
     }
+};
+
+/**
+ * @description Checks whether the image is managed by Ghost storage (local or CDN)
+ * @param {String} imagePath as URL or filepath
+ * @returns {Boolean}
+ */
+exports.isInternalImage = function isInternalImage(imagePath) {
+    if (this.isLocalImage(imagePath)) {
+        return true;
+    }
+
+    const imageBaseUrl = (config.get('urls:image') || '').replace(/\/+$/, '');
+    return imageBaseUrl && imagePath.startsWith(imageBaseUrl + '/');
 };

--- a/ghost/core/core/server/lib/mobiledoc.js
+++ b/ghost/core/core/server/lib/mobiledoc.js
@@ -3,6 +3,7 @@ const errors = require('@tryghost/errors');
 const logging = require('@tryghost/logging');
 const config = require('../../shared/config');
 const storage = require('../adapters/storage');
+const storageUtils = require('../adapters/storage/utils');
 
 let cardFactory;
 let cards;
@@ -132,8 +133,16 @@ module.exports = {
             }
 
             const isUnsplash = payload.src.match(/images\.unsplash\.com/);
+            const isRelativeImagePath = /^\/content\/images\//.test(payload.src);
             try {
-                const size = isUnsplash ? await getUnsplashSize(payload.src) : await imageSize.getOriginalImageSizeFromStorageUrl(payload.src);
+                let size;
+                if (isUnsplash) {
+                    size = await getUnsplashSize(payload.src);
+                } else if (isRelativeImagePath || storageUtils.isLocalImage(payload.src)) {
+                    size = await imageSize.getOriginalImageSizeFromStorageUrl(payload.src);
+                } else {
+                    size = await imageSize.getImageSizeFromUrl(payload.src);
+                }
 
                 if (size && size.width && size.height) {
                     payload.width = size.width;

--- a/ghost/core/core/server/services/email-service/email-renderer.js
+++ b/ghost/core/core/server/services/email-service/email-renderer.js
@@ -16,6 +16,8 @@ const crypto = require('crypto');
 const DEFAULT_LOCALE = 'en-gb';
 const DEFAULT_ACCENT_COLOR = '#15212A';
 const VALID_HEX_REGEX = /#([0-9a-f]{3}){1,2}$/i;
+const CONTENT_IMAGES_PATH_REGEX = /\/content\/images\//;
+const CONTENT_IMAGES_PATH_WITHOUT_SIZE_REGEX = /\/content\/images\/(?!size\/)/;
 
 // Wrapper function so that i18next-parser can find these strings
 const t = (x) => {
@@ -128,6 +130,7 @@ class EmailRenderer {
     #urlUtils;
     #getPostUrl;
     #storageUtils;
+    #imageBaseUrl;
 
     #handlebars;
     #renderTemplate;
@@ -151,6 +154,7 @@ class EmailRenderer {
      * @param {{getCachedImageSizeFromUrl(url: string): Promise<{url: string, width: number, height: number} | null>}} dependencies.imageSize
      * @param {{urlFor(type: string, optionsOrAbsolute, absolute): string, isSiteUrl(url, context): boolean}} dependencies.urlUtils
      * @param {{isLocalImage(url: string): boolean}} dependencies.storageUtils
+     * @param {string} [dependencies.imageBaseUrl] CDN base URL for images (e.g. from config urls:image)
      * @param {(post: Post) => string} dependencies.getPostUrl
      * @param {object} dependencies.linkReplacer
      * @param {object} dependencies.linkTracking
@@ -169,6 +173,7 @@ class EmailRenderer {
         imageSize,
         urlUtils,
         storageUtils,
+        imageBaseUrl,
         getPostUrl,
         linkReplacer,
         linkTracking,
@@ -186,6 +191,7 @@ class EmailRenderer {
         this.#imageSize = imageSize;
         this.#urlUtils = urlUtils;
         this.#storageUtils = storageUtils;
+        this.#imageBaseUrl = (imageBaseUrl || '').replace(/\/+$/, '');
         this.#getPostUrl = getPostUrl;
         this.#linkReplacer = linkReplacer;
         this.#linkTracking = linkTracking;
@@ -1423,10 +1429,11 @@ class EmailRenderer {
                     size.height = visibleHeight;
                 }
 
-                if (this.#storageUtils.isLocalImage(href)) {
+                if (this.#isGhostContentImageUrl(href)) {
+                    const sizePath = 'size/w' + (visibleWidth * 2) + (visibleHeight ? 'h' + (visibleHeight * 2) : '') + '/';
                     // we can safely request a 1200px image - Ghost will serve the original if it's smaller
                     return {
-                        href: href.replace(/\/content\/images\//, '/content/images/size/w' + (visibleWidth * 2) + (visibleHeight ? 'h' + (visibleHeight * 2) : '') + '/'),
+                        href: href.replace(CONTENT_IMAGES_PATH_WITHOUT_SIZE_REGEX, '/content/images/' + sizePath),
                         width: size.width,
                         height: size.height
                     };
@@ -1448,6 +1455,32 @@ class EmailRenderer {
             width: 0,
             height: null
         };
+    }
+
+    #isGhostContentImageUrl(href) {
+        if (!CONTENT_IMAGES_PATH_REGEX.test(href)) {
+            return false;
+        }
+
+        if (this.#storageUtils.isLocalImage(href)) {
+            return true;
+        }
+
+        try {
+            const parsedUrl = new URL(href);
+
+            if (this.#urlUtils?.isSiteUrl?.(parsedUrl)) {
+                return true;
+            }
+        } catch {
+            return false;
+        }
+
+        if (this.#imageBaseUrl && href.startsWith(this.#imageBaseUrl + '/')) {
+            return true;
+        }
+
+        return false;
     }
 }
 

--- a/ghost/core/core/server/services/email-service/email-renderer.js
+++ b/ghost/core/core/server/services/email-service/email-renderer.js
@@ -1451,7 +1451,6 @@ class EmailRenderer {
             height: null
         };
     }
-
 }
 
 module.exports = EmailRenderer;

--- a/ghost/core/core/server/services/email-service/email-renderer.js
+++ b/ghost/core/core/server/services/email-service/email-renderer.js
@@ -16,7 +16,6 @@ const crypto = require('crypto');
 const DEFAULT_LOCALE = 'en-gb';
 const DEFAULT_ACCENT_COLOR = '#15212A';
 const VALID_HEX_REGEX = /#([0-9a-f]{3}){1,2}$/i;
-const CONTENT_IMAGES_PATH_REGEX = /\/content\/images\//;
 const CONTENT_IMAGES_PATH_WITHOUT_SIZE_REGEX = /\/content\/images\/(?!size\/)/;
 
 // Wrapper function so that i18next-parser can find these strings
@@ -130,7 +129,6 @@ class EmailRenderer {
     #urlUtils;
     #getPostUrl;
     #storageUtils;
-    #imageBaseUrl;
 
     #handlebars;
     #renderTemplate;
@@ -153,8 +151,7 @@ class EmailRenderer {
      * @param {{render(object, options): string}} dependencies.renderers.mobiledoc
      * @param {{getCachedImageSizeFromUrl(url: string): Promise<{url: string, width: number, height: number} | null>}} dependencies.imageSize
      * @param {{urlFor(type: string, optionsOrAbsolute, absolute): string, isSiteUrl(url, context): boolean}} dependencies.urlUtils
-     * @param {{isLocalImage(url: string): boolean}} dependencies.storageUtils
-     * @param {string} [dependencies.imageBaseUrl] CDN base URL for images (e.g. from config urls:image)
+     * @param {{isLocalImage(url: string): boolean, isInternalImage(url: string): boolean}} dependencies.storageUtils
      * @param {(post: Post) => string} dependencies.getPostUrl
      * @param {object} dependencies.linkReplacer
      * @param {object} dependencies.linkTracking
@@ -173,7 +170,6 @@ class EmailRenderer {
         imageSize,
         urlUtils,
         storageUtils,
-        imageBaseUrl,
         getPostUrl,
         linkReplacer,
         linkTracking,
@@ -191,7 +187,6 @@ class EmailRenderer {
         this.#imageSize = imageSize;
         this.#urlUtils = urlUtils;
         this.#storageUtils = storageUtils;
-        this.#imageBaseUrl = (imageBaseUrl || '').replace(/\/+$/, '');
         this.#getPostUrl = getPostUrl;
         this.#linkReplacer = linkReplacer;
         this.#linkTracking = linkTracking;
@@ -1429,7 +1424,7 @@ class EmailRenderer {
                     size.height = visibleHeight;
                 }
 
-                if (this.#isGhostContentImageUrl(href)) {
+                if (this.#storageUtils.isInternalImage(href)) {
                     const sizePath = 'size/w' + (visibleWidth * 2) + (visibleHeight ? 'h' + (visibleHeight * 2) : '') + '/';
                     // we can safely request a 1200px image - Ghost will serve the original if it's smaller
                     return {
@@ -1457,31 +1452,6 @@ class EmailRenderer {
         };
     }
 
-    #isGhostContentImageUrl(href) {
-        if (!CONTENT_IMAGES_PATH_REGEX.test(href)) {
-            return false;
-        }
-
-        if (this.#storageUtils.isLocalImage(href)) {
-            return true;
-        }
-
-        try {
-            const parsedUrl = new URL(href);
-
-            if (this.#urlUtils?.isSiteUrl?.(parsedUrl)) {
-                return true;
-            }
-        } catch {
-            return false;
-        }
-
-        if (this.#imageBaseUrl && href.startsWith(this.#imageBaseUrl + '/')) {
-            return true;
-        }
-
-        return false;
-    }
 }
 
 module.exports = EmailRenderer;

--- a/ghost/core/core/server/services/email-service/email-service-wrapper.js
+++ b/ghost/core/core/server/services/email-service/email-service-wrapper.js
@@ -82,6 +82,7 @@ class EmailServiceWrapper {
             imageSize: cachedImageSizeFromUrl,
             urlUtils,
             storageUtils,
+            imageBaseUrl: configService.get('urls:image') || '',
             getPostUrl: this.getPostUrl,
             linkReplacer,
             linkTracking,

--- a/ghost/core/core/server/services/email-service/email-service-wrapper.js
+++ b/ghost/core/core/server/services/email-service/email-service-wrapper.js
@@ -82,7 +82,6 @@ class EmailServiceWrapper {
             imageSize: cachedImageSizeFromUrl,
             urlUtils,
             storageUtils,
-            imageBaseUrl: configService.get('urls:image') || '',
             getPostUrl: this.getPostUrl,
             linkReplacer,
             linkTracking,

--- a/ghost/core/test/unit/frontend/helpers/img-url.test.js
+++ b/ghost/core/test/unit/frontend/helpers/img-url.test.js
@@ -195,6 +195,57 @@ describe('{{img_url}} helper', function () {
             assert.equal(rendered, 'content/images/size/w400/my-coole-img.jpg');
         });
 
+        describe('with CDN image base URL', function () {
+            before(function () {
+                configUtils.set('urls:image', 'https://storage.ghost.is/c/6f/a3/test/content/images');
+            });
+
+            after(async function () {
+                await configUtils.restore();
+                configUtils.set({url: 'http://localhost:65535/'});
+            });
+
+            it('should output sized url for internal CDN image urls', function () {
+                const rendered = img_url('https://storage.ghost.is/c/6f/a3/test/content/images/my-coole-img.jpg', {
+                    hash: {
+                        size: 'medium'
+                    },
+                    data: {
+                        config: {
+                            image_sizes: {
+                                medium: {
+                                    width: 400
+                                }
+                            }
+                        }
+                    }
+                });
+
+                assertExists(rendered);
+                assert.equal(rendered, 'https://storage.ghost.is/c/6f/a3/test/content/images/size/w400/my-coole-img.jpg');
+            });
+
+            it('should not treat prefix-only CDN urls as internal', function () {
+                const rendered = img_url('https://storage.ghost.is/c/6f/a3/test/content/images-something/my-coole-img.jpg', {
+                    hash: {
+                        size: 'medium'
+                    },
+                    data: {
+                        config: {
+                            image_sizes: {
+                                medium: {
+                                    width: 400
+                                }
+                            }
+                        }
+                    }
+                });
+
+                assertExists(rendered);
+                assert.equal(rendered, 'https://storage.ghost.is/c/6f/a3/test/content/images-something/my-coole-img.jpg');
+            });
+        });
+
         it('ignores invalid size options', function () {
             const rendered = img_url('/content/images/author-image-relative-url.png', {hash: {size: 'invalid-size'}});
             assertExists(rendered);

--- a/ghost/core/test/unit/frontend/meta/image-dimensions.test.js
+++ b/ghost/core/test/unit/frontend/meta/image-dimensions.test.js
@@ -329,4 +329,47 @@ describe('getImageDimensions', function () {
             done();
         }).catch(done);
     });
+
+    it('appends image size prefix to CDN-hosted content images', function (done) {
+        const originalMetaData = {
+            coverImage: {
+                url: 'https://storage.ghost.is/c/6f/a3/site/content/images/2026/02/cover.jpg'
+            },
+            authorImage: {
+                url: 'https://storage.ghost.is/c/6f/a3/site/content/images/2026/02/author.jpg'
+            },
+            ogImage: {
+                url: 'https://storage.ghost.is/c/6f/a3/site/content/images/2026/02/og.jpg'
+            },
+            twitterImage: 'https://storage.ghost.is/c/6f/a3/site/content/images/2026/02/twitter.jpg',
+            site: {
+                logo: {
+                    url: 'https://storage.ghost.is/c/6f/a3/site/content/images/2026/02/logo.jpg'
+                }
+            }
+        };
+
+        const metaData = _.cloneDeep(originalMetaData);
+
+        sizeOfStub.callsFake(() => ({
+            width: 2000,
+            height: 1200,
+            type: 'jpg'
+        }));
+
+        getImageDimensions.__set__('imageSizeCache', {
+            getCachedImageSizeFromUrl: sizeOfStub
+        });
+
+        getImageDimensions(metaData).then(function (result) {
+            assertExists(result);
+            assert.equal(result.coverImage.url, 'https://storage.ghost.is/c/6f/a3/site/content/images/size/w1200/2026/02/cover.jpg');
+            assert.equal(result.authorImage.url, 'https://storage.ghost.is/c/6f/a3/site/content/images/size/w1200/2026/02/author.jpg');
+            assert.equal(result.ogImage.url, 'https://storage.ghost.is/c/6f/a3/site/content/images/size/w1200/2026/02/og.jpg');
+            assert.equal(result.twitterImage, 'https://storage.ghost.is/c/6f/a3/site/content/images/size/w1200/2026/02/twitter.jpg');
+            // logo dimensions are computed but logo URL is not resized in this path
+            assert.equal(result.site.logo.url, originalMetaData.site.logo.url);
+            done();
+        }).catch(done);
+    });
 });

--- a/ghost/core/test/unit/server/adapters/storage/utils.test.js
+++ b/ghost/core/test/unit/server/adapters/storage/utils.test.js
@@ -2,6 +2,7 @@ const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../utils/assertions');
 const sinon = require('sinon');
 const urlUtils = require('../../../../../core/shared/url-utils');
+const configUtils = require('../../../../utils/config-utils');
 
 // Stuff we are testing
 const storageUtils = require('../../../../../core/server/adapters/storage/utils');
@@ -159,6 +160,66 @@ describe('storage utils', function () {
             result = storageUtils.isLocalImage(url);
             assertExists(result);
             assert.equal(result, false);
+        });
+    });
+
+    describe('fn: isInternalImage', function () {
+        before(function () {
+            configUtils.set({url: 'http://myblog.com/'});
+        });
+
+        after(async function () {
+            await configUtils.restore();
+        });
+
+        it('should return true for local images', function () {
+            urlForStub = sinon.stub(urlUtils, 'urlFor');
+            urlForStub.withArgs('home').returns('http://myblog.com/');
+            urlGetSubdirStub = sinon.stub(urlUtils, 'getSubdir');
+            urlGetSubdirStub.returns('');
+
+            assert.equal(storageUtils.isInternalImage('http://myblog.com/content/images/2026/02/photo.png'), true);
+        });
+
+        it('should return true for CDN images when urls:image is configured', function () {
+            configUtils.set('urls:image', 'https://storage.ghost.is/c/6f/a3/test/content/images');
+
+            urlForStub = sinon.stub(urlUtils, 'urlFor');
+            urlForStub.withArgs('home').returns('http://myblog.com/');
+            urlGetSubdirStub = sinon.stub(urlUtils, 'getSubdir');
+            urlGetSubdirStub.returns('');
+
+            assert.equal(storageUtils.isInternalImage('https://storage.ghost.is/c/6f/a3/test/content/images/2026/02/photo.png'), true);
+        });
+
+        it('should return false for CDN prefix-only matches', function () {
+            configUtils.set('urls:image', 'https://storage.ghost.is/c/6f/a3/test/content/images');
+
+            urlForStub = sinon.stub(urlUtils, 'urlFor');
+            urlForStub.withArgs('home').returns('http://myblog.com/');
+            urlGetSubdirStub = sinon.stub(urlUtils, 'getSubdir');
+            urlGetSubdirStub.returns('');
+
+            assert.equal(storageUtils.isInternalImage('https://storage.ghost.is/c/6f/a3/test/content/images-other/photo.png'), false);
+        });
+
+        it('should return false for external images', function () {
+            urlForStub = sinon.stub(urlUtils, 'urlFor');
+            urlForStub.withArgs('home').returns('http://myblog.com/');
+            urlGetSubdirStub = sinon.stub(urlUtils, 'getSubdir');
+            urlGetSubdirStub.returns('');
+
+            assert.equal(storageUtils.isInternalImage('https://example.com/content/images/photo.png'), false);
+        });
+
+        it('should fall back to isLocalImage when no CDN config', function () {
+            urlForStub = sinon.stub(urlUtils, 'urlFor');
+            urlForStub.withArgs('home').returns('http://myblog.com/');
+            urlGetSubdirStub = sinon.stub(urlUtils, 'getSubdir');
+            urlGetSubdirStub.returns('');
+
+            assert.equal(storageUtils.isInternalImage('/content/images/2026/02/photo.png'), true);
+            assert.equal(storageUtils.isInternalImage('https://external.com/photo.png'), false);
         });
     });
 });

--- a/ghost/core/test/unit/server/adapters/storage/utils.test.js
+++ b/ghost/core/test/unit/server/adapters/storage/utils.test.js
@@ -164,11 +164,11 @@ describe('storage utils', function () {
     });
 
     describe('fn: isInternalImage', function () {
-        before(function () {
+        beforeEach(function () {
             configUtils.set({url: 'http://myblog.com/'});
         });
 
-        after(async function () {
+        afterEach(async function () {
             await configUtils.restore();
         });
 

--- a/ghost/core/test/unit/server/lib/image/blog-icon.test.js
+++ b/ghost/core/test/unit/server/lib/image/blog-icon.test.js
@@ -33,6 +33,19 @@ describe('lib/image: blog icon', function () {
             assert.deepEqual(blogIcon.getIconUrl(), [{relativeUrl: '/content/images/size/w256h256/2017/04/my-icon.png'}, undefined]);
         });
 
+        it('custom uploaded CDN png blog icon', function () {
+            const blogIcon = new BlogIcon({config: {}, storageUtils: {}, urlUtils: {
+                urlFor: (key, boolean) => [key, boolean]
+            }, settingsCache: {
+                get: (key) => {
+                    if (key === 'icon') {
+                        return 'https://storage.ghost.is/c/6f/a3/site/content/images/2026/02/my-icon.png';
+                    }
+                }
+            }});
+            assert.deepEqual(blogIcon.getIconUrl(), [{relativeUrl: 'https://storage.ghost.is/c/6f/a3/site/content/images/size/w256h256/2026/02/my-icon.png'}, undefined]);
+        });
+
         it('default ico blog icon', function () {
             const blogIcon = new BlogIcon({config: {}, storageUtils: {}, urlUtils: {
                 urlFor: key => key

--- a/ghost/core/test/unit/server/lib/mobiledoc.test.js
+++ b/ghost/core/test/unit/server/lib/mobiledoc.test.js
@@ -334,6 +334,29 @@ describe('lib/mobiledoc', function () {
             assert.equal(transformed.cards.length, 4);
         });
 
+        it('fetches non-local image sizes from URL', async function () {
+            let mobiledoc = {
+                cards: [
+                    ['image', {src: 'https://storage.ghost.is/c/6f/a3/test/content/images/2026/02/ghost-logo.png'}]
+                ]
+            };
+
+            const cdnMock = nock('https://storage.ghost.is')
+                .get('/c/6f/a3/test/content/images/2026/02/ghost-logo.png')
+                .query(true)
+                .replyWithFile(200, path.join(__dirname, '../../../utils/fixtures/images/ghost-logo.png'), {
+                    'Content-Type': 'image/png'
+                });
+
+            const transformedMobiledoc = await mobiledocLib.populateImageSizes(JSON.stringify(mobiledoc));
+            const transformed = JSON.parse(transformedMobiledoc);
+
+            assert.equal(cdnMock.isDone(), true);
+            assert.equal(transformed.cards.length, 1);
+            assert.equal(transformed.cards[0][1].width, 800);
+            assert.equal(transformed.cards[0][1].height, 257);
+        });
+
         // images can be stored with and without subdir when a subdir is configured
         // but storage adapter always needs paths relative to content dir
         it('works with subdir', async function () {

--- a/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
+++ b/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
@@ -2989,7 +2989,7 @@ describe('Email renderer', function () {
 
     describe('limitImageWidth', function () {
         it('Limits width of local images', async function () {
-            const isLocal = (url) => url === 'http://your-blog.com/content/images/2017/01/02/example.png';
+            const isLocal = url => url === 'http://your-blog.com/content/images/2017/01/02/example.png';
             const emailRenderer = new EmailRenderer({
                 imageSize: {
                     getCachedImageSizeFromUrl() {
@@ -3011,7 +3011,7 @@ describe('Email renderer', function () {
         });
 
         it('Limits width and height of local images', async function () {
-            const isLocal = (url) => url === 'http://your-blog.com/content/images/2017/01/02/example.png';
+            const isLocal = url => url === 'http://your-blog.com/content/images/2017/01/02/example.png';
             const emailRenderer = new EmailRenderer({
                 imageSize: {
                     getCachedImageSizeFromUrl() {
@@ -3083,8 +3083,34 @@ describe('Email renderer', function () {
             assert.equal(response.href, 'https://example.com/content/images/example.png');
         });
 
+        it('Does not double-rewrite already-sized CDN image URLs', async function () {
+            const emailRenderer = new EmailRenderer({
+                imageSize: {
+                    getCachedImageSizeFromUrl() {
+                        return {
+                            width: 2000,
+                            height: 1000
+                        };
+                    }
+                },
+                storageUtils: {
+                    isLocalImage() {
+                        return false;
+                    },
+                    isInternalImage(url) {
+                        return url.startsWith('https://storage.ghost.is/c/6f/a3/test/content/images/');
+                    }
+                }
+            });
+
+            const response = await emailRenderer.limitImageWidth('https://storage.ghost.is/c/6f/a3/test/content/images/size/w600/2026/02/example.png');
+            assert.equal(response.width, 600);
+            assert.equal(response.height, 300);
+            assert.equal(response.href, 'https://storage.ghost.is/c/6f/a3/test/content/images/size/w600/2026/02/example.png');
+        });
+
         it('Returns default dimensions when getCachedImageSizeFromUrl returns null', async function () {
-            const isLocal = (url) => url === 'http://your-blog.com/content/images/2017/01/02/example.png';
+            const isLocal = url => url === 'http://your-blog.com/content/images/2017/01/02/example.png';
             const emailRenderer = new EmailRenderer({
                 imageSize: {
                     getCachedImageSizeFromUrl() {

--- a/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
+++ b/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
@@ -3032,6 +3032,63 @@ describe('Email renderer', function () {
             assert.equal(response.href, 'http://your-blog.com/content/images/size/w1200h1200/2017/01/02/example.png');
         });
 
+        it('Limits width of CDN content images', async function () {
+            const emailRenderer = new EmailRenderer({
+                imageSize: {
+                    getCachedImageSizeFromUrl() {
+                        return {
+                            width: 2000,
+                            height: 1000
+                        };
+                    }
+                },
+                storageUtils: {
+                    isLocalImage() {
+                        return false;
+                    }
+                },
+                imageBaseUrl: 'https://storage.ghost.is/c/6f/a3/test/content/images',
+                urlUtils: {
+                    isSiteUrl() {
+                        return false;
+                    }
+                }
+            });
+            const response = await emailRenderer.limitImageWidth('https://storage.ghost.is/c/6f/a3/test/content/images/2026/02/example.png');
+            assert.equal(response.width, 600);
+            assert.equal(response.height, 300);
+            assert.equal(response.href, 'https://storage.ghost.is/c/6f/a3/test/content/images/size/w1200/2026/02/example.png');
+        });
+
+        it('Does not rewrite external content/images URLs', async function () {
+            const emailRenderer = new EmailRenderer({
+                imageSize: {
+                    getCachedImageSizeFromUrl() {
+                        return {
+                            width: 2000,
+                            height: 1000
+                        };
+                    }
+                },
+                storageUtils: {
+                    isLocalImage() {
+                        return false;
+                    }
+                },
+                imageBaseUrl: 'https://storage.ghost.is/c/6f/a3/test/content/images',
+                urlUtils: {
+                    isSiteUrl() {
+                        return false;
+                    }
+                }
+            });
+
+            const response = await emailRenderer.limitImageWidth('https://example.com/content/images/example.png');
+            assert.equal(response.width, 600);
+            assert.equal(response.height, 300);
+            assert.equal(response.href, 'https://example.com/content/images/example.png');
+        });
+
         it('Returns default dimensions when getCachedImageSizeFromUrl returns null', async function () {
             const emailRenderer = new EmailRenderer({
                 imageSize: {

--- a/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
+++ b/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
@@ -2989,6 +2989,7 @@ describe('Email renderer', function () {
 
     describe('limitImageWidth', function () {
         it('Limits width of local images', async function () {
+            const isLocal = (url) => url === 'http://your-blog.com/content/images/2017/01/02/example.png';
             const emailRenderer = new EmailRenderer({
                 imageSize: {
                     getCachedImageSizeFromUrl() {
@@ -2999,9 +3000,8 @@ describe('Email renderer', function () {
                     }
                 },
                 storageUtils: {
-                    isLocalImage(url) {
-                        return url === 'http://your-blog.com/content/images/2017/01/02/example.png';
-                    }
+                    isLocalImage: isLocal,
+                    isInternalImage: isLocal
                 }
             });
             const response = await emailRenderer.limitImageWidth('http://your-blog.com/content/images/2017/01/02/example.png');
@@ -3011,6 +3011,7 @@ describe('Email renderer', function () {
         });
 
         it('Limits width and height of local images', async function () {
+            const isLocal = (url) => url === 'http://your-blog.com/content/images/2017/01/02/example.png';
             const emailRenderer = new EmailRenderer({
                 imageSize: {
                     getCachedImageSizeFromUrl() {
@@ -3021,9 +3022,8 @@ describe('Email renderer', function () {
                     }
                 },
                 storageUtils: {
-                    isLocalImage(url) {
-                        return url === 'http://your-blog.com/content/images/2017/01/02/example.png';
-                    }
+                    isLocalImage: isLocal,
+                    isInternalImage: isLocal
                 }
             });
             const response = await emailRenderer.limitImageWidth('http://your-blog.com/content/images/2017/01/02/example.png', 600, 600);
@@ -3045,12 +3045,9 @@ describe('Email renderer', function () {
                 storageUtils: {
                     isLocalImage() {
                         return false;
-                    }
-                },
-                imageBaseUrl: 'https://storage.ghost.is/c/6f/a3/test/content/images',
-                urlUtils: {
-                    isSiteUrl() {
-                        return false;
+                    },
+                    isInternalImage(url) {
+                        return url.startsWith('https://storage.ghost.is/c/6f/a3/test/content/images/');
                     }
                 }
             });
@@ -3073,11 +3070,8 @@ describe('Email renderer', function () {
                 storageUtils: {
                     isLocalImage() {
                         return false;
-                    }
-                },
-                imageBaseUrl: 'https://storage.ghost.is/c/6f/a3/test/content/images',
-                urlUtils: {
-                    isSiteUrl() {
+                    },
+                    isInternalImage() {
                         return false;
                     }
                 }
@@ -3090,6 +3084,7 @@ describe('Email renderer', function () {
         });
 
         it('Returns default dimensions when getCachedImageSizeFromUrl returns null', async function () {
+            const isLocal = (url) => url === 'http://your-blog.com/content/images/2017/01/02/example.png';
             const emailRenderer = new EmailRenderer({
                 imageSize: {
                     getCachedImageSizeFromUrl() {
@@ -3097,9 +3092,8 @@ describe('Email renderer', function () {
                     }
                 },
                 storageUtils: {
-                    isLocalImage(url) {
-                        return url === 'http://your-blog.com/content/images/2017/01/02/example.png';
-                    }
+                    isLocalImage: isLocal,
+                    isInternalImage: isLocal
                 }
             });
             const response = await emailRenderer.limitImageWidth('http://your-blog.com/content/images/2017/01/02/example.png');
@@ -3118,8 +3112,11 @@ describe('Email renderer', function () {
                     }
                 },
                 storageUtils: {
-                    isLocalImage(url) {
-                        return url === 'http://your-blog.com/content/images/2017/01/02/example.png';
+                    isLocalImage() {
+                        return false;
+                    },
+                    isInternalImage() {
+                        return false;
                     }
                 }
             });
@@ -3140,8 +3137,11 @@ describe('Email renderer', function () {
                     }
                 },
                 storageUtils: {
-                    isLocalImage(url) {
-                        return url === 'http://your-blog.com/content/images/2017/01/02/example.png';
+                    isLocalImage() {
+                        return false;
+                    },
+                    isInternalImage() {
+                        return false;
                     }
                 }
             });
@@ -3161,8 +3161,11 @@ describe('Email renderer', function () {
                     }
                 },
                 storageUtils: {
-                    isLocalImage(url) {
-                        return url === 'http://your-blog.com/content/images/2017/01/02/example.png';
+                    isLocalImage() {
+                        return false;
+                    },
+                    isInternalImage() {
+                        return false;
                     }
                 }
             });
@@ -3186,6 +3189,9 @@ describe('Email renderer', function () {
                 imageSize: cachedImageSize,
                 storageUtils: {
                     isLocalImage() {
+                        return false;
+                    },
+                    isInternalImage() {
                         return false;
                     }
                 }
@@ -3211,6 +3217,9 @@ describe('Email renderer', function () {
                 imageSize: cachedImageSize,
                 storageUtils: {
                     isLocalImage() {
+                        return false;
+                    },
+                    isInternalImage() {
                         return false;
                     }
                 }
@@ -3244,6 +3253,9 @@ describe('Email renderer', function () {
                 storageUtils: {
                     isLocalImage() {
                         return false;
+                    },
+                    isInternalImage() {
+                        return false;
                     }
                 }
             });
@@ -3272,6 +3284,9 @@ describe('Email renderer', function () {
                 imageSize: cachedImageSize,
                 storageUtils: {
                     isLocalImage() {
+                        return false;
+                    },
+                    isInternalImage() {
                         return false;
                     }
                 }


### PR DESCRIPTION
ref https://linear.app/ghost/issue/HKG-1618/

Ghost is migrating image storage from local storage to GCS. Image resizing is now handled by the image proxy rather than local storage, but the rest of the codebase still needs to treat CDN-hosted images the same as local ones -- generating `/content/images/size/...` URLs, fetching dimensions correctly, and applying email optimizations. This PR updates the non-resize paths so CDN images behave identically to local images across rendering, serving, and metadata flows.

- Updated `mobiledoc.populateImageSizes` so CDN/non-local image cards use HTTP URL-based dimension fetching instead of storage-path reads, while preserving local image behavior (including legacy local path compatibility in subdir setups).
- Centralised internal image detection into `storageUtils.isInternalImage`, which checks both local storage paths and configured CDN base URLs (`urls:image`), so callers no longer duplicate CDN detection logic.
- Updated email image rendering and frontend `img_url` helper to use `storageUtils.isInternalImage` for generating `/content/images/size/...` variants, keeping local-like optimization behavior for CDN images while preventing accidental rewrites of third-party `/content/images/...` URLs.
- Added unit tests for all CDN paths above, including a double-rewrite prevention test for already-sized CDN URLs, plus additional non-editor CDN coverage for metadata image sizing, blog icon sizing, and oEmbed image storage flows.
