### PR TITLE
Reverted oembed-service user agent

### DIFF
--- a/ghost/core/core/server/services/oembed/oembed-service.js
+++ b/ghost/core/core/server/services/oembed/oembed-service.js
@@ -10,7 +10,8 @@ const iconv = require('iconv-lite');
 const path = require('path');
 
 // Some sites block non-standard user agents so we need to mimic a typical browser
-const USER_AGENT = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/144.0.0.0 Safari/537.36';
+// Note: the Ghost/5.0 string _may_ be in use by 3rd parties so use caution when updating across majors
+const USER_AGENT = 'Mozilla/5.0 (compatible; Ghost/5.0; +https://ghost.org/)';
 
 const messages = {
     noUrlProvided: 'No url provided.',


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ONC-1429/

- switched back to our own custom user-agent so that Medium.com (and others) have a better identifier for bot protection/firewall exclusions
- added note about the `5.0` version identifier and being careful about modifying during major version bumps
