### PR TITLE
Design improvements for retention offer

### DIFF
--- a/apps/admin-x-settings/src/components/settings/growth/offers/offers-index-retention.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/offers/offers-index-retention.tsx
@@ -87,7 +87,7 @@ const OffersFilterPopover: React.FC<{
         <Popover
             position='end'
             trigger={
-                <Button className='p-1 hover:text-black dark:hover:text-white' label={<LucideIcon.ListFilter size={16} strokeWidth={1.5} />} unstyled={true} />
+                <Button aria-label="Filter options" className='p-1 hover:text-black dark:hover:text-white' label={<LucideIcon.ListFilter size={16} strokeWidth={1.5} />} unstyled={true} />
             }
         >
             <div className='flex min-w-[200px] flex-col p-1 normal-case'>

--- a/apps/admin-x-settings/src/components/settings/growth/offers/offers-index-retention.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/offers/offers-index-retention.tsx
@@ -87,7 +87,7 @@ const OffersFilterPopover: React.FC<{
         <Popover
             position='end'
             trigger={
-                <Button className='flex cursor-pointer items-center justify-center rounded p-1 hover:bg-grey-100 dark:hover:bg-grey-800 dark:[&_svg]:hover:text-white' label={<LucideIcon.ListFilter className='text-grey-700 dark:text-grey-500' size={16} strokeWidth={1.5} />} unstyled={true} />
+                <Button className='p-1 hover:text-black dark:hover:text-white' label={<LucideIcon.ListFilter size={16} strokeWidth={1.5} />} unstyled={true} />
             }
         >
             <div className='flex min-w-[200px] flex-col p-1 normal-case'>
@@ -156,7 +156,7 @@ const RetentionOfferRow: React.FC<{
 
     return (
         <tr className='group relative scale-100 border-b border-b-grey-200 dark:border-grey-800' data-testid='retention-offer-item'>
-            <td className='p-0'>
+            <td className='sticky left-0 z-10 bg-white p-0 dark:bg-black'>
                 <button className='block w-full cursor-pointer p-5 pl-0 text-left' type="button" onClick={onClick}>
                     <span className='font-semibold'>{offer.name}</span><br />
                     <span className='text-sm text-grey-700'>{offer.description}</span>
@@ -318,17 +318,17 @@ export const OffersIndexModal: React.FC = () => {
     ];
 
     const listLayoutOutput = <div className='overflow-x-auto'>
-        <table className='m-0 w-full table-fixed'>
+        <table className='m-0 min-w-[900px]'>
             <colgroup>
-                <col />
+                <col className='w-[25%]' />
                 <col className='w-[200px]' />
                 <col className='w-[200px]' />
                 <col className='w-[200px]' />
-                <col className='w-[200px]' />
+                <col className='w-[220px]' />
             </colgroup>
             <thead>
                 <tr className='border-b border-b-grey-200 dark:border-grey-800'>
-                    <th className='p-0 pb-2.5 pl-0 text-left text-xs font-medium uppercase tracking-wide text-grey-700'>Name</th>
+                    <th className='sticky left-0 z-10 bg-white p-0 pb-2.5 text-left text-xs font-medium uppercase tracking-wide text-grey-700 dark:bg-black'>Name</th>
                     <th className='p-0 pb-2.5 pl-5 text-left text-xs font-medium uppercase tracking-wide text-grey-700'>Terms</th>
                     <th className='p-0 pb-2.5 pl-5 text-left text-xs font-medium uppercase tracking-wide text-grey-700'>Price</th>
                     <th className='p-0 pb-2.5 pl-5 text-left text-xs font-medium uppercase tracking-wide text-grey-700'>Redemptions</th>
@@ -368,7 +368,7 @@ export const OffersIndexModal: React.FC = () => {
 
                     return (
                         <tr key={offer.id} className={`group relative scale-100 border-b border-b-grey-200 dark:border-grey-800 ${archived ? 'opacity-60' : ''}`} data-testid="offer-item">
-                            <td className='p-0'><a className='block cursor-pointer p-5 pl-0' onClick={() => handleOfferEdit(offer.id)}><span className='font-semibold'>{offer?.name}</span><br /><span className='text-sm text-grey-700'>{offerTier.name} {getOfferCadence(offer.cadence)}</span></a></td>
+                            <td className='sticky left-0 z-10 bg-white p-0 dark:bg-black'><a className='block cursor-pointer p-5 pl-0' onClick={() => handleOfferEdit(offer.id)}><span className='font-semibold'>{offer?.name}</span><br /><span className='text-sm text-grey-700'>{offerTier.name} {getOfferCadence(offer.cadence)}</span></a></td>
                             <td className='whitespace-nowrap p-0 text-sm'><a className='block cursor-pointer p-5' onClick={() => handleOfferEdit(offer.id)}><span className='text-[1.3rem] font-medium uppercase'>{discountOffer}</span><br /><span className='text-grey-700'>{offer.type !== 'trial' ? getOfferDuration(offer.duration) : 'Trial period'}</span></a></td>
                             <td className='whitespace-nowrap p-0 text-sm'><a className='block cursor-pointer p-5' onClick={() => handleOfferEdit(offer.id)}><span className='font-medium'>{updatedPriceWithCurrency}</span> {offer.type !== 'trial' ? <span className='relative text-xs text-grey-700 before:absolute before:-inset-x-0.5 before:top-1/2 before:rotate-[-20deg] before:border-t before:content-[""]'>{originalPriceWithCurrency}</span> : null}</a></td>
                             <td className='whitespace-nowrap p-0 text-sm'><a className={`block cursor-pointer p-5 ${offer.redemption_count === 0 ? '' : 'hover:underline'}`} href={offer.redemption_count > 0 && offer.id ? createRedemptionFilterUrl(offer.id) : undefined} onClick={offer.redemption_count === 0 && offer.id ? () => handleOfferEdit(offer.id) : undefined}>{offer.redemption_count}</a></td>

--- a/apps/admin-x-settings/src/components/settings/growth/offers/offers-index-retention.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/offers/offers-index-retention.tsx
@@ -155,7 +155,7 @@ const RetentionOfferRow: React.FC<{
         : undefined;
 
     return (
-        <tr className='group relative scale-100 border-b border-b-grey-200 dark:border-grey-800' data-testid='retention-offer-item'>
+        <tr className='group relative border-b border-b-grey-200 dark:border-grey-800' data-testid='retention-offer-item'>
             <td className='sticky left-0 z-10 bg-white p-0 dark:bg-black'>
                 <button className='block w-full cursor-pointer p-5 pl-0 text-left' type="button" onClick={onClick}>
                     <span className='font-semibold'>{offer.name}</span><br />
@@ -367,7 +367,7 @@ export const OffersIndexModal: React.FC = () => {
                     const {discountOffer, originalPriceWithCurrency, updatedPriceWithCurrency} = getOfferDiscount(offer.type, offer.amount, offer.cadence, offer.currency || 'USD', offerTier);
 
                     return (
-                        <tr key={offer.id} className={`group relative scale-100 border-b border-b-grey-200 dark:border-grey-800 ${archived ? 'opacity-60' : ''}`} data-testid="offer-item">
+                        <tr key={offer.id} className={`group relative border-b border-b-grey-200 dark:border-grey-800 ${archived ? 'opacity-60' : ''}`} data-testid="offer-item">
                             <td className='sticky left-0 z-10 bg-white p-0 dark:bg-black'><a className='block cursor-pointer p-5 pl-0' onClick={() => handleOfferEdit(offer.id)}><span className='font-semibold'>{offer?.name}</span><br /><span className='text-sm text-grey-700'>{offerTier.name} {getOfferCadence(offer.cadence)}</span></a></td>
                             <td className='whitespace-nowrap p-0 text-sm'><a className='block cursor-pointer p-5' onClick={() => handleOfferEdit(offer.id)}><span className='text-[1.3rem] font-medium uppercase'>{discountOffer}</span><br /><span className='text-grey-700'>{offer.type !== 'trial' ? getOfferDuration(offer.duration) : 'Trial period'}</span></a></td>
                             <td className='whitespace-nowrap p-0 text-sm'><a className='block cursor-pointer p-5' onClick={() => handleOfferEdit(offer.id)}><span className='font-medium'>{updatedPriceWithCurrency}</span> {offer.type !== 'trial' ? <span className='relative text-xs text-grey-700 before:absolute before:-inset-x-0.5 before:top-1/2 before:rotate-[-20deg] before:border-t before:content-[""]'>{originalPriceWithCurrency}</span> : null}</a></td>

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.65.1",
+  "version": "2.65.2",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/portal/src/components/pages/account-plan-page.js
+++ b/apps/portal/src/components/pages/account-plan-page.js
@@ -52,11 +52,15 @@ export const AccountPlanPageStyles = `
         display: flex;
         align-items: center;
         gap: 6px;
-        margin-top: 20px;
+        margin-top: 16px;
     }
 
     .gh-portal-retention-offer-price .gh-portal-offer-oldprice {
         margin: 4px 0 0;
+    }
+
+    .gh-portal-retention-offer .gh-portal-offer-details > .footnote:first-child {
+        margin-top: 12px;
     }
 `;
 
@@ -345,19 +349,17 @@ const RetentionOfferSection = ({subscription, offer, onAcceptOffer, onDeclineOff
                 </div>
 
                 <div className="gh-portal-offer-details">
-                    <div className="gh-portal-retention-offer-price">
-                        {!isFreeMonthsOffer(offer) && (
-                            <>
-                                <div className="gh-portal-product-price">
-                                    <span className="currency-sign">{currency}</span>
-                                    <span className="amount">{discountedPrice}</span>
-                                </div>
-                                <div className="gh-portal-offer-oldprice">
-                                    {currency}{originalPrice}
-                                </div>
-                            </>
-                        )}
-                    </div>
+                    {!isFreeMonthsOffer(offer) && (
+                        <div className="gh-portal-retention-offer-price">
+                            <div className="gh-portal-product-price">
+                                <span className="currency-sign">{currency}</span>
+                                <span className="amount">{discountedPrice}</span>
+                            </div>
+                            <div className="gh-portal-offer-oldprice">
+                                {currency}{originalPrice}
+                            </div>
+                        </div>
+                    )}
                     <p className="footnote">
                         {offerMessage}
                     </p>
@@ -374,7 +376,7 @@ const RetentionOfferSection = ({subscription, offer, onAcceptOffer, onDeclineOff
                     style={{
                         width: '100%',
                         height: '40px',
-                        marginTop: '28px'
+                        marginTop: '20px'
                     }}
                 />
             </div>

--- a/apps/portal/src/components/pages/account-plan-page.js
+++ b/apps/portal/src/components/pages/account-plan-page.js
@@ -15,6 +15,10 @@ export const AccountPlanPageStyles = `
         margin-top: 44px;
     }
 
+    .account-plan:not(.full-size) .gh-portal-detail-header {
+        padding-inline: 60px;
+    }
+
     .gh-portal-accountplans-main {
         margin-top: 24px;
         margin-bottom: 0;


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3388/design-bugsimprovements

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely presentational/layout and accessibility tweaks with no changes to business logic or data flows; primary risk is minor CSS/layout regressions in the offers list and retention-offer screen.
> 
> **Overview**
> Improves retention-offer UI in both Admin and Portal.
> 
> In Admin (`offers-index-retention.tsx`), updates the offers table for better horizontal scrolling: makes the Name column sticky, sets a minimum table width/column sizing, and tweaks the filter button styling and accessibility (`aria-label`).
> 
> In Portal (`account-plan-page.js`), adjusts retention-offer spacing and markup so the price block only renders when applicable, and tightens button/footnote margins; bumps `@tryghost/portal` version to `2.65.2`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e18bcd79f59c3080880f792bc01f505e1e342ab5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->