### PR TITLE
🐛 Fixed broken redirects to Google Ad Manager URLs in newsletters

### DIFF
--- a/ghost/core/core/server/services/member-attribution/outbound-link-tagger.js
+++ b/ghost/core/core/server/services/member-attribution/outbound-link-tagger.js
@@ -83,16 +83,22 @@ class OutboundLinkTagger {
 
         // Tag url with site's base domain, excluding www
         const domain = this.getDomainFromUrl(this.siteUrl);
+        let ref;
         if (useNewsletter) {
             const name = slugify(useNewsletter.get('name'));
 
             // If newsletter name ends with newsletter, don't add it again
-            const ref = name.endsWith('newsletter') ? name : `${name}-newsletter`;
-            url.searchParams.append('ref', ref);
+            ref = name.endsWith('newsletter') ? name : `${name}-newsletter`;
         } else {
-            url.searchParams.append('ref', domain);
+            ref = domain;
         }
-        return url;
+
+        // Append ref param via string concatenation instead of searchParams.append()
+        // to avoid re-serializing the entire query string through the
+        // application/x-www-form-urlencoded encoder, which encodes characters
+        // like / and [ that some services (e.g. Google Ad Manager) need unescaped
+        const separator = url.search ? '&' : '?';
+        return new URL(url.href.replace(/#.*$/, '') + separator + 'ref=' + encodeURIComponent(ref) + url.hash);
     }
 
     async addToHtml(html) {

--- a/ghost/core/test/unit/server/services/member-attribution/outbound-link-tagger.test.js
+++ b/ghost/core/test/unit/server/services/member-attribution/outbound-link-tagger.test.js
@@ -122,6 +122,17 @@ describe('OutboundLinkTagger', function () {
             assert.equal(updatedUrl.toString(), 'https://example.com/?source=hello');
         });
 
+        it('preserves existing query param encoding when appending ref', async function () {
+            const service = new OutboundLinkTagger({
+                getSiteUrl: () => 'https://blog.com',
+                isEnabled: () => true
+            });
+            const url = new URL('https://adserver.example.com/jump?iu=/12345678/Ad_Unit_1&sz=300x250&c=[TIMESTAMP]');
+            const updatedUrl = await service.addToUrl(url);
+
+            assert.equal(updatedUrl.toString(), 'https://adserver.example.com/jump?iu=/12345678/Ad_Unit_1&sz=300x250&c=[TIMESTAMP]&ref=blog.com');
+        });
+
         it('does not add ref if the protocol is not http(s)', async function () {
             const service = new OutboundLinkTagger({
                 getSiteUrl: () => 'https://blog.com',


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ONC-1458/

## Summary

- When appending query params (e.g. `ref=`) to external URLs, `url.searchParams.set/append()` re-serializes the entire query string through the `application/x-www-form-urlencoded` encoder, which encodes characters like `/` → `%2F` and `[` → `%5B`. Google Ad Manager does a literal match on the `iu` param (ad unit path) so the encoded slashes cause it to fail with a redirect to an empty URL.
- Fixed by appending query params via string concatenation instead of using `searchParams` mutations, preserving the original query string encoding. Applied in both the outbound link tagger (email send time) and the link edit flow (admin URL editing).