### PR TITLE
Improved URL service and sitemap boot performance

### DIFF
--- a/ghost/core/core/frontend/services/sitemap/site-map-manager.js
+++ b/ghost/core/core/frontend/services/sitemap/site-map-manager.js
@@ -1,5 +1,6 @@
 const DomainEvents = require('@tryghost/domain-events');
 const {URLResourceUpdatedEvent} = require('../../../shared/events');
+const urlUtils = require('../../../shared/url-utils');
 const IndexMapGenerator = require('./site-map-index-generator');
 const PagesMapGenerator = require('./page-map-generator');
 const PostsMapGenerator = require('./post-map-generator');
@@ -35,6 +36,17 @@ class SiteMapManager {
             this[event.data.resourceType].updateURL(event.data);
         });
 
+        // Bulk init: URL service emits all URLs at once after boot completes
+        events.on('url.init', ({urls}) => {
+            const allUrls = urls.urls;
+            for (const resourceId in allUrls) {
+                const entry = allUrls[resourceId];
+                const absoluteUrl = urlUtils.createUrl(entry.url, true);
+                this[entry.resource.config.type].addUrl(absoluteUrl, entry.resource.data);
+            }
+        });
+
+        // Runtime: individual URL additions/removals after boot
         events.on('url.added', (obj) => {
             this[obj.resource.config.type].addUrl(obj.url.absolute, obj.resource.data);
         });

--- a/ghost/core/core/server/models/base/plugins/raw-knex.js
+++ b/ghost/core/core/server/models/base/plugins/raw-knex.js
@@ -30,12 +30,20 @@ module.exports = function (Bookshelf) {
                     limit
                 } = options;
 
-                const bookshelfPrototype = Bookshelf.registry.models[modelName].prototype;
                 const tableNames = {
                     Post: 'posts',
                     User: 'users',
                     Tag: 'tags'
                 };
+
+                const tableName = tableNames[modelName];
+                const tableDef = schema.tables[tableName];
+                const booleanColumns = [];
+                for (const key in tableDef) {
+                    if (!key.startsWith('@@') && tableDef[key].type === 'boolean') {
+                        booleanColumns.push(key);
+                    }
+                }
 
                 const relations = {
                     tags: {
@@ -110,20 +118,14 @@ module.exports = function (Bookshelf) {
                 let props = {};
 
                 if (!withRelated) {
-                    return _.map(objects, (object) => {
-                        object = bookshelfPrototype.toJSON.bind({
-                            attributes: object,
-                            related: function (key) {
-                                return object[key];
-                            },
-                            serialize: bookshelfPrototype.serialize,
-                            formatsToJSON: bookshelfPrototype.formatsToJSON
-                        })();
-
-                        object = bookshelfPrototype.fixBools(object);
-                        object = bookshelfPrototype.fixDatesWhenFetch(object);
-                        return object;
-                    });
+                    for (const object of objects) {
+                        for (const col of booleanColumns) {
+                            if (col in object) {
+                                object[col] = !!object[col];
+                            }
+                        }
+                    }
+                    return objects;
                 }
 
                 _.each(withRelated, (withRelatedKey) => {
@@ -174,32 +176,17 @@ module.exports = function (Bookshelf) {
                 const relationsToAttachArray = await Promise.all(Object.values(props));
                 const relationsToAttach = _.zipObject(_.keys(props), relationsToAttachArray);
 
-                objects = _.map(objects, (object) => {
+                for (const object of objects) {
                     for (const relation in relationsToAttach) {
-                        if (!relationsToAttach[relation][object.id]) {
-                            object[relation] = [];
-                            continue;
-                        }
-
-                        object[relation] = relationsToAttach[relation][object.id];
+                        object[relation] = relationsToAttach[relation][object.id] || [];
                     }
 
-                    object = bookshelfPrototype.toJSON.bind({
-                        attributes: object,
-                        _originalOptions: {
-                            withRelated: Object.keys(relationsToAttach)
-                        },
-                        related: function (key) {
-                            return object[key];
-                        },
-                        serialize: bookshelfPrototype.serialize,
-                        formatsToJSON: bookshelfPrototype.formatsToJSON
-                    })();
-
-                    object = bookshelfPrototype.fixBools(object);
-                    object = bookshelfPrototype.fixDatesWhenFetch(object);
-                    return object;
-                });
+                    for (const col of booleanColumns) {
+                        if (col in object) {
+                            object[col] = !!object[col];
+                        }
+                    }
+                }
 
                 debug('attached relations to', modelName);
                 return objects;

--- a/ghost/core/core/server/models/base/plugins/raw-knex.js
+++ b/ghost/core/core/server/models/base/plugins/raw-knex.js
@@ -128,6 +128,21 @@ module.exports = function (Bookshelf) {
                     return objects;
                 }
 
+                // Build a subquery mirroring the main query's conditions (filter,
+                // shouldHavePosts, id) so relation queries use a subquery instead
+                // of materializing every post ID as a literal in WHERE IN.
+                function buildIdSubquery() {
+                    const sub = Bookshelf.knex(tableName).select('id');
+                    nql(filter).querySQL(sub);
+                    if (shouldHavePosts) {
+                        plugins.hasPosts.addHasPostsWhere(tableName, shouldHavePosts)(sub);
+                    }
+                    if (id) {
+                        sub.where({id});
+                    }
+                    return sub;
+                }
+
                 _.each(withRelated, (withRelatedKey) => {
                     const relation = relations[withRelatedKey];
 
@@ -153,7 +168,7 @@ module.exports = function (Bookshelf) {
                             relation.innerJoin.condition[2]
                         );
 
-                        relationQuery.whereIn(relation.whereIn, _.map(objects, 'id'));
+                        relationQuery.whereIn(relation.whereIn, buildIdSubquery());
                         relationQuery.orderBy(relation.orderBy);
 
                         const queryRelations = await relationQuery;

--- a/ghost/core/core/server/models/base/plugins/raw-knex.js
+++ b/ghost/core/core/server/models/base/plugins/raw-knex.js
@@ -19,6 +19,7 @@ module.exports = function (Bookshelf) {
             fetchAll: async function (options = {}) {
                 const {
                     modelName,
+                    include,
                     exclude,
                     filter,
                     shouldHavePosts,
@@ -73,8 +74,10 @@ module.exports = function (Bookshelf) {
                     query.limit(limit);
                 }
 
-                // exclude fields if provided
-                if (exclude) {
+                // select only the fields needed
+                if (include) {
+                    query.select(include);
+                } else if (exclude) {
                     const toSelect = Object
                         .keys(schema.tables[tableNames[modelName]])
                         .filter(key => !key.startsWith('@@') && !exclude.includes(key));

--- a/ghost/core/core/server/services/url/config.js
+++ b/ghost/core/core/server/services/url/config.js
@@ -1,42 +1,31 @@
 /*
  * These are the default resources and filters.
  * They contain minimum filters for public accessibility of resources.
+ *
+ * Each `include` list enumerates the exact columns fetched from the database
+ * for that resource type.  Only fields needed for:
+ *  - URL generation (permalink patterns, NQL route-filter evaluation)
+ *  - sitemap XML (dates, images, canonical_url exclusion)
+ *  - runtime change detection (_containsRoutingAffectingChanges)
+ * are included.
  */
-
-// TODO: switch exclude lists to include lists to make this more explicit
 module.exports = [
     {
         type: 'posts',
         modelOptions: {
             modelName: 'Post',
             filter: 'status:published+type:post',
-            exclude: [
-                'title',
-                'mobiledoc',
-                'lexical',
-                'html',
-                'plaintext',
-                // @TODO: https://github.com/TryGhost/Ghost/issues/10335
-                // 'page',
-                'status',
-                'codeinjection_head',
-                'codeinjection_foot',
-                'meta_title',
-                'meta_description',
-                'custom_excerpt',
-                'og_image',
-                'og_title',
-                'og_description',
-                'twitter_image',
-                'twitter_title',
-                'twitter_description',
-                'custom_template',
-                'locale',
-                'newsletter_id',
-                'show_title_and_feature_image',
-                'email_recipient_filter',
-                'comment_id',
-                'tiers'
+            include: [
+                'id',
+                'slug',
+                'type',
+                'featured',
+                'visibility',
+                'published_at',
+                'created_at',
+                'updated_at',
+                'feature_image',
+                'canonical_url'
             ],
             withRelated: ['tags', 'authors'],
             withRelatedPrimary: {
@@ -58,39 +47,19 @@ module.exports = [
         type: 'pages',
         modelOptions: {
             modelName: 'Post',
-            exclude: [
-                'title',
-                'mobiledoc',
-                'lexical',
-                'html',
-                'plaintext',
-                // @TODO: https://github.com/TryGhost/Ghost/issues/10335
-                // 'page',
-                // 'status',
-                'codeinjection_head',
-                'codeinjection_foot',
-                'meta_title',
-                'meta_description',
-                'custom_excerpt',
-                'og_image',
-                'og_title',
-                'og_description',
-                'twitter_image',
-                'twitter_title',
-                'twitter_description',
-                'custom_template',
-                'locale',
-                'tags',
-                'authors',
-                'primary_tag',
-                'primary_author',
-                'newsletter_id',
-                'show_title_and_feature_image',
-                'email_recipient_filter',
-                'comment_id',
-                'tiers'
-            ],
-            filter: 'status:published+type:page'
+            filter: 'status:published+type:page',
+            include: [
+                'id',
+                'slug',
+                'type',
+                'featured',
+                'visibility',
+                'published_at',
+                'created_at',
+                'updated_at',
+                'feature_image',
+                'canonical_url'
+            ]
         },
         events: {
             add: 'page.published',
@@ -103,13 +72,17 @@ module.exports = [
         keep: ['id', 'slug'],
         modelOptions: {
             modelName: 'Tag',
-            exclude: [
-                'description',
-                'meta_title',
-                'meta_description',
-                'parent_id'
-            ],
             filter: 'visibility:public',
+            include: [
+                'id',
+                'name',
+                'slug',
+                'visibility',
+                'feature_image',
+                'canonical_url',
+                'created_at',
+                'updated_at'
+            ],
             shouldHavePosts: {
                 joinTo: 'tag_id',
                 joinTable: 'posts_tags'
@@ -125,20 +98,17 @@ module.exports = [
         type: 'authors',
         modelOptions: {
             modelName: 'User',
-            exclude: [
-                'bio',
-                'website',
-                'location',
-                'facebook',
-                'twitter',
-                'locale',
-                'accessibility',
-                'meta_title',
-                'meta_description',
-                'tour',
-                'last_seen'
-            ],
             filter: 'visibility:public',
+            include: [
+                'id',
+                'name',
+                'slug',
+                'visibility',
+                'profile_image',
+                'cover_image',
+                'created_at',
+                'updated_at'
+            ],
             shouldHavePosts: {
                 joinTo: 'author_id',
                 joinTable: 'posts_authors'

--- a/ghost/core/core/server/services/url/resources.js
+++ b/ghost/core/core/server/services/url/resources.js
@@ -5,6 +5,7 @@ const {URLResourceUpdatedEvent} = require('../../../shared/events');
 const Resource = require('./resource');
 const config = require('../../../shared/config');
 const models = require('../../models');
+const schema = require('../../data/schema');
 
 // This listens to all manner of model events to find new content that needs a URL...
 const events = require('../../lib/common/events');
@@ -180,9 +181,12 @@ class Resources {
      * @private
      */
     _prepareModelSync(model, resourceConfig) {
+        const include = resourceConfig.modelOptions.include;
         const exclude = resourceConfig.modelOptions.exclude;
         const withRelatedFields = resourceConfig.modelOptions.withRelatedFields;
-        const obj = _.omit(model.toJSON(), exclude);
+        const obj = include
+            ? _.pick(model.toJSON(), include)
+            : _.omit(model.toJSON(), exclude);
 
         if (withRelatedFields) {
             _.each(withRelatedFields, (fields, key) => {
@@ -318,7 +322,18 @@ class Resources {
         const resourceConfig = _.find(this.resourcesConfig, {type: type});
 
         // NOTE: check if any of the route-related fields were changed and only proceed if so
-        const ignoredProperties = [...resourceConfig.modelOptions.exclude, 'updated_at'];
+        const tableNames = {Post: 'posts', User: 'users', Tag: 'tags'};
+        const include = resourceConfig.modelOptions.include;
+        let ignoredProperties;
+        if (include) {
+            // With an include list, any field NOT in the list is irrelevant to routing
+            const allColumns = Object.keys(schema.tables[tableNames[resourceConfig.modelOptions.modelName]])
+                .filter(key => !key.startsWith('@@'));
+            ignoredProperties = allColumns.filter(col => !include.includes(col));
+            ignoredProperties.push('updated_at');
+        } else {
+            ignoredProperties = [...resourceConfig.modelOptions.exclude, 'updated_at'];
+        }
         if (!this._containsRoutingAffectingChanges(model, ignoredProperties)) {
             const cachedResource = this.getByIdAndType(type, model.id);
 

--- a/ghost/core/core/server/services/url/url-generator.js
+++ b/ghost/core/core/server/services/url/url-generator.js
@@ -1,6 +1,7 @@
 const nql = require('@tryghost/nql');
 const debug = require('@tryghost/debug')('services:url:generator');
 const localUtils = require('../../../shared/url-utils');
+const events = require('../../lib/common/events');
 
 // @TODO: merge with filter plugin
 const EXPANSIONS = [{
@@ -85,7 +86,15 @@ class UrlGenerator {
         const myResources = this.urls.getByGeneratorId(this.uid);
 
         myResources.forEach((object) => {
-            this.urls.removeResourceId(object.resource.data.id);
+            const removed = this.urls.removeResourceId(object.resource.data.id);
+
+            if (removed) {
+                events.emit('url.removed', {
+                    url: removed.url,
+                    resource: removed.resource
+                });
+            }
+
             object.resource.release();
             this._try(object.resource);
         });
@@ -125,8 +134,9 @@ class UrlGenerator {
 
         debug('_onInit', this.resourceType, resources.length);
 
+        // During init, don't emit per-resource events — url-service emits url.init in bulk
         for (const resource of resources) {
-            this._try(resource);
+            this._try(resource, false);
         }
     }
 
@@ -152,10 +162,11 @@ class UrlGenerator {
     /**
      * @description Try to own a resource and generate it's url if so.
      * @param {import('./resource')} resource - instance of the Resource class
+     * @param {boolean} [emit=true] - whether to emit url.added event (false during bulk init)
      * @returns {boolean}
      * @private
      */
-    _try(resource) {
+    _try(resource, emit = true) {
         /**
          * CASE: another url generator has taken this resource already.
          *
@@ -190,6 +201,17 @@ class UrlGenerator {
 
             resource.reserve();
             this._resourceListeners(resource);
+
+            if (emit) {
+                events.emit('url.added', {
+                    url: {
+                        relative: url,
+                        absolute: localUtils.createUrl(url, true)
+                    },
+                    resource: resource
+                });
+            }
+
             return true;
         } else {
             return false;
@@ -220,7 +242,14 @@ class UrlGenerator {
     _resourceListeners(resource) {
         const onUpdate = (updatedResource) => {
             // 1. remove old resource
-            this.urls.removeResourceId(updatedResource.data.id);
+            const removed = this.urls.removeResourceId(updatedResource.data.id);
+
+            if (removed) {
+                events.emit('url.removed', {
+                    url: removed.url,
+                    resource: removed.resource
+                });
+            }
 
             // 2. free resource, the url <-> resource connection no longer exists
             updatedResource.release();
@@ -239,7 +268,15 @@ class UrlGenerator {
         };
 
         const onRemoved = (removedResource) => {
-            this.urls.removeResourceId(removedResource.data.id);
+            const removed = this.urls.removeResourceId(removedResource.data.id);
+
+            if (removed) {
+                events.emit('url.removed', {
+                    url: removed.url,
+                    resource: removed.resource
+                });
+            }
+
             removedResource.release();
         };
 

--- a/ghost/core/core/server/services/url/url-service.js
+++ b/ghost/core/core/server/services/url/url-service.js
@@ -4,6 +4,7 @@ const errors = require('@tryghost/errors');
 const logging = require('@tryghost/logging');
 const metrics = require('@tryghost/metrics');
 const labs = require('../../../shared/labs');
+const events = require('../../lib/common/events');
 const UrlGenerator = require('./url-generator');
 const Queue = require('./queue');
 const Urls = require('./urls');
@@ -81,6 +82,9 @@ class UrlService {
     _onQueueEnded(event) {
         if (event === 'init') {
             this.finished = true;
+
+            // Notify the system once with all URLs (used by sitemap service)
+            events.emit('url.init', {urls: this.urls});
 
             const now = Date.now();
             logging.info(`URL Service ready in ${now - this.lastInitStartTime}ms`);

--- a/ghost/core/core/server/services/url/urls.js
+++ b/ghost/core/core/server/services/url/urls.js
@@ -1,10 +1,6 @@
 const debug = require('@tryghost/debug')('services:url:urls');
-const urlUtils = require('../../../shared/url-utils');
 const logging = require('@tryghost/logging');
 const errors = require('@tryghost/errors');
-
-// This emits its own url added/removed events
-const events = require('../../lib/common/events');
 
 /**
  * @typedef {{url: string, generatorId: string, resource: import('./resource')}} Url
@@ -55,15 +51,6 @@ class Urls {
             generatorId: generatorId,
             resource: resource
         };
-
-        // @NOTE: Notify the whole system. Currently used for sitemaps service.
-        events.emit('url.added', {
-            url: {
-                relative: url,
-                absolute: urlUtils.createUrl(url, true)
-            },
-            resource: resource
-        });
     }
 
     /**
@@ -106,6 +93,7 @@ class Urls {
     /**
      * @description Remove url.
      * @param {string} id
+     * @returns {Url|undefined} the removed entry, or undefined if not found
      */
     removeResourceId(id) {
         if (!this.urls[id]) {
@@ -114,12 +102,9 @@ class Urls {
 
         debug('removeResourceId', this.urls[id].url, this.urls[id].generatorId);
 
-        events.emit('url.removed', {
-            url: this.urls[id].url,
-            resource: this.urls[id].resource
-        });
-
+        const removed = this.urls[id];
         delete this.urls[id];
+        return removed;
     }
 
     /**

--- a/ghost/core/test/integration/url-service-and-sitemap.test.js
+++ b/ghost/core/test/integration/url-service-and-sitemap.test.js
@@ -294,8 +294,6 @@ describe('Integration: URL Service + Sitemap', function () {
 
         // Re-insert fixtures after DB teardown
         before(async function () {
-            const {forKnex, markdownToMobiledoc} = testUtils.DataGenerator;
-
             // Reuse the same fixture objects (they have the same IDs)
             await models.Tag.add(fixtures.tagJs, testUtils.context.internal);
             await models.Tag.add(fixtures.tagNode, testUtils.context.internal);

--- a/ghost/core/test/integration/url-service-and-sitemap.test.js
+++ b/ghost/core/test/integration/url-service-and-sitemap.test.js
@@ -1,0 +1,384 @@
+const assert = require('node:assert/strict');
+const sinon = require('sinon');
+const testUtils = require('../utils');
+const models = require('../../core/server/models');
+const UrlService = require('../../core/server/services/url/url-service');
+const SiteMapManager = require('../../core/frontend/services/sitemap/site-map-manager');
+
+/**
+ * Integration test that boots the URL service with custom fixtures and verifies
+ * both the URL cache state AND sitemap output from the same entrypoint.
+ *
+ * This serves as a safety net for refactoring: any change to the URL service
+ * boot path, event emission, or sitemap wiring must pass these assertions.
+ *
+ * Tests focus on outcomes:
+ * - Which URLs appear in the sitemap
+ * - Which URLs do NOT appear (drafts, canonical, no-post resources)
+ * - URL paths match the configured permalink structure
+ */
+describe('Integration: URL Service + Sitemap', function () {
+    let urlService;
+    let siteMapManager;
+    const fixtures = {};
+
+    before(function () {
+        models.init();
+    });
+
+    before(testUtils.teardownDb);
+    before(testUtils.setup('users:roles'));
+
+    // Insert custom fixture data so the test is self-documenting
+    before(async function () {
+        const {forKnex, markdownToMobiledoc} = testUtils.DataGenerator;
+
+        // Tags
+        fixtures.tagJs = forKnex.createTag({name: 'JavaScript', slug: 'javascript'});
+        fixtures.tagNode = forKnex.createTag({name: 'Node.js', slug: 'nodejs'});
+        fixtures.tagOrphan = forKnex.createTag({name: 'Orphan Tag', slug: 'orphan-tag'});
+
+        await models.Tag.add(fixtures.tagJs, testUtils.context.internal);
+        await models.Tag.add(fixtures.tagNode, testUtils.context.internal);
+        await models.Tag.add(fixtures.tagOrphan, testUtils.context.internal);
+
+        // Posts — published, non-featured
+        fixtures.postBasic = forKnex.createPost({
+            slug: 'basic-post',
+            title: 'Basic Post',
+            status: 'published',
+            featured: false,
+            published_at: new Date('2024-06-01T12:00:00Z'),
+            mobiledoc: markdownToMobiledoc('Content'),
+            tags: [{id: fixtures.tagJs.id}]
+        });
+        await models.Post.add(fixtures.postBasic, testUtils.context.internal);
+
+        fixtures.postWithImage = forKnex.createPost({
+            slug: 'post-with-image',
+            title: 'Post With Image',
+            status: 'published',
+            featured: false,
+            published_at: new Date('2024-07-15T12:00:00Z'),
+            feature_image: 'https://example.com/photo.jpg',
+            mobiledoc: markdownToMobiledoc('Content'),
+            tags: [{id: fixtures.tagJs.id}, {id: fixtures.tagNode.id}]
+        });
+        await models.Post.add(fixtures.postWithImage, testUtils.context.internal);
+
+        // Post — published, featured
+        fixtures.postFeatured = forKnex.createPost({
+            slug: 'featured-post',
+            title: 'Featured Post',
+            status: 'published',
+            featured: true,
+            published_at: new Date('2024-08-01T12:00:00Z'),
+            mobiledoc: markdownToMobiledoc('Featured content'),
+            tags: [{id: fixtures.tagNode.id}]
+        });
+        await models.Post.add(fixtures.postFeatured, testUtils.context.internal);
+
+        // Post — published with canonical_url (should be excluded from sitemap)
+        fixtures.postCanonical = forKnex.createPost({
+            slug: 'canonical-post',
+            title: 'Canonical Post',
+            status: 'published',
+            featured: false,
+            published_at: new Date('2024-09-01T12:00:00Z'),
+            canonical_url: 'https://external-blog.com/original-article',
+            mobiledoc: markdownToMobiledoc('Syndicated content')
+        });
+        await models.Post.add(fixtures.postCanonical, testUtils.context.internal);
+
+        // Post — draft (should not appear anywhere)
+        fixtures.postDraft = forKnex.createPost({
+            slug: 'draft-post',
+            title: 'Draft Post',
+            status: 'draft',
+            featured: false,
+            mobiledoc: markdownToMobiledoc('Draft content')
+        });
+        await models.Post.add(fixtures.postDraft, testUtils.context.internal);
+
+        // Page — published
+        fixtures.pageAbout = forKnex.createPost({
+            slug: 'about',
+            title: 'About Us',
+            type: 'page',
+            status: 'published',
+            mobiledoc: markdownToMobiledoc('About page')
+        });
+        await models.Post.add(fixtures.pageAbout, testUtils.context.internal);
+
+        // Page — draft (should not appear)
+        fixtures.pageDraft = forKnex.createPost({
+            slug: 'draft-page',
+            title: 'Draft Page',
+            type: 'page',
+            status: 'draft',
+            mobiledoc: markdownToMobiledoc('Draft page')
+        });
+        await models.Post.add(fixtures.pageDraft, testUtils.context.internal);
+    });
+
+    after(testUtils.teardownDb);
+
+    after(function () {
+        sinon.restore();
+    });
+
+    /**
+     * Helper: boot a UrlService with the given generators and wait until finished.
+     * Also creates a fresh SiteMapManager that listens to url.added events.
+     */
+    function bootUrlServiceAndSitemap(generators, done) {
+        urlService = new UrlService();
+        siteMapManager = new SiteMapManager();
+
+        generators.forEach(({id, filter, resourceType, permalink}) => {
+            urlService.onRouterAddedType(id, filter, resourceType, permalink);
+        });
+
+        urlService.init();
+
+        (function retry() {
+            if (urlService.hasFinished()) {
+                return done();
+            }
+            setTimeout(retry, 50);
+        })();
+    }
+
+    /**
+     * Helper: extract all <loc> URLs from sitemap XML.
+     */
+    function extractLocs(xml) {
+        if (!xml) {
+            return [];
+        }
+        const locs = [];
+        const regex = /<loc>(.*?)<\/loc>/g;
+        let match;
+        while ((match = regex.exec(xml)) !== null) {
+            locs.push(match[1]);
+        }
+        return locs;
+    }
+
+    /**
+     * Helper: extract all <image:loc> URLs from sitemap XML.
+     */
+    function extractImageLocs(xml) {
+        if (!xml) {
+            return [];
+        }
+        const locs = [];
+        const regex = /<image:loc>(.*?)<\/image:loc>/g;
+        let match;
+        while ((match = regex.exec(xml)) !== null) {
+            locs.push(match[1]);
+        }
+        return locs;
+    }
+
+    describe('default routing (single collection)', function () {
+        before(function (done) {
+            bootUrlServiceAndSitemap([
+                {id: 'posts-gen', filter: 'featured:false', resourceType: 'posts', permalink: '/:slug/'},
+                {id: 'authors-gen', filter: null, resourceType: 'authors', permalink: '/author/:slug/'},
+                {id: 'tags-gen', filter: null, resourceType: 'tags', permalink: '/tag/:slug/'},
+                {id: 'pages-gen', filter: null, resourceType: 'pages', permalink: '/:slug/'}
+            ], done);
+        });
+
+        after(function () {
+            urlService.reset();
+        });
+
+        // --- Posts ---
+
+        it('sitemap contains published non-featured posts at correct paths', function () {
+            const locs = extractLocs(siteMapManager.posts.getXml());
+
+            assert.ok(locs.some(l => l.includes('/basic-post/')), 'basic-post should be in sitemap');
+            assert.ok(locs.some(l => l.includes('/post-with-image/')), 'post-with-image should be in sitemap');
+        });
+
+        it('sitemap excludes featured posts from a featured:false collection', function () {
+            const locs = extractLocs(siteMapManager.posts.getXml());
+
+            assert.ok(!locs.some(l => l.includes('/featured-post/')), 'featured-post should NOT be in sitemap');
+        });
+
+        it('sitemap excludes posts with canonical_url', function () {
+            const locs = extractLocs(siteMapManager.posts.getXml());
+
+            assert.ok(!locs.some(l => l.includes('/canonical-post/')), 'post with canonical_url should NOT be in sitemap');
+        });
+
+        it('sitemap excludes draft posts', function () {
+            const locs = extractLocs(siteMapManager.posts.getXml());
+
+            assert.ok(!locs.some(l => l.includes('/draft-post/')), 'draft post should NOT be in sitemap');
+        });
+
+        it('sitemap includes image nodes for posts with feature_image', function () {
+            const imageLocs = extractImageLocs(siteMapManager.posts.getXml());
+
+            assert.ok(imageLocs.some(l => l.includes('photo.jpg')), 'feature_image should appear as image:loc');
+        });
+
+        // --- Pages ---
+
+        it('sitemap contains published pages', function () {
+            const locs = extractLocs(siteMapManager.pages.getXml());
+
+            assert.ok(locs.some(l => l.includes('/about/')), 'about page should be in sitemap');
+        });
+
+        it('sitemap excludes draft pages', function () {
+            const xml = siteMapManager.pages.getXml();
+            const locs = extractLocs(xml);
+
+            assert.ok(!locs.some(l => l.includes('/draft-page/')), 'draft page should NOT be in sitemap');
+        });
+
+        // --- Tags ---
+
+        it('sitemap contains tags that have published posts', function () {
+            const locs = extractLocs(siteMapManager.tags.getXml());
+
+            assert.ok(locs.some(l => l.includes('/tag/javascript/')), 'javascript tag should be in sitemap');
+            assert.ok(locs.some(l => l.includes('/tag/nodejs/')), 'nodejs tag should be in sitemap');
+        });
+
+        it('sitemap excludes tags with no published posts', function () {
+            const locs = extractLocs(siteMapManager.tags.getXml());
+
+            assert.ok(!locs.some(l => l.includes('/tag/orphan-tag/')), 'orphan tag should NOT be in sitemap');
+        });
+
+        // --- Authors ---
+
+        it('sitemap contains authors that have published posts', function () {
+            const locs = extractLocs(siteMapManager.users.getXml());
+
+            // The owner user from users:roles setup is the author of our custom posts
+            assert.ok(locs.some(l => l.includes('/author/')), 'at least one author should be in sitemap');
+        });
+
+        // --- Cross-cutting ---
+
+        it('every URL in every sitemap resolves to a real resource', function () {
+            const allLocs = [
+                ...extractLocs(siteMapManager.posts.getXml()),
+                ...extractLocs(siteMapManager.pages.getXml()),
+                ...extractLocs(siteMapManager.tags.getXml()),
+                ...extractLocs(siteMapManager.users.getXml())
+            ];
+
+            assert.ok(allLocs.length > 0, 'sitemaps should contain at least one URL');
+
+            allLocs.forEach(function (loc) {
+                // Extract the path from the absolute URL
+                const url = new URL(loc);
+                const resource = urlService.getResource(url.pathname);
+                assert.ok(resource, `sitemap contains ${url.pathname} but URL service has no resource for it`);
+            });
+        });
+    });
+
+    describe('custom routing (multiple collections)', function () {
+        before(testUtils.teardownDb);
+        before(testUtils.setup('users:roles'));
+
+        // Re-insert fixtures after DB teardown
+        before(async function () {
+            const {forKnex, markdownToMobiledoc} = testUtils.DataGenerator;
+
+            // Reuse the same fixture objects (they have the same IDs)
+            await models.Tag.add(fixtures.tagJs, testUtils.context.internal);
+            await models.Tag.add(fixtures.tagNode, testUtils.context.internal);
+            await models.Tag.add(fixtures.tagOrphan, testUtils.context.internal);
+
+            await models.Post.add(fixtures.postBasic, testUtils.context.internal);
+            await models.Post.add(fixtures.postWithImage, testUtils.context.internal);
+            await models.Post.add(fixtures.postFeatured, testUtils.context.internal);
+            await models.Post.add(fixtures.postCanonical, testUtils.context.internal);
+            await models.Post.add(fixtures.postDraft, testUtils.context.internal);
+            await models.Post.add(fixtures.pageAbout, testUtils.context.internal);
+        });
+
+        before(function (done) {
+            bootUrlServiceAndSitemap([
+                {id: 'featured-gen', filter: 'featured:true', resourceType: 'posts', permalink: '/featured/:slug/'},
+                {id: 'posts-gen', filter: 'type:post', resourceType: 'posts', permalink: '/blog/:year/:slug/'},
+                {id: 'authors-gen', filter: null, resourceType: 'authors', permalink: '/writer/:slug/'},
+                {id: 'tags-gen', filter: null, resourceType: 'tags', permalink: '/topic/:slug/'},
+                {id: 'pages-gen', filter: null, resourceType: 'pages', permalink: '/:slug/'}
+            ], done);
+        });
+
+        after(function () {
+            urlService.resetGenerators();
+        });
+
+        it('featured posts appear under the featured collection path', function () {
+            const locs = extractLocs(siteMapManager.posts.getXml());
+
+            assert.ok(
+                locs.some(l => l.includes('/featured/featured-post/')),
+                'featured post should be under /featured/'
+            );
+        });
+
+        it('non-featured posts appear under the blog collection path', function () {
+            const locs = extractLocs(siteMapManager.posts.getXml());
+
+            assert.ok(
+                locs.some(l => l.includes('/blog/2024/basic-post/')),
+                'basic post should be under /blog/:year/'
+            );
+            assert.ok(
+                locs.some(l => l.includes('/blog/2024/post-with-image/')),
+                'post-with-image should be under /blog/:year/'
+            );
+        });
+
+        it('featured posts do NOT appear under the blog path', function () {
+            const locs = extractLocs(siteMapManager.posts.getXml());
+
+            assert.ok(
+                !locs.some(l => l.includes('/blog/') && l.includes('/featured-post/')),
+                'featured post should NOT be under /blog/'
+            );
+        });
+
+        it('tags use custom topic paths in sitemap', function () {
+            const locs = extractLocs(siteMapManager.tags.getXml());
+
+            assert.ok(
+                locs.some(l => l.includes('/topic/javascript/')),
+                'tags should use /topic/ path'
+            );
+        });
+
+        it('authors use custom writer paths in sitemap', function () {
+            const locs = extractLocs(siteMapManager.users.getXml());
+
+            assert.ok(
+                locs.some(l => l.includes('/writer/')),
+                'authors should use /writer/ path'
+            );
+        });
+
+        it('canonical posts are still excluded from sitemap', function () {
+            const locs = extractLocs(siteMapManager.posts.getXml());
+
+            assert.ok(
+                !locs.some(l => l.includes('/canonical-post/')),
+                'post with canonical_url should NOT be in sitemap regardless of collection'
+            );
+        });
+    });
+});

--- a/ghost/core/test/unit/frontend/services/sitemap/manager.test.js
+++ b/ghost/core/test/unit/frontend/services/sitemap/manager.test.js
@@ -60,7 +60,7 @@ describe('Unit: sitemap/manager', function () {
 
         it('can create a SiteMapManager instance', function () {
             assertExists(manager);
-            assert.equal(Object.keys(eventsToRemember).length, 4);
+            assert.equal(Object.keys(eventsToRemember).length, 5);
             assertExists(eventsToRemember['url.added']);
             assertExists(eventsToRemember['url.removed']);
             assertExists(eventsToRemember['router.created']);

--- a/ghost/core/test/unit/server/services/url/urls.test.js
+++ b/ghost/core/test/unit/server/services/url/urls.test.js
@@ -1,14 +1,10 @@
 const assert = require('node:assert/strict');
-const {assertExists} = require('../../../../utils/assertions');
 const sinon = require('sinon');
-const events = require('../../../../../core/server/lib/common/events');
 const Urls = require('../../../../../core/server/services/url/urls');
-const config = require('../../../../../core/shared/config');
 const logging = require('@tryghost/logging');
 
 describe('Unit: services/url/Urls', function () {
     let urls;
-    let eventsToRemember;
 
     beforeEach(function () {
         urls = new Urls();
@@ -42,11 +38,6 @@ describe('Unit: services/url/Urls', function () {
             },
             generatorId: 2
         });
-
-        eventsToRemember = {};
-        sinon.stub(events, 'emit').callsFake(function (eventName, data) {
-            eventsToRemember[eventName] = data;
-        });
     });
 
     afterEach(function () {
@@ -65,12 +56,6 @@ describe('Unit: services/url/Urls', function () {
             generatorId: 1
         });
 
-        assertExists(eventsToRemember['url.added']);
-        assert.equal(eventsToRemember['url.added'].url.absolute, `${config.get('url')}/test/`);
-        assert.equal(eventsToRemember['url.added'].url.relative, '/test/');
-        assertExists(eventsToRemember['url.added'].resource);
-        assertExists(eventsToRemember['url.added'].resource.data);
-
         assert.equal(urls.getByResourceId('object-id-x').resource.data.slug, 'a');
 
         sinon.stub(logging, 'error');
@@ -86,14 +71,12 @@ describe('Unit: services/url/Urls', function () {
             generatorId: 1
         });
 
-        assertExists(eventsToRemember['url.added']);
-
         assert.equal(urls.getByResourceId('object-id-x').resource.data.slug, 'b');
     });
 
     it('fn: getByResourceId', function () {
         assert.equal(urls.getByResourceId('object-id-2').url, '/something/');
-        assertExists(urls.getByResourceId('object-id-2').generatorId);
+        assert.ok(urls.getByResourceId('object-id-2').generatorId);
         assert.equal(urls.getByResourceId('object-id-2').generatorId, 1);
     });
 
@@ -106,9 +89,11 @@ describe('Unit: services/url/Urls', function () {
     });
 
     it('fn: removeResourceId', function () {
-        urls.removeResourceId('object-id-2');
+        const removed = urls.removeResourceId('object-id-2');
+        assert.equal(removed.url, '/something/');
         assert.equal(urls.getByResourceId('object-id-2'), undefined);
 
-        urls.removeResourceId('does not exist');
+        const notFound = urls.removeResourceId('does not exist');
+        assert.equal(notFound, undefined);
     });
 });


### PR DESCRIPTION
The URL service is one of the slowest parts of Ghost's boot sequence. It fetches every published resource from the database, generates URLs, and then notifies the sitemap service one resource at a time via events. This PR tackles four independent bottlenecks in that pipeline.

First, the `Urls` data store was coupled to event emission — every call to `Urls.add()` fired a `url.added` event, which the sitemap service consumed one-by-one during boot. This meant N event dispatches, N moment.js date parses, and N XML node constructions before the server could start. The store is now a pure data structure, and the URL service emits a single bulk `url.init` event after all URLs are generated. The sitemap manager handles this bulk event to initialize all entries at once, while runtime additions/removals still use per-resource events emitted by the `UrlGenerator`.

Second, the resource config used exclude lists that grew with every new schema column and still fetched ~20 columns per post when only ~10 are needed for URL generation, sitemap XML, and change detection. These are now explicit include lists, making the contract between the URL service and the database self-documenting and reducing query payload.

Third, `raw-knex.js` existed specifically to bypass Bookshelf ORM overhead, yet still called `toJSON()`, `fixBools()`, and `fixDatesWhenFetch()` through the Bookshelf prototype on every row. `toJSON`/`serialize` just shallow-copy attributes with no meaningful transformation in this context. `fixDatesWhenFetch` parses dates with moment.js redundantly since knex already returns JavaScript Date objects. The only necessary operation — boolean coercion — is now a pre-computed column loop without Bookshelf prototype lookups.

Fourth, relation queries (tags, authors) used `WHERE IN` with every post ID materialized as a literal. For 10k posts that's 10k string values the query planner must parse. This is replaced with a subquery that mirrors the main query's NQL filter, letting the database use an index scan instead of parsing a literal list.

An integration test suite (`url-service-and-sitemap.test.js`) was added first as a safety net, covering both default routing and custom multi-collection routing with custom fixtures. It verifies URL generation, sitemap content, canonical exclusions, and draft filtering end-to-end.