### PR TITLE
Changed Sinon to always restore after every test

### DIFF
--- a/ghost/core/test/unit/frontend/helpers/asset.test.js
+++ b/ghost/core/test/unit/frontend/helpers/asset.test.js
@@ -16,7 +16,9 @@ describe('{{asset}} helper', function () {
     before(function () {
         configUtils.set({assetHash: 'abc'});
         configUtils.set({useMinFiles: true});
+    });
 
+    beforeEach(function () {
         sinon.stub(settingsCache, 'get').callsFake(function (key) {
             return localSettingsCache[key];
         });
@@ -24,7 +26,6 @@ describe('{{asset}} helper', function () {
 
     after(async function () {
         await configUtils.restore();
-        sinon.restore();
     });
 
     describe('no subdirectory', function () {

--- a/ghost/core/test/unit/frontend/helpers/meta-description.test.js
+++ b/ghost/core/test/unit/frontend/helpers/meta-description.test.js
@@ -7,14 +7,10 @@ const settingsCache = require('../../../../core/shared/settings-cache');
 describe('{{meta_description}} helper', function () {
     const localSettingsCache = {};
 
-    before(function () {
+    beforeEach(function () {
         sinon.stub(settingsCache, 'get').callsFake(function (key) {
             return localSettingsCache[key];
         });
-    });
-
-    after(function () {
-        sinon.restore();
     });
 
     describe('no meta_description', function () {

--- a/ghost/core/test/unit/frontend/helpers/meta-title.test.js
+++ b/ghost/core/test/unit/frontend/helpers/meta-title.test.js
@@ -7,7 +7,7 @@ const settingsCache = require('../../../../core/shared/settings-cache');
 
 describe('{{meta_title}} helper', function () {
     describe('no meta_title', function () {
-        before(function () {
+        beforeEach(function () {
             sinon.stub(settingsCache, 'get').callsFake(function (key) {
                 return {
                     title: 'Ghost'
@@ -17,7 +17,6 @@ describe('{{meta_title}} helper', function () {
 
         after(async function () {
             await configUtils.restore();
-            sinon.restore();
         });
 
         it('returns correct title for homepage', function () {
@@ -154,14 +153,16 @@ describe('{{meta_title}} helper', function () {
     });
 
     describe('with meta_title', function () {
-        it('returns correct title for homepage when meta_title is defined', function () {
+        beforeEach(function () {
             sinon.stub(settingsCache, 'get').callsFake(function (key) {
                 return {
                     title: 'Ghost',
                     meta_title: 'Meta Title Ghost'
                 }[key];
             });
+        });
 
+        it('returns correct title for homepage when meta_title is defined', function () {
             const rendered = meta_title.call(
                 {},
                 {data: {root: {context: ['home']}}}

--- a/ghost/core/test/unit/frontend/helpers/recommendations.test.js
+++ b/ghost/core/test/unit/frontend/helpers/recommendations.test.js
@@ -32,7 +32,9 @@ describe('{{#recommendations}} helper', function () {
         // The recommendation template expects this helper
         hbs.registerHelper('foreach', foreach);
         hbs.registerHelper('readable_url', readable_url);
+    });
 
+    beforeEach(function () {
         // Stub settings cache
         sinon.stub(settingsCache, 'get');
         // @ts-ignore
@@ -54,10 +56,6 @@ describe('{{#recommendations}} helper', function () {
             error: sinon.stub(loggingLib, 'error'),
             warn: sinon.stub(loggingLib, 'warn')
         };
-    });
-
-    after(function () {
-        sinon.restore();
     });
 
     it('renders a template with recommendations', async function () {
@@ -103,7 +101,7 @@ describe('{{#recommendations}} helper', function () {
     });
 
     describe('when there are no recommendations', function () {
-        before(function () {
+        beforeEach(function () {
             sinon.stub(api, 'recommendationsPublic').get(() => {
                 return {
                     browse: () => {
@@ -129,9 +127,9 @@ describe('{{#recommendations}} helper', function () {
     });
 
     describe('when recommendations_enabled is false', function () {
-        before(function () {
+        beforeEach(function () {
             // @ts-ignore
-            settingsCache.get.withArgs('recommendations_enabled').returns(true);
+            settingsCache.get.withArgs('recommendations_enabled').returns(false);
         });
 
         it('renders nothing', async function () {
@@ -140,13 +138,12 @@ describe('{{#recommendations}} helper', function () {
             );
 
             // No HTML is rendered
-            assert(response !== null && typeof response === 'object');
-            assert.equal(response.string, '');
+            assert.equal(response, undefined);
         });
     });
 
     describe('when timeout is exceeded', function () {
-        before(function () {
+        beforeEach(function () {
             sinon.stub(api, 'recommendationsPublic').get(() => {
                 return {
                     browse: () => {

--- a/ghost/core/test/unit/frontend/helpers/t-new.test.js
+++ b/ghost/core/test/unit/frontend/helpers/t-new.test.js
@@ -9,7 +9,6 @@ describe('NEW{{t}} helper', function () {
     let ogBasePath = themeI18next.basePath;
 
     before(function () {
-        sinon.stub(labs, 'isSet').withArgs('themeTranslation').returns(true);
         themeI18next.basePath = path.join(__dirname, '../../../utils/fixtures/themes/');
     });
 
@@ -19,6 +18,8 @@ describe('NEW{{t}} helper', function () {
     });
 
     beforeEach(function () {
+        sinon.stub(labs, 'isSet').withArgs('themeTranslation').returns(true);
+
         // Reset the i18n instance before each test
         themeI18next._i18n = null;
     });

--- a/ghost/core/test/unit/frontend/meta/description.test.js
+++ b/ghost/core/test/unit/frontend/meta/description.test.js
@@ -6,14 +6,10 @@ const settingsCache = require('../../../../core/shared/settings-cache');
 describe('getMetaDescription', function () {
     let localSettingsCache = {};
 
-    before(function () {
+    beforeEach(function () {
         sinon.stub(settingsCache, 'get').callsFake(function (key) {
             return localSettingsCache[key];
         });
-    });
-
-    after(function () {
-        sinon.restore();
     });
 
     beforeEach(function () {

--- a/ghost/core/test/unit/server/services/stats/members.test.js
+++ b/ghost/core/test/unit/server/services/stats/members.test.js
@@ -45,10 +45,10 @@ describe('MembersStatsService', function () {
             tomorrowDate = moment.utc(tomorrow).toDate();
             yesterdayDate = moment.utc(yesterday).toDate();
             dayBeforeYesterdayDate = moment.utc(dayBeforeYesterday).toDate();
-            sinon.useFakeTimers(todayDate.getTime());
         });
 
         beforeEach(async function () {
+            sinon.useFakeTimers(todayDate.getTime());
             db = knex({client: 'sqlite3', connection: {filename: ':memory:'}, useNullAsDefault: true});
             membersStatsService = new MembersStatsService({knex: db});
 

--- a/ghost/core/test/unit/server/services/stats/mrr.test.js
+++ b/ghost/core/test/unit/server/services/stats/mrr.test.js
@@ -95,16 +95,9 @@ describe('MrrStatsService', function () {
             };
         }
 
-        before(function () {
-            // Set fake timers to our test "today"
-            sinon.useFakeTimers(testToday.toDate().getTime());
-        });
-
-        after(function () {
-            sinon.restore();
-        });
-
         beforeEach(async function () {
+            sinon.useFakeTimers(testToday.toDate().getTime());
+
             db = knex({client: 'sqlite3', connection: {filename: ':memory:'}, useNullAsDefault: true});
             mrrStatsService = new MrrStatsService({knex: db});
 

--- a/ghost/core/test/utils/overrides.js
+++ b/ghost/core/test/utils/overrides.js
@@ -1,4 +1,5 @@
 const crypto = require('crypto');
+const sinon = require('sinon');
 
 process.env.NODE_ENV = process.env.NODE_ENV || 'testing';
 process.env.WEBHOOK_SECRET = process.env.WEBHOOK_SECRET || 'TEST_STRIPE_WEBHOOK_SECRET';
@@ -102,6 +103,8 @@ mochaHooks.afterEach = async function () {
     await domainEvents.allSettled();
 
     clearTimeout(timeout);
+
+    sinon.restore();
 
     if (originalAfterEach) {
         await originalAfterEach();


### PR DESCRIPTION
no ref

This test-only change should have no user impact.

This always calls `sinon.restore()` after every test, instead of having to remember to do it. I feel this is less error-prone, and is a little shorter.
