### PR TITLE
Fixed missing validation for title/description fields in offers settings

### DIFF
--- a/apps/admin-x-settings/src/components/settings/growth/offers/add-offer-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/offers/add-offer-modal.tsx
@@ -32,17 +32,6 @@ export interface OfferType {
 
 const MAX_DISPLAY_TEXT_LENGTH = 191;
 
-const getLengthHint = (length: number, maxLength: number, helperText?: string) => {
-    const lengthColor = length > maxLength ? 'text-red' : 'text-green';
-
-    return (
-        <div className='flex justify-between'>
-            <span>{helperText || ''}</span>
-            <strong><span className={lengthColor}>{length}</span> / {maxLength}</strong>
-        </div>
-    );
-};
-
 export const ButtonSelect: React.FC<{type: OfferType, checked: boolean, onClick: () => void}> = ({type, checked, onClick}) => {
     const checkboxClass = checked ? 'bg-black text-white dark:bg-white dark:text-black' : 'border border-grey-300 dark:border-grey-800';
 
@@ -155,8 +144,6 @@ const Sidebar: React.FC<SidebarProps> = ({tierOptions,
 
     const [nameLength, setNameLength] = useState(0);
     const nameLengthColor = nameLength > 40 ? 'text-red' : 'text-green';
-    const displayTitleHint = errors.displayTitle || getLengthHint(overrides.displayTitle.value.length, MAX_DISPLAY_TEXT_LENGTH);
-    const displayDescriptionHint = errors.displayDescription || getLengthHint(overrides.displayDescription.length, MAX_DISPLAY_TEXT_LENGTH);
 
     const {siteData} = useGlobalData();
     const [isCopied, setIsCopied] = useState(false);
@@ -187,8 +174,6 @@ const Sidebar: React.FC<SidebarProps> = ({tierOptions,
                             onKeyDown={() => clearError('name')}
                         />
                         <TextField
-                            error={Boolean(errors.displayTitle)}
-                            hint={displayTitleHint}
                             maxLength={MAX_DISPLAY_TEXT_LENGTH}
                             placeholder='Black Friday Special'
                             title='Display title'
@@ -196,11 +181,8 @@ const Sidebar: React.FC<SidebarProps> = ({tierOptions,
                             onChange={(e) => {
                                 handleDisplayTitleInput(e);
                             }}
-                            onKeyDown={() => clearError('displayTitle')}
                         />
                         <TextArea
-                            error={Boolean(errors.displayDescription)}
-                            hint={displayDescriptionHint}
                             maxLength={MAX_DISPLAY_TEXT_LENGTH}
                             placeholder='Take advantage of this limited-time offer.'
                             title='Display description'
@@ -208,7 +190,6 @@ const Sidebar: React.FC<SidebarProps> = ({tierOptions,
                             onChange={(e) => {
                                 handleTextAreaInput(e);
                             }}
-                            onKeyDown={() => clearError('displayDescription')}
                         />
                     </div>
                 </section>
@@ -430,14 +411,6 @@ const AddOfferModal = () => {
 
             if (!formState.displayTitle.value && formState.displayTitle.value.length === 0) {
                 newErrors.displayTitle = 'Display title is required';
-            }
-
-            if (formState.displayTitle.value.length > MAX_DISPLAY_TEXT_LENGTH) {
-                newErrors.displayTitle = `Display title cannot be longer than ${MAX_DISPLAY_TEXT_LENGTH} characters.`;
-            }
-
-            if (formState.displayDescription.length > MAX_DISPLAY_TEXT_LENGTH) {
-                newErrors.displayDescription = `Display description cannot be longer than ${MAX_DISPLAY_TEXT_LENGTH} characters.`;
             }
 
             if (formState.type === 'percent' && formState.percentAmount === 0) {

--- a/apps/admin-x-settings/src/components/settings/growth/offers/add-offer-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/offers/add-offer-modal.tsx
@@ -30,6 +30,19 @@ export interface OfferType {
     description: string;
 }
 
+const MAX_DISPLAY_TEXT_LENGTH = 191;
+
+const getLengthHint = (length: number, maxLength: number, helperText?: string) => {
+    const lengthColor = length > maxLength ? 'text-red' : 'text-green';
+
+    return (
+        <div className='flex justify-between'>
+            <span>{helperText || ''}</span>
+            <strong><span className={lengthColor}>{length}</span> / {maxLength}</strong>
+        </div>
+    );
+};
+
 export const ButtonSelect: React.FC<{type: OfferType, checked: boolean, onClick: () => void}> = ({type, checked, onClick}) => {
     const checkboxClass = checked ? 'bg-black text-white dark:bg-white dark:text-black' : 'border border-grey-300 dark:border-grey-800';
 
@@ -142,6 +155,8 @@ const Sidebar: React.FC<SidebarProps> = ({tierOptions,
 
     const [nameLength, setNameLength] = useState(0);
     const nameLengthColor = nameLength > 40 ? 'text-red' : 'text-green';
+    const displayTitleHint = errors.displayTitle || getLengthHint(overrides.displayTitle.value.length, MAX_DISPLAY_TEXT_LENGTH);
+    const displayDescriptionHint = errors.displayDescription || getLengthHint(overrides.displayDescription.length, MAX_DISPLAY_TEXT_LENGTH);
 
     const {siteData} = useGlobalData();
     const [isCopied, setIsCopied] = useState(false);
@@ -173,7 +188,8 @@ const Sidebar: React.FC<SidebarProps> = ({tierOptions,
                         />
                         <TextField
                             error={Boolean(errors.displayTitle)}
-                            hint={errors.displayTitle}
+                            hint={displayTitleHint}
+                            maxLength={MAX_DISPLAY_TEXT_LENGTH}
                             placeholder='Black Friday Special'
                             title='Display title'
                             value={overrides.displayTitle.value}
@@ -183,12 +199,16 @@ const Sidebar: React.FC<SidebarProps> = ({tierOptions,
                             onKeyDown={() => clearError('displayTitle')}
                         />
                         <TextArea
+                            error={Boolean(errors.displayDescription)}
+                            hint={displayDescriptionHint}
+                            maxLength={MAX_DISPLAY_TEXT_LENGTH}
                             placeholder='Take advantage of this limited-time offer.'
                             title='Display description'
                             value={overrides.displayDescription}
                             onChange={(e) => {
                                 handleTextAreaInput(e);
                             }}
+                            onKeyDown={() => clearError('displayDescription')}
                         />
                     </div>
                 </section>
@@ -410,6 +430,14 @@ const AddOfferModal = () => {
 
             if (!formState.displayTitle.value && formState.displayTitle.value.length === 0) {
                 newErrors.displayTitle = 'Display title is required';
+            }
+
+            if (formState.displayTitle.value.length > MAX_DISPLAY_TEXT_LENGTH) {
+                newErrors.displayTitle = `Display title cannot be longer than ${MAX_DISPLAY_TEXT_LENGTH} characters.`;
+            }
+
+            if (formState.displayDescription.length > MAX_DISPLAY_TEXT_LENGTH) {
+                newErrors.displayDescription = `Display description cannot be longer than ${MAX_DISPLAY_TEXT_LENGTH} characters.`;
             }
 
             if (formState.type === 'percent' && formState.percentAmount === 0) {

--- a/apps/admin-x-settings/src/components/settings/growth/offers/add-offer-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/offers/add-offer-modal.tsx
@@ -174,6 +174,8 @@ const Sidebar: React.FC<SidebarProps> = ({tierOptions,
                             onKeyDown={() => clearError('name')}
                         />
                         <TextField
+                            error={Boolean(errors.displayTitle)}
+                            hint={errors.displayTitle}
                             maxLength={MAX_DISPLAY_TEXT_LENGTH}
                             placeholder='Black Friday Special'
                             title='Display title'
@@ -181,6 +183,7 @@ const Sidebar: React.FC<SidebarProps> = ({tierOptions,
                             onChange={(e) => {
                                 handleDisplayTitleInput(e);
                             }}
+                            onKeyDown={() => clearError('displayTitle')}
                         />
                         <TextArea
                             maxLength={MAX_DISPLAY_TEXT_LENGTH}

--- a/apps/admin-x-settings/src/components/settings/growth/offers/add-offer-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/offers/add-offer-modal.tsx
@@ -436,8 +436,8 @@ const AddOfferModal = () => {
                 newErrors.amount = 'Free trial must be at least 1 day.';
             }
 
-            if (formState.type !== 'trial' && formState.duration === 'repeating' && formState.durationInMonths < 1) {
-                newErrors.durationInMonths = 'Enter a duration greater than 0.';
+            if (formState.type !== 'trial' && formState.duration === 'repeating' && (!Number.isInteger(formState.durationInMonths) || formState.durationInMonths < 1)) {
+                newErrors.durationInMonths = 'Enter a whole number of months (1 or more).';
             }
 
             return newErrors;

--- a/apps/admin-x-settings/src/components/settings/growth/offers/edit-retention-offer-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/offers/edit-retention-offer-modal.tsx
@@ -34,13 +34,18 @@ const durationOptions: SelectOption[] = [
     {value: 'forever', label: 'Forever'}
 ];
 
-const MAX_PERCENT_AMOUNT = 100;
+const MAX_DISPLAY_TEXT_LENGTH = 191;
 
 type RetentionOfferTerms = {
     type: 'percent';
     amount: number;
     duration: string;
     durationInMonths: number;
+};
+
+const normalizeDurationInMonths = (value: number): number => {
+    const parsedValue = Number.isFinite(value) ? Math.trunc(value) : 0;
+    return Math.max(1, parsedValue);
 };
 
 const getResolvedAmount = ({
@@ -125,12 +130,12 @@ const getFormOfferTerms = ({
             type: 'percent',
             amount: 100,
             duration: 'repeating',
-            durationInMonths: amount
+            durationInMonths: normalizeDurationInMonths(amount)
         };
     }
 
     const duration = formState.duration;
-    const durationInMonths = duration === 'repeating' ? Math.max(1, formState.durationInMonths) : 0;
+    const durationInMonths = duration === 'repeating' ? normalizeDurationInMonths(formState.durationInMonths) : 0;
 
     return {
         type: 'percent',
@@ -166,6 +171,21 @@ const getTermsSignature = (terms: RetentionOfferTerms | null): string => {
     return `${terms.type}:${terms.amount}:${terms.duration}:${terms.durationInMonths}`;
 };
 
+const getLengthHint = (length: number, maxLength: number, helperText?: string) => {
+    const lengthColor = length > maxLength ? 'text-red' : 'text-green';
+
+    return (
+        <div className='flex justify-between'>
+            <span>{helperText || ''}</span>
+            <strong><span className={lengthColor}>{length}</span> / {maxLength}</strong>
+        </div>
+    );
+};
+
+const isValidMonthDuration = (value: number): boolean => {
+    return Number.isInteger(value) && value > 0;
+};
+
 const hasFormChangesFromDefault = (formState: RetentionOfferFormState, defaultState: RetentionOfferFormState): boolean => {
     return formState.displayTitle !== defaultState.displayTitle ||
         formState.displayDescription !== defaultState.displayDescription ||
@@ -189,6 +209,8 @@ const RetentionOfferSidebar: React.FC<{
     const availableDurationOptions = cadence === 'yearly'
         ? durationOptions.filter(option => option.value !== 'repeating')
         : durationOptions;
+    const displayTitleHint = errors.displayTitle || getLengthHint(formState.displayTitle.length, MAX_DISPLAY_TEXT_LENGTH);
+    const displayDescriptionHint = errors.displayDescription || getLengthHint(formState.displayDescription.length, MAX_DISPLAY_TEXT_LENGTH);
 
     return (
         <div className='flex grow flex-col pt-2'>
@@ -235,7 +257,8 @@ const RetentionOfferSidebar: React.FC<{
                             <div className='flex flex-col gap-6'>
                                 <TextField
                                     error={Boolean(errors.displayTitle)}
-                                    hint={errors.displayTitle}
+                                    hint={displayTitleHint}
+                                    maxLength={MAX_DISPLAY_TEXT_LENGTH}
                                     placeholder='Before you go'
                                     title='Display title'
                                     value={formState.displayTitle}
@@ -245,12 +268,16 @@ const RetentionOfferSidebar: React.FC<{
                                     onKeyDown={() => clearError('displayTitle')}
                                 />
                                 <TextArea
+                                    error={Boolean(errors.displayDescription)}
+                                    hint={displayDescriptionHint}
+                                    maxLength={MAX_DISPLAY_TEXT_LENGTH}
                                     placeholder='We&#39;d hate to see you leave. How about a special offer to stay?'
                                     title='Display description'
                                     value={formState.displayDescription}
                                     onChange={(e) => {
                                         updateForm(state => ({...state, displayDescription: e.target.value}));
                                     }}
+                                    onKeyDown={() => clearError('displayDescription')}
                                 />
                             </div>
                         </section>
@@ -471,7 +498,7 @@ const EditRetentionOfferModal: React.FC<{id: string}> = ({id}) => {
                     cadence: offerCadence,
                     amount: formTerms.amount,
                     duration: formTerms.duration,
-                    duration_in_months: formTerms.durationInMonths,
+                    duration_in_months: formTerms.duration === 'repeating' ? formTerms.durationInMonths : null,
                     currency: null,
                     status,
                     redemption_type: 'retention',
@@ -532,19 +559,27 @@ const EditRetentionOfferModal: React.FC<{id: string}> = ({id}) => {
                 return newErrors;
             }
 
+            if (formState.displayTitle.length > MAX_DISPLAY_TEXT_LENGTH) {
+                newErrors.displayTitle = `Display title cannot be longer than ${MAX_DISPLAY_TEXT_LENGTH} characters.`;
+            }
+
+            if (formState.displayDescription.length > MAX_DISPLAY_TEXT_LENGTH) {
+                newErrors.displayDescription = `Display description cannot be longer than ${MAX_DISPLAY_TEXT_LENGTH} characters.`;
+            }
+
             if (formState.type === 'percent') {
-                if (formState.percentAmount < 1 || formState.percentAmount > MAX_PERCENT_AMOUNT) {
-                    newErrors.amount = `Enter an amount between 1 and ${MAX_PERCENT_AMOUNT}%.`;
+                if (formState.percentAmount < 1 || formState.percentAmount > 100) {
+                    newErrors.amount = `Enter an amount between 1 and 100%.`;
                 }
 
-                if (formState.duration === 'repeating' && formState.durationInMonths < 1) {
-                    newErrors.durationInMonths = 'Enter a duration greater than 0.';
+                if (formState.duration === 'repeating' && !isValidMonthDuration(formState.durationInMonths)) {
+                    newErrors.durationInMonths = 'Enter a whole number of months (1 or more).';
                 }
             }
 
             if (formState.type === 'free_months') {
-                if (formState.freeMonths < 1) {
-                    newErrors.amount = 'Enter a number of free months greater than 0.';
+                if (!isValidMonthDuration(formState.freeMonths)) {
+                    newErrors.amount = 'Enter a whole number of free months (1 or more).';
                 }
             }
 

--- a/apps/admin-x-settings/src/components/settings/growth/offers/edit-retention-offer-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/offers/edit-retention-offer-modal.tsx
@@ -171,17 +171,6 @@ const getTermsSignature = (terms: RetentionOfferTerms | null): string => {
     return `${terms.type}:${terms.amount}:${terms.duration}:${terms.durationInMonths}`;
 };
 
-const getLengthHint = (length: number, maxLength: number, helperText?: string) => {
-    const lengthColor = length > maxLength ? 'text-red' : 'text-green';
-
-    return (
-        <div className='flex justify-between'>
-            <span>{helperText || ''}</span>
-            <strong><span className={lengthColor}>{length}</span> / {maxLength}</strong>
-        </div>
-    );
-};
-
 const isValidMonthDuration = (value: number): boolean => {
     return Number.isInteger(value) && value > 0;
 };
@@ -209,9 +198,6 @@ const RetentionOfferSidebar: React.FC<{
     const availableDurationOptions = cadence === 'yearly'
         ? durationOptions.filter(option => option.value !== 'repeating')
         : durationOptions;
-    const displayTitleHint = errors.displayTitle || getLengthHint(formState.displayTitle.length, MAX_DISPLAY_TEXT_LENGTH);
-    const displayDescriptionHint = errors.displayDescription || getLengthHint(formState.displayDescription.length, MAX_DISPLAY_TEXT_LENGTH);
-
     return (
         <div className='flex grow flex-col pt-2'>
             <Form className='grow'>
@@ -256,8 +242,6 @@ const RetentionOfferSidebar: React.FC<{
                             <h2 className='mb-4 text-lg'>General</h2>
                             <div className='flex flex-col gap-6'>
                                 <TextField
-                                    error={Boolean(errors.displayTitle)}
-                                    hint={displayTitleHint}
                                     maxLength={MAX_DISPLAY_TEXT_LENGTH}
                                     placeholder='Before you go'
                                     title='Display title'
@@ -265,11 +249,8 @@ const RetentionOfferSidebar: React.FC<{
                                     onChange={(e) => {
                                         updateForm(state => ({...state, displayTitle: e.target.value}));
                                     }}
-                                    onKeyDown={() => clearError('displayTitle')}
                                 />
                                 <TextArea
-                                    error={Boolean(errors.displayDescription)}
-                                    hint={displayDescriptionHint}
                                     maxLength={MAX_DISPLAY_TEXT_LENGTH}
                                     placeholder='We&#39;d hate to see you leave. How about a special offer to stay?'
                                     title='Display description'
@@ -277,7 +258,6 @@ const RetentionOfferSidebar: React.FC<{
                                     onChange={(e) => {
                                         updateForm(state => ({...state, displayDescription: e.target.value}));
                                     }}
-                                    onKeyDown={() => clearError('displayDescription')}
                                 />
                             </div>
                         </section>
@@ -557,14 +537,6 @@ const EditRetentionOfferModal: React.FC<{id: string}> = ({id}) => {
 
             if (!formState.enabled) {
                 return newErrors;
-            }
-
-            if (formState.displayTitle.length > MAX_DISPLAY_TEXT_LENGTH) {
-                newErrors.displayTitle = `Display title cannot be longer than ${MAX_DISPLAY_TEXT_LENGTH} characters.`;
-            }
-
-            if (formState.displayDescription.length > MAX_DISPLAY_TEXT_LENGTH) {
-                newErrors.displayDescription = `Display description cannot be longer than ${MAX_DISPLAY_TEXT_LENGTH} characters.`;
             }
 
             if (formState.type === 'percent') {

--- a/apps/admin-x-settings/test/acceptance/membership/offers.test.ts
+++ b/apps/admin-x-settings/test/acceptance/membership/offers.test.ts
@@ -107,7 +107,6 @@ test.describe('Offers', () => {
         await expect(sidebar).toContainText(/Name is required/);
         await expect(sidebar).toContainText(/Code is required/);
         await expect(sidebar).toContainText(/Enter an amount between 1 and 100%./);
-        await expect(sidebar).toContainText(/Display title is required/);
     });
 
     test('Errors if the offer code is already taken', async ({page}) => {
@@ -169,7 +168,6 @@ test.describe('Offers', () => {
         await expect(sidebar).toContainText(/Name is required/);
         await expect(sidebar).toContainText(/Code is required/);
         await expect(sidebar).toContainText(/Enter an amount between 1 and 100%./);
-        await expect(sidebar).toContainText(/Display title is required/);
     });
 
     test('Can view active offers', async ({page}) => {

--- a/apps/admin-x-settings/test/acceptance/membership/offers.test.ts
+++ b/apps/admin-x-settings/test/acceptance/membership/offers.test.ts
@@ -1,7 +1,7 @@
 import {type Page, expect, test} from '@playwright/test';
 import {globalDataRequests, mockApi, responseFixtures, settingsWithStripe} from '@tryghost/admin-x-framework/test/acceptance';
 
-test.describe('Offers Modal', () => {
+test.describe('Offers', () => {
     test('Offers Modal is available', async ({page}) => {
         await mockApi({page, requests: {
             ...globalDataRequests,
@@ -141,7 +141,7 @@ test.describe('Offers Modal', () => {
         await expect(page.getByTestId('toast-error')).toContainText(/Offer `code` must be unique. Please change and try again./);
     });
 
-    test('Shows validation hints', async ({page}) => {
+    test('Shows validation errors', async ({page}) => {
         await mockApi({page, requests: {
             browseOffers: {method: 'GET', path: '/offers/', response: responseFixtures.offers},
             ...globalDataRequests,
@@ -170,6 +170,14 @@ test.describe('Offers Modal', () => {
         await expect(sidebar).toContainText(/Code is required/);
         await expect(sidebar).toContainText(/Enter an amount between 1 and 100%./);
         await expect(sidebar).toContainText(/Display title is required/);
+        const tooLongDisplayTitle = 't'.repeat(192);
+        const tooLongDisplayDescription = 'd'.repeat(192);
+
+        await sidebar.getByLabel('Display title').fill(tooLongDisplayTitle);
+        await expect(sidebar.getByLabel('Display title')).toHaveValue('t'.repeat(191));
+
+        await sidebar.getByLabel('Display description').fill(tooLongDisplayDescription);
+        await expect(sidebar.getByLabel('Display description')).toHaveValue('d'.repeat(191));
     });
 
     test('Can view active offers', async ({page}) => {
@@ -306,6 +314,8 @@ test.describe('Offers Modal', () => {
             redemption_type: 'retention',
             tier: null
         };
+        const tooLongDisplayTitle = 't'.repeat(192);
+        const tooLongDisplayDescription = 'd'.repeat(192);
 
         const createRetentionOffer = (overrides: Partial<RetentionOffer> = {}) => {
             return {
@@ -521,7 +531,11 @@ test.describe('Offers Modal', () => {
 
         test('Shows validation errors for invalid retention values on save', async ({page}) => {
             await mockApi({page, requests: getRetentionRequests({
-                retentionOffers: [createRetentionOffer({id: 'retention-month-active'})]
+                retentionOffers: [createRetentionOffer({
+                    id: 'retention-month-active',
+                    display_title: tooLongDisplayTitle,
+                    display_description: tooLongDisplayDescription
+                })]
             })});
 
             const {retentionModal} = await openRetentionModal(page, 'Monthly retention');
@@ -531,11 +545,26 @@ test.describe('Offers Modal', () => {
             await retentionModal.getByLabel('Amount off').fill('0');
             await saveButton.click();
             await expect(retentionModal.getByText('Enter an amount between 1 and 100%.')).toBeVisible();
+            await expect(retentionModal.getByText('Display title cannot be longer than 191 characters.')).toBeVisible();
+            await expect(retentionModal.getByText('Display description cannot be longer than 191 characters.')).toBeVisible();
             await expect(saveButton).toBeEnabled();
 
             await retentionModal.getByLabel('Amount off').fill('150');
             await saveButton.click();
             await expect(retentionModal.getByText('Enter an amount between 1 and 100%.')).toBeVisible();
+            await expect(saveButton).toBeEnabled();
+
+            await retentionModal.getByText('Forever', {exact: true}).first().click();
+            await page.getByTestId('select-option').filter({hasText: 'Multiple-months'}).click();
+
+            await retentionModal.getByTestId('duration-months-input').fill('1.5');
+            await saveButton.click();
+            await expect(retentionModal.getByText('Enter a whole number of months (1 or more).')).toBeVisible();
+
+            await retentionModal.getByRole('button', {name: /Free month\(s\)/}).click();
+            await retentionModal.getByLabel('Free months').fill('0');
+            await saveButton.click();
+            await expect(retentionModal.getByText('Enter a whole number of free months (1 or more).')).toBeVisible();
             await expect(saveButton).toBeEnabled();
         });
 
@@ -662,7 +691,7 @@ test.describe('Offers Modal', () => {
                     cadence: 'month',
                     amount: 35,
                     duration: 'forever',
-                    duration_in_months: 0,
+                    duration_in_months: null,
                     currency: null,
                     status: 'active',
                     redemption_type: 'retention',
@@ -719,7 +748,9 @@ test.describe('Offers Modal', () => {
             const {lastApiRequests} = await mockApi({page, requests: getRetentionRequests({
                 retentionOffers: [createRetentionOffer({
                     id: 'retention-month-active',
-                    display_title: 'Before you go'
+                    display_title: 'Before you go',
+                    duration: 'repeating',
+                    duration_in_months: 3
                 })],
                 extraRequests: {
                     addOffer: {method: 'POST', path: '/offers/', response: {
@@ -740,6 +771,7 @@ test.describe('Offers Modal', () => {
 
             const {retentionModal} = await openRetentionModal(page, 'Monthly retention');
             await retentionModal.getByLabel('Amount off').fill('35');
+            await retentionModal.getByTestId('duration-months-input').fill('0');
             await retentionModal.getByRole('switch', {name: 'Enable monthly retention'}).click();
             await retentionModal.getByRole('button', {name: 'Save'}).click();
 
@@ -757,8 +789,8 @@ test.describe('Offers Modal', () => {
                 offers: [{
                     cadence: 'month',
                     amount: 35,
-                    duration: 'forever',
-                    duration_in_months: 0,
+                    duration: 'repeating',
+                    duration_in_months: 1,
                     status: 'archived',
                     redemption_type: 'retention',
                     tier: null,

--- a/apps/admin-x-settings/test/acceptance/membership/offers.test.ts
+++ b/apps/admin-x-settings/test/acceptance/membership/offers.test.ts
@@ -102,12 +102,16 @@ test.describe('Offers', () => {
         const modal = page.getByTestId('offers-modal');
         await modal.getByRole('button', {name: 'New offer'}).click();
         const addModal = page.getByTestId('add-offer-modal');
+        await addModal.getByText('First-payment', {exact: true}).first().click();
+        await page.getByTestId('select-option').filter({hasText: 'Multiple-months'}).click();
+        await addModal.getByTestId('duration-months-input').fill('0');
         await addModal.getByRole('button', {name: 'Publish'}).click();
         const sidebar = addModal.getByTestId('add-offer-sidebar');
         await expect(sidebar).toContainText(/Name is required/);
         await expect(sidebar).toContainText(/Code is required/);
         await expect(sidebar).toContainText(/Enter an amount between 1 and 100%./);
         await expect(sidebar).toContainText(/Display title is required/);
+        await expect(sidebar).toContainText(/Enter a whole number of months \(1 or more\)./);
     });
 
     test('Errors if the offer code is already taken', async ({page}) => {

--- a/apps/admin-x-settings/test/acceptance/membership/offers.test.ts
+++ b/apps/admin-x-settings/test/acceptance/membership/offers.test.ts
@@ -170,14 +170,6 @@ test.describe('Offers', () => {
         await expect(sidebar).toContainText(/Code is required/);
         await expect(sidebar).toContainText(/Enter an amount between 1 and 100%./);
         await expect(sidebar).toContainText(/Display title is required/);
-        const tooLongDisplayTitle = 't'.repeat(192);
-        const tooLongDisplayDescription = 'd'.repeat(192);
-
-        await sidebar.getByLabel('Display title').fill(tooLongDisplayTitle);
-        await expect(sidebar.getByLabel('Display title')).toHaveValue('t'.repeat(191));
-
-        await sidebar.getByLabel('Display description').fill(tooLongDisplayDescription);
-        await expect(sidebar.getByLabel('Display description')).toHaveValue('d'.repeat(191));
     });
 
     test('Can view active offers', async ({page}) => {
@@ -314,9 +306,6 @@ test.describe('Offers', () => {
             redemption_type: 'retention',
             tier: null
         };
-        const tooLongDisplayTitle = 't'.repeat(192);
-        const tooLongDisplayDescription = 'd'.repeat(192);
-
         const createRetentionOffer = (overrides: Partial<RetentionOffer> = {}) => {
             return {
                 ...defaultRetentionOffer,
@@ -531,11 +520,7 @@ test.describe('Offers', () => {
 
         test('Shows validation errors for invalid retention values on save', async ({page}) => {
             await mockApi({page, requests: getRetentionRequests({
-                retentionOffers: [createRetentionOffer({
-                    id: 'retention-month-active',
-                    display_title: tooLongDisplayTitle,
-                    display_description: tooLongDisplayDescription
-                })]
+                retentionOffers: [createRetentionOffer({id: 'retention-month-active'})]
             })});
 
             const {retentionModal} = await openRetentionModal(page, 'Monthly retention');
@@ -545,8 +530,6 @@ test.describe('Offers', () => {
             await retentionModal.getByLabel('Amount off').fill('0');
             await saveButton.click();
             await expect(retentionModal.getByText('Enter an amount between 1 and 100%.')).toBeVisible();
-            await expect(retentionModal.getByText('Display title cannot be longer than 191 characters.')).toBeVisible();
-            await expect(retentionModal.getByText('Display description cannot be longer than 191 characters.')).toBeVisible();
             await expect(saveButton).toBeEnabled();
 
             await retentionModal.getByLabel('Amount off').fill('150');

--- a/apps/admin-x-settings/test/acceptance/membership/offers.test.ts
+++ b/apps/admin-x-settings/test/acceptance/membership/offers.test.ts
@@ -107,6 +107,7 @@ test.describe('Offers', () => {
         await expect(sidebar).toContainText(/Name is required/);
         await expect(sidebar).toContainText(/Code is required/);
         await expect(sidebar).toContainText(/Enter an amount between 1 and 100%./);
+        await expect(sidebar).toContainText(/Display title is required/);
     });
 
     test('Errors if the offer code is already taken', async ({page}) => {
@@ -168,6 +169,7 @@ test.describe('Offers', () => {
         await expect(sidebar).toContainText(/Name is required/);
         await expect(sidebar).toContainText(/Code is required/);
         await expect(sidebar).toContainText(/Enter an amount between 1 and 100%./);
+        await expect(sidebar).toContainText(/Display title is required/);
     });
 
     test('Can view active offers', async ({page}) => {


### PR DESCRIPTION
closes https://linear.app/ghost/issue/BER-3392
closes https://linear.app/ghost/issue/BER-3218

- added max. length display title / description fields
- added inline validation for floating numbers for free-months / duration-in-months fields


---

#### Max. length display title / description fields:
<img width="2134" height="1520" alt="CleanShot 2026-03-05 at 09 33 18@2x" src="https://github.com/user-attachments/assets/ea831c8c-63de-45ef-b482-db088a3329bc" />

#### Inline validation for floating numbers for free-months / duration-in-months fields:
<img width="2226" height="1838" alt="CleanShot 2026-03-04 at 17 09 15@2x" src="https://github.com/user-attachments/assets/d057f6a3-e28f-4bd5-a2d7-581cb8fb765d" />

