### PR TITLE
Fixed label select ordering with infinite scroll

### DIFF
--- a/ghost/admin/app/services/labels-manager.js
+++ b/ghost/admin/app/services/labels-manager.js
@@ -26,7 +26,7 @@ export default class LabelsManagerService extends Service {
     sortLabels(labels = []) {
         return labels
             .filter(label => label.get('id') !== null)
-            .sort((labelA, labelB) => (labelA.name || '').localeCompare((labelB.name || ''), undefined, {ignorePunctuation: true}));
+            .sort((labelA, labelB) => (labelA.name || '').localeCompare((labelB.name || '')));
     }
 
     findBySlug(slug) {


### PR DESCRIPTION
## Summary
- Removed `ignorePunctuation: true` from label client-side sort to match server ordering
- `ignorePunctuation` caused `#`-prefixed labels to sort as if the `#` didn't exist, but the server's `name asc` puts `#` before alphabetical characters
- This mismatch meant each new page of labels loaded via infinite scroll appeared in the wrong position instead of appending to the list

ref https://linear.app/ghost/issue/BER-3402/