### PR TITLE
Replaced limit=all with paginated loading for label dropdowns

### DIFF
--- a/e2e/helpers/pages/admin/members/members-page.ts
+++ b/e2e/helpers/pages/admin/members/members-page.ts
@@ -68,7 +68,7 @@ class SettingsSection extends BasePage {
     async addLabelToSelectedMembers(labelName: string): Promise<void> {
         await this.addLabelForSelectedMembersButton.click();
         await this.selectLabel.waitFor({state: 'visible'});
-        await this.selectLabel.selectOption({label: labelName});
+        await this.selectLabelOption(labelName);
 
         await this.confirmAddLabelButton.click();
         await this.labelAdded.waitFor({state: 'visible'});
@@ -76,7 +76,8 @@ class SettingsSection extends BasePage {
 
     async removeLabelFromSelectedMembers(labelName: string): Promise<void> {
         await this.removeLabelForSelectedMembersButton.click();
-        await this.selectLabel.selectOption({label: labelName});
+        await this.selectLabel.waitFor({state: 'visible'});
+        await this.selectLabelOption(labelName);
 
         await this.confirmRemoveLabelButton.click();
         await this.labelRemoved.waitFor({state: 'visible'});
@@ -84,6 +85,16 @@ class SettingsSection extends BasePage {
 
     getSuccessMessage(): Locator {
         return this.page.getByTestId('label-success-message');
+    }
+
+    private async selectLabelOption(labelName: string): Promise<void> {
+        await this.selectLabel.click();
+
+        const dropdown = this.page.locator('.ember-power-select-dropdown').last();
+        const searchInput = dropdown.locator('.ember-power-select-search input');
+        await searchInput.fill(labelName);
+
+        await dropdown.getByRole('option', {name: labelName, exact: true}).click();
     }
 }
 

--- a/ghost/admin/.lint-todo
+++ b/ghost/admin/.lint-todo
@@ -167,3 +167,4 @@ remove|ember-template-lint|require-valid-alt-text|4|12|4|12|8369d1b06deac93e8c8e
 remove|ember-template-lint|no-action|1|71|1|71|2e6351f546807d88cc8eb9dbe8baa149468b5cb9|1746489600000|||app/components/gh-view-title.hbs
 remove|ember-template-lint|no-invalid-role|1|0|1|0|3e651d38e0110e1be20e5082075db1b879b59a36|1746489600000|||app/components/gh-view-title.hbs
 add|ember-template-lint|no-yield-only|1|0|1|0|a5fa6e8c1e0f03fb31b5cd17770e4368d44932e4|1771200000000|||app/components/gh-view-title.hbs
+add|ember-template-lint|require-mandatory-role-attributes|5|6|5|6|eebcf58749b98cfb1e9d462bb4f3e497474df6cb|1772409600000|||app/components/power-select-options-with-scroll.hbs

--- a/ghost/admin/app/components/gh-member-label-input.hbs
+++ b/ghost/admin/app/components/gh-member-label-input.hbs
@@ -6,10 +6,16 @@
     @triggerClass={{@triggerClass}}
     @onChange={{this.updateLabels}}
     @onCreate={{this.createLabel}}
+    @onOpen={{this.loadInitialLabels}}
     @options={{this.availableLabels}}
+    @optionsComponent={{component "power-select-vertical-collection-options" lastReached=(perform this.loadMoreLabelsTask)}}
+    @registerAPI={{this.registerPowerSelectAPI}}
     @renderInPlace={{@renderInPlace}}
+    {{!-- null falls back to GhTokenInput's client-side search --}}
+    @search={{if this.useServerSideSearch (perform this.searchLabelsTask) null}}
     @selected={{this.selectedLabels}}
-    @showCreateWhen={{this.hideCreateOptionOnMatchingLabel}}
+    {{!-- null falls back to GhTokenInput's default of showing create option when nothing matches client-side search results --}}
+    @showCreateWhen={{if this.useServerSideSearch this.showCreateWhen null}}
     @triggerId={{this.triggerId}}
     @selectedItemComponent={{component "gh-token-input/label-selected-item"}}
     @disabled={{@disabled}}

--- a/ghost/admin/app/components/gh-member-label-input.js
+++ b/ghost/admin/app/components/gh-member-label-input.js
@@ -72,12 +72,12 @@ export default class GhMemberLabelInput extends Component {
     @action
     async loadInitialLabels() {
         if (!this._hasLoadedInitialLabels) {
-            await this.loadMoreLabelsTask.perform(false);
+            await this.loadMoreLabelsTask.perform();
             this._hasLoadedInitialLabels = true;
         }
     }
 
-    @task
+    @task({drop: true})
     *loadMoreLabelsTask() {
         const isSearch = !!this._powerSelectAPI?.searchText;
         if (isSearch) {
@@ -89,7 +89,7 @@ export default class GhMemberLabelInput extends Component {
                 return;
             }
 
-            if (this._searchedLabelsMeta?.pagination && this._searchedLabelsMeta.pagination.pages <= this._searchedLabelsMeta.pagination.page) {
+            if (!this._searchedLabelsMeta || (this._searchedLabelsMeta.pagination.pages <= this._searchedLabelsMeta.pagination.page)) {
                 return;
             }
 

--- a/ghost/admin/app/components/gh-member-label-input.js
+++ b/ghost/admin/app/components/gh-member-label-input.js
@@ -1,53 +1,141 @@
 import Component from '@glimmer/component';
+import {TrackedArray} from 'tracked-built-ins';
 import {action} from '@ember/object';
 import {inject as service} from '@ember/service';
+import {task} from 'ember-concurrency';
+import {tracked} from '@glimmer/tracking';
+
+const PAGE_SIZE = 100;
 
 export default class GhMemberLabelInput extends Component {
     @service store;
+    @service labelsManager;
+
+    @tracked _initialLabels = new TrackedArray();
+    @tracked _searchedLabels = new TrackedArray();
+
+    _initialLabelsMeta = null;
+    _hasLoadedInitialLabels = false;
+    _searchedLabelsQuery = null;
+    _searchedLabelsMeta = null;
+
+    _powerSelectAPI = null;
+
+    constructor() {
+        super(...arguments);
+        this.addInitialLabels(this.selectedLabels);
+    }
 
     get availableLabels() {
-        return this._availableLabels.toArray().sort((labelA, labelB) => {
-            return (labelA.name || '').localeCompare((labelB.name || ''), undefined, {ignorePunctuation: true});
-        });
+        const selectedLabels = this.selectedLabels;
+        return this.labelsManager.sortLabels(this._initialLabels.filter(label => !selectedLabels.includes(label)));
     }
 
-    get availableLabelNames() {
-        return this.availableLabels.map(label => label.name.toLowerCase());
-    }
+    get useServerSideSearch() {
+        const hasLoadedAnyLabels = !!this._initialLabelsMeta;
+        const hasLoadedAllLabels = hasLoadedAnyLabels && parseInt(this._initialLabelsMeta.pagination.pages, 10) === parseInt(this._initialLabelsMeta.pagination.page, 10);
 
-    constructor(...args) {
-        super(...args);
-        // perform a background query to fetch all users and set `availableLabels`
-        // to a live-query that will be immediately populated with what's in the
-        // store and be updated when the above query returns
-        this.store.query('label', {limit: 'all'});
-        this._availableLabels = this.store.peekAll('label');
+        return !hasLoadedAllLabels;
     }
 
     get selectedLabels() {
         if (typeof this.args.labels === 'object') {
             if (this.args.labels?.length && typeof this.args.labels[0] === 'string') {
                 return this.args.labels.map((d) => {
-                    return this.availableLabels.find(label => label.slug === d);
-                }) || [];
+                    return this._findLabelBySlug(d);
+                }).filter(Boolean) || [];
             }
             return this.args.labels || [];
         }
         return [];
     }
 
+    @action
+    addInitialLabels(labels) {
+        const selectedLabels = this.selectedLabels;
+        const deduplicatedLabels = labels.filter(label => !selectedLabels.includes(label) && !this._initialLabels.includes(label));
+        this._initialLabels.push(...deduplicatedLabels);
+    }
+
+    @action
+    addSearchedLabels(labels) {
+        const selectedLabels = this.selectedLabels;
+        const deduplicatedLabels = labels.filter(label => !selectedLabels.includes(label));
+        this._searchedLabels.push(...deduplicatedLabels);
+    }
+
+    @action
+    registerPowerSelectAPI(api) {
+        this._powerSelectAPI = api;
+    }
+
+    @action
+    async loadInitialLabels() {
+        if (!this._hasLoadedInitialLabels) {
+            await this.loadMoreLabelsTask.perform(false);
+            this._hasLoadedInitialLabels = true;
+        }
+    }
+
+    @task
+    *loadMoreLabelsTask() {
+        const isSearch = !!this._powerSelectAPI?.searchText;
+        if (isSearch) {
+            if (!this.useServerSideSearch) {
+                return;
+            }
+
+            if (this.searchLabelsTask.isRunning) {
+                return;
+            }
+
+            if (this._searchedLabelsMeta?.pagination && this._searchedLabelsMeta.pagination.pages <= this._searchedLabelsMeta.pagination.page) {
+                return;
+            }
+
+            const page = this._searchedLabelsMeta.pagination.page + 1;
+            const labels = yield this.labelsManager.searchLabelsTask.perform(this._searchedLabelsQuery, {page});
+            this.addSearchedLabels(labels.toArray());
+            this._searchedLabelsMeta = labels.meta;
+        } else {
+            if (this._initialLabelsMeta?.pagination && this._initialLabelsMeta.pagination.pages <= this._initialLabelsMeta.pagination.page) {
+                return;
+            }
+
+            const page = this._initialLabelsMeta?.pagination.page ? this._initialLabelsMeta.pagination.page + 1 : 1;
+            const labels = yield this.store.query('label', {limit: PAGE_SIZE, page, order: 'name asc'});
+            this.addInitialLabels(labels.toArray());
+            this._initialLabelsMeta = labels.meta;
+        }
+    }
+
+    @task
+    *searchLabelsTask(term) {
+        this._searchedLabelsQuery = term;
+        const labels = yield this.labelsManager.searchLabelsTask.perform(term);
+        this._searchedLabelsMeta = labels.meta;
+
+        this._searchedLabels = new TrackedArray();
+        this.addSearchedLabels(labels.toArray());
+        return this._searchedLabels;
+    }
+
+    @action
+    showCreateWhen(term) {
+        const availableLabelNames = this._searchedLabels.map(label => label.name.toLowerCase());
+        availableLabelNames.push(...this.selectedLabels.map(label => label.name.toLowerCase()));
+
+        const foundMatchingLabelName = availableLabelNames.includes(term.toLowerCase());
+        return !foundMatchingLabelName;
+    }
+
     willDestroy() {
         super.willDestroy?.(...arguments);
-        this._availableLabels.forEach((label) => {
+        this._initialLabels.forEach((label) => {
             if (label.get('isNew')) {
                 this.store.deleteRecord(label);
             }
         });
-    }
-
-    @action
-    hideCreateOptionOnMatchingLabel(term) {
-        return !this.availableLabelNames.includes(term.toLowerCase());
     }
 
     @action
@@ -61,7 +149,6 @@ export default class GhMemberLabelInput extends Component {
             }
         });
 
-        // update labels
         this.args.onChange(newLabels);
     }
 
@@ -101,8 +188,15 @@ export default class GhMemberLabelInput extends Component {
 
     _findLabelByName(name) {
         let withMatchingName = function (label) {
+            if (label.__isSuggestion__) {
+                return false;
+            }
             return label.name.toLowerCase() === name.toLowerCase();
         };
-        return this.availableLabels.find(withMatchingName);
+        return this._searchedLabels.find(withMatchingName) || this._initialLabels.find(withMatchingName);
+    }
+
+    _findLabelBySlug(slug) {
+        return this._initialLabels.find(label => label.slug === slug) || this.store.peekAll('label').find(label => label.slug === slug);
     }
 }

--- a/ghost/admin/app/components/gh-member-label-input.js
+++ b/ghost/admin/app/components/gh-member-label-input.js
@@ -5,56 +5,36 @@ import {inject as service} from '@ember/service';
 import {task} from 'ember-concurrency';
 import {tracked} from '@glimmer/tracking';
 
-const PAGE_SIZE = 100;
-
 export default class GhMemberLabelInput extends Component {
     @service store;
     @service labelsManager;
 
-    @tracked _initialLabels = new TrackedArray();
     @tracked _searchedLabels = new TrackedArray();
 
-    _initialLabelsMeta = null;
-    _hasLoadedInitialLabels = false;
     _searchedLabelsQuery = null;
     _searchedLabelsMeta = null;
 
     _powerSelectAPI = null;
 
-    constructor() {
-        super(...arguments);
-        this.addInitialLabels(this.selectedLabels);
-    }
-
     get availableLabels() {
         const selectedLabels = this.selectedLabels;
-        return this.labelsManager.sortLabels(this._initialLabels.filter(label => !selectedLabels.includes(label)));
+        return this.labelsManager.sortLabels(this.labelsManager._labels.filter(label => !selectedLabels.includes(label)));
     }
 
     get useServerSideSearch() {
-        const hasLoadedAnyLabels = !!this._initialLabelsMeta;
-        const hasLoadedAllLabels = hasLoadedAnyLabels && parseInt(this._initialLabelsMeta.pagination.pages, 10) === parseInt(this._initialLabelsMeta.pagination.page, 10);
-
-        return !hasLoadedAllLabels;
+        return !this.labelsManager.hasLoadedAll;
     }
 
     get selectedLabels() {
         if (typeof this.args.labels === 'object') {
             if (this.args.labels?.length && typeof this.args.labels[0] === 'string') {
                 return this.args.labels.map((d) => {
-                    return this._findLabelBySlug(d);
+                    return this.labelsManager.findBySlug(d);
                 }).filter(Boolean) || [];
             }
             return this.args.labels || [];
         }
         return [];
-    }
-
-    @action
-    addInitialLabels(labels) {
-        const selectedLabels = this.selectedLabels;
-        const deduplicatedLabels = labels.filter(label => !selectedLabels.includes(label) && !this._initialLabels.includes(label));
-        this._initialLabels.push(...deduplicatedLabels);
     }
 
     @action
@@ -71,9 +51,8 @@ export default class GhMemberLabelInput extends Component {
 
     @action
     async loadInitialLabels() {
-        if (!this._hasLoadedInitialLabels) {
-            await this.loadMoreLabelsTask.perform();
-            this._hasLoadedInitialLabels = true;
+        if (!this.labelsManager.hasLoaded) {
+            await this.labelsManager.loadMoreTask.perform();
         }
     }
 
@@ -98,14 +77,7 @@ export default class GhMemberLabelInput extends Component {
             this.addSearchedLabels(labels.toArray());
             this._searchedLabelsMeta = labels.meta;
         } else {
-            if (this._initialLabelsMeta?.pagination && this._initialLabelsMeta.pagination.pages <= this._initialLabelsMeta.pagination.page) {
-                return;
-            }
-
-            const page = this._initialLabelsMeta?.pagination.page ? this._initialLabelsMeta.pagination.page + 1 : 1;
-            const labels = yield this.store.query('label', {limit: PAGE_SIZE, page, order: 'name asc'});
-            this.addInitialLabels(labels.toArray());
-            this._initialLabelsMeta = labels.meta;
+            yield this.labelsManager.loadMoreTask.perform();
         }
     }
 
@@ -131,7 +103,7 @@ export default class GhMemberLabelInput extends Component {
 
     willDestroy() {
         super.willDestroy?.(...arguments);
-        this._initialLabels.forEach((label) => {
+        this.store.peekAll('label').forEach((label) => {
             if (label.get('isNew')) {
                 this.store.deleteRecord(label);
             }
@@ -193,10 +165,6 @@ export default class GhMemberLabelInput extends Component {
             }
             return label.name.toLowerCase() === name.toLowerCase();
         };
-        return this._searchedLabels.find(withMatchingName) || this._initialLabels.find(withMatchingName);
-    }
-
-    _findLabelBySlug(slug) {
-        return this._initialLabels.find(label => label.slug === slug) || this.store.peekAll('label').find(label => label.slug === slug);
+        return this._searchedLabels.find(withMatchingName) || this.labelsManager._labels.find(withMatchingName);
     }
 }

--- a/ghost/admin/app/components/gh-member-single-label-input.hbs
+++ b/ghost/admin/app/components/gh-member-single-label-input.hbs
@@ -5,9 +5,10 @@
     @search={{if this.useServerSideSearch (perform this.searchLabelsTask) null}}
     @searchField="name"
     @onChange={{this.updateLabel}}
-    @optionsComponent={{component "power-select-vertical-collection-options" lastReached=(perform this.loadMoreLabelsTask)}}
+    @optionsComponent={{component "power-select-options-with-scroll" lastReached=(perform this.loadMoreLabelsTask)}}
     @registerAPI={{this.registerPowerSelectAPI}}
     @searchPlaceholder="Search labels..."
+    @dropdownClass="gh-resource-select-dropdown"
     @renderInPlace={{true}}
     @triggerId={{@triggerId}}
     data-testid="label-select"

--- a/ghost/admin/app/components/gh-member-single-label-input.hbs
+++ b/ghost/admin/app/components/gh-member-single-label-input.hbs
@@ -1,11 +1,17 @@
-<span class="gh-select">
-    <OneWaySelect
-        @options={{this.availableLabels}}
-        @optionValuePath="id"
-        @optionLabelPath="name"
-        @optionTargetPath="id"
-        @update={{this.updateLabel}}
-        data-testid="label-select"
-    />
-    {{svg-jar "arrow-down-small"}}
-</span>
+<PowerSelect
+    @selected={{this._selectedLabel}}
+    @options={{this.availableLabels}}
+    @searchEnabled={{true}}
+    @search={{if this.useServerSideSearch (perform this.searchLabelsTask) null}}
+    @searchField="name"
+    @onChange={{this.updateLabel}}
+    @optionsComponent={{component "power-select-vertical-collection-options" lastReached=(perform this.loadMoreLabelsTask)}}
+    @registerAPI={{this.registerPowerSelectAPI}}
+    @searchPlaceholder="Search labels..."
+    @renderInPlace={{true}}
+    @triggerId={{@triggerId}}
+    data-testid="label-select"
+    as |label|
+>
+    {{label.name}}
+</PowerSelect>

--- a/ghost/admin/app/components/gh-member-single-label-input.js
+++ b/ghost/admin/app/components/gh-member-single-label-input.js
@@ -1,39 +1,110 @@
 import Component from '@glimmer/component';
+import {TrackedArray} from 'tracked-built-ins';
 import {action} from '@ember/object';
 import {inject as service} from '@ember/service';
 import {task} from 'ember-concurrency';
 import {tracked} from '@glimmer/tracking';
 
+const PAGE_SIZE = 100;
+
 export default class GhMemberSingleLabelInput extends Component {
     @service store;
     @service labelsManager;
 
-    @tracked selectedLabel;
-    @tracked _availableLabels = [];
-    @tracked _hasLoaded = false;
+    @tracked _selectedLabel = null;
+    @tracked _initialLabels = new TrackedArray();
+    @tracked _searchedLabels = new TrackedArray();
+
+    _initialLabelsMeta = null;
+    _hasLoadedInitialLabels = false;
+    _searchedLabelsQuery = null;
+    _searchedLabelsMeta = null;
+
+    _powerSelectAPI = null;
 
     get availableLabels() {
-        return this.labelsManager.sortLabels(this._availableLabels);
+        return this.labelsManager.sortLabels(this._initialLabels.toArray());
+    }
+
+    get useServerSideSearch() {
+        const hasLoadedAnyLabels = !!this._initialLabelsMeta;
+        const hasLoadedAllLabels = hasLoadedAnyLabels && parseInt(this._initialLabelsMeta.pagination.pages, 10) === parseInt(this._initialLabelsMeta.pagination.page, 10);
+
+        return !hasLoadedAllLabels;
     }
 
     constructor(...args) {
         super(...args);
-        this.loadLabelsTask.perform();
+        this.loadInitialLabelsTask.perform();
     }
 
     @task
-    *loadLabelsTask() {
-        const labels = yield this.store.query('label', {limit: 100, page: 1, order: 'name asc'});
-        this._availableLabels = labels.toArray();
-        this._hasLoaded = true;
+    *loadInitialLabelsTask() {
+        const labels = yield this.store.query('label', {limit: PAGE_SIZE, page: 1, order: 'name asc'});
+        this._initialLabels.push(...labels.toArray());
+        this._initialLabelsMeta = labels.meta;
 
-        this.selectedLabel = this.args.label || this.availableLabels[0]?.get('id');
-        this.args.onChange(this.selectedLabel);
+        const sorted = this.availableLabels;
+        if (this.args.label) {
+            this._selectedLabel = sorted.find(l => l.id === this.args.label) || sorted[0];
+        } else {
+            this._selectedLabel = sorted[0];
+        }
+        if (this._selectedLabel) {
+            this.args.onChange(this._selectedLabel.id);
+        }
     }
 
     @action
-    updateLabel(newLabel) {
-        this.selectedLabel = newLabel;
-        this.args.onChange(newLabel);
+    registerPowerSelectAPI(api) {
+        this._powerSelectAPI = api;
+    }
+
+    @task
+    *loadMoreLabelsTask() {
+        const isSearch = !!this._powerSelectAPI?.searchText;
+        if (isSearch) {
+            if (!this.useServerSideSearch) {
+                return;
+            }
+
+            if (this.searchLabelsTask.isRunning) {
+                return;
+            }
+
+            if (this._searchedLabelsMeta?.pagination && this._searchedLabelsMeta.pagination.pages <= this._searchedLabelsMeta.pagination.page) {
+                return;
+            }
+
+            const page = this._searchedLabelsMeta.pagination.page + 1;
+            const labels = yield this.labelsManager.searchLabelsTask.perform(this._searchedLabelsQuery, {page});
+            this._searchedLabels.push(...labels.toArray());
+            this._searchedLabelsMeta = labels.meta;
+        } else {
+            if (this._initialLabelsMeta?.pagination && this._initialLabelsMeta.pagination.pages <= this._initialLabelsMeta.pagination.page) {
+                return;
+            }
+
+            const page = this._initialLabelsMeta?.pagination.page ? this._initialLabelsMeta.pagination.page + 1 : 1;
+            const labels = yield this.store.query('label', {limit: PAGE_SIZE, page, order: 'name asc'});
+            this._initialLabels.push(...labels.toArray());
+            this._initialLabelsMeta = labels.meta;
+        }
+    }
+
+    @task
+    *searchLabelsTask(term) {
+        this._searchedLabelsQuery = term;
+        const labels = yield this.labelsManager.searchLabelsTask.perform(term);
+        this._searchedLabelsMeta = labels.meta;
+
+        this._searchedLabels = new TrackedArray(this.labelsManager.sortLabels(labels.toArray()));
+        return this._searchedLabels;
+    }
+
+    @action
+    updateLabel(label) {
+        this._selectedLabel = label;
+        this.args.onChange(label?.id);
     }
 }

--- a/ghost/admin/app/components/gh-member-single-label-input.js
+++ b/ghost/admin/app/components/gh-member-single-label-input.js
@@ -5,31 +5,24 @@ import {inject as service} from '@ember/service';
 import {task} from 'ember-concurrency';
 import {tracked} from '@glimmer/tracking';
 
-const PAGE_SIZE = 100;
-
 export default class GhMemberSingleLabelInput extends Component {
     @service store;
     @service labelsManager;
 
     @tracked _selectedLabel = null;
-    @tracked _initialLabels = new TrackedArray();
     @tracked _searchedLabels = new TrackedArray();
 
-    _initialLabelsMeta = null;
     _searchedLabelsQuery = null;
     _searchedLabelsMeta = null;
 
     _powerSelectAPI = null;
 
     get availableLabels() {
-        return this.labelsManager.sortLabels(this._initialLabels.toArray());
+        return this.labelsManager.labels;
     }
 
     get useServerSideSearch() {
-        const hasLoadedAnyLabels = !!this._initialLabelsMeta;
-        const hasLoadedAllLabels = hasLoadedAnyLabels && parseInt(this._initialLabelsMeta.pagination.pages, 10) === parseInt(this._initialLabelsMeta.pagination.page, 10);
-
-        return !hasLoadedAllLabels;
+        return !this.labelsManager.hasLoadedAll;
     }
 
     constructor(...args) {
@@ -39,9 +32,9 @@ export default class GhMemberSingleLabelInput extends Component {
 
     @task
     *loadInitialLabelsTask() {
-        const labels = yield this.store.query('label', {limit: PAGE_SIZE, page: 1, order: 'name asc'});
-        this._initialLabels.push(...labels.toArray());
-        this._initialLabelsMeta = labels.meta;
+        if (!this.labelsManager.hasLoaded) {
+            yield this.labelsManager.loadMoreTask.perform();
+        }
 
         const sorted = this.availableLabels;
         if (this.args.label) {
@@ -80,14 +73,7 @@ export default class GhMemberSingleLabelInput extends Component {
             this._searchedLabels.push(...labels.toArray());
             this._searchedLabelsMeta = labels.meta;
         } else {
-            if (this._initialLabelsMeta?.pagination && this._initialLabelsMeta.pagination.pages <= this._initialLabelsMeta.pagination.page) {
-                return;
-            }
-
-            const page = this._initialLabelsMeta?.pagination.page ? this._initialLabelsMeta.pagination.page + 1 : 1;
-            const labels = yield this.store.query('label', {limit: PAGE_SIZE, page, order: 'name asc'});
-            this._initialLabels.push(...labels.toArray());
-            this._initialLabelsMeta = labels.meta;
+            yield this.labelsManager.loadMoreTask.perform();
         }
     }
 

--- a/ghost/admin/app/components/gh-member-single-label-input.js
+++ b/ghost/admin/app/components/gh-member-single-label-input.js
@@ -16,7 +16,6 @@ export default class GhMemberSingleLabelInput extends Component {
     @tracked _searchedLabels = new TrackedArray();
 
     _initialLabelsMeta = null;
-    _hasLoadedInitialLabels = false;
     _searchedLabelsQuery = null;
     _searchedLabelsMeta = null;
 
@@ -60,7 +59,7 @@ export default class GhMemberSingleLabelInput extends Component {
         this._powerSelectAPI = api;
     }
 
-    @task
+    @task({drop: true})
     *loadMoreLabelsTask() {
         const isSearch = !!this._powerSelectAPI?.searchText;
         if (isSearch) {
@@ -72,7 +71,7 @@ export default class GhMemberSingleLabelInput extends Component {
                 return;
             }
 
-            if (this._searchedLabelsMeta?.pagination && this._searchedLabelsMeta.pagination.pages <= this._searchedLabelsMeta.pagination.page) {
+            if (!this._searchedLabelsMeta || (this._searchedLabelsMeta.pagination.pages <= this._searchedLabelsMeta.pagination.page)) {
                 return;
             }
 

--- a/ghost/admin/app/components/gh-member-single-label-input.js
+++ b/ghost/admin/app/components/gh-member-single-label-input.js
@@ -1,37 +1,38 @@
 import Component from '@glimmer/component';
 import {action} from '@ember/object';
 import {inject as service} from '@ember/service';
+import {task} from 'ember-concurrency';
 import {tracked} from '@glimmer/tracking';
 
-export default class GhMemberLabelInput extends Component {
+export default class GhMemberSingleLabelInput extends Component {
     @service store;
+    @service labelsManager;
 
     @tracked selectedLabel;
+    @tracked _availableLabels = [];
+    @tracked _hasLoaded = false;
 
     get availableLabels() {
-        return this._availableLabels.toArray().sort((labelA, labelB) => {
-            return labelA.name.localeCompare(labelB.name, undefined, {ignorePunctuation: true});
-        });
-    }
-
-    get availableLabelNames() {
-        return this.availableLabels.map(label => label.name.toLowerCase());
+        return this.labelsManager.sortLabels(this._availableLabels);
     }
 
     constructor(...args) {
         super(...args);
-        // perform a background query to fetch all users and set `availableLabels`
-        // to a live-query that will be immediately populated with what's in the
-        // store and be updated when the above query returns
-        this.store.query('label', {limit: 'all'});
-        this._availableLabels = this.store.peekAll('label');
+        this.loadLabelsTask.perform();
+    }
+
+    @task
+    *loadLabelsTask() {
+        const labels = yield this.store.query('label', {limit: 100, page: 1, order: 'name asc'});
+        this._availableLabels = labels.toArray();
+        this._hasLoaded = true;
+
         this.selectedLabel = this.args.label || this.availableLabels[0]?.get('id');
         this.args.onChange(this.selectedLabel);
     }
 
     @action
     updateLabel(newLabel) {
-        // update labels
         this.selectedLabel = newLabel;
         this.args.onChange(newLabel);
     }

--- a/ghost/admin/app/components/gh-members-recipient-select.hbs
+++ b/ghost/admin/app/components/gh-members-recipient-select.hbs
@@ -55,7 +55,7 @@
             </div>
         </div>
     {{/if}}
-    {{#if this.specificOptions}}
+    {{#if this.specificOptions.length}}
         <div class="gh-publish-send-to-option">
             <div class="for-checkbox {{if @disabled "disabled"}}">
                 <label class="checkbox" for="send-email-to-specific">
@@ -88,7 +88,7 @@
             @selected={{this.selectedSpecificOptions}}
             @disabled={{@disabled}}
             @searchMessage="All labels selected"
-            @optionsComponent={{component "power-select/options"}}
+            @optionsComponent={{component "power-select-options-with-scroll" lastReached=(perform this.loadMoreLabelsTask)}}
             @allowCreation={{false}}
             @renderInPlace={{this.renderInPlace}}
             @onChange={{this.selectSpecificOptions}}

--- a/ghost/admin/app/components/gh-members-recipient-select.js
+++ b/ghost/admin/app/components/gh-members-recipient-select.js
@@ -139,9 +139,9 @@ export default class GhMembersRecipientSelect extends Component {
     *fetchSpecificOptionsTask() {
         const options = [];
 
-        // fetch all labels w̶i̶t̶h̶ c̶o̶u̶n̶t̶s̶
+        // fetch labels w̶i̶t̶h̶ c̶o̶u̶n̶t̶s̶
         // TODO: add `include: 'count.members` to query once API is fixed
-        const labels = yield this.store.query('label', {limit: 'all'});
+        const labels = yield this.store.query('label', {limit: 100, order: 'name asc'});
 
         if (labels.length > 0) {
             const labelsGroup = {

--- a/ghost/admin/app/components/gh-members-recipient-select.js
+++ b/ghost/admin/app/components/gh-members-recipient-select.js
@@ -152,7 +152,7 @@ export default class GhMembersRecipientSelect extends Component {
         this.args.onChange?.(newFilter);
     }
 
-    @task
+    @task({drop: true})
     *loadMoreLabelsTask() {
         if (this._labelsMeta?.pagination && this._labelsMeta.pagination.pages <= this._labelsMeta.pagination.page) {
             return;

--- a/ghost/admin/app/components/gh-members-recipient-select.js
+++ b/ghost/admin/app/components/gh-members-recipient-select.js
@@ -1,5 +1,6 @@
 import Component from '@glimmer/component';
 import flattenGroupedOptions from 'ghost-admin/utils/flatten-grouped-options';
+import {TrackedArray} from 'tracked-built-ins';
 import {action} from '@ember/object';
 import {isBlank} from '@ember/utils';
 import {inject as service} from '@ember/service';
@@ -7,13 +8,16 @@ import {task} from 'ember-concurrency';
 import {tracked} from '@glimmer/tracking';
 
 const BASE_FILTERS = ['status:free', 'status:-free'];
+const PAGE_SIZE = 100;
 
 export default class GhMembersRecipientSelect extends Component {
     @service membersUtils;
     @service store;
 
     @tracked forceSpecificChecked = false;
-    @tracked specificOptions = [];
+    @tracked _tierOptions = [];
+    @tracked _labelOptions = new TrackedArray();
+    _labelsMeta = null;
 
     constructor() {
         super(...arguments);
@@ -51,6 +55,19 @@ export default class GhMembersRecipientSelect extends Component {
 
     get isSpecificChecked() {
         return this.forceSpecificChecked || this.specificFilters.size > 0;
+    }
+
+    get specificOptions() {
+        const options = [...this._tierOptions];
+
+        if (this._labelOptions.length > 0) {
+            options.unshift({
+                groupName: 'Labels',
+                options: [...this._labelOptions]
+            });
+        }
+
+        return options;
     }
 
     get selectedSpecificOptions() {
@@ -136,33 +153,36 @@ export default class GhMembersRecipientSelect extends Component {
     }
 
     @task
-    *fetchSpecificOptionsTask() {
-        const options = [];
-
-        // fetch labels w̶i̶t̶h̶ c̶o̶u̶n̶t̶s̶
-        // TODO: add `include: 'count.members` to query once API is fixed
-        const labels = yield this.store.query('label', {limit: 100, order: 'name asc'});
-
-        if (labels.length > 0) {
-            const labelsGroup = {
-                groupName: 'Labels',
-                options: []
-            };
-
-            labels.forEach((label) => {
-                labelsGroup.options.push({
-                    name: label.name,
-                    segment: `label:${label.slug}`,
-                    count: label.count?.members,
-                    class: 'segment-label'
-                });
-            });
-
-            options.push(labelsGroup);
+    *loadMoreLabelsTask() {
+        if (this._labelsMeta?.pagination && this._labelsMeta.pagination.pages <= this._labelsMeta.pagination.page) {
+            return;
         }
+
+        const page = this._labelsMeta?.pagination.page ? this._labelsMeta.pagination.page + 1 : 1;
+        const labels = yield this.store.query('label', {limit: PAGE_SIZE, page, order: 'name asc'});
+
+        labels.forEach((label) => {
+            this._labelOptions.push({
+                name: label.name,
+                segment: `label:${label.slug}`,
+                count: label.count?.members,
+                class: 'segment-label'
+            });
+        });
+
+        this._labelsMeta = labels.meta;
+    }
+
+    @task
+    *fetchSpecificOptionsTask() {
+        // fetch first page of labels (labels are last so infinite scroll works)
+        // TODO: add `include: 'count.members` to query once API is fixed
+        yield this.loadMoreLabelsTask.perform();
+
         // fetch all tiers w̶i̶t̶h̶ c̶o̶u̶n̶t̶s̶
         // TODO: add `include: 'count.members` to query once API supports
         const tiers = yield this.store.query('tier', {filter: 'type:paid', limit: 'all'});
+        const tierOptions = [];
 
         if (tiers.length > 1) {
             const activeTiersGroup = {
@@ -190,10 +210,10 @@ export default class GhMembersRecipientSelect extends Component {
                 }
             });
 
-            options.push(activeTiersGroup);
-            options.push(archivedTiersGroup);
+            tierOptions.push(activeTiersGroup);
+            tierOptions.push(archivedTiersGroup);
         }
 
-        this.specificOptions = options;
+        this._tierOptions = tierOptions;
     }
 }

--- a/ghost/admin/app/components/gh-members-recipient-select.js
+++ b/ghost/admin/app/components/gh-members-recipient-select.js
@@ -1,6 +1,5 @@
 import Component from '@glimmer/component';
 import flattenGroupedOptions from 'ghost-admin/utils/flatten-grouped-options';
-import {TrackedArray} from 'tracked-built-ins';
 import {action} from '@ember/object';
 import {isBlank} from '@ember/utils';
 import {inject as service} from '@ember/service';
@@ -8,16 +7,14 @@ import {task} from 'ember-concurrency';
 import {tracked} from '@glimmer/tracking';
 
 const BASE_FILTERS = ['status:free', 'status:-free'];
-const PAGE_SIZE = 100;
 
 export default class GhMembersRecipientSelect extends Component {
     @service membersUtils;
     @service store;
+    @service labelsManager;
 
     @tracked forceSpecificChecked = false;
     @tracked _tierOptions = [];
-    @tracked _labelOptions = new TrackedArray();
-    _labelsMeta = null;
 
     constructor() {
         super(...arguments);
@@ -59,11 +56,17 @@ export default class GhMembersRecipientSelect extends Component {
 
     get specificOptions() {
         const options = [...this._tierOptions];
+        const labels = this.labelsManager.labels;
 
-        if (this._labelOptions.length > 0) {
+        if (labels.length > 0) {
             options.unshift({
                 groupName: 'Labels',
-                options: [...this._labelOptions]
+                options: labels.map(label => ({
+                    name: label.name,
+                    segment: `label:${label.slug}`,
+                    count: label.count?.members,
+                    class: 'segment-label'
+                }))
             });
         }
 
@@ -154,30 +157,14 @@ export default class GhMembersRecipientSelect extends Component {
 
     @task({drop: true})
     *loadMoreLabelsTask() {
-        if (this._labelsMeta?.pagination && this._labelsMeta.pagination.pages <= this._labelsMeta.pagination.page) {
-            return;
-        }
-
-        const page = this._labelsMeta?.pagination.page ? this._labelsMeta.pagination.page + 1 : 1;
-        const labels = yield this.store.query('label', {limit: PAGE_SIZE, page, order: 'name asc'});
-
-        labels.forEach((label) => {
-            this._labelOptions.push({
-                name: label.name,
-                segment: `label:${label.slug}`,
-                count: label.count?.members,
-                class: 'segment-label'
-            });
-        });
-
-        this._labelsMeta = labels.meta;
+        yield this.labelsManager.loadMoreTask.perform();
     }
 
     @task
     *fetchSpecificOptionsTask() {
         // fetch first page of labels (labels are last so infinite scroll works)
         // TODO: add `include: 'count.members` to query once API is fixed
-        yield this.loadMoreLabelsTask.perform();
+        yield this.labelsManager.loadMoreTask.perform();
 
         // fetch all tiers w̶i̶t̶h̶ c̶o̶u̶n̶t̶s̶
         // TODO: add `include: 'count.members` to query once API supports

--- a/ghost/admin/app/components/gh-members-segment-select.hbs
+++ b/ghost/admin/app/components/gh-members-segment-select.hbs
@@ -2,7 +2,7 @@
     @options={{this.options}}
     @selected={{this.selectedOptions}}
     @disabled={{or @disabled this.fetchOptionsTask.isRunning}}
-    @optionsComponent={{component "power-select/options"}}
+    @optionsComponent={{component "power-select-options-with-scroll" lastReached=(perform this.loadMoreLabelsTask)}}
     @allowCreation={{false}}
     @renderInPlace={{this.renderInPlace}}
     @onChange={{this.setSegment}}

--- a/ghost/admin/app/components/gh-members-segment-select.js
+++ b/ghost/admin/app/components/gh-members-segment-select.js
@@ -1,14 +1,19 @@
 import Component from '@glimmer/component';
+import {TrackedArray} from 'tracked-built-ins';
 import {action} from '@ember/object';
 import {inject as service} from '@ember/service';
 import {task} from 'ember-concurrency';
 import {tracked} from '@glimmer/tracking';
 
+const PAGE_SIZE = 100;
+
 export default class GhMembersSegmentSelect extends Component {
     @service store;
     @service feature;
 
-    @tracked _options = [];
+    @tracked _baseOptions = [];
+    @tracked _labelOptions = new TrackedArray();
+    _labelsMeta = null;
 
     get renderInPlace() {
         return this.args.renderInPlace === undefined ? false : this.args.renderInPlace;
@@ -17,6 +22,19 @@ export default class GhMembersSegmentSelect extends Component {
     constructor() {
         super(...arguments);
         this.fetchOptionsTask.perform();
+    }
+
+    get _options() {
+        const options = [...this._baseOptions];
+
+        if (this._labelOptions.length > 0 && !this.args.hideLabels) {
+            options.push({
+                groupName: 'Labels',
+                options: [...this._labelOptions]
+            });
+        }
+
+        return options;
     }
 
     get options() {
@@ -55,6 +73,27 @@ export default class GhMembersSegmentSelect extends Component {
     setSegment(options) {
         const segment = options.mapBy('segment').join(',') || null;
         this.args.onChange?.(segment);
+    }
+
+    @task
+    *loadMoreLabelsTask() {
+        if (this._labelsMeta?.pagination && this._labelsMeta.pagination.pages <= this._labelsMeta.pagination.page) {
+            return;
+        }
+
+        const page = this._labelsMeta?.pagination.page ? this._labelsMeta.pagination.page + 1 : 1;
+        const labels = yield this.store.query('label', {limit: PAGE_SIZE, page, order: 'name asc'});
+
+        labels.forEach((label) => {
+            this._labelOptions.push({
+                name: label.name,
+                segment: `label:${label.slug}`,
+                count: label.count?.members,
+                class: 'segment-label'
+            });
+        });
+
+        this._labelsMeta = labels.meta;
     }
 
     @task
@@ -111,28 +150,6 @@ export default class GhMembersSegmentSelect extends Component {
             }
         }
 
-        // fetch labels w̶i̶t̶h̶ c̶o̶u̶n̶t̶s̶
-        // TODO: add `include: 'count.members` to query once API is fixed
-        const labels = yield this.store.query('label', {limit: 100, order: 'name asc'});
-
-        if (labels.length > 0 && !this.args.hideLabels) {
-            const labelsGroup = {
-                groupName: 'Labels',
-                options: []
-            };
-
-            labels.forEach((label) => {
-                labelsGroup.options.push({
-                    name: label.name,
-                    segment: `label:${label.slug}`,
-                    count: label.count?.members,
-                    class: 'segment-label'
-                });
-            });
-
-            options.push(labelsGroup);
-        }
-
         const offers = yield this.store.findAll('offer');
 
         if (offers.length > 0) {
@@ -153,6 +170,10 @@ export default class GhMembersSegmentSelect extends Component {
             options.push(offersGroup);
         }
 
-        this._options = options;
+        this._baseOptions = options;
+
+        // fetch first page of labels (labels are last so infinite scroll works)
+        // TODO: add `include: 'count.members` to query once API is fixed
+        yield this.loadMoreLabelsTask.perform();
     }
 }

--- a/ghost/admin/app/components/gh-members-segment-select.js
+++ b/ghost/admin/app/components/gh-members-segment-select.js
@@ -75,7 +75,7 @@ export default class GhMembersSegmentSelect extends Component {
         this.args.onChange?.(segment);
     }
 
-    @task
+    @task({drop: true})
     *loadMoreLabelsTask() {
         if (this._labelsMeta?.pagination && this._labelsMeta.pagination.pages <= this._labelsMeta.pagination.page) {
             return;

--- a/ghost/admin/app/components/gh-members-segment-select.js
+++ b/ghost/admin/app/components/gh-members-segment-select.js
@@ -1,19 +1,15 @@
 import Component from '@glimmer/component';
-import {TrackedArray} from 'tracked-built-ins';
 import {action} from '@ember/object';
 import {inject as service} from '@ember/service';
 import {task} from 'ember-concurrency';
 import {tracked} from '@glimmer/tracking';
 
-const PAGE_SIZE = 100;
-
 export default class GhMembersSegmentSelect extends Component {
     @service store;
     @service feature;
+    @service labelsManager;
 
     @tracked _baseOptions = [];
-    @tracked _labelOptions = new TrackedArray();
-    _labelsMeta = null;
 
     get renderInPlace() {
         return this.args.renderInPlace === undefined ? false : this.args.renderInPlace;
@@ -26,11 +22,17 @@ export default class GhMembersSegmentSelect extends Component {
 
     get _options() {
         const options = [...this._baseOptions];
+        const labels = this.labelsManager.labels;
 
-        if (this._labelOptions.length > 0 && !this.args.hideLabels) {
+        if (labels.length > 0 && !this.args.hideLabels) {
             options.push({
                 groupName: 'Labels',
-                options: [...this._labelOptions]
+                options: labels.map(label => ({
+                    name: label.name,
+                    segment: `label:${label.slug}`,
+                    count: label.count?.members,
+                    class: 'segment-label'
+                }))
             });
         }
 
@@ -77,23 +79,7 @@ export default class GhMembersSegmentSelect extends Component {
 
     @task({drop: true})
     *loadMoreLabelsTask() {
-        if (this._labelsMeta?.pagination && this._labelsMeta.pagination.pages <= this._labelsMeta.pagination.page) {
-            return;
-        }
-
-        const page = this._labelsMeta?.pagination.page ? this._labelsMeta.pagination.page + 1 : 1;
-        const labels = yield this.store.query('label', {limit: PAGE_SIZE, page, order: 'name asc'});
-
-        labels.forEach((label) => {
-            this._labelOptions.push({
-                name: label.name,
-                segment: `label:${label.slug}`,
-                count: label.count?.members,
-                class: 'segment-label'
-            });
-        });
-
-        this._labelsMeta = labels.meta;
+        yield this.labelsManager.loadMoreTask.perform();
     }
 
     @task
@@ -174,6 +160,6 @@ export default class GhMembersSegmentSelect extends Component {
 
         // fetch first page of labels (labels are last so infinite scroll works)
         // TODO: add `include: 'count.members` to query once API is fixed
-        yield this.loadMoreLabelsTask.perform();
+        yield this.labelsManager.loadMoreTask.perform();
     }
 }

--- a/ghost/admin/app/components/gh-members-segment-select.js
+++ b/ghost/admin/app/components/gh-members-segment-select.js
@@ -111,9 +111,9 @@ export default class GhMembersSegmentSelect extends Component {
             }
         }
 
-        // fetch all labels w̶i̶t̶h̶ c̶o̶u̶n̶t̶s̶
+        // fetch labels w̶i̶t̶h̶ c̶o̶u̶n̶t̶s̶
         // TODO: add `include: 'count.members` to query once API is fixed
-        const labels = yield this.store.query('label', {limit: 'all'});
+        const labels = yield this.store.query('label', {limit: 100, order: 'name asc'});
 
         if (labels.length > 0 && !this.args.hideLabels) {
             const labelsGroup = {

--- a/ghost/admin/app/components/koenig-lexical-editor.js
+++ b/ghost/admin/app/components/koenig-lexical-editor.js
@@ -242,7 +242,18 @@ export default class KoenigLexicalEditor extends Component {
             return this.labels;
         }
 
-        this.labels = yield this.store.query('label', {limit: 100, fields: 'id, name', order: 'name asc'});
+        let allLabels = [];
+        let page = 1;
+        let totalPages = 1;
+
+        while (page <= totalPages) {
+            const result = yield this.store.query('label', {limit: 100, page, fields: 'id, name', order: 'name asc'});
+            allLabels.push(...result.toArray());
+            totalPages = result.meta.pagination.pages;
+            page += 1;
+        }
+
+        this.labels = allLabels;
         return this.labels;
     }
 

--- a/ghost/admin/app/components/koenig-lexical-editor.js
+++ b/ghost/admin/app/components/koenig-lexical-editor.js
@@ -242,18 +242,7 @@ export default class KoenigLexicalEditor extends Component {
             return this.labels;
         }
 
-        let allLabels = [];
-        let page = 1;
-        let totalPages = 1;
-
-        while (page <= totalPages) {
-            const result = yield this.store.query('label', {limit: 100, page, fields: 'id, name', order: 'name asc'});
-            allLabels.push(...result.toArray());
-            totalPages = result.meta.pagination.pages;
-            page += 1;
-        }
-
-        this.labels = allLabels;
+        this.labels = yield this.store.query('label', {limit: 'all', fields: 'id, name'});
         return this.labels;
     }
 

--- a/ghost/admin/app/components/koenig-lexical-editor.js
+++ b/ghost/admin/app/components/koenig-lexical-editor.js
@@ -242,7 +242,7 @@ export default class KoenigLexicalEditor extends Component {
             return this.labels;
         }
 
-        this.labels = yield this.store.query('label', {limit: 'all', fields: 'id, name'});
+        this.labels = yield this.store.query('label', {limit: 100, fields: 'id, name', order: 'name asc'});
         return this.labels;
     }
 

--- a/ghost/admin/app/components/modal-members-label-form.js
+++ b/ghost/admin/app/components/modal-members-label-form.js
@@ -7,6 +7,7 @@ import {task} from 'ember-concurrency';
 export default ModalComponent.extend({
     router: service(),
     notifications: service(),
+    labelsManager: service(),
     model: null,
     showDeleteLabelModal: false,
 
@@ -74,6 +75,7 @@ export default ModalComponent.extend({
         }
         try {
             yield label.destroyRecord();
+            this.labelsManager.removeLabel(label);
             let routeName = this.router.currentRouteName;
             this.notifications.showNotification('Label deleted');
             this.send('closeModal');

--- a/ghost/admin/app/components/power-select-options-with-scroll.hbs
+++ b/ghost/admin/app/components/power-select-options-with-scroll.hbs
@@ -1,0 +1,40 @@
+<ul role="listbox" {{did-insert this.addHandlers}} {{will-destroy this.removeHandlers}} ...attributes>
+  {{! template-lint-disable no-unnecessary-concat }}
+  {{#if @select.loading}}
+    {{#if @loadingMessage}}
+      <li class="ember-power-select-option ember-power-select-option--loading-message" role="option">{{@loadingMessage}}</li>
+    {{/if}}
+  {{/if}}
+  {{#let
+    (component (ensure-safe-component @groupComponent))
+    (component (ensure-safe-component @optionsComponent))
+  as |Group Options|}}
+    {{#each @options as |opt index|}}
+      {{#if (ember-power-select-is-group opt)}}
+        <Group @group={{opt}} @select={{@select}} @extra={{@extra}}>
+          <Options
+            @options={{opt.options}}
+            @select={{@select}}
+            @groupIndex="{{@groupIndex}}{{index}}."
+            @optionsComponent={{@optionsComponent}}
+            @groupComponent={{@groupComponent}}
+            @extra={{@extra}}
+            role="group"
+            class="ember-power-select-options" as |option|>
+            {{yield option @select}}
+          </Options>
+        </Group>
+      {{else}}
+        <li class="ember-power-select-option"
+          id="{{@select.uniqueId}}-{{@groupIndex}}{{index}}"
+          aria-selected="{{ember-power-select-is-selected opt @select.selected}}"
+          aria-disabled={{if opt.disabled "true"}}
+          aria-current="{{eq opt @select.highlighted}}"
+          data-option-index="{{@groupIndex}}{{index}}"
+          role="option">
+          {{yield opt @select}}
+        </li>
+      {{/if}}
+    {{/each}}
+  {{/let}}
+</ul>

--- a/ghost/admin/app/components/power-select-options-with-scroll.hbs
+++ b/ghost/admin/app/components/power-select-options-with-scroll.hbs
@@ -1,6 +1,6 @@
 <ul role="listbox" {{did-insert this.addHandlers}} {{will-destroy this.removeHandlers}} ...attributes>
   {{! template-lint-disable no-unnecessary-concat }}
-  {{#if @select.loading}}
+  {{#if (and @select.loading (eq @options.length 0))}}
     {{#if @loadingMessage}}
       <li class="ember-power-select-option ember-power-select-option--loading-message" role="option">{{@loadingMessage}}</li>
     {{/if}}

--- a/ghost/admin/app/components/power-select-options-with-scroll.js
+++ b/ghost/admin/app/components/power-select-options-with-scroll.js
@@ -1,0 +1,29 @@
+import OptionsComponent from 'ember-power-select/components/power-select/options';
+import {action} from '@ember/object';
+
+export default class PowerSelectOptionsWithScroll extends OptionsComponent {
+    @action
+    addHandlers(element) {
+        super.addHandlers(element);
+
+        if (element.getAttribute('role') === 'group') {
+            return;
+        }
+
+        this._scrollHandler = () => {
+            const threshold = 100;
+            if (element.scrollTop + element.clientHeight >= element.scrollHeight - threshold) {
+                this.args.lastReached?.();
+            }
+        };
+        element.addEventListener('scroll', this._scrollHandler);
+    }
+
+    @action
+    removeHandlers(element) {
+        super.removeHandlers(element);
+        if (this._scrollHandler) {
+            element.removeEventListener('scroll', this._scrollHandler);
+        }
+    }
+}

--- a/ghost/admin/app/controllers/member.js
+++ b/ghost/admin/app/controllers/member.js
@@ -23,6 +23,7 @@ export default class MemberController extends Controller {
     @service modals;
     @service notifications;
     @service router;
+    @service labelsManager;
     @service store;
 
     queryParams = [
@@ -221,6 +222,7 @@ export default class MemberController extends Controller {
 
             yield member.save();
             member.updateLabels();
+            member.labels.forEach(label => this.labelsManager.addLabel(label));
             this.members.refreshData();
 
             this.setInitialRelationshipValues();

--- a/ghost/admin/app/controllers/members.js
+++ b/ghost/admin/app/controllers/members.js
@@ -16,8 +16,6 @@ import {resetQueryParams} from 'ghost-admin/helpers/reset-query-params';
 import {inject as service} from '@ember/service';
 import {tracked} from '@glimmer/tracking';
 
-const LABEL_PAGE_SIZE = 100;
-
 const PAID_PARAMS = [{
     name: 'All members',
     value: null
@@ -67,9 +65,6 @@ export default class MembersController extends Controller {
     @tracked softFilters = A([]);
     @tracked isExporting = false;
 
-    @tracked _initialLabels = new TrackedArray();
-    _initialLabelsMeta = null;
-    _hasLoadedInitialLabels = false;
     @tracked _searchedLabels = new TrackedArray();
     _searchedLabelsQuery = null;
     _searchedLabelsMeta = null;
@@ -154,10 +149,10 @@ export default class MembersController extends Controller {
     get availableLabels() {
         let options = [{name: 'All labels', slug: null}];
 
-        options = options.concat(this.labelsManager.sortLabels(this._initialLabels));
+        options = options.concat(this.labelsManager.labels);
 
         if (this.label && !options.findBy('slug', this.label)) {
-            const foundLabel = this.store.peekAll('label').find(l => l.slug === this.label);
+            const foundLabel = this.labelsManager.findBySlug(this.label);
             if (foundLabel) {
                 options.push(foundLabel);
             }
@@ -168,9 +163,8 @@ export default class MembersController extends Controller {
 
     @action
     async loadInitialLabels() {
-        if (!this._hasLoadedInitialLabels) {
-            await this.loadMoreLabelsTask.perform(false);
-            this._hasLoadedInitialLabels = true;
+        if (!this.labelsManager.hasLoaded) {
+            await this.labelsManager.loadMoreTask.perform();
         }
     }
 
@@ -190,14 +184,7 @@ export default class MembersController extends Controller {
             this._searchedLabels.push(...this.labelsManager.sortLabels(labels.toArray()));
             this._searchedLabelsMeta = labels.meta;
         } else {
-            if (this._initialLabelsMeta && this._initialLabelsMeta?.pagination.pages <= this._initialLabelsMeta.pagination.page) {
-                return;
-            }
-
-            const page = this._initialLabelsMeta?.pagination.page ? this._initialLabelsMeta.pagination.page + 1 : 1;
-            const labels = yield this.store.query('label', {limit: LABEL_PAGE_SIZE, page, order: 'name asc'});
-            this._initialLabels.push(...labels.toArray());
-            this._initialLabelsMeta = labels.meta;
+            yield this.labelsManager.loadMoreTask.perform();
         }
     }
 
@@ -548,9 +535,8 @@ export default class MembersController extends Controller {
 
     @task({restartable: true})
     *fetchLabelsTask() {
-        // Labels are now loaded on-demand via loadInitialLabels/loadMoreLabelsTask
-        yield this.loadMoreLabelsTask.perform(false);
-        this._hasLoadedInitialLabels = true;
+        this.labelsManager.reset();
+        yield this.labelsManager.loadMoreTask.perform();
     }
 
     @task({restartable: true})

--- a/ghost/admin/app/controllers/members.js
+++ b/ghost/admin/app/controllers/members.js
@@ -7,6 +7,7 @@ import fetch from 'fetch';
 import ghostPaths from 'ghost-admin/utils/ghost-paths';
 import moment from 'moment-timezone';
 import {A} from '@ember/array';
+import {TrackedArray} from 'tracked-built-ins';
 import {action} from '@ember/object';
 import {didCancel, task, timeout} from 'ember-concurrency';
 import {ghPluralize} from 'ghost-admin/helpers/gh-pluralize';
@@ -34,6 +35,7 @@ export default class MembersController extends Controller {
     @service membersStats;
     @service modals;
     @service router;
+    @service labelsManager;
     @service store;
     @service utils;
     @service settings;
@@ -63,7 +65,12 @@ export default class MembersController extends Controller {
     @tracked softFilters = A([]);
     @tracked isExporting = false;
 
-    @tracked _availableLabels = A([]);
+    @tracked _initialLabels = new TrackedArray();
+    _initialLabelsMeta = null;
+    _hasLoadedInitialLabels = false;
+    @tracked _searchedLabels = new TrackedArray();
+    _searchedLabelsQuery = null;
+    _searchedLabelsMeta = null;
 
     @tracked parseFilterParamCounter = 0;
 
@@ -83,7 +90,6 @@ export default class MembersController extends Controller {
 
     constructor() {
         super(...arguments);
-        this._availableLabels = this.store.peekAll('label');
     }
 
     // Computed properties -----------------------------------------------------
@@ -144,15 +150,63 @@ export default class MembersController extends Controller {
     }
 
     get availableLabels() {
-        let labels = this._availableLabels
-            .filter(label => !label.isNew)
-            .filter(label => label.id !== null)
-            .sort((labelA, labelB) => labelA.name.localeCompare(labelB.name, undefined, {ignorePunctuation: true}));
-        let options = labels.toArray();
+        let options = [{name: 'All labels', slug: null}];
 
-        options.unshiftObject({name: 'All labels', slug: null});
+        options = options.concat(this.labelsManager.sortLabels(this._initialLabels));
+
+        if (this.label && !options.findBy('slug', this.label)) {
+            const foundLabel = this.store.peekAll('label').find(l => l.slug === this.label);
+            if (foundLabel) {
+                options.push(foundLabel);
+            }
+        }
 
         return options;
+    }
+
+    @action
+    async loadInitialLabels() {
+        if (!this._hasLoadedInitialLabels) {
+            await this.loadMoreLabelsTask.perform(false);
+            this._hasLoadedInitialLabels = true;
+        }
+    }
+
+    @task({drop: true})
+    *loadMoreLabelsTask(isSearch = false) {
+        if (isSearch) {
+            if (this.searchLabelsTask.isRunning) {
+                return;
+            }
+
+            if (this._searchedLabelsMeta && this._searchedLabelsMeta.pagination.pages <= this._searchedLabelsMeta.pagination.page) {
+                return;
+            }
+
+            const page = this._searchedLabelsMeta.pagination.page + 1;
+            const labels = yield this.labelsManager.searchLabelsTask.perform(this._searchedLabelsQuery, {page});
+            this._searchedLabels.push(...this.labelsManager.sortLabels(labels.toArray()));
+            this._searchedLabelsMeta = labels.meta;
+        } else {
+            if (this._initialLabelsMeta && this._initialLabelsMeta?.pagination.pages <= this._initialLabelsMeta.pagination.page) {
+                return;
+            }
+
+            const page = this._initialLabelsMeta?.pagination.page ? this._initialLabelsMeta.pagination.page + 1 : 1;
+            const labels = yield this.store.query('label', {limit: 100, page, order: 'name asc'});
+            this._initialLabels.push(...labels.toArray());
+            this._initialLabelsMeta = labels.meta;
+        }
+    }
+
+    @task
+    *searchLabelsTask(term) {
+        this._searchedLabelsQuery = term;
+        const labels = yield this.labelsManager.searchLabelsTask.perform(term);
+        this._searchedLabelsMeta = labels.meta;
+
+        this._searchedLabels = new TrackedArray(this.labelsManager.sortLabels(labels.toArray()));
+        return this._searchedLabels;
     }
 
     get selectedLabel() {
@@ -492,7 +546,9 @@ export default class MembersController extends Controller {
 
     @task({restartable: true})
     *fetchLabelsTask() {
-        yield this.store.query('label', {limit: 'all'});
+        // Labels are now loaded on-demand via loadInitialLabels/loadMoreLabelsTask
+        yield this.loadMoreLabelsTask.perform(false);
+        this._hasLoadedInitialLabels = true;
     }
 
     @task({restartable: true})

--- a/ghost/admin/app/controllers/members.js
+++ b/ghost/admin/app/controllers/members.js
@@ -16,6 +16,8 @@ import {resetQueryParams} from 'ghost-admin/helpers/reset-query-params';
 import {inject as service} from '@ember/service';
 import {tracked} from '@glimmer/tracking';
 
+const LABEL_PAGE_SIZE = 100;
+
 const PAID_PARAMS = [{
     name: 'All members',
     value: null
@@ -179,7 +181,7 @@ export default class MembersController extends Controller {
                 return;
             }
 
-            if (this._searchedLabelsMeta && this._searchedLabelsMeta.pagination.pages <= this._searchedLabelsMeta.pagination.page) {
+            if (!this._searchedLabelsMeta || (this._searchedLabelsMeta.pagination.pages <= this._searchedLabelsMeta.pagination.page)) {
                 return;
             }
 
@@ -193,7 +195,7 @@ export default class MembersController extends Controller {
             }
 
             const page = this._initialLabelsMeta?.pagination.page ? this._initialLabelsMeta.pagination.page + 1 : 1;
-            const labels = yield this.store.query('label', {limit: 100, page, order: 'name asc'});
+            const labels = yield this.store.query('label', {limit: LABEL_PAGE_SIZE, page, order: 'name asc'});
             this._initialLabels.push(...labels.toArray());
             this._initialLabelsMeta = labels.meta;
         }

--- a/ghost/admin/app/services/labels-manager.js
+++ b/ghost/admin/app/services/labels-manager.js
@@ -1,6 +1,8 @@
 import Service, {inject as service} from '@ember/service';
 import {task, timeout} from 'ember-concurrency';
 
+const PAGE_SIZE = 100;
+
 export default class LabelsManagerService extends Service {
     @service store;
 
@@ -14,6 +16,6 @@ export default class LabelsManagerService extends Service {
     *searchLabelsTask(term, {page = 1} = {}) {
         yield timeout(250);
         const safeTerm = term.replace(/'/g, `\\'`);
-        return yield this.store.query('label', {filter: `name:~'${safeTerm}'`, limit: 100, page, order: 'name asc'});
+        return yield this.store.query('label', {filter: `name:~'${safeTerm}'`, limit: PAGE_SIZE, page, order: 'name asc'});
     }
 }

--- a/ghost/admin/app/services/labels-manager.js
+++ b/ghost/admin/app/services/labels-manager.js
@@ -1,0 +1,19 @@
+import Service, {inject as service} from '@ember/service';
+import {task, timeout} from 'ember-concurrency';
+
+export default class LabelsManagerService extends Service {
+    @service store;
+
+    sortLabels(labels = []) {
+        return labels
+            .filter(label => label.get('id') !== null)
+            .sort((labelA, labelB) => (labelA.name || '').localeCompare((labelB.name || ''), undefined, {ignorePunctuation: true}));
+    }
+
+    @task({restartable: true})
+    *searchLabelsTask(term, {page = 1} = {}) {
+        yield timeout(250);
+        const safeTerm = term.replace(/'/g, `\\'`);
+        return yield this.store.query('label', {filter: `name:~'${safeTerm}'`, limit: 100, page, order: 'name asc'});
+    }
+}

--- a/ghost/admin/app/services/labels-manager.js
+++ b/ghost/admin/app/services/labels-manager.js
@@ -1,15 +1,73 @@
 import Service, {inject as service} from '@ember/service';
+import {TrackedArray} from 'tracked-built-ins';
 import {task, timeout} from 'ember-concurrency';
+import {tracked} from '@glimmer/tracking';
 
 const PAGE_SIZE = 100;
 
 export default class LabelsManagerService extends Service {
     @service store;
 
+    @tracked _labels = new TrackedArray();
+    _meta = null;
+
+    get labels() {
+        return this.sortLabels(this._labels);
+    }
+
+    get hasLoaded() {
+        return !!this._meta;
+    }
+
+    get hasLoadedAll() {
+        return this.hasLoaded && parseInt(this._meta.pagination.pages, 10) === parseInt(this._meta.pagination.page, 10);
+    }
+
     sortLabels(labels = []) {
         return labels
             .filter(label => label.get('id') !== null)
             .sort((labelA, labelB) => (labelA.name || '').localeCompare((labelB.name || ''), undefined, {ignorePunctuation: true}));
+    }
+
+    findBySlug(slug) {
+        return this._labels.find(label => label.slug === slug) || this.store.peekAll('label').find(label => label.slug === slug);
+    }
+
+    addLabel(label) {
+        if (!this._labels.includes(label)) {
+            this._labels.push(label);
+        }
+    }
+
+    removeLabel(label) {
+        const index = this._labels.indexOf(label);
+        if (index > -1) {
+            this._labels.splice(index, 1);
+        }
+    }
+
+    reset() {
+        this._labels = new TrackedArray();
+        this._meta = null;
+    }
+
+    @task({drop: true})
+    *loadMoreTask() {
+        if (this._meta?.pagination && this._meta.pagination.pages <= this._meta.pagination.page) {
+            return;
+        }
+
+        const page = this._meta?.pagination.page ? this._meta.pagination.page + 1 : 1;
+        const labels = yield this.store.query('label', {limit: PAGE_SIZE, page, order: 'name asc'});
+
+        const existingSlugs = new Set(this._labels.map(l => l.slug));
+        labels.forEach((label) => {
+            if (!existingSlugs.has(label.slug)) {
+                this._labels.push(label);
+            }
+        });
+
+        this._meta = labels.meta;
     }
 
     @task({restartable: true})

--- a/ghost/admin/tests/acceptance/members/filter-test.js
+++ b/ghost/admin/tests/acceptance/members/filter-test.js
@@ -82,6 +82,12 @@ describe('Acceptance: Members filtering', function () {
 
             await visit('/members');
 
+            const getLabelRequests = () => {
+                return this.server.pretender.handledRequests.filter((request) => {
+                    return request.url.includes('/ghost/api/admin/labels/');
+                });
+            };
+
             expect(findAll('[data-test-list="members-list-item"]').length, '# of initial member rows')
                 .to.equal(7);
 
@@ -100,6 +106,17 @@ describe('Acceptance: Members filtering', function () {
             // value dropdown can open and has all labels
             await click(`${filterSelector} .gh-member-label-input`);
             expect(findAll(`${filterSelector} [data-test-label-filter]`).length, '# of label options').to.equal(5);
+
+            const labelRequests = getLabelRequests();
+            expect(labelRequests.length).to.be.greaterThan(0);
+            labelRequests.forEach((request) => {
+                const parsedUrl = new URL(request.url);
+                expect(parsedUrl.searchParams.get('limit')).to.not.equal('all');
+            });
+            expect(labelRequests.some((request) => {
+                const parsedUrl = new URL(request.url);
+                return parsedUrl.searchParams.get('limit') === '100';
+            })).to.be.true;
 
             // selecting a value updates table
             await selectChoose(`${filterSelector} .gh-member-label-input`, label.name);

--- a/ghost/admin/tests/integration/services/labels-manager-test.js
+++ b/ghost/admin/tests/integration/services/labels-manager-test.js
@@ -1,0 +1,112 @@
+import sinon from 'sinon';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {setupTest} from 'ember-mocha';
+
+function buildLabel({id, slug, name}) {
+    return {
+        id,
+        slug,
+        name,
+        get(key) {
+            return this[key];
+        }
+    };
+}
+
+function buildCollection(records, {page, pages}) {
+    records.meta = {
+        pagination: {
+            page,
+            pages
+        }
+    };
+    return records;
+}
+
+describe('Integration: Service: labels-manager', function () {
+    setupTest();
+
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    it('loads labels page-by-page and deduplicates by slug', async function () {
+        const store = this.owner.lookup('service:store');
+        const labelsManager = this.owner.lookup('service:labels-manager');
+
+        const pageOne = buildCollection([
+            buildLabel({id: '1', slug: 'alpha', name: 'Alpha'}),
+            buildLabel({id: '2', slug: 'beta', name: 'Beta'})
+        ], {page: 1, pages: 2});
+
+        const pageTwo = buildCollection([
+            buildLabel({id: '2', slug: 'beta', name: 'Beta'}),
+            buildLabel({id: '3', slug: 'gamma', name: 'Gamma'})
+        ], {page: 2, pages: 2});
+
+        const queryStub = sinon.stub(store, 'query');
+        queryStub.onCall(0).resolves(pageOne);
+        queryStub.onCall(1).resolves(pageTwo);
+
+        await labelsManager.loadMoreTask.perform();
+        await labelsManager.loadMoreTask.perform();
+        await labelsManager.loadMoreTask.perform();
+
+        expect(queryStub.callCount).to.equal(2);
+        expect(queryStub.firstCall.args[1]).to.deep.equal({limit: 100, page: 1, order: 'name asc'});
+        expect(queryStub.secondCall.args[1]).to.deep.equal({limit: 100, page: 2, order: 'name asc'});
+
+        expect(labelsManager._labels.map(label => label.slug)).to.deep.equal(['alpha', 'beta', 'gamma']);
+        expect(labelsManager.hasLoaded).to.be.true;
+        expect(labelsManager.hasLoadedAll).to.be.true;
+    });
+
+    it('escapes single quotes in search filters', async function () {
+        const store = this.owner.lookup('service:store');
+        const labelsManager = this.owner.lookup('service:labels-manager');
+
+        const results = buildCollection([], {page: 1, pages: 1});
+        const queryStub = sinon.stub(store, 'query').resolves(results);
+
+        await labelsManager.searchLabelsTask.perform('Bob\'s');
+
+        expect(queryStub.calledOnce).to.be.true;
+        expect(queryStub.firstCall.args[0]).to.equal('label');
+        expect(queryStub.firstCall.args[1]).to.deep.equal({
+            filter: 'name:~\'Bob\\\'s\'',
+            limit: 100,
+            page: 1,
+            order: 'name asc'
+        });
+    });
+
+    it('falls back to store labels when findBySlug cache is empty', function () {
+        const store = this.owner.lookup('service:store');
+        const labelsManager = this.owner.lookup('service:labels-manager');
+        const fallbackLabel = buildLabel({id: '10', slug: 'fallback', name: 'Fallback'});
+
+        sinon.stub(store, 'peekAll').returns([fallbackLabel]);
+
+        expect(labelsManager.findBySlug('fallback')).to.equal(fallbackLabel);
+    });
+
+    it('supports cache mutation helpers and reset', function () {
+        const labelsManager = this.owner.lookup('service:labels-manager');
+        const alpha = buildLabel({id: '1', slug: 'alpha', name: 'Alpha'});
+        const beta = buildLabel({id: '2', slug: 'beta', name: 'Beta'});
+
+        labelsManager.addLabel(alpha);
+        labelsManager.addLabel(alpha);
+        labelsManager.addLabel(beta);
+
+        expect(labelsManager._labels.map(label => label.slug)).to.deep.equal(['alpha', 'beta']);
+
+        labelsManager.removeLabel(alpha);
+        expect(labelsManager._labels.map(label => label.slug)).to.deep.equal(['beta']);
+
+        labelsManager.reset();
+        expect(labelsManager._labels.length).to.equal(0);
+        expect(labelsManager.hasLoaded).to.be.false;
+    });
+});


### PR DESCRIPTION
## Summary
- Added `labels-manager` service with shared paginated label cache, debounced server-side search, and `sortLabels`/`findBySlug` helpers — all label dropdowns share one cache instead of each fetching independently
- Rewrote `gh-member-label-input` to lazy-load labels on dropdown open with infinite scroll and automatic server-side/client-side search toggle based on whether all labels have been loaded
- Converted `gh-member-single-label-input` from `OneWaySelect` to `PowerSelect` with search and infinite scroll support
- Added `power-select-options-with-scroll` component for infinite-scroll pagination in `PowerSelect` dropdowns (segment select, recipient select)
- Added cache invalidation to the shared label cache: `addLabel()`/`removeLabel()` for targeted mutations (member save, label delete), `reset()` for full reload on `refreshData`

refs https://linear.app/tryghost/issue/ONC-1518