### PR TITLE
Fixed outdated types when building admin-x-framework

### DIFF
--- a/apps/admin-x-design-system/package.json
+++ b/apps/admin-x-design-system/package.json
@@ -95,7 +95,8 @@
             "build": {
                 "dependsOn": [
                     "^build"
-                ]
+                ],
+                "outputs": ["{projectRoot}/es", "{projectRoot}/types"]
             },
             "test:unit": {
                 "dependsOn": [

--- a/apps/admin-x-framework/package.json
+++ b/apps/admin-x-framework/package.json
@@ -109,7 +109,8 @@
             "build": {
                 "dependsOn": [
                     "^build"
-                ]
+                ],
+                "outputs": ["{projectRoot}/dist", "{projectRoot}/types"]
             },
             "test:unit": {
                 "dependsOn": [


### PR DESCRIPTION
towards https://linear.app/ghost/issue/NY-1097

The `nx` cache needs to be more properly purged for some of these projects, otherwise we get [CI failures][0]. This defines what files are part of the output, so it can properly cache them.

[0]: https://github.com/TryGhost/Ghost/actions/runs/22409070748/job/64877688336?pr=26569
