### PR TITLE
Updated CODEOWNERS for e2e and tinybird

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,8 +4,8 @@
 
 # E2E Test Ownership
 # The top-level e2e directory requires review from designated owners
-/e2e/ @9larsons @cmraible @ibalosh
+/e2e/ @9larsons
 
 # Tinybird Analytics
 # Tinybird data pipelines and services require review from designated owners
-**/tinybird/ @9larsons @cmraible @troyciesco
+**/tinybird/ @9larsons @cmraible @evanhahn @troyciesco


### PR DESCRIPTION
## Summary

- Removed @cmraible and @ibalosh from `/e2e/` code ownership
- Added @evanhahn to `**/tinybird/` code ownership