### PR TITLE
Fixed review issues in paginated label dropdowns

### DIFF
--- a/e2e/helpers/pages/admin/members/members-page.ts
+++ b/e2e/helpers/pages/admin/members/members-page.ts
@@ -88,13 +88,19 @@ class SettingsSection extends BasePage {
     }
 
     private async selectLabelOption(labelName: string): Promise<void> {
+        await this.selectLabel.waitFor({state: 'visible'});
         await this.selectLabel.click();
 
         const dropdown = this.page.locator('.ember-power-select-dropdown').last();
+        await dropdown.waitFor({state: 'visible'});
+
         const searchInput = dropdown.locator('.ember-power-select-search input');
+        await searchInput.waitFor({state: 'visible'});
         await searchInput.fill(labelName);
 
-        await dropdown.getByRole('option', {name: labelName, exact: true}).click();
+        const option = dropdown.getByRole('option', {name: labelName, exact: true});
+        await option.waitFor({state: 'visible'});
+        await option.click();
     }
 }
 

--- a/ghost/admin/.lint-todo
+++ b/ghost/admin/.lint-todo
@@ -167,4 +167,3 @@ remove|ember-template-lint|require-valid-alt-text|4|12|4|12|8369d1b06deac93e8c8e
 remove|ember-template-lint|no-action|1|71|1|71|2e6351f546807d88cc8eb9dbe8baa149468b5cb9|1746489600000|||app/components/gh-view-title.hbs
 remove|ember-template-lint|no-invalid-role|1|0|1|0|3e651d38e0110e1be20e5082075db1b879b59a36|1746489600000|||app/components/gh-view-title.hbs
 add|ember-template-lint|no-yield-only|1|0|1|0|a5fa6e8c1e0f03fb31b5cd17770e4368d44932e4|1771200000000|||app/components/gh-view-title.hbs
-add|ember-template-lint|require-mandatory-role-attributes|5|6|5|6|eebcf58749b98cfb1e9d462bb4f3e497474df6cb|1772409600000|||app/components/power-select-options-with-scroll.hbs

--- a/ghost/admin/app/components/gh-member-label-input.js
+++ b/ghost/admin/app/components/gh-member-label-input.js
@@ -18,7 +18,7 @@ export default class GhMemberLabelInput extends Component {
 
     get availableLabels() {
         const selectedLabels = this.selectedLabels;
-        return this.labelsManager.sortLabels(this.labelsManager._labels.filter(label => !selectedLabels.includes(label)));
+        return this.labelsManager.labels.filter(label => !selectedLabels.includes(label));
     }
 
     get useServerSideSearch() {
@@ -30,7 +30,7 @@ export default class GhMemberLabelInput extends Component {
             if (this.args.labels?.length && typeof this.args.labels[0] === 'string') {
                 return this.args.labels.map((d) => {
                     return this.labelsManager.findBySlug(d);
-                }).filter(Boolean) || [];
+                }).filter(Boolean);
             }
             return this.args.labels || [];
         }
@@ -39,8 +39,11 @@ export default class GhMemberLabelInput extends Component {
 
     @action
     addSearchedLabels(labels) {
-        const selectedLabels = this.selectedLabels;
-        const deduplicatedLabels = labels.filter(label => !selectedLabels.includes(label));
+        const existingIds = new Set([
+            ...this.selectedLabels.map(l => l.id),
+            ...this._searchedLabels.map(l => l.id)
+        ]);
+        const deduplicatedLabels = labels.filter(label => !existingIds.has(label.id));
         this._searchedLabels.push(...deduplicatedLabels);
     }
 
@@ -81,7 +84,7 @@ export default class GhMemberLabelInput extends Component {
         }
     }
 
-    @task
+    @task({restartable: true})
     *searchLabelsTask(term) {
         this._searchedLabelsQuery = term;
         const labels = yield this.labelsManager.searchLabelsTask.perform(term);
@@ -165,6 +168,6 @@ export default class GhMemberLabelInput extends Component {
             }
             return label.name.toLowerCase() === name.toLowerCase();
         };
-        return this._searchedLabels.find(withMatchingName) || this.labelsManager._labels.find(withMatchingName);
+        return this._searchedLabels.find(withMatchingName) || this.labelsManager.labels.find(withMatchingName);
     }
 }

--- a/ghost/admin/app/components/gh-member-single-label-input.js
+++ b/ghost/admin/app/components/gh-member-single-label-input.js
@@ -38,12 +38,15 @@ export default class GhMemberSingleLabelInput extends Component {
 
         const sorted = this.availableLabels;
         if (this.args.label) {
-            this._selectedLabel = sorted.find(l => l.id === this.args.label) || sorted[0];
+            const found = sorted.find(l => l.id === this.args.label);
+            if (found) {
+                this._selectedLabel = found;
+            }
         } else {
             this._selectedLabel = sorted[0];
-        }
-        if (this._selectedLabel) {
-            this.args.onChange(this._selectedLabel.id);
+            if (this._selectedLabel) {
+                this.args.onChange(this._selectedLabel.id);
+            }
         }
     }
 

--- a/ghost/admin/app/components/gh-members-recipient-select.js
+++ b/ghost/admin/app/components/gh-members-recipient-select.js
@@ -59,7 +59,7 @@ export default class GhMembersRecipientSelect extends Component {
         const labels = this.labelsManager.labels;
 
         if (labels.length > 0) {
-            options.unshift({
+            options.push({
                 groupName: 'Labels',
                 options: labels.map(label => ({
                     name: label.name,

--- a/ghost/admin/app/components/power-select-options-with-scroll.hbs
+++ b/ghost/admin/app/components/power-select-options-with-scroll.hbs
@@ -2,7 +2,7 @@
   {{! template-lint-disable no-unnecessary-concat }}
   {{#if (and @select.loading (eq @options.length 0))}}
     {{#if @loadingMessage}}
-      <li class="ember-power-select-option ember-power-select-option--loading-message" role="option">{{@loadingMessage}}</li>
+      <li class="ember-power-select-option ember-power-select-option--loading-message" role="option" aria-selected="false">{{@loadingMessage}}</li>
     {{/if}}
   {{/if}}
   {{#let

--- a/ghost/admin/app/services/labels-manager.js
+++ b/ghost/admin/app/services/labels-manager.js
@@ -9,7 +9,7 @@ export default class LabelsManagerService extends Service {
     @service store;
 
     @tracked _labels = new TrackedArray();
-    _meta = null;
+    @tracked _meta = null;
 
     get labels() {
         return this.sortLabels(this._labels);
@@ -53,7 +53,7 @@ export default class LabelsManagerService extends Service {
 
     @task({drop: true})
     *loadMoreTask() {
-        if (this._meta?.pagination && this._meta.pagination.pages <= this._meta.pagination.page) {
+        if (this._meta?.pagination && parseInt(this._meta.pagination.pages, 10) <= parseInt(this._meta.pagination.page, 10)) {
             return;
         }
 


### PR DESCRIPTION
## Summary

Addresses review feedback from #26655 and fixes additional issues found during follow-up testing.

**Review comment fixes:**
- Added `aria-selected="false"` to loading option in `power-select-options-with-scroll.hbs` to fix a11y lint violation instead of suppressing it
- Fixed `gh-member-single-label-input` to not overwrite a preselected label with the first available option when the selected label isn't in the first loaded page — only calls `onChange` for default (no pre-selection) case
- Changed `options.unshift` to `options.push` in `gh-members-recipient-select` so the Labels group appears after Tiers, keeping infinite scroll predictable
- Added `@tracked` to `_meta` in `labels-manager` so `hasLoaded`/`hasLoadedAll` getters reactively update
- Added `parseInt` to pagination comparison in `loadMoreTask` for consistency with `hasLoadedAll`

**Additional fixes:**
- Used public `labelsManager.labels` getter instead of private `labelsManager._labels` in `gh-member-label-input`
- Switched `addSearchedLabels` deduplication to ID-based `Set` lookup (reference equality can fail with Ember Data models)
- Made `searchLabelsTask` restartable to prevent stacking concurrent search requests
- Removed redundant `|| []` after `.filter(Boolean)` in `selectedLabels`
- Added explicit `waitFor` calls in E2E label selection helpers to prevent flaky tests with paginated dropdown loading

refs https://github.com/TryGhost/Ghost/pull/26655