### PR TITLE
Disabled v8-compile-cache to fix intermittent V8 deserializer crashes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,12 @@ env:
     ~/.cache/ms-playwright/
   NX_REJECT_UNKNOWN_LOCAL_CACHE: 0
   NODE_VERSION: 22.18.0
+  # Disable v8-compile-cache to prevent intermittent V8 deserializer crashes
+  # when multiple parallel Nx workers race to read/write shared bytecode cache
+  # files. The cache lives in /tmp and is discarded after each run anyway,
+  # so disabling it has no meaningful performance impact in CI.
+  # See: https://github.com/nodejs/node/issues/51555
+  DISABLE_V8_COMPILE_CACHE: 1
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
## Problem

CI intermittently fails with a fatal V8 crash during `Build TS packages`:

```
# Fatal error in , line 0
# unreachable code
v8::internal::Deserializer<v8::internal::Isolate>::ReadSingleBytecodeData
...
v8::internal::CodeSerializer::Deserialize
v8::internal::Compiler::GetSharedFunctionInfoForScriptWithCachedData
```

Example failing run: https://github.com/TryGhost/Ghost/actions/runs/22564490904/job/65358043431

## Root cause

The dependency chain `ts-node` → `v8-compile-cache-lib` is responsible. When `ts-node` loads the TypeScript compiler it calls `v8-compile-cache-lib.install()`, which caches compiled V8 bytecode to disk in `/tmp`.

With Nx running 4 parallel worker processes (the default), multiple workers call this simultaneously and race to read/write the same blob cache files. This corrupts the bytecode, causing the crash on deserialization.

This is a known Node.js issue: https://github.com/nodejs/node/issues/51555

The Node.js core team confirmed: _"Incorrect use of the v8 code cache can lead to corruption and crashes like this... This might be especially true if you have concurrent processes or threads which need careful synchronization."_

## Fix

Set `DISABLE_V8_COMPILE_CACHE=1` globally in the CI workflow environment. This is the confirmed workaround from the Node.js issue thread.

## Performance impact

None. The bytecode cache is written to `/tmp` and discarded at the end of each run — it never persists between CI jobs. Every run was already starting cold.

## Test plan

- [ ] Verify CI passes without the intermittent V8 crash on a few runs