### PR TITLE
⚡ Optimized comment count subquery to avoid full table scan

### DIFF
--- a/ghost/core/core/server/models/comment.js
+++ b/ghost/core/core/server/models/comment.js
@@ -265,22 +265,21 @@ const Comment = ghostBookshelf.Model.extend({
             },
             direct_replies(modelOrCollection, options) {
                 const excludedCommentStatuses = options.isAdmin ? ['deleted'] : ['hidden', 'deleted'];
+                const statusPlaceholders = excludedCommentStatuses.map(() => '?').join(',');
 
-                modelOrCollection.query('columns', 'comments.*', (qb) => {
-                    qb.count('replies.id')
-                        .from('comments AS replies')
-                        .where(function () {
-                            // Root comments: count direct replies (parent_id = this, in_reply_to_id IS NULL)
-                            this.where(function () {
-                                this.whereRaw('replies.parent_id = comments.id')
-                                    .whereNull('replies.in_reply_to_id');
-                            })
-                                // Child comments: count replies-to-this-child (in_reply_to_id = this)
-                                .orWhereRaw('replies.in_reply_to_id = comments.id');
-                        })
-                        .whereNotIn('replies.status', excludedCommentStatuses)
-                        .as('count__direct_replies');
-                });
+                // Split into two separate indexed subqueries instead of a single OR-based query.
+                // The OR between parent_id and in_reply_to_id defeats MySQL index usage,
+                // causing full table scans. Two separate subqueries each use their own index.
+                modelOrCollection.query('columns', 'comments.*', ghostBookshelf.knex.raw(`(
+                    (SELECT COUNT(*) FROM comments AS r1
+                     WHERE r1.parent_id = comments.id
+                       AND r1.in_reply_to_id IS NULL
+                       AND r1.status NOT IN (${statusPlaceholders}))
+                    +
+                    (SELECT COUNT(*) FROM comments AS r2
+                     WHERE r2.in_reply_to_id = comments.id
+                       AND r2.status NOT IN (${statusPlaceholders}))
+                ) as count__direct_replies`, [...excludedCommentStatuses, ...excludedCommentStatuses]));
             },
             likes(modelOrCollection) {
                 modelOrCollection.query('columns', 'comments.*', (qb) => {

--- a/ghost/core/core/server/models/comment.js
+++ b/ghost/core/core/server/models/comment.js
@@ -268,7 +268,7 @@ const Comment = ghostBookshelf.Model.extend({
                 const statusPlaceholders = excludedCommentStatuses.map(() => '?').join(',');
 
                 // Split into two separate indexed subqueries instead of a single OR-based query.
-                // The OR between parent_id and in_reply_to_id defeats MySQL index usage,
+                // An OR between parent_id and in_reply_to_id defeats MySQL index usage,
                 // causing full table scans. Two separate subqueries each use their own index.
                 modelOrCollection.query('columns', 'comments.*', ghostBookshelf.knex.raw(`(
                     (SELECT COUNT(*) FROM comments AS r1


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ONC-1509/

The `OR` condition between `parent_id` and `in_reply_to_id` columns in the `direct_replies` count subquery defeats MySQL index usage, causing a full table scan per comment row. Split into two separate indexed COUNT subqueries summed together, allowing MySQL to use the existing foreign key indexes.

This could easily end up reading several million rows for a single query to get the top 20 comments+replies.