### PR TITLE
Changed Ghost core nodemon config to ignore noisy asset paths

### DIFF
--- a/ghost/core/nodemon.json
+++ b/ghost/core/nodemon.json
@@ -1,0 +1,13 @@
+{
+  "watch": [
+    ".",
+    "../*"
+  ],
+  "ignore": [
+    "../admin/**",
+    "content/**",
+    "core/built/**"
+  ],
+  "ext": "js,mjs,cjs,json,ts,tsx",
+  "exec": "node --import=tsx"
+}

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "archive": "npm pack",
     "pack:standalone": "rm -rf package ghost-*.tgz && npm pack && tar -xzf ghost-*.tgz && cp ../../yarn.lock package/ && rm ghost-*.tgz",
-    "dev": "nodemon --watch . --watch ../i18n --watch ../parse-email-address --ext js,mjs,cjs,json,ts,tsx --exec \"node --import=tsx\" index.js",
+    "dev": "nodemon index.js",
     "build:assets": "yarn build:assets:css && yarn build:assets:js",
     "build:assets:js": "node bin/minify-assets.js",
     "build:assets:css": "postcss core/frontend/public/ghost.css --no-map --use cssnano -o core/frontend/public/ghost.min.css",


### PR DESCRIPTION
no ref

Moved nodemon settings into ghost/core/nodemon.json so dev watch behavior is configured in one place. The config watches core and shared workspaces, while ignoring content and core/built to avoid unnecessary restarts from generated content and built admin assets.