### PR TITLE
Removed the welcomeEmails labs flag

### DIFF
--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -25,8 +25,7 @@ const GA_FEATURES = [
     'customFonts',
     'explore',
     'commentModeration',
-    'featurebaseFeedback',
-    'welcomeEmails'
+    'featurebaseFeedback'
 ];
 
 // These features are considered publicly available and can be enabled/disabled by users

--- a/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
@@ -31,7 +31,6 @@ Object {
       "transistor": true,
       "urlCache": true,
       "welcomeEmailEditor": true,
-      "welcomeEmails": true,
     },
     "mail": "",
     "mailgunIsConfigured": false,

--- a/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
@@ -1675,7 +1675,7 @@ exports[`Settings API Edit can edit Stripe settings when Stripe Connect limit is
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "5171",
+  "content-length": "5148",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-971/post-ga-cleanup-remove-the-welcomeemails-labs-flag-from-admin

Now that `welcomeEmails` is fully rolled out, and all conditional behavior based on the flag has been removed, we can remove the flag itself. 