### PR TITLE
🐛 Fixed comments-ui permalink crash when iframe is detached

### DIFF
--- a/apps/comments-ui/package.json
+++ b/apps/comments-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/comments-ui",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/comments-ui/src/components/content/content.tsx
+++ b/apps/comments-ui/src/components/content/content.tsx
@@ -101,8 +101,17 @@ const Content = () => {
     }, []);
 
     useEffect(() => {
+        // Capture the parent window reference once so the handler and cleanup
+        // always use the same object. window.parent becomes null when the
+        // iframe is detached from the DOM, but the captured reference remains
+        // valid for removing the listener.
+        const parentWindow = window.parent;
+        if (!parentWindow) {
+            return;
+        }
+
         const handleHashChange = () => {
-            const commentId = parseCommentIdFromHash(window.parent.location.hash);
+            const commentId = parseCommentIdFromHash(parentWindow.location.hash);
             if (commentId && containerRef.current) {
                 const doc = containerRef.current.ownerDocument;
                 const element = doc.getElementById(commentId);
@@ -112,8 +121,8 @@ const Content = () => {
             }
         };
 
-        window.parent.addEventListener('hashchange', handleHashChange);
-        return () => window.parent.removeEventListener('hashchange', handleHashChange);
+        parentWindow.addEventListener('hashchange', handleHashChange);
+        return () => parentWindow.removeEventListener('hashchange', handleHashChange);
     }, [scrollToComment]);
 
     useEffect(() => {


### PR DESCRIPTION
## Summary

- Captured `window.parent` into a local variable at `useEffect` setup time in the comments-ui `Content` component, instead of reading it fresh in the `hashchange` handler and cleanup
- When the comments-ui iframe is detached from the DOM (e.g. navigating away in Ghost Admin), the browser nulls `window.parent` but the `hashchange` listener on the host window survives — causing a `TypeError` on the next hash change
- The captured reference remains valid for both the handler callback and the effect cleanup, eliminating the crash without adding defensive null guards

Resolves 4 Sentry issues (all the same root cause, different browser error messages):

| Sentry Issue | Browser | Events | Users |
|---|---|---|---|
| [ADMIN-19WW](https://ghost-foundation.sentry.io/issues/ADMIN-19WW) | Chrome/Edge | 1,755 | 180 |
| [ADMIN-19X0](https://ghost-foundation.sentry.io/issues/ADMIN-19X0) | Safari | 137 | 56 |
| [ADMIN-19WY](https://ghost-foundation.sentry.io/issues/ADMIN-19WY) | Firefox | 38 | 22 |
| [ADMIN-19X6](https://ghost-foundation.sentry.io/issues/ADMIN-19X6) | Firefox ESR | 1 | 1 |

fixes https://linear.app/ghost/issue/BER-3351/

Fixes ADMIN-19WW
Fixes ADMIN-19X0
Fixes ADMIN-19WY
Fixes ADMIN-19X6