### PR TITLE
🐛 Fixed contributor posts list not being scrollable

### DIFF
--- a/apps/admin/src/layout/admin-layout.tsx
+++ b/apps/admin/src/layout/admin-layout.tsx
@@ -23,7 +23,9 @@ export function AdminLayout({ children }: AdminLayoutProps) {
     if (isContributor) {
         return (
             <div className="relative h-full bg-background">
-                <main className="h-full overflow-auto">{children}</main>
+                <main className="flex h-full flex-col overflow-y-auto">
+                    <div className="flex-1">{children}</div>
+                </main>
                 <div className="fixed bottom-3.5 left-3.5 lg:bottom-8 lg:left-8 z-20">
                     <ContributorUserMenu />
                 </div>


### PR DESCRIPTION
fixes https://linear.app/ghost/issue/ONC-1512/

The contributor layout used `h-full overflow-auto` on the `<main>` element, with the EmberRoot child also using `h-full`. This constrained the Ember content to exactly the scroll container's height, so `.gh-viewport`'s `overflow: hidden` clipped the posts list with no way to scroll.

Changed the contributor layout to use the same flex column pattern as the non-contributor `SidebarInset` layout — a `flex flex-col overflow-y-auto` container with a `flex-1` wrapper for children. This allows the content to grow beyond the container via `min-height: auto`, enabling scroll.