### PR TITLE
Fixed incorrect usage of file upload progress

### DIFF
--- a/ghost/admin/app/components/koenig-lexical-editor.js
+++ b/ghost/admin/app/components/koenig-lexical-editor.js
@@ -528,7 +528,7 @@ export default class KoenigLexicalEditor extends Component {
             };
 
             const _uploadFile = async (file, {formData = {}} = {}) => {
-                progressTracker.current[file] = 0;
+                progressTracker.current.set(file, 0);
 
                 const fileFormData = new FormData();
                 fileFormData.append('file', file, file.name);


### PR DESCRIPTION
towards https://linear.app/ghost/issue/NY-1075

`progressTracker.current` is a `Map`, but this line treated it like an object. This fixes that.
