### PR TITLE
Fixed next billing date/amount display for free month offers

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.64.13",
+  "version": "2.64.14",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/portal/src/components/pages/AccountHomePage/components/account-welcome.js
+++ b/apps/portal/src/components/pages/AccountHomePage/components/account-welcome.js
@@ -1,5 +1,5 @@
 import AppContext from '../../../../app-context';
-import {getCompExpiry, getMemberSubscription, hasOnlyFreePlan, isComplimentaryMember, subscriptionHasFreeMonthsOffer, subscriptionHasFreeTrial} from '../../../../utils/helpers';
+import {getCompExpiry, getMemberSubscription, hasOnlyFreePlan, isComplimentaryMember, subscriptionHasFreeTrial} from '../../../../utils/helpers';
 import {getDateString} from '../../../../utils/date-time';
 import {useContext} from 'react';
 
@@ -46,13 +46,9 @@ const AccountWelcome = () => {
             );
         }
 
-        const renewalDate = subscriptionHasFreeMonthsOffer({sub: subscription})
-            ? subscription?.next_payment?.discount?.end
-            : currentPeriodEnd;
-
         return (
             <div className='gh-portal-section'>
-                <p className='gh-portal-text-center gh-portal-free-ctatext'>{t(`Your subscription will renew on {renewalDate}`, {renewalDate: getDateString(renewalDate)})}</p>
+                <p className='gh-portal-text-center gh-portal-free-ctatext'>{t(`Your subscription will renew on {renewalDate}`, {renewalDate: getDateString(currentPeriodEnd)})}</p>
             </div>
         );
     }

--- a/apps/portal/src/components/pages/AccountHomePage/components/paid-account-actions.js
+++ b/apps/portal/src/components/pages/AccountHomePage/components/paid-account-actions.js
@@ -1,5 +1,5 @@
 import AppContext from '../../../../app-context';
-import {getCompExpiry, getMemberSubscription, getMemberTierName, hasMultipleProductsFeature, hasOnlyFreePlan, isComplimentaryMember, isPaidMember, subscriptionHasFreeTrial, subscriptionHasFreeMonthsOffer} from '../../../../utils/helpers';
+import {getCompExpiry, getMemberSubscription, getMemberTierName, hasMultipleProductsFeature, hasOnlyFreePlan, isComplimentaryMember, isPaidMember, subscriptionHasFreeTrial} from '../../../../utils/helpers';
 import {getDateString} from '../../../../utils/date-time';
 import {ReactComponent as LoaderIcon} from '../../../../images/icons/loader.svg';
 import {ReactComponent as OfferTagIcon} from '../../../../images/icons/offer-tag.svg';
@@ -55,19 +55,6 @@ const PaidAccountActions = () => {
                         {label}
                     </p>
                     <FreeTrialLabel subscription={subscription} />
-                </>
-            );
-        }
-
-        const freeMonthOffer = subscriptionHasFreeMonthsOffer({sub: subscription});
-
-        if (freeMonthOffer) {
-            return (
-                <>
-                    <p className={oldPriceClassName}>
-                        {label}
-                    </p>
-                    <FreeMonthsLabel nextPayment={nextPayment} subscription={subscription} />
                 </>
             );
         }
@@ -199,22 +186,6 @@ function FreeTrialLabel({subscription}) {
         );
     }
     return null;
-}
-
-// TODO: Add i18n once copy is finalized
-function FreeMonthsLabel({nextPayment, subscription}) {
-    const months = subscription?.offer?.duration_in_months ?? 0;
-    const discountEnd = nextPayment?.discount?.end;
-    const renewalDate = discountEnd ? getDateString(discountEnd) : null;
-    const monthsText = months === 1 ? '1 month free' : `${months} months free`;
-    const label = renewalDate ? `${monthsText} - Renews ${renewalDate}` : monthsText;
-
-    return (
-        <p className="gh-portal-account-discountcontainer" data-testid="offer-label">
-            <OfferTagIcon className="gh-portal-account-tagicon" />
-            <span>{label}</span>
-        </p>
-    );
 }
 
 /**

--- a/apps/portal/src/components/pages/account-plan-page.js
+++ b/apps/portal/src/components/pages/account-plan-page.js
@@ -274,7 +274,7 @@ function getOfferMessage(offer, originalPrice, currency, amountOff, subscription
             const daysInTargetMonth = new Date(Date.UTC(targetYear, targetMonth + 1, 0)).getUTCDate();
             const newDate = new Date(Date.UTC(targetYear, targetMonth, Math.min(originalDay, daysInTargetMonth)));
             const newBillingDate = newDate.toLocaleDateString('en-GB', {year: 'numeric', month: 'short', day: 'numeric', timeZone: 'UTC'});
-            return `Enjoy ${monthLabel} on us. Your next billing date will be ${newBillingDate}.`;
+            return `Enjoy ${monthLabel} on us. You won't be charged until ${newBillingDate}.`;
         }
 
         return `Enjoy ${monthLabel} on us.`;

--- a/apps/portal/src/utils/helpers.js
+++ b/apps/portal/src/utils/helpers.js
@@ -547,14 +547,6 @@ export function isFreeMonthsOffer(offer) {
         && offer?.redemption_type === 'retention';
 }
 
-export function subscriptionHasFreeMonthsOffer({sub} = {}) {
-    if (!isFreeMonthsOffer(sub?.offer)) {
-        return false;
-    }
-    const discountEnd = sub?.next_payment?.discount?.end;
-    return discountEnd && !isInThePast(new Date(discountEnd));
-}
-
 export function isInThePast(date) {
     return date < new Date();
 }

--- a/apps/portal/test/unit/components/pages/AccountHomePage/account-welcome.test.js
+++ b/apps/portal/test/unit/components/pages/AccountHomePage/account-welcome.test.js
@@ -1,0 +1,58 @@
+import {render} from '../../../../utils/test-utils';
+import AccountWelcome from '../../../../../src/components/pages/AccountHomePage/components/account-welcome';
+import {getDiscountData, getMemberData, getNextPaymentData, getProductsData, getSiteData, getSubscriptionData} from '../../../../../src/utils/fixtures-generator';
+
+const setup = (overrides) => {
+    return render(
+        <AccountWelcome />,
+        {
+            overrideContext: {
+                ...overrides
+            }
+        }
+    );
+};
+
+describe('AccountWelcome', () => {
+    test('uses current period end for renewal date on free months offers', () => {
+        const products = getProductsData({numOfProducts: 1});
+        const site = getSiteData({products, portalProducts: products.map(p => p.id)});
+
+        const member = getMemberData({
+            paid: true,
+            subscriptions: [
+                getSubscriptionData({
+                    status: 'active',
+                    amount: 500,
+                    currency: 'USD',
+                    interval: 'month',
+                    currentPeriodEnd: '2099-01-15T12:00:00.000Z',
+                    offer: {
+                        type: 'percent',
+                        amount: 100,
+                        duration: 'repeating',
+                        duration_in_months: 2,
+                        redemption_type: 'retention'
+                    },
+                    nextPayment: getNextPaymentData({
+                        originalAmount: 500,
+                        amount: 0,
+                        interval: 'month',
+                        currency: 'USD',
+                        discount: getDiscountData({
+                            duration: 'repeating',
+                            type: 'percent',
+                            amount: 100,
+                            end: '2099-03-15T12:00:00.000Z'
+                        })
+                    })
+                })
+            ]
+        });
+
+        const {queryByText} = setup({site, member});
+
+        expect(queryByText('Your subscription will renew on 15 Jan 2099')).toBeInTheDocument();
+        expect(queryByText('Your subscription will renew on 15 Mar 2099')).not.toBeInTheDocument();
+    });
+});

--- a/apps/portal/test/unit/components/pages/AccountHomePage/paid-account-actions.test.js
+++ b/apps/portal/test/unit/components/pages/AccountHomePage/paid-account-actions.test.js
@@ -125,50 +125,6 @@ describe('PaidAccountActions', () => {
             expect(queryByText(/1 Jan 2099/)).toBeInTheDocument();
         });
 
-        test('displays "{x} month(s) free" for free months (percent/100/repeating) offers', () => {
-            const products = getProductsData({numOfProducts: 1});
-            const site = getSiteData({products, portalProducts: products.map(p => p.id)});
-
-            const discountEnd = new Date('2099-02-01T12:00:00.000Z');
-
-            const member = getMemberData({
-                paid: true,
-                subscriptions: [
-                    getSubscriptionData({
-                        status: 'active',
-                        amount: 500,
-                        currency: 'USD',
-                        interval: 'month',
-                        offer: {
-                            type: 'percent',
-                            amount: 100,
-                            duration: 'repeating',
-                            duration_in_months: 1,
-                            redemption_type: 'retention'
-                        },
-                        nextPayment: getNextPaymentData({
-                            originalAmount: 500,
-                            amount: 500,
-                            interval: 'month',
-                            currency: 'USD',
-                            discount: getDiscountData({
-                                duration: 'repeating',
-                                type: 'percent',
-                                amount: 100,
-                                end: discountEnd.toISOString()
-                            })
-                        })
-                    })
-                ]
-            });
-
-            const {queryByText, queryByTestId} = setup({site, member});
-
-            expect(queryByText('$5.00/month')).toBeInTheDocument();
-            expect(queryByTestId('offer-label')).toBeInTheDocument();
-            expect(queryByText(/1 month free/)).toBeInTheDocument();
-        });
-
         test('displays "Complimentary" with expiry date', () => {
             const products = getProductsData({numOfProducts: 1});
             const site = getSiteData({products, portalProducts: products.map(p => p.id)});
@@ -327,6 +283,51 @@ describe('PaidAccountActions', () => {
             expect(queryByText(/\$4\.00\/month/)).toBeInTheDocument();
             expect(queryByText(/Ends/)).toBeInTheDocument();
             expect(queryByText(/1 Jan 2099/)).toBeInTheDocument();
+        });
+
+        test('displays $0.00/month - Ends {date} for free months offers', () => {
+            const products = getProductsData({numOfProducts: 1});
+            const site = getSiteData({products, portalProducts: products.map(p => p.id)});
+
+            const discountEnd = new Date('2099-02-01T12:00:00.000Z');
+
+            const member = getMemberData({
+                paid: true,
+                subscriptions: [
+                    getSubscriptionData({
+                        status: 'active',
+                        amount: 500,
+                        currency: 'USD',
+                        interval: 'month',
+                        offer: {
+                            type: 'percent',
+                            amount: 100,
+                            duration: 'repeating',
+                            duration_in_months: 1,
+                            redemption_type: 'retention'
+                        },
+                        nextPayment: getNextPaymentData({
+                            originalAmount: 500,
+                            amount: 0,
+                            interval: 'month',
+                            currency: 'USD',
+                            discount: getDiscountData({
+                                duration: 'repeating',
+                                type: 'percent',
+                                amount: 100,
+                                end: discountEnd.toISOString()
+                            })
+                        })
+                    })
+                ]
+            });
+
+            const {queryByText, queryByTestId} = setup({site, member});
+
+            expect(queryByText('$5.00/month')).toBeInTheDocument();
+            expect(queryByText('$5.00/month')).toHaveClass('gh-portal-account-old-price');
+            expect(queryByTestId('offer-label')).toBeInTheDocument();
+            expect(queryByText('$0.00/month — Ends 1 Feb 2099')).toBeInTheDocument();
         });
 
         test('displays "Next payment" for once duration offers', () => {

--- a/apps/portal/test/unit/components/pages/account-plan-page.test.js
+++ b/apps/portal/test/unit/components/pages/account-plan-page.test.js
@@ -436,7 +436,53 @@ describe('Account Plan Page', () => {
         fireEvent.click(cancelButton);
 
         expect(queryByText('1 month free')).toBeInTheDocument();
-        expect(queryByText('Enjoy 1 free month on us. Your next billing date will be 5 Nov 2022.')).toBeInTheDocument();
+        expect(queryByText('Enjoy 1 free month on us. You won\'t be charged until 5 Nov 2022.')).toBeInTheDocument();
+    });
+
+    test('renders multi-month free months retention offers', async () => {
+        const paidProduct = getProductData({
+            name: 'Basic',
+            monthlyPrice: getPriceData({interval: 'month', amount: 1000, currency: 'usd'}),
+            yearlyPrice: getPriceData({interval: 'year', amount: 10000, currency: 'usd'})
+        });
+        const products = [paidProduct, getProductData({type: 'free'})];
+        const site = getSiteData({
+            products,
+            portalProducts: [paidProduct.id]
+        });
+        const member = getMemberData({
+            paid: true,
+            subscriptions: [
+                getSubscriptionData({
+                    status: 'active',
+                    interval: 'month',
+                    amount: paidProduct.monthlyPrice.amount,
+                    currency: 'USD',
+                    priceId: paidProduct.monthlyPrice.id
+                })
+            ]
+        });
+
+        const retentionOffer = {
+            ...getOfferData({
+                type: 'percent',
+                amount: 100,
+                cadence: 'month',
+                duration: 'repeating',
+                durationInMonths: 3,
+                tierId: paidProduct.id,
+                tierName: paidProduct.name
+            }),
+            redemption_type: 'retention'
+        };
+
+        const {queryByRole, queryByText} = customSetup({site, member, offers: [retentionOffer]});
+        const cancelButton = queryByRole('button', {name: 'Cancel subscription'});
+
+        fireEvent.click(cancelButton);
+
+        expect(queryByText('3 months free')).toBeInTheDocument();
+        expect(queryByText('Enjoy 3 free months on us. You won\'t be charged until 5 Jan 2023.')).toBeInTheDocument();
     });
 
     test('renders forever percent retention offers', async () => {

--- a/apps/portal/test/utils/helpers.test.js
+++ b/apps/portal/test/utils/helpers.test.js
@@ -26,7 +26,6 @@ import {
     hasNewsletterSendingEnabled,
     getUpdatedOfferPrice,
     isComplimentaryMember,
-    subscriptionHasFreeMonthsOffer,
     subscriptionHasFreeTrial
 } from '../../src/utils/helpers';
 import * as Fixtures from '../../src/utils/fixtures-generator';
@@ -719,63 +718,6 @@ describe('Helpers - ', () => {
             };
 
             expect(subscriptionHasFreeTrial({sub})).toBe(false);
-        });
-    });
-
-    describe('subscriptionHasFreeMonthsOffer', () => {
-        it('returns true for active percent/100/repeating retention offers with future discount end', () => {
-            const futureDate = new Date();
-            futureDate.setDate(futureDate.getDate() + 3);
-            const sub = {
-                offer: {type: 'percent', amount: 100, duration: 'repeating', redemption_type: 'retention'},
-                next_payment: {discount: {end: futureDate.toISOString()}}
-            };
-
-            expect(subscriptionHasFreeMonthsOffer({sub})).toBe(true);
-        });
-
-        it('returns false for trial offers', () => {
-            const futureDate = new Date();
-            futureDate.setDate(futureDate.getDate() + 3);
-            const sub = {
-                offer: {type: 'trial'},
-                trial_end_at: futureDate.toISOString()
-            };
-
-            expect(subscriptionHasFreeMonthsOffer({sub})).toBe(false);
-        });
-
-        it('returns false for regular percent offers (not 100%)', () => {
-            const futureDate = new Date();
-            futureDate.setDate(futureDate.getDate() + 3);
-            const sub = {
-                offer: {type: 'percent', amount: 50, duration: 'repeating', redemption_type: 'retention'},
-                next_payment: {discount: {end: futureDate.toISOString()}}
-            };
-
-            expect(subscriptionHasFreeMonthsOffer({sub})).toBe(false);
-        });
-
-        it('returns false when discount end date is in the past', () => {
-            const pastDate = new Date();
-            pastDate.setDate(pastDate.getDate() - 3);
-            const sub = {
-                offer: {type: 'percent', amount: 100, duration: 'repeating', redemption_type: 'retention'},
-                next_payment: {discount: {end: pastDate.toISOString()}}
-            };
-
-            expect(subscriptionHasFreeMonthsOffer({sub})).toBe(false);
-        });
-
-        it('returns false for null offer', () => {
-            const futureDate = new Date();
-            futureDate.setDate(futureDate.getDate() + 3);
-            const sub = {
-                offer: null,
-                trial_end_at: futureDate.toISOString()
-            };
-
-            expect(subscriptionHasFreeMonthsOffer({sub})).toBe(false);
         });
     });
 


### PR DESCRIPTION
closes https://linear.app/ghost/issue/BER-3382

- Fixed wording in retention offer popup for free-month offers: "Your next billing date will be {current_period_end + x month(s)}" -> "You won't be charged until {current_period_end + x months}"
- Fixed next billing date for free-month offers in Portal account page, and re-used the existing "$0.00/month - Ends {discount_end}" from signup % coupons to display the next payment amount

<img width="1450" height="1144" alt="image" src="https://github.com/user-attachments/assets/43ed80e9-aa8b-498f-86c2-23fe09d4ade3" />

<img width="952" height="1322" alt="CleanShot 2026-03-02 at 07 32 53@2x" src="https://github.com/user-attachments/assets/e0704d2d-ec0f-4f5d-abfc-626cf43dbf1c" />


