### PR TITLE
Improved some details on the members-forward page

### DIFF
--- a/apps/posts/src/views/members/components/members-actions.tsx
+++ b/apps/posts/src/views/members/components/members-actions.tsx
@@ -195,39 +195,43 @@ const MembersActions: React.FC<MembersActionsProps> = ({
                     </Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end">
-                    {/* Export */}
-                    <DropdownMenuItem onClick={handleExport}>
-                        <LucideIcon.Download className="mr-2 size-4" />
-                        {isFiltered
-                            ? `Export ${memberCount.toLocaleString()} members`
-                            : 'Export all members'}
-                    </DropdownMenuItem>
+                    {memberCount > 0 && (
+                        <>
+                            {/* Export */}
+                            <DropdownMenuItem onClick={handleExport}>
+                                <LucideIcon.Download className="mr-2 size-4" />
+                                {isFiltered
+                                    ? `Export ${memberCount.toLocaleString()} members`
+                                    : 'Export all members'}
+                            </DropdownMenuItem>
 
-                    <DropdownMenuSeparator />
-                    <DropdownMenuItem onClick={() => setShowAddLabelModal(true)}>
-                        <LucideIcon.Tags className="mr-2 size-4" />
-                            Add label to {memberCount.toLocaleString()} {memberCount === 1 ? 'member' : 'members'}
-                    </DropdownMenuItem>
-                    <DropdownMenuItem onClick={() => setShowRemoveLabelModal(true)}>
-                        <LucideIcon.Tag className="mr-2 size-4" />
-                            Remove label from {memberCount.toLocaleString()} {memberCount === 1 ? 'member' : 'members'}
-                    </DropdownMenuItem>
-                    <DropdownMenuItem
-                        disabled={isLoadingNewsletters}
-                        onClick={() => setShowUnsubscribeModal(true)}
-                    >
-                        <LucideIcon.MailX className="mr-2 size-4" />
-                            Unsubscribe {memberCount.toLocaleString()} {memberCount === 1 ? 'member' : 'members'}
-                    </DropdownMenuItem>
-                    <DropdownMenuSeparator />
-                    <DropdownMenuItem
-                        className="text-destructive focus:text-destructive"
-                        disabled={!canBulkDelete}
-                        onClick={() => setShowDeleteModal(true)}
-                    >
-                        <LucideIcon.Trash2 className="mr-2 size-4" />
-                            Delete {memberCount.toLocaleString()} {memberCount === 1 ? 'member' : 'members'}
-                    </DropdownMenuItem>
+                            <DropdownMenuSeparator />
+                            <DropdownMenuItem onClick={() => setShowAddLabelModal(true)}>
+                                <LucideIcon.Tags className="mr-2 size-4" />
+                                    Add label to {memberCount.toLocaleString()} {memberCount === 1 ? 'member' : 'members'}
+                            </DropdownMenuItem>
+                            <DropdownMenuItem onClick={() => setShowRemoveLabelModal(true)}>
+                                <LucideIcon.Tag className="mr-2 size-4" />
+                                    Remove label from {memberCount.toLocaleString()} {memberCount === 1 ? 'member' : 'members'}
+                            </DropdownMenuItem>
+                            <DropdownMenuItem
+                                disabled={isLoadingNewsletters}
+                                onClick={() => setShowUnsubscribeModal(true)}
+                            >
+                                <LucideIcon.MailX className="mr-2 size-4" />
+                                    Unsubscribe {memberCount.toLocaleString()} {memberCount === 1 ? 'member' : 'members'}
+                            </DropdownMenuItem>
+                            <DropdownMenuSeparator />
+                            <DropdownMenuItem
+                                className="text-destructive focus:text-destructive"
+                                disabled={!canBulkDelete}
+                                onClick={() => setShowDeleteModal(true)}
+                            >
+                                <LucideIcon.Trash2 className="mr-2 size-4" />
+                                    Delete {memberCount.toLocaleString()} {memberCount === 1 ? 'member' : 'members'}
+                            </DropdownMenuItem>
+                        </>
+                    )}
                 </DropdownMenuContent>
             </DropdownMenu>
 

--- a/apps/posts/src/views/members/components/members-list-item.tsx
+++ b/apps/posts/src/views/members/components/members-list-item.tsx
@@ -80,11 +80,10 @@ function MembersListItemStatus({status, tiers}: {status: Member['status']; tiers
 }
 
 function MembersListItemOpenRate({emailOpenRate}: {emailOpenRate: number | null | undefined}) {
+    const isKnown = emailOpenRate !== null && emailOpenRate !== undefined;
     return (
-        <div className="hidden text-sm text-muted-foreground lg:block">
-            {emailOpenRate !== null && emailOpenRate !== undefined
-                ? `${Math.round(emailOpenRate)}%`
-                : 'N/A'}
+        <div className={`hidden text-sm lg:block ${isKnown ? 'text-foreground' : 'text-muted-foreground'}`}>
+            {isKnown ? `${Math.round(emailOpenRate)}%` : 'N/A'}
         </div>
     );
 }


### PR DESCRIPTION
Ref https://linear.app/ghost/issue/BER-3408/design-clean-up

- Hid bulk actions for 0 selected members
- Used text-foreground for columns with values for open rate


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, UI-only conditional rendering and styling changes with minimal behavioral impact beyond hiding actions when the selection is empty.
> 
> **Overview**
> Improves the members list UX by **hiding all bulk action dropdown items** (export/label/unsubscribe/delete) when `memberCount` is `0`, preventing no-op actions.
> 
> Adjusts `MembersListItemOpenRate` styling so known open-rate values use `text-foreground` while unknown values remain `text-muted-foreground` (still rendering `N/A`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 889dc0c646528a2a4dcd80d40132d6145ba37c3c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->