### PR TITLE
Fixed admin-x-settings `files` entry

### DIFF
--- a/apps/admin-x-framework/package.json
+++ b/apps/admin-x-framework/package.json
@@ -70,7 +70,7 @@
         "lint:test": "eslint -c test/.eslintrc.cjs --ext .js,.ts,.cjs,.tsx test/ --cache"
     },
     "files": [
-        "es",
+        "dist",
         "types"
     ],
     "devDependencies": {


### PR DESCRIPTION
no ref

This chain should have no user impact.

The `es` folder doesn't exist for this package. It uses `dist` instead.