### PR TITLE
WIP: Changed the verification system to use a webhook

### DIFF
--- a/ghost/core/core/server/services/members/service.js
+++ b/ghost/core/core/server/services/members/service.js
@@ -16,7 +16,7 @@ const models = require('../../models');
 const {GhostMailer} = require('../mail');
 const jobsService = require('../jobs');
 const tiersService = require('../tiers');
-const VerificationTrigger = require('../verification-trigger');
+const {VerificationTrigger, verificationService} = require('../verification');
 const DatabaseInfo = require('@tryghost/database-info');
 const settingsHelpers = require('../settings-helpers');
 const RequestIntegrityTokenProvider = require('./request-integrity-token-provider');
@@ -90,25 +90,7 @@ const initVerificationTrigger = () => {
         getImportTriggerThreshold: () => _.get(config.get('hostSettings'), 'emailVerification.importThreshold'),
         isVerified: () => config.get('hostSettings:emailVerification:verified') === true,
         isVerificationRequired: () => settingsCache.get('email_verification_required') === true,
-        sendVerificationEmail: async ({subject, message, amountTriggered}) => {
-            const escalationAddress = config.get('hostSettings:emailVerification:escalationAddress');
-            const replyTo = config.get('user_email');
-            const fromAddress = settingsHelpers.getDefaultEmailAddress();
-
-            if (escalationAddress) {
-                await ghostMailer.send({
-                    subject,
-                    html: tpl(message, {
-                        amountTriggered: amountTriggered,
-                        siteUrl: urlUtils.getSiteUrl()
-                    }),
-                    forceTextContent: true,
-                    from: fromAddress,
-                    replyTo,
-                    to: escalationAddress
-                });
-            }
-        },
+        sendVerificationWebhook: verificationService.sendVerificationWebhook.bind(verificationService),
         membersStats,
         Settings: models.Settings,
         eventRepository: membersApi.events

--- a/ghost/core/core/server/services/verification/index.js
+++ b/ghost/core/core/server/services/verification/index.js
@@ -1,0 +1,4 @@
+module.exports = {
+    VerificationTrigger: require('./verification-trigger'),
+    verificationService: require('./verification-webhook-service')
+};

--- a/ghost/core/core/server/services/verification/verification-webhook-service.js
+++ b/ghost/core/core/server/services/verification/verification-webhook-service.js
@@ -1,0 +1,63 @@
+const crypto = require('crypto');
+const logging = require('@tryghost/logging');
+const request = require('@tryghost/request');
+const ghostVersion = require('@tryghost/version');
+const config = require('../../../shared/config');
+
+class VerificationService {
+    /**
+     * Sends a verification webhook to the configured endpoint
+     * @param {object} params
+     * @param {number} params.amountTriggered - Number of members that triggered verification
+     * @param {number} params.threshold - The threshold that was exceeded
+     * @param {string} params.method - The source that triggered verification ('api', 'admin', or 'import')
+     */
+    async sendVerificationWebhook({amountTriggered, threshold, method}) {
+        const webhookUrl = config.get('hostSettings:verificationTrigger:webhookUrl');
+        const webhookSecret = config.get('hostSettings:verificationTrigger:webhookSecret') || '';
+        const siteId = config.get('hostSettings:siteId');
+
+        if (!webhookUrl) {
+            return;
+        }
+
+        const payload = {
+            siteId,
+            amountTriggered,
+            threshold,
+            method
+        };
+
+        const reqPayload = JSON.stringify(payload);
+        const ts = Date.now();
+
+        const headers = {
+            'Content-Length': Buffer.byteLength(reqPayload),
+            'Content-Type': 'application/json',
+            'Content-Version': `v${ghostVersion.safe}`,
+            'X-Ghost-Request-Timestamp': ts
+        };
+
+        if (webhookSecret !== '') {
+            const baseString = `${ts}:${reqPayload}`;
+            headers['X-Ghost-Signature'] = crypto.createHmac('sha256', webhookSecret).update(baseString).digest('base64');
+        }
+
+        const opts = {
+            body: reqPayload,
+            headers,
+            timeout: {
+                request: 30 * 1000
+            },
+            retry: {
+                limit: process.env.NODE_ENV?.startsWith('test') ? 0 : 5
+            }
+        };
+
+        logging.info(`Triggering verification webhook to "${webhookUrl}"`);
+
+        await request(webhookUrl, opts);
+    }
+}
+
+module.exports = new VerificationService();


### PR DESCRIPTION
ref [GVA-690](https://linear.app/ghost/issue/GVA-690/change-logic-in-ghost-to-send-webhook-instead-of-email)

Draft, this was a one-shot PR to see whether it was possible to swap to using a webhook (based on a URL defined in config:hostSettings) instead of directly sending the verification email from Ghost