### PR TITLE
Converted initial outbox logs to structured logging

### DIFF
--- a/ghost/core/core/server/services/outbox/handlers/member-created.js
+++ b/ghost/core/core/server/services/outbox/handlers/member-created.js
@@ -12,7 +12,12 @@ async function handle({payload}) {
     try {
         const slug = MEMBER_WELCOME_EMAIL_SLUGS[payload.status];
         if (!slug) {
-            logging.warn(`${LOG_KEY} No automated email slug found for member status: ${payload.status}`);
+            logging.warn({
+                system: {
+                    event: 'outbox.member_created.no_slug_mapping',
+                    member_status: payload.status
+                }
+            }, 'No automated email slug found for member status');
             return;
         }
 

--- a/ghost/core/core/server/services/outbox/handlers/member-created.js
+++ b/ghost/core/core/server/services/outbox/handlers/member-created.js
@@ -17,7 +17,7 @@ async function handle({payload}) {
                     event: 'outbox.member_created.no_slug_mapping',
                     member_status: payload.status
                 }
-            }, 'No automated email slug found for member status');
+            }, `${LOG_KEY} No automated email slug found for member status`);
             return;
         }
 
@@ -40,7 +40,7 @@ async function handle({payload}) {
                 event: 'outbox.member_created.track_send_failed'
             },
             err
-        }, 'Failed to track automated email send');
+        }, `${LOG_KEY} Failed to track automated email send`);
     }
 }
 

--- a/ghost/core/core/server/services/outbox/handlers/member-created.js
+++ b/ghost/core/core/server/services/outbox/handlers/member-created.js
@@ -36,9 +36,11 @@ async function handle({payload}) {
         });
     } catch (err) {
         logging.error({
-            message: `${LOG_KEY} Failed to track automated email send`,
+            system: {
+                event: 'outbox.member_created.track_send_failed'
+            },
             err
-        });
+        }, 'Failed to track automated email send');
     }
 }
 

--- a/ghost/core/core/server/services/outbox/index.js
+++ b/ghost/core/core/server/services/outbox/index.js
@@ -28,7 +28,7 @@ class OutboxServiceWrapper {
                 system: {
                     event: 'outbox.processing.skipped_already_running'
                 }
-            }, 'Outbox job already running, skipping');
+            }, `${OUTBOX_LOG_KEY}: Outbox job already running, skipping`);
             return;
         }
         this.processing = true;

--- a/ghost/core/core/server/services/outbox/index.js
+++ b/ghost/core/core/server/services/outbox/index.js
@@ -24,7 +24,11 @@ class OutboxServiceWrapper {
 
     async startProcessing() {
         if (this.processing) {
-            logging.info(`${OUTBOX_LOG_KEY}: Outbox job already running, skipping`);
+            logging.info({
+                system: {
+                    event: 'outbox.processing.skipped_already_running'
+                }
+            }, 'Outbox job already running, skipping');
             return;
         }
         this.processing = true;

--- a/ghost/core/test/unit/server/services/outbox/handlers/member-created.test.js
+++ b/ghost/core/test/unit/server/services/outbox/handlers/member-created.test.js
@@ -2,7 +2,7 @@ const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const rewire = require('rewire');
 const logging = require('@tryghost/logging');
-const {captureLoggerOutput} = require('../../../../../utils/logging-utils');
+const {captureLoggerOutput, findByEvent} = require('../../../../../utils/logging-utils');
 
 describe('member-created handler', function () {
     let handler;
@@ -90,7 +90,7 @@ describe('member-created handler', function () {
         });
 
         sinon.assert.calledOnce(memberWelcomeEmailServiceStub.api.send);
-        const warningLog = logCapture.output.find(log => log.level === 40 && log.msg === 'No automated email slug found for member status');
+        const warningLog = findByEvent(logCapture.output, 'outbox.member_created.no_slug_mapping');
         assert.ok(warningLog);
         assert.deepEqual(warningLog.system, {
             event: 'outbox.member_created.no_slug_mapping',

--- a/ghost/core/test/unit/server/services/outbox/handlers/member-created.test.js
+++ b/ghost/core/test/unit/server/services/outbox/handlers/member-created.test.js
@@ -53,8 +53,9 @@ describe('member-created handler', function () {
         });
 
         sinon.assert.calledOnce(memberWelcomeEmailServiceStub.api.send);
-        const errorLog = logCapture.output.find(log => log.level === 50 && log.message?.includes('Failed to track automated email send'));
+        const errorLog = findByEvent(logCapture.output, 'outbox.member_created.track_send_failed');
         assert.ok(errorLog);
+        assert.ok(errorLog.msg.startsWith('Failed to track automated email send'));
     });
 
     it('logs error when tracking fails', async function () {
@@ -71,9 +72,10 @@ describe('member-created handler', function () {
             }
         });
 
-        const errorLog = logCapture.output.find(log => log.level === 50 && log.message?.includes('Failed to track automated email send'));
+        const errorLog = findByEvent(logCapture.output, 'outbox.member_created.track_send_failed');
         assert.ok(errorLog);
-        assert.equal(errorLog.msg, dbError.message);
+        assert.ok(errorLog.msg.startsWith('Failed to track automated email send'));
+        assert.ok(errorLog.msg.includes(dbError.message));
     });
 
     it('logs warning when status has no slug mapping', async function () {

--- a/ghost/core/test/unit/server/services/outbox/handlers/member-created.test.js
+++ b/ghost/core/test/unit/server/services/outbox/handlers/member-created.test.js
@@ -55,7 +55,6 @@ describe('member-created handler', function () {
         sinon.assert.calledOnce(memberWelcomeEmailServiceStub.api.send);
         const errorLog = findByEvent(logCapture.output, 'outbox.member_created.track_send_failed');
         assert.ok(errorLog);
-        assert.ok(errorLog.msg.startsWith('Failed to track automated email send'));
     });
 
     it('logs error when tracking fails', async function () {
@@ -74,8 +73,6 @@ describe('member-created handler', function () {
 
         const errorLog = findByEvent(logCapture.output, 'outbox.member_created.track_send_failed');
         assert.ok(errorLog);
-        assert.ok(errorLog.msg.startsWith('Failed to track automated email send'));
-        assert.ok(errorLog.msg.includes(dbError.message));
     });
 
     it('logs warning when status has no slug mapping', async function () {

--- a/ghost/core/test/unit/server/services/outbox/handlers/member-created.test.js
+++ b/ghost/core/test/unit/server/services/outbox/handlers/member-created.test.js
@@ -7,9 +7,9 @@ const {captureLoggerOutput} = require('../../../../../utils/logging-utils');
 describe('member-created handler', function () {
     let handler;
     let memberWelcomeEmailServiceStub;
-    let loggingStub;
     let AutomatedEmailStub;
     let AutomatedEmailRecipientStub;
+    let logCapture;
 
     beforeEach(function () {
         handler = rewire('../../../../../../core/server/services/outbox/handlers/member-created.js');
@@ -20,11 +20,6 @@ describe('member-created handler', function () {
             }
         };
 
-        loggingStub = {
-            warn: sinon.stub(),
-            error: sinon.stub()
-        };
-
         AutomatedEmailStub = {
             findOne: sinon.stub().resolves({id: 'ae123'})
         };
@@ -33,13 +28,16 @@ describe('member-created handler', function () {
             add: sinon.stub().resolves()
         };
 
+        logCapture = captureLoggerOutput(logging);
+
         handler.__set__('memberWelcomeEmailService', memberWelcomeEmailServiceStub);
-        handler.__set__('logging', loggingStub);
+        handler.__set__('logging', logging);
         handler.__set__('AutomatedEmail', AutomatedEmailStub);
         handler.__set__('AutomatedEmailRecipient', AutomatedEmailRecipientStub);
     });
 
     afterEach(function () {
+        logCapture.restore();
         sinon.restore();
     });
 
@@ -57,7 +55,8 @@ describe('member-created handler', function () {
         });
 
         sinon.assert.calledOnce(memberWelcomeEmailServiceStub.api.send);
-        sinon.assert.calledOnce(loggingStub.error);
+        const errorLog = logCapture.output.find(log => log.level === 50 && log.message?.includes('Failed to track automated email send'));
+        assert.ok(errorLog);
     });
 
     it('logs error when tracking fails', async function () {
@@ -74,37 +73,29 @@ describe('member-created handler', function () {
             }
         });
 
-        sinon.assert.calledOnce(loggingStub.error);
-        const errorCall = loggingStub.error.getCall(0);
-        assert.ok(errorCall.args[0].message.includes('Failed to track automated email send'));
-        assert.equal(errorCall.args[0].err, dbError);
+        const errorLog = logCapture.output.find(log => log.level === 50 && log.message?.includes('Failed to track automated email send'));
+        assert.ok(errorLog);
+        assert.equal(errorLog.msg, dbError.message);
     });
 
     it('logs warning when status has no slug mapping', async function () {
-        const capture = captureLoggerOutput(logging);
-        handler.__set__('logging', logging);
+        await handler.handle({
+            payload: {
+                memberId: 'member123',
+                uuid: 'uuid-123',
+                email: 'test@example.com',
+                name: 'Test Member',
+                status: 'comped'
+            }
+        });
 
-        try {
-            await handler.handle({
-                payload: {
-                    memberId: 'member123',
-                    uuid: 'uuid-123',
-                    email: 'test@example.com',
-                    name: 'Test Member',
-                    status: 'comped'
-                }
-            });
-
-            sinon.assert.calledOnce(memberWelcomeEmailServiceStub.api.send);
-            const warningLog = capture.output.find(log => log.level === 40 && log.msg === 'No automated email slug found for member status');
-            assert.ok(warningLog);
-            assert.deepEqual(warningLog.system, {
-                event: 'outbox.member_created.no_slug_mapping',
-                member_status: 'comped'
-            });
-            sinon.assert.notCalled(AutomatedEmailRecipientStub.add);
-        } finally {
-            capture.restore();
-        }
+        sinon.assert.calledOnce(memberWelcomeEmailServiceStub.api.send);
+        const warningLog = logCapture.output.find(log => log.level === 40 && log.msg === 'No automated email slug found for member status');
+        assert.ok(warningLog);
+        assert.deepEqual(warningLog.system, {
+            event: 'outbox.member_created.no_slug_mapping',
+            member_status: 'comped'
+        });
+        sinon.assert.notCalled(AutomatedEmailRecipientStub.add);
     });
 });

--- a/ghost/core/test/unit/server/services/outbox/handlers/member-created.test.js
+++ b/ghost/core/test/unit/server/services/outbox/handlers/member-created.test.js
@@ -1,9 +1,8 @@
 const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const rewire = require('rewire');
-const bunyan = require('bunyan');
-const {PassThrough} = require('stream');
 const logging = require('@tryghost/logging');
+const {captureLoggerOutput} = require('../../../../../utils/logging-utils');
 
 describe('member-created handler', function () {
     let handler;
@@ -44,49 +43,6 @@ describe('member-created handler', function () {
         sinon.restore();
     });
 
-    function captureLoggerOutput() {
-        const output = [];
-        const stream = new PassThrough();
-        let buffered = '';
-
-        stream.on('data', (chunk) => {
-            buffered += chunk.toString();
-            const lines = buffered.split('\n');
-            buffered = lines.pop();
-
-            for (const line of lines) {
-                if (!line.trim()) {
-                    continue;
-                }
-
-                output.push(JSON.parse(line));
-            }
-        });
-
-        const originalStreams = logging.streams;
-        logging.streams = {
-            capture: {
-                name: 'capture',
-                log: bunyan.createLogger({
-                    name: 'test-logger',
-                    streams: [{
-                        type: 'stream',
-                        stream,
-                        level: 'trace'
-                    }]
-                })
-            }
-        };
-
-        return {
-            output,
-            restore() {
-                logging.streams = originalStreams;
-                stream.destroy();
-            }
-        };
-    }
-
     it('sends email even when tracking fails', async function () {
         AutomatedEmailRecipientStub.add.rejects(new Error('Database error'));
 
@@ -125,7 +81,7 @@ describe('member-created handler', function () {
     });
 
     it('logs warning when status has no slug mapping', async function () {
-        const capture = captureLoggerOutput();
+        const capture = captureLoggerOutput(logging);
         handler.__set__('logging', logging);
 
         try {

--- a/ghost/core/test/unit/server/services/outbox/handlers/member-created.test.js
+++ b/ghost/core/test/unit/server/services/outbox/handlers/member-created.test.js
@@ -53,8 +53,6 @@ describe('member-created handler', function () {
         });
 
         sinon.assert.calledOnce(memberWelcomeEmailServiceStub.api.send);
-        const errorLog = findByEvent(logCapture.output, 'outbox.member_created.track_send_failed');
-        assert.ok(errorLog);
     });
 
     it('logs error when tracking fails', async function () {

--- a/ghost/core/test/unit/server/services/outbox/handlers/member-created.test.js
+++ b/ghost/core/test/unit/server/services/outbox/handlers/member-created.test.js
@@ -1,7 +1,6 @@
 const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const rewire = require('rewire');
-const logging = require('@tryghost/logging');
 const {captureLoggerOutput, findByEvent} = require('../../../../../utils/logging-utils');
 
 describe('member-created handler', function () {
@@ -28,7 +27,7 @@ describe('member-created handler', function () {
             add: sinon.stub().resolves()
         };
 
-        logCapture = captureLoggerOutput(logging);
+        logCapture = captureLoggerOutput();
 
         handler.__set__('memberWelcomeEmailService', memberWelcomeEmailServiceStub);
         handler.__set__('AutomatedEmail', AutomatedEmailStub);

--- a/ghost/core/test/unit/server/services/outbox/handlers/member-created.test.js
+++ b/ghost/core/test/unit/server/services/outbox/handlers/member-created.test.js
@@ -1,6 +1,9 @@
 const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const rewire = require('rewire');
+const bunyan = require('bunyan');
+const {PassThrough} = require('stream');
+const logging = require('@tryghost/logging');
 
 describe('member-created handler', function () {
     let handler;
@@ -41,6 +44,49 @@ describe('member-created handler', function () {
         sinon.restore();
     });
 
+    function captureLoggerOutput() {
+        const output = [];
+        const stream = new PassThrough();
+        let buffered = '';
+
+        stream.on('data', (chunk) => {
+            buffered += chunk.toString();
+            const lines = buffered.split('\n');
+            buffered = lines.pop();
+
+            for (const line of lines) {
+                if (!line.trim()) {
+                    continue;
+                }
+
+                output.push(JSON.parse(line));
+            }
+        });
+
+        const originalStreams = logging.streams;
+        logging.streams = {
+            capture: {
+                name: 'capture',
+                log: bunyan.createLogger({
+                    name: 'test-logger',
+                    streams: [{
+                        type: 'stream',
+                        stream,
+                        level: 'trace'
+                    }]
+                })
+            }
+        };
+
+        return {
+            output,
+            restore() {
+                logging.streams = originalStreams;
+                stream.destroy();
+            }
+        };
+    }
+
     it('sends email even when tracking fails', async function () {
         AutomatedEmailRecipientStub.add.rejects(new Error('Database error'));
 
@@ -79,19 +125,30 @@ describe('member-created handler', function () {
     });
 
     it('logs warning when status has no slug mapping', async function () {
-        await handler.handle({
-            payload: {
-                memberId: 'member123',
-                uuid: 'uuid-123',
-                email: 'test@example.com',
-                name: 'Test Member',
-                status: 'comped'
-            }
-        });
+        const capture = captureLoggerOutput();
+        handler.__set__('logging', logging);
 
-        sinon.assert.calledOnce(memberWelcomeEmailServiceStub.api.send);
-        sinon.assert.calledOnce(loggingStub.warn);
-        assert.ok(loggingStub.warn.getCall(0).args[0].includes('No automated email slug found'));
-        sinon.assert.notCalled(AutomatedEmailRecipientStub.add);
+        try {
+            await handler.handle({
+                payload: {
+                    memberId: 'member123',
+                    uuid: 'uuid-123',
+                    email: 'test@example.com',
+                    name: 'Test Member',
+                    status: 'comped'
+                }
+            });
+
+            sinon.assert.calledOnce(memberWelcomeEmailServiceStub.api.send);
+            const warningLog = capture.output.find(log => log.level === 40 && log.msg === 'No automated email slug found for member status');
+            assert.ok(warningLog);
+            assert.deepEqual(warningLog.system, {
+                event: 'outbox.member_created.no_slug_mapping',
+                member_status: 'comped'
+            });
+            sinon.assert.notCalled(AutomatedEmailRecipientStub.add);
+        } finally {
+            capture.restore();
+        }
     });
 });

--- a/ghost/core/test/unit/server/services/outbox/handlers/member-created.test.js
+++ b/ghost/core/test/unit/server/services/outbox/handlers/member-created.test.js
@@ -31,7 +31,6 @@ describe('member-created handler', function () {
         logCapture = captureLoggerOutput(logging);
 
         handler.__set__('memberWelcomeEmailService', memberWelcomeEmailServiceStub);
-        handler.__set__('logging', logging);
         handler.__set__('AutomatedEmail', AutomatedEmailStub);
         handler.__set__('AutomatedEmailRecipient', AutomatedEmailRecipientStub);
     });

--- a/ghost/core/test/unit/server/services/outbox/index.test.js
+++ b/ghost/core/test/unit/server/services/outbox/index.test.js
@@ -3,7 +3,7 @@ const sinon = require('sinon');
 const rewire = require('rewire');
 const DomainEvents = require('@tryghost/domain-events');
 const logging = require('@tryghost/logging');
-const {captureLoggerOutput} = require('../../../../utils/logging-utils');
+const {captureLoggerOutput, findByEvent} = require('../../../../utils/logging-utils');
 const StartOutboxProcessingEvent = require('../../../../../core/server/services/outbox/events/start-outbox-processing-event');
 
 describe('Outbox Service', function () {
@@ -50,7 +50,7 @@ describe('Outbox Service', function () {
             await service.startProcessing();
 
             sinon.assert.notCalled(processOutboxStub);
-            const infoLog = logCapture.output.find(log => log.level === 30 && log.msg === 'Outbox job already running, skipping');
+            const infoLog = findByEvent(logCapture.output, 'outbox.processing.skipped_already_running');
             assert.ok(infoLog);
             assert.deepEqual(infoLog.system, {
                 event: 'outbox.processing.skipped_already_running'

--- a/ghost/core/test/unit/server/services/outbox/index.test.js
+++ b/ghost/core/test/unit/server/services/outbox/index.test.js
@@ -1,6 +1,10 @@
+const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const rewire = require('rewire');
 const DomainEvents = require('@tryghost/domain-events');
+const bunyan = require('bunyan');
+const {PassThrough} = require('stream');
+const logging = require('@tryghost/logging');
 const StartOutboxProcessingEvent = require('../../../../../core/server/services/outbox/events/start-outbox-processing-event');
 
 describe('Outbox Service', function () {
@@ -26,6 +30,49 @@ describe('Outbox Service', function () {
         await DomainEvents.allSettled();
     });
 
+    function captureLoggerOutput() {
+        const output = [];
+        const stream = new PassThrough();
+        let buffered = '';
+
+        stream.on('data', (chunk) => {
+            buffered += chunk.toString();
+            const lines = buffered.split('\n');
+            buffered = lines.pop();
+
+            for (const line of lines) {
+                if (!line.trim()) {
+                    continue;
+                }
+
+                output.push(JSON.parse(line));
+            }
+        });
+
+        const originalStreams = logging.streams;
+        logging.streams = {
+            capture: {
+                name: 'capture',
+                log: bunyan.createLogger({
+                    name: 'test-logger',
+                    streams: [{
+                        type: 'stream',
+                        stream,
+                        level: 'trace'
+                    }]
+                })
+            }
+        };
+
+        return {
+            output,
+            restore() {
+                logging.streams = originalStreams;
+                stream.destroy();
+            }
+        };
+    }
+
     describe('StartOutboxProcessingEvent subscription', function () {
         it('calls startProcessing when event is dispatched', async function () {
             service.init();
@@ -47,6 +94,28 @@ describe('Outbox Service', function () {
 
             sinon.assert.notCalled(processOutboxStub);
             sinon.assert.calledOnce(loggingStub.info);
+        });
+
+        it('logs structured info if already running', async function () {
+            const capture = captureLoggerOutput();
+            service.__set__('logging', logging);
+
+            try {
+                service.init();
+                service.processing = true;
+
+                await service.startProcessing();
+
+                sinon.assert.notCalled(processOutboxStub);
+
+                const infoLog = capture.output.find(log => log.level === 30 && log.msg === 'Outbox job already running, skipping');
+                assert.ok(infoLog);
+                assert.deepEqual(infoLog.system, {
+                    event: 'outbox.processing.skipped_already_running'
+                });
+            } finally {
+                capture.restore();
+            }
         });
     });
 });

--- a/ghost/core/test/unit/server/services/outbox/index.test.js
+++ b/ghost/core/test/unit/server/services/outbox/index.test.js
@@ -2,9 +2,8 @@ const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const rewire = require('rewire');
 const DomainEvents = require('@tryghost/domain-events');
-const bunyan = require('bunyan');
-const {PassThrough} = require('stream');
 const logging = require('@tryghost/logging');
+const {captureLoggerOutput} = require('../../../../utils/logging-utils');
 const StartOutboxProcessingEvent = require('../../../../../core/server/services/outbox/events/start-outbox-processing-event');
 
 describe('Outbox Service', function () {
@@ -30,49 +29,6 @@ describe('Outbox Service', function () {
         await DomainEvents.allSettled();
     });
 
-    function captureLoggerOutput() {
-        const output = [];
-        const stream = new PassThrough();
-        let buffered = '';
-
-        stream.on('data', (chunk) => {
-            buffered += chunk.toString();
-            const lines = buffered.split('\n');
-            buffered = lines.pop();
-
-            for (const line of lines) {
-                if (!line.trim()) {
-                    continue;
-                }
-
-                output.push(JSON.parse(line));
-            }
-        });
-
-        const originalStreams = logging.streams;
-        logging.streams = {
-            capture: {
-                name: 'capture',
-                log: bunyan.createLogger({
-                    name: 'test-logger',
-                    streams: [{
-                        type: 'stream',
-                        stream,
-                        level: 'trace'
-                    }]
-                })
-            }
-        };
-
-        return {
-            output,
-            restore() {
-                logging.streams = originalStreams;
-                stream.destroy();
-            }
-        };
-    }
-
     describe('StartOutboxProcessingEvent subscription', function () {
         it('calls startProcessing when event is dispatched', async function () {
             service.init();
@@ -97,7 +53,7 @@ describe('Outbox Service', function () {
         });
 
         it('logs structured info if already running', async function () {
-            const capture = captureLoggerOutput();
+            const capture = captureLoggerOutput(logging);
             service.__set__('logging', logging);
 
             try {

--- a/ghost/core/test/unit/server/services/outbox/index.test.js
+++ b/ghost/core/test/unit/server/services/outbox/index.test.js
@@ -9,22 +9,23 @@ const StartOutboxProcessingEvent = require('../../../../../core/server/services/
 describe('Outbox Service', function () {
     let service;
     let processOutboxStub;
-    let loggingStub;
     let jobsStub;
+    let logCapture;
 
     beforeEach(function () {
         service = rewire('../../../../../core/server/services/outbox/index.js');
 
         processOutboxStub = sinon.stub().resolves('Processed');
-        loggingStub = {info: sinon.stub(), error: sinon.stub()};
         jobsStub = {scheduleOutboxJob: sinon.stub()};
+        logCapture = captureLoggerOutput(logging);
 
         service.__set__('processOutbox', processOutboxStub);
-        service.__set__('logging', loggingStub);
+        service.__set__('logging', logging);
         service.__set__('jobs', jobsStub);
     });
 
     afterEach(async function () {
+        logCapture.restore();
         sinon.restore();
         await DomainEvents.allSettled();
     });
@@ -49,29 +50,11 @@ describe('Outbox Service', function () {
             await service.startProcessing();
 
             sinon.assert.notCalled(processOutboxStub);
-            sinon.assert.calledOnce(loggingStub.info);
-        });
-
-        it('logs structured info if already running', async function () {
-            const capture = captureLoggerOutput(logging);
-            service.__set__('logging', logging);
-
-            try {
-                service.init();
-                service.processing = true;
-
-                await service.startProcessing();
-
-                sinon.assert.notCalled(processOutboxStub);
-
-                const infoLog = capture.output.find(log => log.level === 30 && log.msg === 'Outbox job already running, skipping');
-                assert.ok(infoLog);
-                assert.deepEqual(infoLog.system, {
-                    event: 'outbox.processing.skipped_already_running'
-                });
-            } finally {
-                capture.restore();
-            }
+            const infoLog = logCapture.output.find(log => log.level === 30 && log.msg === 'Outbox job already running, skipping');
+            assert.ok(infoLog);
+            assert.deepEqual(infoLog.system, {
+                event: 'outbox.processing.skipped_already_running'
+            });
         });
     });
 });

--- a/ghost/core/test/unit/server/services/outbox/index.test.js
+++ b/ghost/core/test/unit/server/services/outbox/index.test.js
@@ -2,7 +2,6 @@ const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const rewire = require('rewire');
 const DomainEvents = require('@tryghost/domain-events');
-const logging = require('@tryghost/logging');
 const {captureLoggerOutput, findByEvent} = require('../../../../utils/logging-utils');
 const StartOutboxProcessingEvent = require('../../../../../core/server/services/outbox/events/start-outbox-processing-event');
 
@@ -17,7 +16,7 @@ describe('Outbox Service', function () {
 
         processOutboxStub = sinon.stub().resolves('Processed');
         jobsStub = {scheduleOutboxJob: sinon.stub()};
-        logCapture = captureLoggerOutput(logging);
+        logCapture = captureLoggerOutput();
 
         service.__set__('processOutbox', processOutboxStub);
         service.__set__('jobs', jobsStub);

--- a/ghost/core/test/unit/server/services/outbox/index.test.js
+++ b/ghost/core/test/unit/server/services/outbox/index.test.js
@@ -20,7 +20,6 @@ describe('Outbox Service', function () {
         logCapture = captureLoggerOutput(logging);
 
         service.__set__('processOutbox', processOutboxStub);
-        service.__set__('logging', logging);
         service.__set__('jobs', jobsStub);
     });
 

--- a/ghost/core/test/utils/logging-utils.js
+++ b/ghost/core/test/utils/logging-utils.js
@@ -1,0 +1,49 @@
+const bunyan = require('bunyan');
+const {PassThrough} = require('stream');
+
+function captureLoggerOutput(logging) {
+    const output = [];
+    const stream = new PassThrough();
+    let buffered = '';
+
+    stream.on('data', (chunk) => {
+        buffered += chunk.toString();
+        const lines = buffered.split('\n');
+        buffered = lines.pop();
+
+        for (const line of lines) {
+            if (!line.trim()) {
+                continue;
+            }
+
+            output.push(JSON.parse(line));
+        }
+    });
+
+    const originalStreams = logging.streams;
+    logging.streams = {
+        capture: {
+            name: 'capture',
+            log: bunyan.createLogger({
+                name: 'test-logger',
+                streams: [{
+                    type: 'stream',
+                    stream,
+                    level: 'trace'
+                }]
+            })
+        }
+    };
+
+    return {
+        output,
+        restore() {
+            logging.streams = originalStreams;
+            stream.destroy();
+        }
+    };
+}
+
+module.exports = {
+    captureLoggerOutput
+};

--- a/ghost/core/test/utils/logging-utils.js
+++ b/ghost/core/test/utils/logging-utils.js
@@ -1,6 +1,37 @@
 const bunyan = require('bunyan');
 const {PassThrough} = require('stream');
 
+/**
+ * Parse newline-delimited JSON log records from a buffered string.
+ *
+ * @param {string} buffer - Buffered log text that may contain multiple records.
+ * @param {Array<object>} output - Collected parsed log records.
+ * @returns {string} Remaining partial record that did not end with a newline.
+ */
+function parseBufferedJsonLogs(buffer, output) {
+    const lines = buffer.split('\n');
+    const remaining = lines.pop();
+
+    for (const line of lines) {
+        if (!line.trim()) {
+            continue;
+        }
+
+        output.push(JSON.parse(line));
+    }
+
+    return remaining;
+}
+
+/**
+ * Temporarily redirects Ghost logger streams to an in-memory Bunyan stream.
+ *
+ * This allows tests to assert on real serialized JSON output from
+ * `@tryghost/logging` without stubbing logger methods.
+ *
+ * @param {import('@tryghost/logging')} logging - Logger singleton to capture.
+ * @returns {{output: Array<object>, restore: () => void}} Capture handle.
+ */
 function captureLoggerOutput(logging) {
     const output = [];
     const stream = new PassThrough();
@@ -8,16 +39,7 @@ function captureLoggerOutput(logging) {
 
     stream.on('data', (chunk) => {
         buffered += chunk.toString();
-        const lines = buffered.split('\n');
-        buffered = lines.pop();
-
-        for (const line of lines) {
-            if (!line.trim()) {
-                continue;
-            }
-
-            output.push(JSON.parse(line));
-        }
+        buffered = parseBufferedJsonLogs(buffered, output);
     });
 
     const originalStreams = logging.streams;
@@ -38,6 +60,7 @@ function captureLoggerOutput(logging) {
     return {
         output,
         restore() {
+            buffered = parseBufferedJsonLogs(buffered, output);
             logging.streams = originalStreams;
             stream.destroy();
         }

--- a/ghost/core/test/utils/logging-utils.js
+++ b/ghost/core/test/utils/logging-utils.js
@@ -1,5 +1,6 @@
 const bunyan = require('bunyan');
 const {PassThrough} = require('stream');
+const logging = require('@tryghost/logging');
 
 /**
  * Parse newline-delimited JSON log records from a buffered string.
@@ -29,10 +30,9 @@ function parseBufferedJsonLogs(buffer, output) {
  * This allows tests to assert on real serialized JSON output from
  * `@tryghost/logging` without stubbing logger methods.
  *
- * @param {import('@tryghost/logging')} logging - Logger singleton to capture.
  * @returns {{output: Array<object>, restore: () => void}} Capture handle.
  */
-function captureLoggerOutput(logging) {
+function captureLoggerOutput() {
     const output = [];
     const stream = new PassThrough();
     let buffered = '';

--- a/ghost/core/test/utils/logging-utils.js
+++ b/ghost/core/test/utils/logging-utils.js
@@ -78,19 +78,7 @@ function findByEvent(output, event) {
     return output.find(log => log.system?.event === event);
 }
 
-/**
- * Find all structured log records matching a system event.
- *
- * @param {Array<object>} output - Captured log records.
- * @param {string} event - Structured event name to match.
- * @returns {Array<object>} Matching log records.
- */
-function findAllByEvent(output, event) {
-    return output.filter(log => log.system?.event === event);
-}
-
 module.exports = {
     captureLoggerOutput,
-    findByEvent,
-    findAllByEvent
+    findByEvent
 };

--- a/ghost/core/test/utils/logging-utils.js
+++ b/ghost/core/test/utils/logging-utils.js
@@ -67,6 +67,30 @@ function captureLoggerOutput(logging) {
     };
 }
 
+/**
+ * Find the first structured log record matching a system event.
+ *
+ * @param {Array<object>} output - Captured log records.
+ * @param {string} event - Structured event name to match.
+ * @returns {object|undefined} First matching log record.
+ */
+function findByEvent(output, event) {
+    return output.find(log => log.system?.event === event);
+}
+
+/**
+ * Find all structured log records matching a system event.
+ *
+ * @param {Array<object>} output - Captured log records.
+ * @param {string} event - Structured event name to match.
+ * @returns {Array<object>} Matching log records.
+ */
+function findAllByEvent(output, event) {
+    return output.filter(log => log.system?.event === event);
+}
+
 module.exports = {
-    captureLoggerOutput
+    captureLoggerOutput,
+    findByEvent,
+    findAllByEvent
 };

--- a/ghost/core/test/utils/logging-utils.js
+++ b/ghost/core/test/utils/logging-utils.js
@@ -43,11 +43,13 @@ function captureLoggerOutput() {
     });
 
     const originalStreams = logging.streams;
+    const originalSerializerSource = Object.values(originalStreams)[0]?.log?.serializers;
     logging.streams = {
         capture: {
             name: 'capture',
             log: bunyan.createLogger({
                 name: 'test-logger',
+                serializers: originalSerializerSource || logging.serializers,
                 streams: [{
                     type: 'stream',
                     stream,


### PR DESCRIPTION
refs https://linear.app/ghost/issue/NY-1020/convert-outbox-logs-to-structured-logs

## Summary

- converted the outbox missing-slug warning and outbox already-running guard logs to structured logging with a top-level `system` object and message second argument
- added red/green unit coverage that captures real `@tryghost/logging` Bunyan JSON output in-memory and asserts structured fields
- extracted shared test log capture utility (`ghost/core/test/utils/logging-utils.js`) with JSDoc and updated outbox unit tests to use top-level capture hooks

## Reviewer notes

Mostly I'm looking for feedback on the new testing pattern introduced here. The new `captureLoggerOutput()` test helper redirects the actual JSON logs emitted by @tryghost/logging into an in-memory stream. This way we can assert on the _actual_ JSON that is output by the logger, which feels more useful to me than asserting on which arguments we pass to the logger.

This doesn't cover all the logs that I want to change to structured logs for the referenced issue, but I wanted to align on the pattern here while keeping the PR relatively small; once we're aligned on the approach I can extend it to the other outbox/welcome email logs in a follow up PR.