### PR TITLE
[Draft] Removed GHOST_CDN_URL from Ghost(Pro) admin CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1768,8 +1768,6 @@ jobs:
         env:
           DEPENDENCY_CACHE_KEY: ${{ needs.job_setup.outputs.dependency_cache_key }}
       - name: Build Admin
-        env:
-          GHOST_CDN_URL: https://assets.ghost.io/admin-forward/
         run: yarn nx run admin:build
       - name: Upload build artifact
         id: upload-artifacts


### PR DESCRIPTION
> **Draft proposal** — not ready to merge. See [full proposal](https://www.notion.so/ghost/Proposal-Relative-admin-build-with-CDN-asset-proxy-build-once-deploy-everywhere-30c51439c0308187a658dd8f42fff126).

## Context

Ghost(Pro) is moving to relative-path admin builds so a single artifact works across staging and production. The `GHOST_CDN_URL` config option is fully preserved for anyone who uses it — this PR only stops setting it in Ghost(Pro)'s CI build.

## This PR

Removes the `GHOST_CDN_URL` env var from the `deploy_admin` CI job. Without it set, Vite defaults to `base: './'` (relative paths) and Ember defaults to relative asset URLs. The existing code paths that read `GHOST_CDN_URL` are untouched — self-hosters and contributors who set the env var get the same behaviour as before.

Depends on BlackPearl's asset proxy being deployed first so that relative paths in `index.html` resolve correctly via the CDN.