### PR TITLE
Updated popover margins and improved user details layout

### DIFF
--- a/apps/admin-x-design-system/src/global/popover.tsx
+++ b/apps/admin-x-design-system/src/global/popover.tsx
@@ -40,7 +40,7 @@ const Popover: React.FC<PopoverProps> = ({
                     {trigger}
                 </PopoverPrimitive.Trigger>
             </PopoverPrimitive.Anchor>
-            <PopoverPrimitive.Content align={position} className="z-[9999] mt-2 origin-top-right rounded bg-white shadow-md ring-1 ring-[rgba(0,0,0,0.01)] focus:outline-none dark:bg-grey-900 dark:text-white"
+            <PopoverPrimitive.Content align={position} className="z-[9999] origin-top-right rounded bg-white shadow-md ring-1 ring-[rgba(0,0,0,0.01)] focus:outline-none dark:bg-grey-900 dark:text-white"
                 data-testid='popover-content' side={side} sideOffset={8} onClick={handleContentClick}>
                 {children}
             </PopoverPrimitive.Content>

--- a/apps/admin-x-settings/src/components/settings/general/user-detail-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/user-detail-modal.tsx
@@ -282,7 +282,7 @@ const UserDetailModalContent: React.FC<{user: User}> = ({user}) => {
             title: 'Are you sure you want to delete this user?',
             prompt: (
                 <>
-                    <p className='mb-3'><span className='font-bold'>{_user.name || _user.email}</span> will be permanently deleted and all their posts will be automatically assigned to the <span className='font-bold'>{owner.name}</span>.</p>
+                    <p className='mb-3'><span className='font-bold'>{_user.name || _user.email}</span> will be permanently deleted and all their posts will be automatically assigned to <span className='font-bold'>{owner.name}</span>.</p>
                     <p>To make these easy to find in the future, each post will be given an internal tag of <span className='font-bold'>#{user.slug}</span></p>
                 </>
             ),
@@ -377,27 +377,6 @@ const UserDetailModalContent: React.FC<{user: User}> = ({user}) => {
         });
     }
 
-    if (formState.id !== currentUser.id && (
-        (hasAdminAccess(currentUser) && !isOwnerUser(user)) ||
-        (isEditorUser(currentUser) && isAuthorOrContributor(user))
-    )) {
-        let suspendUserLabel = formState.status === 'inactive' ? 'Un-suspend user' : 'Suspend user';
-
-        menuItems.push({
-            id: 'delete-user',
-            label: 'Delete user',
-            onClick: () => {
-                confirmDelete(user, {owner: ownerUser});
-            }
-        }, {
-            id: 'suspend-user',
-            label: suspendUserLabel,
-            onClick: () => {
-                confirmSuspend(formState);
-            }
-        });
-    }
-
     menuItems.push({
         id: 'view-user-activity',
         label: 'View user activity',
@@ -406,6 +385,28 @@ const UserDetailModalContent: React.FC<{user: User}> = ({user}) => {
             updateRoute(`history/view/${formState.id}`);
         }
     });
+
+    if (formState.id !== currentUser.id && (
+        (hasAdminAccess(currentUser) && !isOwnerUser(user)) ||
+        (isEditorUser(currentUser) && isAuthorOrContributor(user))
+    )) {
+        let suspendUserLabel = formState.status === 'inactive' ? 'Un-suspend user' : 'Suspend user';
+
+        menuItems.push({
+            id: 'suspend-user',
+            label: suspendUserLabel,
+            onClick: () => {
+                confirmSuspend(formState);
+            }
+        }, {
+            id: 'delete-user',
+            label: 'Delete user',
+            destructive: true,
+            onClick: () => {
+                confirmDelete(user, {owner: ownerUser});
+            }
+        });
+    }
 
     const noCoverButtonClasses = 'rounded text-sm flex flex-nowrap items-center justify-center px-3 h-8 transition-all cursor-pointer font-medium border border-grey-300 bg-transparent text-black dark:border-grey-800 dark:text-white';
 


### PR DESCRIPTION
No ref. 

Our popovers had excessive top margin so I removed it. Also improved the ordering of the elements in the user details modal, made the delete action destructive and updated the delete modal phrasing to make sense.

| Before | After |
|--------|--------|
| <img width="336" height="234" alt="Screenshot 2026-02-18 at 20 17 28" src="https://github.com/user-attachments/assets/e3a080b4-7d8c-475e-ac02-3043a22f0240" /> | <img width="369" height="236" alt="Screenshot 2026-02-18 at 20 17 06" src="https://github.com/user-attachments/assets/8038b5c2-296a-4bc1-adc3-6e5bf49b137d" /> |