### PR TITLE
Converted remaining outbox and welcome email logs to structured logs

### DIFF
--- a/ghost/core/core/server/services/member-welcome-emails/service.js
+++ b/ghost/core/core/server/services/member-welcome-emails/service.js
@@ -123,7 +123,12 @@ class MemberWelcomeEmailService {
         }
 
         const name = member?.name ? `${member.name} at ` : '';
-        logging.info(`${MEMBER_WELCOME_EMAIL_LOG_KEY} Sending welcome email to ${name}${member.email}`);
+        logging.info({
+            system: {
+                event: 'member_welcome_email.sending',
+                member_status: memberStatus
+            }
+        }, `${MEMBER_WELCOME_EMAIL_LOG_KEY} Sending welcome email to ${name}${member.email}`);
 
         const memberWelcomeEmail = this.#memberWelcomeEmails[memberStatus];
 

--- a/ghost/core/core/server/services/outbox/handlers/member-created.js
+++ b/ghost/core/core/server/services/outbox/handlers/member-created.js
@@ -23,7 +23,12 @@ async function handle({payload}) {
 
         const automatedEmail = await AutomatedEmail.findOne({slug});
         if (!automatedEmail) {
-            logging.warn(`${LOG_KEY} No automated email found for slug: ${slug}`);
+            logging.warn({
+                system: {
+                    event: 'outbox.member_created.no_automated_email',
+                    slug
+                }
+            }, `${LOG_KEY} No automated email found for slug: ${slug}`);
             return;
         }
 

--- a/ghost/core/core/server/services/outbox/index.js
+++ b/ghost/core/core/server/services/outbox/index.js
@@ -34,7 +34,8 @@ class OutboxServiceWrapper {
         this.processing = true;
 
         try {
-            await processOutbox();
+            const statusMessage = await processOutbox();
+            logging.info(statusMessage);
         } catch (e) {
             logging.error({
                 system: {

--- a/ghost/core/core/server/services/outbox/index.js
+++ b/ghost/core/core/server/services/outbox/index.js
@@ -34,10 +34,14 @@ class OutboxServiceWrapper {
         this.processing = true;
 
         try {
-            const statusMessage = await processOutbox();
-            logging.info(statusMessage);
+            await processOutbox();
         } catch (e) {
-            logging.error(e, `${OUTBOX_LOG_KEY}: Error while processing outbox`);
+            logging.error({
+                system: {
+                    event: 'outbox.processing.error'
+                },
+                err: e
+            }, `${OUTBOX_LOG_KEY}: Error while processing outbox`);
         } finally {
             this.processing = false;
         }

--- a/ghost/core/core/server/services/outbox/index.js
+++ b/ghost/core/core/server/services/outbox/index.js
@@ -36,12 +36,12 @@ class OutboxServiceWrapper {
         try {
             const statusMessage = await processOutbox();
             logging.info(statusMessage);
-        } catch (e) {
+        } catch (err) {
             logging.error({
                 system: {
                     event: 'outbox.processing.error'
                 },
-                err: e
+                err
             }, `${OUTBOX_LOG_KEY}: Error while processing outbox`);
         } finally {
             this.processing = false;

--- a/ghost/core/core/server/services/outbox/jobs/lib/process-entries.js
+++ b/ghost/core/core/server/services/outbox/jobs/lib/process-entries.js
@@ -54,14 +54,16 @@ async function processEntry({db, entry}) {
     }
 
     let payload;
+    let payloadParsed = false;
     try {
         payload = JSON.parse(entry.payload);
+        payloadParsed = true;
         await handler.handle({payload});
     } catch (err) {
         const errorMessage = err?.message ?? 'Unknown error';
         await updateFailedEntry({db, entryId: entry.id, retryCount: entry.retry_count, errorMessage});
 
-        if (!payload) {
+        if (!payloadParsed) {
             logging.error({
                 system: {
                     event: 'outbox.entry.payload_parse_failed',

--- a/ghost/core/core/server/services/outbox/jobs/lib/process-entries.js
+++ b/ghost/core/core/server/services/outbox/jobs/lib/process-entries.js
@@ -56,37 +56,36 @@ async function processEntry({db, entry}) {
     let payload;
     try {
         payload = JSON.parse(entry.payload);
-    } catch (err) {
-        const errorMessage = err?.message ?? 'Unknown error';
-        await updateFailedEntry({db, entryId: entry.id, retryCount: entry.retry_count, errorMessage});
-        logging.error({
-            system: {
-                event: 'outbox.entry.payload_parse_failed',
-                entry_id: entry.id
-            },
-            err
-        }, `${handler.LOG_KEY} Failed to parse payload for entry ${entry.id}`);
-        return {success: false};
-    }
-
-    try {
         await handler.handle({payload});
     } catch (err) {
         const errorMessage = err?.message ?? 'Unknown error';
         await updateFailedEntry({db, entryId: entry.id, retryCount: entry.retry_count, errorMessage});
-        logging.error({
-            system: {
-                event: 'outbox.entry.send_failed',
-                entry_id: entry.id
-            },
-            err
-        }, `${handler.LOG_KEY} Failed to send to ${handler.getLogInfo(payload)}`);
+
+        if (!payload) {
+            logging.error({
+                system: {
+                    event: 'outbox.entry.payload_parse_failed',
+                    entry_id: entry.id
+                },
+                err
+            }, `${handler.LOG_KEY} Failed to parse payload for entry ${entry.id}: ${errorMessage}`);
+        } else {
+            logging.error({
+                system: {
+                    event: 'outbox.entry.send_failed',
+                    entry_id: entry.id
+                },
+                err
+            }, `${handler.LOG_KEY} Failed to send to ${handler.getLogInfo(payload)}: ${errorMessage}`);
+        }
+
         return {success: false};
     }
 
     try {
         await deleteProcessedEntry({db, entryId: entry.id});
     } catch (err) {
+        const cleanupError = err?.message ?? 'Unknown error';
         await markEntryCompleted({db, entryId: entry.id});
         logging.error({
             system: {
@@ -94,7 +93,7 @@ async function processEntry({db, entry}) {
                 entry_id: entry.id
             },
             err
-        }, `${handler.LOG_KEY} Sent to ${handler.getLogInfo(payload)} but failed to delete outbox entry ${entry.id}`);
+        }, `${handler.LOG_KEY} Sent to ${handler.getLogInfo(payload)} but failed to delete outbox entry ${entry.id}: ${cleanupError}`);
     }
 
     return {success: true};

--- a/ghost/core/core/server/services/outbox/jobs/lib/process-entries.js
+++ b/ghost/core/core/server/services/outbox/jobs/lib/process-entries.js
@@ -43,7 +43,12 @@ async function markEntryCompleted({db, entryId}) {
 async function processEntry({db, entry}) {
     const handler = EVENT_HANDLERS[entry.event_type];
     if (!handler) {
-        logging.warn(`${OUTBOX_LOG_KEY} No handler for event type: ${entry.event_type}`);
+        logging.warn({
+            system: {
+                event: 'outbox.entry.no_handler',
+                event_type: entry.event_type
+            }
+        }, `${OUTBOX_LOG_KEY} No handler for event type: ${entry.event_type}`);
         await updateFailedEntry({db, entryId: entry.id, retryCount: entry.retry_count, errorMessage: `No handler for event type: ${entry.event_type}`});
         return {success: false};
     }
@@ -57,9 +62,21 @@ async function processEntry({db, entry}) {
         await updateFailedEntry({db, entryId: entry.id, retryCount: entry.retry_count, errorMessage});
 
         if (!payload) {
-            logging.error(`${handler.LOG_KEY} Failed to parse payload for entry ${entry.id}: ${errorMessage}`);
+            logging.error({
+                system: {
+                    event: 'outbox.entry.payload_parse_failed',
+                    entry_id: entry.id
+                },
+                err
+            }, `${handler.LOG_KEY} Failed to parse payload for entry ${entry.id}`);
         } else {
-            logging.error(`${handler.LOG_KEY} Failed to send to ${handler.getLogInfo(payload)}: ${errorMessage}`);
+            logging.error({
+                system: {
+                    event: 'outbox.entry.send_failed',
+                    entry_id: entry.id
+                },
+                err
+            }, `${handler.LOG_KEY} Failed to send to ${handler.getLogInfo(payload)}`);
         }
 
         return {success: false};
@@ -68,9 +85,14 @@ async function processEntry({db, entry}) {
     try {
         await deleteProcessedEntry({db, entryId: entry.id});
     } catch (err) {
-        const cleanupError = err?.message ?? 'Unknown error';
         await markEntryCompleted({db, entryId: entry.id});
-        logging.error(`${handler.LOG_KEY} Sent to ${handler.getLogInfo(payload)} but failed to delete outbox entry ${entry.id}: ${cleanupError}`);
+        logging.error({
+            system: {
+                event: 'outbox.entry.delete_failed',
+                entry_id: entry.id
+            },
+            err
+        }, `${handler.LOG_KEY} Sent to ${handler.getLogInfo(payload)} but failed to delete outbox entry ${entry.id}`);
     }
 
     return {success: true};

--- a/ghost/core/core/server/services/outbox/jobs/lib/process-entries.js
+++ b/ghost/core/core/server/services/outbox/jobs/lib/process-entries.js
@@ -54,33 +54,33 @@ async function processEntry({db, entry}) {
     }
 
     let payload;
-    let payloadParsed = false;
     try {
         payload = JSON.parse(entry.payload);
-        payloadParsed = true;
+    } catch (err) {
+        const errorMessage = err?.message ?? 'Unknown error';
+        await updateFailedEntry({db, entryId: entry.id, retryCount: entry.retry_count, errorMessage});
+        logging.error({
+            system: {
+                event: 'outbox.entry.payload_parse_failed',
+                entry_id: entry.id
+            },
+            err
+        }, `${handler.LOG_KEY} Failed to parse payload for entry ${entry.id}`);
+        return {success: false};
+    }
+
+    try {
         await handler.handle({payload});
     } catch (err) {
         const errorMessage = err?.message ?? 'Unknown error';
         await updateFailedEntry({db, entryId: entry.id, retryCount: entry.retry_count, errorMessage});
-
-        if (!payloadParsed) {
-            logging.error({
-                system: {
-                    event: 'outbox.entry.payload_parse_failed',
-                    entry_id: entry.id
-                },
-                err
-            }, `${handler.LOG_KEY} Failed to parse payload for entry ${entry.id}`);
-        } else {
-            logging.error({
-                system: {
-                    event: 'outbox.entry.send_failed',
-                    entry_id: entry.id
-                },
-                err
-            }, `${handler.LOG_KEY} Failed to send to ${handler.getLogInfo(payload)}`);
-        }
-
+        logging.error({
+            system: {
+                event: 'outbox.entry.send_failed',
+                entry_id: entry.id
+            },
+            err
+        }, `${handler.LOG_KEY} Failed to send to ${handler.getLogInfo(payload)}`);
         return {success: false};
     }
 

--- a/ghost/core/core/server/services/outbox/jobs/lib/process-entries.js
+++ b/ghost/core/core/server/services/outbox/jobs/lib/process-entries.js
@@ -85,7 +85,6 @@ async function processEntry({db, entry}) {
     try {
         await deleteProcessedEntry({db, entryId: entry.id});
     } catch (err) {
-        const cleanupError = err?.message ?? 'Unknown error';
         await markEntryCompleted({db, entryId: entry.id});
         logging.error({
             system: {

--- a/ghost/core/core/server/services/outbox/jobs/lib/process-entries.js
+++ b/ghost/core/core/server/services/outbox/jobs/lib/process-entries.js
@@ -68,7 +68,7 @@ async function processEntry({db, entry}) {
                     entry_id: entry.id
                 },
                 err
-            }, `${handler.LOG_KEY} Failed to parse payload for entry ${entry.id}: ${errorMessage}`);
+            }, `${handler.LOG_KEY} Failed to parse payload for entry ${entry.id}.`);
         } else {
             logging.error({
                 system: {
@@ -76,7 +76,7 @@ async function processEntry({db, entry}) {
                     entry_id: entry.id
                 },
                 err
-            }, `${handler.LOG_KEY} Failed to send to ${handler.getLogInfo(payload)}: ${errorMessage}`);
+            }, `${handler.LOG_KEY} Failed to send to ${handler.getLogInfo(payload)}.`);
         }
 
         return {success: false};
@@ -93,7 +93,7 @@ async function processEntry({db, entry}) {
                 entry_id: entry.id
             },
             err
-        }, `${handler.LOG_KEY} Sent to ${handler.getLogInfo(payload)} but failed to delete outbox entry ${entry.id}: ${cleanupError}`);
+        }, `${handler.LOG_KEY} Sent to ${handler.getLogInfo(payload)} but failed to delete outbox entry ${entry.id}.`);
     }
 
     return {success: true};

--- a/ghost/core/core/server/services/outbox/jobs/lib/process-outbox.js
+++ b/ghost/core/core/server/services/outbox/jobs/lib/process-outbox.js
@@ -51,7 +51,7 @@ async function processOutbox() {
                 event: 'outbox.init.failed'
             },
             err
-        }, `${OUTBOX_LOG_KEY} Service initialization failed: ${errorMessage}`);
+        }, `${OUTBOX_LOG_KEY} Service initialization failed.`);
         return `${OUTBOX_LOG_KEY} Job aborted: Service initialization failed`;
     }
 

--- a/ghost/core/core/server/services/outbox/jobs/lib/process-outbox.js
+++ b/ghost/core/core/server/services/outbox/jobs/lib/process-outbox.js
@@ -46,8 +46,13 @@ async function processOutbox() {
         await memberWelcomeEmailService.api.loadMemberWelcomeEmails();
     } catch (err) {
         const errorMessage = err?.message ?? 'Unknown error';
-        logging.error(`${OUTBOX_LOG_KEY} Service initialization failed: ${errorMessage}`);
-        return `${OUTBOX_LOG_KEY} Job aborted: Service initialization failed`;
+        logging.error({
+            system: {
+                event: 'outbox.init.failed'
+            },
+            err
+        }, `${OUTBOX_LOG_KEY} Service initialization failed: ${errorMessage}`);
+        return;
     }
 
     let totalProcessed = 0;
@@ -70,16 +75,28 @@ async function processOutbox() {
         totalProcessed += processed;
         totalFailed += failed;
 
-        logging.info(`${OUTBOX_LOG_KEY} Batch complete: ${processed} processed, ${failed} failed in ${(batchDurationMs / 1000).toFixed(2)}s (${batchRate} entries/sec)`);
+        logging.info({
+            system: {
+                event: 'outbox.batch.complete',
+                entries_processed: processed,
+                entries_failed: failed,
+                duration_ms: batchDurationMs
+            }
+        }, `${OUTBOX_LOG_KEY} Batch complete: ${processed} processed, ${failed} failed in ${(batchDurationMs / 1000).toFixed(2)}s (${batchRate} entries/sec)`);
     }
 
     const durationMs = Date.now() - jobStartMs;
 
-    if (totalProcessed + totalFailed === 0) {
-        return `${OUTBOX_LOG_KEY} ${MESSAGES.NO_ENTRIES}`;
-    }
-
-    return `${OUTBOX_LOG_KEY} Job complete: Processed ${totalProcessed} outbox entries, ${totalFailed} failed in ${(durationMs / 1000).toFixed(2)}s`;
+    logging.info({
+        system: {
+            event: 'outbox.job.complete',
+            entries_processed: totalProcessed,
+            entries_failed: totalFailed,
+            duration_ms: durationMs
+        }
+    }, totalProcessed + totalFailed === 0
+        ? `${OUTBOX_LOG_KEY} ${MESSAGES.NO_ENTRIES}`
+        : `${OUTBOX_LOG_KEY} Job complete: Processed ${totalProcessed} outbox entries, ${totalFailed} failed in ${(durationMs / 1000).toFixed(2)}s`);
 }
 
 module.exports = processOutbox;

--- a/ghost/core/core/server/services/outbox/jobs/lib/process-outbox.js
+++ b/ghost/core/core/server/services/outbox/jobs/lib/process-outbox.js
@@ -52,7 +52,7 @@ async function processOutbox() {
             },
             err
         }, `${OUTBOX_LOG_KEY} Service initialization failed: ${errorMessage}`);
-        return;
+        return `${OUTBOX_LOG_KEY} Job aborted: Service initialization failed`;
     }
 
     let totalProcessed = 0;
@@ -87,16 +87,11 @@ async function processOutbox() {
 
     const durationMs = Date.now() - jobStartMs;
 
-    logging.info({
-        system: {
-            event: 'outbox.job.complete',
-            entries_processed: totalProcessed,
-            entries_failed: totalFailed,
-            duration_ms: durationMs
-        }
-    }, totalProcessed + totalFailed === 0
-        ? `${OUTBOX_LOG_KEY} ${MESSAGES.NO_ENTRIES}`
-        : `${OUTBOX_LOG_KEY} Job complete: Processed ${totalProcessed} outbox entries, ${totalFailed} failed in ${(durationMs / 1000).toFixed(2)}s`);
+    if (totalProcessed + totalFailed === 0) {
+        return `${OUTBOX_LOG_KEY} ${MESSAGES.NO_ENTRIES}`;
+    }
+
+    return `${OUTBOX_LOG_KEY} Job complete: Processed ${totalProcessed} outbox entries, ${totalFailed} failed in ${(durationMs / 1000).toFixed(2)}s`;
 }
 
 module.exports = processOutbox;

--- a/ghost/core/core/server/services/outbox/jobs/lib/process-outbox.js
+++ b/ghost/core/core/server/services/outbox/jobs/lib/process-outbox.js
@@ -45,7 +45,6 @@ async function processOutbox() {
     try {
         await memberWelcomeEmailService.api.loadMemberWelcomeEmails();
     } catch (err) {
-        const errorMessage = err?.message ?? 'Unknown error';
         logging.error({
             system: {
                 event: 'outbox.init.failed'

--- a/ghost/core/test/unit/server/services/outbox/handlers/member-created.test.js
+++ b/ghost/core/test/unit/server/services/outbox/handlers/member-created.test.js
@@ -93,4 +93,27 @@ describe('member-created handler', function () {
         });
         sinon.assert.notCalled(AutomatedEmailRecipientStub.add);
     });
+
+    it('logs warning when no automated email found for slug', async function () {
+        AutomatedEmailStub.findOne.resolves(null);
+
+        await handler.handle({
+            payload: {
+                memberId: 'member123',
+                uuid: 'uuid-123',
+                email: 'test@example.com',
+                name: 'Test Member',
+                status: 'free'
+            }
+        });
+
+        sinon.assert.calledOnce(memberWelcomeEmailServiceStub.api.send);
+        const warningLog = findByEvent(logCapture.output, 'outbox.member_created.no_automated_email');
+        assert.ok(warningLog);
+        assert.deepEqual(warningLog.system, {
+            event: 'outbox.member_created.no_automated_email',
+            slug: 'member-welcome-email-free'
+        });
+        sinon.assert.notCalled(AutomatedEmailRecipientStub.add);
+    });
 });

--- a/ghost/core/test/unit/server/services/outbox/index.test.js
+++ b/ghost/core/test/unit/server/services/outbox/index.test.js
@@ -14,7 +14,7 @@ describe('Outbox Service', function () {
     beforeEach(function () {
         service = rewire('../../../../../core/server/services/outbox/index.js');
 
-        processOutboxStub = sinon.stub().resolves();
+        processOutboxStub = sinon.stub().resolves('Processed');
         jobsStub = {scheduleOutboxJob: sinon.stub()};
         logCapture = captureLoggerOutput();
 

--- a/ghost/core/test/unit/server/services/outbox/index.test.js
+++ b/ghost/core/test/unit/server/services/outbox/index.test.js
@@ -14,7 +14,7 @@ describe('Outbox Service', function () {
     beforeEach(function () {
         service = rewire('../../../../../core/server/services/outbox/index.js');
 
-        processOutboxStub = sinon.stub().resolves('Processed');
+        processOutboxStub = sinon.stub().resolves();
         jobsStub = {scheduleOutboxJob: sinon.stub()};
         logCapture = captureLoggerOutput();
 
@@ -52,6 +52,21 @@ describe('Outbox Service', function () {
             assert.ok(infoLog);
             assert.deepEqual(infoLog.system, {
                 event: 'outbox.processing.skipped_already_running'
+            });
+        });
+    });
+
+    describe('startProcessing error handling', function () {
+        it('logs structured error when processOutbox throws', async function () {
+            processOutboxStub.rejects(new Error('Unexpected failure'));
+            service.init();
+
+            await service.startProcessing();
+
+            const errorLog = findByEvent(logCapture.output, 'outbox.processing.error');
+            assert.ok(errorLog);
+            assert.deepEqual(errorLog.system, {
+                event: 'outbox.processing.error'
             });
         });
     });

--- a/ghost/core/test/unit/server/services/outbox/jobs/lib/process-entries.test.js
+++ b/ghost/core/test/unit/server/services/outbox/jobs/lib/process-entries.test.js
@@ -1,0 +1,124 @@
+const assert = require('node:assert/strict');
+const sinon = require('sinon');
+const rewire = require('rewire');
+const {captureLoggerOutput, findByEvent} = require('../../../../../../utils/logging-utils');
+
+describe('processEntries', function () {
+    let processEntries;
+    let handlerStub;
+    let dbStub;
+    let logCapture;
+
+    function createDbStub({deleteShouldFail = false} = {}) {
+        const chainable = {
+            where: sinon.stub().returnsThis(),
+            whereIn: sinon.stub().returnsThis(),
+            update: sinon.stub().resolves(),
+            delete: deleteShouldFail
+                ? sinon.stub().rejects(new Error('Delete failed'))
+                : sinon.stub().resolves()
+        };
+        const knex = sinon.stub().returns(chainable);
+        knex.raw = sinon.stub().returns('RAW_TIMESTAMP');
+        return {knex};
+    }
+
+    beforeEach(function () {
+        processEntries = rewire('../../../../../../../core/server/services/outbox/jobs/lib/process-entries.js');
+
+        handlerStub = {
+            handle: sinon.stub().resolves(),
+            getLogInfo: sinon.stub().returns('test@example.com'),
+            LOG_KEY: '[OUTBOX][MEMBER-WELCOME-EMAIL]'
+        };
+
+        processEntries.__set__('EVENT_HANDLERS', {
+            MemberCreatedEvent: handlerStub
+        });
+
+        dbStub = createDbStub();
+
+        logCapture = captureLoggerOutput();
+    });
+
+    afterEach(function () {
+        logCapture.restore();
+        sinon.restore();
+    });
+
+    it('logs structured warning when no handler exists for event type', async function () {
+        const entries = [{
+            id: 'entry-1',
+            event_type: 'UnknownEvent',
+            payload: '{}',
+            retry_count: 0
+        }];
+
+        await processEntries({db: dbStub, entries});
+
+        const warningLog = findByEvent(logCapture.output, 'outbox.entry.no_handler');
+        assert.ok(warningLog);
+        assert.deepEqual(warningLog.system, {
+            event: 'outbox.entry.no_handler',
+            event_type: 'UnknownEvent'
+        });
+    });
+
+    it('logs structured error when payload parsing fails', async function () {
+        const entries = [{
+            id: 'entry-2',
+            event_type: 'MemberCreatedEvent',
+            payload: 'invalid-json',
+            retry_count: 0
+        }];
+
+        await processEntries({db: dbStub, entries});
+
+        const errorLog = findByEvent(logCapture.output, 'outbox.entry.payload_parse_failed');
+        assert.ok(errorLog);
+        assert.deepEqual(errorLog.system, {
+            event: 'outbox.entry.payload_parse_failed',
+            entry_id: 'entry-2'
+        });
+    });
+
+    it('logs structured error when handler fails', async function () {
+        handlerStub.handle.rejects(new Error('Send failed'));
+
+        const entries = [{
+            id: 'entry-3',
+            event_type: 'MemberCreatedEvent',
+            payload: JSON.stringify({email: 'test@example.com'}),
+            retry_count: 0
+        }];
+
+        await processEntries({db: dbStub, entries});
+
+        const errorLog = findByEvent(logCapture.output, 'outbox.entry.send_failed');
+        assert.ok(errorLog);
+        assert.deepEqual(errorLog.system, {
+            event: 'outbox.entry.send_failed',
+            entry_id: 'entry-3'
+        });
+    });
+
+    it('logs structured error when delete fails after successful processing', async function () {
+        dbStub = createDbStub({deleteShouldFail: true});
+
+        const entries = [{
+            id: 'entry-4',
+            event_type: 'MemberCreatedEvent',
+            payload: JSON.stringify({email: 'test@example.com'}),
+            retry_count: 0
+        }];
+
+        await processEntries({db: dbStub, entries});
+
+        const errorLog = findByEvent(logCapture.output, 'outbox.entry.delete_failed');
+        assert.ok(errorLog);
+        assert.deepEqual(errorLog.system, {
+            event: 'outbox.entry.delete_failed',
+            entry_id: 'entry-4'
+        });
+    });
+});


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1020/convert-outbox-logs-to-structured-logs

## Summary
- Follows up on #26599 to convert the remaining logging statements in the outbox and member welcome email services to structured logging with `system.event` fields
- Adds structured metadata (entry IDs, event types, batch stats, durations) to each log for easier dashboard filtering and debugging
- No behavioral changes — only logging call formats are changed

## New structured events
| Event | Level | File |
|-------|-------|------|
| `outbox.processing.error` | error | `outbox/index.js` |
| `outbox.entry.no_handler` | warn | `process-entries.js` |
| `outbox.entry.payload_parse_failed` | error | `process-entries.js` |
| `outbox.entry.send_failed` | error | `process-entries.js` |
| `outbox.entry.delete_failed` | error | `process-entries.js` |
| `outbox.init.failed` | error | `process-outbox.js` |
| `outbox.batch.complete` | info | `process-outbox.js` |
| `outbox.member_created.no_automated_email` | warn | `member-created.js` |
| `member_welcome_email.sending` | info | `service.js` |

## Note for reviewer
The `logging.info(statusMessage)` in `outbox/index.js` is left as-is — `processOutbox()` returns a string that the caller logs. Converting this one would require changing the return value contract. Worth discussing whether the return-for-logging pattern should be refactored in a separate PR.

## Test plan
- [x] All 11 outbox unit tests passing (3 index + 4 member-created + 4 new process-entries)
- [x] Lint passes on all modified files
- [ ] Integration test `process-outbox.test.js` still passes (exercises full pipeline)

ref https://linear.app/ghost/issue/NY-1020


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only changes across outbox processing and member welcome emails; low risk aside from potential differences in log output/alerting and added metadata payload size.
> 
> **Overview**
> Converts remaining outbox processing and member welcome email log lines to **structured logs** with `system.event` fields, and attaches useful metadata such as `member_status`, `slug`, `event_type`, `entry_id`, and batch timing/counts.
> 
> Standardizes error/warn reporting in `outbox/index.js`, `process-outbox.js`, `process-entries.js`, `handlers/member-created.js`, and `member-welcome-emails/service.js` (including passing the caught `err` object), and expands unit tests to assert the new structured events (plus adds a new `process-entries` unit test suite).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd730e717e8160b6426f8358682068b6c13c6e74. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->