### PR TITLE
Added offers filter to members-forward page

### DIFF
--- a/apps/posts/src/views/members/components/members-filters.tsx
+++ b/apps/posts/src/views/members/components/members-filters.tsx
@@ -1,13 +1,70 @@
-import React from 'react';
-import {Filter, Filters, LucideIcon} from '@tryghost/shade';
+import React, {useCallback, useMemo} from 'react';
+import {Filter, FilterOption, Filters, LucideIcon} from '@tryghost/shade';
+import {Offer} from '@tryghost/admin-x-framework/api/offers';
 import {getSettingValue, useBrowseSettings} from '@tryghost/admin-x-framework/api/settings';
 import {getSiteTimezone} from '@src/utils/get-site-timezone';
 import {useBrowseConfig} from '@tryghost/admin-x-framework/api/config';
 import {useBrowseLabels} from '@tryghost/admin-x-framework/api/labels';
 import {useBrowseNewsletters} from '@tryghost/admin-x-framework/api/newsletters';
+import {useBrowseOffers} from '@tryghost/admin-x-framework/api/offers';
 import {useBrowseTiers} from '@tryghost/admin-x-framework/api/tiers';
 import {useMembersFilterConfig} from '../hooks/use-members-filter-config';
 import {useResourceSearch} from '../hooks/use-resource-search';
+
+/**
+ * Build a map of synthetic retention IDs to their underlying real offer IDs.
+ * e.g. 'retention:month' -> ['offer-id-1', 'offer-id-2']
+ */
+function buildRetentionOfferIdMap(offers: Offer[]): Map<string, string[]> {
+    const map = new Map<string, string[]>();
+    const monthlyIds: string[] = [];
+    const yearlyIds: string[] = [];
+
+    for (const offer of offers) {
+        if (offer.redemption_type === 'retention') {
+            if (offer.cadence === 'month') {
+                monthlyIds.push(offer.id);
+            } else if (offer.cadence === 'year') {
+                yearlyIds.push(offer.id);
+            }
+        }
+    }
+
+    if (monthlyIds.length > 0) {
+        map.set('retention:month', monthlyIds);
+    }
+    if (yearlyIds.length > 0) {
+        map.set('retention:year', yearlyIds);
+    }
+
+    return map;
+}
+
+/**
+ * Build offer filter options, grouping retention offers into
+ * "Monthly Retention" / "Yearly Retention" when the labs flag is enabled.
+ */
+function buildOfferOptions(offers: Offer[], retentionOffersEnabled: boolean, retentionMap: Map<string, string[]>): FilterOption[] {
+    const options: FilterOption[] = [];
+
+    for (const offer of offers) {
+        if (retentionOffersEnabled && offer.redemption_type === 'retention') {
+            continue;
+        }
+        options.push({value: offer.id, label: offer.name});
+    }
+
+    if (retentionOffersEnabled) {
+        if (retentionMap.has('retention:month')) {
+            options.push({value: 'retention:month', label: 'Monthly Retention'});
+        }
+        if (retentionMap.has('retention:year')) {
+            options.push({value: 'retention:year', label: 'Yearly Retention'});
+        }
+    }
+
+    return options;
+}
 
 interface MembersFiltersProps {
     filters: Filter[];
@@ -21,6 +78,7 @@ const MembersFilters: React.FC<MembersFiltersProps> = ({
     // Fetch required data for filters
     const {data: labelsData} = useBrowseLabels({searchParams: {limit: '100'}});
     const {data: tiersData} = useBrowseTiers({searchParams: {limit: '100'}});
+    const {data: offersData} = useBrowseOffers({});
     const {data: newslettersData} = useBrowseNewsletters({searchParams: {limit: '100'}});
     const {data: settingsData} = useBrowseSettings({});
     const {data: configData} = useBrowseConfig({});
@@ -33,14 +91,81 @@ const MembersFilters: React.FC<MembersFiltersProps> = ({
     const emailTrackOpens = getSettingValue<boolean>(settings, 'email_track_opens') === true;
     const emailTrackClicks = getSettingValue<boolean>(settings, 'email_track_clicks') === true;
     const audienceFeedbackEnabled = configData?.config?.labs?.audienceFeedback === true;
+    const retentionOffersEnabled = configData?.config?.labs?.retentionOffers === true;
     const siteTimezone = getSiteTimezone(settings);
 
     // Get data
     const labels = labelsData?.labels || [];
     const tiers = tiersData?.tiers || [];
     const newsletters = newslettersData?.newsletters || [];
+    const offers = offersData?.offers || [];
     const activePaidTiers = tiers.filter(t => t.type === 'paid' && t.active);
     const hasMultipleTiers = activePaidTiers.length > 1;
+
+    // Build offer options with retention grouping
+    const retentionMap = useMemo(() => {
+        return retentionOffersEnabled ? buildRetentionOfferIdMap(offers) : new Map<string, string[]>();
+    }, [offers, retentionOffersEnabled]);
+
+    const offersOptions = useMemo(() => {
+        return buildOfferOptions(offers, retentionOffersEnabled, retentionMap);
+    }, [offers, retentionOffersEnabled, retentionMap]);
+
+    // When retention grouping is active, translate between synthetic IDs (for display)
+    // and real offer IDs (stored in URL / sent to API)
+    const displayFilters = useMemo(() => {
+        if (retentionMap.size === 0) {
+            return filters;
+        }
+        return filters.map((filter) => {
+            if (filter.field !== 'offer_redemptions') {
+                return filter;
+            }
+            const values = [...filter.values as string[]];
+            const collapsed: string[] = [];
+            const consumed = new Set<string>();
+
+            // Collapse real IDs into synthetic IDs where all IDs in the group are present
+            for (const [syntheticId, realIds] of retentionMap) {
+                if (realIds.length > 0 && realIds.every(id => values.includes(id))) {
+                    collapsed.push(syntheticId);
+                    realIds.forEach(id => consumed.add(id));
+                }
+            }
+
+            // Keep any remaining real IDs that weren't part of a complete group
+            for (const v of values) {
+                if (!consumed.has(v)) {
+                    collapsed.push(v);
+                }
+            }
+
+            return {...filter, values: collapsed};
+        });
+    }, [filters, retentionMap]);
+
+    const handleFiltersChange = useCallback((newFilters: Filter[]) => {
+        if (retentionMap.size === 0) {
+            onFiltersChange(newFilters);
+            return;
+        }
+        const expanded = newFilters.map((filter) => {
+            if (filter.field !== 'offer_redemptions') {
+                return filter;
+            }
+            const values: string[] = [];
+            for (const value of filter.values as string[]) {
+                const realIds = retentionMap.get(value as string);
+                if (realIds) {
+                    values.push(...realIds);
+                } else {
+                    values.push(value as string);
+                }
+            }
+            return {...filter, values: [...new Set(values)]};
+        });
+        onFiltersChange(expanded);
+    }, [onFiltersChange, retentionMap]);
 
     // Resource search hooks for post/page and email pickers
     const postSearch = useResourceSearch('post');
@@ -56,6 +181,8 @@ const MembersFilters: React.FC<MembersFiltersProps> = ({
         emailAnalyticsEnabled,
         labelsOptions: labels.map(l => ({value: l.slug, label: l.name})),
         tiersOptions: activePaidTiers.map(t => ({value: t.id, label: t.name})),
+        offersOptions,
+        hasOffers: offers.length > 0,
         postResourceOptions: postSearch.options,
         onPostResourceSearchChange: postSearch.onSearchChange,
         postResourceSearchValue: postSearch.searchValue,
@@ -91,12 +218,12 @@ const MembersFilters: React.FC<MembersFiltersProps> = ({
             clearButtonIcon={<LucideIcon.X />}
             clearButtonText="Clear"
             fields={filterFields}
-            filters={filters}
+            filters={displayFilters}
             keyboardShortcut="f"
             popoverAlign={hasFilters ? 'start' : 'end'}
             showClearButton={hasFilters}
             showSearchInput={false}
-            onChange={onFiltersChange}
+            onChange={handleFiltersChange}
         />
     );
 };

--- a/apps/posts/src/views/members/hooks/use-members-filter-config.tsx
+++ b/apps/posts/src/views/members/hooks/use-members-filter-config.tsx
@@ -29,6 +29,9 @@ export interface UseMembersFilterConfigOptions {
     onEmailResourceSearchChange?: (search: string) => void;
     emailResourceSearchValue?: string;
     emailResourceLoading?: boolean;
+    // Offers
+    offersOptions?: FilterOption[];
+    hasOffers?: boolean;
     // Feature/setting flags for resource filters
     membersTrackSources?: boolean;
     emailTrackOpens?: boolean;
@@ -116,6 +119,8 @@ export function useMembersFilterConfig({
     onTiersSearchChange,
     tiersSearchValue,
     tiersLoading = false,
+    offersOptions = [],
+    hasOffers = false,
     postResourceOptions = [],
     onPostResourceSearchChange,
     postResourceSearchValue,
@@ -366,6 +371,21 @@ export function useMembersFilterConfig({
                 });
             }
 
+            if (hasOffers) {
+                subscriptionFields.push({
+                    key: 'offer_redemptions',
+                    label: 'Offer',
+                    type: 'multiselect',
+                    icon: <LucideIcon.Ticket className="size-4" />,
+                    options: offersOptions,
+                    defaultOperator: 'is_any_of',
+                    hideOperatorSelect: true,
+                    autoCloseOnSelect: true,
+                    searchable: true,
+                    className: 'w-64'
+                });
+            }
+
             groups.push({
                 group: 'Subscription',
                 fields: subscriptionFields
@@ -505,6 +525,8 @@ export function useMembersFilterConfig({
         onTiersSearchChange,
         tiersSearchValue,
         tiersLoading,
+        offersOptions,
+        hasOffers,
         postResourceOptions,
         onPostResourceSearchChange,
         postResourceSearchValue,

--- a/apps/posts/src/views/members/hooks/use-members-filter-state.ts
+++ b/apps/posts/src/views/members/hooks/use-members-filter-state.ts
@@ -39,7 +39,7 @@ export const MEMBER_FILTER_FIELDS = [
 export type MemberFilterField = typeof MEMBER_FILTER_FIELDS[number];
 
 // Fields that support multiselect (comma-separated values in URL)
-const MULTISELECT_FIELDS = new Set<string>(['label']);
+const MULTISELECT_FIELDS = new Set<string>(['label', 'offer_redemptions']);
 
 /**
  * Escape a string for NQL (escape single quotes)


### PR DESCRIPTION
Ref https://linear.app/ghost/issue/BER-3359/add-offers-as-a-member-filter-option

Includes the recent changes made to `/members` to account for retention offers.

