### PR TITLE
Added configurable customer ignore list for stripe webhook events

### DIFF
--- a/ghost/core/core/server/services/stripe/config.js
+++ b/ghost/core/core/server/services/stripe/config.js
@@ -47,6 +47,16 @@ module.exports = {
             };
         }
 
+        function parseIgnoreCustomerList(value) {
+            if (!Array.isArray(value)) {
+                return [];
+            }
+
+            return value
+                .map(customerId => String(customerId).trim())
+                .filter(Boolean);
+        }
+
         const keys = settingsHelpers.getActiveStripeKeys();
         if (!keys) {
             return null;
@@ -63,6 +73,7 @@ module.exports = {
         }
 
         const webhookHandlerUrl = new URL('members/webhooks/stripe/', urlUtils.getSiteUrl());
+        const webhookCustomerIgnoreList = parseIgnoreCustomerList(config.get('stripe_webhook_customer_ignore_list'));
 
         const urls = getStripeUrlConfig();
         const siteUrl = urlUtils.getSiteUrl();
@@ -76,6 +87,7 @@ module.exports = {
             },
             webhookSecret: webhookSecret,
             webhookHandlerUrl: webhookHandlerUrl.href,
+            webhookCustomerIgnoreList,
             siteUrl
         };
     }

--- a/ghost/core/core/server/services/stripe/config.js
+++ b/ghost/core/core/server/services/stripe/config.js
@@ -73,7 +73,7 @@ module.exports = {
         }
 
         const webhookHandlerUrl = new URL('members/webhooks/stripe/', urlUtils.getSiteUrl());
-        const webhookCustomerIgnoreList = parseIgnoreCustomerList(config.get('stripe_webhook_customer_ignore_list'));
+        const webhookCustomerIgnoreList = parseIgnoreCustomerList(config.get('stripeWebhookCustomerIgnoreList'));
 
         const urls = getStripeUrlConfig();
         const siteUrl = urlUtils.getSiteUrl();

--- a/ghost/core/core/server/services/stripe/stripe-service.js
+++ b/ghost/core/core/server/services/stripe/stripe-service.js
@@ -23,6 +23,7 @@ const memberWelcomeEmailService = require('../member-welcome-emails/service');
  * @prop {boolean} testEnv Whether this is a test environment
  * @prop {string} webhookSecret The Stripe webhook secret
  * @prop {string} webhookHandlerUrl The URL to handle Stripe webhooks
+ * @prop {string[]} webhookCustomerIgnoreList List of customer IDs for customer.subscription.updated webhook bypass
  * @prop {string} siteUrl The site URL for billing portal return URL
  */
 
@@ -182,6 +183,10 @@ module.exports = class StripeService {
             checkoutSetupSessionSuccessUrl: config.checkoutSetupSessionSuccessUrl,
             checkoutSetupSessionCancelUrl: config.checkoutSetupSessionCancelUrl,
             testEnv: config.testEnv
+        });
+
+        this.webhookController.configure({
+            webhookCustomerIgnoreList: config.webhookCustomerIgnoreList
         });
 
         await this.webhookManager.configure({

--- a/ghost/core/core/server/services/stripe/webhook-controller.js
+++ b/ghost/core/core/server/services/stripe/webhook-controller.js
@@ -86,7 +86,7 @@ module.exports = class WebhookController {
 
         const customerId = this.getEventCustomerId(event);
         if (this.shouldIgnoreEvent(event, customerId)) {
-            logging.info(`Ignoring webhook ${event.type} for customer ${customerId} based on stripe_webhook_customer_ignore_list config.`);
+            logging.info(`Ignoring webhook ${event.type} for customer ${customerId} based on stripeWebhookCustomerIgnoreList config.`);
 
             res.writeHead(200);
             return res.end();

--- a/ghost/core/core/server/services/stripe/webhook-controller.js
+++ b/ghost/core/core/server/services/stripe/webhook-controller.js
@@ -23,6 +23,45 @@ module.exports = class WebhookController {
     }
 
     /**
+     * @param {object} config
+     * @param {string[]} config.webhookCustomerIgnoreList
+     */
+    configure({webhookCustomerIgnoreList = []}) {
+        this.webhookCustomerIgnoreSet = new Set(
+            webhookCustomerIgnoreList.filter(Boolean)
+        );
+    }
+
+    /**
+     * @param {import('stripe').Stripe.Event} event
+     * @returns {string | null}
+     */
+    getEventCustomerId(event) {
+        const customer = event?.data?.object?.customer;
+        if (typeof customer === 'string') {
+            return customer;
+        }
+
+        if (customer && typeof customer.id === 'string') {
+            return customer.id;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param {import('stripe').Stripe.Event} event
+     * @returns {boolean}
+     */
+    shouldIgnoreEvent(event, customerId) {
+        if (event.type !== 'customer.subscription.updated') {
+            return false;
+        }
+
+        return typeof customerId === 'string' && this.webhookCustomerIgnoreSet?.has(customerId) === true;
+    }
+
+    /**
      * Handles a Stripe webhook event.
      * - Parses the webhook event
      * - Delegates the event to the appropriate handler
@@ -45,7 +84,16 @@ module.exports = class WebhookController {
             return res.end();
         }
 
+        const customerId = this.getEventCustomerId(event);
+        if (this.shouldIgnoreEvent(event, customerId)) {
+            logging.info(`Ignoring webhook ${event.type} for customer ${customerId} based on stripe_webhook_customer_ignore_list config.`);
+
+            res.writeHead(200);
+            return res.end();
+        }
+
         logging.info(`Handling webhook ${event.type}`);
+
         try {
             await this.handleEvent(event);
             res.writeHead(200);

--- a/ghost/core/test/unit/server/services/stripe/config.test.js
+++ b/ghost/core/test/unit/server/services/stripe/config.test.js
@@ -28,6 +28,8 @@ function createUrlUtilsMock() {
 }
 
 describe('Stripe - config', function () {
+    const ignoreCustomerConfigKey = 'stripe_webhook_customer_ignore_list';
+
     beforeEach(function () {
         configUtils.set({
             url: 'http://domain.tld/subdir',
@@ -36,6 +38,7 @@ describe('Stripe - config', function () {
     });
 
     afterEach(async function () {
+        configUtils.set(ignoreCustomerConfigKey, null);
         await configUtils.restore();
     });
 
@@ -70,5 +73,15 @@ describe('Stripe - config', function () {
         assertExists(config.checkoutSetupSessionSuccessUrl);
         assertExists(config.checkoutSetupSessionCancelUrl);
         assertExists(config.billingPortalReturnUrl);
+    });
+
+    it('Parses Stripe webhook customer ignore list from config', function () {
+        configUtils.set(ignoreCustomerConfigKey, ['cust_123', ' cust_456 ']);
+        const settingsHelpers = createSettingsHelpersMock();
+        const fakeUrlUtils = createUrlUtilsMock();
+
+        const config = getConfig({settingsHelpers, config: configUtils.config, urlUtils: fakeUrlUtils});
+
+        assert.deepEqual(config.webhookCustomerIgnoreList, ['cust_123', 'cust_456']);
     });
 });

--- a/ghost/core/test/unit/server/services/stripe/config.test.js
+++ b/ghost/core/test/unit/server/services/stripe/config.test.js
@@ -28,7 +28,7 @@ function createUrlUtilsMock() {
 }
 
 describe('Stripe - config', function () {
-    const ignoreCustomerConfigKey = 'stripe_webhook_customer_ignore_list';
+    const ignoreCustomerConfigKey = 'stripeWebhookCustomerIgnoreList';
 
     beforeEach(function () {
         configUtils.set({


### PR DESCRIPTION
ref INC-243
ref https://github.com/TryGhost/Zuul/pull/1003

- A Ghost(Pro) site is experiencing failed stripe webhook deliveries due to a high number of `customer.subscription.updated` events for a single member
- With this config-based change, we can temporarily skip processing `customer.subscription.updated` for Stripe customers on an ignore list, to drain the number of pending Stripe events

## Example usage:

With config set to:
```
"stripeWebhookCustomerIgnoreList": ["cus_123"]
```

All incoming `customer.subscription.updated` Stripe webhook events for Stripe customer `cus_123` will immediately respond back with HTTP 200, instead of processing the event.

