### PR TITLE
Refactored static theme middleware to normalize paths consistently

### DIFF
--- a/ghost/core/core/frontend/web/middleware/static-theme.js
+++ b/ghost/core/core/frontend/web/middleware/static-theme.js
@@ -4,15 +4,10 @@ const themeEngine = require('../../services/theme-engine');
 const express = require('../../../shared/express');
 const AASA_PATH = '/.well-known/apple-app-site-association';
 
-function isDeniedFile(file) {
-    const deniedFileTypes = ['.hbs', '.md', '.json', '.lock', '.log'];
-    const deniedFiles = ['gulpfile.js', 'gruntfile.js'];
-
-    const ext = path.extname(file);
-    const base = path.basename(file);
-
-    return deniedFiles.includes(base) || deniedFileTypes.includes(ext);
-}
+const DENIED_FILE_TYPES = ['.hbs', '.md', '.json', '.lock', '.log'];
+const DENIED_FILES = ['gulpfile.js', 'gruntfile.js'];
+const ALLOWED_FILES = ['manifest.json', 'assetlinks.json'];
+const ALLOWED_PATH = '/assets/';
 
 /**
  * Copy from:
@@ -33,26 +28,26 @@ function decode(filePath) {
 }
 
 /**
- *
- * @param {string} file path to a requested file
+ * @param {string} normalizedPath - already decoded and normalized
  * @returns {boolean}
  */
-function isAllowedFile(file) {
-    const decodedFilePath = decode(file);
-    if (decodedFilePath === -1) {
-        return false;
-    }
+function isDeniedFile(normalizedPath) {
+    const ext = path.extname(normalizedPath);
+    const base = path.basename(normalizedPath);
 
-    const normalizedFilePath = path.normalize(decodedFilePath);
+    return DENIED_FILES.includes(base) || DENIED_FILE_TYPES.includes(ext);
+}
 
-    const allowedFiles = ['manifest.json', 'assetlinks.json'];
-    const allowedPath = '/assets/';
-    const alwaysDeny = ['.hbs'];
+/**
+ * @param {string} normalizedPath - already decoded and normalized
+ * @returns {boolean}
+ */
+function isAllowedFile(normalizedPath) {
+    const ext = path.extname(normalizedPath);
+    const base = path.basename(normalizedPath);
 
-    const ext = path.extname(normalizedFilePath);
-    const base = path.basename(normalizedFilePath);
-
-    return allowedFiles.includes(base) || (normalizedFilePath.startsWith(allowedPath) && !alwaysDeny.includes(ext));
+    // .hbs files are never allowed, even in /assets/
+    return ALLOWED_FILES.includes(base) || (normalizedPath.startsWith(ALLOWED_PATH) && ext !== '.hbs');
 }
 
 /**
@@ -108,11 +103,22 @@ function staticTheme() {
             });
         }
 
-        if (!path.extname(req.path)) {
+        const decodedPath = decode(req.path.toLowerCase());
+        if (decodedPath === -1) {
             return next();
         }
 
-        if (!isAllowedFile(req.path.toLowerCase()) && isDeniedFile(req.path.toLowerCase())) {
+        const normalizedPath = path.normalize(decodedPath);
+
+        if (!path.extname(normalizedPath)) {
+            return next();
+        }
+
+        if (isAllowedFile(normalizedPath)) {
+            return forwardToExpressStatic(req, res, next);
+        }
+
+        if (isDeniedFile(normalizedPath)) {
             return next();
         }
 

--- a/ghost/core/test/unit/frontend/web/middleware/static-theme.test.js
+++ b/ghost/core/test/unit/frontend/web/middleware/static-theme.test.js
@@ -242,6 +242,96 @@ describe('staticTheme', function () {
         });
     });
 
+    describe('URL-encoded extension bypass prevention', function () {
+        it('should skip for URL-encoded .hbs extension (h%62s)', function (done) {
+            req.path = 'mytemplate.h%62s';
+
+            staticTheme()(req, res, function next() {
+                sinon.assert.notCalled(activeThemeStub);
+                sinon.assert.notCalled(expressStaticStub);
+
+                done();
+            });
+        });
+
+        it('should skip for URL-encoded .json extension (%6Ason)', function (done) {
+            req.path = 'package.%6Ason';
+
+            staticTheme()(req, res, function next() {
+                sinon.assert.notCalled(activeThemeStub);
+                sinon.assert.notCalled(expressStaticStub);
+
+                done();
+            });
+        });
+
+        it('should skip for URL-encoded .md extension (%6Dd)', function (done) {
+            req.path = 'README.%6Dd';
+
+            staticTheme()(req, res, function next() {
+                sinon.assert.notCalled(activeThemeStub);
+                sinon.assert.notCalled(expressStaticStub);
+
+                done();
+            });
+        });
+
+        it('should skip for URL-encoded .lock extension (l%6Fck)', function (done) {
+            req.path = 'yarn.l%6Fck';
+
+            staticTheme()(req, res, function next() {
+                sinon.assert.notCalled(activeThemeStub);
+                sinon.assert.notCalled(expressStaticStub);
+
+                done();
+            });
+        });
+
+        it('should skip for URL-encoded .log extension (%6Cog)', function (done) {
+            req.path = 'ghost.%6Cog';
+
+            staticTheme()(req, res, function next() {
+                sinon.assert.notCalled(activeThemeStub);
+                sinon.assert.notCalled(expressStaticStub);
+
+                done();
+            });
+        });
+
+        it('should skip for URL-encoded gulpfile.js (g%75lpfile.js)', function (done) {
+            req.path = 'g%75lpfile.js';
+
+            staticTheme()(req, res, function next() {
+                sinon.assert.notCalled(activeThemeStub);
+                sinon.assert.notCalled(expressStaticStub);
+
+                done();
+            });
+        });
+
+        it('should skip for URL-encoded .hbs in /assets/ path', function (done) {
+            req.path = '/assets/mytemplate.h%62s';
+
+            staticTheme()(req, res, function next() {
+                sinon.assert.notCalled(activeThemeStub);
+                sinon.assert.notCalled(expressStaticStub);
+
+                done();
+            });
+        });
+
+        it('should skip for malformed URL encoding in denied file', function (done) {
+            req.path = 'mytemplate.h%ZZs';
+
+            staticTheme()(req, res, function next() {
+                sinon.assert.notCalled(activeThemeStub);
+                sinon.assert.notCalled(expressStaticStub);
+
+                done();
+            });
+        });
+    });
+
     describe('paths without file extensions', function () {
         it('should skip for root path /', function (done) {
             req.path = '/';


### PR DESCRIPTION
## Summary
- Moved URL decoding and path normalization to a single place at the top of the
  request handler, rather than having each helper function decode independently
- `isDeniedFile` and `isAllowedFile` are now pure functions that operate on an
  already-decoded path
- Extracted denylist and allowlist constants to module level for clarity