### PR TITLE
Added extra DOM validation for rendered AP content

### DIFF
--- a/apps/activitypub/package.json
+++ b/apps/activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/activitypub",
-  "version": "3.0.8",
+  "version": "3.1.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -31,6 +31,7 @@
   "devDependencies": {
     "@playwright/test": "1.55.1",
     "@testing-library/react": "14.3.1",
+    "@types/dompurify": "3.2.0",
     "@types/jest": "29.5.14",
     "@types/react": "18.3.26",
     "@types/react-dom": "18.3.7",
@@ -70,6 +71,7 @@
     "@tryghost/admin-x-framework": "0.0.0",
     "@tryghost/shade": "0.0.0",
     "clsx": "2.1.1",
+    "dompurify": "3.3.1",
     "html2canvas-objectfit-fix": "1.2.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",

--- a/apps/activitypub/src/components/feed/feed-item.tsx
+++ b/apps/activitypub/src/components/feed/feed-item.tsx
@@ -13,7 +13,7 @@ import clsx from 'clsx';
 import getReadingTime from '../../utils/get-reading-time';
 import getUsername from '../../utils/get-username';
 import {handleProfileClick} from '../../utils/handle-profile-click';
-import {openLinksInNewTab, stripHtml} from '../../utils/content-formatters';
+import {openLinksInNewTab, sanitizeHtml, stripHtml} from '../../utils/content-formatters';
 import {renderTimestamp} from '../../utils/render-timestamp';
 import {useDeleteMutationForUser, useFollowMutationForUser, useUnfollowMutationForUser} from '../../hooks/use-activity-pub-queries';
 import {useNavigateWithBasePath} from '@src/hooks/use-navigate-with-base-path';
@@ -489,7 +489,7 @@ const FeedItem: React.FC<FeedItemProps> = ({
                                                 <div className='ap-note-content line-clamp-[10] text-pretty leading-[1.4285714286] tracking-[-0.006em] text-gray-900 break-anywhere dark:text-gray-300 [&_p+p]:mt-3'>
                                                     {!isLoading ?
                                                         <div dangerouslySetInnerHTML={{
-                                                            __html: openLinksInNewTab(object.content || '') ?? ''
+                                                            __html: sanitizeHtml(openLinksInNewTab(object.content || '') ?? '')
                                                         }} ref={contentRef}
                                                         onClick={(e) => {
                                                             const target = e.target as HTMLElement;
@@ -569,7 +569,7 @@ const FeedItem: React.FC<FeedItemProps> = ({
                                 <div className={`relative z-10 col-start-1 col-end-3 w-full gap-4`}>
                                     <div className='flex flex-col items-start'>
                                         {object.name && <H4 className='mb-1 leading-tight break-anywhere' data-test-activity-heading>{object.name}</H4>}
-                                        <div dangerouslySetInnerHTML={({__html: openLinksInNewTab(object.content || '') ?? ''})} ref={contentRef} className='ap-note-content-large text-pretty text-[1.6rem] tracking-[-0.011em] text-gray-900 break-anywhere dark:text-gray-300 [&_p+p]:mt-3'></div>
+                                        <div dangerouslySetInnerHTML={({__html: sanitizeHtml(openLinksInNewTab(object.content || '') ?? '')})} ref={contentRef} className='ap-note-content-large text-pretty text-[1.6rem] tracking-[-0.011em] text-gray-900 break-anywhere dark:text-gray-300 [&_p+p]:mt-3'></div>
                                         {renderFeedAttachment(object, openLightbox, brokenImages, handleImageError)}
                                         <div className='space-between ml-[-8px] mt-3 flex'>
                                             {showStats && <FeedItemStats
@@ -646,7 +646,7 @@ const FeedItem: React.FC<FeedItemProps> = ({
                                 <div className='flex flex-col items-start'>
                                     {(object.type === 'Article') && renderFeedAttachment(object, onClick, brokenImages, handleImageError)}
                                     {object.name && <H4 className='mt-2.5 text-pretty leading-tight break-anywhere' data-test-activity-heading>{object.name}</H4>}
-                                    {(object.preview && object.type === 'Article') ? <div className='mt-1 line-clamp-3 leading-tight'>{object.preview.content}</div> : <div dangerouslySetInnerHTML={({__html: openLinksInNewTab(object.content || '') ?? ''})} ref={contentRef} className='ap-note-content text-pretty tracking-[-0.006em] text-gray-900 break-anywhere dark:text-gray-300 [&_p+p]:mt-3'></div>}
+                                    {(object.preview && object.type === 'Article') ? <div className='mt-1 line-clamp-3 leading-tight'>{object.preview.content}</div> : <div dangerouslySetInnerHTML={({__html: sanitizeHtml(openLinksInNewTab(object.content || '') ?? '')})} ref={contentRef} className='ap-note-content text-pretty tracking-[-0.006em] text-gray-900 break-anywhere dark:text-gray-300 [&_p+p]:mt-3'></div>}
                                     {(object.type === 'Note') && renderFeedAttachment(object, openLightbox, brokenImages, handleImageError)}
                                     {(object.type === 'Article') && <Button
                                         className='mt-3 w-full'
@@ -718,14 +718,14 @@ const FeedItem: React.FC<FeedItemProps> = ({
                                     <H4 className='line-clamp-2 w-full max-w-[600px] text-pretty leading-tight break-anywhere' data-test-activity-heading>
                                         {isLoading ? <Skeleton className='w-full max-w-96' /> : (object.name ? object.name : (
                                             <span dangerouslySetInnerHTML={{
-                                                __html: stripHtml(object.content || '')
+                                                __html: sanitizeHtml(stripHtml(object.content || ''))
                                             }}></span>
                                         ))}
                                     </H4>
                                     <div className='ap-note-content line-clamp-2 w-full max-w-[600px] text-pretty text-base leading-normal text-gray-900 break-anywhere dark:text-gray-300 [&_p+p]:mt-3'>
                                         {!isLoading ?
                                             <div dangerouslySetInnerHTML={{
-                                                __html: stripHtml(object.preview?.content ?? object.content ?? '')
+                                                __html: sanitizeHtml(stripHtml(object.preview?.content ?? object.content ?? ''))
                                             }} />
                                             :
                                             <Skeleton count={2} />

--- a/apps/activitypub/src/components/global/profile-preview-hover-card.tsx
+++ b/apps/activitypub/src/components/global/profile-preview-hover-card.tsx
@@ -4,7 +4,7 @@ import getUsername from '../../utils/get-username';
 import {Account} from '@src/api/activitypub';
 import {ActorProperties} from '@tryghost/admin-x-framework/api/activitypub';
 import {Avatar, AvatarFallback, AvatarImage, Badge, H3, HoverCard, HoverCardContent, HoverCardTrigger, LucideIcon, Skeleton, abbreviateNumber} from '@tryghost/shade';
-import {openLinksInNewTab, stripHtml} from '../../utils/content-formatters';
+import {openLinksInNewTab, sanitizeHtml, stripHtml} from '../../utils/content-formatters';
 import {useAccountForUser} from '../../hooks/use-activity-pub-queries';
 import {useNavigateWithBasePath} from '@src/hooks/use-navigate-with-base-path';
 
@@ -170,7 +170,7 @@ const ProfilePreviewHoverCard: React.FC<ProfilePreviewHoverCardProps> = ({
                     {isLoading ? (
                         <Skeleton className='h-4 w-48' />
                     ) : !hasLoadingError && bio ? (
-                        <div dangerouslySetInnerHTML={{__html: bio}} className='leading-tight dark:text-gray-300 [&_.invisible]:hidden [&_a:hover]:underline [&_a]:text-[#00a4eb]' />
+                        <div dangerouslySetInnerHTML={{__html: sanitizeHtml(bio)}} className='leading-tight dark:text-gray-300 [&_.invisible]:hidden [&_a:hover]:underline [&_a]:text-[#00a4eb]' />
                     ) : null}
                 </div>
             </HoverCardContent>

--- a/apps/activitypub/src/components/layout/onboarding/step-1.tsx
+++ b/apps/activitypub/src/components/layout/onboarding/step-1.tsx
@@ -3,6 +3,7 @@ import React, {useState} from 'react';
 import apNodes from '@assets/images/onboarding/ap-nodes.png';
 import apNodesDark from '@assets/images/onboarding/ap-nodes-dark.png';
 import {Button, H3, LucideIcon, Skeleton} from '@tryghost/shade';
+import {sanitizeHtml} from '@src/utils/content-formatters';
 import {useAccountForUser} from '@src/hooks/use-activity-pub-queries';
 import {useBrowseUsers} from '@tryghost/admin-x-framework/api/users';
 import {useNavigateWithBasePath} from '@src/hooks/use-navigate-with-base-path';
@@ -80,7 +81,7 @@ const Step1: React.FC = () => {
                         </div>
                         <p className='leading-tight text-gray-800 dark:text-gray-600'>
                             {account?.bio ? (
-                                <span dangerouslySetInnerHTML={{__html: account.bio}} />
+                                <span dangerouslySetInnerHTML={{__html: sanitizeHtml(account.bio)}} />
                             ) : (
                                 <Skeleton count={3} randomize={true} />
                             )}

--- a/apps/activitypub/src/utils/content-formatters.ts
+++ b/apps/activitypub/src/utils/content-formatters.ts
@@ -1,3 +1,29 @@
+import DOMPurify from 'dompurify';
+
+const SAFE_URL_PROTOCOLS = ['http:', 'https:', 'mailto:'];
+
+export function isSafeUrl(url: string): boolean {
+    try {
+        const parsed = new URL(url);
+        return SAFE_URL_PROTOCOLS.includes(parsed.protocol);
+    } catch {
+        return false;
+    }
+}
+
+export function escapeHtml(str: string): string {
+    return str
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#x27;');
+}
+
+export function sanitizeHtml(html: string): string {
+    return DOMPurify.sanitize(html);
+}
+
 export function stripHtml(html: string, exclude: string[] = []): string {
     // If no exclusions, use the original logic
     if (exclude.length === 0) {

--- a/apps/activitypub/src/views/explore/explore.tsx
+++ b/apps/activitypub/src/views/explore/explore.tsx
@@ -6,7 +6,7 @@ import React, {useEffect} from 'react';
 import TopicFilter, {type Topic} from '@src/components/topic-filter';
 import {type Account, type ExploreAccount} from '@src/api/activitypub';
 import {Button, H4, LoadingIndicator, LucideIcon, Skeleton} from '@tryghost/shade';
-import {openLinksInNewTab, stripHtml} from '@src/utils/content-formatters';
+import {openLinksInNewTab, sanitizeHtml, stripHtml} from '@src/utils/content-formatters';
 import {useAccountForUser, useExploreProfilesForUserByTopic} from '@hooks/use-activity-pub-queries';
 import {useNavigateWithBasePath} from '@src/hooks/use-navigate-with-base-path';
 import {useOnboardingStatus} from '@src/components/layout/onboarding';
@@ -88,7 +88,7 @@ export const ExploreProfile: React.FC<ExploreProfileProps & {
                         :
                         profile.bio &&
                         <div
-                            dangerouslySetInnerHTML={{__html: openLinksInNewTab(stripHtml(profile.bio, ['a', 'br']))}}
+                            dangerouslySetInnerHTML={{__html: sanitizeHtml(openLinksInNewTab(stripHtml(profile.bio, ['a', 'br'])))}}
                             className='ap-profile-content pointer-events-none mt-0 line-clamp-2 max-w-[460px] break-anywhere'
                         />
                     }

--- a/apps/activitypub/src/views/inbox/components/reader.tsx
+++ b/apps/activitypub/src/views/inbox/components/reader.tsx
@@ -20,9 +20,9 @@ import articleBodyStyles from '@src/components/article-body-styles';
 import getReadingTime from '../../../utils/get-reading-time';
 import {Activity} from '@src/api/activitypub';
 import {cardsCSS, cardsJS} from '@src/utils/cards-assets';
+import {escapeHtml, isSafeUrl, openLinksInNewTab} from '@src/utils/content-formatters';
 import {handleProfileClick} from '@src/utils/handle-profile-click';
 import {isPendingActivity} from '../../../utils/pending-activity';
-import {openLinksInNewTab} from '@src/utils/content-formatters';
 import {useDebounce} from 'use-debounce';
 import {useNavigateWithBasePath} from '@src/hooks/use-navigate-with-base-path';
 
@@ -163,15 +163,15 @@ const ArticleBody: React.FC<{
         </head>
         <body>
             <header class='gh-article-header gh-canvas'>
-                <h1 class='gh-article-title is-title' data-test-article-heading>${heading}</h1>
-                ${excerpt ? `<p class='gh-article-excerpt'>${excerpt}</p>` : ''}
-                <a href="${postUrl}" target="_blank" rel="noopener noreferrer" class="gh-article-meta">
+                <h1 class='gh-article-title is-title' data-test-article-heading>${escapeHtml(heading)}</h1>
+                ${excerpt ? `<p class='gh-article-excerpt'>${escapeHtml(excerpt)}</p>` : ''}
+                <a href="${postUrl && isSafeUrl(postUrl) ? escapeHtml(postUrl) : '#'}" target="_blank" rel="noopener noreferrer" class="gh-article-meta">
                     ${authors && authors.length > 0 ? `
                         <div class="gh-article-author-image">
                         ${authors.map(author => `
                                 <span>
                                     ${author.profile_image
-        ? `<img src="${author.profile_image}" alt="${author.name}">`
+        ? `<img src="${escapeHtml(author.profile_image)}" alt="${escapeHtml(author.name)}">`
         : `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" height="24" width="24"><path d="M6.75 6a5.25 5.25 0 1 0 10.5 0 5.25 5.25 0 1 0 -10.5 0" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"></path><path d="M2.25 23.25a9.75 9.75 0 0 1 19.5 0" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"></path></svg>`
 }
                                 </span>
@@ -181,15 +181,15 @@ const ArticleBody: React.FC<{
                     <div class="gh-article-meta-wrapper">
                         ${authors && authors.length > 0 ? `
                             <span class="gh-article-author-name">
-                                ${authors.length > 1 ? `${authors[0].name} and ${authors.length - 1} ${authors.length - 1 === 1 ? 'other' : 'others'}` : authors[0].name}
+                                ${authors.length > 1 ? `${escapeHtml(authors[0].name)} and ${authors.length - 1} ${authors.length - 1 === 1 ? 'other' : 'others'}` : escapeHtml(authors[0].name)}
                             </span>
                         ` : ''}
-                        <span class="gh-article-source">${postUrl ? new URL(postUrl).hostname : ''} <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-external-link-icon lucide-external-link"><path d="M15 3h6v6"/><path d="M10 14 21 3"/><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/></svg></span>
+                        <span class="gh-article-source">${postUrl && isSafeUrl(postUrl) ? escapeHtml(new URL(postUrl).hostname) : ''} <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-external-link-icon lucide-external-link"><path d="M15 3h6v6"/><path d="M10 14 21 3"/><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/></svg></span>
                     </div>
                 </a>
                 ${image ? `
                 <figure class='gh-article-image'>
-                    <img src='${image}' alt='${heading}' />
+                    <img src='${escapeHtml(image)}' alt='${escapeHtml(heading)}' />
                 </figure>
                 ` : ''}
             </header>

--- a/apps/activitypub/src/views/profile/components/profile-page.tsx
+++ b/apps/activitypub/src/views/profile/components/profile-page.tsx
@@ -8,7 +8,7 @@ import {Account} from '@src/api/activitypub';
 import {Badge, Button, Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger, H2, H4, LucideIcon, NoValueLabel, NoValueLabelIcon, Skeleton, Tabs, TabsContent, TabsList, TabsTrigger, TabsTriggerCount, abbreviateNumber} from '@tryghost/shade';
 import {EmptyViewIcon, EmptyViewIndicator} from '@src/components/global/empty-view-indicator';
 import {SettingAction} from '@src/views/preferences/components/settings';
-import {openLinksInNewTab, stripHtml} from '@src/utils/content-formatters';
+import {openLinksInNewTab, sanitizeHtml, stripHtml} from '@src/utils/content-formatters';
 import {toast} from 'sonner';
 import {useAccountForUser, useBlockDomainMutationForUser, useBlockMutationForUser, useUnblockDomainMutationForUser, useUnblockMutationForUser} from '@src/hooks/use-activity-pub-queries';
 import {useEffect, useMemo, useRef, useState} from 'react';
@@ -270,7 +270,7 @@ const ProfilePage:React.FC<ProfilePageProps> = ({
                             </div>
                             {(account?.bio || customFields?.length > 0) && (<div ref={contentRef} className={`ap-profile-content relative text-[1.5rem] break-anywhere [&>p]:mb-3 ${isExpanded ? 'max-h-none pb-7' : 'max-h-[160px] overflow-hidden'} relative`}>
                                 {!isLoadingAccount ?
-                                    <div dangerouslySetInnerHTML={{__html: openLinksInNewTab(stripHtml(account?.bio ?? '', ['a', 'br']))}} /> :
+                                    <div dangerouslySetInnerHTML={{__html: sanitizeHtml(openLinksInNewTab(stripHtml(account?.bio ?? '', ['a', 'br'])))}} /> :
                                     <>
                                         <Skeleton />
                                         <Skeleton className='w-full max-w-48' />
@@ -279,7 +279,7 @@ const ProfilePage:React.FC<ProfilePageProps> = ({
                                 {customFields?.map((attachment: {name: string, value: string}) => (
                                     <span className='mt-3 line-clamp-1 flex flex-col text-[1.5rem]'>
                                         <span className={`text-xs font-semibold`}>{attachment.name}</span>
-                                        <span dangerouslySetInnerHTML={{__html: attachment.value}} className='ap-profile-content truncate'/>
+                                        <span dangerouslySetInnerHTML={{__html: sanitizeHtml(attachment.value)}} className='ap-profile-content truncate'/>
                                     </span>
                                 ))}
                                 {!isExpanded && isOverflowing && (

--- a/apps/activitypub/test/acceptance/dom-validation.test.ts
+++ b/apps/activitypub/test/acceptance/dom-validation.test.ts
@@ -1,0 +1,235 @@
+import inboxFixture from '../utils/responses/activitypub/inbox.json';
+import {expect, test} from '@playwright/test';
+import {mockApi} from '@tryghost/admin-x-framework/test/acceptance';
+import {mockInitialApiRequests} from '../utils/initial-api-requests';
+
+test.describe('DOM validation for rendered AP content', async () => {
+    test.beforeEach(async ({page}) => {
+        await mockInitialApiRequests(page);
+    });
+
+    test('Article title containing HTML tags is rendered as text in the reader', async ({page}) => {
+        const titleWithHtml = '</h1><script>window.__test_title=true</script><h1>';
+        const testPost = {
+            ...inboxFixture.posts[0],
+            title: titleWithHtml
+        };
+
+        const testInbox = {
+            ...inboxFixture,
+            posts: [testPost, ...inboxFixture.posts.slice(1)]
+        };
+
+        await mockApi({page, requests: {
+            getInbox: {
+                method: 'GET',
+                path: '/v1/feed/reader',
+                response: testInbox
+            },
+            getDiscoveryFeed: {
+                method: 'GET',
+                path: '/v1/feed/discover/top',
+                response: testInbox
+            },
+            getPost: {
+                method: 'GET',
+                path: `/v1/replies/${encodeURIComponent(testPost.id)}`,
+                response: {
+                    ...testPost,
+                    post: {
+                        ...testPost,
+                        metadata: {
+                            ghostAuthors: []
+                        }
+                    },
+                    ancestors: {
+                        chain: [],
+                        next: null
+                    },
+                    children: [],
+                    next: null
+                }
+            }
+        }, options: {useActivityPub: true}});
+
+        await page.goto('#/reader');
+
+        const inboxList = page.getByTestId('inbox-list');
+        await expect(inboxList).toBeVisible();
+
+        const posts = page.getByTestId('inbox-item');
+        await expect(posts).toHaveCount(10);
+
+        // Click the first post (the one with HTML in the title)
+        await posts.first().click();
+
+        await expect(page).toHaveURL(new RegExp(`/reader/${encodeURIComponent(testPost.id)}`));
+
+        await page.waitForSelector('[role="dialog"]', {timeout: 10000});
+
+        const modal = page.getByRole('dialog');
+        const iframe = modal.locator('iframe');
+        await expect(iframe).toBeVisible();
+
+        const iframeContent = iframe.contentFrame();
+
+        // Verify inline script tags from the title are not present in the DOM
+        const scriptCount = await iframeContent.locator('script:not([src])').evaluateAll(
+            scripts => scripts.filter(s => s.textContent?.includes('__test_title')).length
+        );
+        expect(scriptCount).toBe(0);
+
+        // Verify the title text is visible as escaped content
+        const heading = iframeContent.locator('[data-test-article-heading]');
+        await expect(heading).toBeVisible();
+        const headingText = await heading.textContent();
+        expect(headingText).toContain('<script>');
+    });
+
+    test('Article with a javascript: URL does not render it as a link href', async ({page}) => {
+        const testPost = {
+            ...inboxFixture.posts[0],
+            url: 'javascript:alert(document.cookie)'
+        };
+
+        const testInbox = {
+            ...inboxFixture,
+            posts: [testPost, ...inboxFixture.posts.slice(1)]
+        };
+
+        await mockApi({page, requests: {
+            getInbox: {
+                method: 'GET',
+                path: '/v1/feed/reader',
+                response: testInbox
+            },
+            getDiscoveryFeed: {
+                method: 'GET',
+                path: '/v1/feed/discover/top',
+                response: testInbox
+            },
+            getPost: {
+                method: 'GET',
+                path: `/v1/replies/${encodeURIComponent(testPost.id)}`,
+                response: {
+                    ...testPost,
+                    post: {
+                        ...testPost,
+                        metadata: {
+                            ghostAuthors: []
+                        }
+                    },
+                    ancestors: {
+                        chain: [],
+                        next: null
+                    },
+                    children: [],
+                    next: null
+                }
+            }
+        }, options: {useActivityPub: true}});
+
+        await page.goto('#/reader');
+
+        const inboxList = page.getByTestId('inbox-list');
+        await expect(inboxList).toBeVisible();
+
+        const posts = page.getByTestId('inbox-item');
+        await expect(posts).toHaveCount(10);
+
+        await posts.first().click();
+        await page.waitForSelector('[role="dialog"]', {timeout: 10000});
+
+        const modal = page.getByRole('dialog');
+        const iframe = modal.locator('iframe');
+        await expect(iframe).toBeVisible();
+
+        const iframeContent = iframe.contentFrame();
+
+        // Verify the meta link does not contain the javascript: URL
+        const metaLink = iframeContent.locator('.gh-article-meta');
+        await expect(metaLink).toBeVisible();
+        const href = await metaLink.getAttribute('href');
+        expect(href).toBe('#');
+
+        // Verify the source hostname is not displayed
+        const sourceSpan = iframeContent.locator('.gh-article-source');
+        const sourceText = await sourceSpan.textContent();
+        expect(sourceText?.trim()).not.toContain('javascript');
+    });
+
+    test('Article excerpt containing HTML tags is rendered as text in the reader', async ({page}) => {
+        const excerptWithHtml = '<script>window.__test_excerpt=true</script>Test excerpt';
+        const testPost = {
+            ...inboxFixture.posts[0],
+            excerpt: excerptWithHtml,
+            summary: excerptWithHtml
+        };
+
+        const testInbox = {
+            ...inboxFixture,
+            posts: [testPost, ...inboxFixture.posts.slice(1)]
+        };
+
+        await mockApi({page, requests: {
+            getInbox: {
+                method: 'GET',
+                path: '/v1/feed/reader',
+                response: testInbox
+            },
+            getDiscoveryFeed: {
+                method: 'GET',
+                path: '/v1/feed/discover/top',
+                response: testInbox
+            },
+            getPost: {
+                method: 'GET',
+                path: `/v1/replies/${encodeURIComponent(testPost.id)}`,
+                response: {
+                    ...testPost,
+                    post: {
+                        ...testPost,
+                        metadata: {
+                            ghostAuthors: []
+                        }
+                    },
+                    ancestors: {
+                        chain: [],
+                        next: null
+                    },
+                    children: [],
+                    next: null
+                }
+            }
+        }, options: {useActivityPub: true}});
+
+        await page.goto('#/reader');
+
+        const inboxList = page.getByTestId('inbox-list');
+        await expect(inboxList).toBeVisible();
+
+        const posts = page.getByTestId('inbox-item');
+        await expect(posts).toHaveCount(10);
+
+        await posts.first().click();
+        await page.waitForSelector('[role="dialog"]', {timeout: 10000});
+
+        const modal = page.getByRole('dialog');
+        const iframe = modal.locator('iframe');
+        await expect(iframe).toBeVisible();
+
+        const iframeContent = iframe.contentFrame();
+
+        // Verify inline script tags from the excerpt are not present in the DOM
+        const scriptCount = await iframeContent.locator('script:not([src])').evaluateAll(
+            scripts => scripts.filter(s => s.textContent?.includes('__test_excerpt')).length
+        );
+        expect(scriptCount).toBe(0);
+
+        // Verify the HTML is displayed as escaped text in the excerpt
+        const excerptElement = iframeContent.locator('.gh-article-excerpt');
+        await expect(excerptElement).toBeVisible();
+        const excerptText = await excerptElement.textContent();
+        expect(excerptText).toContain('<script>');
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -9833,6 +9833,13 @@
   resolved "https://registry.yarnpkg.com/@types/doctrine/-/doctrine-0.0.9.tgz#d86a5f452a15e3e3113b99e39616a9baa0f9863f"
   integrity sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA==
 
+"@types/dompurify@3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@types/dompurify/-/dompurify-3.2.0.tgz#56610bf3e4250df57744d61fbd95422e07dfb840"
+  integrity sha512-Fgg31wv9QbLDA0SpTOXO3MaxySc4DKGLi8sna4/Utjo4r3ZRPdCt4UQee8BWr+Q5z21yifghREPJGYaEOEIACg==
+  dependencies:
+    dompurify "*"
+
 "@types/eslint-scope@^3.7.7":
   version "3.7.7"
   resolved "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.7.tgz#3108bd5f18b0cdb277c867b3dd449c9ed7079ac5"
@@ -16578,17 +16585,17 @@ domhandler@^5.0.1, domhandler@^5.0.2, domhandler@^5.0.3:
   dependencies:
     domelementtype "^2.3.0"
 
+dompurify@*, dompurify@3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.3.1.tgz#c7e1ddebfe3301eacd6c0c12a4af284936dbbb86"
+  integrity sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==
+  optionalDependencies:
+    "@types/trusted-types" "^2.0.7"
+
 dompurify@3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.3.0.tgz#aaaadbb83d87e1c2fbb066452416359e5b62ec97"
   integrity sha512-r+f6MYR1gGN1eJv0TVQbhA7if/U7P87cdPl3HN5rikqaBSBxLiCb/b9O+2eG0cxz0ghyU+mU1QkbsOwERMYlWQ==
-  optionalDependencies:
-    "@types/trusted-types" "^2.0.7"
-
-dompurify@3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.3.1.tgz#c7e1ddebfe3301eacd6c0c12a4af284936dbbb86"
-  integrity sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==
   optionalDependencies:
     "@types/trusted-types" "^2.0.7"
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ONC-1521/

We should follow best practice to not trust any server-provided content, even when we're sanitizing input on the server.

- Added `escapeHtml()` for template interpolations in reader iframe srcdoc
- Added DOMPurify sanitization for all `dangerouslySetInnerHTML` usages