### PR TITLE
🐛 Fixed incoming recommendations disappearing on transient errors

### DIFF
--- a/ghost/admin/package.json
+++ b/ghost/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ghost-admin",
-  "version": "6.44.2-rc.0",
+  "version": "6.45.0-rc.0",
   "description": "Ember.js admin client for Ghost",
   "author": "Ghost Foundation",
   "homepage": "http://ghost.org",

--- a/ghost/core/core/server/data/migrations/versions/6.45/2026-06-08-11-23-46-add-revalidation-failure-count-to-mentions.js
+++ b/ghost/core/core/server/data/migrations/versions/6.45/2026-06-08-11-23-46-add-revalidation-failure-count-to-mentions.js
@@ -1,0 +1,8 @@
+const {createAddColumnMigration} = require('../../utils');
+
+module.exports = createAddColumnMigration('mentions', 'revalidation_failure_count', {
+    type: 'integer',
+    nullable: false,
+    unsigned: true,
+    defaultTo: 0
+});

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -1080,7 +1080,8 @@ module.exports = {
         created_at: {type: 'dateTime', nullable: false},
         payload: {type: 'text', maxlength: 65535, nullable: true},
         deleted: {type: 'boolean', nullable: false, defaultTo: false},
-        verified: {type: 'boolean', nullable: false, defaultTo: false}
+        verified: {type: 'boolean', nullable: false, defaultTo: false},
+        revalidation_failure_count: {type: 'integer', nullable: false, unsigned: true, defaultTo: 0}
     },
     milestones: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},

--- a/ghost/core/core/server/models/mention.js
+++ b/ghost/core/core/server/models/mention.js
@@ -4,7 +4,8 @@ const Mention = ghostBookshelf.Model.extend({
     tableName: 'mentions',
     defaults: {
         deleted: false,
-        verified: false
+        verified: false,
+        revalidation_failure_count: 0
     },
     defaultFilters() {
         return 'deleted:false';

--- a/ghost/core/core/server/services/mentions/bookshelf-mention-repository.js
+++ b/ghost/core/core/server/services/mentions/bookshelf-mention-repository.js
@@ -58,7 +58,8 @@ module.exports = class BookshelfMentionRepository {
             sourceFavicon: model.get('source_favicon'),
             sourceFeaturedImage: model.get('source_featured_image'),
             verified: model.get('verified'),
-            deleted: model.get('deleted')
+            deleted: model.get('deleted'),
+            revalidationFailureCount: model.get('revalidation_failure_count')
         });
     }
 
@@ -133,7 +134,8 @@ module.exports = class BookshelfMentionRepository {
             resource_type: mention.resourceType,
             payload: mention.payload ? JSON.stringify(mention.payload) : null,
             deleted: Mention.isDeleted(mention),
-            verified: mention.verified
+            verified: mention.verified,
+            revalidation_failure_count: mention.revalidationFailureCount
         };
 
         const existing = await this.#MentionModel.findOne({id: data.id}, {require: false});

--- a/ghost/core/core/server/services/mentions/mention.js
+++ b/ghost/core/core/server/services/mentions/mention.js
@@ -29,6 +29,22 @@ module.exports = class Mention {
         this.#deleted = true;
     }
 
+    /** @type {number} */
+    #revalidationFailureCount = 0;
+
+    get revalidationFailureCount() {
+        return this.#revalidationFailureCount;
+    }
+
+    recordRevalidationFailure() {
+        this.#revalidationFailureCount += 1;
+        return this.#revalidationFailureCount;
+    }
+
+    clearRevalidationFailures() {
+        this.#revalidationFailureCount = 0;
+    }
+
     #undelete() {
         // When an earlier mention is deleted, but then it gets verified again, we need to undelete it
         if (this.#deleted) {
@@ -229,6 +245,7 @@ module.exports = class Mention {
         this.#resourceType = data.resourceType;
         this.#verified = data.verified;
         this.#deleted = data.deleted || false;
+        this.#revalidationFailureCount = data.revalidationFailureCount || 0;
     }
 
     /**
@@ -315,7 +332,8 @@ module.exports = class Mention {
             resourceId,
             resourceType,
             verified,
-            deleted: isNew ? false : !!data.deleted
+            deleted: isNew ? false : !!data.deleted,
+            revalidationFailureCount: isNew ? 0 : (data.revalidationFailureCount || 0)
         });
 
         mention.setSourceMetadata(data);

--- a/ghost/core/core/server/services/mentions/mentions-api.js
+++ b/ghost/core/core/server/services/mentions/mentions-api.js
@@ -2,6 +2,8 @@ const errors = require('@tryghost/errors');
 const logging = require('@tryghost/logging');
 const Mention = require('./mention');
 
+const MAX_REVALIDATION_FAILURES = 3;
+
 /**
  * @template Model
  * @typedef {object} Page<Model>
@@ -210,12 +212,25 @@ module.exports = class MentionsAPI {
                         sourceFavicon: metadata.favicon,
                         sourceFeaturedImage: metadata.image
                     });
+                    mention.clearRevalidationFailures();
                 }
             } catch (err) {
                 if (!mention) {
                     throw err;
                 }
-                mention.delete();
+
+                if (err.transient) {
+                    logging.warn(`[Webmention Revalidation] Transient error fetching ${webmention.source.href}: ${err.message} (status: ${err.statusCode || 'N/A'})`);
+                    return mention;
+                }
+
+                const count = mention.recordRevalidationFailure();
+                logging.warn(`[Webmention Revalidation] Hard failure ${count}/${MAX_REVALIDATION_FAILURES} for ${webmention.source.href}: ${err.message} (status: ${err.statusCode || 'N/A'})`);
+
+                if (count >= MAX_REVALIDATION_FAILURES) {
+                    logging.warn(`[Webmention Revalidation] Deleting mention after ${count} consecutive failures: ${webmention.source.href}`);
+                    mention.delete();
+                }
             }
 
             if (!mention) {

--- a/ghost/core/core/server/services/mentions/webmention-metadata.js
+++ b/ghost/core/core/server/services/mentions/webmention-metadata.js
@@ -1,5 +1,15 @@
 const oembedService = require('../oembed');
 
+function isTransientError(err) {
+    const statusCode = err.statusCode || err.response?.statusCode;
+    return statusCode === 429 || statusCode === 503 || err.name === 'TimeoutError' || err.code === 'ETIMEDOUT';
+}
+
+function tagFetchError(err) {
+    err.transient = isTransientError(err);
+    return err;
+}
+
 module.exports = class WebmentionMetadata {
     /**
      * Helpers that change the URL for which metadata for a given external resource is fetched. Return undefined to now handle the URL.
@@ -34,15 +44,21 @@ module.exports = class WebmentionMetadata {
      */
     async fetch(url) {
         const mappedUrl = this.#getMappedUrl(url);
-        const data = await oembedService.fetchOembedDataFromUrl(mappedUrl.href, 'mention', {
-            timeout: {
-                request: 15000
-            },
-            retry: {
-                // Only retry on network issues, or specific HTTP status codes
-                limit: 3
-            }
-        });
+        let data;
+        try {
+            data = await oembedService.fetchOembedDataFromUrl(mappedUrl.href, 'mention', {
+                timeout: {
+                    request: 15000
+                },
+                retry: {
+                    // Only retry on network issues, or specific HTTP status codes
+                    limit: 3
+                },
+                shouldRethrowFetchError: isTransientError
+            });
+        } catch (err) {
+            throw tagFetchError(err);
+        }
 
         const result = {
             siteTitle: data.metadata.publisher,
@@ -58,17 +74,21 @@ module.exports = class WebmentionMetadata {
         if (mappedUrl.href !== url.href) {
             // Still need to fetch body and contentType separately now
             // For verification
-            const {body, contentType} = await oembedService.fetchPageHtml(url, {
-                timeout: {
-                    request: 15000
-                },
-                retry: {
-                    // Only retry on network issues, or specific HTTP status codes
-                    limit: 3
-                }
-            });
-            result.body = body;
-            result.contentType = contentType;
+            try {
+                const {body, contentType} = await oembedService.fetchPageHtml(url, {
+                    timeout: {
+                        request: 15000
+                    },
+                    retry: {
+                        // Only retry on network issues, or specific HTTP status codes
+                        limit: 3
+                    }
+                });
+                result.body = body;
+                result.contentType = contentType;
+            } catch (err) {
+                throw tagFetchError(err);
+            }
         }
         return result;
     }

--- a/ghost/core/core/server/services/oembed/oembed-service.js
+++ b/ghost/core/core/server/services/oembed/oembed-service.js
@@ -464,6 +464,8 @@ class OEmbedService {
      * @returns {Promise<Object>}
      */
     async fetchOembedDataFromUrl(url, type, options = {}) {
+        const {shouldRethrowFetchError, ...fetchOptions} = options;
+
         try {
             const urlObject = new URL(url);
 
@@ -502,7 +504,7 @@ class OEmbedService {
             }
 
             // Not in the list, we need to fetch the content
-            const {url: pageUrl, body, contentType} = await this.fetchPageHtml(url, options);
+            const {url: pageUrl, body, contentType} = await this.fetchPageHtml(url, fetchOptions);
 
             // fetch only bookmark when explicitly requested
             if (type === 'bookmark') {
@@ -558,6 +560,10 @@ class OEmbedService {
 
             return data;
         } catch (err) {
+            if (shouldRethrowFetchError?.(err)) {
+                throw err;
+            }
+
             // allow specific validation errors through for better error messages
             if (errors.utils.isGhostError(err) && err.errorType === 'ValidationError') {
                 throw err;

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ghost",
-  "version": "6.44.2-rc.0",
+  "version": "6.45.0-rc.0",
   "description": "The professional publishing platform",
   "author": "Ghost Foundation",
   "homepage": "https://ghost.org",

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = 'fafc9d5ad026f5eef11f9229a34994eb';
+    const currentSchemaHash = '7f386a2e943ae71a246858e896ecf314';
     const currentFixturesHash = '823aa0e8a8f083e80e271c47836a7e5d';
     const currentSettingsHash = '397be8628c753b1959b8954d5610f83f';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';

--- a/ghost/core/test/unit/server/services/mentions/mentions-api.test.js
+++ b/ghost/core/test/unit/server/services/mentions/mentions-api.test.js
@@ -227,17 +227,23 @@ describe('MentionsAPI', function () {
 
     it('Can update recommendations', async function () {
         const repository = new InMemoryMentionRepository();
+        const fetchStub = sinon.stub();
+        // First two calls succeed (processWebmention for source1 and source2)
+        fetchStub.onCall(0).resolves(mockWebmentionMetadata.fetch());
+        fetchStub.onCall(1).resolves(mockWebmentionMetadata.fetch());
+        // refreshMentions: source1 succeeds, source2 fails 3 times in a row
+        fetchStub.onCall(2).resolves(mockWebmentionMetadata.fetch()); // refresh source1 pass 1
+        fetchStub.onCall(3).rejects(new Error('fail')); // refresh source2 fail 1
+        fetchStub.onCall(4).resolves(mockWebmentionMetadata.fetch()); // refresh source1 pass 2
+        fetchStub.onCall(5).rejects(new Error('fail')); // refresh source2 fail 2
+        fetchStub.onCall(6).resolves(mockWebmentionMetadata.fetch()); // refresh source1 pass 3
+        fetchStub.onCall(7).rejects(new Error('fail')); // refresh source2 fail 3 → deleted
+
         const api = new MentionsAPI({
             repository,
             routingService: mockRoutingService,
             resourceService: mockResourceService,
-            webmentionMetadata: {
-                fetch: sinon.stub()
-                    .onFirstCall().resolves(mockWebmentionMetadata.fetch())
-                    .onSecondCall().resolves(mockWebmentionMetadata.fetch())
-                    .onThirdCall().resolves(mockWebmentionMetadata.fetch())
-                    .onCall(3).rejects()
-            }
+            webmentionMetadata: {fetch: fetchStub}
         });
 
         await api.processWebmention({
@@ -259,16 +265,112 @@ describe('MentionsAPI', function () {
         });
         assert(page.meta.pagination.total === 2);
 
-        // Now we invalidate the second mention
+        // First refresh: source2 gets failure 1 of 3 — not deleted yet
+        await api.refreshMentions({limit: 'all'});
+        page = await api.listMentions({limit: 'all'});
+        assert.equal(page.meta.pagination.total, 2, 'Mention should survive first hard failure');
 
-        await api.refreshMentions({
-            limit: 'all'
+        // Second refresh: source2 gets failure 2 of 3 — still not deleted
+        await api.refreshMentions({limit: 'all'});
+        page = await api.listMentions({limit: 'all'});
+        assert.equal(page.meta.pagination.total, 2, 'Mention should survive second hard failure');
+
+        // Third refresh: source2 gets failure 3 of 3 — now deleted
+        await api.refreshMentions({limit: 'all'});
+        page = await api.listMentions({limit: 'all'});
+        assert.equal(page.meta.pagination.total, 1, 'Mention should be deleted after 3rd consecutive hard failure');
+    });
+
+    it('Does not delete mention on transient error during refresh', async function () {
+        const repository = new InMemoryMentionRepository();
+        const transientErr = new Error('Too Many Requests');
+        transientErr.transient = true;
+        transientErr.statusCode = 429;
+
+        const api = new MentionsAPI({
+            repository,
+            routingService: mockRoutingService,
+            resourceService: mockResourceService,
+            webmentionMetadata: {
+                fetch: sinon.stub()
+                    .onFirstCall().resolves(mockWebmentionMetadata.fetch())
+                    .onSecondCall().rejects(transientErr)
+            }
         });
 
-        page = await api.listMentions({
-            limit: 'all'
+        await api.processWebmention({
+            source: new URL('https://source.com'),
+            target: new URL('https://target.com'),
+            payload: {}
         });
-        assert(page.meta.pagination.total === 1);
+
+        await api.refreshMentions({limit: 'all'});
+
+        const page = await api.listMentions({limit: 'all'});
+        assert.equal(page.meta.pagination.total, 1, 'Mention should not be deleted on transient error');
+    });
+
+    it('Increments hard failure count but does not delete when count < 3', async function () {
+        const repository = new InMemoryMentionRepository();
+        const api = new MentionsAPI({
+            repository,
+            routingService: mockRoutingService,
+            resourceService: mockResourceService,
+            webmentionMetadata: {
+                fetch: sinon.stub()
+                    .onFirstCall().resolves(mockWebmentionMetadata.fetch())
+                    .onSecondCall().rejects(new Error('404'))
+            }
+        });
+
+        await api.processWebmention({
+            source: new URL('https://source.com'),
+            target: new URL('https://target.com'),
+            payload: {}
+        });
+
+        await api.refreshMentions({limit: 'all'});
+
+        const page = await api.listMentions({limit: 'all'});
+        assert.equal(page.meta.pagination.total, 1, 'Mention should survive a single hard failure');
+    });
+
+    it('Successful fetch after failures resets the failure count', async function () {
+        const repository = new InMemoryMentionRepository();
+        const fetchStub = sinon.stub();
+        fetchStub.onCall(0).resolves(mockWebmentionMetadata.fetch()); // processWebmention
+        fetchStub.onCall(1).rejects(new Error('fail')); // refresh 1: hard failure 1
+        fetchStub.onCall(2).rejects(new Error('fail')); // refresh 2: hard failure 2
+        fetchStub.onCall(3).resolves(mockWebmentionMetadata.fetch()); // refresh 3: success → resets count
+        fetchStub.onCall(4).rejects(new Error('fail')); // refresh 4: hard failure 1 again
+        fetchStub.onCall(5).rejects(new Error('fail')); // refresh 5: hard failure 2
+
+        const api = new MentionsAPI({
+            repository,
+            routingService: mockRoutingService,
+            resourceService: mockResourceService,
+            webmentionMetadata: {fetch: fetchStub}
+        });
+
+        await api.processWebmention({
+            source: new URL('https://source.com'),
+            target: new URL('https://target.com'),
+            payload: {}
+        });
+
+        // Two hard failures
+        await api.refreshMentions({limit: 'all'});
+        await api.refreshMentions({limit: 'all'});
+
+        // One success — should reset count
+        await api.refreshMentions({limit: 'all'});
+
+        // Two more hard failures — count should be 2, not 4
+        await api.refreshMentions({limit: 'all'});
+        await api.refreshMentions({limit: 'all'});
+
+        const page = await api.listMentions({limit: 'all'});
+        assert.equal(page.meta.pagination.total, 1, 'Mention should survive because success reset the failure count');
     });
 
     it('Can handle updating mentions', async function () {
@@ -449,8 +551,10 @@ describe('MentionsAPI', function () {
             webmentionMetadata: {
                 fetch: sinon.stub()
                     .onFirstCall().resolves(mockWebmentionMetadata.fetch())
-                    .onSecondCall().rejects()
-                    .onThirdCall().resolves(mockWebmentionMetadata.fetch())
+                    .onSecondCall().rejects(new Error('fail'))
+                    .onThirdCall().rejects(new Error('fail'))
+                    .onCall(3).rejects(new Error('fail'))
+                    .onCall(4).resolves(mockWebmentionMetadata.fetch())
             }
         });
 
@@ -470,6 +574,17 @@ describe('MentionsAPI', function () {
         }
 
         checkMentionDeleted: {
+            // Need 3 consecutive hard failures to delete
+            await api.processWebmention({
+                source: new URL('https://source.com'),
+                target: new URL('https://target.com'),
+                payload: {}
+            });
+            await api.processWebmention({
+                source: new URL('https://source.com'),
+                target: new URL('https://target.com'),
+                payload: {}
+            });
             await api.processWebmention({
                 source: new URL('https://source.com'),
                 target: new URL('https://target.com'),

--- a/ghost/core/test/unit/server/services/mentions/webmention-metadata.test.js
+++ b/ghost/core/test/unit/server/services/mentions/webmention-metadata.test.js
@@ -1,0 +1,85 @@
+const assert = require('node:assert/strict');
+const sinon = require('sinon');
+
+const oembedService = require('../../../../../core/server/services/oembed');
+const WebmentionMetadata = require('../../../../../core/server/services/mentions/webmention-metadata');
+
+describe('WebmentionMetadata', function () {
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    it('passes a transient fetch error classifier to the oEmbed service', async function () {
+        const error = new Error('Too Many Requests');
+        error.response = {
+            statusCode: 429
+        };
+
+        const fetchStub = sinon.stub(oembedService, 'fetchOembedDataFromUrl').rejects(error);
+        const webmentionMetadata = new WebmentionMetadata();
+
+        await assert.rejects(
+            () => webmentionMetadata.fetch(new URL('https://example.com')),
+            (err) => {
+                assert.equal(err, error);
+                assert.equal(err.transient, true);
+                return true;
+            }
+        );
+
+        const options = fetchStub.firstCall.args[2];
+        assert.equal(options.shouldRethrowFetchError(error), true);
+    });
+
+    it('tags 503 fetch errors with got response shape as transient', async function () {
+        const error = new Error('Service Unavailable');
+        error.response = {
+            statusCode: 503
+        };
+
+        sinon.stub(oembedService, 'fetchOembedDataFromUrl').rejects(error);
+        const webmentionMetadata = new WebmentionMetadata();
+
+        await assert.rejects(
+            () => webmentionMetadata.fetch(new URL('https://example.com')),
+            (err) => {
+                assert.equal(err.transient, true);
+                return true;
+            }
+        );
+    });
+
+    it('tags timeout fetch errors as transient', async function () {
+        const error = new Error('Timeout awaiting request');
+        error.name = 'TimeoutError';
+
+        sinon.stub(oembedService, 'fetchOembedDataFromUrl').rejects(error);
+        const webmentionMetadata = new WebmentionMetadata();
+
+        await assert.rejects(
+            () => webmentionMetadata.fetch(new URL('https://example.com')),
+            (err) => {
+                assert.equal(err.transient, true);
+                return true;
+            }
+        );
+    });
+
+    it('does not tag hard fetch errors as transient', async function () {
+        const error = new Error('Not Found');
+        error.response = {
+            statusCode: 404
+        };
+
+        sinon.stub(oembedService, 'fetchOembedDataFromUrl').rejects(error);
+        const webmentionMetadata = new WebmentionMetadata();
+
+        await assert.rejects(
+            () => webmentionMetadata.fetch(new URL('https://example.com')),
+            (err) => {
+                assert.equal(err.transient, false);
+                return true;
+            }
+        );
+    });
+});

--- a/ghost/core/test/unit/server/services/oembed/oembed-service.test.js
+++ b/ghost/core/test/unit/server/services/oembed/oembed-service.test.js
@@ -259,6 +259,87 @@ describe('oembed-service', function () {
 
             await oembedService.fetchOembedDataFromUrl('https://youtube.com/live/1234?param=existing');
         });
+
+        it('keeps unknown provider fallback by default when the page fetch fails', async function () {
+            const fetchError = new Error('Service Unavailable');
+            fetchError.response = {
+                statusCode: 503
+            };
+
+            const service = new OembedService({
+                config: {get() {
+                    return true;
+                }},
+                externalRequest() {
+                    throw fetchError;
+                }
+            });
+
+            await assert.rejects(
+                () => service.fetchOembedDataFromUrl('https://www.example.com', 'mention'),
+                {
+                    name: 'ValidationError',
+                    message: 'No provider found for supplied URL.'
+                }
+            );
+        });
+
+        it('does not pass the rethrow callback to the external request', async function () {
+            const service = new OembedService({
+                config: {get() {
+                    return true;
+                }},
+                externalRequest(url, options) {
+                    assert.equal(url, 'https://www.example.com');
+                    assert.equal(options.shouldRethrowFetchError, undefined);
+
+                    return {
+                        headers: {
+                            'content-type': 'text/html'
+                        },
+                        body: Buffer.from('<html><head><title>Example</title></head></html>'),
+                        url
+                    };
+                }
+            });
+
+            const response = await service.fetchOembedDataFromUrl('https://www.example.com', 'bookmark', {
+                shouldRethrowFetchError() {
+                    return true;
+                }
+            });
+
+            assert.equal(response.metadata.title, 'Example');
+        });
+
+        it('allows callers to rethrow selected page fetch errors', async function () {
+            const fetchError = new Error('Service Unavailable');
+            fetchError.response = {
+                statusCode: 503
+            };
+
+            const service = new OembedService({
+                config: {get() {
+                    return true;
+                }},
+                externalRequest() {
+                    throw fetchError;
+                }
+            });
+
+            await assert.rejects(
+                () => service.fetchOembedDataFromUrl('https://www.example.com', 'mention', {
+                    shouldRethrowFetchError(err) {
+                        return err.response?.statusCode === 503;
+                    }
+                }),
+                (err) => {
+                    assert.equal(err, fetchError);
+                    assert.equal(err.response.statusCode, 503);
+                    return true;
+                }
+            );
+        });
     });
 
     describe('processImageFromUrl', function () {


### PR DESCRIPTION
closes https://linear.app/ghost/issue/BER-3490

During boot, incoming recommendation mentions are revalidated. If the
metadata fetch failed for any reason (including transient errors like
429 rate limits or network timeouts), the mention was immediately
soft-deleted, causing valid recommendations to disappear from Ghost
Admin. Now transient errors are ignored entirely, and hard failures
require 3 consecutive occurrences before deletion. A successful fetch
resets the failure count.

## Changes
- Transient fetch errors (429, 503) during incoming recommendation revalidation are now ignored instead of immediately deleting the mention
- Hard failures now require 3 consecutive occurrences before a mention is soft-deleted, tracked via a new `revalidation_failure_count` column on the `mentions` table
- A successful metadata fetch resets the failure counter to zero
- All failures are logged with a `[Webmention Revalidation]` prefix for easy diagnosis

