### PR TITLE
🐛 Fix Admin API Post update method to not save a revision when save_revision=false

### DIFF
--- a/ghost/core/core/server/models/post.js
+++ b/ghost/core/core/server/models/post.js
@@ -932,7 +932,7 @@ Post = ghostBookshelf.Model.extend({
                         columns: ['id', 'lexical', 'created_at', 'author_id', 'title', 'reason', 'post_status', 'created_at_ts', 'feature_image']
                     }, _.pick(options, 'transacting')));
 
-                const revisions = revisionModels.toJSON();
+                const revisions = revisionModels.toJSON().reverse();
 
                 const current = {
                     id: model.id,

--- a/ghost/core/core/server/models/post.js
+++ b/ghost/core/core/server/models/post.js
@@ -932,7 +932,9 @@ Post = ghostBookshelf.Model.extend({
                         columns: ['id', 'lexical', 'created_at', 'author_id', 'title', 'reason', 'post_status', 'created_at_ts', 'feature_image']
                     }, _.pick(options, 'transacting')));
 
-                const revisions = revisionModels.toJSON().reverse();
+                // PostRevisions expects revisions in ascending order (latest last)
+                const revisions = revisionModels.toJSON()
+                    .sort((a, b) => a.created_at_ts - b.created_at_ts);
 
                 const current = {
                     id: model.id,

--- a/ghost/core/test/e2e-api/admin/posts.test.js
+++ b/ghost/core/test/e2e-api/admin/posts.test.js
@@ -496,6 +496,41 @@ describe('Posts API', function () {
             assert.equal(mobiledocRevisions.length, 0);
         });
 
+        it('Does not create a revision when editing a lexical post without save_revision within the revision interval', async function () {
+            const originalLexical = createLexical('Original text for interval test');
+            const updatedLexical = createLexical('First update for interval test');
+            const secondUpdateLexical = createLexical('Second update for interval test');
+
+            const {body: postBody} = await agent
+                .post('/posts/?formats=mobiledoc,lexical,html')
+                .body({posts: [{title: 'Lexical interval test', lexical: originalLexical}]})
+                .expectStatus(201);
+
+            const [postResponse] = postBody.posts;
+
+            // Force a second revision so we have multiple revisions to test ordering against
+            const {body: firstEditBody} = await agent
+                .put(`/posts/${postResponse.id}/?formats=mobiledoc,lexical,html&save_revision=true`)
+                .body({posts: [Object.assign({}, postResponse, {lexical: updatedLexical})]})
+                .expectStatus(200);
+
+            const revisionsBeforeTest = await models.PostRevision
+                .where('post_id', postResponse.id)
+                .fetchAll();
+            assert.equal(revisionsBeforeTest.length, 2);
+
+            // Edit again without save_revision — should NOT create a revision within the interval
+            await agent
+                .put(`/posts/${firstEditBody.posts[0].id}/?formats=mobiledoc,lexical,html`)
+                .body({posts: [Object.assign({}, firstEditBody.posts[0], {lexical: secondUpdateLexical})]})
+                .expectStatus(200);
+
+            const revisionsAfter = await models.PostRevision
+                .where('post_id', postResponse.id)
+                .fetchAll();
+            assert.equal(revisionsAfter.length, 2, 'No new revision should be created within the interval without save_revision');
+        });
+
         describe('Access', function () {
             describe('Visibility is set to tiers', function () {
                 it('Saves only paid tiers', async function () {

--- a/ghost/core/test/unit/server/lib/post-revisions.test.ts
+++ b/ghost/core/test/unit/server/lib/post-revisions.test.ts
@@ -198,6 +198,27 @@ describe('PostRevisions', function () {
 
             assert.deepEqual(actual, expected);
         });
+
+        it('treats the last revision in the array as the latest', function () {
+            const postRevisions = new PostRevisions({config, model: {}});
+
+            const expected = {value: false};
+            const actual = postRevisions.shouldGenerateRevision(makePostLike({
+                lexical: 'current',
+                html: 'current',
+                title: 'blah'
+            }), [{
+                lexical: 'older',
+                title: 'blah',
+                created_at_ts: Date.now() - 2000
+            }, {
+                lexical: 'current',
+                title: 'blah',
+                created_at_ts: Date.now() - 100
+            }].map(makeRevision), {});
+
+            assert.deepEqual(actual, expected);
+        });
     });
 
     describe('getRevisions', function () {
@@ -305,6 +326,35 @@ describe('PostRevisions', function () {
             });
 
             assert.equal(actual.length, 1);
+        });
+
+        it('keeps the newest revisions when limiting to the max_revisions count', async function () {
+            const postRevisions = new PostRevisions({
+                config: {
+                    max_revisions: 2,
+                    revision_interval_ms: config.revision_interval_ms
+                },
+                model: {}
+            });
+            const now = Date.now();
+
+            const actual = await postRevisions.getRevisions(makePostLike({
+                id: '1',
+                lexical: 'current',
+                html: 'current'
+            }), [{
+                lexical: 'oldest',
+                created_at_ts: now - 2000
+            }, {
+                lexical: 'newer',
+                created_at_ts: now - 1000
+            }].map(makeRevision), {
+                forceRevision: true
+            });
+
+            assert.equal(actual.length, 2);
+            assert.equal(actual[0].lexical, 'newer');
+            assert.equal(actual[1].lexical, 'current');
         });
     });
 


### PR DESCRIPTION
fixes https://github.com/TryGhost/ghost/issues/26677

There's a sort order bug in Ghost's revision logic. Here's the chain:

    post-revision.js:32-33 — orderDefaultRaw() returns 'created_at_ts DESC' — newest first
    post.js:920-926 — revisions are fetched via findAll → gets them in DESC order (newest first)
    post-revisions.ts:56 — const latestRevision = revisions[revisions.length - 1] — grabs the last element

So latestRevision is actually the oldest revision, not the newest. The time check on line 84 compares Date.now() against the oldest revision's timestamp — which is almost always >10 minutes old. This means the background_save condition passes every time content has changed, regardless of how recently the last revision was created.

This bug is masked in the Ghost Admin UI because it always sends save_revision=true and there was no test coverage in the test suite for the condition.

The flag is not documented in the Admin API docs, helping the issue to go undetected.
Steps to Reproduce

    Make an Admin API call to create a post.
    Check revisions.
    Make an Admin API call to update a post with save_revision=false in the query string.
    Check revision count.
    Make an Admin API call to update a post with save_revision=false in the query string.

Revision count should not be increasing, but it is.

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [x] I've written an automated test to prove my change works

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit fc10425340517efcd21e515b920108ed307b9096. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->