### PR TITLE
Fixed textarea width regression in spam filters settings

### DIFF
--- a/apps/admin-x-design-system/src/global/form/text-area.tsx
+++ b/apps/admin-x-design-system/src/global/form/text-area.tsx
@@ -55,7 +55,7 @@ const TextArea: React.FC<TextAreaProps> = ({
     };
 
     let styles = clsx(
-        'order-2 rounded-lg border bg-grey-150 px-3 py-2 transition-all dark:bg-grey-900 dark:text-white',
+        'order-2 w-full rounded-lg border bg-grey-150 px-3 py-2 transition-all dark:bg-grey-900 dark:text-white',
         error ? 'border-red bg-white' : 'border-transparent placeholder:text-grey-500 hover:bg-grey-100 focus:border-green focus:bg-white focus:shadow-[0_0_0_2px_rgba(48,207,67,0.25)] dark:placeholder:text-grey-800 dark:hover:bg-grey-925 dark:focus:bg-grey-950',
         title && 'mt-1.5',
         fontStyle === 'mono' && 'font-mono text-sm',
@@ -82,7 +82,7 @@ const TextArea: React.FC<TextAreaProps> = ({
 
     return (
         <FormPrimitive.Root asChild>
-            <div className='flex flex-col'>
+            <div className='flex w-full flex-col'>
                 <FormPrimitive.Field name={id} asChild>
                     <FormPrimitive.Control asChild>
                         <textarea

--- a/apps/admin-x-design-system/src/global/form/text-area.tsx
+++ b/apps/admin-x-design-system/src/global/form/text-area.tsx
@@ -55,7 +55,7 @@ const TextArea: React.FC<TextAreaProps> = ({
     };
 
     let styles = clsx(
-        'order-2 w-full rounded-lg border bg-grey-150 px-3 py-2 transition-all dark:bg-grey-900 dark:text-white',
+        'order-2 w-full max-w-none rounded-lg border bg-grey-150 px-3 py-2 transition-all dark:bg-grey-900 dark:text-white',
         error ? 'border-red bg-white' : 'border-transparent placeholder:text-grey-500 hover:bg-grey-100 focus:border-green focus:bg-white focus:shadow-[0_0_0_2px_rgba(48,207,67,0.25)] dark:placeholder:text-grey-800 dark:hover:bg-grey-925 dark:focus:bg-grey-950',
         title && 'mt-1.5',
         fontStyle === 'mono' && 'font-mono text-sm',
@@ -82,7 +82,7 @@ const TextArea: React.FC<TextAreaProps> = ({
 
     return (
         <FormPrimitive.Root asChild>
-            <div className='flex w-full flex-col'>
+            <div className='flex flex-col'>
                 <FormPrimitive.Field name={id} asChild>
                     <FormPrimitive.Control asChild>
                         <textarea


### PR DESCRIPTION
ref  https://linear.app/ghost/issue/DES-1298

The global textarea rule in ghost.css sets `max-width: 500px`, which prevented the TextArea component from stretching to full width. Added `max-w-none` to override this constraint.     

