### PR TITLE
Added duration_in_months to next payment object

### DIFF
--- a/ghost/core/core/server/services/members/members-api/services/next-payment-calculator.js
+++ b/ghost/core/core/server/services/members/members-api/services/next-payment-calculator.js
@@ -8,6 +8,7 @@
  * @prop {string} start
  * @prop {string|null} end
  * @prop {'once'|'repeating'|'forever'} duration
+ * @prop {number|null} duration_in_months
  * @prop {'percent'|'fixed'} type
  * @prop {number} amount
  */
@@ -75,6 +76,7 @@ class NextPaymentCalculator {
                 start: activeDiscount.start ? new Date(activeDiscount.start).toISOString() : null,
                 end: activeDiscount.end ? new Date(activeDiscount.end).toISOString() : null,
                 duration: offer.duration,
+                duration_in_months: offer.duration_in_months,
                 type: offer.type,
                 amount: offer.amount
             }

--- a/ghost/core/test/unit/server/services/members/members-api/services/members-bread-service.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/services/members-bread-service.test.js
@@ -590,6 +590,7 @@ describe('MemberBreadService', function () {
             assert.equal(nextPayment.discount.type, 'percent');
             assert.equal(nextPayment.discount.amount, 20);
             assert.equal(nextPayment.discount.duration, 'repeating');
+            assert.equal(nextPayment.discount.duration_in_months, 12);
         });
 
         it('attaches offer_redemptions to subscriptions', async function () {

--- a/ghost/core/test/unit/server/services/members/members-api/services/next-payment-calculator.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/services/next-payment-calculator.test.js
@@ -182,6 +182,7 @@ describe('NextPaymentCalculator', function () {
             assert.equal(result.discount.end, null);
             assert.equal(result.discount.amount, 50);
             assert.equal(result.discount.type, 'percent');
+            assert.equal(result.discount.duration_in_months, null);
         });
 
         it('handles once duration', function () {
@@ -202,6 +203,7 @@ describe('NextPaymentCalculator', function () {
             assert.equal(result.discount.amount, 50);
             assert.equal(result.discount.type, 'percent');
             assert.equal(result.discount.offer_id, 'offer_123');
+            assert.equal(result.discount.duration_in_months, null);
         });
 
         it('handles active repeating offers', function () {
@@ -223,6 +225,7 @@ describe('NextPaymentCalculator', function () {
             assert.equal(result.discount.amount, 20);
             assert.equal(result.discount.type, 'percent');
             assert.equal(result.discount.offer_id, 'offer_123');
+            assert.equal(result.discount.duration_in_months, 888);
         });
 
         // Backportability tests - for signup offers without discount_start/discount_end
@@ -276,6 +279,7 @@ describe('NextPaymentCalculator', function () {
                 assert.notEqual(result.discount, null);
                 assert.equal(result.discount.start, '2025-01-01T00:00:00.000Z');
                 assert.equal(result.discount.end, '2099-01-01T00:00:00.000Z'); // start_date + 888 months
+                assert.equal(result.discount.duration_in_months, 888);
             });
 
             it('repeating offer is inactive when start_date + duration_in_months is in the past', function () {


### PR DESCRIPTION
closes https://linear.app/ghost/issue/BER-3377

- this change will allow to display the next payment details fully from the next payment object in Portal and later in themes
