### PR TITLE
Skipped 'Add offer' route when retentionOffers flag is enabled 

### DIFF
--- a/apps/admin-x-settings/src/components/settings/growth/offers.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/offers.tsx
@@ -73,16 +73,22 @@ const Offers: React.FC<{ keywords: string[] }> = ({keywords}) => {
     let offerButtonText = 'Manage offers';
     let offerButtonLink = openOfferListModal;
     let descriptionButtonText = 'Learn more';
-    if (signupOffers.length > 0) {
-        offerButtonText = 'Manage offers';
-        offerButtonLink = openOfferListModal;
-    } else if (paidActiveTiers.length === 0 && signupOffers.length === 0) {
+    if (!retentionOffersEnabled) {
+        if (signupOffers.length > 0) {
+            offerButtonText = 'Manage offers';
+            offerButtonLink = openOfferListModal;
+        } else if (paidActiveTiers.length === 0 && signupOffers.length === 0) {
+            offerButtonText = '';
+            offerButtonLink = openTiers;
+            descriptionButtonText = '';
+        } else if (paidActiveTiers.length > 0 && signupOffers.length === 0) {
+            offerButtonText = 'Add offer';
+            offerButtonLink = openAddModal;
+        }
+    } else if (paidActiveTiers.length === 0) {
         offerButtonText = '';
         offerButtonLink = openTiers;
         descriptionButtonText = '';
-    } else if (paidActiveTiers.length > 0 && signupOffers.length === 0) {
-        offerButtonText = 'Add offer';
-        offerButtonLink = openAddModal;
     }
 
     return (


### PR DESCRIPTION
https://linear.app/ghost/issue/BER-3375/offers-admin-shows-add-offer-and-jumps-on-refresh

When the `retentionOffers` flag is enabled, there will always be static retention offers in the list, so the "Add offer" button is no longer needed. This wraps the existing button/link conditional logic so it only runs when the flag is off, keeping the default "Manage offers" button for the new flow. The no-paid-tiers empty state and "Manage tiers" link still apply in both cases since retention offers also require paid tiers.