### PR TITLE
🐛 Fixed contributor user menu Posts link navigating to wrong route

### DIFF
--- a/apps/admin/src/layout/app-sidebar/user-menu.tsx
+++ b/apps/admin/src/layout/app-sidebar/user-menu.tsx
@@ -222,7 +222,7 @@ function ContributorUserMenu() {
                 </UserMenuHeader>
                 <DropdownMenuSeparator />
                 <UserMenuItem>
-                    <Link to="/">
+                    <Link to="/posts">
                         <LucideIcon.FileText />
                         <UserMenuItem.Label>Posts</UserMenuItem.Label>
                     </Link>


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ONC-1512/

- Fixed the "Posts" link in the contributor user menu pointing to `/` instead of `/posts`, causing navigation to the wrong route