### PR TITLE
Fixed sign-out redirecting to wrong URL on subdirectory sites

### DIFF
--- a/apps/admin/src/layout/app-sidebar/user-menu.tsx
+++ b/apps/admin/src/layout/app-sidebar/user-menu.tsx
@@ -11,6 +11,7 @@ import {
     Switch
 } from "@tryghost/shade"
 import { useCurrentUser } from "@tryghost/admin-x-framework/api/current-user";
+import { getGhostPaths } from "@tryghost/admin-x-framework/helpers";
 import { useUserPreferences, useEditUserPreferences } from "@/hooks/user-preferences";
 import { useWhatsNew } from "@/whats-new/hooks/use-whats-new";
 import { useUpgradeStatus } from "./hooks/use-upgrade-status";
@@ -65,10 +66,11 @@ function UserMenuDarkMode() {
 
 function UserMenuSignOut() {
     const handleSignOut = () => {
-        fetch("/ghost/api/admin/session", {
+        const {apiRoot, adminRoot} = getGhostPaths();
+        fetch(`${apiRoot}/session`, {
             method: "DELETE",
         }).then(() => {
-            window.location.href = "/ghost";
+            window.location.href = adminRoot;
         }).catch((error) => {
             console.error(error);
         });


### PR DESCRIPTION
## Summary

Sites using a subdirectory/proxy setup (e.g. `example.com/blog/ghost/`) could not sign out via the admin UI — the sign-out handler in the React admin app hardcoded `/ghost` paths without accounting for the subdirectory, resulting in a redirect to `/ghost` instead of `/blog/ghost/` and a "Cannot GET /ghost" error.

- Replaced hardcoded `/ghost/api/admin/session` fetch URL with `getGhostPaths().apiRoot` which derives the correct subdirectory from the current URL
- Replaced hardcoded `/ghost` redirect with `getGhostPaths().adminRoot` so the post-signout redirect respects the subdirectory

fixes https://linear.app/ghost/issue/ONC-1510