### PR TITLE
Consolidated thread sidebar e2e tests from 8 to 3

### DIFF
--- a/e2e/tests/admin/comments/thread-sidebar.test.ts
+++ b/e2e/tests/admin/comments/thread-sidebar.test.ts
@@ -17,6 +17,8 @@ test.describe('Ghost Admin - Thread Sidebar', () => {
     let post: Awaited<ReturnType<PostFactory['create']>>;
     let member: Awaited<ReturnType<MemberFactory['create']>>;
 
+    test.use({labs: {commentModeration: true}});
+
     test.beforeEach(async ({page}) => {
         postFactory = createPostFactory(page.request);
         memberFactory = createMemberFactory(page.request);
@@ -30,248 +32,134 @@ test.describe('Ghost Admin - Thread Sidebar', () => {
         ]);
     });
 
-    test.describe('thread pagination', () => {
-        test.use({labs: {commentModeration: true}});
-
-        test('loads more replies when clicking load more button', async ({page}) => {
-            const rootComment = await commentFactory.create({
-                post_id: post.id,
-                member_id: member.id,
-                html: '<p>Root comment for pagination test</p>'
-            });
-
-            // Create 5 replies in parallel (order doesn't matter for this test)
-            await Promise.all(
-                Array.from({length: 5}, (_, i) => commentFactory.create({
-                    post_id: post.id,
-                    member_id: member.id,
-                    parent_id: rootComment.id,
-                    html: `<p>Reply number ${i + 1}</p>`
-                }))
-            );
-
-            // Intercept API to set a low limit (3) to trigger pagination
-            await page.route('**/ghost/api/admin/comments/**', async (route) => {
-                const url = new URL(route.request().url());
-                // Only modify browse requests (not single comment reads)
-                if (url.searchParams.has('filter') && url.searchParams.get('limit') === '100') {
-                    url.searchParams.set('limit', '3');
-                    await route.continue({url: url.toString()});
-                } else {
-                    await route.continue();
-                }
-            });
-
-            const commentsPage = new CommentsPage(page);
-            await page.goto(`/ghost/#/comments?thread=is:${rootComment.id}`);
-            await commentsPage.waitForThreadSidebar();
-
-            // Should see the root comment
-            await expect(commentsPage.threadSidebar.getByText('Root comment for pagination test')).toBeVisible();
-
-            // Should see exactly 3 replies initially (not all 5)
-            const threadRows = commentsPage.threadSidebar.getByTestId(/^comment-thread-row-/);
-            // 4 = 1 root comment + 3 replies
-            await expect(threadRows).toHaveCount(4);
-
-            // Load more button should be visible
-            const loadMoreButton = commentsPage.threadSidebar.getByRole('button', {name: 'Load more replies'});
-            await expect(loadMoreButton).toBeVisible();
-
-            // Click load more
-            await loadMoreButton.click();
-
-            // Now all 5 replies should be visible (6 total = 1 root + 5 replies)
-            await expect(threadRows).toHaveCount(6);
-
-            // Load more button should be hidden now (no more pages)
-            await expect(loadMoreButton).toBeHidden();
+    test('can navigate within threads and shows correct replied-to context', async ({page}) => {
+        const rootComment = await commentFactory.create({
+            post_id: post.id,
+            member_id: member.id,
+            html: '<p>Root comment</p>'
         });
+        const firstReply = await commentFactory.create({
+            post_id: post.id,
+            member_id: member.id,
+            parent_id: rootComment.id,
+            in_reply_to_id: rootComment.id,
+            html: '<p>First level reply</p>'
+        });
+        const nestedReply = await commentFactory.create({
+            post_id: post.id,
+            member_id: member.id,
+            parent_id: rootComment.id,
+            in_reply_to_id: firstReply.id,
+            html: '<p>Nested reply to first level</p>'
+        });
+
+        const commentsPage = new CommentsPage(page);
+
+        // Open thread for root comment — should show root and direct replies
+        await page.goto(`/ghost/#/comments?thread=is:${rootComment.id}`);
+        await commentsPage.waitForThreadSidebar();
+        await expect(commentsPage.threadSidebar.getByText('Root comment')).toBeVisible();
+        await expect(commentsPage.threadSidebar.getByText('First level reply', {exact: true})).toBeVisible();
+
+        // Direct children should not show "Replied to:" context
+        const directReply = commentsPage.getThreadCommentByText('First level reply');
+        await expect(directReply.getByText('Replied to:')).toBeHidden();
+
+        // Click replies metric on first reply to navigate into its sub-thread
+        const firstReplyRow = commentsPage.getThreadCommentById(firstReply.id);
+        await commentsPage.getRepliesButton(firstReplyRow).click();
+        await page.waitForURL(new RegExp(`thread=is%3A${firstReply.id}`));
+
+        // Sub-thread should show the reply and its children
+        await expect(commentsPage.getThreadCommentById(firstReply.id)).toBeVisible();
+        await expect(commentsPage.getThreadCommentById(nestedReply.id)).toBeVisible();
+
+        // Thread root (a reply itself) should show "Replied to:" for context
+        const threadRoot = commentsPage.getThreadCommentByText('First level reply');
+        await expect(threadRoot.getByText('Replied to:')).toBeVisible();
     });
 
-    test.describe('thread navigation', () => {
-        test.use({labs: {commentModeration: true}});
-
-        test('opening thread for root comment shows root and direct replies', async ({page}) => {
-            const rootComment = await commentFactory.create({
-                post_id: post.id,
-                member_id: member.id,
-                html: '<p>Root comment</p>'
-            });
-            await commentFactory.create({
-                post_id: post.id,
-                member_id: member.id,
-                parent_id: rootComment.id,
-                html: '<p>Direct reply to root</p>'
-            });
-
-            const commentsPage = new CommentsPage(page);
-            await page.goto(`/ghost/#/comments?thread=is:${rootComment.id}`);
-            await commentsPage.waitForThreadSidebar();
-
-            await expect(commentsPage.threadSidebar.getByText('Root comment')).toBeVisible();
-            await expect(commentsPage.threadSidebar.getByText('Direct reply to root')).toBeVisible();
+    test('can open threads from the main comment list', async ({page}) => {
+        const rootComment = await commentFactory.create({
+            post_id: post.id,
+            member_id: member.id,
+            html: '<p>Comment with replies</p>'
+        });
+        await commentFactory.create({
+            post_id: post.id,
+            member_id: member.id,
+            parent_id: rootComment.id,
+            in_reply_to_id: rootComment.id,
+            html: '<p>A reply to the comment</p>'
         });
 
-        test('opening thread for reply comment shows reply and its children', async ({page}) => {
-            const rootComment = await commentFactory.create({
-                post_id: post.id,
-                member_id: member.id,
-                html: '<p>Root comment</p>'
-            });
-            const replyComment = await commentFactory.create({
-                post_id: post.id,
-                member_id: member.id,
-                parent_id: rootComment.id,
-                html: '<p>First level reply</p>'
-            });
-            await commentFactory.create({
-                post_id: post.id,
-                member_id: member.id,
-                parent_id: rootComment.id,
-                in_reply_to_id: replyComment.id,
-                html: '<p>Reply to first level reply</p>'
-            });
+        const commentsPage = new CommentsPage(page);
+        await commentsPage.goto();
+        await commentsPage.waitForComments();
 
-            const commentsPage = new CommentsPage(page);
-            await page.goto(`/ghost/#/comments?thread=is:${replyComment.id}`);
-            await commentsPage.waitForThreadSidebar();
+        // Click replies metric on root comment to open its thread
+        const commentRow = commentsPage.commentRows.filter({
+            has: page.getByRole('paragraph').filter({hasText: 'Comment with replies'})
+        });
+        await commentsPage.openThread(commentRow);
 
-            await expect(commentsPage.threadSidebar.getByText('First level reply', {exact: true})).toBeVisible();
-            await expect(commentsPage.threadSidebar.getByText('Reply to first level reply')).toBeVisible();
+        expect(page.url()).toContain(`thread=is%3A${rootComment.id}`);
+        await expect(commentsPage.threadSidebar.getByText('Comment with replies')).toBeVisible();
+        await expect(commentsPage.threadSidebar.getByText('A reply to the comment')).toBeVisible();
+
+        // Navigate back to the list to test the "Replied to:" link entry point
+        await commentsPage.goto();
+        await commentsPage.waitForComments();
+
+        const replyRow = commentsPage.getCommentRowByText('A reply to the comment');
+        await commentsPage.getRepliedToLink(replyRow).click();
+
+        await commentsPage.waitForThreadSidebar();
+        expect(page.url()).toContain(`thread=is%3A${rootComment.id}`);
+    });
+
+    test('loads more replies when clicking load more button', async ({page}) => {
+        const rootComment = await commentFactory.create({
+            post_id: post.id,
+            member_id: member.id,
+            html: '<p>Root comment for pagination test</p>'
         });
 
-        test('replied to link in main list opens thread focused on that comment', async ({page}) => {
-            const rootComment = await commentFactory.create({
-                post_id: post.id,
-                member_id: member.id,
-                html: '<p>This is the root comment that was replied to</p>'
-            });
-            await commentFactory.create({
+        await Promise.all(
+            Array.from({length: 5}, (_, i) => commentFactory.create({
                 post_id: post.id,
                 member_id: member.id,
                 parent_id: rootComment.id,
-                in_reply_to_id: rootComment.id,
-                html: '<p>Reply that shows replied to</p>'
-            });
+                html: `<p>Reply number ${i + 1}</p>`
+            }))
+        );
 
-            const commentsPage = new CommentsPage(page);
-            await commentsPage.goto();
-            await commentsPage.waitForComments();
-
-            const replyRow = commentsPage.getCommentRowByText('Reply that shows replied to');
-            const repliedToLink = commentsPage.getRepliedToLink(replyRow);
-            await repliedToLink.click();
-
-            await commentsPage.waitForThreadSidebar();
-            expect(page.url()).toContain(`thread=is%3A${rootComment.id}`);
+        // Intercept API to set a low limit (3) to trigger pagination
+        await page.route('**/ghost/api/admin/comments/**', async (route) => {
+            const url = new URL(route.request().url());
+            if (url.searchParams.has('filter') && url.searchParams.get('limit') === '100') {
+                url.searchParams.set('limit', '3');
+                await route.continue({url: url.toString()});
+            } else {
+                await route.continue();
+            }
         });
 
-        test('clicking replies metric in main list opens thread for that comment', async ({page}) => {
-            const rootComment = await commentFactory.create({
-                post_id: post.id,
-                member_id: member.id,
-                html: '<p>Comment with replies</p>'
-            });
-            await commentFactory.create({
-                post_id: post.id,
-                member_id: member.id,
-                parent_id: rootComment.id,
-                html: '<p>A reply to the comment</p>'
-            });
+        const commentsPage = new CommentsPage(page);
+        await page.goto(`/ghost/#/comments?thread=is:${rootComment.id}`);
+        await commentsPage.waitForThreadSidebar();
 
-            const commentsPage = new CommentsPage(page);
-            await commentsPage.goto();
-            await commentsPage.waitForComments();
+        await expect(commentsPage.threadSidebar.getByText('Root comment for pagination test')).toBeVisible();
 
-            // Filter by paragraph content to avoid matching the reply row's "Replied to:" link
-            const commentRow = commentsPage.commentRows.filter({
-                has: page.getByRole('paragraph').filter({hasText: 'Comment with replies'})
-            });
-            await commentsPage.openThread(commentRow);
+        const threadRows = commentsPage.threadSidebar.getByTestId(/^comment-thread-row-/);
+        await expect(threadRows).toHaveCount(4); // 1 root + 3 replies
 
-            expect(page.url()).toContain(`thread=is%3A${rootComment.id}`);
-            await expect(commentsPage.threadSidebar.getByText('Comment with replies')).toBeVisible();
-            await expect(commentsPage.threadSidebar.getByText('A reply to the comment')).toBeVisible();
-        });
+        const loadMoreButton = commentsPage.threadSidebar.getByRole('button', {name: 'Load more replies'});
+        await expect(loadMoreButton).toBeVisible();
 
-        test('clicking replies metric in thread navigates to that reply', async ({page}) => {
-            const rootComment = await commentFactory.create({
-                post_id: post.id,
-                member_id: member.id,
-                html: '<p>Root comment</p>'
-            });
-            const firstReply = await commentFactory.create({
-                post_id: post.id,
-                member_id: member.id,
-                parent_id: rootComment.id,
-                html: '<p>First reply with its own replies</p>'
-            });
-            const nestedReply = await commentFactory.create({
-                post_id: post.id,
-                member_id: member.id,
-                parent_id: rootComment.id,
-                in_reply_to_id: firstReply.id,
-                html: '<p>Nested reply to first reply</p>'
-            });
+        await loadMoreButton.click();
 
-            const commentsPage = new CommentsPage(page);
-            await page.goto(`/ghost/#/comments?thread=is:${rootComment.id}`);
-            await commentsPage.waitForThreadSidebar();
-
-            const firstReplyRow = commentsPage.getThreadCommentById(firstReply.id);
-            const repliesButton = commentsPage.getRepliesButton(firstReplyRow);
-            await repliesButton.click();
-
-            await page.waitForURL(new RegExp(`thread=is%3A${firstReply.id}`));
-            expect(page.url()).toContain(`thread=is%3A${firstReply.id}`);
-            // Children being nested in the parent comment row required explicit targetting by ID
-            await expect(commentsPage.getThreadCommentById(firstReply.id)).toBeVisible();
-            await expect(commentsPage.getThreadCommentById(nestedReply.id)).toBeVisible();
-        });
-
-        test('shows replied to context for selected reply comment in thread', async ({page}) => {
-            const rootComment = await commentFactory.create({
-                post_id: post.id,
-                member_id: member.id,
-                html: '<p>Root comment content</p>'
-            });
-            const replyComment = await commentFactory.create({
-                post_id: post.id,
-                member_id: member.id,
-                parent_id: rootComment.id,
-                in_reply_to_id: rootComment.id,
-                html: '<p>Reply with replied-to context</p>'
-            });
-
-            const commentsPage = new CommentsPage(page);
-            await page.goto(`/ghost/#/comments?thread=is:${replyComment.id}`);
-            await commentsPage.waitForThreadSidebar();
-
-            const selectedComment = commentsPage.getThreadCommentByText('Reply with replied-to context');
-            await expect(selectedComment.getByText('Replied to:')).toBeVisible();
-        });
-
-        test('hides replied to context for direct children in thread', async ({page}) => {
-            const rootComment = await commentFactory.create({
-                post_id: post.id,
-                member_id: member.id,
-                html: '<p>Thread root</p>'
-            });
-            await commentFactory.create({
-                post_id: post.id,
-                member_id: member.id,
-                parent_id: rootComment.id,
-                in_reply_to_id: rootComment.id,
-                html: '<p>Direct reply to root</p>'
-            });
-
-            const commentsPage = new CommentsPage(page);
-            await page.goto(`/ghost/#/comments?thread=is:${rootComment.id}`);
-            await commentsPage.waitForThreadSidebar();
-
-            const directReply = commentsPage.getThreadCommentByText('Direct reply to root');
-            await expect(directReply.getByText('Replied to:')).toBeHidden();
-        });
+        await expect(threadRows).toHaveCount(6); // 1 root + 5 replies
+        await expect(loadMoreButton).toBeHidden();
     });
 });


### PR DESCRIPTION
## Summary
- Collapsed 8 unit-style thread sidebar e2e tests into 3 user-flow tests, reducing expensive test runs while maintaining the same coverage
- Fixed an ambiguous locator where `getCommentRowByText` matched both the root comment and reply row (via its "Replied to:" link text), causing intermittent clicks on the wrong element
- Moved shared post/member/settings setup into `beforeEach`

### Test flows

**1. Can navigate within threads and shows correct replied-to context**
Opens a root comment's thread, verifies content and that direct children hide "Replied to:" context. Navigates into a sub-thread via the replies metric, verifies the reply and its children are visible, and that the thread root (a reply itself) shows "Replied to:" for context.

**2. Can open threads from the main comment list**
From the main comments list, opens a thread via the replies metric on a root comment. Then navigates back and opens a thread via the "Replied to:" link on a reply.

**3. Loads more replies when clicking load more button**
Opens a thread with paginated replies, verifies the initial page and load more button, clicks it, and verifies all replies appear.