### PR TITLE
Uninstalled Should.js

### DIFF
--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -257,7 +257,6 @@
     "postcss": "8.5.6",
     "postcss-cli": "11.0.1",
     "rewire": "8.0.0",
-    "should": "13.2.3",
     "sinon": "18.0.1",
     "supertest": "6.3.4",
     "tmp": "0.2.5",

--- a/ghost/core/test/e2e-api/admin/actions.test.js
+++ b/ghost/core/test/e2e-api/admin/actions.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const sinon = require('sinon');
 const supertest = require('supertest');
 const testUtils = require('../../utils');

--- a/ghost/core/test/e2e-api/admin/comments.test.js
+++ b/ghost/core/test/e2e-api/admin/comments.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-require('should');
 const ObjectId = require('bson-objectid').default;
 const {
     agentProvider,

--- a/ghost/core/test/e2e-api/admin/files.test.js
+++ b/ghost/core/test/e2e-api/admin/files.test.js
@@ -1,7 +1,6 @@
 const assert = require('node:assert/strict');
 const path = require('path');
 const fs = require('fs-extra');
-const should = require('should');
 const supertest = require('supertest');
 const localUtils = require('./utils');
 const config = require('../../../core/shared/config');

--- a/ghost/core/test/e2e-api/admin/integrations.test.js
+++ b/ghost/core/test/e2e-api/admin/integrations.test.js
@@ -1,7 +1,6 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../utils/assertions');
 const _ = require('lodash');
-const should = require('should');
 const supertest = require('supertest');
 const config = require('../../../core/shared/config');
 const testUtils = require('../../utils');

--- a/ghost/core/test/e2e-api/admin/invites.test.js
+++ b/ghost/core/test/e2e-api/admin/invites.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../utils/assertions');
-const should = require('should');
 const supertest = require('supertest');
 const sinon = require('sinon');
 const testUtils = require('../../utils');

--- a/ghost/core/test/e2e-api/admin/key-authentication.test.js
+++ b/ghost/core/test/e2e-api/admin/key-authentication.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../utils/assertions');
-const should = require('should');
 const supertest = require('supertest');
 const testUtils = require('../../utils');
 const config = require('../../../core/shared/config');

--- a/ghost/core/test/e2e-api/admin/max-limit-cap.test.js
+++ b/ghost/core/test/e2e-api/admin/max-limit-cap.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {agentProvider, fixtureManager} = require('../../utils/e2e-framework');
-const should = require('should');
 const sinon = require('sinon');
 const db = require('../../../core/server/data/db');
 const ObjectId = require('bson-objectid').default;

--- a/ghost/core/test/e2e-api/admin/media.test.js
+++ b/ghost/core/test/e2e-api/admin/media.test.js
@@ -1,7 +1,6 @@
 const assert = require('node:assert/strict');
 const path = require('path');
 const fs = require('fs-extra');
-const should = require('should');
 const supertest = require('supertest');
 const sinon = require('sinon');
 const localUtils = require('./utils');

--- a/ghost/core/test/e2e-api/admin/members-importer.test.js
+++ b/ghost/core/test/e2e-api/admin/members-importer.test.js
@@ -1,7 +1,6 @@
 const path = require('path');
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../utils/assertions');
-const should = require('should');
 const supertest = require('supertest');
 const testUtils = require('../../utils');
 const localUtils = require('./utils');

--- a/ghost/core/test/e2e-api/admin/members.test.js
+++ b/ghost/core/test/e2e-api/admin/members.test.js
@@ -7,7 +7,6 @@ const assert = require('node:assert/strict');
 const {assertExists, assertArrayContainsDeep, assertObjectMatches, assertArrayMatchesWithoutOrder} = require('../../utils/assertions');
 const nock = require('nock');
 const sinon = require('sinon');
-const should = require('should');
 
 const testUtils = require('../../utils');
 const configUtils = require('../../utils/config-utils');

--- a/ghost/core/test/e2e-api/admin/oembed.test.js
+++ b/ghost/core/test/e2e-api/admin/oembed.test.js
@@ -2,7 +2,6 @@ const assert = require('node:assert/strict');
 const {assertExists} = require('../../utils/assertions');
 const nock = require('nock');
 const sinon = require('sinon');
-const should = require('should');
 const supertest = require('supertest');
 const testUtils = require('../../utils/index');
 const config = require('../../../core/shared/config/index');

--- a/ghost/core/test/e2e-api/admin/pages-legacy.test.js
+++ b/ghost/core/test/e2e-api/admin/pages-legacy.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../utils/assertions');
-const should = require('should');
 const supertest = require('supertest');
 const moment = require('moment');
 const _ = require('lodash');

--- a/ghost/core/test/e2e-api/admin/posts-bulk.test.js
+++ b/ghost/core/test/e2e-api/admin/posts-bulk.test.js
@@ -1,4 +1,3 @@
-const should = require('should');
 const DomainEvents = require('@tryghost/domain-events');
 const {mobiledocToLexical} = require('@tryghost/kg-converters');
 const {agentProvider, fixtureManager, mockManager} = require('../../utils/e2e-framework');

--- a/ghost/core/test/e2e-api/admin/posts-legacy.test.js
+++ b/ghost/core/test/e2e-api/admin/posts-legacy.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../utils/assertions');
-const should = require('should');
 const nock = require('nock');
 const path = require('path');
 const supertest = require('supertest');

--- a/ghost/core/test/e2e-api/admin/redirects.test.js
+++ b/ghost/core/test/e2e-api/admin/redirects.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const supertest = require('supertest');
 const fs = require('fs-extra');
 const path = require('path');

--- a/ghost/core/test/e2e-api/admin/snippets.test.js
+++ b/ghost/core/test/e2e-api/admin/snippets.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-require('should');
 const sinon = require('sinon');
 const {agentProvider, fixtureManager, matchers} = require('../../utils/e2e-framework');
 const {anyContentVersion, anyEtag, anyLocationFor, anyObjectId, anyISODateTime, anyErrorId} = matchers;

--- a/ghost/core/test/e2e-api/admin/storage-adapter-switching.test.js
+++ b/ghost/core/test/e2e-api/admin/storage-adapter-switching.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../utils/assertions');
-const should = require('should');
 const sinon = require('sinon');
 const {agentProvider, fixtureManager} = require('../../utils/e2e-framework');
 const config = require('../../../core/shared/config');

--- a/ghost/core/test/e2e-api/admin/tags.test.js
+++ b/ghost/core/test/e2e-api/admin/tags.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../utils/assertions');
-const should = require('should');
 const sinon = require('sinon');
 const supertest = require('supertest');
 const testUtils = require('../../utils');

--- a/ghost/core/test/e2e-api/content/key-authentication.test.js
+++ b/ghost/core/test/e2e-api/content/key-authentication.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const supertest = require('supertest');
 const testUtils = require('../../utils');
 const localUtils = require('./utils');

--- a/ghost/core/test/e2e-api/content/max-limit-cap.test.js
+++ b/ghost/core/test/e2e-api/content/max-limit-cap.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {agentProvider, fixtureManager} = require('../../utils/e2e-framework');
-const should = require('should');
 const sinon = require('sinon');
 const sharedMiddleware = require('../../../core/server/web/shared/middleware');
 

--- a/ghost/core/test/e2e-api/content/tags.test.js
+++ b/ghost/core/test/e2e-api/content/tags.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../utils/assertions');
-const should = require('should');
 const supertest = require('supertest');
 const _ = require('lodash');
 const url = require('url');

--- a/ghost/core/test/e2e-api/members-comments/comments.test.js
+++ b/ghost/core/test/e2e-api/members-comments/comments.test.js
@@ -1,7 +1,6 @@
 const assert = require('node:assert/strict');
 const {agentProvider, mockManager, fixtureManager, matchers, configUtils, dbUtils} = require('../../utils/e2e-framework');
 const {nullable, anyEtag, anyObjectId, anyLocationFor, anyISODateTime, anyErrorId, anyUuid, anyNumber, anyBoolean, stringMatching} = matchers;
-const should = require('should');
 const models = require('../../../core/server/models');
 const moment = require('moment-timezone');
 const settingsCache = require('../../../core/shared/settings-cache');

--- a/ghost/core/test/e2e-api/members-comments/max-limit-cap.test.js
+++ b/ghost/core/test/e2e-api/members-comments/max-limit-cap.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {agentProvider, fixtureManager} = require('../../utils/e2e-framework');
-const should = require('should');
 const sinon = require('sinon');
 const settingsCache = require('../../../core/shared/settings-cache');
 const sharedMiddleware = require('../../../core/server/web/shared/middleware');

--- a/ghost/core/test/e2e-api/members/create-stripe-checkout-session.test.js
+++ b/ghost/core/test/e2e-api/members/create-stripe-checkout-session.test.js
@@ -2,7 +2,6 @@ const assert = require('node:assert/strict');
 const querystring = require('querystring');
 const {agentProvider, mockManager, fixtureManager, matchers} = require('../../utils/e2e-framework');
 const nock = require('nock');
-const should = require('should');
 const models = require('../../../core/server/models');
 const urlService = require('../../../core/server/services/url');
 

--- a/ghost/core/test/e2e-api/members/middleware.test.js
+++ b/ghost/core/test/e2e-api/members/middleware.test.js
@@ -3,7 +3,6 @@ const crypto = require('crypto');
 const {agentProvider, mockManager, fixtureManager, matchers, configUtils} = require('../../utils/e2e-framework');
 const {anyEtag, anyObjectId, anyUuid, anyISODateTime, stringMatching} = matchers;
 const models = require('../../../core/server/models');
-const should = require('should');
 const sinon = require('sinon');
 const settingsHelpers = require('../../../core/server/services/settings-helpers');
 

--- a/ghost/core/test/e2e-frontend/custom-routes.test.js
+++ b/ghost/core/test/e2e-frontend/custom-routes.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../utils/assertions');
-const should = require('should');
 const supertest = require('supertest');
 const path = require('path');
 const moment = require('moment');

--- a/ghost/core/test/e2e-frontend/email-routes.test.js
+++ b/ghost/core/test/e2e-frontend/email-routes.test.js
@@ -4,7 +4,6 @@
 // But then again testing real code, rather than mock code, might be more useful...
 const assert = require('node:assert/strict');
 const {assertExists} = require('../utils/assertions');
-const should = require('should');
 const sinon = require('sinon');
 const supertest = require('supertest');
 const cheerio = require('cheerio');

--- a/ghost/core/test/e2e-frontend/helpers/next-post.test.js
+++ b/ghost/core/test/e2e-frontend/helpers/next-post.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const sinon = require('sinon');
 const testUtils = require('../../utils');
 const models = require('../../../core/server/models/index');

--- a/ghost/core/test/e2e-frontend/member-stats.test.js
+++ b/ghost/core/test/e2e-frontend/member-stats.test.js
@@ -1,5 +1,4 @@
 const {assertExists} = require('../utils/assertions');
-const should = require('should');
 const {getMemberStats} = require('../../core/frontend/utils/member-count.js');
 
 describe('Front-end member stats ', function () {

--- a/ghost/core/test/e2e-server/admin.test.js
+++ b/ghost/core/test/e2e-server/admin.test.js
@@ -5,7 +5,6 @@
 
 const assert = require('node:assert/strict');
 const {assertExists} = require('../utils/assertions');
-const should = require('should');
 const path = require('path');
 const fs = require('fs');
 

--- a/ghost/core/test/integration/exporter/exporter.test.js
+++ b/ghost/core/test/integration/exporter/exporter.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../utils/assertions');
-const should = require('should');
 const sinon = require('sinon');
 const testUtils = require('../../utils');
 const _ = require('lodash');

--- a/ghost/core/test/integration/importer/v1.test.js
+++ b/ghost/core/test/integration/importer/v1.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const testUtils = require('../../utils');
 const {exportedBodyV1} = require('../../utils/fixtures/export/body-generator');
 

--- a/ghost/core/test/integration/importer/v2.test.js
+++ b/ghost/core/test/integration/importer/v2.test.js
@@ -1,4 +1,3 @@
-const should = require('should');
 const sinon = require('sinon');
 const testUtils = require('../../utils');
 const moment = require('moment-timezone');

--- a/ghost/core/test/integration/migrations/nullable-utils.test.js
+++ b/ghost/core/test/integration/migrations/nullable-utils.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const sinon = require('sinon');
 const testUtils = require('../../utils');
 const dbUtils = require('../../utils/db-utils');

--- a/ghost/core/test/integration/services/last-seen-at-updater.test.js
+++ b/ghost/core/test/integration/services/last-seen-at-updater.test.js
@@ -1,4 +1,3 @@
-require('should');
 const {agentProvider, fixtureManager, mockManager} = require('../../utils/e2e-framework');
 const models = require('../../../core/server/models');
 const assert = require('node:assert/strict');

--- a/ghost/core/test/integration/url-service.test.js
+++ b/ghost/core/test/integration/url-service.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const sinon = require('sinon');
 const testUtils = require('../utils');
 const configUtils = require('../utils/config-utils');

--- a/ghost/core/test/legacy/api/admin/identities.test.js
+++ b/ghost/core/test/legacy/api/admin/identities.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../utils/assertions');
-const should = require('should');
 const supertest = require('supertest');
 const jwt = require('jsonwebtoken');
 const jwksClient = require('jwks-rsa');

--- a/ghost/core/test/legacy/api/admin/images.test.js
+++ b/ghost/core/test/legacy/api/admin/images.test.js
@@ -1,6 +1,5 @@
 const path = require('path');
 const fs = require('fs-extra');
-const should = require('should');
 const supertest = require('supertest');
 const localUtils = require('./utils');
 const config = require('../../../../core/shared/config');

--- a/ghost/core/test/legacy/api/admin/members-importer.test.js
+++ b/ghost/core/test/legacy/api/admin/members-importer.test.js
@@ -1,5 +1,4 @@
 const path = require('path');
-const should = require('should');
 const supertest = require('supertest');
 const testUtils = require('../../../utils');
 const localUtils = require('./utils');

--- a/ghost/core/test/legacy/api/admin/members-signin-url.test.js
+++ b/ghost/core/test/legacy/api/admin/members-signin-url.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../utils/assertions');
-const should = require('should');
 const supertest = require('supertest');
 const testUtils = require('../../../utils');
 const localUtils = require('./utils');

--- a/ghost/core/test/legacy/api/admin/pages.test.js
+++ b/ghost/core/test/legacy/api/admin/pages.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const supertest = require('supertest');
 const testUtils = require('../../../utils');
 const config = require('../../../../core/shared/config');

--- a/ghost/core/test/legacy/api/admin/posts.test.js
+++ b/ghost/core/test/legacy/api/admin/posts.test.js
@@ -1,7 +1,6 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../utils/assertions');
 const _ = require('lodash');
-const should = require('should');
 const supertest = require('supertest');
 const ObjectId = require('bson-objectid').default;
 const moment = require('moment-timezone');

--- a/ghost/core/test/legacy/api/admin/redirects.test.js
+++ b/ghost/core/test/legacy/api/admin/redirects.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const supertest = require('supertest');
 const fs = require('fs-extra');
 const path = require('path');

--- a/ghost/core/test/legacy/api/admin/schedules.test.js
+++ b/ghost/core/test/legacy/api/admin/schedules.test.js
@@ -1,7 +1,6 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../utils/assertions');
 const _ = require('lodash');
-const should = require('should');
 const supertest = require('supertest');
 const sinon = require('sinon');
 const moment = require('moment-timezone');

--- a/ghost/core/test/legacy/api/admin/settings.test.js
+++ b/ghost/core/test/legacy/api/admin/settings.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../utils/assertions');
-const should = require('should');
 const supertest = require('supertest');
 const config = require('../../../../core/shared/config');
 const testUtils = require('../../../utils');

--- a/ghost/core/test/legacy/api/admin/users.test.js
+++ b/ghost/core/test/legacy/api/admin/users.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../utils/assertions');
-const should = require('should');
 const supertest = require('supertest');
 const ObjectId = require('bson-objectid').default;
 const testUtils = require('../../../utils');

--- a/ghost/core/test/legacy/api/admin/webhooks.test.js
+++ b/ghost/core/test/legacy/api/admin/webhooks.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../utils/assertions');
-const should = require('should');
 const supertest = require('supertest');
 const testUtils = require('../../../utils');
 const config = require('../../../../core/shared/config');

--- a/ghost/core/test/legacy/api/content/authors.test.js
+++ b/ghost/core/test/legacy/api/content/authors.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const supertest = require('supertest');
 const localUtils = require('./utils');
 const testUtils = require('../../../utils');

--- a/ghost/core/test/legacy/api/content/pages.test.js
+++ b/ghost/core/test/legacy/api/content/pages.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const supertest = require('supertest');
 const testUtils = require('../../../utils');
 const localUtils = require('./utils');

--- a/ghost/core/test/legacy/api/content/posts.test.js
+++ b/ghost/core/test/legacy/api/content/posts.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../utils/assertions');
-const should = require('should');
 const supertest = require('supertest');
 const _ = require('lodash');
 const testUtils = require('../../../utils');

--- a/ghost/core/test/legacy/api/content/tags.test.js
+++ b/ghost/core/test/legacy/api/content/tags.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../utils/assertions');
-const should = require('should');
 const supertest = require('supertest');
 const _ = require('lodash');
 const localUtils = require('./utils');

--- a/ghost/core/test/legacy/mock-express-style/api-vs-frontend.test.js
+++ b/ghost/core/test/legacy/mock-express-style/api-vs-frontend.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../utils/assertions');
-const should = require('should');
 const sinon = require('sinon');
 const cheerio = require('cheerio');
 const testUtils = require('../../utils');

--- a/ghost/core/test/legacy/mock-express-style/parent-app-vhosts.test.js
+++ b/ghost/core/test/legacy/mock-express-style/parent-app-vhosts.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const sinon = require('sinon');
 const path = require('path');
 

--- a/ghost/core/test/legacy/models/base/listeners.test.js
+++ b/ghost/core/test/legacy/models/base/listeners.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const sinon = require('sinon');
 const moment = require('moment-timezone');
 const rewire = require('rewire');

--- a/ghost/core/test/legacy/models/model-member-stripe-customer.test.js
+++ b/ghost/core/test/legacy/models/model-member-stripe-customer.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../utils/assertions');
-const should = require('should');
 const {Member} = require('../../../core/server/models/member');
 const {MemberStripeCustomer} = require('../../../core/server/models/member-stripe-customer');
 const {Product} = require('../../../core/server/models/product');

--- a/ghost/core/test/legacy/models/model-members.test.js
+++ b/ghost/core/test/legacy/models/model-members.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../utils/assertions');
-const should = require('should');
 const BaseModel = require('../../../core/server/models/base');
 const {Label} = require('../../../core/server/models/label');
 const {Product} = require('../../../core/server/models/product');

--- a/ghost/core/test/legacy/models/model-newsletters.test.js
+++ b/ghost/core/test/legacy/models/model-newsletters.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../utils/assertions');
-const should = require('should');
 const sinon = require('sinon');
 const testUtils = require('../../utils');
 const configUtils = require('../../utils/config-utils');

--- a/ghost/core/test/legacy/models/model-posts.test.js
+++ b/ghost/core/test/legacy/models/model-posts.test.js
@@ -1,7 +1,6 @@
 const assert = require('node:assert/strict');
 const {assertExists, assertObjectMatches} = require('../../utils/assertions');
 const errors = require('@tryghost/errors');
-const should = require('should');
 const sinon = require('sinon');
 const testUtils = require('../../utils');
 const moment = require('moment');

--- a/ghost/core/test/legacy/models/model-settings.test.js
+++ b/ghost/core/test/legacy/models/model-settings.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const testUtils = require('../../utils');
 const db = require('../../../core/server/data/db');
 

--- a/ghost/core/test/legacy/models/model-snippets.test.js
+++ b/ghost/core/test/legacy/models/model-snippets.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../utils/assertions');
-const should = require('should');
 const sinon = require('sinon');
 const testUtils = require('../../utils');
 const configUtils = require('../../utils/config-utils');

--- a/ghost/core/test/legacy/models/model-stripe-customer-subscription.test.js
+++ b/ghost/core/test/legacy/models/model-stripe-customer-subscription.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../utils/assertions');
-const should = require('should');
 const {Member} = require('../../../core/server/models/member');
 const {MemberStripeCustomer} = require('../../../core/server/models/member-stripe-customer');
 const {Product} = require('../../../core/server/models/product');

--- a/ghost/core/test/legacy/models/model-tags.test.js
+++ b/ghost/core/test/legacy/models/model-tags.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../utils/assertions');
-const should = require('should');
 const sinon = require('sinon');
 const testUtils = require('../../utils');
 const configUtils = require('../../utils/config-utils');

--- a/ghost/core/test/legacy/models/model-users.test.js
+++ b/ghost/core/test/legacy/models/model-users.test.js
@@ -1,7 +1,6 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../utils/assertions');
 const errors = require('@tryghost/errors');
-const should = require('should');
 const sinon = require('sinon');
 const testUtils = require('../../utils');
 const config = require('../../../core/shared/config');

--- a/ghost/core/test/legacy/site/dynamic-routing.test.js
+++ b/ghost/core/test/legacy/site/dynamic-routing.test.js
@@ -4,7 +4,6 @@
 // tested with the unit tests
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../utils/assertions');
-const should = require('should');
 const supertest = require('supertest');
 const sinon = require('sinon');
 const moment = require('moment');

--- a/ghost/core/test/legacy/site/frontend.test.js
+++ b/ghost/core/test/legacy/site/frontend.test.js
@@ -4,7 +4,6 @@
 // But then again testing real code, rather than mock code, might be more useful...
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../utils/assertions');
-const should = require('should');
 
 const sinon = require('sinon');
 const supertest = require('supertest');

--- a/ghost/core/test/unit/api/canary/session.test.js
+++ b/ghost/core/test/unit/api/canary/session.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const sinon = require('sinon');
 const {UnauthorizedError} = require('@tryghost/errors');
 

--- a/ghost/core/test/unit/api/canary/utils/index.test.js
+++ b/ghost/core/test/unit/api/canary/utils/index.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const sinon = require('sinon');
 const utils = require('../../../../../core/server/api/endpoints/utils');
 

--- a/ghost/core/test/unit/api/canary/utils/serializers/input/members.test.js
+++ b/ghost/core/test/unit/api/canary/utils/serializers/input/members.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const serializers = require('../../../../../../../core/server/api/endpoints/utils/serializers');
 
 describe('Unit: endpoints/utils/serializers/input/members', function () {

--- a/ghost/core/test/unit/api/canary/utils/serializers/output/all.test.js
+++ b/ghost/core/test/unit/api/canary/utils/serializers/output/all.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../../../utils/assertions');
-const should = require('should');
 const serializers = require('../../../../../../../core/server/api/endpoints/utils/serializers');
 
 describe('Unit: endpoints/utils/serializers/output/all', function () {

--- a/ghost/core/test/unit/api/canary/utils/serializers/output/mapper.test.js
+++ b/ghost/core/test/unit/api/canary/utils/serializers/output/mapper.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../../../utils/assertions');
-const should = require('should');
 const sinon = require('sinon');
 const testUtils = require('../../../../../../utils');
 const dateUtil = require('../../../../../../../core/server/api/endpoints/utils/serializers/output/utils/date');

--- a/ghost/core/test/unit/api/canary/utils/serializers/output/members.test.js
+++ b/ghost/core/test/unit/api/canary/utils/serializers/output/members.test.js
@@ -1,5 +1,4 @@
 const {assertExists} = require('../../../../../../utils/assertions');
-const should = require('should');
 const sinon = require('sinon');
 const testUtils = require('../../../../../../utils');
 const labs = require('../../../../../../../core/shared/labs');

--- a/ghost/core/test/unit/frontend/apps/private-blogging/controller.test.js
+++ b/ghost/core/test/unit/frontend/apps/private-blogging/controller.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../utils/assertions');
-const should = require('should');
 const sinon = require('sinon');
 const path = require('path');
 const configUtils = require('../../../../utils/config-utils');

--- a/ghost/core/test/unit/frontend/apps/private-blogging/input-password.test.js
+++ b/ghost/core/test/unit/frontend/apps/private-blogging/input-password.test.js
@@ -1,7 +1,6 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../utils/assertions');
 // We use the name input_password to match the helper for consistency:
-const should = require('should');
 
 // Stuff we are testing
 const input_password = require('../../../../../core/frontend/apps/private-blogging/lib/helpers/input_password');

--- a/ghost/core/test/unit/frontend/apps/private-blogging/middleware.test.js
+++ b/ghost/core/test/unit/frontend/apps/private-blogging/middleware.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const errors = require('@tryghost/errors');
-const should = require('should');
 const sinon = require('sinon');
 const crypto = require('crypto');
 const fs = require('fs-extra');

--- a/ghost/core/test/unit/frontend/helpers/authors.test.js
+++ b/ghost/core/test/unit/frontend/helpers/authors.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../utils/assertions');
-const should = require('should');
 const sinon = require('sinon');
 const urlService = require('../../../../core/server/services/url');
 const authorsHelper = require('../../../../core/frontend/helpers/authors');

--- a/ghost/core/test/unit/frontend/helpers/body-class.test.js
+++ b/ghost/core/test/unit/frontend/helpers/body-class.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../utils/assertions');
-const should = require('should');
 const themeList = require('../../../../core/server/services/themes/list');
 const sinon = require('sinon');
 

--- a/ghost/core/test/unit/frontend/helpers/comment-count.test.js
+++ b/ghost/core/test/unit/frontend/helpers/comment-count.test.js
@@ -1,4 +1,3 @@
-const should = require('should');
 const sinon = require('sinon');
 const configUtils = require('../../../utils/config-utils');
 const {mockManager} = require('../../../utils/e2e-framework');

--- a/ghost/core/test/unit/frontend/helpers/comments.test.js
+++ b/ghost/core/test/unit/frontend/helpers/comments.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../utils/assertions');
-const should = require('should');
 const sinon = require('sinon');
 const configUtils = require('../../../utils/config-utils');
 const {mockManager} = require('../../../utils/e2e-framework');

--- a/ghost/core/test/unit/frontend/helpers/concat.test.js
+++ b/ghost/core/test/unit/frontend/helpers/concat.test.js
@@ -1,4 +1,3 @@
-const should = require('should');
 const handlebars = require('../../../../core/frontend/services/theme-engine/engine').handlebars;
 
 const concat = require('../../../../core/frontend/helpers/concat');

--- a/ghost/core/test/unit/frontend/helpers/content-api-key.test.js
+++ b/ghost/core/test/unit/frontend/helpers/content-api-key.test.js
@@ -2,7 +2,6 @@ const assert = require('node:assert/strict');
 const {assertExists} = require('../../../utils/assertions');
 const proxy = require('../../../../core/frontend/services/proxy');
 const {getFrontendKey} = proxy;
-const should = require('should');
 
 // Stuff we are testing
 const content_api_key = require('../../../../core/frontend/helpers/content_api_key');

--- a/ghost/core/test/unit/frontend/helpers/content-api-url.test.js
+++ b/ghost/core/test/unit/frontend/helpers/content-api-url.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const sinon = require('sinon');
 const configUtils = require('../../../utils/config-utils');
 

--- a/ghost/core/test/unit/frontend/helpers/content.test.js
+++ b/ghost/core/test/unit/frontend/helpers/content.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../utils/assertions');
-const should = require('should');
 const hbs = require('../../../../core/frontend/services/theme-engine/engine');
 const configUtils = require('../../../utils/config-utils');
 const path = require('path');

--- a/ghost/core/test/unit/frontend/helpers/date.test.js
+++ b/ghost/core/test/unit/frontend/helpers/date.test.js
@@ -1,7 +1,6 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../utils/assertions');
 const sinon = require('sinon');
-const should = require('should');
 
 // Stuff we are testing
 const date = require('../../../../core/frontend/helpers/date');

--- a/ghost/core/test/unit/frontend/helpers/encode.test.js
+++ b/ghost/core/test/unit/frontend/helpers/encode.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../utils/assertions');
-const should = require('should');
 
 // Stuff we are testing
 const encode = require('../../../../core/frontend/helpers/encode');

--- a/ghost/core/test/unit/frontend/helpers/excerpt.test.js
+++ b/ghost/core/test/unit/frontend/helpers/excerpt.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../utils/assertions');
-const should = require('should');
 
 // Stuff we are testing
 const excerptHelper = require('../../../../core/frontend/helpers/excerpt');

--- a/ghost/core/test/unit/frontend/helpers/facebook-url.test.js
+++ b/ghost/core/test/unit/frontend/helpers/facebook-url.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 
 // Stuff we are testing
 const facebook_url = require('../../../../core/frontend/helpers/facebook_url');

--- a/ghost/core/test/unit/frontend/helpers/foreach.test.js
+++ b/ghost/core/test/unit/frontend/helpers/foreach.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const sinon = require('sinon');
 const _ = require('lodash');
 const foreach = require('../../../../core/frontend/helpers/foreach');

--- a/ghost/core/test/unit/frontend/helpers/get.test.js
+++ b/ghost/core/test/unit/frontend/helpers/get.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const sinon = require('sinon');
 const {SafeString} = require('../../../../core/frontend/services/handlebars');
 const configUtils = require('../../../utils/config-utils');

--- a/ghost/core/test/unit/frontend/helpers/ghost-foot.test.js
+++ b/ghost/core/test/unit/frontend/helpers/ghost-foot.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../utils/assertions');
-const should = require('should');
 const sinon = require('sinon');
 const ghost_foot = require('../../../../core/frontend/helpers/ghost_foot');
 const {settingsCache} = require('../../../../core/frontend/services/proxy');

--- a/ghost/core/test/unit/frontend/helpers/ghost-head.test.js
+++ b/ghost/core/test/unit/frontend/helpers/ghost-head.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../utils/assertions');
-const should = require('should');
 
 const sinon = require('sinon');
 const {assertMatchSnapshot} = require('../../../utils/assertions');

--- a/ghost/core/test/unit/frontend/helpers/has.test.js
+++ b/ghost/core/test/unit/frontend/helpers/has.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const sinon = require('sinon');
 
 // Stuff we are testing

--- a/ghost/core/test/unit/frontend/helpers/img-url.test.js
+++ b/ghost/core/test/unit/frontend/helpers/img-url.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../utils/assertions');
-const should = require('should');
 const sinon = require('sinon');
 const configUtils = require('../../../utils/config-utils');
 

--- a/ghost/core/test/unit/frontend/helpers/link-class.test.js
+++ b/ghost/core/test/unit/frontend/helpers/link-class.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const concat = require('../../../../core/frontend/helpers/concat');
 const link_class = require('../../../../core/frontend/helpers/link_class');
 const handlebars = require('../../../../core/frontend/services/theme-engine/engine').handlebars;

--- a/ghost/core/test/unit/frontend/helpers/link.test.js
+++ b/ghost/core/test/unit/frontend/helpers/link.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const concat = require('../../../../core/frontend/helpers/concat');
 const link = require('../../../../core/frontend/helpers/link');
 const url = require('../../../../core/frontend/helpers/url');

--- a/ghost/core/test/unit/frontend/helpers/match.test.js
+++ b/ghost/core/test/unit/frontend/helpers/match.test.js
@@ -1,4 +1,3 @@
-const should = require('should');
 const sinon = require('sinon');
 const _ = require('lodash');
 

--- a/ghost/core/test/unit/frontend/helpers/meta-description.test.js
+++ b/ghost/core/test/unit/frontend/helpers/meta-description.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../utils/assertions');
-const should = require('should');
 const sinon = require('sinon');
 const meta_description = require('../../../../core/frontend/helpers/meta_description');
 const settingsCache = require('../../../../core/shared/settings-cache');

--- a/ghost/core/test/unit/frontend/helpers/meta-title.test.js
+++ b/ghost/core/test/unit/frontend/helpers/meta-title.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../utils/assertions');
-const should = require('should');
 const sinon = require('sinon');
 const configUtils = require('../../../utils/config-utils');
 const meta_title = require('../../../../core/frontend/helpers/meta_title');

--- a/ghost/core/test/unit/frontend/helpers/navigation.test.js
+++ b/ghost/core/test/unit/frontend/helpers/navigation.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../utils/assertions');
-const should = require('should');
 const hbs = require('../../../../core/frontend/services/theme-engine/engine');
 const configUtils = require('../../../utils/config-utils');
 const path = require('path');

--- a/ghost/core/test/unit/frontend/helpers/page-url.test.js
+++ b/ghost/core/test/unit/frontend/helpers/page-url.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 
 // Stuff we are testing
 const page_url = require('../../../../core/frontend/helpers/page_url');

--- a/ghost/core/test/unit/frontend/helpers/plural.test.js
+++ b/ghost/core/test/unit/frontend/helpers/plural.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../utils/assertions');
-const should = require('should');
 
 // Stuff we are testing
 const plural = require('../../../../core/frontend/helpers/plural');

--- a/ghost/core/test/unit/frontend/helpers/post-class.test.js
+++ b/ghost/core/test/unit/frontend/helpers/post-class.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../utils/assertions');
-const should = require('should');
 
 // Stuff we are testing
 const post_class = require('../../../../core/frontend/helpers/post_class');

--- a/ghost/core/test/unit/frontend/helpers/raw.test.js
+++ b/ghost/core/test/unit/frontend/helpers/raw.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const raw = require('../../../../core/frontend/helpers/raw');
 const handlebars = require('../../../../core/frontend/services/theme-engine/engine').handlebars;
 

--- a/ghost/core/test/unit/frontend/helpers/reading-time.test.js
+++ b/ghost/core/test/unit/frontend/helpers/reading-time.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 
 // Stuff we are testing
 const reading_time = require('../../../../core/frontend/helpers/reading_time');

--- a/ghost/core/test/unit/frontend/helpers/search.test.js
+++ b/ghost/core/test/unit/frontend/helpers/search.test.js
@@ -1,4 +1,3 @@
-const should = require('should');
 const sinon = require('sinon');
 
 const {registerHelper, shouldCompileToExpected} = require('./utils/handlebars');

--- a/ghost/core/test/unit/frontend/helpers/social-url.test.js
+++ b/ghost/core/test/unit/frontend/helpers/social-url.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const handlebars = require('../../../../core/frontend/services/theme-engine/engine').handlebars;
 const helpers = require('../../../../core/frontend/services/helpers');
 const social_url = require('../../../../core/frontend/helpers/social_url');

--- a/ghost/core/test/unit/frontend/helpers/t-new.test.js
+++ b/ghost/core/test/unit/frontend/helpers/t-new.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const path = require('path');
 const sinon = require('sinon');
 const t = require('../../../../core/frontend/helpers/t');

--- a/ghost/core/test/unit/frontend/helpers/t.test.js
+++ b/ghost/core/test/unit/frontend/helpers/t.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const path = require('path');
 const t = require('../../../../core/frontend/helpers/t');
 const themeI18n = require('../../../../core/frontend/services/theme-engine/i18n');

--- a/ghost/core/test/unit/frontend/helpers/tags.test.js
+++ b/ghost/core/test/unit/frontend/helpers/tags.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../utils/assertions');
-const should = require('should');
 const sinon = require('sinon');
 const testUtils = require('../../../utils');
 const urlService = require('../../../../core/server/services/url');

--- a/ghost/core/test/unit/frontend/helpers/tiers.test.js
+++ b/ghost/core/test/unit/frontend/helpers/tiers.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../utils/assertions');
-const should = require('should');
 const tiersHelper = require('../../../../core/frontend/helpers/tiers');
 
 describe('{{tiers}} helper', function () {

--- a/ghost/core/test/unit/frontend/helpers/title.test.js
+++ b/ghost/core/test/unit/frontend/helpers/title.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../utils/assertions');
-const should = require('should');
 
 // Stuff we are testing
 const title = require('../../../../core/frontend/helpers/title');

--- a/ghost/core/test/unit/frontend/helpers/total-paid-members.test.js
+++ b/ghost/core/test/unit/frontend/helpers/total-paid-members.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 
 const total_paid_members = require('../../../../core/frontend/helpers/total_paid_members');
 

--- a/ghost/core/test/unit/frontend/helpers/twitter-url.test.js
+++ b/ghost/core/test/unit/frontend/helpers/twitter-url.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 
 // Stuff we are testing
 const twitter_url = require('../../../../core/frontend/helpers/twitter_url');

--- a/ghost/core/test/unit/frontend/helpers/url.test.js
+++ b/ghost/core/test/unit/frontend/helpers/url.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../utils/assertions');
-const should = require('should');
 const sinon = require('sinon');
 const testUtils = require('../../../utils');
 

--- a/ghost/core/test/unit/frontend/meta/author-fb-url.test.js
+++ b/ghost/core/test/unit/frontend/meta/author-fb-url.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const getAuthorFacebookUrl = require('../../../../core/frontend/meta/author-fb-url');
 
 describe('getAuthorFacebookUrl', function () {

--- a/ghost/core/test/unit/frontend/meta/author-image.test.js
+++ b/ghost/core/test/unit/frontend/meta/author-image.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const sinon = require('sinon');
 const getAuthorImage = require('../../../../core/frontend/meta/author-image');
 

--- a/ghost/core/test/unit/frontend/meta/author-url.test.js
+++ b/ghost/core/test/unit/frontend/meta/author-url.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../utils/assertions');
-const should = require('should');
 const sinon = require('sinon');
 const ObjectId = require('bson-objectid').default;
 const urlService = require('../../../../core/server/services/url');

--- a/ghost/core/test/unit/frontend/meta/blog-logo.test.js
+++ b/ghost/core/test/unit/frontend/meta/blog-logo.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../utils/assertions');
-const should = require('should');
 const getBlogLogo = require('../../../../core/frontend/meta/blog-logo');
 const sinon = require('sinon');
 const settingsCache = require('../../../../core/shared/settings-cache');

--- a/ghost/core/test/unit/frontend/meta/context-object.test.js
+++ b/ghost/core/test/unit/frontend/meta/context-object.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../utils/assertions');
-const should = require('should');
 const sinon = require('sinon');
 const getContextObject = require('../../../../core/frontend/meta/context-object.js');
 const settingsCache = require('../../../../core/shared/settings-cache');

--- a/ghost/core/test/unit/frontend/meta/cover-image.test.js
+++ b/ghost/core/test/unit/frontend/meta/cover-image.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const getCoverImage = require('../../../../core/frontend/meta/cover-image');
 
 describe('getCoverImage', function () {

--- a/ghost/core/test/unit/frontend/meta/creator-url.test.js
+++ b/ghost/core/test/unit/frontend/meta/creator-url.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const getCreatorTwitterUrl = require('../../../../core/frontend/meta/creator-url');
 
 describe('getCreatorTwitterUrl', function () {

--- a/ghost/core/test/unit/frontend/meta/description.test.js
+++ b/ghost/core/test/unit/frontend/meta/description.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const sinon = require('sinon');
 const getMetaDescription = require('../../../../core/frontend/meta/description');
 const settingsCache = require('../../../../core/shared/settings-cache');

--- a/ghost/core/test/unit/frontend/meta/image-dimensions.test.js
+++ b/ghost/core/test/unit/frontend/meta/image-dimensions.test.js
@@ -1,7 +1,6 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../utils/assertions');
 const _ = require('lodash');
-const should = require('should');
 const sinon = require('sinon');
 const rewire = require('rewire');
 const getImageDimensions = rewire('../../../../core/frontend/meta/image-dimensions');

--- a/ghost/core/test/unit/frontend/meta/keywords.test.js
+++ b/ghost/core/test/unit/frontend/meta/keywords.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const sinon = require('sinon');
 const models = require('../../../../core/server/models');
 const getKeywords = require('../../../../core/frontend/meta/keywords');

--- a/ghost/core/test/unit/frontend/meta/modified-date.test.js
+++ b/ghost/core/test/unit/frontend/meta/modified-date.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const getModifiedDate = require('../../../../core/frontend/meta/modified-date');
 
 describe('getModifiedDate', function () {

--- a/ghost/core/test/unit/frontend/meta/og-image.test.js
+++ b/ghost/core/test/unit/frontend/meta/og-image.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const sinon = require('sinon');
 const getOgImage = require('../../../../core/frontend/meta/og-image');
 const settingsCache = require('../../../../core/shared/settings-cache');

--- a/ghost/core/test/unit/frontend/meta/og-type.test.js
+++ b/ghost/core/test/unit/frontend/meta/og-type.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const getOgType = require('../../../../core/frontend/meta/og-type');
 
 describe('getOgType', function () {

--- a/ghost/core/test/unit/frontend/meta/paginated-url.test.js
+++ b/ghost/core/test/unit/frontend/meta/paginated-url.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../utils/assertions');
-const should = require('should');
 const getPaginatedUrl = require('../../../../core/frontend/meta/paginated-url');
 const configUtils = require('../../../utils/config-utils');
 

--- a/ghost/core/test/unit/frontend/meta/published-date.test.js
+++ b/ghost/core/test/unit/frontend/meta/published-date.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const getPublishedDate = require('../../../../core/frontend/meta/published-date');
 
 describe('getPublishedDate', function () {

--- a/ghost/core/test/unit/frontend/meta/rss-url.test.js
+++ b/ghost/core/test/unit/frontend/meta/rss-url.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const sinon = require('sinon');
 const routing = require('../../../../core/frontend/services/routing');
 const getRssUrl = require('../../../../core/frontend/meta/rss-url');

--- a/ghost/core/test/unit/frontend/meta/schema.test.js
+++ b/ghost/core/test/unit/frontend/meta/schema.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../utils/assertions');
-const should = require('should');
 const {getSchema, SOCIAL_PLATFORMS} = require('../../../../core/frontend/meta/schema');
 const socialUrls = require('@tryghost/social-urls');
 

--- a/ghost/core/test/unit/frontend/meta/title.test.js
+++ b/ghost/core/test/unit/frontend/meta/title.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const sinon = require('sinon');
 const getTitle = require('../../../../core/frontend/meta/title');
 const settingsCache = require('../../../../core/shared/settings-cache');

--- a/ghost/core/test/unit/frontend/meta/twitter-image.test.js
+++ b/ghost/core/test/unit/frontend/meta/twitter-image.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const sinon = require('sinon');
 const getTwitterImage = require('../../../../core/frontend/meta/twitter-image');
 const settingsCache = require('../../../../core/shared/settings-cache');

--- a/ghost/core/test/unit/frontend/services/apps/proxy.test.js
+++ b/ghost/core/test/unit/frontend/services/apps/proxy.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../utils/assertions');
-const should = require('should');
 const sinon = require('sinon');
 const helpers = require('../../../../../core/frontend/services/helpers');
 const AppProxy = require('../../../../../core/frontend/services/apps/proxy');

--- a/ghost/core/test/unit/frontend/services/assets-minification/minifier.test.js
+++ b/ghost/core/test/unit/frontend/services/assets-minification/minifier.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../utils/assertions');
-const should = require('should');
 
 const path = require('path');
 const fs = require('fs').promises;

--- a/ghost/core/test/unit/frontend/services/card-assets.test.js
+++ b/ghost/core/test/unit/frontend/services/card-assets.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 
 const path = require('path');
 const fs = require('fs').promises;

--- a/ghost/core/test/unit/frontend/services/data/checks.test.js
+++ b/ghost/core/test/unit/frontend/services/data/checks.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const {checks} = require('../../../../../core/frontend/services/data');
 
 describe('Checks', function () {

--- a/ghost/core/test/unit/frontend/services/data/entry-lookup.test.js
+++ b/ghost/core/test/unit/frontend/services/data/entry-lookup.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../utils/assertions');
-const should = require('should');
 const sinon = require('sinon');
 
 const api = require('../../../../../core/frontend/services/proxy').api;

--- a/ghost/core/test/unit/frontend/services/rendering/context.test.js
+++ b/ghost/core/test/unit/frontend/services/rendering/context.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../utils/assertions');
-const should = require('should');
 const sinon = require('sinon');
 const testUtils = require('../../../../utils');
 const renderer = require('../../../../../core/frontend/services/rendering');

--- a/ghost/core/test/unit/frontend/services/rendering/format-response.test.js
+++ b/ghost/core/test/unit/frontend/services/rendering/format-response.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const testUtils = require('../../../../utils');
 const helpers = require('../../../../../core/frontend/services/rendering');
 const {SafeString} = require('../../../../../core/frontend/services/handlebars');

--- a/ghost/core/test/unit/frontend/services/rendering/templates.test.js
+++ b/ghost/core/test/unit/frontend/services/rendering/templates.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../utils/assertions');
-const should = require('should');
 const sinon = require('sinon');
 const rewire = require('rewire');
 const templates = rewire('../../../../../core/frontend/services/rendering/templates');

--- a/ghost/core/test/unit/frontend/services/routing/bootstrap.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/bootstrap.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const sinon = require('sinon');
 const CollectionRouter = require('../../../../../core/frontend/services/routing/collection-router');
 const RouterManager = require('../../../../../core/frontend/services/routing/router-manager');

--- a/ghost/core/test/unit/frontend/services/routing/collection-router.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/collection-router.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../utils/assertions');
-const should = require('should');
 const sinon = require('sinon');
 const express = require('../../../../../core/shared/express')._express;
 const events = require('../../../../../core/server/lib/common/events');

--- a/ghost/core/test/unit/frontend/services/routing/controllers/channel.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/controllers/channel.test.js
@@ -1,7 +1,6 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../../utils/assertions');
 const errors = require('@tryghost/errors');
-const should = require('should');
 const sinon = require('sinon');
 const testUtils = require('../../../../../utils');
 const security = require('@tryghost/security');

--- a/ghost/core/test/unit/frontend/services/routing/controllers/collection.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/controllers/collection.test.js
@@ -1,7 +1,6 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../../utils/assertions');
 const errors = require('@tryghost/errors');
-const should = require('should');
 const sinon = require('sinon');
 const testUtils = require('../../../../../utils');
 const security = require('@tryghost/security');

--- a/ghost/core/test/unit/frontend/services/routing/controllers/entry.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/controllers/entry.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../../utils/assertions');
-const should = require('should');
 const sinon = require('sinon');
 const testUtils = require('../../../../../utils');
 const configUtils = require('../../../../../utils/config-utils');

--- a/ghost/core/test/unit/frontend/services/routing/controllers/previews.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/controllers/previews.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../../utils/assertions');
-const should = require('should');
 const sinon = require('sinon');
 const testUtils = require('../../../../../utils');
 const configUtils = require('../../../../../utils/config-utils');

--- a/ghost/core/test/unit/frontend/services/routing/controllers/static.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/controllers/static.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../../utils/assertions');
-const should = require('should');
 const sinon = require('sinon');
 
 const api = require('../../../../../../core/frontend/services/proxy').api;

--- a/ghost/core/test/unit/frontend/services/routing/middlewares/page-param.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/middlewares/page-param.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const sinon = require('sinon');
 const errors = require('@tryghost/errors');
 const urlUtils = require('../../../../../../core/shared/url-utils');

--- a/ghost/core/test/unit/frontend/services/routing/parent-router.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/parent-router.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../utils/assertions');
-const should = require('should');
 const sinon = require('sinon');
 const configUtils = require('../../../../utils/config-utils');
 const urlUtils = require('../../../../../core/shared/url-utils');

--- a/ghost/core/test/unit/frontend/services/routing/registry.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/registry.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const sinon = require('sinon');
 const registry = require('../../../../../core/frontend/services/routing/registry');
 

--- a/ghost/core/test/unit/frontend/services/routing/rss-router.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/rss-router.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../utils/assertions');
-const should = require('should');
 const sinon = require('sinon');
 const configUtils = require('../../../../utils/config-utils');
 const controllers = require('../../../../../core/frontend/services/routing/controllers');

--- a/ghost/core/test/unit/frontend/services/routing/static-routes-router.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/static-routes-router.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../utils/assertions');
-const should = require('should');
 const sinon = require('sinon');
 const controllers = require('../../../../../core/frontend/services/routing/controllers');
 const StaticRoutesRouter = require('../../../../../core/frontend/services/routing/static-routes-router');

--- a/ghost/core/test/unit/frontend/services/routing/taxonomy-router.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/taxonomy-router.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../utils/assertions');
-const should = require('should');
 const sinon = require('sinon');
 const settingsCache = require('../../../../../core/shared/settings-cache');
 const controllers = require('../../../../../core/frontend/services/routing/controllers');

--- a/ghost/core/test/unit/frontend/services/rss/cache.test.js
+++ b/ghost/core/test/unit/frontend/services/rss/cache.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const sinon = require('sinon');
 const rewire = require('rewire');
 const configUtils = require('../../../../utils/config-utils');

--- a/ghost/core/test/unit/frontend/services/rss/generate-feed.test.js
+++ b/ghost/core/test/unit/frontend/services/rss/generate-feed.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../utils/assertions');
-const should = require('should');
 const sinon = require('sinon');
 const _ = require('lodash');
 const testUtils = require('../../../../utils');

--- a/ghost/core/test/unit/frontend/services/rss/renderer.test.js
+++ b/ghost/core/test/unit/frontend/services/rss/renderer.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const sinon = require('sinon');
 const rssCache = require('../../../../../core/frontend/services/rss/cache');
 const renderer = require('../../../../../core/frontend/services/rss/renderer');

--- a/ghost/core/test/unit/frontend/services/sitemap/manager.test.js
+++ b/ghost/core/test/unit/frontend/services/sitemap/manager.test.js
@@ -1,4 +1,3 @@
-const should = require('should');
 const sinon = require('sinon');
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../utils/assertions');

--- a/ghost/core/test/unit/frontend/services/theme-engine/active.test.js
+++ b/ghost/core/test/unit/frontend/services/theme-engine/active.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const sinon = require('sinon');
 const config = require('../../../../../core/shared/config');
 

--- a/ghost/core/test/unit/frontend/services/theme-engine/config.test.js
+++ b/ghost/core/test/unit/frontend/services/theme-engine/config.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const sinon = require('sinon');
 const themeConfig = require('../../../../../core/frontend/services/theme-engine/config');
 

--- a/ghost/core/test/unit/frontend/services/theme-engine/i18n.test.js
+++ b/ghost/core/test/unit/frontend/services/theme-engine/i18n.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const sinon = require('sinon');
 
 const I18n = require('../../../../../core/frontend/services/theme-engine/i18n/i18n');

--- a/ghost/core/test/unit/frontend/services/theme-engine/middleware.test.js
+++ b/ghost/core/test/unit/frontend/services/theme-engine/middleware.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../utils/assertions');
-const should = require('should');
 const sinon = require('sinon');
 const hbs = require('../../../../../core/frontend/services/theme-engine/engine');
 const middleware = require('../../../../../core/frontend/services/theme-engine').middleware;

--- a/ghost/core/test/unit/frontend/services/theme-engine/theme-i18n.test.js
+++ b/ghost/core/test/unit/frontend/services/theme-engine/theme-i18n.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 
 const ThemeI18n = require('../../../../../core/frontend/services/theme-engine/i18n').ThemeI18n;
 

--- a/ghost/core/test/unit/frontend/src/privacy.test.js
+++ b/ghost/core/test/unit/frontend/src/privacy.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 
 // Use path relative to test file
 const {

--- a/ghost/core/test/unit/frontend/src/url-attribution.test.js
+++ b/ghost/core/test/unit/frontend/src/url-attribution.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../utils/assertions');
-const should = require('should');
 const sinon = require('sinon');
 const {JSDOM} = require('jsdom');
 

--- a/ghost/core/test/unit/frontend/utils/frontend-apps.test.js
+++ b/ghost/core/test/unit/frontend/utils/frontend-apps.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const {getFrontendAppConfig, getDataAttributes} = require('../../../../core/frontend/utils/frontend-apps');
 const configUtils = require('../../../utils/config-utils');
 

--- a/ghost/core/test/unit/frontend/utils/member-count.test.js
+++ b/ghost/core/test/unit/frontend/utils/member-count.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const {memberCountRounding, getMemberStats} = require('../../../../core/frontend/utils/member-count');
 
 const getMemberStatsMock = [

--- a/ghost/core/test/unit/frontend/web/middleware/error-handler.test.js
+++ b/ghost/core/test/unit/frontend/web/middleware/error-handler.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const sinon = require('sinon');
 const errors = require('@tryghost/errors');
 

--- a/ghost/core/test/unit/frontend/web/middleware/handle-image-sizes.test.js
+++ b/ghost/core/test/unit/frontend/web/middleware/handle-image-sizes.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const sinon = require('sinon');
 const storage = require('../../../../../core/server/adapters/storage');
 const activeTheme = require('../../../../../core/frontend/services/theme-engine/active');

--- a/ghost/core/test/unit/frontend/web/middleware/redirect-ghost-to-admin.test.js
+++ b/ghost/core/test/unit/frontend/web/middleware/redirect-ghost-to-admin.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../utils/assertions');
-const should = require('should');
 const sinon = require('sinon');
 const redirectGhostToAdmin = require('../../../../../core/frontend/web/middleware/redirect-ghost-to-admin');
 const {handleAdminRedirect} = require('../../../../../core/frontend/web/middleware/redirect-ghost-to-admin');

--- a/ghost/core/test/unit/frontend/web/middleware/serve-public-file.test.js
+++ b/ghost/core/test/unit/frontend/web/middleware/serve-public-file.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const sinon = require('sinon');
 const fs = require('fs-extra');
 const config = require('../../../../../core/shared/config');

--- a/ghost/core/test/unit/server/adapters/scheduling/scheduling-default.test.js
+++ b/ghost/core/test/unit/server/adapters/scheduling/scheduling-default.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const sinon = require('sinon');
 const moment = require('moment');
 const _ = require('lodash');

--- a/ghost/core/test/unit/server/adapters/scheduling/utils.test.js
+++ b/ghost/core/test/unit/server/adapters/scheduling/utils.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../utils/assertions');
-const should = require('should');
 const fs = require('fs-extra');
 const configUtils = require('../../../../utils/config-utils');
 const schedulingUtils = require('../../../../../core/server/adapters/scheduling/utils');

--- a/ghost/core/test/unit/server/adapters/storage/index.test.js
+++ b/ghost/core/test/unit/server/adapters/storage/index.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../utils/assertions');
-const should = require('should');
 const fs = require('fs-extra');
 const StorageBase = require('ghost-storage-base');
 const configUtils = require('../../../../utils/config-utils');

--- a/ghost/core/test/unit/server/adapters/storage/local-base-storage.test.js
+++ b/ghost/core/test/unit/server/adapters/storage/local-base-storage.test.js
@@ -2,7 +2,6 @@ const assert = require('node:assert/strict');
 const path = require('path');
 const http = require('http');
 const express = require('express');
-const should = require('should');
 const sinon = require('sinon');
 const fs = require('fs-extra');
 const LocalStorageBase = require('../../../../../core/server/adapters/storage/LocalStorageBase');

--- a/ghost/core/test/unit/server/adapters/storage/local-images-storage.test.js
+++ b/ghost/core/test/unit/server/adapters/storage/local-images-storage.test.js
@@ -1,7 +1,6 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../utils/assertions');
 const errors = require('@tryghost/errors');
-const should = require('should');
 const sinon = require('sinon');
 const fs = require('fs-extra');
 const moment = require('moment');

--- a/ghost/core/test/unit/server/data/db/backup.test.js
+++ b/ghost/core/test/unit/server/data/db/backup.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const sinon = require('sinon');
 const fs = require('fs-extra');
 const models = require('../../../../../core/server/models');

--- a/ghost/core/test/unit/server/data/exporter/index.test.js
+++ b/ghost/core/test/unit/server/data/exporter/index.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../utils/assertions');
-const should = require('should');
 const sinon = require('sinon');
 const errors = require('@tryghost/errors');
 const db = require('../../../../../core/server/data/db');

--- a/ghost/core/test/unit/server/data/importer/handlers/image.test.js
+++ b/ghost/core/test/unit/server/data/importer/handlers/image.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-require('should');
 const sinon = require('sinon');
 const _ = require('lodash');
 

--- a/ghost/core/test/unit/server/data/importer/import-manager.test.js
+++ b/ghost/core/test/unit/server/data/importer/import-manager.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const fs = require('fs-extra');
 const path = require('path');
 const glob = require('glob');

--- a/ghost/core/test/unit/server/data/importer/importers/data/newsletters.test.js
+++ b/ghost/core/test/unit/server/data/importer/importers/data/newsletters.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const NewslettersImporter = require('../../../../../../../core/server/data/importer/importers/data/newsletters-importer');
 
 const fakeNewsletters = [{

--- a/ghost/core/test/unit/server/data/importer/importers/data/posts.test.js
+++ b/ghost/core/test/unit/server/data/importer/importers/data/posts.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../../../utils/assertions');
-const should = require('should');
 const find = require('lodash/find');
 const PostsImporter = require('../../../../../../../core/server/data/importer/importers/data/posts-importer');
 

--- a/ghost/core/test/unit/server/data/importer/importers/data/settings.test.js
+++ b/ghost/core/test/unit/server/data/importer/importers/data/settings.test.js
@@ -1,7 +1,6 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../../../utils/assertions');
 const find = require('lodash/find');
-const should = require('should');
 const SettingsImporter = require('../../../../../../../core/server/data/importer/importers/data/settings-importer');
 
 describe('SettingsImporter', function () {

--- a/ghost/core/test/unit/server/data/migrations/utils.test.js
+++ b/ghost/core/test/unit/server/data/migrations/utils.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const sinon = require('sinon');
 const errors = require('@tryghost/errors');
 const logging = require('@tryghost/logging');

--- a/ghost/core/test/unit/server/data/schema/commands.test.js
+++ b/ghost/core/test/unit/server/data/schema/commands.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const errors = require('@tryghost/errors');
 
 const commands = require('../../../../../core/server/data/schema/commands');

--- a/ghost/core/test/unit/server/data/schema/fixtures/fixture-manager.test.js
+++ b/ghost/core/test/unit/server/data/schema/fixtures/fixture-manager.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../../utils/assertions');
-const should = require('should');
 const sinon = require('sinon');
 const _ = require('lodash');
 

--- a/ghost/core/test/unit/server/data/schema/schema.test.js
+++ b/ghost/core/test/unit/server/data/schema/schema.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../utils/assertions');
-const should = require('should');
 const _ = require('lodash');
 
 const schema = require('../../../../../core/server/data/schema/schema');

--- a/ghost/core/test/unit/server/lib/image/blog-icon.test.js
+++ b/ghost/core/test/unit/server/lib/image/blog-icon.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../utils/assertions');
-const should = require('should');
 const sinon = require('sinon');
 const path = require('path');
 const BlogIcon = require('../../../../../core/server/lib/image/blog-icon');

--- a/ghost/core/test/unit/server/lib/image/cached-image-size-from-url.test.js
+++ b/ghost/core/test/unit/server/lib/image/cached-image-size-from-url.test.js
@@ -1,7 +1,6 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../utils/assertions');
 const errors = require('@tryghost/errors');
-const should = require('should');
 const sinon = require('sinon');
 const CachedImageSizeFromUrl = require('../../../../../core/server/lib/image/cached-image-size-from-url');
 const InMemoryCache = require('../../../../../core/server/adapters/cache/MemoryCache');

--- a/ghost/core/test/unit/server/lib/image/gravatar.test.js
+++ b/ghost/core/test/unit/server/lib/image/gravatar.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../utils/assertions');
-const should = require('should');
 const Gravatar = require('../../../../../core/server/lib/image/gravatar');
 
 describe('lib/image: gravatar', function () {

--- a/ghost/core/test/unit/server/lib/image/image-size.test.js
+++ b/ghost/core/test/unit/server/lib/image/image-size.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../utils/assertions');
-const should = require('should');
 const sinon = require('sinon');
 const nock = require('nock');
 const path = require('path');

--- a/ghost/core/test/unit/server/lib/lexical.test.js
+++ b/ghost/core/test/unit/server/lib/lexical.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const sinon = require('sinon');
 const jsdom = require('jsdom');
 const lexicalLib = require('../../../../core/server/lib/lexical');

--- a/ghost/core/test/unit/server/lib/mobiledoc.test.js
+++ b/ghost/core/test/unit/server/lib/mobiledoc.test.js
@@ -1,7 +1,6 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../utils/assertions');
 const path = require('path');
-const should = require('should');
 const sinon = require('sinon');
 const nock = require('nock');
 const configUtils = require('../../../utils/config-utils');

--- a/ghost/core/test/unit/server/lib/package-json/parse.test.js
+++ b/ghost/core/test/unit/server/lib/package-json/parse.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-require('should');
 
 const tmp = require('tmp');
 const fs = require('fs-extra');

--- a/ghost/core/test/unit/server/lib/package-json/read.test.js
+++ b/ghost/core/test/unit/server/lib/package-json/read.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-require('should');
 
 const tmp = require('tmp');
 const join = require('path').join;

--- a/ghost/core/test/unit/server/lib/request-external.test.js
+++ b/ghost/core/test/unit/server/lib/request-external.test.js
@@ -1,7 +1,6 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../utils/assertions');
 const sinon = require('sinon');
-const should = require('should');
 const nock = require('nock');
 const externalRequest = require('../../../../core/server/lib/request-external');
 const configUtils = require('../../../utils/config-utils');

--- a/ghost/core/test/unit/server/models/api-key.test.js
+++ b/ghost/core/test/unit/server/models/api-key.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const models = require('../../../../core/server/models');
-const should = require('should');
 const sinon = require('sinon');
 
 describe('Unit: models/api_key', function () {

--- a/ghost/core/test/unit/server/models/base/crud.test.js
+++ b/ghost/core/test/unit/server/models/base/crud.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const errors = require('@tryghost/errors');
-const should = require('should');
 const sinon = require('sinon');
 const models = require('../../../../../core/server/models');
 

--- a/ghost/core/test/unit/server/models/base/index.test.js
+++ b/ghost/core/test/unit/server/models/base/index.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const sinon = require('sinon');
 const security = require('@tryghost/security');
 const models = require('../../../../../core/server/models');

--- a/ghost/core/test/unit/server/models/base/relations.test.js
+++ b/ghost/core/test/unit/server/models/base/relations.test.js
@@ -1,4 +1,3 @@
-const should = require('should');
 const sinon = require('sinon');
 const models = require('../../../../../core/server/models');
 const assert = require('node:assert/strict');

--- a/ghost/core/test/unit/server/models/comment.test.js
+++ b/ghost/core/test/unit/server/models/comment.test.js
@@ -1,4 +1,3 @@
-require('should');
 const sinon = require('sinon');
 const models = require('../../../../core/server/models');
 

--- a/ghost/core/test/unit/server/models/custom-theme-setting.test.js
+++ b/ghost/core/test/unit/server/models/custom-theme-setting.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const models = require('../../../../core/server/models');
 const config = require('../../../../core/shared/config');
 

--- a/ghost/core/test/unit/server/models/integration.test.js
+++ b/ghost/core/test/unit/server/models/integration.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const sinon = require('sinon');
 const models = require('../../../../core/server/models');
 const {knex} = require('../../../../core/server/data/db');

--- a/ghost/core/test/unit/server/models/member-created-event.test.js
+++ b/ghost/core/test/unit/server/models/member-created-event.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const sinon = require('sinon');
 const errors = require('@tryghost/errors');
 const models = require('../../../../core/server/models');

--- a/ghost/core/test/unit/server/models/member-feedback.test.js
+++ b/ghost/core/test/unit/server/models/member-feedback.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const sinon = require('sinon');
 const errors = require('@tryghost/errors');
 const models = require('../../../../core/server/models');

--- a/ghost/core/test/unit/server/models/member-subscribe-event.test.js
+++ b/ghost/core/test/unit/server/models/member-subscribe-event.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const sinon = require('sinon');
 const errors = require('@tryghost/errors');
 const models = require('../../../../core/server/models');

--- a/ghost/core/test/unit/server/models/member.test.js
+++ b/ghost/core/test/unit/server/models/member.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const sinon = require('sinon');
-const should = require('should');
 const models = require('../../../../core/server/models');
 const configUtils = require('../../../utils/config-utils');
 const labs = require('../../../../core/shared/labs');

--- a/ghost/core/test/unit/server/models/newsletter.test.js
+++ b/ghost/core/test/unit/server/models/newsletter.test.js
@@ -2,7 +2,6 @@
 const assert = require('node:assert/strict');
 const errors = require('@tryghost/errors');
 const sinon = require('sinon');
-const should = require('should');
 const models = require('../../../../core/server/models');
 
 describe('Unit: models/newsletter', function () {

--- a/ghost/core/test/unit/server/models/permission.test.js
+++ b/ghost/core/test/unit/server/models/permission.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const sinon = require('sinon');
 const models = require('../../../../core/server/models');
 const configUtils = require('../../../utils/config-utils');

--- a/ghost/core/test/unit/server/models/post.test.js
+++ b/ghost/core/test/unit/server/models/post.test.js
@@ -2,7 +2,6 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../utils/assertions');
 const errors = require('@tryghost/errors');
-const should = require('should');
 const sinon = require('sinon');
 const testUtils = require('../../../utils');
 const knex = require('../../../../core/server/data/db').knex;

--- a/ghost/core/test/unit/server/models/session.test.js
+++ b/ghost/core/test/unit/server/models/session.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const sinon = require('sinon');
 const models = require('../../../../core/server/models');
 

--- a/ghost/core/test/unit/server/models/set-is-roles.test.js
+++ b/ghost/core/test/unit/server/models/set-is-roles.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../utils/assertions');
-const should = require('should');
 const {setIsRoles} = require('../../../../core/server/models/role-utils');
 const _ = require('lodash');
 

--- a/ghost/core/test/unit/server/models/settings.test.js
+++ b/ghost/core/test/unit/server/models/settings.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../utils/assertions');
-const should = require('should');
 const sinon = require('sinon');
 const mockDb = require('mock-knex');
 const models = require('../../../../core/server/models');

--- a/ghost/core/test/unit/server/models/single-use-token.test.js
+++ b/ghost/core/test/unit/server/models/single-use-token.test.js
@@ -1,5 +1,4 @@
 const models = require('../../../../core/server/models');
-const should = require('should');
 const sinon = require('sinon');
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../utils/assertions');

--- a/ghost/core/test/unit/server/models/stripe-customer-subscription.test.js
+++ b/ghost/core/test/unit/server/models/stripe-customer-subscription.test.js
@@ -1,6 +1,5 @@
 const {assertExists} = require('../../../utils/assertions');
 const sinon = require('sinon');
-const should = require('should');
 const models = require('../../../../core/server/models');
 
 describe('Unit: models/stripe-customer-subscription', function () {

--- a/ghost/core/test/unit/server/models/subscription-created-event.test.js
+++ b/ghost/core/test/unit/server/models/subscription-created-event.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const sinon = require('sinon');
 const errors = require('@tryghost/errors');
 const models = require('../../../../core/server/models');

--- a/ghost/core/test/unit/server/models/tag.test.js
+++ b/ghost/core/test/unit/server/models/tag.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const sinon = require('sinon');
 const models = require('../../../../core/server/models');
 const {knex} = require('../../../../core/server/data/db');

--- a/ghost/core/test/unit/server/models/user.test.js
+++ b/ghost/core/test/unit/server/models/user.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const sinon = require('sinon');
 const errors = require('@tryghost/errors');
 const models = require('../../../../core/server/models');

--- a/ghost/core/test/unit/server/notify.test.js
+++ b/ghost/core/test/unit/server/notify.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const sinon = require('sinon');
 
 const configUtils = require('../../utils/config-utils');

--- a/ghost/core/test/unit/server/overrides.test.js
+++ b/ghost/core/test/unit/server/overrides.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const luxon = require('luxon');
 
 require('../../../core/server/overrides');

--- a/ghost/core/test/unit/server/services/adapter-manager/options-resolver.test.js
+++ b/ghost/core/test/unit/server/services/adapter-manager/options-resolver.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 
 const resolveAdapterOptions = require('../../../../../core/server/services/adapter-manager/options-resolver');
 

--- a/ghost/core/test/unit/server/services/auth/api-key/admin.test.js
+++ b/ghost/core/test/unit/server/services/auth/api-key/admin.test.js
@@ -2,7 +2,6 @@ const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../../utils/assertions');
 const errors = require('@tryghost/errors');
 const jwt = require('jsonwebtoken');
-const should = require('should');
 const sinon = require('sinon');
 const apiKeyAuth = require('../../../../../../core/server/services/auth/api-key');
 const models = require('../../../../../../core/server/models');

--- a/ghost/core/test/unit/server/services/auth/api-key/content.test.js
+++ b/ghost/core/test/unit/server/services/auth/api-key/content.test.js
@@ -3,7 +3,6 @@ const {assertExists} = require('../../../../../utils/assertions');
 const errors = require('@tryghost/errors');
 const {authenticateContentApiKey} = require('../../../../../../core/server/services/auth/api-key/content');
 const models = require('../../../../../../core/server/models');
-const should = require('should');
 const sinon = require('sinon');
 
 describe('Content API Key Auth', function () {

--- a/ghost/core/test/unit/server/services/auth/members/index.test.js
+++ b/ghost/core/test/unit/server/services/auth/members/index.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const jwt = require('jsonwebtoken');
-const should = require('should');
 const {UnauthorizedError} = require('@tryghost/errors');
 const members = require('../../../../../../core/server/services/auth/members');
 

--- a/ghost/core/test/unit/server/services/auth/session-from-token.test.js
+++ b/ghost/core/test/unit/server/services/auth/session-from-token.test.js
@@ -1,7 +1,6 @@
 const assert = require('node:assert/strict');
 const express = require('express');
 const sinon = require('sinon');
-const should = require('should');
 const SessionFromToken = require('../../../../../core/server/services/auth/session/session-from-token');
 
 describe('SessionFromToken', function () {

--- a/ghost/core/test/unit/server/services/auth/session/middleware.test.js
+++ b/ghost/core/test/unit/server/services/auth/session/middleware.test.js
@@ -3,7 +3,6 @@ const sessionMiddleware = require('../../../../../../core/server/services/auth')
 const SessionMiddlware = require('../../../../../../core/server/services/auth/session/middleware');
 const models = require('../../../../../../core/server/models');
 const sinon = require('sinon');
-const should = require('should');
 const labs = require('../../../../../../core/shared/labs');
 
 describe('Session Service', function () {

--- a/ghost/core/test/unit/server/services/auth/session/session-service.test.js
+++ b/ghost/core/test/unit/server/services/auth/session/session-service.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../../utils/assertions');
-const should = require('should');
 const sinon = require('sinon');
 const express = require('express');
 const SessionService = require('../../../../../../core/server/services/auth/session/session-service');

--- a/ghost/core/test/unit/server/services/auth/session/store.test.js
+++ b/ghost/core/test/unit/server/services/auth/session/store.test.js
@@ -4,7 +4,6 @@ const models = require('../../../../../../core/server/models');
 const EventEmitter = require('events');
 const {Store} = require('express-session');
 const sinon = require('sinon');
-const should = require('should');
 
 describe('Auth Service SessionStore', function () {
     before(function () {

--- a/ghost/core/test/unit/server/services/comments/comments-service-emails-renderer.test.js
+++ b/ghost/core/test/unit/server/services/comments/comments-service-emails-renderer.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const i18nLib = require('@tryghost/i18n');
-const should = require('should');
 const CommentsServiceEmailRenderer = require('../../../../../core/server/services/comments/comments-service-email-renderer');
 
 describe('Comments Service Email Renderer', function () {

--- a/ghost/core/test/unit/server/services/comments/comments-service-emails.test.js
+++ b/ghost/core/test/unit/server/services/comments/comments-service-emails.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const sinon = require('sinon');
 const CommentsServiceEmails = require('../../../../../core/server/services/comments/comments-service-emails');
 

--- a/ghost/core/test/unit/server/services/email-analytics/email-analytics-service.test.js
+++ b/ghost/core/test/unit/server/services/email-analytics/email-analytics-service.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-require('should');
 
 const sinon = require('sinon');
 const configUtils = require('../../../../utils/config-utils');

--- a/ghost/core/test/unit/server/services/koenig/node-renderers/header-v2-renderer.test.js
+++ b/ghost/core/test/unit/server/services/koenig/node-renderers/header-v2-renderer.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const {callRenderer, html, assertPrettifiesTo, assertPrettifiedIncludes} = require('../test-utils');
 
 describe('services/koenig/node-renderers/header-v2-renderer', function () {

--- a/ghost/core/test/unit/server/services/lib/dynamic-redirect-manager.test.js
+++ b/ghost/core/test/unit/server/services/lib/dynamic-redirect-manager.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const DynamicRedirectManager = require('../../../../../core/server/services/lib/dynamic-redirect-manager');
 
 const urlJoin = (...parts) => {

--- a/ghost/core/test/unit/server/services/link-tracking/link-click-repository.test.js
+++ b/ghost/core/test/unit/server/services/link-tracking/link-click-repository.test.js
@@ -1,4 +1,3 @@
-const should = require('should');
 const sinon = require('sinon');
 const ObjectID = require('bson-objectid').default;
 const configUtils = require('../../../../utils/config-utils');

--- a/ghost/core/test/unit/server/services/link-tracking/post-link-repository.test.js
+++ b/ghost/core/test/unit/server/services/link-tracking/post-link-repository.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const sinon = require('sinon');
 
 const PostLinkRepository = require('../../../../../core/server/services/link-tracking/post-link-repository');

--- a/ghost/core/test/unit/server/services/mail/ghost-mailer.test.js
+++ b/ghost/core/test/unit/server/services/mail/ghost-mailer.test.js
@@ -1,5 +1,4 @@
 const dns = require('dns');
-const should = require('should');
 const sinon = require('sinon');
 const mail = require('../../../../../core/server/services/mail');
 const settingsCache = require('../../../../../core/shared/settings-cache');

--- a/ghost/core/test/unit/server/services/member-attribution/attribution.test.js
+++ b/ghost/core/test/unit/server/services/member-attribution/attribution.test.js
@@ -1,4 +1,3 @@
-const should = require('should');
 const {assertObjectMatches} = require('../../../../utils/assertions');
 
 const UrlHistory = require('../../../../../core/server/services/member-attribution/url-history');

--- a/ghost/core/test/unit/server/services/member-attribution/outbound-link-tagger.test.js
+++ b/ghost/core/test/unit/server/services/member-attribution/outbound-link-tagger.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 
 const OutboundLinkTagger = require('../../../../../core/server/services/member-attribution/outbound-link-tagger');
 

--- a/ghost/core/test/unit/server/services/member-attribution/referrer-translator.test.js
+++ b/ghost/core/test/unit/server/services/member-attribution/referrer-translator.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 
 const ReferrerTranslator = require('../../../../../core/server/services/member-attribution/referrer-translator');
 

--- a/ghost/core/test/unit/server/services/member-welcome-emails/member-welcome-email-renderer.test.js
+++ b/ghost/core/test/unit/server/services/member-welcome-emails/member-welcome-email-renderer.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const sinon = require('sinon');
-const should = require('should');
 const rewire = require('rewire');
 const errors = require('@tryghost/errors');
 

--- a/ghost/core/test/unit/server/services/members-events/last-seen-at-updater.test.js
+++ b/ghost/core/test/unit/server/services/members-events/last-seen-at-updater.test.js
@@ -1,4 +1,3 @@
-const should = require('should');
 const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const LastSeenAtUpdater = require('../../../../../core/server/services/members-events/last-seen-at-updater');

--- a/ghost/core/test/unit/server/services/members/importer/members-csv-importer-stripe-utils.test.js
+++ b/ghost/core/test/unit/server/services/members/importer/members-csv-importer-stripe-utils.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-require('should');
 const sinon = require('sinon');
 const MembersCSVImporterStripeUtils = require('../../../../../../core/server/services/members/importer/members-csv-importer-stripe-utils');
 

--- a/ghost/core/test/unit/server/services/members/importer/members-csv-importer.test.js
+++ b/ghost/core/test/unit/server/services/members/importer/members-csv-importer.test.js
@@ -1,5 +1,3 @@
-const should = require('should');
-
 const Tier = require('../../../../../../core/server/services/tiers/tier');
 const ObjectID = require('bson-objectid').default;
 const assert = require('node:assert/strict');

--- a/ghost/core/test/unit/server/services/members/members-api/controllers/router-controller.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/controllers/router-controller.test.js
@@ -1,4 +1,3 @@
-require('should');
 const sinon = require('sinon');
 const assert = require('node:assert/strict');
 const errors = require('@tryghost/errors');

--- a/ghost/core/test/unit/server/services/members/members-api/repositories/member-repository.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/repositories/member-repository.test.js
@@ -1,4 +1,3 @@
-require('should');
 const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const errors = require('@tryghost/errors');

--- a/ghost/core/test/unit/server/services/members/members-api/services/geolocation-service.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/services/geolocation-service.test.js
@@ -1,7 +1,6 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../../../utils/assertions');
 const nock = require('nock');
-const should = require('should');
 const GeolocationService = require('../../../../../../../core/server/services/members/members-api/services/geolocation-service');
 
 const RESPONSE = {

--- a/ghost/core/test/unit/server/services/members/middleware.test.js
+++ b/ghost/core/test/unit/server/services/members/middleware.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const sinon = require('sinon');
 
 const urlUtils = require('../../../../../core/shared/url-utils');

--- a/ghost/core/test/unit/server/services/members/request-integrity-token-provider.test.js
+++ b/ghost/core/test/unit/server/services/members/request-integrity-token-provider.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const sinon = require('sinon');
-const should = require('should');
 
 const RequestIntegrityTokenProvider = require('../../../../../core/server/services/members/request-integrity-token-provider');
 

--- a/ghost/core/test/unit/server/services/members/stripe-connect.test.js
+++ b/ghost/core/test/unit/server/services/members/stripe-connect.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../utils/assertions');
-const should = require('should');
 const stripeConnect = require('../../../../../core/server/services/members/stripe-connect');
 
 describe('Members - Stripe Connect', function () {

--- a/ghost/core/test/unit/server/services/members/utils.test.js
+++ b/ghost/core/test/unit/server/services/members/utils.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const sinon = require('sinon');
-const should = require('should');
 const {formattedMemberResponse} = require('../../../../../core/server/services/members/utils');
 const labs = require('../../../../../core/shared/labs');
 

--- a/ghost/core/test/unit/server/services/notifications/notifications.test.js
+++ b/ghost/core/test/unit/server/services/notifications/notifications.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../utils/assertions');
-const should = require('should');
 const sinon = require('sinon');
 
 const ghostVersion = require('@tryghost/version');

--- a/ghost/core/test/unit/server/services/offers/application/unique-checker.test.js
+++ b/ghost/core/test/unit/server/services/offers/application/unique-checker.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const sinon = require('sinon');
-const should = require('should');
 const UniqueChecker = require('../../../../../../core/server/services/offers/application/unique-checker');
 
 describe('UniqueChecker', function () {

--- a/ghost/core/test/unit/server/services/offers/domain/models/offer-amount.test.js
+++ b/ghost/core/test/unit/server/services/offers/domain/models/offer-amount.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 
 const {OfferPercentageAmount, OfferFixedAmount, OfferTrialAmount, OfferFreeMonthsAmount} = require('../../../../../../../core/server/services/offers/domain/models/offer-amount');
 

--- a/ghost/core/test/unit/server/services/offers/domain/models/offer-cadence.test.js
+++ b/ghost/core/test/unit/server/services/offers/domain/models/offer-cadence.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 
 const OfferCadence = require('../../../../../../../core/server/services/offers/domain/models/offer-cadence');
 

--- a/ghost/core/test/unit/server/services/offers/domain/models/offer-code.test.js
+++ b/ghost/core/test/unit/server/services/offers/domain/models/offer-code.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 
 const OfferCode = require('../../../../../../../core/server/services/offers/domain/models/offer-code');
 

--- a/ghost/core/test/unit/server/services/offers/domain/models/offer-currency.test.js
+++ b/ghost/core/test/unit/server/services/offers/domain/models/offer-currency.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 
 const OfferCurrency = require('../../../../../../../core/server/services/offers/domain/models/offer-currency');
 

--- a/ghost/core/test/unit/server/services/offers/domain/models/offer-description.test.js
+++ b/ghost/core/test/unit/server/services/offers/domain/models/offer-description.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 
 const OfferDescription = require('../../../../../../../core/server/services/offers/domain/models/offer-description');
 

--- a/ghost/core/test/unit/server/services/offers/domain/models/offer-duration.test.js
+++ b/ghost/core/test/unit/server/services/offers/domain/models/offer-duration.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 
 const OfferDuration = require('../../../../../../../core/server/services/offers/domain/models/offer-duration');
 

--- a/ghost/core/test/unit/server/services/offers/domain/models/offer-name.test.js
+++ b/ghost/core/test/unit/server/services/offers/domain/models/offer-name.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 
 const OfferName = require('../../../../../../../core/server/services/offers/domain/models/offer-name');
 

--- a/ghost/core/test/unit/server/services/offers/domain/models/offer-redemption-type.test.js
+++ b/ghost/core/test/unit/server/services/offers/domain/models/offer-redemption-type.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 
 const OfferRedemptionType = require('../../../../../../../core/server/services/offers/domain/models/offer-redemption-type');
 

--- a/ghost/core/test/unit/server/services/offers/domain/models/offer-status.test.js
+++ b/ghost/core/test/unit/server/services/offers/domain/models/offer-status.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 
 const OfferStatus = require('../../../../../../../core/server/services/offers/domain/models/offer-status');
 

--- a/ghost/core/test/unit/server/services/offers/domain/models/offer-title.test.js
+++ b/ghost/core/test/unit/server/services/offers/domain/models/offer-title.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 
 const OfferTitle = require('../../../../../../../core/server/services/offers/domain/models/offer-title');
 

--- a/ghost/core/test/unit/server/services/offers/domain/models/offer-type.test.js
+++ b/ghost/core/test/unit/server/services/offers/domain/models/offer-type.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 
 const OfferType = require('../../../../../../../core/server/services/offers/domain/models/offer-type');
 

--- a/ghost/core/test/unit/server/services/offers/domain/models/offer.test.js
+++ b/ghost/core/test/unit/server/services/offers/domain/models/offer.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../../../utils/assertions');
-const should = require('should');
 const ObjectID = require('bson-objectid').default;
 const errors = require('../../../../../../../core/server/services/offers/domain/errors');
 const Offer = require('../../../../../../../core/server/services/offers/domain/models/offer');

--- a/ghost/core/test/unit/server/services/offers/domain/models/stripe-coupon.test.js
+++ b/ghost/core/test/unit/server/services/offers/domain/models/stripe-coupon.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const StripeCoupon = require('../../../../../../../core/server/services/offers/domain/models/stripe-coupon');
 
 describe('StripeCoupon', function () {

--- a/ghost/core/test/unit/server/services/permissions/can-this.test.js
+++ b/ghost/core/test/unit/server/services/permissions/can-this.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const sinon = require('sinon');
 const testUtils = require('../../../../utils');
 const _ = require('lodash');

--- a/ghost/core/test/unit/server/services/permissions/index.test.js
+++ b/ghost/core/test/unit/server/services/permissions/index.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../utils/assertions');
-const should = require('should');
 const sinon = require('sinon');
 const testUtils = require('../../../../utils');
 const _ = require('lodash');

--- a/ghost/core/test/unit/server/services/permissions/parse-context.test.js
+++ b/ghost/core/test/unit/server/services/permissions/parse-context.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const parseContext = require('../../../../../core/server/services/permissions/parse-context');
 
 describe('Permissions', function () {

--- a/ghost/core/test/unit/server/services/permissions/providers.test.js
+++ b/ghost/core/test/unit/server/services/permissions/providers.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const sinon = require('sinon');
 const testUtils = require('../../../../utils');
 const models = require('../../../../../core/server/models');

--- a/ghost/core/test/unit/server/services/route-settings/route-settings.test.js
+++ b/ghost/core/test/unit/server/services/route-settings/route-settings.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const sinon = require('sinon');
-const should = require('should');
 const fs = require('fs-extra');
 const path = require('path');
 const bridge = require('../../../../../core/bridge');

--- a/ghost/core/test/unit/server/services/route-settings/settings-loader.test.js
+++ b/ghost/core/test/unit/server/services/route-settings/settings-loader.test.js
@@ -1,7 +1,6 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../utils/assertions');
 const sinon = require('sinon');
-const should = require('should');
 const rewire = require('rewire');
 const fs = require('fs-extra');
 const path = require('path');

--- a/ghost/core/test/unit/server/services/route-settings/validate.test.js
+++ b/ghost/core/test/unit/server/services/route-settings/validate.test.js
@@ -1,9 +1,6 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const errors = require('@tryghost/errors');
 const validate = require('../../../../../core/server/services/route-settings/validate');
-
-should.equal(true, true);
 
 describe('UNIT: services/settings/validate', function () {
     it('no type definitions / empty yaml file', function () {

--- a/ghost/core/test/unit/server/services/settings-helpers/settings-helpers.test.js
+++ b/ghost/core/test/unit/server/services/settings-helpers/settings-helpers.test.js
@@ -1,4 +1,3 @@
-const should = require('should');
 const sinon = require('sinon');
 const configUtils = require('../../../../utils/config-utils');
 const SettingsHelpers = require('../../../../../core/server/services/settings-helpers/settings-helpers');

--- a/ghost/core/test/unit/server/services/settings/default-settings-manager.test.js
+++ b/ghost/core/test/unit/server/services/settings/default-settings-manager.test.js
@@ -1,7 +1,6 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../utils/assertions');
 const sinon = require('sinon');
-const should = require('should');
 const fs = require('fs-extra');
 const path = require('path');
 const DefaultSettingsManager = require('../../../../../core/server/services/route-settings/default-settings-manager');

--- a/ghost/core/test/unit/server/services/settings/settings-bread-service.test.js
+++ b/ghost/core/test/unit/server/services/settings/settings-bread-service.test.js
@@ -4,7 +4,6 @@ const mail = require('../../../../../core/server/services/mail');
 const SettingsBreadService = require('../../../../../core/server/services/settings/settings-bread-service');
 const urlUtils = require('../../../../../core/shared/url-utils.js');
 const {mockManager} = require('../../../../utils/e2e-framework');
-const should = require('should');
 const emailAddress = require('../../../../../core/server/services/email-address');
 describe('UNIT > Settings BREAD Service:', function () {
     let emailMockReceiver;

--- a/ghost/core/test/unit/server/services/settings/settings-utils.test.js
+++ b/ghost/core/test/unit/server/services/settings/settings-utils.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const sinon = require('sinon');
-const should = require('should');
 
 describe('Unit: services/settings/settings-utils', function () {
     describe('getOrGenerateSiteUuid', function () {

--- a/ghost/core/test/unit/server/services/staff/staff-service.test.js
+++ b/ghost/core/test/unit/server/services/staff/staff-service.test.js
@@ -8,7 +8,6 @@ const MilestoneCreatedEvent = require('../../../../../core/server/services/miles
 // Stuff we are testing
 const DomainEvents = require('@tryghost/domain-events');
 
-require('should');
 const StaffService = require('../../../../../core/server/services/staff/staff-service');
 
 function testCommonMailData({mailStub, getEmailAlertUsersStub}) {

--- a/ghost/core/test/unit/server/services/stats/content.test.js
+++ b/ghost/core/test/unit/server/services/stats/content.test.js
@@ -1,7 +1,6 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../utils/assertions');
 const sinon = require('sinon');
-const should = require('should');
 const ContentStatsService = require('../../../../../core/server/services/stats/content-stats-service');
 const tinybird = require('../../../../../core/server/services/stats/utils/tinybird');
 

--- a/ghost/core/test/unit/server/services/stats/mrr.test.js
+++ b/ghost/core/test/unit/server/services/stats/mrr.test.js
@@ -3,7 +3,6 @@ const MrrStatsService = require('../../../../../core/server/services/stats/mrr-s
 const moment = require('moment');
 const sinon = require('sinon');
 const knex = require('knex').default;
-const should = require('should');
 
 describe('MrrStatsService', function () {
     describe('getHistory', function () {

--- a/ghost/core/test/unit/server/services/stripe/config.test.js
+++ b/ghost/core/test/unit/server/services/stripe/config.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../utils/assertions');
-const should = require('should');
 const sinon = require('sinon');
 const UrlUtils = require('@tryghost/url-utils');
 

--- a/ghost/core/test/unit/server/services/stripe/stripe-api.test.js
+++ b/ghost/core/test/unit/server/services/stripe/stripe-api.test.js
@@ -1,7 +1,6 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../utils/assertions');
 const sinon = require('sinon');
-const should = require('should');
 const rewire = require('rewire');
 const StripeAPI = rewire('../../../../../core/server/services/stripe/stripe-api');
 

--- a/ghost/core/test/unit/server/services/themes/loader.test.js
+++ b/ghost/core/test/unit/server/services/themes/loader.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const sinon = require('sinon');
 const fs = require('fs-extra');
 const tmp = require('tmp');

--- a/ghost/core/test/unit/server/services/themes/validate.test.js
+++ b/ghost/core/test/unit/server/services/themes/validate.test.js
@@ -1,4 +1,3 @@
-const should = require('should');
 const sinon = require('sinon');
 const validate = require('../../../../../core/server/services/themes/validate');
 const list = require('../../../../../core/server/services/themes/list');

--- a/ghost/core/test/unit/server/services/update-check.test.js
+++ b/ghost/core/test/unit/server/services/update-check.test.js
@@ -1,4 +1,3 @@
-require('should');
 const sinon = require('sinon');
 const nock = require('nock');
 const moment = require('moment');

--- a/ghost/core/test/unit/server/services/url/local-file-cache.test.js
+++ b/ghost/core/test/unit/server/services/url/local-file-cache.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../utils/assertions');
-const should = require('should');
 const sinon = require('sinon');
 const fs = require('fs-extra');
 

--- a/ghost/core/test/unit/server/services/url/queue.test.js
+++ b/ghost/core/test/unit/server/services/url/queue.test.js
@@ -1,7 +1,6 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../utils/assertions');
 const _ = require('lodash');
-const should = require('should');
 const sinon = require('sinon');
 const logging = require('@tryghost/logging');
 const Queue = require('../../../../../core/server/services/url/queue');

--- a/ghost/core/test/unit/server/services/url/url-generator.test.js
+++ b/ghost/core/test/unit/server/services/url/url-generator.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const sinon = require('sinon');
 const urlUtils = require('../../../../../core/shared/url-utils');
 const UrlGenerator = require('../../../../../core/server/services/url/url-generator');

--- a/ghost/core/test/unit/server/services/url/url-service.test.js
+++ b/ghost/core/test/unit/server/services/url/url-service.test.js
@@ -2,7 +2,6 @@ const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../utils/assertions');
 const errors = require('@tryghost/errors');
 const rewire = require('rewire');
-const should = require('should');
 const sinon = require('sinon');
 const Queue = require('../../../../../core/server/services/url/queue');
 const Resources = require('../../../../../core/server/services/url/resources');

--- a/ghost/core/test/unit/server/services/url/urls.test.js
+++ b/ghost/core/test/unit/server/services/url/urls.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../utils/assertions');
-const should = require('should');
 const sinon = require('sinon');
 const events = require('../../../../../core/server/lib/common/events');
 const Urls = require('../../../../../core/server/services/url/urls');

--- a/ghost/core/test/unit/server/services/verification-trigger.test.js
+++ b/ghost/core/test/unit/server/services/verification-trigger.test.js
@@ -2,7 +2,6 @@
 // const testUtils = require('./utils');
 const sinon = require('sinon');
 const assert = require('node:assert/strict');
-require('should');
 const VerificationTrigger = require('../../../../core/server/services/verification-trigger');
 const DomainEvents = require('@tryghost/domain-events');
 const {MemberCreatedEvent} = require('../../../../core/shared/events');

--- a/ghost/core/test/unit/server/services/webhooks/webhook-service.test.js
+++ b/ghost/core/test/unit/server/services/webhooks/webhook-service.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const sinon = require('sinon');
 
 const createWebhookService = require('../../../../../core/server/services/webhooks/webhooks-service');

--- a/ghost/core/test/unit/server/web/admin/controller.test.js
+++ b/ghost/core/test/unit/server/web/admin/controller.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-require('should');
 const sinon = require('sinon');
 const path = require('path');
 const configUtils = require('../../../../utils/config-utils');

--- a/ghost/core/test/unit/server/web/api/canary/content/middleware.test.js
+++ b/ghost/core/test/unit/server/web/api/canary/content/middleware.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../../../utils/assertions');
-const should = require('should');
 const middleware = require('../../../../../../../core/server/web/api/endpoints/content/middleware');
 
 describe('Content API middleware', function () {

--- a/ghost/core/test/unit/server/web/api/middleware/cors.test.js
+++ b/ghost/core/test/unit/server/web/api/middleware/cors.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const sinon = require('sinon');
 const rewire = require('rewire');
 const configUtils = require('../../../../../utils/config-utils');

--- a/ghost/core/test/unit/server/web/api/middleware/update-user-last-seen.test.js
+++ b/ghost/core/test/unit/server/web/api/middleware/update-user-last-seen.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const sinon = require('sinon');
 const moment = require('moment');
 const updateUserLastSeenMiddleware = require('../../../../../../core/server/web/api/middleware/update-user-last-seen');

--- a/ghost/core/test/unit/server/web/parent/middleware/ghost-locals.test.js
+++ b/ghost/core/test/unit/server/web/parent/middleware/ghost-locals.test.js
@@ -1,7 +1,6 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../../utils/assertions');
 const _ = require('lodash');
-const should = require('should');
 const sinon = require('sinon');
 const ghostLocals = require('../../../../../../core/server/web/parent/middleware/ghost-locals');
 

--- a/ghost/core/test/unit/server/web/parent/middleware/request-id.test.js
+++ b/ghost/core/test/unit/server/web/parent/middleware/request-id.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../../utils/assertions');
-const should = require('should');
 const sinon = require('sinon');
 const validator = require('@tryghost/validator');
 

--- a/ghost/core/test/unit/shared/config/helpers.test.js
+++ b/ghost/core/test/unit/shared/config/helpers.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-require('should');
 const configUtils = require('../../../utils/config-utils');
 
 describe('vhost utils', function () {

--- a/ghost/core/test/unit/shared/config/loader.test.js
+++ b/ghost/core/test/unit/shared/config/loader.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const path = require('path');
 const rewire = require('rewire');
 const _ = require('lodash');

--- a/ghost/core/test/unit/shared/config/utils.test.js
+++ b/ghost/core/test/unit/shared/config/utils.test.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict');
-const should = require('should');
 const _ = require('lodash');
 const configUtils = require('../../../../core/shared/config/utils');
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -30698,50 +30698,6 @@ shimmer@^1.2.1:
   resolved "https://registry.yarnpkg.com/shimmer/-/shimmer-1.2.1.tgz#610859f7de327b587efebf501fb43117f9aff337"
   integrity sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==
 
-should-equal@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/should-equal/-/should-equal-2.0.0.tgz#6072cf83047360867e68e98b09d71143d04ee0c3"
-  integrity sha512-ZP36TMrK9euEuWQYBig9W55WPC7uo37qzAEmbjHz4gfyuXrEUgF8cUvQVO+w+d3OMfPvSRQJ22lSm8MQJ43LTA==
-  dependencies:
-    should-type "^1.4.0"
-
-should-format@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/should-format/-/should-format-3.0.3.tgz#9bfc8f74fa39205c53d38c34d717303e277124f1"
-  integrity sha512-hZ58adtulAk0gKtua7QxevgUaXTTXxIi8t41L3zo9AHvjXO1/7sdLECuHeIN2SRtYXpNkmhoUP2pdeWgricQ+Q==
-  dependencies:
-    should-type "^1.3.0"
-    should-type-adaptors "^1.0.1"
-
-should-type-adaptors@^1.0.1:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/should-type-adaptors/-/should-type-adaptors-1.1.0.tgz#401e7f33b5533033944d5cd8bf2b65027792e27a"
-  integrity sha512-JA4hdoLnN+kebEp2Vs8eBe9g7uy0zbRo+RMcU0EsNy+R+k049Ki+N5tT5Jagst2g7EAja+euFuoXFCa8vIklfA==
-  dependencies:
-    should-type "^1.3.0"
-    should-util "^1.0.0"
-
-should-type@^1.3.0, should-type@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/should-type/-/should-type-1.4.0.tgz#0756d8ce846dfd09843a6947719dfa0d4cff5cf3"
-  integrity sha512-MdAsTu3n25yDbIe1NeN69G4n6mUnJGtSJHygX3+oN0ZbO3DTiATnf7XnYJdGT42JCXurTb1JI0qOBR65shvhPQ==
-
-should-util@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/should-util/-/should-util-1.0.1.tgz#fb0d71338f532a3a149213639e2d32cbea8bcb28"
-  integrity sha512-oXF8tfxx5cDk8r2kYqlkUJzZpDBqVY/II2WhvU0n9Y3XYvAYRmeaf1PvvIvTgPnv4KJ+ES5M0PyDq5Jp+Ygy2g==
-
-should@13.2.3:
-  version "13.2.3"
-  resolved "https://registry.yarnpkg.com/should/-/should-13.2.3.tgz#96d8e5acf3e97b49d89b51feaa5ae8d07ef58f10"
-  integrity sha512-ggLesLtu2xp+ZxI+ysJTmNjh2U0TsC+rQ/pfED9bUZZ4DKefP27D+7YJVVTvKsmjLpIi9jAa7itwDGkDDmt1GQ==
-  dependencies:
-    should-equal "^2.0.0"
-    should-format "^3.0.3"
-    should-type "^1.4.0"
-    should-type-adaptors "^1.0.1"
-    should-util "^1.0.0"
-
 side-channel-list@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/side-channel-list/-/side-channel-list-1.0.0.tgz#10cb5984263115d3b7a0e336591e290a830af8ad"


### PR DESCRIPTION
no ref

This is a test-only change that should have no user impact.

Now that we're not using Should.js any more, we can remove it completely.
