### PR TITLE
🐛 Fixed inbox links when user is logged into multiple Gmail accounts

### DIFF
--- a/ghost/core/core/server/lib/get-inbox-links.ts
+++ b/ghost/core/core/server/lib/get-inbox-links.ts
@@ -61,12 +61,16 @@ const buildUrl = (baseHref: string, key: string, value: string): string => {
     return result.toString();
 };
 
+const encodeRecipientForGmailUrl = (recipient: string) => (
+    encodeURIComponent(recipient).replaceAll('%40', '@')
+);
+
 const PROVIDERS: ReadonlyArray<Provider> = [
     {
         name: 'gmail',
         domains: ['gmail.com', 'googlemail.com', 'google.com'],
         getDesktopLink: ({recipient, sender}) => (
-            `https://mail.google.com/mail/u/${encodeURIComponent(
+            `https://mail.google.com/mail/u/${encodeRecipientForGmailUrl(
                 recipient
             )}/#search/from%3A(${encodeURIComponent(
                 sender

--- a/ghost/core/test/unit/server/lib/get-inbox-links.test.ts
+++ b/ghost/core/test/unit/server/lib/get-inbox-links.test.ts
@@ -42,12 +42,20 @@ describe('getInboxLinks', function () {
             });
             assert.equal(result?.provider, 'gmail');
             assert(result?.desktop.startsWith('https://mail.google.com/'));
-            assert(result?.desktop.includes(encodeURIComponent(recipient)));
+            assert(result?.desktop.includes(recipient));
             assert(result?.desktop.includes(encodeURIComponent('sender@example.com')));
             assert(result?.android.startsWith('intent:'));
             assert(result?.android.includes('com.google.android.gm'));
             assert(result?.android.includes('browser_fallback_url'));
         }));
+
+        const nonAsciiResult = await getInboxLinks({
+            recipient: 'examplé@gmail.com',
+            sender: 'sendér@example.com',
+            dnsResolver: resolverThatShouldNeverBeUsed
+        });
+        assert(nonAsciiResult?.desktop.includes('exampl%C3%A9@gmail.com'));
+        assert(nonAsciiResult?.desktop.includes(encodeURIComponent('sendér@example.com')));
     });
 
     it('handles Yahoo emails', async function () {


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1069

When a user is logged into multiple Gmail accounts, we want to send them to the right inbox.

To do that, we shouldn't be escaping the `@` sign.
