### PR TITLE
Refactored `hasActiveOffer` and `_getActiveDiscount` to share common logic

### DIFF
--- a/ghost/core/core/server/services/members/members-api/services/next-payment-calculator.js
+++ b/ghost/core/core/server/services/members/members-api/services/next-payment-calculator.js
@@ -104,11 +104,10 @@ class NextPaymentCalculator {
      */
     _getActiveDiscount(subscription, offer) {
         // Skip if there's no Stripe discount data and the offer isn't eligible for legacy backport:
-        // - free_months offers use trial periods (always eligible)
         // - signup offers are backported for legacy data without discount_start
         // - retention offers are excluded because they were introduced after discount_start
         //   was available, so missing discount_start means there's no active discount
-        if (!subscription.discount_start && offer.type !== 'free_months' && offer.redemption_type !== 'signup') {
+        if (!subscription.discount_start && offer.redemption_type !== 'signup') {
             return null;
         }
 

--- a/ghost/core/core/server/services/members/members-api/services/next-payment-calculator.js
+++ b/ghost/core/core/server/services/members/members-api/services/next-payment-calculator.js
@@ -1,3 +1,5 @@
+const getDiscountWindow = require('../utils/get-discount-window');
+
 /**
  * @typedef {import('../../../../services/offers/application/offer-mapper').OfferDTO} OfferDTO
  */
@@ -101,42 +103,16 @@ class NextPaymentCalculator {
      * @returns {ActiveDiscount|null}
      */
     _getActiveDiscount(subscription, offer) {
-        // Offers are based on a Stripe coupon, with a discount_start / discount_end
-        if (subscription.discount_start) {
-            return {
-                start: subscription.discount_start,
-                end: subscription.discount_end
-            };
-        }
-
-        // Backportability for old signup offers without discount_start / discount_end
-        if (offer.redemption_type !== 'signup') {
+        // Skip if there's no Stripe discount data and the offer isn't eligible for legacy backport:
+        // - free_months offers use trial periods (always eligible)
+        // - signup offers are backported for legacy data without discount_start
+        // - retention offers are excluded because they were introduced after discount_start
+        //   was available, so missing discount_start means there's no active discount
+        if (!subscription.discount_start && offer.type !== 'free_months' && offer.redemption_type !== 'signup') {
             return null;
         }
 
-        // Signup offers with once have already been applied to first payment
-        if (offer.duration === 'once') {
-            return null;
-        }
-
-        // Signup offer with forever don't expire
-        if (offer.duration === 'forever') {
-            return {start: subscription.start_date, end: null};
-        }
-
-        // Signup repeating offer expire after start_date + duration_in_months
-        if (offer.duration === 'repeating' && offer.duration_in_months > 0) {
-            const end = new Date(subscription.start_date);
-            end.setUTCMonth(end.getUTCMonth() + offer.duration_in_months);
-
-            if (new Date() >= end) {
-                return null;
-            }
-
-            return {start: subscription.start_date, end};
-        }
-
-        return null;
+        return getDiscountWindow(subscription, offer);
     }
 
     /**

--- a/ghost/core/core/server/services/members/members-api/utils/get-discount-window.js
+++ b/ghost/core/core/server/services/members/members-api/utils/get-discount-window.js
@@ -2,36 +2,16 @@
  * Computes the discount window for a subscription based on available data.
  * Returns {start, end} if a discount window can be determined, null otherwise.
  *
- * Handles three data paths:
- * 1. Free months offers - uses trial_start_at / trial_end_at
- * 2. Stripe coupon discounts (post-6.16) - uses discount_start / discount_end
- * 3. Legacy fallback - computes from offer duration and start_date
+ * Handles two data paths:
+ * 1. Stripe coupon discounts (post-6.16) - uses discount_start / discount_end
+ * 2. Legacy fallback - computes from offer duration and start_date
  *
- * @param {object} subscription - plain object with: discount_start, discount_end,
- *   trial_start_at, trial_end_at, start_date
- * @param {object|null} offer - offer data with: type, duration, duration_in_months.
+ * @param {object} subscription - plain object with: discount_start, discount_end, start_date
+ * @param {object|null} offer - offer data with: duration, duration_in_months.
  *   Pass null to skip offer-dependent checks.
  * @returns {{start: *, end: *}|null}
  */
 module.exports = function getDiscountWindow(subscription, offer) {
-    // Free months offers use trial periods in Stripe
-    if (offer?.type === 'free_months') {
-        if (!subscription.trial_end_at) {
-            return null;
-        }
-
-        const end = new Date(subscription.trial_end_at);
-
-        if (new Date() >= end) {
-            return null;
-        }
-
-        return {
-            start: subscription.trial_start_at,
-            end
-        };
-    }
-
     // Stripe coupon discount (post-6.16 data)
     if (subscription.discount_start) {
         return {

--- a/ghost/core/core/server/services/members/members-api/utils/get-discount-window.js
+++ b/ghost/core/core/server/services/members/members-api/utils/get-discount-window.js
@@ -1,0 +1,68 @@
+/**
+ * Computes the discount window for a subscription based on available data.
+ * Returns {start, end} if a discount window can be determined, null otherwise.
+ *
+ * Handles three data paths:
+ * 1. Free months offers - uses trial_start_at / trial_end_at
+ * 2. Stripe coupon discounts (post-6.16) - uses discount_start / discount_end
+ * 3. Legacy fallback - computes from offer duration and start_date
+ *
+ * @param {object} subscription - plain object with: discount_start, discount_end,
+ *   trial_start_at, trial_end_at, start_date
+ * @param {object|null} offer - offer data with: type, duration, duration_in_months.
+ *   Pass null to skip offer-dependent checks.
+ * @returns {{start: *, end: *}|null}
+ */
+module.exports = function getDiscountWindow(subscription, offer) {
+    // Free months offers use trial periods in Stripe
+    if (offer?.type === 'free_months') {
+        if (!subscription.trial_end_at) {
+            return null;
+        }
+
+        const end = new Date(subscription.trial_end_at);
+
+        if (new Date() >= end) {
+            return null;
+        }
+
+        return {
+            start: subscription.trial_start_at,
+            end
+        };
+    }
+
+    // Stripe coupon discount (post-6.16 data)
+    if (subscription.discount_start) {
+        return {
+            start: subscription.discount_start,
+            end: subscription.discount_end || null
+        };
+    }
+
+    // Legacy fallback: compute window from offer duration
+    if (!offer) {
+        return null;
+    }
+
+    if (offer.duration === 'once') {
+        return null;
+    }
+
+    if (offer.duration === 'forever') {
+        return {start: subscription.start_date, end: null};
+    }
+
+    if (offer.duration === 'repeating' && offer.duration_in_months > 0) {
+        const end = new Date(subscription.start_date);
+        end.setUTCMonth(end.getUTCMonth() + offer.duration_in_months);
+
+        if (new Date() >= end) {
+            return null;
+        }
+
+        return {start: subscription.start_date, end};
+    }
+
+    return null;
+};

--- a/ghost/core/core/server/services/members/members-api/utils/has-active-offer.js
+++ b/ghost/core/core/server/services/members/members-api/utils/has-active-offer.js
@@ -13,8 +13,6 @@ module.exports = async function hasActiveOffer(subscriptionModel, offersAPI) {
     const subscriptionData = {
         discount_start: subscriptionModel.get('discount_start'),
         discount_end: subscriptionModel.get('discount_end'),
-        trial_start_at: subscriptionModel.get('trial_start_at'),
-        trial_end_at: subscriptionModel.get('trial_end_at'),
         start_date: subscriptionModel.get('start_date')
     };
 
@@ -25,8 +23,9 @@ module.exports = async function hasActiveOffer(subscriptionModel, offersAPI) {
         return !discountWindow.end || new Date(discountWindow.end) > new Date();
     }
 
-    // Check for active trial (trial/free_months offers)
-    if (subscriptionData.trial_end_at && new Date(subscriptionData.trial_end_at) > new Date()) {
+    // Check for active trial (trial offers)
+    const trialEndAt = subscriptionModel.get('trial_end_at');
+    if (trialEndAt && new Date(trialEndAt) > new Date()) {
         return true;
     }
 

--- a/ghost/core/test/unit/server/services/members/members-api/utils/get-discount-window.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/utils/get-discount-window.test.js
@@ -6,65 +6,10 @@ describe('getDiscountWindow', function () {
         return {
             discount_start: null,
             discount_end: null,
-            trial_start_at: null,
-            trial_end_at: null,
             start_date: new Date('2025-01-01T00:00:00.000Z'),
             ...overrides
         };
     }
-
-    // Free months offers (trial-based)
-
-    describe('free months offers', function () {
-        it('returns window when trial is still active', function () {
-            const now = new Date();
-            const trialStart = new Date(now.getTime() - (7 * 24 * 60 * 60 * 1000));
-            const trialEnd = new Date(now.getTime() + (30 * 24 * 60 * 60 * 1000));
-            const subscription = createSubscription({
-                trial_start_at: trialStart,
-                trial_end_at: trialEnd
-            });
-
-            const result = getDiscountWindow(subscription, {type: 'free_months'});
-
-            assert.deepEqual(result, {start: trialStart, end: trialEnd});
-        });
-
-        it('returns null when trial has expired', function () {
-            const now = new Date();
-            const trialStart = new Date(now.getTime() - (60 * 24 * 60 * 60 * 1000));
-            const trialEnd = new Date(now.getTime() - (30 * 24 * 60 * 60 * 1000));
-            const subscription = createSubscription({
-                trial_start_at: trialStart,
-                trial_end_at: trialEnd
-            });
-
-            const result = getDiscountWindow(subscription, {type: 'free_months'});
-
-            assert.equal(result, null);
-        });
-
-        it('returns null when trial_end_at is missing', function () {
-            const subscription = createSubscription();
-
-            const result = getDiscountWindow(subscription, {type: 'free_months'});
-
-            assert.equal(result, null);
-        });
-
-        it('returns null for trial_start_at but uses fallback', function () {
-            const now = new Date();
-            const trialEnd = new Date(now.getTime() + (30 * 24 * 60 * 60 * 1000));
-            const subscription = createSubscription({
-                trial_start_at: null,
-                trial_end_at: trialEnd
-            });
-
-            const result = getDiscountWindow(subscription, {type: 'free_months'});
-
-            assert.deepEqual(result, {start: null, end: trialEnd});
-        });
-    });
 
     // Stripe coupon discount (post-6.16 data)
 

--- a/ghost/core/test/unit/server/services/members/members-api/utils/get-discount-window.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/utils/get-discount-window.test.js
@@ -1,0 +1,188 @@
+const assert = require('node:assert/strict');
+const getDiscountWindow = require('../../../../../../../core/server/services/members/members-api/utils/get-discount-window');
+
+describe('getDiscountWindow', function () {
+    function createSubscription(overrides = {}) {
+        return {
+            discount_start: null,
+            discount_end: null,
+            trial_start_at: null,
+            trial_end_at: null,
+            start_date: new Date('2025-01-01T00:00:00.000Z'),
+            ...overrides
+        };
+    }
+
+    // Free months offers (trial-based)
+
+    describe('free months offers', function () {
+        it('returns window when trial is still active', function () {
+            const now = new Date();
+            const trialStart = new Date(now.getTime() - (7 * 24 * 60 * 60 * 1000));
+            const trialEnd = new Date(now.getTime() + (30 * 24 * 60 * 60 * 1000));
+            const subscription = createSubscription({
+                trial_start_at: trialStart,
+                trial_end_at: trialEnd
+            });
+
+            const result = getDiscountWindow(subscription, {type: 'free_months'});
+
+            assert.deepEqual(result, {start: trialStart, end: trialEnd});
+        });
+
+        it('returns null when trial has expired', function () {
+            const now = new Date();
+            const trialStart = new Date(now.getTime() - (60 * 24 * 60 * 60 * 1000));
+            const trialEnd = new Date(now.getTime() - (30 * 24 * 60 * 60 * 1000));
+            const subscription = createSubscription({
+                trial_start_at: trialStart,
+                trial_end_at: trialEnd
+            });
+
+            const result = getDiscountWindow(subscription, {type: 'free_months'});
+
+            assert.equal(result, null);
+        });
+
+        it('returns null when trial_end_at is missing', function () {
+            const subscription = createSubscription();
+
+            const result = getDiscountWindow(subscription, {type: 'free_months'});
+
+            assert.equal(result, null);
+        });
+
+        it('returns null for trial_start_at but uses fallback', function () {
+            const now = new Date();
+            const trialEnd = new Date(now.getTime() + (30 * 24 * 60 * 60 * 1000));
+            const subscription = createSubscription({
+                trial_start_at: null,
+                trial_end_at: trialEnd
+            });
+
+            const result = getDiscountWindow(subscription, {type: 'free_months'});
+
+            assert.deepEqual(result, {start: null, end: trialEnd});
+        });
+    });
+
+    // Stripe coupon discount (post-6.16 data)
+
+    describe('stripe coupon discount', function () {
+        it('returns window when discount_start is present with discount_end', function () {
+            const discountStart = new Date('2025-05-01T00:00:00.000Z');
+            const discountEnd = new Date('2025-11-01T00:00:00.000Z');
+            const subscription = createSubscription({
+                discount_start: discountStart,
+                discount_end: discountEnd
+            });
+
+            const result = getDiscountWindow(subscription, null);
+
+            assert.deepEqual(result, {start: discountStart, end: discountEnd});
+        });
+
+        it('returns window with null end for forever discounts', function () {
+            const discountStart = new Date('2025-05-01T00:00:00.000Z');
+            const subscription = createSubscription({
+                discount_start: discountStart,
+                discount_end: null
+            });
+
+            const result = getDiscountWindow(subscription, null);
+
+            assert.deepEqual(result, {start: discountStart, end: null});
+        });
+
+        it('returns window even when discount_end is in the past (trusts Stripe data)', function () {
+            const discountStart = new Date('2025-01-01T00:00:00.000Z');
+            const discountEnd = new Date('2025-06-01T00:00:00.000Z');
+            const subscription = createSubscription({
+                discount_start: discountStart,
+                discount_end: discountEnd
+            });
+
+            const result = getDiscountWindow(subscription, null);
+
+            assert.deepEqual(result, {start: discountStart, end: discountEnd});
+        });
+
+        it('discount_start takes precedence over legacy offer data', function () {
+            const discountStart = new Date('2025-05-01T00:00:00.000Z');
+            const subscription = createSubscription({
+                discount_start: discountStart,
+                discount_end: null
+            });
+
+            const result = getDiscountWindow(subscription, {duration: 'once'});
+
+            assert.deepEqual(result, {start: discountStart, end: null});
+        });
+    });
+
+    // Legacy fallback (no discount_start, uses offer duration)
+
+    describe('legacy fallback', function () {
+        it('returns null when no offer is provided', function () {
+            const subscription = createSubscription();
+
+            const result = getDiscountWindow(subscription, null);
+
+            assert.equal(result, null);
+        });
+
+        it('returns null for once duration', function () {
+            const subscription = createSubscription();
+
+            const result = getDiscountWindow(subscription, {duration: 'once'});
+
+            assert.equal(result, null);
+        });
+
+        it('returns window with null end for forever duration', function () {
+            const startDate = new Date('2025-01-01T00:00:00.000Z');
+            const subscription = createSubscription({start_date: startDate});
+
+            const result = getDiscountWindow(subscription, {duration: 'forever'});
+
+            assert.deepEqual(result, {start: startDate, end: null});
+        });
+
+        it('returns window for repeating offer still within duration', function () {
+            const startDate = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000); // 3 months ago
+            const subscription = createSubscription({start_date: startDate});
+
+            const result = getDiscountWindow(subscription, {duration: 'repeating', duration_in_months: 6});
+
+            assert.notEqual(result, null);
+            assert.deepEqual(result.start, startDate);
+            assert.ok(result.end instanceof Date);
+            assert.ok(result.end > new Date());
+        });
+
+        it('returns null for repeating offer past its duration', function () {
+            const startDate = new Date(Date.now() - 365 * 24 * 60 * 60 * 1000); // 1 year ago
+            const subscription = createSubscription({start_date: startDate});
+
+            const result = getDiscountWindow(subscription, {duration: 'repeating', duration_in_months: 6});
+
+            assert.equal(result, null);
+        });
+
+        it('returns null for repeating offer with zero duration_in_months', function () {
+            const subscription = createSubscription();
+
+            const result = getDiscountWindow(subscription, {duration: 'repeating', duration_in_months: 0});
+
+            assert.equal(result, null);
+        });
+
+        it('returns null for unknown duration', function () {
+            const subscription = createSubscription();
+
+            const result = getDiscountWindow(subscription, {duration: 'unknown'});
+
+            assert.equal(result, null);
+        });
+    });
+});

--- a/ghost/core/test/unit/server/services/members/members-api/utils/has-active-offer.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/utils/has-active-offer.test.js
@@ -7,13 +7,12 @@ describe('hasActiveOffer', function () {
         sinon.restore();
     });
 
-    function createSubscriptionModel({discountStart = null, discountEnd = null, trialStartAt = null, trialEndAt = null, offerId = null, startDate = null} = {}) {
+    function createSubscriptionModel({discountStart = null, discountEnd = null, trialEndAt = null, offerId = null, startDate = null} = {}) {
         return {
             get: sinon.stub().callsFake((key) => {
                 const values = {
                     discount_start: discountStart,
                     discount_end: discountEnd,
-                    trial_start_at: trialStartAt,
                     trial_end_at: trialEndAt,
                     offer_id: offerId,
                     start_date: startDate

--- a/ghost/core/test/unit/server/services/members/members-api/utils/has-active-offer.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/utils/has-active-offer.test.js
@@ -7,12 +7,13 @@ describe('hasActiveOffer', function () {
         sinon.restore();
     });
 
-    function createSubscriptionModel({discountStart = null, discountEnd = null, trialEndAt = null, offerId = null, startDate = null} = {}) {
+    function createSubscriptionModel({discountStart = null, discountEnd = null, trialStartAt = null, trialEndAt = null, offerId = null, startDate = null} = {}) {
         return {
             get: sinon.stub().callsFake((key) => {
                 const values = {
                     discount_start: discountStart,
                     discount_end: discountEnd,
+                    trial_start_at: trialStartAt,
                     trial_end_at: trialEndAt,
                     offer_id: offerId,
                     start_date: startDate
@@ -97,7 +98,7 @@ describe('hasActiveOffer', function () {
     });
 
     it('returns true for a forever offer (legacy data)', async function () {
-        const model = createSubscriptionModel({offerId: 'offer_123'});
+        const model = createSubscriptionModel({offerId: 'offer_123', startDate: new Date('2025-01-01')});
         const offersAPI = createOffersAPI({duration: 'forever'});
         const result = await hasActiveOffer(model, offersAPI);
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3338

Both functions independently computed discount windows using the same three data paths (trial periods, Stripe coupon data, and legacy offer duration fallback). This extracts the shared computation into a single `getDiscountWindow` utility so the two callers stay in sync as the discount model evolves.