### PR TITLE
Updated labs tests to not rely on specific flags

### DIFF
--- a/ghost/core/test/unit/shared/labs.test.js
+++ b/ghost/core/test/unit/shared/labs.test.js
@@ -28,54 +28,47 @@ describe('Labs Service', function () {
         }));
     });
 
-    it('returns an alpha flag when dev experiments in toggled', function () {
-        configUtils.set('enableDeveloperExperiments', true);
-        sinon.stub(process.env, 'NODE_ENV').value('production');
-        const getSpy = sinon.stub(settingsCache, 'get');
-        getSpy.withArgs('labs').returns({
-            urlCache: true
-        });
-
-        // NOTE: this test should be rewritten to test the alpha flag independently of the internal ALPHA_FEATURES list
-        //       otherwise we end up in the endless maintenance loop and need to update it every time a feature graduates from alpha
-        assert.deepEqual(labs.getAll(), expectedLabsObject({
-            urlCache: true,
-            members: true
-        }));
-
-        assert.equal(labs.isSet('members'), true);
-        assert.equal(labs.isSet('urlCache'), true);
-    });
-
     it('respects the value in config over settings', function () {
+        if (labs.WRITABLE_KEYS_ALLOWLIST.length === 0) {
+            this.skip();
+        }
+
+        const flag = labs.WRITABLE_KEYS_ALLOWLIST[0];
+
         configUtils.set('labs', {
-            collections: false
+            [flag]: false
         });
         const getSpy = sinon.stub(settingsCache, 'get');
         getSpy.withArgs('labs').returns({
-            collections: true,
+            [flag]: true,
             members: true
         });
 
         assert.deepEqual(labs.getAll(), expectedLabsObject({
-            collections: false,
+            [flag]: false,
             members: true
         }));
 
-        assert.equal(labs.isSet('collections'), false);
+        assert.equal(labs.isSet(flag), false);
     });
 
     it('respects the value in config over GA keys', function () {
+        if (labs.GA_KEYS.length === 0) {
+            this.skip();
+        }
+
+        const gaKey = labs.GA_KEYS[0];
+
         configUtils.set('labs', {
-            announcementBar: false
+            [gaKey]: false
         });
 
         assert.deepEqual(labs.getAll(), expectedLabsObject({
-            announcementBar: false,
+            [gaKey]: false,
             members: true
         }));
 
-        assert.equal(labs.isSet('announcementBar'), false);
+        assert.equal(labs.isSet(gaKey), false);
     });
 
     it('members flag is true when members_signup_access setting is "all"', function () {
@@ -90,19 +83,25 @@ describe('Labs Service', function () {
     });
 
     it('returns other allowlisted flags along with members', function () {
+        if (labs.WRITABLE_KEYS_ALLOWLIST.length === 0) {
+            this.skip();
+        }
+
+        const flag = labs.WRITABLE_KEYS_ALLOWLIST[0];
+
         const getSpy = sinon.stub(settingsCache, 'get');
         getSpy.withArgs('members_signup_access').returns('all');
         getSpy.withArgs('labs').returns({
-            activitypub: false
+            [flag]: false
         });
 
         assert.deepEqual(labs.getAll(), expectedLabsObject({
             members: true,
-            activitypub: false
+            [flag]: false
         }));
 
         assert.equal(labs.isSet('members'), true);
-        assert.equal(labs.isSet('activitypub'), false);
+        assert.equal(labs.isSet(flag), false);
     });
 
     it('members flag is false when members_signup_access setting is "none"', function () {

--- a/ghost/core/test/unit/shared/labs.test.js
+++ b/ghost/core/test/unit/shared/labs.test.js
@@ -31,6 +31,7 @@ describe('Labs Service', function () {
     it('respects the value in config over settings', function () {
         if (labs.WRITABLE_KEYS_ALLOWLIST.length === 0) {
             this.skip();
+            return;
         }
 
         const flag = labs.WRITABLE_KEYS_ALLOWLIST[0];
@@ -55,6 +56,7 @@ describe('Labs Service', function () {
     it('respects the value in config over GA keys', function () {
         if (labs.GA_KEYS.length === 0) {
             this.skip();
+            return;
         }
 
         const gaKey = labs.GA_KEYS[0];
@@ -85,6 +87,7 @@ describe('Labs Service', function () {
     it('returns other allowlisted flags along with members', function () {
         if (labs.WRITABLE_KEYS_ALLOWLIST.length === 0) {
             this.skip();
+            return;
         }
 
         const flag = labs.WRITABLE_KEYS_ALLOWLIST[0];


### PR DESCRIPTION
no ref

- a test for labs ensures that config values take precedence over GA keys. However, the test referenced the `announcementBar` flag was removed in https://github.com/TryGhost/Ghost/pull/26196. That means this test was looking at a state that wasn't really true
- instead, we can check for the first item in the `GA_KEYS` list. If there's nothing in the list, the test can be skipped.
- a few other tests had this same issue, so this PR updates them as well
- there was a test for alpha flags that wasn't actually doing anything, so it's deleted

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that reduce brittleness by avoiding references to specific feature flags; no production logic is modified.
> 
> **Overview**
> Updates `labs.test.js` to stop hard-coding specific labs flag names and instead derive test flags from `labs.WRITABLE_KEYS_ALLOWLIST` and `labs.GA_KEYS`, skipping tests when those lists are empty.
> 
> Removes a brittle/ineffective alpha-flag test and adjusts remaining assertions to validate precedence rules (config overrides settings/GA) using dynamically selected flags.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ef1b59286e2a4778136c749f90f7ebc64fa2be5e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->