### PR TITLE
Fixed offer end date for repeating offers in Portal 

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.65.3",
+  "version": "2.65.4",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/portal/src/components/pages/AccountHomePage/components/paid-account-actions.js
+++ b/apps/portal/src/components/pages/AccountHomePage/components/paid-account-actions.js
@@ -1,5 +1,5 @@
 import AppContext from '../../../../app-context';
-import {getCompExpiry, getMemberSubscription, getMemberTierName, hasMultipleProductsFeature, hasOnlyFreePlan, isComplimentaryMember, isPaidMember, subscriptionHasFreeTrial} from '../../../../utils/helpers';
+import {addMonths, getCompExpiry, getMemberSubscription, getMemberTierName, hasMultipleProductsFeature, hasOnlyFreePlan, isComplimentaryMember, isPaidMember, subscriptionHasFreeTrial} from '../../../../utils/helpers';
 import {getDateString} from '../../../../utils/date-time';
 import {ReactComponent as LoaderIcon} from '../../../../images/icons/loader.svg';
 import {ReactComponent as OfferTagIcon} from '../../../../images/icons/offer-tag.svg';
@@ -210,11 +210,12 @@ function FreeTrialLabel({subscription}) {
  * @param {'month'|'year'} nextPayment.interval
  * @param {Object|null} nextPayment.discount
  * @param {'once'|'repeating'|'forever'} nextPayment.discount.duration
+ * @param {number|null} nextPayment.discount.duration_in_months - Discount duration in months for "repeating" offers
  * @param {string} nextPayment.discount.start - Discount start date (ISO 8601 date string)
  * @param {string|null} nextPayment.discount.end - Discount end date (ISO 8601 date string), null for forever / once offers
  * @param {'fixed'|'percent'} nextPayment.discount.type
  * @param {number} nextPayment.discount.amount - Discount amount (e.g. 20 for 20% percent offer, or 2 for $2 fixed offer)
- * @param {string} currentPeriodEnd - Subscription current period end (ISO 8601 date string), needed to display the end of "once" offers
+ * @param {string} currentPeriodEnd - Subscription current period end (ISO 8601 date string)
  *
  * @returns {string}
  */
@@ -233,8 +234,12 @@ function getOfferLabel({nextPayment, currentPeriodEnd}) {
     let durationLabel = '';
     if (discount.duration === 'forever') {
         durationLabel = t('Forever');
-    } else if (discount.duration === 'repeating' && discount.end) {
-        durationLabel = t('Ends {offerEndDate}', {offerEndDate: getDateString(discount.end)});
+    } else if (discount.duration === 'repeating' && currentPeriodEnd) {
+        // Stripe discount dates are anchored to redemption time, not billing cycle, so we can't use discount.end here
+        const offerEndDate = addMonths(currentPeriodEnd, discount.duration_in_months - 1);
+        if (offerEndDate) {
+            durationLabel = t('Ends {offerEndDate}', {offerEndDate: getDateString(offerEndDate)});
+        }
     } else if (discount.duration === 'once' && currentPeriodEnd) {
         // By design, "once" offers don't have a discount end in Stripe. They expire at the end of the current billing period.
         durationLabel = t('Ends {offerEndDate}', {offerEndDate: getDateString(currentPeriodEnd)});

--- a/apps/portal/src/utils/fixtures-generator.js
+++ b/apps/portal/src/utils/fixtures-generator.js
@@ -143,6 +143,7 @@ export function getDiscountData({
     start = '2025-01-01T00:00:00.000Z',
     end = null,
     duration = 'forever',
+    durationInMonths = null,
     type = 'percent',
     amount = 20
 } = {}) {
@@ -151,6 +152,7 @@ export function getDiscountData({
         start,
         end,
         duration,
+        ...(duration === 'repeating' ? {duration_in_months: durationInMonths ?? 1} : {}),
         type,
         amount
     };

--- a/apps/portal/src/utils/helpers.js
+++ b/apps/portal/src/utils/helpers.js
@@ -941,13 +941,29 @@ export function addMonths(date, numberOfMonths = 1) {
         return null;
     }
 
+    if (!Number.isInteger(numberOfMonths) || numberOfMonths < 1) {
+        return originalDate;
+    }
+
     const originalDay = originalDate.getUTCDate();
+    const originalHours = originalDate.getUTCHours();
+    const originalMinutes = originalDate.getUTCMinutes();
+    const originalSeconds = originalDate.getUTCSeconds();
+    const originalMilliseconds = originalDate.getUTCMilliseconds();
     let targetMonth = originalDate.getUTCMonth() + numberOfMonths;
     let targetYear = originalDate.getUTCFullYear() + Math.floor(targetMonth / 12);
     targetMonth = targetMonth % 12;
     const daysInTargetMonth = new Date(Date.UTC(targetYear, targetMonth + 1, 0)).getUTCDate();
 
-    return new Date(Date.UTC(targetYear, targetMonth, Math.min(originalDay, daysInTargetMonth)));
+    return new Date(Date.UTC(
+        targetYear,
+        targetMonth,
+        Math.min(originalDay, daysInTargetMonth),
+        originalHours,
+        originalMinutes,
+        originalSeconds,
+        originalMilliseconds
+    ));
 }
 
 // Check if member is a recent member, i.e. created in last 24 hours

--- a/apps/portal/test/unit/components/pages/AccountHomePage/paid-account-actions.test.js
+++ b/apps/portal/test/unit/components/pages/AccountHomePage/paid-account-actions.test.js
@@ -241,7 +241,8 @@ describe('PaidAccountActions', () => {
             const products = getProductsData({numOfProducts: 1});
             const site = getSiteData({products, portalProducts: products.map(p => p.id)});
 
-            const endDate = new Date('2099-01-01T12:00:00.000Z');
+            const currentPeriodEnd = new Date('2099-04-03T12:00:00.000Z');
+            const discountEnd = new Date('2099-05-05T12:00:00.000Z');
 
             const member = getMemberData({
                 paid: true,
@@ -255,8 +256,9 @@ describe('PaidAccountActions', () => {
                             type: 'percent',
                             amount: 20,
                             duration: 'repeating',
-                            duration_in_months: 6
+                            duration_in_months: 2
                         },
+                        currentPeriodEnd: currentPeriodEnd.toISOString(),
                         nextPayment: getNextPaymentData({
                             originalAmount: 500,
                             amount: 400,
@@ -264,9 +266,10 @@ describe('PaidAccountActions', () => {
                             currency: 'USD',
                             discount: getDiscountData({
                                 duration: 'repeating',
+                                durationInMonths: 2,
                                 type: 'percent',
                                 amount: 20,
-                                end: endDate.toISOString()
+                                end: discountEnd.toISOString()
                             })
                         })
                     })
@@ -282,7 +285,8 @@ describe('PaidAccountActions', () => {
             // Should show the discounted price with end date
             expect(queryByText(/\$4\.00\/month/)).toBeInTheDocument();
             expect(queryByText(/Ends/)).toBeInTheDocument();
-            expect(queryByText(/1 Jan 2099/)).toBeInTheDocument();
+            expect(queryByText('$4.00/month — Ends 3 May 2099')).toBeInTheDocument();
+            expect(queryByText('$4.00/month — Ends 5 May 2099')).not.toBeInTheDocument();
         });
 
         test('displays $0.00/month - Ends {date} for free months offers', () => {
@@ -290,6 +294,7 @@ describe('PaidAccountActions', () => {
             const site = getSiteData({products, portalProducts: products.map(p => p.id)});
 
             const discountEnd = new Date('2099-02-01T12:00:00.000Z');
+            const currentPeriodEnd = new Date('2099-01-03T12:00:00.000Z');
 
             const member = getMemberData({
                 paid: true,
@@ -306,6 +311,7 @@ describe('PaidAccountActions', () => {
                             duration_in_months: 1,
                             redemption_type: 'retention'
                         },
+                        currentPeriodEnd: currentPeriodEnd.toISOString(),
                         nextPayment: getNextPaymentData({
                             originalAmount: 500,
                             amount: 0,
@@ -313,6 +319,7 @@ describe('PaidAccountActions', () => {
                             currency: 'USD',
                             discount: getDiscountData({
                                 duration: 'repeating',
+                                durationInMonths: 1,
                                 type: 'percent',
                                 amount: 100,
                                 end: discountEnd.toISOString()
@@ -327,7 +334,8 @@ describe('PaidAccountActions', () => {
             expect(queryByText('$5.00/month')).toBeInTheDocument();
             expect(queryByText('$5.00/month')).toHaveClass('gh-portal-account-old-price');
             expect(queryByTestId('offer-label')).toBeInTheDocument();
-            expect(queryByText('$0.00/month — Ends 1 Feb 2099')).toBeInTheDocument();
+            expect(queryByText('$0.00/month — Ends 3 Jan 2099')).toBeInTheDocument();
+            expect(queryByText('$0.00/month — Ends 1 Feb 2099')).not.toBeInTheDocument();
         });
 
         test('displays discounted price with "Ends {date}" for once offers', () => {

--- a/apps/portal/test/utils/helpers.test.js
+++ b/apps/portal/test/utils/helpers.test.js
@@ -765,6 +765,11 @@ describe('Helpers - ', () => {
             expect(result).toEqual(new Date(Date.UTC(2026, 1, 1)));
         });
 
+        it('preserves UTC time when adding months', () => {
+            const result = addMonths('2099-04-03T18:30:45.123Z', 1);
+            expect(result).toEqual(new Date('2099-05-03T18:30:45.123Z'));
+        });
+
         it('accepts a date string', () => {
             const result = addMonths('2024-03-15T00:00:00.000Z', 2);
             expect(result).toEqual(new Date(Date.UTC(2024, 4, 15)));
@@ -782,6 +787,16 @@ describe('Helpers - ', () => {
 
         it('returns null for undefined', () => {
             expect(addMonths(undefined, 1)).toBeNull();
+        });
+
+        it('returns the original date when month count is less than 1', () => {
+            const date = '2024-03-15T00:00:00.000Z';
+            expect(addMonths(date, 0)).toEqual(new Date(date));
+        });
+
+        it('returns the original date when month count is not an integer', () => {
+            const date = '2024-03-15T00:00:00.000Z';
+            expect(addMonths(date, 1.5)).toEqual(new Date(date));
         });
     });
 


### PR DESCRIPTION
closes https://linear.app/ghost/issue/BER-3413/account-page-date-mismatch-between-discount-end-billing-period

- When a member redeems a 1-month free offer, Stripe sets the discount start date to now and end date to now + 1 month, i.e. anchors them to the redemption date, not the billing date
- In Portal, to avoid confusion, we want to anchor the `"- Ends {date}"` to a billing date to avoid confusion
- For example, today is 5 Mar 2026 and my subscription renews on 3 Apr 2026. I hit cancel, redeem a free-month offer that applies to my next payment. I expect to see `"$0.00/month - Ends 3 Apr 2026"`, not `"$0.00/month - Ends 5 Apr 2026"`

---

Before:
<img width="978" height="1356" alt="image" src="https://github.com/user-attachments/assets/7f40f6fd-f74a-4e03-885f-50f93e8de345" />

After:
<img width="996" height="1362" alt="CleanShot 2026-03-05 at 11 07 31@2x" src="https://github.com/user-attachments/assets/37518151-8f03-4255-955b-9cc6d45ac0dc" />
