### PR TITLE
Handle staff/me redirect to current user's profile

### DIFF
--- a/ghost/admin/app/routes/settings-x.js
+++ b/ghost/admin/app/routes/settings-x.js
@@ -10,11 +10,19 @@ export default class SettingsXRoute extends AuthenticatedRoute {
     beforeModel(transition) {
         super.beforeModel(...arguments);
 
+        const subPath = transition.to?.params?.sub;
+        const userSlug = this.session.user.slug;
+
+        // Handle staff/me redirect - redirect to current user's profile
+        // Also handles subpaths like staff/me/edit -> staff/{slug}/edit
+        if (subPath?.startsWith('staff/me')) {
+            const suffix = subPath.slice('staff/me'.length); // e.g., '/edit' or ''
+            return this.transitionTo('settings-x.settings-x', `staff/${userSlug}${suffix}`);
+        }
+
         // Contributors and Authors can only access their own profile in settings
         if (this.session.user.isAuthorOrContributor) {
-            // Check if they're trying to access their own profile route
-            const subPath = transition.to?.params?.sub;
-            const ownProfilePath = `staff/${this.session.user.slug}`;
+            const ownProfilePath = `staff/${userSlug}`;
 
             // Only allow access to their own profile, redirect everything else
             if (subPath !== ownProfilePath) {

--- a/ghost/admin/tests/acceptance/settings/staff-me-redirect-test.js
+++ b/ghost/admin/tests/acceptance/settings/staff-me-redirect-test.js
@@ -1,0 +1,44 @@
+import {beforeEach, describe, it} from 'mocha';
+import {authenticateSession} from 'ember-simple-auth/test-support';
+import {currentURL} from '@ember/test-helpers';
+import {expect} from 'chai';
+import {setupApplicationTest} from 'ember-mocha';
+import {setupMirage} from 'ember-cli-mirage/test-support';
+import {visit} from '../../helpers/visit';
+
+describe('Acceptance: Settings - Staff /me redirect', function () {
+    let hooks = setupApplicationTest();
+    setupMirage(hooks);
+
+    beforeEach(async function () {
+        let role = this.server.create('role', {name: 'Administrator'});
+        this.server.create('user', {id: '1', roles: [role], slug: 'admin-user'});
+        await authenticateSession();
+    });
+
+    it('redirects /settings/staff/me to current user profile', async function () {
+        await visit('/settings/staff/me');
+        expect(currentURL()).to.equal('/settings/staff/admin-user');
+    });
+
+    it('redirects /settings/staff/me/edit to current user edit', async function () {
+        await visit('/settings/staff/me/edit');
+        expect(currentURL()).to.equal('/settings/staff/admin-user/edit');
+    });
+
+    it('redirects /settings/staff/me for non-admin roles', async function () {
+        let role = this.server.create('role', {name: 'Editor'});
+        this.server.db.users.update(1, {roles: [role]});
+
+        await visit('/settings/staff/me');
+        expect(currentURL()).to.equal('/settings/staff/admin-user');
+    });
+
+    it('redirects /settings/staff/me for contributors to own profile', async function () {
+        let role = this.server.create('role', {name: 'Contributor'});
+        this.server.db.users.update(1, {roles: [role]});
+
+        await visit('/settings/staff/me');
+        expect(currentURL()).to.equal('/settings/staff/admin-user');
+    });
+});


### PR DESCRIPTION
## What's changing?

This PR adds support for redirecting `staff/me` URLs to the current user's profile, including handling subpaths like `staff/me/edit`.

## Why?

Previously, there was no handling for the `staff/me` pattern, which is a common convention for "my own profile" URLs. This change allows users to navigate to `/settings/staff/me` and be automatically redirected to their actual profile at `/settings/staff/{their-slug}`, with any subpaths (like `/edit`) preserved.

## How does it work?

The change adds a new redirect handler in the `beforeModel` hook that:
1. Checks if the requested subpath starts with `staff/me`
2. Extracts any suffix (e.g., `/edit`)
3. Redirects to the user's actual profile path with the suffix appended

This redirect happens before the existing contributor/author access control check, ensuring all users benefit from the convenience of the `staff/me` shorthand.

## Checklist

- [x] I've explained my change
- [x] Change is straightforward and focused on URL redirect logic

https://claude.ai/code/session_01VLK2nER3rRUWhmuT41oD9M