### PR TITLE
Fixed offers CTA to always show "Manage offers"

### DIFF
--- a/apps/admin-x-settings/src/components/settings/growth/offers.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/offers.tsx
@@ -71,7 +71,6 @@ const Offers: React.FC<{ keywords: string[] }> = ({keywords}) => {
         updateRoute(`offers/edit/${offerId}`);
     };
 
-    // Get retention offers to check if any are active
     const retentionOffers = getRetentionOffers(allOffers);
     const hasActiveRetentionOffer = retentionOffers.some(offer => offer.status === 'active');
 
@@ -80,23 +79,14 @@ const Offers: React.FC<{ keywords: string[] }> = ({keywords}) => {
     let descriptionButtonText = 'Learn more';
 
     if (paidActiveTiers.length === 0 && signupOffers.length === 0) {
-        // No paid tiers - need to create tiers first
         offerButtonText = '';
         offerButtonLink = openTiers;
         descriptionButtonText = '';
     } else if (retentionOffersEnabled) {
-        // When retention offers feature is enabled, always show "Manage offers"
-        // since there will always be retention offers to manage
-        offerButtonText = 'Manage offers';
-        offerButtonLink = openOfferListModal;
-        // Only show help link when there are no signup offers AND no active retention offers
         if (signupOffers.length > 0 || hasActiveRetentionOffer) {
             descriptionButtonText = '';
         }
-    } else if (signupOffers.length > 0) {
-        offerButtonText = 'Manage offers';
-        offerButtonLink = openOfferListModal;
-    } else if (paidActiveTiers.length > 0 && signupOffers.length === 0) {
+    } else if (!signupOffers.length) {
         offerButtonText = 'Add offer';
         offerButtonLink = openAddModal;
     }

--- a/apps/admin-x-settings/src/components/settings/growth/offers.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/offers.tsx
@@ -78,14 +78,14 @@ const Offers: React.FC<{ keywords: string[] }> = ({keywords}) => {
     let offerButtonLink = openOfferListModal;
     let descriptionButtonText = 'Learn more';
 
-    if (retentionOffersEnabled) {
-        if (signupOffers.length > 0 || hasActiveRetentionOffer) {
-            descriptionButtonText = '';
-        }
-    } else if (paidActiveTiers.length === 0 && signupOffers.length === 0) {
+    if (paidActiveTiers.length === 0 && signupOffers.length === 0) {
         offerButtonText = '';
         offerButtonLink = openTiers;
         descriptionButtonText = '';
+    } else if (retentionOffersEnabled) {
+        if (signupOffers.length > 0 || hasActiveRetentionOffer) {
+            descriptionButtonText = '';
+        }
     } else if (!signupOffers.length) {
         offerButtonText = 'Add offer';
         offerButtonLink = openAddModal;
@@ -123,7 +123,7 @@ const Offers: React.FC<{ keywords: string[] }> = ({keywords}) => {
                 </div> :
                 null
             }
-            {!retentionOffersEnabled && paidActiveTiers.length === 0 && signupOffers.length === 0 ?
+            {paidActiveTiers.length === 0 && signupOffers.length === 0 ?
                 (<div>
                     <span>You must have an active tier to create an offer.</span>
                     {` `}

--- a/apps/admin-x-settings/src/components/settings/growth/offers.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/offers.tsx
@@ -78,14 +78,14 @@ const Offers: React.FC<{ keywords: string[] }> = ({keywords}) => {
     let offerButtonLink = openOfferListModal;
     let descriptionButtonText = 'Learn more';
 
-    if (paidActiveTiers.length === 0 && signupOffers.length === 0) {
-        offerButtonText = '';
-        offerButtonLink = openTiers;
-        descriptionButtonText = '';
-    } else if (retentionOffersEnabled) {
+    if (retentionOffersEnabled) {
         if (signupOffers.length > 0 || hasActiveRetentionOffer) {
             descriptionButtonText = '';
         }
+    } else if (paidActiveTiers.length === 0 && signupOffers.length === 0) {
+        offerButtonText = '';
+        offerButtonLink = openTiers;
+        descriptionButtonText = '';
     } else if (!signupOffers.length) {
         offerButtonText = 'Add offer';
         offerButtonLink = openAddModal;
@@ -123,7 +123,7 @@ const Offers: React.FC<{ keywords: string[] }> = ({keywords}) => {
                 </div> :
                 null
             }
-            {paidActiveTiers.length === 0 && signupOffers.length === 0 ?
+            {!retentionOffersEnabled && paidActiveTiers.length === 0 && signupOffers.length === 0 ?
                 (<div>
                     <span>You must have an active tier to create an offer.</span>
                     {` `}


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3375/offers-admin-shows-add-offer-and-jumps-on-refresh

When the retentionOffers feature flag is enabled, there will always be retention offers to manage (even if inactive). This change ensures:
- The CTA always shows "Manage offers" and opens the offers list modal
- The help link only appears when no signup offers AND no active retention offers