### PR TITLE
Fixed rounding for percent-off offer prices

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.64.6",
+  "version": "2.64.7",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/portal/src/components/pages/offer-page.js
+++ b/apps/portal/src/components/pages/offer-page.js
@@ -4,7 +4,7 @@ import AppContext from '../../app-context';
 import {ReactComponent as CheckmarkIcon} from '../../images/icons/checkmark.svg';
 import CloseButton from '../common/close-button';
 import InputForm from '../common/input-form';
-import {getCurrencySymbol, getProductFromId, hasMultipleProductsFeature, isSameCurrency, formatNumber, hasMultipleNewsletters} from '../../utils/helpers';
+import {getCurrencySymbol, getProductFromId, hasMultipleProductsFeature, getUpdatedOfferPrice, formatNumber, hasMultipleNewsletters} from '../../utils/helpers';
 import {ValidateInputForm} from '../../utils/form';
 import {interceptAnchorClicks} from '../../utils/links';
 import {sanitizeHtml} from '../../utils/sanitize-html';
@@ -487,20 +487,6 @@ export default class OfferPage extends React.Component {
         return `${getCurrencySymbol(price.currency)}${originalAmount}/${offer.cadence}`;
     }
 
-    getUpdatedPrice({offer, product}) {
-        const price = offer.cadence === 'month' ? product.monthlyPrice : product.yearlyPrice;
-        const originalAmount = price.amount;
-        let updatedAmount;
-        if (offer.type === 'fixed' && isSameCurrency(offer.currency, price.currency)) {
-            updatedAmount = ((originalAmount - offer.amount)) / 100;
-            return updatedAmount > 0 ? updatedAmount : 0;
-        } else if (offer.type === 'percent') {
-            updatedAmount = (originalAmount - ((originalAmount * offer.amount) / 100)) / 100;
-            return updatedAmount;
-        }
-        return originalAmount / 100;
-    }
-
     renderRoundedPrice(price) {
         if (price % 1 !== 0) {
             const roundedPrice = Math.round(price * 100) / 100;
@@ -657,7 +643,7 @@ export default class OfferPage extends React.Component {
             return null;
         }
         const price = offer.cadence === 'month' ? product.monthlyPrice : product.yearlyPrice;
-        const updatedPrice = this.getUpdatedPrice({offer, product});
+        const updatedPrice = getUpdatedOfferPrice({offer, price});
         const benefits = product.benefits || [];
 
         const currencyClass = (getCurrencySymbol(price.currency)).length > 1 ? 'long' : '';

--- a/apps/portal/src/utils/helpers.js
+++ b/apps/portal/src/utils/helpers.js
@@ -808,17 +808,18 @@ export const getOfferOffAmount = ({offer}) => {
 };
 
 export const getUpdatedOfferPrice = ({offer, price, useFormatted = false}) => {
-    const originalAmount = price.amount;
-    let updatedAmount;
+    const originalAmountInCents = price.amount;
+    let updatedAmountInCents = originalAmountInCents;
 
     if (offer.type === 'fixed' && isSameCurrency(offer.currency, price.currency)) {
-        updatedAmount = ((originalAmount - offer.amount)) / 100;
-        updatedAmount = updatedAmount > 0 ? updatedAmount : 0;
+        updatedAmountInCents = Math.max(0, (originalAmountInCents - offer.amount));
     } else if (offer.type === 'percent') {
-        updatedAmount = (originalAmount - ((originalAmount * offer.amount) / 100)) / 100;
-    } else {
-        updatedAmount = originalAmount / 100;
+        const discountInCents = Math.round(originalAmountInCents * (offer.amount / 100));
+        updatedAmountInCents = Math.max(0, (originalAmountInCents - discountInCents));
     }
+
+    const updatedAmount = updatedAmountInCents / 100;
+
     if (useFormatted) {
         return Intl.NumberFormat('en', {currency: price?.currency, style: 'currency'}).format(updatedAmount);
     }

--- a/apps/portal/test/utils/helpers.test.js
+++ b/apps/portal/test/utils/helpers.test.js
@@ -227,6 +227,24 @@ describe('Helpers - ', () => {
             expect(updatedPrice).toBe(6.69);
         });
 
+        // Edge-case: Stripe applies the rounding per invoice line item, i.e. on the discount line, not on the final invoice amount
+        //
+        // Example:
+        // - Original amount: 101 ($1.01)
+        // - Percent amount: 50 (50%)
+        // - Discount amount should be rounded: 101 * 50/100 = 50.5 -> Rounded to 51 ($0.51)
+        // - Final amount: 101 - 51 = $0.50
+        //
+        // Instead, if we apply rounding to the final amount, we end up with a 1-cent drift: 101 - (101 * 50/100) = 101 - 50.5 = 50.5 -> Rounded to 51 ($0.51)
+        test('rounds 50% off $1.01 to $0.50', () => {
+            const updatedPrice = getUpdatedOfferPrice({
+                offer: {type: 'percent', amount: 50},
+                price: {amount: 101, currency: 'usd'}
+            });
+
+            expect(updatedPrice).toBe(0.50);
+        });
+
         test('returns exact discounted amount when no rounding is needed', () => {
             const updatedPrice = getUpdatedOfferPrice({
                 offer: {type: 'percent', amount: 50},

--- a/apps/portal/test/utils/helpers.test.js
+++ b/apps/portal/test/utils/helpers.test.js
@@ -24,12 +24,13 @@ import {
     getCompExpiry,
     isInThePast,
     hasNewsletterSendingEnabled,
+    getUpdatedOfferPrice,
+    isComplimentaryMember,
     subscriptionHasFreeMonthsOffer,
     subscriptionHasFreeTrial
 } from '../../src/utils/helpers';
 import * as Fixtures from '../../src/utils/fixtures-generator';
 import {site as FixturesSite, member as FixtureMember, offer as FixtureOffer, transformTierFixture as TransformFixtureTiers} from './test-fixtures';
-import {isComplimentaryMember} from '../../src/utils/helpers';
 
 describe('Helpers - ', () => {
     describe('isComplimentaryMember -', () => {
@@ -204,6 +205,63 @@ describe('Helpers - ', () => {
             let currency1 = 'eur';
             let currency2 = 'usd';
             expect(isSameCurrency(currency1, currency2)).toBe(false);
+        });
+    });
+
+    describe('getUpdatedOfferPrice - ', () => {
+        test('rounds 20% off $5.99 to $4.79', () => {
+            const updatedPrice = getUpdatedOfferPrice({
+                offer: {type: 'percent', amount: 20},
+                price: {amount: 599, currency: 'usd'}
+            });
+
+            expect(updatedPrice).toBe(4.79);
+        });
+
+        test('rounds 33% off $9.99 to $6.69', () => {
+            const updatedPrice = getUpdatedOfferPrice({
+                offer: {type: 'percent', amount: 33},
+                price: {amount: 999, currency: 'usd'}
+            });
+
+            expect(updatedPrice).toBe(6.69);
+        });
+
+        test('returns exact discounted amount when no rounding is needed', () => {
+            const updatedPrice = getUpdatedOfferPrice({
+                offer: {type: 'percent', amount: 50},
+                price: {amount: 1000, currency: 'usd'}
+            });
+
+            expect(updatedPrice).toBe(5);
+        });
+
+        test('rounds 15% off $3.33 to $2.83', () => {
+            const updatedPrice = getUpdatedOfferPrice({
+                offer: {type: 'percent', amount: 15},
+                price: {amount: 333, currency: 'usd'}
+            });
+
+            expect(updatedPrice).toBe(2.83);
+        });
+
+        test('returns expected amount for fixed offers', () => {
+            const updatedPrice = getUpdatedOfferPrice({
+                offer: {type: 'fixed', amount: 100, currency: 'usd'},
+                price: {amount: 599, currency: 'usd'}
+            });
+
+            expect(updatedPrice).toBe(4.99);
+        });
+
+        test('returns formatted price when useFormatted is true', () => {
+            const updatedPrice = getUpdatedOfferPrice({
+                offer: {type: 'percent', amount: 20},
+                price: {amount: 599, currency: 'usd'},
+                useFormatted: true
+            });
+
+            expect(updatedPrice).toBe('$4.79');
         });
     });
 

--- a/ghost/core/core/server/services/members/members-api/services/next-payment-calculator.js
+++ b/ghost/core/core/server/services/members/members-api/services/next-payment-calculator.js
@@ -160,7 +160,7 @@ class NextPaymentCalculator {
     _calculateDiscountedAmount(originalAmount, offer) {
         if (offer.type === 'percent') {
             const discount = Math.round(originalAmount * (offer.amount / 100));
-            return Math.max(0, originalAmount - discount);
+            return originalAmount - discount;
         }
 
         if (offer.type === 'fixed') {


### PR DESCRIPTION
closes https://linear.app/ghost/issue/BER-3344

- Added rounding for percent-off prices, so that the displayed price matches the amount being billed by Stripe. Example: 20% off $5.99 renders $4.79 (not $4.792)
- Cleaned up duplicate code