### PR TITLE
Removed Should.js from `{{cancel_link}}` helper tests

### DIFF
--- a/ghost/core/test/unit/frontend/helpers/cancel-link.test.js
+++ b/ghost/core/test/unit/frontend/helpers/cancel-link.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../utils/assertions');
-const should = require('should');
 const sinon = require('sinon');
 const hbs = require('../../../../core/frontend/services/theme-engine/engine');
 const cancel_link = require('../../../../core/frontend/helpers/cancel_link');
@@ -52,11 +51,11 @@ describe('{{cancel_link}} helper', function () {
         });
         assertExists(rendered);
 
-        rendered.string.should.match(defaultLinkClass);
+        assert.match(rendered.string, defaultLinkClass);
         assert.match(rendered.string, /data-members-cancel-subscription="sub_cancel"/);
-        rendered.string.should.match(defaultCancelLinkText);
+        assert.match(rendered.string, defaultCancelLinkText);
 
-        rendered.string.should.match(defaultErrorElementClass);
+        assert.match(rendered.string, defaultErrorElementClass);
     });
 
     it('can render continue subscription link', function () {
@@ -66,9 +65,9 @@ describe('{{cancel_link}} helper', function () {
         });
         assertExists(rendered);
 
-        rendered.string.should.match(defaultLinkClass);
+        assert.match(rendered.string, defaultLinkClass);
         assert.match(rendered.string, /data-members-continue-subscription="sub_continue"/);
-        rendered.string.should.match(defaultContinueLinkText);
+        assert.match(rendered.string, defaultContinueLinkText);
     });
 
     it('can render custom link class', function () {


### PR DESCRIPTION
This test-only change should have no user impact.
