### PR TITLE
Fixed missing error for creating a repeating offer for 0 month

### DIFF
--- a/apps/admin-x-framework/src/api/offers.ts
+++ b/apps/admin-x-framework/src/api/offers.ts
@@ -27,7 +27,7 @@ export type Offer = {
 }
 
 export type PartialNewOffer = Omit<Offer, 'redemption_count'>;
-export type NewOffer = Partial<Pick<PartialNewOffer, 'id'>> & Omit<PartialNewOffer, 'id'>;
+export type NewOffer = Partial<Pick<PartialNewOffer, 'id' | 'duration_in_months'>> & Omit<PartialNewOffer, 'id' | 'duration_in_months'>;
 
 export interface OffersResponseType {
     meta?: Meta

--- a/apps/admin-x-settings/src/components/settings/growth/offers/add-offer-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/offers/add-offer-modal.tsx
@@ -135,7 +135,7 @@ const Sidebar: React.FC<SidebarProps> = ({tierOptions,
     handleTrialAmountInput,
     amountOptions}) => {
     // const handleError = useHandleError();
-    const isYearlyTier = overrides.cadence === 'year' || overrides.cadence === 'yearly' || selectedTier?.label?.includes('Yearly');
+    const isYearlyTier = overrides.cadence === 'year';
     const filteredDurationOptions = isYearlyTier
         ? durationOptions.filter(option => option.value !== 'repeating')
         : durationOptions;
@@ -416,8 +416,8 @@ const AddOfferModal = () => {
                 newErrors.amount = 'Enter an amount greater than 0.';
             }
 
-            if (formState.type === 'percent' && (formState.percentAmount < 0 || formState.percentAmount > 100)) {
-                newErrors.amount = 'Amount must be between 1 and 100%.';
+            if (formState.type === 'percent' && (formState.percentAmount < 1 || formState.percentAmount > 100)) {
+                newErrors.amount = 'Enter an amount between 1 and 100%.';
             }
 
             if (formState.type === 'fixed' && formState.fixedAmount === 0 || formState.type === 'fixed' && formState.fixedAmount < 1) {
@@ -448,7 +448,7 @@ const AddOfferModal = () => {
 
     const handleTierChange = (tier: SelectOption) => {
         const parsedTier = parseData(tier.value);
-        const isYearlyCadence = parsedTier.period === 'year' || parsedTier.period === 'yearly';
+        const isYearlyCadence = parsedTier.period === 'year';
 
         setSelectedTier({
             tier,

--- a/apps/admin-x-settings/src/components/settings/growth/offers/add-offer-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/offers/add-offer-modal.tsx
@@ -135,15 +135,10 @@ const Sidebar: React.FC<SidebarProps> = ({tierOptions,
     handleTrialAmountInput,
     amountOptions}) => {
     // const handleError = useHandleError();
-    const getFilteredDurationOptions = () => {
-        // Check if the selected tier's cadence is 'yearly'
-        if (selectedTier?.label?.includes('Yearly')) {
-            // Filter out 'repeating' from duration options
-            return durationOptions.filter(option => option.value !== 'repeating');
-        }
-        return durationOptions;
-    };
-    const filteredDurationOptions = getFilteredDurationOptions();
+    const isYearlyTier = overrides.cadence === 'year' || overrides.cadence === 'yearly' || selectedTier?.label?.includes('Yearly');
+    const filteredDurationOptions = isYearlyTier
+        ? durationOptions.filter(option => option.value !== 'repeating')
+        : durationOptions;
 
     const [nameLength, setNameLength] = useState(0);
     const nameLengthColor = nameLength > 40 ? 'text-red' : 'text-green';
@@ -254,14 +249,26 @@ const Sidebar: React.FC<SidebarProps> = ({tierOptions,
                                 selectedOption={filteredDurationOptions.find(option => option.value === overrides.duration)}
                                 testId='duration-select-offers'
                                 title='Duration'
-                                onSelect={e => handleDurationChange(e?.value || '')}
+                                onSelect={(e) => {
+                                    clearError('durationInMonths');
+                                    handleDurationChange(e?.value || '');
+                                }}
                             />
 
                             {
-                                overrides.duration === 'repeating' && <div className='-mt-4'>
-                                    <TextField data-testid='duration-months-input' rightPlaceholder={`${overrides.durationInMonths === 1 ? 'month' : 'months'}`} type='number' value={overrides.durationInMonths === 0 ? '' : String(overrides.durationInMonths)} onChange={(e) => {
-                                        handleDurationInMonthsInput(e);
-                                    }} />
+                                overrides.duration === 'repeating' && !isYearlyTier && <div className='-mt-4'>
+                                    <TextField
+                                        data-testid='duration-months-input'
+                                        error={Boolean(errors.durationInMonths)}
+                                        hint={errors.durationInMonths}
+                                        rightPlaceholder={`${overrides.durationInMonths === 1 ? 'month' : 'months'}`}
+                                        type='number'
+                                        value={overrides.durationInMonths === 0 ? '' : String(overrides.durationInMonths)}
+                                        onChange={(e) => {
+                                            handleDurationInMonthsInput(e);
+                                        }}
+                                        onKeyDown={() => clearError('durationInMonths')}
+                                    />
                                 </div>
                             }
                             </>
@@ -363,6 +370,7 @@ const AddOfferModal = () => {
             percentAmount: 0
         },
         onSave: async () => {
+            const duration = formState.type === 'trial' ? 'trial' : formState.duration;
             const dataset = {
                 name: formState.name,
                 code: formState.code.value,
@@ -370,8 +378,8 @@ const AddOfferModal = () => {
                 display_description: formState.displayDescription,
                 cadence: formState.cadence,
                 amount: calculateAmount(formState) || 0,
-                duration: formState.type === 'trial' ? 'trial' : formState.duration,
-                duration_in_months: Number(formState.durationInMonths),
+                duration,
+                ...(duration === 'repeating' ? {duration_in_months: formState.durationInMonths} : {}),
                 currency: formState.currency,
                 status: formState.status,
                 redemption_type: 'signup' as const,
@@ -409,7 +417,7 @@ const AddOfferModal = () => {
             }
 
             if (formState.type === 'percent' && (formState.percentAmount < 0 || formState.percentAmount > 100)) {
-                newErrors.amount = 'Amount must be between 0 and 100%.';
+                newErrors.amount = 'Amount must be between 1 and 100%.';
             }
 
             if (formState.type === 'fixed' && formState.fixedAmount === 0 || formState.type === 'fixed' && formState.fixedAmount < 1) {
@@ -424,6 +432,10 @@ const AddOfferModal = () => {
                 newErrors.amount = 'Free trial must be at least 1 day.';
             }
 
+            if (formState.type !== 'trial' && formState.duration === 'repeating' && formState.durationInMonths < 1) {
+                newErrors.durationInMonths = 'Enter a duration greater than 0.';
+            }
+
             return newErrors;
         },
         savingDelay: 500
@@ -435,19 +447,32 @@ const AddOfferModal = () => {
     ];
 
     const handleTierChange = (tier: SelectOption) => {
+        const parsedTier = parseData(tier.value);
+        const isYearlyCadence = parsedTier.period === 'year' || parsedTier.period === 'yearly';
+
         setSelectedTier({
             tier,
-            dataset: parseData(tier.value)
+            dataset: parsedTier
         });
         updateForm(state => ({
             ...state,
-            cadence: parseData(tier.value).period,
-            currency: parseData(tier.value).currency,
-            tierId: parseData(tier.value).id
+            cadence: parsedTier.period,
+            currency: parsedTier.currency,
+            tierId: parsedTier.id,
+            duration: isYearlyCadence && state.duration === 'repeating' ? 'once' : state.duration
         }));
+
+        if (isYearlyCadence) {
+            clearError('durationInMonths');
+        }
     };
 
     const handleTypeChange = (type: string) => {
+        if (type === 'trial') {
+            clearError('amount');
+            clearError('durationInMonths');
+        }
+
         updateForm(state => ({
             ...state,
             type: type
@@ -484,9 +509,11 @@ const AddOfferModal = () => {
 
     const handleDurationInMonthsInput = (e: React.ChangeEvent<HTMLInputElement>) => {
         const target = e.target as HTMLInputElement;
+        const nextValue = Number(target.value);
+
         updateForm(state => ({
             ...state,
-            durationInMonths: Number(target.value)
+            durationInMonths: Number.isNaN(nextValue) ? 0 : nextValue
         }));
     };
 

--- a/apps/admin-x-settings/test/acceptance/membership/offers.test.ts
+++ b/apps/admin-x-settings/test/acceptance/membership/offers.test.ts
@@ -106,7 +106,7 @@ test.describe('Offers Modal', () => {
         const sidebar = addModal.getByTestId('add-offer-sidebar');
         await expect(sidebar).toContainText(/Name is required/);
         await expect(sidebar).toContainText(/Code is required/);
-        await expect(sidebar).toContainText(/Enter an amount greater than 0./);
+        await expect(sidebar).toContainText(/Enter an amount between 1 and 100%./);
         await expect(sidebar).toContainText(/Display title is required/);
     });
 
@@ -168,7 +168,7 @@ test.describe('Offers Modal', () => {
         const sidebar = addModal.getByTestId('add-offer-sidebar');
         await expect(sidebar).toContainText(/Name is required/);
         await expect(sidebar).toContainText(/Code is required/);
-        await expect(sidebar).toContainText(/Enter an amount greater than 0./);
+        await expect(sidebar).toContainText(/Enter an amount between 1 and 100%./);
         await expect(sidebar).toContainText(/Display title is required/);
     });
 


### PR DESCRIPTION
closes https://linear.app/ghost/issue/BER-3369/fix-empty-duration-in-months-input-allowing-invalid-offer-submissions

- The "Add offer" modal did not display a UI error when selecting "0 month" for a repeating offer
- Similarly, it was possible to pass a repeating offer for a yearly offer
- In both these cases, the backend did return an error and prevented invalid offers from being created (good!). This change improves the UX/UI by rendering the error in the form, using the existing error rendering pattern

<img width="2132" height="1510" alt="CleanShot 2026-02-26 at 13 59 48@2x" src="https://github.com/user-attachments/assets/d2ac921d-d05c-45b1-b18d-b204837c1a3d" />

