### PR TITLE
Added ESLint rule to prevent hardcoded /ghost/ paths in admin app

### DIFF
--- a/apps/admin/eslint.config.js
+++ b/apps/admin/eslint.config.js
@@ -7,6 +7,40 @@ import { globalIgnores } from 'eslint/config'
 import noRelativeImportPaths from 'eslint-plugin-no-relative-import-paths'
 import ghostPlugin from 'eslint-plugin-ghost';
 
+const noHardcodedGhostPaths = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow hardcoded /ghost/ paths that break subdirectory installations',
+    },
+    messages: {
+      noHardcodedPath: 'Do not hardcode /ghost/ paths. Use getGhostPaths() from @tryghost/admin-x-framework/helpers to support subdirectory installations.',
+    },
+  },
+  create(context) {
+    const pattern = /^\/ghost\//;
+    return {
+      Literal(node) {
+        if (typeof node.value === 'string' && pattern.test(node.value)) {
+          context.report({node, messageId: 'noHardcodedPath'});
+        }
+      },
+      TemplateLiteral(node) {
+        const first = node.quasis[0];
+        if (first && pattern.test(first.value.raw)) {
+          context.report({node, messageId: 'noHardcodedPath'});
+        }
+      },
+    };
+  },
+};
+
+const localPlugin = {
+  rules: {
+    'no-hardcoded-ghost-paths': noHardcodedGhostPaths,
+  },
+};
+
 export default tseslint.config([
   globalIgnores(['dist']),
   {
@@ -20,6 +54,7 @@ export default tseslint.config([
     plugins: {
       'no-relative-import-paths': noRelativeImportPaths,
       ghost: ghostPlugin,
+      local: localPlugin,
     },
     languageOptions: {
       parserOptions: {
@@ -41,6 +76,14 @@ export default tseslint.config([
         'error',
         { allowSameFolder: true, rootDir: 'src', prefix: '@' },
       ],
+    },
+  },
+  // Prevent hardcoded /ghost/ paths in production code (not tests, where mocks need fixed paths)
+  {
+    files: ['src/**/*.{ts,tsx}'],
+    ignores: ['src/**/*.test.*'],
+    rules: {
+      'local/no-hardcoded-ghost-paths': 'error',
     },
   },
   // Apply no-relative-import-paths rule for test-utils files


### PR DESCRIPTION
## Summary

Adds a custom ESLint rule (`local/no-hardcoded-ghost-paths`) to the React admin app that flags string literals and template literals starting with `/ghost/`. This prevents developers from accidentally hardcoding paths that break subdirectory installations.

- Defined as a local ESLint plugin inline in `eslint.config.js` — no new dependencies needed
- Applied only to `src/**` files so test mocks are unaffected
- Catches both regular strings (`"/ghost/api/..."`) and template literals (`` `/ghost/api/...` ``)
- Error message directs developers to use `getGhostPaths()` from `@tryghost/admin-x-framework/helpers`

ref https://github.com/TryGhost/Ghost/pull/26640