### PR TITLE
Added entitlements JWT endpoint

### DIFF
--- a/ghost/core/core/server/services/members/members-api/members-api.js
+++ b/ghost/core/core/server/services/members/members-api/members-api.js
@@ -330,7 +330,6 @@ module.exports = function MembersAPI({
 
         return tokenService.encodeEntitlementToken({
             sub: member.email,
-            memberId: member.id,
             memberUuid: member.uuid,
             paid: member.status !== 'free',
             activeTierIds

--- a/ghost/core/core/server/services/members/members-api/members-api.js
+++ b/ghost/core/core/server/services/members/members-api/members-api.js
@@ -329,8 +329,7 @@ module.exports = function MembersAPI({
             .filter(Boolean))];
 
         return tokenService.encodeEntitlementToken({
-            sub: member.email,
-            memberUuid: member.uuid,
+            sub: member.uuid,
             paid: member.status !== 'free',
             activeTierIds
         });

--- a/ghost/core/core/server/services/members/members-api/members-api.js
+++ b/ghost/core/core/server/services/members/members-api/members-api.js
@@ -329,7 +329,8 @@ module.exports = function MembersAPI({
             .filter(Boolean))];
 
         return tokenService.encodeEntitlementToken({
-            sub: member.uuid,
+            sub: member.email,
+            memberUuid: member.uuid,
             paid: member.status !== 'free',
             activeTierIds
         });

--- a/ghost/core/core/server/services/members/members-api/members-api.js
+++ b/ghost/core/core/server/services/members/members-api/members-api.js
@@ -317,6 +317,26 @@ module.exports = function MembersAPI({
         return tokenService.encodeIdentityToken({sub: member.email});
     }
 
+    async function getMemberEntitlementToken(transientId) {
+        const member = await getMemberIdentityDataFromTransientId(transientId);
+        if (!member) {
+            return null;
+        }
+
+        const activeTierIds = [...new Set((member.subscriptions || [])
+            .filter(sub => users.isActiveSubscriptionStatus(sub.status))
+            .map(sub => sub?.tier?.id)
+            .filter(Boolean))];
+
+        return tokenService.encodeEntitlementToken({
+            sub: member.email,
+            memberId: member.id,
+            memberUuid: member.uuid,
+            paid: member.status !== 'free',
+            activeTierIds
+        });
+    }
+
     async function setMemberGeolocationFromIp(email, ip) {
         if (!email || !ip) {
             throw new errors.IncorrectUsageError({
@@ -417,6 +437,7 @@ module.exports = function MembersAPI({
         middleware,
         getMemberDataFromMagicLinkToken,
         getMemberIdentityToken,
+        getMemberEntitlementToken,
         getMemberIdentityDataFromTransientId,
         getMemberIdentityData,
         cycleTransientId,

--- a/ghost/core/core/server/services/members/members-api/services/token-service.js
+++ b/ghost/core/core/server/services/members/members-api/services/token-service.js
@@ -47,7 +47,7 @@ module.exports = class TokenService {
             keyid: jwk.kid,
             algorithm: 'RS512',
             audience: this._issuer,
-            expiresIn: '2m',
+            expiresIn: '5m',
             issuer: this._issuer
         });
     }

--- a/ghost/core/core/server/services/members/members-api/services/token-service.js
+++ b/ghost/core/core/server/services/members/members-api/services/token-service.js
@@ -31,6 +31,7 @@ module.exports = class TokenService {
 
     async encodeEntitlementToken({
         sub,
+        memberUuid,
         paid,
         activeTierIds = []
     }) {
@@ -40,6 +41,7 @@ module.exports = class TokenService {
             sub,
             kid: jwk.kid,
             scope: 'members:entitlements:read',
+            member_uuid: memberUuid,
             paid,
             active_tier_ids: activeTierIds,
             jti: crypto.randomUUID()

--- a/ghost/core/core/server/services/members/members-api/services/token-service.js
+++ b/ghost/core/core/server/services/members/members-api/services/token-service.js
@@ -1,5 +1,6 @@
 const jose = require('node-jose');
 const jwt = require('jsonwebtoken');
+const crypto = require('crypto');
 
 module.exports = class TokenService {
     constructor({
@@ -24,6 +25,33 @@ module.exports = class TokenService {
             algorithm: 'RS512',
             audience: this._issuer,
             expiresIn: '10m',
+            issuer: this._issuer
+        });
+    }
+
+    async encodeEntitlementToken({
+        sub,
+        memberId,
+        memberUuid,
+        paid,
+        activeTierIds = []
+    }) {
+        const jwk = await this._keyStoreReady;
+
+        return jwt.sign({
+            sub,
+            kid: jwk.kid,
+            scope: 'members:entitlements:read',
+            member_id: memberId,
+            member_uuid: memberUuid,
+            paid,
+            active_tier_ids: activeTierIds,
+            jti: crypto.randomUUID()
+        }, this._privateKey, {
+            keyid: jwk.kid,
+            algorithm: 'RS512',
+            audience: this._issuer,
+            expiresIn: '2m',
             issuer: this._issuer
         });
     }

--- a/ghost/core/core/server/services/members/members-api/services/token-service.js
+++ b/ghost/core/core/server/services/members/members-api/services/token-service.js
@@ -31,7 +31,6 @@ module.exports = class TokenService {
 
     async encodeEntitlementToken({
         sub,
-        memberUuid,
         paid,
         activeTierIds = []
     }) {
@@ -41,7 +40,6 @@ module.exports = class TokenService {
             sub,
             kid: jwk.kid,
             scope: 'members:entitlements:read',
-            member_uuid: memberUuid,
             paid,
             active_tier_ids: activeTierIds,
             jti: crypto.randomUUID()

--- a/ghost/core/core/server/services/members/members-api/services/token-service.js
+++ b/ghost/core/core/server/services/members/members-api/services/token-service.js
@@ -31,7 +31,6 @@ module.exports = class TokenService {
 
     async encodeEntitlementToken({
         sub,
-        memberId,
         memberUuid,
         paid,
         activeTierIds = []
@@ -42,7 +41,6 @@ module.exports = class TokenService {
             sub,
             kid: jwk.kid,
             scope: 'members:entitlements:read',
-            member_id: memberId,
             member_uuid: memberUuid,
             paid,
             active_tier_ids: activeTierIds,

--- a/ghost/core/core/server/services/members/members-ssr.js
+++ b/ghost/core/core/server/services/members/members-ssr.js
@@ -206,6 +206,11 @@ class MembersSSR {
         return api.getMemberIdentityToken(transientId);
     }
 
+    async _getMemberEntitlementToken(transientId) {
+        const api = await this._getMembersApi();
+        return api.getMemberEntitlementToken(transientId);
+    }
+
     /**
      * @method _setMemberGeolocationFromIp
      * @param {string} email
@@ -318,6 +323,18 @@ class MembersSSR {
             await this.deleteSession(req, res);
             throw new BadRequestError({
                 message: 'Invalid session, could not get identity token'
+            });
+        }
+        return token;
+    }
+
+    async getEntitlementTokenForMemberFromSession(req, res) {
+        const transientId = this._getSessionCookies(req, res);
+        const token = await this._getMemberEntitlementToken(transientId);
+        if (!token) {
+            await this.deleteSession(req, res);
+            throw new BadRequestError({
+                message: 'Invalid session, could not get entitlement token'
             });
         }
         return token;

--- a/ghost/core/core/server/services/members/middleware.js
+++ b/ghost/core/core/server/services/members/middleware.js
@@ -157,6 +157,17 @@ const getIdentityToken = async function getIdentityToken(req, res) {
     }
 };
 
+const getEntitlementToken = async function getEntitlementToken(req, res) {
+    try {
+        const token = await membersService.ssr.getEntitlementTokenForMemberFromSession(req, res);
+        res.writeHead(200);
+        res.end(token);
+    } catch (err) {
+        res.writeHead(204);
+        res.end();
+    }
+};
+
 const createIntegrityToken = async function createIntegrityToken(req, res) {
     try {
         const token = membersService.requestIntegrityTokenProvider.create();
@@ -429,6 +440,7 @@ module.exports = {
     authMemberByUuid,
     createSessionFromMagicLink,
     getIdentityToken,
+    getEntitlementToken,
     getMemberNewsletters,
     getMemberData,
     updateMemberData,

--- a/ghost/core/core/server/web/members/app.js
+++ b/ghost/core/core/server/web/members/app.js
@@ -74,7 +74,8 @@ module.exports = function setupMembersApp() {
     // Manage session
     membersApp.get('/api/session', middleware.getIdentityToken);
     membersApp.delete('/api/session', bodyParser.json({limit: '5mb'}), middleware.deleteSession);
-
+    
+    membersApp.get('/api/entitlements', middleware.getEntitlementToken);
     membersApp.get('/api/integrity-token', middleware.createIntegrityToken);
 
     membersApp.post(

--- a/ghost/core/test/e2e-frontend/members.test.js
+++ b/ghost/core/test/e2e-frontend/members.test.js
@@ -127,8 +127,9 @@ describe('Front-end members behavior', function () {
 
             const decodedToken = jwt.decode(res.text);
 
-            assert.equal(decodedToken.sub, member.get('uuid'));
+            assert.equal(decodedToken.sub, 'member1@test.com');
             assert.equal(decodedToken.scope, 'members:entitlements:read');
+            assert.equal(decodedToken.member_uuid, member.get('uuid'));
             assert.equal(decodedToken.paid, member.get('status') !== 'free');
             assert(Array.isArray(decodedToken.active_tier_ids));
             assert.equal(decodedToken.exp - decodedToken.iat, 300);

--- a/ghost/core/test/e2e-frontend/members.test.js
+++ b/ghost/core/test/e2e-frontend/members.test.js
@@ -131,7 +131,7 @@ describe('Front-end members behavior', function () {
             assert.equal(decodedToken.scope, 'members:entitlements:read');
             assert.equal(decodedToken.paid, member.get('status') !== 'free');
             assert(Array.isArray(decodedToken.active_tier_ids));
-            assert.equal(decodedToken.exp - decodedToken.iat, 120);
+            assert.equal(decodedToken.exp - decodedToken.iat, 300);
         });
 
         it('should return no content when removing member sessions', async function () {

--- a/ghost/core/test/e2e-frontend/members.test.js
+++ b/ghost/core/test/e2e-frontend/members.test.js
@@ -3,6 +3,7 @@ const {assertExists} = require('../utils/assertions');
 const sinon = require('sinon');
 const supertest = require('supertest');
 const moment = require('moment');
+const jwt = require('jsonwebtoken');
 const testUtils = require('../utils');
 const configUtils = require('../utils/config-utils');
 const config = require('../../core/shared/config');
@@ -111,6 +112,28 @@ describe('Front-end members behavior', function () {
         it('should return no content for invalid token passed in session', async function () {
             await request.get('/members/api/session')
                 .expect(204);
+        });
+
+        it('should return no content for invalid token passed in entitlements', async function () {
+            await request.get('/members/api/entitlements')
+                .expect(204);
+        });
+
+        it('returns an entitlement token for a valid member session', async function () {
+            const member = await loginAsMember('member1@test.com');
+
+            const res = await request.get('/members/api/entitlements')
+                .expect(200);
+
+            const decodedToken = jwt.decode(res.text);
+
+            assert.equal(decodedToken.sub, 'member1@test.com');
+            assert.equal(decodedToken.scope, 'members:entitlements:read');
+            assert.equal(decodedToken.member_id, member.get('id'));
+            assert.equal(decodedToken.member_uuid, member.get('uuid'));
+            assert.equal(decodedToken.paid, member.get('status') !== 'free');
+            assert(Array.isArray(decodedToken.active_tier_ids));
+            assert.equal(decodedToken.exp - decodedToken.iat, 120);
         });
 
         it('should return no content when removing member sessions', async function () {

--- a/ghost/core/test/e2e-frontend/members.test.js
+++ b/ghost/core/test/e2e-frontend/members.test.js
@@ -129,7 +129,6 @@ describe('Front-end members behavior', function () {
 
             assert.equal(decodedToken.sub, 'member1@test.com');
             assert.equal(decodedToken.scope, 'members:entitlements:read');
-            assert.equal(decodedToken.member_id, member.get('id'));
             assert.equal(decodedToken.member_uuid, member.get('uuid'));
             assert.equal(decodedToken.paid, member.get('status') !== 'free');
             assert(Array.isArray(decodedToken.active_tier_ids));

--- a/ghost/core/test/e2e-frontend/members.test.js
+++ b/ghost/core/test/e2e-frontend/members.test.js
@@ -127,9 +127,8 @@ describe('Front-end members behavior', function () {
 
             const decodedToken = jwt.decode(res.text);
 
-            assert.equal(decodedToken.sub, 'member1@test.com');
+            assert.equal(decodedToken.sub, member.get('uuid'));
             assert.equal(decodedToken.scope, 'members:entitlements:read');
-            assert.equal(decodedToken.member_uuid, member.get('uuid'));
             assert.equal(decodedToken.paid, member.get('status') !== 'free');
             assert(Array.isArray(decodedToken.active_tier_ids));
             assert.equal(decodedToken.exp - decodedToken.iat, 120);

--- a/ghost/core/test/unit/server/services/members/members-api/services/token-service.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/services/token-service.test.js
@@ -34,19 +34,17 @@ describe('TokenService', function () {
         it('can encode an entitlement token and decode it afterwards', async function () {
             const token = await tokenService.encodeEntitlementToken({
                 sub: 'member@example.com',
-                memberId: '123',
                 memberUuid: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
                 paid: true,
                 activeTierIds: ['tier_1', 'tier_2']
             });
             const decodedToken = await tokenService.decodeToken(token);
 
-            assert.deepEqual(Object.keys(decodedToken), ['sub', 'kid', 'scope', 'member_id', 'member_uuid', 'paid', 'active_tier_ids', 'jti', 'iat', 'exp', 'aud', 'iss']);
+            assert.deepEqual(Object.keys(decodedToken), ['sub', 'kid', 'scope', 'member_uuid', 'paid', 'active_tier_ids', 'jti', 'iat', 'exp', 'aud', 'iss']);
             assert.equal(decodedToken.aud, 'http://127.0.0.1:2369/members/api');
             assert.equal(decodedToken.iss, 'http://127.0.0.1:2369/members/api');
             assert.equal(decodedToken.sub, 'member@example.com');
             assert.equal(decodedToken.scope, 'members:entitlements:read');
-            assert.equal(decodedToken.member_id, '123');
             assert.equal(decodedToken.member_uuid, 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee');
             assert.equal(decodedToken.paid, true);
             assert.deepEqual(decodedToken.active_tier_ids, ['tier_1', 'tier_2']);

--- a/ghost/core/test/unit/server/services/members/members-api/services/token-service.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/services/token-service.test.js
@@ -30,6 +30,31 @@ describe('TokenService', function () {
         });
     });
 
+    describe('encodeEntitlementToken', function () {
+        it('can encode an entitlement token and decode it afterwards', async function () {
+            const token = await tokenService.encodeEntitlementToken({
+                sub: 'member@example.com',
+                memberId: '123',
+                memberUuid: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+                paid: true,
+                activeTierIds: ['tier_1', 'tier_2']
+            });
+            const decodedToken = await tokenService.decodeToken(token);
+
+            assert.deepEqual(Object.keys(decodedToken), ['sub', 'kid', 'scope', 'member_id', 'member_uuid', 'paid', 'active_tier_ids', 'jti', 'iat', 'exp', 'aud', 'iss']);
+            assert.equal(decodedToken.aud, 'http://127.0.0.1:2369/members/api');
+            assert.equal(decodedToken.iss, 'http://127.0.0.1:2369/members/api');
+            assert.equal(decodedToken.sub, 'member@example.com');
+            assert.equal(decodedToken.scope, 'members:entitlements:read');
+            assert.equal(decodedToken.member_id, '123');
+            assert.equal(decodedToken.member_uuid, 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee');
+            assert.equal(decodedToken.paid, true);
+            assert.deepEqual(decodedToken.active_tier_ids, ['tier_1', 'tier_2']);
+            assert.equal(typeof decodedToken.jti, 'string');
+            assert.equal(decodedToken.exp - decodedToken.iat, 120);
+        });
+    });
+
     describe('getPublicKeys', function () {
         it('can verify the token using public keys', async function () {
             const token = await tokenService.encodeIdentityToken({sub: 'member@example.com'});

--- a/ghost/core/test/unit/server/services/members/members-api/services/token-service.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/services/token-service.test.js
@@ -47,7 +47,7 @@ describe('TokenService', function () {
             assert.equal(decodedToken.paid, true);
             assert.deepEqual(decodedToken.active_tier_ids, ['tier_1', 'tier_2']);
             assert.equal(typeof decodedToken.jti, 'string');
-            assert.equal(decodedToken.exp - decodedToken.iat, 120);
+            assert.equal(decodedToken.exp - decodedToken.iat, 300);
         });
     });
 

--- a/ghost/core/test/unit/server/services/members/members-api/services/token-service.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/services/token-service.test.js
@@ -33,19 +33,17 @@ describe('TokenService', function () {
     describe('encodeEntitlementToken', function () {
         it('can encode an entitlement token and decode it afterwards', async function () {
             const token = await tokenService.encodeEntitlementToken({
-                sub: 'member@example.com',
-                memberUuid: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+                sub: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
                 paid: true,
                 activeTierIds: ['tier_1', 'tier_2']
             });
             const decodedToken = await tokenService.decodeToken(token);
 
-            assert.deepEqual(Object.keys(decodedToken), ['sub', 'kid', 'scope', 'member_uuid', 'paid', 'active_tier_ids', 'jti', 'iat', 'exp', 'aud', 'iss']);
+            assert.deepEqual(Object.keys(decodedToken), ['sub', 'kid', 'scope', 'paid', 'active_tier_ids', 'jti', 'iat', 'exp', 'aud', 'iss']);
             assert.equal(decodedToken.aud, 'http://127.0.0.1:2369/members/api');
             assert.equal(decodedToken.iss, 'http://127.0.0.1:2369/members/api');
-            assert.equal(decodedToken.sub, 'member@example.com');
+            assert.equal(decodedToken.sub, 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee');
             assert.equal(decodedToken.scope, 'members:entitlements:read');
-            assert.equal(decodedToken.member_uuid, 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee');
             assert.equal(decodedToken.paid, true);
             assert.deepEqual(decodedToken.active_tier_ids, ['tier_1', 'tier_2']);
             assert.equal(typeof decodedToken.jti, 'string');

--- a/ghost/core/test/unit/server/services/members/members-api/services/token-service.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/services/token-service.test.js
@@ -33,17 +33,19 @@ describe('TokenService', function () {
     describe('encodeEntitlementToken', function () {
         it('can encode an entitlement token and decode it afterwards', async function () {
             const token = await tokenService.encodeEntitlementToken({
-                sub: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+                sub: 'member@example.com',
+                memberUuid: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
                 paid: true,
                 activeTierIds: ['tier_1', 'tier_2']
             });
             const decodedToken = await tokenService.decodeToken(token);
 
-            assert.deepEqual(Object.keys(decodedToken), ['sub', 'kid', 'scope', 'paid', 'active_tier_ids', 'jti', 'iat', 'exp', 'aud', 'iss']);
+            assert.deepEqual(Object.keys(decodedToken), ['sub', 'kid', 'scope', 'member_uuid', 'paid', 'active_tier_ids', 'jti', 'iat', 'exp', 'aud', 'iss']);
             assert.equal(decodedToken.aud, 'http://127.0.0.1:2369/members/api');
             assert.equal(decodedToken.iss, 'http://127.0.0.1:2369/members/api');
-            assert.equal(decodedToken.sub, 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee');
+            assert.equal(decodedToken.sub, 'member@example.com');
             assert.equal(decodedToken.scope, 'members:entitlements:read');
+            assert.equal(decodedToken.member_uuid, 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee');
             assert.equal(decodedToken.paid, true);
             assert.deepEqual(decodedToken.active_tier_ids, ['tier_1', 'tier_2']);
             assert.equal(typeof decodedToken.jti, 'string');


### PR DESCRIPTION
ref https://ghost.slack.com/archives/C018EKC56JF/p1771527734858719

The existing JWT is used for identity and only contains the email address. It has a TTL of 10 minutes which is reasonable for the use case but little else.

We have another use case where integrations often want to validate the source, but are left with no option but to hit the members Admin API endpoint with an Admin API key because the email isn't sufficient to know if the member has access to a tier, is paid, isn't specific to email (which could change), etc., all of which are used for integrations.

This endpoint would still require the members session cookie and has the following props, e.g.:
```
 sub: darylmayer880479@example.com
 scope: members:entitlements:read
 member_uuid: 629c5190-f068-4f49-b533-00d7477a7aed
 paid: false
 active_tier_ids: []
 jti: present
 iat: 1771555398
 exp: 1771555518
 aud/iss: http://localhost:2368/members/api
 Lifetime: 120s (2 minutes)
```