### PR TITLE
Removed GHOST_CDN_URL from CI admin build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1717,9 +1717,13 @@ jobs:
         env:
           DEPENDENCY_CACHE_KEY: ${{ needs.job_setup.outputs.dependency_cache_key }}
       - name: Build Admin
-        env:
-          GHOST_CDN_URL: https://assets.ghost.io/admin-forward/
         run: yarn nx run admin:build
+      - name: Validate admin build
+        run: |
+          test -f apps/admin/dist/index.html
+          grep -q '"./assets/' apps/admin/dist/index.html
+          grep -q 'ghost-cdn-url' apps/admin/dist/index.html
+          echo "Admin build validated: relative paths, ghost-cdn-url meta present"
       - name: Upload build artifact
         id: upload-artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Context

This is **PR 3 of 3** in the deploy-time admin rewrite initiative.

**Proposal:** [Build once, deploy everywhere — deploy-time index.html rewrite](https://www.notion.so/ghost/Build-Once-Deploy-Everywhere-Deploy-Time-index-html-Rewrite-30c51439c0308187a658dd8f42fff126)

### Summary

Ghost(Pro) currently bakes `GHOST_CDN_URL=https://assets.ghost.io/admin-forward/` into the admin build at CI time, producing absolute CDN URLs in the artifact. This means Ghost-Moya must string-replace production URLs with staging URLs at deploy time — a fragile process that couples the build to the deployment target.

The new approach builds admin with relative paths (`./assets/...`) and a `ghost-cdn-url` meta tag. At deploy time, a simple `sed` command in Ghost-Moya rewrites `index.html` per environment — no Node.js script, no string replacement across JS bundles.

### What this PR does

- Removes the `GHOST_CDN_URL` environment variable from the `deploy_admin` CI job
- Adds a validation step that confirms the build output:
  - Uses relative asset paths (`./assets/`)
  - Includes the `ghost-cdn-url` meta tag (added by PR 1)

### Dependencies

| PR | Status |
|----|--------|
| [PR 1: Ghost #26555](https://github.com/TryGhost/Ghost/pull/26555) — meta tag + bridge script | Must be merged first |
| [PR 2: Ghost-Moya #135](https://github.com/TryGhost/Ghost-Moya/pull/135) — sed-based deploy | Must be deployed first |

> **Merge order:** PR 1 → PR 2 → **this PR**. If this merges before PR 2 is deployed, the deploy workflow would receive a relative-path artifact but still try the old Node.js replacement — which would silently produce broken staging builds.

### Impact

- **Ghost(Pro):** Admin artifacts switch from absolute CDN URLs to relative paths. Ghost-Moya's deploy workflow (PR 2) detects the format and applies `sed` rewriting.
- **Self-hosted:** No change. `GHOST_CDN_URL` remains a supported build-time option in `vite.config.ts` — only the CI environment variable is removed.

## Test plan

- [ ] CI build produces `apps/admin/dist/index.html` with relative paths
- [ ] Validation step passes (relative paths present, `ghost-cdn-url` meta present)
- [ ] After deploy via Ghost-Moya, staging admin loads assets from staging CDN
- [ ] After deploy via Ghost-Moya, production admin loads assets from production CDN
- [ ] Self-hosted builds with `GHOST_CDN_URL` still work as before