### PR TITLE
Normalize day calculations in domain warming test

### DIFF
--- a/ghost/core/test/integration/services/email-service/domain-warming.test.js
+++ b/ghost/core/test/integration/services/email-service/domain-warming.test.js
@@ -76,16 +76,16 @@ describe('Domain Warming Integration Tests', function () {
     }
 
     // Helper: Set fake time to specific day
-    // Uses a fixed base date to ensure consistent day progression
+    // Uses fixed 24-hour increments from a normalized base to avoid DST drift
+    const MILLISECONDS_IN_DAY = 24 * 60 * 60 * 1000;
     const baseDate = new Date();
-    baseDate.setHours(12, 0, 0, 0);
+    baseDate.setUTCHours(12, 0, 0, 0);
 
     function setDay(daysFromNow = 0) {
         if (clock) {
             clock.restore();
         }
-        const time = new Date(baseDate.getTime());
-        time.setDate(time.getDate() + daysFromNow);
+        const time = new Date(baseDate.getTime() + (daysFromNow * MILLISECONDS_IN_DAY));
         clock = sinon.useFakeTimers({
             now: time.getTime(),
             shouldAdvanceTime: true


### PR DESCRIPTION
## Problem
The `Domain Warming Integration Tests` were flaky in `mysql8` acceptance CI because the test clock advanced days using `Date#setDate()`.

CI runs acceptance tests with timezone set to `America/New_York`. Around DST transition (for example, March 8, 2026), a local "day jump" can be 23 hours instead of 24. The production code computes warmup day as elapsed milliseconds divided by 24 hours, so on the DST boundary the test expected Day 4 (`392`) while runtime still computed Day 3 (`332`).

## Root Cause
The test helper and the production day calculation use different notions of "day":
- Test helper: calendar-date increment (`setDate`)
- Production logic: fixed 24-hour elapsed-time buckets

That mismatch made the assertion nondeterministic across DST boundaries.

## Fix
Updated the test fake-time helper to:
- normalize base time with `setUTCHours(12, 0, 0, 0)`
- advance by fixed `24 * 60 * 60 * 1000` millisecond increments

This aligns test-time progression with the production elapsed-time day calculation and removes DST-dependent drift.

## Why This Is Safe
- Test-only change (no runtime behavior change)
- Keeps existing expected warmup sequence (`200, 237, 280, 332, 392, ...`)
- Makes the assertion deterministic regardless of local timezone/DST transitions

## Verification
Locally ran the target file in mysql mode:
- `NODE_ENV=testing-mysql ... yarn test:single test/integration/services/email-service/domain-warming.test.js`
- Result: `8 passing`
