### PR TITLE
Required all TypeScript syntax to be erasable in `parse-email-address`

### DIFF
--- a/ghost/parse-email-address/tsconfig.json
+++ b/ghost/parse-email-address/tsconfig.json
@@ -101,6 +101,7 @@
     "noPropertyAccessFromIndexSignature": true,          /* Enforces using indexed accessors for keys declared using an indexed type. */
     "allowUnusedLabels": false,                          /* Disable error reporting for unused labels. */
     "allowUnreachableCode": false,                       /* Disable error reporting for unreachable code. */
+    "erasableSyntaxOnly": true,                          /* Require all TypeScript code to be erasable. */
 
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */


### PR DESCRIPTION
no ref

Node can natively run TypeScript files, but only if they have "erasable syntax". This means it can't handle things like enums and namespaces.

This enforces that in the `@tryghost/parse-email-address` package.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-time TypeScript configuration change only; main risk is new compilation errors if the package uses non-erasable TS constructs (e.g., enums/namespaces).
> 
> **Overview**
> Adds `"erasableSyntaxOnly": true` to `ghost/parse-email-address/tsconfig.json`, enforcing that the package’s TypeScript uses only syntax Node can erase when running TS natively.
> 
> This tightens the compiler constraints and will cause the build to fail if `@tryghost/parse-email-address` introduces non-erasable constructs (e.g., `enum`, `namespace`) going forward.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 841bb6aa8c0fd242bae7236f1146a70c184232b7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->