### PR TITLE
Changed members label filter to use multiselect

### DIFF
--- a/apps/posts/src/views/members/hooks/use-members-filter-config.tsx
+++ b/apps/posts/src/views/members/hooks/use-members-filter-config.tsx
@@ -163,13 +163,15 @@ export function useMembersFilterConfig({
             basicFields.push({
                 key: 'label',
                 label: 'Label',
-                type: 'select',
+                type: 'multiselect',
                 icon: <LucideIcon.Tag className="size-4" />,
                 options: labelsOptions.length > 0 ? labelsOptions : labels.map(l => ({
                     value: l.slug,
                     label: l.name
                 })),
-                operators: IS_IS_NOT_OPERATORS,
+                defaultOperator: 'is_any_of',
+                hideOperatorSelect: true,
+                autoCloseOnSelect: true,
                 searchable: true,
                 onSearchChange: onLabelsSearchChange,
                 searchValue: labelsSearchValue,


### PR DESCRIPTION
Ref https://linear.app/ghost/issue/BER-3358/make-labels-filter-multi-select-like-ember

Label filters previously used a single select. This switches it out for a multiselect to keep parity with the existing members page.

<img width="567" height="381" alt="Screenshot 2026-02-24 at 11 20 47" src="https://github.com/user-attachments/assets/f5dc7799-6b9c-4328-8b3c-a48253a891a7" />

