### PR TITLE
Fixed file upload content type passthrough to storage adapter

### DIFF
--- a/ghost/core/core/server/api/endpoints/files.js
+++ b/ghost/core/core/server/api/endpoints/files.js
@@ -12,7 +12,8 @@ const controller = {
         async query(frame) {
             const filePath = await storage.getStorage('files').save({
                 name: frame.file.originalname,
-                path: frame.file.path
+                path: frame.file.path,
+                type: frame.file.mimetype
             });
 
             return {

--- a/ghost/core/test/e2e-api/admin/files.test.js
+++ b/ghost/core/test/e2e-api/admin/files.test.js
@@ -2,8 +2,10 @@ const assert = require('node:assert/strict');
 const path = require('path');
 const fs = require('fs-extra');
 const supertest = require('supertest');
+const sinon = require('sinon');
 const localUtils = require('./utils');
 const config = require('../../../core/shared/config');
+const storage = require('../../../core/server/adapters/storage');
 
 describe('Files API', function () {
     const files = [];
@@ -21,6 +23,10 @@ describe('Files API', function () {
         });
     });
 
+    afterEach(function () {
+        sinon.restore();
+    });
+
     it('Can upload a file', async function () {
         const res = await request.post(localUtils.API.getApiQuery('files/upload'))
             .set('Origin', config.get('url'))
@@ -33,5 +39,41 @@ describe('Files API', function () {
         assert.equal(res.body.files[0].ref, '934203942');
 
         files.push(new URL(res.body.files[0].url).pathname);
+    });
+
+    it('Passes the content type to the storage adapter when uploading a PDF', async function () {
+        const store = storage.getStorage('files');
+        const saveSpy = sinon.spy(store, 'save');
+
+        const res = await request.post(localUtils.API.getApiQuery('files/upload'))
+            .set('Origin', config.get('url'))
+            .expect('Content-Type', /json/)
+            .attach('file', path.join(__dirname, '/../../utils/fixtures/files/test.pdf'))
+            .expect(201);
+
+        assert.match(new URL(res.body.files[0].url).pathname, /\/content\/files\/\d+\/\d+\/test\.pdf/);
+        files.push(new URL(res.body.files[0].url).pathname);
+
+        assert.ok(saveSpy.calledOnce, 'save() should have been called once');
+        const fileArg = saveSpy.firstCall.args[0];
+        assert.equal(fileArg.type, 'application/pdf', 'save() should receive the correct content type for PDF files');
+    });
+
+    it('Passes the content type to the storage adapter when uploading a JSON file', async function () {
+        const store = storage.getStorage('files');
+        const saveSpy = sinon.spy(store, 'save');
+
+        const res = await request.post(localUtils.API.getApiQuery('files/upload'))
+            .set('Origin', config.get('url'))
+            .expect('Content-Type', /json/)
+            .attach('file', path.join(__dirname, '/../../utils/fixtures/data/redirects.json'))
+            .expect(201);
+
+        assert.match(new URL(res.body.files[0].url).pathname, /\/content\/files\/\d+\/\d+\/redirects\.json/);
+        files.push(new URL(res.body.files[0].url).pathname);
+
+        assert.ok(saveSpy.calledOnce, 'save() should have been called once');
+        const fileArg = saveSpy.firstCall.args[0];
+        assert.equal(fileArg.type, 'application/json', 'save() should receive the correct content type for JSON files');
     });
 });

--- a/ghost/core/test/e2e-api/admin/images.test.js
+++ b/ghost/core/test/e2e-api/admin/images.test.js
@@ -446,8 +446,13 @@ describe('Images API', function () {
 
         const originalFilePath = p.join(__dirname, '/../../utils/fixtures/images/loadingcat.gif');
         const fileContents = await fs.readFile(originalFilePath);
-        await uploadImageRequest({fileContents, filename: 'loadingcat.gif', contentType: 'image/gif'})
+        const {body} = await uploadImageRequest({fileContents, filename: 'loadingcat.gif', contentType: 'image/gif'})
             .expectStatus(201);
+
+        const relativePath = body.images[0].url.replace(urlUtils.urlFor('home', true), '/');
+        const filePath = config.getContentPath('images') + relativePath.replace('/content/images/', '');
+        images.push(filePath);
+        images.push(imageTransform.generateOriginalImageName(filePath));
 
         assert.ok(saveSpy.called, 'save() should have been called');
         const fileArg = saveSpy.firstCall.args[0];

--- a/ghost/core/test/e2e-api/admin/images.test.js
+++ b/ghost/core/test/e2e-api/admin/images.test.js
@@ -440,6 +440,20 @@ describe('Images API', function () {
             });
     });
 
+    it('Passes the content type to the storage adapter when uploading a GIF', async function () {
+        const store = storage.getStorage('images');
+        const saveSpy = sinon.spy(store, 'save');
+
+        const originalFilePath = p.join(__dirname, '/../../utils/fixtures/images/loadingcat.gif');
+        const fileContents = await fs.readFile(originalFilePath);
+        await uploadImageRequest({fileContents, filename: 'loadingcat.gif', contentType: 'image/gif'})
+            .expectStatus(201);
+
+        assert.ok(saveSpy.called, 'save() should have been called');
+        const fileArg = saveSpy.firstCall.args[0];
+        assert.equal(fileArg.type, 'image/gif', 'save() should receive the correct content type for image files');
+    });
+
     it('Does not return HTTP 500 when image processing fails', async function () {
         sinon.stub(imageTransform, 'resizeFromPath').rejects(new Error('Image processing failed'));
 

--- a/ghost/core/test/e2e-api/admin/media.test.js
+++ b/ghost/core/test/e2e-api/admin/media.test.js
@@ -6,6 +6,7 @@ const sinon = require('sinon');
 const localUtils = require('./utils');
 const config = require('../../../core/shared/config');
 const logging = require('@tryghost/logging');
+const storage = require('../../../core/server/adapters/storage');
 
 describe('Media API', function () {
     // NOTE: holds paths to media that need to be cleaned up after the tests are run
@@ -116,6 +117,45 @@ describe('Media API', function () {
             assert.equal(res.body.media[0].ref, 'audio_file_x_m4a');
 
             media.push(new URL(res.body.media[0].url).pathname);
+        });
+
+        it('Passes the content type to the storage adapter when uploading an MP4', async function () {
+            const store = storage.getStorage('media');
+            const saveSpy = sinon.spy(store, 'save');
+
+            const res = await request.post(localUtils.API.getApiQuery('media/upload'))
+                .set('Origin', config.get('url'))
+                .expect('Content-Type', /json/)
+                .attach('file', path.join(__dirname, '/../../utils/fixtures/media/sample_640x360.mp4'))
+                .attach('thumbnail', path.join(__dirname, '/../../utils/fixtures/images/ghost-logo.png'))
+                .expect(201);
+
+            media.push(new URL(res.body.media[0].url).pathname);
+            media.push(new URL(res.body.media[0].thumbnail_url).pathname);
+
+            // save() is called twice: first for the thumbnail, then for the media file
+            assert.equal(saveSpy.callCount, 2, 'save() should have been called twice (thumbnail + media)');
+            const thumbnailArg = saveSpy.firstCall.args[0];
+            assert.equal(thumbnailArg.type, 'image/png', 'save() should receive the correct content type for the thumbnail');
+            const mediaArg = saveSpy.secondCall.args[0];
+            assert.equal(mediaArg.type, 'video/mp4', 'save() should receive the correct content type for the media file');
+        });
+
+        it('Passes the content type to the storage adapter when uploading an MP3', async function () {
+            const store = storage.getStorage('media');
+            const saveSpy = sinon.spy(store, 'save');
+
+            const res = await request.post(localUtils.API.getApiQuery('media/upload'))
+                .set('Origin', config.get('url'))
+                .expect('Content-Type', /json/)
+                .attach('file', path.join(__dirname, '/../../utils/fixtures/media/sample.mp3'))
+                .expect(201);
+
+            media.push(new URL(res.body.media[0].url).pathname);
+
+            assert.ok(saveSpy.calledOnce, 'save() should have been called once');
+            const fileArg = saveSpy.firstCall.args[0];
+            assert.equal(fileArg.type, 'audio/mpeg', 'save() should receive the correct content type for audio files');
         });
 
         it('Rejects non-media file type', async function () {

--- a/ghost/core/test/utils/fixtures/files/test.pdf
+++ b/ghost/core/test/utils/fixtures/files/test.pdf
@@ -1,0 +1,14 @@
+%PDF-1.4
+1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj
+2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj
+3 0 obj<</Type/Page/MediaBox[0 0 612 792]/Parent 2 0 R>>endobj
+xref
+0 4
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+trailer<</Size 4/Root 1 0 R>>
+startxref
+190
+%%EOF


### PR DESCRIPTION
ref https://linear.app/ghost/issue/HKG-1637
https://linear.app/ghost/issue/HKG-1636/

After migrating from Gluster to GCS, files uploaded through Ghost's file upload endpoint were stored with `content-type: application/octet-stream` instead of their actual MIME type. This caused browsers like Safari to trigger downloads instead of displaying files inline. The root cause was that `files.js` only passed name and path to the storage adapter's `save()` method — never the MIME type. The S3Storage adapter uses `file.type` for ContentType, but it was always `undefined`.

- Fixed the files upload endpoint (files.js) not passing the MIME type to the storage adapter's `save()` method, causing uploaded files like PDFs to be stored with `content-type:application/octet-stream` instead of their actual MIME type. 
- Added the MIME type (`frame.file.mimetype`) to the file object passed to `save()` in the files upload endpoint, matching how images and media endpoints already handle this 
- This did not matter before because `LocalStorageBase.save()` simply does an `fs.copy()` and never looks at file.type. When files were later served to browsers, Express's serveStatic automatically detected the MIME type from the file extension. In Ghost Pro's old Gluster setup, OpenResty sat in front and handled content-type detection as well. 
- This became an issue now because the new S3Storage adapter explicitly uses `file.type` as the ContentType when uploading to S3/GCS. Without it, `file.type` was `undefined`, causing S3/GCS to default to `application/octet-stream`. 

As part of this we'll have to remediate existing GCS objects with incorrect Content-Type. Tracked here: https://linear.app/ghost/issue/HKG-1638/

### Tested this on staging. 

Before:-
```
$ curl -sI "https://storage.ghost.is/c/24/09/24098866-0ebc-4dd8-a28e-b3d5508937e3/content/files/2026/03/PI---SR-Advertiser-2026-02-18-Web-1.pdf" 2>&1 | grep -i content-type

OUTPUT: content-type: application/octet-stream
```

After:-
```
curl -sI "https://storage.ghost.is/c/24/09/24098866-0ebc-4dd8-a28e-b3d5508937e3/content/files/2026/03/PI---SR-Advertiser-2026-02-18-Web-2.pdf" 2>&1 | grep -i content-type

OUTPUT: content-type: application/pdf
```