### PR TITLE
Fixed sidebar banners appearing in Editor

### DIFF
--- a/apps/admin/src/layout/app-sidebar/app-sidebar-banner.test.tsx
+++ b/apps/admin/src/layout/app-sidebar/app-sidebar-banner.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import AppSidebarBanner from "./app-sidebar-banner";
+import type { SidebarBannerState } from "./hooks/use-sidebar-banner-state";
+
+const mockUseSidebarBannerState = vi.fn<() => SidebarBannerState>(() => ({
+    bannerType: null,
+    banner: null,
+    hasBanner: false
+}));
+
+vi.mock("./hooks/use-sidebar-banner-state", () => ({
+    useSidebarBannerState: () => mockUseSidebarBannerState()
+}));
+
+describe("AppSidebarBanner", () => {
+    beforeEach(() => {
+        mockUseSidebarBannerState.mockReturnValue({
+            bannerType: null,
+            banner: null,
+            hasBanner: false
+        });
+    });
+
+    test("does not render when no banner is available", () => {
+        const {container} = render(<AppSidebarBanner />);
+        expect(container).toBeEmptyDOMElement();
+    });
+
+    test("renders banner from shared state hook", () => {
+        mockUseSidebarBannerState.mockReturnValue({
+            bannerType: 'theme-errors',
+            banner: <div>Theme Error Banner</div>,
+            hasBanner: true
+        });
+
+        render(<AppSidebarBanner />);
+
+        expect(screen.getByText("Theme Error Banner")).toBeInTheDocument();
+    });
+
+    test("renders banner prop when explicitly provided", () => {
+        mockUseSidebarBannerState.mockReturnValue({
+            bannerType: 'theme-errors',
+            banner: <div>Hook Banner</div>,
+            hasBanner: true
+        });
+
+        render(<AppSidebarBanner banner={<div>Provided Banner</div>} />);
+
+        expect(screen.getByText("Provided Banner")).toBeInTheDocument();
+        expect(screen.queryByText("Hook Banner")).not.toBeInTheDocument();
+    });
+});

--- a/apps/admin/src/layout/app-sidebar/app-sidebar-banner.tsx
+++ b/apps/admin/src/layout/app-sidebar/app-sidebar-banner.tsx
@@ -1,0 +1,24 @@
+import type { ReactNode } from "react";
+
+import { useSidebarBannerState } from "./hooks/use-sidebar-banner-state";
+
+interface AppSidebarBannerProps {
+    banner?: ReactNode;
+}
+
+function AppSidebarBanner({banner}: AppSidebarBannerProps) {
+    const sidebarBannerState = useSidebarBannerState();
+    const resolvedBanner = banner ?? sidebarBannerState.banner;
+
+    if (!resolvedBanner) {
+        return null;
+    }
+
+    return (
+        <div className="fixed left-3 bottom-[92px] max-w-[276px] z-50">
+            {resolvedBanner}
+        </div>
+    );
+}
+
+export default AppSidebarBanner;

--- a/apps/admin/src/layout/app-sidebar/app-sidebar-content.tsx
+++ b/apps/admin/src/layout/app-sidebar/app-sidebar-content.tsx
@@ -1,53 +1,35 @@
 import {
     SidebarContent,
 } from "@tryghost/shade"
-import type { ReactNode } from "react";
 
-import WhatsNewBanner from "@/whats-new/components/whats-new-banner";
-
+import AppSidebarBanner from "./app-sidebar-banner";
 import NavMain from "./nav-main";
 import NavContent from "./nav-content";
 import NavGhostPro from "./nav-ghost-pro";
 import NavSettings from "./nav-settings";
-import ThemeErrorsBanner from "./theme-errors-banner";
-import UpgradeBanner from "./upgrade-banner";
-import { useUpgradeStatus } from "./hooks/use-upgrade-status";
-import { useWhatsNewStatus } from "./hooks/use-whats-new-status";
-import { useActiveThemeErrors } from "./hooks/use-theme-errors";
+import { useSidebarBannerState } from "./hooks/use-sidebar-banner-state";
 
 function AppSidebarContent() {
-    const {hasErrors} = useActiveThemeErrors();
-    const { showUpgradeBanner, trialDaysRemaining } = useUpgradeStatus();
-    const { showWhatsNewBanner } = useWhatsNewStatus();
-    let banner: ReactNode = null;
+    const {banner, bannerType} = useSidebarBannerState();
     let bannerContainerClassName = '';
 
-    if (hasErrors) {
-        banner = <ThemeErrorsBanner />;
+    if (bannerType === 'theme-errors') {
         bannerContainerClassName = 'pb-[110px]';
-    } else {
-        if (showUpgradeBanner) {
-            banner = <UpgradeBanner trialDaysRemaining={trialDaysRemaining} />;
-            bannerContainerClassName = 'pb-[254px]';
-        } else if (showWhatsNewBanner) {
-            banner = <WhatsNewBanner />;
-            bannerContainerClassName = 'pb-[180px]';
-        }
+    } else if (bannerType === 'upgrade') {
+        bannerContainerClassName = 'pb-[254px]';
+    } else if (bannerType === 'whats-new') {
+        bannerContainerClassName = 'pb-[180px]';
     }
 
     return (
-        <SidebarContent className={`px-3 pt-4 ${!banner && 'justify-between'}`}>
+        <SidebarContent className="px-3 pt-4 justify-between">
             <div className="flex flex-col gap-2 sidebar:gap-4">
                 <NavMain />
                 <NavContent />
                 <NavGhostPro />
             </div>
             <div className={`flex flex-col gap-2 sidebar:gap-4 ${bannerContainerClassName}`}>
-                {banner &&
-                    <div className="fixed left-3 bottom-[92px] max-w-[276px] z-50">
-                        {banner}
-                    </div>
-                }
+                <AppSidebarBanner banner={banner} />
                 <NavSettings className="pb-0" />
             </div>
         </SidebarContent>

--- a/apps/admin/src/layout/app-sidebar/app-sidebar-footer.tsx
+++ b/apps/admin/src/layout/app-sidebar/app-sidebar-footer.tsx
@@ -8,21 +8,16 @@ import {
 } from "@tryghost/shade"
 import WhatsNewDialog from "@/whats-new/components/whats-new-dialog";
 import { UserMenu } from "./user-menu";
-import { useUpgradeStatus } from "./hooks/use-upgrade-status";
-import { useWhatsNewStatus } from "./hooks/use-whats-new-status";
-import { useActiveThemeErrors } from "./hooks/use-theme-errors";
+import { useSidebarBannerState } from "./hooks/use-sidebar-banner-state";
 
 function AppSidebarFooter({ ...props }: React.ComponentProps<typeof SidebarFooter>) {
     const [isWhatsNewDialogOpen, setIsWhatsNewDialogOpen] = useState(false);
-    const { showUpgradeBanner } = useUpgradeStatus();
-    const { showWhatsNewBanner } = useWhatsNewStatus();
-    const {hasErrors} = useActiveThemeErrors();
-    const banner = showUpgradeBanner || showWhatsNewBanner || hasErrors;
+    const {hasBanner} = useSidebarBannerState();
 
     return (
         <>
             <SidebarFooter {...props}>
-                <SidebarGroup className={banner ? 'pt-3' : ''}>
+                <SidebarGroup className={hasBanner ? 'pt-3' : ''}>
                     <SidebarMenu>
                         <SidebarMenuItem>
                             <UserMenu onOpenWhatsNew={() => setIsWhatsNewDialogOpen(true)} />

--- a/apps/admin/src/layout/app-sidebar/hooks/use-sidebar-banner-state.test.tsx
+++ b/apps/admin/src/layout/app-sidebar/hooks/use-sidebar-banner-state.test.tsx
@@ -1,0 +1,88 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { useSidebarBannerState } from "./use-sidebar-banner-state";
+
+const mockUseSidebarVisibility = vi.fn<() => boolean>(() => true);
+const mockUseActiveThemeErrors = vi.fn<() => {hasErrors: boolean}>(() => ({hasErrors: false}));
+const mockUseUpgradeStatus = vi.fn<() => {showUpgradeBanner: boolean; trialDaysRemaining: number}>(() => ({showUpgradeBanner: false, trialDaysRemaining: 0}));
+const mockUseWhatsNewStatus = vi.fn<() => {showWhatsNewBanner: boolean}>(() => ({showWhatsNewBanner: false}));
+
+vi.mock("@/ember-bridge/ember-bridge", () => ({
+    useSidebarVisibility: () => mockUseSidebarVisibility(),
+}));
+
+vi.mock("./use-theme-errors", () => ({
+    useActiveThemeErrors: () => mockUseActiveThemeErrors(),
+}));
+
+vi.mock("./use-upgrade-status", () => ({
+    useUpgradeStatus: () => mockUseUpgradeStatus(),
+}));
+
+vi.mock("./use-whats-new-status", () => ({
+    useWhatsNewStatus: () => mockUseWhatsNewStatus(),
+}));
+
+vi.mock("../theme-errors-banner", () => ({
+    default: () => <div>Theme Error Banner</div>,
+}));
+
+vi.mock("../upgrade-banner", () => ({
+    default: ({trialDaysRemaining}: {trialDaysRemaining: number}) => <div>Upgrade Banner ({trialDaysRemaining})</div>,
+}));
+
+vi.mock("@/whats-new/components/whats-new-banner", () => ({
+    default: () => <div>Whats New Banner</div>,
+}));
+
+describe("useSidebarBannerState", () => {
+    beforeEach(() => {
+        mockUseSidebarVisibility.mockReturnValue(true);
+        mockUseActiveThemeErrors.mockReturnValue({hasErrors: false});
+        mockUseUpgradeStatus.mockReturnValue({showUpgradeBanner: false, trialDaysRemaining: 0});
+        mockUseWhatsNewStatus.mockReturnValue({showWhatsNewBanner: false});
+    });
+
+    test("returns no banner when editor is open", () => {
+        mockUseSidebarVisibility.mockReturnValue(false);
+        mockUseActiveThemeErrors.mockReturnValue({hasErrors: true});
+        mockUseUpgradeStatus.mockReturnValue({showUpgradeBanner: true, trialDaysRemaining: 7});
+        mockUseWhatsNewStatus.mockReturnValue({showWhatsNewBanner: true});
+
+        const {result} = renderHook(() => useSidebarBannerState());
+
+        expect(result.current.hasBanner).toBe(false);
+        expect(result.current.banner).toBeNull();
+        expect(result.current.bannerType).toBeNull();
+    });
+
+    test("prefers theme error banner over other banners", () => {
+        mockUseActiveThemeErrors.mockReturnValue({hasErrors: true});
+        mockUseUpgradeStatus.mockReturnValue({showUpgradeBanner: true, trialDaysRemaining: 7});
+        mockUseWhatsNewStatus.mockReturnValue({showWhatsNewBanner: true});
+
+        const {result} = renderHook(() => useSidebarBannerState());
+
+        expect(result.current.hasBanner).toBe(true);
+        expect(result.current.bannerType).toBe('theme-errors');
+    });
+
+    test("returns upgrade banner state when only upgrade is active", () => {
+        mockUseUpgradeStatus.mockReturnValue({showUpgradeBanner: true, trialDaysRemaining: 7});
+
+        const {result} = renderHook(() => useSidebarBannerState());
+
+        expect(result.current.hasBanner).toBe(true);
+        expect(result.current.bannerType).toBe('upgrade');
+    });
+
+    test("returns whats new banner state when only whats new is active", () => {
+        mockUseWhatsNewStatus.mockReturnValue({showWhatsNewBanner: true});
+
+        const {result} = renderHook(() => useSidebarBannerState());
+
+        expect(result.current.hasBanner).toBe(true);
+        expect(result.current.bannerType).toBe('whats-new');
+    });
+});

--- a/apps/admin/src/layout/app-sidebar/hooks/use-sidebar-banner-state.tsx
+++ b/apps/admin/src/layout/app-sidebar/hooks/use-sidebar-banner-state.tsx
@@ -1,0 +1,61 @@
+import type { ReactNode } from "react";
+
+import { useSidebarVisibility } from "@/ember-bridge/ember-bridge";
+import ThemeErrorsBanner from "@/layout/app-sidebar/theme-errors-banner";
+import UpgradeBanner from "@/layout/app-sidebar/upgrade-banner";
+import WhatsNewBanner from "@/whats-new/components/whats-new-banner";
+
+import { useUpgradeStatus } from "./use-upgrade-status";
+import { useWhatsNewStatus } from "./use-whats-new-status";
+import { useActiveThemeErrors } from "./use-theme-errors";
+
+export interface SidebarBannerState {
+    bannerType: 'theme-errors' | 'upgrade' | 'whats-new' | null;
+    banner: ReactNode;
+    hasBanner: boolean;
+}
+
+export function useSidebarBannerState(): SidebarBannerState {
+    const {hasErrors} = useActiveThemeErrors();
+    const {showUpgradeBanner, trialDaysRemaining} = useUpgradeStatus();
+    const {showWhatsNewBanner} = useWhatsNewStatus();
+    const sidebarVisible = useSidebarVisibility();
+
+    if (!sidebarVisible) {
+        return {
+            bannerType: null,
+            banner: null,
+            hasBanner: false
+        };
+    }
+
+    if (hasErrors) {
+        return {
+            bannerType: 'theme-errors',
+            banner: <ThemeErrorsBanner />,
+            hasBanner: true
+        };
+    }
+
+    if (showUpgradeBanner) {
+        return {
+            bannerType: 'upgrade',
+            banner: <UpgradeBanner trialDaysRemaining={trialDaysRemaining} />,
+            hasBanner: true
+        };
+    }
+
+    if (showWhatsNewBanner) {
+        return {
+            bannerType: 'whats-new',
+            banner: <WhatsNewBanner />,
+            hasBanner: true
+        };
+    }
+
+    return {
+        bannerType: null,
+        banner: null,
+        hasBanner: false
+    };
+}


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/commit/2110267efb5b9fc66a6f863279d983dd3654140f

- We introduced a regression of the sidebar banners with the above change, that the banner would appear in the Editor.
- Made sense to restructure and make sidebar banners a bit more robust