### PR TITLE
Add legacy members filter conversion support

### DIFF
--- a/apps/posts/package.json
+++ b/apps/posts/package.json
@@ -40,6 +40,7 @@
     },
     "dependencies": {
         "@tryghost/admin-x-framework": "0.0.0",
+        "@tryghost/nql-lang": "0.6.4",
         "@tryghost/shade": "0.0.0",
         "i18n-iso-countries": "7.14.0",
         "moment": "2.24.0",

--- a/apps/posts/src/nql-lang.d.ts
+++ b/apps/posts/src/nql-lang.d.ts
@@ -1,0 +1,7 @@
+declare module '@tryghost/nql-lang' {
+    const nql: {
+        parse: (input: string, options?: Record<string, unknown>) => unknown;
+    };
+
+    export default nql;
+}

--- a/apps/posts/src/views/members/hooks/use-members-filter-state.ts
+++ b/apps/posts/src/views/members/hooks/use-members-filter-state.ts
@@ -1,3 +1,4 @@
+import {normalizeLegacyMembersFilter, translateLegacyMembersFilter} from '../utils/legacy-members-filter';
 import {useCallback, useMemo} from 'react';
 import {useSearchParams} from '@tryghost/admin-x-framework';
 import type {Filter} from '@tryghost/shade';
@@ -340,10 +341,46 @@ interface UseFilterStateReturn {
 export function useMembersFilterState(): UseFilterStateReturn {
     const [searchParams, setSearchParams] = useSearchParams();
 
-    // Parse filters from URL
-    const filters = useMemo(() => {
+    // Parse canonical filters from URL
+    const canonicalFilters = useMemo(() => {
         return searchParamsToFilters(searchParams);
     }, [searchParams]);
+
+    // Parse legacy filter params from old Ember bookmarkable URLs
+    const legacyFilterParam = useMemo(() => {
+        return searchParams.get('filter') ?? searchParams.get('filterParam') ?? undefined;
+    }, [searchParams]);
+
+    const legacyFilterState = useMemo(() => {
+        if (!legacyFilterParam || canonicalFilters.length > 0) {
+            return {
+                filters: [] as Filter[],
+                fallbackNql: undefined as string | undefined
+            };
+        }
+
+        const translated = translateLegacyMembersFilter(legacyFilterParam);
+
+        if (translated.isComplete) {
+            return {
+                filters: translated.filters,
+                fallbackNql: undefined as string | undefined
+            };
+        }
+
+        return {
+            filters: [] as Filter[],
+            fallbackNql: normalizeLegacyMembersFilter(legacyFilterParam)
+        };
+    }, [canonicalFilters.length, legacyFilterParam]);
+
+    const filters = useMemo(() => {
+        if (canonicalFilters.length > 0) {
+            return canonicalFilters;
+        }
+
+        return legacyFilterState.filters;
+    }, [canonicalFilters, legacyFilterState.filters]);
 
     // Get search from URL
     const search = useMemo(() => {
@@ -373,9 +410,11 @@ export function useMembersFilterState(): UseFilterStateReturn {
         setSearchParams(new URLSearchParams(), {replace});
     }, [setSearchParams]);
 
-    const nql = useMemo(() => buildMemberNqlFilter(filters), [filters]);
+    const nql = useMemo(() => {
+        return legacyFilterState.fallbackNql ?? buildMemberNqlFilter(filters);
+    }, [filters, legacyFilterState.fallbackNql]);
 
-    const isFiltered = filters.length > 0 || search.length > 0;
+    const isFiltered = filters.length > 0 || search.length > 0 || !!legacyFilterState.fallbackNql;
 
     return {filters, nql, search, setFilters, setSearch, clearFilters, isFiltered};
 }

--- a/apps/posts/src/views/members/utils/legacy-members-filter.ts
+++ b/apps/posts/src/views/members/utils/legacy-members-filter.ts
@@ -1,0 +1,363 @@
+import nql from '@tryghost/nql-lang';
+import type {Filter} from '@tryghost/shade';
+
+type LegacyNode = Record<string, unknown>;
+
+interface TranslationResult {
+    filters: Filter[];
+    isComplete: boolean;
+}
+
+const SUPPORTED_FIELDS = new Set([
+    'name',
+    'email',
+    'label',
+    'tier_id',
+    'status',
+    'subscribed',
+    'signup',
+    'conversion',
+    'email_count',
+    'email_opened_count',
+    'email_open_rate',
+    'emails.post_id',
+    'opened_emails.post_id',
+    'clicked_links.post_id',
+    'offer_redemptions',
+    'subscriptions.plan_interval',
+    'subscriptions.status'
+]);
+
+const MULTISELECT_FIELDS = new Set(['label', 'tier_id', 'offer_redemptions']);
+
+const DATE_FIELDS = new Set([
+    'last_seen_at',
+    'created_at',
+    'subscriptions.start_date',
+    'subscriptions.current_period_end'
+]);
+
+function isObject(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null;
+}
+
+function isLegacyNodeArray(value: unknown): value is LegacyNode[] {
+    return Array.isArray(value) && value.every(isObject);
+}
+
+function isTrueLike(value: unknown): boolean {
+    return value === true || value === 1 || value === '1';
+}
+
+function isFalseLike(value: unknown): boolean {
+    return value === false || value === 0 || value === '0';
+}
+
+function getComparatorNode(nodes: LegacyNode[], key: string): unknown {
+    const match = nodes.find(node => Object.prototype.hasOwnProperty.call(node, key));
+    return match?.[key];
+}
+
+function parseRegexNode(nqlValue: unknown): {operator: string; value: string} | null {
+    if (!isObject(nqlValue)) {
+        return null;
+    }
+
+    const regexValue = nqlValue.$regex;
+    if (regexValue instanceof RegExp) {
+        const source = regexValue.source;
+        if (source.startsWith('^')) {
+            return {operator: 'starts-with', value: source.slice(1)};
+        }
+        if (source.endsWith('$')) {
+            return {operator: 'ends-with', value: source.slice(0, -1)};
+        }
+        return {operator: 'contains', value: source};
+    }
+
+    const notValue = nqlValue.$not;
+    if (notValue instanceof RegExp) {
+        return {operator: 'does-not-contain', value: notValue.source};
+    }
+
+    return null;
+}
+
+function parseSimpleCondition(field: string, nqlValue: unknown): {operator: string; values: string[]} | null {
+    if (DATE_FIELDS.has(field)) {
+        return null;
+    }
+
+    if (!isObject(nqlValue)) {
+        const value = String(nqlValue);
+        if (MULTISELECT_FIELDS.has(field)) {
+            return {operator: 'is_any_of', values: [value]};
+        }
+        return {operator: 'is', values: [value]};
+    }
+
+    const regexNode = parseRegexNode(nqlValue);
+    if (regexNode) {
+        return {operator: regexNode.operator, values: [regexNode.value]};
+    }
+
+    if (Array.isArray(nqlValue.$in)) {
+        return {
+            operator: 'is_any_of',
+            values: nqlValue.$in.map(value => String(value))
+        };
+    }
+
+    if (Array.isArray(nqlValue.$nin)) {
+        return {
+            operator: 'is_not_any_of',
+            values: nqlValue.$nin.map(value => String(value))
+        };
+    }
+
+    if (nqlValue.$ne !== undefined) {
+        return {operator: 'is-not', values: [String(nqlValue.$ne)]};
+    }
+
+    if (nqlValue.$gt !== undefined) {
+        return {operator: 'is-greater', values: [String(nqlValue.$gt)]};
+    }
+
+    if (nqlValue.$gte !== undefined) {
+        return {operator: 'is-or-greater', values: [String(nqlValue.$gte)]};
+    }
+
+    if (nqlValue.$lt !== undefined) {
+        return {operator: 'is-less', values: [String(nqlValue.$lt)]};
+    }
+
+    if (nqlValue.$lte !== undefined) {
+        return {operator: 'is-or-less', values: [String(nqlValue.$lte)]};
+    }
+
+    return null;
+}
+
+function parseSubscribedFilter(node: LegacyNode): Filter | null {
+    if (Object.keys(node).length === 1 && Object.prototype.hasOwnProperty.call(node, 'email_disabled')) {
+        return {
+            id: 'subscribed',
+            field: 'subscribed',
+            operator: isTrueLike(node.email_disabled) ? 'is' : 'is-not',
+            values: ['email-disabled']
+        };
+    }
+
+    if (isLegacyNodeArray(node.$and)) {
+        const subscribed = getComparatorNode(node.$and, 'subscribed');
+        const emailDisabled = getComparatorNode(node.$and, 'email_disabled');
+
+        if (typeof subscribed === 'boolean' && isFalseLike(emailDisabled)) {
+            return {
+                id: 'subscribed',
+                field: 'subscribed',
+                operator: 'is',
+                values: [subscribed ? 'subscribed' : 'unsubscribed']
+            };
+        }
+    }
+
+    if (isLegacyNodeArray(node.$or)) {
+        const subscribed = getComparatorNode(node.$or, 'subscribed');
+        const emailDisabled = getComparatorNode(node.$or, 'email_disabled');
+
+        if (typeof subscribed === 'boolean' && isTrueLike(emailDisabled)) {
+            return {
+                id: 'subscribed',
+                field: 'subscribed',
+                operator: 'is-not',
+                values: [subscribed ? 'unsubscribed' : 'subscribed']
+            };
+        }
+    }
+
+    return null;
+}
+
+function parseNewsletterFilter(node: LegacyNode): Filter | null {
+    if (isLegacyNodeArray(node.$and)) {
+        const slugNode = getComparatorNode(node.$and, 'newsletters.slug');
+        const emailDisabled = getComparatorNode(node.$and, 'email_disabled');
+
+        if (typeof slugNode === 'string' && isFalseLike(emailDisabled)) {
+            return {
+                id: `newsletters.${slugNode}`,
+                field: `newsletters.${slugNode}`,
+                operator: 'is',
+                values: ['subscribed']
+            };
+        }
+    }
+
+    if (isLegacyNodeArray(node.$or)) {
+        const slugNode = getComparatorNode(node.$or, 'newsletters.slug');
+        const emailDisabled = getComparatorNode(node.$or, 'email_disabled');
+
+        if (isObject(slugNode) && typeof slugNode.$ne === 'string' && isTrueLike(emailDisabled)) {
+            return {
+                id: `newsletters.${slugNode.$ne}`,
+                field: `newsletters.${slugNode.$ne}`,
+                operator: 'is',
+                values: ['unsubscribed']
+            };
+        }
+    }
+
+    if (Object.keys(node).length === 1 && Object.prototype.hasOwnProperty.call(node, 'newsletters.slug')) {
+        const slugNode = node['newsletters.slug'];
+
+        if (typeof slugNode === 'string') {
+            return {
+                id: `newsletters.${slugNode}`,
+                field: `newsletters.${slugNode}`,
+                operator: 'is',
+                values: ['subscribed']
+            };
+        }
+
+        if (isObject(slugNode) && typeof slugNode.$ne === 'string') {
+            return {
+                id: `newsletters.${slugNode.$ne}`,
+                field: `newsletters.${slugNode.$ne}`,
+                operator: 'is',
+                values: ['unsubscribed']
+            };
+        }
+    }
+
+    return null;
+}
+
+function parseNewsletterFeedbackFilter(node: LegacyNode): Filter | null {
+    if (!isLegacyNodeArray(node.$and) || node.$and.length !== 2) {
+        return null;
+    }
+
+    const postIdNode = getComparatorNode(node.$and, 'feedback.post_id');
+    const scoreNode = getComparatorNode(node.$and, 'feedback.score');
+
+    if (typeof postIdNode !== 'string' || (scoreNode !== 0 && scoreNode !== 1)) {
+        return null;
+    }
+
+    return {
+        id: 'newsletter_feedback',
+        field: 'newsletter_feedback',
+        operator: String(scoreNode),
+        values: [postIdNode]
+    };
+}
+
+function parseNode(node: LegacyNode, context: {nextId: number}): {filters: Filter[]; isComplete: boolean} {
+    const subscribedFilter = parseSubscribedFilter(node);
+    if (subscribedFilter) {
+        return {filters: [subscribedFilter], isComplete: true};
+    }
+
+    const newsletterFilter = parseNewsletterFilter(node);
+    if (newsletterFilter) {
+        return {filters: [newsletterFilter], isComplete: true};
+    }
+
+    const newsletterFeedbackFilter = parseNewsletterFeedbackFilter(node);
+    if (newsletterFeedbackFilter) {
+        return {filters: [newsletterFeedbackFilter], isComplete: true};
+    }
+
+    if (isLegacyNodeArray(node.$and)) {
+        const filters: Filter[] = [];
+        let isComplete = true;
+
+        for (const child of node.$and) {
+            const parsed = parseNode(child, context);
+            filters.push(...parsed.filters);
+            isComplete = isComplete && parsed.isComplete;
+        }
+
+        return {filters, isComplete};
+    }
+
+    if (isLegacyNodeArray(node.$or)) {
+        return {filters: [], isComplete: false};
+    }
+
+    const filters: Filter[] = [];
+    let isComplete = true;
+
+    for (const [field, nqlValue] of Object.entries(node)) {
+        if (field === '$and' || field === '$or') {
+            continue;
+        }
+
+        if (!SUPPORTED_FIELDS.has(field)) {
+            isComplete = false;
+            continue;
+        }
+
+        const parsed = parseSimpleCondition(field, nqlValue);
+
+        if (!parsed || parsed.values.length === 0) {
+            isComplete = false;
+            continue;
+        }
+
+        context.nextId += 1;
+        filters.push({
+            id: `${field}-${context.nextId}`,
+            field,
+            operator: parsed.operator,
+            values: parsed.values
+        });
+    }
+
+    return {filters, isComplete};
+}
+
+export function normalizeLegacyMembersFilter(filterParam: string): string {
+    const trimmed = filterParam.trim();
+    const surroundedBySingleGroup = /^\(.*\)$/.test(trimmed) && !/\).*\(/.test(trimmed);
+
+    if (surroundedBySingleGroup) {
+        return trimmed.slice(1, -1);
+    }
+
+    return trimmed;
+}
+
+export function translateLegacyMembersFilter(filterParam: string): TranslationResult {
+    let parsed: unknown;
+    const normalizedFilter = normalizeLegacyMembersFilter(filterParam);
+
+    try {
+        parsed = nql.parse(normalizedFilter);
+    } catch {
+        return {
+            filters: [],
+            isComplete: false
+        };
+    }
+
+    if (!isObject(parsed)) {
+        return {
+            filters: [],
+            isComplete: false
+        };
+    }
+
+    const context = {nextId: 0};
+    const result = parseNode(parsed, context);
+
+    if (!result.filters.length) {
+        return {
+            filters: [],
+            isComplete: false
+        };
+    }
+
+    return result;
+}

--- a/apps/posts/src/views/members/utils/legacy-members-filter.ts
+++ b/apps/posts/src/views/members/utils/legacy-members-filter.ts
@@ -58,6 +58,11 @@ function getComparatorNode(nodes: LegacyNode[], key: string): unknown {
     return match?.[key];
 }
 
+function unescapeRegexSource(value: string): string {
+    // Keep parity with Ember filter parsing which unescapes regex-derived values.
+    return value.replace(/\\/g, '');
+}
+
 function parseRegexNode(nqlValue: unknown): {operator: string; value: string} | null {
     if (!isObject(nqlValue)) {
         return null;
@@ -67,17 +72,17 @@ function parseRegexNode(nqlValue: unknown): {operator: string; value: string} | 
     if (regexValue instanceof RegExp) {
         const source = regexValue.source;
         if (source.startsWith('^')) {
-            return {operator: 'starts-with', value: source.slice(1)};
+            return {operator: 'starts-with', value: unescapeRegexSource(source.slice(1))};
         }
         if (source.endsWith('$')) {
-            return {operator: 'ends-with', value: source.slice(0, -1)};
+            return {operator: 'ends-with', value: unescapeRegexSource(source.slice(0, -1))};
         }
-        return {operator: 'contains', value: source};
+        return {operator: 'contains', value: unescapeRegexSource(source)};
     }
 
     const notValue = nqlValue.$not;
     if (notValue instanceof RegExp) {
-        return {operator: 'does-not-contain', value: notValue.source};
+        return {operator: 'does-not-contain', value: unescapeRegexSource(notValue.source)};
     }
 
     return null;

--- a/apps/posts/src/views/members/utils/legacy-members-filter.ts
+++ b/apps/posts/src/views/members/utils/legacy-members-filter.ts
@@ -58,6 +58,36 @@ function getComparatorNode(nodes: LegacyNode[], key: string): unknown {
     return match?.[key];
 }
 
+function getExactComparatorValues(nodes: LegacyNode[], keys: string[]): Record<string, unknown> | null {
+    if (nodes.length !== keys.length) {
+        return null;
+    }
+
+    const keySet = new Set(keys);
+    const values: Record<string, unknown> = {};
+
+    for (const node of nodes) {
+        const nodeKeys = Object.keys(node);
+
+        if (nodeKeys.length !== 1) {
+            return null;
+        }
+
+        const [nodeKey] = nodeKeys;
+        if (!keySet.has(nodeKey) || Object.prototype.hasOwnProperty.call(values, nodeKey)) {
+            return null;
+        }
+
+        values[nodeKey] = node[nodeKey];
+    }
+
+    if (!keys.every(key => Object.prototype.hasOwnProperty.call(values, key))) {
+        return null;
+    }
+
+    return values;
+}
+
 function unescapeRegexSource(value: string): string {
     // Keep parity with Ember filter parsing which unescapes regex-derived values.
     return value.replace(/\\/g, '');
@@ -154,8 +184,9 @@ function parseSubscribedFilter(node: LegacyNode): Filter | null {
     }
 
     if (isLegacyNodeArray(node.$and)) {
-        const subscribed = getComparatorNode(node.$and, 'subscribed');
-        const emailDisabled = getComparatorNode(node.$and, 'email_disabled');
+        const values = getExactComparatorValues(node.$and, ['subscribed', 'email_disabled']);
+        const subscribed = values?.subscribed;
+        const emailDisabled = values?.email_disabled;
 
         if (typeof subscribed === 'boolean' && isFalseLike(emailDisabled)) {
             return {
@@ -168,8 +199,9 @@ function parseSubscribedFilter(node: LegacyNode): Filter | null {
     }
 
     if (isLegacyNodeArray(node.$or)) {
-        const subscribed = getComparatorNode(node.$or, 'subscribed');
-        const emailDisabled = getComparatorNode(node.$or, 'email_disabled');
+        const values = getExactComparatorValues(node.$or, ['subscribed', 'email_disabled']);
+        const subscribed = values?.subscribed;
+        const emailDisabled = values?.email_disabled;
 
         if (typeof subscribed === 'boolean' && isTrueLike(emailDisabled)) {
             return {
@@ -186,8 +218,9 @@ function parseSubscribedFilter(node: LegacyNode): Filter | null {
 
 function parseNewsletterFilter(node: LegacyNode): Filter | null {
     if (isLegacyNodeArray(node.$and)) {
-        const slugNode = getComparatorNode(node.$and, 'newsletters.slug');
-        const emailDisabled = getComparatorNode(node.$and, 'email_disabled');
+        const values = getExactComparatorValues(node.$and, ['newsletters.slug', 'email_disabled']);
+        const slugNode = values?.['newsletters.slug'];
+        const emailDisabled = values?.email_disabled;
 
         if (typeof slugNode === 'string' && isFalseLike(emailDisabled)) {
             return {
@@ -200,32 +233,11 @@ function parseNewsletterFilter(node: LegacyNode): Filter | null {
     }
 
     if (isLegacyNodeArray(node.$or)) {
-        const slugNode = getComparatorNode(node.$or, 'newsletters.slug');
-        const emailDisabled = getComparatorNode(node.$or, 'email_disabled');
+        const values = getExactComparatorValues(node.$or, ['newsletters.slug', 'email_disabled']);
+        const slugNode = values?.['newsletters.slug'];
+        const emailDisabled = values?.email_disabled;
 
         if (isObject(slugNode) && typeof slugNode.$ne === 'string' && isTrueLike(emailDisabled)) {
-            return {
-                id: `newsletters.${slugNode.$ne}`,
-                field: `newsletters.${slugNode.$ne}`,
-                operator: 'is',
-                values: ['unsubscribed']
-            };
-        }
-    }
-
-    if (Object.keys(node).length === 1 && Object.prototype.hasOwnProperty.call(node, 'newsletters.slug')) {
-        const slugNode = node['newsletters.slug'];
-
-        if (typeof slugNode === 'string') {
-            return {
-                id: `newsletters.${slugNode}`,
-                field: `newsletters.${slugNode}`,
-                operator: 'is',
-                values: ['subscribed']
-            };
-        }
-
-        if (isObject(slugNode) && typeof slugNode.$ne === 'string') {
             return {
                 id: `newsletters.${slugNode.$ne}`,
                 field: `newsletters.${slugNode.$ne}`,

--- a/apps/posts/test/unit/views/members/legacy-members-filter.test.ts
+++ b/apps/posts/test/unit/views/members/legacy-members-filter.test.ts
@@ -1,0 +1,71 @@
+import {normalizeLegacyMembersFilter, translateLegacyMembersFilter} from '@src/views/members/utils/legacy-members-filter';
+
+describe('legacy-members-filter', () => {
+    it('normalizes single wrapped groups', () => {
+        const normalized = normalizeLegacyMembersFilter('(email_disabled:1)');
+
+        expect(normalized).toEqual('email_disabled:1');
+    });
+
+    it('translates legacy label filters to canonical filters', () => {
+        const translated = translateLegacyMembersFilter('label:[blue-consultant]');
+
+        expect(translated.isComplete).toBe(true);
+        expect(translated.filters).toHaveLength(1);
+        expect(translated.filters[0]).toMatchObject({
+            field: 'label',
+            operator: 'is_any_of',
+            values: ['blue-consultant']
+        });
+    });
+
+    it('translates legacy subscribed expression', () => {
+        const translated = translateLegacyMembersFilter('(subscribed:true+email_disabled:0)');
+
+        expect(translated.isComplete).toBe(true);
+        expect(translated.filters).toHaveLength(1);
+        expect(translated.filters[0]).toMatchObject({
+            field: 'subscribed',
+            operator: 'is',
+            values: ['subscribed']
+        });
+    });
+
+    it('translates legacy newsletter expression', () => {
+        const translated = translateLegacyMembersFilter('(newsletters.slug:weekly+email_disabled:0)');
+
+        expect(translated.isComplete).toBe(true);
+        expect(translated.filters).toHaveLength(1);
+        expect(translated.filters[0]).toMatchObject({
+            field: 'newsletters.weekly',
+            operator: 'is',
+            values: ['subscribed']
+        });
+    });
+
+    it('translates legacy feedback expression', () => {
+        const translated = translateLegacyMembersFilter('(feedback.post_id:\'post_1\'+feedback.score:1)');
+
+        expect(translated.isComplete).toBe(true);
+        expect(translated.filters).toHaveLength(1);
+        expect(translated.filters[0]).toMatchObject({
+            field: 'newsletter_feedback',
+            operator: '1',
+            values: ['post_1']
+        });
+    });
+
+    it('falls back for legacy date filters to preserve behavior', () => {
+        const translated = translateLegacyMembersFilter('subscriptions.start_date:>\'1999-01-01 05:59:59\'');
+
+        expect(translated.isComplete).toBe(false);
+        expect(translated.filters).toHaveLength(0);
+    });
+
+    it('falls back when parsing invalid NQL', () => {
+        const translated = translateLegacyMembersFilter('status:');
+
+        expect(translated.isComplete).toBe(false);
+        expect(translated.filters).toHaveLength(0);
+    });
+});

--- a/apps/posts/test/unit/views/members/legacy-members-filter.test.ts
+++ b/apps/posts/test/unit/views/members/legacy-members-filter.test.ts
@@ -55,6 +55,30 @@ describe('legacy-members-filter', () => {
         });
     });
 
+    it('unescapes regex values for contains operators', () => {
+        const translated = translateLegacyMembersFilter('name:~\'test+test\'');
+
+        expect(translated.isComplete).toBe(true);
+        expect(translated.filters).toHaveLength(1);
+        expect(translated.filters[0]).toMatchObject({
+            field: 'name',
+            operator: 'contains',
+            values: ['test+test']
+        });
+    });
+
+    it('unescapes regex values for does-not-contain operators', () => {
+        const translated = translateLegacyMembersFilter('name:-~\'test+test\'');
+
+        expect(translated.isComplete).toBe(true);
+        expect(translated.filters).toHaveLength(1);
+        expect(translated.filters[0]).toMatchObject({
+            field: 'name',
+            operator: 'does-not-contain',
+            values: ['test+test']
+        });
+    });
+
     it('falls back for legacy date filters to preserve behavior', () => {
         const translated = translateLegacyMembersFilter('subscriptions.start_date:>\'1999-01-01 05:59:59\'');
 

--- a/apps/posts/test/unit/views/members/legacy-members-filter.test.ts
+++ b/apps/posts/test/unit/views/members/legacy-members-filter.test.ts
@@ -55,6 +55,26 @@ describe('legacy-members-filter', () => {
         });
     });
 
+    it('keeps additional clauses for subscribed expressions with extra clauses', () => {
+        const translated = translateLegacyMembersFilter('(subscribed:false+email_disabled:0+label:[vip])');
+
+        expect(translated.isComplete).toBe(true);
+        expect(translated.filters.some(filter => filter.field === 'label' && filter.values.includes('vip'))).toBe(true);
+    });
+
+    it('falls back for newsletter expressions without email_disabled clause', () => {
+        const translated = translateLegacyMembersFilter('newsletters.slug:weekly');
+
+        expect(translated.isComplete).toBe(false);
+        expect(translated.filters).toHaveLength(0);
+    });
+
+    it('falls back for newsletter expressions with extra clauses', () => {
+        const translated = translateLegacyMembersFilter('(newsletters.slug:weekly+email_disabled:0+label:[vip])');
+
+        expect(translated.isComplete).toBe(false);
+    });
+
     it('unescapes regex values for contains operators', () => {
         const translated = translateLegacyMembersFilter('name:~\'test+test\'');
 

--- a/apps/posts/test/unit/views/members/use-members-filter-state.test.tsx
+++ b/apps/posts/test/unit/views/members/use-members-filter-state.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import {MemoryRouter} from 'react-router';
+import {renderHook} from '@testing-library/react';
+import {useMembersFilterState} from '@src/views/members/hooks/use-members-filter-state';
+import {vi} from 'vitest';
+
+vi.mock('@tryghost/admin-x-framework', async () => {
+    const reactRouter = await import('react-router');
+
+    return {
+        useSearchParams: reactRouter.useSearchParams
+    };
+});
+
+function createWrapper(initialEntry: string) {
+    return function Wrapper({children}: {children: React.ReactNode}) {
+        return (
+            <MemoryRouter initialEntries={[initialEntry]}>
+                {children}
+            </MemoryRouter>
+        );
+    };
+}
+
+describe('useMembersFilterState (legacy URL support)', () => {
+    it('uses translated filters from legacy filter param when possible', () => {
+        const wrapper = createWrapper('/members-forward?filter=label%3A%5Bblue-consultant%5D');
+        const {result} = renderHook(() => useMembersFilterState(), {wrapper});
+
+        expect(result.current.filters).toHaveLength(1);
+        expect(result.current.filters[0]).toMatchObject({
+            field: 'label',
+            operator: 'is_any_of',
+            values: ['blue-consultant']
+        });
+        expect(result.current.nql).toEqual('label:[blue-consultant]');
+        expect(result.current.isFiltered).toBe(true);
+    });
+
+    it('falls back to raw legacy nql when translation is incomplete', () => {
+        const wrapper = createWrapper('/members-forward?filter=subscriptions.start_date%3A%3E%271999-01-01%2005%3A59%3A59%27');
+        const {result} = renderHook(() => useMembersFilterState(), {wrapper});
+
+        expect(result.current.filters).toHaveLength(0);
+        expect(result.current.nql).toEqual('subscriptions.start_date:>\'1999-01-01 05:59:59\'');
+        expect(result.current.isFiltered).toBe(true);
+    });
+
+    it('supports legacy filterParam links', () => {
+        const wrapper = createWrapper('/members-forward?filterParam=signup%3A%27post_1%27%2Bconversion%3A-%27post_1%27');
+        const {result} = renderHook(() => useMembersFilterState(), {wrapper});
+
+        expect(result.current.filters).toHaveLength(2);
+        expect(result.current.nql).toEqual('signup:\'post_1\'+conversion:-\'post_1\'');
+        expect(result.current.isFiltered).toBe(true);
+    });
+});

--- a/apps/posts/test/unit/views/members/use-members-filter-state.test.tsx
+++ b/apps/posts/test/unit/views/members/use-members-filter-state.test.tsx
@@ -54,4 +54,22 @@ describe('useMembersFilterState (legacy URL support)', () => {
         expect(result.current.nql).toEqual('signup:\'post_1\'+conversion:-\'post_1\'');
         expect(result.current.isFiltered).toBe(true);
     });
+
+    it('preserves additional clauses for mixed subscribed expressions', () => {
+        const wrapper = createWrapper('/members-forward?filter=%28subscribed%3Afalse%2Bemail_disabled%3A0%2Blabel%3A%5Bvip%5D%29');
+        const {result} = renderHook(() => useMembersFilterState(), {wrapper});
+
+        expect(result.current.nql).toContain('subscribed:false+email_disabled:0');
+        expect(result.current.nql).toContain('label:[vip]');
+        expect(result.current.isFiltered).toBe(true);
+    });
+
+    it('falls back to raw nql for newsletter expressions without email_disabled', () => {
+        const wrapper = createWrapper('/members-forward?filter=newsletters.slug%3Aweekly');
+        const {result} = renderHook(() => useMembersFilterState(), {wrapper});
+
+        expect(result.current.filters).toHaveLength(0);
+        expect(result.current.nql).toEqual('newsletters.slug:weekly');
+        expect(result.current.isFiltered).toBe(true);
+    });
 });

--- a/e2e/tests/admin/members/legacy-filter-conversion.test.ts
+++ b/e2e/tests/admin/members/legacy-filter-conversion.test.ts
@@ -1,0 +1,173 @@
+import {MemberFactory, createMemberFactory} from '@/data-factory';
+import {MembersPage} from '@/helpers/pages';
+import {expect, test} from '@/helpers/playwright';
+import type {Page} from '@playwright/test';
+
+const MEMBERS_BROWSE_PATH = '/ghost/api/admin/members/';
+
+function buildLegacyMembersUrl(param: 'filter' | 'filterParam', value: string): string {
+    return `/ghost/#/members-forward?${param}=${encodeURIComponent(value)}`;
+}
+
+async function waitForMembersBrowseFilter(page: Page): Promise<string | null> {
+    const request = await page.waitForRequest((candidate) => {
+        if (candidate.method() !== 'GET') {
+            return false;
+        }
+
+        const candidateUrl = new URL(candidate.url());
+        return candidateUrl.pathname === MEMBERS_BROWSE_PATH && candidateUrl.searchParams.has('filter');
+    });
+
+    const requestUrl = new URL(request.url());
+    return requestUrl.searchParams.get('filter');
+}
+
+test.describe('Ghost Admin - Members Legacy Filter Conversion', () => {
+    let memberFactory: MemberFactory;
+
+    test.use({labs: {membersForward: true}});
+
+    test.beforeEach(async ({page}) => {
+        memberFactory = createMemberFactory(page.request);
+    });
+
+    test('legacy filter query converts label filter for members-forward route', async ({page}) => {
+        await memberFactory.createMany([
+            {
+                name: 'Blue Consultant',
+                email: 'blue-consultant@example.com',
+                labels: ['blue-consultant']
+            },
+            {
+                name: 'Orange Member',
+                email: 'orange-member@example.com',
+                labels: ['orange-member']
+            }
+        ]);
+
+        const membersPage = new MembersPage(page);
+        const membersFilterRequest = waitForMembersBrowseFilter(page);
+        await membersPage.goto(buildLegacyMembersUrl('filter', 'label:[blue-consultant]'));
+
+        expect(await membersFilterRequest).toBe('label:[blue-consultant]');
+        await expect(membersPage.memberListItems).toHaveCount(1);
+        await expect(membersPage.getMemberByName('Blue Consultant')).toBeVisible();
+    });
+
+    test('legacy filterParam query converts text filters for members-forward route', async ({page}) => {
+        await memberFactory.createMany([
+            {
+                name: 'alpha team',
+                email: 'alpha-team@example.com'
+            },
+            {
+                name: 'beta team',
+                email: 'beta-team@example.com'
+            }
+        ]);
+
+        const membersPage = new MembersPage(page);
+        const membersFilterRequest = waitForMembersBrowseFilter(page);
+        await membersPage.goto(buildLegacyMembersUrl('filterParam', 'name:~\'alpha\''));
+
+        expect(await membersFilterRequest).toBe('name:~\'alpha\'');
+        await expect(membersPage.memberListItems).toHaveCount(1);
+        await expect(membersPage.getMemberByName('alpha team')).toBeVisible();
+    });
+
+    test('legacy filter query falls back to raw nql for unsupported conversions', async ({page}) => {
+        await memberFactory.createMany([
+            {
+                name: 'Dog Member',
+                email: 'dog-member@example.com',
+                labels: ['dog']
+            },
+            {
+                name: 'Cat Member',
+                email: 'cat-member@example.com',
+                labels: ['cat']
+            },
+            {
+                name: 'Bird Member',
+                email: 'bird-member@example.com',
+                labels: ['bird']
+            }
+        ]);
+
+        const membersPage = new MembersPage(page);
+        const membersFilterRequest = waitForMembersBrowseFilter(page);
+        await membersPage.goto(buildLegacyMembersUrl('filter', '(label:[dog],label:[cat])'));
+
+        expect(await membersFilterRequest).toBe('label:[dog],label:[cat]');
+        await expect(membersPage.memberListItems).toHaveCount(2);
+        await expect(membersPage.getMemberByName('Dog Member')).toBeVisible();
+        await expect(membersPage.getMemberByName('Cat Member')).toBeVisible();
+        await expect(membersPage.getMemberByName('Bird Member')).toHaveCount(0);
+    });
+
+    test('legacy subscribed expression from Ember converts to canonical subscribed filter', async ({page}) => {
+        await memberFactory.create({
+            name: 'Seed Member',
+            email: 'seed-member@example.com'
+        });
+
+        const membersPage = new MembersPage(page);
+        const membersFilterRequest = waitForMembersBrowseFilter(page);
+        await membersPage.goto(buildLegacyMembersUrl('filter', '(subscribed:false+email_disabled:0)'));
+
+        expect(await membersFilterRequest).toBe('(subscribed:false+email_disabled:0)');
+    });
+
+    test('legacy email-disabled expression from Ember converts to canonical subscribed filter', async ({page}) => {
+        await memberFactory.create({
+            name: 'Email Disabled Seed',
+            email: 'email-disabled-seed@example.com'
+        });
+
+        const membersPage = new MembersPage(page);
+        const membersFilterRequest = waitForMembersBrowseFilter(page);
+        await membersPage.goto(buildLegacyMembersUrl('filter', '(email_disabled:1)'));
+
+        expect(await membersFilterRequest).toBe('(email_disabled:1)');
+    });
+
+    test('legacy newsletter unsubscribed expression from Ember converts to newsletter filter', async ({page}) => {
+        await memberFactory.create({
+            name: 'Newsletter Seed',
+            email: 'newsletter-seed@example.com'
+        });
+
+        const membersPage = new MembersPage(page);
+        const membersFilterRequest = waitForMembersBrowseFilter(page);
+        await membersPage.goto(buildLegacyMembersUrl('filter', 'newsletters.slug:-weekly,email_disabled:1'));
+
+        expect(await membersFilterRequest).toBe('(newsletters.slug:-weekly,email_disabled:1)');
+    });
+
+    test('legacy newsletter subscribed expression from Ember converts to newsletter filter', async ({page}) => {
+        await memberFactory.create({
+            name: 'Newsletter Subscribed Seed',
+            email: 'newsletter-subscribed-seed@example.com'
+        });
+
+        const membersPage = new MembersPage(page);
+        const membersFilterRequest = waitForMembersBrowseFilter(page);
+        await membersPage.goto(buildLegacyMembersUrl('filter', 'newsletters.slug:weekly+email_disabled:0'));
+
+        expect(await membersFilterRequest).toBe('(newsletters.slug:weekly+email_disabled:0)');
+    });
+
+    test('legacy date expression keeps raw nql fallback and removes single wrapper group', async ({page}) => {
+        await memberFactory.create({
+            name: 'Date Fallback Seed',
+            email: 'date-fallback-seed@example.com'
+        });
+
+        const membersPage = new MembersPage(page);
+        const membersFilterRequest = waitForMembersBrowseFilter(page);
+        await membersPage.goto(buildLegacyMembersUrl('filter', '(subscriptions.start_date:>\'1999-01-01 05:59:59\')'));
+
+        expect(await membersFilterRequest).toBe('subscriptions.start_date:>\'1999-01-01 05:59:59\'');
+    });
+});

--- a/e2e/tests/admin/members/legacy-filter-conversion.test.ts
+++ b/e2e/tests/admin/members/legacy-filter-conversion.test.ts
@@ -158,6 +158,34 @@ test.describe('Ghost Admin - Members Legacy Filter Conversion', () => {
         expect(await membersFilterRequest).toBe('(newsletters.slug:weekly+email_disabled:0)');
     });
 
+    test('mixed subscribed expression with extra clauses preserves all clauses', async ({page}) => {
+        await memberFactory.create({
+            name: 'Mixed Subscribed Seed',
+            email: 'mixed-subscribed-seed@example.com'
+        });
+
+        const membersPage = new MembersPage(page);
+        const membersFilterRequest = waitForMembersBrowseFilter(page);
+        await membersPage.goto(buildLegacyMembersUrl('filter', '(subscribed:false+email_disabled:0+label:[dog])'));
+
+        const requestFilter = await membersFilterRequest;
+        expect(requestFilter).toContain('subscribed:false+email_disabled:0');
+        expect(requestFilter).toContain('label:[dog]');
+    });
+
+    test('newsletter expression without email_disabled falls back to raw nql', async ({page}) => {
+        await memberFactory.create({
+            name: 'Newsletter Raw Fallback Seed',
+            email: 'newsletter-raw-fallback-seed@example.com'
+        });
+
+        const membersPage = new MembersPage(page);
+        const membersFilterRequest = waitForMembersBrowseFilter(page);
+        await membersPage.goto(buildLegacyMembersUrl('filter', 'newsletters.slug:weekly'));
+
+        expect(await membersFilterRequest).toBe('newsletters.slug:weekly');
+    });
+
     test('legacy date expression keeps raw nql fallback and removes single wrapper group', async ({page}) => {
         await memberFactory.create({
             name: 'Date Fallback Seed',


### PR DESCRIPTION
When we release the new members list, we want to continue to support the old filter syntax in the URL so that bookmarked versions of the member list will continue to work.

The old filter syntax is converted to the new one, and raw NQL is used as a fallback when a straightforward conversion isn't possible. 