### PR TITLE
Added close button to email failure modal

### DIFF
--- a/ghost/admin/app/components/editor/modals/publish-flow.hbs
+++ b/ghost/admin/app/components/editor/modals/publish-flow.hbs
@@ -2,7 +2,7 @@
     <header class="gh-publish-header">
         <h2>Publish</h2>
 
-        {{#if (not this.isComplete)}}
+        {{#unless this.isComplete}}
             <div class="gh-btn-group-right">
                 <button
                     type="button"
@@ -24,7 +24,7 @@
                     </button>
                 {{/unless}}
             </div>
-        {{/if}}
+        {{/unless}}
     </header>
 
     <div class="gh-publish-settings-container {{unless @data.skipAnimation "fade-in"}}">

--- a/ghost/admin/app/components/editor/modals/publish-flow.hbs
+++ b/ghost/admin/app/components/editor/modals/publish-flow.hbs
@@ -2,7 +2,7 @@
     <header class="gh-publish-header">
         <h2>Publish</h2>
 
-        {{#if (and (not this.emailErrorMessage) (not this.isComplete))}}
+        {{#if (not this.isComplete)}}
             <div class="gh-btn-group-right">
                 <button
                     type="button"
@@ -13,14 +13,16 @@
                 >
                     <span>Close</span>
                 </button>
-                <button
-                    type="button"
-                    class="gh-btn"
-                    {{on "click" @data.togglePreviewPublish}}
-                    data-test-button="publish-flow-preview"
-                >
-                    <span>Preview</span>
-                </button>
+                {{#unless this.emailErrorMessage}}
+                    <button
+                        type="button"
+                        class="gh-btn"
+                        {{on "click" @data.togglePreviewPublish}}
+                        data-test-button="publish-flow-preview"
+                    >
+                        <span>Preview</span>
+                    </button>
+                {{/unless}}
             </div>
         {{/if}}
     </header>


### PR DESCRIPTION
Ref https://linear.app/ghost/issue/DES-1293/add-back-button-escape-hatch-on-email-failure-screen

There was previously no way to escape the email failed to send modal without hitting escape. This just keeps the close button that's visible on the pre-publish step.

| Header | After |
|--------|--------|
| <img width="1440" height="1024" alt="localhost_2368_ghost_ (16)" src="https://github.com/user-attachments/assets/15145a24-eb47-4504-8d4c-7d12968abc24" /> | <img width="1440" height="1024" alt="localhost_2368_ghost_ (15)" src="https://github.com/user-attachments/assets/9b452941-ddbe-4f03-9561-ccbbdf4899fb" /> | 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Template-only UI logic changes to button visibility/wiring in the publish modal, with no data or auth impact.
> 
> **Overview**
> Ensures the publish flow header always shows the **Close** button whenever the modal isn’t complete, including when an `emailErrorMessage` is present, so users can exit the email-failure screen without using Escape.
> 
> The **Preview** button is now suppressed while an email error is shown, and the email-error step receives `@close` so it can trigger the same exit behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d62d09a3d4f29a4aa2475804f91373774b493af. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->