### PR TITLE
Experiment — remove NX_SKIP_LOG_GROUPING from unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -452,7 +452,6 @@ jobs:
         env:
           FORCE_COLOR: 0
           GHOST_UNIT_TEST_VARIANT: ci
-          NX_SKIP_LOG_GROUPING: true
 
       - uses: actions/upload-artifact@v4
         if: matrix.node == env.NODE_VERSION

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -35,7 +35,7 @@
     "test:debug": "DEBUG=ghost:test* yarn test",
     "test:unit": "c8 yarn test:unit:${GHOST_UNIT_TEST_VARIANT:-base}",
     "test:unit:base": "yarn test:base './test/unit' --timeout=2000",
-    "test:unit:ci": "yarn test:unit:base --reporter=min",
+    "test:unit:ci": "yarn test:unit:base --reporter=spec",
     "test:integration": "yarn test:base './test/integration' --timeout=10000",
     "test:e2e": "yarn test:base ./test/e2e-* --timeout=15000",
     "test:legacy": "yarn test:base './test/legacy' --timeout=60000",

--- a/ghost/core/test/unit/frontend/helpers/concat.test.js
+++ b/ghost/core/test/unit/frontend/helpers/concat.test.js
@@ -154,3 +154,10 @@ describe('{{concat}} helper', function () {
         shouldCompileToExpected(templateString, {post: {title: 'My Post', slug: 'my-post'}}, expected);
     });
 });
+
+// TEMPORARY: Deliberate failure to test CI log output legibility — remove before merging
+describe('CI log output experiment', function () {
+    it('TEMPORARY FAILING TEST — do not merge', function () {
+        throw new Error('This test is intentionally failing to test CI log output legibility');
+    });
+});


### PR DESCRIPTION
## What

Removes `NX_SKIP_LOG_GROUPING=true` from the unit tests CI step, keeping `FORCE_COLOR=0`.

## Why

`NX_SKIP_LOG_GROUPING=true` and `FORCE_COLOR=0` were added together in #26395 to fix truncated/mangled unit test failure output. However, they were never tested independently, so it's unclear whether both are necessary or if `FORCE_COLOR=0` alone is sufficient.

The root cause of the truncation was Yarn's progress spinner emitting `[2K[1G` ANSI clear-line sequences (with `FORCE_COLOR=1`) that overwrote parts of stack traces in GHA's log viewer. `FORCE_COLOR=0` eliminates these sequences entirely.

`NX_SKIP_LOG_GROUPING=true` disables Nx's `##[group]`/`##[endgroup]` wrapping in GitHub Actions, which prevents each task's output from appearing in a collapsible section. Removing it would restore those collapsible groups — meaning you could immediately spot the ❌ task and expand just that section, rather than scanning through a flat wall of output from all 16 parallel tasks.

## This is an experiment

- If this run shows clean, readable failure output → `NX_SKIP_LOG_GROUPING` can stay removed
- If failure output is mangled/truncated again → restore it

ref #26395

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only tweaks GitHub Actions CI environment for the unit-test job, affecting log formatting/grouping but not build artifacts or runtime code.
> 
> **Overview**
> Removes `NX_SKIP_LOG_GROUPING=true` from the `Run unit tests` step in `.github/workflows/ci.yml`, leaving `FORCE_COLOR=0` and other env vars unchanged.
> 
> This is an experiment to restore Nx/GitHub Actions log grouping for unit tests without reintroducing previously mangled output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 573259aa52e20f968e9a0afaa8c168aa25af8160. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->