### PR TITLE
Routes configuration validation

### DIFF
--- a/ghost/core/core/server/services/custom-redirects/custom-redirects-api.js
+++ b/ghost/core/core/server/services/custom-redirects/custom-redirects-api.js
@@ -11,7 +11,38 @@ const messages = {
     yamlParse: 'Could not parse YAML: {context}.',
     yamlInvalid: 'YAML input is invalid. Check the contents of your YAML file.',
     redirectsHelp: 'https://ghost.org/docs/themes/routing/#redirects',
-    redirectsRegister: 'Could not register custom redirects.'
+    redirectsRegister: 'Could not register custom redirects.',
+    dangerousKeyError: 'The key "{key}" is not allowed in redirects configuration.'
+};
+
+const DANGEROUS_KEYS = ['__proto__', 'constructor', 'prototype'];
+
+/**
+ * Recursively checks an object for dangerous keys that could lead to prototype pollution
+ * @param {Object} obj - The object to check
+ * @param {String} path - The current path in the object (for error messages)
+ */
+const checkForDangerousKeys = (obj, objectPath = '') => {
+    if (!obj || typeof obj !== 'object') {
+        return;
+    }
+
+    if (Array.isArray(obj)) {
+        obj.forEach((item, index) => {
+            checkForDangerousKeys(item, `${objectPath}[${index}]`);
+        });
+        return;
+    }
+
+    for (const key of Object.keys(obj)) {
+        if (DANGEROUS_KEYS.includes(key)) {
+            throw new errors.BadRequestError({
+                message: tpl(messages.dangerousKeyError, {key: objectPath ? `${objectPath}.${key}` : key}),
+                help: tpl(messages.redirectsHelp)
+            });
+        }
+        checkForDangerousKeys(obj[key], objectPath ? `${objectPath}.${key}` : key);
+    }
 };
 
 /**
@@ -63,6 +94,8 @@ const parseRedirectsFile = (content, ext) => {
             });
         }
 
+        checkForDangerousKeys(redirects);
+
         return redirects;
     }
 
@@ -84,6 +117,8 @@ const parseRedirectsFile = (content, ext) => {
                 help: tpl(messages.redirectsHelp)
             });
         }
+
+        checkForDangerousKeys(configYaml);
 
         /**
          * 302: Temporary redirects

--- a/ghost/core/core/server/services/custom-redirects/validation.js
+++ b/ghost/core/core/server/services/custom-redirects/validation.js
@@ -5,7 +5,38 @@ const errors = require('@tryghost/errors');
 const messages = {
     redirectsWrongFormat: 'Incorrect redirects file format.',
     invalidRedirectsFromRegex: 'Incorrect RegEx in redirects file.',
-    redirectsHelp: 'https://ghost.org/docs/themes/routing/#redirects'
+    redirectsHelp: 'https://ghost.org/docs/themes/routing/#redirects',
+    dangerousKeyError: 'The key "{key}" is not allowed in redirects configuration.'
+};
+
+const DANGEROUS_KEYS = ['__proto__', 'constructor', 'prototype'];
+
+/**
+ * Recursively checks an object for dangerous keys that could lead to prototype pollution
+ * @param {Object} obj - The object to check
+ * @param {String} path - The current path in the object (for error messages)
+ */
+const checkForDangerousKeys = (obj, path = '') => {
+    if (!obj || typeof obj !== 'object') {
+        return;
+    }
+
+    if (Array.isArray(obj)) {
+        obj.forEach((item, index) => {
+            checkForDangerousKeys(item, `${path}[${index}]`);
+        });
+        return;
+    }
+
+    for (const key of Object.keys(obj)) {
+        if (DANGEROUS_KEYS.includes(key)) {
+            throw new errors.ValidationError({
+                message: tpl(messages.dangerousKeyError, {key: path ? `${path}.${key}` : key}),
+                help: tpl(messages.redirectsHelp)
+            });
+        }
+        checkForDangerousKeys(obj[key], path ? `${path}.${key}` : key);
+    }
 };
 
 /**
@@ -22,6 +53,9 @@ const messages = {
  * @param {RedirectConfig[]} redirects
  */
 const validate = (redirects) => {
+    // Check for dangerous keys that could lead to prototype pollution attacks
+    checkForDangerousKeys(redirects);
+
     if (!_.isArray(redirects)) {
         throw new errors.ValidationError({
             message: tpl(messages.redirectsWrongFormat),

--- a/ghost/core/core/server/services/route-settings/validate.js
+++ b/ghost/core/core/server/services/route-settings/validate.js
@@ -10,7 +10,57 @@ const messages = {
     invalidResourceHelp: 'Please use: tag, user, post or page.',
     badDatError: 'Please wrap the data definition into a custom name.',
     badDataHelp: 'Example:\n data:\n  my-tag:\n    resource: tags\n    ...\n',
-    authorDeprecatedError: 'Please choose a different name. We recommend not using author.'
+    authorDeprecatedError: 'Please choose a different name. We recommend not using author.',
+    dangerousKeyError: 'The key "{key}" is not allowed in routes configuration.',
+    unknownTopLevelKeyError: 'Unknown top-level key "{key}". Only "routes", "collections", and "taxonomies" are allowed.'
+};
+
+const ALLOWED_TOP_LEVEL_KEYS = ['routes', 'collections', 'taxonomies'];
+const DANGEROUS_KEYS = ['__proto__', 'constructor', 'prototype'];
+
+/**
+ * Recursively checks an object for dangerous keys that could lead to prototype pollution
+ * @param {Object} obj - The object to check
+ * @param {String} path - The current path in the object (for error messages)
+ */
+_private.checkForDangerousKeys = function checkForDangerousKeys(obj, path = '') {
+    if (!obj || typeof obj !== 'object') {
+        return;
+    }
+
+    if (Array.isArray(obj)) {
+        obj.forEach((item, index) => {
+            _private.checkForDangerousKeys(item, `${path}[${index}]`);
+        });
+        return;
+    }
+
+    for (const key of Object.keys(obj)) {
+        if (DANGEROUS_KEYS.includes(key)) {
+            throw new errors.ValidationError({
+                message: tpl(messages.dangerousKeyError, {key: path ? `${path}.${key}` : key})
+            });
+        }
+        _private.checkForDangerousKeys(obj[key], path ? `${path}.${key}` : key);
+    }
+};
+
+/**
+ * Validates that only allowed top-level keys are present
+ * @param {Object} obj - The routes configuration object
+ */
+_private.validateTopLevelKeys = function validateTopLevelKeys(obj) {
+    if (!obj || typeof obj !== 'object') {
+        return;
+    }
+
+    for (const key of Object.keys(obj)) {
+        if (!ALLOWED_TOP_LEVEL_KEYS.includes(key)) {
+            throw new errors.ValidationError({
+                message: tpl(messages.unknownTopLevelKeyError, {key})
+            });
+        }
+    }
 };
 
 _private.validateTemplate = function validateTemplate(object) {
@@ -415,6 +465,12 @@ module.exports = function validate(object) {
     if (!object) {
         object = {};
     }
+
+    // Check for dangerous keys that could lead to prototype pollution attacks
+    _private.checkForDangerousKeys(object);
+
+    // Only allow known top-level keys to prevent unexpected behavior
+    _private.validateTopLevelKeys(object);
 
     if (!object.routes) {
         object.routes = {};

--- a/ghost/core/test/unit/server/services/custom-redirects/api.test.js
+++ b/ghost/core/test/unit/server/services/custom-redirects/api.test.js
@@ -286,5 +286,100 @@ describe('UNIT: redirects CustomRedirectsAPI class', function () {
             sinon.assert.notCalled(fsUnlinkStub);
             sinon.assert.notCalled(fsMoveStub);
         });
+
+        it('rejects YAML with prototype pollution keys', async function () {
+            const incomingFilePath = path.join(__dirname, '/malicious/redirects.yaml');
+            const backupFilePath = path.join(basePath, 'backup.yaml');
+
+            const maliciousYaml = `
+                constructor:
+                    prototype:
+                        polluted: true
+            `;
+
+            fsPathExistsStub.withArgs(`${basePath}redirects.json`).resolves(false);
+            fsPathExistsStub.withArgs(`${basePath}redirects.yaml`).resolves(true);
+            fsReadFileStub.withArgs(incomingFilePath, 'utf-8').resolves(maliciousYaml);
+            fsPathExistsStub.withArgs(backupFilePath).resolves(false);
+
+            customRedirectsAPI = new CustomRedirectsAPI({
+                basePath,
+                redirectManager,
+                getBackupFilePath: () => backupFilePath,
+                validate: () => {}
+            });
+
+            await assert.rejects(async () => {
+                await customRedirectsAPI.setFromFilePath(incomingFilePath, '.yaml');
+            }, {
+                errorType: 'BadRequestError',
+                message: /not allowed/
+            });
+
+            sinon.assert.notCalled(fsMoveStub);
+        });
+
+        it('rejects JSON with prototype pollution keys', async function () {
+            const incomingFilePath = path.join(__dirname, '/malicious/redirects.json');
+            const backupFilePath = path.join(basePath, 'backup.json');
+
+            const maliciousJSON = JSON.stringify([{
+                from: '/test',
+                to: '/dest',
+                constructor: {prototype: {polluted: true}}
+            }]);
+
+            fsPathExistsStub.withArgs(`${basePath}redirects.json`).resolves(true);
+            fsPathExistsStub.withArgs(`${basePath}redirects.yaml`).resolves(false);
+            fsReadFileStub.withArgs(incomingFilePath, 'utf-8').resolves(maliciousJSON);
+            fsPathExistsStub.withArgs(backupFilePath).resolves(false);
+
+            customRedirectsAPI = new CustomRedirectsAPI({
+                basePath,
+                redirectManager,
+                getBackupFilePath: () => backupFilePath,
+                validate: () => {}
+            });
+
+            await assert.rejects(async () => {
+                await customRedirectsAPI.setFromFilePath(incomingFilePath, '.json');
+            }, {
+                errorType: 'BadRequestError',
+                message: /not allowed/
+            });
+
+            sinon.assert.notCalled(fsMoveStub);
+        });
+
+        it('rejects YAML with __proto__ key', async function () {
+            const incomingFilePath = path.join(__dirname, '/malicious/proto.yaml');
+            const backupFilePath = path.join(basePath, 'backup.yaml');
+
+            const maliciousYaml = `
+                __proto__:
+                    polluted: true
+            `;
+
+            fsPathExistsStub.withArgs(`${basePath}redirects.json`).resolves(false);
+            fsPathExistsStub.withArgs(`${basePath}redirects.yaml`).resolves(true);
+            fsReadFileStub.withArgs(incomingFilePath, 'utf-8').resolves(maliciousYaml);
+            fsPathExistsStub.withArgs(backupFilePath).resolves(false);
+
+            customRedirectsAPI = new CustomRedirectsAPI({
+                basePath,
+                redirectManager,
+                getBackupFilePath: () => backupFilePath,
+                validate: () => {}
+            });
+
+            await assert.rejects(async () => {
+                await customRedirectsAPI.setFromFilePath(incomingFilePath, '.yaml');
+            }, {
+                errorType: 'BadRequestError',
+                message: /not allowed/
+            });
+
+            sinon.assert.notCalled(fsMoveStub);
+        });
     });
 });

--- a/ghost/core/test/unit/server/services/custom-redirects/validation.test.js
+++ b/ghost/core/test/unit/server/services/custom-redirects/validation.test.js
@@ -46,4 +46,52 @@ describe('UNIT: custom redirects validation', function () {
             validate(/** @type {any} */ (config));
         }, {message: 'Incorrect redirects file format.'});
     });
+
+    describe('prototype pollution protection', function () {
+        it('throws error when __proto__ key is present in redirect object', function () {
+            // Use Object.defineProperty to create an object with __proto__ as a literal key
+            // (JavaScript object literals treat __proto__ specially)
+            const redirectObj = {
+                permanent: true,
+                from: '/test',
+                to: '/dest'
+            };
+            Object.defineProperty(redirectObj, '__proto__', {
+                value: {polluted: true},
+                enumerable: true,
+                configurable: true
+            });
+            const config = [redirectObj];
+
+            assert.throws(() => {
+                validate(config);
+            }, {message: /not allowed/});
+        });
+
+        it('throws error when constructor key is present in redirect object', function () {
+            const config = [{
+                permanent: true,
+                from: '/test',
+                to: '/dest',
+                constructor: {prototype: {polluted: true}}
+            }];
+
+            assert.throws(() => {
+                validate(config);
+            }, {message: /not allowed/});
+        });
+
+        it('throws error when prototype key is present', function () {
+            const config = [{
+                permanent: true,
+                from: '/test',
+                to: '/dest',
+                prototype: {polluted: true}
+            }];
+
+            assert.throws(() => {
+                validate(config);
+            }, {message: /not allowed/});
+        });
+    });
 });

--- a/ghost/core/test/unit/server/services/route-settings/validate.test.js
+++ b/ghost/core/test/unit/server/services/route-settings/validate.test.js
@@ -9,6 +9,136 @@ describe('UNIT: services/settings/validate', function () {
         assert.deepEqual(object, {collections: {}, routes: {}, taxonomies: {}});
     });
 
+    describe('prototype pollution protection', function () {
+        it('throws error when __proto__ key is present at top level', function () {
+            // Use Object.defineProperty to create an object with __proto__ as a literal key
+            // (JavaScript object literals treat __proto__ specially)
+            const maliciousObj = Object.defineProperty({}, '__proto__', {
+                value: {polluted: true},
+                enumerable: true,
+                configurable: true
+            });
+
+            try {
+                validate(maliciousObj);
+            } catch (err) {
+                assert.equal((err instanceof errors.ValidationError), true);
+                assert.equal(err.message.includes('__proto__'), true);
+                return;
+            }
+
+            throw new Error('should fail');
+        });
+
+        it('throws error when constructor key is present at top level', function () {
+            try {
+                validate({
+                    constructor: {
+                        prototype: {
+                            polluted: true
+                        }
+                    }
+                });
+            } catch (err) {
+                assert.equal((err instanceof errors.ValidationError), true);
+                assert.equal(err.message.includes('constructor'), true);
+                return;
+            }
+
+            throw new Error('should fail');
+        });
+
+        it('throws error when prototype key is present at top level', function () {
+            try {
+                validate({
+                    prototype: {
+                        polluted: true
+                    }
+                });
+            } catch (err) {
+                assert.equal((err instanceof errors.ValidationError), true);
+                assert.equal(err.message.includes('prototype'), true);
+                return;
+            }
+
+            throw new Error('should fail');
+        });
+
+        it('throws error when dangerous keys are nested in routes', function () {
+            // Create route object with __proto__ as a literal key using Object.defineProperty
+            const routeObj = {};
+            Object.defineProperty(routeObj, '__proto__', {
+                value: {polluted: true},
+                enumerable: true,
+                configurable: true
+            });
+
+            try {
+                validate({
+                    routes: {
+                        '/test/': routeObj
+                    }
+                });
+            } catch (err) {
+                assert.equal((err instanceof errors.ValidationError), true);
+                assert.equal(err.message.includes('__proto__'), true);
+                return;
+            }
+
+            throw new Error('should fail');
+        });
+
+        it('throws error when dangerous keys are deeply nested', function () {
+            try {
+                validate({
+                    routes: {
+                        '/test/': {
+                            data: {
+                                nested: {
+                                    constructor: {prototype: {polluted: true}}
+                                }
+                            }
+                        }
+                    }
+                });
+            } catch (err) {
+                assert.equal((err instanceof errors.ValidationError), true);
+                assert.equal(err.message.includes('constructor'), true);
+                return;
+            }
+
+            throw new Error('should fail');
+        });
+    });
+
+    describe('unknown top-level keys protection', function () {
+        it('throws error when unknown top-level key is present', function () {
+            try {
+                validate({
+                    unknownKey: {
+                        someConfig: true
+                    }
+                });
+            } catch (err) {
+                assert.equal((err instanceof errors.ValidationError), true);
+                assert.equal(err.message.includes('unknownKey'), true);
+                return;
+            }
+
+            throw new Error('should fail');
+        });
+
+        it('allows valid top-level keys', function () {
+            const result = validate({
+                routes: {},
+                collections: {},
+                taxonomies: {}
+            });
+
+            assert.deepEqual(result, {routes: {}, collections: {}, taxonomies: {}});
+        });
+    });
+
     it('throws error when using :\w+ notiation in collection', function () {
         try {
             validate({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Got some code for us? Awesome 🎊!

Please take a minute to explain the change you're making:
- **Why are you making it?**
  This change addresses Linear issue BER-3397, which reported that a specially crafted YAML file (e.g., for routes or redirects) could lead to prototype pollution, effectively breaking the site's routing and causing all pages to return a 404 error. While requiring admin rights, this prevents an administrator from accidentally or maliciously breaking the site.

- **What does it do?**
  This PR introduces robust validation for uploaded routes and redirects configuration files (YAML/JSON). It prevents files containing dangerous keys (`__proto__`, `constructor`, `prototype`) from being processed. For routes, it also enforces strict validation of top-level keys, only allowing `routes`, `collections`, and `taxonomies`. This validation occurs at the time of upload, rejecting malformed files before they can affect the site.

- **Why is this something Ghost users or developers need?**
  This prevents a critical site-breaking scenario, ensuring the stability and reliability of Ghost blogs. It provides a safeguard against accidental misconfigurations or malicious uploads, making the platform more resilient and user-friendly for administrators managing routing settings.

Please check your PR against these items:

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [x] I've written an automated test to prove my change works

We appreciate your contribution! 🙏

---
Linear Issue: [BER-3397](https://linear.app/ghost/issue/BER-3397/malicious-redirects-and-routes-configuration-can-break-site)

<p><a href="https://cursor.com/agents/bc-82ff2bb1-2c78-412e-952a-bf7c97f113bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-82ff2bb1-2c78-412e-952a-bf7c97f113bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->