### PR TITLE
🐛 Fixed editor alerts positioning

### DIFF
--- a/apps/admin/src/index.css
+++ b/apps/admin/src/index.css
@@ -40,18 +40,6 @@ body.react-admin #ember-app {
     height: 100%;
 }
 
-/* Override Ember's fixed positioning to work within our flex layout */
-body.react-admin #ember-app .gh-app {
-    position: static;
-    width: 100%;
-    height: 100%;
-}
-
-/* Remove Ember's overflow since we handle scrolling at the SidebarInset level */
-body.react-admin .gh-main {
-    overflow-y: visible;
-}
-
 /* Temporary overrides until Ember transition is finished */
 body.react-admin .gh-canvas-header {
     padding-top: 24px;

--- a/apps/admin/src/layout/admin-layout.tsx
+++ b/apps/admin/src/layout/admin-layout.tsx
@@ -34,7 +34,7 @@ export function AdminLayout({ children }: AdminLayoutProps) {
     return (
         <SidebarProvider open={!!currentUser && sidebarVisible}>
             <AppSidebar />
-            <SidebarInset className="bg-background overflow-y-scroll max-h-[calc(100%-var(--mobile-navbar-height))] sidebar:max-h-full">
+            <SidebarInset className={`bg-background overflow-y-auto sidebar:max-h-full ${sidebarVisible ? 'max-h-[calc(100%-var(--mobile-navbar-height))]' : 'max-h-full'}`}>
                 <main className="flex-1">{children}</main>
                 <MobileNavBar />
             </SidebarInset>

--- a/ghost/admin/app/styles/components/koenig.css
+++ b/ghost/admin/app/styles/components/koenig.css
@@ -8,8 +8,8 @@
 /* Scroll container for the editor canvas */
 .gh-koenig-editor {
     width: 100%;
-    height: 100vh; /* fallback for browsers that don't support dvh */
-    height: 100dvh;
+    flex: 1;
+    min-height: 0;
     overflow-x: hidden;
     overflow-y: auto;
 }

--- a/ghost/admin/app/styles/components/settings-menu.css
+++ b/ghost/admin/app/styles/components/settings-menu.css
@@ -46,11 +46,20 @@
 
 .settings-menu-container {
     z-index: 999;
-    height: 100dvh;
+    height: 100%;
     min-width: 420px;
-    overflow-x: visible;
-    overflow-y: auto;
+    overflow: hidden;
     border-left: 1px solid var(--whitegrey-d1);
+    display: flex;
+    flex-direction: column;
+}
+
+.settings-menu-container #entry-controls {
+    flex: 1;
+    min-height: 0;
+    position: relative;
+    display: flex;
+    flex-direction: column;
 }
 
 .settings-menu-container-wide {
@@ -101,7 +110,11 @@
     top: auto;
     right: auto;
     bottom: auto;
-    height: 100dvh;
+    flex: 1;
+    min-height: 0;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
 }
 
 @media (max-width: 500px) {
@@ -115,15 +128,18 @@
 /* ---------------------------------------------------------- */
 
 .settings-menu-header {
-    position: fixed;
+    position: sticky;
+    top: 0;
     display: flex;
     height: 82px; /* 34px + 24px + 24px */
+    min-height: 82px;
     width: 100%;
     padding: 24px;
     justify-content: space-between;
     align-items: center;
     z-index: 3;
     background: var(--white);
+    flex-shrink: 0;
 }
 
 @media (max-width: 1024px) {
@@ -188,7 +204,10 @@
 }
 
 .settings-menu-content {
-    padding: 92px 0 0;
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+    padding: 0;
 }
 
 .gh-post-settings {
@@ -197,7 +216,7 @@
 
 @media (max-width: 1024px) {
     .settings-menu-content {
-        padding-top: 72px;
+        padding-top: 0;
     }
 }
 

--- a/ghost/admin/app/styles/layouts/editor.css
+++ b/ghost/admin/app/styles/layouts/editor.css
@@ -284,7 +284,8 @@
 /* ---------------------------------------------------------- */
 
 .gh-editor {
-    max-width: calc(100vw - var(--editor-sidebar-width))
+    max-width: calc(100vw - var(--editor-sidebar-width));
+    min-height: 0;
 }
 
 @media (max-width: 1024px) {
@@ -294,11 +295,19 @@
 }
 
 .gh-editor-fullscreen-container {
-    position: fixed;
+    position: absolute;
     top: 0;
     left: 0;
     right: 0;
     bottom: 0;
+    display: flex;
+    flex-direction: column;
+}
+
+/* Ensure the editor flex row fills the fullscreen container */
+.gh-editor-fullscreen-container > .flex {
+    flex: 1;
+    min-height: 0;
 }
 
 .gh-editor-header {

--- a/ghost/admin/app/styles/layouts/main.css
+++ b/ghost/admin/app/styles/layouts/main.css
@@ -8,13 +8,8 @@
 /* ---------------------------------------------------------- */
 
 /* Main viewport, contains main content, and alerts */
-/* Use `position: fixed`, covering full window area so scrolling on mobile doesn't trigger elastic scroll */
 .gh-app {
-    position: fixed;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
+    position: static;
     display: flex;
     flex-direction: column;
     overflow: hidden;
@@ -35,10 +30,7 @@
     display: flex;
     flex-direction: column;
     background: var(--main-bg-color);
-    overflow-y: auto;
-    /* prevent horizontal scroll in IE11 */
-    overflow-x: hidden;
-    -webkit-overflow-scrolling: touch;
+    overflow: hidden;
 }
 
 body:not(.gh-body-fullscreen) .gh-viewport {


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/26125
closes https://linear.app/ghost/issue/BER-3271/

- Alerts rendered into `#ember-alerts-wormhole` (body grid row 1) did not push editor content down and appeared behind the editor header because `.gh-editor-fullscreen-container` used `position: fixed`, covering the entire viewport and ignoring the grid layout
- Changed the editor fullscreen container from `position: fixed` to `position: absolute` and established a flex height chain so `.gh-koenig-editor` remains the sole scroll container for editor content
- Simplified the layout so each page context has one scroll container: SidebarInset for non-editor pages, `.gh-koenig-editor` for editor content
- Fixed the post settings sidebar to use flex column layout with a pinned header and independently scrollable content area to resolve issues on mobile
- Moved Ember CSS overrides (`.gh-app` position, `.gh-main` overflow) from the React shell into Ember source styles directly, removing redundant overrides
- Fixed mobile editor layout to fill the full viewport when the mobile navbar is hidden