### PR TITLE
Fixed Linear MCP server auth in triage workflow

### DIFF
--- a/.github/workflows/linear-triage.lock.yml
+++ b/.github/workflows/linear-triage.lock.yml
@@ -23,7 +23,7 @@
 #
 # Triage new Linear issues for the Berlin Bureau (BER) team — classify type, assign priority, tag product area, and post reasoning comments.
 #
-# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"572d937d65a98dde9938544c30ed304e6fd6faeb113f27559bcada65817858ae","compiler_version":"v0.49.3"}
+# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"1e1d21353d1d28f4313b6d94510c79a616f93ac5ad328a3718b0a1489bad3094","compiler_version":"v0.49.3"}
 
 name: "Linear Issue Triage Agent"
 "on":
@@ -653,13 +653,13 @@ jobs:
                   "mcp-remote",
                   "https://mcp.linear.app/mcp",
                   "--header",
-                  "Authorization:${LINEAR_AUTH_HEADER}"
+                  "Authorization:Bearer \${LINEAR_API_KEY}"
                 ],
                 "tools": [
                   "*"
                 ],
                 "env": {
-                  "LINEAR_AUTH_HEADER": "Bearer \${LINEAR_API_KEY}"
+                  "LINEAR_API_KEY": "\${LINEAR_API_KEY}"
                 }
               },
               "safeoutputs": {

--- a/.github/workflows/linear-triage.md
+++ b/.github/workflows/linear-triage.md
@@ -10,9 +10,9 @@ tools:
 mcp-servers:
   linear:
     command: "npx"
-    args: ["-y", "mcp-remote", "https://mcp.linear.app/mcp", "--header", "Authorization:${LINEAR_AUTH_HEADER}"]
+    args: ["-y", "mcp-remote", "https://mcp.linear.app/mcp", "--header", "Authorization:Bearer ${{ secrets.LINEAR_API_KEY }}"]
     env:
-      LINEAR_AUTH_HEADER: Bearer ${{ secrets.LINEAR_API_KEY }}
+      LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
 network:
   allowed:
     - defaults


### PR DESCRIPTION
## Summary

- Fixed the Linear MCP server authentication failing with empty tools list
- Root cause: the compiled lock file uses an unquoted heredoc, so `${LINEAR_AUTH_HEADER}` in the `mcp-remote --header` arg was shell-expanded to empty before the MCP Gateway could resolve it
- Fix: pass the secret directly via `${{ secrets.LINEAR_API_KEY }}` in the args, which the compiler correctly escapes as `\${LINEAR_API_KEY}` (backslash-escaped) in the heredoc, allowing the MCPG to resolve it from its environment