### PR TITLE
Updated copy for once offers in Portal account page

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.65.1",
+  "version": "2.65.2",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/portal/src/components/pages/AccountHomePage/components/paid-account-actions.js
+++ b/apps/portal/src/components/pages/AccountHomePage/components/paid-account-actions.js
@@ -59,7 +59,10 @@ const PaidAccountActions = () => {
             );
         }
 
-        let offerLabelStr = getOfferLabel({nextPayment});
+        let offerLabelStr = getOfferLabel({
+            nextPayment,
+            currentPeriodEnd: subscription?.current_period_end
+        });
 
         if (offerLabelStr) {
             oldPriceClassName = 'gh-portal-account-old-price';
@@ -192,9 +195,8 @@ function FreeTrialLabel({subscription}) {
  * Display discounted price if an offer is active
  *
  * Examples:
- * - "$10.00 — Next payment" (once offer)
  * - "$10.00/month — Forever" (forever offer)
- * - "$10.00/month — Ends 2026-01-01" (repeating offer)
+ * - "$10.00/month — Ends 2026-01-01" (once or repeating offer)
  *
  * @param {Object} nextPayment
  * @param {number} nextPayment.originalAmount - Original amount
@@ -207,10 +209,11 @@ function FreeTrialLabel({subscription}) {
  * @param {string|null} nextPayment.discount.end - Discount end date (ISO 8601 date string), null for forever / once offers
  * @param {'fixed'|'percent'} nextPayment.discount.type
  * @param {number} nextPayment.discount.amount - Discount amount (e.g. 20 for 20% percent offer, or 2 for $2 fixed offer)
-
+ * @param {string} currentPeriodEnd - Subscription current period end (ISO 8601 date string), needed to display the end of "once" offers
+ *
  * @returns {string}
  */
-function getOfferLabel({nextPayment}) {
+function getOfferLabel({nextPayment, currentPeriodEnd}) {
     if (!nextPayment) {
         return '';
     }
@@ -225,20 +228,19 @@ function getOfferLabel({nextPayment}) {
     let durationLabel = '';
     if (discount.duration === 'forever') {
         durationLabel = t('Forever');
-    } else if (discount.duration === 'once') {
-        durationLabel = t('Next payment');
     } else if (discount.duration === 'repeating' && discount.end) {
         durationLabel = t('Ends {offerEndDate}', {offerEndDate: getDateString(discount.end)});
+    } else if (discount.duration === 'once' && currentPeriodEnd) {
+        // By design, "once" offers don't have a discount end in Stripe. They expire at the end of the current billing period.
+        durationLabel = t('Ends {offerEndDate}', {offerEndDate: getDateString(currentPeriodEnd)});
     }
 
     const formattedPrice = Intl.NumberFormat('en', {currency: nextPayment.currency, style: 'currency'}).format(nextPayment.amount / 100);
 
-    let displayedPrice = '';
-    if (discount.duration === 'once') {
-        displayedPrice = formattedPrice;
-    } else {
-        displayedPrice = `${formattedPrice}/${nextPayment.interval}`;
-    }
+    // Possible values for nextPayment.interval for i18n parser:
+    // t('month')
+    // t('year')
+    const displayedPrice = `${formattedPrice}/${t(nextPayment.interval)}`;
 
     return `${displayedPrice}${durationLabel ? ` — ${durationLabel}` : ''}`;
 }

--- a/apps/portal/test/unit/components/pages/AccountHomePage/paid-account-actions.test.js
+++ b/apps/portal/test/unit/components/pages/AccountHomePage/paid-account-actions.test.js
@@ -330,9 +330,10 @@ describe('PaidAccountActions', () => {
             expect(queryByText('$0.00/month — Ends 1 Feb 2099')).toBeInTheDocument();
         });
 
-        test('displays "Next payment" for once duration offers', () => {
+        test('displays discounted price with "Ends {date}" for once offers', () => {
             const products = getProductsData({numOfProducts: 1});
             const site = getSiteData({products, portalProducts: products.map(p => p.id)});
+            const currentPeriodEnd = new Date('2099-03-01T12:00:00.000Z');
 
             const member = getMemberData({
                 paid: true,
@@ -347,6 +348,7 @@ describe('PaidAccountActions', () => {
                             amount: 20,
                             duration: 'once'
                         },
+                        currentPeriodEnd: currentPeriodEnd.toISOString(),
 
                         nextPayment: getNextPaymentData({
                             originalAmount: 500,
@@ -370,8 +372,8 @@ describe('PaidAccountActions', () => {
             expect(queryByText('$5.00/month')).toBeInTheDocument();
             // Should have the offer label
             expect(queryByTestId('offer-label')).toBeInTheDocument();
-            // Should show the discounted price (without interval) with "Next payment"
-            expect(queryByText('$4.00 — Next payment')).toBeInTheDocument();
+            // Should show the discounted price with end date from current period end
+            expect(queryByText('$4.00/month — Ends 1 Mar 2099')).toBeInTheDocument();
         });
 
         test('displays fixed amount discount correctly', () => {

--- a/ghost/i18n/locales/af/portal.json
+++ b/ghost/i18n/locales/af/portal.json
@@ -130,7 +130,6 @@
     "Name": "Naam",
     "Need more help? Contact support": "Benodig meer hulp? Kontak kliëntediens",
     "Newsletters can be disabled on your account for two reasons: A previous email was marked as spam, or attempting to send an email resulted in a permanent failure (bounce).": "Nuusbriewe kan op u rekening afgeskakel word vir twee redes: 'n Vorige e-pos is as spam gemerk, of 'n poging om 'n e-pos te stuur het tot 'n permanente fout gelei (bounce).",
-    "Next payment": "",
     "No member exists with this e-mail address.": "",
     "No member exists with this e-mail address. Please sign up first.": "",
     "No thanks, I want to cancel": "",

--- a/ghost/i18n/locales/ar/portal.json
+++ b/ghost/i18n/locales/ar/portal.json
@@ -130,7 +130,6 @@
     "Name": "الاسم",
     "Need more help? Contact support": "تحتاج إلى المزيد من المساعدة؟ اتصل بالدعم",
     "Newsletters can be disabled on your account for two reasons: A previous email was marked as spam, or attempting to send an email resulted in a permanent failure (bounce).": ".(bounce) يمكن تعطيل النشرات الإخبارية على حسابك لسببين: تم تصنيف بريد إلكتروني سابق كرسالة غير مرغوب فيها، أو محاولة إرسال بريدإلكترونى أدى إلى فشل دائم",
-    "Next payment": "",
     "No member exists with this e-mail address.": ".لا يوجد عضو بهذا عنوان البريد الإلكتروني",
     "No member exists with this e-mail address. Please sign up first.": ".لا يوجد عضو بهذا عنوان البريد الإلكتروني، يرجى التسجيل أولًا",
     "No thanks, I want to cancel": "",

--- a/ghost/i18n/locales/bg/portal.json
+++ b/ghost/i18n/locales/bg/portal.json
@@ -130,7 +130,6 @@
     "Name": "Име",
     "Need more help? Contact support": "Още имате нужда от помощ? Потърсете поддръжката",
     "Newsletters can be disabled on your account for two reasons: A previous email was marked as spam, or attempting to send an email resulted in a permanent failure (bounce).": "Бюлетините могат да бъдат деактивирани в профила ви по две причини: предишен имейл е бил маркиран като спам или опитът за изпращане на имейл е довел до траен неуспех (отказ).",
-    "Next payment": "Следващо плащане",
     "No member exists with this e-mail address.": "Няма абонат с такъв имейл адрес.",
     "No member exists with this e-mail address. Please sign up first.": "Няма абонат с такъв имейл адрес. Моля, първо се регистрирайте.",
     "No thanks, I want to cancel": "",

--- a/ghost/i18n/locales/bn/portal.json
+++ b/ghost/i18n/locales/bn/portal.json
@@ -130,7 +130,6 @@
     "Name": "নাম",
     "Need more help? Contact support": "আরও সাহায্য প্রয়োজন? সাপোর্টের সাথে যোগাযোগ করুন",
     "Newsletters can be disabled on your account for two reasons: A previous email was marked as spam, or attempting to send an email resulted in a permanent failure (bounce).": "আপনার অ্যাকাউন্টে দুটি কারণে নিউজলেটার নিষ্ক্রিয় করা যেতে পারে: একটি পূর্ববর্তী ইমেল স্প্যাম হিসাবে চিহ্নিত করা হয়েছিল, অথবা একটি ইমেল পাঠানোর চেষ্টা স্থায়ী ব্যর্থতার (বাউন্স) ফলাফল।",
-    "Next payment": "",
     "No member exists with this e-mail address.": "",
     "No member exists with this e-mail address. Please sign up first.": "",
     "No thanks, I want to cancel": "",

--- a/ghost/i18n/locales/bs/portal.json
+++ b/ghost/i18n/locales/bs/portal.json
@@ -130,7 +130,6 @@
     "Name": "Ime",
     "Need more help? Contact support": "Treba ti dodatna pomoć? Kontaktiraj podršku",
     "Newsletters can be disabled on your account for two reasons: A previous email was marked as spam, or attempting to send an email resulted in a permanent failure (bounce).": "Newletteri na vašem računu se mogu onemogućiti iz dva razloga: Prethodni Email označena je kao spam ili pokušaj slanja Email poruke rezultirao je greškom (došlo je do odbacivanja nakon više neuspjelih pokušaja).",
-    "Next payment": "",
     "No member exists with this e-mail address.": "",
     "No member exists with this e-mail address. Please sign up first.": "",
     "No thanks, I want to cancel": "",

--- a/ghost/i18n/locales/ca/portal.json
+++ b/ghost/i18n/locales/ca/portal.json
@@ -130,7 +130,6 @@
     "Name": "Nom",
     "Need more help? Contact support": "Necessites més ajuda? Contacta amb suport tècnic",
     "Newsletters can be disabled on your account for two reasons: A previous email was marked as spam, or attempting to send an email resulted in a permanent failure (bounce).": "Els butlletins de notícies poden estar desactivats al teu compte per dos motius: un correu electrònic anterior s'ha marcat com a correu brossa o bé s'ha intentat enviar un correu electrònic que ha provocat un error permanent (rebot).",
-    "Next payment": "",
     "No member exists with this e-mail address.": "No existeix cap membre amb aquesta adreça d'email",
     "No member exists with this e-mail address. Please sign up first.": "No existeix cap membre amb aquesta adreça d'email. Si-us-plau, registra't abans",
     "No thanks, I want to cancel": "",

--- a/ghost/i18n/locales/context.json
+++ b/ghost/i18n/locales/context.json
@@ -176,7 +176,6 @@
     "New reply to your comment on {siteTitle}": "Email subject when notifying user about reply to his comment",
     "Newest": "Text appears in the sorting selector for comments",
     "Newsletters can be disabled on your account for two reasons: A previous email was marked as spam, or attempting to send an email resulted in a permanent failure (bounce).": "A paragraph in the email suppression FAQ",
-    "Next payment": "",
     "No matches found": "Shown in search when 0 results",
     "No member exists with this e-mail address.": "Shown when trying to sign in.",
     "No member exists with this e-mail address. Please sign up first.": "Shown when trying to sign in.",

--- a/ghost/i18n/locales/cs/portal.json
+++ b/ghost/i18n/locales/cs/portal.json
@@ -130,7 +130,6 @@
     "Name": "Jméno",
     "Need more help? Contact support": "Potřebujete další pomoc? Kontaktujte podporu",
     "Newsletters can be disabled on your account for two reasons: A previous email was marked as spam, or attempting to send an email resulted in a permanent failure (bounce).": "Newslettery mohou být na vašem účtu deaktivovány ze dvou důvodů: Předchozí e-mail byl označen jako spam, nebo pokus o odeslání e-mailu skončil trvalým selháním (odrazem).",
-    "Next payment": "",
     "No member exists with this e-mail address.": "",
     "No member exists with this e-mail address. Please sign up first.": "",
     "No thanks, I want to cancel": "",

--- a/ghost/i18n/locales/da/portal.json
+++ b/ghost/i18n/locales/da/portal.json
@@ -130,7 +130,6 @@
     "Name": "Navn",
     "Need more help? Contact support": "Brug for hjælp? Kontakt support",
     "Newsletters can be disabled on your account for two reasons: A previous email was marked as spam, or attempting to send an email resulted in a permanent failure (bounce).": "Nyhedsbreve kan deaktiveres på din konto af to årsager: En tidligere e-mail blev markeret som spam, eller forsøg på at sende en e-mail resulterede i en permanent fejl (bounce).",
-    "Next payment": "",
     "No member exists with this e-mail address.": "Der findes ingen medlem med denne e-mailadresse.",
     "No member exists with this e-mail address. Please sign up first.": "Der findes ingen medlem med denne e-mailadresse. Du skal først tilmelde dig.",
     "No thanks, I want to cancel": "",

--- a/ghost/i18n/locales/de-CH/portal.json
+++ b/ghost/i18n/locales/de-CH/portal.json
@@ -130,7 +130,6 @@
     "Name": "Name",
     "Need more help? Contact support": "Sie benötigen weitere Hilfe? Kontaktieren Sie den Support.",
     "Newsletters can be disabled on your account for two reasons: A previous email was marked as spam, or attempting to send an email resulted in a permanent failure (bounce).": "Newsletter können aus zwei Gründen in Ihrem Konto deaktiviert werden: Eine frühere E-Mail wurde als Spam markiert oder der Versuch, eine E-Mail zu senden, führte zu einem dauerhaften Fehler (Bounce).",
-    "Next payment": "Nächste Zahlung",
     "No member exists with this e-mail address.": "Es existiert kein Mitglied mit dieser E-Mail-Adresse.",
     "No member exists with this e-mail address. Please sign up first.": "Es existiert kein Mitglied mit dieser E-Mail-Adresse. Bitte registrieren Sie sich zuerst.",
     "No thanks, I want to cancel": "",

--- a/ghost/i18n/locales/de/portal.json
+++ b/ghost/i18n/locales/de/portal.json
@@ -130,7 +130,6 @@
     "Name": "Name",
     "Need more help? Contact support": "Du benötigst weitere Hilfe? Kontaktiere den Support",
     "Newsletters can be disabled on your account for two reasons: A previous email was marked as spam, or attempting to send an email resulted in a permanent failure (bounce).": "Newsletter können aus zwei Gründen in deinem Konto deaktiviert werden: Eine frühere E-Mail wurde als Spam markiert oder der Versuch, eine E-Mail zu senden, führte zu einem dauerhaften Fehler (Bounce).",
-    "Next payment": "",
     "No member exists with this e-mail address.": "Mit dieser E-Mail Adresse existiert kein Mitglied.",
     "No member exists with this e-mail address. Please sign up first.": "Mit dieser E-Mail Adresse existiert kein Mitglied. Bitte versuche es erneut.",
     "No thanks, I want to cancel": "",

--- a/ghost/i18n/locales/el/portal.json
+++ b/ghost/i18n/locales/el/portal.json
@@ -130,7 +130,6 @@
     "Name": "Όνομα",
     "Need more help? Contact support": "Χρειάζεστε περισσότερη βοήθεια; Επικοινωνήστε με την υποστήριξη",
     "Newsletters can be disabled on your account for two reasons: A previous email was marked as spam, or attempting to send an email resulted in a permanent failure (bounce).": "Τα ενημερωτικά δελτία μπορούν να απενεργοποιηθούν στον λογαριασμό σας για δύο λόγους: Ένα προηγούμενο email επισημάνθηκε ως ανεπιθύμητο ή η προσπάθεια αποστολής email είχε ως αποτέλεσμα μόνιμη αποτυχία (αναπήδηση).",
-    "Next payment": "",
     "No member exists with this e-mail address.": "",
     "No member exists with this e-mail address. Please sign up first.": "",
     "No thanks, I want to cancel": "",

--- a/ghost/i18n/locales/en/portal.json
+++ b/ghost/i18n/locales/en/portal.json
@@ -130,7 +130,6 @@
     "Name": "",
     "Need more help? Contact support": "",
     "Newsletters can be disabled on your account for two reasons: A previous email was marked as spam, or attempting to send an email resulted in a permanent failure (bounce).": "",
-    "Next payment": "",
     "No member exists with this e-mail address.": "",
     "No member exists with this e-mail address. Please sign up first.": "",
     "No thanks, I want to cancel": "",

--- a/ghost/i18n/locales/eo/portal.json
+++ b/ghost/i18n/locales/eo/portal.json
@@ -130,7 +130,6 @@
     "Name": "Nomo",
     "Need more help? Contact support": "",
     "Newsletters can be disabled on your account for two reasons: A previous email was marked as spam, or attempting to send an email resulted in a permanent failure (bounce).": "",
-    "Next payment": "",
     "No member exists with this e-mail address.": "",
     "No member exists with this e-mail address. Please sign up first.": "",
     "No thanks, I want to cancel": "",

--- a/ghost/i18n/locales/es/portal.json
+++ b/ghost/i18n/locales/es/portal.json
@@ -130,7 +130,6 @@
     "Name": "Nombre",
     "Need more help? Contact support": "¿Necesitas más ayuda? Contacta con soporte técnico.",
     "Newsletters can be disabled on your account for two reasons: A previous email was marked as spam, or attempting to send an email resulted in a permanent failure (bounce).": "Los boletines se pueden deshabilitar en tu cuenta por dos razones: Un correo electrónico anterior se marcó como correo no deseado o el intento de enviar un correo electrónico resultó en un fallo permanente (bounce).",
-    "Next payment": "",
     "No member exists with this e-mail address.": "No existe un miembro con este correo electrónico",
     "No member exists with this e-mail address. Please sign up first.": "No existe un miembro con este correo electrónico. Por favor regístrate primero.",
     "No thanks, I want to cancel": "",

--- a/ghost/i18n/locales/et/portal.json
+++ b/ghost/i18n/locales/et/portal.json
@@ -130,7 +130,6 @@
     "Name": "Nimi",
     "Need more help? Contact support": "Vajate rohkem abi? Võtke ühendust toega",
     "Newsletters can be disabled on your account for two reasons: A previous email was marked as spam, or attempting to send an email resulted in a permanent failure (bounce).": "Uudiskirjad võidakse teie kontol keelata kahel põhjusel: eelmine e-kiri märgiti rämpspostiks või e-kirja saatmise katse põhjustas püsiva tõrke (tagasipõrke).",
-    "Next payment": "",
     "No member exists with this e-mail address.": "",
     "No member exists with this e-mail address. Please sign up first.": "",
     "No thanks, I want to cancel": "",

--- a/ghost/i18n/locales/eu/portal.json
+++ b/ghost/i18n/locales/eu/portal.json
@@ -130,7 +130,6 @@
     "Name": "Izena",
     "Need more help? Contact support": "Laguntza gehiago behar al duzu? Jarri harremanetan",
     "Newsletters can be disabled on your account for two reasons: A previous email was marked as spam, or attempting to send an email resulted in a permanent failure (bounce).": "Zure kontuan buletinak desgaitzeko bi arrazoi daude: aurreko mezuetako bat baztergarritzat jo izana, edo ePosta bideltzean etengabeko hutsegitea (bounce).",
-    "Next payment": "",
     "No member exists with this e-mail address.": "Ez dago ePosta helbide hau duen kiderik.",
     "No member exists with this e-mail address. Please sign up first.": "Ez dago ePosta helbide hau duen kiderik. Eman izena hasteko.",
     "No thanks, I want to cancel": "",

--- a/ghost/i18n/locales/fa/portal.json
+++ b/ghost/i18n/locales/fa/portal.json
@@ -130,7 +130,6 @@
     "Name": "نام",
     "Need more help? Contact support": "کمک بیشتری لازم دارید؟ با پشتیبانی تماس بگیرید",
     "Newsletters can be disabled on your account for two reasons: A previous email was marked as spam, or attempting to send an email resulted in a permanent failure (bounce).": "خبرنامه\u200cها ممکن است به خاطر دو دلیل برای شما غیرفعال شده باشند: ایمیلی که قبلاً برای شما ارسال شده به عنوان اسپم علامت\u200cگذاری شده باشد و یا این که با یک شکست دائمی (bounce) روبرو شده باشد.",
-    "Next payment": "",
     "No member exists with this e-mail address.": "",
     "No member exists with this e-mail address. Please sign up first.": "",
     "No thanks, I want to cancel": "",

--- a/ghost/i18n/locales/fi/portal.json
+++ b/ghost/i18n/locales/fi/portal.json
@@ -130,7 +130,6 @@
     "Name": "Nimi",
     "Need more help? Contact support": "Tarvitsetko lisää apua? Ota yhteyttä tukeen",
     "Newsletters can be disabled on your account for two reasons: A previous email was marked as spam, or attempting to send an email resulted in a permanent failure (bounce).": "Uutiskirjeet sähköpostiisi voivat peruuntua kahdesta syystä: edellinen sähköposti oli merkattu spammiksi, tai sähköpostin lähetyksestä tuli bounce.",
-    "Next payment": "",
     "No member exists with this e-mail address.": "Tälle sähköpostiosoitteelle ei löydy jäsenyyttä.",
     "No member exists with this e-mail address. Please sign up first.": "Tälle sähköpostiosoitteelle ei löydy jäsenyyttä. Rekisteröidy ensin.",
     "No thanks, I want to cancel": "",

--- a/ghost/i18n/locales/fr/portal.json
+++ b/ghost/i18n/locales/fr/portal.json
@@ -130,7 +130,6 @@
     "Name": "Nom",
     "Need more help? Contact support": "Besoin d'aide? Écrivez au support",
     "Newsletters can be disabled on your account for two reasons: A previous email was marked as spam, or attempting to send an email resulted in a permanent failure (bounce).": "Les newsletters peuvent être désactivées de votre compte pour deux raisons : un précédent e-mail a été marqué indésirable ou une tentative d'envoi d'e-mail a entraîné une erreur persistante (renvoi).",
-    "Next payment": "",
     "No member exists with this e-mail address.": "Aucun(e) abonné(e) n'existe avec cette adresse e-mail.",
     "No member exists with this e-mail address. Please sign up first.": "Aucun(e) abonné(e) n'existe avec cette adresse e-mail. Veuillez vous inscrire d'abord.",
     "No thanks, I want to cancel": "",

--- a/ghost/i18n/locales/gd/portal.json
+++ b/ghost/i18n/locales/gd/portal.json
@@ -130,7 +130,6 @@
     "Name": "Ainm",
     "Need more help? Contact support": "’Eil thu feumach air barrachd chobhair? Leig fios dhan sgioba-taice",
     "Newsletters can be disabled on your account for two reasons: A previous email was marked as spam, or attempting to send an email resulted in a permanent failure (bounce).": "Dh’fhaodadh gu bheil cuairt-litrichean à comas air sgàth ’s gun deach post-d roimhe a chomharradh mar spama, no air sgàth ’s nach do ghabh e a lìbhreachadh.",
-    "Next payment": "",
     "No member exists with this e-mail address.": "Chan eil cleachdaiche ann leis a' phost-d seo.",
     "No member exists with this e-mail address. Please sign up first.": "Chan eil cleachdaiche ann leis a' phost-d seo. Clàraich an toiseach.",
     "No thanks, I want to cancel": "",

--- a/ghost/i18n/locales/he/portal.json
+++ b/ghost/i18n/locales/he/portal.json
@@ -130,7 +130,6 @@
     "Name": "שם",
     "Need more help? Contact support": "צריכים עזרה נוספת? צרו קשר עם התמיכה",
     "Newsletters can be disabled on your account for two reasons: A previous email was marked as spam, or attempting to send an email resulted in a permanent failure (bounce).": "ניוזלטרים יכולים להיות מושבתים בחשבון שלכם משני סיבות: מייל קודם סומן כספאם, או ניסיון לשלוח מייל גרם לתקלה קבועה (הקפצה).",
-    "Next payment": "",
     "No member exists with this e-mail address.": "לא קיים חבר עם כתובת המייל הזו.",
     "No member exists with this e-mail address. Please sign up first.": "לא קיים חבר עם כתובת המייל הזו. נא להירשם תחילה.",
     "No thanks, I want to cancel": "",

--- a/ghost/i18n/locales/hi/portal.json
+++ b/ghost/i18n/locales/hi/portal.json
@@ -130,7 +130,6 @@
     "Name": "नाम",
     "Need more help? Contact support": "और अधिक मदद चाहिए? समर्थन से संपर्क करें",
     "Newsletters can be disabled on your account for two reasons: A previous email was marked as spam, or attempting to send an email resulted in a permanent failure (bounce).": "आपके खाते पर न्यूज़लेटर को दो कारणों से निष्क्रिय किया जा सकता है: एक पिछला ईमेल स्पैम के रूप में चिह्नित किया गया था, या एक ईमेल भेजने का प्रयास एक स्थायी विफलता (बाउंस) के कारण हुआ।",
-    "Next payment": "",
     "No member exists with this e-mail address.": "इस ईमेल पते के साथ कोई सदस्य मौजूद नहीं है।",
     "No member exists with this e-mail address. Please sign up first.": "इस ईमेल पते के साथ कोई सदस्य मौजूद नहीं है। कृपया पहले साइनअप करें।",
     "No thanks, I want to cancel": "",

--- a/ghost/i18n/locales/hr/portal.json
+++ b/ghost/i18n/locales/hr/portal.json
@@ -130,7 +130,6 @@
     "Name": "Ime i prezime",
     "Need more help? Contact support": "Kontaktirajte nas ako trebate dodatnu pomoć",
     "Newsletters can be disabled on your account for two reasons: A previous email was marked as spam, or attempting to send an email resulted in a permanent failure (bounce).": "Slanje newsletter-a se može onemogućiti na vašem računu iz dva razloga: prethodna e-pošta je označena kao neželjena pošta (spam) ili je pokušaj slanja e-pošte rezultirao trajnim neuspjehom (odbijanje).",
-    "Next payment": "",
     "No member exists with this e-mail address.": "Korisnik sa ovom email adresom ne postoji.",
     "No member exists with this e-mail address. Please sign up first.": "Korisnik sa ovom email adresom ne postoji. Prvo se registrirajte.",
     "No thanks, I want to cancel": "",

--- a/ghost/i18n/locales/hu/portal.json
+++ b/ghost/i18n/locales/hu/portal.json
@@ -130,7 +130,6 @@
     "Name": "Név",
     "Need more help? Contact support": "További segítségre van szükséged? Lépj velünk kapcsolatba",
     "Newsletters can be disabled on your account for two reasons: A previous email was marked as spam, or attempting to send an email resulted in a permanent failure (bounce).": "A hírlevelek két okból tilthatók le a fiókodban: egy korábbi e-mail spamként lett megjelölve, vagy egy e-mail küldési kísérlet tartós hibához (visszapattanáshoz) vezetett.",
-    "Next payment": "",
     "No member exists with this e-mail address.": "Ehhez az e-mail-címhez nem tartozik fiók.",
     "No member exists with this e-mail address. Please sign up first.": "Ehhez az e-mail-címhez nem tartozik fiók. Kérjük, először regisztrálj.",
     "No thanks, I want to cancel": "",

--- a/ghost/i18n/locales/id/portal.json
+++ b/ghost/i18n/locales/id/portal.json
@@ -130,7 +130,6 @@
     "Name": "Nama",
     "Need more help? Contact support": "Perlu bantuan lebih lanjut? Hubungi layanan dukungan",
     "Newsletters can be disabled on your account for two reasons: A previous email was marked as spam, or attempting to send an email resulted in a permanent failure (bounce).": "Buletin dapat dinonaktifkan pada akun Anda dengan dua alasan: Email sebelumnya ditandai sebagai spam, atau percobaan pengiriman email menghasilkan kegagalan permanen (bounce).",
-    "Next payment": "",
     "No member exists with this e-mail address.": "Tidak ada anggota yang terdaftar dengan alamat email ini.",
     "No member exists with this e-mail address. Please sign up first.": "Tidak ada anggota yang terdaftar dengan alamat email ini. Silakan daftar terlebih dahulu.",
     "No thanks, I want to cancel": "",

--- a/ghost/i18n/locales/is/portal.json
+++ b/ghost/i18n/locales/is/portal.json
@@ -130,7 +130,6 @@
     "Name": "Nafn",
     "Need more help? Contact support": "Þarftu meiri aðstoð? Hafðu samband við þjónustuverið",
     "Newsletters can be disabled on your account for two reasons: A previous email was marked as spam, or attempting to send an email resulted in a permanent failure (bounce).": "",
-    "Next payment": "",
     "No member exists with this e-mail address.": "",
     "No member exists with this e-mail address. Please sign up first.": "",
     "No thanks, I want to cancel": "",

--- a/ghost/i18n/locales/it/portal.json
+++ b/ghost/i18n/locales/it/portal.json
@@ -130,7 +130,6 @@
     "Name": "Nome",
     "Need more help? Contact support": "Hai ancora bisogno di aiuto? Contatta l'assistenza",
     "Newsletters can be disabled on your account for two reasons: A previous email was marked as spam, or attempting to send an email resulted in a permanent failure (bounce).": "Le newsletter possono essere disabilitate nel tuo account per due ragioni: un'email precedente è stata segnalata come spam, o l'invio di un'email ha restituito un fallimento permanente (rimbalzo).",
-    "Next payment": "Prossimo pagamento",
     "No member exists with this e-mail address.": "Nessun membro esistente con questo indirizzo e-mail.",
     "No member exists with this e-mail address. Please sign up first.": "Nessun membro esistente con questo indirizzo e-mail. Effettua prima la registrazione.",
     "No thanks, I want to cancel": "",

--- a/ghost/i18n/locales/ja/portal.json
+++ b/ghost/i18n/locales/ja/portal.json
@@ -130,7 +130,6 @@
     "Name": "名前",
     "Need more help? Contact support": "サポートが必要ですか？お問い合わせください。",
     "Newsletters can be disabled on your account for two reasons: A previous email was marked as spam, or attempting to send an email resulted in a permanent failure (bounce).": "ニュースレターは、2つの理由によってアカウント上で無効になる場合があります: 以前のメールがスパムとしてマークされた場合、またはメールの送信が永続的な障害によって失敗した場合です。",
-    "Next payment": "",
     "No member exists with this e-mail address.": "このメールアドレスを持つメンバーはいません。",
     "No member exists with this e-mail address. Please sign up first.": "このメールアドレスを持つメンバーはいません。まず登録してください。",
     "No thanks, I want to cancel": "",

--- a/ghost/i18n/locales/ko/portal.json
+++ b/ghost/i18n/locales/ko/portal.json
@@ -130,7 +130,6 @@
     "Name": "이름",
     "Need more help? Contact support": "더 많은 도움이 필요하신가요? 지원팀에 문의해 주세요",
     "Newsletters can be disabled on your account for two reasons: A previous email was marked as spam, or attempting to send an email resulted in a permanent failure (bounce).": "뉴스레터는 계정에서 두 가지 이유로 사용 중지될 수 있어요: 이전 이메일이 스팸으로 표시되었거나, 이메일을 보내려고 시도했지만 영구적인 실패가 발생했을 때(바운스).",
-    "Next payment": "",
     "No member exists with this e-mail address.": "이 이메일 주소로 등록된 회원이 없어요.",
     "No member exists with this e-mail address. Please sign up first.": "이 이메일 주소로 등록된 회원이 없어요. 먼저 가입해 주세요.",
     "No thanks, I want to cancel": "",

--- a/ghost/i18n/locales/kz/portal.json
+++ b/ghost/i18n/locales/kz/portal.json
@@ -130,7 +130,6 @@
     "Name": "Есімі",
     "Need more help? Contact support": "Қосымша көмек керек пе? Қолдау бөліміне хабарласыңыз",
     "Newsletters can be disabled on your account for two reasons: A previous email was marked as spam, or attempting to send an email resulted in a permanent failure (bounce).": "Ақпараттық бюллетеньдер аккаунтыңызда екі себеп бойынша өшірілуі мүмкін: Алдыңғы хат спам ретінде белгіленген немесе хат жіберу әрекеті тұрақты қате (қайту) шыққан.",
-    "Next payment": "",
     "No member exists with this e-mail address.": "",
     "No member exists with this e-mail address. Please sign up first.": "",
     "No thanks, I want to cancel": "",

--- a/ghost/i18n/locales/lt/portal.json
+++ b/ghost/i18n/locales/lt/portal.json
@@ -130,7 +130,6 @@
     "Name": "Vardas",
     "Need more help? Contact support": "Reikia daugiau pagalbos? Susisiekite",
     "Newsletters can be disabled on your account for two reasons: A previous email was marked as spam, or attempting to send an email resulted in a permanent failure (bounce).": "Naujienlaiškiai gali būti išjungti paskyroje dėl dviejų priežasčių: ankstesnis el. laiškas buvo pažymėtas kaip šlamštas arba bandymai išsiųsti el. laišką buvo nuolatos atmetami.",
-    "Next payment": "",
     "No member exists with this e-mail address.": "",
     "No member exists with this e-mail address. Please sign up first.": "",
     "No thanks, I want to cancel": "",

--- a/ghost/i18n/locales/lv/portal.json
+++ b/ghost/i18n/locales/lv/portal.json
@@ -130,7 +130,6 @@
     "Name": "Vārds",
     "Need more help? Contact support": "Vai nepieciešama papildu palīdzība? Sazinieties ar atbalsta dienestu",
     "Newsletters can be disabled on your account for two reasons: A previous email was marked as spam, or attempting to send an email resulted in a permanent failure (bounce).": "Informatīvos izdevumus jūsu kontā var atspējot divu iemeslu dēļ: iepriekšējais e-pasts tika atzīmēts kā mēstule vai mēģinājums nosūtīt e-pastu izraisīja neatgriezenisku kļūmi (bounce).",
-    "Next payment": "",
     "No member exists with this e-mail address.": "Nav neviena dalībnieka ar šo e-pasta adresi.",
     "No member exists with this e-mail address. Please sign up first.": "Nav neviena dalībnieka ar šo e-pasta adresi. Lūdzu, vispirms pierakstieties.",
     "No thanks, I want to cancel": "",

--- a/ghost/i18n/locales/mk/portal.json
+++ b/ghost/i18n/locales/mk/portal.json
@@ -130,7 +130,6 @@
     "Name": "Име",
     "Need more help? Contact support": "Ви треба помош? Контактирајте подршка",
     "Newsletters can be disabled on your account for two reasons: A previous email was marked as spam, or attempting to send an email resulted in a permanent failure (bounce).": "Билтените можат да бидат оневозможени за вашата сметка поради две причини: претходна порака била обележана како спам, или обидот за исппраќање на порака резултирал со траен неуспех (отскокнување).",
-    "Next payment": "",
     "No member exists with this e-mail address.": "",
     "No member exists with this e-mail address. Please sign up first.": "",
     "No thanks, I want to cancel": "",

--- a/ghost/i18n/locales/mn/portal.json
+++ b/ghost/i18n/locales/mn/portal.json
@@ -130,7 +130,6 @@
     "Name": "Нэр",
     "Need more help? Contact support": "Тусламж хэрэгтэй юу? Лавлахтай холбогдоно уу",
     "Newsletters can be disabled on your account for two reasons: A previous email was marked as spam, or attempting to send an email resulted in a permanent failure (bounce).": "Таны бүртгэл дээрх товхимолууд хоёр шалтгаанаар идэвхгүй болсон байж болно: Өмнөх имэйлийг спам гэж тэмдэглэсэн, эсвэл имэйлийг илгээх оролдлого байнгын алдаа (баунс) гаргасан.",
-    "Next payment": "",
     "No member exists with this e-mail address.": "Энэ имэйл хаягтай гишүүн байхгүй байна.",
     "No member exists with this e-mail address. Please sign up first.": "Энэ имэйл хаягтай гишүүн байхгүй байна. Эхлээд бүртгүүлнэ үү.",
     "No thanks, I want to cancel": "",

--- a/ghost/i18n/locales/ms/portal.json
+++ b/ghost/i18n/locales/ms/portal.json
@@ -130,7 +130,6 @@
     "Name": "Nama",
     "Need more help? Contact support": "Perlukan bantuan lagi? Hubungi sokongan",
     "Newsletters can be disabled on your account for two reasons: A previous email was marked as spam, or attempting to send an email resulted in a permanent failure (bounce).": "Newsletter boleh dilumpuhkan pada akaun anda atas dua sebab: E-mel sebelumnya telah ditandakan sebagai spam atau percubaan menghantar e-mel mengakibatkan kegagalan kekal (bounce).",
-    "Next payment": "",
     "No member exists with this e-mail address.": "",
     "No member exists with this e-mail address. Please sign up first.": "",
     "No thanks, I want to cancel": "",

--- a/ghost/i18n/locales/nb/portal.json
+++ b/ghost/i18n/locales/nb/portal.json
@@ -130,7 +130,6 @@
     "Name": "Navn",
     "Need more help? Contact support": "Trenger du mer hjelp? Ta kontakt",
     "Newsletters can be disabled on your account for two reasons: A previous email was marked as spam, or attempting to send an email resulted in a permanent failure (bounce).": "Nyhetsbrev kan bli deaktivert på kontoen din av to grunner: En tidligere e-post ble markert som søppelpost, eller forsøk på å sende e-post resulterte i en permanent feil (bounce).",
-    "Next payment": "",
     "No member exists with this e-mail address.": "Ingen medlem eksisterer med denne e-postadressen.",
     "No member exists with this e-mail address. Please sign up first.": "Ingen medlem eksisterer med denne e-postadressen. Vennligst registrer deg først.",
     "No thanks, I want to cancel": "",

--- a/ghost/i18n/locales/ne/portal.json
+++ b/ghost/i18n/locales/ne/portal.json
@@ -130,7 +130,6 @@
     "Name": "",
     "Need more help? Contact support": "",
     "Newsletters can be disabled on your account for two reasons: A previous email was marked as spam, or attempting to send an email resulted in a permanent failure (bounce).": "",
-    "Next payment": "",
     "No member exists with this e-mail address.": "",
     "No member exists with this e-mail address. Please sign up first.": "",
     "No thanks, I want to cancel": "",

--- a/ghost/i18n/locales/nl/portal.json
+++ b/ghost/i18n/locales/nl/portal.json
@@ -130,7 +130,6 @@
     "Name": "Naam",
     "Need more help? Contact support": "Meer hulp nodig? Contacteer support",
     "Newsletters can be disabled on your account for two reasons: A previous email was marked as spam, or attempting to send an email resulted in a permanent failure (bounce).": "Nieuwsbrieven kunnen om twee redenen zijn uitgeschakeld voor je account: een eerdere e-mail werd als spam gemarkeerd, of het verzenden van een e-mail resulteerde in een permanente fout (bounce).",
-    "Next payment": "",
     "No member exists with this e-mail address.": "Er bestaat geen lid met dit e-mailadres.",
     "No member exists with this e-mail address. Please sign up first.": "Er bestaat geen lid met dit e-mailadres. Registreer je eerst.",
     "No thanks, I want to cancel": "",

--- a/ghost/i18n/locales/nn/portal.json
+++ b/ghost/i18n/locales/nn/portal.json
@@ -130,7 +130,6 @@
     "Name": "Namn",
     "Need more help? Contact support": "Treng du meir hjelp? Ta kontakt med brukarstøtte",
     "Newsletters can be disabled on your account for two reasons: A previous email was marked as spam, or attempting to send an email resulted in a permanent failure (bounce).": "Nyheitsbrev kan bli skrudd av for brukaren din av to grunner: Ein tidlegare e-post har blitt markert som spam. Eller så har eit forsøk på å senda ein e-post resultert i ein permanent feil.",
-    "Next payment": "",
     "No member exists with this e-mail address.": "",
     "No member exists with this e-mail address. Please sign up first.": "",
     "No thanks, I want to cancel": "",

--- a/ghost/i18n/locales/pa/portal.json
+++ b/ghost/i18n/locales/pa/portal.json
@@ -130,7 +130,6 @@
     "Name": "ਨਾਮ",
     "Need more help? Contact support": "ਹੋਰ ਮਦਦ ਦੀ ਲੋੜ ਹੈ? ਸਹਾਇਤਾ ਨਾਲ ਸੰਪਰਕ ਕਰੋ",
     "Newsletters can be disabled on your account for two reasons: A previous email was marked as spam, or attempting to send an email resulted in a permanent failure (bounce).": "ਤੁਹਾਡੇ ਖਾਤੇ 'ਤੇ ਨਿਊਜ਼ਲੈਟਰ ਦੋ ਕਾਰਨਾਂ ਕਰਕੇ ਅਸਮਰੱਥ ਕੀਤੇ ਜਾ ਸਕਦੇ ਹਨ: ਪਿਛਲੀ ਈਮੇਲ ਨੂੰ ਸਪੈਮ ਵਜੋਂ ਮਾਰਕ ਕੀਤਾ ਗਿਆ ਸੀ, ਜਾਂ ਈਮੇਲ ਭੇਜਣ ਦੀ ਕੋਸ਼ਿਸ਼ ਦੇ ਨਤੀਜੇ ਵਜੋਂ ਸਥਾਈ ਅਸਫਲਤਾ (ਬਾਊਂਸ) ਹੋਈ ਸੀ।",
-    "Next payment": "",
     "No member exists with this e-mail address.": "ਇਸ ਈ-ਮੇਲ ਪਤੇ ਨਾਲ ਕੋਈ ਮੈਂਬਰ ਮੌਜੂਦ ਨਹੀਂ ਹੈ।",
     "No member exists with this e-mail address. Please sign up first.": "ਇਸ ਈ-ਮੇਲ ਪਤੇ ਨਾਲ ਕੋਈ ਮੈਂਬਰ ਮੌਜੂਦ ਨਹੀਂ ਹੈ। ਕਿਰਪਾ ਕਰਕੇ ਪਹਿਲਾਂ ਸਾਈਨ ਅੱਪ ਕਰੋ।",
     "No thanks, I want to cancel": "",

--- a/ghost/i18n/locales/pl/portal.json
+++ b/ghost/i18n/locales/pl/portal.json
@@ -130,7 +130,6 @@
     "Name": "Imię",
     "Need more help? Contact support": "Potrzebujesz pomocy? Skontaktuj się z pomocą techniczną",
     "Newsletters can be disabled on your account for two reasons: A previous email was marked as spam, or attempting to send an email resulted in a permanent failure (bounce).": "Newslettery mogą zostać wyłączone na Twoim koncie z dwóch powodów: poprzedni email został oznaczony jako spam lub próba wysłania wiadomości zakończyła się niepowodzeniem (odesłaniem).",
-    "Next payment": "",
     "No member exists with this e-mail address.": "Nie istnieje żaden użytkownik o tym adresie e-mail.",
     "No member exists with this e-mail address. Please sign up first.": "Żaden członek nie istnieje z tym adresem e-mail. Proszę się najpierw zarejestrować.",
     "No thanks, I want to cancel": "",

--- a/ghost/i18n/locales/pt-BR/portal.json
+++ b/ghost/i18n/locales/pt-BR/portal.json
@@ -130,7 +130,6 @@
     "Name": "Nome",
     "Need more help? Contact support": "Precisa de mais ajuda? Contate o suporte",
     "Newsletters can be disabled on your account for two reasons: A previous email was marked as spam, or attempting to send an email resulted in a permanent failure (bounce).": "As newsletters podem ser desativadas na sua conta por dois motivos: Um e-mail anterior foi marcado como spam ou a tentativa de enviar um e-mail resultou em uma falha permanente (bounce).",
-    "Next payment": "",
     "No member exists with this e-mail address.": "Não existe nenhum membro com este endereço de e-mail.",
     "No member exists with this e-mail address. Please sign up first.": "Não encontramos nenhum membro com este endereço de e-mail. Faça seu cadastro primeiro.",
     "No thanks, I want to cancel": "",

--- a/ghost/i18n/locales/pt/portal.json
+++ b/ghost/i18n/locales/pt/portal.json
@@ -130,7 +130,6 @@
     "Name": "Nome",
     "Need more help? Contact support": "Precisa de mais ajuda? Entre em contacto com o suporte",
     "Newsletters can be disabled on your account for two reasons: A previous email was marked as spam, or attempting to send an email resulted in a permanent failure (bounce).": "As newsletters podem ser desativadas na sua conta por dois motivos: um email anterior foi marcado como spam, ou a tentativa de enviar um email resultou numa falha permanente (bounce).",
-    "Next payment": "",
     "No member exists with this e-mail address.": "",
     "No member exists with this e-mail address. Please sign up first.": "",
     "No thanks, I want to cancel": "",

--- a/ghost/i18n/locales/ro/portal.json
+++ b/ghost/i18n/locales/ro/portal.json
@@ -130,7 +130,6 @@
     "Name": "Nume",
     "Need more help? Contact support": "Aveți nevoie de mai mult ajutor? Contactați suportul",
     "Newsletters can be disabled on your account for two reasons: A previous email was marked as spam, or attempting to send an email resulted in a permanent failure (bounce).": "Buletinele informative pot fi dezactivate pe contul dvs. din două motive: Un email anterior a fost marcat ca spam, sau încercarea de a trimite un email a rezultat într-o eroare permanentă (respins).",
-    "Next payment": "",
     "No member exists with this e-mail address.": "",
     "No member exists with this e-mail address. Please sign up first.": "",
     "No thanks, I want to cancel": "",

--- a/ghost/i18n/locales/ru/portal.json
+++ b/ghost/i18n/locales/ru/portal.json
@@ -130,7 +130,6 @@
     "Name": "Имя",
     "Need more help? Contact support": "Нужна дополнительная помощь? Обратитесь в службу поддержки",
     "Newsletters can be disabled on your account for two reasons: A previous email was marked as spam, or attempting to send an email resulted in a permanent failure (bounce).": "Рассылка могла быть отключена в вашей учётной записи (для вашего email адреса) по двум причинам: предыдущее электронное письмо было помечено как спам или попытка отправки приводила к постоянной ошибке (например: авто-возврату).",
-    "Next payment": "",
     "No member exists with this e-mail address.": "Участника с таким email адресом не существует.",
     "No member exists with this e-mail address. Please sign up first.": "Участника с таким email адресом не существует. Пожалуйста, зарегистрируйтесь сначала.",
     "No thanks, I want to cancel": "",

--- a/ghost/i18n/locales/si/portal.json
+++ b/ghost/i18n/locales/si/portal.json
@@ -130,7 +130,6 @@
     "Name": "නම",
     "Need more help? Contact support": "තවදුරටත් සහාය අවශ්\u200dයයි ද? සහායක සේවාව සම්බන්ධ කරගන්න",
     "Newsletters can be disabled on your account for two reasons: A previous email was marked as spam, or attempting to send an email resulted in a permanent failure (bounce).": "ඔබගේ ගිණුමෙහි newsletters අක්\u200dරීය වීමට හේතු දෙකක් දැක්විය හැකිය: පෙර යවන ලද email එකක් spam ලෙස සටහන් කිරීම, හෝ email එකක් යැවීමට උත්සාහ කිරීමේදී permenent faulure (bounce) එකක් වීමක් වාර්ථා වීම.",
-    "Next payment": "",
     "No member exists with this e-mail address.": "",
     "No member exists with this e-mail address. Please sign up first.": "",
     "No thanks, I want to cancel": "",

--- a/ghost/i18n/locales/sk/portal.json
+++ b/ghost/i18n/locales/sk/portal.json
@@ -130,7 +130,6 @@
     "Name": "Meno",
     "Need more help? Contact support": "Potrebujete pomoc? Kontaktujte podporu",
     "Newsletters can be disabled on your account for two reasons: A previous email was marked as spam, or attempting to send an email resulted in a permanent failure (bounce).": "Newsletter môže byť na vašom účte zakázaný z dvoch dôvodov: Predchádzajúci e-mail bol označený ako spam alebo pokus o odoslanie e-mailu viedol k trvalému zlyhaniu (bounce).",
-    "Next payment": "",
     "No member exists with this e-mail address.": "Používateľ s danou emailovou adresou neexistuje.",
     "No member exists with this e-mail address. Please sign up first.": "Používateľ s danou emailovou adresou neexistuje. Prosím zaregistrujte sa najprv.",
     "No thanks, I want to cancel": "",

--- a/ghost/i18n/locales/sl/portal.json
+++ b/ghost/i18n/locales/sl/portal.json
@@ -130,7 +130,6 @@
     "Name": "Ime",
     "Need more help? Contact support": "Potrebujete več pomoči? Obrnite se na podporo",
     "Newsletters can be disabled on your account for two reasons: A previous email was marked as spam, or attempting to send an email resulted in a permanent failure (bounce).": "E-poštne novice so na vašem računu lahko onemogočene iz dveh razlogov: prejšnja e-pošta je bila označeno kot vsiljena pošta ali pa je pri pošiljanju e-pošte prišlo do trajne napake (odboj).",
-    "Next payment": "",
     "No member exists with this e-mail address.": "Član s tem e-poštnim naslovom ne obstaja.",
     "No member exists with this e-mail address. Please sign up first.": "Član s tem e-poštnim naslovom ne obstaja. Prosimo, da se najprej prijavite.",
     "No thanks, I want to cancel": "",

--- a/ghost/i18n/locales/sq/portal.json
+++ b/ghost/i18n/locales/sq/portal.json
@@ -130,7 +130,6 @@
     "Name": "Emri",
     "Need more help? Contact support": "Te duhet me shume ndihme? Kontakto suportin",
     "Newsletters can be disabled on your account for two reasons: A previous email was marked as spam, or attempting to send an email resulted in a permanent failure (bounce).": "Buletinet mund të çaktivizohen në llogarinë tuaj për dy arsye: Një email i mëparshëm u shënua si i padëshiruar, ose përpjekja për të dërguar një email rezultoi në një dështim të përhershëm (kercim).",
-    "Next payment": "",
     "No member exists with this e-mail address.": "",
     "No member exists with this e-mail address. Please sign up first.": "",
     "No thanks, I want to cancel": "",

--- a/ghost/i18n/locales/sr-Cyrl/portal.json
+++ b/ghost/i18n/locales/sr-Cyrl/portal.json
@@ -130,7 +130,6 @@
     "Name": "Име",
     "Need more help? Contact support": "Треба Вам више помоћи? Контактирајте подршку",
     "Newsletters can be disabled on your account for two reasons: A previous email was marked as spam, or attempting to send an email resulted in a permanent failure (bounce).": "Билтени могу бити онемогућени на Вашем налогу из два разлога: претходни email је означен као нежељена пошта или је покушај слања email-а резултирао трајним неуспехом (одбијено).",
-    "Next payment": "Наредна уплата",
     "No member exists with this e-mail address.": "Не постоји члан са овом email адресом.",
     "No member exists with this e-mail address. Please sign up first.": "Не постоји члан са овом email адресом. Молимо да се прво региструјете.",
     "No thanks, I want to cancel": "",

--- a/ghost/i18n/locales/sr/portal.json
+++ b/ghost/i18n/locales/sr/portal.json
@@ -130,7 +130,6 @@
     "Name": "Ime",
     "Need more help? Contact support": "Treba Vam više pomoći? Kontaktirajte podršku",
     "Newsletters can be disabled on your account for two reasons: A previous email was marked as spam, or attempting to send an email resulted in a permanent failure (bounce).": "Bilteni mogu biti onemogućeni na Vašem nalogu iz dva razloga: prethodni email je označen kao neželjena pošta ili je pokušaj slanja email-a rezultirao trajnim neuspehom (odbijeno).",
-    "Next payment": "Naredna uplata",
     "No member exists with this e-mail address.": "Ne postoji član sa ovom email adresom.",
     "No member exists with this e-mail address. Please sign up first.": "Ne postoji član sa ovom email adresom. Molimo da se prvo registrujete.",
     "No thanks, I want to cancel": "",

--- a/ghost/i18n/locales/sv/portal.json
+++ b/ghost/i18n/locales/sv/portal.json
@@ -130,7 +130,6 @@
     "Name": "Namn",
     "Need more help? Contact support": "Behöver du mer hjälp? Kontakta administratören.",
     "Newsletters can be disabled on your account for two reasons: A previous email was marked as spam, or attempting to send an email resulted in a permanent failure (bounce).": "Nyhetsbrev kan inaktiveras på ditt konto av två anledningar: ett tidigare utskick markerades som spam, eller ett försök att skicka ett e-postmeddelande resulterade i ett permanent fel.",
-    "Next payment": "",
     "No member exists with this e-mail address.": "Ingen medlem existerar med den här e-postadressen.",
     "No member exists with this e-mail address. Please sign up first.": "Ingen medlem existerar med den här e-postadressen. Vänligen skapa konto först.",
     "No thanks, I want to cancel": "",

--- a/ghost/i18n/locales/sw/portal.json
+++ b/ghost/i18n/locales/sw/portal.json
@@ -130,7 +130,6 @@
     "Name": "Jina",
     "Need more help? Contact support": "Unahitaji msaada zaidi? Wasiliana na usaidizi",
     "Newsletters can be disabled on your account for two reasons: A previous email was marked as spam, or attempting to send an email resulted in a permanent failure (bounce).": "Majarida yanaweza kuzimwa kwenye akaunti yako kwa sababu mbili: Barua pepe ya awali iliyowekwa alama kama spam, au jaribio la kutuma barua pepe lilisababisha hitilafu ya kudumu (bounce).",
-    "Next payment": "",
     "No member exists with this e-mail address.": "",
     "No member exists with this e-mail address. Please sign up first.": "",
     "No thanks, I want to cancel": "",

--- a/ghost/i18n/locales/ta/portal.json
+++ b/ghost/i18n/locales/ta/portal.json
@@ -130,7 +130,6 @@
     "Name": "பெயர்",
     "Need more help? Contact support": "மேலும் உதவி தேவையா? ஆதரவைத் தொடர்பு கொள்ளவும்",
     "Newsletters can be disabled on your account for two reasons: A previous email was marked as spam, or attempting to send an email resulted in a permanent failure (bounce).": "இரண்டு காரணங்களுக்காக உங்கள் கணக்கில் செய்திமடல்கள் முடக்கப்படலாம்: முந்தைய மின்னஞ்சல் ஸ்பாம் என குறிக்கப்பட்டது, அல்லது மின்னஞ்சலை அனுப்ப முயற்சிப்பது நிரந்தர தோல்வியில் முடிந்தது (பவுன்ஸ்).",
-    "Next payment": "",
     "No member exists with this e-mail address.": "இந்த மின்னஞ்சல் முகவரியுடன் எந்த உறுப்பினரும் இல்லை.",
     "No member exists with this e-mail address. Please sign up first.": "இந்த மின்னஞ்சல் முகவரியுடன் எந்த உறுப்பினரும் இல்லை. முதலில் பதிவு செய்யவும்.",
     "No thanks, I want to cancel": "",

--- a/ghost/i18n/locales/th/portal.json
+++ b/ghost/i18n/locales/th/portal.json
@@ -130,7 +130,6 @@
     "Name": "ชื่อ",
     "Need more help? Contact support": "ต้องการความช่วยเหลือเพิ่มเติม? ติดต่อฝ่ายสนับสนุน",
     "Newsletters can be disabled on your account for two reasons: A previous email was marked as spam, or attempting to send an email resulted in a permanent failure (bounce).": "จดหมายข่าวสามารถปิดการใช้งานในบัญชีของคุณด้วยเหตุผลสองประการ: อีเมลก่อนหน้านี้ถูกทำเครื่องหมายว่าเป็นสแปม หรือการพยายามที่ส่งอีเมล ส่งผลให้เกิดความล้มเหลวถาวร (อีเมลตีกลับ)",
-    "Next payment": "",
     "No member exists with this e-mail address.": "",
     "No member exists with this e-mail address. Please sign up first.": "",
     "No thanks, I want to cancel": "",

--- a/ghost/i18n/locales/tr/portal.json
+++ b/ghost/i18n/locales/tr/portal.json
@@ -130,7 +130,6 @@
     "Name": "İsim",
     "Need more help? Contact support": "Daha fazla yardıma mı ihtiyacınız var? Desteğe başvurun",
     "Newsletters can be disabled on your account for two reasons: A previous email was marked as spam, or attempting to send an email resulted in a permanent failure (bounce).": "Bültenler, hesabınızda iki nedenden dolayı devre dışı bırakılabilir: Önceki bir e-posta istenmeyen posta olarak işaretlendi veya bir e-posta gönderilmeye çalışıldığında kalıcı bir başarısızlıkla (geri dönme) sonuçlandı.",
-    "Next payment": "",
     "No member exists with this e-mail address.": "Bu e-posta adresine sahip üye bulunmamaktadır.",
     "No member exists with this e-mail address. Please sign up first.": "Bu e-posta adresine sahip bir üye bulunmamaktadır. Lütfen öncelikle kayıt olun.",
     "No thanks, I want to cancel": "",

--- a/ghost/i18n/locales/uk/portal.json
+++ b/ghost/i18n/locales/uk/portal.json
@@ -130,7 +130,6 @@
     "Name": "Ім'я",
     "Need more help? Contact support": "Потрібна допомога? Зверніться до служби підтримки",
     "Newsletters can be disabled on your account for two reasons: A previous email was marked as spam, or attempting to send an email resulted in a permanent failure (bounce).": "Розсилки можуть бути вимкнені у вашому обліковому записі з двох причин: попередній електронний лист було позначено як спам або спроба надіслати електронний лист призвела до збою (чи відмови).",
-    "Next payment": "",
     "No member exists with this e-mail address.": "Не існує жодного учасника з цією адресою електронної пошти.",
     "No member exists with this e-mail address. Please sign up first.": "Не існує жодного учасника з цією адресою електронної пошти. Будь ласка, спочатку зареєструйтеся.",
     "No thanks, I want to cancel": "",

--- a/ghost/i18n/locales/ur/portal.json
+++ b/ghost/i18n/locales/ur/portal.json
@@ -130,7 +130,6 @@
     "Name": "نام",
     "Need more help? Contact support": "مزید مدد چاہیے؟ حمایت سے رابطہ کریں",
     "Newsletters can be disabled on your account for two reasons: A previous email was marked as spam, or attempting to send an email resulted in a permanent failure (bounce).": "نیوزلیٹرز کو آپکے اکاؤنٹ پر غیر فعال کرنے کے دو ممکنہ وجوہات ہیں: پچھلا ای میل اسپیم مارک کیا گیا تھا یا ای میل بھیجنے کی کوشش نے ہمیشہ کے لئے ناکامی (باؤنس) کا نتیجہ دیا۔",
-    "Next payment": "",
     "No member exists with this e-mail address.": "",
     "No member exists with this e-mail address. Please sign up first.": "",
     "No thanks, I want to cancel": "",

--- a/ghost/i18n/locales/uz/portal.json
+++ b/ghost/i18n/locales/uz/portal.json
@@ -130,7 +130,6 @@
     "Name": "Ism",
     "Need more help? Contact support": "",
     "Newsletters can be disabled on your account for two reasons: A previous email was marked as spam, or attempting to send an email resulted in a permanent failure (bounce).": "",
-    "Next payment": "",
     "No member exists with this e-mail address.": "",
     "No member exists with this e-mail address. Please sign up first.": "",
     "No thanks, I want to cancel": "",

--- a/ghost/i18n/locales/vi/portal.json
+++ b/ghost/i18n/locales/vi/portal.json
@@ -130,7 +130,6 @@
     "Name": "Tên",
     "Need more help? Contact support": "Cần giúp đỡ? Liên hệ hỗ trợ",
     "Newsletters can be disabled on your account for two reasons: A previous email was marked as spam, or attempting to send an email resulted in a permanent failure (bounce).": "Tài khoản của bạn có thể không nhận được bản tin email bởi hai lý do: Email trước đó đã bị đánh dấu là thư rác hoặc lỗi thất bại vĩnh viễn (thư bị trả lại).",
-    "Next payment": "",
     "No member exists with this e-mail address.": "Chưa có thành viên nào với email này",
     "No member exists with this e-mail address. Please sign up first.": "Chưa có thành viên nào với email này. Vui lòng đăng ký trước.",
     "No thanks, I want to cancel": "",

--- a/ghost/i18n/locales/zh-Hant/portal.json
+++ b/ghost/i18n/locales/zh-Hant/portal.json
@@ -130,7 +130,6 @@
     "Name": "名字",
     "Need more help? Contact support": "需要更多協助？聯繫客服",
     "Newsletters can be disabled on your account for two reasons: A previous email was marked as spam, or attempting to send an email resulted in a permanent failure (bounce).": "您的帳號可能會因為兩個原因而停止接收電子報：先前的郵件被標記為垃圾郵件，或者嘗試發送郵件時出現永久失敗（郵件遭到退回）。",
-    "Next payment": "",
     "No member exists with this e-mail address.": "沒有會員使用此電子郵件地址。",
     "No member exists with this e-mail address. Please sign up first.": "沒有會員使用此電子郵件地址。請您先註冊。",
     "No thanks, I want to cancel": "",

--- a/ghost/i18n/locales/zh/portal.json
+++ b/ghost/i18n/locales/zh/portal.json
@@ -130,7 +130,6 @@
     "Name": "姓名",
     "Need more help? Contact support": "需要更多帮助？联系支持服务",
     "Newsletters can be disabled on your account for two reasons: A previous email was marked as spam, or attempting to send an email resulted in a permanent failure (bounce).": "您账户的新闻信被禁用的可能原因有两个：先前的电子邮件被标记为垃圾邮件，或者发送邮件遇到永久错误 (bounce)",
-    "Next payment": "",
     "No member exists with this e-mail address.": "没有会员使用此电子邮箱地址。",
     "No member exists with this e-mail address. Please sign up first.": "没有会员使用此电子邮箱地址。请先注册。",
     "No thanks, I want to cancel": "",


### PR DESCRIPTION
closes https://linear.app/ghost/issue/BER-3393

- aligned the copy for once offers with the repeating / free months offers:
    - Before "$4.00 - Next payment"
    - After: "$4.00/month - Ends {date}"
    
 
   
<img width="896" height="1262" alt="CleanShot 2026-03-02 at 11 50 53@2x" src="https://github.com/user-attachments/assets/896a43f6-0319-407b-b9be-53d2c8e67a10" />
