### PR TITLE
Fixed forbidden API calls when Editor opens staff settings

### DIFF
--- a/apps/admin/src/layout/app-sidebar/hooks/use-member-count.ts
+++ b/apps/admin/src/layout/app-sidebar/hooks/use-member-count.ts
@@ -1,15 +1,22 @@
 import { useBrowseMembers } from "@tryghost/admin-x-framework/api/members";
+import { useCurrentUser } from "@tryghost/admin-x-framework/api/current-user";
+import { canManageMembers } from "@tryghost/admin-x-framework/api/users";
 
 /**
  * Hook to fetch the total member count efficiently.
  * Only fetches pagination metadata (limit=1) to minimize API overhead.
  * Automatically invalidates when members are created/updated/deleted in Ember.
+ * Only fetches for users with member management permissions to avoid 403 errors.
  */
 export function useMemberCount() {
+    const { data: currentUser } = useCurrentUser();
+    const hasPermission = currentUser ? canManageMembers(currentUser) : false;
+
     const { data: membersData } = useBrowseMembers({
-        searchParams: { limit: '1' }
+        searchParams: { limit: '1' },
+        enabled: hasPermission
     });
-    
+
     return membersData?.meta?.pagination.total;
 }
 

--- a/apps/admin/src/layout/app-sidebar/nav-main.tsx
+++ b/apps/admin/src/layout/app-sidebar/nav-main.tsx
@@ -25,15 +25,18 @@ function NavMain({ ...props }: React.ComponentProps<typeof SidebarGroup>) {
     const url = site.data?.site.url;
 
 
+    const isAdmin = currentUser && hasAdminAccess(currentUser);
+
     // The network app has its own notification state, so we don't want to show
     // multiple indicators when you have navigated there.
-    const { data: networkNotificationCount = 0 } = useNotificationsCountForUser(currentUser?.slug || '', networkEnabled);
+    // Only fetch for admin users — the identities API requires admin permissions.
+    const { data: networkNotificationCount = 0 } = useNotificationsCountForUser(currentUser?.slug || '', networkEnabled && !!isAdmin);
     const isNetworkRouteActive = useIsActiveLink({ path: 'network', activeOnSubpath: true })
     const isActivitypubRouteActive = useIsActiveLink({ path: 'activitypub', activeOnSubpath: true });
     const showNetworkBadge = networkNotificationCount > 0 && !isNetworkRouteActive && !isActivitypubRouteActive;
 
     // Only show NavMain for admin users
-    if (!currentUser || !hasAdminAccess(currentUser)) {
+    if (!isAdmin) {
         return null;
     }
     return (


### PR DESCRIPTION
## Summary

- **Members API 403**: The `useMemberCount` sidebar hook was unconditionally calling `useBrowseMembers` for all users, including Editors who lack `browse members` permission. Added a `canManageMembers` permission gate so the query only fires for Owner/Admin/Super Editor roles.

- **Identities API 403**: The `NavMain` sidebar component was calling `useNotificationsCountForUser` (which hits the `/identities/` endpoint via the ActivityPub API) before the `hasAdminAccess` guard returned `null`. Since React hooks run unconditionally, the API call fired even for non-admin users. Added `hasAdminAccess` check to the hook's `enabled` parameter.

Both issues caused noisy 403 errors, an error toast ("You do not have permission to browse members"), and UI unresponsiveness when logged in as an Editor.

closes https://github.com/TryGhost/Ghost/issues/26607