### PR TITLE
Removed `offer_redemptions` fallback logic from admin

### DIFF
--- a/ghost/admin/app/components/member/subscription-detail-box.js
+++ b/ghost/admin/app/components/member/subscription-detail-box.js
@@ -6,20 +6,8 @@ import {tracked} from '@glimmer/tracking';
 export default class SubscriptionDetailBox extends Component {
     @tracked showDetails = false;
 
-    // TODO: remove this fallback once offer_redemptions is available on all environments
-    get offerRedemptions() {
-        const sub = this.args.sub;
-        if (sub.offer_redemptions) {
-            return sub.offer_redemptions;
-        }
-        if (sub.offer) {
-            return [sub.offer];
-        }
-        return [];
-    }
-
     get formattedOffers() {
-        return this.offerRedemptions.map(offer => getOfferDisplayData(offer, this.args.sub));
+        return (this.args.sub.offer_redemptions ?? []).map(offer => getOfferDisplayData(offer, this.args.sub));
     }
 
     @action

--- a/ghost/admin/app/components/members/filters/offers.js
+++ b/ghost/admin/app/components/members/filters/offers.js
@@ -28,11 +28,8 @@ export const OFFERS_FILTER = {
     getColumnValue: (member) => {
         return {
             class: 'gh-members-list-labels',
-            // TODO: remove sub.offer fallback once offer_redemptions is available on all environments
             text: (member.subscriptions ?? [])
-                .flatMap(sub => (sub.offer_redemptions
-                    ? sub.offer_redemptions.map(getOfferNameForColumn).filter(Boolean)
-                    : [getOfferNameForColumn(sub.offer)].filter(Boolean)))
+                .flatMap(sub => (sub.offer_redemptions ?? []).map(getOfferNameForColumn).filter(Boolean))
                 .join(', ')
         };
     }

--- a/ghost/admin/tests/unit/components/members/filters/offers-test.js
+++ b/ghost/admin/tests/unit/components/members/filters/offers-test.js
@@ -20,17 +20,14 @@ describe('Unit: Component: members/filters/offers', function () {
             expect(value.text).to.equal('Monthly Retention, Welcome discount, Yearly Retention');
         });
 
-        it('renders fallback sub.offer with the same retention label rules', function () {
+        it('returns empty text when offer_redemptions is missing', function () {
             const member = {
-                subscriptions: [
-                    {offer: {name: 'Monthly v2', redemption_type: 'retention', cadence: 'month'}},
-                    {offer: {name: 'Signup offer', redemption_type: 'signup', cadence: 'month'}}
-                ]
+                subscriptions: [{}]
             };
 
             const value = OFFERS_FILTER.getColumnValue(member);
 
-            expect(value.text).to.equal('Monthly Retention, Signup offer');
+            expect(value.text).to.equal('');
         });
     });
 });


### PR DESCRIPTION
closes https://linear.app/ghost/issue/BER-3336

The fallback to `sub.offer` was added as a transitional measure while core and admin could be out of sync during CD. Both are now fully deployed with `offer_redemptions` always populated, making the fallback dead code