### PR TITLE
Fixed retention offer preview sizing in Portal

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.64.11",
+  "version": "2.64.12",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/portal/src/components/frame.styles.js
+++ b/apps/portal/src/components/frame.styles.js
@@ -387,18 +387,21 @@ html[dir="rtl"] .gh-portal-btn-site-title-back span {
     animation: none !important;
 }
 
-.gh-portal-popup-wrapper.preview.offer {
+.gh-portal-popup-wrapper.preview.offer,
+.gh-portal-popup-wrapper.preview.account-plan {
     padding-top: 0;
 }
 
-.gh-portal-popup-container.preview.offer {
+.gh-portal-popup-container.preview.offer,
+.gh-portal-popup-container.preview.account-plan {
     max-width: 420px;
     transform: scale(0.9);
-    margin-top: 3.2vw;
+    margin: 3.2vw auto 0;
 }
 
 @media (max-width: 480px) {
-    .gh-portal-popup-container.preview.offer {
+    .gh-portal-popup-container.preview.offer,
+    .gh-portal-popup-container.preview.account-plan {
         transform-origin: top;
         margin-top: 0;
     }
@@ -940,6 +943,13 @@ const MobileStyles = `
         overflow: auto;
         justify-content: flex-start;
     }
+
+    .gh-portal-popup-wrapper.full-size .gh-portal-popup-container.preview.account-plan {
+        max-width: 420px;
+        width: auto;
+        margin: 3.2vw auto 0;
+        transform: scale(0.9);
+    }
 }
 
 @media (max-width: 480px) {
@@ -998,7 +1008,8 @@ const MobileStyles = `
         margin-bottom: 0;
     }
 
-    .gh-portal-popup-container.preview:not(.full-size).offer {
+    .gh-portal-popup-container.preview:not(.full-size).offer,
+    .gh-portal-popup-container.preview:not(.full-size).account-plan {
         max-height: 860px;
         padding-bottom: 0 !important;
     }

--- a/apps/portal/src/components/pages/account-plan-page.js
+++ b/apps/portal/src/components/pages/account-plan-page.js
@@ -39,6 +39,15 @@ export const AccountPlanPageStyles = `
         padding: 6px 12px;
     }
 
+    .gh-portal-retention-offer {
+        margin-top: -24px !important;
+    }
+
+    .gh-portal-retention-offer > p {
+        max-width: 400px;
+        margin-inline: auto;
+    }
+
     .gh-portal-retention-offer-price {
         display: flex;
         align-items: center;


### PR DESCRIPTION
no issues

Applied the same preview container sizing used by the offer page to the account-plan page so the retention offer preview renders at the correct width and scale in Admin. Also tightened retention offer spacing and constrained the description text width.