### PR TITLE
Fixed retention offers not rendering for members on archived tiers

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.65.0",
+  "version": "2.65.1",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/portal/src/components/pages/account-plan-page.js
+++ b/apps/portal/src/components/pages/account-plan-page.js
@@ -5,7 +5,7 @@ import CloseButton from '../common/close-button';
 import BackButton from '../common/back-button';
 import {MultipleProductsPlansSection} from '../common/plans-section';
 import {getDateString} from '../../utils/date-time';
-import {addMonths, formatNumber, getAvailablePrices, getCurrencySymbol, getFilteredPrices, isFreeMonthsOffer, getMemberActivePrice, getMemberActiveProduct, getMemberSubscription, getOfferOffAmount, getPriceFromSubscription, getProductFromId, getProductFromPrice, getSubscriptionFromId, getUpdatedOfferPrice, getUpgradeProducts, hasMultipleProductsFeature, isComplimentaryMember, isPaidMember} from '../../utils/helpers';
+import {addMonths, formatNumber, getAvailablePrices, getCurrencySymbol, getFilteredPrices, isFreeMonthsOffer, getMemberActivePrice, getMemberActiveProduct, getMemberSubscription, getOfferOffAmount, getPriceFromSubscription, getProductFromPrice, getSubscriptionFromId, getUpdatedOfferPrice, getUpgradeProducts, hasMultipleProductsFeature, isComplimentaryMember, isPaidMember} from '../../utils/helpers';
 import Interpolate from '@doist/react-interpolate';
 import {t} from '../../utils/i18n';
 
@@ -309,18 +309,24 @@ function getRetentionOfferMessage(offer, originalPrice, currency, amountOff, sub
     return '';
 }
 
-const RetentionOfferSection = ({offer, product, price, onAcceptOffer, onDeclineOffer}) => {
-    const {brandColor, action, member} = useContext(AppContext);
+const RetentionOfferSection = ({subscription, offer, onAcceptOffer, onDeclineOffer}) => {
+    const {brandColor, action} = useContext(AppContext);
     const isAcceptingOffer = action === 'applyOffer:running';
-    const subscription = getMemberSubscription({member});
 
+    const price = getPriceFromSubscription({subscription});
     const originalPrice = formatNumber(price.amount / 100);
     const currency = getCurrencySymbol(price.currency);
     const discountedPrice = formatNumber(getUpdatedOfferPrice({offer, price}));
     const amountOff = getOfferOffAmount({offer});
 
     const cadenceLabel = offer.cadence === 'month' ? t('Monthly') : t('Yearly');
-    const productCadenceLabel = `${product.name} - ${cadenceLabel}`;
+
+    let productCadenceLabel = cadenceLabel;
+    const tier = subscription.tier;
+    if (tier && tier.name) {
+        productCadenceLabel = `${tier.name} - ${cadenceLabel}`;
+    }
+
     const displayDescription = offer.display_description || t('We\'d hate to see you leave. How about a special offer to stay?');
 
     const offerLabel = getRetentionOfferLabel(offer, amountOff);
@@ -429,7 +435,7 @@ const PlansContainer = ({
     pendingOffer, onPlanSelect, onPlanCheckout, onConfirm, onCancelSubscription,
     onAcceptRetentionOffer, onDeclineRetentionOffer
 }) => {
-    const {member, site} = useContext(AppContext);
+    const {member} = useContext(AppContext);
     // Plan upgrade flow for free member or complimentary member
     if (!isPaidMember({member}) || isComplimentaryMember({member})) {
         return (
@@ -451,18 +457,13 @@ const PlansContainer = ({
 
     // Retention offer flow - shown before cancellation confirmation
     if (confirmationType === 'offerRetention' && pendingOffer) {
-        const offerProduct = pendingOffer.tier
-            ? getProductFromId({site, productId: pendingOffer.tier.id})
-            : getMemberActiveProduct({member, site});
-        const offerPrice = pendingOffer.cadence === 'month' ? offerProduct?.monthlyPrice : offerProduct?.yearlyPrice;
+        const subscription = getMemberSubscription({member});
 
-        // Skip retention offer if product or price is invalid
-        if (offerProduct && offerPrice) {
+        if (subscription) {
             return (
                 <RetentionOfferSection
+                    subscription={subscription}
                     offer={pendingOffer}
-                    product={offerProduct}
-                    price={offerPrice}
                     onAcceptOffer={onAcceptRetentionOffer}
                     onDeclineOffer={onDeclineRetentionOffer}
                 />

--- a/apps/portal/test/unit/components/pages/account-plan-page.test.js
+++ b/apps/portal/test/unit/components/pages/account-plan-page.test.js
@@ -101,7 +101,7 @@ describe('Account Plan Page', () => {
         expect(confirmCancelButton).toBeInTheDocument();
     });
 
-    test('shows retention offer when opened with cancel pageData and retention offers exist', async () => {
+    test('shows retention offer during cancellation flow', async () => {
         const paidProduct = getProductData({
             name: 'Basic',
             monthlyPrice: getPriceData({interval: 'month', amount: 1000, currency: 'usd'}),
@@ -144,6 +144,66 @@ describe('Account Plan Page', () => {
         // Should show retention offer section instead of cancellation confirmation
         const acceptOfferButton = await findByRole('button', {name: 'Continue subscription'});
         expect(acceptOfferButton).toBeInTheDocument();
+    });
+
+    test('shows retention offer during cancellation flow for members on an archived tier', async () => {
+        const paidTier = getProductData({
+            name: 'Basic',
+            monthlyPrice: getPriceData({interval: 'month', amount: 1000, currency: 'usd'}),
+            yearlyPrice: getPriceData({interval: 'year', amount: 10000, currency: 'usd'})
+        });
+
+        const archivedTier = getProductData({
+            name: 'Archived',
+            monthlyPrice: getPriceData({interval: 'month', amount: 1000, currency: 'usd'}),
+            yearlyPrice: getPriceData({interval: 'year', amount: 10000, currency: 'usd'})
+        });
+
+        // As archived products are not returned by the /tiers endpoint, omit archivedTier
+        const site = getSiteData({
+            products: [paidTier, getProductData({type: 'free'})],
+            portalProducts: [paidTier.id]
+        });
+
+        // Subscription is linked to archivedTier
+        const subscription = getSubscriptionData({
+            status: 'active',
+            interval: 'month',
+            amount: 1200,
+            currency: 'USD',
+            priceId: archivedTier.monthlyPrice.id,
+            tier: {
+                id: archivedTier.id,
+                name: archivedTier.name
+            }
+        });
+        subscription.price.product.product_id = subscription.tier.id;
+
+        const member = getMemberData({
+            paid: true,
+            subscriptions: [subscription]
+        });
+
+        const retentionOffer = {
+            ...getOfferData({
+                redemptionType: 'retention',
+                type: 'percent',
+                amount: 20,
+                cadence: 'month'
+            }),
+            tier: null
+        };
+
+        const {findByRole, queryByText} = customSetup({
+            site,
+            member,
+            offers: [retentionOffer],
+            pageData: {action: 'cancel', subscriptionId: subscription.id}
+        });
+
+        const acceptOfferButton = await findByRole('button', {name: 'Continue subscription'});
+        expect(acceptOfferButton).toBeInTheDocument();
+        expect(queryByText(`${archivedTier.name} - Monthly`)).toBeInTheDocument();
     });
 
     test('refreshes retention preview details when offer context changes', () => {


### PR DESCRIPTION
closes https://linear.app/ghost/issue/BER-3406

- previously, we expected the /tiers endpoint to always have tier-related data to render retention offer popups
- however, archived tiers are not returned as part of the `/tiers` endpoint
- with this fix, we directly get necessary data from the member subscription object