### PR TITLE
Welcome email editor refinements

### DIFF
--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/member-email-editor.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/member-email-editor.tsx
@@ -55,6 +55,8 @@ const MemberEmailsEditor: React.FC<MemberEmailsEditorProps> = ({
 
         // Content typography
         '[&_:is(p,blockquote,aside,ul,ol)]:font-inter [&_:is(p,blockquote,aside,ul,ol)]:text-xl [&_:is(p,blockquote,aside,ul,ol)]:tracking-tight',
+        // Reset content typography inside card captions to match Koenig's caption styles
+        '[&_figcaption_:is(p,blockquote,aside,ul,ol)]:text-[1.4rem] [&_figcaption_:is(p,blockquote,aside,ul,ol)]:tracking-[.025em]',
         '[&_:is(h1)]:text-[36px] [&_:is(h2)]:text-[32px] [&_:is(h3)]:text-[26px] [&_:is(h4)]:text-[21px] [&_:is(h5)]:text-[19px] [&_:is(h6)]:text-[19px] [&_:is(h1,h2,h3,h4,h5,h6)]:mb-[0.5em]',
         // Horizontal ruler
         '[&_:is(hr)]:pt-0',

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/member-email-editor.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/member-email-editor.tsx
@@ -52,7 +52,8 @@ const MemberEmailsEditor: React.FC<MemberEmailsEditorProps> = ({
         '[&_.koenig-lexical-editor-input-placeholder]:font-inter [&_.koenig-lexical-editor-input-placeholder]:text-xl [&_.koenig-lexical-editor-input-placeholder]:tracking-tight',
         // Headings dark mode
         '[&_:is(h2,h3)]:dark:text-white',
-
+        // Inputs
+        '[&_.koenig-lexical_input]:text-[1.4rem]',
         // Content typography
         '[&_:is(p,blockquote,aside,ul,ol)]:font-inter [&_:is(p,blockquote,aside,ul,ol)]:text-xl [&_:is(p,blockquote,aside,ul,ol)]:tracking-tight',
         // Reset content typography inside card captions to match Koenig's caption styles

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/member-email-editor.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/member-email-editor.tsx
@@ -45,7 +45,7 @@ const MemberEmailsEditor: React.FC<MemberEmailsEditorProps> = ({
 
     const baseEditorStyles = cn(
         // Base typography
-        'text-[1.6rem] leading-[1.6] tracking-[-0.01em]',
+        'text-[1.6rem] leading-[1.6] tracking-[-0.01em] pb-10',
         // Dark mode
         'dark:text-white dark:selection:bg-[rgba(88,101,116,0.99)]',
         // Placeholder styling

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/member-email-editor.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/member-email-editor.tsx
@@ -56,6 +56,8 @@ const MemberEmailsEditor: React.FC<MemberEmailsEditorProps> = ({
         '[&_.koenig-lexical_input]:text-[1.4rem]',
         // Plus icon
         '[&_[data-kg-plus-button]]:top-[-4px]',
+        // Settings panel
+        '[&_[data-kg-card-selected]]:isolate',
         // Content typography
         '[&_:is(p,blockquote,aside,ul,ol)]:font-inter [&_:is(p,blockquote,aside,ul,ol)]:text-xl [&_:is(p,blockquote,aside,ul,ol)]:tracking-tight',
         // Reset content typography inside card captions to match Koenig's caption styles

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/member-email-editor.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/member-email-editor.tsx
@@ -54,6 +54,8 @@ const MemberEmailsEditor: React.FC<MemberEmailsEditorProps> = ({
         '[&_:is(h2,h3)]:dark:text-white',
         // Inputs
         '[&_.koenig-lexical_input]:text-[1.4rem]',
+        // Plus icon
+        '[&_[data-kg-plus-button]]:top-[-4px]',
         // Content typography
         '[&_:is(p,blockquote,aside,ul,ol)]:font-inter [&_:is(p,blockquote,aside,ul,ol)]:text-xl [&_:is(p,blockquote,aside,ul,ol)]:tracking-tight',
         // Reset content typography inside card captions to match Koenig's caption styles

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/member-email-editor.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/member-email-editor.tsx
@@ -57,6 +57,7 @@ const MemberEmailsEditor: React.FC<MemberEmailsEditorProps> = ({
         '[&_:is(p,blockquote,aside,ul,ol)]:font-inter [&_:is(p,blockquote,aside,ul,ol)]:text-xl [&_:is(p,blockquote,aside,ul,ol)]:tracking-tight',
         // Reset content typography inside card captions to match Koenig's caption styles
         '[&_figcaption_:is(p,blockquote,aside,ul,ol)]:text-[1.4rem] [&_figcaption_:is(p,blockquote,aside,ul,ol)]:tracking-[.025em]',
+        '[&_figcaption_p]:mb-0',
         '[&_:is(h1)]:text-[36px] [&_:is(h2)]:text-[32px] [&_:is(h3)]:text-[26px] [&_:is(h4)]:text-[21px] [&_:is(h5)]:text-[19px] [&_:is(h6)]:text-[19px] [&_:is(h1,h2,h3,h4,h5,h6)]:mb-[0.5em]',
         // Horizontal ruler
         '[&_:is(hr)]:pt-0',

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-modal.tsx
@@ -390,7 +390,7 @@ const WelcomeEmailModal = NiceModal.create<WelcomeEmailModalProps>(({emailType =
                             </div>
                         </div>
                     </EmailPreviewEmailHeader>
-                    <EmailPreviewBody className={errors.lexical ? 'border-red-500' : ''}>
+                    <EmailPreviewBody className={errors.lexical ? 'border border-red-500' : ''}>
                         <div
                             className='mx-auto w-full max-w-[600px] pb-8 pt-10 transition-[max-width,padding] duration-300 ease-out motion-reduce:transition-none'
                             onFocus={() => {

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-modal.tsx
@@ -328,6 +328,7 @@ const WelcomeEmailModal = NiceModal.create<WelcomeEmailModalProps>(({emailType =
             width='full'
         >
             <EmailPreviewModalContent
+                className='dark:bg-[#151719]'
                 headerActions={
                     <>
                         <Button variant="outline" onClick={handleClose}>Close</Button>
@@ -342,7 +343,7 @@ const WelcomeEmailModal = NiceModal.create<WelcomeEmailModalProps>(({emailType =
                 title={modalTitle}
             >
                 <div className='flex grow flex-col items-center p-6 pt-0'>
-                    <div className='bg-gray-100 dark:bg-gray-975 sticky top-0 z-10 w-full p-0 pt-6'>
+                    <div className='bg-gray-100 sticky top-0 z-10 w-full p-0 pt-6 dark:bg-[#151719]'>
                         <EmailPreviewEmailHeader className='!border-x-0 !border-b !border-t-0'>
                             <div className='flex flex-col gap-2'>
                                 <div className='flex items-center py-1'>

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-modal.tsx
@@ -342,7 +342,7 @@ const WelcomeEmailModal = NiceModal.create<WelcomeEmailModalProps>(({emailType =
                 title={modalTitle}
             >
                 <div className='flex grow flex-col items-center p-6 pt-0'>
-                    <div className='bg-gray-100 dark:bg-gray-975 sticky top-0 z-50 w-full p-0 pt-6'>
+                    <div className='bg-gray-100 dark:bg-gray-975 sticky top-0 z-10 w-full p-0 pt-6'>
                         <EmailPreviewEmailHeader className='!border-x-0 !border-b !border-t-0'>
                             <div className='flex flex-col gap-2'>
                                 <div className='flex items-center py-1'>

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-modal.tsx
@@ -40,7 +40,7 @@ const EmailPreviewModalContent = React.forwardRef<
             className
         )}
     >
-        <div className="border-gray-200 dark:border-gray-900 dark:bg-gray-975 flex shrink-0 items-center justify-between border-b bg-white px-5 py-3">
+        <div className="border-gray-200 dark:border-gray-900 dark:bg-gray-975 sticky top-0 flex shrink-0 items-center justify-between border-b bg-white px-5 py-3">
             <h3 className="text-xl font-semibold">
                 {title}
             </h3>
@@ -48,7 +48,7 @@ const EmailPreviewModalContent = React.forwardRef<
                 {headerActions}
             </div>
         </div>
-        <div className="flex min-h-0 grow flex-col overflow-y-auto">
+        <div className="flex h-[clamp(0px,calc(100dvh-320px),82vh)] min-h-0 grow flex-col overflow-y-auto">
             {children}
         </div>
     </div>
@@ -76,7 +76,7 @@ interface EmailPreviewBodyProps {
 
 const EmailPreviewBody: React.FC<EmailPreviewBodyProps> = ({children, className}) => (
     <div className={cn(
-        'flex mx-auto w-full h-[clamp(0px,calc(100dvh-320px),82vh)] overflow-y-auto rounded-b-lg border border-gray-200 bg-white shadow-sm transition-[max-width,height,padding] duration-300 ease-out motion-reduce:transition-none dark:border-grey-900 dark:bg-grey-975 dark:shadow-none grow max-w-[780px] px-6',
+        'flex mx-auto w-full rounded-b-lg bg-white shadow-sm transition-[max-width,height,padding] duration-300 ease-out motion-reduce:transition-none dark:border-grey-900 dark:bg-grey-975 dark:shadow-none grow max-w-[780px] px-6',
         className
     )}>
         {children}
@@ -322,6 +322,7 @@ const WelcomeEmailModal = NiceModal.create<WelcomeEmailModalProps>(({emailType =
             footer={false}
             header={false}
             padding={false}
+            scrolling={false}
             size='full'
             testId='welcome-email-modal'
             width='full'
@@ -340,54 +341,56 @@ const WelcomeEmailModal = NiceModal.create<WelcomeEmailModalProps>(({emailType =
                 }
                 title={modalTitle}
             >
-                <div className='flex grow flex-col items-center p-6'>
-                    <EmailPreviewEmailHeader>
-                        <div className='flex flex-col gap-2'>
-                            <div className='flex items-center py-1'>
-                                <div className='w-20 shrink-0 text-sm font-semibold'>From:</div>
-                                <div className='min-w-0 grow pr-4 text-sm'>
-                                    <span className='flex gap-1 truncate whitespace-nowrap'>
-                                        <span>{resolvedSenderName}</span>
-                                        <span className='text-gray-500 dark:text-gray-400'>{`<${resolvedSenderEmail}>`}</span>
-                                    </span>
-                                </div>
-                                <div ref={dropdownRef} className='relative'>
-                                    <LegacyButton
-                                        className='border border-grey-200 font-semibold hover:border-grey-300 hover:!bg-white dark:border-grey-900 dark:hover:border-grey-800 dark:hover:!bg-grey-950'
-                                        color="clear"
-                                        icon='send'
-                                        label="Test"
-                                        onClick={() => setShowTestDropdown(!showTestDropdown)}
-                                    />
-                                    {showTestDropdown && (
-                                        <TestEmailDropdown automatedEmailId={automatedEmail.id} lexical={formState.lexical} subject={formState.subject} validateForm={validate} onClose={() => setShowTestDropdown(false)} />
-                                    )}
-                                </div>
-                            </div>
-                            {hasDistinctReplyTo && (
-                                <div className='flex items-center'>
-                                    <div className='w-20 shrink-0 text-sm font-semibold'>Reply-to:</div>
-                                    <div className='text-gray-500 dark:text-gray-400 grow text-sm'>
-                                        {resolvedReplyToEmail}
+                <div className='flex grow flex-col items-center p-6 pt-0'>
+                    <div className='bg-gray-100 dark:bg-gray-975 sticky top-0 z-50 w-full p-0 pt-6'>
+                        <EmailPreviewEmailHeader className='!border-x-0 !border-b !border-t-0'>
+                            <div className='flex flex-col gap-2'>
+                                <div className='flex items-center py-1'>
+                                    <div className='w-20 shrink-0 text-sm font-semibold'>From:</div>
+                                    <div className='min-w-0 grow pr-4 text-sm'>
+                                        <span className='flex gap-1 truncate whitespace-nowrap'>
+                                            <span>{resolvedSenderName}</span>
+                                            <span className='text-gray-500 dark:text-gray-400'>{`<${resolvedSenderEmail}>`}</span>
+                                        </span>
+                                    </div>
+                                    <div ref={dropdownRef} className='relative'>
+                                        <LegacyButton
+                                            className='border border-grey-200 font-semibold hover:border-grey-300 hover:!bg-white dark:border-grey-900 dark:hover:border-grey-800 dark:hover:!bg-grey-950'
+                                            color="clear"
+                                            icon='send'
+                                            label="Test"
+                                            onClick={() => setShowTestDropdown(!showTestDropdown)}
+                                        />
+                                        {showTestDropdown && (
+                                            <TestEmailDropdown automatedEmailId={automatedEmail.id} lexical={formState.lexical} subject={formState.subject} validateForm={validate} onClose={() => setShowTestDropdown(false)} />
+                                        )}
                                     </div>
                                 </div>
-                            )}
-                            <div className='flex items-center'>
-                                <div className='w-20 shrink-0 text-sm font-semibold'>Subject:</div>
-                                <div className='grow'>
-                                    <TextField
-                                        className='w-full'
-                                        error={Boolean(errors.subject)}
-                                        hint={errors.subject || ''}
-                                        maxLength={300}
-                                        placeholder={`Welcome to ${siteTitle}`}
-                                        value={formState.subject}
-                                        onChange={e => updateForm(state => ({...state, subject: e.target.value}))}
-                                    />
+                                {hasDistinctReplyTo && (
+                                    <div className='flex items-center'>
+                                        <div className='w-20 shrink-0 text-sm font-semibold'>Reply-to:</div>
+                                        <div className='text-gray-500 dark:text-gray-400 grow text-sm'>
+                                            {resolvedReplyToEmail}
+                                        </div>
+                                    </div>
+                                )}
+                                <div className='flex items-center'>
+                                    <div className='w-20 shrink-0 text-sm font-semibold'>Subject:</div>
+                                    <div className='grow'>
+                                        <TextField
+                                            className='w-full'
+                                            error={Boolean(errors.subject)}
+                                            hint={errors.subject || ''}
+                                            maxLength={300}
+                                            placeholder={`Welcome to ${siteTitle}`}
+                                            value={formState.subject}
+                                            onChange={e => updateForm(state => ({...state, subject: e.target.value}))}
+                                        />
+                                    </div>
                                 </div>
                             </div>
-                        </div>
-                    </EmailPreviewEmailHeader>
+                        </EmailPreviewEmailHeader>
+                    </div>
                     <EmailPreviewBody className={errors.lexical ? 'border-red-500' : ''}>
                         <div
                             className='mx-auto w-full max-w-[600px] pb-8 pt-10 transition-[max-width,padding] duration-300 ease-out motion-reduce:transition-none'

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-modal.tsx
@@ -62,7 +62,7 @@ interface EmailPreviewEmailHeaderProps {
 
 const EmailPreviewEmailHeader: React.FC<EmailPreviewEmailHeaderProps> = ({children, className}) => (
     <div className={cn(
-        'relative z-20 mx-auto w-full max-w-[780px] rounded-t-lg border border-b-0 border-gray-200 bg-white px-6 py-4 transition-[max-width,padding] duration-300 ease-out motion-reduce:transition-none dark:border-grey-900 dark:bg-grey-975',
+        'relative z-20 isolate mx-auto w-full max-w-[780px] rounded-t-lg border border-b-0 border-gray-200 bg-white px-6 py-4 transition-[max-width,padding] duration-300 ease-out motion-reduce:transition-none dark:border-grey-900 dark:bg-grey-975',
         className
     )}>
         {children}
@@ -342,56 +342,54 @@ const WelcomeEmailModal = NiceModal.create<WelcomeEmailModalProps>(({emailType =
                 }
                 title={modalTitle}
             >
-                <div className='flex grow flex-col items-center p-6 pt-0'>
-                    <div className='bg-gray-100 sticky top-0 z-10 w-full p-0 pt-6 dark:bg-[#151719]'>
-                        <EmailPreviewEmailHeader className='!border-x-0 !border-b !border-t-0'>
-                            <div className='flex flex-col gap-2'>
-                                <div className='flex items-center py-1'>
-                                    <div className='w-20 shrink-0 text-sm font-semibold'>From:</div>
-                                    <div className='min-w-0 grow pr-4 text-sm'>
-                                        <span className='flex gap-1 truncate whitespace-nowrap'>
-                                            <span>{resolvedSenderName}</span>
-                                            <span className='text-gray-500 dark:text-gray-400'>{`<${resolvedSenderEmail}>`}</span>
-                                        </span>
-                                    </div>
-                                    <div ref={dropdownRef} className='relative'>
-                                        <LegacyButton
-                                            className='border border-grey-200 font-semibold hover:border-grey-300 hover:!bg-white dark:border-grey-900 dark:hover:border-grey-800 dark:hover:!bg-grey-950'
-                                            color="clear"
-                                            icon='send'
-                                            label="Test"
-                                            onClick={() => setShowTestDropdown(!showTestDropdown)}
-                                        />
-                                        {showTestDropdown && (
-                                            <TestEmailDropdown automatedEmailId={automatedEmail.id} lexical={formState.lexical} subject={formState.subject} validateForm={validate} onClose={() => setShowTestDropdown(false)} />
-                                        )}
-                                    </div>
+                <div className='flex grow flex-col items-center p-6'>
+                    <EmailPreviewEmailHeader className='!border-x-0 !border-b !border-t-0'>
+                        <div className='flex flex-col gap-2'>
+                            <div className='flex items-center py-1'>
+                                <div className='w-20 shrink-0 text-sm font-semibold'>From:</div>
+                                <div className='min-w-0 grow pr-4 text-sm'>
+                                    <span className='flex gap-1 truncate whitespace-nowrap'>
+                                        <span>{resolvedSenderName}</span>
+                                        <span className='text-gray-500 dark:text-gray-400'>{`<${resolvedSenderEmail}>`}</span>
+                                    </span>
                                 </div>
-                                {hasDistinctReplyTo && (
-                                    <div className='flex items-center'>
-                                        <div className='w-20 shrink-0 text-sm font-semibold'>Reply-to:</div>
-                                        <div className='text-gray-500 dark:text-gray-400 grow text-sm'>
-                                            {resolvedReplyToEmail}
-                                        </div>
-                                    </div>
-                                )}
-                                <div className='flex items-center'>
-                                    <div className='w-20 shrink-0 text-sm font-semibold'>Subject:</div>
-                                    <div className='grow'>
-                                        <TextField
-                                            className='w-full'
-                                            error={Boolean(errors.subject)}
-                                            hint={errors.subject || ''}
-                                            maxLength={300}
-                                            placeholder={`Welcome to ${siteTitle}`}
-                                            value={formState.subject}
-                                            onChange={e => updateForm(state => ({...state, subject: e.target.value}))}
-                                        />
-                                    </div>
+                                <div ref={dropdownRef} className='relative'>
+                                    <LegacyButton
+                                        className='border border-grey-200 font-semibold hover:border-grey-300 hover:!bg-white dark:border-grey-900 dark:hover:border-grey-800 dark:hover:!bg-grey-950'
+                                        color="clear"
+                                        icon='send'
+                                        label="Test"
+                                        onClick={() => setShowTestDropdown(!showTestDropdown)}
+                                    />
+                                    {showTestDropdown && (
+                                        <TestEmailDropdown automatedEmailId={automatedEmail.id} lexical={formState.lexical} subject={formState.subject} validateForm={validate} onClose={() => setShowTestDropdown(false)} />
+                                    )}
                                 </div>
                             </div>
-                        </EmailPreviewEmailHeader>
-                    </div>
+                            {hasDistinctReplyTo && (
+                                <div className='flex items-center'>
+                                    <div className='w-20 shrink-0 text-sm font-semibold'>Reply-to:</div>
+                                    <div className='text-gray-500 dark:text-gray-400 grow text-sm'>
+                                        {resolvedReplyToEmail}
+                                    </div>
+                                </div>
+                            )}
+                            <div className='flex items-center'>
+                                <div className='w-20 shrink-0 text-sm font-semibold'>Subject:</div>
+                                <div className='grow'>
+                                    <TextField
+                                        className='w-full'
+                                        error={Boolean(errors.subject)}
+                                        hint={errors.subject || ''}
+                                        maxLength={300}
+                                        placeholder={`Welcome to ${siteTitle}`}
+                                        value={formState.subject}
+                                        onChange={e => updateForm(state => ({...state, subject: e.target.value}))}
+                                    />
+                                </div>
+                            </div>
+                        </div>
+                    </EmailPreviewEmailHeader>
                     <EmailPreviewBody className={errors.lexical ? 'border-red-500' : ''}>
                         <div
                             className='mx-auto w-full max-w-[600px] pb-8 pt-10 transition-[max-width,padding] duration-300 ease-out motion-reduce:transition-none'

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-modal.tsx
@@ -343,7 +343,7 @@ const WelcomeEmailModal = NiceModal.create<WelcomeEmailModalProps>(({emailType =
                 title={modalTitle}
             >
                 <div className='flex grow flex-col items-center p-6'>
-                    <EmailPreviewEmailHeader className='!border-x-0 !border-b !border-t-0'>
+                    <EmailPreviewEmailHeader className='border-x-0 border-b border-t-0'>
                         <div className='flex flex-col gap-2'>
                             <div className='flex items-center py-1'>
                                 <div className='w-20 shrink-0 text-sm font-semibold'>From:</div>


### PR DESCRIPTION
ref https://linear.app/ghost/issue/NY-1128/welcome-emails-editor-visual-refinements
ref https://linear.app/ghost/issue/NY-1121/need-a-little-padding-at-the-bottom-of-the-editor-when-a-new-node-is
ref https://linear.app/ghost/issue/NY-1120/caption-styling-on-image-and-bookmark-is-bigger-than-it-should-be-non

- The editor didn't have enough contrast in dark mode
- Font sizes and spacings were overridden in the editor toolbar
- Scrolling was attached to the editor area instead of the whole inner container
- Missed some padding at the bottom
- Safari had clipping issue