### PR TITLE
Fixed flaky admin comments browse test ordering

### DIFF
--- a/ghost/core/test/e2e-api/admin/comments.test.js
+++ b/ghost/core/test/e2e-api/admin/comments.test.js
@@ -1337,12 +1337,14 @@ describe(`Admin Comments API`, function () {
             await dbFns.addComment({
                 post_id: fixtureManager.get('posts', 0).id,
                 member_id: fixtureManager.get('members', 0).id,
-                html: '<p>Comment on post 1</p>'
+                html: '<p>Comment on post 1</p>',
+                created_at: new Date('2025-01-01T00:00:00.000Z')
             });
             await dbFns.addComment({
                 post_id: fixtureManager.get('posts', 1).id,
                 member_id: fixtureManager.get('members', 0).id,
-                html: '<p>Comment on post 2</p>'
+                html: '<p>Comment on post 2</p>',
+                created_at: new Date('2024-01-01T00:00:00.000Z')
             });
 
             await adminApi.get('/comments/')


### PR DESCRIPTION
## Summary
- Fixed non-deterministic ordering in the "Can browse all comments across posts" acceptance test that was causing sporadic CI failures on SQLite
- The test created two comments without explicit `created_at` values — when both were inserted within the same timestamp, the `created_at desc` ordering was non-deterministic, causing snapshot mismatches
- Added explicit `created_at` values to ensure consistent ordering

ref https://github.com/TryGhost/Ghost/actions/runs/22576914703/job/65398534722?pr=26638