### PR TITLE
Fixed relative urls in member welcome emails

### DIFF
--- a/ghost/core/core/server/services/member-welcome-emails/member-welcome-email-renderer.js
+++ b/ghost/core/core/server/services/member-welcome-emails/member-welcome-email-renderer.js
@@ -7,6 +7,7 @@ const errors = require('@tryghost/errors');
 const {textColorForBackgroundColor} = require('@tryghost/color-utils');
 const {MESSAGES} = require('./constants');
 const {wrapReplacementStrings} = require('../koenig/render-utils/replacement-strings');
+const linkReplacer = require('../lib/link-replacer');
 
 const REPLACEMENT_REGEX = /%%\{(\w+?)(?:,? *"(.*?)")?\}%%/g;
 const UNMATCHED_TOKEN_REGEX = /%%\{.*?\}%%/g;
@@ -116,13 +117,18 @@ class MemberWelcomeEmailRenderer {
         const contentWithReplacements = this.#applyReplacements({definitions, text: content, escapeHtml: true});
         const subjectWithReplacements = this.#applyReplacements({definitions, text: subject, escapeHtml: false});
 
+        // Resolve relative links (e.g. #/portal/signup) to absolute URLs using the site URL
+        const contentWithAbsoluteLinks = await linkReplacer.replace(contentWithReplacements, (url) => {
+            return url;
+        }, {base: siteSettings.url});
+
         const managePreferencesUrl = new URL('#/portal/account/newsletters', siteSettings.url).href;
         const year = new Date().getFullYear();
         const accentColor = siteSettings.accentColor || '#15212A';
         const accentContrastColor = textColorForBackgroundColor(accentColor).hex();
 
         const html = this.#wrapperTemplate({
-            content: contentWithReplacements,
+            content: contentWithAbsoluteLinks,
             subject: subjectWithReplacements,
             siteTitle: siteSettings.title,
             siteUrl: siteSettings.url,

--- a/ghost/core/test/unit/server/services/member-welcome-emails/member-welcome-email-renderer.test.js
+++ b/ghost/core/test/unit/server/services/member-welcome-emails/member-welcome-email-renderer.test.js
@@ -228,6 +228,21 @@ describe('MemberWelcomeEmailRenderer', function () {
             assert(result.html.includes('https://example.com/#/portal/account'));
         });
 
+        it('resolves relative portal links to absolute URLs', async function () {
+            lexicalRenderStub.resolves('<table class="kg-card kg-button-card"><tbody><tr><td><table class="btn"><tbody><tr><td align="center"><a href="#/portal/support">Support us</a></td></tr></tbody></table></td></tr></tbody></table>');
+            const renderer = new MemberWelcomeEmailRenderer({t: key => key});
+
+            const result = await renderer.render({
+                lexical: '{}',
+                subject: 'Welcome!',
+                member: {name: 'John', email: 'john@example.com'},
+                siteSettings: defaultSiteSettings
+            });
+
+            assert(result.html.includes('https://example.com/#/portal/support'));
+            assert(!result.html.match(/href="[^"]*"[^>]*>[^<]*Support us/).toString().includes('href="#/portal/support"'));
+        });
+
         it('generates plain text from HTML', async function () {
             lexicalRenderStub.resolves('<p>Hello World</p>');
             const renderer = new MemberWelcomeEmailRenderer({t: key => key});


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1127/

- made urls full instead of relative, which won't work in email