### PR TITLE
Added instructions for bypassing mailpit with local dev

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,9 @@
 #STRIPE_PUBLISHABLE_KEY=
 ## Stripe Account ID: acct_1*******
 #STRIPE_ACCOUNT_ID=
+
+# Mailgun SMTP credentials - used with `yarn dev:mailgun`
+## SMTP username from Mailgun (often starts with `postmaster@`)
+# MAILGUN_SMTP_USER=
+## SMTP password from Mailgun
+# MAILGUN_SMTP_PASS=

--- a/compose.dev.mailgun.yaml
+++ b/compose.dev.mailgun.yaml
@@ -1,0 +1,10 @@
+services:
+  ghost-dev:
+    environment:
+      # Route Ghost transactional/test emails via Mailgun SMTP instead of Mailpit.
+      # Values come from the host environment/.env file.
+      mail__transport: SMTP
+      mail__options__host: smtp.mailgun.org
+      mail__options__port: 587
+      mail__options__auth__user: ${MAILGUN_SMTP_USER}
+      mail__options__auth__pass: ${MAILGUN_SMTP_PASS}

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "build:clean": "nx reset && rimraf -g 'ghost/*/build' && rimraf -g 'ghost/*/tsconfig.tsbuildinfo'",
     "clean:hard": "node ./.github/scripts/clean.js",
     "dev": "nx run ghost-monorepo:docker:dev",
+    "dev:mailgun": "DEV_COMPOSE_FILES='-f compose.dev.mailgun.yaml' nx run ghost-monorepo:docker:dev",
     "dev:lexical": "EDITOR_URL=http://localhost:2368/ghost/assets/koenig-lexical/ yarn dev",
     "dev:analytics": "DEV_COMPOSE_FILES='-f compose.dev.analytics.yaml' nx run ghost-monorepo:docker:dev",
     "dev:storage": "DEV_COMPOSE_FILES='-f compose.dev.storage.yaml' nx run ghost-monorepo:docker:dev",


### PR DESCRIPTION
no ref
- added yarn dev:mailgun script to bypass mailpit when needing to use a real service for testing trx emails