### PR TITLE
Added CTA and product cards to email editor

### DIFF
--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/member-email-editor.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/member-email-editor.tsx
@@ -69,6 +69,8 @@ const MemberEmailsEditor: React.FC<MemberEmailsEditorProps> = ({
         '[&_:is(hr)]:pt-0',
         // Paragraph spacing & bold
         '[&_p]:mb-4 [&_strong]:font-semibold',
+        // Keep settings panel copy compact
+        '[&_[data-kg-settings-panel]_p]:!mb-0',
         // Nested-editor (callout, etc.) fixes: align placeholder with text
         // 1. Override placeholder font/size/line-height to match the <p> styles
         '[&_.not-kg-prose>div]:!font-inter [&_.not-kg-prose>div]:!tracking-tight [&_.not-kg-prose>div]:!text-xl [&_.not-kg-prose>div]:!leading-[1.6]',

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/member-email-editor.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/member-email-editor.tsx
@@ -136,12 +136,14 @@ const MemberEmailsEditor: React.FC<MemberEmailsEditorProps> = ({
                                 <koenig.BookmarkPlugin />
                                 <koenig.ButtonPlugin />
                                 <koenig.CalloutPlugin />
+                                <koenig.CallToActionPlugin />
                                 <koenig.CardMenuPlugin />
                                 <koenig.EmailCtaPlugin />
                                 <koenig.EmbedPlugin />
                                 <koenig.HtmlPlugin />
                                 <koenig.ImagePlugin />
                                 <koenig.KoenigSelectorPlugin />
+                                <koenig.ProductPlugin />
                             </>
                         )}
 

--- a/apps/admin-x-settings/test/acceptance/membership/member-welcome-emails.test.ts
+++ b/apps/admin-x-settings/test/acceptance/membership/member-welcome-emails.test.ts
@@ -311,6 +311,62 @@ test.describe('Member emails settings', async () => {
             await expect.poll(() => lastApiRequests.fetchOembed?.url || '').toContain('type=bookmark');
         });
 
+        test('welcome email editor inserts call to action card via slash menu', async ({page}) => {
+            await mockApi({page, requests: {
+                ...globalDataRequests,
+                ...newslettersRequest,
+                browseConfig: {method: 'GET', path: '/config/', response: configWithWelcomeEmailEditorEnabled},
+                browseAutomatedEmails: {method: 'GET', path: '/automated_emails/', response: automatedEmailsFixture}
+            }});
+
+            await page.goto('/#/memberemails');
+            await page.waitForLoadState('networkidle');
+
+            const section = page.getByTestId('memberemails');
+            await expect(section).toBeVisible({timeout: 10000});
+            await section.getByTestId('free-welcome-email-preview').click();
+
+            const modal = page.getByTestId('welcome-email-modal');
+            await expect(modal).toBeVisible();
+
+            const editor = modal.locator('[data-kg="editor"] div[contenteditable="true"]').first();
+            await editor.click({timeout: 5000});
+            await page.keyboard.press('ControlOrMeta+a');
+            await page.keyboard.press('Backspace');
+            await page.keyboard.type('/call-to-action');
+            await page.keyboard.press('Enter');
+
+            await expect(modal.locator('[data-kg-card="call-to-action"]')).toBeVisible();
+        });
+
+        test('welcome email editor inserts product card via slash menu', async ({page}) => {
+            await mockApi({page, requests: {
+                ...globalDataRequests,
+                ...newslettersRequest,
+                browseConfig: {method: 'GET', path: '/config/', response: configWithWelcomeEmailEditorEnabled},
+                browseAutomatedEmails: {method: 'GET', path: '/automated_emails/', response: automatedEmailsFixture}
+            }});
+
+            await page.goto('/#/memberemails');
+            await page.waitForLoadState('networkidle');
+
+            const section = page.getByTestId('memberemails');
+            await expect(section).toBeVisible({timeout: 10000});
+            await section.getByTestId('free-welcome-email-preview').click();
+
+            const modal = page.getByTestId('welcome-email-modal');
+            await expect(modal).toBeVisible();
+
+            const editor = modal.locator('[data-kg="editor"] div[contenteditable="true"]').first();
+            await editor.click({timeout: 5000});
+            await page.keyboard.press('ControlOrMeta+a');
+            await page.keyboard.press('Backspace');
+            await page.keyboard.type('/product');
+            await page.keyboard.press('Enter');
+
+            await expect(modal.locator('[data-kg-card="product"]')).toBeVisible();
+        });
+
         test('uses automated email sender fields when populated, even if newsletter differs', async ({page}) => {
             const populatedAutomatedEmailsFixture = {
                 automated_emails: [{

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -15,7 +15,7 @@
     "@tryghost/activitypub": "*",
     "@tryghost/admin-x-framework": "*",
     "@tryghost/admin-x-settings": "*",
-    "@tryghost/koenig-lexical": "1.7.18",
+    "@tryghost/koenig-lexical": "1.7.19",
     "@tryghost/posts": "*",
     "@tryghost/shade": "*",
     "@tryghost/stats": "*",

--- a/ghost/admin/package.json
+++ b/ghost/admin/package.json
@@ -50,7 +50,7 @@
     "@tryghost/helpers": "1.1.97",
     "@tryghost/kg-clean-basic-html": "4.2.18",
     "@tryghost/kg-converters": "1.1.18",
-    "@tryghost/koenig-lexical": "1.7.18",
+    "@tryghost/koenig-lexical": "1.7.19",
     "@tryghost/limit-service": "1.4.1",
     "@tryghost/members-csv": "2.0.3",
     "@tryghost/nql": "0.12.10",

--- a/ghost/core/core/server/services/member-welcome-emails/email-templates/partials/card-styles.hbs
+++ b/ghost/core/core/server/services/member-welcome-emails/email-templates/partials/card-styles.hbs
@@ -305,6 +305,304 @@ figcaption a {
     font-size: 20px;
 }
 
+.kg-cta-card {
+    margin: 0 0 1.5em 0;
+    padding: 0 24px;
+    {{#if hasRoundedImageCorners}}
+        border-radius: 6px;
+    {{else}}
+        border-radius: 0;
+    {{/if}}
+}
+
+.kg-cta-card + * {
+    margin-top: 1.5em !important;
+}
+
+.kg-cta-card + hr {
+    margin-top: 3em !important;
+}
+
+.kg-cta-card.kg-cta-bg-none {
+    padding: 0;
+    border-radius: 0;
+}
+
+.kg-cta-card.kg-cta-bg-none:not(.kg-cta-no-dividers) {
+    border-bottom: 1px solid {{dividerColor}};
+}
+
+.kg-cta-bg-none.kg-cta-no-label:not(.kg-cta-no-dividers) {
+    border-top: 1px solid {{dividerColor}};
+}
+
+.kg-cta-bg-white {
+    {{#if backgroundIsDark}}
+        background-color: #15212A;
+        background-color: rgba(0, 0, 0, 0.15);
+        border: 1px solid #343434;
+        border: 1px solid rgba(255, 255, 255, 0.25);
+    {{else}}
+        background-color: #ffffff;
+        background-color: rgba(255, 255, 255, 0.25);
+        border: 1px solid #e0e7eb;
+        border: 1px solid rgba(0, 0, 0, 0.12);
+    {{/if}}
+}
+
+.kg-cta-bg-grey {
+    background: #f1f2f4;
+}
+
+.kg-cta-bg-blue {
+    background: #E9F6FB;
+}
+
+.kg-cta-bg-green {
+    background: #E8F8EA;
+}
+
+.kg-cta-bg-yellow {
+    background: #FCF4E3;
+}
+
+.kg-cta-bg-red {
+    background: #FBE9E9;
+}
+
+.kg-cta-bg-pink {
+    background: #FCEEF8;
+}
+
+.kg-cta-bg-purple {
+    background: #F2EDFC;
+}
+
+.kg-cta-sponsor-label {
+    padding: 12px 0;
+    border-bottom: 1px solid {{dividerColor}};
+}
+
+.kg-cta-bg-none .kg-cta-sponsor-label {
+    padding-top: 0;
+}
+
+.kg-cta-immersive.kg-cta-has-img:not(.kg-cta-bg-none) .kg-cta-sponsor-label,
+.kg-cta-bg-none.kg-cta-no-dividers .kg-cta-sponsor-label {
+    border-bottom: 0;
+}
+
+.kg-cta-bg-none .kg-cta-sponsor-label {
+    border-color: {{dividerColor}};
+}
+
+.kg-cta-bg-white .kg-cta-sponsor-label {
+    {{#if backgroundIsDark}}
+    border-color: rgba(255, 255, 255, 0.25);
+    {{else}}
+    border-color: rgba(0, 0, 0, 0.12);
+    {{/if}}
+}
+
+.kg-cta-bg-grey .kg-cta-sponsor-label {
+    border-color: #d0d1d2;
+}
+
+.kg-cta-bg-blue .kg-cta-sponsor-label {
+    border-color: #cddee5;
+}
+
+.kg-cta-bg-green .kg-cta-sponsor-label {
+    border-color: #cce0ce;
+}
+
+.kg-cta-bg-yellow .kg-cta-sponsor-label {
+    border-color: #e3d9c4;
+}
+
+.kg-cta-bg-red .kg-cta-sponsor-label {
+    border-color: #e7d0d0;
+}
+
+.kg-cta-bg-pink .kg-cta-sponsor-label {
+    border-color: #e6d6e1;
+}
+
+.kg-cta-bg-purple .kg-cta-sponsor-label {
+    border-color: #dbd5e7;
+}
+
+.kg-cta-sponsor-label p {
+    margin: 0;
+    color: #89959f;
+    font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif;
+    font-size: 12px;
+    font-weight: 500;
+    text-transform: uppercase;
+}
+
+.kg-cta-bg-blue .kg-cta-sponsor-label p {
+    color: #97A0A3;
+}
+
+.kg-cta-bg-green .kg-cta-sponsor-label p {
+    color: #97A198;
+}
+
+.kg-cta-bg-yellow .kg-cta-sponsor-label p {
+    color: #A49F94;
+}
+
+.kg-cta-bg-red .kg-cta-sponsor-label p {
+    color: #A39797;
+}
+
+.kg-cta-bg-pink .kg-cta-sponsor-label p {
+    color: #A49BA1;
+}
+
+.kg-cta-bg-purple .kg-cta-sponsor-label p {
+    color: #9D9AA4;
+}
+
+.kg-cta-sponsor-label a {
+    color: #15212A;
+}
+
+.kg-cta-link-accent .kg-cta-sponsor-label a {
+    color: {{accentColor}} !important;
+}
+
+table.kg-cta-content-wrapper:not(.kg-cta-bg-none.kg-cta-no-dividers table.kg-cta-content-wrapper) {
+    padding: 24px 0 26px;
+}
+
+.kg-cta-immersive.kg-cta-has-img:not(.kg-cta-bg-none):not(.kg-cta-no-label) table.kg-cta-content-wrapper {
+    padding-top: 0;
+}
+
+.kg-cta-minimal .kg-cta-image-container {
+    padding-right: 24px;
+}
+
+.kg-cta-immersive .kg-cta-image-container {
+    padding-bottom: 24px;
+}
+
+.kg-cta-immersive.kg-cta-no-text .kg-cta-image-container {
+    padding-bottom: 0;
+}
+
+img.kg-cta-image {
+    display: block;
+    border: 0;
+    {{#if hasRoundedImageCorners}}
+        border-radius: 4px;
+    {{else}}
+        border-radius: 0;
+    {{/if}}
+}
+
+.kg-cta-bg-none img.kg-cta-image {
+    {{#if hasRoundedImageCorners}}
+        border-radius: 6px;
+    {{else}}
+        border-radius: 0;
+    {{/if}}
+}
+
+.kg-cta-minimal img.kg-cta-image {
+    width: 64px;
+    height: 64px;
+    object-fit: cover;
+}
+
+.kg-cta-immersive img.kg-cta-image {
+    margin: 0 auto;
+    height: auto;
+    width: 100%;
+    max-width: 100%;
+}
+
+.post-content .kg-cta-text {
+    font-family: Georgia, serif;
+}
+
+.kg-cta-text a:not(.kg-cta-link-accent .kg-cta-text a) {
+    color: #15212A;
+    text-decoration: underline;
+}
+
+.kg-cta-link-accent .kg-cta-text a {
+    color: {{accentColor}} !important;
+}
+
+.post-content-sans-serif .kg-cta-text {
+    font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif;
+    font-size: 17px;
+}
+
+.kg-cta-text p {
+    margin-bottom: 1em;
+    line-height: 1.4em;
+}
+
+.kg-cta-text p:last-child {
+    margin-bottom: 0;
+}
+
+.kg-cta-bg-none:not(.kg-cta-minimal.kg-cta-has-img) .kg-cta-text p {
+    line-height: 1.6em;
+}
+
+.kg-cta-immersive.kg-cta-centered .kg-cta-text p {
+    text-align: center;
+}
+
+.kg-cta-button-container {
+    padding-top: 20px;
+}
+
+.kg-cta-immersive.kg-cta-centered table.btn {
+    margin-left: auto;
+    margin-right: auto;
+}
+
+.kg-cta-minimal table.btn td.kg-style-accent {
+    {{#if hasOutlineButtons}}
+    background-color: transparent !important;
+    color: {{accentColor}} !important;
+    border: 1px solid {{accentColor}} !important;
+    {{else}}
+    background-color: {{accentColor}} !important;
+    {{/if}}
+}
+
+.kg-cta-immersive table.btn td.kg-style-accent {
+    {{#if hasOutlineButtons}}
+    background-color: transparent !important;
+    color: {{accentColor}} !important;
+    border: 1px solid {{accentColor}} !important;
+    {{else}}
+    background-color: {{accentColor}} !important;
+    color: #fff !important;
+    {{/if}}
+}
+
+.kg-cta-card .btn a.kg-style-accent {
+    {{#if hasOutlineButtons}}
+    background-color: transparent !important;
+    color: {{accentColor}} !important;
+    {{else}}
+    background-color: {{accentColor}} !important;
+    color: #fff !important;
+    {{/if}}
+}
+
+.kg-cta-has-img.kg-cta-immersive table.btn {
+    width: 100%;
+}
+
 /* -------------------------------------
     BUTTONS
 ------------------------------------- */
@@ -367,6 +665,102 @@ table.btn-accent a {
     {{/if}}
 }
 
+.kg-product-card {
+    margin: 0 0 1.5em;
+    {{#if hasRoundedImageCorners}}
+        border-radius: 6px;
+    {{else}}
+        border-radius: 0;
+    {{/if}}
+    {{#if backgroundIsDark}}
+        background-color: #15212A;
+        background-color: rgba(0, 0, 0, 0.15);
+        border: 1px solid #343434;
+        border: 1px solid rgba(255, 255, 255, 0.25);
+    {{else}}
+        background-color: #FFFFFF;
+        background-color: rgba(255, 255, 255, 0.25);
+        border: 1px solid #e0e7eb;
+        border: 1px solid rgba(0, 0, 0, 0.12);
+    {{/if}}
+}
+
+.kg-product-card h4 {
+    {{#if sectionTitleColor}}
+        color: {{sectionTitleColor}} !important;
+    {{else}}
+        {{#if backgroundIsDark}}
+            color: #ffffff !important;
+        {{else}}
+            color: #15212A !important;
+        {{/if}}
+    {{/if}}
+}
+
+.kg-product-card-container {
+    padding: 20px;
+}
+
+.kg-product-image {
+    margin-bottom: 0;
+    padding-top: 0;
+    padding-bottom: 16px;
+}
+
+.kg-product-image img {
+    width: 100%;
+    height: auto;
+    padding: 0;
+    border: none;
+    {{#if hasRoundedImageCorners}}
+        border-radius: 4px;
+    {{/if}}
+}
+
+.kg-product-title {
+    margin-top: 0 !important;
+    margin-bottom: 0 !important;
+    font-size: 22px !important;
+    font-weight: {{titleWeight}};
+}
+
+.kg-product-rating {
+    margin-bottom: 0;
+    padding-top: 0;
+    padding-bottom: 0;
+}
+
+.kg-product-rating img {
+    width: 96px;
+}
+
+.kg-product-description-wrapper {
+    margin-bottom: 0;
+    padding-top: 8px;
+    padding-bottom: 0;
+}
+
+.kg-product-description-wrapper p {
+    margin: 0;
+    font-size: 17px;
+    line-height: 1.4;
+    opacity: 0.7;
+}
+
+.kg-product-description-wrapper li {
+    opacity: 0.7;
+}
+
+.kg-product-button-wrapper {
+    margin-top: 0;
+    padding-top: 16px;
+    padding-bottom: 0;
+}
+
+.kg-product-button-wrapper table.btn {
+    width: 100%;
+}
+
 @media only screen and (max-width: 620px) {
     table.body .kg-bookmark-card {
         width: 90vw;
@@ -378,6 +772,61 @@ table.btn-accent a {
 
     table.body .kg-bookmark-metadata span {
         font-size: 13px !important;
+    }
+
+    table.body .kg-cta-card {
+        padding: 0 20px;
+    }
+
+    table.body .kg-cta-card.kg-cta-bg-none {
+        padding: 0;
+    }
+
+    table.body .kg-cta-sponsor-label {
+        padding: 10px 0;
+    }
+
+    table.body table.kg-cta-content-wrapper:not(.kg-cta-bg-none.kg-cta-no-dividers table.kg-cta-content-wrapper) {
+        padding: 20px 0;
+    }
+
+    table.body .kg-cta-immersive.kg-cta-has-img:not(.kg-cta-bg-none):not(.kg-cta-no-label) table.kg-cta-content-wrapper {
+        padding-top: 0;
+    }
+
+    table.body .kg-cta-minimal .kg-cta-image-container {
+        padding-right: 20px;
+    }
+
+    table.body .kg-cta-immersive .kg-cta-image-container {
+        padding-bottom: 20px;
+    }
+
+    table.body .kg-cta-immersive.kg-cta-no-text .kg-cta-image-container {
+        padding-bottom: 0;
+    }
+
+    table.body .kg-cta-button-container {
+        padding-top: 16px;
+    }
+
+    table.body .kg-cta-minimal .kg-cta-image-container {
+        display: inline-block !important;
+        width: 100% !important;
+        padding: 0 !important;
+        padding-bottom: 16px !important;
+        padding-right: 0 !important;  /* Reset the desktop padding */
+    }
+
+    table.body .kg-cta-minimal .kg-cta-content-inner {
+        display: inline-block !important;
+        width: 100% !important;
+        padding: 0 !important;
+    }
+
+    table.body .kg-cta-minimal img.kg-cta-image {
+        width: 52px !important;
+        height: 52px !important;
     }
 
     table.body .kg-embed-card {

--- a/ghost/core/core/server/services/member-welcome-emails/email-templates/wrapper.hbs
+++ b/ghost/core/core/server/services/member-welcome-emails/email-templates/wrapper.hbs
@@ -319,7 +319,7 @@
     <table border="0" cellpadding="0" cellspacing="0" class="body" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;">
       <tr>
         <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top;">&nbsp;</td>
-        <td class="container" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top; display: block; Margin: 0 auto; max-width: 540px; padding: 10px; width: 540px;">
+        <td class="container" align="center" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top; display: block; Margin: 0 auto; max-width: 540px; padding: 10px; width: 540px;">
           <div class="content" style="box-sizing: border-box; display: block; Margin: 0 auto; max-width: 600px; padding: 30px 20px;">
             <table class="main" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; background: #ffffff; border-radius: 8px;">
               <tr>

--- a/ghost/core/core/server/services/member-welcome-emails/member-welcome-email-renderer.js
+++ b/ghost/core/core/server/services/member-welcome-emails/member-welcome-email-renderer.js
@@ -138,6 +138,7 @@ class MemberWelcomeEmailRenderer {
             backgroundIsDark: false,
             hasRoundedImageCorners: false,
             sectionTitleColor: null,
+            dividerColor: '#e0e7eb',
             titleWeight: '700',
             hasOutlineButtons: false,
             buttonColor: accentColor,

--- a/ghost/core/core/server/services/member-welcome-emails/member-welcome-email-renderer.js
+++ b/ghost/core/core/server/services/member-welcome-emails/member-welcome-email-renderer.js
@@ -138,7 +138,6 @@ class MemberWelcomeEmailRenderer {
             backgroundIsDark: false,
             hasRoundedImageCorners: false,
             sectionTitleColor: null,
-            dividerColor: '#e0e7eb',
             titleWeight: '700',
             hasOutlineButtons: false,
             buttonColor: accentColor,

--- a/ghost/core/test/unit/server/services/member-welcome-emails/member-welcome-email-renderer.test.js
+++ b/ghost/core/test/unit/server/services/member-welcome-emails/member-welcome-email-renderer.test.js
@@ -486,6 +486,71 @@ describe('MemberWelcomeEmailRenderer', function () {
             assert(result.html.includes('Embed note'));
         });
 
+        it('applies call-to-action and product card styles', async function () {
+            lexicalRenderStub.resolves(`
+                <table class="kg-card kg-cta-card kg-cta-bg-none kg-cta-immersive kg-cta-link-accent" border="0" cellpadding="0" cellspacing="0" width="100%">
+                    <tr>
+                        <td class="kg-cta-sponsor-label"><p><a href="https://example.com/sponsor">Sponsor</a></p></td>
+                    </tr>
+                    <tr>
+                        <td class="kg-cta-content">
+                            <table border="0" cellpadding="0" cellspacing="0" width="100%" class="kg-cta-content-wrapper">
+                                <tr>
+                                    <td class="kg-cta-text"><p>CTA body with <a href="https://example.com/cta">link</a></p></td>
+                                </tr>
+                            </table>
+                        </td>
+                    </tr>
+                </table>
+                <table class="kg-product-card" cellspacing="0" cellpadding="0" border="0">
+                    <tr>
+                        <td class="kg-product-card-container">
+                            <table cellspacing="0" cellpadding="0" border="0">
+                                <tr>
+                                    <td class="kg-product-image" align="center">
+                                        <img src="https://example.com/product.jpg" border="0"/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td valign="top">
+                                        <h4 class="kg-product-title">Product title</h4>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td class="kg-product-description-wrapper"><p>Product description</p></td>
+                                </tr>
+                                <tr>
+                                    <td class="kg-product-button-wrapper">
+                                        <table class="btn" border="0" cellspacing="0" cellpadding="0">
+                                            <tr>
+                                                <td align="center"><a href="https://example.com/buy">Buy now</a></td>
+                                            </tr>
+                                        </table>
+                                    </td>
+                                </tr>
+                            </table>
+                        </td>
+                    </tr>
+                </table>
+            `);
+            const renderer = new MemberWelcomeEmailRenderer({t: key => key});
+
+            const result = await renderer.render({
+                lexical: '{}',
+                subject: 'Welcome!',
+                member: {name: 'John', email: 'john@example.com'},
+                siteSettings: defaultSiteSettings
+            });
+
+            assert.match(result.html, /class="kg-card kg-cta-card kg-cta-bg-none kg-cta-immersive kg-cta-link-accent"[^>]*style="[^"]*border-bottom: 1px solid #e0e7eb/);
+            assert.match(result.html, /class="kg-cta-sponsor-label"[^>]*style="[^"]*border-bottom: 1px solid #e0e7eb/);
+            assert.match(result.html, /class="kg-product-card"[^>]*style="[^"]*background-color: rgba\(255, 255, 255, 0.25\)/);
+
+            const productButtonTableMatch = result.html.match(/class="kg-product-button-wrapper"[\s\S]*?<table[^>]*class="btn"[^>]*style="([^"]*)"/);
+            assert(productButtonTableMatch, 'product button table should have inline styles');
+            assert(productButtonTableMatch[1].includes('width: 100%'), 'product button table should have width: 100%');
+        });
+
         it('does not inline margin 0 auto on button tables that would override alignment', async function () {
             lexicalRenderStub.resolves(`
                 <table class="kg-card kg-button-card" border="0" cellpadding="0" cellspacing="0">

--- a/yarn.lock
+++ b/yarn.lock
@@ -9245,10 +9245,10 @@
   dependencies:
     semver "^7.7.3"
 
-"@tryghost/koenig-lexical@1.7.18":
-  version "1.7.18"
-  resolved "https://registry.yarnpkg.com/@tryghost/koenig-lexical/-/koenig-lexical-1.7.18.tgz#563d498db96cad7cf01f55d41ea6a172bf7c87f6"
-  integrity sha512-ljbYfv3PduBT1gJDjqwQyGFHWRvG9hhXhuwRXrpQmzO7YOP23WMuofW45EKOGHxA66ArUSPYQOxTNs4KGCCDYQ==
+"@tryghost/koenig-lexical@1.7.19":
+  version "1.7.19"
+  resolved "https://registry.yarnpkg.com/@tryghost/koenig-lexical/-/koenig-lexical-1.7.19.tgz#a20d3505cc0b81d15c7d60e62df3fc6db628791f"
+  integrity sha512-6jWUjtY0tNR8akj1F46XAZtrce7wBMaQHhEgCoxd59ktQoVe4Qfi1TkLetVyCYVnruIgEdeEnQwtRktAMO0Q0Q==
 
 "@tryghost/limit-service@1.4.1":
   version "1.4.1"


### PR DESCRIPTION
ref https://linear.app/ghost/issue/NY-1123
ref https://github.com/TryGhost/Koenig/pull/1754

![Screenshot](https://github.com/user-attachments/assets/610223dd-5e29-43e7-87a6-554486b7f431)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes welcome email HTML/CSS output and editor capabilities, which can affect email client rendering and existing templates. Changes are scoped and covered by new acceptance and unit tests.
> 
> **Overview**
> Enables **call-to-action** and **product** cards in the Admin-X welcome email editor when the `welcomeEmailEditor` flag is on, and tweaks editor typography to keep settings-panel copy compact.
> 
> Updates welcome email HTML rendering to include styling for CTA/product cards (including responsive adjustments) and centers the main email container for more consistent layout. Adds Playwright acceptance coverage for inserting these cards via the slash menu, and unit coverage to assert their styles are properly inlined during welcome email rendering.
> 
> Bumps `@tryghost/koenig-lexical` to `1.7.19` across Admin packages to pick up the required editor/card support.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f24fda9f523a295c0d47e6c80ffeb90274d045e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->