### PR TITLE
Hid offer type selector for yearly retention offers

### DIFF
--- a/apps/admin-x-settings/src/components/settings/growth/offers/edit-retention-offer-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/offers/edit-retention-offer-modal.tsx
@@ -257,19 +257,19 @@ const RetentionOfferSidebar: React.FC<{
                         <section className='mt-4'>
                             <h2 className='mb-4 text-lg'>Details</h2>
                             <div className='flex flex-col gap-6'>
-                                <div className='flex flex-col gap-4 rounded-md border border-grey-200 p-4 dark:border-grey-800'>
-                                    <ButtonSelect
-                                        checked={formState.type === 'percent'}
-                                        type={typeOptions[0]}
-                                        onClick={() => {
-                                            clearError('amount');
-                                            clearError('durationInMonths');
-                                            updateForm((state) => {
-                                                return {...state, type: 'percent', percentAmount: state.percentAmount};
-                                            });
-                                        }}
-                                    />
-                                    {cadence === 'monthly' && (
+                                {cadence === 'monthly' && (
+                                    <div className='flex flex-col gap-4 rounded-md border border-grey-200 p-4 dark:border-grey-800'>
+                                        <ButtonSelect
+                                            checked={formState.type === 'percent'}
+                                            type={typeOptions[0]}
+                                            onClick={() => {
+                                                clearError('amount');
+                                                clearError('durationInMonths');
+                                                updateForm((state) => {
+                                                    return {...state, type: 'percent', percentAmount: state.percentAmount};
+                                                });
+                                            }}
+                                        />
                                         <ButtonSelect
                                             checked={formState.type === 'free_months'}
                                             type={typeOptions[1]}
@@ -279,8 +279,8 @@ const RetentionOfferSidebar: React.FC<{
                                                 updateForm(state => ({...state, type: 'free_months'}));
                                             }}
                                         />
-                                    )}
-                                </div>
+                                    </div>
+                                )}
                                 {formState.type === 'percent' && (
                                     <>
                                         <TextField


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3364/use-a-stripe-coupon-instead-of-a-trial-for-free-month-offers

When `cadence` is yearly, the "Free month(s)" option is already excluded, leaving the type selector with only "Percentage discount" — a radio-style control with a single option. This hides the entire type selector container for yearly retention offers since there's no choice to make.
