### PR TITLE
Added smarterCounts labs flag for optimized pagination count queries

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
@@ -67,6 +67,10 @@ const features: Feature[] = [{
     title: 'Picture Element',
     description: 'Use the HTML picture element to serve modern image formats (AVIF, WebP) with automatic fallbacks',
     flag: 'pictureImageFormats'
+}, {
+    title: 'Smarter Counts',
+    description: 'Use optimized COUNT queries for API pagination when safe',
+    flag: 'smarterCounts'
 }];
 
 const AlphaFeatures: React.FC = () => {

--- a/ghost/core/core/server/models/base/plugins/crud.js
+++ b/ghost/core/core/server/models/base/plugins/crud.js
@@ -2,6 +2,7 @@ const _ = require('lodash');
 const errors = require('@tryghost/errors');
 
 const tpl = require('@tryghost/tpl');
+const labs = require('../../../../shared/labs');
 
 const messages = {
     couldNotUnderstandRequest: 'Could not understand request.'
@@ -142,6 +143,10 @@ module.exports = function (Bookshelf) {
             //option param to skip distinct from count query, distinct adds a lot of latency and in this case the result set will always be unique.
             if (unfilteredOptions.useBasicCount) {
                 options.useBasicCount = unfilteredOptions.useBasicCount;
+            }
+
+            if (labs.isSet('smarterCounts')) {
+                options.useSmartCount = true;
             }
 
             const response = await itemCollection.fetchPage(options);

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -52,7 +52,8 @@ const PRIVATE_FEATURES = [
     'verificationFlow',
     'membersForward',
     'welcomeEmailsDesignCustomization',
-    'pictureImageFormats'
+    'pictureImageFormats',
+    'smarterCounts'
 ];
 
 module.exports.GA_KEYS = [...GA_FEATURES];

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -74,7 +74,7 @@
     "@tryghost/adapter-base-cache": "0.1.17",
     "@tryghost/admin-api-schema": "4.5.10",
     "@tryghost/api-framework": "1.0.3",
-    "@tryghost/bookshelf-plugins": "0.6.29",
+    "@tryghost/bookshelf-plugins": "2.0.2",
     "@tryghost/color-utils": "0.2.10",
     "@tryghost/config-url-helpers": "1.0.17",
     "@tryghost/custom-fonts": "1.0.2",

--- a/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
@@ -24,6 +24,7 @@ Object {
       "membersForward": true,
       "pictureImageFormats": true,
       "retentionOffers": true,
+      "smarterCounts": true,
       "stripeAutomaticTax": true,
       "superEditors": true,
       "tagsX": true,

--- a/ghost/core/test/e2e-api/content/__snapshots__/posts.test.js.snap
+++ b/ghost/core/test/e2e-api/content/__snapshots__/posts.test.js.snap
@@ -7017,7 +7017,7 @@ Object {
   "errors": Array [
     Object {
       "code": "ER_WRONG_VALUE",
-      "context": "Invalid value select count(distinct posts.id) as aggregate from \`posts\` where (\`posts\`.\`status\` = 'published' and (\`posts\`.\`published_at\` < '1715091791890' and \`posts\`.\`type\` = 'post')) - Incorrect DATETIME value: '1715091791890'",
+      "context": "Invalid value select count(*) as aggregate from \`posts\` where (\`posts\`.\`status\` = 'published' and (\`posts\`.\`published_at\` < '1715091791890' and \`posts\`.\`type\` = 'post')) - Incorrect DATETIME value: '1715091791890'",
       "details": null,
       "ghostErrorCode": null,
       "help": null,

--- a/ghost/core/test/e2e-api/content/posts.test.js
+++ b/ghost/core/test/e2e-api/content/posts.test.js
@@ -420,19 +420,22 @@ describe('Posts Content API', function () {
         let queries = await trackDb(() => agent.get('posts/?limit=all').expectStatus(200), this.skip.bind(this));
         let postsRelatedQueries = queries.filter(q => q.sql.includes('`posts`'));
         for (const query of postsRelatedQueries) {
-            assert(!query.sql.includes('*'), 'Query should not select *');
+            const sqlWithoutCount = query.sql.replace(/count\(\*\)/g, '');
+            assert(!sqlWithoutCount.includes('*'), 'Query should not select *');
         }
 
         queries = await trackDb(() => agent.get('posts/?limit=3').expectStatus(200), this.skip.bind(this));
         postsRelatedQueries = queries.filter(q => q.sql.includes('`posts`'));
         for (const query of postsRelatedQueries) {
-            assert(!query.sql.includes('*'), 'Query should not select *');
+            const sqlWithoutCount = query.sql.replace(/count\(\*\)/g, '');
+            assert(!sqlWithoutCount.includes('*'), 'Query should not select *');
         }
 
         queries = await trackDb(() => agent.get('posts/?include=tags,authors').expectStatus(200), this.skip.bind(this));
         postsRelatedQueries = queries.filter(q => q.sql.includes('`posts`'));
         for (const query of postsRelatedQueries) {
-            assert(!query.sql.includes('*'), 'Query should not select *');
+            const sqlWithoutCount = query.sql.replace(/count\(\*\)/g, '');
+            assert(!sqlWithoutCount.includes('*'), 'Query should not select *');
         }
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8962,95 +8962,95 @@
     json-stable-stringify "1.3.0"
     lodash "4.17.23"
 
-"@tryghost/bookshelf-collision@^0.1.49":
-  version "0.1.49"
-  resolved "https://registry.yarnpkg.com/@tryghost/bookshelf-collision/-/bookshelf-collision-0.1.49.tgz#f3e15954446d89ae867e40a1bb488be1d7c65d38"
-  integrity sha512-WW2+Uk6h7nEL5cW2BOaoDMLZeWuur+PEXV726JpH4vQK9D7UQcHwRQW7CBu+NW6tMbjWkhPPp4q0lBKdoosusQ==
+"@tryghost/bookshelf-collision@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@tryghost/bookshelf-collision/-/bookshelf-collision-2.0.2.tgz#a1eea15908370ae6487525fa6da38bb279bb722f"
+  integrity sha512-a9UEHIUKu3+Hst3xs0VFXZDuQsoZFyB4SInvXFfdbdORbRifmWYOhyxd4UhAUash+8EAEv3oD0WaB3aol0RKrg==
   dependencies:
-    "@tryghost/errors" "^1.3.9"
-    lodash "^4.17.21"
+    "@tryghost/errors" "^3.0.2"
+    lodash "4.17.23"
     moment-timezone "^0.5.33"
 
-"@tryghost/bookshelf-custom-query@^0.1.31":
-  version "0.1.31"
-  resolved "https://registry.yarnpkg.com/@tryghost/bookshelf-custom-query/-/bookshelf-custom-query-0.1.31.tgz#9bea3f73168224a42f2bf312ce3e939977ed2085"
-  integrity sha512-HZs/WnNQpKLG+nkBSbe+wsi1WP+jq56wiIZCnbWTfX3xKFqLh+QRtkmgvJCpyd9iEgexWzodmyIZY3th3sv6wA==
+"@tryghost/bookshelf-custom-query@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@tryghost/bookshelf-custom-query/-/bookshelf-custom-query-2.0.2.tgz#73c534cdcd7b9130b1d01f60db859ee0b821f006"
+  integrity sha512-SNVn7iAWPfww3LW1TLRUI+PUF+evFO1uVnBnGv+4qYk776bwM97uhEmZeqLCGY1xTdyJOv0U2DyHFDl8QZyKxA==
 
-"@tryghost/bookshelf-eager-load@^0.1.35":
-  version "0.1.35"
-  resolved "https://registry.yarnpkg.com/@tryghost/bookshelf-eager-load/-/bookshelf-eager-load-0.1.35.tgz#b04e21e94ae9b24fde35194662f8f5d412f2c06a"
-  integrity sha512-8BkBxnETuoVoK48rlCdlCL0upTWwc1Ku21Wjfafor6kJDOO9DxsLDi/e0fNQxMTqgH0aWdWYDeyNAjHJgiNJJQ==
+"@tryghost/bookshelf-eager-load@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@tryghost/bookshelf-eager-load/-/bookshelf-eager-load-2.0.2.tgz#d13fe52ab5cdc3b72114f2433fb48407026f9f3b"
+  integrity sha512-zOMBrnmzEbjFR6xzsuDAL6IvBPeb8aSciPdQTfVja3tgWRvUe5S028NiBoLEbjMw/EqJwV0Hhr999ZE0XUs/2A==
   dependencies:
-    "@tryghost/debug" "^0.1.36"
-    lodash "^4.17.21"
+    "@tryghost/debug" "^2.0.2"
+    lodash "4.17.23"
 
-"@tryghost/bookshelf-filter@^0.5.24":
-  version "0.5.24"
-  resolved "https://registry.yarnpkg.com/@tryghost/bookshelf-filter/-/bookshelf-filter-0.5.24.tgz#13609c3c98f825bfbe713b7ee1f5ac751c18b498"
-  integrity sha512-ysPM3pVj4gFbX95Ba+fAkujCvM9/uSI61Hc2XiOLhCjOYCeETNOg1yuIYp/P72dRRnh9ibOBXhuXo71jxzrN4g==
+"@tryghost/bookshelf-filter@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@tryghost/bookshelf-filter/-/bookshelf-filter-2.0.2.tgz#6156837841468731c9d77c27f40b2ac85508888e"
+  integrity sha512-OdRXOygWD2XQDO2u4hq1ekgRzsdYbDN1BZD+wAhRm4qdoB14e4Et4xDQjX6IzQYOU8c/0dIq6/jjR32c1F1htA==
   dependencies:
-    "@tryghost/debug" "^0.1.36"
-    "@tryghost/errors" "^1.3.9"
-    "@tryghost/nql" "0.12.6"
-    "@tryghost/tpl" "^0.1.36"
+    "@tryghost/debug" "^2.0.2"
+    "@tryghost/errors" "^3.0.2"
+    "@tryghost/nql" "0.12.10"
+    "@tryghost/tpl" "^2.0.2"
 
-"@tryghost/bookshelf-has-posts@^0.1.36":
-  version "0.1.36"
-  resolved "https://registry.yarnpkg.com/@tryghost/bookshelf-has-posts/-/bookshelf-has-posts-0.1.36.tgz#795eaacfb31cf48a08b41537d0b8035bc54f3833"
-  integrity sha512-qUhy2nqJVlmBXkCihHuxVALf/CGKVRxwFb2GIH5aAJVmET/HyfIRG+5lutbbJvQX7ns2RqQ325azgWSDnUvmoA==
+"@tryghost/bookshelf-has-posts@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@tryghost/bookshelf-has-posts/-/bookshelf-has-posts-2.0.2.tgz#9ec571cb433f20bb1c5e5cf1fabceaf1457d5d4d"
+  integrity sha512-QbYXgi9kl+QQhPIWdJD+LjRBf9qmII7O71uizhXR2ompmW2IAngNm9Ly4gu73PKuijUxNwkGX2QxnKSnTCzjxw==
   dependencies:
-    "@tryghost/debug" "^0.1.36"
-    lodash "^4.17.21"
+    "@tryghost/debug" "^2.0.2"
+    lodash "4.17.23"
 
-"@tryghost/bookshelf-include-count@^0.3.19":
-  version "0.3.19"
-  resolved "https://registry.yarnpkg.com/@tryghost/bookshelf-include-count/-/bookshelf-include-count-0.3.19.tgz#dc8b9a9b244ca71c22f58945acb55f4c0333a5de"
-  integrity sha512-2iD8bxB+8wr3NpGz/WzoJun7c6eJDPXWGfduYOy/SPl/XUroQTuSbdmUKhks2H9Y6fy++QWf34HN51930YldTw==
+"@tryghost/bookshelf-include-count@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@tryghost/bookshelf-include-count/-/bookshelf-include-count-2.0.2.tgz#e31a122aeeb2443c0ffcebd5d2b0d9993d7e53f3"
+  integrity sha512-xdyctliYf8pBMv5lktEZ4YUf0hhlTg1oou5+Dp7y5pyk1vwblf/y8RFSvsTYi81YFjg2cHlK+KMiji0D3IN1WQ==
   dependencies:
-    "@tryghost/debug" "^0.1.36"
-    lodash "^4.17.21"
+    "@tryghost/debug" "^2.0.2"
+    lodash "4.17.23"
 
-"@tryghost/bookshelf-order@^0.1.31":
-  version "0.1.31"
-  resolved "https://registry.yarnpkg.com/@tryghost/bookshelf-order/-/bookshelf-order-0.1.31.tgz#86cf18ee36a24231f866e6b02211701fdd89eb4d"
-  integrity sha512-6Nyj+nB966EFtwEpL/ibrmKFXj6ms32LUdpOMWbe2IM9IF9whDoFFUiYDW2g6rTzsU2B4hfLhyQQlMzmEAI/HA==
+"@tryghost/bookshelf-order@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@tryghost/bookshelf-order/-/bookshelf-order-2.0.2.tgz#27420f4b4330fac7537dbebcc847b67496f9a7b7"
+  integrity sha512-iAaSots6bYDVssuPwurIhu/XZUM9BaOdss0nr58WklwLqylDhBYJV0q5VYzW7ncvlJvZQ5La03lSARp0k7Uuow==
   dependencies:
-    lodash "^4.17.21"
+    lodash "4.17.23"
 
-"@tryghost/bookshelf-pagination@^0.1.53":
-  version "0.1.53"
-  resolved "https://registry.yarnpkg.com/@tryghost/bookshelf-pagination/-/bookshelf-pagination-0.1.53.tgz#e046b4889aa07ac81136346dcf6bb0fdc516f261"
-  integrity sha512-admXVnNJpiJy9rPx3oAlbKtF+sNCJMKj4wPhcACmBhv+HWvuGQcCECZJuuHOecEV3RuB8Y5iIC72QiG5MUNUZg==
+"@tryghost/bookshelf-pagination@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@tryghost/bookshelf-pagination/-/bookshelf-pagination-2.0.2.tgz#603d57846820a5c688f102e5b4a1cdfa757ff418"
+  integrity sha512-x/YmX2ppf9BBByIA8HR4JBWeNjZ8H8uT+T297DO1X9WcTvHJcEfYNDZ34oqXzFg8p0saDzBmpvIo//JiavsHfg==
   dependencies:
-    "@tryghost/errors" "^1.3.9"
-    "@tryghost/tpl" "^0.1.36"
-    lodash "^4.17.21"
+    "@tryghost/errors" "^3.0.2"
+    "@tryghost/tpl" "^2.0.2"
+    lodash "4.17.23"
 
-"@tryghost/bookshelf-plugins@0.6.29":
-  version "0.6.29"
-  resolved "https://registry.yarnpkg.com/@tryghost/bookshelf-plugins/-/bookshelf-plugins-0.6.29.tgz#920d129d68adf41f0bfa97ab9a9f63f3b25f386e"
-  integrity sha512-vwQoMOZZgL2GF607/e6Fad4p0UuAY4UFP7XTUxGSt4PPVLZZ51UvqiC8h0QqjPOb6DmksKtrO6b8iKRtSaLEzA==
+"@tryghost/bookshelf-plugins@2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@tryghost/bookshelf-plugins/-/bookshelf-plugins-2.0.2.tgz#068ce14b8b0fc55f1fdab1d3e4a7df490c1dba40"
+  integrity sha512-MFpStBVv6vmWhYKoEfsZix8V3yyc2sXCuWD+4CpLl4tJzoFtR16FqCWYY2P+pVEWc1GM/fyuEvqjloMaKQuxnA==
   dependencies:
-    "@tryghost/bookshelf-collision" "^0.1.49"
-    "@tryghost/bookshelf-custom-query" "^0.1.31"
-    "@tryghost/bookshelf-eager-load" "^0.1.35"
-    "@tryghost/bookshelf-filter" "^0.5.24"
-    "@tryghost/bookshelf-has-posts" "^0.1.36"
-    "@tryghost/bookshelf-include-count" "^0.3.19"
-    "@tryghost/bookshelf-order" "^0.1.31"
-    "@tryghost/bookshelf-pagination" "^0.1.53"
-    "@tryghost/bookshelf-search" "^0.1.31"
-    "@tryghost/bookshelf-transaction-events" "^0.2.20"
+    "@tryghost/bookshelf-collision" "^2.0.2"
+    "@tryghost/bookshelf-custom-query" "^2.0.2"
+    "@tryghost/bookshelf-eager-load" "^2.0.2"
+    "@tryghost/bookshelf-filter" "^2.0.2"
+    "@tryghost/bookshelf-has-posts" "^2.0.2"
+    "@tryghost/bookshelf-include-count" "^2.0.2"
+    "@tryghost/bookshelf-order" "^2.0.2"
+    "@tryghost/bookshelf-pagination" "^2.0.2"
+    "@tryghost/bookshelf-search" "^2.0.2"
+    "@tryghost/bookshelf-transaction-events" "^2.0.2"
 
-"@tryghost/bookshelf-search@^0.1.31":
-  version "0.1.31"
-  resolved "https://registry.yarnpkg.com/@tryghost/bookshelf-search/-/bookshelf-search-0.1.31.tgz#8627035a19bb3f21f5b4e167b4d1b6292a30e7fe"
-  integrity sha512-6/TgNXHP4YGGa481q5ikGpv4cBd+Ott7aq358yO80mvcVtp1VWiX9R4dn9HRj/EDqJmVJ9SArPgD8p0QgJlr/A==
+"@tryghost/bookshelf-search@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@tryghost/bookshelf-search/-/bookshelf-search-2.0.2.tgz#66fcd59c77397744f135eb5fcd8acfec4bf580cf"
+  integrity sha512-J0fDbPHxCOoGmFHyCvc/e47D0bdMEVh/LgEUwqueo400mhv+le7e1ieH+lgmupUYR8Kz7IFwS+uINhZjiaCPFA==
 
-"@tryghost/bookshelf-transaction-events@^0.2.20":
-  version "0.2.20"
-  resolved "https://registry.yarnpkg.com/@tryghost/bookshelf-transaction-events/-/bookshelf-transaction-events-0.2.20.tgz#0cabab289ff7773e2eb94a054cc4935f7ff3a13d"
-  integrity sha512-I/aiR64Rk+J78459qbGw2XnPN1f2PoUW21mEe+WHPLDV5sNzqSReI4kDW8s+text2cTLbcHjokQCOaG4l4HIug==
+"@tryghost/bookshelf-transaction-events@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@tryghost/bookshelf-transaction-events/-/bookshelf-transaction-events-2.0.2.tgz#8fdde42dd4da9f8e555e4b78b568b2e304d627f4"
+  integrity sha512-V3VPbU9kKVjgHyxrXN/lXVdjMBZ1ielAi2AhNM3KbJoYR4Z8anqv5hxzRQwOWxO0kwRSDekj7j5V2LS9pbB/3w==
 
 "@tryghost/bunyan-rotating-filestream@^0.0.7":
   version "0.0.7"
@@ -9498,7 +9498,7 @@
     mobiledoc-dom-renderer "0.7.0"
     mobiledoc-text-renderer "0.4.0"
 
-"@tryghost/mongo-knex@^0.9.1", "@tryghost/mongo-knex@^0.9.4":
+"@tryghost/mongo-knex@^0.9.4":
   version "0.9.4"
   resolved "https://registry.yarnpkg.com/@tryghost/mongo-knex/-/mongo-knex-0.9.4.tgz#bd92d191c28d95367d4898aefc57cf82a1d95304"
   integrity sha512-R5mqpuQ1nN4qWAii9Tvg5POZ0nLO7Voy7QaQF+95sseUpfe4XEUsr3+mm4HYPC8MNKginlUm/unLf5QFzFQl5w==
@@ -9506,7 +9506,7 @@
     debug "^4.3.3"
     lodash "^4.17.21"
 
-"@tryghost/mongo-utils@^0.6.2", "@tryghost/mongo-utils@^0.6.3":
+"@tryghost/mongo-utils@^0.6.3":
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/@tryghost/mongo-utils/-/mongo-utils-0.6.3.tgz#7e367a291e397cdce7027f0ae7d854ed22fde1b1"
   integrity sha512-BOgflEMywUXnTxXqOPuppFRD50IuIERAt06UEsyGTLRI6GSuO18BDygo72UpMHtM+NspGM0jPc1eQOeVvUJNAw==
@@ -9542,7 +9542,7 @@
     nodemailer-mailgun-transport "^2.1.5"
     nodemailer-stub-transport "^1.1.0"
 
-"@tryghost/nql-lang@0.6.4", "@tryghost/nql-lang@^0.6.2", "@tryghost/nql-lang@^0.6.4":
+"@tryghost/nql-lang@0.6.4", "@tryghost/nql-lang@^0.6.4":
   version "0.6.4"
   resolved "https://registry.yarnpkg.com/@tryghost/nql-lang/-/nql-lang-0.6.4.tgz#2e2af47362b586c9ee0200bebb76ca69f0ba6567"
   integrity sha512-m984kPFEexS3N1j/LeG51ChTJCplN/+IWoBP6/vsBxz0cnneY87J7rwr96gTmNR+s1xDzuQOpj3heoFD9Dw+7A==
@@ -9557,16 +9557,6 @@
     "@tryghost/mongo-knex" "^0.9.4"
     "@tryghost/mongo-utils" "^0.6.3"
     "@tryghost/nql-lang" "^0.6.4"
-    mingo "^2.2.2"
-
-"@tryghost/nql@0.12.6":
-  version "0.12.6"
-  resolved "https://registry.yarnpkg.com/@tryghost/nql/-/nql-0.12.6.tgz#18c8b57f73d37269e2c0ab23b6c3f4f4030804b4"
-  integrity sha512-IIcfxSgK++O/6om42T+waIjuJCeZ0Ma88ITp/DRbaqgGzUpd9tRAyOzsTTxQkZ7OUbHXd165+ee4myHTh7fmSw==
-  dependencies:
-    "@tryghost/mongo-knex" "^0.9.1"
-    "@tryghost/mongo-utils" "^0.6.2"
-    "@tryghost/nql-lang" "^0.6.2"
     mingo "^2.2.2"
 
 "@tryghost/pretty-cli@1.2.47":
@@ -9720,6 +9710,11 @@
   integrity sha512-1bgvGE06ABEuXQqVeuYK3i58YiEFf6fHiXSCq4CzA+MIBUoUs4ID9oQLkdPJwPQ9TsuuJt3z4DPiG8KnLt06fg==
   dependencies:
     lodash.template "^4.5.0"
+
+"@tryghost/tpl@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@tryghost/tpl/-/tpl-2.0.2.tgz#9b7e4349983d929f50489d63955ede3ea7875422"
+  integrity sha512-/GQ1qJfKbkJgvSD2C3Llef96c9/ibqF5dXc9A22mpULTLC8k0gSgz8/JpuNaDBU0agdm1C4kJykBMp+p0wn7rA==
 
 "@tryghost/url-utils@5.1.2":
   version "5.1.2"


### PR DESCRIPTION
## Summary
- Adds a `smarterCounts` private labs flag that automatically optimizes pagination count queries
- When enabled, inspects the query builder for JOINs and uses `COUNT(*)` when safe (no JOINs), falling back to `COUNT(DISTINCT table.id)` when JOINs are present
- The only model with JOINs is `products` (LEFT JOIN on `stripe_prices`) — all other models benefit from the faster `COUNT(*)`
- During e2e API tests (1178 tests, all passing), **313 out of 727 count queries (43%) switched from `COUNT(DISTINCT)` to `COUNT(*)`**

### Tables that benefit (based on queries made during e2e-api tests)
| Table | Queries improved |
|-------|-----------------|
| posts | 79 |
| comments | 71 |
| newsletters | 58 |
| members | 42 |
| tags | 13 |
| users | 10 |
| actions, snippets, email_recipient_failures, invites, and others | 40 |

### Changes
- `ghost/core/core/shared/labs.js` — Added `smarterCounts` to private features
- `ghost/core/core/server/models/base/plugins/crud.js` — Sets `useSmartCount` option when labs flag is enabled
- `apps/admin-x-settings/.../private-features.tsx` — Added labs UI toggle
- `ghost/core/test/e2e-api/content/posts.test.js` — Fixed overly broad `select *` assertion that was catching `count(*)`
- Snapshot updated for new labs flag

### Companion PR
Framework: https://github.com/TryGhost/framework/pull/434 (adds `useSmartCount` option to `@tryghost/bookshelf-pagination`)