### PR TITLE
Added Stripe service and webhook e2e test

### DIFF
--- a/e2e/helpers/environment/environment-manager.ts
+++ b/e2e/helpers/environment/environment-manager.ts
@@ -96,7 +96,13 @@ export class EnvironmentManager {
     /**
      * Per-test setup - creates containers on first call, then clones database and restarts Ghost.
      */
-    async perTestSetup(options: {config?: GhostEnvOverrides} = {}): Promise<GhostInstance> {
+    async perTestSetup(options: {
+        config?: GhostEnvOverrides;
+        stripe?: {
+            secretKey: string;
+            publishableKey: string;
+        };
+    } = {}): Promise<GhostInstance> {
         // Lazy initialization of Ghost containers (once per worker)
         if (!this.initialized) {
             debug('Initializing Ghost containers for worker', this.workerIndex, 'in mode', this.mode);
@@ -108,7 +114,9 @@ export class EnvironmentManager {
         const instanceId = `ghost_e2e_${siteUuid.replace(/-/g, '_')}`;
 
         // Setup database
-        await this.mysql.setupTestDatabase(instanceId, siteUuid);
+        await this.mysql.setupTestDatabase(instanceId, siteUuid, {
+            stripe: options.stripe
+        });
 
         // Restart Ghost with new database
         await this.ghost.restartWithDatabase(instanceId, options.config);

--- a/e2e/helpers/environment/service-managers/mysql-manager.ts
+++ b/e2e/helpers/environment/service-managers/mysql-manager.ts
@@ -27,12 +27,20 @@ export class MySQLManager {
         this.containerName = containerName;
     }
 
-    async setupTestDatabase(databaseName: string, siteUuid: string): Promise<void> {
+    async setupTestDatabase(databaseName: string, siteUuid: string, options: {
+        stripe?: {
+            secretKey: string;
+            publishableKey: string;
+        };
+    } = {}): Promise<void> {
         debug('Setting up test database:', databaseName);
         try {
             await this.createDatabase(databaseName);
             await this.restoreDatabaseFromSnapshot(databaseName);
             await this.updateSiteUuid(databaseName, siteUuid);
+            if (options.stripe) {
+                await this.updateStripeSettings(databaseName, options.stripe.secretKey, options.stripe.publishableKey);
+            }
 
             debug('Test database setup completed:', databaseName, 'with site_uuid:', siteUuid);
         } catch (error) {
@@ -165,6 +173,26 @@ export class MySQLManager {
         await this.exec(command);
 
         debug('site_uuid updated in database settings:', siteUuid);
+    }
+
+    async updateStripeSettings(database: string, secretKey: string, publishableKey: string): Promise<void> {
+        debug('Updating Stripe settings in database:', database);
+
+        const escapedSecretKey = secretKey.replace(/'/g, '\\\'');
+        const escapedPublishableKey = publishableKey.replace(/'/g, '\\\'');
+
+        // Use INSERT ... ON DUPLICATE KEY UPDATE so this works whether or not
+        // the settings rows already exist. In dev mode the base DB is empty
+        // (only schema, no seeded rows), so a plain UPDATE would be a no-op.
+        const command = 'mysql -uroot -proot -e "INSERT INTO \\`' + database + '\\`.settings ' +
+            '(id, \\`group\\`, \\`key\\`, value, type, flags, created_at, updated_at) VALUES ' +
+            '(SUBSTRING(REPLACE(UUID(), \'-\', \'\'), 1, 24), \'members\', \'stripe_secret_key\', \'' + escapedSecretKey + '\', \'string\', NULL, NOW(), NOW()), ' +
+            '(SUBSTRING(REPLACE(UUID(), \'-\', \'\'), 1, 24), \'members\', \'stripe_publishable_key\', \'' + escapedPublishableKey + '\', \'string\', NULL, NOW(), NOW()) ' +
+            'ON DUPLICATE KEY UPDATE value = VALUES(value), updated_at = NOW();"';
+
+        await this.exec(command);
+
+        debug('Stripe settings updated in database');
     }
 
     private async exec(command: string) {

--- a/e2e/helpers/playwright/fixture.ts
+++ b/e2e/helpers/playwright/fixture.ts
@@ -1,5 +1,6 @@
 import baseDebug from '@tryghost/debug';
 import {Browser, BrowserContext, Page, TestInfo, test as base} from '@playwright/test';
+import {FakeStripeServer, StripeTestService, WebhookClient} from '@/helpers/services/stripe';
 import {GhostInstance, getEnvironmentManager} from '@/helpers/environment';
 import {SettingsService} from '@/helpers/services/settings/settings-service';
 import {faker} from '@faker-js/faker';
@@ -7,6 +8,10 @@ import {loginToGetAuthenticatedSession} from '@/helpers/playwright/flows/sign-in
 import {setupUser} from '@/helpers/utils';
 
 const debug = baseDebug('e2e:ghost-fixture');
+const STRIPE_FAKE_SERVER_PORT = 40000 + parseInt(process.env.TEST_PARALLEL_INDEX || '0', 10);
+const STRIPE_SECRET_KEY = 'sk_test_e2eTestKey';
+const STRIPE_PUBLISHABLE_KEY = 'pk_test_e2eTestKey';
+
 export interface User {
     name: string;
     email: string;
@@ -23,7 +28,9 @@ export interface GhostInstanceFixture {
     ghostInstance: GhostInstance;
     labs?: Record<string, boolean>;
     config?: GhostConfig;
-    stripeConnected?: boolean;
+    stripeEnabled?: boolean;
+    stripeServer?: FakeStripeServer;
+    stripe?: StripeTestService;
     ghostAccountOwner: User;
     pageWithAuthenticatedUser: {
         page: Page;
@@ -59,19 +66,47 @@ async function setupNewAuthenticatedPage(browser: Browser, baseURL: string, ghos
  * - Build mode: Same isolation model, but Ghost runs from a prebuilt image
  *
  * Optionally allows setting labs flags via test.use({labs: {featureName: true}})
- * and Stripe connection via test.use({stripeConnected: true})
+ * and Stripe connection via test.use({stripeEnabled: true})
  */
 export const test = base.extend<GhostInstanceFixture>({
     // Define options that can be set per test or describe block
     config: [undefined, {option: true}],
     labs: [undefined, {option: true}],
-    stripeConnected: [false, {option: true}],
+    stripeEnabled: [false, {option: true}],
 
-    // Each test gets its own Ghost instance with isolated database
-    ghostInstance: async ({config}, use, testInfo: TestInfo) => {
+    stripeServer: async ({stripeEnabled}, use) => {
+        if (!stripeEnabled) {
+            await use(undefined);
+            return;
+        }
+
+        const server = new FakeStripeServer(STRIPE_FAKE_SERVER_PORT);
+        await server.start();
+        debug('Fake Stripe server started on port', STRIPE_FAKE_SERVER_PORT);
+
+        await use(server);
+
+        await server.stop();
+        debug('Fake Stripe server stopped');
+    },
+
+    // Each test gets its own Ghost instance with isolated database.
+    ghostInstance: async ({config, stripeEnabled, stripeServer}, use, testInfo: TestInfo) => {
         debug('Setting up Ghost instance for test:', testInfo.title);
+        const stripeConfig = stripeEnabled ? {
+            STRIPE_API_HOST: 'host.docker.internal',
+            STRIPE_API_PORT: String(STRIPE_FAKE_SERVER_PORT),
+            STRIPE_API_PROTOCOL: 'http'
+        } : {};
+        const mergedConfig = {...(config || {}), ...stripeConfig};
         const environmentManager = await getEnvironmentManager();
-        const ghostInstance = await environmentManager.perTestSetup({config});
+        const ghostInstance = await environmentManager.perTestSetup({
+            config: mergedConfig,
+            stripe: stripeServer ? {
+                secretKey: STRIPE_SECRET_KEY,
+                publishableKey: STRIPE_PUBLISHABLE_KEY
+            } : undefined
+        });
 
         debug('Ghost instance ready for test:', {
             testTitle: testInfo.title,
@@ -82,6 +117,17 @@ export const test = base.extend<GhostInstanceFixture>({
         debug('Tearing down Ghost instance for test:', testInfo.title);
         await environmentManager.perTestTeardown(ghostInstance);
         debug('Teardown completed for test:', testInfo.title);
+    },
+
+    stripe: async ({stripeEnabled, baseURL, stripeServer}, use) => {
+        if (!stripeEnabled || !baseURL || !stripeServer) {
+            await use(undefined);
+            return;
+        }
+
+        const webhookClient = new WebhookClient(baseURL);
+        const service = new StripeTestService(stripeServer, webhookClient);
+        await use(service);
     },
 
     baseURL: async ({ghostInstance}, use) => {
@@ -116,22 +162,17 @@ export const test = base.extend<GhostInstanceFixture>({
     },
 
     // Extract the page from pageWithAuthenticatedUser and apply labs/stripe settings
-    page: async ({pageWithAuthenticatedUser, labs, stripeConnected}, use) => {
+    page: async ({pageWithAuthenticatedUser, labs}, use) => {
         const page = pageWithAuthenticatedUser.page;
-        const settingsService = new SettingsService(page.request);
-
-        if (stripeConnected) {
-            debug('Setting up Stripe connection for test');
-            await settingsService.setStripeConnected();
-        }
 
         const labsFlagsSpecified = labs && Object.keys(labs).length > 0;
         if (labsFlagsSpecified) {
+            const settingsService = new SettingsService(page.request);
             debug('Updating labs settings:', labs);
             await settingsService.updateLabsSettings(labs);
         }
 
-        const needsReload = stripeConnected || labsFlagsSpecified;
+        const needsReload = labsFlagsSpecified;
         if (needsReload) {
             await page.reload({waitUntil: 'load'});
             debug('Settings applied and page reloaded');

--- a/e2e/helpers/services/stripe/builders.ts
+++ b/e2e/helpers/services/stripe/builders.ts
@@ -1,0 +1,182 @@
+import crypto from 'crypto';
+
+function generateId(prefix: string): string {
+    return `${prefix}_${crypto.randomBytes(8).toString('hex')}`;
+}
+
+export interface StripeCustomer {
+    id: string;
+    object: 'customer';
+    name: string;
+    email: string;
+    subscriptions: {
+        type: 'list';
+        data: StripeSubscription[];
+    };
+}
+
+export interface StripePrice {
+    id: string;
+    object: 'price';
+    unit_amount: number;
+    currency: string;
+    recurring: {
+        interval: string;
+    };
+    product: string;
+    type: 'recurring';
+    active: boolean;
+    nickname: string | null;
+}
+
+export interface StripePaymentMethod {
+    id: string;
+    object: 'payment_method';
+    type: 'card';
+    card: {
+        brand: string;
+        last4: string;
+        exp_month: number;
+        exp_year: number;
+        country: string;
+    };
+    billing_details: {
+        name: string;
+    };
+}
+
+export interface StripeSubscription {
+    id: string;
+    object: 'subscription';
+    status: string;
+    cancel_at_period_end: boolean;
+    canceled_at: number | null;
+    current_period_end: number;
+    start_date: number;
+    default_payment_method: string | null;
+    items: {
+        type: 'list';
+        data: Array<{price: StripePrice}>;
+    };
+    customer: string;
+}
+
+export interface StripeEvent {
+    id: string;
+    object: 'event';
+    type: string;
+    data: {
+        object: Record<string, unknown>;
+    };
+}
+
+export function buildPrice(overrides: Partial<StripePrice> = {}): StripePrice {
+    return {
+        id: generateId('price'),
+        object: 'price',
+        unit_amount: 500,
+        currency: 'usd',
+        recurring: {interval: 'month'},
+        product: generateId('prod'),
+        type: 'recurring',
+        active: true,
+        nickname: null,
+        ...overrides
+    };
+}
+
+export function buildPaymentMethod(overrides: {id?: string; name?: string} = {}): StripePaymentMethod {
+    return {
+        id: overrides.id ?? generateId('pm'),
+        object: 'payment_method',
+        type: 'card',
+        card: {
+            brand: 'visa',
+            last4: '4242',
+            exp_month: 12,
+            exp_year: 2030,
+            country: 'US'
+        },
+        billing_details: {
+            name: overrides.name ?? 'Test User'
+        }
+    };
+}
+
+export function buildCustomer(opts: {id?: string; email: string; name: string}): StripeCustomer {
+    return {
+        id: opts.id ?? generateId('cus'),
+        object: 'customer',
+        name: opts.name,
+        email: opts.email,
+        subscriptions: {
+            type: 'list',
+            data: []
+        }
+    };
+}
+
+export function buildSubscription(opts: {
+    id?: string;
+    customerId: string;
+    priceId?: string;
+    productId?: string;
+    status?: string;
+    price?: StripePrice;
+    paymentMethod?: StripePaymentMethod | null;
+}): StripeSubscription {
+    const price = opts.price ?? buildPrice({
+        id: opts.priceId,
+        product: opts.productId ?? generateId('prod')
+    });
+
+    return {
+        id: opts.id ?? generateId('sub'),
+        object: 'subscription',
+        status: opts.status ?? 'active',
+        cancel_at_period_end: false,
+        canceled_at: null,
+        current_period_end: Math.floor(Date.now() / 1000) + (60 * 60 * 24 * 31),
+        start_date: Math.floor(Date.now() / 1000),
+        default_payment_method: opts.paymentMethod?.id ?? null,
+        items: {
+            type: 'list',
+            data: [{price}]
+        },
+        customer: opts.customerId
+    };
+}
+
+export function buildCheckoutSessionCompletedEvent(opts: {
+    customerId: string;
+    metadata?: Record<string, string>;
+}): StripeEvent {
+    return {
+        id: generateId('evt'),
+        object: 'event',
+        type: 'checkout.session.completed',
+        data: {
+            object: {
+                mode: 'subscription',
+                customer: opts.customerId,
+                metadata: {
+                    checkoutType: 'signup',
+                    ...(opts.metadata ?? {})
+                }
+            }
+        }
+    };
+}
+
+export function buildSubscriptionCreatedEvent(opts: {
+    subscription: StripeSubscription;
+}): StripeEvent {
+    return {
+        id: generateId('evt'),
+        object: 'event',
+        type: 'customer.subscription.created',
+        data: {
+            object: opts.subscription as unknown as Record<string, unknown>
+        }
+    };
+}

--- a/e2e/helpers/services/stripe/fake-stripe-server.ts
+++ b/e2e/helpers/services/stripe/fake-stripe-server.ts
@@ -1,0 +1,142 @@
+import baseDebug from '@tryghost/debug';
+import express from 'express';
+import http from 'http';
+import type {StripeCustomer, StripePaymentMethod, StripeSubscription} from './builders';
+
+const debug = baseDebug('e2e:fake-stripe');
+
+export class FakeStripeServer {
+    private server: http.Server | null = null;
+    private readonly app = express();
+    private readonly _port: number;
+    private readonly customers: Map<string, StripeCustomer> = new Map();
+    private readonly subscriptions: Map<string, StripeSubscription> = new Map();
+    private readonly paymentMethods: Map<string, StripePaymentMethod> = new Map();
+
+    constructor(port: number) {
+        this._port = port;
+        this.setupRoutes();
+    }
+
+    get port(): number {
+        return this._port;
+    }
+
+    upsertCustomer(customer: StripeCustomer): void {
+        this.customers.set(customer.id, customer);
+    }
+
+    upsertSubscription(subscription: StripeSubscription): void {
+        this.subscriptions.set(subscription.id, subscription);
+    }
+
+    upsertPaymentMethod(paymentMethod: StripePaymentMethod): void {
+        this.paymentMethods.set(paymentMethod.id, paymentMethod);
+    }
+
+    async start(): Promise<void> {
+        return new Promise((resolve, reject) => {
+            this.server = this.app.listen(this._port, () => {
+                resolve();
+            });
+            this.server.on('error', reject);
+        });
+    }
+
+    async stop(): Promise<void> {
+        return new Promise((resolve) => {
+            if (!this.server) {
+                resolve();
+                return;
+            }
+            this.server.close(() => {
+                this.server = null;
+                resolve();
+            });
+        });
+    }
+
+    private setupRoutes(): void {
+        this.app.use((req, _res, next) => {
+            debug(`${req.method} ${req.originalUrl}`);
+            next();
+        });
+
+        // GET /v1/customers/:id — returns customer with embedded subscriptions
+        this.app.get('/v1/customers/:id', (req, res) => {
+            const customerId = req.params.id;
+            const customer = this.customers.get(customerId);
+
+            if (!customer) {
+                debug(`Customer not found: ${customerId}`);
+                res.status(404).json({error: {type: 'invalid_request_error', message: 'No such customer'}});
+                return;
+            }
+
+            // Build response with embedded subscriptions (handles expand[]=subscriptions)
+            // Expand default_payment_method from ID to full object (handles expand[]=subscriptions.data.default_payment_method)
+            const customerSubscriptions = Array.from(this.subscriptions.values())
+                .filter(s => s.customer === customerId)
+                .map(s => ({
+                    ...s,
+                    default_payment_method: s.default_payment_method
+                        ? (this.paymentMethods.get(s.default_payment_method) ?? s.default_payment_method)
+                        : null
+                }));
+
+            const response = {
+                ...customer,
+                subscriptions: {
+                    type: 'list' as const,
+                    data: customerSubscriptions
+                }
+            };
+
+            debug(`Returning customer: ${customerId} with ${customerSubscriptions.length} subscription(s)`);
+            res.status(200).json(response);
+        });
+
+        // GET /v1/subscriptions/:id — returns subscription
+        this.app.get('/v1/subscriptions/:id', (req, res) => {
+            const subscriptionId = req.params.id;
+            const subscription = this.subscriptions.get(subscriptionId);
+
+            if (!subscription) {
+                debug(`Subscription not found: ${subscriptionId}`);
+                res.status(404).json({error: {type: 'invalid_request_error', message: 'No such subscription'}});
+                return;
+            }
+
+            debug(`Returning subscription: ${subscriptionId}`);
+            res.status(200).json(subscription);
+        });
+
+        // GET /v1/payment_methods/:id — returns payment method
+        this.app.get('/v1/payment_methods/:id', (req, res) => {
+            const paymentMethodId = req.params.id;
+            const paymentMethod = this.paymentMethods.get(paymentMethodId);
+
+            if (!paymentMethod) {
+                debug(`Payment method not found: ${paymentMethodId}`);
+                res.status(404).json({error: {type: 'invalid_request_error', message: 'No such payment method'}});
+                return;
+            }
+
+            debug(`Returning payment method: ${paymentMethodId}`);
+            res.status(200).json(paymentMethod);
+        });
+
+        // POST /v1/billing_portal/configurations(/:id) — returns a portal config
+        this.app.post('/v1/billing_portal/configurations/:id?', (req, res) => {
+            const id = req.params.id || 'bpc_fake';
+            debug(`Returning billing portal configuration: ${id}`);
+            res.status(200).json({id, object: 'billing_portal.configuration'});
+        });
+
+        // Fallback: return 200 with empty object for unhandled routes
+        this.app.use((req, res) => {
+            debug(`Unhandled route: ${req.method} ${req.originalUrl} — returning fallback`);
+            res.status(200).json({id: 'fake', object: 'unknown'});
+        });
+    }
+}

--- a/e2e/helpers/services/stripe/index.ts
+++ b/e2e/helpers/services/stripe/index.ts
@@ -1,0 +1,18 @@
+export {FakeStripeServer} from './fake-stripe-server';
+export {WebhookClient} from './webhook-client';
+export {StripeTestService} from './stripe-service';
+export {
+    buildCustomer,
+    buildSubscription,
+    buildPrice,
+    buildPaymentMethod,
+    buildCheckoutSessionCompletedEvent,
+    buildSubscriptionCreatedEvent
+} from './builders';
+export type {
+    StripeCustomer,
+    StripeSubscription,
+    StripePrice,
+    StripePaymentMethod,
+    StripeEvent
+} from './builders';

--- a/e2e/helpers/services/stripe/stripe-service.ts
+++ b/e2e/helpers/services/stripe/stripe-service.ts
@@ -1,0 +1,64 @@
+import baseDebug from '@tryghost/debug';
+import {FakeStripeServer} from './fake-stripe-server';
+import {WebhookClient} from './webhook-client';
+import {
+    buildCheckoutSessionCompletedEvent,
+    buildCustomer,
+    buildPaymentMethod,
+    buildPrice,
+    buildSubscription,
+    buildSubscriptionCreatedEvent
+} from './builders';
+
+const debug = baseDebug('e2e:stripe-service');
+
+export class StripeTestService {
+    private readonly server: FakeStripeServer;
+    private readonly webhookClient: WebhookClient;
+
+    constructor(server: FakeStripeServer, webhookClient: WebhookClient) {
+        this.server = server;
+        this.webhookClient = webhookClient;
+    }
+
+    async createPaidMemberViaWebhooks(opts: {email: string; name: string}): Promise<void> {
+        // Build Stripe objects
+        const customer = buildCustomer({email: opts.email, name: opts.name});
+        const price = buildPrice();
+        const paymentMethod = buildPaymentMethod({name: opts.name});
+        const subscription = buildSubscription({
+            customerId: customer.id,
+            price,
+            paymentMethod
+        });
+
+        // Add subscription to customer
+        customer.subscriptions.data.push(subscription);
+
+        // Seed server so Ghost can look up all objects
+        this.server.upsertCustomer(customer);
+        this.server.upsertSubscription(subscription);
+        this.server.upsertPaymentMethod(paymentMethod);
+
+        debug('Seeded server with customer=%s, subscription=%s, paymentMethod=%s',
+            customer.id, subscription.id, paymentMethod.id);
+
+        // Send checkout.session.completed webhook
+        const checkoutEvent = buildCheckoutSessionCompletedEvent({customerId: customer.id});
+        const checkoutResponse = await this.webhookClient.sendWebhook(checkoutEvent);
+        debug('checkout.session.completed webhook response: %d', checkoutResponse.status);
+        if (!checkoutResponse.ok) {
+            const body = await checkoutResponse.text();
+            throw new Error(`checkout.session.completed webhook failed (${checkoutResponse.status}): ${body}`);
+        }
+
+        // Send customer.subscription.created webhook
+        const subscriptionEvent = buildSubscriptionCreatedEvent({subscription});
+        const subscriptionResponse = await this.webhookClient.sendWebhook(subscriptionEvent);
+        debug('customer.subscription.created webhook response: %d', subscriptionResponse.status);
+        if (!subscriptionResponse.ok) {
+            const body = await subscriptionResponse.text();
+            throw new Error(`customer.subscription.created webhook failed (${subscriptionResponse.status}): ${body}`);
+        }
+    }
+}

--- a/e2e/helpers/services/stripe/webhook-client.ts
+++ b/e2e/helpers/services/stripe/webhook-client.ts
@@ -1,0 +1,34 @@
+import crypto from 'crypto';
+import type {StripeEvent} from './builders';
+
+const WEBHOOK_SECRET = process.env.WEBHOOK_SECRET || 'DEFAULT_WEBHOOK_SECRET';
+
+export class WebhookClient {
+    private readonly ghostUrl: string;
+
+    constructor(ghostUrl: string) {
+        this.ghostUrl = ghostUrl;
+    }
+
+    async sendWebhook(event: StripeEvent): Promise<Response> {
+        const payload = JSON.stringify(event);
+        const timestamp = Math.floor(Date.now() / 1000);
+        const signature = crypto
+            .createHmac('sha256', WEBHOOK_SECRET)
+            .update(`${timestamp}.${payload}`)
+            .digest('hex');
+        const header = `t=${timestamp},v1=${signature}`;
+
+        const url = `${this.ghostUrl}/members/webhooks/stripe/`;
+        const response = await fetch(url, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'Stripe-Signature': header
+            },
+            body: payload
+        });
+
+        return response;
+    }
+}

--- a/e2e/tests/admin/members/stripe-webhooks.test.ts
+++ b/e2e/tests/admin/members/stripe-webhooks.test.ts
@@ -1,0 +1,17 @@
+import {MembersService} from '@/helpers/services/members';
+import {expect, test} from '@/helpers/playwright';
+
+test.describe('Ghost Admin - Stripe Webhooks', () => {
+    test.use({stripeEnabled: true});
+
+    // Ghost creates a member from Stripe checkout webhooks; this tests the post-Portal redirect flow
+    test('member created via webhooks - has paid status', async ({stripe, page}) => {
+        const membersService = new MembersService(page.request);
+        const email = `stripe-test-${Date.now()}@example.com`;
+
+        await stripe!.createPaidMemberViaWebhooks({email, name: 'Test User'});
+
+        const member = await membersService.getByEmail(email);
+        expect(member.status).toBe('paid');
+    });
+});

--- a/e2e/tests/admin/settings/member-welcome-emails.test.ts
+++ b/e2e/tests/admin/settings/member-welcome-emails.test.ts
@@ -153,7 +153,7 @@ test.describe('Ghost Admin - Welcome Email Customize Button - flag disabled', ()
 });
 
 test.describe('Ghost Admin - Paid Member Welcome Emails', () => {
-    test.use({stripeConnected: true});
+    test.use({stripeEnabled: true});
 
     test('can enable paid welcome emails', async ({page}) => {
         const welcomeEmailsSection = new MemberWelcomeEmailsSection(page);

--- a/ghost/core/core/server/services/stripe/stripe-api.js
+++ b/ghost/core/core/server/services/stripe/stripe-api.js
@@ -2,6 +2,7 @@
 const {VersionMismatchError} = require('@tryghost/errors');
 // @ts-ignore
 const debug = require('@tryghost/debug')('stripe');
+const ghostConfig = require('../../../shared/config');
 const Stripe = require('stripe').Stripe;
 
 /* Stripe has the following rate limits:
@@ -125,9 +126,22 @@ module.exports = class StripeAPI {
         // Lazyloaded to protect sites without Stripe configured
         const LeakyBucket = require('leaky-bucket');
 
-        this._stripe = new Stripe(config.secretKey, {
+        const stripeConfig = {
             apiVersion: STRIPE_API_VERSION
-        });
+        };
+        const stripeApiHost = ghostConfig.get('STRIPE_API_HOST');
+        if (stripeApiHost) {
+            stripeConfig.host = stripeApiHost;
+        }
+        const stripeApiPort = ghostConfig.get('STRIPE_API_PORT');
+        if (stripeApiPort !== undefined && stripeApiPort !== null && stripeApiPort !== '') {
+            stripeConfig.port = parseInt(stripeApiPort, 10);
+        }
+        const stripeApiProtocol = ghostConfig.get('STRIPE_API_PROTOCOL');
+        if (stripeApiProtocol) {
+            stripeConfig.protocol = stripeApiProtocol;
+        }
+        this._stripe = new Stripe(config.secretKey, stripeConfig);
         this._config = config;
         this._testMode = config.secretKey && config.secretKey.startsWith('sk_test_');
         if (this._testMode) {


### PR DESCRIPTION
no ref
- added mock Stripe server
- added webhook builders, client
- added Stripe fixtures
- added first Stripe webhook test to /e2e/

We'd like to build out Stripe mocks in the /e2e/ package in order to move all existing browser tests into our new /e2e/ testing suite. This is the first of several slices in an attempt to break up all of the pieces of Stripe functionality we need.

The first test here is creating a Ghost member on receiving the checkout webhook, which is effectively the back end of the Portal workflow where Portal -> Stripe -> Ghost. 

The Stripe server is stateful, unlike the other options out there for Stripe mocking/testing, meaning we are stuck rolling our own.