### PR TITLE
Updated members filtering by retention offer 

### DIFF
--- a/apps/admin-x-settings/src/components/settings/growth/offers/edit-retention-offer-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/offers/edit-retention-offer-modal.tsx
@@ -5,6 +5,7 @@ import {type ErrorMessages, useForm} from '@tryghost/admin-x-framework/hooks';
 import {Form, PreviewModalContent, Select, type SelectOption, TextArea, TextField, Toggle, showToast} from '@tryghost/admin-x-design-system';
 import {JSONError} from '@tryghost/admin-x-framework/errors';
 import {type Offer, useAddOffer, useBrowseOffers, useEditOffer, useInvalidateOffers} from '@tryghost/admin-x-framework/api/offers';
+import {createOfferRedemptionsFilterUrl, formatOfferTimestamp} from './offer-helpers';
 import {getOfferPortalPreviewUrl, type offerPortalPreviewUrlTypes} from '../../../../utils/get-offers-portal-preview-url';
 import {getPaidActiveTiers, useBrowseTiers} from '@tryghost/admin-x-framework/api/tiers';
 import {useEffect, useMemo, useState} from 'react';
@@ -176,8 +177,11 @@ const RetentionOfferSidebar: React.FC<{
     clearError: (field: string) => void;
     errors: ErrorMessages;
     cadence: 'monthly' | 'yearly';
+    createdAt?: string;
+    lastRedeemed?: string | null;
+    membersFilterUrl?: string | null;
     redemptions: number;
-}> = ({formState, updateForm, clearError, errors, cadence, redemptions}) => {
+}> = ({formState, updateForm, clearError, errors, cadence, createdAt, lastRedeemed, membersFilterUrl, redemptions}) => {
     const availableDurationOptions = cadence === 'yearly'
         ? durationOptions.filter(option => option.value !== 'repeating')
         : durationOptions;
@@ -188,8 +192,26 @@ const RetentionOfferSidebar: React.FC<{
                 <section>
                     <div className='flex flex-col gap-5 rounded-md border border-grey-300 p-4 pb-3.5 dark:border-grey-800'>
                         <div className='flex flex-col gap-1.5'>
-                            <span className='text-xs font-semibold leading-none text-grey-700'>Performance</span>
-                            <span>{redemptions} redemptions</span>
+                            <span className='text-xs font-semibold leading-none text-grey-700'>Created on</span>
+                            <span>{createdAt ? formatOfferTimestamp(createdAt) : '-'}</span>
+                        </div>
+                        <div className='flex flex-col gap-1.5'>
+                            <div className='flex items-end justify-between'>
+                                <div className='flex flex-col gap-5'>
+                                    <div className='flex flex-col gap-1.5'>
+                                        <span className='text-xs font-semibold leading-none text-grey-700'>Performance</span>
+                                        <span>{redemptions} {redemptions === 1 ? 'redemption' : 'redemptions'}</span>
+                                    </div>
+                                    {redemptions > 0 && lastRedeemed ?
+                                        <div className='flex flex-col gap-1.5'>
+                                            <span className='text-xs font-semibold leading-none text-grey-700'>Last redemption</span>
+                                            <span>{formatOfferTimestamp(lastRedeemed)}</span>
+                                        </div> :
+                                        null
+                                    }
+                                </div>
+                                {redemptions > 0 && membersFilterUrl ? <a className='font-semibold text-green' href={membersFilterUrl}>See members →</a> : null}
+                            </div>
                         </div>
                     </div>
                 </section>
@@ -358,6 +380,32 @@ const EditRetentionOfferModal: React.FC<{id: string}> = ({id}) => {
             return total + (offer.redemption_count || 0);
         }, 0);
     }, [retentionOffersByCadence]);
+    const retentionOfferIdsByCadence = useMemo(() => {
+        return retentionOffersByCadence.map(offer => offer.id);
+    }, [retentionOffersByCadence]);
+    const firstRetentionOfferCreatedAt = useMemo(() => {
+        return retentionOffersByCadence
+            .map(offer => offer.created_at)
+            .filter((createdAt): createdAt is string => !!createdAt)
+            .sort((left, right) => {
+                return new Date(left).getTime() - new Date(right).getTime();
+            })[0];
+    }, [retentionOffersByCadence]);
+    const latestRetentionRedemption = useMemo(() => {
+        return retentionOffersByCadence
+            .map(offer => offer.last_redeemed)
+            .filter((lastRedeemed): lastRedeemed is string => !!lastRedeemed)
+            .sort((left, right) => {
+                return new Date(right).getTime() - new Date(left).getTime();
+            })[0] || null;
+    }, [retentionOffersByCadence]);
+    const retentionMembersFilterUrl = useMemo(() => {
+        if (retentionRedemptions === 0 || retentionOfferIdsByCadence.length === 0) {
+            return null;
+        }
+
+        return createOfferRedemptionsFilterUrl(retentionOfferIdsByCadence);
+    }, [retentionOfferIdsByCadence, retentionRedemptions]);
     const [lastPreviewPercentAmount, setLastPreviewPercentAmount] = useState(20);
     const [lastPreviewFreeMonths, setLastPreviewFreeMonths] = useState(1);
     const [initializedOfferKey, setInitializedOfferKey] = useState<string | null>(null);
@@ -523,8 +571,11 @@ const EditRetentionOfferModal: React.FC<{id: string}> = ({id}) => {
         <RetentionOfferSidebar
             cadence={cadence}
             clearError={clearError}
+            createdAt={firstRetentionOfferCreatedAt}
             errors={errors}
             formState={formState}
+            lastRedeemed={latestRetentionRedemption}
+            membersFilterUrl={retentionMembersFilterUrl}
             redemptions={retentionRedemptions}
             updateForm={updateForm}
         />

--- a/apps/admin-x-settings/src/components/settings/growth/offers/edit-retention-offer-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/offers/edit-retention-offer-modal.tsx
@@ -177,11 +177,10 @@ const RetentionOfferSidebar: React.FC<{
     clearError: (field: string) => void;
     errors: ErrorMessages;
     cadence: 'monthly' | 'yearly';
-    createdAt?: string;
     lastRedeemed?: string | null;
     membersFilterUrl?: string | null;
     redemptions: number;
-}> = ({formState, updateForm, clearError, errors, cadence, createdAt, lastRedeemed, membersFilterUrl, redemptions}) => {
+}> = ({formState, updateForm, clearError, errors, cadence, lastRedeemed, membersFilterUrl, redemptions}) => {
     const availableDurationOptions = cadence === 'yearly'
         ? durationOptions.filter(option => option.value !== 'repeating')
         : durationOptions;
@@ -191,10 +190,6 @@ const RetentionOfferSidebar: React.FC<{
             <Form className='grow'>
                 <section>
                     <div className='flex flex-col gap-5 rounded-md border border-grey-300 p-4 pb-3.5 dark:border-grey-800'>
-                        <div className='flex flex-col gap-1.5'>
-                            <span className='text-xs font-semibold leading-none text-grey-700'>Created on</span>
-                            <span>{createdAt ? formatOfferTimestamp(createdAt) : '-'}</span>
-                        </div>
                         <div className='flex flex-col gap-1.5'>
                             <div className='flex items-end justify-between'>
                                 <div className='flex flex-col gap-5'>
@@ -383,14 +378,6 @@ const EditRetentionOfferModal: React.FC<{id: string}> = ({id}) => {
     const retentionOfferIdsByCadence = useMemo(() => {
         return retentionOffersByCadence.map(offer => offer.id);
     }, [retentionOffersByCadence]);
-    const firstRetentionOfferCreatedAt = useMemo(() => {
-        return retentionOffersByCadence
-            .map(offer => offer.created_at)
-            .filter((createdAt): createdAt is string => !!createdAt)
-            .sort((left, right) => {
-                return new Date(left).getTime() - new Date(right).getTime();
-            })[0];
-    }, [retentionOffersByCadence]);
     const latestRetentionRedemption = useMemo(() => {
         return retentionOffersByCadence
             .map(offer => offer.last_redeemed)
@@ -571,7 +558,6 @@ const EditRetentionOfferModal: React.FC<{id: string}> = ({id}) => {
         <RetentionOfferSidebar
             cadence={cadence}
             clearError={clearError}
-            createdAt={firstRetentionOfferCreatedAt}
             errors={errors}
             formState={formState}
             lastRedeemed={latestRetentionRedemption}

--- a/apps/admin-x-settings/src/components/settings/growth/offers/offer-helpers.ts
+++ b/apps/admin-x-settings/src/components/settings/growth/offers/offer-helpers.ts
@@ -1,0 +1,18 @@
+export const formatOfferTimestamp = (timestamp: string): string => {
+    const date = new Date(timestamp);
+    return date.toLocaleDateString('default', {
+        year: 'numeric',
+        month: 'short',
+        day: '2-digit'
+    });
+};
+
+export const createOfferRedemptionsFilterUrl = (offerIds: string[]): string => {
+    const baseHref = '/ghost/#/members';
+    const filterValue = `offer_redemptions:[${offerIds.join(',')}]`;
+    return `${baseHref}?filter=${encodeURIComponent(filterValue)}`;
+};
+
+export const createOfferRedemptionFilterUrl = (offerId: string): string => {
+    return createOfferRedemptionsFilterUrl([offerId]);
+};

--- a/apps/admin-x-settings/src/components/settings/growth/offers/offers-retention.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/offers/offers-retention.tsx
@@ -120,7 +120,7 @@ const OffersRetention: React.FC = () => {
     const {data: {offers: allOffers = []} = {}} = useBrowseOffers();
     const retentionOffers = getRetentionOffers(allOffers);
 
-    const handleRetentionOfferClick = (id: string) => {
+    const handleOfferEdit = (id: string) => {
         updateRoute(`offers/edit/retention/${id}`);
     };
 
@@ -142,13 +142,13 @@ const OffersRetention: React.FC = () => {
                     return (
                         <tr key={offer.id} className='group relative scale-100 border-b border-b-grey-200 dark:border-grey-800' data-testid='retention-offer-item'>
                             <td className='p-0'>
-                                <a className='block cursor-pointer p-5 pl-0' onClick={() => handleRetentionOfferClick(offer.id)}>
+                                <a className='block cursor-pointer p-5 pl-0' onClick={() => handleOfferEdit(offer.id)}>
                                     <span className='font-semibold'>{offer.name}</span><br />
                                     <span className='text-sm text-grey-700'>{offer.description}</span>
                                 </a>
                             </td>
                             <td className='whitespace-nowrap p-0 text-sm'>
-                                <a className='block cursor-pointer p-5' onClick={() => handleRetentionOfferClick(offer.id)}>
+                                <a className='block cursor-pointer p-5' onClick={() => handleOfferEdit(offer.id)}>
                                     {offer.terms ? (
                                         <>
                                             <span className='text-[1.3rem] font-medium uppercase'>{offer.terms}</span><br />
@@ -164,13 +164,13 @@ const OffersRetention: React.FC = () => {
                                     className={`block cursor-pointer p-5 ${redemptionFilterUrl ? 'hover:underline' : ''}`}
                                     data-testid={`retention-redemptions-link-${offer.id}`}
                                     href={redemptionFilterUrl}
-                                    onClick={!redemptionFilterUrl ? () => handleRetentionOfferClick(offer.id) : undefined}
+                                    onClick={!redemptionFilterUrl ? () => handleOfferEdit(offer.id) : undefined}
                                 >
                                     {offer.redemptions}
                                 </a>
                             </td>
                             <td className='whitespace-nowrap p-0 text-sm'>
-                                <a className='block cursor-pointer p-5' onClick={() => handleRetentionOfferClick(offer.id)}>
+                                <a className='block cursor-pointer p-5' onClick={() => handleOfferEdit(offer.id)}>
                                     {offer.status === 'active' ? (
                                         <span className='text-sm font-semibold text-green'>Active</span>
                                     ) : (

--- a/apps/admin-x-settings/src/components/settings/growth/offers/offers-retention.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/offers/offers-retention.tsx
@@ -1,4 +1,5 @@
 import {type Offer, useBrowseOffers} from '@tryghost/admin-x-framework/api/offers';
+import {createOfferRedemptionsFilterUrl} from './offer-helpers';
 import {useRouting} from '@tryghost/admin-x-framework/routing';
 
 type RetentionCadence = 'month' | 'year';
@@ -9,6 +10,7 @@ type RetentionOffer = {
     description: string;
     terms: string | null; // e.g. "50% OFF" when active
     termsDetail: string | null; // e.g. "Next payment" when active
+    redemptionOfferIds: string[];
     redemptions: number;
     status: 'active' | 'inactive';
 };
@@ -29,6 +31,14 @@ const getRetentionRedemptionsByCadence = (offers: Offer[], cadence: RetentionCad
 
         return total + (offer.redemption_count || 0);
     }, 0);
+};
+
+const getRetentionOfferIdsByCadence = (offers: Offer[], cadence: RetentionCadence): string[] => {
+    return offers
+        .filter((offer) => {
+            return offer.redemption_type === 'retention' && offer.cadence === cadence;
+        })
+        .map(offer => offer.id);
 };
 
 const getRetentionTerms = (offer: Offer | null): string | null => {
@@ -76,6 +86,8 @@ const getRetentionTermsDetail = (offer: Offer | null): string | null => {
 const getRetentionOffers = (offers: Offer[]): RetentionOffer[] => {
     const monthlyOffer = getActiveRetentionOfferByCadence(offers, 'month');
     const yearlyOffer = getActiveRetentionOfferByCadence(offers, 'year');
+    const monthlyOfferIds = getRetentionOfferIdsByCadence(offers, 'month');
+    const yearlyOfferIds = getRetentionOfferIdsByCadence(offers, 'year');
     const monthlyRedemptions = getRetentionRedemptionsByCadence(offers, 'month');
     const yearlyRedemptions = getRetentionRedemptionsByCadence(offers, 'year');
 
@@ -86,6 +98,7 @@ const getRetentionOffers = (offers: Offer[]): RetentionOffer[] => {
             description: 'Applied to monthly plans',
             terms: getRetentionTerms(monthlyOffer),
             termsDetail: getRetentionTermsDetail(monthlyOffer),
+            redemptionOfferIds: monthlyOfferIds,
             redemptions: monthlyRedemptions,
             status: monthlyOffer ? 'active' : 'inactive'
         },
@@ -95,6 +108,7 @@ const getRetentionOffers = (offers: Offer[]): RetentionOffer[] => {
             description: 'Applied to annual plans',
             terms: getRetentionTerms(yearlyOffer),
             termsDetail: getRetentionTermsDetail(yearlyOffer),
+            redemptionOfferIds: yearlyOfferIds,
             redemptions: yearlyRedemptions,
             status: yearlyOffer ? 'active' : 'inactive'
         }
@@ -120,43 +134,54 @@ const OffersRetention: React.FC = () => {
                     <col className='w-[220px]' />
                     <col className='w-[80px]' />
                 </colgroup>
-                {retentionOffers.map(offer => (
-                    <tr key={offer.id} className='group relative scale-100 border-b border-b-grey-200 dark:border-grey-800' data-testid='retention-offer-item'>
-                        <td className='p-0'>
-                            <a className='block cursor-pointer p-5 pl-0' onClick={() => handleRetentionOfferClick(offer.id)}>
-                                <span className='font-semibold'>{offer.name}</span><br />
-                                <span className='text-sm text-grey-700'>{offer.description}</span>
-                            </a>
-                        </td>
-                        <td className='whitespace-nowrap p-0 text-sm'>
-                            <a className='block cursor-pointer p-5' onClick={() => handleRetentionOfferClick(offer.id)}>
-                                {offer.terms ? (
-                                    <>
-                                        <span className='text-[1.3rem] font-medium uppercase'>{offer.terms}</span><br />
-                                        <span className='text-grey-700'>{offer.termsDetail}</span>
-                                    </>
-                                ) : (
-                                    <span className='text-grey-700'>&ndash;</span>
-                                )}
-                            </a>
-                        </td>
-                        <td className='whitespace-nowrap p-0 text-sm'>
-                            <a className='block cursor-pointer p-5' onClick={() => handleRetentionOfferClick(offer.id)}>
-                                {offer.redemptions}
-                            </a>
-                        </td>
-                        <td className='whitespace-nowrap p-0 text-sm'>
-                            <a className='block cursor-pointer p-5' onClick={() => handleRetentionOfferClick(offer.id)}>
-                                {offer.status === 'active' ? (
-                                    <span className='text-sm font-semibold text-green'>Active</span>
-                                ) : (
-                                    <span className='text-sm text-grey-700'>Inactive</span>
-                                )}
-                            </a>
-                        </td>
-                        <td className='w-[80px] p-0'></td>
-                    </tr>
-                ))}
+                {retentionOffers.map((offer) => {
+                    const redemptionFilterUrl = offer.redemptions > 0 && offer.redemptionOfferIds.length > 0
+                        ? createOfferRedemptionsFilterUrl(offer.redemptionOfferIds)
+                        : undefined;
+
+                    return (
+                        <tr key={offer.id} className='group relative scale-100 border-b border-b-grey-200 dark:border-grey-800' data-testid='retention-offer-item'>
+                            <td className='p-0'>
+                                <a className='block cursor-pointer p-5 pl-0' onClick={() => handleRetentionOfferClick(offer.id)}>
+                                    <span className='font-semibold'>{offer.name}</span><br />
+                                    <span className='text-sm text-grey-700'>{offer.description}</span>
+                                </a>
+                            </td>
+                            <td className='whitespace-nowrap p-0 text-sm'>
+                                <a className='block cursor-pointer p-5' onClick={() => handleRetentionOfferClick(offer.id)}>
+                                    {offer.terms ? (
+                                        <>
+                                            <span className='text-[1.3rem] font-medium uppercase'>{offer.terms}</span><br />
+                                            <span className='text-grey-700'>{offer.termsDetail}</span>
+                                        </>
+                                    ) : (
+                                        <span className='text-grey-700'>&ndash;</span>
+                                    )}
+                                </a>
+                            </td>
+                            <td className='whitespace-nowrap p-0 text-sm'>
+                                <a
+                                    className={`block cursor-pointer p-5 ${redemptionFilterUrl ? 'hover:underline' : ''}`}
+                                    data-testid={`retention-redemptions-link-${offer.id}`}
+                                    href={redemptionFilterUrl}
+                                    onClick={!redemptionFilterUrl ? () => handleRetentionOfferClick(offer.id) : undefined}
+                                >
+                                    {offer.redemptions}
+                                </a>
+                            </td>
+                            <td className='whitespace-nowrap p-0 text-sm'>
+                                <a className='block cursor-pointer p-5' onClick={() => handleRetentionOfferClick(offer.id)}>
+                                    {offer.status === 'active' ? (
+                                        <span className='text-sm font-semibold text-green'>Active</span>
+                                    ) : (
+                                        <span className='text-sm text-grey-700'>Inactive</span>
+                                    )}
+                                </a>
+                            </td>
+                            <td className='w-[80px] p-0'></td>
+                        </tr>
+                    );
+                })}
             </table>
         </div>
     );

--- a/apps/admin-x-settings/test/acceptance/membership/offers.test.ts
+++ b/apps/admin-x-settings/test/acceptance/membership/offers.test.ts
@@ -283,6 +283,8 @@ test.describe('Offers Modal', () => {
             redemption_count: number;
             redemption_type: 'retention';
             tier: null;
+            created_at?: string;
+            last_redeemed?: string;
         };
 
         const signupOffers = (responseFixtures.offers.offers || []).filter(offer => offer.redemption_type === 'signup');
@@ -365,6 +367,16 @@ test.describe('Offers Modal', () => {
             return {modal, retentionModal};
         };
 
+        const formatOfferDateForBrowser = async (page: Page, timestamp: string) => {
+            return await page.evaluate((value) => {
+                return new Date(value).toLocaleDateString('default', {
+                    year: 'numeric',
+                    month: 'short',
+                    day: '2-digit'
+                });
+            }, timestamp);
+        };
+
         test('Lists monthly and yearly retention offers', async ({page}) => {
             await mockApi({page, requests: getRetentionRequests({
                 retentionOffers: [
@@ -410,11 +422,13 @@ test.describe('Offers Modal', () => {
             await expect(monthlyRow).toContainText('First payment');
             await expect(monthlyRow).toContainText('10');
             await expect(monthlyRow).toContainText('Active');
+            await expect(monthlyRow.getByTestId('retention-redemptions-link-monthly')).toHaveAttribute('href', '/ghost/#/members?filter=offer_redemptions%3A%5Bretention-month-active%2Cretention-month-archived%5D');
 
             const yearlyRow = rows.nth(1);
             await expect(yearlyRow).toContainText('Yearly retention');
             await expect(yearlyRow).toContainText('Inactive');
             await expect(yearlyRow).toContainText('9');
+            await expect(yearlyRow.getByTestId('retention-redemptions-link-yearly')).toHaveAttribute('href', '/ghost/#/members?filter=offer_redemptions%3A%5Bretention-year-archived%5D');
             await expect(yearlyRow).not.toContainText('2 MONTHS FREE');
         });
 
@@ -430,7 +444,9 @@ test.describe('Offers Modal', () => {
                         amount: 40,
                         duration: 'repeating',
                         duration_in_months: 3,
-                        redemption_count: 7
+                        redemption_count: 7,
+                        created_at: '2026-02-17T12:00:00.000Z',
+                        last_redeemed: '2026-02-18T12:00:00.000Z'
                     }),
                     createRetentionOffer({
                         id: 'retention-year-active',
@@ -442,7 +458,9 @@ test.describe('Offers Modal', () => {
                         cadence: 'year',
                         amount: 2,
                         duration: 'free_months',
-                        redemption_count: 4
+                        redemption_count: 4,
+                        created_at: '2026-02-16T12:00:00.000Z',
+                        last_redeemed: '2026-02-17T12:00:00.000Z'
                     }),
                     createRetentionOffer({
                         id: 'retention-month-archived',
@@ -452,7 +470,9 @@ test.describe('Offers Modal', () => {
                         amount: 30,
                         duration: 'once',
                         status: 'archived',
-                        redemption_count: 4
+                        redemption_count: 4,
+                        created_at: '2026-01-19T12:00:00.000Z',
+                        last_redeemed: '2026-02-19T12:00:00.000Z'
                     }),
                     createRetentionOffer({
                         id: 'retention-year-archived',
@@ -464,13 +484,22 @@ test.describe('Offers Modal', () => {
                         amount: 1,
                         duration: 'free_months',
                         status: 'archived',
-                        redemption_count: 5
+                        redemption_count: 5,
+                        created_at: '2026-01-25T12:00:00.000Z',
+                        last_redeemed: '2026-02-18T12:00:00.000Z'
                     })
                 ]
             })});
 
             const {modal, retentionModal: monthlyModal} = await openRetentionModal(page, 'Monthly retention');
+            const expectedMonthlyCreatedOn = await formatOfferDateForBrowser(page, '2026-01-19T12:00:00.000Z');
+            const expectedMonthlyLastRedemption = await formatOfferDateForBrowser(page, '2026-02-19T12:00:00.000Z');
+            await expect(monthlyModal).toContainText('Created on');
+            await expect(monthlyModal).toContainText(expectedMonthlyCreatedOn);
             await expect(monthlyModal).toContainText('11 redemptions');
+            await expect(monthlyModal).toContainText('Last redemption');
+            await expect(monthlyModal).toContainText(expectedMonthlyLastRedemption);
+            await expect(monthlyModal.getByRole('link', {name: 'See members →'})).toHaveAttribute('href', /offer_redemptions%3A%5Bretention-month-active%2Cretention-month-archived%5D/);
             await expect(monthlyModal.getByLabel('Enable monthly retention')).toBeChecked();
             await expect(monthlyModal.getByLabel('Display title')).toHaveValue('Stay monthly');
             await expect(monthlyModal.getByLabel('Display description')).toHaveValue('Monthly description');
@@ -481,8 +510,15 @@ test.describe('Offers Modal', () => {
             await modal.getByText('Yearly retention').click();
 
             const yearlyModal = page.getByTestId('retention-offer-modal');
+            const expectedYearlyCreatedOn = await formatOfferDateForBrowser(page, '2026-01-25T12:00:00.000Z');
+            const expectedYearlyLastRedemption = await formatOfferDateForBrowser(page, '2026-02-18T12:00:00.000Z');
             await expect(yearlyModal).toBeVisible();
+            await expect(yearlyModal).toContainText('Created on');
+            await expect(yearlyModal).toContainText(expectedYearlyCreatedOn);
             await expect(yearlyModal).toContainText('9 redemptions');
+            await expect(yearlyModal).toContainText('Last redemption');
+            await expect(yearlyModal).toContainText(expectedYearlyLastRedemption);
+            await expect(yearlyModal.getByRole('link', {name: 'See members →'})).toHaveAttribute('href', /offer_redemptions%3A%5Bretention-year-active%2Cretention-year-archived%5D/);
             await expect(yearlyModal.getByLabel('Enable yearly retention')).toBeChecked();
             await expect(yearlyModal.getByLabel('Display title')).toHaveValue('Stay yearly');
             await expect(yearlyModal.getByLabel('Display description')).toHaveValue('Yearly description');

--- a/apps/admin-x-settings/test/acceptance/membership/offers.test.ts
+++ b/apps/admin-x-settings/test/acceptance/membership/offers.test.ts
@@ -492,10 +492,7 @@ test.describe('Offers Modal', () => {
             })});
 
             const {modal, retentionModal: monthlyModal} = await openRetentionModal(page, 'Monthly retention');
-            const expectedMonthlyCreatedOn = await formatOfferDateForBrowser(page, '2026-01-19T12:00:00.000Z');
             const expectedMonthlyLastRedemption = await formatOfferDateForBrowser(page, '2026-02-19T12:00:00.000Z');
-            await expect(monthlyModal).toContainText('Created on');
-            await expect(monthlyModal).toContainText(expectedMonthlyCreatedOn);
             await expect(monthlyModal).toContainText('11 redemptions');
             await expect(monthlyModal).toContainText('Last redemption');
             await expect(monthlyModal).toContainText(expectedMonthlyLastRedemption);
@@ -510,11 +507,8 @@ test.describe('Offers Modal', () => {
             await modal.getByText('Yearly retention').click();
 
             const yearlyModal = page.getByTestId('retention-offer-modal');
-            const expectedYearlyCreatedOn = await formatOfferDateForBrowser(page, '2026-01-25T12:00:00.000Z');
             const expectedYearlyLastRedemption = await formatOfferDateForBrowser(page, '2026-02-18T12:00:00.000Z');
             await expect(yearlyModal).toBeVisible();
-            await expect(yearlyModal).toContainText('Created on');
-            await expect(yearlyModal).toContainText(expectedYearlyCreatedOn);
             await expect(yearlyModal).toContainText('9 redemptions');
             await expect(yearlyModal).toContainText('Last redemption');
             await expect(yearlyModal).toContainText(expectedYearlyLastRedemption);

--- a/ghost/admin/app/components/members/filters/offers.js
+++ b/ghost/admin/app/components/members/filters/offers.js
@@ -1,5 +1,23 @@
 import {MATCH_RELATION_OPTIONS} from './relation-options';
 
+const getOfferNameForColumn = (offer) => {
+    if (!offer) {
+        return null;
+    }
+
+    if (offer.redemption_type === 'retention') {
+        if (offer.cadence === 'month') {
+            return 'Monthly Retention';
+        }
+
+        if (offer.cadence === 'year') {
+            return 'Yearly Retention';
+        }
+    }
+
+    return offer.name;
+};
+
 export const OFFERS_FILTER = {
     label: 'Offers',
     name: 'offer_redemptions',
@@ -13,8 +31,8 @@ export const OFFERS_FILTER = {
             // TODO: remove sub.offer fallback once offer_redemptions is available on all environments
             text: (member.subscriptions ?? [])
                 .flatMap(sub => (sub.offer_redemptions
-                    ? sub.offer_redemptions.map(o => o.name)
-                    : (sub.offer?.name ? [sub.offer.name] : [])))
+                    ? sub.offer_redemptions.map(getOfferNameForColumn).filter(Boolean)
+                    : [getOfferNameForColumn(sub.offer)].filter(Boolean)))
                 .join(', ')
         };
     }

--- a/ghost/admin/app/components/offers/segment-select.js
+++ b/ghost/admin/app/components/offers/segment-select.js
@@ -116,7 +116,7 @@ export default class OffersSegmentSelect extends Component {
             const offer = this.getOfferById(id);
             return {
                 id,
-                name: offer?.name || id
+                name: offer.name
             };
         }) || [];
         this.args.onChange?.(ids);

--- a/ghost/admin/app/components/offers/segment-select.js
+++ b/ghost/admin/app/components/offers/segment-select.js
@@ -4,6 +4,19 @@ import {inject as service} from '@ember/service';
 import {task} from 'ember-concurrency';
 import {tracked} from '@glimmer/tracking';
 
+const RETENTION_OFFER_OPTIONS = [
+    {
+        cadence: 'month',
+        id: 'retention:month',
+        name: 'Monthly Retention'
+    },
+    {
+        cadence: 'year',
+        id: 'retention:year',
+        name: 'Yearly Retention'
+    }
+];
+
 export default class OffersSegmentSelect extends Component {
     @service store;
     @service feature;
@@ -38,29 +51,106 @@ export default class OffersSegmentSelect extends Component {
         return options;
     }
 
+    getOfferById(id) {
+        return this.offers.find((offer) => {
+            return offer.id === id;
+        });
+    }
+
+    getOfferRedemptionType(offer) {
+        return offer.redemptionType || offer.redemption_type || 'signup';
+    }
+
     get selectedOptions() {
-        const offerList = (this.args.offers || []).map((offer) => {
-            return this.offers.find((p) => {
-                return p.id === offer.id || p.name === offer.name;
+        const selectedIds = new Set((this.args.offers || []).map(offer => offer.id).filter(id => !!id));
+        const selected = [];
+        const consumedIds = new Set();
+        const retentionCadenceOptions = this.flatOptions.filter(option => Array.isArray(option.offerIds));
+
+        retentionCadenceOptions.forEach((option) => {
+            if (option.offerIds.length > 0 && option.offerIds.every(id => selectedIds.has(id))) {
+                selected.push(option);
+                option.offerIds.forEach(id => consumedIds.add(id));
+            }
+        });
+
+        selectedIds.forEach((id) => {
+            if (consumedIds.has(id)) {
+                return;
+            }
+
+            const option = this.flatOptions.find((flatOption) => {
+                return !Array.isArray(flatOption.offerIds) && flatOption.id === id;
             });
-        }).filter(d => !!d);
-        const offerIdList = offerList.map(d => d.id);
-        const selectedList = this.flatOptions.filter(option => offerIdList.includes(option.id));
-        return selectedList;
+
+            if (option) {
+                selected.push(option);
+                return;
+            }
+
+            const offer = this.getOfferById(id);
+            if (offer) {
+                selected.push({
+                    id: offer.id,
+                    name: offer.name,
+                    class: 'segment-offer-redemptions-hidden'
+                });
+            }
+        });
+
+        return selected;
     }
 
     @action
     setSegment(options) {
-        let ids = options.mapBy('id').map((id) => {
-            let offer = this.offers.find((p) => {
-                return p.id === id;
-            });
+        const offerIds = new Set();
+
+        options.forEach((option) => {
+            if (Array.isArray(option.offerIds)) {
+                option.offerIds.forEach(id => offerIds.add(id));
+                return;
+            }
+
+            if (option.id) {
+                offerIds.add(option.id);
+            }
+        });
+
+        let ids = Array.from(offerIds).map((id) => {
+            const offer = this.getOfferById(id);
             return {
-                id: offer.id,
-                name: offer.name
+                id,
+                name: offer?.name || id
             };
         }) || [];
         this.args.onChange?.(ids);
+    }
+
+    getRetentionOptions(offers) {
+        const retentionOffersByCadence = {
+            month: [],
+            year: []
+        };
+
+        offers.forEach((offer) => {
+            const redemptionType = this.getOfferRedemptionType(offer);
+            if (redemptionType !== 'retention') {
+                return;
+            }
+
+            if (offer.cadence === 'month' || offer.cadence === 'year') {
+                retentionOffersByCadence[offer.cadence].push(offer.id);
+            }
+        });
+
+        return RETENTION_OFFER_OPTIONS
+            .filter(definition => retentionOffersByCadence[definition.cadence].length > 0)
+            .map(definition => ({
+                name: definition.name,
+                id: definition.id,
+                offerIds: retentionOffersByCadence[definition.cadence],
+                class: 'segment-offer-redemptions'
+            }));
     }
 
     @task
@@ -71,6 +161,7 @@ export default class OffersSegmentSelect extends Component {
         // TODO: add `include: 'count.members` to query once API supports
         const offers = yield this.store.findAll('offer');
         this.offers = offers;
+
         if (offers.length > 0) {
             const offersGroup = {
                 groupName: 'Offers',
@@ -78,6 +169,10 @@ export default class OffersSegmentSelect extends Component {
             };
 
             offers.forEach((offer) => {
+                if (this.getOfferRedemptionType(offer) === 'retention') {
+                    return;
+                }
+
                 offersGroup.options.push({
                     name: offer.name,
                     id: offer.id,
@@ -85,7 +180,12 @@ export default class OffersSegmentSelect extends Component {
                     class: 'segment-offer-redemptions'
                 });
             });
-            options.push(offersGroup);
+
+            offersGroup.options.push(...this.getRetentionOptions(offers));
+
+            if (offersGroup.options.length > 0) {
+                options.push(offersGroup);
+            }
         }
 
         this._options = options;

--- a/ghost/admin/app/components/offers/segment-select.js
+++ b/ghost/admin/app/components/offers/segment-select.js
@@ -112,13 +112,21 @@ export default class OffersSegmentSelect extends Component {
             }
         });
 
-        let ids = Array.from(offerIds).map((id) => {
+        const ids = Array.from(offerIds).reduce((result, id) => {
             const offer = this.getOfferById(id);
-            return {
+
+            if (!offer) {
+                return result;
+            }
+
+            result.push({
                 id,
                 name: offer.name
-            };
-        }) || [];
+            });
+
+            return result;
+        }, []);
+
         this.args.onChange?.(ids);
     }
 

--- a/ghost/admin/app/components/offers/segment-select.js
+++ b/ghost/admin/app/components/offers/segment-select.js
@@ -176,7 +176,7 @@ export default class OffersSegmentSelect extends Component {
                 offersGroup.options.push({
                     name: offer.name,
                     id: offer.id,
-                    count: offers.count?.members,
+                    count: offer.count?.members,
                     class: 'segment-offer-redemptions'
                 });
             });

--- a/ghost/admin/app/components/offers/segment-select.js
+++ b/ghost/admin/app/components/offers/segment-select.js
@@ -156,6 +156,7 @@ export default class OffersSegmentSelect extends Component {
     @task
     *fetchOptionsTask() {
         const options = yield [];
+        const retentionOffersEnabled = Boolean(this.feature.labs?.retentionOffers);
 
         // fetch all offers with count
         // TODO: add `include: 'count.members` to query once API supports
@@ -169,7 +170,7 @@ export default class OffersSegmentSelect extends Component {
             };
 
             offers.forEach((offer) => {
-                if (this.getOfferRedemptionType(offer) === 'retention') {
+                if (retentionOffersEnabled && this.getOfferRedemptionType(offer) === 'retention') {
                     return;
                 }
 
@@ -181,7 +182,9 @@ export default class OffersSegmentSelect extends Component {
                 });
             });
 
-            offersGroup.options.push(...this.getRetentionOptions(offers));
+            if (retentionOffersEnabled) {
+                offersGroup.options.push(...this.getRetentionOptions(offers));
+            }
 
             if (offersGroup.options.length > 0) {
                 options.push(offersGroup);

--- a/ghost/admin/app/components/offers/segment-select.js
+++ b/ghost/admin/app/components/offers/segment-select.js
@@ -154,8 +154,6 @@ export default class OffersSegmentSelect extends Component {
         const options = yield [];
         const retentionOffersEnabled = Boolean(this.feature.labs?.retentionOffers);
 
-        // fetch all offers with count
-        // TODO: add `include: 'count.members` to query once API supports
         const offers = yield this.store.findAll('offer');
         this.offers = offers;
 
@@ -173,7 +171,6 @@ export default class OffersSegmentSelect extends Component {
                 offersGroup.options.push({
                     name: offer.name,
                     id: offer.id,
-                    count: offer.count?.members,
                     class: 'segment-offer-redemptions'
                 });
             });

--- a/ghost/admin/app/components/offers/segment-select.js
+++ b/ghost/admin/app/components/offers/segment-select.js
@@ -57,10 +57,6 @@ export default class OffersSegmentSelect extends Component {
         });
     }
 
-    getOfferRedemptionType(offer) {
-        return offer.redemptionType || offer.redemption_type || 'signup';
-    }
-
     get selectedOptions() {
         const selectedIds = new Set((this.args.offers || []).map(offer => offer.id).filter(id => !!id));
         const selected = [];
@@ -133,7 +129,7 @@ export default class OffersSegmentSelect extends Component {
         };
 
         offers.forEach((offer) => {
-            const redemptionType = this.getOfferRedemptionType(offer);
+            const redemptionType = offer.redemptionType;
             if (redemptionType !== 'retention') {
                 return;
             }
@@ -170,7 +166,7 @@ export default class OffersSegmentSelect extends Component {
             };
 
             offers.forEach((offer) => {
-                if (retentionOffersEnabled && this.getOfferRedemptionType(offer) === 'retention') {
+                if (retentionOffersEnabled && offer.redemptionType === 'retention') {
                     return;
                 }
 

--- a/ghost/admin/app/models/offer.js
+++ b/ghost/admin/app/models/offer.js
@@ -7,6 +7,7 @@ export default Model.extend(ValidationEngine, {
     name: attr('string'),
     code: attr('string'),
     cadence: attr('string'),
+    redemptionType: attr('string', {defaultValue: 'signup'}),
     status: attr('string', {defaultValue: 'active'}),
     tier: attr(),
     stripeCouponId: attr('string'),

--- a/ghost/admin/tests/acceptance/members/filter-test.js
+++ b/ghost/admin/tests/acceptance/members/filter-test.js
@@ -201,6 +201,91 @@ describe('Acceptance: Members filtering', function () {
             expect(findAll('[data-test-list="members-list-item"]').length, '# of filtered member rows').to.equal(1);
         });
 
+        it('shows synthetic retention options instead of individual retention offers', async function () {
+            const tier = this.server.create('tier');
+
+            this.server.create('offer', {
+                name: 'Welcome offer',
+                tier: {id: tier.id},
+                redemptionType: 'signup',
+                cadence: 'month'
+            });
+            this.server.create('offer', {
+                name: 'Monthly retention v1',
+                tier: null,
+                redemptionType: 'retention',
+                cadence: 'month'
+            });
+            this.server.create('offer', {
+                name: 'Monthly retention v2',
+                tier: null,
+                redemptionType: 'retention',
+                cadence: 'month'
+            });
+            this.server.create('offer', {
+                name: 'Yearly retention v1',
+                tier: null,
+                redemptionType: 'retention',
+                cadence: 'year'
+            });
+
+            this.server.createList('member', 2, {status: 'paid', tiers: [tier]});
+
+            await visit('/members');
+            await click('[data-test-button="members-filter-actions"]');
+            const filterSelector = `[data-test-members-filter="0"]`;
+            await fillIn(`${filterSelector} [data-test-select="members-filter"]`, 'offer_redemptions');
+            await click(`${filterSelector} [data-test-token-input]`);
+
+            const offerOptions = findAll(`${filterSelector} [data-test-offers-segment]`).map(node => node.textContent.trim());
+
+            expect(offerOptions).to.include('Welcome offer');
+            expect(offerOptions).to.include('Monthly Retention');
+            expect(offerOptions).to.include('Yearly Retention');
+            expect(offerOptions).to.not.include('Monthly retention v1');
+            expect(offerOptions).to.not.include('Monthly retention v2');
+            expect(offerOptions).to.not.include('Yearly retention v1');
+        });
+
+        it('keeps specific retention offer URL filters without listing that version in dropdown', async function () {
+            const tier = this.server.create('tier');
+            const monthlyRetentionV1 = this.server.create('offer', {
+                name: 'Monthly retention v1',
+                tier: null,
+                redemptionType: 'retention',
+                cadence: 'month'
+            });
+            const monthlyRetentionV2 = this.server.create('offer', {
+                name: 'Monthly retention v2',
+                tier: null,
+                redemptionType: 'retention',
+                cadence: 'month'
+            });
+
+            const memberA = this.server.create('member', {status: 'paid', tiers: [tier]});
+            const memberB = this.server.create('member', {status: 'paid', tiers: [tier]});
+
+            const subscriptionA = this.server.create('subscription', {member: memberA, tier, offer: monthlyRetentionV1});
+            const subscriptionB = this.server.create('subscription', {member: memberB, tier, offer: monthlyRetentionV2});
+
+            memberA.update({subscriptions: [subscriptionA]});
+            memberB.update({subscriptions: [subscriptionB]});
+
+            await visit('/members?filter=' + encodeURIComponent(`offer_redemptions:'${monthlyRetentionV2.id}'`));
+
+            expect(findAll('[data-test-list="members-list-item"]').length, '# of filtered member rows').to.equal(1);
+
+            await click('[data-test-button="members-filter-actions"]');
+            const filterSelector = `[data-test-members-filter="0"]`;
+            await click(`${filterSelector} [data-test-token-input]`);
+
+            const offerOptions = findAll(`${filterSelector} [data-test-offers-segment]`).map(node => node.textContent.trim());
+
+            expect(offerOptions).to.include('Monthly Retention');
+            expect(offerOptions).to.not.include('Monthly retention v1');
+            expect(offerOptions).to.not.include('Monthly retention v2');
+        });
+
         it('can filter by newsletter subscription when there is only one newsletter', async function () {
             // Create a single newsletter
             this.server.createList('newsletter', 1);

--- a/ghost/admin/tests/acceptance/members/filter-test.js
+++ b/ghost/admin/tests/acceptance/members/filter-test.js
@@ -4,6 +4,7 @@ import {authenticateSession} from 'ember-simple-auth/test-support';
 import {blur, click, currentURL, fillIn, find, findAll, focus} from '@ember/test-helpers';
 import {cleanupMockAnalyticsApps, mockAnalyticsApps} from '../../helpers/mock-analytics-apps';
 import {datepickerSelect} from 'ember-power-datepicker/test-support';
+import {enableLabsFlag} from '../helpers/labs-flag';
 import {enableNewsletters} from '../../helpers/newsletters';
 import {enablePaidMembers} from '../../helpers/members';
 import {enableStripe} from '../../helpers/stripe';
@@ -203,6 +204,7 @@ describe('Acceptance: Members filtering', function () {
 
         it('shows synthetic retention options instead of individual retention offers', async function () {
             const tier = this.server.create('tier');
+            enableLabsFlag(this.server, 'retentionOffers');
 
             this.server.create('offer', {
                 name: 'Welcome offer',
@@ -247,8 +249,55 @@ describe('Acceptance: Members filtering', function () {
             expect(offerOptions).to.not.include('Yearly retention v1');
         });
 
+        it('shows individual retention offers when retention offers feature flag is off', async function () {
+            const tier = this.server.create('tier');
+
+            this.server.create('offer', {
+                name: 'Welcome offer',
+                tier: {id: tier.id},
+                redemptionType: 'signup',
+                cadence: 'month'
+            });
+            this.server.create('offer', {
+                name: 'Monthly retention v1',
+                tier: null,
+                redemptionType: 'retention',
+                cadence: 'month'
+            });
+            this.server.create('offer', {
+                name: 'Monthly retention v2',
+                tier: null,
+                redemptionType: 'retention',
+                cadence: 'month'
+            });
+            this.server.create('offer', {
+                name: 'Yearly retention v1',
+                tier: null,
+                redemptionType: 'retention',
+                cadence: 'year'
+            });
+
+            this.server.createList('member', 2, {status: 'paid', tiers: [tier]});
+
+            await visit('/members');
+            await click('[data-test-button="members-filter-actions"]');
+            const filterSelector = `[data-test-members-filter="0"]`;
+            await fillIn(`${filterSelector} [data-test-select="members-filter"]`, 'offer_redemptions');
+            await click(`${filterSelector} [data-test-token-input]`);
+
+            const offerOptions = findAll(`${filterSelector} [data-test-offers-segment]`).map(node => node.textContent.trim());
+
+            expect(offerOptions).to.include('Welcome offer');
+            expect(offerOptions).to.include('Monthly retention v1');
+            expect(offerOptions).to.include('Monthly retention v2');
+            expect(offerOptions).to.include('Yearly retention v1');
+            expect(offerOptions).to.not.include('Monthly Retention');
+            expect(offerOptions).to.not.include('Yearly Retention');
+        });
+
         it('keeps specific retention offer URL filters without listing that version in dropdown', async function () {
             const tier = this.server.create('tier');
+            enableLabsFlag(this.server, 'retentionOffers');
             const monthlyRetentionV1 = this.server.create('offer', {
                 name: 'Monthly retention v1',
                 tier: null,

--- a/ghost/admin/tests/acceptance/members/filter-test.js
+++ b/ghost/admin/tests/acceptance/members/filter-test.js
@@ -4,7 +4,7 @@ import {authenticateSession} from 'ember-simple-auth/test-support';
 import {blur, click, currentURL, fillIn, find, findAll, focus} from '@ember/test-helpers';
 import {cleanupMockAnalyticsApps, mockAnalyticsApps} from '../../helpers/mock-analytics-apps';
 import {datepickerSelect} from 'ember-power-datepicker/test-support';
-import {enableLabsFlag} from '../helpers/labs-flag';
+import {enableLabsFlag} from '../../helpers/labs-flag';
 import {enableNewsletters} from '../../helpers/newsletters';
 import {enablePaidMembers} from '../../helpers/members';
 import {enableStripe} from '../../helpers/stripe';

--- a/ghost/admin/tests/unit/components/members/filters/offers-test.js
+++ b/ghost/admin/tests/unit/components/members/filters/offers-test.js
@@ -1,0 +1,36 @@
+import {OFFERS_FILTER} from 'ghost-admin/components/members/filters/offers';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+
+describe('Unit: Component: members/filters/offers', function () {
+    describe('OFFERS_FILTER.getColumnValue', function () {
+        it('renders retention offers using cadence labels', function () {
+            const member = {
+                subscriptions: [{
+                    offer_redemptions: [
+                        {name: 'One month on us', redemption_type: 'retention', cadence: 'month'},
+                        {name: 'Welcome discount', redemption_type: 'signup', cadence: 'month'},
+                        {name: 'Two months on us', redemption_type: 'retention', cadence: 'year'}
+                    ]
+                }]
+            };
+
+            const value = OFFERS_FILTER.getColumnValue(member);
+
+            expect(value.text).to.equal('Monthly Retention, Welcome discount, Yearly Retention');
+        });
+
+        it('renders fallback sub.offer with the same retention label rules', function () {
+            const member = {
+                subscriptions: [
+                    {offer: {name: 'Monthly v2', redemption_type: 'retention', cadence: 'month'}},
+                    {offer: {name: 'Signup offer', redemption_type: 'signup', cadence: 'month'}}
+                ]
+            };
+
+            const value = OFFERS_FILTER.getColumnValue(member);
+
+            expect(value.text).to.equal('Monthly Retention, Signup offer');
+        });
+    });
+});


### PR DESCRIPTION
closes https://linear.app/ghost/issue/BER-3349

This change ensures that only 1 retention offer per cadence is visible in the offer select when filtering members by retention. This also updates the retention modal to link the members list pre-filtered when clicking on the redemption count