### PR TITLE
Fixed next payment details for free month offers

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.64.11",
+  "version": "2.64.12",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/portal/src/components/pages/AccountHomePage/components/account-welcome.js
+++ b/apps/portal/src/components/pages/AccountHomePage/components/account-welcome.js
@@ -1,5 +1,5 @@
 import AppContext from '../../../../app-context';
-import {getCompExpiry, getMemberSubscription, hasOnlyFreePlan, isComplimentaryMember, subscriptionHasFreeMonthsOffer, subscriptionHasFreeTrial} from '../../../../utils/helpers';
+import {getCompExpiry, getFreeMonthsOfferRenewalDate, getMemberSubscription, hasOnlyFreePlan, isComplimentaryMember, subscriptionHasFreeMonthsOffer, subscriptionHasFreeTrial} from '../../../../utils/helpers';
 import {getDateString} from '../../../../utils/date-time';
 import {useContext} from 'react';
 
@@ -47,12 +47,15 @@ const AccountWelcome = () => {
         }
 
         const renewalDate = subscriptionHasFreeMonthsOffer({sub: subscription})
-            ? subscription?.next_payment?.discount?.end
-            : currentPeriodEnd;
+            ? getFreeMonthsOfferRenewalDate({
+                currentPeriodEnd,
+                durationInMonths: subscription?.offer?.duration_in_months
+            })
+            : getDateString(currentPeriodEnd);
 
         return (
             <div className='gh-portal-section'>
-                <p className='gh-portal-text-center gh-portal-free-ctatext'>{t(`Your subscription will renew on {renewalDate}`, {renewalDate: getDateString(renewalDate)})}</p>
+                <p className='gh-portal-text-center gh-portal-free-ctatext'>{t(`Your subscription will renew on {renewalDate}`, {renewalDate})}</p>
             </div>
         );
     }

--- a/apps/portal/src/components/pages/AccountHomePage/components/paid-account-actions.js
+++ b/apps/portal/src/components/pages/AccountHomePage/components/paid-account-actions.js
@@ -1,5 +1,5 @@
 import AppContext from '../../../../app-context';
-import {getCompExpiry, getMemberSubscription, getMemberTierName, hasMultipleProductsFeature, hasOnlyFreePlan, isComplimentaryMember, isPaidMember, subscriptionHasFreeTrial, subscriptionHasFreeMonthsOffer} from '../../../../utils/helpers';
+import {getCompExpiry, getFreeMonthsOfferRenewalDate, getMemberSubscription, getMemberTierName, hasMultipleProductsFeature, hasOnlyFreePlan, isComplimentaryMember, isPaidMember, subscriptionHasFreeTrial, subscriptionHasFreeMonthsOffer} from '../../../../utils/helpers';
 import {getDateString} from '../../../../utils/date-time';
 import {ReactComponent as LoaderIcon} from '../../../../images/icons/loader.svg';
 import {ReactComponent as OfferTagIcon} from '../../../../images/icons/offer-tag.svg';
@@ -67,7 +67,7 @@ const PaidAccountActions = () => {
                     <p className={oldPriceClassName}>
                         {label}
                     </p>
-                    <FreeMonthsLabel nextPayment={nextPayment} subscription={subscription} />
+                    <FreeMonthsLabel subscription={subscription} />
                 </>
             );
         }
@@ -202,10 +202,12 @@ function FreeTrialLabel({subscription}) {
 }
 
 // TODO: Add i18n once copy is finalized
-function FreeMonthsLabel({nextPayment, subscription}) {
+function FreeMonthsLabel({subscription}) {
     const months = subscription?.offer?.duration_in_months ?? 0;
-    const discountEnd = nextPayment?.discount?.end;
-    const renewalDate = discountEnd ? getDateString(discountEnd) : null;
+    const renewalDate = getFreeMonthsOfferRenewalDate({
+        currentPeriodEnd: subscription?.current_period_end,
+        durationInMonths: months
+    });
     const monthsText = months === 1 ? '1 month free' : `${months} months free`;
     const label = renewalDate ? `${monthsText} - Renews ${renewalDate}` : monthsText;
 

--- a/apps/portal/src/components/pages/account-plan-page.js
+++ b/apps/portal/src/components/pages/account-plan-page.js
@@ -5,7 +5,7 @@ import CloseButton from '../common/close-button';
 import BackButton from '../common/back-button';
 import {MultipleProductsPlansSection} from '../common/plans-section';
 import {getDateString} from '../../utils/date-time';
-import {formatNumber, getAvailablePrices, getCurrencySymbol, getFilteredPrices, isFreeMonthsOffer, getMemberActivePrice, getMemberActiveProduct, getMemberSubscription, getOfferOffAmount, getPriceFromSubscription, getProductFromId, getProductFromPrice, getSubscriptionFromId, getUpdatedOfferPrice, getUpgradeProducts, hasMultipleProductsFeature, isComplimentaryMember, isPaidMember} from '../../utils/helpers';
+import {formatNumber, getAvailablePrices, getCurrencySymbol, getFilteredPrices, getFreeMonthsOfferRenewalDate, isFreeMonthsOffer, getMemberActivePrice, getMemberActiveProduct, getMemberSubscription, getOfferOffAmount, getPriceFromSubscription, getProductFromId, getProductFromPrice, getSubscriptionFromId, getUpdatedOfferPrice, getUpgradeProducts, hasMultipleProductsFeature, isComplimentaryMember, isPaidMember} from '../../utils/helpers';
 import Interpolate from '@doist/react-interpolate';
 import {t} from '../../utils/i18n';
 
@@ -255,16 +255,12 @@ function getOfferMessage(offer, originalPrice, currency, amountOff, subscription
     if (isFreeMonthsOffer(offer)) {
         const months = offer.duration_in_months;
         const monthLabel = months === 1 ? '1 free month' : `${months} free months`;
+        const newBillingDate = getFreeMonthsOfferRenewalDate({
+            currentPeriodEnd: subscription?.current_period_end,
+            durationInMonths: months
+        });
 
-        if (subscription?.current_period_end) {
-            const date = new Date(subscription.current_period_end);
-            const originalDay = date.getUTCDate();
-            let targetMonth = date.getUTCMonth() + months;
-            let targetYear = date.getUTCFullYear() + Math.floor(targetMonth / 12);
-            targetMonth = targetMonth % 12;
-            const daysInTargetMonth = new Date(Date.UTC(targetYear, targetMonth + 1, 0)).getUTCDate();
-            const newDate = new Date(Date.UTC(targetYear, targetMonth, Math.min(originalDay, daysInTargetMonth)));
-            const newBillingDate = newDate.toLocaleDateString('en-GB', {year: 'numeric', month: 'short', day: 'numeric', timeZone: 'UTC'});
+        if (newBillingDate) {
             return `Enjoy ${monthLabel} on us. Your next billing date will be ${newBillingDate}.`;
         }
 

--- a/apps/portal/src/utils/helpers.js
+++ b/apps/portal/src/utils/helpers.js
@@ -547,6 +547,29 @@ export function isFreeMonthsOffer(offer) {
         && offer?.redemption_type === 'retention';
 }
 
+export function getFreeMonthsOfferRenewalDate({currentPeriodEnd, durationInMonths} = {}) {
+    const months = Number(durationInMonths);
+    const periodEndDate = new Date(currentPeriodEnd);
+
+    if (Number.isNaN(periodEndDate.getTime()) || Number.isNaN(months) || months < 1) {
+        return '';
+    }
+
+    const originalDay = periodEndDate.getUTCDate();
+    const totalMonths = periodEndDate.getUTCMonth() + Math.trunc(months);
+    const targetYear = periodEndDate.getUTCFullYear() + Math.floor(totalMonths / 12);
+    const targetMonth = totalMonths % 12;
+    const daysInTargetMonth = new Date(Date.UTC(targetYear, targetMonth + 1, 0)).getUTCDate();
+    const nextBillingDate = new Date(Date.UTC(targetYear, targetMonth, Math.min(originalDay, daysInTargetMonth)));
+
+    return nextBillingDate.toLocaleDateString('en-GB', {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+        timeZone: 'UTC'
+    });
+}
+
 export function subscriptionHasFreeMonthsOffer({sub} = {}) {
     if (!isFreeMonthsOffer(sub?.offer)) {
         return false;

--- a/apps/portal/test/unit/components/pages/AccountHomePage/account-home-page.test.js
+++ b/apps/portal/test/unit/components/pages/AccountHomePage/account-home-page.test.js
@@ -1,7 +1,7 @@
 import {render, fireEvent} from '../../../../utils/test-utils';
 import AccountHomePage from '../../../../../src/components/pages/AccountHomePage/account-home-page';
 import {site} from '../../../../../src/utils/fixtures';
-import {getSiteData, getNewslettersData} from '../../../../../src/utils/fixtures-generator';
+import {getDiscountData, getMemberData, getNewslettersData, getNextPaymentData, getProductsData, getSiteData, getSubscriptionData} from '../../../../../src/utils/fixtures-generator';
 
 const setup = (overrides) => {
     const {mockDoActionFn, ...utils} = render(
@@ -34,6 +34,49 @@ describe('Account Home Page', () => {
 
         fireEvent.click(logoutBtn);
         expect(mockDoActionFn).toHaveBeenCalledWith('signout');
+    });
+
+    test('shows free months renewal date based on the paid billing date', () => {
+        const products = getProductsData({numOfProducts: 1});
+        const siteData = getSiteData({products, portalProducts: products.map(p => p.id)});
+        const currentPeriodEnd = new Date('2099-01-01T12:00:00.000Z');
+        const discountEnd = new Date('2099-01-01T12:00:00.000Z');
+
+        const member = getMemberData({
+            paid: true,
+            subscriptions: [
+                getSubscriptionData({
+                    status: 'active',
+                    amount: 500,
+                    currency: 'USD',
+                    interval: 'month',
+                    offer: {
+                        type: 'percent',
+                        amount: 100,
+                        duration: 'repeating',
+                        duration_in_months: 1,
+                        redemption_type: 'retention'
+                    },
+                    currentPeriodEnd: currentPeriodEnd.toISOString(),
+                    nextPayment: getNextPaymentData({
+                        originalAmount: 500,
+                        amount: 500,
+                        interval: 'month',
+                        currency: 'USD',
+                        discount: getDiscountData({
+                            duration: 'repeating',
+                            type: 'percent',
+                            amount: 100,
+                            end: discountEnd.toISOString()
+                        })
+                    })
+                })
+            ]
+        });
+
+        const {utils} = setup({site: siteData, member});
+
+        expect(utils.queryByText('Your subscription will renew on 1 Feb 2099')).toBeInTheDocument();
     });
 
     test('can show Manage button for few newsletters', () => {

--- a/apps/portal/test/unit/components/pages/AccountHomePage/paid-account-actions.test.js
+++ b/apps/portal/test/unit/components/pages/AccountHomePage/paid-account-actions.test.js
@@ -129,7 +129,8 @@ describe('PaidAccountActions', () => {
             const products = getProductsData({numOfProducts: 1});
             const site = getSiteData({products, portalProducts: products.map(p => p.id)});
 
-            const discountEnd = new Date('2099-02-01T12:00:00.000Z');
+            const currentPeriodEnd = new Date('2099-01-01T12:00:00.000Z');
+            const discountEnd = new Date('2099-01-01T12:00:00.000Z');
 
             const member = getMemberData({
                 paid: true,
@@ -157,7 +158,8 @@ describe('PaidAccountActions', () => {
                                 amount: 100,
                                 end: discountEnd.toISOString()
                             })
-                        })
+                        }),
+                        currentPeriodEnd: currentPeriodEnd.toISOString()
                     })
                 ]
             });
@@ -166,7 +168,7 @@ describe('PaidAccountActions', () => {
 
             expect(queryByText('$5.00/month')).toBeInTheDocument();
             expect(queryByTestId('offer-label')).toBeInTheDocument();
-            expect(queryByText(/1 month free/)).toBeInTheDocument();
+            expect(queryByText('1 month free - Renews 1 Feb 2099')).toBeInTheDocument();
         });
 
         test('displays "Complimentary" with expiry date', () => {

--- a/apps/portal/test/utils/helpers.test.js
+++ b/apps/portal/test/utils/helpers.test.js
@@ -22,6 +22,7 @@ import {
     isSigninAllowed,
     isSignupAllowed,
     getCompExpiry,
+    getFreeMonthsOfferRenewalDate,
     isInThePast,
     hasNewsletterSendingEnabled,
     getUpdatedOfferPrice,
@@ -684,6 +685,32 @@ describe('Helpers - ', () => {
 
             expect(isInThePast(pastDate)).toEqual(true);
             expect(isInThePast(futureDate)).toEqual(false);
+        });
+    });
+
+    describe('getFreeMonthsOfferRenewalDate', () => {
+        it('adds the free month duration to the current period end date', () => {
+            const renewalDate = getFreeMonthsOfferRenewalDate({
+                currentPeriodEnd: '2026-03-26T12:00:00.000Z',
+                durationInMonths: 1
+            });
+
+            expect(renewalDate).toBe('26 Apr 2026');
+        });
+
+        it('clamps to the end of target month when the original day does not exist', () => {
+            const renewalDate = getFreeMonthsOfferRenewalDate({
+                currentPeriodEnd: '2025-01-31T12:00:00.000Z',
+                durationInMonths: 1
+            });
+
+            expect(renewalDate).toBe('28 Feb 2025');
+        });
+
+        it('returns an empty string for invalid input', () => {
+            expect(getFreeMonthsOfferRenewalDate({durationInMonths: 1})).toBe('');
+            expect(getFreeMonthsOfferRenewalDate({currentPeriodEnd: '2025-01-01T00:00:00.000Z', durationInMonths: 0})).toBe('');
+            expect(getFreeMonthsOfferRenewalDate({currentPeriodEnd: 'not-a-date', durationInMonths: 1})).toBe('');
         });
     });
 

--- a/ghost/admin/app/utils/subscription-data.js
+++ b/ghost/admin/app/utils/subscription-data.js
@@ -2,6 +2,7 @@ import moment from 'moment-timezone';
 import {getNonDecimal, getSymbol} from 'ghost-admin/utils/currency';
 
 export function getSubscriptionData(sub) {
+    const freeMonthsRenewalDate = getFreeMonthsRenewalDate(sub);
     const data = {
         ...sub,
         attribution: {
@@ -10,7 +11,7 @@ export function getSubscriptionData(sub) {
             referrerMedium: sub.attribution?.referrer_medium || '-'
         },
         startDate: sub.start_date ? moment(sub.start_date).format('D MMM YYYY') : '-',
-        validUntil: validUntil(sub),
+        validUntil: freeMonthsRenewalDate || validUntil(sub),
         hasEnded: isCanceled(sub),
         willEndSoon: isSetToCancel(sub),
         cancellationReason: sub.cancellation_reason,
@@ -88,6 +89,26 @@ export function trialUntil(sub) {
     return undefined;
 }
 
+function isFreeMonthsOffer(offer) {
+    return offer?.type === 'percent'
+        && offer?.amount === 100
+        && offer?.duration === 'repeating'
+        && offer?.redemption_type === 'retention';
+}
+
+function getFreeMonthsRenewalDate(sub = {}) {
+    const freeMonthsOffer = sub.offer;
+
+    if (!isFreeMonthsOffer(freeMonthsOffer)) {
+        return undefined;
+    }
+
+    const durationInMonths = Number(freeMonthsOffer.duration_in_months);
+    const currentPeriodEnd = moment.utc(sub.current_period_end);
+
+    return currentPeriodEnd.add(Math.trunc(durationInMonths), 'months').format('D MMM YYYY');
+}
+
 export function validityDetails(data, separatorNeeded = false) {
     const separator = separatorNeeded ? ' – ' : '';
     const space = data.validUntil ? ' ' : '';
@@ -129,7 +150,7 @@ export function getOfferDisplayData(offer, sub = {}) {
     const isRetention = offer.redemption_type === 'retention';
     const label = isRetention ? 'Retention offer' : 'Signup offer';
 
-    const isFreeMonths = offer.type === 'percent' && offer.amount === 100 && offer.duration === 'repeating';
+    const isFreeMonths = isFreeMonthsOffer(offer);
 
     let discount;
     if (offer.type === 'trial') {
@@ -169,6 +190,10 @@ export function getOfferDisplayData(offer, sub = {}) {
 
 export function getDiscountPrice(sub) {
     if (!sub.next_payment || !sub.next_payment.discount) {
+        return null;
+    }
+
+    if (isFreeMonthsOffer(sub.offer)) {
         return null;
     }
 

--- a/ghost/admin/tests/unit/utils/subscription-data-test.js
+++ b/ghost/admin/tests/unit/utils/subscription-data-test.js
@@ -305,9 +305,17 @@ describe('Unit: Util: subscription-data', function () {
                 cancel_at_period_end: false,
                 current_period_end: '2222-05-31',
                 offer: {
+                    id: 'offer_1',
                     type: 'percent',
                     amount: 100,
-                    duration: 'repeating'
+                    duration: 'repeating',
+                    duration_in_months: 1
+                },
+                next_payment: {
+                    amount: 0,
+                    original_amount: 5000,
+                    currency: 'usd',
+                    discount: {offer_id: 'offer_1', end: '2222-05-31'}
                 },
                 tier: null,
                 price: {
@@ -322,11 +330,11 @@ describe('Unit: Util: subscription-data', function () {
                 isComplimentary: false,
                 compExpiry: undefined,
                 hasEnded: false,
-                validUntil: '31 May 2222',
+                validUntil: '30 Jun 2222',
                 willEndSoon: false,
                 trialUntil: undefined,
                 priceLabel: 'Free tier',
-                validityDetails: ' – Renews 31 May 2222'
+                validityDetails: ' – Renews 30 Jun 2222'
             });
         });
 
@@ -479,6 +487,35 @@ describe('Unit: Util: subscription-data', function () {
 
             expect(data.hasActiveDiscount).to.be.undefined;
         });
+
+        it('does not set hasActiveDiscount for free months offers', function () {
+            const sub = {
+                id: 'sub_1',
+                status: 'active',
+                cancel_at_period_end: false,
+                current_period_end: '2026-03-26',
+                offer: {
+                    id: 'offer_1',
+                    type: 'percent',
+                    amount: 100,
+                    duration: 'repeating',
+                    duration_in_months: 1
+                },
+                price: {currency: 'usd', amount: 500},
+                next_payment: {
+                    amount: 0,
+                    original_amount: 500,
+                    currency: 'usd',
+                    discount: {offer_id: 'offer_1', end: '2026-03-26'}
+                }
+            };
+
+            const data = getSubscriptionData(sub);
+
+            expect(data.hasActiveDiscount).to.be.undefined;
+            expect(data.discountedPrice).to.be.undefined;
+            expect(data.originalPrice).to.be.undefined;
+        });
     });
 
     describe('getOfferDisplayData', function () {
@@ -615,6 +652,26 @@ describe('Unit: Util: subscription-data', function () {
                 discountedPrice: {currencySymbol: '€', nonDecimalAmount: 70},
                 originalPrice: {currencySymbol: '€', nonDecimalAmount: 100}
             });
+        });
+
+        it('returns null for free months offers', function () {
+            const result = getDiscountPrice({
+                offer: {
+                    id: 'offer_1',
+                    type: 'percent',
+                    amount: 100,
+                    duration: 'repeating',
+                    duration_in_months: 1
+                },
+                next_payment: {
+                    amount: 0,
+                    original_amount: 5000,
+                    currency: 'usd',
+                    discount: {offer_id: 'offer_1', end: '2026-09-01'}
+                }
+            });
+
+            expect(result).to.be.null;
         });
     });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3376

- we've recently switched to using a Stripe coupon for free-month offers (instead of a trial period)
- in this transition, the next billing date and amount were left inconsistent in Admin / Portal


---


## Before

<img width="1140" height="1020" alt="CleanShot 2026-02-26 at 10 09 59@2x" src="https://github.com/user-attachments/assets/f96e81da-024a-457d-bf9e-02f905443f5f" />
<img width="1252" height="1420" alt="CleanShot 2026-02-26 at 10 10 17@2x" src="https://github.com/user-attachments/assets/1c5a3adb-d358-4579-aaf1-02aba6daa6ae" />
<img width="1620" height="614" alt="CleanShot 2026-02-26 at 10 18 00@2x" src="https://github.com/user-attachments/assets/2bb679dd-2933-4327-8a95-ab55088a2985" />

## After
<img width="1140" height="1020" alt="image" src="https://github.com/user-attachments/assets/09dfbbc7-70c6-43fb-bcd3-9ce34ed3eee8" />
<img width="1606" height="594" alt="image" src="https://github.com/user-attachments/assets/cfb09c53-11e7-4181-a124-a8878fc37e0f" />
<img width="978" height="1328" alt="image" src="https://github.com/user-attachments/assets/b93d130c-5406-457f-8663-6f052d7bca4d" />


