### PR TITLE
Improved stability of browser tests that depend on Stripe Checkout

### DIFF
--- a/ghost/core/test/e2e-browser/portal/donations.spec.js
+++ b/ghost/core/test/e2e-browser/portal/donations.spec.js
@@ -50,7 +50,6 @@ test.describe('Portal', () => {
             // Use URL success params as a stable sync point, then assert the notification UI.
             await expect.poll(() => sharedPage.url(), {timeout: 60000}).toContain('action=support&success=true');
             const notificationFrame = sharedPage.frameLocator('[data-testid="portal-notification-frame"]');
-            await expect(sharedPage.getByTestId('portal-notification-frame')).toBeVisible();
             await expect(notificationFrame.getByText('Thank you for your support!')).toBeVisible();
         });
 

--- a/ghost/core/test/e2e-browser/portal/donations.spec.js
+++ b/ghost/core/test/e2e-browser/portal/donations.spec.js
@@ -47,10 +47,11 @@ test.describe('Portal', () => {
             }
             await submitStripePayment(sharedPage);
 
-            // Check success notification
+            // Use URL success params as a stable sync point, then assert the notification UI.
+            await expect.poll(() => sharedPage.url(), {timeout: 60000}).toContain('action=support&success=true');
             const notificationFrame = sharedPage.frameLocator('[data-testid="portal-notification-frame"]');
-            // todo: replace class locator on data-attr locator
-            await expect(notificationFrame.locator('.gh-portal-notification.success')).toHaveCount(1);
+            await expect(sharedPage.getByTestId('portal-notification-frame')).toBeVisible();
+            await expect(notificationFrame.getByText('Thank you for your support!')).toBeVisible();
         });
 
         test('Can donate with a fixed amount set and different currency', async ({sharedPage}) => {

--- a/ghost/core/test/e2e-browser/portal/donations.spec.js
+++ b/ghost/core/test/e2e-browser/portal/donations.spec.js
@@ -47,10 +47,10 @@ test.describe('Portal', () => {
             }
             await submitStripePayment(sharedPage);
 
-            // Use URL success params as a stable sync point, then assert the notification UI.
-            await expect.poll(() => sharedPage.url(), {timeout: 60000}).toContain('action=support&success=true');
+            // Check success notification
             const notificationFrame = sharedPage.frameLocator('[data-testid="portal-notification-frame"]');
-            await expect(notificationFrame.getByText('Thank you for your support!')).toBeVisible();
+            // todo: replace class locator on data-attr locator
+            await expect(notificationFrame.locator('.gh-portal-notification.success')).toHaveCount(1);
         });
 
         test('Can donate with a fixed amount set and different currency', async ({sharedPage}) => {

--- a/ghost/core/test/e2e-browser/utils/e2e-browser-utils.js
+++ b/ghost/core/test/e2e-browser/utils/e2e-browser-utils.js
@@ -357,6 +357,10 @@ const submitStripePayment = async (page) => {
      * could trigger a duplicate charge in non-test environments.
      */
     for (let attempt = 1; attempt <= 3; attempt++) {
+        if (!page.url().includes('checkout.stripe.com')) {
+            return;
+        }
+
         try {
             // Wait for submit button complete
             await page.waitForSelector('[data-testid="hosted-payment-submit-button"].SubmitButton--complete', {

--- a/ghost/core/test/e2e-browser/utils/e2e-browser-utils.js
+++ b/ghost/core/test/e2e-browser/utils/e2e-browser-utils.js
@@ -357,14 +357,14 @@ const submitStripePayment = async (page) => {
      * could trigger a duplicate charge in non-test environments.
      */
     for (let attempt = 1; attempt <= 3; attempt++) {
-        // Wait for submit button complete
-        await page.waitForSelector('[data-testid="hosted-payment-submit-button"].SubmitButton--complete', {
-            state: 'attached',
-            timeout: 5_000
-        });
-        await page.getByTestId('hosted-payment-submit-button').click();
-
         try {
+            // Wait for submit button complete
+            await page.waitForSelector('[data-testid="hosted-payment-submit-button"].SubmitButton--complete', {
+                state: 'attached',
+                timeout: 5_000
+            });
+            await page.getByTestId('hosted-payment-submit-button').click();
+
             // Stripe can redirect without reaching "load"; "commit" catches early URL change.
             await page.waitForURL(url => !url.hostname.includes('checkout.stripe.com'), {
                 timeout: 25_000,

--- a/ghost/core/test/e2e-browser/utils/e2e-browser-utils.js
+++ b/ghost/core/test/e2e-browser/utils/e2e-browser-utils.js
@@ -351,10 +351,24 @@ const submitStripePayment = async (page) => {
         }
     }
 
-    // Wait for submit button complete
-    await page.waitForSelector('[data-testid="hosted-payment-submit-button"].SubmitButton--complete', {state: 'attached'});
+    for (let attempt = 1; attempt <= 3; attempt++) {
+        // Wait for submit button complete
+        await page.waitForSelector('[data-testid="hosted-payment-submit-button"].SubmitButton--complete', {state: 'attached'});
+        await page.getByTestId('hosted-payment-submit-button').click();
 
-    await page.getByTestId('hosted-payment-submit-button').click();
+        try {
+            // Stripe can redirect without reaching "load"; "commit" catches early URL change.
+            await page.waitForURL(url => !url.hostname.includes('checkout.stripe.com'), {
+                timeout: 25_000,
+                waitUntil: 'commit'
+            });
+            return;
+        } catch (err) {
+            if (attempt === 3) {
+                throw err;
+            }
+        }
+    }
 };
 
 /**

--- a/ghost/core/test/e2e-browser/utils/e2e-browser-utils.js
+++ b/ghost/core/test/e2e-browser/utils/e2e-browser-utils.js
@@ -353,8 +353,6 @@ const submitStripePayment = async (page) => {
 
     /**
      * Retry submit in case Stripe leaves checkout in a transient state.
-     * Note: if attempt 1 actually charged but redirect exceeds 25s, attempt 2
-     * could trigger a duplicate charge in non-test environments.
      */
     for (let attempt = 1; attempt <= 3; attempt++) {
         if (!page.url().includes('checkout.stripe.com')) {

--- a/ghost/core/test/e2e-browser/utils/e2e-browser-utils.js
+++ b/ghost/core/test/e2e-browser/utils/e2e-browser-utils.js
@@ -351,24 +351,15 @@ const submitStripePayment = async (page) => {
         }
     }
 
-    for (let attempt = 1; attempt <= 3; attempt++) {
-        // Wait for submit button complete
-        await page.waitForSelector('[data-testid="hosted-payment-submit-button"].SubmitButton--complete', {state: 'attached'});
-        await page.getByTestId('hosted-payment-submit-button').click();
+    // Wait for submit button complete
+    await page.waitForSelector('[data-testid="hosted-payment-submit-button"].SubmitButton--complete', {state: 'attached'});
+    await page.getByTestId('hosted-payment-submit-button').click();
 
-        try {
-            // Stripe can redirect without reaching "load"; "commit" catches early URL change.
-            await page.waitForURL(url => !url.hostname.includes('checkout.stripe.com'), {
-                timeout: 25_000,
-                waitUntil: 'commit'
-            });
-            return;
-        } catch (err) {
-            if (attempt === 3) {
-                throw err;
-            }
-        }
-    }
+    // Stripe can redirect without reaching "load"; "commit" catches early URL change.
+    await page.waitForURL(url => !url.hostname.includes('checkout.stripe.com'), {
+        timeout: 25_000,
+        waitUntil: 'commit'
+    });
 };
 
 /**

--- a/ghost/core/test/e2e-browser/utils/e2e-browser-utils.js
+++ b/ghost/core/test/e2e-browser/utils/e2e-browser-utils.js
@@ -351,15 +351,24 @@ const submitStripePayment = async (page) => {
         }
     }
 
-    // Wait for submit button complete
-    await page.waitForSelector('[data-testid="hosted-payment-submit-button"].SubmitButton--complete', {state: 'attached'});
-    await page.getByTestId('hosted-payment-submit-button').click();
+    for (let attempt = 1; attempt <= 3; attempt++) {
+        // Wait for submit button complete
+        await page.waitForSelector('[data-testid="hosted-payment-submit-button"].SubmitButton--complete', {state: 'attached'});
+        await page.getByTestId('hosted-payment-submit-button').click();
 
-    // Stripe can redirect without reaching "load"; "commit" catches early URL change.
-    await page.waitForURL(url => !url.hostname.includes('checkout.stripe.com'), {
-        timeout: 25_000,
-        waitUntil: 'commit'
-    });
+        try {
+            // Stripe can redirect without reaching "load"; "commit" catches early URL change.
+            await page.waitForURL(url => !url.hostname.includes('checkout.stripe.com'), {
+                timeout: 25_000,
+                waitUntil: 'commit'
+            });
+            return;
+        } catch (err) {
+            if (attempt === 3) {
+                throw err;
+            }
+        }
+    }
 };
 
 /**

--- a/ghost/core/test/e2e-browser/utils/e2e-browser-utils.js
+++ b/ghost/core/test/e2e-browser/utils/e2e-browser-utils.js
@@ -351,9 +351,17 @@ const submitStripePayment = async (page) => {
         }
     }
 
+    /**
+     * Retry submit in case Stripe leaves checkout in a transient state.
+     * Note: if attempt 1 actually charged but redirect exceeds 25s, attempt 2
+     * could trigger a duplicate charge in non-test environments.
+     */
     for (let attempt = 1; attempt <= 3; attempt++) {
         // Wait for submit button complete
-        await page.waitForSelector('[data-testid="hosted-payment-submit-button"].SubmitButton--complete', {state: 'attached'});
+        await page.waitForSelector('[data-testid="hosted-payment-submit-button"].SubmitButton--complete', {
+            state: 'attached',
+            timeout: 5_000
+        });
         await page.getByTestId('hosted-payment-submit-button').click();
 
         try {


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/actions/runs/22159115008/job/64071040152

Portal donations tests were flaking fairly frequently in CI. 

The `submitStripePayment` flow in e2e-browser-utils was clicking on the submit button in Stripe Checkout and then exiting. This prematurely started subsequent assertions in the tests, before the redirect back to Ghost had completed.

This fixes that by waiting for the url to no longer include stripe.checkout.com, indicating that the redirect back to Ghost has completed, and only then starting the assertions in the tests themselves.

This fix was in response to flaky donations tests, but it should also improve the reliability of any test that uses Stripe checkout:
  - ghost/core/test/e2e-browser/portal/donations.spec.js
  - ghost/core/test/e2e-browser/portal/tiers.spec.js
  - ghost/core/test/e2e-browser/portal/upgrade.spec.js
  - ghost/core/test/e2e-browser/portal/offers.spec.js
