### PR TITLE
Added validation for outbox statuses

### DIFF
--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -1125,7 +1125,13 @@ module.exports = {
     outbox: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
         event_type: {type: 'string', maxlength: 50, nullable: false},
-        status: {type: 'string', maxlength: 50, nullable: false, defaultTo: 'pending'},
+        status: {
+            type: 'string',
+            maxlength: 50,
+            nullable: false,
+            defaultTo: 'pending',
+            validations: {isIn: [['pending', 'processing', 'failed', 'completed']]}
+        },
         payload: {type: 'text', maxlength: 65535, nullable: false},
         created_at: {type: 'dateTime', nullable: false},
         updated_at: {type: 'dateTime', nullable: true},

--- a/ghost/core/test/unit/server/models/outbox.test.js
+++ b/ghost/core/test/unit/server/models/outbox.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const errors = require('@tryghost/errors');
 const models = require('../../../../core/server/models');
 const {OUTBOX_STATUSES} = require('../../../../core/server/models/outbox');
 
@@ -39,6 +40,25 @@ describe('Unit: models/outbox', function () {
             assert.equal(Object.keys(defaults).length, 2);
             assert.equal(defaults.status, OUTBOX_STATUSES.PENDING);
             assert.equal(defaults.retry_count, 0);
+        });
+    });
+
+    describe('validation', function () {
+        it('rejects invalid status values', function () {
+            return models.Outbox.add({
+                event_type: 'MemberCreatedEvent',
+                payload: '{}',
+                status: 'not-a-real-status'
+            })
+                .then(function () {
+                    throw new Error('expected ValidationError');
+                })
+                .catch(function (err) {
+                    assert(Array.isArray(err));
+                    assert.equal(err.length, 1);
+                    assert.equal((err[0] instanceof errors.ValidationError), true);
+                    assert.match(err[0].context, /outbox\.status/);
+                });
         });
     });
 });


### PR DESCRIPTION
closes [NY-809](https://linear.app/ghost/issue/NY-809/cleanup-consider-adding-constraints-to-status-fields-on-automated)

- No user-facing changes
- Adds schema validation to the `outbox.status` field
- While developing outbox functionality we deliberately left this validation off so that we could develop more easily. Now that we have a live use case (welcome emails) it makes sense to formalize the valid values for this field