### PR TITLE
Added newsletter selection to bulk member unsubscribe

### DIFF
--- a/apps/admin-x-framework/src/api/members.ts
+++ b/apps/admin-x-framework/src/api/members.ts
@@ -182,6 +182,7 @@ export interface BulkEditAction {
     meta?: {
         label?: {id: string};
     };
+    newsletter?: string | null;
 }
 
 export interface BulkOperationResponseType {
@@ -204,7 +205,8 @@ export const useBulkEditMembers = createMutation<
     body: ({action}) => ({
         bulk: {
             action: action.type,
-            meta: action.meta || {}
+            meta: action.meta || {},
+            newsletter: action.newsletter
         }
     }),
     searchParams: ({filter, all}) => {

--- a/apps/posts/src/views/members/components/bulk-action-modals/unsubscribe-modal.tsx
+++ b/apps/posts/src/views/members/components/bulk-action-modals/unsubscribe-modal.tsx
@@ -1,47 +1,237 @@
 import {
+    Badge,
     Button,
+    Command,
+    CommandCheck,
+    CommandEmpty,
+    CommandItem,
+    CommandList,
     Dialog,
     DialogContent,
-    DialogDescription,
     DialogFooter,
     DialogHeader,
-    DialogTitle
+    DialogTitle,
+    LucideIcon
 } from '@tryghost/shade';
+import {Newsletter} from '@tryghost/admin-x-framework/api/newsletters';
+import {useCallback, useEffect, useRef, useState} from 'react';
+
+type UnsubscribeMode = 'all' | 'selected';
 
 interface UnsubscribeModalProps {
     open: boolean;
+    newsletters: Newsletter[];
     memberCount: number;
     onOpenChange: (open: boolean) => void;
-    onConfirm: () => void;
+    onConfirm: (newsletterIds: string[] | null) => void;
     isLoading?: boolean;
 }
 
 export function UnsubscribeModal({
     open,
+    newsletters,
     memberCount,
     onOpenChange,
     onConfirm,
     isLoading = false
 }: UnsubscribeModalProps) {
+    const [mode, setMode] = useState<UnsubscribeMode>('all');
+    const [selectedIds, setSelectedIds] = useState<string[]>([]);
+    const [search, setSearch] = useState('');
+    const [listOpen, setListOpen] = useState(false);
+    const pickerRef = useRef<HTMLDivElement>(null);
+    const inputRef = useRef<HTMLInputElement>(null);
+
+    // Reset state when dialog is closed externally (e.g. parent sets open=false after confirm)
+    useEffect(() => {
+        if (!open) {
+            setMode('all');
+            setSelectedIds([]);
+            setSearch('');
+            setListOpen(false);
+        }
+    }, [open]);
+
+    // Close list on click outside the picker
+    useEffect(() => {
+        if (!listOpen) {
+            return;
+        }
+        const handlePointerDown = (e: PointerEvent) => {
+            if (pickerRef.current && !pickerRef.current.contains(e.target as Node)) {
+                setListOpen(false);
+            }
+        };
+        document.addEventListener('pointerdown', handlePointerDown);
+        return () => document.removeEventListener('pointerdown', handlePointerDown);
+    }, [listOpen]);
+
+    const handleOpenChange = (isOpen: boolean) => {
+        if (!isOpen) {
+            setMode('all');
+            setSelectedIds([]);
+            setSearch('');
+            setListOpen(false);
+        }
+        onOpenChange(isOpen);
+    };
+
+    const toggleNewsletter = useCallback((id: string) => {
+        setSelectedIds((prev) => {
+            return prev.includes(id) ? prev.filter(i => i !== id) : [...prev, id];
+        });
+    }, []);
+
+    const showPicker = newsletters.length >= 2;
+
+    const handleConfirm = () => {
+        if (!showPicker || mode === 'all') {
+            onConfirm(null);
+        } else {
+            onConfirm(selectedIds);
+        }
+    };
+
+    const isDisabled = isLoading || (showPicker && mode === 'selected' && selectedIds.length === 0);
+    const memberLabel = memberCount === 1 ? 'member' : 'members';
+
     return (
-        <Dialog open={open} onOpenChange={onOpenChange}>
+        <Dialog open={open} onOpenChange={handleOpenChange}>
             <DialogContent className="gap-5">
                 <DialogHeader>
                     <DialogTitle>Unsubscribe members</DialogTitle>
-                    <DialogDescription>
-                        Are you sure you want to unsubscribe {memberCount.toLocaleString()} {memberCount === 1 ? 'member' : 'members'} from all newsletters?
-                        They will no longer receive any email newsletters from you.
-                    </DialogDescription>
                 </DialogHeader>
 
+                {showPicker ? (
+                    <>
+                        <div aria-label="Unsubscribe scope" className="flex flex-col gap-3" role="radiogroup">
+                            <label className="flex cursor-pointer items-start gap-3">
+                                <input
+                                    checked={mode === 'all'}
+                                    className="mt-0.5 size-4 cursor-pointer accent-black"
+                                    name="unsubscribe-mode"
+                                    type="radio"
+                                    value="all"
+                                    onChange={() => setMode('all')}
+                                />
+                                <div className="flex flex-col">
+                                    <span className="text-sm font-semibold">Unsubscribe from all newsletters</span>
+                                    <span className="text-sm text-muted-foreground">
+                                        {memberCount.toLocaleString()} {memberLabel} will be unsubscribed from {newsletters.length} {newsletters.length === 1 ? 'newsletter' : 'newsletters'}.
+                                    </span>
+                                </div>
+                            </label>
+
+                            <label className="flex cursor-pointer items-start gap-3">
+                                <input
+                                    checked={mode === 'selected'}
+                                    className="mt-0.5 size-4 cursor-pointer accent-black"
+                                    name="unsubscribe-mode"
+                                    type="radio"
+                                    value="selected"
+                                    onChange={() => setMode('selected')}
+                                />
+                                <div className="flex flex-col">
+                                    <span className="text-sm font-semibold">Unsubscribe from selected newsletters</span>
+                                    <span className="text-sm text-muted-foreground">
+                                        Select which newsletters to unsubscribe {memberCount.toLocaleString()} {memberLabel} from.
+                                    </span>
+                                </div>
+                            </label>
+                        </div>
+
+                        {mode === 'selected' && (
+                            <div ref={pickerRef} className="relative space-y-2">
+                                <label className="text-sm font-semibold" htmlFor="newsletter-search">Newsletters</label>
+                                <div
+                                    className="flex min-h-9 w-full cursor-text flex-wrap items-center gap-1.5 rounded-md border bg-background px-3 py-1 text-sm"
+                                    onClick={() => {
+                                        inputRef.current?.focus();
+                                        setListOpen(true);
+                                    }}
+                                >
+                                    {selectedIds.map((id) => {
+                                        const nl = newsletters.find(n => n.id === id);
+                                        if (!nl) {
+                                            return null;
+                                        }
+                                        return (
+                                            <Badge
+                                                key={id}
+                                                className="cursor-pointer gap-1 pr-1"
+                                                variant="outline"
+                                                onClick={(e) => {
+                                                    e.stopPropagation();
+                                                    toggleNewsletter(id);
+                                                }}
+                                            >
+                                                {nl.name}
+                                                <LucideIcon.X className="size-3" />
+                                            </Badge>
+                                        );
+                                    })}
+                                    <input
+                                        ref={inputRef}
+                                        className="min-w-[80px] flex-1 bg-transparent py-1 text-sm outline-none placeholder:text-muted-foreground"
+                                        id="newsletter-search"
+                                        placeholder={selectedIds.length === 0 ? 'Search newsletters...' : ''}
+                                        value={search}
+                                        onChange={(e) => {
+                                            setSearch(e.target.value);
+                                            if (!listOpen) {
+                                                setListOpen(true);
+                                            }
+                                        }}
+                                        onFocus={() => setListOpen(true)}
+                                        onKeyDown={(e) => {
+                                            if (e.key === 'Escape') {
+                                                setListOpen(false);
+                                                inputRef.current?.blur();
+                                            }
+                                            if (e.key === 'Backspace' && !search && selectedIds.length > 0) {
+                                                toggleNewsletter(selectedIds[selectedIds.length - 1]);
+                                            }
+                                        }}
+                                    />
+                                </div>
+                                {listOpen && (
+                                    <div className="absolute left-0 top-full z-50 mt-1 w-full rounded-md border bg-white shadow-md dark:bg-gray-950">
+                                        <Command shouldFilter={false}>
+                                            <CommandList className="max-h-64 overflow-y-auto">
+                                                <CommandEmpty>No newsletters found.</CommandEmpty>
+                                                {newsletters
+                                                    .filter(n => n.name.toLowerCase().includes(search.toLowerCase()))
+                                                    .map(newsletter => (
+                                                        <CommandItem
+                                                            key={newsletter.id}
+                                                            value={newsletter.name}
+                                                            onSelect={() => toggleNewsletter(newsletter.id)}
+                                                        >
+                                                            {newsletter.name}
+                                                            {selectedIds.includes(newsletter.id) && <CommandCheck />}
+                                                        </CommandItem>
+                                                    ))}
+                                            </CommandList>
+                                        </Command>
+                                    </div>
+                                )}
+                            </div>
+                        )}
+                    </>
+                ) : (
+                    <p className="text-sm text-muted-foreground">
+                        Are you sure you want to unsubscribe {memberCount.toLocaleString()} {memberLabel} from all newsletters? They will no longer receive any email newsletters from you.
+                    </p>
+                )}
+
                 <DialogFooter>
-                    <Button variant="outline" onClick={() => onOpenChange(false)}>
+                    <Button variant="outline" onClick={() => handleOpenChange(false)}>
                         Cancel
                     </Button>
                     <Button
-                        disabled={isLoading}
+                        disabled={isDisabled}
                         variant="destructive"
-                        onClick={onConfirm}
+                        onClick={handleConfirm}
                     >
                         {isLoading ? 'Unsubscribing...' : 'Unsubscribe'}
                     </Button>

--- a/apps/posts/src/views/members/components/members-actions.tsx
+++ b/apps/posts/src/views/members/components/members-actions.tsx
@@ -11,6 +11,7 @@ import {
 } from '@tryghost/shade';
 import {blobDownloadFromEndpoint} from '@tryghost/admin-x-framework/helpers';
 import {toast} from 'sonner';
+import {useBrowseNewsletters} from '@tryghost/admin-x-framework/api/newsletters';
 import {useBulkDeleteMembers, useBulkEditMembers} from '@tryghost/admin-x-framework/api/members';
 
 interface MembersActionsProps {
@@ -35,8 +36,14 @@ const MembersActions: React.FC<MembersActionsProps> = ({
     nql,
     canBulkDelete
 }) => {
+    const {data: newslettersData, isLoading: isLoadingNewsletters} = useBrowseNewsletters({
+        searchParams: {filter: 'status:-archived', limit: '50'}
+    });
+    const activeNewsletters = newslettersData?.newsletters || [];
+
     const {mutateAsync: bulkEditAsync, isLoading: isBulkEditing} = useBulkEditMembers();
     const {mutate: bulkDelete, isLoading: isBulkDeleting} = useBulkDeleteMembers();
+    const [isUnsubscribing, setIsUnsubscribing] = useState(false);
 
     const [showAddLabelModal, setShowAddLabelModal] = useState(false);
     const [showRemoveLabelModal, setShowRemoveLabelModal] = useState(false);
@@ -96,21 +103,58 @@ const MembersActions: React.FC<MembersActionsProps> = ({
         }
     }, [bulkEditAsync, nql]);
 
-    const handleUnsubscribe = useCallback(() => {
-        bulkEditAsync({
+    const handleUnsubscribe = useCallback(async (newsletterIds: string[] | null) => {
+        const baseParams = {
             filter: nql || '',
-            all: !nql,
-            action: {
-                type: 'unsubscribe'
+            all: !nql
+        };
+
+        if (newsletterIds === null) {
+            try {
+                await bulkEditAsync({
+                    ...baseParams,
+                    action: {type: 'unsubscribe'}
+                });
+                setShowUnsubscribeModal(false);
+                toast.success('Members unsubscribed successfully');
+            } catch {
+                toast.error('Failed to unsubscribe members', {
+                    description: 'There was a problem unsubscribing these members. Please try again.'
+                });
             }
-        }).then(() => {
+            return;
+        }
+
+        setIsUnsubscribing(true);
+        try {
+            const results = await Promise.allSettled(
+                newsletterIds.map(id => bulkEditAsync({
+                    ...baseParams,
+                    action: {type: 'unsubscribe', newsletter: id}
+                }))
+            );
+            const succeeded = results.filter(r => r.status === 'fulfilled').length;
+            const total = results.length;
+
             setShowUnsubscribeModal(false);
-            toast.success('Members unsubscribed successfully');
-        }).catch(() => {
+            if (succeeded === total) {
+                toast.success(`Unsubscribed from ${total} ${total === 1 ? 'newsletter' : 'newsletters'}`);
+            } else if (succeeded > 0) {
+                toast.warning(`Unsubscribed from ${succeeded} of ${total} newsletters`, {
+                    description: 'Some newsletters could not be unsubscribed. Please try again.'
+                });
+            } else {
+                toast.error('Failed to unsubscribe members', {
+                    description: 'There was a problem unsubscribing these members. Please try again.'
+                });
+            }
+        } catch {
             toast.error('Failed to unsubscribe members', {
                 description: 'There was a problem unsubscribing these members. Please try again.'
             });
-        });
+        } finally {
+            setIsUnsubscribing(false);
+        }
     }, [bulkEditAsync, nql]);
 
     const handleDelete = useCallback(() => {
@@ -168,7 +212,10 @@ const MembersActions: React.FC<MembersActionsProps> = ({
                         <LucideIcon.Tag className="mr-2 size-4" />
                             Remove label from {memberCount.toLocaleString()} {memberCount === 1 ? 'member' : 'members'}
                     </DropdownMenuItem>
-                    <DropdownMenuItem onClick={() => setShowUnsubscribeModal(true)}>
+                    <DropdownMenuItem
+                        disabled={isLoadingNewsletters}
+                        onClick={() => setShowUnsubscribeModal(true)}
+                    >
                         <LucideIcon.MailX className="mr-2 size-4" />
                             Unsubscribe {memberCount.toLocaleString()} {memberCount === 1 ? 'member' : 'members'}
                     </DropdownMenuItem>
@@ -208,8 +255,9 @@ const MembersActions: React.FC<MembersActionsProps> = ({
                 onOpenChange={setShowRemoveLabelModal}
             />
             <UnsubscribeModal
-                isLoading={isBulkEditing}
+                isLoading={isBulkEditing || isUnsubscribing}
                 memberCount={memberCount}
+                newsletters={activeNewsletters}
                 open={showUnsubscribeModal}
                 onConfirm={handleUnsubscribe}
                 onOpenChange={setShowUnsubscribeModal}


### PR DESCRIPTION
The React members list bulk unsubscribe action previously removed members from all newsletters unconditionally. Sites with multiple active newsletters had no way to target a specific newsletter, unlike the Ember admin which already supported this.

The unsubscribe modal now detects how many active newsletters exist. When there are two or more, it renders a newsletter selector with an "All newsletters" default and individual newsletter options. When there's only one (or none), it shows the existing simple confirmation dialog. These two flows are implemented as separate components to keep the logic clean. The backend already accepted an optional `newsletter` parameter on the bulk unsubscribe endpoint, so no server-side changes were needed.