### PR TITLE
Fixed member deletion errors from concurrent API requests

### DIFF
--- a/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
@@ -805,9 +805,10 @@ module.exports = class MemberRepository {
             }
         }
 
+        // require: false so concurrent deletes don't throw "No Rows Deleted"
         return this._Member.destroy({
             id: data.id
-        }, options);
+        }, {...options, require: false});
     }
 
     async bulkDestroy(options) {

--- a/ghost/core/test/unit/server/services/members/members-api/repositories/member-repository.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/repositories/member-repository.test.js
@@ -1953,4 +1953,47 @@ describe('MemberRepository', function () {
             sinon.assert.notCalled(Outbox.add);
         });
     });
+
+    describe('destroy', function () {
+        it('passes require: false to tolerate concurrent deletes', async function () {
+            const Member = {
+                findOne: sinon.stub().resolves({
+                    id: 'member_id_123',
+                    related: () => ({
+                        fetch: sinon.stub().resolves({models: []})
+                    })
+                }),
+                destroy: sinon.stub().resolves()
+            };
+
+            const repo = new MemberRepository({
+                Member,
+                stripeAPIService: {configured: false},
+                OfferRedemption: mockOfferRedemption
+            });
+
+            await repo.destroy({id: 'member_id_123'}, {});
+
+            sinon.assert.calledOnce(Member.destroy);
+            const destroyOptions = Member.destroy.firstCall.args[1];
+            assert.equal(destroyOptions.require, false);
+        });
+
+        it('returns early when member does not exist', async function () {
+            const Member = {
+                findOne: sinon.stub().resolves(null),
+                destroy: sinon.stub()
+            };
+
+            const repo = new MemberRepository({
+                Member,
+                stripeAPIService: {configured: false},
+                OfferRedemption: mockOfferRedemption
+            });
+
+            await repo.destroy({id: 'nonexistent'}, {});
+
+            sinon.assert.notCalled(Member.destroy);
+        });
+    });
 });


### PR DESCRIPTION
## Summary
- When multiple `DELETE /members/{id}` requests target the same member concurrently, a race condition causes Bookshelf to throw "No Rows Deleted" errors that bubble up as 500s to Sentry
- The `findOne` check passes for both requests (member exists), but by the time the second request's `destroy()` runs, the member is already gone
- Fixed by passing `require: false` to Bookshelf's `destroy()` so it treats a missing row as a no-op — the member is already deleted, which is the desired outcome

refs https://linear.app/ghost/issue/ONC-1516