### PR TITLE
🐛 Fixed double-encoded HTML entities in email newsletter cards

### DIFF
--- a/ghost/core/core/server/services/koenig/node-renderers/bookmark-renderer.js
+++ b/ghost/core/core/server/services/koenig/node-renderers/bookmark-renderer.js
@@ -23,7 +23,8 @@ function emailTemplate(node, document) {
     const title = escapeHtml(node.title);
     const publisher = escapeHtml(node.publisher);
     const author = escapeHtml(node.author);
-    const description = escapeHtml(node.description);
+    // Description is escaped in truncateHtml, keep raw input here to avoid double-escaping entities.
+    const description = node.description || '';
 
     const icon = node.icon;
     const url = node.url;

--- a/ghost/core/core/server/services/koenig/render-utils/escape-html.js
+++ b/ghost/core/core/server/services/koenig/render-utils/escape-html.js
@@ -1,10 +1,12 @@
+const {decodeHTML} = require('entities');
+
 /**
  * Escape HTML special characters
  * @param {string} unsafe
  * @returns string
  */
 function escapeHtml(unsafe) {
-    return unsafe
+    return decodeHTML(unsafe ?? '')
         .replace(/&/g, '&amp;')
         .replace(/</g, '&lt;')
         .replace(/>/g, '&gt;')

--- a/ghost/core/test/unit/server/services/koenig/node-renderers/bookmark-renderer.test.js
+++ b/ghost/core/test/unit/server/services/koenig/node-renderers/bookmark-renderer.test.js
@@ -176,12 +176,27 @@ describe('services/koenig/node-renderers/bookmark-renderer', function () {
 
             // Check that text fields are escaped
             assert.ok(result.html.includes('Ghost: Independent technology &lt;script&gt;alert("XSS")&lt;/script&gt; for modern publishing.'));
-            assert.ok(result.html.includes('doing &amp;quot;kewl&amp;quot; stuff'));
+            assert.ok(result.html.includes('doing &quot;kewl&quot; stuff'));
             assert.ok(result.html.includes('fa\'ker'));
             assert.ok(result.html.includes('Fake &lt;script&gt;alert("XSS")&lt;/script&gt;'));
 
             // Check that caption is not escaped
             assert.ok(result.html.includes('<p dir="ltr"><span style="white-space: pre-wrap;">This is a </span><b><strong style="white-space: pre-wrap;">caption</strong></b></p>'));
+        });
+
+        it('decodes pre-encoded entities before escaping', function () {
+            const result = renderForEmail(getTestData({
+                title: 'Q&amp;A with Bernardo Kastrup',
+                description: '13th Jan Q&amp;A with Bernardo Kastrup',
+                publisher: 'Research &amp; Development'
+            }));
+
+            assert.ok(result.html.includes('Q&amp;A with Bernardo Kastrup'));
+            assert.ok(!result.html.includes('Q&amp;amp;A with Bernardo Kastrup'));
+            assert.ok(result.html.includes('13th Jan Q&amp;A with Bernardo Kastrup'));
+            assert.ok(!result.html.includes('13th Jan Q&amp;amp;A with Bernardo Kastrup'));
+            assert.ok(result.html.includes('Research &amp; Development'));
+            assert.ok(!result.html.includes('Research &amp;amp; Development'));
         });
     });
 });

--- a/ghost/core/test/unit/server/services/koenig/node-renderers/file-renderer.test.js
+++ b/ghost/core/test/unit/server/services/koenig/node-renderers/file-renderer.test.js
@@ -132,6 +132,21 @@ describe('services/koenig/node-renderers/file-renderer', function () {
             `);
         });
 
+        it('does not double-escape pre-encoded entities', function () {
+            const result = renderForEmail(getTestData({
+                fileTitle: 'Q&amp;A download',
+                fileCaption: 'Research &amp; Development notes',
+                fileName: 'Q&amp;A.pdf'
+            }));
+
+            assert.ok(result.html.includes('Q&amp;A download'));
+            assert.ok(!result.html.includes('Q&amp;amp;A download'));
+            assert.ok(result.html.includes('Research &amp; Development notes'));
+            assert.ok(!result.html.includes('Research &amp;amp; Development notes'));
+            assert.ok(result.html.includes('Q&amp;A.pdf'));
+            assert.ok(!result.html.includes('Q&amp;amp;A.pdf'));
+        });
+
         it('renders nothing with a missing src', function () {
             const result = renderForEmail(getTestData({src: ''}));
             assert.equal(result.html, '');

--- a/ghost/core/test/unit/server/services/koenig/render-utils/escape-html.test.js
+++ b/ghost/core/test/unit/server/services/koenig/render-utils/escape-html.test.js
@@ -1,0 +1,16 @@
+const assert = require('node:assert/strict');
+const {escapeHtml} = require('../../../../../../core/server/services/koenig/render-utils/escape-html');
+
+describe('services/koenig/render-utils/escape-html', function () {
+    it('escapes unsafe html characters', function () {
+        const escaped = escapeHtml('<script>alert("x")</script> & data');
+
+        assert.equal(escaped, '&lt;script&gt;alert(&quot;x&quot;)&lt;/script&gt; &amp; data');
+    });
+
+    it('does not double-escape pre-encoded entities', function () {
+        const escaped = escapeHtml('Q&amp;A &quot;session&quot;');
+
+        assert.equal(escaped, 'Q&amp;A &quot;session&quot;');
+    });
+});


### PR DESCRIPTION
closes https://linear.app/ghost/issue/BER-3229/

## Summary
- Bookmark card descriptions containing pre-encoded HTML entities (e.g. `&amp;`) were being double-escaped when rendering for email newsletters, showing `&amp;amp;` to readers
- Fixed the shared `escapeHtml` utility to decode existing entities before re-escaping, preventing double-encoding
- Removed redundant `escapeHtml` call on bookmark descriptions since `truncateHtml` already handles escaping