### PR TITLE
Prevent ref tagging for DoubleClick redirect targets

### DIFF
--- a/ghost/core/core/server/services/member-attribution/outbound-link-tagger.js
+++ b/ghost/core/core/server/services/member-attribution/outbound-link-tagger.js
@@ -10,8 +10,20 @@ const blockedReferrerDomains = [
     'www.federalreserve.gov',
     'www.chicagomag.com',
     'bailii.org',
-    'www.bailii.org'
+    'www.bailii.org',
+    '*.doubleclick.net'
 ];
+
+const isBlockedReferrerDomain = (domain) => {
+    return blockedReferrerDomains.some((blockedDomain) => {
+        if (blockedDomain.startsWith('*.')) {
+            const suffix = blockedDomain.slice(1);
+            return domain.endsWith(suffix);
+        }
+
+        return blockedDomain === domain;
+    });
+};
 
 /**
  * Adds ?ref to outbound links
@@ -65,7 +77,7 @@ class OutboundLinkTagger {
 
         // Check blocked domains
         const referrerDomain = url.hostname;
-        if (blockedReferrerDomains.includes(referrerDomain)) {
+        if (isBlockedReferrerDomain(referrerDomain)) {
             return url;
         }
 

--- a/ghost/core/test/unit/server/services/member-attribution/outbound-link-tagger.test.js
+++ b/ghost/core/test/unit/server/services/member-attribution/outbound-link-tagger.test.js
@@ -85,6 +85,11 @@ describe('OutboundLinkTagger', function () {
             const updatedUrlTwo = await service.addToUrl(urlTwo);
 
             assert.equal(updatedUrlTwo.toString(), 'https://web.archive.org/');
+
+            const urlThree = new URL('https://ad.doubleclick.net/');
+            const updatedUrlThree = await service.addToUrl(urlThree);
+
+            assert.equal(updatedUrlThree.toString(), 'https://ad.doubleclick.net/');
         });
 
         it('does not add ref if utm_source is present', async function () {


### PR DESCRIPTION
### Motivation
- Outbound `?ref=` tagging can break ad redirect flows (Google Ad Manager/DoubleClick); redirects to DoubleClick hosts should not receive `ref` tracking parameters.

### Description
- Added wildcard-aware denylist matching for blocked referrer domains by introducing `isBlockedReferrerDomain(domain)` in `ghost/core/core/server/services/member-attribution/outbound-link-tagger.js`.
- Added `*.doubleclick.net` to the `blockedReferrerDomains` list so hosts like `ad.doubleclick.net` are excluded from tagging.
- Switched the blocked-domain check to use `isBlockedReferrerDomain(...)` instead of simple exact matches.
- Added a unit test case in `ghost/core/test/unit/server/services/member-attribution/outbound-link-tagger.test.js` to verify `https://ad.doubleclick.net/` remains unchanged.

### Testing
- Ran `yarn test:single test/unit/server/services/member-attribution/outbound-link-tagger.test.js` and all tests passed (`21 passing`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699db60ed5808329b4aa8b6e954cad94)