### PR TITLE
🐛 Fixed invisible comments filter dropdown in Safari

### DIFF
--- a/apps/shade/src/components/ui/popover.tsx
+++ b/apps/shade/src/components/ui/popover.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import * as PopoverPrimitive from '@radix-ui/react-popover';
+import {SHADE_APP_NAMESPACES} from '@/shade-app';
 
 import {cn} from '@/lib/utils';
 
@@ -15,16 +16,20 @@ const PopoverContent = React.forwardRef<
   React.ElementRef<typeof PopoverPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
 >(({className, align = 'center', sideOffset = 4, ...props}, ref) => (
-    <PopoverPrimitive.Content
-        ref={ref}
-        align={align}
-        className={cn(
-            'z-50 rounded-md bg-white dark:bg-gray-950 p-5 text-popover-foreground shadow-md border outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
-            className
-        )}
-        sideOffset={sideOffset}
-        {...props}
-    />
+    <PopoverPrimitive.Portal>
+        <div className={SHADE_APP_NAMESPACES}>
+            <PopoverPrimitive.Content
+                ref={ref}
+                align={align}
+                className={cn(
+                    'z-50 rounded-md bg-white dark:bg-gray-950 p-5 text-popover-foreground shadow-md border outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-popover-content-transform-origin]',
+                    className
+                )}
+                sideOffset={sideOffset}
+                {...props}
+            />
+        </div>
+    </PopoverPrimitive.Portal>
 ));
 PopoverContent.displayName = PopoverPrimitive.Content.displayName;
 


### PR DESCRIPTION
fixes https://linear.app/ghost/issue/BER-3153/

- Wrapped shade `PopoverContent` in `PopoverPrimitive.Portal` to fix filter popover positioning in Safari
- Without a Portal, Safari resolved the offset parent differently from Chrome, causing the popover's `translateX` to be off by exactly the sidebar width (300px), pushing it off-screen
- Matches the Portal pattern already used by `SelectContent` and `HoverCardContent` in shade, and the standard shadcn/ui popover implementation