### PR TITLE
Removed last Should.js invocations

### DIFF
--- a/ghost/core/test/e2e-api/admin/members-importer.test.js
+++ b/ghost/core/test/e2e-api/admin/members-importer.test.js
@@ -118,7 +118,7 @@ describe('Members Importer API', function () {
     //             assertExists(jsonResponse.meta.stats);
     //             assertExists(jsonResponse.meta.import_label);
 
-    //             jsonResponse.meta.stats.imported.should.equal(8);
+    //             assert.equal(jsonResponse.meta.stats.imported, 8);
 
     //             return jsonResponse.meta.import_label;
     //         })
@@ -134,7 +134,7 @@ describe('Members Importer API', function () {
     //                     const jsonResponse = res.body;
     //                     assertExists(jsonResponse);
     //                     assertExists(jsonResponse.members);
-    //                     jsonResponse.members.should.have.length(8);
+    //                     assert.equal(jsonResponse.members.length, 8);
     //                 })
     //                 .then(() => importLabel);
     //         })
@@ -168,7 +168,7 @@ describe('Members Importer API', function () {
     //                     const jsonResponse = res.body;
     //                     assertExists(jsonResponse);
     //                     assertExists(jsonResponse.members);
-    //                     jsonResponse.members.should.have.length(0);
+    //                     assert.equal(jsonResponse.members.length, 0);
     //                 });
     //         });
     // });

--- a/ghost/core/test/e2e-frontend/default-routes.test.js
+++ b/ghost/core/test/e2e-frontend/default-routes.test.js
@@ -128,7 +128,7 @@ describe('Default Frontend routing', function () {
                     assert(res.text.includes('<title>Start here for a quick overview of everything you need to know</title>'));
                     assert.match(res.text, /<h1[^>]*?>Start here for a quick overview of everything you need to know<\/h1>/);
                     // We should write a single test for this, or encapsulate it as an assertion
-                    // E.g. res.text.should.not.containInvalidUrls()
+                    // E.g. assertDoesNotContainInvalidUrls(res.text)
                     assert(!res.text.includes('__GHOST_URL__'));
                 });
         });

--- a/ghost/core/test/legacy/models/model-posts.test.js
+++ b/ghost/core/test/legacy/models/model-posts.test.js
@@ -814,7 +814,7 @@ describe('Post Model', function () {
                     assert.equal(createdPost.get('html'), newPostDB.html);
                     assert.equal(createdPost.has('plaintext'), true);
                     assert.match(createdPost.get('plaintext'), /^testing/);
-                    // createdPost.get('slug').should.equal(newPostDB.slug + '-3');
+                    // assert.equal(createdPost.get('slug'), newPostDB.slug + '-3');
                     assert.equal((!!createdPost.get('featured')), false);
                     assert.equal((!!createdPost.get('page')), false);
 

--- a/ghost/core/test/unit/frontend/helpers/prev-post.test.js
+++ b/ghost/core/test/unit/frontend/helpers/prev-post.test.js
@@ -4,7 +4,6 @@ const sinon = require('sinon');
 const markdownToMobiledoc = require('../../../utils/fixtures/data-generator').markdownToMobiledoc;
 const prev_post = require('../../../../core/frontend/helpers/prev_post');
 const api = require('../../../../core/frontend/services/proxy').api;
-const should = require('should');
 const logging = require('@tryghost/logging');
 
 describe('{{prev_post}} helper', function () {
@@ -57,14 +56,21 @@ describe('{{prev_post}} helper', function () {
                     url: '/current/'
                 }, optionsData);
 
-            assert.equal(fn.calledOnce, true);
-            assert.equal(inverse.calledOnce, false);
+            sinon.assert.calledOnceWithExactly(
+                fn,
+                sinon.match({
+                    slug: sinon.match.string,
+                    title: sinon.match.string
+                }),
+                sinon.match({data: sinon.match.any})
+            );
 
-            assert.equal(fn.firstCall.args.length, 2);
-            fn.firstCall.args[0].should.have.properties('slug', 'title');
-            fn.firstCall.args[1].should.be.an.Object().and.have.property('data');
-            assert.equal(browsePostsStub.calledOnce, true);
-            assert.equal(browsePostsStub.firstCall.args[0].include, 'author,authors,tags,tiers');
+            sinon.assert.notCalled(inverse);
+
+            sinon.assert.calledOnceWithExactly(
+                browsePostsStub,
+                sinon.match({include: 'author,authors,tags,tiers'})
+            );
         });
     });
 
@@ -93,12 +99,16 @@ describe('{{prev_post}} helper', function () {
                     url: '/current/'
                 }, optionsData);
 
-            assert.equal(fn.called, false);
-            assert.equal(inverse.called, true);
+            sinon.assert.notCalled(fn);
 
-            assert.equal(inverse.firstCall.args.length, 2);
-            inverse.firstCall.args[0].should.have.properties('slug', 'title');
-            inverse.firstCall.args[1].should.be.an.Object().and.have.property('data');
+            sinon.assert.calledOnceWithExactly(
+                inverse,
+                sinon.match({
+                    slug: sinon.match.string,
+                    title: sinon.match.string
+                }),
+                sinon.match({data: sinon.match.any})
+            );
         });
     });
 
@@ -228,15 +238,24 @@ describe('{{prev_post}} helper', function () {
                     url: '/current/'
                 }, optionsData);
 
-            assert.equal(fn.calledOnce, true);
-            assert.equal(inverse.calledOnce, false);
+            sinon.assert.calledOnceWithExactly(
+                fn,
+                sinon.match({
+                    slug: sinon.match.string,
+                    title: sinon.match.string
+                }),
+                sinon.match({data: sinon.match.any})
+            );
 
-            assert.equal(fn.firstCall.args.length, 2);
-            fn.firstCall.args[0].should.have.properties('slug', 'title');
-            fn.firstCall.args[1].should.be.an.Object().and.have.property('data');
-            assert.equal(browsePostsStub.calledOnce, true);
-            assert.equal(browsePostsStub.firstCall.args[0].include, 'author,authors,tags,tiers');
-            assert.match(browsePostsStub.firstCall.args[0].filter, /\+primary_tag:test/);
+            sinon.assert.notCalled(inverse);
+
+            sinon.assert.calledOnceWithExactly(
+                browsePostsStub,
+                sinon.match({
+                    include: 'author,authors,tags,tiers',
+                    filter: sinon.match(/\+primary_tag:test/)
+                })
+            );
         });
 
         it('shows \'if\' template with prev post data with primary_author set', async function () {
@@ -256,15 +275,24 @@ describe('{{prev_post}} helper', function () {
                     url: '/current/'
                 }, optionsData);
 
-            assert.equal(fn.calledOnce, true);
-            assert.equal(inverse.calledOnce, false);
+            sinon.assert.calledOnceWithExactly(
+                fn,
+                sinon.match({
+                    slug: sinon.match.string,
+                    title: sinon.match.string
+                }),
+                sinon.match({data: sinon.match.any})
+            );
 
-            assert.equal(fn.firstCall.args.length, 2);
-            fn.firstCall.args[0].should.have.properties('slug', 'title');
-            fn.firstCall.args[1].should.be.an.Object().and.have.property('data');
-            assert.equal(browsePostsStub.calledOnce, true);
-            assert.equal(browsePostsStub.firstCall.args[0].include, 'author,authors,tags,tiers');
-            assert.match(browsePostsStub.firstCall.args[0].filter, /\+primary_author:hans/);
+            sinon.assert.notCalled(inverse);
+
+            sinon.assert.calledOnceWithExactly(
+                browsePostsStub,
+                sinon.match({
+                    include: 'author,authors,tags,tiers',
+                    filter: sinon.match(/\+primary_author:hans/)
+                })
+            );
         });
 
         it('shows \'if\' template with prev post data with author set', async function () {
@@ -284,15 +312,24 @@ describe('{{prev_post}} helper', function () {
                     url: '/current/'
                 }, optionsData);
 
-            assert.equal(fn.calledOnce, true);
-            assert.equal(inverse.calledOnce, false);
+            sinon.assert.calledOnceWithExactly(
+                fn,
+                sinon.match({
+                    slug: sinon.match.string,
+                    title: sinon.match.string
+                }),
+                sinon.match({data: sinon.match.any})
+            );
 
-            assert.equal(fn.firstCall.args.length, 2);
-            fn.firstCall.args[0].should.have.properties('slug', 'title');
-            fn.firstCall.args[1].should.be.an.Object().and.have.property('data');
-            assert.equal(browsePostsStub.calledOnce, true);
-            assert.equal(browsePostsStub.firstCall.args[0].include, 'author,authors,tags,tiers');
-            assert.match(browsePostsStub.firstCall.args[0].filter, /\+author:author-name/);
+            sinon.assert.notCalled(inverse);
+
+            sinon.assert.calledOnceWithExactly(
+                browsePostsStub,
+                sinon.match({
+                    include: 'author,authors,tags,tiers',
+                    filter: sinon.match(/\+author:author-name/)
+                })
+            );
         });
 
         it('shows \'if\' template with prev post data & ignores in author if author isnt present', async function () {
@@ -311,15 +348,24 @@ describe('{{prev_post}} helper', function () {
                     url: '/current/'
                 }, optionsData);
 
-            assert.equal(fn.calledOnce, true);
-            assert.equal(inverse.calledOnce, false);
+            sinon.assert.calledOnceWithExactly(
+                fn,
+                sinon.match({
+                    slug: sinon.match.string,
+                    title: sinon.match.string
+                }),
+                sinon.match({data: sinon.match.any})
+            );
 
-            assert.equal(fn.firstCall.args.length, 2);
-            fn.firstCall.args[0].should.have.properties('slug', 'title');
-            fn.firstCall.args[1].should.be.an.Object().and.have.property('data');
-            assert.equal(browsePostsStub.calledOnce, true);
-            assert.equal(browsePostsStub.firstCall.args[0].include, 'author,authors,tags,tiers');
-            assert.doesNotMatch(browsePostsStub.firstCall.args[0].filter, /\+author:/);
+            sinon.assert.notCalled(inverse);
+
+            sinon.assert.calledOnceWithExactly(
+                browsePostsStub,
+                sinon.match({
+                    include: 'author,authors,tags,tiers',
+                    filter: sinon.match(filter => !/\+author:/.test(filter))
+                })
+            );
         });
 
         it('shows \'if\' template with prev post data & ignores unknown in value', async function () {
@@ -339,15 +385,24 @@ describe('{{prev_post}} helper', function () {
                     url: '/current/'
                 }, optionsData);
 
-            assert.equal(fn.calledOnce, true);
-            assert.equal(inverse.calledOnce, false);
+            sinon.assert.calledOnceWithExactly(
+                fn,
+                sinon.match({
+                    slug: sinon.match.string,
+                    title: sinon.match.string
+                }),
+                sinon.match({data: sinon.match.any})
+            );
 
-            assert.equal(fn.firstCall.args.length, 2);
-            fn.firstCall.args[0].should.have.properties('slug', 'title');
-            fn.firstCall.args[1].should.be.an.Object().and.have.property('data');
-            assert.equal(browsePostsStub.calledOnce, true);
-            assert.equal(browsePostsStub.firstCall.args[0].include, 'author,authors,tags,tiers');
-            assert.doesNotMatch(browsePostsStub.firstCall.args[0].filter, /\+magic/);
+            sinon.assert.notCalled(inverse);
+
+            sinon.assert.calledOnceWithExactly(
+                browsePostsStub,
+                sinon.match({
+                    include: 'author,authors,tags,tiers',
+                    filter: sinon.match(filter => !/\+magic/.test(filter))
+                })
+            );
         });
     });
 
@@ -375,13 +430,19 @@ describe('{{prev_post}} helper', function () {
                     url: '/current/'
                 }, optionsData);
 
-            assert.equal(fn.called, false);
-            assert.equal(inverse.calledOnce, true);
-            assert.equal(loggingStub.calledOnce, true);
+            sinon.assert.notCalled(fn);
 
-            inverse.firstCall.args[1].should.be.an.Object().and.have.property('data');
-            inverse.firstCall.args[1].data.should.be.an.Object().and.have.property('error');
-            assert.match(inverse.firstCall.args[1].data.error, /^Something wasn't found/);
+            sinon.assert.calledOnceWithExactly(
+                inverse,
+                sinon.match.any,
+                sinon.match({
+                    data: sinon.match({
+                        error: sinon.match(/^Something wasn't found/)
+                    })
+                })
+            );
+
+            sinon.assert.calledOnce(loggingStub);
         });
 
         it('should show warning for call without any options', async function () {
@@ -435,17 +496,25 @@ describe('{{prev_post}} helper', function () {
                     url: '/current/'
                 }, optionsData);
 
-            assert.equal(fn.calledOnce, true);
-            assert.equal(inverse.calledOnce, false);
+            sinon.assert.calledOnceWithExactly(
+                fn,
+                sinon.match({
+                    slug: sinon.match.string,
+                    title: sinon.match.string
+                }),
+                sinon.match({data: sinon.match.any})
+            );
 
-            assert.equal(fn.firstCall.args.length, 2);
-            fn.firstCall.args[0].should.have.properties('slug', 'title');
-            fn.firstCall.args[1].should.be.an.Object().and.have.property('data');
-            assert.equal(browsePostsStub.calledOnce, true);
-            assert.equal(browsePostsStub.firstCall.args[0].include, 'author,authors,tags,tiers');
+            sinon.assert.notCalled(inverse);
 
-            // Check context passed
-            assert.equal(browsePostsStub.firstCall.args[0].context.member, member);
+            sinon.assert.calledOnceWithExactly(
+                browsePostsStub,
+                sinon.match({
+                    include: 'author,authors,tags,tiers',
+                    // Check context passed
+                    context: sinon.match({member})
+                })
+            );
         });
     });
 });

--- a/ghost/core/test/unit/frontend/services/routing/static-routes-router.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/static-routes-router.test.js
@@ -82,13 +82,12 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
             staticRoutesRouter._prepareStaticRouteContext(req, res, next);
             assert.equal(next.called, true);
 
-            res.routerOptions.should.have.properties('type', 'templates', 'defaultTemplate', 'context', 'data', 'contentType');
             assert.equal(res.routerOptions.type, 'custom');
             assert.deepEqual(res.routerOptions.templates, []);
             assert.equal(typeof res.routerOptions.defaultTemplate, 'function');
             assert.deepEqual(res.routerOptions.context, ['about']);
             assert.deepEqual(res.routerOptions.data, {});
-
+            assert('contentType' in res.routerOptions);
             assert.equal(res.routerOptions.contentType, undefined);
             assert.equal(res.locals.slug, undefined);
         });
@@ -99,13 +98,12 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
             staticRoutesRouter._prepareStaticRouteContext(req, res, next);
             assert.equal(next.called, true);
 
-            res.routerOptions.should.have.properties('type', 'templates', 'defaultTemplate', 'context', 'data', 'contentType');
             assert.equal(res.routerOptions.type, 'custom');
             assert.deepEqual(res.routerOptions.templates, []);
             assert.equal(typeof res.routerOptions.defaultTemplate, 'function');
             assert.deepEqual(res.routerOptions.context, ['index']);
             assert.deepEqual(res.routerOptions.data, {});
-
+            assert('contentType' in res.routerOptions);
             assert.equal(res.locals.slug, undefined);
         });
     });

--- a/ghost/core/test/unit/frontend/services/theme-engine/handlebars/template.test.js
+++ b/ghost/core/test/unit/frontend/services/theme-engine/handlebars/template.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../../utils/assertions');
-const should = require('should');
 const errors = require('@tryghost/errors');
 const {hbs, templates} = require('../../../../../../core/frontend/services/handlebars');
 
@@ -11,7 +10,7 @@ describe('Helpers Template', function () {
         const safeString = templates.execute('test', {name: 'world'});
 
         assertExists(safeString);
-        safeString.should.have.property('string').and.equal('<h1>Hello world</h1>');
+        assert.equal(safeString.string, '<h1>Hello world</h1>');
     });
 
     it('will throw an IncorrectUsageError if the partial does not exist', function () {

--- a/ghost/core/test/unit/server/data/exporter/index.test.js
+++ b/ghost/core/test/unit/server/data/exporter/index.test.js
@@ -52,7 +52,7 @@ describe('Exporter', function () {
                 assert.equal(db.knex.called, true);
 
                 assert.equal(knexMock.callCount, expectedCallCount);
-                queryMock.select.callCount.should.have.eql(expectedCallCount);
+                sinon.assert.callCount(queryMock.select, expectedCallCount);
 
                 const expectedTables = new Set([
                     'posts',
@@ -99,7 +99,7 @@ describe('Exporter', function () {
                 assert.equal(queryMock.select.called, true);
 
                 assert.equal(knexMock.callCount, expectedCallCount);
-                queryMock.select.callCount.should.have.eql(expectedCallCount);
+                sinon.assert.callCount(queryMock.select, expectedCallCount);
 
                 const expectedTables = new Set([
                     'posts',

--- a/ghost/core/test/unit/server/services/mail/ghost-mailer.test.js
+++ b/ghost/core/test/unit/server/services/mail/ghost-mailer.test.js
@@ -58,7 +58,7 @@ describe('Mail: Ghostmailer', function () {
         mailer = new mail.GhostMailer();
 
         assertExists(mailer);
-        mailer.should.have.property('send').and.be.a.Function();
+        assert.equal(typeof mailer.send, 'function');
     });
 
     it('should setup SMTP transport on initialization', function () {

--- a/ghost/core/test/unit/server/services/members/members-api/services/geolocation-service.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/services/geolocation-service.test.js
@@ -40,7 +40,7 @@ describe('lib/geolocation', function () {
 
             assert.equal(scope.isDone(), true, 'request was not made');
             assertExists(result, 'nothing was returned');
-            result.should.deepEqual(RESPONSE, 'result didn\'t match expected response');
+            assert.deepEqual(result, RESPONSE, 'result didn\'t match expected response');
         });
 
         it('fetches from geojs.io with IPv6 address', async function () {
@@ -52,7 +52,7 @@ describe('lib/geolocation', function () {
 
             assert.equal(scope.isDone(), true, 'request was not made');
             assertExists(result, 'nothing was returned');
-            result.should.deepEqual(RESPONSE, 'result didn\'t match expected response');
+            assert.deepEqual(result, RESPONSE, 'result didn\'t match expected response');
         });
 
         it('handles non-IP addresses', async function () {

--- a/ghost/core/test/unit/server/services/stats/content.test.js
+++ b/ghost/core/test/unit/server/services/stats/content.test.js
@@ -148,7 +148,6 @@ describe('ContentStatsService', function () {
             const result = await service.lookupPostTitles(['post-1', 'post-2']);
 
             assertExists(result);
-            result.should.have.properties(['post-1', 'post-2']);
             assert.equal(result['post-1'].title, 'Test Post 1');
             assert.equal(result['post-1'].id, 'post-id-1');
             assert.equal(result['post-2'].title, 'Test Post 2');
@@ -183,7 +182,6 @@ describe('ContentStatsService', function () {
 
             const result = service.getResourceTitle('/about/');
             assertExists(result);
-            result.should.have.properties(['title', 'resourceType']);
             assert.equal(result.title, 'About Us');
             assert.equal(result.resourceType, 'page');
         });
@@ -198,7 +196,6 @@ describe('ContentStatsService', function () {
 
             const result = service.getResourceTitle('/tag/news/');
             assertExists(result);
-            result.should.have.properties(['title', 'resourceType']);
             assert.equal(result.title, 'News');
             assert.equal(result.resourceType, 'tag');
         });


### PR DESCRIPTION
no ref

This test-only change should have no user impact.

`git grep -F .should.` returns no results after this change.
