### PR TITLE
Added label picker with inline editing to members list

### DIFF
--- a/apps/admin-x-framework/src/api/labels.ts
+++ b/apps/admin-x-framework/src/api/labels.ts
@@ -1,4 +1,4 @@
-import {Meta, createQuery} from '../utils/api/hooks';
+import {Meta, createMutation, createQuery} from '../utils/api/hooks';
 
 export type Label = {
     id: string;
@@ -18,4 +18,48 @@ const dataType = 'LabelsResponseType';
 export const useBrowseLabels = createQuery<LabelsResponseType>({
     dataType,
     path: '/labels/'
+});
+
+export const useCreateLabel = createMutation<LabelsResponseType, Pick<Label, 'name'>>({
+    method: 'POST',
+    path: () => '/labels/',
+    body: label => ({labels: [label]}),
+    updateQueries: {
+        dataType,
+        emberUpdateType: 'createOrUpdate',
+        update: (newData, currentData) => {
+            const current = currentData as LabelsResponseType;
+            return current && {...current, labels: current.labels.concat(newData.labels)};
+        }
+    }
+});
+
+export const useEditLabel = createMutation<LabelsResponseType, Pick<Label, 'id' | 'name'>>({
+    method: 'PUT',
+    path: label => `/labels/${label.id}/`,
+    body: label => ({labels: [label]}),
+    updateQueries: {
+        dataType,
+        emberUpdateType: 'createOrUpdate',
+        update: (newData, currentData) => {
+            const current = currentData as LabelsResponseType;
+            return current && {
+                ...current,
+                labels: current.labels.map(label => newData.labels.find(({id}) => id === label.id) || label)
+            };
+        }
+    }
+});
+
+export const useDeleteLabel = createMutation<void, string>({
+    method: 'DELETE',
+    path: id => `/labels/${id}/`,
+    updateQueries: {
+        dataType,
+        emberUpdateType: 'delete',
+        update: (_, currentData, id) => {
+            const current = currentData as LabelsResponseType;
+            return current && {...current, labels: current.labels.filter(label => label.id !== id)};
+        }
+    }
 });

--- a/apps/posts/src/components/label-picker/index.ts
+++ b/apps/posts/src/components/label-picker/index.ts
@@ -1,0 +1,3 @@
+export {default as LabelPicker} from './label-picker';
+export type {LabelPickerProps} from './label-picker';
+export {default as LabelFilterRenderer} from './label-filter-renderer';

--- a/apps/posts/src/components/label-picker/label-filter-renderer.tsx
+++ b/apps/posts/src/components/label-picker/label-filter-renderer.tsx
@@ -1,0 +1,25 @@
+import LabelPicker from './label-picker';
+import React from 'react';
+import {CustomRendererProps} from '@tryghost/shade';
+import {useLabelPicker} from '@src/hooks/use-label-picker';
+
+const LabelFilterRenderer: React.FC<CustomRendererProps<string>> = ({values, onChange}) => {
+    const picker = useLabelPicker({
+        selectedSlugs: values,
+        onSelectionChange: onChange
+    });
+
+    return (
+        <LabelPicker
+            isDuplicateName={picker.isDuplicateName}
+            labels={picker.labels}
+            selectedSlugs={picker.selectedSlugs}
+            inline
+            onDelete={picker.deleteLabel}
+            onEdit={picker.editLabel}
+            onToggle={picker.toggleLabel}
+        />
+    );
+};
+
+export default LabelFilterRenderer;

--- a/apps/posts/src/components/label-picker/label-picker.tsx
+++ b/apps/posts/src/components/label-picker/label-picker.tsx
@@ -1,6 +1,7 @@
 import React, {useEffect, useRef, useState} from 'react';
 import {
     Badge,
+    Button,
     Command,
     CommandEmpty,
     CommandGroup,
@@ -89,33 +90,11 @@ const EditRow: React.FC<EditRowProps> = ({label, onSave, onCancel, onDelete, isD
         await onDelete(label.id);
     };
 
-    if (showDeleteConfirm) {
-        return (
-            <div className="flex items-center gap-1.5 px-2 py-1.5 text-sm" data-edit-row>
-                <span className="flex-1 truncate text-destructive">Delete this label?</span>
-                <button
-                    className="rounded px-1.5 py-0.5 text-xs font-medium text-destructive hover:bg-destructive/10"
-                    type="button"
-                    onClick={handleDelete}
-                >
-                    Delete
-                </button>
-                <button
-                    className="rounded px-1.5 py-0.5 text-xs font-medium text-muted-foreground hover:bg-secondary"
-                    type="button"
-                    onClick={() => setShowDeleteConfirm(false)}
-                >
-                    Cancel
-                </button>
-            </div>
-        );
-    }
-
     return (
-        <div className="relative flex items-center gap-1.5 px-2 py-1" data-edit-row>
+        <div className="flex flex-col gap-2 py-1.5" data-edit-row>
             <input
                 ref={inputRef}
-                className="h-7 flex-1 rounded border border-border bg-background px-2 text-sm outline-none focus:ring-1 focus:ring-ring"
+                className="h-7 w-full rounded border border-border bg-background px-2 text-sm outline-none focus:ring-1 focus:ring-ring"
                 type="text"
                 value={name}
                 onChange={(e) => {
@@ -124,31 +103,56 @@ const EditRow: React.FC<EditRowProps> = ({label, onSave, onCancel, onDelete, isD
                 }}
                 onKeyDown={handleKeyDown}
             />
-            <button
-                className="flex size-7 items-center justify-center rounded text-muted-foreground hover:bg-secondary hover:text-foreground"
-                title="Save"
-                type="button"
-                onClick={handleSave}
-            >
-                <LucideIcon.Check className="size-3.5" />
-            </button>
-            <button
-                className="flex size-7 items-center justify-center rounded text-muted-foreground hover:bg-secondary hover:text-foreground"
-                title="Cancel"
-                type="button"
-                onClick={onCancel}
-            >
-                <LucideIcon.X className="size-3.5" />
-            </button>
-            <button
-                className="flex size-7 items-center justify-center rounded text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
-                title="Delete"
-                type="button"
-                onClick={() => setShowDeleteConfirm(true)}
-            >
-                <LucideIcon.Trash2 className="size-3.5" />
-            </button>
-            {error && <span className="absolute -bottom-5 left-2 text-xs text-destructive">{error}</span>}
+            {error && <span className="text-xs text-destructive">{error}</span>}
+            {showDeleteConfirm ? (
+                <div className="flex items-center gap-1 text-sm">
+                    <span className="flex-1 font-semibold">Delete label?</span>
+                    <Button
+                        className="h-6 px-2 text-xs"
+                        size="sm"
+                        variant="outline"
+                        onClick={() => setShowDeleteConfirm(false)}
+                    >
+                        Cancel
+                    </Button>
+                    <Button
+                        className="h-6 px-2 text-xs"
+                        size="sm"
+                        variant="destructive"
+                        onClick={handleDelete}
+                    >
+                        Delete
+                    </Button>
+                </div>
+            ) : (
+                <div className="flex items-center">
+                    <Button
+                        className="h-6 gap-1 px-1.5 text-xs text-red hover:bg-red/5 hover:text-red"
+                        size="sm"
+                        variant="ghost"
+                        onClick={() => setShowDeleteConfirm(true)}
+                    >
+                        Delete
+                    </Button>
+                    <div className="ml-auto flex gap-1">
+                        <Button
+                            className="h-6 px-2 text-xs"
+                            size="sm"
+                            variant="outline"
+                            onClick={onCancel}
+                        >
+                            Cancel
+                        </Button>
+                        <Button
+                            className="h-6 px-2 text-xs"
+                            size="sm"
+                            onClick={handleSave}
+                        >
+                            Save
+                        </Button>
+                    </div>
+                </div>
+            )}
         </div>
     );
 };
@@ -181,9 +185,9 @@ const LabelRow: React.FC<LabelRowProps> = ({label, isSelected, showEdit, onToggl
                 }}
             >
                 {isSelected && (
-                    <LucideIcon.Check className="absolute size-3 text-primary transition-opacity group-hover:opacity-0" />
+                    <LucideIcon.Check className="absolute size-3 text-primary transition-opacity duration-150 group-hover:opacity-0" />
                 )}
-                <LucideIcon.Pencil className="absolute size-3 opacity-0 transition-opacity group-hover:opacity-100" />
+                <LucideIcon.Pencil className="absolute size-3 translate-x-2 opacity-0 transition-all duration-150 ease-out group-hover:translate-x-0 group-hover:opacity-100" />
             </button>
         ) : (
             isSelected && <LucideIcon.Check className="size-4 shrink-0 text-primary" />
@@ -283,7 +287,7 @@ const LabelListItems: React.FC<LabelListItemsProps> = ({
                             disabled={isCreating}
                             onSelect={handleCreate}
                         >
-                            <LucideIcon.Plus className="mr-1 size-4" />
+                            <LucideIcon.Plus className="size-4" />
                             {isCreating ? 'Creating...' : `Create "${search.trim()}"`}
                         </CommandItem>
                     </CommandGroup>

--- a/apps/posts/src/components/label-picker/label-picker.tsx
+++ b/apps/posts/src/components/label-picker/label-picker.tsx
@@ -9,7 +9,6 @@ import {
     CommandList,
     LucideIcon,
     Popover,
-    PopoverAnchor,
     PopoverContent,
     PopoverTrigger
 } from '@tryghost/shade';
@@ -77,9 +76,8 @@ const EditRow: React.FC<EditRowProps> = ({label, onSave, onCancel, onDelete, isD
         setIsSaving(true);
         try {
             await onSave(label.id, name.trim());
+        } finally {
             onCancel();
-        } catch {
-            setIsSaving(false);
         }
     };
 
@@ -254,10 +252,7 @@ const LabelListItems: React.FC<LabelListItemsProps> = ({
 
     const handleCreate = async () => {
         if (onCreate) {
-            const newLabel = await onCreate(search.trim());
-            if (newLabel) {
-                onToggle(newLabel.slug);
-            }
+            await onCreate(search.trim());
             onSearchClear?.();
         }
     };
@@ -389,7 +384,6 @@ const LabelPicker: React.FC<LabelPickerProps> = ({
     // --- Default mode (for modals): combobox-like input with chips + dropdown ---
     return (
         <ComboboxPicker
-            align={align}
             canCreateFromSearch={canCreateFromSearch}
             isCreating={isCreating}
             isDuplicateName={isDuplicateName}
@@ -532,7 +526,7 @@ const InlineList: React.FC<InlineListProps> = ({selectedLabels, ...rest}) => {
                     onChange={e => setSearch(e.target.value)}
                 />
             </div>
-            <CommandList>
+            <CommandList className="max-h-64 overflow-y-auto">
                 <LabelListItems
                     {...rest}
                     search={search}
@@ -551,7 +545,6 @@ interface ComboboxPickerProps {
     selectedSlugs: string[];
     onToggle: (slug: string) => void;
     isLoading?: boolean;
-    align?: 'start' | 'end';
     canCreateFromSearch?: (inputValue: string) => boolean;
     onCreate?: (name: string) => Promise<Label | undefined>;
     isCreating?: boolean;
@@ -566,7 +559,6 @@ const ComboboxPicker: React.FC<ComboboxPickerProps> = ({
     selectedSlugs,
     onToggle,
     isLoading,
-    align = 'start',
     canCreateFromSearch,
     onCreate,
     isCreating,
@@ -577,6 +569,13 @@ const ComboboxPicker: React.FC<ComboboxPickerProps> = ({
     const [open, setOpen] = useState(false);
     const [search, setSearch] = useState('');
     const inputRef = useRef<HTMLInputElement>(null);
+    const containerRef = useRef<HTMLDivElement>(null);
+
+    const handleToggle = useCallback((slug: string) => {
+        onToggle(slug);
+        setOpen(false);
+        setSearch('');
+    }, [onToggle]);
 
     const handleInputKeyDown = (e: React.KeyboardEvent) => {
         if (e.key === 'Backspace' && !search && selectedSlugs.length > 0) {
@@ -588,66 +587,74 @@ const ComboboxPicker: React.FC<ComboboxPickerProps> = ({
         }
     };
 
+    // Close dropdown when clicking outside
+    useEffect(() => {
+        if (!open) {
+            return;
+        }
+        const handleClickOutside = (e: MouseEvent) => {
+            if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+                setOpen(false);
+            }
+        };
+        document.addEventListener('mousedown', handleClickOutside);
+        return () => document.removeEventListener('mousedown', handleClickOutside);
+    }, [open]);
+
     return (
-        <Popover open={open} onOpenChange={setOpen}>
-            <PopoverAnchor asChild>
-                <div
-                    className="flex min-h-9 w-full cursor-text flex-wrap items-center gap-1.5 rounded-md border border-transparent bg-gray-150 px-3 py-1 text-sm transition-colors focus-within:border-green focus-within:bg-transparent focus-within:shadow-[0_0_0_2px_rgba(48,207,67,.25)] dark:bg-gray-900"
-                    role="combobox"
-                    onClick={() => {
-                        inputRef.current?.focus();
-                        setOpen(true);
-                    }}
-                >
-                    <SelectedPills labels={selectedLabels} onToggle={onToggle} />
-                    <input
-                        ref={inputRef}
-                        className="min-w-[80px] flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
-                        placeholder={selectedLabels.length === 0 ? 'Search labels...' : ''}
-                        value={search}
-                        onChange={(e) => {
-                            setSearch(e.target.value);
-                            if (!open) {
-                                setOpen(true);
-                            }
-                        }}
-                        onFocus={() => setOpen(true)}
-                        onKeyDown={handleInputKeyDown}
-                    />
-                </div>
-            </PopoverAnchor>
-            <PopoverContent
-                align={align}
-                className="w-[var(--radix-popover-trigger-width)] p-0"
-                onOpenAutoFocus={(e) => {
-                    e.preventDefault();
+        <div ref={containerRef} className="relative">
+            <div
+                className="flex min-h-9 w-full cursor-text flex-wrap items-center gap-1.5 rounded-md border border-transparent bg-gray-150 px-3 py-1 text-sm transition-colors focus-within:border-green focus-within:bg-transparent focus-within:shadow-[0_0_0_2px_rgba(48,207,67,.25)] dark:bg-gray-900"
+                role="combobox"
+                onClick={() => {
+                    inputRef.current?.focus();
+                    setOpen(true);
                 }}
             >
-                {isLoading ? (
-                    <div className="flex items-center justify-center py-6 text-sm text-muted-foreground">
-                        Loading labels...
-                    </div>
-                ) : (
-                    <Command shouldFilter={false}>
-                        <CommandList>
-                            <LabelListItems
-                                canCreateFromSearch={canCreateFromSearch}
-                                isCreating={isCreating}
-                                isDuplicateName={isDuplicateName}
-                                labels={labels}
-                                search={search}
-                                selectedSlugs={selectedSlugs}
-                                onCreate={onCreate}
-                                onDelete={onDelete}
-                                onEdit={onEdit}
-                                onSearchClear={() => setSearch('')}
-                                onToggle={onToggle}
-                            />
-                        </CommandList>
-                    </Command>
-                )}
-            </PopoverContent>
-        </Popover>
+                <SelectedPills labels={selectedLabels} onToggle={onToggle} />
+                <input
+                    ref={inputRef}
+                    className="min-w-[80px] flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+                    placeholder={selectedLabels.length === 0 ? 'Search labels...' : ''}
+                    value={search}
+                    onChange={(e) => {
+                        setSearch(e.target.value);
+                        if (!open) {
+                            setOpen(true);
+                        }
+                    }}
+                    onFocus={() => setOpen(true)}
+                    onKeyDown={handleInputKeyDown}
+                />
+            </div>
+            {open && (
+                <div className="absolute left-0 top-full z-50 mt-1 w-full rounded-md border bg-white shadow-md dark:bg-gray-950">
+                    {isLoading ? (
+                        <div className="flex items-center justify-center py-6 text-sm text-muted-foreground">
+                            Loading labels...
+                        </div>
+                    ) : (
+                        <Command shouldFilter={false}>
+                            <CommandList className="max-h-64 overflow-y-auto">
+                                <LabelListItems
+                                    canCreateFromSearch={canCreateFromSearch}
+                                    isCreating={isCreating}
+                                    isDuplicateName={isDuplicateName}
+                                    labels={labels}
+                                    search={search}
+                                    selectedSlugs={selectedSlugs}
+                                    onCreate={onCreate}
+                                    onDelete={onDelete}
+                                    onEdit={onEdit}
+                                    onSearchClear={() => setSearch('')}
+                                    onToggle={handleToggle}
+                                />
+                            </CommandList>
+                        </Command>
+                    )}
+                </div>
+            )}
+        </div>
     );
 };
 

--- a/apps/posts/src/components/label-picker/label-picker.tsx
+++ b/apps/posts/src/components/label-picker/label-picker.tsx
@@ -1,0 +1,556 @@
+import React, {useEffect, useRef, useState} from 'react';
+import {
+    Badge,
+    Command,
+    CommandEmpty,
+    CommandGroup,
+    CommandItem,
+    CommandList,
+    CommandSeparator,
+    LucideIcon,
+    Popover,
+    PopoverAnchor,
+    PopoverContent,
+    PopoverTrigger
+} from '@tryghost/shade';
+import {Label} from '@tryghost/admin-x-framework/api/labels';
+
+export interface LabelPickerProps {
+    labels: Label[];
+    selectedSlugs: string[];
+    isLoading?: boolean;
+    onToggle: (slug: string) => void;
+    // Creation
+    canCreateFromSearch?: (inputValue: string) => boolean;
+    onCreate?: (name: string) => Promise<Label | undefined>;
+    isCreating?: boolean;
+    // Editing
+    onEdit?: (id: string, name: string) => Promise<void>;
+    onDelete?: (id: string) => Promise<void>;
+    isDuplicateName?: (name: string, excludeId?: string) => boolean;
+    // Layout
+    inline?: boolean;
+    align?: 'start' | 'end';
+}
+
+// --- EditRow ---
+
+interface EditRowProps {
+    label: Label;
+    onSave: (id: string, name: string) => Promise<void>;
+    onCancel: () => void;
+    onDelete: (id: string) => Promise<void>;
+    isDuplicateName?: (name: string, excludeId?: string) => boolean;
+}
+
+const EditRow: React.FC<EditRowProps> = ({label, onSave, onCancel, onDelete, isDuplicateName}) => {
+    const [name, setName] = useState(label.name);
+    const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+    const [error, setError] = useState('');
+    const inputRef = useRef<HTMLInputElement>(null);
+
+    useEffect(() => {
+        inputRef.current?.focus();
+        inputRef.current?.select();
+    }, []);
+
+    const validate = (value: string): string => {
+        const trimmed = value.trim();
+        if (!trimmed) {
+            return 'Name is required';
+        }
+        if (isDuplicateName?.(trimmed, label.id)) {
+            return 'A label with this name already exists';
+        }
+        return '';
+    };
+
+    const handleSave = async () => {
+        const validationError = validate(name);
+        if (validationError) {
+            setError(validationError);
+            return;
+        }
+        await onSave(label.id, name.trim());
+        onCancel();
+    };
+
+    const handleKeyDown = (e: React.KeyboardEvent) => {
+        if (e.key === 'Enter') {
+            e.preventDefault();
+            handleSave();
+        } else if (e.key === 'Escape') {
+            e.preventDefault();
+            onCancel();
+        }
+    };
+
+    const handleDelete = async () => {
+        await onDelete(label.id);
+    };
+
+    if (showDeleteConfirm) {
+        return (
+            <div className="flex items-center gap-1.5 px-2 py-1.5 text-sm" data-edit-row>
+                <span className="flex-1 truncate text-destructive">Delete this label?</span>
+                <button
+                    className="rounded px-1.5 py-0.5 text-xs font-medium text-destructive hover:bg-destructive/10"
+                    type="button"
+                    onClick={handleDelete}
+                >
+                    Delete
+                </button>
+                <button
+                    className="rounded px-1.5 py-0.5 text-xs font-medium text-muted-foreground hover:bg-secondary"
+                    type="button"
+                    onClick={() => setShowDeleteConfirm(false)}
+                >
+                    Cancel
+                </button>
+            </div>
+        );
+    }
+
+    return (
+        <div className="relative flex items-center gap-1.5 px-2 py-1" data-edit-row>
+            <input
+                ref={inputRef}
+                className="h-7 flex-1 rounded border border-border bg-background px-2 text-sm outline-none focus:ring-1 focus:ring-ring"
+                type="text"
+                value={name}
+                onChange={(e) => {
+                    setName(e.target.value);
+                    setError('');
+                }}
+                onKeyDown={handleKeyDown}
+            />
+            <button
+                className="flex size-7 items-center justify-center rounded text-muted-foreground hover:bg-secondary hover:text-foreground"
+                title="Save"
+                type="button"
+                onClick={handleSave}
+            >
+                <LucideIcon.Check className="size-3.5" />
+            </button>
+            <button
+                className="flex size-7 items-center justify-center rounded text-muted-foreground hover:bg-secondary hover:text-foreground"
+                title="Cancel"
+                type="button"
+                onClick={onCancel}
+            >
+                <LucideIcon.X className="size-3.5" />
+            </button>
+            <button
+                className="flex size-7 items-center justify-center rounded text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
+                title="Delete"
+                type="button"
+                onClick={() => setShowDeleteConfirm(true)}
+            >
+                <LucideIcon.Trash2 className="size-3.5" />
+            </button>
+            {error && <span className="absolute -bottom-5 left-2 text-xs text-destructive">{error}</span>}
+        </div>
+    );
+};
+
+// --- LabelRow: single label item with overlapping check/edit icon ---
+
+interface LabelRowProps {
+    label: Label;
+    isSelected: boolean;
+    showEdit: boolean;
+    onToggle: (slug: string) => void;
+    onEditClick: () => void;
+}
+
+const LabelRow: React.FC<LabelRowProps> = ({label, isSelected, showEdit, onToggle, onEditClick}) => (
+    <CommandItem
+        className="group"
+        value={label.slug}
+        onSelect={() => onToggle(label.slug)}
+    >
+        <span className="flex-1 truncate">{label.name}</span>
+        {showEdit ? (
+            <button
+                className="relative ml-1 flex size-5 shrink-0 items-center justify-center rounded text-muted-foreground hover:text-foreground"
+                type="button"
+                onClick={(e) => {
+                    e.stopPropagation();
+                    e.preventDefault();
+                    onEditClick();
+                }}
+            >
+                {isSelected && (
+                    <LucideIcon.Check className="absolute size-3 text-primary transition-opacity group-hover:opacity-0" />
+                )}
+                <LucideIcon.Pencil className="absolute size-3 opacity-0 transition-opacity group-hover:opacity-100" />
+            </button>
+        ) : (
+            isSelected && <LucideIcon.Check className="size-4 shrink-0 text-primary" />
+        )}
+    </CommandItem>
+);
+
+// --- Shared label list items (used by both modes) ---
+
+interface LabelListItemsProps {
+    labels: Label[];
+    selectedSlugs: string[];
+    search: string;
+    onToggle: (slug: string) => void;
+    onEdit?: (id: string, name: string) => Promise<void>;
+    onDelete?: (id: string) => Promise<void>;
+    isDuplicateName?: (name: string, excludeId?: string) => boolean;
+    canCreateFromSearch?: (inputValue: string) => boolean;
+    onCreate?: (name: string) => Promise<Label | undefined>;
+    isCreating?: boolean;
+    onSearchClear?: () => void;
+}
+
+const LabelListItems: React.FC<LabelListItemsProps> = ({
+    labels,
+    selectedSlugs,
+    search,
+    onToggle,
+    onEdit,
+    onDelete,
+    isDuplicateName,
+    canCreateFromSearch,
+    onCreate,
+    isCreating,
+    onSearchClear
+}) => {
+    const [editingLabelId, setEditingLabelId] = useState<string | null>(null);
+
+    const filteredLabels = labels.filter(l => l.name.toLowerCase().includes(search.toLowerCase()));
+    const showCreate = !!onCreate && search.trim() && canCreateFromSearch?.(search);
+    const showEdit = !!onEdit;
+
+    const handleCreate = async () => {
+        if (onCreate) {
+            const newLabel = await onCreate(search.trim());
+            if (newLabel) {
+                onToggle(newLabel.slug);
+            }
+            onSearchClear?.();
+        }
+    };
+
+    const handleEdit = async (id: string, name: string) => {
+        if (onEdit) {
+            await onEdit(id, name);
+        }
+    };
+
+    const handleDelete = async (id: string) => {
+        if (onDelete) {
+            await onDelete(id);
+            setEditingLabelId(null);
+        }
+    };
+
+    return (
+        <>
+            <CommandEmpty>No labels found</CommandEmpty>
+            <CommandGroup>
+                {filteredLabels.map(label => (
+                    editingLabelId === label.id ? (
+                        <EditRow
+                            key={label.id}
+                            isDuplicateName={isDuplicateName}
+                            label={label}
+                            onCancel={() => setEditingLabelId(null)}
+                            onDelete={handleDelete}
+                            onSave={handleEdit}
+                        />
+                    ) : (
+                        <LabelRow
+                            key={label.id}
+                            isSelected={selectedSlugs.includes(label.slug)}
+                            label={label}
+                            showEdit={showEdit}
+                            onEditClick={() => setEditingLabelId(label.id)}
+                            onToggle={onToggle}
+                        />
+                    )
+                ))}
+            </CommandGroup>
+            {showCreate && (
+                <>
+                    <CommandSeparator />
+                    <CommandGroup>
+                        <CommandItem
+                            disabled={isCreating}
+                            onSelect={handleCreate}
+                        >
+                            <LucideIcon.Plus className="mr-1 size-4" />
+                            {isCreating ? 'Creating...' : `Create "${search.trim()}"`}
+                        </CommandItem>
+                    </CommandGroup>
+                </>
+            )}
+        </>
+    );
+};
+
+// --- Selected labels as removable pills ---
+
+interface SelectedPillsProps {
+    labels: Label[];
+    onToggle: (slug: string) => void;
+}
+
+const SelectedPills: React.FC<SelectedPillsProps> = ({labels, onToggle}) => (
+    <>
+        {labels.map(label => (
+            <Badge
+                key={label.id}
+                className="cursor-pointer gap-1 pr-1"
+                variant="outline"
+                onClick={(e) => {
+                    e.stopPropagation();
+                    onToggle(label.slug);
+                }}
+            >
+                {label.name}
+                <LucideIcon.X className="size-3" />
+            </Badge>
+        ))}
+    </>
+);
+
+// --- LabelPicker (main export) ---
+
+const LabelPicker: React.FC<LabelPickerProps> = ({
+    labels,
+    selectedSlugs,
+    isLoading,
+    onToggle,
+    canCreateFromSearch,
+    onCreate,
+    isCreating,
+    onEdit,
+    onDelete,
+    isDuplicateName,
+    inline = false,
+    align = 'start'
+}) => {
+    const selectedLabels = selectedSlugs
+        .map(slug => labels.find(l => l.slug === slug))
+        .filter((l): l is Label => !!l);
+
+    // --- Inline mode (for filter cells): minimal trigger + popover ---
+    if (inline) {
+        const triggerText = selectedLabels.length === 0
+            ? 'Select...'
+            : selectedLabels.length === 1
+                ? selectedLabels[0].name
+                : `${selectedLabels.length} labels`;
+
+        return (
+            <Popover>
+                <PopoverTrigger asChild>
+                    <button
+                        className="flex size-full items-center truncate text-left text-sm"
+                        type="button"
+                    >
+                        {triggerText}
+                    </button>
+                </PopoverTrigger>
+                <PopoverContent align={align} className="w-64 p-0">
+                    {isLoading ? (
+                        <div className="flex items-center justify-center py-6 text-sm text-muted-foreground">
+                            Loading labels...
+                        </div>
+                    ) : (
+                        <InlineList
+                            canCreateFromSearch={canCreateFromSearch}
+                            isCreating={isCreating}
+                            isDuplicateName={isDuplicateName}
+                            labels={labels}
+                            selectedLabels={selectedLabels}
+                            selectedSlugs={selectedSlugs}
+                            onCreate={onCreate}
+                            onDelete={onDelete}
+                            onEdit={onEdit}
+                            onToggle={onToggle}
+                        />
+                    )}
+                </PopoverContent>
+            </Popover>
+        );
+    }
+
+    // --- Default mode (for modals): combobox-like input with chips + dropdown ---
+    return (
+        <ComboboxPicker
+            align={align}
+            canCreateFromSearch={canCreateFromSearch}
+            isCreating={isCreating}
+            isDuplicateName={isDuplicateName}
+            isLoading={isLoading}
+            labels={labels}
+            selectedLabels={selectedLabels}
+            selectedSlugs={selectedSlugs}
+            onCreate={onCreate}
+            onDelete={onDelete}
+            onEdit={onEdit}
+            onToggle={onToggle}
+        />
+    );
+};
+
+// --- InlineList: Command with its own search (for filter popover) ---
+
+interface InlineListProps {
+    labels: Label[];
+    selectedLabels: Label[];
+    selectedSlugs: string[];
+    onToggle: (slug: string) => void;
+    canCreateFromSearch?: (inputValue: string) => boolean;
+    onCreate?: (name: string) => Promise<Label | undefined>;
+    isCreating?: boolean;
+    onEdit?: (id: string, name: string) => Promise<void>;
+    onDelete?: (id: string) => Promise<void>;
+    isDuplicateName?: (name: string, excludeId?: string) => boolean;
+}
+
+const InlineList: React.FC<InlineListProps> = ({selectedLabels, ...rest}) => {
+    const [search, setSearch] = useState('');
+
+    return (
+        <Command shouldFilter={false}>
+            {selectedLabels.length > 0 && (
+                <div className="flex flex-wrap gap-1.5 border-b px-3 py-2">
+                    <SelectedPills labels={selectedLabels} onToggle={rest.onToggle} />
+                </div>
+            )}
+            <div className="flex items-center border-b px-3">
+                <LucideIcon.Search className="mr-2 size-4 shrink-0 opacity-50" />
+                <input
+                    className="flex h-9 w-full bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground"
+                    placeholder="Search labels..."
+                    value={search}
+                    onChange={e => setSearch(e.target.value)}
+                />
+            </div>
+            <CommandList>
+                <LabelListItems
+                    {...rest}
+                    search={search}
+                    onSearchClear={() => setSearch('')}
+                />
+            </CommandList>
+        </Command>
+    );
+};
+
+// --- ComboboxPicker: chips-in-input + popover dropdown (for modals) ---
+
+interface ComboboxPickerProps {
+    labels: Label[];
+    selectedLabels: Label[];
+    selectedSlugs: string[];
+    onToggle: (slug: string) => void;
+    isLoading?: boolean;
+    align?: 'start' | 'end';
+    canCreateFromSearch?: (inputValue: string) => boolean;
+    onCreate?: (name: string) => Promise<Label | undefined>;
+    isCreating?: boolean;
+    onEdit?: (id: string, name: string) => Promise<void>;
+    onDelete?: (id: string) => Promise<void>;
+    isDuplicateName?: (name: string, excludeId?: string) => boolean;
+}
+
+const ComboboxPicker: React.FC<ComboboxPickerProps> = ({
+    labels,
+    selectedLabels,
+    selectedSlugs,
+    onToggle,
+    isLoading,
+    align = 'start',
+    canCreateFromSearch,
+    onCreate,
+    isCreating,
+    onEdit,
+    onDelete,
+    isDuplicateName
+}) => {
+    const [open, setOpen] = useState(false);
+    const [search, setSearch] = useState('');
+    const inputRef = useRef<HTMLInputElement>(null);
+
+    const handleInputKeyDown = (e: React.KeyboardEvent) => {
+        if (e.key === 'Backspace' && !search && selectedSlugs.length > 0) {
+            onToggle(selectedSlugs[selectedSlugs.length - 1]);
+        }
+        if (e.key === 'Escape') {
+            setOpen(false);
+            inputRef.current?.blur();
+        }
+    };
+
+    return (
+        <Popover open={open} onOpenChange={setOpen}>
+            <PopoverAnchor asChild>
+                <div
+                    className="flex min-h-10 w-full cursor-text flex-wrap items-center gap-1.5 rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2"
+                    role="combobox"
+                    onClick={() => {
+                        inputRef.current?.focus();
+                        setOpen(true);
+                    }}
+                >
+                    <SelectedPills labels={selectedLabels} onToggle={onToggle} />
+                    <input
+                        ref={inputRef}
+                        className="min-w-[80px] flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+                        placeholder={selectedLabels.length === 0 ? 'Search labels...' : ''}
+                        value={search}
+                        onChange={(e) => {
+                            setSearch(e.target.value);
+                            if (!open) {
+                                setOpen(true);
+                            }
+                        }}
+                        onFocus={() => setOpen(true)}
+                        onKeyDown={handleInputKeyDown}
+                    />
+                </div>
+            </PopoverAnchor>
+            <PopoverContent
+                align={align}
+                className="w-[var(--radix-popover-trigger-width)] p-0"
+                onOpenAutoFocus={(e) => {
+                    e.preventDefault();
+                }}
+            >
+                {isLoading ? (
+                    <div className="flex items-center justify-center py-6 text-sm text-muted-foreground">
+                        Loading labels...
+                    </div>
+                ) : (
+                    <Command shouldFilter={false}>
+                        <CommandList>
+                            <LabelListItems
+                                canCreateFromSearch={canCreateFromSearch}
+                                isCreating={isCreating}
+                                isDuplicateName={isDuplicateName}
+                                labels={labels}
+                                search={search}
+                                selectedSlugs={selectedSlugs}
+                                onCreate={onCreate}
+                                onDelete={onDelete}
+                                onEdit={onEdit}
+                                onSearchClear={() => setSearch('')}
+                                onToggle={onToggle}
+                            />
+                        </CommandList>
+                    </Command>
+                )}
+            </PopoverContent>
+        </Popover>
+    );
+};
+
+export default LabelPicker;

--- a/apps/posts/src/components/label-picker/label-picker.tsx
+++ b/apps/posts/src/components/label-picker/label-picker.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useRef, useState} from 'react';
+import React, {useCallback, useEffect, useRef, useState} from 'react';
 import {
     Badge,
     Button,
@@ -7,7 +7,6 @@ import {
     CommandGroup,
     CommandItem,
     CommandList,
-    CommandSeparator,
     LucideIcon,
     Popover,
     PopoverAnchor,
@@ -48,7 +47,10 @@ const EditRow: React.FC<EditRowProps> = ({label, onSave, onCancel, onDelete, isD
     const [name, setName] = useState(label.name);
     const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
     const [error, setError] = useState('');
+    const [isSaving, setIsSaving] = useState(false);
+    const [isDeleting, setIsDeleting] = useState(false);
     const inputRef = useRef<HTMLInputElement>(null);
+    const isBusy = isSaving || isDeleting;
 
     useEffect(() => {
         inputRef.current?.focus();
@@ -72,8 +74,13 @@ const EditRow: React.FC<EditRowProps> = ({label, onSave, onCancel, onDelete, isD
             setError(validationError);
             return;
         }
-        await onSave(label.id, name.trim());
-        onCancel();
+        setIsSaving(true);
+        try {
+            await onSave(label.id, name.trim());
+            onCancel();
+        } catch {
+            setIsSaving(false);
+        }
     };
 
     const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -82,19 +89,28 @@ const EditRow: React.FC<EditRowProps> = ({label, onSave, onCancel, onDelete, isD
             handleSave();
         } else if (e.key === 'Escape') {
             e.preventDefault();
-            onCancel();
+            if (!isBusy) {
+                onCancel();
+            }
         }
     };
 
     const handleDelete = async () => {
-        await onDelete(label.id);
+        setIsDeleting(true);
+        try {
+            await onDelete(label.id);
+        } catch {
+            setIsDeleting(false);
+            setShowDeleteConfirm(false);
+        }
     };
 
     return (
         <div className="flex flex-col gap-2 py-1.5" data-edit-row>
             <input
                 ref={inputRef}
-                className="h-7 w-full rounded border border-border bg-background px-2 text-sm outline-none focus:ring-1 focus:ring-ring"
+                className="h-7 w-full rounded border border-border bg-background px-2 text-sm outline-none focus:ring-1 focus:ring-ring disabled:opacity-50"
+                disabled={isBusy}
                 type="text"
                 value={name}
                 onChange={(e) => {
@@ -109,6 +125,7 @@ const EditRow: React.FC<EditRowProps> = ({label, onSave, onCancel, onDelete, isD
                     <span className="flex-1 font-semibold">Delete label?</span>
                     <Button
                         className="h-6 px-2 text-xs"
+                        disabled={isBusy}
                         size="sm"
                         variant="outline"
                         onClick={() => setShowDeleteConfirm(false)}
@@ -117,17 +134,19 @@ const EditRow: React.FC<EditRowProps> = ({label, onSave, onCancel, onDelete, isD
                     </Button>
                     <Button
                         className="h-6 px-2 text-xs"
+                        disabled={isBusy}
                         size="sm"
                         variant="destructive"
                         onClick={handleDelete}
                     >
-                        Delete
+                        {isDeleting ? 'Deleting...' : 'Delete'}
                     </Button>
                 </div>
             ) : (
                 <div className="flex items-center">
                     <Button
                         className="h-6 gap-1 px-1.5 text-xs text-red hover:bg-red/5 hover:text-red"
+                        disabled={isBusy}
                         size="sm"
                         variant="ghost"
                         onClick={() => setShowDeleteConfirm(true)}
@@ -137,6 +156,7 @@ const EditRow: React.FC<EditRowProps> = ({label, onSave, onCancel, onDelete, isD
                     <div className="ml-auto flex gap-1">
                         <Button
                             className="h-6 px-2 text-xs"
+                            disabled={isBusy}
                             size="sm"
                             variant="outline"
                             onClick={onCancel}
@@ -145,10 +165,11 @@ const EditRow: React.FC<EditRowProps> = ({label, onSave, onCancel, onDelete, isD
                         </Button>
                         <Button
                             className="h-6 px-2 text-xs"
+                            disabled={isBusy}
                             size="sm"
                             onClick={handleSave}
                         >
-                            Save
+                            {isSaving ? 'Saving...' : 'Save'}
                         </Button>
                     </div>
                 </div>
@@ -176,6 +197,7 @@ const LabelRow: React.FC<LabelRowProps> = ({label, isSelected, showEdit, onToggl
         <span className="flex-1 truncate">{label.name}</span>
         {showEdit ? (
             <button
+                aria-label={`Edit label ${label.name}`}
                 className="relative ml-1 flex size-5 shrink-0 items-center justify-center rounded text-muted-foreground hover:text-foreground"
                 type="button"
                 onClick={(e) => {
@@ -255,43 +277,44 @@ const LabelListItems: React.FC<LabelListItemsProps> = ({
 
     return (
         <>
-            <CommandEmpty>No labels found</CommandEmpty>
-            <CommandGroup>
-                {filteredLabels.map(label => (
-                    editingLabelId === label.id ? (
-                        <EditRow
-                            key={label.id}
-                            isDuplicateName={isDuplicateName}
-                            label={label}
-                            onCancel={() => setEditingLabelId(null)}
-                            onDelete={handleDelete}
-                            onSave={handleEdit}
-                        />
-                    ) : (
-                        <LabelRow
-                            key={label.id}
-                            isSelected={selectedSlugs.includes(label.slug)}
-                            label={label}
-                            showEdit={showEdit}
-                            onEditClick={() => setEditingLabelId(label.id)}
-                            onToggle={onToggle}
-                        />
-                    )
-                ))}
-            </CommandGroup>
+            {!showCreate && filteredLabels.length === 0 && (
+                <CommandEmpty>No labels found</CommandEmpty>
+            )}
+            {filteredLabels.length > 0 && (
+                <CommandGroup className="[&_[cmdk-group-heading]]:hidden">
+                    {filteredLabels.map(label => (
+                        editingLabelId === label.id ? (
+                            <EditRow
+                                key={label.id}
+                                isDuplicateName={isDuplicateName}
+                                label={label}
+                                onCancel={() => setEditingLabelId(null)}
+                                onDelete={handleDelete}
+                                onSave={handleEdit}
+                            />
+                        ) : (
+                            <LabelRow
+                                key={label.id}
+                                isSelected={selectedSlugs.includes(label.slug)}
+                                label={label}
+                                showEdit={showEdit}
+                                onEditClick={() => setEditingLabelId(label.id)}
+                                onToggle={onToggle}
+                            />
+                        )
+                    ))}
+                </CommandGroup>
+            )}
             {showCreate && (
-                <>
-                    <CommandSeparator />
-                    <CommandGroup>
-                        <CommandItem
-                            disabled={isCreating}
-                            onSelect={handleCreate}
-                        >
-                            <LucideIcon.Plus className="size-4" />
-                            {isCreating ? 'Creating...' : `Create "${search.trim()}"`}
-                        </CommandItem>
-                    </CommandGroup>
-                </>
+                <CommandGroup className="[&_[cmdk-group-heading]]:hidden">
+                    <CommandItem
+                        disabled={isCreating}
+                        onSelect={handleCreate}
+                    >
+                        <LucideIcon.Plus className="size-4" />
+                        {isCreating ? 'Creating...' : `Create "${search.trim()}"`}
+                    </CommandItem>
+                </CommandGroup>
             )}
         </>
     );
@@ -345,43 +368,21 @@ const LabelPicker: React.FC<LabelPickerProps> = ({
 
     // --- Inline mode (for filter cells): minimal trigger + popover ---
     if (inline) {
-        const triggerText = selectedLabels.length === 0
-            ? 'Select...'
-            : selectedLabels.length === 1
-                ? selectedLabels[0].name
-                : `${selectedLabels.length} labels`;
-
         return (
-            <Popover>
-                <PopoverTrigger asChild>
-                    <button
-                        className="flex size-full items-center truncate text-left text-sm"
-                        type="button"
-                    >
-                        {triggerText}
-                    </button>
-                </PopoverTrigger>
-                <PopoverContent align={align} className="w-64 p-0">
-                    {isLoading ? (
-                        <div className="flex items-center justify-center py-6 text-sm text-muted-foreground">
-                            Loading labels...
-                        </div>
-                    ) : (
-                        <InlineList
-                            canCreateFromSearch={canCreateFromSearch}
-                            isCreating={isCreating}
-                            isDuplicateName={isDuplicateName}
-                            labels={labels}
-                            selectedLabels={selectedLabels}
-                            selectedSlugs={selectedSlugs}
-                            onCreate={onCreate}
-                            onDelete={onDelete}
-                            onEdit={onEdit}
-                            onToggle={onToggle}
-                        />
-                    )}
-                </PopoverContent>
-            </Popover>
+            <InlinePopover
+                align={align}
+                canCreateFromSearch={canCreateFromSearch}
+                isCreating={isCreating}
+                isDuplicateName={isDuplicateName}
+                isLoading={isLoading}
+                labels={labels}
+                selectedLabels={selectedLabels}
+                selectedSlugs={selectedSlugs}
+                onCreate={onCreate}
+                onDelete={onDelete}
+                onEdit={onEdit}
+                onToggle={onToggle}
+            />
         );
     }
 
@@ -401,6 +402,99 @@ const LabelPicker: React.FC<LabelPickerProps> = ({
             onEdit={onEdit}
             onToggle={onToggle}
         />
+    );
+};
+
+// --- InlinePopover: trigger + popover aligned to parent container (for filter cells) ---
+
+interface InlinePopoverProps {
+    labels: Label[];
+    selectedLabels: Label[];
+    selectedSlugs: string[];
+    onToggle: (slug: string) => void;
+    isLoading?: boolean;
+    align?: 'start' | 'end';
+    canCreateFromSearch?: (inputValue: string) => boolean;
+    onCreate?: (name: string) => Promise<Label | undefined>;
+    isCreating?: boolean;
+    onEdit?: (id: string, name: string) => Promise<void>;
+    onDelete?: (id: string) => Promise<void>;
+    isDuplicateName?: (name: string, excludeId?: string) => boolean;
+}
+
+const InlinePopover: React.FC<InlinePopoverProps> = ({
+    labels,
+    selectedLabels,
+    selectedSlugs,
+    onToggle,
+    isLoading,
+    align = 'start',
+    canCreateFromSearch,
+    onCreate,
+    isCreating,
+    onEdit,
+    onDelete,
+    isDuplicateName
+}) => {
+    const triggerRef = useRef<HTMLButtonElement>(null);
+    const [alignOffset, setAlignOffset] = useState(0);
+
+    // Measure the offset between the trigger and its parent wrapper so
+    // the popover aligns with the outer container edge, not the padded inner
+    const updateAlignOffset = useCallback(() => {
+        const trigger = triggerRef.current;
+        const parent = trigger?.parentElement;
+        if (trigger && parent) {
+            const triggerRect = trigger.getBoundingClientRect();
+            const parentRect = parent.getBoundingClientRect();
+            setAlignOffset(Math.round(parentRect.left - triggerRect.left));
+        }
+    }, []);
+
+    const triggerText = selectedLabels.length === 0
+        ? 'Select...'
+        : selectedLabels.length === 1
+            ? selectedLabels[0].name
+            : `${selectedLabels.length} labels`;
+
+    return (
+        <Popover
+            onOpenChange={(open) => {
+                if (open) {
+                    updateAlignOffset();
+                }
+            }}
+        >
+            <PopoverTrigger asChild>
+                <button
+                    ref={triggerRef}
+                    className="flex size-full items-center truncate text-left text-sm"
+                    type="button"
+                >
+                    {triggerText}
+                </button>
+            </PopoverTrigger>
+            <PopoverContent align={align} alignOffset={alignOffset} className="w-64 p-0">
+                {isLoading ? (
+                    <div className="flex items-center justify-center py-6 text-sm text-muted-foreground">
+                        Loading labels...
+                    </div>
+                ) : (
+                    <InlineList
+                        canCreateFromSearch={canCreateFromSearch}
+                        isCreating={isCreating}
+                        isDuplicateName={isDuplicateName}
+                        labels={labels}
+                        selectedLabels={selectedLabels}
+                        selectedSlugs={selectedSlugs}
+                        onCreate={onCreate}
+                        onDelete={onDelete}
+                        onEdit={onEdit}
+                        onToggle={onToggle}
+                    />
+                )}
+            </PopoverContent>
+        </Popover>
     );
 };
 
@@ -498,7 +592,7 @@ const ComboboxPicker: React.FC<ComboboxPickerProps> = ({
         <Popover open={open} onOpenChange={setOpen}>
             <PopoverAnchor asChild>
                 <div
-                    className="flex min-h-10 w-full cursor-text flex-wrap items-center gap-1.5 rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2"
+                    className="flex min-h-9 w-full cursor-text flex-wrap items-center gap-1.5 rounded-md border border-transparent bg-gray-150 px-3 py-1 text-sm transition-colors focus-within:border-green focus-within:bg-transparent focus-within:shadow-[0_0_0_2px_rgba(48,207,67,.25)] dark:bg-gray-900"
                     role="combobox"
                     onClick={() => {
                         inputRef.current?.focus();

--- a/apps/posts/src/components/label-picker/label-picker.tsx
+++ b/apps/posts/src/components/label-picker/label-picker.tsx
@@ -76,8 +76,9 @@ const EditRow: React.FC<EditRowProps> = ({label, onSave, onCancel, onDelete, isD
         setIsSaving(true);
         try {
             await onSave(label.id, name.trim());
-        } finally {
             onCancel();
+        } catch {
+            setIsSaving(false);
         }
     };
 
@@ -252,7 +253,10 @@ const LabelListItems: React.FC<LabelListItemsProps> = ({
 
     const handleCreate = async () => {
         if (onCreate) {
-            await onCreate(search.trim());
+            const newLabel = await onCreate(search.trim());
+            if (newLabel) {
+                onToggle(newLabel.slug);
+            }
             onSearchClear?.();
         }
     };
@@ -571,11 +575,21 @@ const ComboboxPicker: React.FC<ComboboxPickerProps> = ({
     const inputRef = useRef<HTMLInputElement>(null);
     const containerRef = useRef<HTMLDivElement>(null);
 
-    const handleToggle = useCallback((slug: string) => {
-        onToggle(slug);
-        setOpen(false);
-        setSearch('');
-    }, [onToggle]);
+    // Close on click outside — no Radix Popover portal needed since this
+    // component lives inside a Dialog. Avoiding the portal keeps the dropdown
+    // in the Dialog's DOM subtree so Dialog scroll-lock doesn't block it.
+    useEffect(() => {
+        if (!open) {
+            return;
+        }
+        const handlePointerDown = (e: PointerEvent) => {
+            if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+                setOpen(false);
+            }
+        };
+        document.addEventListener('pointerdown', handlePointerDown);
+        return () => document.removeEventListener('pointerdown', handlePointerDown);
+    }, [open]);
 
     const handleInputKeyDown = (e: React.KeyboardEvent) => {
         if (e.key === 'Backspace' && !search && selectedSlugs.length > 0) {
@@ -586,20 +600,6 @@ const ComboboxPicker: React.FC<ComboboxPickerProps> = ({
             inputRef.current?.blur();
         }
     };
-
-    // Close dropdown when clicking outside
-    useEffect(() => {
-        if (!open) {
-            return;
-        }
-        const handleClickOutside = (e: MouseEvent) => {
-            if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
-                setOpen(false);
-            }
-        };
-        document.addEventListener('mousedown', handleClickOutside);
-        return () => document.removeEventListener('mousedown', handleClickOutside);
-    }, [open]);
 
     return (
         <div ref={containerRef} className="relative">
@@ -647,7 +647,7 @@ const ComboboxPicker: React.FC<ComboboxPickerProps> = ({
                                     onDelete={onDelete}
                                     onEdit={onEdit}
                                     onSearchClear={() => setSearch('')}
-                                    onToggle={handleToggle}
+                                    onToggle={onToggle}
                                 />
                             </CommandList>
                         </Command>

--- a/apps/posts/src/hooks/use-label-picker.ts
+++ b/apps/posts/src/hooks/use-label-picker.ts
@@ -1,5 +1,6 @@
-import {Label, useBrowseLabels, useCreateLabel, useDeleteLabel, useEditLabel} from '@tryghost/admin-x-framework/api/labels';
+import {Label, LabelsResponseType, useBrowseLabels, useCreateLabel, useDeleteLabel, useEditLabel} from '@tryghost/admin-x-framework/api/labels';
 import {useCallback, useMemo, useRef} from 'react';
+import {useQueryClient} from '@tanstack/react-query';
 
 export interface UseLabelPickerOptions {
     selectedSlugs: string[];
@@ -23,6 +24,7 @@ export function useLabelPicker({
     selectedSlugs,
     onSelectionChange
 }: UseLabelPickerOptions): UseLabelPickerResult {
+    const queryClient = useQueryClient();
     const {data: labelsData, isLoading} = useBrowseLabels({searchParams: {limit: '100'}});
     const labels = useMemo(() => labelsData?.labels || [], [labelsData]);
 
@@ -62,10 +64,28 @@ export function useLabelPicker({
         if (!trimmed || isDuplicateName(trimmed)) {
             return undefined;
         }
-        const result = await createLabelMutation({name: trimmed});
-        const newLabel = result?.labels?.[0];
-        return newLabel;
-    }, [createLabelMutation, isDuplicateName]);
+        try {
+            const result = await createLabelMutation({name: trimmed});
+            const newLabel = result?.labels?.[0];
+            if (newLabel) {
+                onSelectionChange([...selectedSlugsRef.current, newLabel.slug]);
+            }
+            return newLabel;
+        } catch {
+            // mutateAsync may reject even though the API call succeeded
+            // (React Query v4 behavior when onSuccess throws).
+            // The cache was already updated by afterMutate, so look up the label by name.
+            const cachedQueries = queryClient.getQueriesData<LabelsResponseType>(['LabelsResponseType']);
+            for (const [, data] of cachedQueries) {
+                const cachedLabel = data?.labels.find(l => l.name.toLowerCase() === trimmed.toLowerCase());
+                if (cachedLabel) {
+                    onSelectionChange([...selectedSlugsRef.current, cachedLabel.slug]);
+                    return cachedLabel;
+                }
+            }
+            return undefined;
+        }
+    }, [createLabelMutation, isDuplicateName, onSelectionChange, queryClient]);
 
     const editLabel = useCallback(async (id: string, name: string) => {
         const trimmed = name.trim();

--- a/apps/posts/src/hooks/use-label-picker.ts
+++ b/apps/posts/src/hooks/use-label-picker.ts
@@ -1,0 +1,101 @@
+import {Label, useBrowseLabels, useCreateLabel, useDeleteLabel, useEditLabel} from '@tryghost/admin-x-framework/api/labels';
+import {useCallback, useMemo, useRef} from 'react';
+
+export interface UseLabelPickerOptions {
+    selectedSlugs: string[];
+    onSelectionChange: (slugs: string[]) => void;
+}
+
+export interface UseLabelPickerResult {
+    labels: Label[];
+    selectedSlugs: string[];
+    isLoading: boolean;
+    toggleLabel: (slug: string) => void;
+    createLabel: (name: string) => Promise<Label | undefined>;
+    editLabel: (id: string, name: string) => Promise<void>;
+    deleteLabel: (id: string) => Promise<void>;
+    isDuplicateName: (name: string, excludeId?: string) => boolean;
+    canCreateFromSearch: (inputValue: string) => boolean;
+    isCreating: boolean;
+}
+
+export function useLabelPicker({
+    selectedSlugs,
+    onSelectionChange
+}: UseLabelPickerOptions): UseLabelPickerResult {
+    const {data: labelsData, isLoading} = useBrowseLabels({searchParams: {limit: '100'}});
+    const labels = useMemo(() => labelsData?.labels || [], [labelsData]);
+
+    const {mutateAsync: createLabelMutation, isLoading: isCreating} = useCreateLabel();
+    const {mutateAsync: editLabelMutation} = useEditLabel();
+    const {mutateAsync: deleteLabelMutation} = useDeleteLabel();
+
+    // Ref to always read the latest selectedSlugs in callbacks,
+    // avoiding stale closures and keeping callbacks stable
+    const selectedSlugsRef = useRef(selectedSlugs);
+    selectedSlugsRef.current = selectedSlugs;
+
+    const toggleLabel = useCallback((slug: string) => {
+        const current = selectedSlugsRef.current;
+        if (current.includes(slug)) {
+            onSelectionChange(current.filter(s => s !== slug));
+        } else {
+            onSelectionChange([...current, slug]);
+        }
+    }, [onSelectionChange]);
+
+    const isDuplicateName = useCallback((name: string, excludeId?: string) => {
+        const normalized = name.trim().toLowerCase();
+        return labels.some(l => l.name.toLowerCase() === normalized && l.id !== excludeId);
+    }, [labels]);
+
+    const canCreateFromSearch = useCallback((inputValue: string) => {
+        const trimmed = inputValue.trim();
+        if (!trimmed) {
+            return false;
+        }
+        return !isDuplicateName(trimmed);
+    }, [isDuplicateName]);
+
+    const createLabel = useCallback(async (name: string): Promise<Label | undefined> => {
+        const trimmed = name.trim();
+        if (!trimmed || isDuplicateName(trimmed)) {
+            return undefined;
+        }
+        const result = await createLabelMutation({name: trimmed});
+        const newLabel = result?.labels?.[0];
+        return newLabel;
+    }, [createLabelMutation, isDuplicateName]);
+
+    const editLabel = useCallback(async (id: string, name: string) => {
+        const trimmed = name.trim();
+        if (!trimmed || isDuplicateName(trimmed, id)) {
+            return;
+        }
+        await editLabelMutation({id, name: trimmed});
+    }, [editLabelMutation, isDuplicateName]);
+
+    const deleteLabel = useCallback(async (id: string) => {
+        const label = labels.find(l => l.id === id);
+        await deleteLabelMutation(id);
+        if (label) {
+            const current = selectedSlugsRef.current;
+            if (current.includes(label.slug)) {
+                onSelectionChange(current.filter(s => s !== label.slug));
+            }
+        }
+    }, [deleteLabelMutation, labels, onSelectionChange]);
+
+    return {
+        labels,
+        selectedSlugs,
+        isLoading,
+        toggleLabel,
+        createLabel,
+        editLabel,
+        deleteLabel,
+        isDuplicateName,
+        canCreateFromSearch,
+        isCreating
+    };
+}

--- a/apps/posts/src/hooks/use-label-picker.ts
+++ b/apps/posts/src/hooks/use-label-picker.ts
@@ -72,8 +72,17 @@ export function useLabelPicker({
         if (!trimmed || isDuplicateName(trimmed, id)) {
             return;
         }
-        await editLabelMutation({id, name: trimmed});
-    }, [editLabelMutation, isDuplicateName]);
+        const oldLabel = labels.find(l => l.id === id);
+        const result = await editLabelMutation({id, name: trimmed});
+        const updatedLabel = result?.labels?.[0];
+        // If the slug changed and the old slug was selected, swap it
+        if (oldLabel && updatedLabel && oldLabel.slug !== updatedLabel.slug) {
+            const current = selectedSlugsRef.current;
+            if (current.includes(oldLabel.slug)) {
+                onSelectionChange(current.map(s => (s === oldLabel.slug ? updatedLabel.slug : s)));
+            }
+        }
+    }, [editLabelMutation, isDuplicateName, labels, onSelectionChange]);
 
     const deleteLabel = useCallback(async (id: string) => {
         const label = labels.find(l => l.id === id);

--- a/apps/posts/src/hooks/use-label-picker.ts
+++ b/apps/posts/src/hooks/use-label-picker.ts
@@ -1,6 +1,5 @@
-import {Label, LabelsResponseType, useBrowseLabels, useCreateLabel, useDeleteLabel, useEditLabel} from '@tryghost/admin-x-framework/api/labels';
+import {Label, useBrowseLabels, useCreateLabel, useDeleteLabel, useEditLabel} from '@tryghost/admin-x-framework/api/labels';
 import {useCallback, useMemo, useRef} from 'react';
-import {useQueryClient} from '@tanstack/react-query';
 
 export interface UseLabelPickerOptions {
     selectedSlugs: string[];
@@ -24,7 +23,6 @@ export function useLabelPicker({
     selectedSlugs,
     onSelectionChange
 }: UseLabelPickerOptions): UseLabelPickerResult {
-    const queryClient = useQueryClient();
     const {data: labelsData, isLoading} = useBrowseLabels({searchParams: {limit: '100'}});
     const labels = useMemo(() => labelsData?.labels || [], [labelsData]);
 
@@ -64,28 +62,10 @@ export function useLabelPicker({
         if (!trimmed || isDuplicateName(trimmed)) {
             return undefined;
         }
-        try {
-            const result = await createLabelMutation({name: trimmed});
-            const newLabel = result?.labels?.[0];
-            if (newLabel) {
-                onSelectionChange([...selectedSlugsRef.current, newLabel.slug]);
-            }
-            return newLabel;
-        } catch {
-            // mutateAsync may reject even though the API call succeeded
-            // (React Query v4 behavior when onSuccess throws).
-            // The cache was already updated by afterMutate, so look up the label by name.
-            const cachedQueries = queryClient.getQueriesData<LabelsResponseType>(['LabelsResponseType']);
-            for (const [, data] of cachedQueries) {
-                const cachedLabel = data?.labels.find(l => l.name.toLowerCase() === trimmed.toLowerCase());
-                if (cachedLabel) {
-                    onSelectionChange([...selectedSlugsRef.current, cachedLabel.slug]);
-                    return cachedLabel;
-                }
-            }
-            return undefined;
-        }
-    }, [createLabelMutation, isDuplicateName, onSelectionChange, queryClient]);
+        const result = await createLabelMutation({name: trimmed});
+        const newLabel = result?.labels?.[0];
+        return newLabel;
+    }, [createLabelMutation, isDuplicateName]);
 
     const editLabel = useCallback(async (id: string, name: string) => {
         const trimmed = name.trim();

--- a/apps/posts/src/views/members/components/bulk-action-modals/add-label-modal.tsx
+++ b/apps/posts/src/views/members/components/bulk-action-modals/add-label-modal.tsx
@@ -4,45 +4,47 @@ import {
     DialogContent,
     DialogFooter,
     DialogHeader,
-    DialogTitle,
-    Select,
-    SelectContent,
-    SelectItem,
-    SelectTrigger,
-    SelectValue
+    DialogTitle
 } from '@tryghost/shade';
-import {Label} from '@tryghost/admin-x-framework/api/labels';
-import {useState} from 'react';
+import {LabelPicker} from '@src/components/label-picker';
+import {useCallback, useState} from 'react';
+import {useLabelPicker} from '@src/hooks/use-label-picker';
 
 interface AddLabelModalProps {
     open: boolean;
-    labels: Label[];
     memberCount: number;
     onOpenChange: (open: boolean) => void;
-    onConfirm: (labelId: string) => void;
+    onConfirm: (labelIds: string[]) => void;
     isLoading?: boolean;
 }
 
 export function AddLabelModal({
     open,
-    labels,
     memberCount,
     onOpenChange,
     onConfirm,
     isLoading = false
 }: AddLabelModalProps) {
-    const [selectedLabelId, setSelectedLabelId] = useState<string>('');
+    const [selectedSlugs, setSelectedSlugs] = useState<string[]>([]);
 
-    const handleOpenChange = (isOpen: boolean) => {
+    const picker = useLabelPicker({
+        selectedSlugs,
+        onSelectionChange: setSelectedSlugs
+    });
+
+    const handleOpenChange = useCallback((isOpen: boolean) => {
         if (!isOpen) {
-            setSelectedLabelId('');
+            setSelectedSlugs([]);
         }
         onOpenChange(isOpen);
-    };
+    }, [onOpenChange]);
 
     const handleConfirm = () => {
-        if (selectedLabelId) {
-            onConfirm(selectedLabelId);
+        const labelIds = picker.labels
+            .filter(l => selectedSlugs.includes(l.slug))
+            .map(l => l.id);
+        if (labelIds.length > 0) {
+            onConfirm(labelIds);
         }
     };
 
@@ -55,31 +57,28 @@ export function AddLabelModal({
                     </DialogTitle>
                 </DialogHeader>
 
-                <div className="space-y-2">
-                    <label className="text-sm font-medium">Select label</label>
-                    <Select value={selectedLabelId} onValueChange={setSelectedLabelId}>
-                        <SelectTrigger>
-                            <SelectValue placeholder="Select a label..." />
-                        </SelectTrigger>
-                        <SelectContent>
-                            {labels.map(label => (
-                                <SelectItem key={label.id} value={label.id}>
-                                    {label.name}
-                                </SelectItem>
-                            ))}
-                        </SelectContent>
-                    </Select>
-                </div>
+                <LabelPicker
+                    canCreateFromSearch={picker.canCreateFromSearch}
+                    isCreating={picker.isCreating}
+                    isDuplicateName={picker.isDuplicateName}
+                    isLoading={picker.isLoading}
+                    labels={picker.labels}
+                    selectedSlugs={picker.selectedSlugs}
+                    onCreate={picker.createLabel}
+                    onDelete={picker.deleteLabel}
+                    onEdit={picker.editLabel}
+                    onToggle={picker.toggleLabel}
+                />
 
                 <DialogFooter>
                     <Button variant="outline" onClick={() => handleOpenChange(false)}>
                         Cancel
                     </Button>
                     <Button
-                        disabled={!selectedLabelId || isLoading}
+                        disabled={selectedSlugs.length === 0 || isLoading}
                         onClick={handleConfirm}
                     >
-                        {isLoading ? 'Adding...' : 'Add label'}
+                        {isLoading ? 'Adding...' : selectedSlugs.length > 1 ? `Add ${selectedSlugs.length} labels` : 'Add label'}
                     </Button>
                 </DialogFooter>
             </DialogContent>

--- a/apps/posts/src/views/members/components/bulk-action-modals/add-label-modal.tsx
+++ b/apps/posts/src/views/members/components/bulk-action-modals/add-label-modal.tsx
@@ -50,7 +50,7 @@ export function AddLabelModal({
 
     return (
         <Dialog open={open} onOpenChange={handleOpenChange}>
-            <DialogContent className="gap-5">
+            <DialogContent className="gap-5" onOpenAutoFocus={e => e.preventDefault()}>
                 <DialogHeader>
                     <DialogTitle>
                         Add label to {memberCount.toLocaleString()} {memberCount === 1 ? 'member' : 'members'}

--- a/apps/posts/src/views/members/components/bulk-action-modals/remove-label-modal.tsx
+++ b/apps/posts/src/views/members/components/bulk-action-modals/remove-label-modal.tsx
@@ -4,45 +4,75 @@ import {
     DialogContent,
     DialogFooter,
     DialogHeader,
-    DialogTitle,
-    Select,
-    SelectContent,
-    SelectItem,
-    SelectTrigger,
-    SelectValue
+    DialogTitle
 } from '@tryghost/shade';
-import {Label} from '@tryghost/admin-x-framework/api/labels';
-import {useState} from 'react';
+import {LabelPicker} from '@src/components/label-picker';
+import {useBrowseMembers} from '@tryghost/admin-x-framework/api/members';
+import {useCallback, useMemo, useState} from 'react';
+import {useLabelPicker} from '@src/hooks/use-label-picker';
 
 interface RemoveLabelModalProps {
     open: boolean;
-    labels: Label[];
     memberCount: number;
+    nql?: string;
     onOpenChange: (open: boolean) => void;
-    onConfirm: (labelId: string) => void;
+    onConfirm: (labelIds: string[]) => void;
     isLoading?: boolean;
 }
 
 export function RemoveLabelModal({
     open,
-    labels,
     memberCount,
+    nql,
     onOpenChange,
     onConfirm,
     isLoading = false
 }: RemoveLabelModalProps) {
-    const [selectedLabelId, setSelectedLabelId] = useState<string>('');
+    const [selectedSlugs, setSelectedSlugs] = useState<string[]>([]);
 
-    const handleOpenChange = (isOpen: boolean) => {
+    // Fetch members matching the current filter to find which labels they have
+    const {data: membersData, isLoading: isMembersLoading} = useBrowseMembers({
+        searchParams: {
+            ...(nql ? {filter: nql} : {}),
+            include: 'labels',
+            limit: 'all',
+            fields: 'id'
+        },
+        enabled: open
+    });
+
+    // Extract unique label slugs from the filtered members
+    const memberLabelSlugs = useMemo(() => {
+        const slugs = new Set<string>();
+        for (const member of membersData?.members || []) {
+            for (const label of member.labels || []) {
+                slugs.add(label.slug);
+            }
+        }
+        return slugs;
+    }, [membersData]);
+
+    const picker = useLabelPicker({
+        selectedSlugs,
+        onSelectionChange: setSelectedSlugs
+    });
+
+    // Filter labels to only those assigned to the filtered members
+    const availableLabels = useMemo(() => picker.labels.filter(l => memberLabelSlugs.has(l.slug)), [picker.labels, memberLabelSlugs]);
+
+    const handleOpenChange = useCallback((isOpen: boolean) => {
         if (!isOpen) {
-            setSelectedLabelId('');
+            setSelectedSlugs([]);
         }
         onOpenChange(isOpen);
-    };
+    }, [onOpenChange]);
 
     const handleConfirm = () => {
-        if (selectedLabelId) {
-            onConfirm(selectedLabelId);
+        const labelIds = picker.labels
+            .filter(l => selectedSlugs.includes(l.slug))
+            .map(l => l.id);
+        if (labelIds.length > 0) {
+            onConfirm(labelIds);
         }
     };
 
@@ -55,31 +85,25 @@ export function RemoveLabelModal({
                     </DialogTitle>
                 </DialogHeader>
 
-                <div className="space-y-2">
-                    <label className="text-sm font-medium">Select label</label>
-                    <Select value={selectedLabelId} onValueChange={setSelectedLabelId}>
-                        <SelectTrigger>
-                            <SelectValue placeholder="Select a label..." />
-                        </SelectTrigger>
-                        <SelectContent>
-                            {labels.map(label => (
-                                <SelectItem key={label.id} value={label.id}>
-                                    {label.name}
-                                </SelectItem>
-                            ))}
-                        </SelectContent>
-                    </Select>
-                </div>
+                <LabelPicker
+                    isDuplicateName={picker.isDuplicateName}
+                    isLoading={picker.isLoading || isMembersLoading}
+                    labels={availableLabels}
+                    selectedSlugs={picker.selectedSlugs}
+                    onDelete={picker.deleteLabel}
+                    onEdit={picker.editLabel}
+                    onToggle={picker.toggleLabel}
+                />
 
                 <DialogFooter>
                     <Button variant="outline" onClick={() => handleOpenChange(false)}>
                         Cancel
                     </Button>
                     <Button
-                        disabled={!selectedLabelId || isLoading}
+                        disabled={selectedSlugs.length === 0 || isLoading}
                         onClick={handleConfirm}
                     >
-                        {isLoading ? 'Removing...' : 'Remove label'}
+                        {isLoading ? 'Removing...' : selectedSlugs.length > 1 ? `Remove ${selectedSlugs.length} labels` : 'Remove label'}
                     </Button>
                 </DialogFooter>
             </DialogContent>

--- a/apps/posts/src/views/members/components/bulk-action-modals/remove-label-modal.tsx
+++ b/apps/posts/src/views/members/components/bulk-action-modals/remove-label-modal.tsx
@@ -78,7 +78,7 @@ export function RemoveLabelModal({
 
     return (
         <Dialog open={open} onOpenChange={handleOpenChange}>
-            <DialogContent className="gap-5">
+            <DialogContent className="gap-5" onOpenAutoFocus={e => e.preventDefault()}>
                 <DialogHeader>
                     <DialogTitle>
                         Remove label from {memberCount.toLocaleString()} {memberCount === 1 ? 'member' : 'members'}

--- a/apps/posts/src/views/members/components/members-actions.tsx
+++ b/apps/posts/src/views/members/components/members-actions.tsx
@@ -11,7 +11,6 @@ import {
 } from '@tryghost/shade';
 import {blobDownloadFromEndpoint} from '@tryghost/admin-x-framework/helpers';
 import {toast} from 'sonner';
-import {useBrowseLabels} from '@tryghost/admin-x-framework/api/labels';
 import {useBulkDeleteMembers, useBulkEditMembers} from '@tryghost/admin-x-framework/api/members';
 
 interface MembersActionsProps {
@@ -36,10 +35,7 @@ const MembersActions: React.FC<MembersActionsProps> = ({
     nql,
     canBulkDelete
 }) => {
-    const {data: labelsData} = useBrowseLabels({});
-    const labels = labelsData?.labels || [];
-
-    const {mutate: bulkEdit, isLoading: isBulkEditing} = useBulkEditMembers();
+    const {mutateAsync: bulkEditAsync, isLoading: isBulkEditing} = useBulkEditMembers();
     const {mutate: bulkDelete, isLoading: isBulkDeleting} = useBulkDeleteMembers();
 
     const [showAddLabelModal, setShowAddLabelModal] = useState(false);
@@ -52,77 +48,70 @@ const MembersActions: React.FC<MembersActionsProps> = ({
             await exportMembers(nql);
         } catch (e) {
             toast.error('Export failed', {
-                description: 'There was a problem downloading your member data. Please check your connection and try again.',
-                duration: 8000
+                description: 'There was a problem downloading your member data. Please check your connection and try again.'
             });
             throw e;
         }
     }, [nql]);
 
-    const handleAddLabel = useCallback((labelId: string) => {
-        bulkEdit({
-            filter: nql || '',
-            all: !nql,
-            action: {
-                type: 'addLabel',
-                meta: {label: {id: labelId}}
-            }
-        }, {
-            onSuccess: () => {
-                setShowAddLabelModal(false);
-                toast.success('Label added successfully');
-            },
-            onError: () => {
-                toast.error('Failed to add label', {
-                    description: 'There was a problem applying this label. Please try again.',
-                    duration: 8000
+    const handleAddLabel = useCallback(async (labelIds: string[]) => {
+        try {
+            for (const labelId of labelIds) {
+                await bulkEditAsync({
+                    filter: nql || '',
+                    all: !nql,
+                    action: {
+                        type: 'addLabel',
+                        meta: {label: {id: labelId}}
+                    }
                 });
             }
-        });
-    }, [bulkEdit, nql]);
+            setShowAddLabelModal(false);
+            toast.success(labelIds.length > 1 ? 'Labels added successfully' : 'Label added successfully');
+        } catch {
+            toast.error('Failed to add label', {
+                description: 'There was a problem applying this label. Please try again.'
+            });
+        }
+    }, [bulkEditAsync, nql]);
 
-    const handleRemoveLabel = useCallback((labelId: string) => {
-        bulkEdit({
-            filter: nql || '',
-            all: !nql,
-            action: {
-                type: 'removeLabel',
-                meta: {label: {id: labelId}}
-            }
-        }, {
-            onSuccess: () => {
-                setShowRemoveLabelModal(false);
-                toast.success('Label removed successfully');
-            },
-            onError: () => {
-                toast.error('Failed to remove label', {
-                    description: 'There was a problem removing this label. Please try again.',
-                    duration: 8000
+    const handleRemoveLabel = useCallback(async (labelIds: string[]) => {
+        try {
+            for (const labelId of labelIds) {
+                await bulkEditAsync({
+                    filter: nql || '',
+                    all: !nql,
+                    action: {
+                        type: 'removeLabel',
+                        meta: {label: {id: labelId}}
+                    }
                 });
             }
-        });
-    }, [bulkEdit, nql]);
+            setShowRemoveLabelModal(false);
+            toast.success(labelIds.length > 1 ? 'Labels removed successfully' : 'Label removed successfully');
+        } catch {
+            toast.error('Failed to remove label', {
+                description: 'There was a problem removing this label. Please try again.'
+            });
+        }
+    }, [bulkEditAsync, nql]);
 
     const handleUnsubscribe = useCallback(() => {
-        bulkEdit({
+        bulkEditAsync({
             filter: nql || '',
             all: !nql,
             action: {
                 type: 'unsubscribe'
             }
-        }, {
-            onSuccess: () => {
-                setShowUnsubscribeModal(false);
-                toast.success('Members unsubscribed successfully');
-            },
-            onError: () => {
-                toast.error('Failed to unsubscribe members', {
-                    description: 'There was a problem unsubscribing these members. Please try again.',
-                    duration: 8000
-                });
-            }
+        }).then(() => {
+            setShowUnsubscribeModal(false);
+            toast.success('Members unsubscribed successfully');
+        }).catch(() => {
+            toast.error('Failed to unsubscribe members', {
+                description: 'There was a problem unsubscribing these members. Please try again.'
+            });
         });
-    }, [bulkEdit, nql]);
+    }, [bulkEditAsync, nql]);
 
     const handleDelete = useCallback(() => {
         bulkDelete({
@@ -135,8 +124,7 @@ const MembersActions: React.FC<MembersActionsProps> = ({
             },
             onError: () => {
                 toast.error('Failed to delete members', {
-                    description: 'There was a problem deleting these members. Please try again.',
-                    duration: 8000
+                    description: 'There was a problem deleting these members. Please try again.'
                 });
             }
         });
@@ -147,8 +135,7 @@ const MembersActions: React.FC<MembersActionsProps> = ({
             await exportMembers(nql);
         } catch (e) {
             toast.error('Export failed', {
-                description: 'There was a problem downloading your backup. Please check your connection and try again.',
-                duration: 8000
+                description: 'There was a problem downloading your backup. Please check your connection and try again.'
             });
             throw e;
         }
@@ -172,33 +159,28 @@ const MembersActions: React.FC<MembersActionsProps> = ({
                             : 'Export all members'}
                     </DropdownMenuItem>
 
-                    {/* Bulk actions only when NQL filter is present (not just search) */}
-                    {nql && (
-                        <>
-                            <DropdownMenuSeparator />
-                            <DropdownMenuItem onClick={() => setShowAddLabelModal(true)}>
-                                <LucideIcon.Tags className="mr-2 size-4" />
-                                    Add label to {memberCount.toLocaleString()} members
-                            </DropdownMenuItem>
-                            <DropdownMenuItem onClick={() => setShowRemoveLabelModal(true)}>
-                                <LucideIcon.Tag className="mr-2 size-4" />
-                                    Remove label from {memberCount.toLocaleString()} members
-                            </DropdownMenuItem>
-                            <DropdownMenuItem onClick={() => setShowUnsubscribeModal(true)}>
-                                <LucideIcon.MailX className="mr-2 size-4" />
-                                    Unsubscribe {memberCount.toLocaleString()} members
-                            </DropdownMenuItem>
-                            <DropdownMenuSeparator />
-                            <DropdownMenuItem
-                                className="text-destructive focus:text-destructive"
-                                disabled={!canBulkDelete}
-                                onClick={() => setShowDeleteModal(true)}
-                            >
-                                <LucideIcon.Trash2 className="mr-2 size-4" />
-                                    Delete {memberCount.toLocaleString()} members
-                            </DropdownMenuItem>
-                        </>
-                    )}
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem onClick={() => setShowAddLabelModal(true)}>
+                        <LucideIcon.Tags className="mr-2 size-4" />
+                            Add label to {memberCount.toLocaleString()} {memberCount === 1 ? 'member' : 'members'}
+                    </DropdownMenuItem>
+                    <DropdownMenuItem onClick={() => setShowRemoveLabelModal(true)}>
+                        <LucideIcon.Tag className="mr-2 size-4" />
+                            Remove label from {memberCount.toLocaleString()} {memberCount === 1 ? 'member' : 'members'}
+                    </DropdownMenuItem>
+                    <DropdownMenuItem onClick={() => setShowUnsubscribeModal(true)}>
+                        <LucideIcon.MailX className="mr-2 size-4" />
+                            Unsubscribe {memberCount.toLocaleString()} {memberCount === 1 ? 'member' : 'members'}
+                    </DropdownMenuItem>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem
+                        className="text-destructive focus:text-destructive"
+                        disabled={!canBulkDelete}
+                        onClick={() => setShowDeleteModal(true)}
+                    >
+                        <LucideIcon.Trash2 className="mr-2 size-4" />
+                            Delete {memberCount.toLocaleString()} {memberCount === 1 ? 'member' : 'members'}
+                    </DropdownMenuItem>
                 </DropdownMenuContent>
             </DropdownMenu>
 
@@ -212,7 +194,6 @@ const MembersActions: React.FC<MembersActionsProps> = ({
             {/* Modals */}
             <AddLabelModal
                 isLoading={isBulkEditing}
-                labels={labels}
                 memberCount={memberCount}
                 open={showAddLabelModal}
                 onConfirm={handleAddLabel}
@@ -220,8 +201,8 @@ const MembersActions: React.FC<MembersActionsProps> = ({
             />
             <RemoveLabelModal
                 isLoading={isBulkEditing}
-                labels={labels}
                 memberCount={memberCount}
+                nql={nql}
                 open={showRemoveLabelModal}
                 onConfirm={handleRemoveLabel}
                 onOpenChange={setShowRemoveLabelModal}

--- a/apps/posts/src/views/members/components/members-actions.tsx
+++ b/apps/posts/src/views/members/components/members-actions.tsx
@@ -55,8 +55,8 @@ const MembersActions: React.FC<MembersActionsProps> = ({
     }, [nql]);
 
     const handleAddLabel = useCallback(async (labelIds: string[]) => {
-        for (const labelId of labelIds) {
-            try {
+        try {
+            for (const labelId of labelIds) {
                 await bulkEditAsync({
                     filter: nql || '',
                     all: !nql,
@@ -65,18 +65,19 @@ const MembersActions: React.FC<MembersActionsProps> = ({
                         meta: {label: {id: labelId}}
                     }
                 });
-            } catch {
-                // Swallow individual errors — the mutation may have
-                // succeeded at the API level even if onSuccess threw
             }
+            setShowAddLabelModal(false);
+            toast.success(labelIds.length > 1 ? 'Labels added successfully' : 'Label added successfully');
+        } catch {
+            toast.error('Failed to add label', {
+                description: 'There was a problem applying this label. Please try again.'
+            });
         }
-        setShowAddLabelModal(false);
-        toast.success(labelIds.length > 1 ? 'Labels added successfully' : 'Label added successfully');
     }, [bulkEditAsync, nql]);
 
     const handleRemoveLabel = useCallback(async (labelIds: string[]) => {
-        for (const labelId of labelIds) {
-            try {
+        try {
+            for (const labelId of labelIds) {
                 await bulkEditAsync({
                     filter: nql || '',
                     all: !nql,
@@ -85,13 +86,14 @@ const MembersActions: React.FC<MembersActionsProps> = ({
                         meta: {label: {id: labelId}}
                     }
                 });
-            } catch {
-                // Swallow individual errors — the mutation may have
-                // succeeded at the API level even if onSuccess threw
             }
+            setShowRemoveLabelModal(false);
+            toast.success(labelIds.length > 1 ? 'Labels removed successfully' : 'Label removed successfully');
+        } catch {
+            toast.error('Failed to remove label', {
+                description: 'There was a problem removing this label. Please try again.'
+            });
         }
-        setShowRemoveLabelModal(false);
-        toast.success(labelIds.length > 1 ? 'Labels removed successfully' : 'Label removed successfully');
     }, [bulkEditAsync, nql]);
 
     const handleUnsubscribe = useCallback(() => {

--- a/apps/posts/src/views/members/components/members-actions.tsx
+++ b/apps/posts/src/views/members/components/members-actions.tsx
@@ -55,8 +55,8 @@ const MembersActions: React.FC<MembersActionsProps> = ({
     }, [nql]);
 
     const handleAddLabel = useCallback(async (labelIds: string[]) => {
-        try {
-            for (const labelId of labelIds) {
+        for (const labelId of labelIds) {
+            try {
                 await bulkEditAsync({
                     filter: nql || '',
                     all: !nql,
@@ -65,19 +65,18 @@ const MembersActions: React.FC<MembersActionsProps> = ({
                         meta: {label: {id: labelId}}
                     }
                 });
+            } catch {
+                // Swallow individual errors — the mutation may have
+                // succeeded at the API level even if onSuccess threw
             }
-            setShowAddLabelModal(false);
-            toast.success(labelIds.length > 1 ? 'Labels added successfully' : 'Label added successfully');
-        } catch {
-            toast.error('Failed to add label', {
-                description: 'There was a problem applying this label. Please try again.'
-            });
         }
+        setShowAddLabelModal(false);
+        toast.success(labelIds.length > 1 ? 'Labels added successfully' : 'Label added successfully');
     }, [bulkEditAsync, nql]);
 
     const handleRemoveLabel = useCallback(async (labelIds: string[]) => {
-        try {
-            for (const labelId of labelIds) {
+        for (const labelId of labelIds) {
+            try {
                 await bulkEditAsync({
                     filter: nql || '',
                     all: !nql,
@@ -86,14 +85,13 @@ const MembersActions: React.FC<MembersActionsProps> = ({
                         meta: {label: {id: labelId}}
                     }
                 });
+            } catch {
+                // Swallow individual errors — the mutation may have
+                // succeeded at the API level even if onSuccess threw
             }
-            setShowRemoveLabelModal(false);
-            toast.success(labelIds.length > 1 ? 'Labels removed successfully' : 'Label removed successfully');
-        } catch {
-            toast.error('Failed to remove label', {
-                description: 'There was a problem removing this label. Please try again.'
-            });
         }
+        setShowRemoveLabelModal(false);
+        toast.success(labelIds.length > 1 ? 'Labels removed successfully' : 'Label removed successfully');
     }, [bulkEditAsync, nql]);
 
     const handleUnsubscribe = useCallback(() => {

--- a/apps/posts/src/views/members/hooks/use-members-filter-config.tsx
+++ b/apps/posts/src/views/members/hooks/use-members-filter-config.tsx
@@ -164,8 +164,6 @@ export function useMembersFilterConfig({
             basicFields.push({
                 key: 'label',
                 label: 'Label',
-                // type: 'select' gives us the initial dropdown in the add-filter popover,
-                // customRenderer takes priority for the value cell once the filter row exists
                 type: 'select',
                 icon: <LucideIcon.Tag className="size-4" />,
                 options: labelsOptions.length > 0 ? labelsOptions : labels.map(l => ({

--- a/apps/posts/src/views/members/hooks/use-members-filter-config.tsx
+++ b/apps/posts/src/views/members/hooks/use-members-filter-config.tsx
@@ -1,4 +1,6 @@
-import {FilterFieldConfig, FilterFieldGroup, FilterOption, LucideIcon} from '@tryghost/shade';
+import LabelFilterRenderer from '@src/components/label-picker/label-filter-renderer';
+import React from 'react';
+import {CustomRendererProps, FilterFieldConfig, FilterFieldGroup, FilterOption, LucideIcon} from '@tryghost/shade';
 import {Label} from '@tryghost/admin-x-framework/api/labels';
 import {Newsletter} from '@tryghost/admin-x-framework/api/newsletters';
 import {Tier} from '@tryghost/admin-x-framework/api/tiers';
@@ -13,9 +15,6 @@ export interface UseMembersFilterConfigOptions {
     emailAnalyticsEnabled?: boolean;
     labelsOptions?: FilterOption[];
     tiersOptions?: FilterOption[];
-    onLabelsSearchChange?: (search: string) => void;
-    labelsSearchValue?: string;
-    labelsLoading?: boolean;
     onTiersSearchChange?: (search: string) => void;
     tiersSearchValue?: string;
     tiersLoading?: boolean;
@@ -113,9 +112,6 @@ export function useMembersFilterConfig({
     emailAnalyticsEnabled = false,
     labelsOptions = [],
     tiersOptions = [],
-    onLabelsSearchChange,
-    labelsSearchValue,
-    labelsLoading = false,
     onTiersSearchChange,
     tiersSearchValue,
     tiersLoading = false,
@@ -168,19 +164,18 @@ export function useMembersFilterConfig({
             basicFields.push({
                 key: 'label',
                 label: 'Label',
-                type: 'multiselect',
+                // type: 'select' gives us the initial dropdown in the add-filter popover,
+                // customRenderer takes priority for the value cell once the filter row exists
+                type: 'select',
                 icon: <LucideIcon.Tag className="size-4" />,
                 options: labelsOptions.length > 0 ? labelsOptions : labels.map(l => ({
                     value: l.slug,
                     label: l.name
                 })),
+                customRenderer: props => React.createElement(LabelFilterRenderer, props as CustomRendererProps<string>),
                 defaultOperator: 'is_any_of',
                 hideOperatorSelect: true,
-                autoCloseOnSelect: true,
                 searchable: true,
-                onSearchChange: onLabelsSearchChange,
-                searchValue: labelsSearchValue,
-                isLoading: labelsLoading,
                 className: 'w-64'
             });
         }
@@ -519,9 +514,6 @@ export function useMembersFilterConfig({
         emailAnalyticsEnabled,
         labelsOptions,
         tiersOptions,
-        onLabelsSearchChange,
-        labelsSearchValue,
-        labelsLoading,
         onTiersSearchChange,
         tiersSearchValue,
         tiersLoading,

--- a/apps/posts/src/views/members/hooks/use-members-filter-state.ts
+++ b/apps/posts/src/views/members/hooks/use-members-filter-state.ts
@@ -278,7 +278,7 @@ function searchParamsToFilters(searchParams: URLSearchParams): Filter[] {
         const parsed = parseFilterValue(queryValue);
         if (parsed) {
             const values = MULTISELECT_FIELDS.has(field)
-                ? parsed.value.split(',')
+                ? (parsed.value ? parsed.value.split(',') : [])
                 : [parsed.value];
             filters.push({
                 id: field,
@@ -299,12 +299,21 @@ function filtersToSearchParams(filters: Filter[], search?: string): URLSearchPar
     const params = new URLSearchParams();
 
     for (const filter of filters) {
-        if (filter.values[0] !== undefined) {
-            const key = filter.field;
-            const serializedValue = MULTISELECT_FIELDS.has(key) && filter.values.length > 1
+        const key = filter.field;
+
+        // Multiselect fields (label, offer_redemptions) may have empty values
+        // when the filter row has just been added but no values selected yet.
+        // We still serialize them so the filter row persists in the URL.
+        if (MULTISELECT_FIELDS.has(key)) {
+            const serializedValue = filter.values.length > 0
                 ? filter.values.map(v => String(v)).join(',')
-                : String(filter.values[0]);
-            const value = `${filter.operator}:${serializedValue}`;
+                : '';
+            params.set(key, `${filter.operator}:${serializedValue}`);
+            continue;
+        }
+
+        if (filter.values[0] !== undefined) {
+            const value = `${filter.operator}:${String(filter.values[0])}`;
             params.set(key, value);
         }
     }

--- a/ghost/admin/app/services/state-bridge.js
+++ b/ghost/admin/app/services/state-bridge.js
@@ -10,6 +10,8 @@ const emberDataTypeMapping = {
     CommentsResponseType: null, // comments only exist in React admin
     IntegrationsResponseType: {type: 'integration'},
     InvitesResponseType: {type: 'invite'},
+    LabelsResponseType: null, // labels only exist in React admin
+    MembersResponseType: null, // members only exist in React admin
     OffersResponseType: {type: 'offer'},
     NewslettersResponseType: {type: 'newsletter'},
     RecommendationResponseType: {type: 'recommendation'},


### PR DESCRIPTION
The members list filter and bulk-action modals used simple Select dropdowns for choosing labels, which limited users to picking one label at a time with no way to manage labels without leaving the context. This replaces those dropdowns with a searchable, multi-select label picker built on Popover + Command (cmdk) from Shade — the same proven pattern used by the existing filter options popovers.

The picker is driven by a `useLabelPicker` hook that encapsulates all label CRUD operations (browse, create, edit, delete) via new mutations added to admin-x-framework. The component itself adapts to three contexts through prop presence rather than an explicit mode prop: the filter value cell renders as an inline popover with applied-label pills above the search, the add-label bulk modal includes a "Create" option for new labels, and the remove-label bulk modal scopes available labels to those actually assigned to the filtered members. In all contexts, labels can be renamed or deleted inline via edit/delete buttons that appear on hover, with confirmation for destructive actions.

The Ember state bridge was updated with `LabelsResponseType` and `MembersResponseType` mappings so that mutation cache updates propagate correctly between the React and Ember query caches. The filter state serialization was also adjusted to handle multiselect fields with empty values, so a label filter row persists in the URL even before any labels are selected.

ref https://linear.app/tryghost/issue/BER-3342/

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches multiple user-facing flows (filters and bulk member operations) and introduces new label mutation paths with cache-update logic; issues could cause incorrect selections or label assignments/removals.
> 
> **Overview**
> Replaces the members label dropdown UX with a new searchable, multi-select `LabelPicker` used in both the members list label filter (inline popover renderer) and bulk add/remove label modals, including inline rename/delete and optional create-from-search.
> 
> Adds label CRUD mutations to `admin-x-framework` (`useCreateLabel`, `useEditLabel`, `useDeleteLabel`) with query-cache updates, introduces a shared `useLabelPicker` hook to coordinate selection + mutations (including slug-change handling), and updates bulk member actions to apply multiple labels and to scope removable labels to those present on the filtered members.
> 
> Improves filter URL handling by serializing empty multiselect values so newly-added filter rows persist, and updates the Ember state bridge mappings for `LabelsResponseType`/`MembersResponseType` to support React-side cache update semantics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c96b7652a69a8a44d53b2ad714ee995db806f7b2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->