### PR TITLE
Updated transistor renderer to use static preview

### DIFF
--- a/ghost/core/core/frontend/src/cards/css/transistor.css
+++ b/ghost/core/core/frontend/src/cards/css/transistor.css
@@ -1,0 +1,88 @@
+.kg-transistor-card {
+    display: flex;
+    justify-content: center;
+}
+
+.kg-transistor-placeholder {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2.4rem;
+    width: 100%;
+    max-width: 100%;
+    padding: 3rem 2.4rem;
+    border: 1px solid rgba(255, 255, 255, 0.14);
+    border: 1px solid color-mix(in srgb, currentColor 14%, transparent);
+    border-radius: 12px;
+    background: rgba(255, 255, 255, 0.04);
+    background: color-mix(in srgb, currentColor 4%, transparent);
+    color: inherit;
+    text-align: center;
+    box-sizing: border-box;
+}
+
+.kg-transistor-icon {
+    display: flex;
+    flex-shrink: 0;
+    align-items: center;
+    justify-content: center;
+    width: 116px;
+    height: 116px;
+    border-radius: 14px;
+    background: var(--ghost-accent-color, #b8a5ac);
+    color: #fff;
+}
+
+.kg-transistor-icon svg {
+    display: block;
+    width: 56px;
+    height: 56px;
+}
+
+.kg-transistor-content {
+    min-width: 0;
+    max-width: 640px;
+}
+
+.kg-transistor-title {
+    margin: 0;
+    color: inherit;
+    font-size: 2.3rem;
+    font-weight: 600;
+    line-height: 1.2;
+}
+
+.kg-transistor-description {
+    margin-top: 1.6rem;
+    color: inherit;
+    font-size: 1.6rem;
+    line-height: 1.5;
+    opacity: 0.65;
+}
+
+@media (max-width: 640px) {
+    .kg-transistor-placeholder {
+        gap: 1.6rem;
+        padding: 2.4rem 1.8rem;
+    }
+
+    .kg-transistor-icon {
+        width: 88px;
+        height: 88px;
+        border-radius: 12px;
+    }
+
+    .kg-transistor-icon svg {
+        width: 44px;
+        height: 44px;
+    }
+
+    .kg-transistor-title {
+        font-size: 1.8rem;
+    }
+
+    .kg-transistor-description {
+        margin-top: 1rem;
+        font-size: 1.45rem;
+    }
+}

--- a/ghost/core/test/unit/server/services/koenig/node-renderers/transistor-renderer.test.js
+++ b/ghost/core/test/unit/server/services/koenig/node-renderers/transistor-renderer.test.js
@@ -21,47 +21,35 @@ describe('services/koenig/node-renderers/transistor-renderer', function () {
     }
 
     describe('web', function () {
-        it('renders iframe with URL-encoded %7Buuid%7D placeholder in data-src', function () {
+        it('renders static placeholder card', function () {
             const result = renderForWeb(getTestData());
 
-            assert.ok(result.html.includes('data-src="https://partner.transistor.fm/ghost/embed/%7Buuid%7D'));
-            assert.ok(result.html.includes('data-kg-transistor-embed'));
+            assert.ok(result.html.includes('kg-transistor-placeholder'));
+            assert.ok(result.html.includes('kg-transistor-icon'));
+            assert.ok(result.html.includes('kg-transistor-content'));
         });
 
-        it('includes noscript fallback with src for non-JS environments', function () {
+        it('renders placeholder title and description', function () {
             const result = renderForWeb(getTestData());
 
-            assert.ok(result.html.includes('<noscript>'));
-            assert.ok(result.html.includes('</noscript>'));
-            // noscript iframe uses src directly (not data-src) so it loads without JS
-            assert.match(result.html, /<noscript><iframe[^>]*src="https:\/\/partner\.transistor\.fm/);
+            assert.ok(result.html.includes('Members-only podcasts'));
+            assert.ok(result.html.includes('Your Transistor podcasts will appear here.'));
         });
 
-        it('includes ctx param', function () {
+        it('does not render iframe embed markup', function () {
             const result = renderForWeb(getTestData());
 
-            assert.ok(result.html.includes('ctx='));
-        });
-
-        it('includes inline script for background color detection', function () {
-            const result = renderForWeb(getTestData());
-
-            assert.ok(result.html.includes('<script>'));
-            assert.ok(result.html.includes('getComputedStyle'));
-            assert.ok(result.html.includes('data-src'));
-            assert.ok(result.html.includes('colorToRgb'));
+            assert.ok(!result.html.includes('<iframe'));
+            assert.ok(!result.html.includes('data-kg-transistor-embed'));
         });
 
         it('matches snapshot for default test data', function () {
             const result = renderForWeb(getTestData());
 
-            // type: 'inner' means output is the figure's innerHTML (iframe + script + noscript)
-            assert.ok(result.html.includes('<iframe'));
-            assert.ok(result.html.includes('data-kg-transistor-embed'));
-            assert.ok(result.html.includes('<script>'));
-            assert.ok(result.html.includes('</script>'));
-            assert.ok(result.html.includes('<noscript>'));
-            assert.ok(result.html.includes('</noscript>'));
+            // type: 'inner' means output is the figure's innerHTML
+            assert.ok(result.html.includes('kg-transistor-placeholder'));
+            assert.ok(result.html.includes('kg-transistor-title'));
+            assert.ok(result.html.includes('kg-transistor-description'));
         });
     });
 

--- a/ghost/core/test/unit/server/services/koenig/node-renderers/transistor-renderer.test.js
+++ b/ghost/core/test/unit/server/services/koenig/node-renderers/transistor-renderer.test.js
@@ -46,7 +46,6 @@ describe('services/koenig/node-renderers/transistor-renderer', function () {
         it('matches snapshot for default test data', function () {
             const result = renderForWeb(getTestData());
 
-            // type: 'inner' means output is the figure's innerHTML
             assert.ok(result.html.includes('kg-transistor-placeholder'));
             assert.ok(result.html.includes('kg-transistor-title'));
             assert.ok(result.html.includes('kg-transistor-description'));


### PR DESCRIPTION
ref https://ghost.slack.com/archives/C07HTEJMR2R/p1772114827156139?thread_ts=1772113303.303589&cid=C07HTEJMR2R

Updated to use static asset with new copy in lieu of embed in order to improve consistency in user experience in the editor.