### PR TITLE
Update nav to be conditional based on members forward flag

### DIFF
--- a/apps/admin/src/layout/app-sidebar/nav-content.tsx
+++ b/apps/admin/src/layout/app-sidebar/nav-content.tsx
@@ -25,6 +25,7 @@ function NavContent({ ...props }: React.ComponentProps<typeof SidebarGroup>) {
     const memberCount = useMemberCount();
     const routing = useEmberRouting();
     const commentModerationEnabled = useFeatureFlag('commentModeration');
+    const membersForwardEnabled = useFeatureFlag('membersForward');
 
     const showTags = currentUser && canManageTags(currentUser);
     const showMembers = currentUser && canManageMembers(currentUser);
@@ -128,7 +129,7 @@ function NavContent({ ...props }: React.ComponentProps<typeof SidebarGroup>) {
                     {showMembers && (
                         <NavMenuItem>
                             <NavMenuItem.Link
-                                to={routing.getRouteUrl('members')}
+                                to={membersForwardEnabled ? 'members-forward' : routing.getRouteUrl('members')}
                                 isActive={routing.isRouteActive(['members', 'member', 'member.new'])}
                             >
                                 <LucideIcon.Users />


### PR DESCRIPTION
No ref

If the membersForward flag is enabled, route to /members-forward. If not, route to members.
