### PR TITLE
Tested `useFetchApi` with real HTTP server

### DIFF
--- a/apps/admin-x-framework/test/unit/utils/api/fetch-api.test.tsx
+++ b/apps/admin-x-framework/test/unit/utils/api/fetch-api.test.tsx
@@ -1,8 +1,12 @@
 import {renderHook} from '@testing-library/react';
+import {type AddressInfo} from 'node:net';
+import http from 'node:http';
+import {setTimeout as sleep} from 'node:timers/promises';
+import {promisify} from 'node:util';
 import React, {ReactNode} from 'react';
 import {FrameworkProvider} from '../../../../src/providers/framework-provider';
 import {useFetchApi} from '../../../../src/utils/api/fetch-api';
-import {withMockFetch} from '../../../utils/mock-fetch';
+import {TimeoutError} from '../../../../src/utils/errors';
 
 const wrapper: React.FC<{ children: ReactNode }> = ({children}) => (
     <FrameworkProvider
@@ -24,34 +28,70 @@ const wrapper: React.FC<{ children: ReactNode }> = ({children}) => (
     </FrameworkProvider>
 );
 
+type TestResponseBody = Pick<http.IncomingMessage, 'method' | 'headers'> & {
+    body: string;
+};
+
 describe('useFetchApi', () => {
-    it('makes an API request', async () => {
-        await withMockFetch({
-            json: {test: 1}
-        }, async (mock) => {
-            const {result} = renderHook(() => useFetchApi(), {wrapper});
+    let server: http.Server;
+    let baseUrl: string;
 
-            const data = await result.current<{test: number}>('http://localhost:3000/ghost/api/admin/test/', {
-                method: 'POST',
-                body: 'test',
-                retry: false
+    beforeEach(async () => {
+        server = http.createServer((req, res) => {
+            const chunks: Buffer[] = [];
+            req.on('data', (chunk: Buffer) => {
+                chunks.push(chunk);
             });
-
-            expect(data).toEqual({test: 1});
-
-            expect(mock.calls.length).toBe(1);
-            expect(mock.calls[0]).toEqual(['http://localhost:3000/ghost/api/admin/test/', {
-                body: 'test',
-                credentials: 'include',
-                headers: {
-                    'app-pragma': 'no-cache',
-                    'x-ghost-version': '5.x',
-                    'content-type': 'application/json'
-                },
-                method: 'POST',
-                mode: 'cors',
-                signal: expect.any(AbortSignal)
-            }]);
+            req.on('end', async () => {
+                if (req.url?.includes('slow')) {
+                    await sleep(100);
+                }
+                res.writeHead(200, {'Content-Type': 'application/json'});
+                res.end(JSON.stringify({
+                    method: req.method,
+                    headers: req.headers,
+                    body: Buffer.concat(chunks).toString('utf8')
+                } satisfies TestResponseBody));
+            });
         });
+
+        await new Promise<void>((resolve) => {
+            server.listen(0, '127.0.0.1', () => {
+                resolve();
+            });
+        });
+
+        const address = server.address() as AddressInfo;
+        baseUrl = `http://127.0.0.1:${address.port}`;
+    });
+
+    afterEach(async () => {
+        const close = promisify(server.close.bind(server));
+        await close();
+    });
+
+    it('makes an API request', async () => {
+        const {result} = renderHook(() => useFetchApi(), {wrapper});
+
+        const data = await result.current<TestResponseBody>(`${baseUrl}/ghost/api/admin/test/`, {
+            method: 'POST',
+            body: 'test',
+            retry: false
+        });
+
+        expect(data.method).toBe('POST');
+        expect(data.headers['x-ghost-version']).toBe('5.x');
+        expect(data.headers['app-pragma']).toBe('no-cache');
+        expect(data.headers['content-type']).toBe('application/json');
+        expect(data.body).toBe('test');
+    });
+
+    it('throws a timeout error when request exceeds timeout', async () => {
+        const {result} = renderHook(() => useFetchApi(), {wrapper});
+
+        await expect(result.current(`${baseUrl}/ghost/api/admin/slow/`, {
+            timeout: 20,
+            retry: false
+        })).rejects.toBeInstanceOf(TimeoutError);
     });
 });


### PR DESCRIPTION
towards https://linear.app/ghost/issue/NY-1075
towards https://linear.app/ghost/issue/NY-1097

This test-only change should have no user impact, but makes upcoming changes easier.
