### PR TITLE
Used Sinon assertions when possible

### DIFF
--- a/ghost/core/test/e2e-api/admin/invites.test.js
+++ b/ghost/core/test/e2e-api/admin/invites.test.js
@@ -49,7 +49,7 @@ describe('Invites API', function () {
             assert.equal(jsonResponse.invites[1].email, 'test2@ghost.org');
             assert.equal(jsonResponse.invites[1].role_id, testUtils.roles.ids.author);
 
-            assert.equal(mailService.GhostMailer.prototype.send.called, false);
+            sinon.assert.notCalled(mailService.GhostMailer.prototype.send);
         });
 
         it('Can read an invitation by id', async function () {
@@ -67,7 +67,7 @@ describe('Invites API', function () {
 
             localUtils.API.checkResponse(jsonResponse.invites[0], 'invite');
 
-            assert.equal(mailService.GhostMailer.prototype.send.called, false);
+            sinon.assert.notCalled(mailService.GhostMailer.prototype.send);
         });
 
         it('Can add a new invite', async function () {
@@ -90,7 +90,7 @@ describe('Invites API', function () {
             localUtils.API.checkResponse(jsonResponse.invites[0], 'invite');
             assert.equal(jsonResponse.invites[0].role_id, testUtils.getExistingData().roles[1].id);
 
-            assert.equal(mailService.GhostMailer.prototype.send.called, true);
+            sinon.assert.called(mailService.GhostMailer.prototype.send);
 
             assertExists(res.headers.location);
             assert.equal(new URL(res.headers.location).pathname, `/ghost/api/admin/invites/${res.body.invites[0].id}/`);
@@ -102,7 +102,7 @@ describe('Invites API', function () {
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(204);
 
-            assert.equal(mailService.GhostMailer.prototype.send.called, false);
+            sinon.assert.notCalled(mailService.GhostMailer.prototype.send);
         });
 
         it('Cannot destroy an non-existent invite', async function () {
@@ -114,7 +114,7 @@ describe('Invites API', function () {
                     assert.equal(res.body.errors[0].message, 'Resource not found error, cannot delete invite.');
                 });
 
-            assert.equal(mailService.GhostMailer.prototype.send.called, false);
+            sinon.assert.notCalled(mailService.GhostMailer.prototype.send);
         });
     });
     
@@ -154,7 +154,7 @@ describe('Invites API', function () {
             localUtils.API.checkResponse(jsonResponse.invites[0], 'invite');
             assert.equal(jsonResponse.invites[0].role_id, roleId);
 
-            assert.equal(mailService.GhostMailer.prototype.send.called, true);
+            sinon.assert.called(mailService.GhostMailer.prototype.send);
 
             assertExists(res.headers.location);
             assert.equal(new URL(res.headers.location).pathname, `/ghost/api/admin/invites/${res.body.invites[0].id}/`);
@@ -181,7 +181,7 @@ describe('Invites API', function () {
             localUtils.API.checkResponse(jsonResponse.invites[0], 'invite');
             assert.equal(jsonResponse.invites[0].role_id, roleId);
 
-            assert.equal(mailService.GhostMailer.prototype.send.called, true);
+            sinon.assert.called(mailService.GhostMailer.prototype.send);
 
             assertExists(res.headers.location);
             assert.equal(new URL(res.headers.location).pathname, `/ghost/api/admin/invites/${res.body.invites[0].id}/`);
@@ -208,7 +208,7 @@ describe('Invites API', function () {
             localUtils.API.checkResponse(jsonResponse.invites[0], 'invite');
             assert.equal(jsonResponse.invites[0].role_id, roleId);
 
-            assert.equal(mailService.GhostMailer.prototype.send.called, true);
+            sinon.assert.called(mailService.GhostMailer.prototype.send);
 
             assertExists(res.headers.location);
             assert.equal(new URL(res.headers.location).pathname, `/ghost/api/admin/invites/${res.body.invites[0].id}/`);
@@ -235,7 +235,7 @@ describe('Invites API', function () {
             localUtils.API.checkResponse(jsonResponse.invites[0], 'invite');
             assert.equal(jsonResponse.invites[0].role_id, roleId);
 
-            assert.equal(mailService.GhostMailer.prototype.send.called, true);
+            sinon.assert.called(mailService.GhostMailer.prototype.send);
 
             assertExists(res.headers.location);
             assert.equal(new URL(res.headers.location).pathname, `/ghost/api/admin/invites/${res.body.invites[0].id}/`);

--- a/ghost/core/test/e2e-api/content/max-limit-cap.test.js
+++ b/ghost/core/test/e2e-api/content/max-limit-cap.test.js
@@ -32,7 +32,7 @@ describe('Content API - Max Limit Cap', function () {
             .expectStatus(200);
 
         // Verify the middleware was called
-        assert.equal(middlewareSpy.called, true);
+        sinon.assert.called(middlewareSpy);
 
         // Verify it modified the req.query param by reference
         const req = middlewareSpy.firstCall.args[0];

--- a/ghost/core/test/e2e-api/members-comments/max-limit-cap.test.js
+++ b/ghost/core/test/e2e-api/members-comments/max-limit-cap.test.js
@@ -43,7 +43,7 @@ describe('Comments API - Max Limit Cap', function () {
             .expectStatus(200);
 
         // Verify the middleware was called
-        assert.equal(middlewareSpy.called, true);
+        sinon.assert.called(middlewareSpy);
 
         // Verify it modified the req.query param by reference
         const req = middlewareSpy.firstCall.args[0];

--- a/ghost/core/test/e2e-server/services/milestones.test.js
+++ b/ghost/core/test/e2e-server/services/milestones.test.js
@@ -242,7 +242,7 @@ describe('Milestones Service', function () {
         assert.ok(arrMilestoneModel.get('created_at'));
         assert.equal(arrMilestoneModel.get('email_sent_at'), null);
 
-        assert(loggingStub.called);
+        sinon.assert.called(loggingStub);
     });
 
     it('Does not run ARR milestones when Stripe is not live enabled', async function () {
@@ -265,7 +265,7 @@ describe('Milestones Service', function () {
         assert.ok(memberMilestoneModel.get('created_at'));
         assert.equal(memberMilestoneModel.get('email_sent_at'), null);
 
-        assert(loggingStub.called);
+        sinon.assert.called(loggingStub);
     });
 
     it('Does not send emails for milestones when imported members present', async function () {
@@ -295,6 +295,6 @@ describe('Milestones Service', function () {
 
         assert.equal(arrMilestoneModel, null);
 
-        assert(loggingStub.called);
+        sinon.assert.called(loggingStub);
     });
 });

--- a/ghost/core/test/integration/jobs/process-outbox.test.js
+++ b/ghost/core/test/integration/jobs/process-outbox.test.js
@@ -90,7 +90,7 @@ describe('Process Outbox Job', function () {
 
             const entriesAfterJob = await models.Outbox.findAll();
             assert.equal(entriesAfterJob.length, 0);
-            assert.equal(mailService.GhostMailer.prototype.send.callCount, 1);
+            sinon.assert.calledOnce(mailService.GhostMailer.prototype.send);
         });
 
         it('does nothing when there are no pending entries', async function () {
@@ -101,7 +101,7 @@ describe('Process Outbox Job', function () {
 
             const entriesAfterJob = await models.Outbox.findAll();
             assert.equal(entriesAfterJob.length, 0);
-            assert.equal(mailService.GhostMailer.prototype.send.callCount, 0);
+            sinon.assert.notCalled(mailService.GhostMailer.prototype.send);
         });
 
         it('processes multiple entries in a batch', async function () {
@@ -145,7 +145,7 @@ describe('Process Outbox Job', function () {
 
             const entriesAfterJob = await models.Outbox.findAll();
             assert.equal(entriesAfterJob.length, 0);
-            assert.equal(mailService.GhostMailer.prototype.send.callCount, 3);
+            sinon.assert.calledThrice(mailService.GhostMailer.prototype.send);
         });
 
         it('ignores entries that are not pending', async function () {
@@ -178,7 +178,7 @@ describe('Process Outbox Job', function () {
 
             const entriesAfterJob = await models.Outbox.findAll();
             assert.equal(entriesAfterJob.length, 2);
-            assert.equal(mailService.GhostMailer.prototype.send.callCount, 0);
+            sinon.assert.notCalled(mailService.GhostMailer.prototype.send);
         });
 
         it('increments retry_count and keeps entry pending when handler fails', async function () {

--- a/ghost/core/test/integration/migrations/nullable-utils.test.js
+++ b/ghost/core/test/integration/migrations/nullable-utils.test.js
@@ -158,7 +158,7 @@ describe('Migrations - schema utils', function () {
             await migration.up({transacting});
             await transacting.commit();
 
-            assert(logSpy.calledWith(sinon.match('skipping as column is already nullable')), 'Should log skip message');
+            sinon.assert.calledWith(logSpy, sinon.match('skipping as column is already nullable'));
 
             // Column should still be nullable
             const isNullableAfter = await isColumnNullable(tableName, 'nullable_col');
@@ -234,7 +234,7 @@ describe('Migrations - schema utils', function () {
             await migration.up({transacting});
             await transacting.commit();
 
-            assert(logSpy.calledWith(sinon.match('skipping as column is already not nullable')), 'Should log skip message');
+            sinon.assert.calledWith(logSpy, sinon.match('skipping as column is already not nullable'));
 
             // Column should still be not nullable
             const isNotNullableAfter = await isColumnNotNullable(tableName, 'not_nullable_col');
@@ -320,7 +320,7 @@ describe('Migrations - schema utils', function () {
             
             if (dbUtils.isMySQL()) {
                 // MySQL should log a warning when checking nullable status fails
-                assert(logWarnSpy.calledWith(sinon.match('Could not check nullable status')), 'MySQL should log warning about checking nullable status');
+                sinon.assert.calledWith(logWarnSpy, sinon.match('Could not check nullable status'));
             }
             
             // Both databases should eventually fail when trying to ALTER the non-existent table

--- a/ghost/core/test/integration/services/email-service/batch-sending.test.js
+++ b/ghost/core/test/integration/services/email-service/batch-sending.test.js
@@ -219,7 +219,7 @@ describe.skip('Batch sending tests', function () {
 
         const {emailModel} = await sendEmail(agent);
 
-        assert(addStub.calledOnce);
+        sinon.assert.calledOnce(addStub);
         assert.ok(laterMember);
         addStub.restore();
 
@@ -597,7 +597,7 @@ describe.skip('Batch sending tests', function () {
             const memberIds = emailRecipients.models.map(recipient => recipient.get('member_id'));
             assert.equal(memberIds.length, _.uniq(memberIds).length);
 
-            assert.equal(stubbedSend.callCount, 4);
+            sinon.assert.callCount(stubbedSend, 4);
             const calls = stubbedSend.getCalls();
             const deadline = new Date(t0.getTime() + targetDeliveryWindow);
 

--- a/ghost/core/test/integration/services/email-service/domain-warming.test.js
+++ b/ghost/core/test/integration/services/email-service/domain-warming.test.js
@@ -167,7 +167,7 @@ describe('Domain Warming Integration Tests', function () {
             assert.equal(customDomainCount, totalCount, 'All emails should use custom domain when total < warmup limit');
             assert.equal(fallbackDomainCount, 0, 'No emails should use fallback domain when total < warmup limit');
 
-            assert.ok(mockManager.getMailgunCreateMessageStub().called);
+            sinon.assert.called(mockManager.getMailgunCreateMessageStub());
         });
 
         it('increases custom domain limit on subsequent day', async function () {

--- a/ghost/core/test/integration/services/last-seen-at-updater.test.js
+++ b/ghost/core/test/integration/services/last-seen-at-updater.test.js
@@ -118,7 +118,7 @@ describe('Last Seen At Updater', function () {
                 membersEvents.lastSeenAtUpdater.cachedUpdateLastSeenAt(memberId, previousLastSeen, firstDate)
             ]);
 
-            assert.equal(spy.callCount, 1);
+            sinon.assert.calledOnce(spy);
 
             clock.restore();
         });

--- a/ghost/core/test/integration/services/member-welcome-emails.test.js
+++ b/ghost/core/test/integration/services/member-welcome-emails.test.js
@@ -209,7 +209,7 @@ describe('Member Welcome Emails Integration', function () {
 
             await scheduleInlineJob();
 
-            assert.equal(mailService.GhostMailer.prototype.send.callCount, 0);
+            sinon.assert.notCalled(mailService.GhostMailer.prototype.send);
 
             const entriesAfterJob = await models.Outbox.findAll();
             assert.equal(entriesAfterJob.length, 1);
@@ -232,7 +232,7 @@ describe('Member Welcome Emails Integration', function () {
 
             await scheduleInlineJob();
 
-            assert.equal(mailService.GhostMailer.prototype.send.callCount, 0);
+            sinon.assert.notCalled(mailService.GhostMailer.prototype.send);
 
             const entriesAfterJob = await models.Outbox.findAll();
             assert.equal(entriesAfterJob.length, 1);
@@ -257,7 +257,7 @@ describe('Member Welcome Emails Integration', function () {
 
             await scheduleInlineJob();
 
-            assert.equal(mailService.GhostMailer.prototype.send.callCount, 0);
+            sinon.assert.notCalled(mailService.GhostMailer.prototype.send);
 
             const entriesAfterJob = await models.Outbox.findAll();
             assert.equal(entriesAfterJob.length, 1);
@@ -280,7 +280,7 @@ describe('Member Welcome Emails Integration', function () {
 
             await scheduleInlineJob();
 
-            assert.equal(mailService.GhostMailer.prototype.send.callCount, 0);
+            sinon.assert.notCalled(mailService.GhostMailer.prototype.send);
 
             const entriesAfterJob = await models.Outbox.findAll();
             assert.equal(entriesAfterJob.length, 1);
@@ -307,7 +307,7 @@ describe('Member Welcome Emails Integration', function () {
 
             await scheduleInlineJob();
 
-            assert.equal(mailService.GhostMailer.prototype.send.callCount, 1);
+            sinon.assert.calledOnce(mailService.GhostMailer.prototype.send);
 
             const trackingRecords = await db.knex('automated_email_recipients')
                 .where('member_id', memberId);
@@ -342,7 +342,7 @@ describe('Member Welcome Emails Integration', function () {
 
             await scheduleInlineJob();
 
-            assert.equal(mailService.GhostMailer.prototype.send.callCount, 1);
+            sinon.assert.calledOnce(mailService.GhostMailer.prototype.send);
             const sendCall = mailService.GhostMailer.prototype.send.firstCall;
             assert.equal(sendCall.args[0].to, memberEmail);
         });
@@ -373,7 +373,7 @@ describe('Member Welcome Emails Integration', function () {
 
             await scheduleInlineJob();
 
-            assert.equal(mailService.GhostMailer.prototype.send.callCount, 1);
+            sinon.assert.calledOnce(mailService.GhostMailer.prototype.send);
             const sendCall = mailService.GhostMailer.prototype.send.firstCall;
             assert.equal(sendCall.args[0].replyTo, senderReplyTo);
             assert.ok(sendCall.args[0].from.includes(senderEmail));

--- a/ghost/core/test/legacy/models/base/overrides.test.js
+++ b/ghost/core/test/legacy/models/base/overrides.test.js
@@ -77,10 +77,10 @@ describe('Models: Base plugins: Overrides', function () {
 
             // called twice because format is also called on fetch
             // see https://github.com/TryGhost/Ghost/commit/426cbeec0f57886fbb4c7a1ebd2ce696913b03eb
-            assert.equal(format.callCount, 2);
+            sinon.assert.calledTwice(format);
 
             // only called once for the actual write
-            assert.equal(formatOnWrite.callCount, 1);
+            sinon.assert.calledOnce(formatOnWrite);
         });
     });
 });

--- a/ghost/core/test/unit/api/canary/session.test.js
+++ b/ghost/core/test/unit/api/canary/session.test.js
@@ -68,7 +68,7 @@ describe('Session controller', function () {
             }}).then((fn) => {
                 fn(fakeReq, fakeRes, fakeNext);
             }).then(function () {
-                assert.equal(fakeReq.brute.reset.callCount, 1);
+                sinon.assert.calledOnce(fakeReq.brute.reset);
 
                 const createSessionStubCall = createSessionStub.getCall(0);
                 assert.equal(fakeReq.user, fakeUser);
@@ -101,8 +101,8 @@ describe('Session controller', function () {
             }}).then((fn) => {
                 fn(fakeReq, fakeRes, fakeNext);
             }).then(function () {
-                assert.equal(fakeReq.brute.reset.callCount, 1);
-                assert.equal(fakeNext.callCount, 1);
+                sinon.assert.calledOnce(fakeReq.brute.reset);
+                sinon.assert.calledOnce(fakeNext);
                 assert.equal(fakeNext.args[0][0], resetError);
             });
         });
@@ -129,7 +129,7 @@ describe('Session controller', function () {
             }}).then((fn) => {
                 fn(fakeReq, fakeRes, fakeNext);
             }).then(function () {
-                assert.equal(fakeReq.brute.reset.callCount, 1);
+                sinon.assert.calledOnce(fakeReq.brute.reset);
 
                 const createSessionStubCall = createSessionStub.getCall(0);
                 assert.equal(fakeReq.user, fakeUser);
@@ -163,7 +163,7 @@ describe('Session controller', function () {
             }}).then((fn) => {
                 fn(fakeReq, fakeRes, fakeNext);
             }).then(function () {
-                assert.equal(fakeReq.brute.reset.callCount, 1);
+                sinon.assert.calledOnce(fakeReq.brute.reset);
 
                 const createSessionStubCall = createSessionStub.getCall(0);
                 assert.equal(fakeReq.user, fakeUser);

--- a/ghost/core/test/unit/api/canary/utils/serializers/output/mapper.test.js
+++ b/ghost/core/test/unit/api/canary/utils/serializers/output/mapper.test.js
@@ -66,17 +66,17 @@ describe('Unit: utils/serializers/output/mappers', function () {
 
             await mappers.posts(post, frame);
 
-            assert.equal(dateUtil.forPost.callCount, 1);
+            sinon.assert.calledOnce(dateUtil.forPost);
 
-            assert.equal(extraAttrsUtils.forPost.callCount, 1);
+            sinon.assert.calledOnce(extraAttrsUtils.forPost);
 
-            assert.equal(cleanUtil.post.callCount, 1);
-            assert.equal(cleanUtil.tag.callCount, 1);
-            assert.equal(cleanUtil.author.callCount, 1);
+            sinon.assert.calledOnce(cleanUtil.post);
+            sinon.assert.calledOnce(cleanUtil.tag);
+            sinon.assert.calledOnce(cleanUtil.author);
 
-            assert.equal(urlUtil.forPost.callCount, 1);
-            assert.equal(urlUtil.forTag.callCount, 1);
-            assert.equal(urlUtil.forUser.callCount, 1);
+            sinon.assert.calledOnce(urlUtil.forPost);
+            sinon.assert.calledOnce(urlUtil.forTag);
+            sinon.assert.calledOnce(urlUtil.forUser);
 
             assert.deepEqual(urlUtil.forTag.getCall(0).args, ['id3', {id: 'id3', feature_image: 'value'}, frame.options]);
             assert.deepEqual(urlUtil.forUser.getCall(0).args, ['id4', {name: 'Ghosty', id: 'id4'}, frame.options]);
@@ -103,9 +103,9 @@ describe('Unit: utils/serializers/output/mappers', function () {
 
             mappers.users(user, frame);
 
-            assert.equal(urlUtil.forUser.callCount, 1);
+            sinon.assert.calledOnce(urlUtil.forUser);
             assert.deepEqual(urlUtil.forUser.getCall(0).args, ['id1', user, frame.options]);
-            assert.equal(cleanUtil.author.callCount, 1);
+            sinon.assert.calledOnce(cleanUtil.author);
         });
     });
 
@@ -129,9 +129,9 @@ describe('Unit: utils/serializers/output/mappers', function () {
 
             mappers.tags(tag, frame);
 
-            assert.equal(urlUtil.forTag.callCount, 1);
+            sinon.assert.calledOnce(urlUtil.forTag);
             assert.deepEqual(urlUtil.forTag.getCall(0).args, ['id3', tag, frame.options]);
-            assert.equal(cleanUtil.tag.callCount, 1);
+            sinon.assert.calledOnce(cleanUtil.tag);
         });
     });
 

--- a/ghost/core/test/unit/api/canary/utils/serializers/output/utils/extra-attrs.test.js
+++ b/ghost/core/test/unit/api/canary/utils/serializers/output/utils/extra-attrs.test.js
@@ -27,7 +27,7 @@ describe('Unit: endpoints/utils/serializers/output/utils/extra-attrs', function 
             const attrs = {};
 
             extraAttrsUtil.forPost(options, model, attrs);
-            assert.ok(modelGetStub.called);
+            sinon.assert.called(modelGetStub);
             assert.equal(attrs.excerpt, new Array(501).join('A'));
         });
 
@@ -35,7 +35,7 @@ describe('Unit: endpoints/utils/serializers/output/utils/extra-attrs', function 
             modelGetStub.withArgs('plaintext').returns(null);
             const attrs = {};
             extraAttrsUtil.forPost(options, model, attrs);
-            assert.ok(modelGetStub.called);
+            sinon.assert.called(modelGetStub);
             assert.equal(Object.prototype.hasOwnProperty.call(attrs, 'excerpt'), true);
             assert.equal(attrs.excerpt, null);
         });
@@ -45,7 +45,7 @@ describe('Unit: endpoints/utils/serializers/output/utils/extra-attrs', function 
             extraAttrsUtil.forPost({
                 columns: ['plaintext']
             }, model, attrs);
-            assert.ok(modelGetStub.called);
+            sinon.assert.called(modelGetStub);
             assert.equal(Object.prototype.hasOwnProperty.call(attrs, 'plaintext'), true);
         });
 
@@ -54,14 +54,14 @@ describe('Unit: endpoints/utils/serializers/output/utils/extra-attrs', function 
             extraAttrsUtil.forPost({
                 formats: ['plaintext']
             }, model, attrs);
-            assert.ok(modelGetStub.called);
+            sinon.assert.called(modelGetStub);
             assert.equal(Object.prototype.hasOwnProperty.call(attrs, 'plaintext'), true);
         });
 
         it('has excerpt when no columns are passed', function () {
             const attrs = {};
             extraAttrsUtil.forPost({}, model, attrs);
-            assert.ok(modelGetStub.called);
+            sinon.assert.called(modelGetStub);
             assert.equal(Object.prototype.hasOwnProperty.call(attrs, 'excerpt'), true);
         });
 

--- a/ghost/core/test/unit/api/endpoints/db.test.js
+++ b/ghost/core/test/unit/api/endpoints/db.test.js
@@ -1,4 +1,3 @@
-const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const models = require('../../../../core/server/models');
 const dbController = require('../../../../core/server/api/endpoints/db');
@@ -38,10 +37,10 @@ describe('DB controller', function () {
             await dbController.importContent.query(frame);
 
             // Verify the user's email was used
-            assert(mockUser.get.calledWith('email'));
-            assert(importer.importFromFile.calledWith(frame.file, sinon.match({
+            sinon.assert.calledWith(mockUser.get, 'email');
+            sinon.assert.calledWith(importer.importFromFile, frame.file, sinon.match({
                 user: {email: 'user@example.com'}
-            })));
+            }));
         });
 
         it('uses owner email fallback when frame.user is missing', async function () {
@@ -58,11 +57,11 @@ describe('DB controller', function () {
             await dbController.importContent.query(frame);
 
             // Verify the owner fallback path was used
-            assert(models.User.getOwnerUser.calledOnce);
-            assert(mockOwnerUser.get.calledWith('email'));
-            assert(importer.importFromFile.calledWith(frame.file, sinon.match({
+            sinon.assert.calledOnce(models.User.getOwnerUser);
+            sinon.assert.calledWith(mockOwnerUser.get, 'email');
+            sinon.assert.calledWith(importer.importFromFile, frame.file, sinon.match({
                 user: {email: 'owner@example.com'}
-            })));
+            }));
         });
     });
 });

--- a/ghost/core/test/unit/api/endpoints/members.test.js
+++ b/ghost/core/test/unit/api/endpoints/members.test.js
@@ -1,4 +1,3 @@
-const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const rewire = require('rewire');
 
@@ -54,10 +53,10 @@ describe('Members controller', function () {
             await membersController.importCSV.query(frame);
 
             // Verify the user's email was used
-            assert(mockUser.get.calledWith('email'));
-            assert(mockMembersService.processImport.calledWith(sinon.match({
+            sinon.assert.calledWith(mockUser.get, 'email');
+            sinon.assert.calledWith(mockMembersService.processImport, sinon.match({
                 user: {email: 'user@example.com'}
-            })));
+            }));
         });
 
         it('uses owner email fallback when frame.user is missing', async function () {
@@ -75,11 +74,11 @@ describe('Members controller', function () {
             await membersController.importCSV.query(frame);
 
             // Verify the owner fallback path was used
-            assert(models.User.getOwnerUser.calledOnce);
-            assert(mockOwnerUser.get.calledWith('email'));
-            assert(mockMembersService.processImport.calledWith(sinon.match({
+            sinon.assert.calledOnce(models.User.getOwnerUser);
+            sinon.assert.calledWith(mockOwnerUser.get, 'email');
+            sinon.assert.calledWith(mockMembersService.processImport, sinon.match({
                 user: {email: 'owner@example.com'}
-            })));
+            }));
         });
     });
 });

--- a/ghost/core/test/unit/frontend/apps/private-blogging/middleware.test.js
+++ b/ghost/core/test/unit/frontend/apps/private-blogging/middleware.test.js
@@ -38,7 +38,7 @@ describe('Private Blogging', function () {
             settingsStub.withArgs('is_private').returns(false);
 
             privateBlogging.checkIsPrivate(req, res, next);
-            assert.equal(next.called, true);
+            sinon.assert.called(next);
             assert.equal(res.isPrivateBlog, false);
         });
 
@@ -46,7 +46,7 @@ describe('Private Blogging', function () {
             settingsStub.withArgs('is_private').returns(true);
 
             privateBlogging.checkIsPrivate(req, res, next);
-            assert.equal(next.called, true);
+            sinon.assert.called(next);
             assert.equal(res.isPrivateBlog, true);
         });
     });
@@ -59,7 +59,7 @@ describe('Private Blogging', function () {
 
         it('filterPrivateRoutes should call next', function () {
             privateBlogging.filterPrivateRoutes(req, res, next);
-            assert.equal(next.called, true);
+            sinon.assert.called(next);
         });
 
         it('redirectPrivateToHomeIfLoggedIn should redirect to home', function () {
@@ -68,13 +68,13 @@ describe('Private Blogging', function () {
                 isPrivateBlog: false
             };
             privateBlogging.redirectPrivateToHomeIfLoggedIn(req, res, next);
-            assert.equal(res.redirect.called, true);
-            assert.equal(res.redirect.calledWith(`${config.get('url')}/`), true);
+            sinon.assert.called(res.redirect);
+            sinon.assert.calledWith(res.redirect, `${config.get('url')}/`);
         });
 
         it('handle404 should still 404', function () {
             privateBlogging.handle404(new errors.NotFoundError(), req, res, next);
-            assert.equal(next.called, true);
+            sinon.assert.called(next);
             assert.equal((next.firstCall.args[0] instanceof errors.NotFoundError), true);
         });
     });
@@ -106,40 +106,40 @@ describe('Private Blogging', function () {
             it('authenticatePrivateSession should redirect', function () {
                 req.path = req.url = '/welcome/';
                 privateBlogging.authenticatePrivateSession(req, res, next);
-                assert.equal(next.called, false);
-                assert.equal(res.redirect.called, true);
-                assert.equal(res.redirect.calledWith('/private/?r=%2Fwelcome%2F'), true);
+                sinon.assert.notCalled(next);
+                sinon.assert.called(res.redirect);
+                sinon.assert.calledWith(res.redirect, '/private/?r=%2Fwelcome%2F');
             });
 
             it('handle404 should redirect', function () {
                 req.path = req.url = '/welcome/';
                 privateBlogging.handle404(new errors.NotFoundError(), req, res, next);
-                assert.equal(next.called, false);
-                assert.equal(res.redirect.called, true);
-                assert.equal(res.redirect.calledWith('/private/?r=%2Fwelcome%2F'), true);
+                sinon.assert.notCalled(next);
+                sinon.assert.called(res.redirect);
+                sinon.assert.calledWith(res.redirect, '/private/?r=%2Fwelcome%2F');
             });
 
             describe('Site privacy managed by filterPrivateRoutes', function () {
                 it('should call next for the /private/ route', function () {
                     req.path = req.url = '/private/';
                     privateBlogging.filterPrivateRoutes(req, res, next);
-                    assert.equal(next.called, true);
+                    sinon.assert.called(next);
                 });
 
                 it('should redirect to /private/ for private route with extra path', function () {
                     req.path = req.url = '/private/welcome/';
 
                     privateBlogging.filterPrivateRoutes(req, res, next);
-                    assert.equal(res.redirect.calledOnce, true);
-                    assert.equal(res.redirect.calledWith('/private/?r=%2Fprivate%2Fwelcome%2F'), true);
+                    sinon.assert.calledOnce(res.redirect);
+                    sinon.assert.calledWith(res.redirect, '/private/?r=%2Fprivate%2Fwelcome%2F');
                 });
 
                 it('should redirect to /private/ for sitemap', function () {
                     req.path = req.url = '/sitemap.xml';
 
                     privateBlogging.filterPrivateRoutes(req, res, next);
-                    assert.equal(res.redirect.calledOnce, true);
-                    assert.equal(res.redirect.calledWith('/private/?r=%2Fsitemap.xml'), true);
+                    sinon.assert.calledOnce(res.redirect);
+                    sinon.assert.calledWith(res.redirect, '/private/?r=%2Fsitemap.xml');
                 });
 
                 it('should redirect to /private/ for sitemap with params', function () {
@@ -147,40 +147,40 @@ describe('Private Blogging', function () {
                     req.path = '/sitemap.xml';
 
                     privateBlogging.filterPrivateRoutes(req, res, next);
-                    assert.equal(res.redirect.calledOnce, true);
-                    assert.equal(res.redirect.calledWith('/private/?r=%2Fsitemap.xml%3Fweird%3Dparam'), true);
+                    sinon.assert.calledOnce(res.redirect);
+                    sinon.assert.calledWith(res.redirect, '/private/?r=%2Fsitemap.xml%3Fweird%3Dparam');
                 });
 
                 it('should redirect to /private/ for /rss/', function () {
                     req.path = req.url = '/rss/';
 
                     privateBlogging.filterPrivateRoutes(req, res, next);
-                    assert.equal(res.redirect.calledOnce, true);
-                    assert.equal(res.redirect.calledWith('/private/?r=%2Frss%2F'), true);
+                    sinon.assert.calledOnce(res.redirect);
+                    sinon.assert.calledWith(res.redirect, '/private/?r=%2Frss%2F');
                 });
 
                 it('should redirect to /private/ for author rss', function () {
                     req.path = req.url = '/author/halfdan/rss/';
 
                     privateBlogging.filterPrivateRoutes(req, res, next);
-                    assert.equal(res.redirect.calledOnce, true);
-                    assert.equal(res.redirect.calledWith('/private/?r=%2Fauthor%2Fhalfdan%2Frss%2F'), true);
+                    sinon.assert.calledOnce(res.redirect);
+                    sinon.assert.calledWith(res.redirect, '/private/?r=%2Fauthor%2Fhalfdan%2Frss%2F');
                 });
 
                 it('should redirect to /private/ for tag rss', function () {
                     req.path = req.url = '/tag/slimer/rss/';
 
                     privateBlogging.filterPrivateRoutes(req, res, next);
-                    assert.equal(res.redirect.calledOnce, true);
-                    assert.equal(res.redirect.calledWith('/private/?r=%2Ftag%2Fslimer%2Frss%2F'), true);
+                    sinon.assert.calledOnce(res.redirect);
+                    sinon.assert.calledWith(res.redirect, '/private/?r=%2Ftag%2Fslimer%2Frss%2F');
                 });
 
                 it('should redirect to /private/ for rss with extra path', function () {
                     req.path = req.url = '/rss/sometag';
 
                     privateBlogging.filterPrivateRoutes(req, res, next);
-                    assert.equal(res.redirect.calledOnce, true);
-                    assert.equal(res.redirect.calledWith('/private/?r=%2Frss%2Fsometag'), true);
+                    sinon.assert.calledOnce(res.redirect);
+                    sinon.assert.calledWith(res.redirect, '/private/?r=%2Frss%2Fsometag');
                 });
 
                 it('should render custom robots.txt', function () {
@@ -193,8 +193,8 @@ describe('Private Blogging', function () {
                         cb(null, 'User-agent: * Disallow: /');
                     });
                     privateBlogging.filterPrivateRoutes(req, res, next);
-                    assert.equal(res.writeHead.called, true);
-                    assert.equal(res.end.called, true);
+                    sinon.assert.called(res.writeHead);
+                    sinon.assert.called(res.end);
                 });
 
                 it('should allow private /rss/ feed', function () {
@@ -202,7 +202,7 @@ describe('Private Blogging', function () {
                     req.params = {};
 
                     privateBlogging.filterPrivateRoutes(req, res, next);
-                    assert.equal(next.called, true);
+                    sinon.assert.called(next);
                     assert.equal(req.url, '/rss/');
                 });
 
@@ -211,7 +211,7 @@ describe('Private Blogging', function () {
                     req.params = {};
 
                     privateBlogging.filterPrivateRoutes(req, res, next);
-                    assert.equal(next.called, true);
+                    sinon.assert.called(next);
                     assert.equal(req.url, '/tag/getting-started/rss/');
                 });
 
@@ -219,15 +219,15 @@ describe('Private Blogging', function () {
                     req.url = req.originalUrl = req.path = '/777aaa/rss/hackme/';
 
                     privateBlogging.filterPrivateRoutes(req, res, next);
-                    assert.equal(res.redirect.calledOnce, true);
-                    assert.equal(res.redirect.calledWith('/private/?r=%2F777aaa%2Frss%2Fhackme%2F'), true);
+                    sinon.assert.calledOnce(res.redirect);
+                    sinon.assert.calledWith(res.redirect, '/private/?r=%2F777aaa%2Frss%2Fhackme%2F');
                 });
             });
 
             describe('/private/ route', function () {
                 it('redirectPrivateToHomeIfLoggedIn should allow /private/ to be rendered', function () {
                     privateBlogging.redirectPrivateToHomeIfLoggedIn(req, res, next);
-                    assert.equal(next.called, true);
+                    sinon.assert.called(next);
                 });
             });
         });
@@ -236,7 +236,7 @@ describe('Private Blogging', function () {
             it('doLoginToPrivateSite should call next if error', function () {
                 res.error = 'Test Error';
                 privateBlogging.doLoginToPrivateSite(req, res, next);
-                assert.equal(next.called, true);
+                sinon.assert.called(next);
             });
 
             it('doLoginToPrivateSite should return next if password is incorrect', function () {
@@ -244,7 +244,7 @@ describe('Private Blogging', function () {
 
                 privateBlogging.doLoginToPrivateSite(req, res, next);
                 assertExists(res.error);
-                assert.equal(next.called, true);
+                sinon.assert.called(next);
             });
 
             it('doLoginToPrivateSite should redirect if password is correct', function () {
@@ -253,7 +253,7 @@ describe('Private Blogging', function () {
                 res.redirect = sinon.spy();
 
                 privateBlogging.doLoginToPrivateSite(req, res, next);
-                assert.equal(res.redirect.called, true);
+                sinon.assert.called(res.redirect);
             });
 
             it('doLoginToPrivateSite should redirect to "/" if r param is a full url', function () {
@@ -265,7 +265,7 @@ describe('Private Blogging', function () {
                 res.redirect = sinon.spy();
 
                 privateBlogging.doLoginToPrivateSite(req, res, next);
-                assert.equal(res.redirect.called, true);
+                sinon.assert.called(res.redirect);
                 assert.equal(res.redirect.args[0][0], '/');
             });
 
@@ -278,7 +278,7 @@ describe('Private Blogging', function () {
                 res.redirect = sinon.spy();
 
                 privateBlogging.doLoginToPrivateSite(req, res, next);
-                assert.equal(res.redirect.called, true);
+                sinon.assert.called(res.redirect);
                 assert.equal(res.redirect.args[0][0], '/test');
             });
 
@@ -291,7 +291,7 @@ describe('Private Blogging', function () {
                 res.redirect = sinon.spy();
 
                 privateBlogging.doLoginToPrivateSite(req, res, next);
-                assert.equal(res.redirect.called, true);
+                sinon.assert.called(res.redirect);
                 assert.equal(res.redirect.args[0][0], '/?utm_source=twitter&utm_campaign=test');
             });
 
@@ -304,7 +304,7 @@ describe('Private Blogging', function () {
                 res.redirect = sinon.spy();
 
                 privateBlogging.doLoginToPrivateSite(req, res, next);
-                assert.equal(res.redirect.called, true);
+                sinon.assert.called(res.redirect);
                 assert.equal(res.redirect.args[0][0], '/welcome/?ref=newsletter&utm_medium=email');
             });
 
@@ -317,7 +317,7 @@ describe('Private Blogging', function () {
                 res.redirect = sinon.spy();
 
                 privateBlogging.doLoginToPrivateSite(req, res, next);
-                assert.equal(res.redirect.called, true);
+                sinon.assert.called(res.redirect);
                 assert.equal(res.redirect.args[0][0], '/');
             });
 
@@ -330,15 +330,15 @@ describe('Private Blogging', function () {
                 });
                 it('redirectPrivateToHomeIfLoggedIn should return next', function () {
                     privateBlogging.redirectPrivateToHomeIfLoggedIn(req, res, next);
-                    assert.equal(next.called, true);
+                    sinon.assert.called(next);
                 });
 
                 it('authenticatePrivateSession should redirect', function () {
                     req.url = '/welcome';
 
                     privateBlogging.authenticatePrivateSession(req, res, next);
-                    assert.equal(res.redirect.called, true);
-                    assert.equal(res.redirect.calledWith('/private/?r=%2Fwelcome'), true);
+                    sinon.assert.called(res.redirect);
+                    sinon.assert.calledWith(res.redirect, '/private/?r=%2Fwelcome');
                 });
             });
         });
@@ -355,12 +355,12 @@ describe('Private Blogging', function () {
 
             it('authenticatePrivateSession should return next', function () {
                 privateBlogging.authenticatePrivateSession(req, res, next);
-                assert.equal(next.called, true);
+                sinon.assert.called(next);
             });
 
             it('handle404 should still 404', function () {
                 privateBlogging.handle404(new errors.NotFoundError(), req, res, next);
-                assert.equal(next.called, true);
+                sinon.assert.called(next);
                 assert.equal((next.firstCall.args[0] instanceof errors.NotFoundError), true);
             });
 
@@ -369,7 +369,7 @@ describe('Private Blogging', function () {
                     req.url = req.path = '/rss/';
 
                     privateBlogging.filterPrivateRoutes(req, res, next);
-                    assert.equal(next.called, true);
+                    sinon.assert.called(next);
                     assert.equal((next.firstCall.args[0] instanceof errors.NotFoundError), true);
                 });
 
@@ -377,7 +377,7 @@ describe('Private Blogging', function () {
                     req.url = req.path = '/tag/welcome/rss/';
 
                     privateBlogging.filterPrivateRoutes(req, res, next);
-                    assert.equal(next.called, true);
+                    sinon.assert.called(next);
                     assert.equal((next.firstCall.args[0] instanceof errors.NotFoundError), true);
                 });
 
@@ -385,7 +385,7 @@ describe('Private Blogging', function () {
                     req.url = req.path = '/tag/rss-test/';
 
                     privateBlogging.filterPrivateRoutes(req, res, next);
-                    assert.equal(next.called, true);
+                    sinon.assert.called(next);
                     assert.equal(next.firstCall.args.length, 0);
                 });
 
@@ -393,7 +393,7 @@ describe('Private Blogging', function () {
                     req.url = req.path = '/ab/';
 
                     privateBlogging.filterPrivateRoutes(req, res, next);
-                    assert.equal(next.called, true);
+                    sinon.assert.called(next);
                     assert.equal(next.firstCall.args.length, 0);
                 });
 
@@ -402,7 +402,7 @@ describe('Private Blogging', function () {
                     req.params = {};
 
                     privateBlogging.filterPrivateRoutes(req, res, next);
-                    assert.equal(next.called, true);
+                    sinon.assert.called(next);
                     assert.equal(req.url, '/rss/');
                 });
 
@@ -411,7 +411,7 @@ describe('Private Blogging', function () {
                     req.params = {};
 
                     privateBlogging.filterPrivateRoutes(req, res, next);
-                    assert.equal(next.called, true);
+                    sinon.assert.called(next);
                     assert.equal(req.url, '/tag/getting-started/rss/');
                 });
             });
@@ -419,7 +419,7 @@ describe('Private Blogging', function () {
             describe('/private/ route', function () {
                 it('redirectPrivateToHomeIfLoggedIn should redirect to home', function () {
                     privateBlogging.redirectPrivateToHomeIfLoggedIn(req, res, next);
-                    assert.equal(res.redirect.called, true);
+                    sinon.assert.called(res.redirect);
                 });
             });
         });

--- a/ghost/core/test/unit/frontend/helpers/content-api-url.test.js
+++ b/ghost/core/test/unit/frontend/helpers/content-api-url.test.js
@@ -30,19 +30,19 @@ describe('{{content_api_url}} helper', function () {
             let result = content_api_url();
             const rendered = String(result);
             assert.equal(rendered, 'https://admin.tld:65535/ghost/api/content/');
-            assert.equal(logWarnStub.called, false);
+            sinon.assert.notCalled(logWarnStub);
         });
         it('should output an absolute url when passed true', async function () {
             let result = content_api_url(true);
             const rendered = String(result);
             assert.equal(rendered, 'https://admin.tld:65535/ghost/api/content/');
-            assert.equal(logWarnStub.called, false);
+            sinon.assert.notCalled(logWarnStub);
         });
         it('should output a relative url when passed false', async function () {
             let result = content_api_url(false);
             const rendered = String(result);
             assert.equal(rendered, '/ghost/api/content/');
-            assert.equal(logWarnStub.called, false);
+            sinon.assert.notCalled(logWarnStub);
         });
     });
     describe('with a sub-directory', function () {
@@ -58,19 +58,19 @@ describe('{{content_api_url}} helper', function () {
             let result = content_api_url();
             const rendered = String(result);
             assert.equal(rendered, 'https://admin.tld:65535/blog/ghost/api/content/');
-            assert.equal(logWarnStub.called, false);
+            sinon.assert.notCalled(logWarnStub);
         });
         it('should output an absolute url when passed true', async function () {
             let result = content_api_url(true);
             const rendered = String(result);
             assert.equal(rendered, 'https://admin.tld:65535/blog/ghost/api/content/');
-            assert.equal(logWarnStub.called, false);
+            sinon.assert.notCalled(logWarnStub);
         });
         it('should output a relative url when passed false', async function () {
             let result = content_api_url(false);
             const rendered = String(result);
             assert.equal(rendered, '/blog/ghost/api/content/');
-            assert.equal(logWarnStub.called, false);
+            sinon.assert.notCalled(logWarnStub);
         });
     });
     describe('uses the site url if no admin:url is set', function () {
@@ -86,14 +86,14 @@ describe('{{content_api_url}} helper', function () {
             let result = content_api_url();
             const rendered = String(result);
             assert.equal(rendered, 'http://localhost:65535/ghost/api/content/');
-            assert.equal(logWarnStub.called, false);
+            sinon.assert.notCalled(logWarnStub);
         });
         it('gives the site url with a subdirectory', async function () {
             configUtils.set({url: 'http://localhost:65535/blog', 'admin:url': undefined});
             let result = content_api_url();
             const rendered = String(result);
             assert.equal(rendered, 'http://localhost:65535/blog/ghost/api/content/');
-            assert.equal(logWarnStub.called, false);
+            sinon.assert.notCalled(logWarnStub);
         });
     });
 });

--- a/ghost/core/test/unit/frontend/helpers/foreach.test.js
+++ b/ghost/core/test/unit/frontend/helpers/foreach.test.js
@@ -47,7 +47,7 @@ describe('{{#foreach}} helper', function () {
 
             runTest(_this, context, options);
 
-            assert.equal(options.fn.called, true);
+            sinon.assert.called(options.fn);
             sinon.assert.callCount(options.fn, _.size(context));
 
             _.each(context, function (value, index) {
@@ -72,7 +72,7 @@ describe('{{#foreach}} helper', function () {
 
             runTest(_this, context, options);
 
-            assert.equal(options.fn.called, true);
+            sinon.assert.called(options.fn);
             sinon.assert.callCount(options.fn, _.size(context));
 
             _.each(_.keys(context), function (value, index) {
@@ -98,7 +98,7 @@ describe('{{#foreach}} helper', function () {
 
             runTest(_this, context, options);
 
-            assert.equal(options.fn.called, true);
+            sinon.assert.called(options.fn);
             sinon.assert.callCount(options.fn, _.size(context));
 
             _.each(context, function (value, index) {
@@ -140,7 +140,7 @@ describe('{{#foreach}} helper', function () {
 
             runTest(_this, context, options);
 
-            assert.equal(options.fn.called, true);
+            sinon.assert.called(options.fn);
             sinon.assert.callCount(options.fn, _.size(context));
 
             _.each(_.keys(context), function (value, index) {
@@ -175,7 +175,7 @@ describe('{{#foreach}} helper', function () {
             context = 'hello world this is ghost'.split(' ');
             runTest(_this, context, options);
 
-            assert.equal(options.fn.called, true);
+            sinon.assert.called(options.fn);
             sinon.assert.callCount(options.fn, _.size(context));
 
             _.each(context, function (value, index) {
@@ -217,7 +217,7 @@ describe('{{#foreach}} helper', function () {
 
             runTest(_this, context, options);
 
-            assert.equal(options.fn.called, true);
+            sinon.assert.called(options.fn);
             sinon.assert.callCount(options.fn, _.size(context));
 
             _.each(_.keys(context), function (value, index) {
@@ -244,9 +244,9 @@ describe('{{#foreach}} helper', function () {
 
             runTest(_this, context, options);
 
-            assert.equal(options.fn.called, false);
-            assert.equal(options.inverse.called, true);
-            assert.equal(options.inverse.calledOnce, true);
+            sinon.assert.notCalled(options.fn);
+            sinon.assert.called(options.inverse);
+            sinon.assert.calledOnce(options.inverse);
         });
     });
 

--- a/ghost/core/test/unit/frontend/helpers/get.test.js
+++ b/ghost/core/test/unit/frontend/helpers/get.test.js
@@ -97,7 +97,7 @@ describe('{{#get}} helper', function () {
                 'posts',
                 {hash: {}, data: locals, fn: fn, inverse: inverse}
             ).then(function () {
-                assert.equal(fn.called, true);
+                sinon.assert.called(fn);
                 const args = fn.firstCall.args[0];
                 assert(args && typeof args === 'object');
                 assert('posts' in args);
@@ -128,12 +128,12 @@ describe('{{#get}} helper', function () {
                 'authors',
                 {hash: {}, data: locals, fn: fn, inverse: inverse}
             ).then(function () {
-                assert.equal(fn.called, true);
+                sinon.assert.called(fn);
                 const args = fn.firstCall.args[0];
                 assert(args && typeof args === 'object');
                 assert('authors' in args);
                 assert.deepEqual(fn.firstCall.args[0].authors, []);
-                assert.equal(inverse.called, false);
+                sinon.assert.notCalled(inverse);
 
                 done();
             }).catch(done);
@@ -159,12 +159,12 @@ describe('{{#get}} helper', function () {
                 'newsletters',
                 {hash: {}, data: locals, fn: fn, inverse: inverse}
             ).then(function () {
-                assert.equal(fn.called, true);
+                sinon.assert.called(fn);
                 const args = fn.firstCall.args[0];
                 assert(args && typeof args === 'object');
                 assert('newsletters' in args);
                 assert.deepEqual(fn.firstCall.args[0].newsletters, []);
-                assert.equal(inverse.called, false);
+                sinon.assert.notCalled(inverse);
 
                 done();
             }).catch(done);
@@ -178,8 +178,8 @@ describe('{{#get}} helper', function () {
                 'magic',
                 {hash: {}, data: locals, fn: fn, inverse: inverse}
             ).then(function () {
-                assert.equal(fn.called, false);
-                assert.equal(inverse.calledOnce, true);
+                sinon.assert.notCalled(fn);
+                sinon.assert.calledOnce(inverse);
                 const args = inverse.firstCall.args[1];
                 assert(args && typeof args === 'object');
                 assert('data' in args);
@@ -198,8 +198,8 @@ describe('{{#get}} helper', function () {
                 'posts',
                 {hash: {slug: 'thing!'}, data: locals, fn: fn, inverse: inverse}
             ).then(function () {
-                assert.equal(fn.called, false);
-                assert.equal(inverse.calledOnce, true);
+                sinon.assert.notCalled(fn);
+                sinon.assert.calledOnce(inverse);
                 const args = inverse.firstCall.args[1];
                 assert(args && typeof args === 'object');
                 assert('data' in args);
@@ -218,8 +218,8 @@ describe('{{#get}} helper', function () {
                 'posts',
                 {data: locals}
             ).then(function () {
-                assert.equal(fn.called, false);
-                assert.equal(inverse.called, false);
+                sinon.assert.notCalled(fn);
+                sinon.assert.notCalled(inverse);
 
                 done();
             }).catch(done);
@@ -584,9 +584,9 @@ describe('{{#get}} helper', function () {
             );
 
             // A log message will be output
-            assert.equal(logging.warn.calledOnce, true);
+            sinon.assert.calledOnce(logging.warn);
             // The get helper will return as per usual
-            assert.equal(fn.calledOnce, true);
+            sinon.assert.calledOnce(fn);
             const args = fn.firstCall.args[0];
             assert(args && typeof args === 'object');
             assert('posts' in args);
@@ -605,9 +605,9 @@ describe('{{#get}} helper', function () {
 
             assert(result.toString().includes('data-aborted-get-helper'));
             // A log message will be output
-            assert.equal(logging.error.calledOnce, true);
+            sinon.assert.calledOnce(logging.error);
             // The get helper gets called with an empty array of results
-            assert.equal(fn.calledOnce, true);
+            sinon.assert.calledOnce(fn);
             const args = fn.firstCall.args[0];
             assert(args && typeof args === 'object');
             assert('posts' in args);
@@ -651,7 +651,7 @@ describe('{{#get}} helper', function () {
             );
 
             // Should make two API calls since deduplication is disabled
-            assert.equal(browseStub.callCount, 2);
+            sinon.assert.calledTwice(browseStub);
         });
 
         it('should deduplicate identical queries when enabled', async function () {
@@ -673,9 +673,9 @@ describe('{{#get}} helper', function () {
             );
 
             // Should only make one API call
-            assert.equal(browseStub.callCount, 1);
+            sinon.assert.calledOnce(browseStub);
             // But both calls should have rendered
-            assert.equal(fn.callCount, 2);
+            sinon.assert.calledTwice(fn);
         });
 
         it('should make separate API calls for different queries when enabled', async function () {
@@ -697,7 +697,7 @@ describe('{{#get}} helper', function () {
             );
 
             // Should make two API calls for different queries
-            assert.equal(browseStub.callCount, 2);
+            sinon.assert.calledTwice(browseStub);
         });
 
         it('should include member uuid in cache key', async function () {
@@ -720,7 +720,7 @@ describe('{{#get}} helper', function () {
             );
 
             // Should make two API calls because member context is different
-            assert.equal(browseStub.callCount, 2);
+            sinon.assert.calledTwice(browseStub);
         });
 
         it('should not cache failed API requests', async function () {
@@ -746,7 +746,7 @@ describe('{{#get}} helper', function () {
             );
 
             // Should make two API calls because first one failed
-            assert.equal(browseStub.callCount, 2);
+            sinon.assert.calledTwice(browseStub);
         });
 
         it('should work without _queryCache in data', async function () {
@@ -761,8 +761,8 @@ describe('{{#get}} helper', function () {
                 {hash: {filter: 'featured:true'}, data: locals, fn: fn, inverse: inverse}
             );
 
-            assert.equal(browseStub.callCount, 1);
-            assert.equal(fn.callCount, 1);
+            sinon.assert.calledOnce(browseStub);
+            sinon.assert.calledOnce(fn);
         });
 
         it('should deduplicate queries with same parameters in different order', async function () {
@@ -784,7 +784,7 @@ describe('{{#get}} helper', function () {
             );
 
             // Should only make one API call
-            assert.equal(browseStub.callCount, 1);
+            sinon.assert.calledOnce(browseStub);
         });
 
         it('should handle concurrent identical requests', async function () {
@@ -810,7 +810,7 @@ describe('{{#get}} helper', function () {
             );
 
             // Verify deduplication while both calls are in-flight.
-            assert.equal(browseStub.callCount, 1);
+            sinon.assert.calledOnce(browseStub);
             assert.equal(typeof resolveBrowse, 'function');
 
             if (!resolveBrowse) {
@@ -820,9 +820,9 @@ describe('{{#get}} helper', function () {
             await Promise.all([firstCall, secondCall]);
 
             // Should only make one API call even for concurrent requests
-            assert.equal(browseStub.callCount, 1);
+            sinon.assert.calledOnce(browseStub);
             // Both should have rendered
-            assert.equal(fn.callCount, 2);
+            sinon.assert.calledTwice(fn);
         });
 
         it('should not reuse the same response object instance across renders', async function () {
@@ -841,7 +841,7 @@ describe('{{#get}} helper', function () {
                 {hash: {filter: 'featured:true'}, data: locals, fn: fn, inverse: inverse}
             );
 
-            assert.equal(browseStub.callCount, 1);
+            sinon.assert.calledOnce(browseStub);
             assert.notEqual(fn.firstCall.args[0], fn.secondCall.args[0]);
         });
     });

--- a/ghost/core/test/unit/frontend/helpers/has.test.js
+++ b/ghost/core/test/unit/frontend/helpers/has.test.js
@@ -1,4 +1,3 @@
-const assert = require('node:assert/strict');
 const sinon = require('sinon');
 
 // Stuff we are testing
@@ -42,8 +41,8 @@ describe('{{#has}} helper', function () {
             // {{#has tag="invalid, bar, wat"}}
             callHasHelper(thisCtx, {tag: 'invalid, bar, wat'});
 
-            assert.equal(fn.called, true);
-            assert.equal(inverse.called, false);
+            sinon.assert.called(fn);
+            sinon.assert.notCalled(inverse);
         });
 
         it('should handle tags with case-insensitivity', function () {
@@ -52,8 +51,8 @@ describe('{{#has}} helper', function () {
             // {{#has tag="GhoSt"}}
             callHasHelper(thisCtx, {tag: 'GhoSt'});
 
-            assert.equal(fn.called, true);
-            assert.equal(inverse.called, false);
+            sinon.assert.called(fn);
+            sinon.assert.notCalled(inverse);
         });
 
         it('should match exact tags, not superstrings', function () {
@@ -61,8 +60,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {tag: 'magic'});
 
-            assert.equal(fn.called, false);
-            assert.equal(inverse.called, true);
+            sinon.assert.notCalled(fn);
+            sinon.assert.called(inverse);
         });
 
         it('should match exact tags, not substrings', function () {
@@ -70,8 +69,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {tag: 'magical'});
 
-            assert.equal(fn.called, false);
-            assert.equal(inverse.called, true);
+            sinon.assert.notCalled(fn);
+            sinon.assert.called(inverse);
         });
 
         it('should handle tag list that validates false', function () {
@@ -79,8 +78,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {tag: 'much, such, wow'});
 
-            assert.equal(fn.called, false);
-            assert.equal(inverse.called, true);
+            sinon.assert.notCalled(fn);
+            sinon.assert.called(inverse);
         });
 
         it('should not do anything if there are no attributes', function () {
@@ -88,8 +87,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx);
 
-            assert.equal(fn.called, false);
-            assert.equal(inverse.called, false);
+            sinon.assert.notCalled(fn);
+            sinon.assert.notCalled(inverse);
         });
 
         it('should not do anything when an invalid attribute is given', function () {
@@ -97,8 +96,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {invalid: 'nonsense'});
 
-            assert.equal(fn.called, false);
-            assert.equal(inverse.called, false);
+            sinon.assert.notCalled(fn);
+            sinon.assert.notCalled(inverse);
         });
 
         it('count:0', function () {
@@ -106,8 +105,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {tag: 'count:0'});
 
-            assert.equal(fn.called, false);
-            assert.equal(inverse.called, true);
+            sinon.assert.notCalled(fn);
+            sinon.assert.called(inverse);
         });
 
         it('count:3', function () {
@@ -115,8 +114,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {tag: 'count:3'});
 
-            assert.equal(fn.called, true);
-            assert.equal(inverse.called, false);
+            sinon.assert.called(fn);
+            sinon.assert.notCalled(inverse);
         });
 
         it('count:11', function () {
@@ -124,8 +123,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {tag: 'count:11'});
 
-            assert.equal(fn.called, false);
-            assert.equal(inverse.called, true);
+            sinon.assert.notCalled(fn);
+            sinon.assert.called(inverse);
         });
 
         it('count:>3', function () {
@@ -133,8 +132,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {tag: 'count:>3'});
 
-            assert.equal(fn.called, false);
-            assert.equal(inverse.called, true);
+            sinon.assert.notCalled(fn);
+            sinon.assert.called(inverse);
         });
 
         it('count:>2', function () {
@@ -142,8 +141,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {tag: 'count:>2'});
 
-            assert.equal(fn.called, true);
-            assert.equal(inverse.called, false);
+            sinon.assert.called(fn);
+            sinon.assert.notCalled(inverse);
         });
 
         it('count:<1', function () {
@@ -151,8 +150,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {tag: 'count:<1'});
 
-            assert.equal(fn.called, false);
-            assert.equal(inverse.called, true);
+            sinon.assert.notCalled(fn);
+            sinon.assert.called(inverse);
         });
 
         it('count:<3', function () {
@@ -160,8 +159,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {tag: 'count:<3'});
 
-            assert.equal(fn.called, true);
-            assert.equal(inverse.called, false);
+            sinon.assert.called(fn);
+            sinon.assert.notCalled(inverse);
         });
     });
 
@@ -171,8 +170,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {author: 'joe, sam, pat'});
 
-            assert.equal(fn.called, true);
-            assert.equal(inverse.called, false);
+            sinon.assert.called(fn);
+            sinon.assert.notCalled(inverse);
         });
 
         it('should handle author list that evaluates to false', function () {
@@ -180,8 +179,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {author: 'joe, sam, pat'});
 
-            assert.equal(fn.called, false);
-            assert.equal(inverse.called, true);
+            sinon.assert.notCalled(fn);
+            sinon.assert.called(inverse);
         });
 
         it('should handle authors with case-insensitivity', function () {
@@ -189,8 +188,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {author: 'joe, sAm, pat'});
 
-            assert.equal(fn.called, true);
-            assert.equal(inverse.called, false);
+            sinon.assert.called(fn);
+            sinon.assert.notCalled(inverse);
         });
 
         it('should handle tags and authors like an OR query (pass)', function () {
@@ -198,8 +197,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {author: 'joe, sam, pat', tag: 'much, such, wow'});
 
-            assert.equal(fn.called, true);
-            assert.equal(inverse.called, false);
+            sinon.assert.called(fn);
+            sinon.assert.notCalled(inverse);
         });
 
         it('should handle tags and authors like an OR query when match both author and tag (pass)', function () {
@@ -207,8 +206,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {author: 'joe, sam, pat', tag: 'much, such, wow'});
 
-            assert.equal(fn.called, true);
-            assert.equal(inverse.called, false);
+            sinon.assert.called(fn);
+            sinon.assert.notCalled(inverse);
         });
 
         it('should handle tags and authors like an OR query (fail)', function () {
@@ -216,8 +215,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {author: 'joe, sam, pat', tag: 'much, such, wow'});
 
-            assert.equal(fn.called, false);
-            assert.equal(inverse.called, true);
+            sinon.assert.notCalled(fn);
+            sinon.assert.called(inverse);
         });
 
         it('count:0', function () {
@@ -225,8 +224,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {author: 'count:0'});
 
-            assert.equal(fn.called, false);
-            assert.equal(inverse.called, true);
+            sinon.assert.notCalled(fn);
+            sinon.assert.called(inverse);
         });
 
         it('count:1', function () {
@@ -234,8 +233,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {author: 'count:1'});
 
-            assert.equal(fn.called, true);
-            assert.equal(inverse.called, false);
+            sinon.assert.called(fn);
+            sinon.assert.notCalled(inverse);
         });
 
         it('count:>1 (fail)', function () {
@@ -243,8 +242,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {author: 'count:>1'});
 
-            assert.equal(fn.called, false);
-            assert.equal(inverse.called, true);
+            sinon.assert.notCalled(fn);
+            sinon.assert.called(inverse);
         });
 
         it('count:>1 (pass)', function () {
@@ -252,8 +251,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {author: 'count:>1'});
 
-            assert.equal(fn.called, true);
-            assert.equal(inverse.called, false);
+            sinon.assert.called(fn);
+            sinon.assert.notCalled(inverse);
         });
 
         it('count:>2', function () {
@@ -261,8 +260,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {author: 'count:>2'});
 
-            assert.equal(fn.called, false);
-            assert.equal(inverse.called, true);
+            sinon.assert.notCalled(fn);
+            sinon.assert.called(inverse);
         });
 
         it('count:<1', function () {
@@ -270,8 +269,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {author: 'count:<1'});
 
-            assert.equal(fn.called, false);
-            assert.equal(inverse.called, true);
+            sinon.assert.notCalled(fn);
+            sinon.assert.called(inverse);
         });
 
         it('count:<3', function () {
@@ -279,8 +278,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {author: 'count:<3'});
 
-            assert.equal(fn.called, true);
-            assert.equal(inverse.called, false);
+            sinon.assert.called(fn);
+            sinon.assert.notCalled(inverse);
         });
     });
 
@@ -290,8 +289,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {number: '6'});
 
-            assert.equal(fn.called, true);
-            assert.equal(inverse.called, false);
+            sinon.assert.called(fn);
+            sinon.assert.notCalled(inverse);
         });
 
         it('will match on an exact number (fail)', function () {
@@ -299,8 +298,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {number: '6'});
 
-            assert.equal(fn.called, false);
-            assert.equal(inverse.called, true);
+            sinon.assert.notCalled(fn);
+            sinon.assert.called(inverse);
         });
 
         it('will match on an exact number (loop)', function () {
@@ -310,9 +309,9 @@ describe('{{#has}} helper', function () {
                 callHasHelper(thisCtx, {number: '6'});
             }
 
-            assert.equal(fn.calledOnce, true);
-            assert.equal(inverse.called, true);
-            assert.equal(inverse.callCount, 7);
+            sinon.assert.calledOnce(fn);
+            sinon.assert.called(inverse);
+            sinon.assert.callCount(inverse, 7);
         });
 
         it('will match on a number list (pass)', function () {
@@ -320,8 +319,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {number: '1, 3, 6,12'});
 
-            assert.equal(fn.called, true);
-            assert.equal(inverse.called, false);
+            sinon.assert.called(fn);
+            sinon.assert.notCalled(inverse);
         });
 
         it('will match on a number list (fail)', function () {
@@ -329,8 +328,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {number: '1, 3, 6,12'});
 
-            assert.equal(fn.called, false);
-            assert.equal(inverse.called, true);
+            sinon.assert.notCalled(fn);
+            sinon.assert.called(inverse);
         });
 
         it('will match on a number list (loop)', function () {
@@ -340,10 +339,10 @@ describe('{{#has}} helper', function () {
                 callHasHelper(thisCtx, {number: '1, 3, 6,12'});
             }
 
-            assert.equal(fn.called, true);
-            assert.equal(fn.callCount, 3);
-            assert.equal(inverse.called, true);
-            assert.equal(inverse.callCount, 5);
+            sinon.assert.called(fn);
+            sinon.assert.calledThrice(fn);
+            sinon.assert.called(inverse);
+            sinon.assert.callCount(inverse, 5);
         });
 
         it('will match on a nth pattern (pass)', function () {
@@ -351,8 +350,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {number: 'nth:3'});
 
-            assert.equal(fn.called, true);
-            assert.equal(inverse.called, false);
+            sinon.assert.called(fn);
+            sinon.assert.notCalled(inverse);
         });
 
         it('will match on a nth pattern (fail)', function () {
@@ -360,8 +359,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {number: 'nth:3'});
 
-            assert.equal(fn.called, false);
-            assert.equal(inverse.called, true);
+            sinon.assert.notCalled(fn);
+            sinon.assert.called(inverse);
         });
 
         it('will match on a nth pattern (loop)', function () {
@@ -371,10 +370,10 @@ describe('{{#has}} helper', function () {
                 callHasHelper(thisCtx, {number: 'nth:3'});
             }
 
-            assert.equal(fn.called, true);
-            assert.equal(fn.callCount, 2);
-            assert.equal(inverse.called, true);
-            assert.equal(inverse.callCount, 6);
+            sinon.assert.called(fn);
+            sinon.assert.calledTwice(fn);
+            sinon.assert.called(inverse);
+            sinon.assert.callCount(inverse, 6);
         });
 
         it('fails gracefully if there is no number property', function () {
@@ -382,8 +381,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {number: 'nth:3'});
 
-            assert.equal(fn.called, false);
-            assert.equal(inverse.called, true);
+            sinon.assert.notCalled(fn);
+            sinon.assert.called(inverse);
         });
 
         it('fails gracefully if there is no data property', function () {
@@ -391,8 +390,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {number: 'nth:3'});
 
-            assert.equal(fn.called, false);
-            assert.equal(inverse.called, true);
+            sinon.assert.notCalled(fn);
+            sinon.assert.called(inverse);
         });
     });
 
@@ -402,8 +401,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {index: '6'});
 
-            assert.equal(fn.called, true);
-            assert.equal(inverse.called, false);
+            sinon.assert.called(fn);
+            sinon.assert.notCalled(inverse);
         });
 
         it('will match on an exact index (fail)', function () {
@@ -411,8 +410,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {index: '6'});
 
-            assert.equal(fn.called, false);
-            assert.equal(inverse.called, true);
+            sinon.assert.notCalled(fn);
+            sinon.assert.called(inverse);
         });
 
         it('will match on an exact index (loop)', function () {
@@ -422,9 +421,9 @@ describe('{{#has}} helper', function () {
                 callHasHelper(thisCtx, {index: '6'});
             }
 
-            assert.equal(fn.calledOnce, true);
-            assert.equal(inverse.called, true);
-            assert.equal(inverse.callCount, 7);
+            sinon.assert.calledOnce(fn);
+            sinon.assert.called(inverse);
+            sinon.assert.callCount(inverse, 7);
         });
 
         it('will match on an index list (pass)', function () {
@@ -432,8 +431,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {index: '1, 3, 6,12'});
 
-            assert.equal(fn.called, true);
-            assert.equal(inverse.called, false);
+            sinon.assert.called(fn);
+            sinon.assert.notCalled(inverse);
         });
 
         it('will match on an index list (fail)', function () {
@@ -441,8 +440,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {index: '1, 3, 6,12'});
 
-            assert.equal(fn.called, false);
-            assert.equal(inverse.called, true);
+            sinon.assert.notCalled(fn);
+            sinon.assert.called(inverse);
         });
 
         it('will match on an index list (loop)', function () {
@@ -452,10 +451,10 @@ describe('{{#has}} helper', function () {
                 callHasHelper(thisCtx, {index: '1, 3, 6,12'});
             }
 
-            assert.equal(fn.called, true);
-            assert.equal(fn.callCount, 3);
-            assert.equal(inverse.called, true);
-            assert.equal(inverse.callCount, 5);
+            sinon.assert.called(fn);
+            sinon.assert.calledThrice(fn);
+            sinon.assert.called(inverse);
+            sinon.assert.callCount(inverse, 5);
         });
 
         it('will match on a nth pattern (pass)', function () {
@@ -463,8 +462,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {index: 'nth:3'});
 
-            assert.equal(fn.called, true);
-            assert.equal(inverse.called, false);
+            sinon.assert.called(fn);
+            sinon.assert.notCalled(inverse);
         });
 
         it('will match on a nth pattern (fail)', function () {
@@ -472,8 +471,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {index: 'nth:3'});
 
-            assert.equal(fn.called, false);
-            assert.equal(inverse.called, true);
+            sinon.assert.notCalled(fn);
+            sinon.assert.called(inverse);
         });
 
         it('will match on a nth pattern (loop)', function () {
@@ -483,10 +482,10 @@ describe('{{#has}} helper', function () {
                 callHasHelper(thisCtx, {index: 'nth:3'});
             }
 
-            assert.equal(fn.called, true);
-            assert.equal(fn.callCount, 3);
-            assert.equal(inverse.called, true);
-            assert.equal(inverse.callCount, 5);
+            sinon.assert.called(fn);
+            sinon.assert.calledThrice(fn);
+            sinon.assert.called(inverse);
+            sinon.assert.callCount(inverse, 5);
         });
 
         it('fails gracefully if there is no index property', function () {
@@ -494,8 +493,8 @@ describe('{{#has}} helper', function () {
 
             callHasHelper(thisCtx, {index: 'nth:3'});
 
-            assert.equal(fn.called, false);
-            assert.equal(inverse.called, true);
+            sinon.assert.notCalled(fn);
+            sinon.assert.called(inverse);
         });
     });
 
@@ -506,8 +505,8 @@ describe('{{#has}} helper', function () {
             // {{#has slug="welcome"}}
             callHasHelper(thisCtx, {slug: 'welcome'});
 
-            assert.equal(fn.called, true);
-            assert.equal(inverse.called, false);
+            sinon.assert.called(fn);
+            sinon.assert.notCalled(inverse);
         });
 
         it('matches on an exact slug (fail)', function () {
@@ -516,8 +515,8 @@ describe('{{#has}} helper', function () {
             // {{#has slug="welcome-to-ghost"}}
             callHasHelper(thisCtx, {slug: 'welcome-to-ghost'});
 
-            assert.equal(fn.called, false);
-            assert.equal(inverse.called, true);
+            sinon.assert.notCalled(fn);
+            sinon.assert.called(inverse);
         });
 
         it('fails gracefully if there is no slug (fail)', function () {
@@ -526,8 +525,8 @@ describe('{{#has}} helper', function () {
             // {{#has slug="welcome-to-ghost"}}
             callHasHelper(thisCtx, {slug: 'welcome-to-ghost'});
 
-            assert.equal(fn.called, false);
-            assert.equal(inverse.called, true);
+            sinon.assert.notCalled(fn);
+            sinon.assert.called(inverse);
         });
     });
 
@@ -538,8 +537,8 @@ describe('{{#has}} helper', function () {
             // {{#has visibility="paid"}}
             callHasHelper(thisCtx, {visibility: 'paid'});
 
-            assert.equal(fn.called, true);
-            assert.equal(inverse.called, false);
+            sinon.assert.called(fn);
+            sinon.assert.notCalled(inverse);
         });
 
         it('matches on an exact visibility (fail)', function () {
@@ -548,8 +547,8 @@ describe('{{#has}} helper', function () {
             // {{#has visibility="members"}}
             callHasHelper(thisCtx, {visibility: 'members'});
 
-            assert.equal(fn.called, false);
-            assert.equal(inverse.called, true);
+            sinon.assert.notCalled(fn);
+            sinon.assert.called(inverse);
         });
 
         it('fails gracefully if there is no visibility (fail)', function () {
@@ -558,8 +557,8 @@ describe('{{#has}} helper', function () {
             // {{#has visibility="welcome-to-ghost"}}
             callHasHelper(thisCtx, {visibility: 'paid'});
 
-            assert.equal(fn.called, false);
-            assert.equal(inverse.called, true);
+            sinon.assert.notCalled(fn);
+            sinon.assert.called(inverse);
         });
     });
 
@@ -570,8 +569,8 @@ describe('{{#has}} helper', function () {
             // {{#has id="5981fbed98141579627e9a5a"}}
             callHasHelper(thisCtx, {id: '5981fbed98141579627e9a5a'});
 
-            assert.equal(fn.called, true);
-            assert.equal(inverse.called, false);
+            sinon.assert.called(fn);
+            sinon.assert.notCalled(inverse);
         });
 
         it('matches on an exact id (fail)', function () {
@@ -580,8 +579,8 @@ describe('{{#has}} helper', function () {
             // {{#has id="5981fbed98141579627e9a5a"}}
             callHasHelper(thisCtx, {id: '5981fbed98141579627e9abc'});
 
-            assert.equal(fn.called, false);
-            assert.equal(inverse.called, true);
+            sinon.assert.notCalled(fn);
+            sinon.assert.called(inverse);
         });
 
         it('fails gracefully if there is no id (fail)', function () {
@@ -590,8 +589,8 @@ describe('{{#has}} helper', function () {
             // {{#has id="5981fbed98141579627e9a5a"}}
             callHasHelper(thisCtx, {id: '5981fbed98141579627e9abc'});
 
-            assert.equal(fn.called, false);
-            assert.equal(inverse.called, true);
+            sinon.assert.notCalled(fn);
+            sinon.assert.called(inverse);
         });
     });
 
@@ -606,8 +605,8 @@ describe('{{#has}} helper', function () {
             // {{#has any="twitter"}}
             callHasHelper(thisCtx, {any: 'twitter'});
 
-            assert.equal(fn.called, true);
-            assert.equal(inverse.called, false);
+            sinon.assert.called(fn);
+            sinon.assert.notCalled(inverse);
         });
 
         it('matches on a single property (fail)', function () {
@@ -620,8 +619,8 @@ describe('{{#has}} helper', function () {
             // {{#has any="facebook"}}
             callHasHelper(thisCtx, {any: 'facebook'});
 
-            assert.equal(fn.called, false);
-            assert.equal(inverse.called, true);
+            sinon.assert.notCalled(fn);
+            sinon.assert.called(inverse);
         });
 
         it('matches on multiple properties (pass)', function () {
@@ -634,8 +633,8 @@ describe('{{#has}} helper', function () {
             // {{#has any="twitter, facebook,website"}}
             callHasHelper(thisCtx, {any: 'twitter, facebook,website'});
 
-            assert.equal(fn.called, true);
-            assert.equal(inverse.called, false);
+            sinon.assert.called(fn);
+            sinon.assert.notCalled(inverse);
         });
 
         it('matches on multiple properties (fail)', function () {
@@ -648,8 +647,8 @@ describe('{{#has}} helper', function () {
             // {{#has any="facebook,website, foo"}}
             callHasHelper(thisCtx, {any: 'facebook,website, foo'});
 
-            assert.equal(fn.called, false);
-            assert.equal(inverse.called, true);
+            sinon.assert.notCalled(fn);
+            sinon.assert.called(inverse);
         });
 
         it('matches on global properties (pass)', function () {
@@ -665,8 +664,8 @@ describe('{{#has}} helper', function () {
             // {{#has any="@site.twitter, @site.facebook,@site.website"}}
             callHasHelper(thisCtx, {any: '@site.twitter, @site.facebook,@site.website'});
 
-            assert.equal(fn.called, true);
-            assert.equal(inverse.called, false);
+            sinon.assert.called(fn);
+            sinon.assert.notCalled(inverse);
         });
 
         it('matches on global properties (fail)', function () {
@@ -682,8 +681,8 @@ describe('{{#has}} helper', function () {
             // {{#has any="@site.facebook,@site.website, @site.foo"}}
             callHasHelper(thisCtx, {any: '@site.facebook,@site.website, @not.foo'});
 
-            assert.equal(fn.called, false);
-            assert.equal(inverse.called, true);
+            sinon.assert.notCalled(fn);
+            sinon.assert.called(inverse);
         });
 
         it('matches on path expressions (pass)', function () {
@@ -698,8 +697,8 @@ describe('{{#has}} helper', function () {
             // {{#has any="author.twitter, author.facebook,author.website"}}
             callHasHelper(thisCtx, {any: 'author.twitter, author.facebook,author.website'});
 
-            assert.equal(fn.called, true);
-            assert.equal(inverse.called, false);
+            sinon.assert.called(fn);
+            sinon.assert.notCalled(inverse);
         });
 
         it('matches on path expressions (fail)', function () {
@@ -714,8 +713,8 @@ describe('{{#has}} helper', function () {
             // {{#has any="author.facebook,author.website, author.foo"}}
             callHasHelper(thisCtx, {any: 'author.facebook,author.website, fred.foo'});
 
-            assert.equal(fn.called, false);
-            assert.equal(inverse.called, true);
+            sinon.assert.notCalled(fn);
+            sinon.assert.called(inverse);
         });
     });
 
@@ -730,8 +729,8 @@ describe('{{#has}} helper', function () {
             // {{#has all="twitter"}}
             callHasHelper(thisCtx, {all: 'twitter'});
 
-            assert.equal(fn.called, true);
-            assert.equal(inverse.called, false);
+            sinon.assert.called(fn);
+            sinon.assert.notCalled(inverse);
         });
 
         it('matches on a single property (fail)', function () {
@@ -744,8 +743,8 @@ describe('{{#has}} helper', function () {
             // {{#has all="website"}}
             callHasHelper(thisCtx, {all: 'website'});
 
-            assert.equal(fn.called, false);
-            assert.equal(inverse.called, true);
+            sinon.assert.notCalled(fn);
+            sinon.assert.called(inverse);
         });
 
         it('matches on multiple properties (pass)', function () {
@@ -758,8 +757,8 @@ describe('{{#has}} helper', function () {
             // {{#has all="twitter, facebook"}}
             callHasHelper(thisCtx, {all: 'twitter, facebook'});
 
-            assert.equal(fn.called, true);
-            assert.equal(inverse.called, false);
+            sinon.assert.called(fn);
+            sinon.assert.notCalled(inverse);
         });
 
         it('matches on multiple properties (fail)', function () {
@@ -772,8 +771,8 @@ describe('{{#has}} helper', function () {
             // {{#has all="facebook,website, foo"}}
             callHasHelper(thisCtx, {all: 'facebook,website, foo'});
 
-            assert.equal(fn.called, false);
-            assert.equal(inverse.called, true);
+            sinon.assert.notCalled(fn);
+            sinon.assert.called(inverse);
         });
 
         it('matches on global properties (pass)', function () {
@@ -789,8 +788,8 @@ describe('{{#has}} helper', function () {
             // {{#has all="@site.twitter, @site.facebook"}}
             callHasHelper(thisCtx, {all: '@site.twitter, @site.facebook'});
 
-            assert.equal(fn.called, true);
-            assert.equal(inverse.called, false);
+            sinon.assert.called(fn);
+            sinon.assert.notCalled(inverse);
         });
 
         it('matches on global properties (fail)', function () {
@@ -806,8 +805,8 @@ describe('{{#has}} helper', function () {
             // {{#has all="@site.facebook,@site.website, @site.foo"}}
             callHasHelper(thisCtx, {all: '@site.facebook,@site.website, @not.foo'});
 
-            assert.equal(fn.called, false);
-            assert.equal(inverse.called, true);
+            sinon.assert.notCalled(fn);
+            sinon.assert.called(inverse);
         });
 
         it('matches on path expressions (pass)', function () {
@@ -822,8 +821,8 @@ describe('{{#has}} helper', function () {
             // {{#has all="author.twitter, author.facebook"}}
             callHasHelper(thisCtx, {all: 'author.twitter, author.facebook'});
 
-            assert.equal(fn.called, true);
-            assert.equal(inverse.called, false);
+            sinon.assert.called(fn);
+            sinon.assert.notCalled(inverse);
         });
 
         it('matches on path expressions (fail)', function () {
@@ -838,8 +837,8 @@ describe('{{#has}} helper', function () {
             // {{#has all="author.facebook,author.website, author.foo"}}
             callHasHelper(thisCtx, {all: 'author.facebook,author.website, fred.foo'});
 
-            assert.equal(fn.called, false);
-            assert.equal(inverse.called, true);
+            sinon.assert.notCalled(fn);
+            sinon.assert.called(inverse);
         });
     });
 });

--- a/ghost/core/test/unit/frontend/helpers/img-url.test.js
+++ b/ghost/core/test/unit/frontend/helpers/img-url.test.js
@@ -32,21 +32,21 @@ describe('{{img_url}} helper', function () {
             const rendered = img_url('/content/images/image-relative-url.png', {});
             assertExists(rendered);
             assert.equal(rendered, '/content/images/image-relative-url.png');
-            assert.equal(logWarnStub.called, false);
+            sinon.assert.notCalled(logWarnStub);
         });
 
         it('should output relative url of image if the input is absolute', function () {
             const rendered = img_url('http://localhost:65535/content/images/image-relative-url.png', {});
             assertExists(rendered);
             assert.equal(rendered, '/content/images/image-relative-url.png');
-            assert.equal(logWarnStub.called, false);
+            sinon.assert.notCalled(logWarnStub);
         });
 
         it('should output absolute url of image if the option is present ', function () {
             const rendered = img_url('/content/images/image-relative-url.png', {hash: {absolute: 'true'}});
             assertExists(rendered);
             assert.equal(rendered, 'http://localhost:65535/content/images/image-relative-url.png');
-            assert.equal(logWarnStub.called, false);
+            sinon.assert.notCalled(logWarnStub);
         });
 
         it('should NOT output absolute url of image if the option is "false" ', function () {
@@ -59,25 +59,25 @@ describe('{{img_url}} helper', function () {
             const rendered = img_url('/content/images/author-image-relative-url.png', {});
             assertExists(rendered);
             assert.equal(rendered, '/content/images/author-image-relative-url.png');
-            assert.equal(logWarnStub.called, false);
+            sinon.assert.notCalled(logWarnStub);
         });
 
         it('should have no output if the image attribute is not provided (with warning)', function () {
             const rendered = img_url({hash: {absolute: 'true'}});
             assert.equal(rendered, undefined);
-            assert.equal(logWarnStub.calledOnce, true);
+            sinon.assert.calledOnce(logWarnStub);
         });
 
         it('should have no output if the image attribute evaluates to undefined (with warning)', function () {
             const rendered = img_url(undefined, {hash: {absolute: 'true'}});
             assert.equal(rendered, undefined);
-            assert.equal(logWarnStub.calledOnce, true);
+            sinon.assert.calledOnce(logWarnStub);
         });
 
         it('should have no output if the image attribute evaluates to null (no waring)', function () {
             const rendered = img_url(null, {hash: {absolute: 'true'}});
             assert.equal(rendered, undefined);
-            assert.equal(logWarnStub.calledOnce, false);
+            sinon.assert.notCalled(logWarnStub);
         });
     });
 
@@ -249,7 +249,7 @@ describe('{{img_url}} helper', function () {
             const rendered = img_url('/content/images/author-image-relative-url.png', {hash: {size: 'invalid-size'}});
             assertExists(rendered);
             assert.equal(rendered, '/content/images/author-image-relative-url.png');
-            assert.equal(logWarnStub.called, false);
+            sinon.assert.notCalled(logWarnStub);
         });
 
         it('ignores misconfigured sizes', function () {
@@ -267,7 +267,7 @@ describe('{{img_url}} helper', function () {
             });
             assertExists(rendered);
             assert.equal(rendered, '/content/images/author-image-relative-url.png');
-            assert.equal(logWarnStub.called, false);
+            sinon.assert.notCalled(logWarnStub);
         });
 
         it('ignores format if size is missing', function () {
@@ -285,7 +285,7 @@ describe('{{img_url}} helper', function () {
             });
             assertExists(rendered);
             assert.equal(rendered, '/content/images/author-image-relative-url.png');
-            assert.equal(logWarnStub.called, false);
+            sinon.assert.notCalled(logWarnStub);
         });
 
         it('adds format and size options', function () {
@@ -304,7 +304,7 @@ describe('{{img_url}} helper', function () {
             });
             assertExists(rendered);
             assert.equal(rendered, '/content/images/size/w600/format/webp/author-image-relative-url.png');
-            assert.equal(logWarnStub.called, false);
+            sinon.assert.notCalled(logWarnStub);
         });
 
         it('ignores invalid formats', function () {
@@ -323,7 +323,7 @@ describe('{{img_url}} helper', function () {
             });
             assertExists(rendered);
             assert.equal(rendered, '/content/images/size/w600/author-image-relative-url.png');
-            assert.equal(logWarnStub.called, false);
+            sinon.assert.notCalled(logWarnStub);
         });
     });
 

--- a/ghost/core/test/unit/frontend/helpers/is.test.js
+++ b/ghost/core/test/unit/frontend/helpers/is.test.js
@@ -1,4 +1,3 @@
-const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const is = require('../../../../core/frontend/helpers/is');
 const logging = require('@tryghost/logging');
@@ -19,8 +18,8 @@ describe('{{#is}} helper', function () {
             {fn: fn, inverse: inverse, data: {root: {context: ['home', 'index']}}}
         );
 
-        assert.equal(fn.called, true);
-        assert.equal(inverse.called, false);
+        sinon.assert.called(fn);
+        sinon.assert.notCalled(inverse);
     });
 
     it('should match OR context "index, paged"', function () {
@@ -33,8 +32,8 @@ describe('{{#is}} helper', function () {
             {fn: fn, inverse: inverse, data: {root: {context: ['tag', 'paged']}}}
         );
 
-        assert.equal(fn.called, true);
-        assert.equal(inverse.called, false);
+        sinon.assert.called(fn);
+        sinon.assert.notCalled(inverse);
     });
 
     it('should not match "paged"', function () {
@@ -47,8 +46,8 @@ describe('{{#is}} helper', function () {
             {fn: fn, inverse: inverse, data: {root: {context: ['index', 'home']}}}
         );
 
-        assert.equal(fn.called, false);
-        assert.equal(inverse.called, true);
+        sinon.assert.notCalled(fn);
+        sinon.assert.called(inverse);
     });
 
     it('should log warning with no args', function () {
@@ -62,8 +61,8 @@ describe('{{#is}} helper', function () {
             {fn: fn, inverse: inverse, data: {root: {context: ['index', 'home']}}}
         );
 
-        assert.equal(logWarn.called, true);
-        assert.equal(fn.called, false);
-        assert.equal(inverse.called, false);
+        sinon.assert.called(logWarn);
+        sinon.assert.notCalled(fn);
+        sinon.assert.notCalled(inverse);
     });
 });

--- a/ghost/core/test/unit/frontend/helpers/prev-post.test.js
+++ b/ghost/core/test/unit/frontend/helpers/prev-post.test.js
@@ -1,4 +1,3 @@
-const assert = require('node:assert/strict');
 const errors = require('@tryghost/errors');
 const sinon = require('sinon');
 const markdownToMobiledoc = require('../../../utils/fixtures/data-generator').markdownToMobiledoc;
@@ -129,9 +128,9 @@ describe('{{prev_post}} helper', function () {
             await prev_post
                 .call({}, optionsData);
 
-            assert.equal(fn.called, false);
-            assert.equal(inverse.called, true);
-            assert.equal(browsePostsStub.called, false);
+            sinon.assert.notCalled(fn);
+            sinon.assert.called(inverse);
+            sinon.assert.notCalled(browsePostsStub);
         });
     });
 
@@ -168,8 +167,8 @@ describe('{{prev_post}} helper', function () {
                     page: true
                 }, optionsData);
 
-            assert.equal(fn.called, false);
-            assert.equal(inverse.called, true);
+            sinon.assert.notCalled(fn);
+            sinon.assert.called(inverse);
         });
     });
 
@@ -205,8 +204,8 @@ describe('{{prev_post}} helper', function () {
                     url: '/current/'
                 }, optionsData);
 
-            assert.equal(fn.called, false);
-            assert.equal(inverse.called, true);
+            sinon.assert.notCalled(fn);
+            sinon.assert.called(inverse);
         });
     });
 
@@ -456,8 +455,8 @@ describe('{{prev_post}} helper', function () {
                     optionsData
                 );
 
-            assert.equal(fn.called, false);
-            assert.equal(inverse.called, false);
+            sinon.assert.notCalled(fn);
+            sinon.assert.notCalled(inverse);
         });
     });
 

--- a/ghost/core/test/unit/frontend/helpers/price.test.js
+++ b/ghost/core/test/unit/frontend/helpers/price.test.js
@@ -25,21 +25,21 @@ describe('{{price}} helper', function () {
         const templateString = '{{price}}';
 
         shouldCompileToExpected(templateString, {}, '');
-        assert.equal(logWarnStub.calledOnce, true);
+        sinon.assert.calledOnce(logWarnStub);
     });
 
     it('throws an error for undefined parameter', function () {
         const templateString = '{{price @dont.exist}}';
 
         shouldCompileToExpected(templateString, {}, '');
-        assert.equal(logWarnStub.calledOnce, true);
+        sinon.assert.calledOnce(logWarnStub);
     });
 
     it('throws if argument is not a number', function () {
         const templateString = '{{price "not_a_number"}}';
 
         shouldCompileToExpected(templateString, {}, '');
-        assert.equal(logWarnStub.calledOnce, true);
+        sinon.assert.calledOnce(logWarnStub);
     });
 
     it('will format decimal adjusted amount', function () {

--- a/ghost/core/test/unit/frontend/helpers/recommendations.test.js
+++ b/ghost/core/test/unit/frontend/helpers/recommendations.test.js
@@ -171,7 +171,7 @@ describe('{{#recommendations}} helper', function () {
             );
 
             // An error message is logged
-            assert.equal(logging.error.calledOnce, true);
+            sinon.assert.calledOnce(logging.error);
 
             // No HTML is rendered
             assert(response !== null && typeof response === 'object');

--- a/ghost/core/test/unit/frontend/meta/canonical-url.test.js
+++ b/ghost/core/test/unit/frontend/meta/canonical-url.test.js
@@ -33,9 +33,9 @@ describe('getCanonicalUrl', function () {
 
         assert.equal(getCanonicalUrl(post), 'canonical url');
 
-        assert.equal(urlJoinStub.calledOnce, true);
-        assert.equal(urlForStub.calledOnce, true);
-        assert.equal(getUrlStub.calledOnce, true);
+        sinon.assert.calledOnce(urlJoinStub);
+        sinon.assert.calledOnce(urlForStub);
+        sinon.assert.calledOnce(getUrlStub);
     });
 
     it('should return canonical url field if present', function () {
@@ -46,7 +46,7 @@ describe('getCanonicalUrl', function () {
             post: post
         }), 'https://example.com/canonical');
 
-        assert.equal(getUrlStub.called, false);
+        sinon.assert.notCalled(getUrlStub);
     });
 
     it('should return home if empty secure data', function () {
@@ -55,8 +55,8 @@ describe('getCanonicalUrl', function () {
 
         assert.equal(getCanonicalUrl({secure: true}), 'canonical url');
 
-        assert.equal(urlJoinStub.calledOnce, true);
-        assert.equal(urlForStub.calledOnce, true);
-        assert.equal(getUrlStub.calledOnce, true);
+        sinon.assert.calledOnce(urlJoinStub);
+        sinon.assert.calledOnce(urlForStub);
+        sinon.assert.calledOnce(getUrlStub);
     });
 });

--- a/ghost/core/test/unit/frontend/meta/image-dimensions.test.js
+++ b/ghost/core/test/unit/frontend/meta/image-dimensions.test.js
@@ -46,10 +46,10 @@ describe('getImageDimensions', function () {
 
         getImageDimensions(metaData).then(function (result) {
             assertExists(result);
-            assert.equal(sizeOfStub.calledWith(metaData.coverImage.url), true);
-            assert.equal(sizeOfStub.calledWith(metaData.authorImage.url), true);
-            assert.equal(sizeOfStub.calledWith(metaData.ogImage.url), true);
-            assert.equal(sizeOfStub.calledWith(metaData.site.logo.url), true);
+            sinon.assert.calledWith(sizeOfStub, metaData.coverImage.url);
+            sinon.assert.calledWith(sizeOfStub, metaData.authorImage.url);
+            sinon.assert.calledWith(sizeOfStub, metaData.ogImage.url);
+            sinon.assert.calledWith(sizeOfStub, metaData.site.logo.url);
             assert('dimensions' in result.coverImage);
             assert('url' in result.coverImage);
             assert.equal(result.coverImage.dimensions.width, 50);
@@ -99,10 +99,10 @@ describe('getImageDimensions', function () {
 
         getImageDimensions(metaData).then(function (result) {
             assertExists(result);
-            assert.equal(sizeOfStub.calledWith(metaData.coverImage.url), true);
-            assert.equal(sizeOfStub.calledWith(metaData.authorImage.url), true);
-            assert.equal(sizeOfStub.calledWith(metaData.ogImage.url), true);
-            assert.equal(sizeOfStub.calledWith(metaData.site.logo.url), true);
+            sinon.assert.calledWith(sizeOfStub, metaData.coverImage.url);
+            sinon.assert.calledWith(sizeOfStub, metaData.authorImage.url);
+            sinon.assert.calledWith(sizeOfStub, metaData.ogImage.url);
+            sinon.assert.calledWith(sizeOfStub, metaData.site.logo.url);
             assert(!('dimensions' in result.coverImage));
             assert('url' in result.coverImage);
             assert(!('dimensions' in result.authorImage));
@@ -145,10 +145,10 @@ describe('getImageDimensions', function () {
 
         getImageDimensions(metaData).then(function (result) {
             assertExists(result);
-            assert.equal(sizeOfStub.calledWith(metaData.coverImage.url), true);
-            assert.equal(sizeOfStub.calledWith(metaData.authorImage.url), true);
-            assert.equal(sizeOfStub.calledWith(metaData.ogImage.url), true);
-            assert.equal(sizeOfStub.calledWith(metaData.site.logo.url), true);
+            sinon.assert.calledWith(sizeOfStub, metaData.coverImage.url);
+            sinon.assert.calledWith(sizeOfStub, metaData.authorImage.url);
+            sinon.assert.calledWith(sizeOfStub, metaData.ogImage.url);
+            sinon.assert.calledWith(sizeOfStub, metaData.site.logo.url);
             assert('url' in result.coverImage);
             assert('dimensions' in result.coverImage);
             assert.equal(result.coverImage.dimensions.height, 480);
@@ -199,10 +199,10 @@ describe('getImageDimensions', function () {
 
         getImageDimensions(metaData).then(function (result) {
             assertExists(result);
-            assert.equal(sizeOfStub.calledWith(metaData.coverImage.url), true);
-            assert.equal(sizeOfStub.calledWith(metaData.authorImage.url), true);
-            assert.equal(sizeOfStub.calledWith(metaData.ogImage.url), true);
-            assert.equal(sizeOfStub.calledWith(metaData.site.logo.url), true);
+            sinon.assert.calledWith(sizeOfStub, metaData.coverImage.url);
+            sinon.assert.calledWith(sizeOfStub, metaData.authorImage.url);
+            sinon.assert.calledWith(sizeOfStub, metaData.ogImage.url);
+            sinon.assert.calledWith(sizeOfStub, metaData.site.logo.url);
             assert('dimensions' in result.coverImage);
             assert('url' in result.coverImage);
             assert.equal(result.coverImage.dimensions.height, 480);
@@ -259,11 +259,11 @@ describe('getImageDimensions', function () {
 
         getImageDimensions(metaData).then(function (result) {
             assertExists(result);
-            assert.equal(sizeOfStub.calledWith(originalMetaData.coverImage.url), true);
-            assert.equal(sizeOfStub.calledWith(originalMetaData.authorImage.url), true);
-            assert.equal(sizeOfStub.calledWith(originalMetaData.ogImage.url), true);
-            assert.equal(sizeOfStub.calledWith(originalMetaData.twitterImage), true);
-            assert.equal(sizeOfStub.calledWith(originalMetaData.site.logo.url), true);
+            sinon.assert.calledWith(sizeOfStub, originalMetaData.coverImage.url);
+            sinon.assert.calledWith(sizeOfStub, originalMetaData.authorImage.url);
+            sinon.assert.calledWith(sizeOfStub, originalMetaData.ogImage.url);
+            sinon.assert.calledWith(sizeOfStub, originalMetaData.twitterImage);
+            sinon.assert.calledWith(sizeOfStub, originalMetaData.site.logo.url);
             assert('url' in result.coverImage);
             assert.equal(result.coverImage.url, 'http://mysite.com/content/images/size/w1200/mypostcoverimage.jpg');
             assert('dimensions' in result.coverImage);

--- a/ghost/core/test/unit/frontend/meta/rss-url.test.js
+++ b/ghost/core/test/unit/frontend/meta/rss-url.test.js
@@ -23,6 +23,6 @@ describe('getRssUrl', function () {
     it('forwards absolute flags', function () {
         getRssUrl({}, true);
 
-        assert.equal(routing.registry.getRssUrl.calledWith({absolute: true}), true);
+        sinon.assert.calledWith(routing.registry.getRssUrl, {absolute: true});
     });
 });

--- a/ghost/core/test/unit/frontend/meta/url.test.js
+++ b/ghost/core/test/unit/frontend/meta/url.test.js
@@ -34,9 +34,8 @@ describe('getUrl', function () {
             urlUtilsUrlForStub.withArgs({relativeUrl: '/p/' + post.uuid + '/'}, null, undefined).returns('relative');
             let url = getUrl(post);
 
-            assert.equal(urlServiceGetUrlByResourceIdStub.calledOnce, true);
-            assert.equal(urlUtilsUrlForStub.withArgs({relativeUrl: '/p/' + post.uuid + '/'}, null, undefined)
-                .calledOnce, true);
+            sinon.assert.calledOnce(urlServiceGetUrlByResourceIdStub);
+            sinon.assert.calledOnce(urlUtilsUrlForStub.withArgs({relativeUrl: '/p/' + post.uuid + '/'}, null, undefined));
 
             assert.equal(url, 'relative');
         });
@@ -47,9 +46,8 @@ describe('getUrl', function () {
             urlUtilsUrlForStub.withArgs({relativeUrl: '/p/' + post.uuid + '/'}, null, true).returns('absolute');
             let url = getUrl(post, true);
 
-            assert.equal(urlServiceGetUrlByResourceIdStub.calledOnce, true);
-            assert.equal(urlUtilsUrlForStub.withArgs({relativeUrl: '/p/' + post.uuid + '/'}, null, true)
-                .calledOnce, true);
+            sinon.assert.calledOnce(urlServiceGetUrlByResourceIdStub);
+            sinon.assert.calledOnce(urlUtilsUrlForStub.withArgs({relativeUrl: '/p/' + post.uuid + '/'}, null, true));
 
             assert.equal(url, 'absolute');
         });

--- a/ghost/core/test/unit/frontend/services/apps/proxy.test.js
+++ b/ghost/core/test/unit/frontend/services/apps/proxy.test.js
@@ -1,4 +1,3 @@
-const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../utils/assertions');
 const sinon = require('sinon');
 const helpers = require('../../../../../core/frontend/services/helpers');
@@ -32,7 +31,7 @@ describe('Apps', function () {
 
             appProxy.helperService.registerHelper('myTestHelper', sinon.stub().returns('test result'));
 
-            assert.equal(registerSpy.called, true);
+            sinon.assert.called(registerSpy);
         });
     });
 });

--- a/ghost/core/test/unit/frontend/services/asset-hash.test.js
+++ b/ghost/core/test/unit/frontend/services/asset-hash.test.js
@@ -57,11 +57,11 @@ describe('Asset Hash Service', function () {
 
             // First call - should read file
             assetHash.getHashForFile(testFilePath);
-            assert.equal(readFileSyncSpy.callCount, 1);
+            sinon.assert.calledOnce(readFileSyncSpy);
 
             // Second call - should use cache
             assetHash.getHashForFile(testFilePath);
-            assert.equal(readFileSyncSpy.callCount, 1); // Still 1, not 2
+            sinon.assert.calledOnce(readFileSyncSpy); // Still 1, not 2
         });
 
         it('should re-read file if mtime has changed', function () {
@@ -71,7 +71,7 @@ describe('Asset Hash Service', function () {
 
             // First call
             const hash1 = assetHash.getHashForFile(testFilePath);
-            assert.equal(readFileSyncSpy.callCount, 1);
+            sinon.assert.calledOnce(readFileSyncSpy);
 
             // Simulate mtime change by stubbing statSync
             const futureTime = new Date(originalStat.mtimeMs + 1000);
@@ -82,7 +82,7 @@ describe('Asset Hash Service', function () {
             // Clear cache entry by calling with different mtime
             // The service should detect mtime change and re-read
             const hash2 = assetHash.getHashForFile(testFilePath);
-            assert.equal(readFileSyncSpy.callCount, 2); // File was re-read
+            sinon.assert.calledTwice(readFileSyncSpy); // File was re-read
 
             // Both hashes should be the same (same content) but cache was invalidated
             assert.equal(hash1, hash2);
@@ -96,14 +96,14 @@ describe('Asset Hash Service', function () {
 
             // First call - should read file
             assetHash.getHashForFile(testFilePath);
-            assert.equal(readFileSyncSpy.callCount, 1);
+            sinon.assert.calledOnce(readFileSyncSpy);
 
             // Clear cache
             assetHash.clearCache();
 
             // Next call should read file again
             assetHash.getHashForFile(testFilePath);
-            assert.equal(readFileSyncSpy.callCount, 2);
+            sinon.assert.calledTwice(readFileSyncSpy);
         });
     });
 

--- a/ghost/core/test/unit/frontend/services/assets-minification/assets-minification-base.test.js
+++ b/ghost/core/test/unit/frontend/services/assets-minification/assets-minification-base.test.js
@@ -48,9 +48,9 @@ describe('AssetsMinificationBase', function () {
             ]);
 
             assert.equal(loadCallCount, 1, 'load() should be called exactly once');
-            assert.equal(next1.callCount, 1);
-            assert.equal(next2.callCount, 1);
-            assert.equal(next3.callCount, 1);
+            sinon.assert.calledOnce(next1);
+            sinon.assert.calledOnce(next2);
+            sinon.assert.calledOnce(next3);
         });
 
         it('writes the asset file only once when concurrent requests trigger load()', async function () {
@@ -113,7 +113,7 @@ describe('AssetsMinificationBase', function () {
             await middleware({}, {}, next);
 
             assert.equal(loadCallCount, 0);
-            assert.equal(next.callCount, 1);
+            sinon.assert.calledOnce(next);
         });
 
         it('calls load() again after invalidate()', async function () {
@@ -174,7 +174,7 @@ describe('AssetsMinificationBase', function () {
             await secondRequest;
 
             assert.equal(loadCallCount, 2, 'load() should be called twice (once per invalidation cycle)');
-            assert.equal(next.callCount, 2);
+            sinon.assert.calledTwice(next);
         });
 
         it('clears loading promise after load() completes', async function () {

--- a/ghost/core/test/unit/frontend/services/data/entry-lookup.test.js
+++ b/ghost/core/test/unit/frontend/services/data/entry-lookup.test.js
@@ -55,8 +55,8 @@ describe('Unit - frontend/data/entry-lookup', function () {
             const testUrl = 'http://127.0.0.1:2369' + pages[0].url;
 
             return data.entryLookup(testUrl, routerOptions, locals).then(function (lookup) {
-                assert.equal(postsReadStub.called, false);
-                assert.equal(pagesReadStub.calledOnce, true);
+                sinon.assert.notCalled(postsReadStub);
+                sinon.assert.calledOnce(pagesReadStub);
                 assertExists(lookup.entry);
                 assert.equal(lookup.entry.url, pages[0].url);
                 assert.equal(lookup.isEditURL, false);
@@ -106,8 +106,8 @@ describe('Unit - frontend/data/entry-lookup', function () {
             const testUrl = 'http://127.0.0.1:2369' + posts[0].url;
 
             return data.entryLookup(testUrl, routerOptions, locals).then(function (lookup) {
-                assert.equal(postsReadStub.calledOnce, true);
-                assert.equal(pagesReadStub.called, false);
+                sinon.assert.calledOnce(postsReadStub);
+                sinon.assert.notCalled(pagesReadStub);
                 assertExists(lookup.entry);
                 assert.equal(lookup.entry.url, posts[0].url);
                 assert.equal(lookup.isEditURL, false);
@@ -118,8 +118,8 @@ describe('Unit - frontend/data/entry-lookup', function () {
             const testUrl = `http://127.0.0.1:2369${posts[0].url}edit/`;
 
             return data.entryLookup(testUrl, routerOptions, locals).then(function (lookup) {
-                assert.equal(postsReadStub.calledOnce, true);
-                assert.equal(pagesReadStub.called, false);
+                sinon.assert.calledOnce(postsReadStub);
+                sinon.assert.notCalled(pagesReadStub);
                 assertExists(lookup.entry);
                 assert.equal(lookup.entry.url, posts[0].url);
                 assert.equal(lookup.isEditURL, true);

--- a/ghost/core/test/unit/frontend/services/data/fetch-data.test.js
+++ b/ghost/core/test/unit/frontend/services/data/fetch-data.test.js
@@ -65,7 +65,7 @@ describe('Unit - frontend/data/fetch-data', function () {
             assert('meta' in result);
             assert(!('data' in result));
 
-            assert.equal(browsePostsStub.calledOnce, true);
+            sinon.assert.calledOnce(browsePostsStub);
             assert(_.isPlainObject(browsePostsStub.firstCall.args[0]));
             assert('include' in browsePostsStub.firstCall.args[0]);
             assert(!('filter' in browsePostsStub.firstCall.args[0]));
@@ -84,7 +84,7 @@ describe('Unit - frontend/data/fetch-data', function () {
 
             assert.equal(result.posts.length, posts.length);
 
-            assert.equal(browsePostsStub.calledOnce, true);
+            sinon.assert.calledOnce(browsePostsStub);
             assert(_.isPlainObject(browsePostsStub.firstCall.args[0]));
             assert('include' in browsePostsStub.firstCall.args[0]);
             assert.equal(browsePostsStub.firstCall.args[0].limit, 10);
@@ -122,7 +122,7 @@ describe('Unit - frontend/data/fetch-data', function () {
             assert.equal(result.posts.length, posts.length);
             assert.equal(result.data.featured.length, posts.length);
 
-            assert.equal(browsePostsStub.calledTwice, true);
+            sinon.assert.calledTwice(browsePostsStub);
             assert.equal(browsePostsStub.firstCall.args[0].include, 'authors,tags,tiers');
             assert.equal(browsePostsStub.secondCall.args[0].filter, 'featured:true');
             assert.equal(browsePostsStub.secondCall.args[0].limit, 3);
@@ -158,7 +158,7 @@ describe('Unit - frontend/data/fetch-data', function () {
             assert.equal(result.posts.length, posts.length);
             assert.equal(result.data.featured.length, posts.length);
 
-            assert.equal(browsePostsStub.calledTwice, true);
+            sinon.assert.calledTwice(browsePostsStub);
             assert.equal(browsePostsStub.firstCall.args[0].include, 'authors,tags,tiers');
             assert.equal(browsePostsStub.firstCall.args[0].page, 2);
             assert.equal(browsePostsStub.secondCall.args[0].filter, 'featured:true');
@@ -196,7 +196,7 @@ describe('Unit - frontend/data/fetch-data', function () {
             assert.equal(result.posts.length, posts.length);
             assert.equal(result.data.tag.length, tags.length);
 
-            assert.equal(browsePostsStub.calledOnce, true);
+            sinon.assert.calledOnce(browsePostsStub);
             assert('include' in browsePostsStub.firstCall.args[0]);
             assert.equal(browsePostsStub.firstCall.args[0].filter, 'tags:testing');
             assert(!('slug' in browsePostsStub.firstCall.args[0]));

--- a/ghost/core/test/unit/frontend/services/rendering/templates.test.js
+++ b/ghost/core/test/unit/frontend/services/rendering/templates.test.js
@@ -409,10 +409,10 @@ describe('templates', function () {
             assert.equal(res._template, 'thing');
 
             // And nothing got called
-            assert.equal(stubs.pickTemplate.called, false);
-            assert.equal(stubs.getTemplateForEntry.called, false);
-            assert.equal(stubs.getTemplateForEntries.called, false);
-            assert.equal(stubs.getTemplateForError.called, false);
+            sinon.assert.notCalled(stubs.pickTemplate);
+            sinon.assert.notCalled(stubs.getTemplateForEntry);
+            sinon.assert.notCalled(stubs.getTemplateForEntries);
+            sinon.assert.notCalled(stubs.getTemplateForError);
         });
 
         it('defaults to index', function () {
@@ -425,10 +425,10 @@ describe('templates', function () {
             assert.equal(res._template, 'index');
 
             // And nothing got called
-            assert.equal(stubs.pickTemplate.called, false);
-            assert.equal(stubs.getTemplateForEntry.called, false);
-            assert.equal(stubs.getTemplateForEntries.called, false);
-            assert.equal(stubs.getTemplateForError.called, false);
+            sinon.assert.notCalled(stubs.pickTemplate);
+            sinon.assert.notCalled(stubs.getTemplateForEntry);
+            sinon.assert.notCalled(stubs.getTemplateForEntries);
+            sinon.assert.notCalled(stubs.getTemplateForError);
         });
 
         it('calls pickTemplate for custom routes', function () {
@@ -445,12 +445,12 @@ describe('templates', function () {
             assert.equal(res._template, 'testFromPickTemplate');
 
             // Only pickTemplate got called
-            assert.equal(stubs.pickTemplate.called, true);
-            assert.equal(stubs.getTemplateForEntry.called, false);
-            assert.equal(stubs.getTemplateForEntries.called, false);
-            assert.equal(stubs.getTemplateForError.called, false);
+            sinon.assert.called(stubs.pickTemplate);
+            sinon.assert.notCalled(stubs.getTemplateForEntry);
+            sinon.assert.notCalled(stubs.getTemplateForEntries);
+            sinon.assert.notCalled(stubs.getTemplateForError);
 
-            assert.equal(stubs.pickTemplate.calledWith('test', 'path/to/local/test.hbs'), true);
+            sinon.assert.calledWith(stubs.pickTemplate, 'test', 'path/to/local/test.hbs');
         });
 
         it('calls getTemplateForEntry for entry routes', function () {
@@ -468,12 +468,12 @@ describe('templates', function () {
             assert.equal(res._template, 'testFromEntry');
 
             // Only pickTemplate got called
-            assert.equal(stubs.pickTemplate.called, false);
-            assert.equal(stubs.getTemplateForEntry.called, true);
-            assert.equal(stubs.getTemplateForEntries.called, false);
-            assert.equal(stubs.getTemplateForError.called, false);
+            sinon.assert.notCalled(stubs.pickTemplate);
+            sinon.assert.called(stubs.getTemplateForEntry);
+            sinon.assert.notCalled(stubs.getTemplateForEntries);
+            sinon.assert.notCalled(stubs.getTemplateForError);
 
-            assert.equal(stubs.getTemplateForEntry.calledWith({slug: 'test'}), true);
+            sinon.assert.calledWith(stubs.getTemplateForEntry, {slug: 'test'});
         });
 
         it('calls getTemplateForEntries for type collection', function () {
@@ -491,12 +491,12 @@ describe('templates', function () {
             assert.equal(res._template, 'testFromEntries');
 
             // Only pickTemplate got called
-            assert.equal(stubs.pickTemplate.called, false);
-            assert.equal(stubs.getTemplateForEntry.called, false);
-            assert.equal(stubs.getTemplateForEntries.called, true);
-            assert.equal(stubs.getTemplateForError.called, false);
+            sinon.assert.notCalled(stubs.pickTemplate);
+            sinon.assert.notCalled(stubs.getTemplateForEntry);
+            sinon.assert.called(stubs.getTemplateForEntries);
+            sinon.assert.notCalled(stubs.getTemplateForError);
 
-            assert.equal(stubs.getTemplateForEntries.calledWith({testCollection: 'test', type: 'collection'}), true);
+            sinon.assert.calledWith(stubs.getTemplateForEntries, {testCollection: 'test', type: 'collection'});
         });
 
         it('calls getTemplateForEntries for type channel', function () {
@@ -514,12 +514,12 @@ describe('templates', function () {
             assert.equal(res._template, 'testFromEntries');
 
             // Only pickTemplate got called
-            assert.equal(stubs.pickTemplate.called, false);
-            assert.equal(stubs.getTemplateForEntry.called, false);
-            assert.equal(stubs.getTemplateForEntries.called, true);
-            assert.equal(stubs.getTemplateForError.called, false);
+            sinon.assert.notCalled(stubs.pickTemplate);
+            sinon.assert.notCalled(stubs.getTemplateForEntry);
+            sinon.assert.called(stubs.getTemplateForEntries);
+            sinon.assert.notCalled(stubs.getTemplateForError);
 
-            assert.equal(stubs.getTemplateForEntries.calledWith({testChannel: 'test', type: 'channel'}), true);
+            sinon.assert.calledWith(stubs.getTemplateForEntries, {testChannel: 'test', type: 'channel'});
         });
 
         it('calls getTemplateForError if there is an error', function () {
@@ -541,12 +541,12 @@ describe('templates', function () {
             assert.equal(res._template, 'testFromError');
 
             // Only pickTemplate got called
-            assert.equal(stubs.pickTemplate.called, false);
-            assert.equal(stubs.getTemplateForEntry.called, false);
-            assert.equal(stubs.getTemplateForEntries.called, false);
-            assert.equal(stubs.getTemplateForError.called, true);
+            sinon.assert.notCalled(stubs.pickTemplate);
+            sinon.assert.notCalled(stubs.getTemplateForEntry);
+            sinon.assert.notCalled(stubs.getTemplateForEntries);
+            sinon.assert.called(stubs.getTemplateForError);
 
-            assert.equal(stubs.getTemplateForError.calledWith(404), true);
+            sinon.assert.calledWith(stubs.getTemplateForError, 404);
         });
     });
 });

--- a/ghost/core/test/unit/frontend/services/routing/bootstrap.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/bootstrap.test.js
@@ -1,4 +1,3 @@
-const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const CollectionRouter = require('../../../../../core/frontend/services/routing/collection-router');
 const RouterManager = require('../../../../../core/frontend/services/routing/router-manager');
@@ -37,7 +36,7 @@ describe('UNIT: services/routing/router-manager', function () {
                     _previousAttributes: {value: 'Europe/London'}
                 });
 
-                assert.equal(routerUpdatedSpy.called, false);
+                sinon.assert.notCalled(routerUpdatedSpy);
             });
 
             it('tz has not changed', function () {
@@ -56,7 +55,7 @@ describe('UNIT: services/routing/router-manager', function () {
                     _previousAttributes: {value: 'America/Los_Angeles'}
                 });
 
-                assert.equal(routerUpdatedSpy.called, false);
+                sinon.assert.notCalled(routerUpdatedSpy);
             });
         });
 
@@ -77,7 +76,7 @@ describe('UNIT: services/routing/router-manager', function () {
                     _previousAttributes: {value: 'Europe/London'}
                 });
 
-                assert.equal(routerUpdatedSpy.called, true);
+                sinon.assert.called(routerUpdatedSpy);
             });
 
             it('tz has not changed', function () {
@@ -96,7 +95,7 @@ describe('UNIT: services/routing/router-manager', function () {
                     _previousAttributes: {value: 'America/Los_Angeles'}
                 });
 
-                assert.equal(routerUpdatedSpy.called, false);
+                sinon.assert.notCalled(routerUpdatedSpy);
             });
         });
     });

--- a/ghost/core/test/unit/frontend/services/routing/collection-router.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/collection-router.test.js
@@ -47,11 +47,11 @@ describe('UNIT - services/routing/CollectionRouter', function () {
             assert.deepEqual(collectionRouter.templates, []);
             assert.equal(collectionRouter.getPermalinks().getValue(), '/:slug/');
 
-            assert.equal(routerCreatedSpy.calledOnce, true);
-            assert.equal(routerCreatedSpy.calledWith(collectionRouter), true);
+            sinon.assert.calledOnce(routerCreatedSpy);
+            sinon.assert.calledWith(routerCreatedSpy, collectionRouter);
 
-            assert.equal(mountRouteSpy.callCount, 3);
-            assert.equal(express.Router.param.callCount, 2);
+            sinon.assert.calledThrice(mountRouteSpy);
+            sinon.assert.calledTwice(express.Router.param);
 
             // parent route
             assert.equal(mountRouteSpy.args[0][0], '/');
@@ -65,7 +65,7 @@ describe('UNIT - services/routing/CollectionRouter', function () {
             assert.equal(mountRouteSpy.args[2][0], '/:slug/:options(edit)?/');
             assert.equal(mountRouteSpy.args[2][1], controllers.entry);
 
-            assert.equal(mountRouterSpy.callCount, 1);
+            sinon.assert.calledOnce(mountRouterSpy);
             assert.equal(mountRouterSpy.args[0][0], '/');
             assert.equal(mountRouterSpy.args[0][1], collectionRouter.rssRouter.router());
         });
@@ -94,10 +94,10 @@ describe('UNIT - services/routing/CollectionRouter', function () {
             assert.deepEqual(collectionRouter.templates, []);
             assert.equal(collectionRouter.getPermalinks().getValue(), '/blog/:year/:slug/');
 
-            assert.equal(routerCreatedSpy.calledOnce, true);
-            assert.equal(routerCreatedSpy.calledWith(collectionRouter), true);
+            sinon.assert.calledOnce(routerCreatedSpy);
+            sinon.assert.calledWith(routerCreatedSpy, collectionRouter);
 
-            assert.equal(mountRouteSpy.callCount, 3);
+            sinon.assert.calledThrice(mountRouteSpy);
 
             // parent route
             assert.equal(mountRouteSpy.args[0][0], '/blog/');
@@ -111,7 +111,7 @@ describe('UNIT - services/routing/CollectionRouter', function () {
             assert.equal(mountRouteSpy.args[2][0], '/blog/:year/:slug/:options(edit)?/');
             assert.equal(mountRouteSpy.args[2][1], controllers.entry);
 
-            assert.equal(mountRouterSpy.callCount, 1);
+            sinon.assert.calledOnce(mountRouterSpy);
             assert.equal(mountRouterSpy.args[0][0], '/blog/');
             assert.equal(mountRouterSpy.args[0][1], collectionRouter.rssRouter.router());
         });
@@ -136,7 +136,7 @@ describe('UNIT - services/routing/CollectionRouter', function () {
 
             collectionRouter._prepareEntriesContext(req, res, next);
 
-            assert.equal(next.calledOnce, true);
+            sinon.assert.calledOnce(next);
             assert.deepEqual(res.routerOptions, {
                 type: 'collection',
                 filter: undefined,
@@ -164,7 +164,7 @@ describe('UNIT - services/routing/CollectionRouter', function () {
 
             collectionRouter._prepareEntriesContext(req, res, next);
 
-            assert.equal(next.calledOnce, true);
+            sinon.assert.calledOnce(next);
             assert.deepEqual(res.routerOptions, {
                 type: 'collection',
                 filter: undefined,

--- a/ghost/core/test/unit/frontend/services/routing/controllers/channel.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/controllers/channel.test.js
@@ -79,9 +79,9 @@ describe('Unit - services/routing/controllers/channel', function () {
             });
 
         controllers.channel(req, res, failTest(done)).then(function () {
-            assert.equal(themeEngine.getActive.calledOnce, true);
-            assert.equal(security.string.safe.calledOnce, false);
-            assert.equal(fetchDataStub.calledOnce, true);
+            sinon.assert.calledOnce(themeEngine.getActive);
+            sinon.assert.notCalled(security.string.safe);
+            sinon.assert.calledOnce(fetchDataStub);
             done();
         }).catch(done);
     });
@@ -100,9 +100,9 @@ describe('Unit - services/routing/controllers/channel', function () {
             });
 
         controllers.channel(req, res, failTest(done)).then(function () {
-            assert.equal(themeEngine.getActive.calledOnce, true);
-            assert.equal(security.string.safe.calledOnce, false);
-            assert.equal(fetchDataStub.calledOnce, true);
+            sinon.assert.calledOnce(themeEngine.getActive);
+            sinon.assert.notCalled(security.string.safe);
+            sinon.assert.calledOnce(fetchDataStub);
             done();
         }).catch(done);
     });
@@ -122,10 +122,10 @@ describe('Unit - services/routing/controllers/channel', function () {
             });
 
         controllers.channel(req, res, failTest(done)).then(function () {
-            assert.equal(themeEngine.getActive.calledOnce, true);
-            assert.equal(themeEngine.getActive().updateTemplateOptions.withArgs({data: {config: {posts_per_page: 3}}}).calledOnce, true);
-            assert.equal(security.string.safe.calledOnce, false);
-            assert.equal(fetchDataStub.calledOnce, true);
+            sinon.assert.calledOnce(themeEngine.getActive);
+            sinon.assert.calledOnce(themeEngine.getActive().updateTemplateOptions.withArgs({data: {config: {posts_per_page: 3}}}));
+            sinon.assert.notCalled(security.string.safe);
+            sinon.assert.calledOnce(fetchDataStub);
             done();
         }).catch(done);
     });
@@ -146,10 +146,10 @@ describe('Unit - services/routing/controllers/channel', function () {
         controllers.channel(req, res, function (err) {
             assert.equal((err instanceof errors.NotFoundError), true);
 
-            assert.equal(themeEngine.getActive.calledOnce, true);
-            assert.equal(security.string.safe.calledOnce, false);
-            assert.equal(fetchDataStub.calledOnce, true);
-            assert.equal(renderStub.calledOnce, false);
+            sinon.assert.calledOnce(themeEngine.getActive);
+            sinon.assert.notCalled(security.string.safe);
+            sinon.assert.calledOnce(fetchDataStub);
+            sinon.assert.notCalled(renderStub);
             done();
         });
     });
@@ -168,9 +168,9 @@ describe('Unit - services/routing/controllers/channel', function () {
             });
 
         controllers.channel(req, res, failTest(done)).then(function () {
-            assert.equal(themeEngine.getActive.calledOnce, true);
-            assert.equal(security.string.safe.calledOnce, true);
-            assert.equal(fetchDataStub.calledOnce, true);
+            sinon.assert.calledOnce(themeEngine.getActive);
+            sinon.assert.calledOnce(security.string.safe);
+            sinon.assert.calledOnce(fetchDataStub);
             done();
         }).catch(done);
     });
@@ -189,9 +189,9 @@ describe('Unit - services/routing/controllers/channel', function () {
             });
 
         controllers.channel(req, res, failTest(done)).then(function () {
-            assert.equal(themeEngine.getActive.calledOnce, true);
-            assert.equal(security.string.safe.calledOnce, false);
-            assert.equal(fetchDataStub.calledOnce, true);
+            sinon.assert.calledOnce(themeEngine.getActive);
+            sinon.assert.notCalled(security.string.safe);
+            sinon.assert.calledOnce(fetchDataStub);
             done();
         }).catch(done);
     });

--- a/ghost/core/test/unit/frontend/services/routing/controllers/collection.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/controllers/collection.test.js
@@ -86,10 +86,10 @@ describe('Unit - services/routing/controllers/collection', function () {
             });
 
         controllers.collection(req, res, failTest(done)).then(function () {
-            assert.equal(themeEngine.getActive.calledOnce, true);
-            assert.equal(security.string.safe.calledOnce, false);
-            assert.equal(fetchDataStub.calledOnce, true);
-            assert.equal(ownsStub.calledOnce, true);
+            sinon.assert.calledOnce(themeEngine.getActive);
+            sinon.assert.notCalled(security.string.safe);
+            sinon.assert.calledOnce(fetchDataStub);
+            sinon.assert.calledOnce(ownsStub);
             done();
         }).catch(done);
     });
@@ -108,10 +108,10 @@ describe('Unit - services/routing/controllers/collection', function () {
             });
 
         controllers.collection(req, res, failTest(done)).then(function () {
-            assert.equal(themeEngine.getActive.calledOnce, true);
-            assert.equal(security.string.safe.calledOnce, false);
-            assert.equal(fetchDataStub.calledOnce, true);
-            assert.equal(ownsStub.calledOnce, true);
+            sinon.assert.calledOnce(themeEngine.getActive);
+            sinon.assert.notCalled(security.string.safe);
+            sinon.assert.calledOnce(fetchDataStub);
+            sinon.assert.calledOnce(ownsStub);
             done();
         }).catch(done);
     });
@@ -131,11 +131,11 @@ describe('Unit - services/routing/controllers/collection', function () {
             });
 
         controllers.collection(req, res, failTest(done)).then(function () {
-            assert.equal(themeEngine.getActive.calledOnce, true);
-            assert.equal(themeEngine.getActive().updateTemplateOptions.withArgs({data: {config: {posts_per_page: 3}}}).calledOnce, true);
-            assert.equal(security.string.safe.calledOnce, false);
-            assert.equal(fetchDataStub.calledOnce, true);
-            assert.equal(ownsStub.calledOnce, true);
+            sinon.assert.calledOnce(themeEngine.getActive);
+            sinon.assert.calledOnce(themeEngine.getActive().updateTemplateOptions.withArgs({data: {config: {posts_per_page: 3}}}));
+            sinon.assert.notCalled(security.string.safe);
+            sinon.assert.calledOnce(fetchDataStub);
+            sinon.assert.calledOnce(ownsStub);
             done();
         }).catch(done);
     });
@@ -156,11 +156,11 @@ describe('Unit - services/routing/controllers/collection', function () {
         controllers.collection(req, res, function (err) {
             assert.equal((err instanceof errors.NotFoundError), true);
 
-            assert.equal(themeEngine.getActive.calledOnce, true);
-            assert.equal(security.string.safe.calledOnce, false);
-            assert.equal(fetchDataStub.calledOnce, true);
-            assert.equal(renderStub.calledOnce, false);
-            assert.equal(ownsStub.calledOnce, false);
+            sinon.assert.calledOnce(themeEngine.getActive);
+            sinon.assert.notCalled(security.string.safe);
+            sinon.assert.calledOnce(fetchDataStub);
+            sinon.assert.notCalled(renderStub);
+            sinon.assert.notCalled(ownsStub);
             done();
         });
     });
@@ -179,10 +179,10 @@ describe('Unit - services/routing/controllers/collection', function () {
             });
 
         controllers.collection(req, res, failTest(done)).then(function () {
-            assert.equal(themeEngine.getActive.calledOnce, true);
-            assert.equal(security.string.safe.calledOnce, true);
-            assert.equal(fetchDataStub.calledOnce, true);
-            assert.equal(ownsStub.calledOnce, true);
+            sinon.assert.calledOnce(themeEngine.getActive);
+            sinon.assert.calledOnce(security.string.safe);
+            sinon.assert.calledOnce(fetchDataStub);
+            sinon.assert.calledOnce(ownsStub);
             done();
         }).catch(done);
     });
@@ -201,10 +201,10 @@ describe('Unit - services/routing/controllers/collection', function () {
             });
 
         controllers.collection(req, res, failTest(done)).then(function () {
-            assert.equal(themeEngine.getActive.calledOnce, true);
-            assert.equal(security.string.safe.calledOnce, false);
-            assert.equal(fetchDataStub.calledOnce, true);
-            assert.equal(ownsStub.calledOnce, true);
+            sinon.assert.calledOnce(themeEngine.getActive);
+            sinon.assert.notCalled(security.string.safe);
+            sinon.assert.calledOnce(fetchDataStub);
+            sinon.assert.calledOnce(ownsStub);
             done();
         }).catch(done);
     });
@@ -239,10 +239,10 @@ describe('Unit - services/routing/controllers/collection', function () {
             });
 
         controllers.collection(req, res, failTest(done)).then(function () {
-            assert.equal(themeEngine.getActive.calledOnce, true);
-            assert.equal(security.string.safe.calledOnce, false);
-            assert.equal(fetchDataStub.calledOnce, true);
-            assert.equal(ownsStub.callCount, 4);
+            sinon.assert.calledOnce(themeEngine.getActive);
+            sinon.assert.notCalled(security.string.safe);
+            sinon.assert.calledOnce(fetchDataStub);
+            sinon.assert.callCount(ownsStub, 4);
             done();
         }).catch(done);
     });

--- a/ghost/core/test/unit/frontend/services/routing/controllers/entry.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/controllers/entry.test.js
@@ -147,7 +147,7 @@ describe('Unit - services/routing/controllers/entry', function () {
 
             controllers.entry(req, res, async (err) => {
                 await configUtils.restore();
-                assert.equal(urlUtilsRedirectToAdminStub.called, false);
+                sinon.assert.notCalled(urlUtilsRedirectToAdminStub);
                 assert.equal(err, undefined);
                 done(err);
             });

--- a/ghost/core/test/unit/frontend/services/routing/controllers/previews.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/controllers/previews.test.js
@@ -1,4 +1,3 @@
-const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../../utils/assertions');
 const sinon = require('sinon');
 const testUtils = require('../../../../../utils');
@@ -83,7 +82,7 @@ describe('Unit - services/routing/controllers/previews', function () {
 
     it('should render post', function (done) {
         controllers.previews(req, res, failTest(done)).then(function () {
-            assert.equal(renderStub.called, true);
+            sinon.assert.called(renderStub);
             done();
         }).catch(done);
     });

--- a/ghost/core/test/unit/frontend/services/routing/controllers/static.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/controllers/static.test.js
@@ -1,4 +1,3 @@
-const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../../utils/assertions');
 const sinon = require('sinon');
 
@@ -78,8 +77,8 @@ describe('Unit - services/routing/controllers/static', function () {
 
     it('no extra data to fetch', function (done) {
         renderer.renderer.callsFake(function () {
-            assert.equal(renderer.formatResponse.entries.calledOnce, true);
-            assert.equal(tagsReadStub.called, false);
+            sinon.assert.calledOnce(renderer.formatResponse.entries);
+            sinon.assert.notCalled(tagsReadStub);
             done();
         });
 
@@ -101,8 +100,8 @@ describe('Unit - services/routing/controllers/static', function () {
         tagsReadStub = sinon.stub().resolves({tags: [{slug: 'bacon'}]});
 
         renderer.renderer.callsFake(function () {
-            assert.equal(tagsReadStub.called, true);
-            assert.equal(renderer.formatResponse.entries.calledOnce, true);
+            sinon.assert.called(tagsReadStub);
+            sinon.assert.calledOnce(renderer.formatResponse.entries);
             done();
         });
 

--- a/ghost/core/test/unit/frontend/services/routing/middlewares/page-param.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/middlewares/page-param.test.js
@@ -29,8 +29,8 @@ describe('UNIT: services/routing/middleware/page-param', function () {
 
         middleware.pageParam(req, res, next, 2);
 
-        assert.equal(urlUtils.redirect301.called, false);
-        assert.equal(next.calledOnce, true);
+        sinon.assert.notCalled(urlUtils.redirect301);
+        sinon.assert.calledOnce(next);
         assert.equal(req.params.page, 2);
     });
 
@@ -40,8 +40,8 @@ describe('UNIT: services/routing/middleware/page-param', function () {
 
         middleware.pageParam(req, res, next, 1);
 
-        assert.equal(urlUtils.redirect301.calledOnce, true);
-        assert.equal(next.called, false);
+        sinon.assert.calledOnce(urlUtils.redirect301);
+        sinon.assert.notCalled(next);
     });
 
     it('404 for /page/0/', function () {
@@ -50,8 +50,8 @@ describe('UNIT: services/routing/middleware/page-param', function () {
 
         middleware.pageParam(req, res, next, 0);
 
-        assert.equal(urlUtils.redirect301.called, false);
-        assert.equal(next.calledOnce, true);
+        sinon.assert.notCalled(urlUtils.redirect301);
+        sinon.assert.calledOnce(next);
         assert.equal((next.args[0][0] instanceof errors.NotFoundError), true);
     });
 
@@ -61,8 +61,8 @@ describe('UNIT: services/routing/middleware/page-param', function () {
 
         middleware.pageParam(req, res, next, 'something');
 
-        assert.equal(urlUtils.redirect301.called, false);
-        assert.equal(next.calledOnce, true);
+        sinon.assert.notCalled(urlUtils.redirect301);
+        sinon.assert.calledOnce(next);
         assert.equal((next.args[0][0] instanceof errors.NotFoundError), true);
     });
 
@@ -72,7 +72,7 @@ describe('UNIT: services/routing/middleware/page-param', function () {
 
         middleware.pageParam(req, res, next, 1);
 
-        assert.equal(urlUtils.redirect301.calledOnce, true);
-        assert.equal(next.called, false);
+        sinon.assert.calledOnce(urlUtils.redirect301);
+        sinon.assert.notCalled(next);
     });
 });

--- a/ghost/core/test/unit/frontend/services/routing/parent-router.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/parent-router.test.js
@@ -75,8 +75,8 @@ describe('UNIT - services/routing/ParentRouter', function () {
             }];
 
             parentRouter._respectDominantRouter(req, res, next, 'bacon');
-            assert.equal(next.called, false);
-            assert.equal(redirect301Stub.withArgs(res, '/channel/').calledOnce, true);
+            sinon.assert.notCalled(next);
+            sinon.assert.calledOnce(redirect301Stub.withArgs(res, '/channel/'));
         });
 
         it('redirect with query params', function () {
@@ -105,8 +105,8 @@ describe('UNIT - services/routing/ParentRouter', function () {
             }];
 
             parentRouter._respectDominantRouter(req, res, next, 'bacon');
-            assert.equal(next.called, false);
-            assert.equal(redirect301Stub.withArgs(res, '/channel/?a=b').calledOnce, true);
+            sinon.assert.notCalled(next);
+            sinon.assert.calledOnce(redirect301Stub.withArgs(res, '/channel/?a=b'));
         });
 
         it('redirect rss', function () {
@@ -135,8 +135,8 @@ describe('UNIT - services/routing/ParentRouter', function () {
             }];
 
             parentRouter._respectDominantRouter(req, res, next, 'bacon');
-            assert.equal(next.called, false);
-            assert.equal(redirect301Stub.withArgs(res, '/channel/rss/').calledOnce, true);
+            sinon.assert.notCalled(next);
+            sinon.assert.calledOnce(redirect301Stub.withArgs(res, '/channel/rss/'));
         });
 
         it('redirect pagination', function () {
@@ -165,8 +165,8 @@ describe('UNIT - services/routing/ParentRouter', function () {
             }];
 
             parentRouter._respectDominantRouter(req, res, next, 'bacon');
-            assert.equal(next.called, false);
-            assert.equal(redirect301Stub.withArgs(res, '/channel/page/2/').calledOnce, true);
+            sinon.assert.notCalled(next);
+            sinon.assert.calledOnce(redirect301Stub.withArgs(res, '/channel/page/2/'));
         });
 
         it('redirect correctly with subdirectory', function () {
@@ -197,8 +197,8 @@ describe('UNIT - services/routing/ParentRouter', function () {
             }];
 
             parentRouter._respectDominantRouter(req, res, next, 'bacon');
-            assert.equal(next.called, false);
-            assert.equal(redirect301Stub.withArgs(res, '/blog/channel/').calledOnce, true);
+            sinon.assert.notCalled(next);
+            sinon.assert.calledOnce(redirect301Stub.withArgs(res, '/blog/channel/'));
         });
 
         it('no redirect: different data key', function () {
@@ -224,8 +224,8 @@ describe('UNIT - services/routing/ParentRouter', function () {
             }];
 
             parentRouter._respectDominantRouter(req, res, next, 'bacon');
-            assert.equal(next.called, true);
-            assert.equal(redirect301Stub.called, false);
+            sinon.assert.called(next);
+            sinon.assert.notCalled(redirect301Stub);
         });
 
         it('no redirect: no channel defined', function () {
@@ -246,8 +246,8 @@ describe('UNIT - services/routing/ParentRouter', function () {
             }];
 
             parentRouter._respectDominantRouter(req, res, next, 'bacon');
-            assert.equal(next.called, true);
-            assert.equal(redirect301Stub.called, false);
+            sinon.assert.called(next);
+            sinon.assert.notCalled(redirect301Stub);
         });
 
         it('redirect primary tag permalink', function () {
@@ -276,8 +276,8 @@ describe('UNIT - services/routing/ParentRouter', function () {
             }];
 
             parentRouter._respectDominantRouter(req, res, next, 'welcome');
-            assert.equal(next.called, false);
-            assert.equal(redirect301Stub.withArgs(res, '/route/?x=y').calledOnce, true);
+            sinon.assert.notCalled(next);
+            sinon.assert.calledOnce(redirect301Stub.withArgs(res, '/route/?x=y'));
         });
     });
 

--- a/ghost/core/test/unit/frontend/services/routing/rss-router.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/rss-router.test.js
@@ -26,7 +26,7 @@ describe('UNIT - services/routing/RSSRouter', function () {
             assertExists(rssRouter.router);
             assert.equal(rssRouter.route.value, '/rss/');
 
-            assert.equal(rssRouter.mountRoute.callCount, 2);
+            sinon.assert.calledTwice(rssRouter.mountRoute);
 
             assert.equal(rssRouter.mountRoute.args[0][0], '/rss/');
             assert.equal(rssRouter.mountRoute.args[0][1], controllers.rss);
@@ -41,7 +41,7 @@ describe('UNIT - services/routing/RSSRouter', function () {
             assertExists(rssRouter.router);
             assert.equal(rssRouter.route.value, '/rss/');
 
-            assert.equal(rssRouter.mountRoute.callCount, 2);
+            sinon.assert.calledTwice(rssRouter.mountRoute);
 
             assert.equal(rssRouter.mountRoute.args[0][0], '/rss/');
             assert.equal(rssRouter.mountRoute.args[0][1], controllers.rss);

--- a/ghost/core/test/unit/frontend/services/routing/static-routes-router.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/static-routes-router.test.js
@@ -43,10 +43,10 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
 
             assert.deepEqual(staticRoutesRouter.templates, ['test']);
 
-            assert.equal(routerCreatedSpy.calledOnce, true);
-            assert.equal(routerCreatedSpy.calledWith(staticRoutesRouter), true);
+            sinon.assert.calledOnce(routerCreatedSpy);
+            sinon.assert.calledWith(routerCreatedSpy, staticRoutesRouter);
 
-            assert.equal(mountRouteSpy.callCount, 1);
+            sinon.assert.calledOnce(mountRouteSpy);
 
             // parent route
             assert.equal(mountRouteSpy.args[0][0], '/about/');
@@ -65,10 +65,10 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
             assert.equal(staticRoutesRouter.filter, undefined);
             assert.deepEqual(staticRoutesRouter.templates, []);
 
-            assert.equal(routerCreatedSpy.calledOnce, true);
-            assert.equal(routerCreatedSpy.calledWith(staticRoutesRouter), true);
+            sinon.assert.calledOnce(routerCreatedSpy);
+            sinon.assert.calledWith(routerCreatedSpy, staticRoutesRouter);
 
-            assert.equal(mountRouteSpy.callCount, 1);
+            sinon.assert.calledOnce(mountRouteSpy);
 
             // parent route
             assert.equal(mountRouteSpy.args[0][0], '/about/');
@@ -79,7 +79,7 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
             const staticRoutesRouter = new StaticRoutesRouter('/about/', {templates: []}, routerCreatedSpy);
 
             staticRoutesRouter._prepareStaticRouteContext(req, res, next);
-            assert.equal(next.called, true);
+            sinon.assert.called(next);
 
             assert.equal(res.routerOptions.type, 'custom');
             assert.deepEqual(res.routerOptions.templates, []);
@@ -95,7 +95,7 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
             const staticRoutesRouter = new StaticRoutesRouter('/', {templates: []}, routerCreatedSpy);
 
             staticRoutesRouter._prepareStaticRouteContext(req, res, next);
-            assert.equal(next.called, true);
+            sinon.assert.called(next);
 
             assert.equal(res.routerOptions.type, 'custom');
             assert.deepEqual(res.routerOptions.templates, []);
@@ -123,10 +123,10 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
                 assert.deepEqual(staticRoutesRouter.templates, []);
                 assertExists(staticRoutesRouter.data);
 
-                assert.equal(routerCreatedSpy.calledOnce, true);
-                assert.equal(routerCreatedSpy.calledWith(staticRoutesRouter), true);
+                sinon.assert.calledOnce(routerCreatedSpy);
+                sinon.assert.calledWith(routerCreatedSpy, staticRoutesRouter);
 
-                assert.equal(mountRouteSpy.callCount, 2);
+                sinon.assert.calledTwice(mountRouteSpy);
 
                 // parent route
                 assert.equal(mountRouteSpy.args[0][0], '/channel/');
@@ -150,10 +150,10 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
 
                 assert.deepEqual(staticRoutesRouter.templates, []);
 
-                assert.equal(routerCreatedSpy.calledOnce, true);
-                assert.equal(routerCreatedSpy.calledWith(staticRoutesRouter), true);
+                sinon.assert.calledOnce(routerCreatedSpy);
+                sinon.assert.calledWith(routerCreatedSpy, staticRoutesRouter);
 
-                assert.equal(mountRouteSpy.callCount, 2);
+                sinon.assert.calledTwice(mountRouteSpy);
 
                 // parent route
                 assert.equal(mountRouteSpy.args[0][0], '/channel/');
@@ -182,7 +182,7 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
                     filter: 'author:michi'
                 }, routerCreatedSpy);
 
-                assert.equal(mountRouteSpy.callCount, 2);
+                sinon.assert.calledTwice(mountRouteSpy);
 
                 // parent route
                 assert.equal(mountRouteSpy.args[0][0], '/channel/');
@@ -203,7 +203,7 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
                 }, routerCreatedSpy);
 
                 staticRoutesRouter._prepareChannelContext(req, res, next);
-                assert.equal(next.calledOnce, true);
+                sinon.assert.calledOnce(next);
                 assert.deepEqual(res.routerOptions, {
                     type: 'channel',
                     context: ['channel'],
@@ -223,7 +223,7 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
                 }, routerCreatedSpy);
 
                 staticRoutesRouter._prepareChannelContext(req, res, next);
-                assert.equal(next.calledOnce, true);
+                sinon.assert.calledOnce(next);
                 assert.deepEqual(res.routerOptions, {
                     type: 'channel',
                     context: ['nothingcomparestoyou'],
@@ -243,7 +243,7 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
                 }, routerCreatedSpy);
 
                 staticRoutesRouter._prepareChannelContext(req, res, next);
-                assert.equal(next.calledOnce, true);
+                sinon.assert.calledOnce(next);
                 assert.deepEqual(res.routerOptions, {
                     type: 'channel',
                     context: ['channel'],
@@ -265,7 +265,7 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
                 }, routerCreatedSpy);
 
                 staticRoutesRouter._prepareChannelContext(req, res, next);
-                assert.equal(next.calledOnce, true);
+                sinon.assert.calledOnce(next);
                 assert.deepEqual(res.routerOptions, {
                     type: 'channel',
                     context: ['channel'],

--- a/ghost/core/test/unit/frontend/services/routing/taxonomy-router.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/taxonomy-router.test.js
@@ -41,14 +41,14 @@ describe('UNIT - services/routing/TaxonomyRouter', function () {
         assert.equal(taxonomyRouter.taxonomyKey, 'tag');
         assert.equal(taxonomyRouter.getPermalinks().getValue(), '/tag/:slug/');
 
-        assert.equal(routerCreatedSpy.calledOnce, true);
-        assert.equal(routerCreatedSpy.calledWith(taxonomyRouter), true);
+        sinon.assert.calledOnce(routerCreatedSpy);
+        sinon.assert.calledWith(routerCreatedSpy, taxonomyRouter);
 
-        assert.equal(taxonomyRouter.mountRouter.callCount, 1);
+        sinon.assert.calledOnce(taxonomyRouter.mountRouter);
         assert.equal(taxonomyRouter.mountRouter.args[0][0], '/tag/:slug/');
         assert.equal(taxonomyRouter.mountRouter.args[0][1], taxonomyRouter.rssRouter.router());
 
-        assert.equal(taxonomyRouter.mountRoute.callCount, 3);
+        sinon.assert.calledThrice(taxonomyRouter.mountRoute);
 
         // permalink route
         assert.equal(taxonomyRouter.mountRoute.args[0][0], '/tag/:slug/');
@@ -68,7 +68,7 @@ describe('UNIT - services/routing/TaxonomyRouter', function () {
     it('_prepareContext behaves as expected', function () {
         const taxonomyRouter = new TaxonomyRouter('tag', '/tag/:slug/', RESOURCE_CONFIG, routerCreatedSpy);
         taxonomyRouter._prepareContext(req, res, next);
-        assert.equal(next.calledOnce, true);
+        sinon.assert.calledOnce(next);
 
         assert.deepEqual(res.routerOptions, {
             type: 'channel',

--- a/ghost/core/test/unit/frontend/services/rss/cache.test.js
+++ b/ghost/core/test/unit/frontend/services/rss/cache.test.js
@@ -35,7 +35,7 @@ describe('RSS: Cache', function () {
                 xmlData1 = _xmlData;
 
                 // We should have called generateFeed
-                assert.equal(generateSpy.callCount, 1);
+                sinon.assert.calledOnce(generateSpy);
 
                 // Call RSS again to check that we didn't rebuild
                 return rssCache.getXML('/rss/', data);
@@ -44,7 +44,7 @@ describe('RSS: Cache', function () {
                 // Assertions
 
                 // We should not have called generateFeed again
-                assert.equal(generateSpy.callCount, 1);
+                sinon.assert.calledOnce(generateSpy);
 
                 // The data should be identical, no changing lastBuildDate
                 assert.equal(xmlData1, xmlData2);

--- a/ghost/core/test/unit/frontend/services/rss/renderer.test.js
+++ b/ghost/core/test/unit/frontend/services/rss/renderer.test.js
@@ -28,14 +28,14 @@ describe('RSS: Renderer', function () {
         rssCacheStub.returns(Promise.resolve('dummyxml'));
 
         renderer.render(res, baseUrl).then(function () {
-            assert.equal(rssCacheStub.calledOnce, true);
+            sinon.assert.calledOnce(rssCacheStub);
             assert.deepEqual(rssCacheStub.firstCall.args, ['/rss/', {}]);
 
-            assert.equal(res.set.calledOnce, true);
-            assert.equal(res.set.calledWith('Content-Type', 'application/rss+xml; charset=UTF-8'), true);
+            sinon.assert.calledOnce(res.set);
+            sinon.assert.calledWith(res.set, 'Content-Type', 'application/rss+xml; charset=UTF-8');
 
-            assert.equal(res.send.calledOnce, true);
-            assert.equal(res.send.calledWith('dummyxml'), true);
+            sinon.assert.calledOnce(res.send);
+            sinon.assert.calledWith(res.send, 'dummyxml');
 
             done();
         }).catch(done);
@@ -47,14 +47,14 @@ describe('RSS: Renderer', function () {
         res.locals = {foo: 'bar'};
 
         renderer.render(res, baseUrl).then(function () {
-            assert.equal(rssCacheStub.calledOnce, true);
+            sinon.assert.calledOnce(rssCacheStub);
             assert.deepEqual(rssCacheStub.firstCall.args, ['/rss/', {foo: 'bar'}]);
 
-            assert.equal(res.set.calledOnce, true);
-            assert.equal(res.set.calledWith('Content-Type', 'application/rss+xml; charset=UTF-8'), true);
+            sinon.assert.calledOnce(res.set);
+            sinon.assert.calledWith(res.set, 'Content-Type', 'application/rss+xml; charset=UTF-8');
 
-            assert.equal(res.send.calledOnce, true);
-            assert.equal(res.send.calledWith('dummyxml'), true);
+            sinon.assert.calledOnce(res.send);
+            sinon.assert.calledWith(res.send, 'dummyxml');
 
             done();
         }).catch(done);
@@ -67,14 +67,14 @@ describe('RSS: Renderer', function () {
         const data = {foo: 'baz', fizz: 'buzz'};
 
         renderer.render(res, baseUrl, data).then(function () {
-            assert.equal(rssCacheStub.calledOnce, true);
+            sinon.assert.calledOnce(rssCacheStub);
             assert.deepEqual(rssCacheStub.firstCall.args, ['/rss/', {foo: 'baz', fizz: 'buzz'}]);
 
-            assert.equal(res.set.calledOnce, true);
-            assert.equal(res.set.calledWith('Content-Type', 'application/rss+xml; charset=UTF-8'), true);
+            sinon.assert.calledOnce(res.set);
+            sinon.assert.calledWith(res.set, 'Content-Type', 'application/rss+xml; charset=UTF-8');
 
-            assert.equal(res.send.calledOnce, true);
-            assert.equal(res.send.calledWith('dummyxml'), true);
+            sinon.assert.calledOnce(res.send);
+            sinon.assert.calledWith(res.send, 'dummyxml');
 
             done();
         }).catch(done);
@@ -88,11 +88,11 @@ describe('RSS: Renderer', function () {
         }).catch(function (err) {
             assert.equal(err.message, 'Fake Error');
 
-            assert.equal(rssCacheStub.calledOnce, true);
+            sinon.assert.calledOnce(rssCacheStub);
             assert.deepEqual(rssCacheStub.firstCall.args, ['/rss/', {}]);
 
-            assert.equal(res.set.called, false);
-            assert.equal(res.send.called, false);
+            sinon.assert.notCalled(res.set);
+            sinon.assert.notCalled(res.send);
 
             done();
         });

--- a/ghost/core/test/unit/frontend/services/sitemap/manager.test.js
+++ b/ghost/core/test/unit/frontend/services/sitemap/manager.test.js
@@ -82,7 +82,7 @@ describe('Unit: sitemap/manager', function () {
                     }
                 });
 
-                assert.equal(PostGenerator.prototype.addUrl.calledOnce, true);
+                sinon.assert.calledOnce(PostGenerator.prototype.addUrl);
             });
 
             it('url.removed', function () {
@@ -99,7 +99,7 @@ describe('Unit: sitemap/manager', function () {
                     }
                 });
 
-                assert.equal(PostGenerator.prototype.removeUrl.calledOnce, true);
+                sinon.assert.calledOnce(PostGenerator.prototype.removeUrl);
             });
 
             it('Listens to URLResourceUpdatedEvent event', async function () {
@@ -110,20 +110,20 @@ describe('Unit: sitemap/manager', function () {
                 }));
                 await DomainEvents.allSettled();
 
-                assert.ok(PostGenerator.prototype.updateURL.calledOnce);
+                sinon.assert.calledOnce(PostGenerator.prototype.updateURL);
             });
         });
 
         it('fn: getSiteMapXml', function () {
             PostGenerator.prototype.getXml.returns('xml');
             assert.equal(manager.getSiteMapXml('posts'), 'xml');
-            assert.equal(PostGenerator.prototype.getXml.calledOnce, true);
+            sinon.assert.calledOnce(PostGenerator.prototype.getXml);
         });
 
         it('fn: getIndexXml', function () {
             IndexGenerator.prototype.getXml.returns('xml');
             assert.equal(manager.getIndexXml(), 'xml');
-            assert.equal(IndexGenerator.prototype.getXml.calledOnce, true);
+            sinon.assert.calledOnce(IndexGenerator.prototype.getXml);
         });
     });
 });

--- a/ghost/core/test/unit/frontend/services/theme-engine/active.test.js
+++ b/ghost/core/test/unit/frontend/services/theme-engine/active.test.js
@@ -63,8 +63,8 @@ describe('Themes', function () {
                 theme.mount(fakeBlogApp);
 
                 // Check the asset hash gets reset
-                assert.equal(configStub.calledOnce, true);
-                assert.equal(configStub.calledWith('assetHash', null), true);
+                sinon.assert.calledOnce(configStub);
+                sinon.assert.calledWith(configStub, 'assetHash', null);
 
                 // Check the file-based asset hash cache is cleared
                 sinon.assert.calledOnce(clearCacheSpy);
@@ -73,12 +73,12 @@ describe('Themes', function () {
                 assert.deepEqual(fakeBlogApp.cache, {});
 
                 // Check the views were set correctly
-                assert.equal(fakeBlogApp.set.calledOnce, true);
-                assert.equal(fakeBlogApp.set.calledWith('views', 'my/fake/theme/path'), true);
+                sinon.assert.calledOnce(fakeBlogApp.set);
+                sinon.assert.calledWith(fakeBlogApp.set, 'views', 'my/fake/theme/path');
 
                 // Check handlebars was configured correctly
-                assert.equal(engineStub.calledOnce, true);
-                assert.equal(engineStub.calledWith('my/fake/theme/path/partials'), true);
+                sinon.assert.calledOnce(engineStub);
+                sinon.assert.calledWith(engineStub, 'my/fake/theme/path/partials');
 
                 // Check the theme is now mounted
                 assert.equal(activeTheme.get().mounted, true);
@@ -100,8 +100,8 @@ describe('Themes', function () {
                 theme.mount(fakeBlogApp);
 
                 // Check the asset hash gets reset
-                assert.equal(configStub.calledOnce, true);
-                assert.equal(configStub.calledWith('assetHash', null), true);
+                sinon.assert.calledOnce(configStub);
+                sinon.assert.calledWith(configStub, 'assetHash', null);
 
                 // Check the file-based asset hash cache is cleared
                 sinon.assert.calledOnce(clearCacheSpy);
@@ -110,12 +110,12 @@ describe('Themes', function () {
                 assert.deepEqual(fakeBlogApp.cache, {});
 
                 // Check the views were set correctly
-                assert.equal(fakeBlogApp.set.calledOnce, true);
-                assert.equal(fakeBlogApp.set.calledWith('views', 'my/fake/theme/path'), true);
+                sinon.assert.calledOnce(fakeBlogApp.set);
+                sinon.assert.calledWith(fakeBlogApp.set, 'views', 'my/fake/theme/path');
 
                 // Check handlebars was configured correctly
-                assert.equal(engineStub.calledOnce, true);
-                assert.equal(engineStub.calledWith(), true);
+                sinon.assert.calledOnce(engineStub);
+                sinon.assert.calledWith(engineStub);
 
                 // Check the theme is now mounted
                 assert.equal(activeTheme.get().mounted, true);

--- a/ghost/core/test/unit/frontend/services/theme-engine/i18n.test.js
+++ b/ghost/core/test/unit/frontend/services/theme-engine/i18n.test.js
@@ -26,7 +26,7 @@ describe('I18n Class behavior', function () {
             i18n.init();
 
             assert.equal(i18n.locale(), 'fr');
-            assert.equal(fileSpy.calledTwice, true);
+            sinon.assert.calledTwice(fileSpy);
             assert.equal(fileSpy.secondCall.args[0], 'en');
         });
     });

--- a/ghost/core/test/unit/frontend/services/theme-engine/middleware.test.js
+++ b/ghost/core/test/unit/frontend/services/theme-engine/middleware.test.js
@@ -96,8 +96,8 @@ describe('Themes middleware', function () {
             try {
                 assert.equal(err, undefined);
 
-                assert.equal(fakeActiveTheme.mount.called, true);
-                assert.equal(fakeActiveTheme.mount.calledWith(req.app), true);
+                sinon.assert.called(fakeActiveTheme.mount);
+                sinon.assert.calledWith(fakeActiveTheme.mount, req.app);
 
                 done();
             } catch (error) {
@@ -113,7 +113,7 @@ describe('Themes middleware', function () {
             try {
                 assert.equal(err, undefined);
 
-                assert.equal(fakeActiveTheme.mount.called, false);
+                sinon.assert.notCalled(fakeActiveTheme.mount);
 
                 done();
             } catch (error) {
@@ -133,8 +133,8 @@ describe('Themes middleware', function () {
                 assertExists(err);
                 assert.equal(err.message, 'The currently active theme "bacon-sensation" is missing.');
 
-                assert.equal(activeThemeGetStub.called, true);
-                assert.equal(fakeActiveTheme.mount.called, false);
+                sinon.assert.called(activeThemeGetStub);
+                sinon.assert.notCalled(fakeActiveTheme.mount);
 
                 done();
             } catch (error) {
@@ -151,7 +151,7 @@ describe('Themes middleware', function () {
                 try {
                     assert.equal(err, undefined);
 
-                    assert.equal(hbsUpdateTemplateOptionsStub.calledOnce, true);
+                    sinon.assert.calledOnce(hbsUpdateTemplateOptionsStub);
                     const templateOptions = hbsUpdateTemplateOptionsStub.firstCall.args[0];
                     const data = templateOptions.data;
 
@@ -222,7 +222,7 @@ describe('Themes middleware', function () {
                 try {
                     assert.equal(err, undefined);
 
-                    assert.equal(hbsUpdateLocalTemplateOptionsStub.calledOnce, true);
+                    sinon.assert.calledOnce(hbsUpdateLocalTemplateOptionsStub);
                     const templateOptions = hbsUpdateLocalTemplateOptionsStub.firstCall.args[1];
                     const data = templateOptions.data;
 
@@ -246,7 +246,7 @@ describe('Themes middleware', function () {
                 try {
                     assert.equal(err, undefined);
 
-                    assert.equal(hbsUpdateLocalTemplateOptionsStub.calledOnce, true);
+                    sinon.assert.calledOnce(hbsUpdateLocalTemplateOptionsStub);
                     const templateOptions = hbsUpdateLocalTemplateOptionsStub.firstCall.args[1];
                     const data = templateOptions.data;
 
@@ -272,7 +272,7 @@ describe('Themes middleware', function () {
                 try {
                     assert.equal(err, undefined);
 
-                    assert.equal(hbsUpdateLocalTemplateOptionsStub.calledOnce, true);
+                    sinon.assert.calledOnce(hbsUpdateLocalTemplateOptionsStub);
                     const templateOptions = hbsUpdateLocalTemplateOptionsStub.firstCall.args[1];
                     const data = templateOptions.data;
 
@@ -298,7 +298,7 @@ describe('Themes middleware', function () {
                 try {
                     assert.equal(err, undefined);
 
-                    assert.equal(hbsUpdateLocalTemplateOptionsStub.calledOnce, true);
+                    sinon.assert.calledOnce(hbsUpdateLocalTemplateOptionsStub);
                     const templateOptions = hbsUpdateLocalTemplateOptionsStub.firstCall.args[1];
                     const data = templateOptions.data;
 
@@ -327,7 +327,7 @@ describe('Themes middleware', function () {
                 try {
                     assert.equal(err, undefined);
 
-                    assert.equal(hbsUpdateLocalTemplateOptionsStub.calledOnce, true);
+                    sinon.assert.calledOnce(hbsUpdateLocalTemplateOptionsStub);
                     const templateOptions = hbsUpdateLocalTemplateOptionsStub.firstCall.args[1];
                     const data = templateOptions.data;
 
@@ -352,7 +352,7 @@ describe('Themes middleware', function () {
                 try {
                     assert.equal(err, undefined);
 
-                    assert.equal(hbsUpdateLocalTemplateOptionsStub.calledOnce, true);
+                    sinon.assert.calledOnce(hbsUpdateLocalTemplateOptionsStub);
                     const templateOptions = hbsUpdateLocalTemplateOptionsStub.firstCall.args[1];
                     const data = templateOptions.data;
 

--- a/ghost/core/test/unit/frontend/web/middleware/error-handler.test.js
+++ b/ghost/core/test/unit/frontend/web/middleware/error-handler.test.js
@@ -40,18 +40,18 @@ describe('Frontend Error Handler', function () {
 
     // Helper functions to reduce assertion duplication
     function assertPlainTextResponse(response, statusCode, message) {
-        assert.equal(response.status.calledOnceWithExactly(statusCode), true);
-        assert.equal(response.type.calledOnceWithExactly('text/plain'), true);
-        assert.equal(response.send.calledOnce, true);
+        sinon.assert.calledOnceWithExactly(response.status, statusCode);
+        sinon.assert.calledOnceWithExactly(response.type, 'text/plain');
+        sinon.assert.calledOnce(response.send);
         assert.equal(response.send.firstCall.args[0], message);
-        assert.equal(response.render.called, false);
+        sinon.assert.notCalled(response.render);
     }
 
     function assertHtmlResponse(response, expectedHtml) {
-        assert.equal(response.render.calledOnce, true);
-        assert.equal(response.send.calledOnceWithExactly(expectedHtml), true);
-        assert.equal(response.status.called, false);
-        assert.equal(response.type.called, false);
+        sinon.assert.calledOnce(response.render);
+        sinon.assert.calledOnceWithExactly(response.send, expectedHtml);
+        sinon.assert.notCalled(response.status);
+        sinon.assert.notCalled(response.type);
     }
 
     describe('themeErrorRenderer', function () {
@@ -196,7 +196,7 @@ describe('Frontend Error Handler', function () {
             await themeErrorRenderer(err, req, res, next);
 
             assertHtmlResponse(res, mockHtml);
-            assert.equal(next.called, false);
+            sinon.assert.notCalled(next);
         });
 
         it('should render HTML for paths with trailing slash', async function () {
@@ -214,7 +214,7 @@ describe('Frontend Error Handler', function () {
             await themeErrorRenderer(err, req, res, next);
 
             assertHtmlResponse(res, mockHtml);
-            assert.equal(next.called, false);
+            sinon.assert.notCalled(next);
         });
 
         it('should handle render failures gracefully', async function () {
@@ -231,9 +231,9 @@ describe('Frontend Error Handler', function () {
 
             await themeErrorRenderer(err, req, res, next);
 
-            assert.equal(res.render.calledOnce, true);
-            assert.equal(res.status.calledOnceWithExactly(500), true);
-            assert.equal(res.send.calledOnce, true);
+            sinon.assert.calledOnce(res.render);
+            sinon.assert.calledOnceWithExactly(res.status, 500);
+            sinon.assert.calledOnce(res.send);
             
             const errorHtml = res.send.firstCall.args[0];
             assert(errorHtml.includes('Oops, seems there is an error in the error template'));

--- a/ghost/core/test/unit/frontend/web/middleware/frontend-caching.test.js
+++ b/ghost/core/test/unit/frontend/web/middleware/frontend-caching.test.js
@@ -35,23 +35,23 @@ describe('frontendCaching', function () {
     it('should set cache control to private if the blog is private', function () {
         res.isPrivateBlog = true;
         middleware(req, res, next);
-        assert(res.set.calledOnce);
-        assert.ok(res.set.calledWith({'Cache-Control': testUtils.cacheRules.private}));
+        sinon.assert.calledOnce(res.set);
+        sinon.assert.calledWith(res.set, {'Cache-Control': testUtils.cacheRules.private});
     });
 
     it('should set cache control to private if the request is made by a member', function () {
         req.member = true;
         middleware(req, res, next);
-        assert.ok(res.set.calledOnce);
-        assert.ok(res.set.calledWith({'Cache-Control': testUtils.cacheRules.private}));
+        sinon.assert.calledOnce(res.set);
+        sinon.assert.calledWith(res.set, {'Cache-Control': testUtils.cacheRules.private});
     });
 
     it('should set cache control to public if the site is public and the request is not made by a member', function () {
         req.member = undefined;
         res.isPrivateBlog = undefined;
         middleware(req, res, next);
-        assert.ok(res.set.calledOnce);
-        assert.ok(res.set.calledWith({'Cache-Control': testUtils.cacheRules.public}));
+        sinon.assert.calledOnce(res.set);
+        sinon.assert.calledWith(res.set, {'Cache-Control': testUtils.cacheRules.public});
     });
 
     it('should set cache control to public if the request is made by a member and caching members content is enabled', function () {
@@ -61,16 +61,16 @@ describe('frontendCaching', function () {
         };
         res.isPrivateBlog = undefined;
         middleware(req, res, next);
-        assert.equal(res.set.callCount, 2);
-        assert.ok(res.set.calledWith({'Cache-Control': testUtils.cacheRules.public}));
-        assert.ok(res.set.calledWith({'X-Member-Cache-Tier': 'freeTierId'}));
+        sinon.assert.calledTwice(res.set);
+        sinon.assert.calledWith(res.set, {'Cache-Control': testUtils.cacheRules.public});
+        sinon.assert.calledWith(res.set, {'X-Member-Cache-Tier': 'freeTierId'});
     });
 
     it('should set cache control to no-cache if the path starts with /p/', function () {
         req.path = '/p/test';
         middleware(req, res, next);
-        assert.equal(res.set.callCount, 1);
-        assert.ok(res.set.calledWith({'Cache-Control': testUtils.cacheRules.noCache}));
+        sinon.assert.calledOnce(res.set);
+        sinon.assert.calledWith(res.set, {'Cache-Control': testUtils.cacheRules.noCache});
     });
 
     describe('calculateMemberTier', function () {

--- a/ghost/core/test/unit/frontend/web/middleware/handle-image-sizes.test.js
+++ b/ghost/core/test/unit/frontend/web/middleware/handle-image-sizes.test.js
@@ -385,7 +385,7 @@ describe('handleImageSizes middleware', function () {
                     return done(err);
                 }
                 try {
-                    assert.equal(spy.calledOnceWithExactly({path: '/blank_o.png'}), true);
+                    sinon.assert.calledOnceWithExactly(spy, {path: '/blank_o.png'});
                 } catch (e) {
                     return done(e);
                 }
@@ -419,8 +419,8 @@ describe('handleImageSizes middleware', function () {
                     return done(err);
                 }
                 try {
-                    assert.equal(spy.calledOnceWithExactly({path: '/blank_o.png'}), true);
-                    assert.equal(typeStub.calledOnceWithExactly('webp'), true);
+                    sinon.assert.calledOnceWithExactly(spy, {path: '/blank_o.png'});
+                    sinon.assert.calledOnceWithExactly(typeStub, 'webp');
                 } catch (e) {
                     return done(e);
                 }
@@ -567,13 +567,13 @@ describe('handleImageSizes middleware', function () {
                     return done(err);
                 }
                 try {
-                    assert.equal(resizeFromBufferStub.calledOnceWithExactly(buffer, {
+                    sinon.assert.calledOnceWithExactly(resizeFromBufferStub, buffer, {
                         withoutEnlargement: false,
                         width: 1000,
                         format: 'png',
                         timeout: handleImageSizes.RESIZE_TIMEOUT_SECONDS
-                    }), true);
-                    assert.equal(typeStub.calledOnceWithExactly('png'), true);
+                    });
+                    sinon.assert.calledOnceWithExactly(typeStub, 'png');
                 } catch (e) {
                     return done(e);
                 }
@@ -607,13 +607,13 @@ describe('handleImageSizes middleware', function () {
                     return done(err);
                 }
                 try {
-                    assert.equal(resizeFromBufferStub.calledOnceWithExactly(buffer, {
+                    sinon.assert.calledOnceWithExactly(resizeFromBufferStub, buffer, {
                         withoutEnlargement: true,
                         width: 1000,
                         format: 'webp',
                         timeout: handleImageSizes.RESIZE_TIMEOUT_SECONDS
-                    }), true);
-                    assert.equal(typeStub.calledOnceWithExactly('webp'), true);
+                    });
+                    sinon.assert.calledOnceWithExactly(typeStub, 'webp');
                 } catch (e) {
                     return done(e);
                 }
@@ -647,13 +647,13 @@ describe('handleImageSizes middleware', function () {
                     return done(err);
                 }
                 try {
-                    assert.equal(resizeFromBufferStub.calledOnceWithExactly(buffer, {
+                    sinon.assert.calledOnceWithExactly(resizeFromBufferStub, buffer, {
                         withoutEnlargement: true,
                         width: 1000,
                         format: 'avif',
                         timeout: handleImageSizes.RESIZE_TIMEOUT_SECONDS
-                    }), true);
-                    assert.equal(typeStub.calledOnceWithExactly('image/avif'), true);
+                    });
+                    sinon.assert.calledOnceWithExactly(typeStub, 'image/avif');
                 } catch (e) {
                     return done(e);
                 }
@@ -687,13 +687,13 @@ describe('handleImageSizes middleware', function () {
                     return done(err);
                 }
                 try {
-                    assert.equal(resizeFromBufferStub.calledOnceWithExactly(buffer, {
+                    sinon.assert.calledOnceWithExactly(resizeFromBufferStub, buffer, {
                         withoutEnlargement: true,
                         width: 1000,
                         format: 'webp',
                         timeout: handleImageSizes.RESIZE_TIMEOUT_SECONDS
-                    }), true);
-                    assert.equal(typeStub.calledOnceWithExactly('webp'), true);
+                    });
+                    sinon.assert.calledOnceWithExactly(typeStub, 'webp');
                 } catch (e) {
                     return done(e);
                 }
@@ -727,13 +727,13 @@ describe('handleImageSizes middleware', function () {
                     return done(err);
                 }
                 try {
-                    assert.equal(resizeFromBufferStub.calledOnceWithExactly(buffer, {
+                    sinon.assert.calledOnceWithExactly(resizeFromBufferStub, buffer, {
                         withoutEnlargement: true,
                         width: 1000,
                         format: 'gif',
                         timeout: handleImageSizes.RESIZE_TIMEOUT_SECONDS
-                    }), true);
-                    assert.equal(typeStub.calledOnceWithExactly('gif'), true);
+                    });
+                    sinon.assert.calledOnceWithExactly(typeStub, 'gif');
                 } catch (e) {
                     return done(e);
                 }

--- a/ghost/core/test/unit/frontend/web/middleware/redirect-ghost-to-admin.test.js
+++ b/ghost/core/test/unit/frontend/web/middleware/redirect-ghost-to-admin.test.js
@@ -31,8 +31,8 @@ describe('Redirect Ghost To Admin', function () {
     const expectPathCallsRedirectToAdminWith = (inputPath, expectedAdminPath) => {
         req.path = inputPath;
         handleAdminRedirect(req, res);
-        assert.equal(redirectToAdminStub.calledOnce, true);
-        assert.equal(redirectToAdminStub.calledWith(301, res, expectedAdminPath), true);
+        sinon.assert.calledOnce(redirectToAdminStub);
+        sinon.assert.calledWith(redirectToAdminStub, 301, res, expectedAdminPath);
     };
 
     describe('handleAdminRedirect function', function () {

--- a/ghost/core/test/unit/frontend/web/middleware/serve-public-file.test.js
+++ b/ghost/core/test/unit/frontend/web/middleware/serve-public-file.test.js
@@ -29,7 +29,7 @@ describe('servePublicFile', function () {
         const middleware = servePublicFile('static', 'robots.txt', 'text/plain', 3600);
         req.path = '/favicon.ico';
         middleware(req, res, next);
-        assert.equal(next.called, true);
+        sinon.assert.called(next);
     });
 
     it('should load the file and send it with the correct headers', function () {
@@ -48,14 +48,14 @@ describe('servePublicFile', function () {
 
         middleware(req, res, next);
 
-        assert.equal(next.called, false);
+        sinon.assert.notCalled(next);
         assert(fileStub.firstCall.args[0].endsWith('core/frontend/public/robots.txt'));
-        assert.equal(res.writeHead.called, true);
+        sinon.assert.called(res.writeHead);
         assert.equal(res.writeHead.args[0][0], 200);
-        assert.equal(res.writeHead.calledWith(200, sinon.match.has('Content-Type')), true);
-        assert.equal(res.writeHead.calledWith(200, sinon.match.has('Content-Length')), true);
-        assert.equal(res.writeHead.calledWith(200, sinon.match.has('ETag')), true);
-        assert.equal(res.writeHead.calledWith(200, sinon.match.has('Cache-Control', 'public, max-age=3600')), true);
+        sinon.assert.calledWith(res.writeHead, 200, sinon.match.has('Content-Type'));
+        sinon.assert.calledWith(res.writeHead, 200, sinon.match.has('Content-Length'));
+        sinon.assert.calledWith(res.writeHead, 200, sinon.match.has('ETag'));
+        sinon.assert.calledWith(res.writeHead, 200, sinon.match.has('Cache-Control', 'public, max-age=3600'));
     });
 
     it('should send the file from the cache the second time', function () {
@@ -75,19 +75,19 @@ describe('servePublicFile', function () {
         middleware(req, res, next);
         middleware(req, res, next);
 
-        assert.equal(next.called, false);
+        sinon.assert.notCalled(next);
 
         // File only gets read onece
-        assert.equal(fileStub.calledOnce, true);
+        sinon.assert.calledOnce(fileStub);
         assert(fileStub.firstCall.args[0].endsWith('core/frontend/public/robots.txt'));
 
         // File gets served twice
-        assert.equal(res.writeHead.calledTwice, true);
+        sinon.assert.calledTwice(res.writeHead);
         assert.equal(res.writeHead.args[0][0], 200);
-        assert.equal(res.writeHead.calledWith(200, sinon.match.has('Content-Type')), true);
-        assert.equal(res.writeHead.calledWith(200, sinon.match.has('Content-Length')), true);
-        assert.equal(res.writeHead.calledWith(200, sinon.match.has('ETag')), true);
-        assert.equal(res.writeHead.calledWith(200, sinon.match.has('Cache-Control', 'public, max-age=3600')), true);
+        sinon.assert.calledWith(res.writeHead, 200, sinon.match.has('Content-Type'));
+        sinon.assert.calledWith(res.writeHead, 200, sinon.match.has('Content-Length'));
+        sinon.assert.calledWith(res.writeHead, 200, sinon.match.has('ETag'));
+        sinon.assert.calledWith(res.writeHead, 200, sinon.match.has('Cache-Control', 'public, max-age=3600'));
     });
 
     it('should not cache files requested with a different v tag', function () {
@@ -112,18 +112,18 @@ describe('servePublicFile', function () {
         req.query = {v: 2};
         middleware(req, res, next);
 
-        assert.equal(fileStub.calledTwice, true);
+        sinon.assert.calledTwice(fileStub);
 
-        assert.equal(next.called, false);
+        sinon.assert.notCalled(next);
         assert(fileStub.firstCall.args[0].endsWith('core/frontend/public/robots.txt'));
         assert(fileStub.secondCall.args[0].endsWith('core/frontend/public/robots.txt'));
 
-        assert.equal(res.writeHead.calledThrice, true);
+        sinon.assert.calledThrice(res.writeHead);
         assert.equal(res.writeHead.args[0][0], 200);
-        assert.equal(res.writeHead.calledWith(200, sinon.match.has('Content-Type')), true);
-        assert.equal(res.writeHead.calledWith(200, sinon.match.has('Content-Length')), true);
-        assert.equal(res.writeHead.calledWith(200, sinon.match.has('ETag')), true);
-        assert.equal(res.writeHead.calledWith(200, sinon.match.has('Cache-Control', 'public, max-age=3600')), true);
+        sinon.assert.calledWith(res.writeHead, 200, sinon.match.has('Content-Type'));
+        sinon.assert.calledWith(res.writeHead, 200, sinon.match.has('Content-Length'));
+        sinon.assert.calledWith(res.writeHead, 200, sinon.match.has('ETag'));
+        sinon.assert.calledWith(res.writeHead, 200, sinon.match.has('Cache-Control', 'public, max-age=3600'));
     });
 
     it('should replace {{blog-url}} in text/plain', function () {
@@ -141,10 +141,10 @@ describe('servePublicFile', function () {
         };
 
         middleware(req, res, next);
-        assert.equal(next.called, false);
-        assert.equal(res.writeHead.called, true);
+        sinon.assert.notCalled(next);
+        sinon.assert.called(res.writeHead);
 
-        assert.equal(res.end.calledWith(`User-agent: ${config.get('url')}`), true);
+        sinon.assert.calledWith(res.end, `User-agent: ${config.get('url')}`);
     });
 
     it('should 404 for ENOENT on general files', function () {
@@ -164,8 +164,8 @@ describe('servePublicFile', function () {
 
         middleware(req, res, next);
 
-        assert.equal(next.called, true);
-        assert.equal(next.calledWith(sinon.match({errorType: 'NotFoundError', code: 'PUBLIC_FILE_NOT_FOUND'})), true);
+        sinon.assert.called(next);
+        sinon.assert.calledWith(next, sinon.match({errorType: 'NotFoundError', code: 'PUBLIC_FILE_NOT_FOUND'}));
     });
 
     it('can serve a built asset file as well as public files', function () {
@@ -184,8 +184,8 @@ describe('servePublicFile', function () {
 
         middleware(req, res, next);
 
-        assert.equal(next.called, false);
-        assert.equal(res.writeHead.called, true);
+        sinon.assert.notCalled(next);
+        sinon.assert.called(res.writeHead);
         assert.equal(res.writeHead.args[0][0], 200);
 
         assert(fileStub.firstCall.args[0].endsWith('/public/something.css'));

--- a/ghost/core/test/unit/frontend/web/middleware/static-theme.test.js
+++ b/ghost/core/test/unit/frontend/web/middleware/static-theme.test.js
@@ -36,8 +36,8 @@ describe('staticTheme', function () {
         req.path = 'mytemplate.hbs';
 
         staticTheme()(req, res, function next() {
-            assert.equal(activeThemeStub.called, false);
-            assert.equal(expressStaticStub.called, false);
+            sinon.assert.notCalled(activeThemeStub);
+            sinon.assert.notCalled(expressStaticStub);
 
             done();
         });
@@ -47,8 +47,8 @@ describe('staticTheme', function () {
         req.path = 'README.md';
 
         staticTheme()(req, res, function next() {
-            assert.equal(activeThemeStub.called, false);
-            assert.equal(expressStaticStub.called, false);
+            sinon.assert.notCalled(activeThemeStub);
+            sinon.assert.notCalled(expressStaticStub);
 
             done();
         });
@@ -58,8 +58,8 @@ describe('staticTheme', function () {
         req.path = 'sample.json';
 
         staticTheme()(req, res, function next() {
-            assert.equal(activeThemeStub.called, false);
-            assert.equal(expressStaticStub.called, false);
+            sinon.assert.notCalled(activeThemeStub);
+            sinon.assert.notCalled(expressStaticStub);
 
             done();
         });
@@ -69,8 +69,8 @@ describe('staticTheme', function () {
         req.path = 'yarn.lock';
 
         staticTheme()(req, res, function next() {
-            assert.equal(activeThemeStub.called, false);
-            assert.equal(expressStaticStub.called, false);
+            sinon.assert.notCalled(activeThemeStub);
+            sinon.assert.notCalled(expressStaticStub);
 
             done();
         });
@@ -80,8 +80,8 @@ describe('staticTheme', function () {
         req.path = 'gulpfile.js';
 
         staticTheme()(req, res, function next() {
-            assert.equal(activeThemeStub.called, false);
-            assert.equal(expressStaticStub.called, false);
+            sinon.assert.notCalled(activeThemeStub);
+            sinon.assert.notCalled(expressStaticStub);
 
             done();
         });
@@ -91,8 +91,8 @@ describe('staticTheme', function () {
         req.path = 'Gulpfile.js';
 
         staticTheme()(req, res, function next() {
-            assert.equal(activeThemeStub.called, false);
-            assert.equal(expressStaticStub.called, false);
+            sinon.assert.notCalled(activeThemeStub);
+            sinon.assert.notCalled(expressStaticStub);
 
             done();
         });
@@ -103,8 +103,8 @@ describe('staticTheme', function () {
 
         staticTheme()(req, res, function next() {
             // Specifically gets called twice
-            assert.equal(activeThemeStub.calledTwice, true);
-            assert.equal(expressStaticStub.called, true);
+            sinon.assert.calledTwice(activeThemeStub);
+            sinon.assert.called(expressStaticStub);
 
             // Check that express static gets called with the theme path + maxAge
             assertExists(expressStaticStub.firstCall.args);
@@ -122,8 +122,8 @@ describe('staticTheme', function () {
 
         staticTheme()(req, res, function next() {
             // Specifically gets called twice
-            assert.equal(activeThemeStub.calledTwice, true);
-            assert.equal(expressStaticStub.called, true);
+            sinon.assert.calledTwice(activeThemeStub);
+            sinon.assert.called(expressStaticStub);
 
             // Check that express static gets called with the theme path + maxAge
             assertExists(expressStaticStub.firstCall.args);
@@ -143,8 +143,8 @@ describe('staticTheme', function () {
         activeThemeStub.returns(undefined);
 
         staticTheme()(req, res, function next() {
-            assert.equal(activeThemeStub.calledOnce, true);
-            assert.equal(expressStaticStub.called, false);
+            sinon.assert.calledOnce(activeThemeStub);
+            sinon.assert.notCalled(expressStaticStub);
 
             done();
         });
@@ -155,8 +155,8 @@ describe('staticTheme', function () {
 
         staticTheme()(req, res, function next() {
             // Specifically gets called twice
-            assert.equal(activeThemeStub.calledTwice, true);
-            assert.equal(expressStaticStub.called, true);
+            sinon.assert.calledTwice(activeThemeStub);
+            sinon.assert.called(expressStaticStub);
 
             // Check that express static gets called with the theme path + maxAge
             assertExists(expressStaticStub.firstCall.args);
@@ -174,8 +174,8 @@ describe('staticTheme', function () {
 
         staticTheme()(req, res, function next() {
             // Specifically gets called twice
-            assert.equal(activeThemeStub.calledTwice, true);
-            assert.equal(expressStaticStub.called, true);
+            sinon.assert.calledTwice(activeThemeStub);
+            sinon.assert.called(expressStaticStub);
 
             // Check that express static gets called with the theme path + maxAge
             assertExists(expressStaticStub.firstCall.args);
@@ -193,8 +193,8 @@ describe('staticTheme', function () {
 
         staticTheme()(req, res, function next() {
             // Specifically gets called twice
-            assert.equal(activeThemeStub.calledTwice, true);
-            assert.equal(expressStaticStub.called, true);
+            sinon.assert.calledTwice(activeThemeStub);
+            sinon.assert.called(expressStaticStub);
 
             // Check that express static gets called with the theme path + maxAge
             assertExists(expressStaticStub.firstCall.args);
@@ -211,8 +211,8 @@ describe('staticTheme', function () {
         req.path = '/assets/mytemplate.hbs';
 
         staticTheme()(req, res, function next() {
-            assert.equal(activeThemeStub.called, false);
-            assert.equal(expressStaticStub.called, false);
+            sinon.assert.notCalled(activeThemeStub);
+            sinon.assert.notCalled(expressStaticStub);
 
             done();
         });
@@ -223,8 +223,8 @@ describe('staticTheme', function () {
         req.method = 'GET';
 
         staticTheme()(req, res, function next() {
-            assert.equal(activeThemeStub.called, false);
-            assert.equal(expressStaticStub.called, false);
+            sinon.assert.notCalled(activeThemeStub);
+            sinon.assert.notCalled(expressStaticStub);
 
             done();
         });
@@ -235,8 +235,8 @@ describe('staticTheme', function () {
         req.method = 'GET';
 
         staticTheme()(req, res, function next() {
-            assert.equal(activeThemeStub.called, false);
-            assert.equal(expressStaticStub.called, false);
+            sinon.assert.notCalled(activeThemeStub);
+            sinon.assert.notCalled(expressStaticStub);
 
             done();
         });
@@ -247,8 +247,8 @@ describe('staticTheme', function () {
             req.path = '/';
 
             staticTheme()(req, res, function next() {
-                assert.equal(activeThemeStub.called, false);
-                assert.equal(expressStaticStub.called, false);
+                sinon.assert.notCalled(activeThemeStub);
+                sinon.assert.notCalled(expressStaticStub);
 
                 done();
             });
@@ -258,8 +258,8 @@ describe('staticTheme', function () {
             req.path = '/about/';
 
             staticTheme()(req, res, function next() {
-                assert.equal(activeThemeStub.called, false);
-                assert.equal(expressStaticStub.called, false);
+                sinon.assert.notCalled(activeThemeStub);
+                sinon.assert.notCalled(expressStaticStub);
 
                 done();
             });
@@ -269,8 +269,8 @@ describe('staticTheme', function () {
             req.path = '/blog/my-post/';
 
             staticTheme()(req, res, function next() {
-                assert.equal(activeThemeStub.called, false);
-                assert.equal(expressStaticStub.called, false);
+                sinon.assert.notCalled(activeThemeStub);
+                sinon.assert.notCalled(expressStaticStub);
 
                 done();
             });
@@ -280,8 +280,8 @@ describe('staticTheme', function () {
             req.path = '/contact';
 
             staticTheme()(req, res, function next() {
-                assert.equal(activeThemeStub.called, false);
-                assert.equal(expressStaticStub.called, false);
+                sinon.assert.notCalled(activeThemeStub);
+                sinon.assert.notCalled(expressStaticStub);
 
                 done();
             });
@@ -292,8 +292,8 @@ describe('staticTheme', function () {
 
             staticTheme()(req, res, function next() {
                 // Specifically gets called twice
-                assert.equal(activeThemeStub.calledTwice, true);
-                assert.equal(expressStaticStub.called, true);
+                sinon.assert.calledTwice(activeThemeStub);
+                sinon.assert.called(expressStaticStub);
 
                 // Check that express static gets called with the theme path + maxAge
                 assertExists(expressStaticStub.firstCall.args);
@@ -311,8 +311,8 @@ describe('staticTheme', function () {
 
             staticTheme()(req, res, function next() {
                 // Specifically gets called twice
-                assert.equal(activeThemeStub.calledTwice, true);
-                assert.equal(expressStaticStub.called, true);
+                sinon.assert.calledTwice(activeThemeStub);
+                sinon.assert.called(expressStaticStub);
 
                 // Check that express static gets called with the theme path + maxAge
                 assertExists(expressStaticStub.firstCall.args);
@@ -330,8 +330,8 @@ describe('staticTheme', function () {
 
             staticTheme()(req, res, function next() {
                 // Specifically gets called twice
-                assert.equal(activeThemeStub.calledTwice, true);
-                assert.equal(expressStaticStub.called, true);
+                sinon.assert.calledTwice(activeThemeStub);
+                sinon.assert.called(expressStaticStub);
 
                 // Check that express static gets called with the theme path + maxAge
                 assertExists(expressStaticStub.firstCall.args);
@@ -356,15 +356,15 @@ describe('staticTheme', function () {
             req.path = '/.well-known/apple-app-site-association';
 
             staticTheme()(req, res, function next() {
-                assert.equal(activeThemeStub.called, true);
-                assert.equal(expressStaticStub.called, true);
+                sinon.assert.called(activeThemeStub);
+                sinon.assert.called(expressStaticStub);
 
                 const options = expressStaticStub.firstCall.args[1];
                 assertExists(options.setHeaders);
 
                 const setHeaderStub = sinon.stub();
                 options.setHeaders({setHeader: setHeaderStub});
-                assert.equal(setHeaderStub.calledWith('Content-Type', 'application/json'), true);
+                sinon.assert.calledWith(setHeaderStub, 'Content-Type', 'application/json');
 
                 done();
             });
@@ -374,7 +374,7 @@ describe('staticTheme', function () {
             req.path = '/.WELL-KNOWN/apple-app-site-association.json';
 
             staticTheme()(req, res, function next() {
-                assert.equal(expressStaticStub.called, false);
+                sinon.assert.notCalled(expressStaticStub);
                 done();
             });
         });
@@ -386,8 +386,8 @@ describe('staticTheme', function () {
 
             staticTheme()(req, res, function next() {
                 // Specifically gets called twice
-                assert.equal(activeThemeStub.calledTwice, true);
-                assert.equal(expressStaticStub.called, true);
+                sinon.assert.calledTwice(activeThemeStub);
+                sinon.assert.called(expressStaticStub);
 
                 // Check that express static gets called with correct options
                 assertExists(expressStaticStub.firstCall.args);
@@ -407,8 +407,8 @@ describe('staticTheme', function () {
 
             staticTheme()(req, res, function next() {
                 // Specifically gets called twice
-                assert.equal(activeThemeStub.calledTwice, true);
-                assert.equal(expressStaticStub.called, true);
+                sinon.assert.calledTwice(activeThemeStub);
+                sinon.assert.called(expressStaticStub);
 
                 // Check that express static gets called with correct options
                 assertExists(expressStaticStub.firstCall.args);
@@ -428,8 +428,8 @@ describe('staticTheme', function () {
 
             staticTheme()(req, res, function next() {
                 // Specifically gets called twice
-                assert.equal(activeThemeStub.calledTwice, true);
-                assert.equal(expressStaticStub.called, true);
+                sinon.assert.calledTwice(activeThemeStub);
+                sinon.assert.called(expressStaticStub);
 
                 // Check that express static gets called with correct options
                 assertExists(expressStaticStub.firstCall.args);
@@ -448,8 +448,8 @@ describe('staticTheme', function () {
             req.path = '/sitemap-posts-2.xml';
 
             staticTheme()(req, res, function next() {
-                assert.equal(activeThemeStub.calledTwice, true);
-                assert.equal(expressStaticStub.called, true);
+                sinon.assert.calledTwice(activeThemeStub);
+                sinon.assert.called(expressStaticStub);
 
                 assertExists(expressStaticStub.firstCall.args);
                 assert.equal(expressStaticStub.firstCall.args[0], 'my/fake/path');
@@ -467,8 +467,8 @@ describe('staticTheme', function () {
             req.path = '/sitemap-posts-99.xml';
 
             staticTheme()(req, res, function next() {
-                assert.equal(activeThemeStub.calledTwice, true);
-                assert.equal(expressStaticStub.called, true);
+                sinon.assert.calledTwice(activeThemeStub);
+                sinon.assert.called(expressStaticStub);
 
                 const options = expressStaticStub.firstCall.args[1];
                 assert.equal(options.fallthrough, true);
@@ -481,8 +481,8 @@ describe('staticTheme', function () {
             req.path = '/sitemap-tags-3.xml';
 
             staticTheme()(req, res, function next() {
-                assert.equal(activeThemeStub.calledTwice, true);
-                assert.equal(expressStaticStub.called, true);
+                sinon.assert.calledTwice(activeThemeStub);
+                sinon.assert.called(expressStaticStub);
 
                 const options = expressStaticStub.firstCall.args[1];
                 assert.equal(options.fallthrough, true);
@@ -495,8 +495,8 @@ describe('staticTheme', function () {
             req.path = '/sitemap-authors-2.xml';
 
             staticTheme()(req, res, function next() {
-                assert.equal(activeThemeStub.calledTwice, true);
-                assert.equal(expressStaticStub.called, true);
+                sinon.assert.calledTwice(activeThemeStub);
+                sinon.assert.called(expressStaticStub);
 
                 const options = expressStaticStub.firstCall.args[1];
                 assert.equal(options.fallthrough, true);
@@ -510,8 +510,8 @@ describe('staticTheme', function () {
 
             staticTheme()(req, res, function next() {
                 // Specifically gets called twice
-                assert.equal(activeThemeStub.calledTwice, true);
-                assert.equal(expressStaticStub.called, true);
+                sinon.assert.calledTwice(activeThemeStub);
+                sinon.assert.called(expressStaticStub);
 
                 // Check that express static gets called with correct options
                 assertExists(expressStaticStub.firstCall.args);
@@ -531,8 +531,8 @@ describe('staticTheme', function () {
 
             staticTheme()(req, res, function next() {
                 // Specifically gets called twice
-                assert.equal(activeThemeStub.calledTwice, true);
-                assert.equal(expressStaticStub.called, true);
+                sinon.assert.calledTwice(activeThemeStub);
+                sinon.assert.called(expressStaticStub);
 
                 // Check that express static gets called with correct options
                 assertExists(expressStaticStub.firstCall.args);
@@ -552,8 +552,8 @@ describe('staticTheme', function () {
 
             staticTheme()(req, res, function next() {
                 // Specifically gets called twice
-                assert.equal(activeThemeStub.calledTwice, true);
-                assert.equal(expressStaticStub.called, true);
+                sinon.assert.calledTwice(activeThemeStub);
+                sinon.assert.called(expressStaticStub);
 
                 // Check that express static gets called with correct options
                 assertExists(expressStaticStub.firstCall.args);

--- a/ghost/core/test/unit/server/adapters/lib/redis/adapter-cache-redis.test.js
+++ b/ghost/core/test/unit/server/adapters/lib/redis/adapter-cache-redis.test.js
@@ -110,14 +110,14 @@ describe('Adapter Cache Redis', function () {
 
             checkFirstRead: {
                 const value = await cache.get(KEY, fetchData);
-                assert.equal(fetchData.callCount, 1);
+                sinon.assert.calledOnce(fetchData);
                 assert.equal(value, 'Da Value');
                 break checkFirstRead;
             }
 
             checkSecondRead: {
                 const value = await cache.get(KEY, fetchData);
-                assert.equal(fetchData.callCount, 1);
+                sinon.assert.calledOnce(fetchData);
                 assert.equal(value, 'Da Value');
                 break checkSecondRead;
             }
@@ -159,7 +159,7 @@ describe('Adapter Cache Redis', function () {
 
             checkFirstRead: {
                 const value = await cache.get(KEY, fetchData);
-                assert.equal(fetchData.callCount, 1);
+                sinon.assert.calledOnce(fetchData);
                 assert.equal(value, 'First Value');
                 break checkFirstRead;
             }
@@ -169,7 +169,7 @@ describe('Adapter Cache Redis', function () {
 
             checkSecondRead: {
                 const value = await cache.get(KEY, fetchData);
-                assert.equal(fetchData.callCount, 1);
+                sinon.assert.calledOnce(fetchData);
                 assert.equal(value, 'First Value');
                 break checkSecondRead;
             }
@@ -179,7 +179,7 @@ describe('Adapter Cache Redis', function () {
 
             checkThirdRead: {
                 const value = await cache.get(KEY, fetchData);
-                assert.equal(fetchData.callCount, 1);
+                sinon.assert.calledOnce(fetchData);
                 assert.equal(value, 'First Value');
                 break checkThirdRead;
             }
@@ -190,7 +190,7 @@ describe('Adapter Cache Redis', function () {
 
             checkFourthRead: {
                 const value = await cache.get(KEY, fetchData);
-                assert.equal(fetchData.callCount, 2);
+                sinon.assert.calledTwice(fetchData);
                 assert.equal(value, 'First Value');
                 break checkFourthRead;
             }
@@ -200,7 +200,7 @@ describe('Adapter Cache Redis', function () {
 
             checkFifthRead: {
                 const value = await cache.get(KEY, fetchData);
-                assert.equal(fetchData.callCount, 2);
+                sinon.assert.calledTwice(fetchData);
                 assert.equal(value, 'Second Value');
                 break checkFifthRead;
             }
@@ -264,7 +264,7 @@ describe('Adapter Cache Redis', function () {
 
             await cache.reset();
 
-            assert.ok(logging.error.calledOnce, 'error was logged');
+            sinon.assert.calledOnce(logging.error);
         });
     });
 });

--- a/ghost/core/test/unit/server/adapters/scheduling/post-scheduling/post-scheduler.test.js
+++ b/ghost/core/test/unit/server/adapters/scheduling/post-scheduling/post-scheduler.test.js
@@ -73,9 +73,9 @@ describe('Scheduling: Post Scheduler', function () {
                     setTimeout(resolve, 100);
                 });
 
-                assert.equal(adapter.schedule.called, true);
+                sinon.assert.called(adapter.schedule);
 
-                assert.equal(adapter.schedule.calledOnce, true);
+                sinon.assert.calledOnce(adapter.schedule);
 
                 assert.equal(adapter.schedule.args[0][0].time, moment(post.get('published_at')).valueOf());
                 assert(adapter.schedule.args[0][0].url.startsWith(urlUtils.urlJoin('http://scheduler.local:1111/', 'schedules', 'posts', post.get('id'), '?token=')));

--- a/ghost/core/test/unit/server/adapters/scheduling/scheduling-default.test.js
+++ b/ghost/core/test/unit/server/adapters/scheduling/scheduling-default.test.js
@@ -49,7 +49,7 @@ describe('Scheduling Default Adapter', function () {
             // 2 jobs get immediately executed
             assert.equal(scope.adapter.allJobs[moment(dates[1]).valueOf()], undefined);
             assert.equal(scope.adapter.allJobs[moment(dates[7]).valueOf()], undefined);
-            assert.equal(scope.adapter._execute.calledTwice, true);
+            sinon.assert.calledTwice(scope.adapter._execute);
 
             assert.equal(Object.keys(scope.adapter.allJobs).length, dates.length - 2);
             assert.deepEqual(Object.keys(scope.adapter.allJobs), [
@@ -96,7 +96,7 @@ describe('Scheduling Default Adapter', function () {
 
             clock.tick(50);
 
-            assert.equal(scope.adapter._pingUrl.calledOnce, true);
+            sinon.assert.calledOnce(scope.adapter._pingUrl);
             done();
         });
 
@@ -124,7 +124,7 @@ describe('Scheduling Default Adapter', function () {
             });
 
             clock.tick(50);
-            assert.equal(scope.adapter._pingUrl.calledOnce, true);
+            sinon.assert.calledOnce(scope.adapter._pingUrl);
             done();
         });
 

--- a/ghost/core/test/unit/server/adapters/storage/local-base-storage.test.js
+++ b/ghost/core/test/unit/server/adapters/storage/local-base-storage.test.js
@@ -86,7 +86,7 @@ describe('Local Storage Base', function () {
                 }, '2026/01');
 
                 // Verify getUniqueFileName was called with the absolute path
-                assert.ok(localStorageBase.getUniqueFileName.calledOnce);
+                sinon.assert.calledOnce(localStorageBase.getUniqueFileName);
                 const [, targetDir] = localStorageBase.getUniqueFileName.firstCall.args;
                 assert.equal(targetDir, '/var/www/ghost/content/media/2026/01');
 
@@ -129,7 +129,7 @@ describe('Local Storage Base', function () {
                 await localStorageBase.exists('video.mp4', '2026/01');
 
                 // Verify fs.stat was called with the correct absolute path
-                assert.ok(statStub.calledOnce);
+                sinon.assert.calledOnce(statStub);
                 assert.equal(statStub.firstCall.args[0], '/var/www/ghost/content/media/2026/01/video.mp4');
             });
         });
@@ -147,7 +147,7 @@ describe('Local Storage Base', function () {
                 await localStorageBase.delete('video.mp4', '2026/01');
 
                 // Verify fs.remove was called with the correct absolute path
-                assert.ok(removeStub.calledOnce);
+                sinon.assert.calledOnce(removeStub);
                 assert.equal(removeStub.firstCall.args[0], '/var/www/ghost/content/media/2026/01/video.mp4');
             });
         });

--- a/ghost/core/test/unit/server/adapters/storage/local-images-storage.test.js
+++ b/ghost/core/test/unit/server/adapters/storage/local-images-storage.test.js
@@ -89,7 +89,7 @@ describe('Local Images Storage', function () {
 
     it('should create month and year directory', function (done) {
         localFileStore.save(image).then(function () {
-            assert.equal(fsMkdirsStub.calledOnce, true);
+            sinon.assert.calledOnce(fsMkdirsStub);
             assert.equal(fsMkdirsStub.args[0][0], path.resolve('./content/images/2013/09'));
 
             done();
@@ -98,7 +98,7 @@ describe('Local Images Storage', function () {
 
     it('should copy temp file to new location', function (done) {
         localFileStore.save(image).then(function () {
-            assert.equal(fsCopyStub.calledOnce, true);
+            sinon.assert.calledOnce(fsCopyStub);
             assert.equal(fsCopyStub.args[0][0], 'tmp/123456.jpg');
             assert.equal(fsCopyStub.args[0][1], path.resolve('./content/images/2013/09/IMAGE.jpg'));
 

--- a/ghost/core/test/unit/server/adapters/storage/s3-storage.test.ts
+++ b/ghost/core/test/unit/server/adapters/storage/s3-storage.test.ts
@@ -332,7 +332,7 @@ describe('S3Storage', function () {
         sendStub.rejects(createNotFoundError());
 
         await storage.delete('ghost.txt', 'content/files');
-        assert.equal(sendStub.callCount, 1);
+        sinon.assert.calledOnce(sendStub);
     });
 
     it('exists rethrows unexpected S3 errors', async function () {
@@ -806,7 +806,7 @@ describe('S3Storage', function () {
             }, '2024/06');
 
             // Should have: CreateMultipartUpload + 3 UploadPart + CompleteMultipartUpload = 5 calls
-            assert.equal(sendStub.callCount, 5);
+            sinon.assert.callCount(sendStub, 5);
 
             // Verify 3 parts were uploaded
             const uploadPartCalls = sendStub.getCalls().filter(call => call.args[0] instanceof UploadPartCommand);

--- a/ghost/core/test/unit/server/data/db/backup.test.js
+++ b/ghost/core/test/unit/server/data/db/backup.test.js
@@ -1,4 +1,3 @@
-const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const fs = require('fs-extra');
 const models = require('../../../../../core/server/models');
@@ -27,9 +26,9 @@ describe('Backup', function () {
 
     it('should create a backup JSON file', function (done) {
         dbBackup.backup().then(function () {
-            assert.equal(exportStub.calledOnce, true);
-            assert.equal(filenameStub.calledOnce, true);
-            assert.equal(fsStub.calledOnce, true);
+            sinon.assert.calledOnce(exportStub);
+            sinon.assert.calledOnce(filenameStub);
+            sinon.assert.calledOnce(fsStub);
 
             done();
         }).catch(done);
@@ -39,9 +38,9 @@ describe('Backup', function () {
         configUtils.set('disableJSBackups', true);
 
         dbBackup.backup().then(function () {
-            assert.equal(exportStub.called, false);
-            assert.equal(filenameStub.called, false);
-            assert.equal(fsStub.called, false);
+            sinon.assert.notCalled(exportStub);
+            sinon.assert.notCalled(filenameStub);
+            sinon.assert.notCalled(fsStub);
 
             done();
         }).catch(done);

--- a/ghost/core/test/unit/server/data/exporter/index.test.js
+++ b/ghost/core/test/unit/server/data/exporter/index.test.js
@@ -47,10 +47,10 @@ describe('Exporter', function () {
 
                 assert.match(exportData.meta.version, /\d+.\d+.\d+/gi);
 
-                assert.equal(tablesStub.calledOnce, true);
-                assert.equal(db.knex.called, true);
+                sinon.assert.calledOnce(tablesStub);
+                sinon.assert.called(db.knex);
 
-                assert.equal(knexMock.callCount, expectedCallCount);
+                sinon.assert.callCount(knexMock, expectedCallCount);
                 sinon.assert.callCount(queryMock.select, expectedCallCount);
 
                 const expectedTables = new Set([
@@ -93,11 +93,11 @@ describe('Exporter', function () {
 
                 assert.match(exportData.meta.version, /\d+.\d+.\d+/gi);
 
-                assert.equal(tablesStub.calledOnce, true);
-                assert.equal(db.knex.called, true);
-                assert.equal(queryMock.select.called, true);
+                sinon.assert.calledOnce(tablesStub);
+                sinon.assert.called(db.knex);
+                sinon.assert.called(queryMock.select);
 
-                assert.equal(knexMock.callCount, expectedCallCount);
+                sinon.assert.callCount(knexMock, expectedCallCount);
                 sinon.assert.callCount(queryMock.select, expectedCallCount);
 
                 const expectedTables = new Set([
@@ -158,7 +158,7 @@ describe('Exporter', function () {
 
             exporter.fileName().then(function (result) {
                 assertExists(result);
-                assert.equal(settingsStub.calledOnce, true);
+                sinon.assert.calledOnce(settingsStub);
                 assert.match(result, /^testblog\.ghost\.[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{2}-[0-9]{2}-[0-9]{2}\.json$/);
 
                 done();
@@ -172,7 +172,7 @@ describe('Exporter', function () {
 
             exporter.fileName().then(function (result) {
                 assertExists(result);
-                assert.equal(settingsStub.calledOnce, true);
+                sinon.assert.calledOnce(settingsStub);
                 assert.match(result, /^ghost\.[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{2}-[0-9]{2}-[0-9]{2}\.json$/);
 
                 done();
@@ -187,8 +187,8 @@ describe('Exporter', function () {
 
             exporter.fileName().then(function (result) {
                 assertExists(result);
-                assert.equal(settingsStub.calledOnce, true);
-                assert.equal(loggingStub.calledOnce, true);
+                sinon.assert.calledOnce(settingsStub);
+                sinon.assert.calledOnce(loggingStub);
                 assert.match(result, /^ghost\.[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{2}-[0-9]{2}-[0-9]{2}\.json$/);
 
                 done();

--- a/ghost/core/test/unit/server/data/importer/handlers/image.test.js
+++ b/ghost/core/test/unit/server/data/importer/handlers/image.test.js
@@ -50,8 +50,8 @@ describe('ImageHandler', function () {
         const storageSpy = sinon.spy(storage, 'getStorage');
 
         ImageHandler.loadFile(_.clone(file)).then(function () {
-            assert.equal(storageSpy.calledOnce, true);
-            assert.equal(storeSpy.calledOnce, true);
+            sinon.assert.calledOnce(storageSpy);
+            sinon.assert.calledOnce(storeSpy);
             assert.equal(storeSpy.firstCall.args[0].originalPath, 'test-image.jpeg');
             assert.match(storeSpy.firstCall.args[0].targetDir, /(\/|\\)content(\/|\\)images$/);
             assert.equal(storeSpy.firstCall.args[0].newPath, '/content/images/test-image.jpeg');
@@ -72,8 +72,8 @@ describe('ImageHandler', function () {
         const storageSpy = sinon.spy(storage, 'getStorage');
 
         ImageHandler.loadFile(_.clone(file)).then(function () {
-            assert.equal(storageSpy.calledOnce, true);
-            assert.equal(storeSpy.calledOnce, true);
+            sinon.assert.calledOnce(storageSpy);
+            sinon.assert.calledOnce(storeSpy);
             assert.equal(storeSpy.firstCall.args[0].originalPath, 'photos/my-cat.jpeg');
             assert.match(storeSpy.firstCall.args[0].targetDir, /(\/|\\)content(\/|\\)images(\/|\\)photos$/);
             assert.equal(storeSpy.firstCall.args[0].newPath, '/content/images/photos/my-cat.jpeg');
@@ -94,8 +94,8 @@ describe('ImageHandler', function () {
         const storageSpy = sinon.spy(storage, 'getStorage');
 
         ImageHandler.loadFile(_.clone(file)).then(function () {
-            assert.equal(storageSpy.calledOnce, true);
-            assert.equal(storeSpy.calledOnce, true);
+            sinon.assert.calledOnce(storageSpy);
+            sinon.assert.calledOnce(storeSpy);
             assert.equal(storeSpy.firstCall.args[0].originalPath, 'content/images/my-cat.jpeg');
             assert.match(storeSpy.firstCall.args[0].targetDir, /(\/|\\)content(\/|\\)images$/);
             assert.equal(storeSpy.firstCall.args[0].newPath, '/content/images/my-cat.jpeg');
@@ -118,8 +118,8 @@ describe('ImageHandler', function () {
         const storageSpy = sinon.spy(storage, 'getStorage');
 
         ImageHandler.loadFile(_.clone(file)).then(function () {
-            assert.equal(storageSpy.calledOnce, true);
-            assert.equal(storeSpy.calledOnce, true);
+            sinon.assert.calledOnce(storageSpy);
+            sinon.assert.calledOnce(storeSpy);
             assert.equal(storeSpy.firstCall.args[0].originalPath, 'test-image.jpeg');
             assert.match(storeSpy.firstCall.args[0].targetDir, /(\/|\\)content(\/|\\)images$/);
             assert.equal(storeSpy.firstCall.args[0].newPath, '/subdir/content/images/test-image.jpeg');
@@ -150,8 +150,8 @@ describe('ImageHandler', function () {
         const storageSpy = sinon.spy(storage, 'getStorage');
 
         ImageHandler.loadFile(_.clone(files)).then(function () {
-            assert.equal(storageSpy.calledOnce, true);
-            assert.equal(storeSpy.callCount, 4);
+            sinon.assert.calledOnce(storageSpy);
+            sinon.assert.callCount(storeSpy, 4);
             assert.equal(storeSpy.firstCall.args[0].originalPath, 'testing.png');
             assert.match(storeSpy.firstCall.args[0].targetDir, /(\/|\\)content(\/|\\)images$/);
             assert.equal(storeSpy.firstCall.args[0].newPath, '/content/images/testing.png');

--- a/ghost/core/test/unit/server/data/importer/importers/content-file-importer.test.js
+++ b/ghost/core/test/unit/server/data/importer/importers/content-file-importer.test.js
@@ -63,7 +63,7 @@ describe('ContentFileImporter', function () {
 
         await imageImporter.doImport(inputData.images);
 
-        assert.equal(storageApi.save.calledTwice, true);
+        sinon.assert.calledTwice(storageApi.save);
     });
 
     it('does import the files correctly', async function () {
@@ -77,7 +77,7 @@ describe('ContentFileImporter', function () {
 
         await imageImporter.doImport(inputData.files);
 
-        assert.equal(storageApi.save.calledOnce, true);
+        sinon.assert.calledOnce(storageApi.save);
         assert.equal(storageApi.save.args[0][0].name, 'best-memes.pdf');
         assert.equal(storageApi.save.args[0][0].newPath, '/content/files/best-memes.pdf');
     });

--- a/ghost/core/test/unit/server/data/importer/index.test.js
+++ b/ghost/core/test/unit/server/data/importer/index.test.js
@@ -148,7 +148,7 @@ describe('Importer', function () {
             const removeStub = sinon.stub(fs, 'remove').withArgs(file).returns(Promise.resolve());
 
             await ImportManager.cleanUp();
-            assert.equal(removeStub.calledOnce, true);
+            sinon.assert.calledOnce(removeStub);
             assert.equal(ImportManager.fileToDelete, null);
         });
 
@@ -157,7 +157,7 @@ describe('Importer', function () {
             const removeStub = sinon.stub(fs, 'remove').returns(Promise.resolve());
 
             await ImportManager.cleanUp();
-            assert.equal(removeStub.called, false);
+            sinon.assert.notCalled(removeStub);
         });
 
         it('silently ignores clean up errors', async function () {
@@ -167,8 +167,8 @@ describe('Importer', function () {
             const removeStub = sinon.stub(fs, 'remove').withArgs(file).returns(Promise.reject(new Error('Unknown file')));
 
             await ImportManager.cleanUp();
-            assert.equal(removeStub.calledOnce, true);
-            assert.equal(loggingStub.calledOnce, true);
+            sinon.assert.calledOnce(removeStub);
+            sinon.assert.calledOnce(loggingStub);
             assert.equal(ImportManager.fileToDelete, null);
         });
 
@@ -180,8 +180,8 @@ describe('Importer', function () {
                 const fileSpy = sinon.stub(ImportManager, 'processFile').returns(Promise.resolve({}));
 
                 ImportManager.loadFile(testFile).then(function () {
-                    assert.equal(zipSpy.calledOnce, false);
-                    assert.equal(fileSpy.calledOnce, true);
+                    sinon.assert.notCalled(zipSpy);
+                    sinon.assert.calledOnce(fileSpy);
                     done();
                 }).catch(done);
             });
@@ -193,8 +193,8 @@ describe('Importer', function () {
                 const fileSpy = sinon.stub(ImportManager, 'processFile').resolves({});
 
                 ImportManager.loadFile(testZip).then(function () {
-                    assert.equal(zipSpy.calledOnce, true);
-                    assert.equal(fileSpy.calledOnce, false);
+                    sinon.assert.calledOnce(zipSpy);
+                    sinon.assert.notCalled(fileSpy);
                     done();
                 }).catch(done);
             });
@@ -219,17 +219,17 @@ describe('Importer', function () {
                 getFileSpy.withArgs(RevueHandler, sinon.match.string).returns([{path: '/tmp/dir/myFile.json', name: 'myFile.json'}]);
 
                 ImportManager.processZip(testZip).then(function (zipResult) {
-                    assert.equal(extractSpy.calledOnce, true);
-                    assert.equal(validSpy.calledOnce, true);
-                    assert.equal(baseDirSpy.calledOnce, true);
-                    assert.equal(getFileSpy.callCount, 6);
-                    assert.equal(jsonSpy.calledOnce, true);
-                    assert.equal(imageSpy.called, false);
-                    assert.equal(mdSpy.called, false);
-                    assert.equal(revueSpy.called, true);
+                    sinon.assert.calledOnce(extractSpy);
+                    sinon.assert.calledOnce(validSpy);
+                    sinon.assert.calledOnce(baseDirSpy);
+                    sinon.assert.callCount(getFileSpy, 6);
+                    sinon.assert.calledOnce(jsonSpy);
+                    sinon.assert.notCalled(imageSpy);
+                    sinon.assert.notCalled(mdSpy);
+                    sinon.assert.called(revueSpy);
 
                     ImportManager.processFile(testFile, '.json').then(function (fileResult) {
-                        assert.equal(jsonSpy.calledTwice, true);
+                        sinon.assert.calledTwice(jsonSpy);
 
                         // They should both have data keys, and they should be equivalent
                         assert('data' in zipResult);
@@ -319,7 +319,7 @@ describe('Importer', function () {
                     const zipResult = await ImportManager.processZip(testZip);
                     assertExists(zipResult.data);
                     assert.equal(zipResult.images, undefined);
-                    assert.equal(extractSpy.calledOnce, true);
+                    sinon.assert.calledOnce(extractSpy);
                 });
 
                 it('accepts a zip without a base directory', async function () {
@@ -329,7 +329,7 @@ describe('Importer', function () {
                     const zipResult = await ImportManager.processZip(testZip);
                     assertExists(zipResult.data);
                     assert.equal(zipResult.images, undefined);
-                    assert.equal(extractSpy.calledOnce, true);
+                    sinon.assert.calledOnce(extractSpy);
                 });
 
                 it('accepts a zip with an image directory', async function () {
@@ -339,7 +339,7 @@ describe('Importer', function () {
                     const zipResult = await ImportManager.processZip(testZip);
                     assert.equal(zipResult.images.length, 1);
                     assert.equal(zipResult.data, undefined);
-                    assert.equal(extractSpy.calledOnce, true);
+                    sinon.assert.calledOnce(extractSpy);
                 });
 
                 it('accepts a zip with uppercase image extensions', async function () {
@@ -349,7 +349,7 @@ describe('Importer', function () {
                     const zipResult = await ImportManager.processZip(testZip);
                     assert.equal(zipResult.images.length, 1);
                     assert.equal(zipResult.data, undefined);
-                    assert.equal(extractSpy.calledOnce, true);
+                    sinon.assert.calledOnce(extractSpy);
                 });
 
                 it('throws zipContainsMultipleDataFormats', async function () {
@@ -357,7 +357,7 @@ describe('Importer', function () {
                     const extractSpy = sinon.stub(ImportManager, 'extractZip').returns(Promise.resolve(testDir));
 
                     await assert.rejects(ImportManager.processZip(testZip), /multiple data formats/);
-                    assert.equal(extractSpy.calledOnce, true);
+                    sinon.assert.calledOnce(extractSpy);
                 });
 
                 it('throws noContentToImport', async function () {
@@ -365,7 +365,7 @@ describe('Importer', function () {
                     const extractSpy = sinon.stub(ImportManager, 'extractZip').returns(Promise.resolve(testDir));
 
                     await assert.rejects(ImportManager.processZip(testZip), /not include any content/);
-                    assert.equal(extractSpy.calledOnce, true);
+                    sinon.assert.calledOnce(extractSpy);
                 });
             });
 
@@ -436,12 +436,12 @@ describe('Importer', function () {
                 const revueSpy = sinon.spy(RevueImporter, 'preProcess');
 
                 ImportManager.preProcess(inputCopy).then(function (output) {
-                    assert.equal(revueSpy.calledOnce, true);
-                    assert.equal(revueSpy.calledWith(inputCopy), true);
-                    assert.equal(dataSpy.calledOnce, true);
-                    assert.equal(dataSpy.calledWith(inputCopy), true);
-                    assert.equal(imageSpy.calledOnce, true);
-                    assert.equal(imageSpy.calledWith(inputCopy), true);
+                    sinon.assert.calledOnce(revueSpy);
+                    sinon.assert.calledWith(revueSpy, inputCopy);
+                    sinon.assert.calledOnce(dataSpy);
+                    sinon.assert.calledWith(dataSpy, inputCopy);
+                    sinon.assert.calledOnce(imageSpy);
+                    sinon.assert.calledWith(imageSpy, inputCopy);
                     // eql checks for equality
                     // equal checks the references are for the same object
                     assert.notEqual(output, input);
@@ -480,8 +480,8 @@ describe('Importer', function () {
                 ImportManager.doImport(inputCopy).then(function (output) {
                     // eql checks for equality
                     // equal checks the references are for the same object
-                    assert.equal(dataSpy.calledOnce, true);
-                    assert.equal(imageSpy.calledOnce, true);
+                    sinon.assert.calledOnce(dataSpy);
+                    sinon.assert.calledOnce(imageSpy);
                     assert.deepEqual(dataSpy.getCall(0).args[0], expectedData);
                     assert.deepEqual(imageSpy.getCall(0).args[0], expectedImages);
 
@@ -514,11 +514,11 @@ describe('Importer', function () {
                 const cleanupSpy = sinon.stub(ImportManager, 'cleanUp').returns(Promise.resolve());
 
                 ImportManager.importFromFile({name: 'test.json', path: '/test.json'}).then(function () {
-                    assert.equal(loadFileSpy.calledOnce, true);
-                    assert.equal(preProcessSpy.calledOnce, true);
-                    assert.equal(doImportSpy.calledOnce, true);
-                    assert.equal(generateReportSpy.calledOnce, true);
-                    assert.equal(cleanupSpy.calledOnce, true);
+                    sinon.assert.calledOnce(loadFileSpy);
+                    sinon.assert.calledOnce(preProcessSpy);
+                    sinon.assert.calledOnce(doImportSpy);
+                    sinon.assert.calledOnce(generateReportSpy);
+                    sinon.assert.calledOnce(cleanupSpy);
                     sinon.assert.callOrder(loadFileSpy, preProcessSpy, doImportSpy, generateReportSpy, cleanupSpy);
 
                     done();

--- a/ghost/core/test/unit/server/data/migrations/utils.test.js
+++ b/ghost/core/test/unit/server/data/migrations/utils.test.js
@@ -783,7 +783,7 @@ describe('migrations/utils/schema nullable functions', function () {
             try {
                 const runDownMigration = await runUpMigration(knex, migration);
 
-                assert(logSpy.calledWith(sinon.match('skipping as column is already nullable')), 'Should log skip message');
+                sinon.assert.calledWith(logSpy, sinon.match('skipping as column is already nullable'));
 
                 // Column should still be nullable
                 const isNullableAfter = await checkColumnNullable('test_nullable_migration', 'nullable_col', knex);
@@ -839,7 +839,7 @@ describe('migrations/utils/schema nullable functions', function () {
             try {
                 const runDownMigration = await runUpMigration(knex, migration);
 
-                assert(logSpy.calledWith(sinon.match('skipping as column is already not nullable')), 'Should log skip message');
+                sinon.assert.calledWith(logSpy, sinon.match('skipping as column is already not nullable'));
 
                 // Column should still be not nullable
                 const isNotNullableAfter = await checkColumnNullable('test_nullable_migration', 'not_nullable_col', knex);

--- a/ghost/core/test/unit/server/data/schema/fixtures/fixture-manager.test.js
+++ b/ghost/core/test/unit/server/data/schema/fixtures/fixture-manager.test.js
@@ -249,63 +249,63 @@ describe('Migration Fixture Utils', function () {
 
         it('should match undefined with no args', function () {
             assert.equal(matchFunc()({get: getStub}), true);
-            assert.equal(getStub.calledOnce, true);
-            assert.equal(getStub.calledWith(undefined), true);
+            sinon.assert.calledOnce(getStub);
+            sinon.assert.calledWith(getStub, undefined);
         });
 
         it('should match key with match string', function () {
             assert.equal(matchFunc('foo', 'bar')({get: getStub}), true);
-            assert.equal(getStub.calledOnce, true);
-            assert.equal(getStub.calledWith('foo'), true);
+            sinon.assert.calledOnce(getStub);
+            sinon.assert.calledWith(getStub, 'foo');
 
             assert.equal(matchFunc('foo', 'buz')({get: getStub}), false);
-            assert.equal(getStub.calledTwice, true);
-            assert.equal(getStub.secondCall.calledWith('foo'), true);
+            sinon.assert.calledTwice(getStub);
+            sinon.assert.calledWith(getStub.secondCall, 'foo');
         });
 
         it('should match value when key is 0', function () {
             assert.equal(matchFunc('foo', 0, 'bar')({get: getStub}), true);
-            assert.equal(getStub.calledOnce, true);
-            assert.equal(getStub.calledWith('foo'), true);
+            sinon.assert.calledOnce(getStub);
+            sinon.assert.calledWith(getStub, 'foo');
 
             assert.equal(matchFunc('foo', 0, 'buz')({get: getStub}), false);
-            assert.equal(getStub.calledTwice, true);
-            assert.equal(getStub.secondCall.calledWith('foo'), true);
+            sinon.assert.calledTwice(getStub);
+            sinon.assert.calledWith(getStub.secondCall, 'foo');
         });
 
         it('should match key & value when match is array', function () {
             assert.equal(matchFunc(['foo', 'fun'], 'bar', 'baz')({get: getStub}), true);
-            assert.equal(getStub.calledTwice, true);
-            assert.equal(getStub.getCall(0).calledWith('fun'), true);
-            assert.equal(getStub.getCall(1).calledWith('foo'), true);
+            sinon.assert.calledTwice(getStub);
+            sinon.assert.calledWith(getStub.getCall(0), 'fun');
+            sinon.assert.calledWith(getStub.getCall(1), 'foo');
 
             assert.equal(matchFunc(['foo', 'fun'], 'baz', 'bar')({get: getStub}), false);
-            assert.equal(getStub.callCount, 4);
-            assert.equal(getStub.getCall(2).calledWith('fun'), true);
-            assert.equal(getStub.getCall(3).calledWith('foo'), true);
+            sinon.assert.callCount(getStub, 4);
+            sinon.assert.calledWith(getStub.getCall(2), 'fun');
+            sinon.assert.calledWith(getStub.getCall(3), 'foo');
         });
 
         it('should match key only when match is array, but value is all', function () {
             assert.equal(matchFunc(['foo', 'fun'], 'bar', 'all')({get: getStub}), true);
-            assert.equal(getStub.calledOnce, true);
-            assert.equal(getStub.calledWith('foo'), true);
+            sinon.assert.calledOnce(getStub);
+            sinon.assert.calledWith(getStub, 'foo');
 
             assert.equal(matchFunc(['foo', 'fun'], 'all', 'bar')({get: getStub}), false);
-            assert.equal(getStub.callCount, 3);
-            assert.equal(getStub.getCall(1).calledWith('fun'), true);
-            assert.equal(getStub.getCall(2).calledWith('foo'), true);
+            sinon.assert.calledThrice(getStub);
+            sinon.assert.calledWith(getStub.getCall(1), 'fun');
+            sinon.assert.calledWith(getStub.getCall(2), 'foo');
         });
 
         it('should match key & value when match and value are arrays', function () {
             assert.equal(matchFunc(['foo', 'fun'], 'bar', ['baz', 'buz'])({get: getStub}), true);
-            assert.equal(getStub.calledTwice, true);
-            assert.equal(getStub.getCall(0).calledWith('fun'), true);
-            assert.equal(getStub.getCall(1).calledWith('foo'), true);
+            sinon.assert.calledTwice(getStub);
+            sinon.assert.calledWith(getStub.getCall(0), 'fun');
+            sinon.assert.calledWith(getStub.getCall(1), 'foo');
 
             assert.equal(matchFunc(['foo', 'fun'], 'bar', ['biz', 'buz'])({get: getStub}), false);
-            assert.equal(getStub.callCount, 4);
-            assert.equal(getStub.getCall(2).calledWith('fun'), true);
-            assert.equal(getStub.getCall(3).calledWith('foo'), true);
+            sinon.assert.callCount(getStub, 4);
+            sinon.assert.calledWith(getStub.getCall(2), 'fun');
+            sinon.assert.calledWith(getStub.getCall(3), 'foo');
         });
     });
 
@@ -316,8 +316,8 @@ describe('Migration Fixture Utils', function () {
 
             await fixtureManager.addAllFixtures();
 
-            assert.equal(addFixturesForModelStub.callCount, fixtures.models.length);
-            assert.equal(addFixturesForRelationStub.callCount, fixtures.relations.length);
+            sinon.assert.callCount(addFixturesForModelStub, fixtures.models.length);
+            sinon.assert.callCount(addFixturesForRelationStub, fixtures.relations.length);
 
             // NOTE: users and roles have to be initialized first for the post fixtures to work
             assert.equal(addFixturesForModelStub.firstCall.args[0].name, 'Role');
@@ -342,8 +342,8 @@ describe('Migration Fixture Utils', function () {
                 assert.equal(result.expected, 11);
                 assert.equal(result.done, 11);
 
-                assert.equal(postOneStub.callCount, 11);
-                assert.equal(postAddStub.callCount, 11);
+                sinon.assert.callCount(postOneStub, 11);
+                sinon.assert.callCount(postAddStub, 11);
 
                 done();
             }).catch(done);
@@ -363,8 +363,8 @@ describe('Migration Fixture Utils', function () {
                 assert.equal(result.expected, 1);
                 assert.equal(result.done, 1);
 
-                assert.equal(newsletterOneStub.callCount, 1);
-                assert.equal(newsletterAddStub.callCount, 1);
+                sinon.assert.calledOnce(newsletterOneStub);
+                sinon.assert.calledOnce(newsletterAddStub);
 
                 done();
             }).catch(done);
@@ -384,8 +384,8 @@ describe('Migration Fixture Utils', function () {
                 assert.equal(result.expected, 11);
                 assert.equal(result.done, 0);
 
-                assert.equal(postOneStub.callCount, 11);
-                assert.equal(postAddStub.callCount, 0);
+                sinon.assert.callCount(postOneStub, 11);
+                sinon.assert.notCalled(postAddStub);
 
                 done();
             }).catch(done);
@@ -418,14 +418,14 @@ describe('Migration Fixture Utils', function () {
                 assert.equal(result.done, FIXTURE_COUNT);
 
                 // Permissions & Roles
-                assert.equal(permsAllStub.calledOnce, true);
-                assert.equal(rolesAllStub.calledOnce, true);
-                assert.equal(dataMethodStub.filter.callCount, FIXTURE_COUNT);
-                assert.equal(dataMethodStub.find.callCount, 10);
-                assert.equal(baseUtilAttachStub.callCount, FIXTURE_COUNT);
+                sinon.assert.calledOnce(permsAllStub);
+                sinon.assert.calledOnce(rolesAllStub);
+                sinon.assert.callCount(dataMethodStub.filter, FIXTURE_COUNT);
+                sinon.assert.callCount(dataMethodStub.find, 10);
+                sinon.assert.callCount(baseUtilAttachStub, FIXTURE_COUNT);
 
-                assert.equal(fromItem.related.callCount, FIXTURE_COUNT);
-                assert.equal(fromItem.find.callCount, FIXTURE_COUNT);
+                sinon.assert.callCount(fromItem.related, FIXTURE_COUNT);
+                sinon.assert.callCount(fromItem.find, FIXTURE_COUNT);
 
                 done();
             }).catch(done);
@@ -455,13 +455,13 @@ describe('Migration Fixture Utils', function () {
                 assert.equal(result.done, 7);
 
                 // Posts & Tags
-                assert.equal(postsAllStub.calledOnce, true);
-                assert.equal(tagsAllStub.calledOnce, true);
-                assert.equal(dataMethodStub.filter.callCount, 7);
-                assert.equal(dataMethodStub.find.callCount, 7);
-                assert.equal(fromItem.related.callCount, 7);
-                assert.equal(fromItem.find.callCount, 7);
-                assert.equal(baseUtilAttachStub.callCount, 7);
+                sinon.assert.calledOnce(postsAllStub);
+                sinon.assert.calledOnce(tagsAllStub);
+                sinon.assert.callCount(dataMethodStub.filter, 7);
+                sinon.assert.callCount(dataMethodStub.find, 7);
+                sinon.assert.callCount(fromItem.related, 7);
+                sinon.assert.callCount(fromItem.find, 7);
+                sinon.assert.callCount(baseUtilAttachStub, 7);
 
                 done();
             }).catch(done);
@@ -492,16 +492,16 @@ describe('Migration Fixture Utils', function () {
                 assert.equal(result.done, 0);
 
                 // Posts & Tags
-                assert.equal(postsAllStub.calledOnce, true);
-                assert.equal(tagsAllStub.calledOnce, true);
-                assert.equal(dataMethodStub.filter.callCount, 7);
-                assert.equal(dataMethodStub.find.callCount, 7);
+                sinon.assert.calledOnce(postsAllStub);
+                sinon.assert.calledOnce(tagsAllStub);
+                sinon.assert.callCount(dataMethodStub.filter, 7);
+                sinon.assert.callCount(dataMethodStub.find, 7);
 
-                assert.equal(fromItem.related.callCount, 7);
-                assert.equal(fromItem.find.callCount, 7);
+                sinon.assert.callCount(fromItem.related, 7);
+                sinon.assert.callCount(fromItem.find, 7);
 
-                assert.equal(fromItem.tags.called, false);
-                assert.equal(fromItem.attach.called, false);
+                sinon.assert.notCalled(fromItem.tags);
+                sinon.assert.notCalled(fromItem.attach);
 
                 done();
             }).catch(done);

--- a/ghost/core/test/unit/server/lib/image/blog-icon.test.js
+++ b/ghost/core/test/unit/server/lib/image/blog-icon.test.js
@@ -116,7 +116,7 @@ describe('lib/image: blog icon', function () {
             }});
 
             blogIcon.getIconPath();
-            assert.equal(stub.calledOnce, true);
+            sinon.assert.calledOnce(stub);
         });
 
         it('custom uploaded png blog icon', function () {
@@ -132,7 +132,7 @@ describe('lib/image: blog icon', function () {
             }});
 
             blogIcon.getIconPath();
-            assert.equal(stub.calledOnce, true);
+            sinon.assert.calledOnce(stub);
         });
 
         it('default ico blog icon', function () {

--- a/ghost/core/test/unit/server/lib/image/cached-image-size-from-url.test.js
+++ b/ghost/core/test/unit/server/lib/image/cached-image-size-from-url.test.js
@@ -50,7 +50,7 @@ describe('lib/image: image size cache', function () {
         // second call to check if values get returned from cache
         await cachedImageSizeFromUrl.getCachedImageSizeFromUrl(url);
 
-        assert.equal(imageSizeSpy.calledOnce, true);
+        sinon.assert.calledOnce(imageSizeSpy);
         assert.equal(imageSizeSpy.calledTwice, false);
 
         assertExists(cacheStore.get(url));
@@ -80,7 +80,7 @@ describe('lib/image: image size cache', function () {
         // Transient errors should NOT be cached
         assert.equal(cacheStore.get(url), undefined);
         sinon.assert.calledOnce(loggingStub);
-        assert.equal(sizeOfStub.calledOnce, true);
+        sinon.assert.calledOnce(sizeOfStub);
 
         // Second call should retry the fetch since nothing was cached
         const result2 = await cachedImageSizeFromUrl.getCachedImageSizeFromUrl(url);
@@ -89,7 +89,7 @@ describe('lib/image: image size cache', function () {
 
         // Cache should still be empty after the second transient error
         assert.equal(cacheStore.get(url), undefined);
-        assert.equal(sizeOfStub.calledTwice, true);
+        sinon.assert.calledTwice(sizeOfStub);
     });
 
     it('should cache NotFoundError permanently and not refetch on subsequent calls', async function () {
@@ -115,7 +115,7 @@ describe('lib/image: image size cache', function () {
         // Second call should NOT refetch — 404 is permanent
         const secondResult = await cachedImageSizeFromUrl.getCachedImageSizeFromUrl(url);
         assert.equal(secondResult, null);
-        assert.equal(sizeOfStub.calledOnce, true);
+        sinon.assert.calledOnce(sizeOfStub);
     });
 
     it('should retry fetch when cache has a stale error entry (no dimensions)', async function () {
@@ -136,7 +136,7 @@ describe('lib/image: image size cache', function () {
 
         assert.equal(result.width, 500);
         assert.equal(result.height, 400);
-        assert.equal(sizeOfStub.calledOnce, true);
+        sinon.assert.calledOnce(sizeOfStub);
 
         // Verify cache was overwritten with valid dimensions
         const cached = cacheStore.get(url);

--- a/ghost/core/test/unit/server/lib/image/image-size.test.js
+++ b/ghost/core/test/unit/server/lib/image/image-size.test.js
@@ -360,12 +360,12 @@ describe('lib/image: image size', function () {
             assert.equal(localResult.url, localImageUrl);
             assert.equal(localResult.width, expectedLocalDimensions.width);
             assert.equal(localResult.height, expectedLocalDimensions.height);
-            assert.equal(storageReadSpy.calledOnce, true);
+            sinon.assert.calledOnce(storageReadSpy);
 
             const cdnResult = await imageSize.getImageSizeFromUrl(cdnImageUrl);
             assert.equal(cdnResult.url, cdnImageUrl);
             assert.equal(cdnRequestMock.isDone(), true);
-            assert.equal(storageReadSpy.calledOnce, true);
+            sinon.assert.calledOnce(storageReadSpy);
         });
 
         it('[failure] can handle an error with statuscode not 200 (probe-image-size)', function (done) {

--- a/ghost/core/test/unit/server/lib/post-revisions.test.ts
+++ b/ghost/core/test/unit/server/lib/post-revisions.test.ts
@@ -344,7 +344,7 @@ describe('PostRevisions', function () {
 
             await postRevisions.removeAuthorFromRevisions(authorId, options);
 
-            assert.equal(modelStub.bulkEdit.calledOnce, true);
+            sinon.assert.calledOnce(modelStub.bulkEdit);
 
             const bulkEditArgs = modelStub.bulkEdit.getCall(0).args;
 
@@ -376,7 +376,7 @@ describe('PostRevisions', function () {
                 transacting: {}
             });
 
-            assert.equal(modelStub.bulkEdit.calledOnce, false);
+            sinon.assert.notCalled(modelStub.bulkEdit);
         });
     });
 });

--- a/ghost/core/test/unit/server/models/base/actions.test.js
+++ b/ghost/core/test/unit/server/models/base/actions.test.js
@@ -258,7 +258,7 @@ describe('Unit: models/base/plugins/actions', function () {
 
                 TestModel.prototype.addAction.call(testModel, testModel, 'edited', options);
 
-                assert.equal(getActionStub.called, false);
+                sinon.assert.notCalled(getActionStub);
             });
         });
 

--- a/ghost/core/test/unit/server/models/base/bulk-filters.test.js
+++ b/ghost/core/test/unit/server/models/base/bulk-filters.test.js
@@ -54,8 +54,8 @@ describe('Models: bulk-filters', function () {
 
             applyWhere(mockQb);
 
-            assert.equal(mockQb.whereIn.calledOnce, true);
-            assert.equal(mockQb.whereIn.calledWith('member_id', ids), true);
+            sinon.assert.calledOnce(mockQb.whereIn);
+            sinon.assert.calledWith(mockQb.whereIn, 'member_id', ids);
         });
 
         it('allows custom chunk size', function () {
@@ -80,8 +80,8 @@ describe('Models: bulk-filters', function () {
 
             applyWhere(mockQb);
 
-            assert.equal(mockQb.whereIn.calledOnce, true);
-            assert.equal(mockQb.whereIn.calledWith('id', ids), true);
+            sinon.assert.calledOnce(mockQb.whereIn);
+            sinon.assert.calledWith(mockQb.whereIn, 'id', ids);
         });
     });
 });

--- a/ghost/core/test/unit/server/models/base/relations.test.js
+++ b/ghost/core/test/unit/server/models/base/relations.test.js
@@ -34,15 +34,15 @@ describe('Models: getLazyRelation', function () {
         const options = {test: true};
         const modelA = TestModel.forge({id: '1'});
         assert.equal((await modelA.getLazyRelation('tiers', options)), rel);
-        assert.equal(fetchStub.calledOnceWithExactly(options), true);
+        sinon.assert.calledOnceWithExactly(fetchStub, options);
 
         // Check if it can reuse it again
         assert.equal((await modelA.getLazyRelation('tiers', options)), rel);
-        assert.equal(fetchStub.calledOnceWithExactly(options), true);
+        sinon.assert.calledOnceWithExactly(fetchStub, options);
 
         // Check if we can force reload
         await assert.rejects(modelA.getLazyRelation('tiers', {forceRefresh: true}), /Called twice/);
-        assert.equal(fetchStub.calledTwice, true);
+        sinon.assert.calledTwice(fetchStub);
     });
 
     it('can fetch models', async function () {
@@ -69,15 +69,15 @@ describe('Models: getLazyRelation', function () {
         const options = {test: true};
         const modelA = TestModel.forge({id: '1'});
         assert.equal((await modelA.getLazyRelation('other', options)), rel);
-        assert.equal(fetchStub.calledOnceWithExactly(options), true);
+        sinon.assert.calledOnceWithExactly(fetchStub, options);
 
         // Check if it can reuse it again
         assert.equal((await modelA.getLazyRelation('other', options)), rel);
-        assert.equal(fetchStub.calledOnceWithExactly(options), true);
+        sinon.assert.calledOnceWithExactly(fetchStub, options);
 
         // Check if we can force reload
         await assert.rejects(modelA.getLazyRelation('other', {forceRefresh: true}), /Called twice/);
-        assert.equal(fetchStub.calledTwice, true);
+        sinon.assert.calledTwice(fetchStub);
     });
 
     it('can handle fetch of model without id for optional relations', async function () {

--- a/ghost/core/test/unit/server/models/member.test.js
+++ b/ghost/core/test/unit/server/models/member.test.js
@@ -75,7 +75,7 @@ describe('Unit: models/member', function () {
                 id: '1'
             }]);
 
-            assert.equal(updatePivot.calledWith({expiry_at: new Date(expiry)}, {query: {where: {product_id: '1'}}}), true);
+            sinon.assert.calledWith(updatePivot, {expiry_at: new Date(expiry)}, {query: {where: {product_id: '1'}}});
         });
 
         it('calls updatePivot on member products to remove expiry', function () {
@@ -83,7 +83,7 @@ describe('Unit: models/member', function () {
                 id: '1'
             }]);
 
-            assert.equal(updatePivot.calledWith({expiry_at: null}, {query: {where: {product_id: '1'}}}), true);
+            sinon.assert.calledWith(updatePivot, {expiry_at: null}, {query: {where: {product_id: '1'}}});
         });
     });
 });

--- a/ghost/core/test/unit/server/models/post.test.js
+++ b/ghost/core/test/unit/server/models/post.test.js
@@ -455,7 +455,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         done(new Error('Permissible function should have rejected.'));
                     }).catch((error) => {
                         assert(error instanceof errors.NoPermissionError);
-                        assert.equal(mockPostObj.get.called, false);
+                        sinon.assert.notCalled(mockPostObj.get);
                         assert.equal(mockPostObj.related.calledTwice, false);
                         done();
                     });
@@ -484,8 +484,8 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                     ).then((result) => {
                         assertExists(result);
                         assert.deepEqual(result.excludedAttrs, ['authors', 'tags']);
-                        assert.equal(mockPostObj.get.callCount, 2);
-                        assert.equal(mockPostObj.related.callCount, 2);
+                        sinon.assert.calledTwice(mockPostObj.get);
+                        sinon.assert.calledTwice(mockPostObj.related);
                         done();
                     }).catch(done);
                 });
@@ -514,8 +514,8 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         done(new Error('Permissible function should have rejected.'));
                     }).catch((error) => {
                         assert(error instanceof errors.NoPermissionError);
-                        assert.equal(mockPostObj.get.callCount, 2);
-                        assert.equal(mockPostObj.related.callCount, 1);
+                        sinon.assert.calledTwice(mockPostObj.get);
+                        sinon.assert.calledOnce(mockPostObj.related);
                         done();
                     });
                 });
@@ -543,7 +543,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         done(new Error('Permissible function should have rejected.'));
                     }).catch((error) => {
                         assert(error instanceof errors.NoPermissionError);
-                        assert.equal(mockPostObj.related.callCount, 1);
+                        sinon.assert.calledOnce(mockPostObj.related);
                         done();
                     });
                 });
@@ -571,8 +571,8 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                     ).then((result) => {
                         assertExists(result);
                         assert.deepEqual(result.excludedAttrs, ['authors', 'tags']);
-                        assert.equal(mockPostObj.get.callCount, 2);
-                        assert.equal(mockPostObj.related.callCount, 1);
+                        sinon.assert.calledTwice(mockPostObj.get);
+                        sinon.assert.calledOnce(mockPostObj.related);
                     });
                 });
             });
@@ -598,7 +598,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         done(new Error('Permissible function should have rejected.'));
                     }).catch((error) => {
                         assert(error instanceof errors.NoPermissionError);
-                        assert.equal(mockPostObj.get.called, false);
+                        sinon.assert.notCalled(mockPostObj.get);
                         done();
                     });
                 });
@@ -623,7 +623,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         done(new Error('Permissible function should have rejected.'));
                     }).catch((error) => {
                         assert(error instanceof errors.NoPermissionError);
-                        assert.equal(mockPostObj.get.called, false);
+                        sinon.assert.notCalled(mockPostObj.get);
                         done();
                     });
                 });
@@ -648,7 +648,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         done(new Error('Permissible function should have rejected.'));
                     }).catch((error) => {
                         assert(error instanceof errors.NoPermissionError);
-                        assert.equal(mockPostObj.get.called, false);
+                        sinon.assert.notCalled(mockPostObj.get);
                         done();
                     });
                 });
@@ -672,7 +672,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                     ).then((result) => {
                         assertExists(result);
                         assert.deepEqual(result.excludedAttrs, ['authors', 'tags']);
-                        assert.equal(mockPostObj.get.called, false);
+                        sinon.assert.notCalled(mockPostObj.get);
                         done();
                     }).catch(done);
                 });
@@ -701,8 +701,8 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         done(new Error('Permissible function should have rejected.'));
                     }).catch((error) => {
                         assert(error instanceof errors.NoPermissionError);
-                        assert.equal(mockPostObj.get.calledOnce, true);
-                        assert.equal(mockPostObj.related.calledOnce, true);
+                        sinon.assert.calledOnce(mockPostObj.get);
+                        sinon.assert.calledOnce(mockPostObj.related);
                         done();
                     });
                 });
@@ -730,8 +730,8 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         done(new Error('Permissible function should have rejected.'));
                     }).catch((error) => {
                         assert(error instanceof errors.NoPermissionError);
-                        assert.equal(mockPostObj.get.calledOnce, true);
-                        assert.equal(mockPostObj.related.calledOnce, true);
+                        sinon.assert.calledOnce(mockPostObj.get);
+                        sinon.assert.calledOnce(mockPostObj.related);
                         done();
                     });
                 });
@@ -758,8 +758,8 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                     ).then((result) => {
                         assertExists(result);
                         assert.deepEqual(result.excludedAttrs, ['authors', 'tags']);
-                        assert.equal(mockPostObj.get.calledOnce, true);
-                        assert.equal(mockPostObj.related.calledOnce, true);
+                        sinon.assert.calledOnce(mockPostObj.get);
+                        sinon.assert.calledOnce(mockPostObj.related);
                     });
                 });
             });
@@ -790,8 +790,8 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         done(new Error('Permissible function should have rejected.'));
                     }).catch((error) => {
                         assert(error instanceof errors.NoPermissionError);
-                        assert.equal(mockPostObj.get.called, false);
-                        assert.equal(mockPostObj.related.calledOnce, true);
+                        sinon.assert.notCalled(mockPostObj.get);
+                        sinon.assert.calledOnce(mockPostObj.related);
                         done();
                     });
                 });
@@ -820,8 +820,8 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         done(new Error('Permissible function should have rejected.'));
                     }).catch((error) => {
                         assert(error instanceof errors.NoPermissionError);
-                        assert.equal(mockPostObj.get.called, false);
-                        assert.equal(mockPostObj.related.calledOnce, true);
+                        sinon.assert.notCalled(mockPostObj.get);
+                        sinon.assert.calledOnce(mockPostObj.related);
                         done();
                     });
                 });
@@ -849,8 +849,8 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         done(new Error('Permissible function should have rejected.'));
                     }).catch((error) => {
                         assert(error instanceof errors.NoPermissionError);
-                        assert.equal(mockPostObj.get.called, false);
-                        assert.equal(mockPostObj.related.calledTwice, true);
+                        sinon.assert.notCalled(mockPostObj.get);
+                        sinon.assert.calledTwice(mockPostObj.related);
                         done();
                     });
                 });
@@ -878,8 +878,8 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         done(new Error('Permissible function should have rejected.'));
                     }).catch((error) => {
                         assert(error instanceof errors.NoPermissionError);
-                        assert.equal(mockPostObj.get.called, false);
-                        assert.equal(mockPostObj.related.calledTwice, true);
+                        sinon.assert.notCalled(mockPostObj.get);
+                        sinon.assert.calledTwice(mockPostObj.related);
                         done();
                     });
                 });
@@ -903,7 +903,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         true,
                         true
                     ).then(() => {
-                        assert.equal(mockPostObj.related.calledOnce, true);
+                        sinon.assert.calledOnce(mockPostObj.related);
                     });
                 });
             });
@@ -929,7 +929,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         done(new Error('Permissible function should have rejected.'));
                     }).catch((error) => {
                         assert(error instanceof errors.NoPermissionError);
-                        assert.equal(mockPostObj.get.called, false);
+                        sinon.assert.notCalled(mockPostObj.get);
                         done();
                     });
                 });
@@ -957,7 +957,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         done(new Error('Permissible function should have rejected.'));
                     }).catch((error) => {
                         assert(error instanceof errors.NoPermissionError);
-                        assert.equal(mockPostObj.get.called, false);
+                        sinon.assert.notCalled(mockPostObj.get);
                         done();
                     });
                 });
@@ -988,8 +988,8 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                     done(new Error('Permissible function should have rejected.'));
                 }).catch((error) => {
                     assert(error instanceof errors.NoPermissionError);
-                    assert.equal(mockPostObj.get.called, false);
-                    assert.equal(mockPostObj.related.calledOnce, true);
+                    sinon.assert.notCalled(mockPostObj.get);
+                    sinon.assert.calledOnce(mockPostObj.related);
                     done();
                 });
             });
@@ -1011,7 +1011,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                     true,
                     true
                 ).then(() => {
-                    assert.equal(mockPostObj.get.called, false);
+                    sinon.assert.notCalled(mockPostObj.get);
                 });
             });
 
@@ -1036,8 +1036,8 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                     true,
                     true
                 ).then(() => {
-                    assert.equal(mockPostObj.get.called, false);
-                    assert.equal(mockPostObj.related.calledOnce, true);
+                    sinon.assert.notCalled(mockPostObj.get);
+                    sinon.assert.calledOnce(mockPostObj.related);
                     done();
                 }).catch(() => {
                     done(new Error('Permissible function should have passed for owner.'));
@@ -1065,8 +1065,8 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                     true,
                     true
                 ).then(() => {
-                    assert.equal(mockPostObj.get.called, false);
-                    assert.equal(mockPostObj.related.calledOnce, true);
+                    sinon.assert.notCalled(mockPostObj.get);
+                    sinon.assert.calledOnce(mockPostObj.related);
                     done();
                 }).catch(() => {
                     done(new Error('Permissible function should have passed for administrator.'));

--- a/ghost/core/test/unit/server/models/settings.test.js
+++ b/ghost/core/test/unit/server/models/settings.test.js
@@ -51,9 +51,9 @@ describe('Unit: models/settings', function () {
                 type: 'string'
             })
                 .then(() => {
-                    assert.equal(eventSpy.calledTwice, true);
-                    assert.equal(eventSpy.firstCall.calledWith('settings.added'), true);
-                    assert.equal(eventSpy.secondCall.calledWith('settings.description.added'), true);
+                    sinon.assert.calledTwice(eventSpy);
+                    sinon.assert.calledWith(eventSpy.firstCall, 'settings.added');
+                    sinon.assert.calledWith(eventSpy.secondCall, 'settings.description.added');
                 });
         });
 
@@ -75,9 +75,9 @@ describe('Unit: models/settings', function () {
                 value: 'edited value'
             })
                 .then(() => {
-                    assert.equal(eventSpy.calledTwice, true);
-                    assert.equal(eventSpy.firstCall.calledWith('settings.edited'), true);
-                    assert.equal(eventSpy.secondCall.calledWith('settings.description.edited'), true);
+                    sinon.assert.calledTwice(eventSpy);
+                    sinon.assert.calledWith(eventSpy.firstCall, 'settings.edited');
+                    sinon.assert.calledWith(eventSpy.secondCall, 'settings.description.edited');
                 });
         });
     });

--- a/ghost/core/test/unit/server/models/user.test.js
+++ b/ghost/core/test/unit/server/models/user.test.js
@@ -169,7 +169,7 @@ describe('Unit: models/user', function () {
                 done(new Error('Permissible function should have errored'));
             }).catch((error) => {
                 assert(error instanceof errors.NoPermissionError);
-                assert.equal(mockUser.hasRole.calledOnce, true);
+                sinon.assert.calledOnce(mockUser.hasRole);
                 done();
             });
         });
@@ -179,7 +179,7 @@ describe('Unit: models/user', function () {
             const context = {user: 3};
 
             return models.User.permissible(mockUser, 'edit', context, {}, testUtils.permissions.contributor, false, true, true).then(() => {
-                assert.equal(mockUser.get.calledOnce, true);
+                sinon.assert.calledOnce(mockUser.get);
             });
         });
 
@@ -205,7 +205,7 @@ describe('Unit: models/user', function () {
 
             return models.User.permissible(mockUser, 'edit', context, {}, testUtils.permissions.contributor, false, true, true)
                 .then(() => {
-                    assert.equal(models.User.findOne.calledOnce, true);
+                    sinon.assert.calledOnce(models.User.findOne);
                 });
         });
 
@@ -258,7 +258,7 @@ describe('Unit: models/user', function () {
 
                 return models.User.permissible(mockUser, 'edit', context, unsafeAttrs, testUtils.permissions.owner, false, true, true)
                     .then(() => {
-                        assert.equal(models.User.getOwnerUser.calledOnce, true);
+                        sinon.assert.calledOnce(models.User.getOwnerUser);
                     });
             });
 
@@ -287,8 +287,8 @@ describe('Unit: models/user', function () {
 
                 return models.User.permissible(mockUser, 'edit', context, unsafeAttrs, testUtils.permissions.admin, true, true, true)
                     .then(() => {
-                        assert.equal(models.User.getOwnerUser.calledOnce, true);
-                        assert.equal(permissions.canThis.calledOnce, true);
+                        sinon.assert.calledOnce(models.User.getOwnerUser);
+                        sinon.assert.calledOnce(permissions.canThis);
                     });
             });
 
@@ -320,8 +320,8 @@ describe('Unit: models/user', function () {
                     done(new Error('Permissible function should have errored'));
                 }).catch((error) => {
                     assert(error instanceof errors.NoPermissionError);
-                    assert.equal(mockUser.hasRole.called, true);
-                    assert.equal(mockUser.get.calledOnce, true);
+                    sinon.assert.called(mockUser.hasRole);
+                    sinon.assert.calledOnce(mockUser.get);
                     done();
                 });
             });
@@ -334,8 +334,8 @@ describe('Unit: models/user', function () {
                     done(new Error('Permissible function should have errored'));
                 }).catch((error) => {
                     assert(error instanceof errors.NoPermissionError);
-                    assert.equal(mockUser.hasRole.called, true);
-                    assert.equal(mockUser.get.calledOnce, true);
+                    sinon.assert.called(mockUser.hasRole);
+                    sinon.assert.calledOnce(mockUser.get);
                     done();
                 });
             });
@@ -348,8 +348,8 @@ describe('Unit: models/user', function () {
                     done(new Error('Permissible function should have errored'));
                 }).catch((error) => {
                     assert(error instanceof errors.NoPermissionError);
-                    assert.equal(mockUser.hasRole.called, true);
-                    assert.equal(mockUser.get.calledOnce, true);
+                    sinon.assert.called(mockUser.hasRole);
+                    sinon.assert.calledOnce(mockUser.get);
                     done();
                 });
             });
@@ -359,8 +359,8 @@ describe('Unit: models/user', function () {
                 const context = {user: 2};
 
                 return models.User.permissible(mockUser, 'edit', context, {}, testUtils.permissions.editor, true, true, true).then(() => {
-                    assert.equal(mockUser.hasRole.called, true);
-                    assert.equal(mockUser.get.calledOnce, true);
+                    sinon.assert.called(mockUser.hasRole);
+                    sinon.assert.calledOnce(mockUser.get);
                 });
             });
 
@@ -369,8 +369,8 @@ describe('Unit: models/user', function () {
                 const context = {user: 2};
 
                 return models.User.permissible(mockUser, 'edit', context, {}, testUtils.permissions.editor, true, true, true).then(() => {
-                    assert.equal(mockUser.hasRole.called, true);
-                    assert.equal(mockUser.get.calledOnce, true);
+                    sinon.assert.called(mockUser.hasRole);
+                    sinon.assert.calledOnce(mockUser.get);
                 });
             });
 
@@ -379,8 +379,8 @@ describe('Unit: models/user', function () {
                 const context = {user: 3};
 
                 return models.User.permissible(mockUser, 'destroy', context, {}, testUtils.permissions.editor, true, true, true).then(() => {
-                    assert.equal(mockUser.hasRole.called, true);
-                    assert.equal(mockUser.get.calledOnce, true);
+                    sinon.assert.called(mockUser.hasRole);
+                    sinon.assert.calledOnce(mockUser.get);
                 });
             });
 
@@ -392,8 +392,8 @@ describe('Unit: models/user', function () {
                     done(new Error('Permissible function should have errored'));
                 }).catch((error) => {
                     assert(error instanceof errors.NoPermissionError);
-                    assert.equal(mockUser.hasRole.called, true);
-                    assert.equal(mockUser.get.calledOnce, true);
+                    sinon.assert.called(mockUser.hasRole);
+                    sinon.assert.calledOnce(mockUser.get);
                     done();
                 });
             });
@@ -406,8 +406,8 @@ describe('Unit: models/user', function () {
                     done(new Error('Permissible function should have errored'));
                 }).catch((error) => {
                     assert(error instanceof errors.NoPermissionError);
-                    assert.equal(mockUser.hasRole.called, true);
-                    assert.equal(mockUser.get.calledOnce, true);
+                    sinon.assert.called(mockUser.hasRole);
+                    sinon.assert.calledOnce(mockUser.get);
                     done();
                 });
             });
@@ -417,8 +417,8 @@ describe('Unit: models/user', function () {
                 const context = {user: 2};
 
                 return models.User.permissible(mockUser, 'destroy', context, {}, testUtils.permissions.editor, true, true, true).then(() => {
-                    assert.equal(mockUser.hasRole.called, true);
-                    assert.equal(mockUser.get.calledOnce, true);
+                    sinon.assert.called(mockUser.hasRole);
+                    sinon.assert.calledOnce(mockUser.get);
                 });
             });
 
@@ -427,8 +427,8 @@ describe('Unit: models/user', function () {
                 const context = {user: 2};
 
                 return models.User.permissible(mockUser, 'destroy', context, {}, testUtils.permissions.editor, true, true, true).then(() => {
-                    assert.equal(mockUser.hasRole.called, true);
-                    assert.equal(mockUser.get.calledOnce, true);
+                    sinon.assert.called(mockUser.hasRole);
+                    sinon.assert.calledOnce(mockUser.get);
                 });
             });
         });
@@ -574,7 +574,7 @@ describe('Unit: models/user', function () {
 
             return models.User.transferOwnership({id: userToChange.context.user}, loggedInUser)
                 .then(() => {
-                    assert.equal(clearSpy.calledOnce, true);
+                    sinon.assert.calledOnce(clearSpy);
                     assert.equal(models.User.ownerIdCache.get(), null);
                 })
                 .finally(() => {
@@ -667,7 +667,7 @@ describe('Unit: models/user', function () {
             return models.User.getOwnerId()
                 .then((ownerId) => {
                     assert.equal(ownerId, 'abc123');
-                    assert.equal(models.User.getOwnerUser.called, false);
+                    sinon.assert.notCalled(models.User.getOwnerUser);
                 });
         });
 
@@ -681,7 +681,7 @@ describe('Unit: models/user', function () {
             return models.User.getOwnerId()
                 .then((ownerId) => {
                     assert.equal(ownerId, mockOwner.id);
-                    assert.equal(models.User.getOwnerUser.calledOnce, true);
+                    sinon.assert.calledOnce(models.User.getOwnerUser);
                     assert.equal(models.User.ownerIdCache.get(), mockOwner.id);
                 });
         });
@@ -696,13 +696,13 @@ describe('Unit: models/user', function () {
             return models.User.getOwnerId()
                 .then((ownerId) => {
                     assert.equal(ownerId, mockOwner.id);
-                    assert.equal(models.User.getOwnerUser.calledOnce, true);
+                    sinon.assert.calledOnce(models.User.getOwnerUser);
 
                     return models.User.getOwnerId();
                 })
                 .then((ownerId) => {
                     assert.equal(ownerId, mockOwner.id);
-                    assert.equal(models.User.getOwnerUser.calledOnce, true);
+                    sinon.assert.calledOnce(models.User.getOwnerUser);
                 });
         });
 
@@ -718,8 +718,8 @@ describe('Unit: models/user', function () {
 
             return models.User.getOwnerId(options)
                 .then(() => {
-                    assert.equal(models.User.getOwnerUser.calledOnce, true);
-                    assert.equal(models.User.getOwnerUser.calledWith(options), true);
+                    sinon.assert.calledOnce(models.User.getOwnerUser);
+                    sinon.assert.calledWith(models.User.getOwnerUser, options);
                 });
         });
     });

--- a/ghost/core/test/unit/server/notify.test.js
+++ b/ghost/core/test/unit/server/notify.test.js
@@ -40,7 +40,7 @@ describe('Notify', function () {
         it('it communicates with IPC correctly on success', function () {
             notify.notifyServerStarted();
 
-            assert.equal(process.send.calledOnce, true);
+            sinon.assert.calledOnce(process.send);
 
             let message = process.send.firstCall.args[0];
             assert(message && typeof message === 'object');
@@ -52,7 +52,7 @@ describe('Notify', function () {
         it('communicates with IPC correctly on failure', function () {
             notify.notifyServerStarted(new Error('something went wrong'));
 
-            assert.equal(process.send.calledOnce, true);
+            sinon.assert.calledOnce(process.send);
 
             let message = process.send.firstCall.args[0];
             assert(message && typeof message === 'object');
@@ -66,7 +66,7 @@ describe('Notify', function () {
 
             notify.notifyServerStarted();
 
-            assert.equal(socketStub.calledOnce, true);
+            sinon.assert.calledOnce(socketStub);
             assert.equal(socketStub.firstCall.args[0], 'testing');
 
             let message = socketStub.firstCall.args[1];
@@ -81,7 +81,7 @@ describe('Notify', function () {
 
             notify.notifyServerStarted(new Error('something went wrong'));
 
-            assert.equal(socketStub.calledOnce, true);
+            sinon.assert.calledOnce(socketStub);
             assert.equal(socketStub.firstCall.args[0], 'testing');
 
             let message = socketStub.firstCall.args[1];
@@ -98,8 +98,8 @@ describe('Notify', function () {
             notify.notifyServerStarted(new Error('something went wrong'));
             notify.notifyServerStarted();
 
-            assert.equal(process.send.calledOnce, true);
-            assert.equal(socketStub.calledOnce, true);
+            sinon.assert.calledOnce(process.send);
+            sinon.assert.calledOnce(socketStub);
         });
     });
 });

--- a/ghost/core/test/unit/server/services/auth/session-from-token.test.js
+++ b/ghost/core/test/unit/server/services/auth/session-from-token.test.js
@@ -1,4 +1,3 @@
-const assert = require('node:assert/strict');
 const express = require('express');
 const sinon = require('sinon');
 const SessionFromToken = require('../../../../../core/server/services/auth/session/session-from-token');
@@ -30,15 +29,15 @@ describe('SessionFromToken', function () {
 
         await handler(req, res, next);
 
-        assert(getTokenFromRequest.calledOnceWith(req));
+        sinon.assert.calledOnceWithExactly(getTokenFromRequest, req);
         const token = await getTokenFromRequest.returnValues[0];
 
-        assert(getLookupFromToken.calledOnceWith(token));
+        sinon.assert.calledOnceWithExactly(getLookupFromToken, token);
         const email = await getLookupFromToken.returnValues[0];
 
-        assert(findUserByLookup.calledOnceWith(email));
+        sinon.assert.calledOnceWithExactly(findUserByLookup, email);
         const foundUser = await findUserByLookup.returnValues[0];
 
-        assert(createSession.calledOnceWith(req, res, foundUser));
+        sinon.assert.calledOnceWithExactly(createSession, req, res, foundUser);
     });
 });

--- a/ghost/core/test/unit/server/services/auth/session/middleware.test.js
+++ b/ghost/core/test/unit/server/services/auth/session/middleware.test.js
@@ -105,7 +105,7 @@ describe('Session Service', function () {
             });
 
             await middleware.createSession(req, res, next);
-            assert.equal(next.callCount, 1);
+            sinon.assert.calledOnce(next);
             assert.equal(next.args[0][0].statusCode, 403);
             assert.equal(next.args[0][0].code, '2FA_NEW_DEVICE_DETECTED');
         });
@@ -141,7 +141,7 @@ describe('Session Service', function () {
             });
 
             await middleware.createSession(req, res, next);
-            assert.equal(next.callCount, 1);
+            sinon.assert.calledOnce(next);
             assert.equal(next.args[0][0].statusCode, 403);
             assert.equal(next.args[0][0].code, '2FA_TOKEN_REQUIRED');
         });
@@ -203,9 +203,9 @@ describe('Session Service', function () {
 
             await middleware.sendAuthCode(req, res, nextStub);
 
-            assert.equal(sendAuthCodeToUserStub.callCount, 1);
-            assert.equal(nextStub.callCount, 0);
-            assert.equal(sendStatusStub.callCount, 1);
+            sinon.assert.calledOnce(sendAuthCodeToUserStub);
+            sinon.assert.notCalled(nextStub);
+            sinon.assert.calledOnce(sendStatusStub);
             assert.equal(sendStatusStub.args[0][0], 200);
         });
 
@@ -225,9 +225,9 @@ describe('Session Service', function () {
 
             await middleware.sendAuthCode(req, res, nextStub);
 
-            assert.equal(sendAuthCodeToUserStub.callCount, 1);
-            assert.equal(nextStub.callCount, 1);
-            assert.equal(sendStatusStub.callCount, 0);
+            sinon.assert.calledOnce(sendAuthCodeToUserStub);
+            sinon.assert.calledOnce(nextStub);
+            sinon.assert.notCalled(sendStatusStub);
         });
     });
 
@@ -249,9 +249,9 @@ describe('Session Service', function () {
 
             await middleware.verifyAuthCode(req, res, nextStub);
 
-            assert.equal(verifyAuthCodeForUserStub.callCount, 1);
-            assert.equal(nextStub.callCount, 0);
-            assert.equal(sendStatusStub.callCount, 1);
+            sinon.assert.calledOnce(verifyAuthCodeForUserStub);
+            sinon.assert.notCalled(nextStub);
+            sinon.assert.calledOnce(sendStatusStub);
             assert.equal(sendStatusStub.args[0][0], 200);
         });
 
@@ -271,9 +271,9 @@ describe('Session Service', function () {
 
             await middleware.verifyAuthCode(req, res, nextStub);
 
-            assert.equal(verifyAuthCodeForUserStub.callCount, 1);
-            assert.equal(nextStub.callCount, 0);
-            assert.equal(sendStatusStub.callCount, 1);
+            sinon.assert.calledOnce(verifyAuthCodeForUserStub);
+            sinon.assert.notCalled(nextStub);
+            sinon.assert.calledOnce(sendStatusStub);
             assert.equal(sendStatusStub.args[0][0], 401);
         });
 
@@ -293,9 +293,9 @@ describe('Session Service', function () {
 
             await middleware.verifyAuthCode(req, res, nextStub);
 
-            assert.equal(verifyAuthCodeForUserStub.callCount, 1);
-            assert.equal(nextStub.callCount, 1);
-            assert.equal(sendStatusStub.callCount, 0);
+            sinon.assert.calledOnce(verifyAuthCodeForUserStub);
+            sinon.assert.calledOnce(nextStub);
+            sinon.assert.notCalled(sendStatusStub);
         });
     });
 });

--- a/ghost/core/test/unit/server/services/auth/session/session-service.test.js
+++ b/ghost/core/test/unit/server/services/auth/session/session-service.test.js
@@ -59,7 +59,7 @@ describe('SessionService', function () {
         assert.equal(req.session.user_id, 'egg');
 
         const actualUser = await sessionService.getUserForSession(req, res);
-        assert(findUserById.calledWith(sinon.match({id: 'egg'})));
+        sinon.assert.calledWith(findUserById, sinon.match({id: 'egg'}));
 
         const expectedUser = await findUserById.returnValues[0];
         assert.equal(actualUser, expectedUser);
@@ -503,7 +503,7 @@ describe('SessionService', function () {
 
         await sessionService.sendAuthCodeToUser(req, res);
 
-        assert(mailer.send.calledOnce);
+        sinon.assert.calledOnce(mailer.send);
         const emailArgs = mailer.send.firstCall.args[0];
         assert.equal(emailArgs.to, 'test@example.com');
         assert.match(emailArgs.subject, /Ghost sign in verification code/);

--- a/ghost/core/test/unit/server/services/email-analytics/email-analytics-service.test.js
+++ b/ghost/core/test/unit/server/services/email-analytics/email-analytics-service.test.js
@@ -124,7 +124,7 @@ describe('EmailAnalyticsService', function () {
                     }]
                 });
                 await service.fetchLatestOpenedEvents();
-                assert.equal(fetchLatestSpy.calledOnce, true);
+                sinon.assert.calledOnce(fetchLatestSpy);
                 assert.deepEqual(fetchLatestSpy.getCall(0).args[1].events, ['opened']);
             });
 
@@ -142,7 +142,7 @@ describe('EmailAnalyticsService', function () {
                     }]
                 });
                 await service.fetchLatestOpenedEvents();
-                assert.equal(fetchLatestSpy.calledOnce, false);
+                sinon.assert.notCalled(fetchLatestSpy);
             });
         });
 
@@ -161,7 +161,7 @@ describe('EmailAnalyticsService', function () {
                     }]
                 });
                 await service.fetchLatestNonOpenedEvents();
-                assert.equal(fetchLatestSpy.calledOnce, true);
+                sinon.assert.calledOnce(fetchLatestSpy);
                 assert.deepEqual(fetchLatestSpy.getCall(0).args[1].events, ['delivered', 'failed', 'unsubscribed', 'complained']);
             });
 
@@ -179,7 +179,7 @@ describe('EmailAnalyticsService', function () {
                     }]
                 });
                 await service.fetchLatestNonOpenedEvents();
-                assert.equal(fetchLatestSpy.calledOnce, false);
+                sinon.assert.notCalled(fetchLatestSpy);
             });
         });
         describe('fetchScheduled', function () {
@@ -216,8 +216,8 @@ describe('EmailAnalyticsService', function () {
             it('returns 0 when nothing is scheduled', async function () {
                 const result = await service.fetchScheduled();
                 assert.equal(result.eventCount, 0);
-                assert.equal(processEventBatchStub.called, false);
-                assert.equal(aggregateStatsStub.called, false);
+                sinon.assert.notCalled(processEventBatchStub);
+                sinon.assert.notCalled(aggregateStatsStub);
             });
 
             it('returns 0 when fetch is canceled', async function () {
@@ -228,8 +228,8 @@ describe('EmailAnalyticsService', function () {
                 service.cancelScheduled();
                 const result = await service.fetchScheduled();
                 assert.equal(result.eventCount, 0);
-                assert.equal(processEventBatchStub.called, false);
-                assert.equal(aggregateStatsStub.called, false);
+                sinon.assert.notCalled(processEventBatchStub);
+                sinon.assert.notCalled(aggregateStatsStub);
             });
 
             it('fetches events with correct parameters', async function () {
@@ -241,8 +241,8 @@ describe('EmailAnalyticsService', function () {
                 const result = await service.fetchScheduled({maxEvents: 100});
 
                 assert.equal(result.eventCount, 10);
-                assert.equal(setJobStatusStub.calledOnce, true);
-                assert.equal(processEventBatchStub.calledOnce, true);
+                sinon.assert.calledOnce(setJobStatusStub);
+                sinon.assert.calledOnce(processEventBatchStub);
             });
 
             it('bails when end date is before begin date', async function () {
@@ -292,7 +292,7 @@ describe('EmailAnalyticsService', function () {
                     }]
                 });
                 await service.fetchMissing();
-                assert.equal(fetchLatestSpy.calledOnce, true);
+                sinon.assert.calledOnce(fetchLatestSpy);
             });
         });
     });
@@ -383,8 +383,8 @@ describe('EmailAnalyticsService', function () {
                             timestamp: new Date(3)
                         }], result, fetchData);
 
-                        assert.equal(eventProcessor.handleDelivered.callCount, 2);
-                        assert.equal(eventProcessor.handleOpened.callCount, 1);
+                        sinon.assert.calledTwice(eventProcessor.handleDelivered);
+                        sinon.assert.calledOnce(eventProcessor.handleOpened);
 
                         assert.deepEqual(result, new EventProcessingResult({
                             delivered: 2,
@@ -414,7 +414,7 @@ describe('EmailAnalyticsService', function () {
                             timestamp: new Date(1)
                         }], result, fetchData);
 
-                        assert.equal(eventProcessor.handleOpened.calledOnce, true);
+                        sinon.assert.calledOnce(eventProcessor.handleOpened);
 
                         assert.deepEqual(result, new EventProcessingResult({
                             delivered: 0,
@@ -444,7 +444,7 @@ describe('EmailAnalyticsService', function () {
                             timestamp: new Date(1)
                         }], result, fetchData);
 
-                        assert.equal(eventProcessor.handleDelivered.calledOnce, true);
+                        sinon.assert.calledOnce(eventProcessor.handleDelivered);
 
                         assert.deepEqual(result, new EventProcessingResult({
                             delivered: 1,
@@ -475,7 +475,7 @@ describe('EmailAnalyticsService', function () {
                             timestamp: new Date(1)
                         }], result, fetchData);
 
-                        assert.equal(eventProcessor.handlePermanentFailed.calledOnce, true);
+                        sinon.assert.calledOnce(eventProcessor.handlePermanentFailed);
 
                         assert.deepEqual(result, new EventProcessingResult({
                             permanentFailed: 1,
@@ -504,7 +504,7 @@ describe('EmailAnalyticsService', function () {
                             timestamp: new Date(1)
                         }], result, fetchData);
 
-                        assert.equal(eventProcessor.handleTemporaryFailed.calledOnce, true);
+                        sinon.assert.calledOnce(eventProcessor.handleTemporaryFailed);
 
                         assert.deepEqual(result, new EventProcessingResult({
                             temporaryFailed: 1,
@@ -532,9 +532,9 @@ describe('EmailAnalyticsService', function () {
                             timestamp: new Date(1)
                         }], result, fetchData);
 
-                        assert.equal(eventProcessor.handleUnsubscribed.calledOnce, true);
-                        assert.equal(eventProcessor.handleDelivered.called, false);
-                        assert.equal(eventProcessor.handleOpened.called, false);
+                        sinon.assert.calledOnce(eventProcessor.handleUnsubscribed);
+                        sinon.assert.notCalled(eventProcessor.handleDelivered);
+                        sinon.assert.notCalled(eventProcessor.handleOpened);
 
                         assert.deepEqual(result, new EventProcessingResult({
                             unsubscribed: 1,
@@ -562,9 +562,9 @@ describe('EmailAnalyticsService', function () {
                             timestamp: new Date(1)
                         }], result, fetchData);
 
-                        assert.equal(eventProcessor.handleComplained.calledOnce, true);
-                        assert.equal(eventProcessor.handleDelivered.called, false);
-                        assert.equal(eventProcessor.handleOpened.called, false);
+                        sinon.assert.calledOnce(eventProcessor.handleComplained);
+                        sinon.assert.notCalled(eventProcessor.handleDelivered);
+                        sinon.assert.notCalled(eventProcessor.handleOpened);
 
                         assert.deepEqual(result, new EventProcessingResult({
                             complained: 1,
@@ -592,8 +592,8 @@ describe('EmailAnalyticsService', function () {
                             timestamp: new Date(1)
                         }], result, fetchData);
 
-                        assert.equal(eventProcessor.handleDelivered.called, false);
-                        assert.equal(eventProcessor.handleOpened.called, false);
+                        sinon.assert.notCalled(eventProcessor.handleDelivered);
+                        sinon.assert.notCalled(eventProcessor.handleOpened);
 
                         assert.deepEqual(result, new EventProcessingResult({
                             unhandled: 1
@@ -764,12 +764,12 @@ describe('EmailAnalyticsService', function () {
 
                     if (batchProcessing) {
                         // In batched mode, should call batchGetRecipients and flushBatchedUpdates
-                        assert.equal(eventProcessor.batchGetRecipients.calledOnce, true);
-                        assert.equal(eventProcessor.flushBatchedUpdates.calledOnce, true);
+                        sinon.assert.calledOnce(eventProcessor.batchGetRecipients);
+                        sinon.assert.calledOnce(eventProcessor.flushBatchedUpdates);
                     } else {
                         // In sequential mode, should not call batch methods
-                        assert.equal(eventProcessor.batchGetRecipients.called, false);
-                        assert.equal(eventProcessor.flushBatchedUpdates.called, false);
+                        sinon.assert.notCalled(eventProcessor.batchGetRecipients);
+                        sinon.assert.notCalled(eventProcessor.flushBatchedUpdates);
                     }
                 });
             });
@@ -805,16 +805,16 @@ describe('EmailAnalyticsService', function () {
                     memberIds: ['m-1', 'm-2']
                 });
 
-                assert.equal(service.queries.aggregateEmailStats.calledTwice, true);
-                assert.equal(service.queries.aggregateEmailStats.calledWith('e-1'), true);
-                assert.equal(service.queries.aggregateEmailStats.calledWith('e-2'), true);
+                sinon.assert.calledTwice(service.queries.aggregateEmailStats);
+                sinon.assert.calledWith(service.queries.aggregateEmailStats, 'e-1');
+                sinon.assert.calledWith(service.queries.aggregateEmailStats, 'e-2');
 
                 // In batched mode, aggregateMemberStatsBatch should be called
-                assert.equal(service.queries.aggregateMemberStatsBatch.calledOnce, true);
-                assert.equal(service.queries.aggregateMemberStatsBatch.calledWith(['m-1', 'm-2']), true);
+                sinon.assert.calledOnce(service.queries.aggregateMemberStatsBatch);
+                sinon.assert.calledWith(service.queries.aggregateMemberStatsBatch, ['m-1', 'm-2']);
 
                 // Sequential method should not be called
-                assert.equal(service.queries.aggregateMemberStats.called, false);
+                sinon.assert.notCalled(service.queries.aggregateMemberStats);
             });
         });
 
@@ -843,17 +843,17 @@ describe('EmailAnalyticsService', function () {
                     memberIds: ['m-1', 'm-2']
                 });
 
-                assert.equal(service.queries.aggregateEmailStats.calledTwice, true);
-                assert.equal(service.queries.aggregateEmailStats.calledWith('e-1'), true);
-                assert.equal(service.queries.aggregateEmailStats.calledWith('e-2'), true);
+                sinon.assert.calledTwice(service.queries.aggregateEmailStats);
+                sinon.assert.calledWith(service.queries.aggregateEmailStats, 'e-1');
+                sinon.assert.calledWith(service.queries.aggregateEmailStats, 'e-2');
 
                 // In sequential mode, aggregateMemberStats should be called for each member
-                assert.equal(service.queries.aggregateMemberStats.calledTwice, true);
-                assert.equal(service.queries.aggregateMemberStats.calledWith('m-1'), true);
-                assert.equal(service.queries.aggregateMemberStats.calledWith('m-2'), true);
+                sinon.assert.calledTwice(service.queries.aggregateMemberStats);
+                sinon.assert.calledWith(service.queries.aggregateMemberStats, 'm-1');
+                sinon.assert.calledWith(service.queries.aggregateMemberStats, 'm-2');
 
                 // Batch method should not be called
-                assert.equal(service.queries.aggregateMemberStatsBatch.called, false);
+                sinon.assert.notCalled(service.queries.aggregateMemberStatsBatch);
             });
         });
     });

--- a/ghost/core/test/unit/server/services/email-service/batch-sending-service.test.js
+++ b/ghost/core/test/unit/server/services/email-service/batch-sending-service.test.js
@@ -491,7 +491,7 @@ describe('Batch Sending Service', function () {
                 newsletter
             });
 
-            assert(captureMessage.calledOnce);
+            sinon.assert.calledOnce(captureMessage);
         });
 
         it('works with multiple batches', async function () {

--- a/ghost/core/test/unit/server/services/email-service/email-event-processor.test.js
+++ b/ghost/core/test/unit/server/services/email-service/email-event-processor.test.js
@@ -101,7 +101,7 @@ describe('Email Event Processor', function () {
                 memberId: 'member-id',
                 emailId: 'email-id'
             });
-            assert.equal(eventStorage.handleDelivered.callCount, 1);
+            sinon.assert.calledOnce(eventStorage.handleDelivered);
             const event = eventStorage.handleDelivered.firstCall.args[0];
             assert.equal(event.email, 'example@example.com');
             assert.equal(event.constructor.name, 'EmailDeliveredEvent');
@@ -114,7 +114,7 @@ describe('Email Event Processor', function () {
                 memberId: 'member-id',
                 emailId: 'email-id'
             });
-            assert.equal(eventStorage.handleOpened.callCount, 1);
+            sinon.assert.calledOnce(eventStorage.handleOpened);
             const event = eventStorage.handleOpened.firstCall.args[0];
             assert.equal(event.email, 'example@example.com');
             assert.equal(event.constructor.name, 'EmailOpenedEvent');
@@ -127,7 +127,7 @@ describe('Email Event Processor', function () {
                 memberId: 'member-id',
                 emailId: 'email-id'
             });
-            assert.equal(eventStorage.handleTemporaryFailed.callCount, 1);
+            sinon.assert.calledOnce(eventStorage.handleTemporaryFailed);
             const event = eventStorage.handleTemporaryFailed.firstCall.args[0];
             assert.equal(event.email, 'example@example.com');
             assert.equal(event.constructor.name, 'EmailTemporaryBouncedEvent');
@@ -140,7 +140,7 @@ describe('Email Event Processor', function () {
                 memberId: 'member-id',
                 emailId: 'email-id'
             });
-            assert.equal(eventStorage.handlePermanentFailed.callCount, 1);
+            sinon.assert.calledOnce(eventStorage.handlePermanentFailed);
             const event = eventStorage.handlePermanentFailed.firstCall.args[0];
             assert.equal(event.email, 'example@example.com');
             assert.equal(event.constructor.name, 'EmailBouncedEvent');
@@ -153,7 +153,7 @@ describe('Email Event Processor', function () {
                 memberId: 'member-id',
                 emailId: 'email-id'
             });
-            assert.equal(eventStorage.handleUnsubscribed.callCount, 1);
+            sinon.assert.calledOnce(eventStorage.handleUnsubscribed);
             const event = eventStorage.handleUnsubscribed.firstCall.args[0];
             assert.equal(event.email, 'example@example.com');
             assert.equal(event.constructor.name, 'EmailUnsubscribedEvent');
@@ -166,7 +166,7 @@ describe('Email Event Processor', function () {
                 memberId: 'member-id',
                 emailId: 'email-id'
             });
-            assert.equal(eventStorage.handleComplained.callCount, 1);
+            sinon.assert.calledOnce(eventStorage.handleComplained);
             const event = eventStorage.handleComplained.firstCall.args[0];
             assert.equal(event.email, 'example@example.com');
             assert.equal(event.constructor.name, 'SpamComplaintEvent');
@@ -184,7 +184,7 @@ describe('Email Event Processor', function () {
                 prometheusClient
             });
             eventProcessor.recordEventProcessed('delivered');
-            assert(incStub.calledOnce);
+            sinon.assert.calledOnce(incStub);
         });
 
         it('does not throw if recording the event metric fails', function () {

--- a/ghost/core/test/unit/server/services/email-service/email-event-storage.test.js
+++ b/ghost/core/test/unit/server/services/email-service/email-event-storage.test.js
@@ -59,7 +59,7 @@ describe('Email Event Storage', function () {
         const eventHandler = new EmailEventStorage({db, prometheusClient});
         sinon.stub(eventHandler, 'recordEventStored').resolves();
         await eventHandler.handleDelivered(event);
-        assert(eventHandler.recordEventStored.calledOnce);
+        sinon.assert.calledOnce(eventHandler.recordEventStored);
     });
 
     it('Handles email opened events', async function () {
@@ -85,7 +85,7 @@ describe('Email Event Storage', function () {
         const eventHandler = new EmailEventStorage({db, prometheusClient});
         sinon.stub(eventHandler, 'recordEventStored').resolves();
         await eventHandler.handleOpened(event);
-        assert(eventHandler.recordEventStored.calledOnce);
+        sinon.assert.calledOnce(eventHandler.recordEventStored);
     });
 
     it('Handles email permanent bounce events with update', async function () {
@@ -131,7 +131,7 @@ describe('Email Event Storage', function () {
         await eventHandler.handlePermanentFailed(event);
         sinon.assert.calledOnce(db.update);
         assert(!!db.update.firstCall.args[0].failed_at);
-        assert(existing.save.calledOnce);
+        sinon.assert.calledOnce(existing.save);
     });
 
     it('Handles email permanent bounce events with update and empty message', async function () {
@@ -177,7 +177,7 @@ describe('Email Event Storage', function () {
         await eventHandler.handlePermanentFailed(event);
         sinon.assert.calledOnce(db.update);
         assert(!!db.update.firstCall.args[0].failed_at);
-        assert(existing.save.calledOnce);
+        sinon.assert.calledOnce(existing.save);
     });
 
     it('Handles email permanent bounce events with update and empty message and without enhanced code', async function () {
@@ -222,7 +222,7 @@ describe('Email Event Storage', function () {
         await eventHandler.handlePermanentFailed(event);
         sinon.assert.calledOnce(db.update);
         assert(!!db.update.firstCall.args[0].failed_at);
-        assert(existing.save.calledOnce);
+        sinon.assert.calledOnce(existing.save);
     });
 
     it('Handles email permanent bounce events with insert', async function () {
@@ -257,7 +257,7 @@ describe('Email Event Storage', function () {
         await eventHandler.handlePermanentFailed(event);
         sinon.assert.calledOnce(db.update);
         assert(!!db.update.firstCall.args[0].failed_at);
-        assert(EmailRecipientFailure.add.calledOnce);
+        sinon.assert.calledOnce(EmailRecipientFailure.add);
     });
 
     it('Handles email permanent bounce events with insert and empty message', async function () {
@@ -292,7 +292,7 @@ describe('Email Event Storage', function () {
         await eventHandler.handlePermanentFailed(event);
         sinon.assert.calledOnce(db.update);
         assert(!!db.update.firstCall.args[0].failed_at);
-        assert(EmailRecipientFailure.add.calledOnce);
+        sinon.assert.calledOnce(EmailRecipientFailure.add);
     });
 
     it('Handles email permanent bounce events with insert and empty message and without enhanced code', async function () {
@@ -326,7 +326,7 @@ describe('Email Event Storage', function () {
         await eventHandler.handlePermanentFailed(event);
         sinon.assert.calledOnce(db.update);
         assert(!!db.update.firstCall.args[0].failed_at);
-        assert(EmailRecipientFailure.add.calledOnce);
+        sinon.assert.calledOnce(EmailRecipientFailure.add);
     });
 
     it('Handles email permanent bounce event without error data', async function () {
@@ -391,8 +391,8 @@ describe('Email Event Storage', function () {
         await eventHandler.handlePermanentFailed(event);
         sinon.assert.calledOnce(db.update);
         assert(!!db.update.firstCall.args[0].failed_at);
-        assert(EmailRecipientFailure.findOne.called);
-        assert(!existing.save.called);
+        sinon.assert.called(EmailRecipientFailure.findOne);
+        sinon.assert.notCalled(existing.save);
     });
 
     it('Handles email temporary bounce events with update', async function () {
@@ -434,7 +434,7 @@ describe('Email Event Storage', function () {
             }
         });
         await eventHandler.handleTemporaryFailed(event);
-        assert(existing.save.calledOnce);
+        sinon.assert.calledOnce(existing.save);
     });
 
     it('Handles email temporary bounce events with skipped update', async function () {
@@ -476,7 +476,7 @@ describe('Email Event Storage', function () {
             }
         });
         await eventHandler.handleTemporaryFailed(event);
-        assert(existing.save.notCalled);
+        sinon.assert.notCalled(existing.save);
     });
 
     it('Handles unsubscribe', async function () {
@@ -500,9 +500,9 @@ describe('Email Event Storage', function () {
             emailSuppressionList
         });
         await eventHandler.handleUnsubscribed(event);
-        assert(update.calledOnce);
+        sinon.assert.calledOnce(update);
         assert(update.firstCall.args[0].newsletters.length === 0);
-        assert(emailSuppressionList.removeUnsubscribe.calledOnce);
+        sinon.assert.calledOnce(emailSuppressionList.removeUnsubscribe);
     });
 
     it('Handles unsubscribe with a non-existent member', async function () {
@@ -522,7 +522,7 @@ describe('Email Event Storage', function () {
             }
         });
         await eventHandler.handleUnsubscribed(event);
-        assert(update.calledOnce);
+        sinon.assert.calledOnce(update);
         assert(update.firstCall.args[0].newsletters.length === 0);
     });
 
@@ -587,9 +587,9 @@ describe('Email Event Storage', function () {
             emailSuppressionList
         });
         await eventHandler.handleComplained(event);
-        assert(EmailSpamComplaintEvent.add.calledOnce);
-        assert(emailSuppressionList.removeComplaint.calledOnce);
-        assert(emailSuppressionList.removeComplaint.calledWith('example@example.com'));
+        sinon.assert.calledOnce(EmailSpamComplaintEvent.add);
+        sinon.assert.calledOnce(emailSuppressionList.removeComplaint);
+        sinon.assert.calledWith(emailSuppressionList.removeComplaint, 'example@example.com');
     });
 
     it('Handles duplicate complaints', async function () {
@@ -615,8 +615,8 @@ describe('Email Event Storage', function () {
             emailSuppressionList
         });
         await eventHandler.handleComplained(event);
-        assert(EmailSpamComplaintEvent.add.calledOnce);
-        assert(!logError.calledOnce);
+        sinon.assert.calledOnce(EmailSpamComplaintEvent.add);
+        sinon.assert.notCalled(logError);
     });
 
     it('Handles logging failed complaint storage', async function () {
@@ -642,8 +642,8 @@ describe('Email Event Storage', function () {
             emailSuppressionList
         });
         await eventHandler.handleComplained(event);
-        assert(EmailSpamComplaintEvent.add.calledOnce);
-        assert(logError.calledOnce);
+        sinon.assert.calledOnce(EmailSpamComplaintEvent.add);
+        sinon.assert.calledOnce(logError);
     });
 
     describe('recordEventStored', function () {

--- a/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
+++ b/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
@@ -412,7 +412,7 @@ describe('Email renderer', function () {
             });
 
             // Verify crypto.randomUUID was never called since uniqueid wasn't used
-            assert.equal(randomUUIDSpy.callCount, 0);
+            sinon.assert.notCalled(randomUUIDSpy);
 
             randomUUIDSpy.restore();
         });
@@ -1897,7 +1897,7 @@ describe('Email renderer', function () {
             );
 
             // Verify tracking was called for the Transistor link
-            assert.equal(addTrackingToUrlStub.called, true);
+            sinon.assert.called(addTrackingToUrlStub);
             const transistorCall = addTrackingToUrlStub.getCalls().find(
                 call => call.args[0].href.includes('transistor.fm')
             );

--- a/ghost/core/test/unit/server/services/email-service/email-segmenter.test.js
+++ b/ghost/core/test/unit/server/services/email-service/email-segmenter.test.js
@@ -36,7 +36,7 @@ describe('Email segmenter', function () {
                 }
             }, 'all', null
             );
-            assert.equal(listStub.calledOnce, true);
+            sinon.assert.calledOnce(listStub);
             sinon.assert.calledWith(listStub, {
                 filter: 'newsletters.id:\'newsletter-123\'+email_disabled:0'
             });
@@ -93,7 +93,7 @@ describe('Email segmenter', function () {
                 null
             );
 
-            assert.equal(listStub.calledOnce, true);
+            sinon.assert.calledOnce(listStub);
             sinon.assert.calledWith(listStub, {
                 filter: 'newsletters.id:\'newsletter-123\'+email_disabled:0+(labels:test)+status:-free'
             });
@@ -117,7 +117,7 @@ describe('Email segmenter', function () {
                 'status:free'
             );
 
-            assert.equal(listStub.calledOnce, true);
+            sinon.assert.calledOnce(listStub);
             sinon.assert.calledWith(listStub, {
                 filter: 'newsletters.id:\'newsletter-123\'+email_disabled:0+(labels:test)+(status:free)'
             });

--- a/ghost/core/test/unit/server/services/explore-ping/explore-ping-service.test.js
+++ b/ghost/core/test/unit/server/services/explore-ping/explore-ping-service.test.js
@@ -240,7 +240,7 @@ describe('ExplorePingService', function () {
 
             await explorePingService.makeRequest('https://test.com', payload);
 
-            assert.equal(requestStub.calledOnce, true);
+            sinon.assert.calledOnce(requestStub);
             assert.equal(requestStub.firstCall.args[0], 'https://test.com');
             assert.deepEqual(requestStub.firstCall.args[1], {
                 method: 'POST',
@@ -256,7 +256,7 @@ describe('ExplorePingService', function () {
 
             await explorePingService.makeRequest('https://test.com', {});
 
-            assert.equal(loggingStub.warn.calledOnce, true);
+            sinon.assert.calledOnce(loggingStub.warn);
             assert.equal(loggingStub.warn.firstCall.args[0], 'Explore Error');
             assert.equal(loggingStub.warn.firstCall.args[1], 'Network error');
         });
@@ -268,7 +268,7 @@ describe('ExplorePingService', function () {
 
             await explorePingService.ping();
 
-            assert.equal(requestStub.called, false);
+            sinon.assert.notCalled(requestStub);
         });
 
         it('does not ping if explore URL is not set', async function () {
@@ -276,8 +276,8 @@ describe('ExplorePingService', function () {
 
             await explorePingService.ping();
 
-            assert.equal(requestStub.called, false);
-            assert.equal(loggingStub.warn.calledOnce, true);
+            sinon.assert.notCalled(requestStub);
+            sinon.assert.calledOnce(loggingStub.warn);
             assert.equal(loggingStub.warn.firstCall.args[0], 'Explore URL not set');
         });
 
@@ -286,7 +286,7 @@ describe('ExplorePingService', function () {
 
             await explorePingService.ping();
 
-            assert.equal(requestStub.called, false);
+            sinon.assert.notCalled(requestStub);
         });
 
         it('pings with constructed payload when properly configured', async function () {
@@ -294,7 +294,7 @@ describe('ExplorePingService', function () {
 
             await explorePingService.ping();
 
-            assert.equal(requestStub.calledOnce, true);
+            sinon.assert.calledOnce(requestStub);
             assert.equal(requestStub.firstCall.args[0], 'https://explore.testing.com');
             const payload = await explorePingService.constructPayload();
             assert.equal(requestStub.firstCall.args[1].body, JSON.stringify(payload));

--- a/ghost/core/test/unit/server/services/indexnow.test.js
+++ b/ghost/core/test/unit/server/services/indexnow.test.js
@@ -35,9 +35,9 @@ describe('IndexNow', function () {
     describe('listen()', function () {
         it('should initialise events correctly', function () {
             indexnow.listen();
-            assert.equal(eventStub.calledTwice, true);
-            assert.equal(eventStub.calledWith('post.published'), true);
-            assert.equal(eventStub.calledWith('post.published.edited'), true);
+            sinon.assert.calledTwice(eventStub);
+            sinon.assert.calledWith(eventStub, 'post.published');
+            sinon.assert.calledWith(eventStub, 'post.published.edited');
         });
     });
 
@@ -73,8 +73,8 @@ describe('IndexNow', function () {
 
             listener(testModel);
 
-            assert.equal(pingStub.calledOnce, true);
-            assert.equal(pingStub.calledWith(testPost), true);
+            sinon.assert.calledOnce(pingStub);
+            sinon.assert.calledWith(pingStub, testPost);
 
             resetIndexNow();
         });
@@ -100,7 +100,7 @@ describe('IndexNow', function () {
 
             listener(testModel, {importing: true});
 
-            assert.equal(pingStub.calledOnce, false);
+            sinon.assert.notCalled(pingStub);
 
             resetIndexNow();
         });
@@ -146,7 +146,7 @@ describe('IndexNow', function () {
 
             listener(testModel);
 
-            assert.equal(pingStub.calledOnce, false);
+            sinon.assert.notCalled(pingStub);
 
             resetIndexNow();
         });
@@ -178,7 +178,7 @@ describe('IndexNow', function () {
 
             listener(testModel);
 
-            assert.equal(pingStub.calledOnce, true);
+            sinon.assert.calledOnce(pingStub);
 
             resetIndexNow();
         });
@@ -210,7 +210,7 @@ describe('IndexNow', function () {
 
             listener(testModel);
 
-            assert.equal(pingStub.calledOnce, true);
+            sinon.assert.calledOnce(pingStub);
 
             resetIndexNow();
         });
@@ -242,7 +242,7 @@ describe('IndexNow', function () {
 
             listener(testModel);
 
-            assert.equal(pingStub.calledOnce, true);
+            sinon.assert.calledOnce(pingStub);
 
             resetIndexNow();
         });
@@ -260,7 +260,7 @@ describe('IndexNow', function () {
 
             await ping(testPost);
 
-            assert.equal(loggingStub.calledOnce, true);
+            sinon.assert.calledOnce(loggingStub);
         });
 
         it('with default post should not execute ping', async function () {
@@ -327,7 +327,7 @@ describe('IndexNow', function () {
             // Should NOT have made the ping request
             assert.equal(pingRequest.isDone(), false);
             // Should have logged a warning
-            assert.equal(loggingStub.calledOnce, true);
+            sinon.assert.calledOnce(loggingStub);
             assert(loggingStub.args[0][0].includes('API key not available'));
         });
 
@@ -341,7 +341,7 @@ describe('IndexNow', function () {
             await ping(testPost);
 
             assert.equal(pingRequest.isDone(), true);
-            assert.equal(loggingStub.calledOnce, true);
+            sinon.assert.calledOnce(loggingStub);
         });
 
         it('captures && logs errors from 400 requests', async function () {
@@ -354,7 +354,7 @@ describe('IndexNow', function () {
             await ping(testPost);
 
             assert.equal(pingRequest.isDone(), true);
-            assert.equal(loggingStub.calledOnce, true);
+            sinon.assert.calledOnce(loggingStub);
         });
 
         it('captures && logs validation errors from 422 requests', async function () {
@@ -367,7 +367,7 @@ describe('IndexNow', function () {
             await ping(testPost);
 
             assert.equal(pingRequest.isDone(), true);
-            assert.equal(loggingStub.calledOnce, true);
+            sinon.assert.calledOnce(loggingStub);
             assert(loggingStub.args[0][0].message.includes('key validation failed'));
         });
 
@@ -381,7 +381,7 @@ describe('IndexNow', function () {
             await ping(testPost);
 
             assert.equal(pingRequest.isDone(), true);
-            assert.equal(loggingStub.calledOnce, true);
+            sinon.assert.calledOnce(loggingStub);
         });
     });
 

--- a/ghost/core/test/unit/server/services/lib/magic-link/index.test.js
+++ b/ghost/core/test/unit/server/services/lib/magic-link/index.test.js
@@ -71,19 +71,19 @@ describe('MagicLink', function () {
             };
             const {token} = await service.sendMagicLink(args);
 
-            assert(options.getSigninURL.calledOnce);
-            assert(options.getSigninURL.firstCall.calledWithExactly(token, 'blazeit', 'https://whatever.com'));
+            sinon.assert.calledOnce(options.getSigninURL);
+            sinon.assert.calledWithExactly(options.getSigninURL.firstCall, token, 'blazeit', 'https://whatever.com');
 
-            assert(options.getText.calledOnce);
-            assert(options.getText.firstCall.calledWithExactly('FAKEURL', 'blazeit', 'test@example.com', null));
+            sinon.assert.calledOnce(options.getText);
+            sinon.assert.calledWithExactly(options.getText.firstCall, 'FAKEURL', 'blazeit', 'test@example.com', null);
 
-            assert(options.getHTML.calledOnce);
-            assert(options.getHTML.firstCall.calledWithExactly('FAKEURL', 'blazeit', 'test@example.com', null));
+            sinon.assert.calledOnce(options.getHTML);
+            sinon.assert.calledWithExactly(options.getHTML.firstCall, 'FAKEURL', 'blazeit', 'test@example.com', null);
 
-            assert(options.getSubject.calledOnce);
-            assert(options.getSubject.firstCall.calledWithExactly('blazeit', null));
+            sinon.assert.calledOnce(options.getSubject);
+            sinon.assert.calledWithExactly(options.getSubject.firstCall, 'blazeit', null);
 
-            assert(options.transporter.sendMail.calledOnce);
+            sinon.assert.calledOnce(options.transporter.sendMail);
             assert.equal(options.transporter.sendMail.firstCall.args[0].to, args.email);
             assert.equal(options.transporter.sendMail.firstCall.args[0].subject, options.getSubject.firstCall.returnValue);
             assert.equal(options.transporter.sendMail.firstCall.args[0].text, options.getText.firstCall.returnValue);
@@ -115,7 +115,7 @@ describe('MagicLink', function () {
             const result = await service.sendMagicLink(args);
 
             assert.equal(result.otcRef, null);
-            assert(mockSingleUseTokenProvider.getRefByToken.notCalled);
+            sinon.assert.notCalled(mockSingleUseTokenProvider.getRefByToken);
         });
 
         it('should work when tokenProvider does not have getRefByToken method', async function () {
@@ -136,7 +136,7 @@ describe('MagicLink', function () {
             const result = await service.sendMagicLink(args);
 
             assert.equal(result.otcRef, null);
-            assert(options.transporter.sendMail.calledOnce);
+            sinon.assert.calledOnce(options.transporter.sendMail);
         });
 
         it('should return otcRef as null when getRefByToken resolves to null', async function () {
@@ -156,8 +156,8 @@ describe('MagicLink', function () {
 
             assert.equal(result.otcRef, null);
             // deriveOTC is only possible with a token so it's skipped if getRefByToken returns null
-            assert(mockSingleUseTokenProvider.deriveOTC.notCalled);
-            assert(mockSingleUseTokenProvider.getRefByToken.calledOnce);
+            sinon.assert.notCalled(mockSingleUseTokenProvider.deriveOTC);
+            sinon.assert.calledOnce(mockSingleUseTokenProvider.getRefByToken);
         });
 
         it('should include OTC when includeOTC is true', async function () {
@@ -174,15 +174,15 @@ describe('MagicLink', function () {
 
             const result = await service.sendMagicLink(args);
 
-            assert(mockSingleUseTokenProvider.getRefByToken.calledTwice);
-            assert(mockSingleUseTokenProvider.deriveOTC.calledOnce);
-            assert(mockSingleUseTokenProvider.deriveOTC.calledWith('test-token-ref-123', 'mock-token'));
+            sinon.assert.calledTwice(mockSingleUseTokenProvider.getRefByToken);
+            sinon.assert.calledOnce(mockSingleUseTokenProvider.deriveOTC);
+            sinon.assert.calledWith(mockSingleUseTokenProvider.deriveOTC, 'test-token-ref-123', 'mock-token');
             assert.equal(result.otcRef, 'test-token-ref-123');
 
             // Verify OTC is passed to email content functions
-            assert(options.getText.firstCall.calledWithExactly('FAKEURL', 'signin', 'test@example.com', '654321'));
-            assert(options.getHTML.firstCall.calledWithExactly('FAKEURL', 'signin', 'test@example.com', '654321'));
-            assert(options.getSubject.firstCall.calledWithExactly('signin', '654321'));
+            sinon.assert.calledWithExactly(options.getText.firstCall, 'FAKEURL', 'signin', 'test@example.com', '654321');
+            sinon.assert.calledWithExactly(options.getHTML.firstCall, 'FAKEURL', 'signin', 'test@example.com', '654321');
+            sinon.assert.calledWithExactly(options.getSubject.firstCall, 'signin', '654321');
         });
 
         it('should not include OTC when includeOTC is false', async function () {
@@ -199,14 +199,14 @@ describe('MagicLink', function () {
 
             const result = await service.sendMagicLink(args);
 
-            assert(mockSingleUseTokenProvider.getRefByToken.notCalled);
-            assert(mockSingleUseTokenProvider.deriveOTC.notCalled);
+            sinon.assert.notCalled(mockSingleUseTokenProvider.getRefByToken);
+            sinon.assert.notCalled(mockSingleUseTokenProvider.deriveOTC);
             assert.equal(result.otcRef, null);
 
             // Verify OTC is not passed to email content functions
-            assert(options.getText.firstCall.calledWithExactly('FAKEURL', 'signin', 'test@example.com', null));
-            assert(options.getHTML.firstCall.calledWithExactly('FAKEURL', 'signin', 'test@example.com', null));
-            assert(options.getSubject.firstCall.calledWithExactly('signin', null));
+            sinon.assert.calledWithExactly(options.getText.firstCall, 'FAKEURL', 'signin', 'test@example.com', null);
+            sinon.assert.calledWithExactly(options.getHTML.firstCall, 'FAKEURL', 'signin', 'test@example.com', null);
+            sinon.assert.calledWithExactly(options.getSubject.firstCall, 'signin', null);
         });
 
         it('should pass OTC to email content functions when OTC is enabled', async function () {
@@ -223,14 +223,14 @@ describe('MagicLink', function () {
 
             await service.sendMagicLink(args);
 
-            assert(options.getText.calledOnce);
-            assert(options.getText.firstCall.calledWithExactly('FAKEURL', 'signin', 'test@example.com', '654321'));
+            sinon.assert.calledOnce(options.getText);
+            sinon.assert.calledWithExactly(options.getText.firstCall, 'FAKEURL', 'signin', 'test@example.com', '654321');
 
-            assert(options.getHTML.calledOnce);
-            assert(options.getHTML.firstCall.calledWithExactly('FAKEURL', 'signin', 'test@example.com', '654321'));
+            sinon.assert.calledOnce(options.getHTML);
+            sinon.assert.calledWithExactly(options.getHTML.firstCall, 'FAKEURL', 'signin', 'test@example.com', '654321');
 
-            assert(options.getSubject.calledOnce);
-            assert(options.getSubject.firstCall.calledWithExactly('signin', '654321'));
+            sinon.assert.calledOnce(options.getSubject);
+            sinon.assert.calledWithExactly(options.getSubject.firstCall, 'signin', '654321');
         });
 
         it('should not include OTC when tokenProvider lacks deriveOTC method', async function () {
@@ -249,14 +249,14 @@ describe('MagicLink', function () {
 
             await service.sendMagicLink(args);
 
-            assert(options.getText.calledOnce);
-            assert(options.getText.firstCall.calledWithExactly('FAKEURL', 'signin', 'test@example.com', null));
+            sinon.assert.calledOnce(options.getText);
+            sinon.assert.calledWithExactly(options.getText.firstCall, 'FAKEURL', 'signin', 'test@example.com', null);
 
-            assert(options.getHTML.calledOnce);
-            assert(options.getHTML.firstCall.calledWithExactly('FAKEURL', 'signin', 'test@example.com', null));
+            sinon.assert.calledOnce(options.getHTML);
+            sinon.assert.calledWithExactly(options.getHTML.firstCall, 'FAKEURL', 'signin', 'test@example.com', null);
 
-            assert(options.getSubject.calledOnce);
-            assert(options.getSubject.firstCall.calledWithExactly('signin', null));
+            sinon.assert.calledOnce(options.getSubject);
+            sinon.assert.calledWithExactly(options.getSubject.firstCall, 'signin', null);
         });
     });
 
@@ -266,8 +266,8 @@ describe('MagicLink', function () {
             const tokenId = await service.getRefFromToken('mock-token');
 
             assert.equal(tokenId, 'test-token-ref-123');
-            assert(mockSingleUseTokenProvider.getRefByToken.calledOnce);
-            assert(mockSingleUseTokenProvider.getRefByToken.calledWith('mock-token'));
+            sinon.assert.calledOnce(mockSingleUseTokenProvider.getRefByToken);
+            sinon.assert.calledWith(mockSingleUseTokenProvider.getRefByToken, 'mock-token');
         });
 
         it('should return null when tokenProvider lacks getRefByToken method', async function () {
@@ -285,9 +285,9 @@ describe('MagicLink', function () {
             const otc = await service.getOTCFromToken('mock-token');
 
             assert.equal(otc, '654321');
-            assert(mockSingleUseTokenProvider.getRefByToken.calledOnce);
-            assert(mockSingleUseTokenProvider.deriveOTC.calledOnce);
-            assert(mockSingleUseTokenProvider.deriveOTC.calledWith('test-token-ref-123', 'mock-token'));
+            sinon.assert.calledOnce(mockSingleUseTokenProvider.getRefByToken);
+            sinon.assert.calledOnce(mockSingleUseTokenProvider.deriveOTC);
+            sinon.assert.calledWith(mockSingleUseTokenProvider.deriveOTC, 'test-token-ref-123', 'mock-token');
         });
 
         it('should return null when tokenProvider lacks getRefByToken method', async function () {
@@ -296,7 +296,7 @@ describe('MagicLink', function () {
             const otc = await service.getOTCFromToken('mock-token');
 
             assert.equal(otc, null);
-            assert(mockSingleUseTokenProvider.deriveOTC.notCalled);
+            sinon.assert.notCalled(mockSingleUseTokenProvider.deriveOTC);
         });
 
         it('should return null when tokenProvider lacks deriveOTC method', async function () {
@@ -305,7 +305,7 @@ describe('MagicLink', function () {
             const otc = await service.getOTCFromToken('mock-token');
 
             assert.equal(otc, null);
-            assert(mockSingleUseTokenProvider.getRefByToken.calledOnce);
+            sinon.assert.calledOnce(mockSingleUseTokenProvider.getRefByToken);
         });
 
         it('should return null when getRefByToken returns null', async function () {
@@ -314,8 +314,8 @@ describe('MagicLink', function () {
             const otc = await service.getOTCFromToken('mock-token');
 
             assert.equal(otc, null);
-            assert(mockSingleUseTokenProvider.getRefByToken.calledOnce);
-            assert(mockSingleUseTokenProvider.deriveOTC.notCalled);
+            sinon.assert.calledOnce(mockSingleUseTokenProvider.getRefByToken);
+            sinon.assert.notCalled(mockSingleUseTokenProvider.deriveOTC);
         });
     });
 });

--- a/ghost/core/test/unit/server/services/lib/mailgun-client.test.js
+++ b/ghost/core/test/unit/server/services/lib/mailgun-client.test.js
@@ -904,7 +904,7 @@ describe('MailgunClient', function () {
 
             assert.equal(firstPageMock.isDone(), true);
             assert.equal(secondPageMock.isDone(), true);
-            assert.equal(batchHandler.callCount, 2); // one per page
+            sinon.assert.calledTwice(batchHandler); // one per page
         });
     });
 

--- a/ghost/core/test/unit/server/services/link-redirection/link-redirect-repository.test.js
+++ b/ghost/core/test/unit/server/services/link-redirection/link-redirect-repository.test.js
@@ -189,7 +189,7 @@ describe('UNIT: LinkRedirectRepository class', function () {
             assert.equal(result.to.href, 'https://google.com/');
             assert.equal(result.edited, true);
             assert.equal(ObjectID.isValid(result.link_id), true);
-            assert.equal(cacheAdapterStub.set.calledOnce, true);
+            sinon.assert.calledOnce(cacheAdapterStub.set);
         });
     });
 
@@ -207,7 +207,7 @@ describe('UNIT: LinkRedirectRepository class', function () {
                 to: new URL('https://google.com')
             });
             await linkRedirectRepository.save(linkRedirect);
-            assert.equal(cacheAdapterStub.set.calledOnce, true);
+            sinon.assert.calledOnce(cacheAdapterStub.set);
         });
 
         it('should clear cache on site.changed event', function () {
@@ -222,7 +222,7 @@ describe('UNIT: LinkRedirectRepository class', function () {
             });
 
             EventRegistry.emit('site.changed');
-            assert.equal(reset.calledOnce, true);
+            sinon.assert.calledOnce(reset);
         });
     });
 });

--- a/ghost/core/test/unit/server/services/link-redirection/link-redirects-service.test.js
+++ b/ghost/core/test/unit/server/services/link-redirection/link-redirects-service.test.js
@@ -59,7 +59,7 @@ describe('LinkRedirectsService', function () {
                 }
             });
             await instance.addRedirect(new URL('https://localhost:2368/a'), new URL('https://localhost:2368/b'));
-            assert.equal(linkRedirectRepository.save.callCount, 1);
+            sinon.assert.calledOnce(linkRedirectRepository.save);
             assert.equal(linkRedirectRepository.save.getCall(0).args[0].from.href, 'https://localhost:2368/a');
             assert.equal(linkRedirectRepository.save.getCall(0).args[0].to.href, 'https://localhost:2368/b');
         });
@@ -113,9 +113,9 @@ describe('LinkRedirectsService', function () {
                 setHeader: sinon.fake()
             };
             await instance.handleRequest(req, res);
-            assert.equal(res.redirect.callCount, 1);
+            sinon.assert.calledOnce(res.redirect);
             assert.equal(res.redirect.getCall(0).args[0], 'https://localhost:2368/b');
-            assert(res.setHeader.calledWith('X-Robots-Tag', 'noindex, nofollow'));
+            sinon.assert.calledWith(res.setHeader, 'X-Robots-Tag', 'noindex, nofollow');
         });
 
         it('does not redirect if not found', async function () {
@@ -134,7 +134,7 @@ describe('LinkRedirectsService', function () {
             const res = {};
             const next = sinon.fake();
             await instance.handleRequest(req, res, next);
-            assert.equal(next.callCount, 1);
+            sinon.assert.calledOnce(next);
         });
 
         it('does not redirect if url does not contain a redirect prefix on site with no subdir', async function () {
@@ -154,7 +154,7 @@ describe('LinkRedirectsService', function () {
 
             await instance.handleRequest(req, res, next);
 
-            assert.equal(next.callCount, 1);
+            sinon.assert.calledOnce(next);
         });
 
         it('does not redirect if url does not contain a redirect prefix on site with subdir', async function () {
@@ -174,7 +174,7 @@ describe('LinkRedirectsService', function () {
 
             await instance.handleRequest(req, res, next);
 
-            assert.equal(next.callCount, 1);
+            sinon.assert.calledOnce(next);
         });
 
         it('substitutes %%{uuid}%% placeholder with member UUID from query param', async function () {

--- a/ghost/core/test/unit/server/services/link-tracking/link-click-tracking-service.test.js
+++ b/ghost/core/test/unit/server/services/link-tracking/link-click-tracking-service.test.js
@@ -20,9 +20,9 @@ describe('LinkClickTrackingService', function () {
                 }
             });
             service.init();
-            assert.ok(subscribe.calledOnce);
+            sinon.assert.calledOnce(subscribe);
             service.init();
-            assert.ok(subscribe.calledOnce);
+            sinon.assert.calledOnce(subscribe);
         });
     });
 
@@ -66,7 +66,7 @@ describe('LinkClickTrackingService', function () {
             assert.equal(updatedUrl.toString(), 'https://example.com/r/uniqueslug');
 
             // Check getSlugUrl called
-            assert(getSlugUrl.calledOnce);
+            sinon.assert.calledOnce(getSlugUrl);
 
             // Check save called
             assert(
@@ -102,7 +102,7 @@ describe('LinkClickTrackingService', function () {
             assert.equal(updatedUrl.toString(), 'https://example.com/r/uniqueslug?m=123');
 
             // Check getSlugUrl called
-            assert(getSlugUrl.calledOnce);
+            sinon.assert.calledOnce(getSlugUrl);
 
             // Check save called
             assert(
@@ -137,7 +137,7 @@ describe('LinkClickTrackingService', function () {
             });
 
             service.subscribe();
-            assert(!save.called);
+            sinon.assert.notCalled(save);
         });
 
         it('Tracks redirects with a member id', async function () {
@@ -163,7 +163,7 @@ describe('LinkClickTrackingService', function () {
             });
 
             service.subscribe();
-            assert(save.calledOnce);
+            sinon.assert.calledOnce(save);
 
             assert.equal(save.firstCall.args[0].member_uuid, 'memberId');
             assert.equal(save.firstCall.args[0].link_id, linkId);
@@ -246,7 +246,7 @@ describe('LinkClickTrackingService', function () {
 
             const result = await service.bulkEdit(data, options);
 
-            assert.equal(postLinkRepositoryStub.updateLinks.calledOnce, true);
+            sinon.assert.calledOnce(postLinkRepositoryStub.updateLinks);
             assert.deepEqual(result, {
                 successful: 0,
                 unsuccessful: 0,
@@ -295,7 +295,7 @@ describe('LinkClickTrackingService', function () {
 
             const result = await service.bulkEdit(data, options);
 
-            assert.equal(postLinkRepositoryStub.updateLinks.calledOnce, true);
+            sinon.assert.calledOnce(postLinkRepositoryStub.updateLinks);
             assert.deepEqual(result, {
                 successful: 0,
                 unsuccessful: 0,

--- a/ghost/core/test/unit/server/services/media-inliner/test/external-media-inliner.test.js
+++ b/ghost/core/test/unit/server/services/media-inliner/test/external-media-inliner.test.js
@@ -103,15 +103,15 @@ describe('ExternalMediaInliner', function () {
             await inliner.inline(['https://img.stockfresh.com']);
 
             assert.ok(requestMock.isDone());
-            assert.ok(postModelStub.edit.calledOnce);
-            assert.ok(postModelStub.edit.calledWith({
+            sinon.assert.calledOnce(postModelStub.edit);
+            sinon.assert.calledWith(postModelStub.edit, {
                 mobiledoc: '{"version":"0.3.1","atoms":[],"cards":[["image",{"src":"__GHOST_URL__/content/images/unique-image.jpg"}]]}'
             }, {
                 id: 'inlined-post-id',
                 context: {
                     internal: true
                 }
-            }));
+            });
         });
 
         it('inlines the image from post\'s mobiledoc containing html card', async function () {
@@ -152,7 +152,7 @@ describe('ExternalMediaInliner', function () {
             await inliner.inline(['https://bucketeer-e05bbc84-baa3-437e-9518-adb32be77984.s3.amazonaws.com']);
 
             assert.ok(requestMock.isDone());
-            assert.ok(postModelStub.edit.calledOnce);
+            sinon.assert.calledOnce(postModelStub.edit);
             assert.deepEqual(postModelStub.edit.args[0][0], {
                 mobiledoc: `{"version":"0.3.1","atoms":[],"cards":[["html",{"html":"<img src="__GHOST_URL__/content/images/unique-image.jpg" alt="Lorem ipsum">"}]],"markups":[],"sections":[[10,0],[1,"p",[]]],"ghostVersion":"4.0"}`
             });
@@ -201,15 +201,15 @@ describe('ExternalMediaInliner', function () {
             await inliner.inline(['https://img.stockfresh.com']);
 
             assert.ok(requestMock.isDone());
-            assert.ok(postModelStub.edit.calledOnce);
-            assert.ok(postModelStub.edit.calledWith({
+            sinon.assert.calledOnce(postModelStub.edit);
+            sinon.assert.calledWith(postModelStub.edit, {
                 lexical: '{"root":{"children":[{"type":"image","version":1,"src":"__GHOST_URL__/content/images/unique-image.jpg","width":1480,"height":486,"title":"","alt":"","caption":"","cardWidth":"regular","href":""}],"direction":null,"format":"","indent":0,"type":"root","version":1}}'
             }, {
                 id: 'inlined-post-id',
                 context: {
                     internal: true
                 }
-            }));
+            });
         });
 
         it('inlines the image from post\'s lexical containing html card', async function () {
@@ -250,7 +250,7 @@ describe('ExternalMediaInliner', function () {
             await inliner.inline(['https://img.stockfresh.com']);
 
             assert.ok(requestMock.isDone());
-            assert.ok(postModelStub.edit.calledOnce);
+            sinon.assert.calledOnce(postModelStub.edit);
             assert.deepEqual(postModelStub.edit.args[0][0], {
                 lexical: `{"root":{"children":[{"type":"html","version":1,"html":"<img src="__GHOST_URL__/content/images/unique-image.jpg" alt="Lorem ipsum">"}],"direction":null,"format":"","indent":0,"type":"root","version":1}}`
             });
@@ -303,7 +303,7 @@ describe('ExternalMediaInliner', function () {
             await inliner.inline(['https://example.com']);
 
             assert.ok(requestMock.isDone());
-            assert.ok(postModelStub.edit.calledOnce);
+            sinon.assert.calledOnce(postModelStub.edit);
             // NOTE: The file names all being the same as a limitation in how this is stubbed. In production, each image is unique
             assert.deepEqual(postModelStub.edit.args[0][0], {
                 lexical: `{"root":{"children":[{"type":"html","version":1,"html":"<img srcset="__GHOST_URL__/content/images/unique-image.jpg, __GHOST_URL__/content/images/unique-image.jpg 2x" src="__GHOST_URL__/content/images/unique-image.jpg" />"}],"direction":null,"format":"","indent":0,"type":"root","version":1}}`
@@ -355,8 +355,8 @@ describe('ExternalMediaInliner', function () {
             await inliner.inline(['https://img.stockfresh.com']);
 
             assert.ok(requestMock.isDone());
-            assert.ok(postModelStub.edit.calledOnce);
-            assert.ok(postModelStub.edit.calledWith({
+            sinon.assert.calledOnce(postModelStub.edit);
+            sinon.assert.calledWith(postModelStub.edit, {
                 mobiledoc: '{"version":"0.3.1","atoms":[],"cards":[["image",{"src":"__GHOST_URL__/content/images/unique-image.jpg"}]]}',
                 lexical: '{"root":{"children":[{"type":"image","version":1,"src":"__GHOST_URL__/content/images/unique-image.jpg","width":1480,"height":486,"title":"","alt":"","caption":"","cardWidth":"regular","href":""}],"direction":null,"format":"","indent":0,"type":"root","version":1}}'
             }, {
@@ -364,7 +364,7 @@ describe('ExternalMediaInliner', function () {
                 context: {
                     internal: true
                 }
-            }));
+            });
         });
 
         it('logs an error when fetching an external media fails', async function () {
@@ -454,7 +454,7 @@ describe('ExternalMediaInliner', function () {
             await inliner.inline(['https://img.stockfresh.com']);
 
             assert.ok(requestMock.isDone());
-            assert.ok(logging.warn.calledOnce);
+            sinon.assert.calledOnce(logging.warn);
             assert.equal(logging.warn.args[0][0], 'No storage adapter found for file extension: .exe');
         });
 
@@ -495,7 +495,7 @@ describe('ExternalMediaInliner', function () {
             await inliner.inline(['https://img.stockfresh.com']);
 
             assert.ok(requestMock.isDone());
-            assert.ok(postModelStub.edit.calledOnce);
+            sinon.assert.calledOnce(postModelStub.edit);
             assert.equal(logging.error.args[0][0], 'Error inlining media for post: errored-post-id');
         });
 
@@ -537,7 +537,7 @@ describe('ExternalMediaInliner', function () {
             await inliner.inline(['https://img.stockfresh.com']);
 
             assert.ok(requestMock.isDone());
-            assert.ok(tagModelStub.edit.calledOnce);
+            sinon.assert.calledOnce(tagModelStub.edit);
             assert.equal(logging.error.args[0][0], 'Error inlining media for: errored-tag-id');
         });
 
@@ -576,15 +576,15 @@ describe('ExternalMediaInliner', function () {
             await inliner.inline(['https://img.stockfresh.com']);
 
             assert.ok(requestMock.isDone());
-            assert.ok(postModelMock.edit.calledOnce);
-            assert.ok(postModelMock.edit.calledWith({
+            sinon.assert.calledOnce(postModelMock.edit);
+            sinon.assert.calledWith(postModelMock.edit, {
                 feature_image: '__GHOST_URL__/content/images/unique-feature-image.jpg'
             }, {
                 id: 'inlined-post-id',
                 context: {
                     internal: true
                 }
-            }));
+            });
         });
 
         it('inlines og_image image in posts_meta table', async function () {
@@ -623,7 +623,7 @@ describe('ExternalMediaInliner', function () {
             await inliner.inline(['https://img.stockfresh.com']);
 
             assert.ok(requestMock.isDone());
-            assert.ok(postMetaModelStub.edit.calledOnce);
+            sinon.assert.calledOnce(postMetaModelStub.edit);
             assert.deepEqual(postMetaModelStub.edit.args[0][0], {
                 og_image: '__GHOST_URL__/content/images/unique-posts-meta-image.jpg'
             });
@@ -671,7 +671,7 @@ describe('ExternalMediaInliner', function () {
             await inliner.inline(['https://img.stockfresh.com']);
 
             assert.ok(requestMock.isDone());
-            assert.ok(tagModelStub.edit.calledOnce);
+            sinon.assert.calledOnce(tagModelStub.edit);
             assert.deepEqual(tagModelStub.edit.args[0][0], {
                 twitter_image: '__GHOST_URL__/content/images/unique-tag-twitter-image.jpg'
             });
@@ -719,7 +719,7 @@ describe('ExternalMediaInliner', function () {
             await inliner.inline(['https://img.stockfresh.com']);
 
             assert.ok(requestMock.isDone());
-            assert.ok(userModelStub.edit.calledOnce);
+            sinon.assert.calledOnce(userModelStub.edit);
             assert.deepEqual(userModelStub.edit.args[0][0], {
                 cover_image: '__GHOST_URL__/content/images/user-cover-image.jpg'
             });
@@ -1005,7 +1005,7 @@ describe('ExternalMediaInliner', function () {
                 const result = await inliner.getRemoteMedia('https://malicious-site.com/image.jpg');
 
                 assert.equal(result, null);
-                assert.ok(logging.error.called);
+                sinon.assert.called(logging.error);
                 assert.equal(logging.error.args[0][0], 'Error downloading remote media: https://malicious-site.com/image.jpg');
             } finally {
                 dnsStub.restore();

--- a/ghost/core/test/unit/server/services/members-events/last-seen-at-updater.test.js
+++ b/ghost/core/test/unit/server/services/members-events/last-seen-at-updater.test.js
@@ -175,7 +175,7 @@ describe('LastSeenAtUpdater', function () {
             DomainEvents.dispatch(EmailOpenedEvent.create({memberId: '1', emailRecipientId: '1', emailId: '1', timestamp: now.toDate()}));
             await DomainEvents.allSettled();
             assert(updater.updateLastSeenAtWithoutKnownLastSeen.calledOnceWithExactly('1', now.toDate()));
-            assert(db.update.calledOnce);
+            sinon.assert.calledOnce(db.update);
         });
 
         it('Catches errors in updateLastSeenAtWithoutKnownLastSeen on EmailOpenedEvents', async function () {

--- a/ghost/core/test/unit/server/services/members/importer/members-csv-importer-stripe-utils.test.js
+++ b/ghost/core/test/unit/server/services/members/importer/members-csv-importer-stripe-utils.test.js
@@ -290,7 +290,7 @@ describe('MembersCSVImporterStripeUtils', function () {
             assert.equal(result.stripePriceId, stripeCustomerSubscriptionItem.price.id);
             assert.equal(result.isNewStripePrice, false);
 
-            assert.equal(stripeAPIServiceStub.updateSubscriptionItemPrice.calledOnce, false);
+            sinon.assert.notCalled(stripeAPIServiceStub.updateSubscriptionItemPrice);
         });
 
         it('updates the Stripe customer\'s subscription if they already have a subscription, but to some other Ghost product', async function () {
@@ -311,7 +311,7 @@ describe('MembersCSVImporterStripeUtils', function () {
             assert.equal(result.stripePriceId, GHOST_PRODUCT_STRIPE_PRICE_ID);
             assert.equal(result.isNewStripePrice, false);
 
-            assert.equal(stripeAPIServiceStub.updateSubscriptionItemPrice.calledOnce, true);
+            sinon.assert.calledOnce(stripeAPIServiceStub.updateSubscriptionItemPrice);
             assert.equal(stripeAPIServiceStub.updateSubscriptionItemPrice.calledWithExactly(
                 stripeCustomer.subscriptions.data[0].id,
                 stripeCustomerSubscriptionItem.id,
@@ -354,7 +354,7 @@ describe('MembersCSVImporterStripeUtils', function () {
             assert.equal(result.isNewStripePrice, true);
 
             // Assert subscription was updated
-            assert.equal(stripeAPIServiceStub.updateSubscriptionItemPrice.calledOnce, true);
+            sinon.assert.calledOnce(stripeAPIServiceStub.updateSubscriptionItemPrice);
             assert.equal(stripeAPIServiceStub.updateSubscriptionItemPrice.calledWithExactly(
                 stripeCustomer.subscriptions.data[0].id,
                 stripeCustomerSubscriptionItem.id,
@@ -378,7 +378,7 @@ describe('MembersCSVImporterStripeUtils', function () {
                 product_id: PRODUCT_ID
             }, OPTIONS);
 
-            assert.equal(productRepositoryStub.update.calledOnce, true);
+            sinon.assert.calledOnce(productRepositoryStub.update);
             assert.equal(productRepositoryStub.update.calledWithExactly(
                 {
                     id: PRODUCT_ID,
@@ -407,7 +407,7 @@ describe('MembersCSVImporterStripeUtils', function () {
 
             await membersCSVImporterStripeUtils.archivePrice(stripePriceId);
 
-            assert.equal(stripeAPIServiceStub.updatePrice.calledOnce, true);
+            sinon.assert.calledOnce(stripeAPIServiceStub.updatePrice);
             assert.equal(stripeAPIServiceStub.updatePrice.calledWithExactly(stripePriceId, {active: false}), true);
         });
     });

--- a/ghost/core/test/unit/server/services/members/importer/members-csv-importer.test.js
+++ b/ghost/core/test/unit/server/services/members/importer/members-csv-importer.test.js
@@ -128,7 +128,7 @@ describe('MembersCSVImporter', function () {
             assertExists(result.meta.originalImportSize);
             assert.equal(result.meta.originalImportSize, 2);
 
-            assert.equal(fsWriteSpy.calledOnce, true);
+            sinon.assert.calledOnce(fsWriteSpy);
 
             // Called at least once
             assert.equal(memberCreateStub.notCalled, false);
@@ -177,10 +177,10 @@ describe('MembersCSVImporter', function () {
             assertExists(result.meta.originalImportSize);
             assert.equal(result.meta.originalImportSize, 2);
 
-            assert.equal(fsWriteSpy.calledOnce, true);
+            sinon.assert.calledOnce(fsWriteSpy);
 
             // member records get inserted
-            assert.equal(membersRepositoryStub.create.calledTwice, true);
+            sinon.assert.calledTwice(membersRepositoryStub.create);
 
             assert.equal(membersRepositoryStub.create.args[0][1].context.import, true, 'inserts are done in the "import" context');
 
@@ -207,13 +207,13 @@ describe('MembersCSVImporter', function () {
             assert.deepEqual(membersRepositoryStub.create.args[1][0].labels, [], 'no labels should be assigned');
 
             // stripe customer import
-            assert.equal(membersRepositoryStub.linkStripeCustomer.calledOnce, true);
+            sinon.assert.calledOnce(membersRepositoryStub.linkStripeCustomer);
             assert.equal(membersRepositoryStub.linkStripeCustomer.args[0][0].customer_id, 'cus_MdR9tqW6bAreiq');
             assert.equal(membersRepositoryStub.linkStripeCustomer.args[0][0].member_id, 'test_member_id');
             assert.equal(membersRepositoryStub.linkStripeCustomer.args[0][1].context.importer, true, 'linkStripeCustomer is called with importer context to prevent welcome emails');
 
             // complimentary_plan import
-            assert.equal(membersRepositoryStub.update.calledOnce, true);
+            sinon.assert.calledOnce(membersRepositoryStub.update);
             assert.deepEqual(membersRepositoryStub.update.args[0][0].products, [{
                 id: defaultTierId.toString()
             }]);
@@ -323,10 +323,10 @@ describe('MembersCSVImporter', function () {
             assertExists(result.meta.originalImportSize);
             assert.equal(result.meta.originalImportSize, 15);
 
-            assert.equal(fsWriteSpy.calledOnce, true);
+            sinon.assert.calledOnce(fsWriteSpy);
 
             // member records get inserted
-            assert.equal(membersRepositoryStub.create.callCount, 5);
+            sinon.assert.callCount(membersRepositoryStub.create, 5);
 
             assert.equal(membersRepositoryStub.create.args[0][1].context.import, true, 'inserts are done in the "import" context');
 
@@ -449,7 +449,7 @@ describe('MembersCSVImporter', function () {
                 importLabel: {name: 'Test import'}
             });
 
-            assert.equal(sendEmailStub.calledWith({
+            sinon.assert.calledWith(sendEmailStub, {
                 to: 'test@example.com',
                 subject: 'Your member import was unsuccessful',
                 html: 'Import was unsuccessful',
@@ -462,7 +462,7 @@ describe('MembersCSVImporter', function () {
                         contentDisposition: 'attachment'
                     }
                 ]
-            }), true);
+            });
         });
     });
 
@@ -478,7 +478,7 @@ describe('MembersCSVImporter', function () {
             assert.equal(result.batches, 2);
             assertExists(result.metadata);
             assert.equal(result.metadata.hasStripeData, false);
-            assert.equal(fsWriteSpy.calledOnce, true);
+            sinon.assert.calledOnce(fsWriteSpy);
         });
 
         it('Does not include columns not in the original CSV or mapped', async function () {
@@ -728,7 +728,7 @@ describe('MembersCSVImporter', function () {
             assert.equal(result.total, 1);
             assert.equal(result.imported, 1);
             assert.equal(result.errors.length, 0);
-            assert.ok(membersRepositoryStub.update.calledOnce);
+            sinon.assert.calledOnce(membersRepositoryStub.update);
             assert.deepEqual(
                 membersRepositoryStub.update.getCall(0).args[0],
                 {products: [{id: tier.id.toString()}]}
@@ -778,7 +778,7 @@ describe('MembersCSVImporter', function () {
             assert.equal(result.total, 1);
             assert.equal(result.imported, 1);
             assert.equal(result.errors.length, 0);
-            assert.ok(stripeUtilsStub.forceStripeSubscriptionToProduct.calledOnce);
+            sinon.assert.calledOnce(stripeUtilsStub.forceStripeSubscriptionToProduct);
             assert.deepEqual(
                 stripeUtilsStub.forceStripeSubscriptionToProduct.getCall(0).args[0],
                 {
@@ -815,8 +815,8 @@ describe('MembersCSVImporter', function () {
             assert.equal(result.total, 1);
             assert.equal(result.imported, 1);
             assert.equal(result.errors.length, 0);
-            assert.ok(stripeUtilsStub.archivePrice.calledOnce);
-            assert.ok(stripeUtilsStub.archivePrice.calledWith(newStripePriceId));
+            sinon.assert.calledOnce(stripeUtilsStub.archivePrice);
+            sinon.assert.calledWith(stripeUtilsStub.archivePrice, newStripePriceId);
         });
     });
 });

--- a/ghost/core/test/unit/server/services/members/members-api/controllers/router-controller.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/controllers/router-controller.test.js
@@ -108,12 +108,12 @@ describe('RouterController', function () {
                 end: () => {}
             });
 
-            assert.equal(getPaymentLinkSpy.calledOnce, true);
+            sinon.assert.calledOnce(getPaymentLinkSpy);
 
             // Payment link is called with the offer id in metadata
-            assert.equal(getPaymentLinkSpy.calledWith(sinon.match({
+            sinon.assert.calledWith(getPaymentLinkSpy, sinon.match({
                 metadata: {offer: 'offer_123'}
-            })), true);
+            }));
         });
 
         it('parses newsletters from the request body', async function () {
@@ -157,13 +157,13 @@ describe('RouterController', function () {
 
             const expectedNewsletters = JSON.stringify([{id: 'abc123'}, {id: 'def456'}]);
 
-            assert.equal(getPaymentLinkSpy.calledOnce, true);
+            sinon.assert.calledOnce(getPaymentLinkSpy);
 
-            assert.equal(getPaymentLinkSpy.calledWith(sinon.match({
+            sinon.assert.calledWith(getPaymentLinkSpy, sinon.match({
                 metadata: {
                     newsletters: expectedNewsletters
                 }
-            })), true);
+            }));
         });
 
         it('sets ghostSignupContext to has_precheckout_magic_link when checkout creates a signup magic link', async function () {
@@ -199,13 +199,13 @@ describe('RouterController', function () {
                 end: () => {}
             });
 
-            assert.equal(magicLinkService.getMagicLink.calledOnce, true);
-            assert.equal(getPaymentLinkSpy.calledWith(sinon.match({
+            sinon.assert.calledOnce(magicLinkService.getMagicLink);
+            sinon.assert.calledWith(getPaymentLinkSpy, sinon.match({
                 successUrl: 'https://example.com/members/?token=abc123&action=signup',
                 metadata: {
                     ghostSignupContext: 'has_precheckout_magic_link'
                 }
-            })), true);
+            }));
         });
 
         it('sets ghostSignupContext to already_authenticated for authenticated members', async function () {
@@ -244,11 +244,11 @@ describe('RouterController', function () {
                 end: () => {}
             });
 
-            assert.equal(getPaymentLinkSpy.calledWith(sinon.match({
+            sinon.assert.calledWith(getPaymentLinkSpy, sinon.match({
                 metadata: {
                     ghostSignupContext: 'already_authenticated'
                 }
-            })), true);
+            }));
         });
 
         it('sets ghostSignupContext to needs_magic_link_email when there is no member context or customer email', async function () {
@@ -275,11 +275,11 @@ describe('RouterController', function () {
                 end: () => {}
             });
 
-            assert.equal(getPaymentLinkSpy.calledWith(sinon.match({
+            sinon.assert.calledWith(getPaymentLinkSpy, sinon.match({
                 metadata: {
                     ghostSignupContext: 'needs_magic_link_email'
                 }
-            })), true);
+            }));
         });
 
         describe('_getSubscriptionCheckoutData', function () {
@@ -480,16 +480,16 @@ describe('RouterController', function () {
                     writeHead: () => {},
                     end: () => {}
                 });
-                assert.equal(getDonationLinkSpy.calledOnce, true);
+                sinon.assert.calledOnce(getDonationLinkSpy);
 
-                assert.equal(getDonationLinkSpy.calledWith(sinon.match({
+                sinon.assert.calledWith(getDonationLinkSpy, sinon.match({
                     successUrl: 'https://example.com/?type=success',
                     cancelUrl: 'https://example.com/?type=cancel',
                     personalNote: 'SVP leave a note here',
                     metadata: {
                         test: 'hello'
                     }
-                })), true);
+                }));
             });
             it('accepts requests without a personalNote included', async function () {
                 const routerController = new RouterController({
@@ -527,16 +527,16 @@ describe('RouterController', function () {
                     writeHead: () => {},
                     end: () => {}
                 });
-                assert.equal(getDonationLinkSpy.calledOnce, true);
+                sinon.assert.calledOnce(getDonationLinkSpy);
 
-                assert.equal(getDonationLinkSpy.calledWith(sinon.match({
+                sinon.assert.calledWith(getDonationLinkSpy, sinon.match({
                     successUrl: 'https://example.com/?type=success',
                     cancelUrl: 'https://example.com/?type=cancel',
                     personalNote: '',
                     metadata: {
                         test: 'hello'
                     }
-                })), true);
+                }));
             });
             it('silently discards too-long personal notes', async function () {
                 const routerController = new RouterController({
@@ -575,15 +575,15 @@ describe('RouterController', function () {
                     writeHead: () => {},
                     end: () => {}
                 });
-                assert.equal(getDonationLinkSpy.calledOnce, true);
-                assert.equal(getDonationLinkSpy.calledWith(sinon.match({
+                sinon.assert.calledOnce(getDonationLinkSpy);
+                sinon.assert.calledWith(getDonationLinkSpy, sinon.match({
                     successUrl: 'https://example.com/?type=success',
                     cancelUrl: 'https://example.com/?type=cancel',
                     personalNote: '',
                     metadata: {
                         test: 'hello'
                     }
-                })), true);
+                }));
             });
             it('silently discards invalid personal notes', async function () {
                 const routerController = new RouterController({
@@ -622,15 +622,15 @@ describe('RouterController', function () {
                     writeHead: () => {},
                     end: () => {}
                 });
-                assert.equal(getDonationLinkSpy.calledOnce, true);
-                assert.equal(getDonationLinkSpy.calledWith(sinon.match({
+                sinon.assert.calledOnce(getDonationLinkSpy);
+                sinon.assert.calledWith(getDonationLinkSpy, sinon.match({
                     successUrl: 'https://example.com/?type=success',
                     cancelUrl: 'https://example.com/?type=cancel',
                     personalNote: '',
                     metadata: {
                         test: 'hello'
                     }
-                })), true);
+                }));
             });
             it('strips any html from the personal note', async function () {
                 const routerController = new RouterController({
@@ -669,15 +669,15 @@ describe('RouterController', function () {
                     writeHead: () => {},
                     end: () => {}
                 });
-                assert.equal(getDonationLinkSpy.calledOnce, true);
-                assert.equal(getDonationLinkSpy.calledWith(sinon.match({
+                sinon.assert.calledOnce(getDonationLinkSpy);
+                sinon.assert.calledWith(getDonationLinkSpy, sinon.match({
                     successUrl: 'https://example.com/?type=success',
                     cancelUrl: 'https://example.com/?type=cancel',
                     personalNote: 'Leave a note here',
                     metadata: {
                         test: 'hello'
                     }
-                })), true);
+                }));
             });
         });
 
@@ -735,7 +735,7 @@ describe('RouterController', function () {
 
             await routerController.createCheckoutSession(req, res);
 
-            assert.equal(res.end.calledOnce, true);
+            sinon.assert.calledOnce(res.end);
             const responseBody = JSON.parse(res.end.firstCall.args[0]);
             assert.equal(responseBody.welcomePageUrl, '/welcome-page/');
         });
@@ -793,7 +793,7 @@ describe('RouterController', function () {
 
             await routerController.createCheckoutSession(req, res);
 
-            assert.equal(res.end.calledOnce, true);
+            sinon.assert.calledOnce(res.end);
             const responseBody = JSON.parse(res.end.firstCall.args[0]);
             assert.equal(responseBody.welcomePageUrl, undefined);
         });
@@ -880,7 +880,7 @@ describe('RouterController', function () {
                 assert.equal(res.writeHead.calledOnceWith(201), true);
                 assert.equal(res.end.calledOnceWith('{}'), true);
 
-                assert.equal(sendEmailWithMagicLinkStub.calledOnce, true);
+                sinon.assert.calledOnce(sendEmailWithMagicLinkStub);
                 assert.deepEqual(sendEmailWithMagicLinkStub.args[0][0].tokenData.newsletters, [
                     {id: newsletters[0].id},
                     {id: newsletters[1].id},
@@ -996,7 +996,7 @@ describe('RouterController', function () {
                 const controller = createRouterController();
 
                 await controller.sendMagicLink(req, res);
-                assert.equal(sendEmailWithMagicLinkStub.calledOnce, true);
+                sinon.assert.calledOnce(sendEmailWithMagicLinkStub);
             });
 
             it('Does not send emails when honeypot is filled', async function () {
@@ -1060,8 +1060,8 @@ describe('RouterController', function () {
 
                 await routerController.sendMagicLink(req, res);
 
-                assert.equal(res.writeHead.calledWith(201, {'Content-Type': 'application/json'}), true);
-                assert.equal(res.end.calledWith(JSON.stringify({otc_ref: 'test-token-123'})), true);
+                sinon.assert.calledWith(res.writeHead, 201, {'Content-Type': 'application/json'});
+                sinon.assert.calledWith(res.end, JSON.stringify({otc_ref: 'test-token-123'}));
             });
 
             it('should not return otc_ref when no otcRef', async function () {
@@ -1069,8 +1069,8 @@ describe('RouterController', function () {
 
                 await routerController.sendMagicLink(req, res);
 
-                assert.equal(res.writeHead.calledWith(201), true);
-                assert.equal(res.end.calledWith('{}'), true);
+                sinon.assert.calledWith(res.writeHead, 201);
+                sinon.assert.calledWith(res.end, '{}');
             });
 
             it('should not return otc_ref when otcRef is undefined', async function () {
@@ -1078,8 +1078,8 @@ describe('RouterController', function () {
 
                 await routerController.sendMagicLink(req, res);
 
-                assert.equal(res.writeHead.calledWith(201), true);
-                assert.equal(res.end.calledWith('{}'), true);
+                sinon.assert.calledWith(res.writeHead, 201);
+                sinon.assert.calledWith(res.end, '{}');
             });
         });
     });
@@ -1599,7 +1599,7 @@ describe('RouterController', function () {
             }, res);
 
             assert.deepEqual(responseData, {offers: []});
-            assert(offersAPIWithError.listOffersAvailableToSubscription.calledOnce);
+            sinon.assert.calledOnce(offersAPIWithError.listOffersAvailableToSubscription);
         });
 
         it('returns empty offers when subscription has an active discount', async function () {
@@ -1616,7 +1616,7 @@ describe('RouterController', function () {
             }, res);
 
             assert.deepEqual(responseData, {offers: []});
-            assert(mockOffersAPI.listOffersAvailableToSubscription.notCalled);
+            sinon.assert.notCalled(mockOffersAPI.listOffersAvailableToSubscription);
         });
 
         it('returns offers when subscription has an expired discount', async function () {
@@ -1637,7 +1637,7 @@ describe('RouterController', function () {
             }, res);
 
             assert.deepEqual(responseData, {offers: [mockOffer]});
-            assert(mockOffersAPI.listOffersAvailableToSubscription.calledOnce);
+            sinon.assert.calledOnce(mockOffersAPI.listOffersAvailableToSubscription);
         });
 
         it('returns offers when subscription has expired once offer (legacy data, no discount_start)', async function () {
@@ -1657,7 +1657,7 @@ describe('RouterController', function () {
             }, res);
 
             assert.deepEqual(responseData, {offers: [mockOffer]});
-            assert(mockOffersAPI.listOffersAvailableToSubscription.calledOnce);
+            sinon.assert.calledOnce(mockOffersAPI.listOffersAvailableToSubscription);
         });
 
         it('returns empty offers when member has multiple active subscriptions', async function () {
@@ -1673,7 +1673,7 @@ describe('RouterController', function () {
             }, res);
 
             assert.deepEqual(responseData, {offers: []});
-            assert(mockOffersAPI.listOffersAvailableToSubscription.notCalled);
+            sinon.assert.notCalled(mockOffersAPI.listOffersAvailableToSubscription);
         });
 
         it('returns empty offers when subscription has an active trial period', async function () {
@@ -1689,7 +1689,7 @@ describe('RouterController', function () {
             }, res);
 
             assert.deepEqual(responseData, {offers: []});
-            assert(mockOffersAPI.listOffersAvailableToSubscription.notCalled);
+            sinon.assert.notCalled(mockOffersAPI.listOffersAvailableToSubscription);
         });
 
         it('returns offers when subscription trial has ended', async function () {
@@ -1708,7 +1708,7 @@ describe('RouterController', function () {
             }, res);
 
             assert.deepEqual(responseData, {offers: [mockOffer]});
-            assert(mockOffersAPI.listOffersAvailableToSubscription.calledOnce);
+            sinon.assert.calledOnce(mockOffersAPI.listOffersAvailableToSubscription);
         });
 
         it('returns offers when subscription has no trial period', async function () {
@@ -1724,7 +1724,7 @@ describe('RouterController', function () {
             }, res);
 
             assert.deepEqual(responseData, {offers: [mockOffer]});
-            assert(mockOffersAPI.listOffersAvailableToSubscription.calledOnce);
+            sinon.assert.calledOnce(mockOffersAPI.listOffersAvailableToSubscription);
         });
     });
 });

--- a/ghost/core/test/unit/server/services/members/members-api/repositories/member-repository.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/repositories/member-repository.test.js
@@ -139,7 +139,7 @@ describe('MemberRepository', function () {
 
                 assert.fail('setComplimentarySubscription should have thrown');
             } catch (err) {
-                assert.equal(productRepository.getDefaultProduct.calledWith({withRelated: ['stripePrices'], transacting: true}), true);
+                sinon.assert.calledWith(productRepository.getDefaultProduct, {withRelated: ['stripePrices'], transacting: true});
                 assert.equal(err.message, 'Could not find Product "default"');
             }
         });
@@ -226,7 +226,7 @@ describe('MemberRepository', function () {
                 context: {}
             });
 
-            assert.equal(MemberSubscribeEvent.add.calledTwice, true);
+            sinon.assert.calledTwice(MemberSubscribeEvent.add);
         });
     });
 
@@ -365,8 +365,8 @@ describe('MemberRepository', function () {
                 context: {}
             });
 
-            assert.equal(subscriptionCreatedNotifySpy.calledOnce, true);
-            assert.equal(offerRedemptionNotifySpy.called, false);
+            sinon.assert.calledOnce(subscriptionCreatedNotifySpy);
+            sinon.assert.notCalled(offerRedemptionNotifySpy);
         });
 
         it('dispatches the offer redemption event for a new member starting a subscription', async function (){
@@ -399,21 +399,21 @@ describe('MemberRepository', function () {
                 context: {}
             });
 
-            assert.equal(subscriptionCreatedNotifySpy.calledOnce, true);
-            assert.equal(subscriptionCreatedNotifySpy.calledWith(sinon.match((event) => {
+            sinon.assert.calledOnce(subscriptionCreatedNotifySpy);
+            sinon.assert.calledWith(subscriptionCreatedNotifySpy, sinon.match((event) => {
                 if (event.data.offerId === 'offer_123') {
                     return true;
                 }
                 return false;
-            })), true);
+            }));
 
-            assert.equal(offerRedemptionNotifySpy.called, true);
-            assert.equal(offerRedemptionNotifySpy.calledWith(sinon.match((event) => {
+            sinon.assert.called(offerRedemptionNotifySpy);
+            sinon.assert.calledWith(offerRedemptionNotifySpy, sinon.match((event) => {
                 if (event.data.offerId === 'offer_123') {
                     return true;
                 }
                 return false;
-            })), true);
+            }));
         });
 
         it('dispatches the offer redemption event for an existing member upgrading to a paid subscription', async function (){
@@ -447,15 +447,15 @@ describe('MemberRepository', function () {
                 context: {}
             });
 
-            assert.equal(subscriptionCreatedNotifySpy.calledOnce, false);
+            sinon.assert.notCalled(subscriptionCreatedNotifySpy);
 
-            assert.equal(offerRedemptionNotifySpy.called, true);
-            assert.equal(offerRedemptionNotifySpy.calledWith(sinon.match((event) => {
+            sinon.assert.called(offerRedemptionNotifySpy);
+            sinon.assert.calledWith(offerRedemptionNotifySpy, sinon.match((event) => {
                 if (event.data.offerId === 'offer_123') {
                     return true;
                 }
                 return false;
-            })), true);
+            }));
         });
 
         it('creates an offer from a Stripe coupon', async function () {
@@ -518,7 +518,7 @@ describe('MemberRepository', function () {
                 context: {}
             });
 
-            assert.equal(offersAPI.ensureOfferForStripeCoupon.calledOnce, true);
+            sinon.assert.calledOnce(offersAPI.ensureOfferForStripeCoupon);
             // Verify the coupon, cadence, tier, and options are passed correctly
             assert.deepEqual(offersAPI.ensureOfferForStripeCoupon.firstCall.args[0], stripeCoupon);
             assert.equal(offersAPI.ensureOfferForStripeCoupon.firstCall.args[1], 'month');
@@ -595,10 +595,10 @@ describe('MemberRepository', function () {
             });
 
             // Verify ensureOfferForStripeCoupon was called
-            assert.equal(offersAPI.ensureOfferForStripeCoupon.calledOnce, true);
+            sinon.assert.calledOnce(offersAPI.ensureOfferForStripeCoupon);
 
             // Verify subscription was still created, but without an offer_id
-            assert.equal(StripeCustomerSubscription.add.calledOnce, true);
+            sinon.assert.calledOnce(StripeCustomerSubscription.add);
             assert.equal(StripeCustomerSubscription.add.firstCall.args[0].offer_id, null);
         });
 
@@ -674,10 +674,10 @@ describe('MemberRepository', function () {
             );
 
             // Verify ensureOfferForStripeCoupon was called
-            assert.equal(offersAPI.ensureOfferForStripeCoupon.calledOnce, true);
+            sinon.assert.calledOnce(offersAPI.ensureOfferForStripeCoupon);
 
             // Verify subscription was NOT created because the error was rethrown
-            assert.equal(StripeCustomerSubscription.add.called, false);
+            sinon.assert.notCalled(StripeCustomerSubscription.add);
         });
 
         it('persists discount_start and discount_end for a new subscription', async function () {
@@ -726,7 +726,7 @@ describe('MemberRepository', function () {
             });
 
             // Verify discount_start and discount_end are set correctly
-            assert.equal(StripeCustomerSubscription.add.calledOnce, true);
+            sinon.assert.calledOnce(StripeCustomerSubscription.add);
             const addedSubscriptionData = StripeCustomerSubscription.add.firstCall.args[0];
 
             assert.ok(addedSubscriptionData.discount_start instanceof Date);
@@ -783,8 +783,8 @@ describe('MemberRepository', function () {
             });
 
             // Verify edit was called (not add) since subscription exists
-            assert.equal(StripeCustomerSubscription.add.called, false);
-            assert.equal(StripeCustomerSubscription.edit.calledOnce, true);
+            sinon.assert.notCalled(StripeCustomerSubscription.add);
+            sinon.assert.calledOnce(StripeCustomerSubscription.edit);
 
             const editedSubscriptionData = StripeCustomerSubscription.edit.firstCall.args[0];
 
@@ -821,7 +821,7 @@ describe('MemberRepository', function () {
                 context: {}
             });
 
-            assert.equal(StripeCustomerSubscription.add.calledOnce, true);
+            sinon.assert.calledOnce(StripeCustomerSubscription.add);
             const addedSubscriptionData = StripeCustomerSubscription.add.firstCall.args[0];
 
             assert.equal(addedSubscriptionData.discount_start, null);
@@ -1045,7 +1045,7 @@ describe('MemberRepository', function () {
                 context: {}
             });
 
-            assert.equal(StripeCustomerSubscription.add.calledOnce, true);
+            sinon.assert.calledOnce(StripeCustomerSubscription.add);
             const addedSubscriptionData = StripeCustomerSubscription.add.firstCall.args[0];
 
             assert.ok(addedSubscriptionData.discount_start instanceof Date);
@@ -1090,7 +1090,7 @@ describe('MemberRepository', function () {
                 context: {}
             });
 
-            assert.equal(StripeCustomerSubscription.edit.calledOnce, true);
+            sinon.assert.calledOnce(StripeCustomerSubscription.edit);
             const editedData = StripeCustomerSubscription.edit.firstCall.args[0];
 
             // offer_id should NOT have been deleted — it should be null (clearing the stale value)
@@ -1138,7 +1138,7 @@ describe('MemberRepository', function () {
                 context: {}
             });
 
-            assert.equal(StripeCustomerSubscription.edit.calledOnce, true);
+            sinon.assert.calledOnce(StripeCustomerSubscription.edit);
             const editedData = StripeCustomerSubscription.edit.firstCall.args[0];
 
             // offer_id should have been deleted from the update data (preserving the existing value)
@@ -1184,7 +1184,7 @@ describe('MemberRepository', function () {
                 context: {}
             });
 
-            assert.equal(StripeCustomerSubscription.edit.calledOnce, true);
+            sinon.assert.calledOnce(StripeCustomerSubscription.edit);
             const editedData = StripeCustomerSubscription.edit.firstCall.args[0];
 
             // offer_id should NOT have been deleted — it should be null (clearing the stale value)
@@ -1249,10 +1249,10 @@ describe('MemberRepository', function () {
                 context: {}
             });
 
-            assert.equal(offerRedemptionNotifySpy.called, true);
-            assert.equal(offerRedemptionNotifySpy.calledWith(sinon.match((event) => {
+            sinon.assert.called(offerRedemptionNotifySpy);
+            sinon.assert.calledWith(offerRedemptionNotifySpy, sinon.match((event) => {
                 return event.data.offerId === 'new_retention_offer_456';
-            })), true);
+            }));
 
             // Timestamp should be the discount start, not the subscription created_at
             const event = offerRedemptionNotifySpy.firstCall.args[0];
@@ -1311,7 +1311,7 @@ describe('MemberRepository', function () {
                 context: {}
             });
 
-            assert.equal(offerRedemptionNotifySpy.called, true);
+            sinon.assert.called(offerRedemptionNotifySpy);
 
             const event = offerRedemptionNotifySpy.firstCall.args[0];
 
@@ -1377,7 +1377,7 @@ describe('MemberRepository', function () {
                 context: {}
             });
 
-            assert.equal(StripeCustomerSubscription.edit.calledOnce, true);
+            sinon.assert.calledOnce(StripeCustomerSubscription.edit);
             const editedData = StripeCustomerSubscription.edit.firstCall.args[0];
 
             // New offer should overwrite — offer_id should be present and set to the new offer
@@ -1385,10 +1385,10 @@ describe('MemberRepository', function () {
             assert.equal(editedData.offer_id, 'offer_new'); // from offersAPI.ensureOfferForStripeCoupon stub
 
             // Should dispatch redemption event for the new offer
-            assert.equal(offerRedemptionNotifySpy.called, true);
-            assert.equal(offerRedemptionNotifySpy.calledWith(sinon.match((event) => {
+            sinon.assert.called(offerRedemptionNotifySpy);
+            sinon.assert.calledWith(offerRedemptionNotifySpy, sinon.match((event) => {
                 return event.data.offerId === 'offer_new';
-            })), true);
+            }));
         });
 
         it('does not dispatch OfferRedemptionEvent when offer_id stays the same', async function () {
@@ -1444,7 +1444,7 @@ describe('MemberRepository', function () {
                 context: {}
             });
 
-            assert.equal(offerRedemptionNotifySpy.called, false);
+            sinon.assert.notCalled(offerRedemptionNotifySpy);
         });
     });
 

--- a/ghost/core/test/unit/server/services/members/members-api/repositories/product-repository.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/repositories/product-repository.test.js
@@ -16,7 +16,7 @@ describe('MemberRepository', function () {
                 withRelated: ['stripePrices']
             });
 
-            assert.ok(listStub.called);
+            sinon.assert.called(listStub);
 
             assert.equal(listStub.args[0][0].filter, 'type:paid+active:true', 'should only take into account paid and active records');
             assert.equal(listStub.args[0][0].limit, 1, 'should only fetch a single record');

--- a/ghost/core/test/unit/server/services/members/middleware.test.js
+++ b/ghost/core/test/unit/server/services/members/middleware.test.js
@@ -55,7 +55,7 @@ describe('Members Service Middleware', function () {
             await membersMiddleware.createSessionFromMagicLink(req, res, next);
 
             // Check behavior
-            assert.equal(next.calledOnce, true);
+            sinon.assert.calledOnce(next);
             assert.deepEqual(next.firstCall.args, []);
         });
 
@@ -77,8 +77,8 @@ describe('Members Service Middleware', function () {
             await membersMiddleware.createSessionFromMagicLink(req, res, next);
 
             // Check behavior
-            assert.equal(next.calledOnce, false);
-            assert.equal(res.redirect.calledOnce, true);
+            sinon.assert.notCalled(next);
+            sinon.assert.calledOnce(res.redirect);
             assert.equal(res.redirect.firstCall.args[0], '/blah/?action=signup&success=true');
         });
 
@@ -93,8 +93,8 @@ describe('Members Service Middleware', function () {
             await membersMiddleware.createSessionFromMagicLink(req, res, next);
 
             // Check behavior
-            assert.equal(next.calledOnce, false);
-            assert.equal(res.redirect.calledOnce, true);
+            sinon.assert.notCalled(next);
+            sinon.assert.calledOnce(res.redirect);
             assert.equal(res.redirect.firstCall.args[0], '/blah/?action=signup&success=false');
         });
 
@@ -116,8 +116,8 @@ describe('Members Service Middleware', function () {
             await membersMiddleware.createSessionFromMagicLink(req, res, next);
 
             // Check behavior
-            assert.equal(next.calledOnce, false);
-            assert.equal(res.redirect.calledOnce, true);
+            sinon.assert.notCalled(next);
+            sinon.assert.calledOnce(res.redirect);
             assert.equal(res.redirect.firstCall.args[0], 'https://custom.com/redirect/');
         });
 
@@ -139,8 +139,8 @@ describe('Members Service Middleware', function () {
             await membersMiddleware.createSessionFromMagicLink(req, res, next);
 
             // Check behavior
-            assert.equal(next.calledOnce, false);
-            assert.equal(res.redirect.calledOnce, true);
+            sinon.assert.notCalled(next);
+            sinon.assert.calledOnce(res.redirect);
             assert.equal(res.redirect.firstCall.args[0], 'https://custom.com/paid/');
         });
 
@@ -155,8 +155,8 @@ describe('Members Service Middleware', function () {
             await membersMiddleware.createSessionFromMagicLink(req, res, next);
 
             // Check behavior
-            assert.equal(next.calledOnce, false);
-            assert.equal(res.redirect.calledOnce, true);
+            sinon.assert.notCalled(next);
+            sinon.assert.calledOnce(res.redirect);
             assert.equal(res.redirect.firstCall.args[0], 'https://site.com/blah/my-post/?action=signin&success=true#comment-123');
         });
 
@@ -171,8 +171,8 @@ describe('Members Service Middleware', function () {
             await membersMiddleware.createSessionFromMagicLink(req, res, next);
 
             // Check behavior
-            assert.equal(next.calledOnce, false);
-            assert.equal(res.redirect.calledOnce, true);
+            sinon.assert.notCalled(next);
+            sinon.assert.calledOnce(res.redirect);
             assert.equal(res.redirect.firstCall.args[0], 'https://site.com/blah/my-post/?action=signup&success=true#comment-123');
         });
 
@@ -187,8 +187,8 @@ describe('Members Service Middleware', function () {
             await membersMiddleware.createSessionFromMagicLink(req, res, next);
 
             // Check behavior
-            assert.equal(next.calledOnce, false);
-            assert.equal(res.redirect.calledOnce, true);
+            sinon.assert.notCalled(next);
+            sinon.assert.calledOnce(res.redirect);
             assert.equal(res.redirect.firstCall.args[0], '/blah/?action=signin&success=true');
         });
     });
@@ -219,9 +219,9 @@ describe('Members Service Middleware', function () {
             await membersMiddleware.updateMemberNewsletters(req, res);
 
             // Check behavior
-            assert.equal(res.writeHead.calledOnce, true);
+            sinon.assert.calledOnce(res.writeHead);
             assert.equal(res.writeHead.firstCall.args[0], 404);
-            assert.equal(res.end.calledOnce, true);
+            sinon.assert.calledOnce(res.end);
             assert.equal(res.end.firstCall.args[0], 'Email address not found.');
         });
 
@@ -240,9 +240,9 @@ describe('Members Service Middleware', function () {
             await membersMiddleware.updateMemberNewsletters(req, res);
 
             // Check behavior
-            assert.equal(res.writeHead.calledOnce, true);
+            sinon.assert.calledOnce(res.writeHead);
             assert.equal(res.writeHead.firstCall.args[0], 404);
-            assert.equal(res.end.calledOnce, true);
+            sinon.assert.calledOnce(res.end);
             assert.equal(res.end.firstCall.args[0], 'Email address not found.');
         });
 
@@ -269,7 +269,7 @@ describe('Members Service Middleware', function () {
             });
             await membersMiddleware.updateMemberNewsletters(req, res);
             // the stubbing of the api is difficult to test with the current design, so we just check that the response is sent
-            assert.equal(res.json.calledOnce, true);
+            sinon.assert.calledOnce(res.json);
         });
 
         it('returns 400 on error', async function () {
@@ -293,9 +293,9 @@ describe('Members Service Middleware', function () {
             await membersMiddleware.updateMemberNewsletters(req, res);
 
             // Check behavior
-            assert.equal(res.writeHead.calledOnce, true);
+            sinon.assert.calledOnce(res.writeHead);
             assert.equal(res.writeHead.firstCall.args[0], 400);
-            assert.equal(res.end.calledOnce, true);
+            sinon.assert.calledOnce(res.end);
             assert.equal(res.end.firstCall.args[0], 'Failed to update newsletters');
         });
     });

--- a/ghost/core/test/unit/server/services/mentions/mention-sending-service.test.js
+++ b/ghost/core/test/unit/server/services/mentions/mention-sending-service.test.js
@@ -208,7 +208,7 @@ describe('MentionSendingService', function () {
                     html: 'same'
                 }
             }));
-            assert(errorLogStub.calledTwice);
+            sinon.assert.calledTwice(errorLogStub);
         });
 
         it('Sends no mentions for posts without html and previous html', async function () {
@@ -226,7 +226,7 @@ describe('MentionSendingService', function () {
                     html: ''
                 }
             }));
-            assert(stub.notCalled);
+            sinon.assert.notCalled(stub);
         });
     });
 
@@ -298,7 +298,7 @@ describe('MentionSendingService', function () {
             `});
             assert.equal(scope.isDone(), true);
             assert.equal(counter, 3);
-            assert(errorLogStub.calledOnce);
+            sinon.assert.calledOnce(errorLogStub);
         });
 
         it('Sends to deleted links', async function () {

--- a/ghost/core/test/unit/server/services/mentions/resource-service.test.js
+++ b/ghost/core/test/unit/server/services/mentions/resource-service.test.js
@@ -57,7 +57,7 @@ describe('ResourceService', function () {
                 new URL('https://site.com/blah/post-resource')
             );
 
-            assert(getResource.calledWithExactly('/post-resource'));
+            sinon.assert.calledWithExactly(getResource, '/post-resource');
 
             assert.equal(result.type, 'post');
             assert.equal(result.id.toHexString(), '63ce473f992390b739b00b01');
@@ -88,7 +88,7 @@ describe('ResourceService', function () {
                 new URL('https://site.com/blah/tag-resource')
             );
 
-            assert(getResource.calledWithExactly('/tag-resource'));
+            sinon.assert.calledWithExactly(getResource, '/tag-resource');
 
             assert.equal(result.type, null);
             assert.equal(result.id, null);
@@ -119,7 +119,7 @@ describe('ResourceService', function () {
                 new URL('https://site.com/blah/no-resource')
             );
 
-            assert(getResource.calledWithExactly('/no-resource'));
+            sinon.assert.calledWithExactly(getResource, '/no-resource');
 
             assert.equal(result.type, null);
             assert.equal(result.id, null);

--- a/ghost/core/test/unit/server/services/milestones/milestones-service.test.js
+++ b/ghost/core/test/unit/server/services/milestones/milestones-service.test.js
@@ -69,7 +69,7 @@ describe('MilestonesService', function () {
             assert(arrResult.name === 'arr-0-usd');
 
             const domainEventSpyResult = domainEventSpy.getCall(0).args[0];
-            assert(domainEventSpy.calledOnce === true);
+            sinon.assert.calledOnce(domainEventSpy);
             assert(domainEventSpyResult.data.milestone);
             assert(domainEventSpyResult.data.meta.currentValue === 43);
             assert(domainEventSpyResult.data.meta.reason === 'initial');
@@ -101,7 +101,7 @@ describe('MilestonesService', function () {
             assert(arrResult.emailSentAt === null);
             assert(arrResult.name === 'arr-1000-usd');
 
-            assert(domainEventSpy.calledTwice === true);
+            sinon.assert.calledTwice(domainEventSpy);
             const firstDomainEventSpyCall = domainEventSpy.getCall(0).args[0];
             const secondDomainEventSpyCall = domainEventSpy.getCall(1).args[0];
             assert(firstDomainEventSpyCall.data.milestone);
@@ -361,7 +361,7 @@ describe('MilestonesService', function () {
             assert(membersResult.name === 'members-0');
 
             const domainEventSpyResult = domainEventSpy.getCall(0).args[0];
-            assert(domainEventSpy.calledOnce === true);
+            sinon.assert.calledOnce(domainEventSpy);
             assert(domainEventSpyResult.data.milestone);
             assert(domainEventSpyResult.data.meta.currentValue === 6);
             assert(domainEventSpyResult.data.meta.reason === 'initial');
@@ -392,7 +392,7 @@ describe('MilestonesService', function () {
             assert(membersResult.emailSentAt === null);
             assert(domainEventSpy.callCount === 2);
 
-            assert(domainEventSpy.calledTwice === true);
+            sinon.assert.calledTwice(domainEventSpy);
             const firstDomainEventSpyCall = domainEventSpy.getCall(0).args[0];
             const secondDomainEventSpyCall = domainEventSpy.getCall(1).args[0];
             assert(firstDomainEventSpyCall.data.milestone);

--- a/ghost/core/test/unit/server/services/notifications/notifications.test.js
+++ b/ghost/core/test/unit/server/services/notifications/notifications.test.js
@@ -255,7 +255,7 @@ describe('Notifications Service', function () {
             assertExists(notifications);
             assert.equal(notifications.length, 0);
 
-            assert.equal(settingsModelStub.called, true);
+            sinon.assert.called(settingsModelStub);
             assert.deepEqual(settingsModelStub.args[0][0], [{
                 key: 'notifications',
                 value: '[]'
@@ -283,7 +283,7 @@ describe('Notifications Service', function () {
             assertExists(notifications);
             assert.equal(notifications.length, 1);
 
-            assert.equal(settingsModelStub.called, false);
+            sinon.assert.notCalled(settingsModelStub);
         });
     });
 });

--- a/ghost/core/test/unit/server/services/oembed/oembed-service.test.js
+++ b/ghost/core/test/unit/server/services/oembed/oembed-service.test.js
@@ -258,9 +258,9 @@ describe('oembed-service', function () {
             const storedUrl = await service.processImageFromUrl('https://example.com/sample.png?token=abc', 'thumbnail');
 
             assert.equal(storedUrl, 'https://storage.ghost.is/c/6f/a3/site/content/images/thumbnail/sample.png');
-            assert.equal(getSanitizedFileName.calledOnce, true);
-            assert.equal(generateUnique.calledOnce, true);
-            assert.equal(saveRaw.calledOnce, true);
+            sinon.assert.calledOnce(getSanitizedFileName);
+            sinon.assert.calledOnce(generateUnique);
+            sinon.assert.calledOnce(saveRaw);
             assert.equal(saveRaw.firstCall.args[1], 'thumbnail/sample.png');
         });
     });

--- a/ghost/core/test/unit/server/services/offers/application/offers-api.test.js
+++ b/ghost/core/test/unit/server/services/offers/application/offers-api.test.js
@@ -161,7 +161,7 @@ describe('OffersAPI', function () {
             });
 
             // Verify getAll was called with status:active filter
-            assert(repository.getAll.calledOnce);
+            sinon.assert.calledOnce(repository.getAll);
             assert.equal(repository.getAll.firstCall.args[0].filter, 'status:active');
 
             // Only active offer returned
@@ -315,7 +315,7 @@ describe('OffersAPI', function () {
             });
 
             assert.deepEqual(result, redemptions);
-            assert.equal(repository.getRedeemedOfferIdsForSubscriptions.calledOnce, true);
+            sinon.assert.calledOnce(repository.getRedeemedOfferIdsForSubscriptions);
         });
 
         it('returns empty array for empty input', async function () {
@@ -331,7 +331,7 @@ describe('OffersAPI', function () {
 
             assert.deepEqual(result, []);
             // Should short-circuit without hitting the repository
-            assert.equal(repository.getRedeemedOfferIdsForSubscriptions.called, false);
+            sinon.assert.notCalled(repository.getRedeemedOfferIdsForSubscriptions);
         });
     });
 
@@ -349,7 +349,7 @@ describe('OffersAPI', function () {
             const result = await api.ensureOfferForStripeCoupon(coupon, 'month', tier);
 
             assert.equal(result.id, 'existing-offer-id');
-            assert.equal(repository.save.called, false);
+            sinon.assert.notCalled(repository.save);
         });
 
         it('creates new offer if none exists for stripe coupon id', async function () {
@@ -366,7 +366,7 @@ describe('OffersAPI', function () {
 
             const result = await api.ensureOfferForStripeCoupon(coupon, 'month', tier);
 
-            assert.equal(repository.save.calledOnce, true);
+            sinon.assert.calledOnce(repository.save);
             assert.ok(result.id);
             assert.equal(result.code, coupon.id);
         });
@@ -396,8 +396,8 @@ describe('OffersAPI', function () {
             const result = await api.ensureOfferForStripeCoupon(coupon, 'month', tier);
 
             assert.equal(result.id, 'race-winner-offer-id');
-            assert.equal(getByStripeCouponIdStub.calledTwice, true);
-            assert.equal(repository.save.calledOnce, true);
+            sinon.assert.calledTwice(getByStripeCouponIdStub);
+            sinon.assert.calledOnce(repository.save);
         });
 
         it('handles race condition with SQLITE_CONSTRAINT by returning existing offer', async function () {
@@ -424,7 +424,7 @@ describe('OffersAPI', function () {
             const result = await api.ensureOfferForStripeCoupon(coupon, 'month', tier);
 
             assert.equal(result.id, 'race-winner-offer-id');
-            assert.equal(getByStripeCouponIdStub.calledTwice, true);
+            sinon.assert.calledTwice(getByStripeCouponIdStub);
         });
 
         it('throws readable error when duplicate entry occurs but offer not found', async function () {
@@ -459,7 +459,7 @@ describe('OffersAPI', function () {
                 assert.match(err.message, /coupon_missing/);
 
                 // Should have checked twice for the offer
-                assert.equal(getByStripeCouponIdStub.calledTwice, true);
+                sinon.assert.calledTwice(getByStripeCouponIdStub);
             }
         });
 
@@ -484,7 +484,7 @@ describe('OffersAPI', function () {
             }
 
             // Should not retry lookup on non-duplicate errors
-            assert.equal(repository.getByStripeCouponId.calledOnce, true);
+            sinon.assert.calledOnce(repository.getByStripeCouponId);
         });
 
         it('reuses existing transaction if provided in options', async function () {
@@ -502,7 +502,7 @@ describe('OffersAPI', function () {
             await api.ensureOfferForStripeCoupon(coupon, 'month', tier, {transacting: existingTransaction});
 
             // Should not create a new transaction
-            assert.equal(repository.createTransaction.called, false);
+            sinon.assert.notCalled(repository.createTransaction);
             // Should use the provided transaction
             const callOptions = repository.getByStripeCouponId.firstCall.args[1];
             assert.equal(callOptions.transacting, existingTransaction);
@@ -522,7 +522,7 @@ describe('OffersAPI', function () {
             await api.ensureOfferForStripeCoupon(coupon, 'month', tier);
 
             // Should create a new transaction
-            assert.equal(repository.createTransaction.calledOnce, true);
+            sinon.assert.calledOnce(repository.createTransaction);
         });
     });
 });

--- a/ghost/core/test/unit/server/services/permissions/can-this.test.js
+++ b/ghost/core/test/unit/server/services/permissions/can-this.test.js
@@ -115,7 +115,7 @@ describe('Permissions', function () {
                         .catch(function (err) {
                             assert.equal(err.errorType, 'NoPermissionError');
 
-                            assert.equal(findPostSpy.callCount, 0);
+                            sinon.assert.notCalled(findPostSpy);
                             done();
                         });
                 });
@@ -131,7 +131,7 @@ describe('Permissions', function () {
                         .catch(function (err) {
                             assert.equal(err.errorType, 'NoPermissionError');
 
-                            assert.equal(findPostSpy.callCount, 1);
+                            sinon.assert.calledOnce(findPostSpy);
                             assert.deepEqual(findPostSpy.firstCall.args[0], {id: 1, status: 'all'});
                             done();
                         });
@@ -148,7 +148,7 @@ describe('Permissions', function () {
                         .catch(function (err) {
                             assert.equal(err.errorType, 'NoPermissionError');
 
-                            assert.equal(findPostSpy.callCount, 1);
+                            sinon.assert.calledOnce(findPostSpy);
                             assert.deepEqual(findPostSpy.firstCall.args[0], {id: 1, status: 'all'});
                             done();
                         });
@@ -161,7 +161,7 @@ describe('Permissions', function () {
                         .post({id: 1}) // post id
                         .then(function () {
                             // We don't get this far, permissions are instantly granted for internal
-                            assert.equal(findPostSpy.callCount, 0);
+                            sinon.assert.notCalled(findPostSpy);
                             done();
                         })
                         .catch(function () {
@@ -180,7 +180,7 @@ describe('Permissions', function () {
                         .catch(function (err) {
                             assert.equal(err.errorType, 'NoPermissionError');
 
-                            assert.equal(findPostSpy.callCount, 1);
+                            sinon.assert.calledOnce(findPostSpy);
                             assert.deepEqual(findPostSpy.firstCall.args[0], {id: 1, status: 'all'});
                             done();
                         });
@@ -200,7 +200,7 @@ describe('Permissions', function () {
                             assert.equal(err.errorType, 'NoPermissionError');
 
                             // We don't look up tags
-                            assert.equal(findTagSpy.callCount, 0);
+                            sinon.assert.notCalled(findTagSpy);
                             done();
                         });
                 });
@@ -212,7 +212,7 @@ describe('Permissions', function () {
                         .tag({id: 1}) // tag id
                         .then(function () {
                             // We don't look up tags
-                            assert.equal(findTagSpy.callCount, 0);
+                            sinon.assert.notCalled(findTagSpy);
                             done();
                         })
                         .catch(function () {
@@ -231,7 +231,7 @@ describe('Permissions', function () {
                         .catch(function (err) {
                             assert.equal(err.errorType, 'NoPermissionError');
 
-                            assert.equal(findTagSpy.callCount, 0);
+                            sinon.assert.notCalled(findTagSpy);
                             done();
                         });
                 });
@@ -260,7 +260,7 @@ describe('Permissions', function () {
                         done(new Error('was able to edit tag without permission'));
                     })
                     .catch(function (err) {
-                        assert.equal(userProviderStub.callCount, 1);
+                        sinon.assert.calledOnce(userProviderStub);
                         assert.equal(err.errorType, 'NoPermissionError');
                         done();
                     });
@@ -280,7 +280,7 @@ describe('Permissions', function () {
                     .edit
                     .tag({id: 1}) // tag id in model syntax
                     .then(function (res) {
-                        assert.equal(userProviderStub.callCount, 1);
+                        sinon.assert.calledOnce(userProviderStub);
                         assert.equal(res, undefined);
                         done();
                     })
@@ -301,7 +301,7 @@ describe('Permissions', function () {
                     .edit
                     .tag() // tag id in model syntax
                     .then(function (res) {
-                        assert.equal(userProviderStub.callCount, 1);
+                        sinon.assert.calledOnce(userProviderStub);
                         assert.equal(res, undefined);
                         done();
                     })
@@ -323,7 +323,7 @@ describe('Permissions', function () {
                     .edit
                     .tag({id: 1}) // tag id in model syntax
                     .then(function (res) {
-                        assert.equal(userProviderStub.callCount, 1);
+                        sinon.assert.calledOnce(userProviderStub);
                         assert.equal(res, undefined);
                         done();
                     })
@@ -351,7 +351,7 @@ describe('Permissions', function () {
                     .edit
                     .tag({id: 1}) // tag id in model syntax
                     .then(function (res) {
-                        assert.equal(apiKeyProviderStub.callCount, 1);
+                        sinon.assert.calledOnce(apiKeyProviderStub);
                         assert.equal(res, undefined);
                         done();
                     })
@@ -386,8 +386,8 @@ describe('Permissions', function () {
                     .edit
                     .tag({id: 1})
                     .then(function (res) {
-                        assert.equal(userProviderStub.callCount, 1);
-                        assert.equal(apiKeyProviderStub.callCount, 1);
+                        sinon.assert.calledOnce(userProviderStub);
+                        sinon.assert.calledOnce(apiKeyProviderStub);
                         assert.equal(res, undefined);
                         done();
                     })
@@ -417,8 +417,8 @@ describe('Permissions', function () {
                     .edit
                     .tag({id: 1})
                     .then(function (res) {
-                        assert.equal(userProviderStub.callCount, 1);
-                        assert.equal(apiKeyProviderStub.callCount, 1);
+                        sinon.assert.calledOnce(userProviderStub);
+                        sinon.assert.calledOnce(apiKeyProviderStub);
                         assert.equal(res, undefined);
                         // Fixed: Now uses USER permission instead of API key logic
                         done();
@@ -454,8 +454,8 @@ describe('Permissions', function () {
                         done(new Error('Should have failed using USER permissions (ignoring API key permissions)'));
                     })
                     .catch(function (err) {
-                        assert.equal(userProviderStub.callCount, 1);
-                        assert.equal(apiKeyProviderStub.callCount, 1);
+                        sinon.assert.calledOnce(userProviderStub);
+                        sinon.assert.calledOnce(apiKeyProviderStub);
                         assert.equal(err.errorType, 'NoPermissionError');
                         // Fixed: Now uses USER permission instead of API key logic
                         done();
@@ -488,8 +488,8 @@ describe('Permissions', function () {
                         done(new Error('Should have failed due to no permissions'));
                     })
                     .catch(function (err) {
-                        assert.equal(userProviderStub.callCount, 1);
-                        assert.equal(apiKeyProviderStub.callCount, 1);
+                        sinon.assert.calledOnce(userProviderStub);
+                        sinon.assert.calledOnce(apiKeyProviderStub);
                         assert.equal(err.errorType, 'NoPermissionError');
                         done();
                     });
@@ -518,8 +518,8 @@ describe('Permissions', function () {
                     .edit
                     .tag({id: 1})
                     .then(function (res) {
-                        assert.equal(userProviderStub.callCount, 1);
-                        assert.equal(apiKeyProviderStub.callCount, 1);
+                        sinon.assert.calledOnce(userProviderStub);
+                        sinon.assert.calledOnce(apiKeyProviderStub);
                         assert.equal(res, undefined);
                         done();
                     })
@@ -551,8 +551,8 @@ describe('Permissions', function () {
                         .edit
                         .tag({id: 1})
                         .then(function (res) {
-                            assert.equal(userProviderStub.callCount, 1);
-                            assert.equal(apiKeyProviderStub.callCount, 1);
+                            sinon.assert.calledOnce(userProviderStub);
+                            sinon.assert.calledOnce(apiKeyProviderStub);
                             assert.equal(res, undefined);
                             done();
                         })
@@ -587,8 +587,8 @@ describe('Permissions', function () {
                             done(new Error('Should have failed using USER permissions (ignoring API key permissions)'));
                         })
                         .catch(function (err) {
-                            assert.equal(userProviderStub.callCount, 1);
-                            assert.equal(apiKeyProviderStub.callCount, 1);
+                            sinon.assert.calledOnce(userProviderStub);
+                            sinon.assert.calledOnce(apiKeyProviderStub);
                             assert.equal(err.errorType, 'NoPermissionError');
                             done();
                         });
@@ -617,8 +617,8 @@ describe('Permissions', function () {
                         .edit
                         .tag({id: 1})
                         .then(function (res) {
-                            assert.equal(userProviderStub.callCount, 1);
-                            assert.equal(apiKeyProviderStub.callCount, 1);
+                            sinon.assert.calledOnce(userProviderStub);
+                            sinon.assert.calledOnce(apiKeyProviderStub);
                             assert.equal(res, undefined);
                             done();
                         })
@@ -657,7 +657,7 @@ describe('Permissions', function () {
                         1, 'edit', sinon.match.object, sinon.match.object, sinon.match.object, true, true
                     );
 
-                    assert.equal(userProviderStub.callCount, 1);
+                    sinon.assert.calledOnce(userProviderStub);
                     assert.equal(err.message, 'Hello World!');
                     done();
                 });
@@ -686,7 +686,7 @@ describe('Permissions', function () {
                         1, 'edit', sinon.match.object, sinon.match.object, sinon.match.object, true, true
                     );
 
-                    assert.equal(userProviderStub.callCount, 1);
+                    sinon.assert.calledOnce(userProviderStub);
                     assert.equal(res, undefined);
                     done();
                 })

--- a/ghost/core/test/unit/server/services/permissions/providers.test.js
+++ b/ghost/core/test/unit/server/services/permissions/providers.test.js
@@ -24,7 +24,7 @@ describe('Permission Providers', function () {
                     done(new Error('Should have thrown a user not found error'));
                 })
                 .catch(function (err) {
-                    assert.equal(findUserSpy.callCount, 1);
+                    sinon.assert.calledOnce(findUserSpy);
                     assert.equal(err.errorType, 'NotFoundError');
                     done();
                 });
@@ -58,7 +58,7 @@ describe('Permission Providers', function () {
             // Get permissions for the user
             providers.user(1)
                 .then(function (res) {
-                    assert.equal(findUserSpy.callCount, 1);
+                    sinon.assert.calledOnce(findUserSpy);
 
                     assert(res && typeof res === 'object');
                     assert('permissions' in res);
@@ -117,7 +117,7 @@ describe('Permission Providers', function () {
             // Get permissions for the user
             providers.user(1)
                 .then(function (res) {
-                    assert.equal(findUserSpy.callCount, 1);
+                    sinon.assert.calledOnce(findUserSpy);
 
                     assert(res && typeof res === 'object');
                     assert('permissions' in res);
@@ -177,7 +177,7 @@ describe('Permission Providers', function () {
             // Get permissions for the user
             providers.user(1)
                 .then(function (res) {
-                    assert.equal(findUserSpy.callCount, 1);
+                    sinon.assert.calledOnce(findUserSpy);
 
                     assert(res && typeof res === 'object');
                     assert('permissions' in res);
@@ -223,7 +223,7 @@ describe('Permission Providers', function () {
                 })
                 .catch((err) => {
                     assert.equal(err.errorType, 'UnauthorizedError');
-                    assert.equal(findUserSpy.callCount, 1);
+                    sinon.assert.calledOnce(findUserSpy);
                     done();
                 });
         });
@@ -238,7 +238,7 @@ describe('Permission Providers', function () {
                     done(new Error('Should have thrown an api key not found error'));
                 })
                 .catch((err) => {
-                    assert.equal(findApiKeySpy.callCount, 1);
+                    sinon.assert.calledOnce(findApiKeySpy);
                     assert.equal(err.errorType, 'NotFoundError');
                     done();
                 });
@@ -258,7 +258,7 @@ describe('Permission Providers', function () {
                 return Promise.resolve(fakeApiKey);
             });
             providers.apiKey(1).then((res) => {
-                assert.equal(findApiKeySpy.callCount, 1);
+                sinon.assert.calledOnce(findApiKeySpy);
                 assert(res && typeof res === 'object');
                 assert('permissions' in res);
                 assert('roles' in res);

--- a/ghost/core/test/unit/server/services/posts/posts-service.test.js
+++ b/ghost/core/test/unit/server/services/posts/posts-service.test.js
@@ -76,13 +76,7 @@ describe('Posts Service', function () {
             const result = await makePostService().copyPost(frame);
 
             // Ensure copied post is created
-            assert.equal(
-                postModelStub.add.calledOnceWithExactly(
-                    sinon.match.object,
-                    frame.options
-                ),
-                true
-            );
+            sinon.assert.calledOnceWithExactly(postModelStub.add, sinon.match.object, frame.options);
 
             // Ensure copied post is returned
             assert.deepEqual(result, copiedPost);

--- a/ghost/core/test/unit/server/services/recommendations/service/incoming-recommendation-controller.test.ts
+++ b/ghost/core/test/unit/server/services/recommendations/service/incoming-recommendation-controller.test.ts
@@ -99,7 +99,7 @@ describe('IncomingRecommendationController', function () {
                     data: {},
                     options: {}
                 });
-                assert(listSpy.calledOnce);
+                sinon.assert.calledOnce(listSpy);
                 const args = listSpy.getCall(0).args[0];
                 assert.deepEqual(args.limit, 5);
             });
@@ -111,7 +111,7 @@ describe('IncomingRecommendationController', function () {
                         limit: 100
                     }
                 });
-                assert(listSpy.calledOnce);
+                sinon.assert.calledOnce(listSpy);
                 const args = listSpy.getCall(0).args[0];
                 assert.deepEqual(args.limit, 100);
             });
@@ -136,7 +136,7 @@ describe('IncomingRecommendationController', function () {
                     options: {
                     }
                 });
-                assert(listSpy.calledOnce);
+                sinon.assert.calledOnce(listSpy);
                 const args = listSpy.getCall(0).args[0];
                 assert.deepEqual(args.page, 1);
             });
@@ -148,7 +148,7 @@ describe('IncomingRecommendationController', function () {
                         page: 2
                     }
                 });
-                assert(listSpy.calledOnce);
+                sinon.assert.calledOnce(listSpy);
                 const args = listSpy.getCall(0).args[0];
                 assert.deepEqual(args.page, 2);
             });

--- a/ghost/core/test/unit/server/services/recommendations/service/incoming-recommendation-service.test.ts
+++ b/ghost/core/test/unit/server/services/recommendations/service/incoming-recommendation-service.test.ts
@@ -51,11 +51,11 @@ describe('IncomingRecommendationService', function () {
                 process.env.NODE_ENV = 'nottesting';
                 await service.init();
                 clock.tick(1000 * 60 * 60 * 24);
-                assert(refreshMentions.calledOnce);
-                assert(refreshMentions.calledWith({
+                sinon.assert.calledOnce(refreshMentions);
+                sinon.assert.calledWith(refreshMentions, {
                     filter: `source:~$'/.well-known/recommendations.json'+deleted:[true,false]`,
                     limit: 100
-                }));
+                });
             } finally {
                 process.env.NODE_ENV = saved;
             }
@@ -70,7 +70,7 @@ describe('IncomingRecommendationService', function () {
                 refreshMentions.rejects(new Error('test'));
                 await service.init();
                 clock.tick(1000 * 60 * 60 * 24);
-                assert(refreshMentions.calledOnce);
+                sinon.assert.calledOnce(refreshMentions);
             } finally {
                 process.env.NODE_ENV = saved;
             }
@@ -89,7 +89,7 @@ describe('IncomingRecommendationService', function () {
                 sourceFavicon: new URL('https://example.com/favicon.ico'),
                 sourceFeaturedImage: new URL('https://example.com/featured.png')
             });
-            assert(send.calledOnce);
+            sinon.assert.calledOnce(send);
         });
 
         it('ignores when mention not convertable to incoming recommendation', async function () {
@@ -104,7 +104,7 @@ describe('IncomingRecommendationService', function () {
                 sourceFavicon: new URL('https://example.com/favicon.ico'),
                 sourceFeaturedImage: new URL('https://example.com/featured.png')
             });
-            assert(!send.calledOnce);
+            sinon.assert.notCalled(send);
         });
     });
 

--- a/ghost/core/test/unit/server/services/recommendations/service/recommendation-controller.test.ts
+++ b/ghost/core/test/unit/server/services/recommendations/service/recommendation-controller.test.ts
@@ -485,7 +485,7 @@ describe('RecommendationController', function () {
                     },
                     user: {}
                 });
-                assert(listSpy.calledOnce);
+                sinon.assert.calledOnce(listSpy);
                 const args = listSpy.getCall(0).args[0];
                 assert.deepEqual(args.order, [
                     {
@@ -503,7 +503,7 @@ describe('RecommendationController', function () {
                     },
                     user: {}
                 });
-                assert(listSpy.calledOnce);
+                sinon.assert.calledOnce(listSpy);
                 const args = listSpy.getCall(0).args[0];
                 assert.deepEqual(args.order, [
                     {
@@ -521,7 +521,7 @@ describe('RecommendationController', function () {
                     },
                     user: {}
                 });
-                assert(listSpy.calledOnce);
+                sinon.assert.calledOnce(listSpy);
                 const args = listSpy.getCall(0).args[0];
                 assert.deepEqual(args.order, [
                     {
@@ -543,7 +543,7 @@ describe('RecommendationController', function () {
                     },
                     user: {}
                 });
-                assert(listSpy.calledOnce);
+                sinon.assert.calledOnce(listSpy);
                 const args = listSpy.getCall(0).args[0];
                 assert.deepEqual(args.order, [
                     {
@@ -622,7 +622,7 @@ describe('RecommendationController', function () {
                     },
                     user: {}
                 });
-                assert(listSpy.calledOnce);
+                sinon.assert.calledOnce(listSpy);
                 const args = listSpy.getCall(0).args[0];
                 assert.deepEqual(args.include, ['clickCount', 'subscriberCount']);
             });

--- a/ghost/core/test/unit/server/services/recommendations/service/recommendation-service.test.ts
+++ b/ghost/core/test/unit/server/services/recommendations/service/recommendation-service.test.ts
@@ -69,7 +69,7 @@ describe('RecommendationService', function () {
         it('should update wellknown', async function () {
             const updateWellknown = sinon.stub(service.wellknownService, 'set').resolves();
             await service.init();
-            assert(updateWellknown.calledOnce);
+            sinon.assert.calledOnce(updateWellknown);
         });
 
         it('should update recommendations on boot', async function () {
@@ -92,7 +92,7 @@ describe('RecommendationService', function () {
                 const spy = sinon.spy(service, 'updateAllRecommendationsMetadata');
                 await service.init();
                 await clock.tick(1000 * 60 * 60 * 24);
-                assert(spy.calledOnce);
+                sinon.assert.calledOnce(spy);
             } finally {
                 process.env.NODE_ENV = saved;
             }
@@ -107,7 +107,7 @@ describe('RecommendationService', function () {
                 spy.rejects(new Error('test'));
                 await service.init();
                 clock.tick(1000 * 60 * 60 * 24);
-                assert(spy.calledOnce);
+                sinon.assert.calledOnce(spy);
             } finally {
                 process.env.NODE_ENV = saved;
             }
@@ -140,7 +140,7 @@ describe('RecommendationService', function () {
                 await new Promise((resolve) => {
                     setTimeout(() => resolve(true), 50);
                 });
-                assert(!!spy.calledOnce);
+                sinon.assert.calledOnce(spy);
             } finally {
                 process.env.NODE_ENV = saved;
             }
@@ -459,7 +459,7 @@ describe('RecommendationService', function () {
                 oneClickSubscribe: false
             }));
 
-            assert(updateRecommendationsEnabledSetting.calledOnce);
+            sinon.assert.calledOnce(updateRecommendationsEnabledSetting);
         });
     });
 

--- a/ghost/core/test/unit/server/services/route-settings/settings-loader.test.js
+++ b/ghost/core/test/unit/server/services/route-settings/settings-loader.test.js
@@ -56,7 +56,7 @@ describe('UNIT > SettingsLoader:', function () {
             assertExists(result);
             assert(typeof result === 'object' && result !== null);
             assert('routes' in result && 'collections' in result && 'taxonomies' in result);
-            assert.equal(fsReadFileStub.calledOnce, true);
+            sinon.assert.calledOnce(fsReadFileStub);
         });
 
         it('can find yaml settings file and returns a settings object', async function () {
@@ -78,8 +78,8 @@ describe('UNIT > SettingsLoader:', function () {
             assert(typeof setting === 'object' && setting !== null);
             assert('routes' in setting && 'collections' in setting && 'taxonomies' in setting);
 
-            assert.equal(fsReadFileSpy.calledOnce, true);
-            assert.equal(fsReadFileSpy.calledWith(expectedSettingsFile), true);
+            sinon.assert.calledOnce(fsReadFileSpy);
+            sinon.assert.calledWith(fsReadFileSpy, expectedSettingsFile);
             sinon.assert.calledOnce(yamlParserStub);
         });
 
@@ -132,8 +132,8 @@ describe('UNIT > SettingsLoader:', function () {
                 throw new Error('Should have failed already');
             } catch (err) {
                 assert.match(err.message, /Error trying to load YAML setting for routes from/);
-                assert.equal(fsReadFileStub.calledWith(expectedSettingsFile), true);
-                assert.equal(yamlParserStub.calledOnce, false);
+                sinon.assert.calledWith(fsReadFileStub, expectedSettingsFile);
+                sinon.assert.notCalled(yamlParserStub);
             }
         });
     });

--- a/ghost/core/test/unit/server/services/route-settings/yaml-parser.test.js
+++ b/ghost/core/test/unit/server/services/route-settings/yaml-parser.test.js
@@ -27,7 +27,7 @@ describe('UNIT > Settings Service yaml parser:', function () {
             assert('routes' in result);
             assert('collections' in result);
             assert('taxonomies' in result);
-            assert.equal(yamlSpy.calledOnce, true);
+            sinon.assert.calledOnce(yamlSpy);
         });
 
         it('rejects with clear error when parsing fails', function () {
@@ -41,7 +41,7 @@ describe('UNIT > Settings Service yaml parser:', function () {
                 assert.equal(error.message, 'Could not parse provided YAML file: bad indentation of a mapping entry.');
                 assert(error.context.includes('bad indentation of a mapping entry (5:14)'));
                 assert.equal(error.help, 'Check provided file for typos and fix the named issues.');
-                assert.equal(yamlSpy.calledOnce, true);
+                sinon.assert.calledOnce(yamlSpy);
             }
         });
     });

--- a/ghost/core/test/unit/server/services/settings/default-settings-manager.test.js
+++ b/ghost/core/test/unit/server/services/settings/default-settings-manager.test.js
@@ -32,7 +32,7 @@ describe('UNIT > Settings Service DefaultSettingsManager:', function () {
             await defaultSettingsManager.ensureSettingsFileExists();
 
             // Assert did not attempt to copy the default config
-            assert.equal(fsCopyStub.called, false);
+            sinon.assert.notCalled(fsCopyStub);
         });
 
         it('copies default settings file if no file found', async function () {
@@ -56,7 +56,7 @@ describe('UNIT > Settings Service DefaultSettingsManager:', function () {
             await defaultSettingsManager.ensureSettingsFileExists();
 
             // Assert attempt to copy the default config
-            assert.equal(fsCopyStub.calledOnce, true);
+            sinon.assert.calledOnce(fsCopyStub);
         });
 
         it('rejects, if error is not a not found error', async function () {
@@ -80,8 +80,8 @@ describe('UNIT > Settings Service DefaultSettingsManager:', function () {
             } catch (error) {
                 assertExists(error);
                 assert.equal(error.message, `Error trying to access settings files in ${destinationFolderPath}.`);
-                assert.equal(fsReadFileStub.calledOnce, true);
-                assert.equal(fsCopyStub.called, false);
+                sinon.assert.calledOnce(fsReadFileStub);
+                sinon.assert.notCalled(fsCopyStub);
             }
         });
     });

--- a/ghost/core/test/unit/server/services/settings/settings-service.test.js
+++ b/ghost/core/test/unit/server/services/settings/settings-service.test.js
@@ -81,7 +81,7 @@ describe('UNIT: Settings Service', function () {
                 await settingsService.validateSiteUuid();
                 assert.fail('Should have thrown IncorrectUsageError');
             } catch (error) {
-                assert.equal(loggingStub.calledOnce, true);
+                sinon.assert.calledOnce(loggingStub);
                 assert.equal(error.constructor.name, 'IncorrectUsageError');
                 assert.equal(error.message, 'Site UUID configuration does not match database value');
             }

--- a/ghost/core/test/unit/server/services/settings/settings-utils.test.js
+++ b/ghost/core/test/unit/server/services/settings/settings-utils.test.js
@@ -30,8 +30,8 @@ describe('Unit: services/settings/settings-utils', function () {
             const result = getOrGenerateSiteUuid();
 
             assert.equal(result, testUuid.toLowerCase());
-            assert.equal(configGetStub.calledOnce, true);
-            assert.equal(loggingInfoStub.calledOnce, true);
+            sinon.assert.calledOnce(configGetStub);
+            sinon.assert.calledOnce(loggingInfoStub);
         });
 
         it('generates new UUID when config value is not a valid UUID', function () {
@@ -41,8 +41,8 @@ describe('Unit: services/settings/settings-utils', function () {
 
             // Should be a valid UUID v4
             assert.match(result, /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
-            assert.equal(configGetStub.calledOnce, true);
-            assert.equal(loggingInfoStub.calledOnce, true);
+            sinon.assert.calledOnce(configGetStub);
+            sinon.assert.calledOnce(loggingInfoStub);
         });
 
         it('generates new UUID when config value is null', function () {
@@ -52,8 +52,8 @@ describe('Unit: services/settings/settings-utils', function () {
 
             // Should be a valid UUID v4
             assert.match(result, /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
-            assert.equal(configGetStub.calledOnce, true);
-            assert.equal(loggingInfoStub.calledOnce, true);
+            sinon.assert.calledOnce(configGetStub);
+            sinon.assert.calledOnce(loggingInfoStub);
         });
 
         it('generates new UUID when config value is undefined', function () {
@@ -63,8 +63,8 @@ describe('Unit: services/settings/settings-utils', function () {
 
             // Should be a valid UUID v4
             assert.match(result, /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
-            assert.equal(configGetStub.calledOnce, true);
-            assert.equal(loggingInfoStub.calledOnce, true);
+            sinon.assert.calledOnce(configGetStub);
+            sinon.assert.calledOnce(loggingInfoStub);
         });
 
         it('generates new UUID when config throws an error', function () {
@@ -75,8 +75,8 @@ describe('Unit: services/settings/settings-utils', function () {
 
             // Should be a valid UUID v4
             assert.match(result, /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
-            assert.equal(configGetStub.calledOnce, true);
-            assert.equal(loggingErrorStub.calledOnce, true);
+            sinon.assert.calledOnce(configGetStub);
+            sinon.assert.calledOnce(loggingErrorStub);
         });
 
         it('converts uppercase UUID to lowercase', function () {
@@ -109,7 +109,7 @@ describe('Unit: services/settings/settings-utils', function () {
             assert.equal(result1, result2);
             assert.equal(result1, testUuid.toLowerCase());
             // Config should only be called once due to caching
-            assert.equal(configGetStub.calledOnce, true);
+            sinon.assert.calledOnce(configGetStub);
         });
     });
 });

--- a/ghost/core/test/unit/server/services/slack-notifications/slack-notifications-service.test.js
+++ b/ghost/core/test/unit/server/services/slack-notifications/slack-notifications-service.test.js
@@ -89,7 +89,7 @@ describe('SlackNotificationsService', function () {
                 await DomainEvents.allSettled();
 
                 assert(loggingSpy.callCount === 0);
-                assert(slackNotificationStub.calledOnce);
+                sinon.assert.calledOnce(slackNotificationStub);
             });
 
             it('does not send notification when milestones is disabled in hostSettings', async function () {
@@ -214,7 +214,7 @@ describe('SlackNotificationsService', function () {
 
                 await DomainEvents.allSettled();
                 const loggingSpyCall = loggingSpy.getCall(0).args[0];
-                assert(loggingSpy.calledOnce);
+                sinon.assert.calledOnce(loggingSpy);
                 assert(loggingSpyCall instanceof Error);
             });
         });

--- a/ghost/core/test/unit/server/services/slack-notifications/slack-notifications.test.js
+++ b/ghost/core/test/unit/server/services/slack-notifications/slack-notifications.test.js
@@ -100,7 +100,7 @@ describe('SlackNotifications', function () {
                 }]
             };
 
-            assert(sendStub.calledOnce === true);
+            sinon.assert.calledOnce(sendStub);
             assert(sendStub.calledWith(expectedResult, 'https://slack-webhook.example') === true);
         });
 
@@ -168,7 +168,7 @@ describe('SlackNotifications', function () {
                 }]
             };
 
-            assert(sendStub.calledOnce === true);
+            sinon.assert.calledOnce(sendStub);
             assert(sendStub.calledWith(expectedResult, 'https://slack-webhook.example') === true);
         });
 
@@ -237,7 +237,7 @@ describe('SlackNotifications', function () {
                 }]
             };
 
-            assert(sendStub.calledOnce === true);
+            sinon.assert.calledOnce(sendStub);
             assert(sendStub.calledWith(expectedResult, 'https://slack-webhook.example') === true);
         });
 
@@ -296,7 +296,7 @@ describe('SlackNotifications', function () {
 
             await slackNotifications.send({data: 'test'}, 'https://slack-webhook.com');
             assert(loggingErrorStub.callCount === 0);
-            assert(gotStub.calledOnce === true);
+            sinon.assert.calledOnce(gotStub);
             const gotStubArgs = gotStub.getCall(0).args;
             assert.deepEqual(gotStubArgs, expectedRequestOptions);
         });

--- a/ghost/core/test/unit/server/services/staff/staff-service.test.js
+++ b/ghost/core/test/unit/server/services/staff/staff-service.test.js
@@ -11,91 +11,58 @@ const DomainEvents = require('@tryghost/domain-events');
 const StaffService = require('../../../../../core/server/services/staff/staff-service');
 
 function testCommonMailData({mailStub, getEmailAlertUsersStub}) {
-    assert.equal(getEmailAlertUsersStub.calledWith(
-        sinon.match.string,
-        sinon.match({transacting: {}, forUpdate: true})
-    ), true);
+    sinon.assert.calledWith(getEmailAlertUsersStub, sinon.match.string, sinon.match({transacting: {}, forUpdate: true}));
 
     // has right from/to address
-    assert.equal(mailStub.calledWith(sinon.match({
+    sinon.assert.calledWith(mailStub, sinon.match({
         from: '"Default" <default@email.com>',
         to: 'owner@ghost.org'
-    })), true);
+    }));
 
     // Email HTML contains important bits
 
     // Has accent color
-    assert.equal(mailStub.calledWith(
-        sinon.match.has('html', sinon.match('#ffffff'))
-    ), true);
+    sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('#ffffff')));
 
     // Has email
-    assert.equal(mailStub.calledWith(
-        sinon.match.has('html', sinon.match('member@example.com'))
-    ), true);
+    sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('member@example.com')));
 
     // Has member url
-    assert.equal(mailStub.calledWith(
-        sinon.match.has('html', sinon.match('https://admin.ghost.example/#/members/abc'))
-    ), true);
+    sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('https://admin.ghost.example/#/members/abc')));
 
     // Has site url
-    assert.equal(mailStub.calledWith(
-        sinon.match.has('html', sinon.match('https://ghost.example'))
-    ), true);
+    sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('https://ghost.example')));
 
     // Has staff admin url
-    assert.equal(mailStub.calledWith(
-        sinon.match.has('html', sinon.match('https://admin.ghost.example/#/settings/staff/ghost/email-notifications'))
-    ), true);
+    sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('https://admin.ghost.example/#/settings/staff/ghost/email-notifications')));
 }
 
 function testCommonPaidSubMailData({member, mailStub, getEmailAlertUsersStub}) {
     testCommonMailData({mailStub, getEmailAlertUsersStub});
-    assert.equal(getEmailAlertUsersStub.calledWith('paid-started'), true);
+    sinon.assert.calledWith(getEmailAlertUsersStub, 'paid-started');
 
     if (member?.name) {
-        assert.equal(mailStub.calledWith(
-            sinon.match({subject: '💸 Paid subscription started: Ghost'})
-        ), true);
+        sinon.assert.calledWith(mailStub, sinon.match({subject: '💸 Paid subscription started: Ghost'}));
 
-        assert.equal(mailStub.calledWith(
-            sinon.match.has('html', sinon.match('💸 Paid subscription started: Ghost'))
-        ), true);
+        sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('💸 Paid subscription started: Ghost')));
     } else {
-        assert.equal(mailStub.calledWith(
-            sinon.match({subject: '💸 Paid subscription started: member@example.com'})
-        ), true);
+        sinon.assert.calledWith(mailStub, sinon.match({subject: '💸 Paid subscription started: member@example.com'}));
 
-        assert.equal(mailStub.calledWith(
-            sinon.match.has('html', sinon.match('💸 Paid subscription started: member@example.com'))
-        ), true);
+        sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('💸 Paid subscription started: member@example.com')));
     }
 
-    assert.equal(mailStub.calledWith(
-        sinon.match.has('html', sinon.match('Test Tier'))
-    ), true);
-    assert.equal(mailStub.calledWith(
-        sinon.match.has('html', sinon.match('$50.00/month'))
-    ), true);
+    sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('Test Tier')));
+    sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('$50.00/month')));
 }
 
 function testCommonPaidSubCancelMailData({mailStub, getEmailAlertUsersStub}) {
     testCommonMailData({mailStub, getEmailAlertUsersStub});
-    assert.equal(getEmailAlertUsersStub.calledWith('paid-canceled'), true);
-    assert.equal(mailStub.calledWith(
-        sinon.match({subject: '⚠️ Cancellation: Ghost'})
-    ), true);
+    sinon.assert.calledWith(getEmailAlertUsersStub, 'paid-canceled');
+    sinon.assert.calledWith(mailStub, sinon.match({subject: '⚠️ Cancellation: Ghost'}));
 
-    assert.equal(mailStub.calledWith(
-        sinon.match.has('html', sinon.match('⚠️ Cancellation: Ghost'))
-    ), true);
-    assert.equal(mailStub.calledWith(
-        sinon.match.has('html', sinon.match('Test Tier'))
-    ), true);
-    assert.equal(mailStub.calledWith(
-        sinon.match.has('html', sinon.match('$50.00/month'))
-    ), true);
+    sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('⚠️ Cancellation: Ghost')));
+    sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('Test Tier')));
+    sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('$50.00/month')));
 }
 
 describe('StaffService', function () {
@@ -197,11 +164,11 @@ describe('StaffService', function () {
         describe('subscribeEvents', function () {
             it('subscribes to events', async function () {
                 service.subscribeEvents();
-                assert.equal(subscribeStub.callCount, 4);
-                assert.equal(subscribeStub.calledWith(SubscriptionActivatedEvent), true);
-                assert.equal(subscribeStub.calledWith(SubscriptionCancelledEvent), true);
-                assert.equal(subscribeStub.calledWith(MemberCreatedEvent), true);
-                assert.equal(subscribeStub.calledWith(MilestoneCreatedEvent), true);
+                sinon.assert.callCount(subscribeStub, 4);
+                sinon.assert.calledWith(subscribeStub, SubscriptionActivatedEvent);
+                sinon.assert.calledWith(subscribeStub, SubscriptionCancelledEvent);
+                sinon.assert.calledWith(subscribeStub, MemberCreatedEvent);
+                sinon.assert.calledWith(subscribeStub, MilestoneCreatedEvent);
             });
 
             it('listens to events', async function () {
@@ -231,7 +198,7 @@ describe('StaffService', function () {
                     memberId: 'member-2'
                 }));
                 await DomainEvents.allSettled();
-                assert.equal(service.handleEvent.calledWith(MemberCreatedEvent), true);
+                sinon.assert.calledWith(service.handleEvent, MemberCreatedEvent);
 
                 DomainEvents.dispatch(SubscriptionActivatedEvent.create({
                     source: 'member',
@@ -241,7 +208,7 @@ describe('StaffService', function () {
                     tierId: 'tier-1'
                 }));
                 await DomainEvents.allSettled();
-                assert.equal(service.handleEvent.calledWith(SubscriptionActivatedEvent), true);
+                sinon.assert.calledWith(service.handleEvent, SubscriptionActivatedEvent);
 
                 DomainEvents.dispatch(SubscriptionCancelledEvent.create({
                     source: 'member',
@@ -250,7 +217,7 @@ describe('StaffService', function () {
                     tierId: 'tier-1'
                 }));
                 await DomainEvents.allSettled();
-                assert.equal(service.handleEvent.calledWith(SubscriptionCancelledEvent), true);
+                sinon.assert.calledWith(service.handleEvent, SubscriptionCancelledEvent);
 
                 DomainEvents.dispatch(MilestoneCreatedEvent.create({
                     milestone: {
@@ -260,7 +227,7 @@ describe('StaffService', function () {
                     }
                 }));
                 await DomainEvents.allSettled();
-                assert.equal(service.handleEvent.calledWith(MilestoneCreatedEvent), true);
+                sinon.assert.calledWith(service.handleEvent, MilestoneCreatedEvent);
             });
         });
 
@@ -370,11 +337,9 @@ describe('StaffService', function () {
                     }
                 });
 
-                assert.equal(service.memberAttributionService.getMemberCreatedAttribution.called, true);
+                sinon.assert.called(service.memberAttributionService.getMemberCreatedAttribution);
 
-                assert.equal(mailStub.calledWith(
-                    sinon.match({subject: '🥳 Free member signup: Jamie'})
-                ), true);
+                sinon.assert.calledWith(mailStub, sinon.match({subject: '🥳 Free member signup: Jamie'}));
             });
             it('handles free member created event with provided attribution', async function () {
                 await service.handleEvent(MemberCreatedEvent, {
@@ -391,12 +356,10 @@ describe('StaffService', function () {
                 });
 
                 // provided attribution should be used instead of fetching it
-                assert.equal(service.memberAttributionService.getMemberCreatedAttribution.called, false);
-                assert.equal(service.memberAttributionService.fetchResource.called, true);
+                sinon.assert.notCalled(service.memberAttributionService.getMemberCreatedAttribution);
+                sinon.assert.called(service.memberAttributionService.fetchResource);
 
-                assert.equal(mailStub.calledWith(
-                    sinon.match({subject: '🥳 Free member signup: Jamie'})
-                ), true);
+                sinon.assert.calledWith(mailStub, sinon.match({subject: '🥳 Free member signup: Jamie'}));
             });
 
             it('handles paid member created event', async function () {
@@ -410,11 +373,9 @@ describe('StaffService', function () {
                     }
                 });
 
-                assert.equal(service.memberAttributionService.getSubscriptionCreatedAttribution.called, true);
+                sinon.assert.called(service.memberAttributionService.getSubscriptionCreatedAttribution);
 
-                assert.equal(mailStub.calledWith(
-                    sinon.match({subject: '💸 Paid subscription started: Jamie'})
-                ), true);
+                sinon.assert.calledWith(mailStub, sinon.match({subject: '💸 Paid subscription started: Jamie'}));
             });
 
             it('handles paid member created event with provided attribution', async function () {
@@ -435,20 +396,14 @@ describe('StaffService', function () {
                 });
 
                 // provided attribution should be used instead of fetching it
-                assert.equal(service.memberAttributionService.getSubscriptionCreatedAttribution.called, false);
-                assert.equal(service.memberAttributionService.fetchResource.called, true);
+                sinon.assert.notCalled(service.memberAttributionService.getSubscriptionCreatedAttribution);
+                sinon.assert.called(service.memberAttributionService.fetchResource);
 
-                assert.equal(mailStub.calledWith(
-                    sinon.match({subject: '💸 Paid subscription started: Jamie'})
-                ), true);
+                sinon.assert.calledWith(mailStub, sinon.match({subject: '💸 Paid subscription started: Jamie'}));
 
-                assert.equal(mailStub.calledWith(
-                    sinon.match.has('html', sinon.match('Welcome Post'))
-                ), true);
+                sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('Welcome Post')));
 
-                assert.equal(mailStub.calledWith(
-                    sinon.match.has('html', sinon.match('Direct'))
-                ), true);
+                sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('Direct')));
             });
 
             it('handles paid member cancellation event', async function () {
@@ -461,9 +416,7 @@ describe('StaffService', function () {
                     }
                 });
 
-                assert.equal(mailStub.calledWith(
-                    sinon.match({subject: '⚠️ Cancellation: Jamie'})
-                ), true);
+                sinon.assert.calledWith(mailStub, sinon.match({subject: '⚠️ Cancellation: Jamie'}));
             });
 
             it('handles milestone created event', async function () {
@@ -477,9 +430,7 @@ describe('StaffService', function () {
                         }
                     }
                 });
-                assert.equal(mailStub.calledWith(
-                    sinon.match({subject: `Ghost Site hit $1,000 ARR`})
-                ), true);
+                sinon.assert.calledWith(mailStub, sinon.match({subject: `Ghost Site hit $1,000 ARR`}));
             });
         });
 
@@ -495,16 +446,12 @@ describe('StaffService', function () {
 
                 await service.emails.notifyFreeMemberSignup({member}, options);
 
-                assert.equal(mailStub.calledOnce, true);
+                sinon.assert.calledOnce(mailStub);
                 testCommonMailData(stubs);
-                assert.equal(getEmailAlertUsersStub.calledWith('free-signup'), true);
+                sinon.assert.calledWith(getEmailAlertUsersStub, 'free-signup');
 
-                assert.equal(mailStub.calledWith(
-                    sinon.match({subject: '🥳 Free member signup: Ghost'})
-                ), true);
-                assert.equal(mailStub.calledWith(
-                    sinon.match.has('html', sinon.match('🥳 Free member signup: Ghost'))
-                ), true);
+                sinon.assert.calledWith(mailStub, sinon.match({subject: '🥳 Free member signup: Ghost'}));
+                sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('🥳 Free member signup: Ghost')));
             });
 
             it('sends free member signup alert without member name', async function () {
@@ -517,16 +464,12 @@ describe('StaffService', function () {
 
                 await service.emails.notifyFreeMemberSignup({member}, options);
 
-                assert.equal(mailStub.calledOnce, true);
+                sinon.assert.calledOnce(mailStub);
                 testCommonMailData(stubs);
-                assert.equal(getEmailAlertUsersStub.calledWith('free-signup'), true);
+                sinon.assert.calledWith(getEmailAlertUsersStub, 'free-signup');
 
-                assert.equal(mailStub.calledWith(
-                    sinon.match({subject: '🥳 Free member signup: member@example.com'})
-                ), true);
-                assert.equal(mailStub.calledWith(
-                    sinon.match.has('html', sinon.match('🥳 Free member signup: member@example.com'))
-                ), true);
+                sinon.assert.calledWith(mailStub, sinon.match({subject: '🥳 Free member signup: member@example.com'}));
+                sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('🥳 Free member signup: member@example.com')));
             });
 
             it('sends free member signup alert with attribution', async function () {
@@ -544,34 +487,22 @@ describe('StaffService', function () {
 
                 await service.emails.notifyFreeMemberSignup({member, attribution}, options);
 
-                assert.equal(mailStub.calledOnce, true);
+                sinon.assert.calledOnce(mailStub);
                 testCommonMailData(stubs);
-                assert.equal(getEmailAlertUsersStub.calledWith('free-signup'), true);
+                sinon.assert.calledWith(getEmailAlertUsersStub, 'free-signup');
 
-                assert.equal(mailStub.calledWith(
-                    sinon.match({subject: '🥳 Free member signup: Ghost'})
-                ), true);
-                assert.equal(mailStub.calledWith(
-                    sinon.match.has('html', sinon.match('🥳 Free member signup: Ghost'))
-                ), true);
+                sinon.assert.calledWith(mailStub, sinon.match({subject: '🥳 Free member signup: Ghost'}));
+                sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('🥳 Free member signup: Ghost')));
 
-                assert.equal(mailStub.calledWith(
-                    sinon.match.has('html', sinon.match('Source'))
-                ), true);
+                sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('Source')));
 
-                assert.equal(mailStub.calledWith(
-                    sinon.match.has('html', sinon.match('Twitter'))
-                ), true);
+                sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('Twitter')));
 
                 // check attribution page
-                assert.equal(mailStub.calledWith(
-                    sinon.match.has('html', sinon.match('Welcome Post'))
-                ), true);
+                sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('Welcome Post')));
 
                 // check attribution url
-                assert.equal(mailStub.calledWith(
-                    sinon.match.has('html', sinon.match('https://example.com/welcome'))
-                ), true);
+                sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('https://example.com/welcome')));
             });
         });
 
@@ -611,34 +542,26 @@ describe('StaffService', function () {
                 };
                 await service.emails.notifyPaidSubscriptionStarted({member, offer: null, tier, subscription, attribution}, options);
 
-                assert.equal(mailStub.calledOnce, true);
+                sinon.assert.calledOnce(mailStub);
                 testCommonPaidSubMailData({...stubs, member});
 
                 // check attribution text
-                assert.equal(mailStub.calledWith(
-                    sinon.match.has('html', sinon.match('Twitter'))
-                ), true);
+                sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('Twitter')));
 
                 // check attribution text
-                assert.equal(mailStub.calledWith(
-                    sinon.match.has('html', sinon.match('Source'))
-                ), true);
+                sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('Source')));
 
                 // check attribution page
-                assert.equal(mailStub.calledWith(
-                    sinon.match.has('html', sinon.match('Welcome Post'))
-                ), true);
+                sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('Welcome Post')));
 
                 // check attribution url
-                assert.equal(mailStub.calledWith(
-                    sinon.match.has('html', sinon.match('https://example.com/welcome'))
-                ), true);
+                sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('https://example.com/welcome')));
             });
 
             it('sends paid subscription start alert without offer', async function () {
                 await service.emails.notifyPaidSubscriptionStarted({member, offer: null, tier, subscription}, options);
 
-                assert.equal(mailStub.calledOnce, true);
+                sinon.assert.calledOnce(mailStub);
                 testCommonPaidSubMailData({...stubs, member});
 
                 assert.equal(mailStub.calledWith(
@@ -653,7 +576,7 @@ describe('StaffService', function () {
                 };
                 await service.emails.notifyPaidSubscriptionStarted({member: memberData, offer: null, tier, subscription}, options);
 
-                assert.equal(mailStub.calledOnce, true);
+                sinon.assert.calledOnce(mailStub);
                 testCommonPaidSubMailData({...stubs, member: memberData});
 
                 assert.equal(mailStub.calledWith(
@@ -661,31 +584,21 @@ describe('StaffService', function () {
                 ), false);
 
                 // check preview text
-                assert.equal(mailStub.calledWith(
-                    sinon.match.has('html', sinon.match('Test Tier: $50.00/month'))
-                ), true);
+                sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('Test Tier: $50.00/month')));
             });
 
             it('sends paid subscription start alert with percent offer - first payment', async function () {
                 await service.emails.notifyPaidSubscriptionStarted({member, offer, tier, subscription}, options);
 
-                assert.equal(mailStub.calledOnce, true);
+                sinon.assert.calledOnce(mailStub);
                 testCommonPaidSubMailData({...stubs, member});
 
-                assert.equal(mailStub.calledWith(
-                    sinon.match.has('html', sinon.match('Half price'))
-                ), true);
-                assert.equal(mailStub.calledWith(
-                    sinon.match.has('html', sinon.match('50% off'))
-                ), true);
-                assert.equal(mailStub.calledWith(
-                    sinon.match.has('html', sinon.match('first payment'))
-                ), true);
+                sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('Half price')));
+                sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('50% off')));
+                sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('first payment')));
 
                 // check preview text
-                assert.equal(mailStub.calledWith(
-                    sinon.match.has('html', sinon.match('Test Tier: $50.00/month - Offer: Half price - 50% off, first payment'))
-                ), true);
+                sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('Test Tier: $50.00/month - Offer: Half price - 50% off, first payment')));
             });
 
             it('sends paid subscription start alert with fixed type offer - repeating duration', async function () {
@@ -700,18 +613,12 @@ describe('StaffService', function () {
 
                 await service.emails.notifyPaidSubscriptionStarted({member, offer, tier, subscription}, options);
 
-                assert.equal(mailStub.calledOnce, true);
+                sinon.assert.calledOnce(mailStub);
                 testCommonPaidSubMailData({...stubs, member});
 
-                assert.equal(mailStub.calledWith(
-                    sinon.match.has('html', sinon.match('Save ten'))
-                ), true);
-                assert.equal(mailStub.calledWith(
-                    sinon.match.has('html', sinon.match('$10.00 off'))
-                ), true);
-                assert.equal(mailStub.calledWith(
-                    sinon.match.has('html', sinon.match('first 3 months'))
-                ), true);
+                sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('Save ten')));
+                sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('$10.00 off')));
+                sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('first 3 months')));
             });
 
             it('sends paid subscription start alert with fixed type offer - forever duration', async function () {
@@ -725,18 +632,12 @@ describe('StaffService', function () {
 
                 await service.emails.notifyPaidSubscriptionStarted({member, offer, tier, subscription}, options);
 
-                assert.equal(mailStub.calledOnce, true);
+                sinon.assert.calledOnce(mailStub);
                 testCommonPaidSubMailData({...stubs, member});
 
-                assert.equal(mailStub.calledWith(
-                    sinon.match.has('html', sinon.match('Save twenty'))
-                ), true);
-                assert.equal(mailStub.calledWith(
-                    sinon.match.has('html', sinon.match('$20.00 off'))
-                ), true);
-                assert.equal(mailStub.calledWith(
-                    sinon.match.has('html', sinon.match('forever'))
-                ), true);
+                sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('Save twenty')));
+                sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('$20.00 off')));
+                sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('forever')));
             });
 
             it('sends paid subscription start alert with free trial offer', async function () {
@@ -749,15 +650,11 @@ describe('StaffService', function () {
 
                 await service.emails.notifyPaidSubscriptionStarted({member, offer, tier, subscription}, options);
 
-                assert.equal(mailStub.calledOnce, true);
+                sinon.assert.calledOnce(mailStub);
                 testCommonPaidSubMailData({...stubs, member});
 
-                assert.equal(mailStub.calledWith(
-                    sinon.match.has('html', sinon.match('Free week'))
-                ), true);
-                assert.equal(mailStub.calledWith(
-                    sinon.match.has('html', sinon.match('7 days free'))
-                ), true);
+                sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('Free week')));
+                sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('7 days free')));
             });
         });
 
@@ -798,45 +695,33 @@ describe('StaffService', function () {
                     cancellationReason: 'Changed my mind!'
                 }, expiryAt, canceledAt, cancelNow}, options);
 
-                assert.equal(mailStub.calledOnce, true);
+                sinon.assert.calledOnce(mailStub);
                 testCommonPaidSubCancelMailData(stubs);
 
                 // Expiration sentence is in the future tense
-                assert.equal(mailStub.calledWith(
-                    sinon.match.has('html', sinon.match('Expires on'))
-                ), true);
+                sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('Expires on')));
 
-                assert.equal(mailStub.calledWith(
-                    sinon.match.has('html', sinon.match('5 Sep 2024'))
-                ), true);
+                sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('5 Sep 2024')));
 
                 assert.equal(mailStub.calledWith(
                     sinon.match.has('html', 'Offer')
                 ), false);
 
-                assert.equal(mailStub.calledWith(
-                    sinon.match.has('html', sinon.match('Cancellation reason'))
-                ), true);
+                sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('Cancellation reason')));
 
-                assert.equal(mailStub.calledWith(
-                    sinon.match.has('html', sinon.match('Changed my mind!'))
-                ), true);
+                sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('Changed my mind!')));
             });
 
             it('sends paid subscription cancel alert when sub is canceled without reason', async function () {
                 await service.emails.notifyPaidSubscriptionCanceled({member, tier, subscription, expiryAt, cancelNow}, options);
 
-                assert.equal(mailStub.calledOnce, true);
+                sinon.assert.calledOnce(mailStub);
                 testCommonPaidSubCancelMailData(stubs);
 
                 // Expiration sentence is in the future tense
-                assert.equal(mailStub.calledWith(
-                    sinon.match.has('html', sinon.match('Expires on'))
-                ), true);
+                sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('Expires on')));
 
-                assert.equal(mailStub.calledWith(
-                    sinon.match.has('html', sinon.match('5 Sep 2024'))
-                ), true);
+                sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('5 Sep 2024')));
 
                 // Cancellation reason block is hidden
                 assert.equal(mailStub.calledWith(
@@ -851,7 +736,7 @@ describe('StaffService', function () {
                     cancellationReason: 'Payment failed'
                 }, expiryAt, canceledAt, cancelNow}, options);
 
-                assert.equal(mailStub.calledOnce, true);
+                sinon.assert.calledOnce(mailStub);
                 testCommonPaidSubCancelMailData(stubs);
 
                 // We don't show "Canceled on" when subscription is canceled immediately
@@ -860,25 +745,17 @@ describe('StaffService', function () {
                 ), false);
 
                 // Expiration sentence is in the past tense
-                assert.equal(mailStub.calledWith(
-                    sinon.match.has('html', sinon.match('Expired on'))
-                ), true);
+                sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('Expired on')));
 
-                assert.equal(mailStub.calledWith(
-                    sinon.match.has('html', sinon.match('5 Sep 2024'))
-                ), true);
+                sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('5 Sep 2024')));
 
                 assert.equal(mailStub.calledWith(
                     sinon.match.has('html', 'Offer')
                 ), false);
 
-                assert.equal(mailStub.calledWith(
-                    sinon.match.has('html', sinon.match('Cancellation reason'))
-                ), true);
+                sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('Cancellation reason')));
 
-                assert.equal(mailStub.calledWith(
-                    sinon.match.has('html', sinon.match('Payment failed'))
-                ), true);
+                sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('Payment failed')));
             });
         });
 
@@ -892,30 +769,20 @@ describe('StaffService', function () {
 
                 await service.emails.notifyMilestoneReceived({milestone});
 
-                assert.equal(getEmailAlertUsersStub.calledWith('milestone-received'), true);
+                sinon.assert.calledWith(getEmailAlertUsersStub, 'milestone-received');
 
-                assert.equal(mailStub.calledOnce, true);
+                sinon.assert.calledOnce(mailStub);
 
-                assert.equal(mailStub.calledWith(
-                    sinon.match.has('html', sinon.match('Ghost Site now has 25k members'))
-                ), true);
+                sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('Ghost Site now has 25k members')));
 
-                assert.equal(mailStub.calledWith(
-                    sinon.match.has('html', sinon.match('Celebrating 25,000 signups'))
-                ), true);
+                sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('Celebrating 25,000 signups')));
 
                 // Correct image and NO height for Members milestone
-                assert.equal(mailStub.calledWith(
-                    sinon.match.has('html', sinon.match('src="https://static.ghost.org/v5.0.0/images/milestone-email-members-25k.png" width="580" align="center"'))
-                ), true);
+                sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('src="https://static.ghost.org/v5.0.0/images/milestone-email-members-25k.png" width="580" align="center"')));
 
-                assert.equal(mailStub.calledWith(
-                    sinon.match.has('html', sinon.match('Congrats, <strong>25k people</strong> have chosen to support and follow your work. That’s an audience big enough to sell out Madison Square Garden. What an incredible milestone!'))
-                ), true);
+                sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('Congrats, <strong>25k people</strong> have chosen to support and follow your work. That’s an audience big enough to sell out Madison Square Garden. What an incredible milestone!')));
 
-                assert.equal(mailStub.calledWith(
-                    sinon.match.has('html', sinon.match('View your dashboard'))
-                ), true);
+                sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('View your dashboard')));
             });
 
             it('send ARR milestone email', async function () {
@@ -928,30 +795,20 @@ describe('StaffService', function () {
 
                 await service.emails.notifyMilestoneReceived({milestone});
 
-                assert.equal(getEmailAlertUsersStub.calledWith('milestone-received'), true);
+                sinon.assert.calledWith(getEmailAlertUsersStub, 'milestone-received');
 
-                assert.equal(mailStub.calledOnce, true);
+                sinon.assert.calledOnce(mailStub);
 
-                assert.equal(mailStub.calledWith(
-                    sinon.match.has('html', sinon.match('Ghost Site hit $500,000 ARR'))
-                ), true);
+                sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('Ghost Site hit $500,000 ARR')));
 
-                assert.equal(mailStub.calledWith(
-                    sinon.match.has('html', sinon.match('Congrats! You reached $500k ARR'))
-                ), true);
+                sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('Congrats! You reached $500k ARR')));
 
                 // Correct image and height for ARR milestone
-                assert.equal(mailStub.calledWith(
-                    sinon.match.has('html', sinon.match('src="https://static.ghost.org/v5.0.0/images/milestone-email-usd-500k.png" width="580" height="348" align="center"'))
-                ), true);
+                sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('src="https://static.ghost.org/v5.0.0/images/milestone-email-usd-500k.png" width="580" height="348" align="center"')));
 
-                assert.equal(mailStub.calledWith(
-                    sinon.match.has('html', sinon.match('<strong>Ghost Site</strong> is now generating <strong>$500,000</strong> in annual recurring revenue. Congratulations &mdash; this is a significant milestone.'))
-                ), true);
+                sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('<strong>Ghost Site</strong> is now generating <strong>$500,000</strong> in annual recurring revenue. Congratulations &mdash; this is a significant milestone.')));
 
-                assert.equal(mailStub.calledWith(
-                    sinon.match.has('html', sinon.match('Login to your dashboard'))
-                ), true);
+                sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('Login to your dashboard')));
             });
 
             it('does not send email when no date provided', async function () {
@@ -964,7 +821,7 @@ describe('StaffService', function () {
 
                 assert.equal(getEmailAlertUsersStub.calledWith('milestone-received'), false);
 
-                assert.equal(mailStub.called, false);
+                sinon.assert.notCalled(mailStub);
             });
 
             it('does not send email when a reason not to send email was provided', async function () {
@@ -981,7 +838,7 @@ describe('StaffService', function () {
 
                 assert.equal(getEmailAlertUsersStub.calledWith('milestone-received'), false);
 
-                assert.equal(mailStub.called, false);
+                sinon.assert.notCalled(mailStub);
             });
 
             it('does not send email for a milestone without correct content', async function () {
@@ -995,9 +852,9 @@ describe('StaffService', function () {
 
                 assert.equal(getEmailAlertUsersStub.calledWith('milestone-received'), false);
 
-                assert.equal(loggingWarningStub.calledOnce, true);
+                sinon.assert.calledOnce(loggingWarningStub);
 
-                assert.equal(mailStub.called, false);
+                sinon.assert.notCalled(mailStub);
             });
         });
 
@@ -1013,13 +870,11 @@ describe('StaffService', function () {
 
                 await service.emails.notifyDonationReceived({donationPaymentEvent});
 
-                assert.equal(getEmailAlertUsersStub.calledWith('donation'), true);
+                sinon.assert.calledWith(getEmailAlertUsersStub, 'donation');
 
-                assert.equal(mailStub.calledOnce, true);
+                sinon.assert.calledOnce(mailStub);
 
-                assert.equal(mailStub.calledWith(
-                    sinon.match.has('html', sinon.match('One-time payment received: €15.00 from Simon'))
-                ), true);
+                sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('One-time payment received: €15.00 from Simon')));
             });
 
             it('has donation message in text', async function () {
@@ -1033,13 +888,11 @@ describe('StaffService', function () {
 
                 await service.emails.notifyDonationReceived({donationPaymentEvent});
 
-                assert.equal(getEmailAlertUsersStub.calledWith('donation'), true);
+                sinon.assert.calledWith(getEmailAlertUsersStub, 'donation');
 
-                assert.equal(mailStub.calledOnce, true);
+                sinon.assert.calledOnce(mailStub);
 
-                assert.equal(mailStub.calledWith(
-                    sinon.match.has('text', sinon.match('Thank you for the awesome newsletter!'))
-                ), true);
+                sinon.assert.calledWith(mailStub, sinon.match.has('text', sinon.match('Thank you for the awesome newsletter!')));
             });
 
             it('has donation message in html', async function () {
@@ -1053,13 +906,11 @@ describe('StaffService', function () {
 
                 await service.emails.notifyDonationReceived({donationPaymentEvent});
 
-                assert.equal(getEmailAlertUsersStub.calledWith('donation'), true);
+                sinon.assert.calledWith(getEmailAlertUsersStub, 'donation');
 
-                assert.equal(mailStub.calledOnce, true);
+                sinon.assert.calledOnce(mailStub);
 
-                assert.equal(mailStub.calledWith(
-                    sinon.match.has('html', sinon.match('Thank you for the awesome newsletter!'))
-                ), true);
+                sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match('Thank you for the awesome newsletter!')));
             });
 
             it('does not contain donation message in HTML if not provided', async function () {
@@ -1073,16 +924,14 @@ describe('StaffService', function () {
 
                 await service.emails.notifyDonationReceived({donationPaymentEvent});
 
-                assert.equal(getEmailAlertUsersStub.calledWith('donation'), true);
-                assert.equal(mailStub.calledOnce, true);
+                sinon.assert.calledWith(getEmailAlertUsersStub, 'donation');
+                sinon.assert.calledOnce(mailStub);
 
                 // Check that the specific HTML block for the donation message is NOT present
-                assert.equal(mailStub.calledWith(
-                    sinon.match.has('html', sinon.match(function (html) {
-                        // Ensure that the block with `{{donation.donationMessage}}` does not exist in the rendered HTML
-                        return !html.includes('“') && !html.includes('”');
-                    }))
-                ), true);
+                sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match(function (html) {
+                    // Ensure that the block with `{{donation.donationMessage}}` does not exist in the rendered HTML
+                    return !html.includes('“') && !html.includes('”');
+                })));
             });
 
             // Not really a relevant test, but it's here to show that the donation message is wrapped in quotation marks
@@ -1098,14 +947,12 @@ describe('StaffService', function () {
 
                 await service.emails.notifyDonationReceived({donationPaymentEvent});
 
-                assert.equal(getEmailAlertUsersStub.calledWith('donation'), true);
-                assert.equal(mailStub.calledOnce, true);
+                sinon.assert.calledWith(getEmailAlertUsersStub, 'donation');
+                sinon.assert.calledOnce(mailStub);
 
-                assert.equal(mailStub.calledWith(
-                    sinon.match.has('html', sinon.match(function (html) {
-                        return html.includes('“') && html.includes('”');
-                    }))
-                ), true);
+                sinon.assert.calledWith(mailStub, sinon.match.has('html', sinon.match(function (html) {
+                    return html.includes('“') && html.includes('”');
+                })));
             });
 
             it('send donation email without message', async function () {
@@ -1119,13 +966,11 @@ describe('StaffService', function () {
 
                 await service.emails.notifyDonationReceived({donationPaymentEvent});
 
-                assert.equal(getEmailAlertUsersStub.calledWith('donation'), true);
+                sinon.assert.calledWith(getEmailAlertUsersStub, 'donation');
 
-                assert.equal(mailStub.calledOnce, true);
+                sinon.assert.calledOnce(mailStub);
 
-                assert.equal(mailStub.calledWith(
-                    sinon.match.has('text', sinon.match('No message provided'))
-                ), true);
+                sinon.assert.calledWith(mailStub, sinon.match.has('text', sinon.match('No message provided')));
             });
         });
     });

--- a/ghost/core/test/unit/server/services/stats/content.test.js
+++ b/ghost/core/test/unit/server/services/stats/content.test.js
@@ -81,7 +81,7 @@ describe('ContentStatsService', function () {
             assertExists(result.options.headers);
             assert.equal(result.options.headers.Authorization, 'Bearer tb-token');
 
-            assert.equal(mockTinybirdClient.buildRequest.calledWith('api_top_pages', options), true);
+            sinon.assert.calledWith(mockTinybirdClient.buildRequest, 'api_top_pages', options);
         });
 
         it('parseResponse handles various response formats', function () {
@@ -104,7 +104,7 @@ describe('ContentStatsService', function () {
             assert(Array.isArray(result));
             assert.equal(result.length, 2);
 
-            assert.equal(mockTinybirdClient.parseResponse.calledWith(mockResponse), true);
+            sinon.assert.calledWith(mockTinybirdClient.parseResponse, mockResponse);
         });
     });
 
@@ -153,9 +153,9 @@ describe('ContentStatsService', function () {
             assert.equal(result['post-2'].id, 'post-id-2');
 
             // Verify knex was called correctly
-            assert.equal(mockKnex.select.calledWith('uuid', 'title', 'id'), true);
-            assert.equal(mockKnex.from.calledWith('posts'), true);
-            assert.equal(mockKnex.whereIn.calledWith('uuid', ['post-1', 'post-2']), true);
+            sinon.assert.calledWith(mockKnex.select, 'uuid', 'title', 'id');
+            sinon.assert.calledWith(mockKnex.from, 'posts');
+            sinon.assert.calledWith(mockKnex.whereIn, 'uuid', ['post-1', 'post-2']);
         });
     });
 
@@ -227,8 +227,8 @@ describe('ContentStatsService', function () {
             assertExists(result);
             assert.deepEqual(result, []);
 
-            assert.equal(service.extractPostUuids.called, false);
-            assert.equal(service.lookupPostTitles.called, false);
+            sinon.assert.notCalled(service.extractPostUuids);
+            sinon.assert.notCalled(service.lookupPostTitles);
         });
 
         it('enriches data with post_uuid titles', async function () {
@@ -253,8 +253,8 @@ describe('ContentStatsService', function () {
             assert.equal(result[1].post_id, 'post-id-2');
             assert.equal(result[1].url_exists, true);
 
-            assert.equal(service.extractPostUuids.calledOnce, true);
-            assert.equal(service.lookupPostTitles.calledOnce, true);
+            sinon.assert.calledOnce(service.extractPostUuids);
+            sinon.assert.calledOnce(service.lookupPostTitles);
         });
 
         it('uses urlService for non-post pages', async function () {
@@ -278,7 +278,7 @@ describe('ContentStatsService', function () {
             assert.equal(result[0].resourceType, 'page');
             assert.equal(result[0].url_exists, true);
 
-            assert.equal(service.getResourceTitle.calledWith('/about/'), true);
+            sinon.assert.calledWith(service.getResourceTitle, '/about/');
         });
 
         it('falls back to formatted pathname for unknown pages', async function () {
@@ -296,7 +296,7 @@ describe('ContentStatsService', function () {
             assert.equal(result[0].title, 'unknown-page');
             assert.equal(result[0].url_exists, false);
 
-            assert.equal(service.getResourceTitle.calledWith('/unknown-page/'), true);
+            sinon.assert.calledWith(service.getResourceTitle, '/unknown-page/');
         });
 
         it('handles home page', async function () {
@@ -338,7 +338,7 @@ describe('ContentStatsService', function () {
             assert.equal(result[0].pathname, '/test/');
             assert.equal(result[0].visits, 100);
 
-            assert.equal(mockTinybirdClient.fetch.calledOnce, true);
+            sinon.assert.calledOnce(mockTinybirdClient.fetch);
 
             // Verify that camelCase conversion happened - the first param should be the pipe name
             const calledWith = mockTinybirdClient.fetch.firstCall.args;
@@ -399,7 +399,7 @@ describe('ContentStatsService', function () {
             assert('title' in result.data[1]);
             assert('post_id' in result.data[1]);
 
-            assert.equal(service.fetchRawTopContentData.calledOnce, true);
+            sinon.assert.calledOnce(service.fetchRawTopContentData);
 
             // Verify the parameters were passed properly
             const options = service.fetchRawTopContentData.firstCall.args[0];
@@ -419,7 +419,7 @@ describe('ContentStatsService', function () {
             assertExists(result.data);
             assert.deepEqual(result.data, []);
 
-            assert.equal(service.fetchRawTopContentData.calledOnce, true);
+            sinon.assert.calledOnce(service.fetchRawTopContentData);
         });
 
         it('returns empty data array on error', async function () {
@@ -476,7 +476,7 @@ describe('ContentStatsService', function () {
             assert.equal(result.length, 2);
 
             // Verify tinybird client was called with correct parameters
-            assert.equal(mockTinybirdClient.fetch.calledOnce, true);
+            sinon.assert.calledOnce(mockTinybirdClient.fetch);
             assert.equal(mockTinybirdClient.fetch.firstCall.args[0], 'api_top_pages');
 
             const tinybirdOptions = mockTinybirdClient.fetch.firstCall.args[1];
@@ -515,7 +515,7 @@ describe('ContentStatsService', function () {
 
             await service.fetchRawTopContentData(options);
 
-            assert.equal(mockTinybirdClient.fetch.calledOnce, true);
+            sinon.assert.calledOnce(mockTinybirdClient.fetch);
             assert.equal(mockTinybirdClient.fetch.firstCall.args[0], 'api_top_pages');
 
             const tinybirdOptions = mockTinybirdClient.fetch.firstCall.args[1];

--- a/ghost/core/test/unit/server/services/stats/utils/tinybird.test.js
+++ b/ghost/core/test/unit/server/services/stats/utils/tinybird.test.js
@@ -224,7 +224,7 @@ describe('Tinybird Client', function () {
             assert.equal(result[0].visits, 100);
 
             // Verify request was called with correct parameters
-            assert.equal(mockRequest.get.calledOnce, true);
+            sinon.assert.calledOnce(mockRequest.get);
             const [url, options] = mockRequest.get.firstCall.args;
             assert(url.startsWith('https://api.tinybird.co/v0/pipes/test_pipe.json?'));
             assert.equal(options.headers.Authorization, 'Bearer mock-jwt-token');
@@ -237,7 +237,7 @@ describe('Tinybird Client', function () {
             const result = await tinybirdClient.fetch('test_pipe', {});
 
             assert.equal(result, null);
-            assert.equal(mockRequest.get.calledOnce, true);
+            sinon.assert.calledOnce(mockRequest.get);
         });
 
         it('returns null when response parsing fails', async function () {
@@ -249,7 +249,7 @@ describe('Tinybird Client', function () {
             const result = await tinybirdClient.fetch('test_pipe', {});
 
             assert.equal(result, null);
-            assert.equal(mockRequest.get.calledOnce, true);
+            sinon.assert.calledOnce(mockRequest.get);
         });
     });
 });

--- a/ghost/core/test/unit/server/services/stripe/billing-portal-manager.test.js
+++ b/ghost/core/test/unit/server/services/stripe/billing-portal-manager.test.js
@@ -49,8 +49,8 @@ describe('BillingPortalManager', function () {
 
             await manager.start();
 
-            assert.equal(mockApi.createBillingPortalConfiguration.called, false);
-            assert.equal(mockApi.updateBillingPortalConfiguration.called, false);
+            sinon.assert.notCalled(mockApi.createBillingPortalConfiguration);
+            sinon.assert.notCalled(mockApi.updateBillingPortalConfiguration);
         });
 
         it('creates new configuration if none exists', async function () {
@@ -67,8 +67,8 @@ describe('BillingPortalManager', function () {
 
             await manager.start();
 
-            assert.equal(mockApi.createBillingPortalConfiguration.calledOnce, true);
-            assert.equal(mockSettingsModel.edit.calledOnce, true);
+            sinon.assert.calledOnce(mockApi.createBillingPortalConfiguration);
+            sinon.assert.calledOnce(mockSettingsModel.edit);
             assert.deepEqual(mockSettingsModel.edit.firstCall.args[0], [{
                 key: 'stripe_billing_portal_configuration_id',
                 value: 'bpc_new123'
@@ -89,9 +89,9 @@ describe('BillingPortalManager', function () {
 
             await manager.start();
 
-            assert.equal(mockApi.updateBillingPortalConfiguration.calledOnce, true);
-            assert.equal(mockApi.createBillingPortalConfiguration.called, false);
-            assert.equal(mockSettingsModel.edit.called, false);
+            sinon.assert.calledOnce(mockApi.updateBillingPortalConfiguration);
+            sinon.assert.notCalled(mockApi.createBillingPortalConfiguration);
+            sinon.assert.notCalled(mockSettingsModel.edit);
         });
 
         it('saves new configuration ID when it changes after update', async function () {
@@ -108,7 +108,7 @@ describe('BillingPortalManager', function () {
 
             await manager.start();
 
-            assert.equal(mockSettingsModel.edit.calledOnce, true);
+            sinon.assert.calledOnce(mockSettingsModel.edit);
             assert.deepEqual(mockSettingsModel.edit.firstCall.args[0], [{
                 key: 'stripe_billing_portal_configuration_id',
                 value: 'bpc_new'
@@ -131,7 +131,7 @@ describe('BillingPortalManager', function () {
             const result = await manager.createOrUpdateConfiguration(null);
 
             assert.equal(result, 'bpc_new123');
-            assert.equal(mockApi.createBillingPortalConfiguration.calledOnce, true);
+            sinon.assert.calledOnce(mockApi.createBillingPortalConfiguration);
         });
 
         it('updates existing configuration when id is provided', async function () {
@@ -148,7 +148,7 @@ describe('BillingPortalManager', function () {
             const result = await manager.createOrUpdateConfiguration('bpc_existing123');
 
             assert.equal(result, 'bpc_existing123');
-            assert.equal(mockApi.updateBillingPortalConfiguration.calledOnce, true);
+            sinon.assert.calledOnce(mockApi.updateBillingPortalConfiguration);
             assert.equal(mockApi.updateBillingPortalConfiguration.firstCall.args[0], 'bpc_existing123');
         });
 
@@ -169,8 +169,8 @@ describe('BillingPortalManager', function () {
             const result = await manager.createOrUpdateConfiguration('bpc_deleted');
 
             assert.equal(result, 'bpc_new456');
-            assert.equal(mockApi.updateBillingPortalConfiguration.calledOnce, true);
-            assert.equal(mockApi.createBillingPortalConfiguration.calledOnce, true);
+            sinon.assert.calledOnce(mockApi.updateBillingPortalConfiguration);
+            sinon.assert.calledOnce(mockApi.createBillingPortalConfiguration);
         });
 
         it('throws error when update fails with non-resource_missing error', async function () {

--- a/ghost/core/test/unit/server/services/stripe/migrations.test.js
+++ b/ghost/core/test/unit/server/services/stripe/migrations.test.js
@@ -150,12 +150,9 @@ describe('Migrations', function () {
                 'Stripe product should be updated if name is "Default Product"'
             );
 
-            assert(
-                api.updateProduct.calledWith('prod_123', {
-                    name: 'Site Title'
-                }),
-                'Stripe product should have been updated with the site title as name'
-            );
+            sinon.assert.calledWith(api.updateProduct, 'prod_123', {
+                name: 'Site Title'
+            });
         });
     });
 });

--- a/ghost/core/test/unit/server/services/stripe/services/webhooks/checkout-session-event-service.test.js
+++ b/ghost/core/test/unit/server/services/stripe/services/webhooks/checkout-session-event-service.test.js
@@ -59,7 +59,7 @@ describe('CheckoutSessionEventService', function () {
 
             await service.handleEvent(session);
 
-            assert(handleSetupEventStub.calledWith(session));
+            sinon.assert.calledWith(handleSetupEventStub, session);
         });
 
         it('should call handleSubscriptionEvent if session mode is subscription', async function () {
@@ -69,7 +69,7 @@ describe('CheckoutSessionEventService', function () {
 
             await service.handleEvent(session);
 
-            assert(handleSubscriptionEventStub.calledWith(session));
+            sinon.assert.calledWith(handleSubscriptionEventStub, session);
         });
 
         it('should call handleDonationEvent if session mode is payment and session metadata ghost_donation is present', async function () {
@@ -79,7 +79,7 @@ describe('CheckoutSessionEventService', function () {
 
             await service.handleEvent(session);
 
-            assert(handleDonationEventStub.calledWith(session));
+            sinon.assert.calledWith(handleDonationEventStub, session);
         });
 
         it('should do nothing if session mode is not setup, subscription, or payment', async function () {
@@ -91,9 +91,9 @@ describe('CheckoutSessionEventService', function () {
 
             await service.handleEvent(session);
 
-            assert(!handleSetupEventStub.called);
-            assert(!handleSubscriptionEventStub.called);
-            assert(!handleDonationEventStub.called);
+            sinon.assert.notCalled(handleSetupEventStub);
+            sinon.assert.notCalled(handleSubscriptionEventStub);
+            sinon.assert.notCalled(handleDonationEventStub);
         });
     });
 
@@ -120,7 +120,7 @@ describe('CheckoutSessionEventService', function () {
 
             await service.handleDonationEvent(session);
 
-            assert(donationRepository.save.calledOnce);
+            sinon.assert.calledOnce(donationRepository.save);
 
             const savedDonationEvent = donationRepository.save.getCall(0).args[0];
 
@@ -160,7 +160,7 @@ describe('CheckoutSessionEventService', function () {
 
             await service.handleDonationEvent(session);
 
-            assert(donationRepository.save.calledOnce);
+            sinon.assert.calledOnce(donationRepository.save);
 
             const savedDonationEvent = donationRepository.save.getCall(0).args[0];
             assert.equal(savedDonationEvent.donationMessage, null);
@@ -198,7 +198,7 @@ describe('CheckoutSessionEventService', function () {
             await service.handleDonationEvent(session);
 
             // expect(donationRepository.save.calledOnce).to.be.true;
-            assert(donationRepository.save.calledOnce);
+            sinon.assert.calledOnce(donationRepository.save);
 
             const savedDonationEvent = donationRepository.save.getCall(0).args[0];
 
@@ -245,7 +245,7 @@ describe('CheckoutSessionEventService', function () {
 
             await service.handleDonationEvent(session);
 
-            assert(donationRepository.save.calledOnce);
+            sinon.assert.calledOnce(donationRepository.save);
 
             const savedDonationEvent = donationRepository.save.getCall(0).args[0];
 
@@ -260,7 +260,7 @@ describe('CheckoutSessionEventService', function () {
 
             service.handleSetupEvent(session);
 
-            assert(api.getSetupIntent.calledWith('si_123'));
+            sinon.assert.calledWith(api.getSetupIntent, 'si_123');
         });
 
         it('fires getSetupIntent and memberRepository.get', async function () {
@@ -272,8 +272,8 @@ describe('CheckoutSessionEventService', function () {
 
             await service.handleSetupEvent(session);
 
-            assert(api.getSetupIntent.calledWith('si_123'));
-            assert(memberRepository.get.calledWith({customer_id: 'cust_123'}));
+            sinon.assert.calledWith(api.getSetupIntent, 'si_123');
+            sinon.assert.calledWith(memberRepository.get, {customer_id: 'cust_123'});
         });
 
         it('fires getSetupIntent, memberRepository.get and attachPaymentMethodToCustomer', async function () {
@@ -295,9 +295,9 @@ describe('CheckoutSessionEventService', function () {
 
             await service.handleSetupEvent(session);
 
-            assert(api.getSetupIntent.calledWith('si_123'));
-            assert(memberRepository.get.calledWith({customer_id: 'cust_123'}));
-            assert(api.attachPaymentMethodToCustomer.called);
+            sinon.assert.calledWith(api.getSetupIntent, 'si_123');
+            sinon.assert.calledWith(memberRepository.get, {customer_id: 'cust_123'});
+            sinon.assert.called(api.attachPaymentMethodToCustomer);
         });
 
         it('if member is not found, it should return early', async function () {
@@ -310,9 +310,9 @@ describe('CheckoutSessionEventService', function () {
 
             await service.handleSetupEvent(session);
 
-            assert(api.getSetupIntent.calledWith('si_123'));
-            assert(memberRepository.get.calledWith({customer_id: 'cust_123'}));
-            assert(!api.attachPaymentMethodToCustomer.called);
+            sinon.assert.calledWith(api.getSetupIntent, 'si_123');
+            sinon.assert.calledWith(memberRepository.get, {customer_id: 'cust_123'});
+            sinon.assert.notCalled(api.attachPaymentMethodToCustomer);
         });
 
         it('if setupIntent has subscription_id, it should update subscription default payment method', async function () {
@@ -328,8 +328,8 @@ describe('CheckoutSessionEventService', function () {
 
             await service.handleSetupEvent(session);
 
-            assert(api.updateSubscriptionDefaultPaymentMethod.calledWith('sub_123', 'pm_123'));
-            assert(memberRepository.linkSubscription.calledWith({id: 'member_123', subscription: updatedSubscription}));
+            sinon.assert.calledWith(api.updateSubscriptionDefaultPaymentMethod, 'sub_123', 'pm_123');
+            sinon.assert.calledWith(memberRepository.linkSubscription, {id: 'member_123', subscription: updatedSubscription});
         });
 
         it('if linkSubscription fails with ER_DUP_ENTRY, it should throw ConflictError', async function () {
@@ -445,7 +445,7 @@ describe('CheckoutSessionEventService', function () {
 
             await service.handleSetupEvent(session);
 
-            assert(api.updateSubscriptionDefaultPaymentMethod.calledTwice);
+            sinon.assert.calledTwice(api.updateSubscriptionDefaultPaymentMethod);
         });
 
         it('throws if updateSubscriptionDefaultPaymentMethod fires but cannot link subscription', async function () {
@@ -597,8 +597,8 @@ describe('CheckoutSessionEventService', function () {
 
             await service.handleSubscriptionEvent(session);
 
-            assert(api.getCustomer.calledWith('cust_123', {expand: ['subscriptions.data.default_payment_method']}));
-            assert(memberRepository.get.calledWith({email: 'customer@example.com'}));
+            sinon.assert.calledWith(api.getCustomer, 'cust_123', {expand: ['subscriptions.data.default_payment_method']});
+            sinon.assert.calledWith(memberRepository.get, {email: 'customer@example.com'});
         });
 
         it('should create new member if not found', async function () {
@@ -607,7 +607,7 @@ describe('CheckoutSessionEventService', function () {
 
             await service.handleSubscriptionEvent(session);
 
-            assert(memberRepository.create.calledOnce);
+            sinon.assert.calledOnce(memberRepository.create);
             const memberData = memberRepository.create.getCall(0).args[0];
 
             assert.equal(memberData.email, 'customer@example.com');
@@ -631,7 +631,7 @@ describe('CheckoutSessionEventService', function () {
 
             await service.handleSubscriptionEvent(session);
 
-            assert(memberRepository.create.calledOnce);
+            sinon.assert.calledOnce(memberRepository.create);
             const memberData = memberRepository.create.getCall(0).args[0];
 
             assert.equal(memberData.email, 'customer@example.com');
@@ -661,7 +661,7 @@ describe('CheckoutSessionEventService', function () {
             customer.subscriptions.data[0].default_payment_method.billing_details.name = 'New Customer Name';
             await service.handleSubscriptionEvent(session);
 
-            assert(memberRepository.update.calledOnce);
+            sinon.assert.calledOnce(memberRepository.update);
             const memberData = memberRepository.update.getCall(0).args[0];
             assert.equal(memberData.name, 'New Customer Name');
         });
@@ -674,7 +674,7 @@ describe('CheckoutSessionEventService', function () {
             customer.subscriptions.data[0].default_payment_method.billing_details.name = 'New Customer Name';
             await service.handleSubscriptionEvent(session);
 
-            assert(memberRepository.update.calledOnce);
+            sinon.assert.calledOnce(memberRepository.update);
             const memberData = memberRepository.update.getCall(0).args[0];
             assert.equal(memberData.name, 'New Customer Name');
         });
@@ -687,7 +687,7 @@ describe('CheckoutSessionEventService', function () {
             customer.subscriptions.data[0].default_payment_method.billing_details.name = 'New Customer Name';
             await service.handleSubscriptionEvent(session);
 
-            assert(memberRepository.update.calledOnce);
+            sinon.assert.calledOnce(memberRepository.update);
             const memberData = memberRepository.update.getCall(0).args[0];
             assert.equal(memberData.newsletters, undefined);
         });
@@ -701,9 +701,9 @@ describe('CheckoutSessionEventService', function () {
 
                 await service.handleSubscriptionEvent(session);
 
-                assert(sendSignupEmail.calledOnce);
-                assert(sendSignupEmail.calledWith('customer@example.com'));
-                assert(!isPaidWelcomeEmailActive.called);
+                sinon.assert.calledOnce(sendSignupEmail);
+                sinon.assert.calledWith(sendSignupEmail, 'customer@example.com');
+                sinon.assert.notCalled(isPaidWelcomeEmailActive);
             });
 
             it('should send signup email when flow is has_precheckout_magic_link and welcome email is not active', async function () {
@@ -714,8 +714,8 @@ describe('CheckoutSessionEventService', function () {
 
                 await service.handleSubscriptionEvent(session);
 
-                assert(sendSignupEmail.calledOnce);
-                assert(sendSignupEmail.calledWith('customer@example.com'));
+                sinon.assert.calledOnce(sendSignupEmail);
+                sinon.assert.calledWith(sendSignupEmail, 'customer@example.com');
             });
 
             it('should NOT send signup email when flow is has_precheckout_magic_link and welcome email is active', async function () {
@@ -726,7 +726,7 @@ describe('CheckoutSessionEventService', function () {
 
                 await service.handleSubscriptionEvent(session);
 
-                assert(!sendSignupEmail.called);
+                sinon.assert.notCalled(sendSignupEmail);
             });
 
             it('should send signup email when flow is already_authenticated and welcome email is not active', async function () {
@@ -737,8 +737,8 @@ describe('CheckoutSessionEventService', function () {
 
                 await service.handleSubscriptionEvent(session);
 
-                assert(sendSignupEmail.calledOnce);
-                assert(sendSignupEmail.calledWith('customer@example.com'));
+                sinon.assert.calledOnce(sendSignupEmail);
+                sinon.assert.calledWith(sendSignupEmail, 'customer@example.com');
             });
 
             it('should NOT send signup email when flow is already_authenticated and welcome email is active', async function () {
@@ -749,7 +749,7 @@ describe('CheckoutSessionEventService', function () {
 
                 await service.handleSubscriptionEvent(session);
 
-                assert(!sendSignupEmail.called);
+                sinon.assert.notCalled(sendSignupEmail);
             });
 
             it('should send signup email when flow metadata is missing for backward compatibility', async function () {
@@ -760,9 +760,9 @@ describe('CheckoutSessionEventService', function () {
 
                 await service.handleSubscriptionEvent(session);
 
-                assert(sendSignupEmail.calledOnce);
-                assert(sendSignupEmail.calledWith('customer@example.com'));
-                assert(!isPaidWelcomeEmailActive.called);
+                sinon.assert.calledOnce(sendSignupEmail);
+                sinon.assert.calledWith(sendSignupEmail, 'customer@example.com');
+                sinon.assert.notCalled(isPaidWelcomeEmailActive);
             });
 
             it('should NOT send signup email on upgrade regardless of flow or welcome email', async function () {
@@ -774,7 +774,7 @@ describe('CheckoutSessionEventService', function () {
 
                 await service.handleSubscriptionEvent(session);
 
-                assert(!sendSignupEmail.called);
+                sinon.assert.notCalled(sendSignupEmail);
             });
         });
     });

--- a/ghost/core/test/unit/server/services/stripe/services/webhooks/invoice-event-service.test.js
+++ b/ghost/core/test/unit/server/services/stripe/services/webhooks/invoice-event-service.test.js
@@ -39,8 +39,7 @@ describe('InvoiceEventService', function () {
         sinon.assert.notCalled(memberRepositoryStub.get);
         sinon.assert.notCalled(eventRepositoryStub.registerPayment);
 
-        // expect(apiStub.getSubscription.called).to.be.false;
-        assert(apiStub.getSubscription.called === false);
+        sinon.assert.notCalled(apiStub.getSubscription);
     });
 
     it('should return early if invoice is a one-time payment', async function () {
@@ -52,8 +51,7 @@ describe('InvoiceEventService', function () {
         sinon.assert.notCalled(memberRepositoryStub.get);
         sinon.assert.notCalled(eventRepositoryStub.registerPayment);
 
-        // expect(apiStub.getSubscription.called).to.be.false;
-        assert(apiStub.getSubscription.called === false);
+        sinon.assert.notCalled(apiStub.getSubscription);
     });
 
     it('should throw NotFoundError if no member is found for subscription customer', async function () {
@@ -99,9 +97,9 @@ describe('InvoiceEventService', function () {
         // sinon.assert.calledOnce(memberRepositoryStub.get);
         // sinon.assert.notCalled(productRepositoryStub.get);
 
-        assert(apiStub.getSubscription.calledOnce);
-        assert(memberRepositoryStub.get.calledOnce);
-        assert(productRepositoryStub.get.notCalled);
+        sinon.assert.calledOnce(apiStub.getSubscription);
+        sinon.assert.calledOnce(memberRepositoryStub.get);
+        sinon.assert.notCalled(productRepositoryStub.get);
     });
 
     it('should return early if product is not found', async function () {
@@ -115,9 +113,9 @@ describe('InvoiceEventService', function () {
 
         await service.handleInvoiceEvent(invoice);
 
-        assert(apiStub.getSubscription.calledOnce);
-        assert(memberRepositoryStub.get.calledOnce);
-        assert(productRepositoryStub.get.calledOnce);
+        sinon.assert.calledOnce(apiStub.getSubscription);
+        sinon.assert.calledOnce(memberRepositoryStub.get);
+        sinon.assert.calledOnce(productRepositoryStub.get);
     });
 
     it('can registerPayment', async function () {
@@ -134,7 +132,7 @@ describe('InvoiceEventService', function () {
         await service.handleInvoiceEvent(invoice);
 
         // sinon.assert.calledOnce(eventRepositoryStub.registerPayment);
-        assert(eventRepositoryStub.registerPayment.calledOnce);
+        sinon.assert.calledOnce(eventRepositoryStub.registerPayment);
     });
 
     it('should not registerPayment if invoice is not paid', async function () {
@@ -151,7 +149,7 @@ describe('InvoiceEventService', function () {
         await service.handleInvoiceEvent(invoice);
 
         // sinon.assert.notCalled(eventRepositoryStub.registerPayment);
-        assert(eventRepositoryStub.registerPayment.notCalled);
+        sinon.assert.notCalled(eventRepositoryStub.registerPayment);
     });
 
     it('should not registerPayment if invoice amount paid is 0', async function () {
@@ -168,7 +166,7 @@ describe('InvoiceEventService', function () {
         await service.handleInvoiceEvent(invoice);
 
         // sinon.assert.notCalled(eventRepositoryStub.registerPayment);
-        assert(eventRepositoryStub.registerPayment.notCalled);
+        sinon.assert.notCalled(eventRepositoryStub.registerPayment);
     });
 
     it('should not register payment if amount paid is 0 and invoice is not paid', async function () {
@@ -184,7 +182,7 @@ describe('InvoiceEventService', function () {
 
         await service.handleInvoiceEvent(invoice);
 
-        assert(eventRepositoryStub.registerPayment.notCalled);
+        sinon.assert.notCalled(eventRepositoryStub.registerPayment);
     });
 
     it('should not registerPayment if member is not found', async function () {
@@ -208,6 +206,6 @@ describe('InvoiceEventService', function () {
 
         assert(error instanceof errors.NotFoundError);
 
-        assert(eventRepositoryStub.registerPayment.notCalled);
+        sinon.assert.notCalled(eventRepositoryStub.registerPayment);
     });
 });

--- a/ghost/core/test/unit/server/services/stripe/services/webhooks/subscription-event-service.test.js
+++ b/ghost/core/test/unit/server/services/stripe/services/webhooks/subscription-event-service.test.js
@@ -110,6 +110,6 @@ describe('SubscriptionEventService', function () {
 
         await service.handleSubscriptionEvent(subscription);
 
-        assert(memberRepository.linkSubscription.calledWith({id: 'member_123', subscription}));
+        sinon.assert.calledWith(memberRepository.linkSubscription, {id: 'member_123', subscription});
     });
 });

--- a/ghost/core/test/unit/server/services/stripe/stripe-api.test.js
+++ b/ghost/core/test/unit/server/services/stripe/stripe-api.test.js
@@ -375,7 +375,7 @@ describe('StripeAPI', function () {
         it('cancels a subscription trial', async function () {
             const result = await api.cancelSubscriptionTrial(mockSubscription.id);
 
-            assert.equal(mockStripe.subscriptions.update.callCount, 1);
+            sinon.assert.calledOnce(mockStripe.subscriptions.update);
 
             assert.equal(mockStripe.subscriptions.update.args[0][0], mockSubscription.id);
             assert.deepEqual(mockStripe.subscriptions.update.args[0][1], {trial_end: 'now'});
@@ -415,7 +415,7 @@ describe('StripeAPI', function () {
         it('adds a coupon to a subscription', async function () {
             const result = await api.addCouponToSubscription('sub_123', 'coupon_abc');
 
-            assert.equal(mockStripe.subscriptions.update.callCount, 1);
+            sinon.assert.calledOnce(mockStripe.subscriptions.update);
             assert.equal(mockStripe.subscriptions.update.args[0][0], 'sub_123');
             assert.deepEqual(mockStripe.subscriptions.update.args[0][1], {coupon: 'coupon_abc'});
 

--- a/ghost/core/test/unit/server/services/stripe/webhook-controller.test.js
+++ b/ghost/core/test/unit/server/services/stripe/webhook-controller.test.js
@@ -1,4 +1,3 @@
-const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const WebhookController = require('../../../../../core/server/services/stripe/webhook-controller');
 
@@ -34,14 +33,14 @@ describe('WebhookController', function () {
     it('should return 400 if request body or signature is missing', async function () {
         req.body = null;
         await controller.handle(req, res);
-        assert(res.writeHead.calledWith(400));
+        sinon.assert.calledWith(res.writeHead, 400);
     });
 
     it('should return 401 if webhook signature is invalid', async function () {
         deps.webhookManager.parseWebhook.throws(new Error('Invalid signature'));
         await controller.handle(req, res);
-        assert(res.writeHead.calledWith(401));
-        assert(res.end.called);
+        sinon.assert.calledWith(res.writeHead, 401);
+        sinon.assert.called(res.end);
     });
 
     it('should handle customer.subscription.created event', async function () {
@@ -55,9 +54,9 @@ describe('WebhookController', function () {
 
         await controller.handle(req, res);
 
-        assert(deps.subscriptionEventService.handleSubscriptionEvent.calledOnce);
-        assert(res.writeHead.calledWith(200));
-        assert(res.end.called);
+        sinon.assert.calledOnce(deps.subscriptionEventService.handleSubscriptionEvent);
+        sinon.assert.calledWith(res.writeHead, 200);
+        sinon.assert.called(res.end);
     });
 
     it('should handle invoice.payment_succeeded event', async function () {
@@ -71,9 +70,9 @@ describe('WebhookController', function () {
 
         await controller.handle(req, res);
 
-        assert(deps.invoiceEventService.handleInvoiceEvent.calledOnce);
-        assert(res.writeHead.calledWith(200));
-        assert(res.end.called);
+        sinon.assert.calledOnce(deps.invoiceEventService.handleInvoiceEvent);
+        sinon.assert.calledWith(res.writeHead, 200);
+        sinon.assert.called(res.end);
 
         // expect(deps.invoiceEventService.handleInvoiceEvent.calledOnce).to.be.true;
         // expect(res.writeHead.calledWith(200)).to.be.true;
@@ -90,9 +89,9 @@ describe('WebhookController', function () {
         deps.webhookManager.parseWebhook.returns(event);
 
         await controller.handle(req, res);
-        assert(deps.checkoutSessionEventService.handleEvent.calledOnce);
-        assert(res.writeHead.calledWith(200));
-        assert(res.end.called);
+        sinon.assert.calledOnce(deps.checkoutSessionEventService.handleEvent);
+        sinon.assert.calledWith(res.writeHead, 200);
+        sinon.assert.called(res.end);
         // expect(deps.checkoutSessionEventService.handleEvent.calledOnce).to.be.true;
         // expect(res.writeHead.calledWith(200)).to.be.true;
         // expect(res.end.called).to.be.true;
@@ -110,9 +109,9 @@ describe('WebhookController', function () {
 
         await controller.handle(req, res);
 
-        assert(deps.subscriptionEventService.handleSubscriptionEvent.calledOnce);
-        assert(res.writeHead.calledWith(200));
-        assert(res.end.called);
+        sinon.assert.calledOnce(deps.subscriptionEventService.handleSubscriptionEvent);
+        sinon.assert.calledWith(res.writeHead, 200);
+        sinon.assert.called(res.end);
     });
 
     it('should ignore customer.subscription.updated events for customers in the ignore list', async function () {
@@ -129,9 +128,9 @@ describe('WebhookController', function () {
 
         await controller.handle(req, res);
 
-        assert(deps.subscriptionEventService.handleSubscriptionEvent.notCalled);
-        assert(res.writeHead.calledWith(200));
-        assert(res.end.called);
+        sinon.assert.notCalled(deps.subscriptionEventService.handleSubscriptionEvent);
+        sinon.assert.calledWith(res.writeHead, 200);
+        sinon.assert.called(res.end);
     });
 
     it('should handle customer.subscription.updated events for customers not in the ignore list', async function () {
@@ -147,9 +146,9 @@ describe('WebhookController', function () {
 
         await controller.handle(req, res);
 
-        assert(deps.subscriptionEventService.handleSubscriptionEvent.calledOnce);
-        assert(res.writeHead.calledWith(200));
-        assert(res.end.called);
+        sinon.assert.calledOnce(deps.subscriptionEventService.handleSubscriptionEvent);
+        sinon.assert.calledWith(res.writeHead, 200);
+        sinon.assert.called(res.end);
     });
 
     it('should handle customer.subscription.deleted event', async function () {
@@ -164,9 +163,9 @@ describe('WebhookController', function () {
 
         await controller.handle(req, res);
 
-        assert(deps.subscriptionEventService.handleSubscriptionEvent.calledOnce);
-        assert(res.writeHead.calledWith(200));
-        assert(res.end.called);
+        sinon.assert.calledOnce(deps.subscriptionEventService.handleSubscriptionEvent);
+        sinon.assert.calledWith(res.writeHead, 200);
+        sinon.assert.called(res.end);
     });
 
     it('should return 500 if an error occurs', async function () {
@@ -182,8 +181,8 @@ describe('WebhookController', function () {
 
         await controller.handle(req, res);
 
-        assert(res.writeHead.calledWith(500));
-        assert(res.end.called);
+        sinon.assert.calledWith(res.writeHead, 500);
+        sinon.assert.called(res.end);
     });
 
     it('should not handle unknown event type', async function () {
@@ -198,7 +197,7 @@ describe('WebhookController', function () {
 
         await controller.handle(req, res);
 
-        assert(res.writeHead.calledWith(200));
-        assert(res.end.called);
+        sinon.assert.calledWith(res.writeHead, 200);
+        sinon.assert.called(res.end);
     });
 });

--- a/ghost/core/test/unit/server/services/themes/list.test.js
+++ b/ghost/core/test/unit/server/services/themes/list.test.js
@@ -65,9 +65,9 @@ describe('Themes', function () {
             const setSpy = sinon.spy(themeList, 'set');
 
             themeList.init({test: {a: 'b'}, casper: {c: 'd'}});
-            assert.equal(setSpy.calledTwice, true);
-            assert.equal(setSpy.firstCall.calledWith('test', {a: 'b'}), true);
-            assert.equal(setSpy.secondCall.calledWith('casper', {c: 'd'}), true);
+            sinon.assert.calledTwice(setSpy);
+            sinon.assert.calledWith(setSpy.firstCall, 'test', {a: 'b'});
+            sinon.assert.calledWith(setSpy.secondCall, 'casper', {c: 'd'});
         });
 
         it('init() with empty object resets the list', function () {

--- a/ghost/core/test/unit/server/services/themes/validate.test.js
+++ b/ghost/core/test/unit/server/services/themes/validate.test.js
@@ -47,10 +47,10 @@ describe('Themes', function () {
 
             return validate.check(testTheme.name, testTheme, {isZip: true})
                 .then((checkedTheme) => {
-                    assert.equal(checkZipStub.calledOnce, true);
-                    assert.equal(checkZipStub.calledWith(testTheme), true);
+                    sinon.assert.calledOnce(checkZipStub);
+                    sinon.assert.calledWith(checkZipStub, testTheme);
                     sinon.assert.notCalled(checkStub);
-                    assert.equal(formatStub.calledOnce, true);
+                    sinon.assert.calledOnce(formatStub);
                     assert(_.isPlainObject(checkedTheme));
 
                     assert.equal(validate.canActivate(checkedTheme), true);
@@ -64,9 +64,9 @@ describe('Themes', function () {
             return validate.check(testTheme.name, testTheme, {isZip: false})
                 .then((checkedTheme) => {
                     sinon.assert.notCalled(checkZipStub);
-                    assert.equal(checkStub.calledOnce, true);
-                    assert.equal(checkStub.calledWith(testTheme.path), true);
-                    assert.equal(formatStub.calledOnce, true);
+                    sinon.assert.calledOnce(checkStub);
+                    sinon.assert.calledWith(checkStub, testTheme.path);
+                    sinon.assert.calledOnce(formatStub);
                     assert(_.isPlainObject(checkedTheme));
 
                     assert.equal(validate.canActivate(checkedTheme), true);
@@ -93,10 +93,10 @@ describe('Themes', function () {
 
             return validate.check(testTheme.name, testTheme, {isZip: true})
                 .then((checkedTheme) => {
-                    assert.equal(checkZipStub.calledOnce, true);
-                    assert.equal(checkZipStub.calledWith(testTheme), true);
+                    sinon.assert.calledOnce(checkZipStub);
+                    sinon.assert.calledWith(checkZipStub, testTheme);
                     sinon.assert.notCalled(checkStub);
-                    assert.equal(formatStub.calledOnce, true);
+                    sinon.assert.calledOnce(formatStub);
 
                     assert.equal(validate.canActivate(checkedTheme), false);
                 });
@@ -122,10 +122,10 @@ describe('Themes', function () {
 
             return validate.check(testTheme.name, testTheme, {isZip: false})
                 .then((checkedTheme) => {
-                    assert.equal(checkStub.calledOnce, true);
-                    assert.equal(checkStub.calledWith(testTheme.path), true);
+                    sinon.assert.calledOnce(checkStub);
+                    sinon.assert.calledWith(checkStub, testTheme.path);
                     sinon.assert.notCalled(checkZipStub);
-                    assert.equal(formatStub.calledOnce, true);
+                    sinon.assert.calledOnce(formatStub);
 
                     assert.equal(validate.canActivate(checkedTheme), false);
                 });

--- a/ghost/core/test/unit/server/services/tiers/tier-repository.test.js
+++ b/ghost/core/test/unit/server/services/tiers/tier-repository.test.js
@@ -37,11 +37,11 @@ describe('TierRepository', function () {
 
         await repository.save(tier);
 
-        assert(ProductModel.add.calledOnce);
+        sinon.assert.calledOnce(ProductModel.add);
 
         const result = await repository.getById(tier.id);
 
-        assert(ProductModel.findOne.notCalled);
+        sinon.assert.notCalled(ProductModel.findOne);
 
         assert(result);
 
@@ -49,6 +49,6 @@ describe('TierRepository', function () {
 
         await repository.save(tier);
 
-        assert(ProductModel.edit.calledOnce);
+        sinon.assert.calledOnce(ProductModel.edit);
     });
 });

--- a/ghost/core/test/unit/server/services/update-check.test.js
+++ b/ghost/core/test/unit/server/services/update-check.test.js
@@ -100,7 +100,7 @@ describe('Update Check', function () {
 
             await updateCheckService.check();
 
-            assert.equal(requestStub.called, false);
+            sinon.assert.notCalled(requestStub);
         });
 
         it('update check will happen if it\'s time to check', async function () {
@@ -280,7 +280,7 @@ describe('Update Check', function () {
 
             await updateCheckService.check();
 
-            assert.equal(notificationsAPIAddStub.calledOnce, true);
+            sinon.assert.calledOnce(notificationsAPIAddStub);
             assert.equal(notificationsAPIAddStub.args[0][0].notifications.length, 1);
 
             const targetNotification = notificationsAPIAddStub.args[0][0].notifications[0];
@@ -290,7 +290,7 @@ describe('Update Check', function () {
             assert.equal(targetNotification.type, 'info');
             assert.equal(targetNotification.message, notification.messages[0].content);
 
-            assert.equal(usersBrowseStub.calledTwice, true);
+            sinon.assert.calledTwice(usersBrowseStub);
 
             // Second (non statistical) call should be looking for admin users with an 'active' status only
             assert.deepEqual(usersBrowseStub.args[1][0], {
@@ -361,13 +361,13 @@ describe('Update Check', function () {
 
             await updateCheckService.check();
 
-            assert.equal(sendEmailStub.called, true);
+            sinon.assert.called(sendEmailStub);
             assert.equal(sendEmailStub.args[0][0].to, 'jbloggs@example.com');
             assert.equal(sendEmailStub.args[0][0].subject, 'Action required: Critical alert from Ghost instance http://127.0.0.1:2369');
             assert.equal(sendEmailStub.args[0][0].html, '<p>Critical message. Upgrade your site!</p>');
             assert.equal(sendEmailStub.args[0][0].forceTextContent, true);
 
-            assert.equal(notificationsAPIAddStub.calledOnce, true);
+            sinon.assert.calledOnce(notificationsAPIAddStub);
             assert.equal(notificationsAPIAddStub.args[0][0].notifications.length, 1);
         });
 
@@ -416,7 +416,7 @@ describe('Update Check', function () {
 
             await updateCheckService.check();
 
-            assert.equal(notificationsAPIAddStub.calledOnce, false);
+            sinon.assert.notCalled(notificationsAPIAddStub);
         });
     });
 
@@ -433,8 +433,8 @@ describe('Update Check', function () {
 
             updateCheckService.updateCheckError({});
 
-            assert.equal(settingsStub.called, true);
-            assert.equal(logging.error.called, true);
+            sinon.assert.called(settingsStub);
+            sinon.assert.called(logging.error);
             assert.equal(logging.error.args[0][0].context, 'Checking for updates failed, your site will continue to function.');
             assert.equal(logging.error.args[0][0].help, 'If you get this error repeatedly, please seek help from https://ghost.org/docs/');
         });
@@ -455,8 +455,8 @@ describe('Update Check', function () {
                 updateCheckService.updateCheckError({});
                 assert.fail('should have thrown');
             } catch (e) {
-                assert.equal(settingsStub.called, true);
-                assert.equal(logging.error.called, true);
+                sinon.assert.called(settingsStub);
+                sinon.assert.called(logging.error);
                 assert.equal(logging.error.args[0][0].context, 'Checking for updates failed, your site will continue to function.');
                 assert.equal(logging.error.args[0][0].help, 'If you get this error repeatedly, please seek help from https://ghost.org/docs/');
 

--- a/ghost/core/test/unit/server/services/url/local-file-cache.test.js
+++ b/ghost/core/test/unit/server/services/url/local-file-cache.test.js
@@ -66,7 +66,7 @@ describe('Unit: services/url/LocalFileCache', function () {
             const result = await localFileCache.write('urls', {data: 'test'});
 
             assert.equal(result, true);
-            assert.equal(writeFileStub.called, true);
+            sinon.assert.called(writeFileStub);
         });
 
         it('does not write to the file system is writes are disabled', async function () {
@@ -83,7 +83,7 @@ describe('Unit: services/url/LocalFileCache', function () {
             const result = await localFileCache.write('urls', {data: 'test'});
 
             assert.equal(result, null);
-            assert.equal(writeFileStub.called, false);
+            sinon.assert.notCalled(writeFileStub);
         });
     });
 });

--- a/ghost/core/test/unit/server/services/url/queue.test.js
+++ b/ghost/core/test/unit/server/services/url/queue.test.js
@@ -55,7 +55,7 @@ describe('Unit: services/url/Queue', function () {
         it('no subscribers', function (done) {
             queue.addListener('ended', function (event) {
                 assert.equal(event, 'nachos');
-                assert.equal(queueRunSpy.callCount, 1);
+                sinon.assert.calledOnce(queueRunSpy);
                 done();
             });
 
@@ -69,7 +69,7 @@ describe('Unit: services/url/Queue', function () {
 
             queue.addListener('ended', function (event) {
                 assert.equal(event, 'nachos');
-                assert.equal(queueRunSpy.callCount, 2);
+                sinon.assert.calledTwice(queueRunSpy);
                 assert.equal(notified, 1);
                 done();
             });
@@ -93,7 +93,7 @@ describe('Unit: services/url/Queue', function () {
                 assert.equal(event, 'nachos');
 
                 // 9 subscribers + start triggers run
-                assert.equal(queueRunSpy.callCount, 10);
+                sinon.assert.callCount(queueRunSpy, 10);
                 assert.equal(notified, 9);
                 assert.deepEqual(order, [0, 1, 2, 3, 4, 5, 6, 7, 8]);
                 done();
@@ -118,7 +118,7 @@ describe('Unit: services/url/Queue', function () {
 
             queue.addListener('ended', function (event) {
                 assert.equal(event, 'nachos');
-                assert.equal(queueRunSpy.callCount, 1);
+                sinon.assert.calledOnce(queueRunSpy);
                 assert.equal(notified, 0);
                 done();
             });
@@ -145,7 +145,7 @@ describe('Unit: services/url/Queue', function () {
                 event: 'nachos'
             });
 
-            assert.equal(logging.error.calledOnce, true);
+            sinon.assert.calledOnce(logging.error);
             assert.equal(queue.toNotify.nachos.notified.length, 0);
         });
     });

--- a/ghost/core/test/unit/server/services/url/url-generator.test.js
+++ b/ghost/core/test/unit/server/services/url/url-generator.test.js
@@ -59,7 +59,7 @@ describe('Unit: services/url/UrlGenerator', function () {
     it('ensure listeners', function () {
         const urlGenerator = new UrlGenerator({router, queue});
 
-        assert.equal(queue.register.calledTwice, true);
+        sinon.assert.calledTwice(queue.register);
         assert.equal(urlGenerator.filter, undefined);
     });
 
@@ -97,10 +97,10 @@ describe('Unit: services/url/UrlGenerator', function () {
 
         urlGenerator.regenerateResources();
 
-        assert.equal(urls.removeResourceId.calledTwice, true);
-        assert.equal(resource.release.calledOnce, true);
-        assert.equal(resource2.release.calledOnce, true);
-        assert.equal(urlGenerator._try.calledTwice, true);
+        sinon.assert.calledTwice(urls.removeResourceId);
+        sinon.assert.calledOnce(resource.release);
+        sinon.assert.calledOnce(resource2.release);
+        sinon.assert.calledTwice(urlGenerator._try);
     });
 
     describe('fn: _onInit', function () {
@@ -117,7 +117,7 @@ describe('Unit: services/url/UrlGenerator', function () {
             sinon.stub(urlGenerator, '_try');
 
             urlGenerator._onInit();
-            assert.equal(urlGenerator._try.calledOnce, true);
+            sinon.assert.calledOnce(urlGenerator._try);
         });
 
         it('no resource', function () {
@@ -133,7 +133,7 @@ describe('Unit: services/url/UrlGenerator', function () {
             sinon.stub(urlGenerator, '_try');
 
             urlGenerator._onInit();
-            assert.equal(urlGenerator._try.called, false);
+            sinon.assert.notCalled(urlGenerator._try);
         });
     });
 
@@ -151,7 +151,7 @@ describe('Unit: services/url/UrlGenerator', function () {
             sinon.stub(urlGenerator, '_try');
 
             urlGenerator._onAdded({id: 1, type: 'posts'});
-            assert.equal(urlGenerator._try.calledOnce, true);
+            sinon.assert.calledOnce(urlGenerator._try);
         });
 
         it('type is not equal', function () {
@@ -165,7 +165,7 @@ describe('Unit: services/url/UrlGenerator', function () {
             sinon.stub(urlGenerator, '_try');
 
             urlGenerator._onAdded({id: 1, type: 'posts'});
-            assert.equal(urlGenerator._try.called, false);
+            sinon.assert.notCalled(urlGenerator._try);
         });
     });
 
@@ -188,10 +188,10 @@ describe('Unit: services/url/UrlGenerator', function () {
 
                 urlGenerator._try(resource);
 
-                assert.equal(urlGenerator._generateUrl.calledOnce, true);
-                assert.equal(urlGenerator._resourceListeners.calledOnce, true);
-                assert.equal(urls.add.calledOnce, true);
-                assert.equal(resource.reserve.calledOnce, true);
+                sinon.assert.calledOnce(urlGenerator._generateUrl);
+                sinon.assert.calledOnce(urlGenerator._resourceListeners);
+                sinon.assert.calledOnce(urls.add);
+                sinon.assert.calledOnce(resource.reserve);
             });
 
             it('resource is taken', function () {
@@ -212,10 +212,10 @@ describe('Unit: services/url/UrlGenerator', function () {
 
                 urlGenerator._try(resource);
 
-                assert.equal(urlGenerator._generateUrl.called, false);
-                assert.equal(urlGenerator._resourceListeners.called, false);
-                assert.equal(urls.add.called, false);
-                assert.equal(resource.reserve.called, false);
+                sinon.assert.notCalled(urlGenerator._generateUrl);
+                sinon.assert.notCalled(urlGenerator._resourceListeners);
+                sinon.assert.notCalled(urls.add);
+                sinon.assert.notCalled(resource.reserve);
             });
         });
 
@@ -238,11 +238,11 @@ describe('Unit: services/url/UrlGenerator', function () {
 
                 urlGenerator._try(resource);
 
-                assert.equal(urlGenerator._generateUrl.calledOnce, true);
-                assert.equal(urlGenerator._resourceListeners.calledOnce, true);
-                assert.equal(urls.add.calledOnce, true);
-                assert.equal(resource.reserve.calledOnce, true);
-                assert.equal(urlGenerator.nql.queryJSON.called, true);
+                sinon.assert.calledOnce(urlGenerator._generateUrl);
+                sinon.assert.calledOnce(urlGenerator._resourceListeners);
+                sinon.assert.calledOnce(urls.add);
+                sinon.assert.calledOnce(resource.reserve);
+                sinon.assert.called(urlGenerator.nql.queryJSON);
             });
 
             it('no match', function () {
@@ -263,11 +263,11 @@ describe('Unit: services/url/UrlGenerator', function () {
 
                 urlGenerator._try(resource);
 
-                assert.equal(urlGenerator._generateUrl.calledOnce, false);
-                assert.equal(urlGenerator._resourceListeners.called, false);
-                assert.equal(urls.add.called, false);
-                assert.equal(resource.reserve.called, false);
-                assert.equal(urlGenerator.nql.queryJSON.called, true);
+                sinon.assert.notCalled(urlGenerator._generateUrl);
+                sinon.assert.notCalled(urlGenerator._resourceListeners);
+                sinon.assert.notCalled(urls.add);
+                sinon.assert.notCalled(resource.reserve);
+                sinon.assert.called(urlGenerator.nql.queryJSON);
             });
 
             it('resource is taken', function () {
@@ -288,11 +288,11 @@ describe('Unit: services/url/UrlGenerator', function () {
 
                 urlGenerator._try(resource);
 
-                assert.equal(urlGenerator._generateUrl.called, false);
-                assert.equal(urlGenerator._resourceListeners.called, false);
-                assert.equal(urls.add.called, false);
-                assert.equal(resource.reserve.called, false);
-                assert.equal(urlGenerator.nql.queryJSON.called, false);
+                sinon.assert.notCalled(urlGenerator._generateUrl);
+                sinon.assert.notCalled(urlGenerator._resourceListeners);
+                sinon.assert.notCalled(urls.add);
+                sinon.assert.notCalled(resource.reserve);
+                sinon.assert.notCalled(urlGenerator.nql.queryJSON);
             });
 
             it('filter is malformed', function () {
@@ -334,7 +334,7 @@ describe('Unit: services/url/UrlGenerator', function () {
             sinon.stub(urlUtils, 'replacePermalink').get(() => replacePermalink);
 
             assert.equal(urlGenerator._generateUrl(resource), '/url/');
-            assert.equal(replacePermalink.calledWith('/:slug/', resource.data), true);
+            sinon.assert.calledWith(replacePermalink, '/:slug/', resource.data);
         });
     });
 
@@ -343,8 +343,8 @@ describe('Unit: services/url/UrlGenerator', function () {
             const urlGenerator = new UrlGenerator({router, queue, resources, urls});
 
             urlGenerator._resourceListeners(resource);
-            assert.equal(resource.removeAllListeners.calledOnce, true);
-            assert.equal(resource.addListener.calledTwice, true);
+            sinon.assert.calledOnce(resource.removeAllListeners);
+            sinon.assert.calledTwice(resource.addListener);
         });
 
         it('resource was updated', function () {
@@ -359,10 +359,10 @@ describe('Unit: services/url/UrlGenerator', function () {
             urlGenerator._resourceListeners(resource);
             resource.addListener.args[0][1](resource);
 
-            assert.equal(urlGenerator._try.called, false);
-            assert.equal(urls.removeResourceId.called, true);
-            assert.equal(resource.release.called, true);
-            assert.equal(queue.start.called, true);
+            sinon.assert.notCalled(urlGenerator._try);
+            sinon.assert.called(urls.removeResourceId);
+            sinon.assert.called(resource.release);
+            sinon.assert.called(queue.start);
         });
 
         it('resource got removed', function () {
@@ -374,8 +374,8 @@ describe('Unit: services/url/UrlGenerator', function () {
             };
 
             resource.addListener.args[1][1](resource);
-            assert.equal(urls.removeResourceId.calledOnce, true);
-            assert.equal(resource.release.calledOnce, true);
+            sinon.assert.calledOnce(urls.removeResourceId);
+            sinon.assert.calledOnce(resource.release);
         });
     });
 });

--- a/ghost/core/test/unit/server/services/url/url-service.test.js
+++ b/ghost/core/test/unit/server/services/url/url-service.test.js
@@ -50,7 +50,7 @@ describe('Unit: services/url/UrlService', function () {
         assert.deepEqual(urlService.urlGenerators, []);
         assert.equal(urlService.hasFinished(), false);
 
-        assert.equal(urlService.queue.addListener.calledTwice, true);
+        sinon.assert.calledTwice(urlService.queue.addListener);
         assert.equal(urlService.queue.addListener.args[0][0], 'started');
         assert.equal(urlService.queue.addListener.args[1][0], 'ended');
     });
@@ -201,7 +201,7 @@ describe('Unit: services/url/UrlService', function () {
             urlService.urls.getByResourceId.withArgs(1).returns(null);
             urlService.getUrlByResourceId(1, {absolute: true});
 
-            assert.equal(urlService.utils.createUrl.calledWith('/404/', true), true);
+            sinon.assert.calledWith(urlService.utils.createUrl, '/404/', true);
         });
 
         it('found', function () {
@@ -215,7 +215,7 @@ describe('Unit: services/url/UrlService', function () {
 
             urlService.urls.getByResourceId.withArgs(1).returns({url: '/post/'});
             urlService.getUrlByResourceId(1, {absolute: true});
-            assert.equal(urlService.utils.createUrl.calledWith('/post/', true), true);
+            sinon.assert.calledWith(urlService.utils.createUrl, '/post/', true);
         });
 
         it('not found: withSubdirectory', function () {
@@ -224,7 +224,7 @@ describe('Unit: services/url/UrlService', function () {
 
             urlService.urls.getByResourceId.withArgs(1).returns(null);
             urlService.getUrlByResourceId(1, {withSubdirectory: true});
-            assert.equal(urlService.utils.createUrl.calledWith('/404/', false), true);
+            sinon.assert.calledWith(urlService.utils.createUrl, '/404/', false);
         });
 
         it('not found: withSubdirectory + absolute', function () {
@@ -233,7 +233,7 @@ describe('Unit: services/url/UrlService', function () {
 
             urlService.urls.getByResourceId.withArgs(1).returns(null);
             urlService.getUrlByResourceId(1, {withSubdirectory: true, absolute: true});
-            assert.equal(urlService.utils.createUrl.calledWith('/404/', true), true);
+            sinon.assert.calledWith(urlService.utils.createUrl, '/404/', true);
         });
 
         it('found: withSubdirectory', function () {
@@ -242,7 +242,7 @@ describe('Unit: services/url/UrlService', function () {
 
             urlService.urls.getByResourceId.withArgs(1).returns({url: '/post/'});
             urlService.getUrlByResourceId(1, {withSubdirectory: true});
-            assert.equal(urlService.utils.createUrl.calledWith('/post/', false), true);
+            sinon.assert.calledWith(urlService.utils.createUrl, '/post/', false);
         });
 
         it('found: withSubdirectory + absolute', function () {
@@ -251,7 +251,7 @@ describe('Unit: services/url/UrlService', function () {
 
             urlService.urls.getByResourceId.withArgs(1).returns({url: '/post/'});
             urlService.getUrlByResourceId(1, {withSubdirectory: true, absolute: true});
-            assert.equal(urlService.utils.createUrl.calledWith('/post/', true), true);
+            sinon.assert.calledWith(urlService.utils.createUrl, '/post/', true);
         });
     });
 });

--- a/ghost/core/test/unit/server/services/users/users-service.test.js
+++ b/ghost/core/test/unit/server/services/users/users-service.test.js
@@ -39,12 +39,12 @@ describe('Users service', function () {
                 context: {}
             });
 
-            assert.equal(mockOptions.auth.passwordreset.generateToken.calledOnce, true);
+            sinon.assert.calledOnce(mockOptions.auth.passwordreset.generateToken);
             assert.equal(mockOptions.auth.passwordreset.generateToken.args[0][0], 'test_email@example.com');
             assert.equal(mockOptions.auth.passwordreset.generateToken.args[0][1], 'fake_api_settings');
             assert.equal(mockOptions.auth.passwordreset.generateToken.args[0][2], 'fake_transaction');
 
-            assert.equal(mockOptions.auth.passwordreset.sendResetNotification.calledOnce, true);
+            sinon.assert.calledOnce(mockOptions.auth.passwordreset.sendResetNotification);
             assert.equal(mockOptions.auth.passwordreset.sendResetNotification.args[0][0], 'secret_fake_token');
             assert.equal(mockOptions.auth.passwordreset.sendResetNotification.args[0][1], 'fake_api_mail');
         });

--- a/ghost/core/test/unit/server/services/verification-trigger.test.js
+++ b/ghost/core/test/unit/server/services/verification-trigger.test.js
@@ -65,7 +65,7 @@ describe('Import threshold', function () {
 
         const result = await trigger.getImportThreshold();
         assert.equal(result, Infinity);
-        assert.equal(membersStub.callCount, 0);
+        sinon.assert.notCalled(membersStub);
     });
 });
 
@@ -97,8 +97,8 @@ describe('Email verification flow', function () {
         });
 
         assert.equal(result.needsVerification, true);
-        assert.equal(emailStub.callCount, 1);
-        assert.equal(settingsStub.callCount, 1);
+        sinon.assert.calledOnce(emailStub);
+        sinon.assert.calledOnce(settingsStub);
     });
 
     it('Does not trigger verification when already verified', async function () {
@@ -119,8 +119,8 @@ describe('Email verification flow', function () {
         });
 
         assert.equal(result.needsVerification, false);
-        assert.equal(emailStub.callCount, 0);
-        assert.equal(settingsStub.callCount, 0);
+        sinon.assert.notCalled(emailStub);
+        sinon.assert.notCalled(settingsStub);
     });
 
     it('Does not trigger verification when already in progress', async function () {
@@ -141,8 +141,8 @@ describe('Email verification flow', function () {
         });
 
         assert.equal(result.needsVerification, false);
-        assert.equal(emailStub.callCount, 0);
-        assert.equal(settingsStub.callCount, 0);
+        sinon.assert.notCalled(emailStub);
+        sinon.assert.notCalled(settingsStub);
     });
 
     it('Throws when `throwsOnTrigger` is true', async function () {
@@ -232,7 +232,7 @@ describe('Email verification flow', function () {
             source: 'api'
         }, new Date()));
 
-        assert.equal(eventStub.callCount, 1);
+        sinon.assert.calledOnce(eventStub);
         assert('source' in eventStub.lastCall.lastArg);
         assert.equal(eventStub.lastCall.lastArg.source, 'api');
         assert('created_at' in eventStub.lastCall.lastArg);
@@ -265,7 +265,7 @@ describe('Email verification flow', function () {
             source: 'api'
         }, new Date()));
 
-        assert.equal(eventStub.callCount, 0);
+        sinon.assert.notCalled(eventStub);
     });
 
     it('Triggers when a number of members are imported', async function () {
@@ -306,14 +306,14 @@ describe('Email verification flow', function () {
 
         await trigger.testImportThreshold();
 
-        assert.equal(eventStub.callCount, 2);
+        sinon.assert.calledTwice(eventStub);
         assert('source' in eventStub.firstCall.lastArg);
         assert.equal(eventStub.firstCall.lastArg.source, 'import');
         assert('created_at' in eventStub.firstCall.lastArg);
         assert('$gt' in eventStub.firstCall.lastArg.created_at);
         assert.match(eventStub.firstCall.lastArg.created_at.$gt, /\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/);
 
-        assert.equal(emailStub.callCount, 1);
+        sinon.assert.calledOnce(emailStub);
         assert.deepEqual(emailStub.lastCall.firstArg, {
             subject: 'Email needs verification',
             message: 'Email verification needed for site: {siteUrl}, has imported: {amountTriggered} members in the last 30 days.',
@@ -429,14 +429,14 @@ describe('Email verification flow', function () {
             }
         });
 
-        assert.equal(eventStub.callCount, 2);
+        sinon.assert.calledTwice(eventStub);
         assert('source' in eventStub.firstCall.lastArg);
         assert.equal(eventStub.firstCall.lastArg.source, 'admin');
         assert('created_at' in eventStub.firstCall.lastArg);
         assert('$gt' in eventStub.firstCall.lastArg.created_at);
         assert.match(eventStub.firstCall.lastArg.created_at.$gt, /\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/);
 
-        assert.equal(emailStub.callCount, 1);
+        sinon.assert.calledOnce(emailStub);
         assert.deepEqual(emailStub.lastCall.firstArg, {
             subject: 'Email needs verification',
             message: 'Email verification needed for site: {siteUrl} has added: {amountTriggered} members through the Admin client in the last 30 days.',
@@ -487,14 +487,14 @@ describe('Email verification flow', function () {
             }
         });
 
-        assert.equal(eventStub.callCount, 2);
+        sinon.assert.calledTwice(eventStub);
         assert('source' in eventStub.firstCall.lastArg);
         assert.equal(eventStub.firstCall.lastArg.source, 'api');
         assert('created_at' in eventStub.firstCall.lastArg);
         assert('$gt' in eventStub.firstCall.lastArg.created_at);
         assert.match(eventStub.firstCall.lastArg.created_at.$gt, /\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/);
 
-        assert.equal(emailStub.callCount, 1);
+        sinon.assert.calledOnce(emailStub);
         assert.deepEqual(emailStub.lastCall.firstArg, {
             subject: 'Email needs verification',
             message: 'Email verification needed for site: {siteUrl} has added: {amountTriggered} members through the API in the last 30 days.',
@@ -541,9 +541,9 @@ describe('Email verification flow', function () {
         await trigger.testImportThreshold();
 
         // We shouldn't be fetching the events if the threshold is Infinity
-        assert.equal(eventStub.callCount, 0);
+        sinon.assert.notCalled(eventStub);
 
         // We shouldn't be sending emails if the threshold is Infinity
-        assert.equal(emailStub.callCount, 0);
+        sinon.assert.notCalled(emailStub);
     });
 });

--- a/ghost/core/test/unit/server/services/webhooks/trigger.test.js
+++ b/ghost/core/test/unit/server/services/webhooks/trigger.test.js
@@ -54,9 +54,9 @@ describe('Webhook Service', function () {
 
             await webhookTrigger.trigger(WEBHOOK_EVENT);
 
-            assert.equal(models.Webhook.findAllByEvent.called, true);
-            assert.equal(payload.called, false);
-            assert.equal(request.called, false);
+            sinon.assert.called(models.Webhook.findAllByEvent);
+            sinon.assert.notCalled(payload);
+            sinon.assert.notCalled(request);
         });
 
         it('does not trigger payload handler when there are hooks registered for an event, but the custom integrations limit is active', async function () {
@@ -81,9 +81,9 @@ describe('Webhook Service', function () {
 
             await webhookTrigger.trigger(WEBHOOK_EVENT);
 
-            assert.equal(models.Webhook.findAllByEvent.called, true);
-            assert.equal(payload.called, false);
-            assert.equal(request.called, false);
+            sinon.assert.called(models.Webhook.findAllByEvent);
+            sinon.assert.notCalled(payload);
+            sinon.assert.notCalled(request);
         });
 
         it('triggers payload handler when there are hooks registered for an event', async function () {
@@ -107,9 +107,9 @@ describe('Webhook Service', function () {
 
             await webhookTrigger.trigger(WEBHOOK_EVENT, postModel);
 
-            assert.equal(models.Webhook.findAllByEvent.called, true);
-            assert.equal(payload.called, true);
-            assert.equal(request.called, true);
+            sinon.assert.called(models.Webhook.findAllByEvent);
+            sinon.assert.called(payload);
+            sinon.assert.called(request);
             assert.equal(request.args[0][0], WEBHOOK_TARGET_URL);
             assert.equal(request.args[0][1].body, '{"data":[1]}');
             assert.deepEqual(Object.keys(request.args[0][1].headers), ['Content-Length', 'Content-Type', 'Content-Version']);
@@ -140,9 +140,9 @@ describe('Webhook Service', function () {
 
             await webhookTrigger.trigger(WEBHOOK_EVENT, postModel);
 
-            assert.equal(models.Webhook.findAllByEvent.called, true);
-            assert.equal(payload.called, true);
-            assert.equal(request.called, true);
+            sinon.assert.called(models.Webhook.findAllByEvent);
+            sinon.assert.called(payload);
+            sinon.assert.called(request);
             assert.equal(request.args[0][0], WEBHOOK_TARGET_URL);
 
             const header = request.args[0][1].headers[SIGNATURE_HEADER];
@@ -173,9 +173,9 @@ describe('Webhook Service', function () {
 
             await webhookTrigger.trigger(WEBHOOK_EVENT, postModel);
 
-            assert.equal(models.Webhook.findAllByEvent.called, true);
-            assert.equal(payload.called, true);
-            assert.equal(request.called, true);
+            sinon.assert.called(models.Webhook.findAllByEvent);
+            sinon.assert.called(payload);
+            sinon.assert.called(request);
             assert.equal(request.args[0][0], WEBHOOK_TARGET_URL);
 
             const expectedHeader = `sha256=${crypto.createHmac('sha256', WEBHOOK_SECRET).update(`{"data":[1]}${ts}`).digest('hex')}, t=${ts}`;

--- a/ghost/core/test/unit/server/web/admin/controller.test.js
+++ b/ghost/core/test/unit/server/web/admin/controller.test.js
@@ -26,18 +26,15 @@ describe('Admin App', function () {
             // default config: configUtils.set('adminFrameProtection', true);
             controller(req, res);
 
-            assert.equal(res.sendFile.called, true);
-            assert.equal(res.sendFile.calledWith(
-                sinon.match.string,
-                sinon.match.hasNested('headers.X-Frame-Options', sinon.match('sameorigin'))
-            ), true);
+            sinon.assert.called(res.sendFile);
+            sinon.assert.calledWith(res.sendFile, sinon.match.string, sinon.match.hasNested('headers.X-Frame-Options', sinon.match('sameorigin')));
         });
 
         it('doesn\'t add x-frame-options header when adminFrameProtection is disabled', function () {
             configUtils.set('adminFrameProtection', false);
             controller(req, res);
 
-            assert.equal(res.sendFile.called, true);
+            sinon.assert.called(res.sendFile);
             assert.equal(res.sendFile.calledWith(
                 sinon.match.string,
                 sinon.match.hasNested('headers.X-Frame-Options')

--- a/ghost/core/test/unit/server/web/admin/middleware.test.js
+++ b/ghost/core/test/unit/server/web/admin/middleware.test.js
@@ -1,4 +1,3 @@
-const assert = require('node:assert/strict');
 const sinon = require('sinon');
 // Thing we are testing
 const redirectAdminUrls = require('../../../../../core/server/web/admin/middleware/redirect-admin-urls');
@@ -27,8 +26,8 @@ describe('Admin App', function () {
 
                 redirectAdminUrls(req, res, next);
 
-                assert.equal(next.called, false);
-                assert.equal(res.redirect.called, true);
+                sinon.assert.notCalled(next);
+                sinon.assert.called(res.redirect);
                 sinon.assert.calledWith(res.redirect, '/ghost/#/x');
             });
 
@@ -37,8 +36,8 @@ describe('Admin App', function () {
 
                 redirectAdminUrls(req, res, next);
 
-                assert.equal(next.called, true);
-                assert.equal(res.redirect.called, false);
+                sinon.assert.called(next);
+                sinon.assert.notCalled(res.redirect);
             });
 
             it('should not redirect url that has no slash', function () {
@@ -46,8 +45,8 @@ describe('Admin App', function () {
 
                 redirectAdminUrls(req, res, next);
 
-                assert.equal(next.called, true);
-                assert.equal(res.redirect.called, false);
+                sinon.assert.called(next);
+                sinon.assert.notCalled(res.redirect);
             });
 
             it('should not redirect url that starts with something other than /ghost/', function () {
@@ -55,8 +54,8 @@ describe('Admin App', function () {
 
                 redirectAdminUrls(req, res, next);
 
-                assert.equal(next.called, true);
-                assert.equal(res.redirect.called, false);
+                sinon.assert.called(next);
+                sinon.assert.notCalled(res.redirect);
             });
         });
     });

--- a/ghost/core/test/unit/server/web/api/admin/middleware.test.js
+++ b/ghost/core/test/unit/server/web/api/admin/middleware.test.js
@@ -33,7 +33,7 @@ describe('Admin API Middleware', function () {
                 const tokenPermissionCheck = middleware.authAdminApi[middleware.authAdminApi.length - 1];
                 tokenPermissionCheck(req, res, next);
 
-                assert.equal(next.calledOnce, true);
+                sinon.assert.calledOnce(next);
                 assert.equal(next.firstCall.args.length, 0);
             });
         });
@@ -54,7 +54,7 @@ describe('Admin API Middleware', function () {
                 const tokenPermissionCheck = middleware.authAdminApi[middleware.authAdminApi.length - 1];
                 tokenPermissionCheck(req, res, next);
 
-                assert.equal(next.calledOnce, true);
+                sinon.assert.calledOnce(next);
                 assert.equal(next.firstCall.args.length, 0);
             });
 
@@ -65,7 +65,7 @@ describe('Admin API Middleware', function () {
                 const tokenPermissionCheck = middleware.authAdminApi[middleware.authAdminApi.length - 1];
                 tokenPermissionCheck(req, res, next);
 
-                assert.equal(next.calledOnce, true);
+                sinon.assert.calledOnce(next);
                 const error = next.firstCall.args[0];
                 assert.equal(error instanceof errors.NoPermissionError, true);
                 assert.equal(error.message, 'Staff tokens are not allowed to access this endpoint');
@@ -78,7 +78,7 @@ describe('Admin API Middleware', function () {
                 const tokenPermissionCheck = middleware.authAdminApi[middleware.authAdminApi.length - 1];
                 tokenPermissionCheck(req, res, next);
 
-                assert.equal(next.calledOnce, true);
+                sinon.assert.calledOnce(next);
                 const error = next.firstCall.args[0];
                 assert.equal(error instanceof errors.NoPermissionError, true);
                 assert.equal(error.message, 'Staff tokens are not allowed to access this endpoint');
@@ -91,7 +91,7 @@ describe('Admin API Middleware', function () {
                 const tokenPermissionCheck = middleware.authAdminApi[middleware.authAdminApi.length - 1];
                 tokenPermissionCheck(req, res, next);
 
-                assert.equal(next.calledOnce, true);
+                sinon.assert.calledOnce(next);
                 assert.equal(next.firstCall.args.length, 0);
             });
 
@@ -102,7 +102,7 @@ describe('Admin API Middleware', function () {
                 const tokenPermissionCheck = middleware.authAdminApi[middleware.authAdminApi.length - 1];
                 tokenPermissionCheck(req, res, next);
 
-                assert.equal(next.calledOnce, true);
+                sinon.assert.calledOnce(next);
                 assert.equal(next.firstCall.args.length, 0);
             });
 
@@ -113,7 +113,7 @@ describe('Admin API Middleware', function () {
                 const notImplemented = middleware.authAdminApi[middleware.authAdminApi.length - 1];
                 notImplemented(req, res, next);
 
-                assert.equal(next.calledOnce, true);
+                sinon.assert.calledOnce(next);
                 assert.equal(next.firstCall.args.length, 0);
             });
 
@@ -124,7 +124,7 @@ describe('Admin API Middleware', function () {
                 const tokenPermissionCheck = middleware.authAdminApi[middleware.authAdminApi.length - 1];
                 tokenPermissionCheck(req, res, next);
 
-                assert.equal(next.calledOnce, true);
+                sinon.assert.calledOnce(next);
                 const error = next.firstCall.args[0];
                 assert.equal(error instanceof errors.NoPermissionError, true);
                 assert.equal(error.message, 'Staff tokens are not allowed to access this endpoint');
@@ -137,7 +137,7 @@ describe('Admin API Middleware', function () {
                 const tokenPermissionCheck = middleware.authAdminApi[middleware.authAdminApi.length - 1];
                 tokenPermissionCheck(req, res, next);
 
-                assert.equal(next.calledOnce, true);
+                sinon.assert.calledOnce(next);
                 const error = next.firstCall.args[0];
                 assert.equal(error instanceof errors.NoPermissionError, true);
                 assert.equal(error.message, 'Staff tokens are not allowed to access this endpoint');
@@ -160,7 +160,7 @@ describe('Admin API Middleware', function () {
                 const notImplemented = middleware.authAdminApi[middleware.authAdminApi.length - 1];
                 notImplemented(req, res, next);
 
-                assert.equal(next.calledOnce, true);
+                sinon.assert.calledOnce(next);
                 assert.equal(next.firstCall.args.length, 0);
             });
 
@@ -171,7 +171,7 @@ describe('Admin API Middleware', function () {
                 const tokenPermissionCheck = middleware.authAdminApi[middleware.authAdminApi.length - 1];
                 tokenPermissionCheck(req, res, next);
 
-                assert.equal(next.calledOnce, true);
+                sinon.assert.calledOnce(next);
                 const error = next.firstCall.args[0];
                 assert.equal(error instanceof errors.NoPermissionError, true);
                 assert.equal(error.statusCode, 403);
@@ -184,7 +184,7 @@ describe('Admin API Middleware', function () {
                 const tokenPermissionCheck = middleware.authAdminApi[middleware.authAdminApi.length - 1];
                 tokenPermissionCheck(req, res, next);
 
-                assert.equal(next.calledOnce, true);
+                sinon.assert.calledOnce(next);
                 assert.equal(next.firstCall.args.length, 0);
             });
 
@@ -195,7 +195,7 @@ describe('Admin API Middleware', function () {
                 const tokenPermissionCheck = middleware.authAdminApi[middleware.authAdminApi.length - 1];
                 tokenPermissionCheck(req, res, next);
 
-                assert.equal(next.calledOnce, true);
+                sinon.assert.calledOnce(next);
                 const error = next.firstCall.args[0];
                 assert.equal(error instanceof errors.NoPermissionError, true);
                 assert.equal(error.statusCode, 403);
@@ -217,7 +217,7 @@ describe('Admin API Middleware', function () {
                 const tokenPermissionCheck = middleware.authAdminApi[middleware.authAdminApi.length - 1];
                 tokenPermissionCheck(req, res, next);
 
-                assert.equal(next.calledOnce, true);
+                sinon.assert.calledOnce(next);
                 assert.equal(next.firstCall.args.length, 0);
 
                 process.env.NODE_ENV = originalEnv;
@@ -237,7 +237,7 @@ describe('Admin API Middleware', function () {
                 const tokenPermissionCheck = middleware.authAdminApi[middleware.authAdminApi.length - 1];
                 tokenPermissionCheck(req, res, next);
 
-                assert.equal(next.calledOnce, true);
+                sinon.assert.calledOnce(next);
                 const error = next.firstCall.args[0];
                 assert.equal(error instanceof errors.NoPermissionError, true);
 

--- a/ghost/core/test/unit/server/web/api/middleware/update-user-last-seen.test.js
+++ b/ghost/core/test/unit/server/web/api/middleware/update-user-last-seen.test.js
@@ -35,7 +35,7 @@ describe('updateUserLastSeenMiddleware', function () {
             };
             updateUserLastSeenMiddleware({user: fakeUser}, {}, function next(err) {
                 assert.equal(err, undefined);
-                assert.equal(fakeUser.updateLastSeen.callCount, 1);
+                sinon.assert.calledOnce(fakeUser.updateLastSeen);
                 done();
             });
         });
@@ -49,7 +49,7 @@ describe('updateUserLastSeenMiddleware', function () {
             };
             updateUserLastSeenMiddleware({user: fakeUser}, {}, function next(err) {
                 assert.equal(err, fakeError);
-                assert.equal(fakeUser.updateLastSeen.callCount, 1);
+                sinon.assert.calledOnce(fakeUser.updateLastSeen);
                 done();
             });
         });

--- a/ghost/core/test/unit/server/web/parent/middleware/ghost-locals.test.js
+++ b/ghost/core/test/unit/server/web/parent/middleware/ghost-locals.test.js
@@ -29,7 +29,7 @@ describe('Theme Handler', function () {
             assertExists(res.locals.version);
             assertExists(res.locals.safeVersion);
             assert.equal(res.locals.relativeUrl, req.path);
-            assert.equal(next.called, true);
+            sinon.assert.called(next);
         });
     });
 });

--- a/ghost/core/test/unit/server/web/parent/middleware/queue-request.test.js
+++ b/ghost/core/test/unit/server/web/parent/middleware/queue-request.test.js
@@ -58,7 +58,7 @@ describe('Queue request middleware', function () {
         mw(req, res, next);
 
         assert(queue.calledOnce, 'queue should be called once');
-        assert(queue.calledWith(req, res, next), 'queue should be called with the correct arguments');
+        sinon.assert.calledWith(queue, req, res, next);
     });
 
     it('should record the queue depth on a request', function () {

--- a/ghost/core/test/unit/server/web/parent/middleware/request-id.test.js
+++ b/ghost/core/test/unit/server/web/parent/middleware/request-id.test.js
@@ -33,7 +33,7 @@ describe('Request ID middleware', function () {
 
         assertExists(req.requestId);
         assert.equal(validator.isUUID(req.requestId), true);
-        assert.equal(res.set.calledOnce, false);
+        sinon.assert.notCalled(res.set);
     });
 
     it('keeps the request ID if X-Request-ID is present', function () {
@@ -44,7 +44,7 @@ describe('Request ID middleware', function () {
 
         assertExists(req.requestId);
         assert.equal(req.requestId, 'abcd');
-        assert.equal(res.set.calledOnce, true);
-        assert.equal(res.set.calledWith('X-Request-ID', 'abcd'), true);
+        sinon.assert.calledOnce(res.set);
+        sinon.assert.calledWith(res.set, 'X-Request-ID', 'abcd');
     });
 });

--- a/ghost/core/test/unit/server/web/shared/middleware/max-limit-cap.test.js
+++ b/ghost/core/test/unit/server/web/shared/middleware/max-limit-cap.test.js
@@ -36,7 +36,7 @@ describe('Max Limit Cap Middleware', function () {
             maxLimitCap[0](req, res, next);
 
             assert.equal(req.query.limit, undefined);
-            assert.equal(next.calledOnce, true);
+            sinon.assert.calledOnce(next);
         });
     });
 
@@ -47,7 +47,7 @@ describe('Max Limit Cap Middleware', function () {
             maxLimitCap[0](req, res, next);
 
             assert.equal(req.query.limit, 50);
-            assert.equal(next.calledOnce, true);
+            sinon.assert.calledOnce(next);
         });
 
         it('should handle string limit values', function () {
@@ -56,7 +56,7 @@ describe('Max Limit Cap Middleware', function () {
             maxLimitCap[0](req, res, next);
 
             assert.equal(req.query.limit, '25');
-            assert.equal(next.calledOnce, true);
+            sinon.assert.calledOnce(next);
         });
     });
 
@@ -67,7 +67,7 @@ describe('Max Limit Cap Middleware', function () {
             maxLimitCap[0](req, res, next);
 
             assert.equal(req.query.limit, 100);
-            assert.equal(next.calledOnce, true);
+            sinon.assert.calledOnce(next);
         });
 
         it('should cap string limit values to 100', function () {
@@ -76,7 +76,7 @@ describe('Max Limit Cap Middleware', function () {
             maxLimitCap[0](req, res, next);
 
             assert.equal(req.query.limit, 100);
-            assert.equal(next.calledOnce, true);
+            sinon.assert.calledOnce(next);
         });
     });
 
@@ -89,7 +89,7 @@ describe('Max Limit Cap Middleware', function () {
             maxLimitCap[0](req, res, next);
 
             assert.equal(req.query.limit, 100);
-            assert.equal(next.calledOnce, true);
+            sinon.assert.calledOnce(next);
         });
 
         it('should allow "all" when allowLimitAll is true', function () {
@@ -100,7 +100,7 @@ describe('Max Limit Cap Middleware', function () {
             maxLimitCap[0](req, res, next);
 
             assert.equal(req.query.limit, 'all');
-            assert.equal(next.calledOnce, true);
+            sinon.assert.calledOnce(next);
         });
     });
 
@@ -113,7 +113,7 @@ describe('Max Limit Cap Middleware', function () {
             maxLimitCap[0](req, res, next);
 
             assert.equal(req.query.limit, 50); // Should cap to configured maxLimit
-            assert.equal(next.calledOnce, true);
+            sinon.assert.calledOnce(next);
         });
 
         it('should not modify limit below custom maxLimit', function () {
@@ -124,7 +124,7 @@ describe('Max Limit Cap Middleware', function () {
             maxLimitCap[0](req, res, next);
 
             assert.equal(req.query.limit, 30);
-            assert.equal(next.calledOnce, true);
+            sinon.assert.calledOnce(next);
         });
     });
 
@@ -137,7 +137,7 @@ describe('Max Limit Cap Middleware', function () {
             maxLimitCap[0](req, res, next);
 
             assert.equal(req.query.limit, 1000);
-            assert.equal(next.calledOnce, true);
+            sinon.assert.calledOnce(next);
         });
 
         it('should not cap limit for /api/admin/emails/ endpoints', function () {
@@ -148,7 +148,7 @@ describe('Max Limit Cap Middleware', function () {
             maxLimitCap[0](req, res, next);
 
             assert.equal(req.query.limit, 500);
-            assert.equal(next.calledOnce, true);
+            sinon.assert.calledOnce(next);
         });
 
         it('should not cap limit for /api/admin/emails/ recipient-failures', function () {
@@ -159,7 +159,7 @@ describe('Max Limit Cap Middleware', function () {
             maxLimitCap[0](req, res, next);
 
             assert.equal(req.query.limit, 'all');
-            assert.equal(next.calledOnce, true);
+            sinon.assert.calledOnce(next);
         });
 
         it('should cap limit for non-exception endpoints', function () {
@@ -170,7 +170,7 @@ describe('Max Limit Cap Middleware', function () {
             maxLimitCap[0](req, res, next);
 
             assert.equal(req.query.limit, 100);
-            assert.equal(next.calledOnce, true);
+            sinon.assert.calledOnce(next);
         });
     });
 
@@ -181,7 +181,7 @@ describe('Max Limit Cap Middleware', function () {
             maxLimitCap[0](req, res, next);
 
             assert.equal(req.query.limit, 100);
-            assert.equal(next.calledOnce, true);
+            sinon.assert.calledOnce(next);
         });
 
         it('should handle limit of 0', function () {
@@ -190,7 +190,7 @@ describe('Max Limit Cap Middleware', function () {
             maxLimitCap[0](req, res, next);
 
             assert.equal(req.query.limit, 0);
-            assert.equal(next.calledOnce, true);
+            sinon.assert.calledOnce(next);
         });
 
         it('should handle negative limit values', function () {
@@ -199,7 +199,7 @@ describe('Max Limit Cap Middleware', function () {
             maxLimitCap[0](req, res, next);
 
             assert.equal(req.query.limit, -10);
-            assert.equal(next.calledOnce, true);
+            sinon.assert.calledOnce(next);
         });
 
         it('should handle non-numeric string limits', function () {
@@ -208,7 +208,7 @@ describe('Max Limit Cap Middleware', function () {
             maxLimitCap[0](req, res, next);
 
             assert.equal(req.query.limit, 100);
-            assert.equal(next.calledOnce, true);
+            sinon.assert.calledOnce(next);
         });
 
         it('should handle paths that partially match exception endpoints', function () {
@@ -219,7 +219,7 @@ describe('Max Limit Cap Middleware', function () {
             maxLimitCap[0](req, res, next);
 
             assert.equal(req.query.limit, 100);
-            assert.equal(next.calledOnce, true);
+            sinon.assert.calledOnce(next);
         });
     });
 

--- a/ghost/core/test/unit/shared/custom-theme-settings-cache/service.test.js
+++ b/ghost/core/test/unit/shared/custom-theme-settings-cache/service.test.js
@@ -113,12 +113,12 @@ describe('Service', function () {
                 }
             });
 
-            assert.equal(model.findAll.callCount, 2);
+            sinon.assert.calledTwice(model.findAll);
             assert.deepEqual(model.findAll.getCall(0).firstArg, {filter: `theme:'test'`});
             assert.deepEqual(model.findAll.getCall(1).firstArg, {filter: `theme:'test'`});
 
             // destroys records that no longer exist in theme
-            assert.equal(model.destroy.callCount, 1);
+            sinon.assert.calledOnce(model.destroy);
             assert.deepEqual(model.destroy.getCall(0).firstArg, {id: 1});
 
             // internal cache is correct
@@ -156,10 +156,10 @@ describe('Service', function () {
             });
 
             // destroys and recreates record
-            assert.equal(model.destroy.callCount, 1);
+            sinon.assert.calledOnce(model.destroy);
             assert.deepEqual(model.destroy.getCall(0).firstArg, {id: 2});
 
-            assert.equal(model.add.callCount, 1);
+            sinon.assert.calledOnce(model.add);
             assert.deepEqual(model.add.getCall(0).firstArg, {
                 theme: 'test',
                 key: 'two',
@@ -210,7 +210,7 @@ describe('Service', function () {
             });
 
             // updates known setting to match new default
-            assert.equal(model.edit.callCount, 1);
+            sinon.assert.calledOnce(model.edit);
             assert.deepEqual(model.edit.getCall(0).firstArg, {value: 'two'});
             assert.deepEqual(model.edit.getCall(0).lastArg, {id: 2, method: 'update'});
         });
@@ -241,7 +241,7 @@ describe('Service', function () {
             });
 
             // new setting is created
-            assert.equal(model.add.callCount, 1);
+            sinon.assert.calledOnce(model.add);
             assert.deepEqual(model.add.getCall(0).firstArg, {
                 theme: 'test',
                 key: 'three',
@@ -317,14 +317,14 @@ describe('Service', function () {
             });
 
             // looks for existing settings, then re-fetches after sync. Twice for each activation
-            assert.equal(model.findAll.callCount, 4);
+            sinon.assert.callCount(model.findAll, 4);
             assert.deepEqual(model.findAll.getCall(0).firstArg, {filter: `theme:'test'`});
             assert.deepEqual(model.findAll.getCall(1).firstArg, {filter: `theme:'test'`});
             assert.deepEqual(model.findAll.getCall(2).firstArg, {filter: `theme:'new'`});
             assert.deepEqual(model.findAll.getCall(3).firstArg, {filter: `theme:'new'`});
 
             // adds new settings
-            assert.equal(model.add.callCount, 2);
+            sinon.assert.calledTwice(model.add);
 
             assert.deepEqual(model.add.firstCall.firstArg, {
                 theme: 'new',
@@ -367,7 +367,7 @@ describe('Service', function () {
         it('exits early if both repository and theme have no settings', async function () {
             await service.activateTheme('no-custom', {name: 'no-custom'});
 
-            assert.equal(model.findAll.callCount, 1);
+            sinon.assert.calledOnce(model.findAll);
         });
 
         it('generates a valid filter string for theme names with dots', async function () {
@@ -384,7 +384,7 @@ describe('Service', function () {
                 }
             });
 
-            assert.equal(model.findAll.callCount, 2);
+            sinon.assert.calledTwice(model.findAll);
 
             assert(model.findAll.getCall(0).firstArg.filter);
             assert.doesNotThrow(() => nql.parse(model.findAll.getCall(0).firstArg.filter));
@@ -443,8 +443,8 @@ describe('Service', function () {
             });
 
             // model methods are only called enough times for one .activate call despite being called twice
-            assert.equal(model.findAll.callCount, 2);
-            assert.equal(model.add.callCount, 1);
+            sinon.assert.calledTwice(model.findAll);
+            sinon.assert.calledOnce(model.add);
 
             // internal cache is correct
             assert.deepEqual(service.listSettings(), [{


### PR DESCRIPTION
no ref

This test-only change should have no user impact.

[Sinon's assertions][0] generally give better error messages than `node:assert`. For example, `sinon.assert.calledOnce(spy)` gives a better error message than `assert(spy.calledOnce)`.

This updates many usages. I used [ast-grep][1] for 100% of the modifications in this patch.

[0]: https://sinonjs.org/releases/v20/assertions/
[1]: https://ast-grep.github.io/
