### PR TITLE
Suppressed dotenv output in e2e tests

### DIFF
--- a/e2e/helpers/utils/app-config.ts
+++ b/e2e/helpers/utils/app-config.ts
@@ -1,6 +1,6 @@
 import dotenv from 'dotenv';
 // load environment variables from .env file
-dotenv.config();
+dotenv.config({quiet: true});
 
 // Simple config object with just the values
 export const appConfig = {

--- a/e2e/playwright.config.mjs
+++ b/e2e/playwright.config.mjs
@@ -1,6 +1,6 @@
 import dotenv from 'dotenv';
 import os from 'os';
-dotenv.config();
+dotenv.config({ quiet: true });
 
 /*
  * 1/3 of the number of CPU cores seems to strike a good balance. Each worker

--- a/e2e/playwright.config.mjs
+++ b/e2e/playwright.config.mjs
@@ -1,6 +1,6 @@
 import dotenv from 'dotenv';
 import os from 'os';
-dotenv.config({ quiet: true });
+dotenv.config({quiet: true});
 
 /*
  * 1/3 of the number of CPU cores seems to strike a good balance. Each worker


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/commit/2705a7a54cf2a4bb2000ba902d9623b054f94fcb

The upgrade to dotenv v17 introduced some noisy logging in the e2e test runs, as the `quiet` configuration now defaults to false. This sets `quiet` to true, to suppress these logs.