### PR TITLE
Improved thread sidebar test URL assertions for consistency

### DIFF
--- a/e2e/tests/admin/comments/thread-sidebar.test.ts
+++ b/e2e/tests/admin/comments/thread-sidebar.test.ts
@@ -68,7 +68,7 @@ test.describe('Ghost Admin - Thread Sidebar', () => {
         // Click replies metric on first reply to navigate into its sub-thread
         const firstReplyRow = commentsPage.getThreadCommentById(firstReply.id);
         await commentsPage.getRepliesButton(firstReplyRow).click();
-        await page.waitForURL(new RegExp(`thread=is%3A${firstReply.id}`));
+        await expect(page).toHaveURL(new RegExp(`thread=is%3A${firstReply.id}`));
 
         // Sub-thread should show the reply and its children
         await expect(commentsPage.getThreadCommentById(firstReply.id)).toBeVisible();
@@ -103,7 +103,7 @@ test.describe('Ghost Admin - Thread Sidebar', () => {
         });
         await commentsPage.openThread(commentRow);
 
-        expect(page.url()).toContain(`thread=is%3A${rootComment.id}`);
+        await expect(page).toHaveURL(new RegExp(`thread=is%3A${rootComment.id}`));
         await expect(commentsPage.threadSidebar.getByText('Comment with replies')).toBeVisible();
         await expect(commentsPage.threadSidebar.getByText('A reply to the comment')).toBeVisible();
 
@@ -115,7 +115,7 @@ test.describe('Ghost Admin - Thread Sidebar', () => {
         await commentsPage.getRepliedToLink(replyRow).click();
 
         await commentsPage.waitForThreadSidebar();
-        expect(page.url()).toContain(`thread=is%3A${rootComment.id}`);
+        await expect(page).toHaveURL(new RegExp(`thread=is%3A${rootComment.id}`));
     });
 
     test('loads more replies when clicking load more button', async ({page}) => {


### PR DESCRIPTION
The thread sidebar e2e tests used three different patterns for URL assertions: synchronous `expect(page.url()).toContain()` (no retry, potential flake source), `page.waitForURL()` (auto-retrying but reads as a wait, not an assertion), and Playwright's `expect(page).toHaveURL()` (auto-retrying assertion).

This aligns all three URL checks to use `await expect(page).toHaveURL()` consistently. This is Playwright's recommended approach — it auto-retries like `waitForURL` but reads as an assertion like `expect`, making the test intent clearer and eliminating the synchronous URL check that could flake if the URL hasn't updated yet.

Follow-up to #26520 addressing CodeRabbit review feedback.