### PR TITLE
Added inbox link to Mailpit in development

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.64.7",
+  "version": "2.64.8",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/portal/src/components/common/inbox-link-button.js
+++ b/apps/portal/src/components/common/inbox-link-button.js
@@ -33,7 +33,8 @@ const PROVIDER_ICONS = {
     icloud: icloudIcon,
     hey: defaultEmailIcon,
     aol: defaultEmailIcon,
-    mailru: defaultEmailIcon
+    mailru: defaultEmailIcon,
+    'dev-mailpit': defaultEmailIcon
 };
 
 const PROVIDER_LABELS = {
@@ -44,7 +45,8 @@ const PROVIDER_LABELS = {
     icloud: t('Open iCloud Mail'),
     hey: t('Open Hey'),
     aol: t('Open AOL Mail'),
-    mailru: t('Open Mail.ru')
+    mailru: t('Open Mail.ru'),
+    'dev-mailpit': 'Open Mailpit (development only)'
 };
 
 /**
@@ -52,7 +54,7 @@ const PROVIDER_LABELS = {
  * @param {object} props.inboxLinks
  * @param {string} props.inboxLinks.android
  * @param {string} props.inboxLinks.desktop
- * @param {'gmail' | 'yahoo' | 'outlook' | 'proton' | 'icloud' | 'hey' | 'aol' | 'mailru'} props.inboxLinks.provider
+ * @param {'gmail' | 'yahoo' | 'outlook' | 'proton' | 'icloud' | 'hey' | 'aol' | 'mailru' | 'dev-mailpit'} props.inboxLinks.provider
  */
 function InboxLinkButton({
     inboxLinks: {android, desktop, provider}

--- a/ghost/core/core/server/lib/get-inbox-links.ts
+++ b/ghost/core/core/server/lib/get-inbox-links.ts
@@ -34,7 +34,7 @@ import logging from '@tryghost/logging';
 
 type GetLinkFn = (options: Readonly<{recipient: string; sender: string}>) => string;
 
-type ProviderName = 'gmail' | 'yahoo' | 'outlook' | 'proton' | 'icloud' | 'hey' | 'aol' | 'mailru';
+type ProviderName = 'gmail' | 'yahoo' | 'outlook' | 'proton' | 'icloud' | 'hey' | 'aol' | 'mailru' | 'dev-mailpit';
 
 type Provider = {
     name: ProviderName;
@@ -115,7 +115,13 @@ const PROVIDERS: ReadonlyArray<Provider> = [
         domains: ['mail.ru'],
         getDesktopLink: ({sender}) => buildUrl('https://e.mail.ru/search/', 'q_from', sender),
         getAndroidLink: () => getAndroidIntentUrl('ru.mail.mailapp', 'https://e.mail.ru/')
-    }
+    },
+    ...(process.env.NODE_ENV === 'development' ? [{
+        name: 'dev-mailpit' as const,
+        domains: ['example.com'],
+        getDesktopLink: () => 'http://localhost:8025',
+        getAndroidLink: () => 'http://localhost:8025'
+    }] : [])
 ];
 
 const PROVIDER_BY_DOMAIN = new Map<string, Provider>();


### PR DESCRIPTION
no ref

<p align="center"><img src="https://github.com/user-attachments/assets/586c3d3e-25b6-49c3-a06e-a8296a9194ed" alt="Screenshot" /></p>

This is a development-only change.

If you use an `example.com` email address, show an inbox link to `localhost:8025`.

Note that this contains a Portal patch release.
