### PR TITLE
🐛 Fixed double-prefixed asset URLs when using CDN

### DIFF
--- a/ghost/admin/app/components/admin-x/admin-x-component.js
+++ b/ghost/admin/app/components/admin-x/admin-x-component.js
@@ -1,7 +1,6 @@
 import * as Sentry from '@sentry/ember';
 import Component from '@glimmer/component';
 import React, {Suspense} from 'react';
-import assetBase from 'ghost-admin/utils/asset-base';
 import config from 'ghost-admin/config/environment';
 import fetch from 'fetch';
 import fetchKoenigLexical from 'ghost-admin/utils/fetch-koenig-lexical';
@@ -9,6 +8,7 @@ import ghostPaths from 'ghost-admin/utils/ghost-paths';
 import {action} from '@ember/object';
 import {camelize} from '@ember/string';
 import {inject} from 'ghost-admin/decorators/inject';
+import {prefixAssetUrl} from 'ghost-admin/utils/asset-base';
 import {inject as service} from '@ember/service';
 import {tracked} from '@glimmer/tracking';
 
@@ -58,7 +58,7 @@ export const importComponent = async (packageName) => {
         throw new Error(`Missing config for ${packageName}. Add it in asset delivery.`);
     }
 
-    const baseUrl = `${assetBase()}assets/`;
+    const baseUrl = prefixAssetUrl('assets/');
     let url = new URL(`${baseUrl}${relativePath}/${config[`${configKey}Filename`]}?v=${config[`${configKey}Hash`]}`);
 
     const customUrl = config[`${configKey}CustomUrl`];

--- a/ghost/admin/app/helpers/parse-history-event.js
+++ b/ghost/admin/app/helpers/parse-history-event.js
@@ -1,5 +1,5 @@
 import Helper from '@ember/component/helper';
-import assetBase from 'ghost-admin/utils/asset-base';
+import {prefixAssetUrl} from 'ghost-admin/utils/asset-base';
 
 export default class ParseHistoryEvent extends Helper {
     compute([ev]) {
@@ -11,8 +11,7 @@ export default class ParseHistoryEvent extends Helper {
         const actor = getActor(ev);
         const actorLinkTarget = getActorLinkTarget(ev);
 
-        const assetRoot = `${assetBase()}assets`;
-        const actorIcon = getActorIcon(ev, assetRoot);
+        const actorIcon = getActorIcon(ev);
 
         return {
             contextResource,
@@ -36,12 +35,11 @@ function getActor(ev) {
     return ev.actor;
 }
 
-function getActorIcon(ev, assetRoot) {
-    const defaultImage = `/img/user-image.png`;
-    let defaultImageUrl = `${assetRoot}${defaultImage}`;
-
+function getActorIcon(ev) {
     if (!ev.actor.id || !ev.actor.image) {
-        return defaultImageUrl;
+        // keep path separate so asset rewriting correctly picks it up
+        const defaultImage = '/img/user-image.png';
+        return prefixAssetUrl(`assets${defaultImage}`);
     }
 
     return ev.actor.image;

--- a/ghost/admin/app/models/user.js
+++ b/ghost/admin/app/models/user.js
@@ -1,10 +1,10 @@
 import BaseModel from './base';
 import ValidationEngine from 'ghost-admin/mixins/validation-engine';
-import assetBase from 'ghost-admin/utils/asset-base';
 import {attr, hasMany} from '@ember-data/model';
 import {computed} from '@ember/object';
 import {equal, or} from '@ember/object/computed';
 import {inject} from 'ghost-admin/decorators/inject';
+import {prefixAssetUrl} from 'ghost-admin/utils/asset-base';
 import {inject as service} from '@ember/service';
 import {task} from 'ember-concurrency';
 
@@ -99,14 +99,14 @@ export default BaseModel.extend(ValidationEngine, {
     profileImageUrl: computed('profileImage', function () {
         // keep path separate so asset rewriting correctly picks it up
         let defaultImage = '/img/user-image.png';
-        let defaultPath = `${assetBase()}assets${defaultImage}`;
+        let defaultPath = prefixAssetUrl(`assets${defaultImage}`);
         return this.profileImage || defaultPath;
     }),
 
     coverImageUrl: computed('coverImage', function () {
         // keep path separate so asset rewriting correctly picks it up
         let defaultImage = '/img/user-cover.png';
-        let defaultPath = `${assetBase()}assets${defaultImage}`;
+        let defaultPath = prefixAssetUrl(`assets${defaultImage}`);
         return this.coverImage || defaultPath;
     }),
 

--- a/ghost/admin/app/services/lazy-loader.js
+++ b/ghost/admin/app/services/lazy-loader.js
@@ -1,8 +1,8 @@
 import RSVP from 'rsvp';
 import Service, {inject as service} from '@ember/service';
-import assetBase from 'ghost-admin/utils/asset-base';
 import classic from 'ember-classic-decorator';
 import config from 'ghost-admin/config/environment';
+import {prefixAssetUrl} from 'ghost-admin/utils/asset-base';
 
 @classic
 export default class LazyLoaderService extends Service {
@@ -35,7 +35,7 @@ export default class LazyLoaderService extends Service {
             let script = document.createElement('script');
             script.type = 'text/javascript';
             script.async = true;
-            script.src = `${assetBase()}${url}`;
+            script.src = prefixAssetUrl(url);
 
             let el = document.getElementsByTagName('script')[0];
             el.parentNode.insertBefore(script, el);
@@ -63,7 +63,7 @@ export default class LazyLoaderService extends Service {
             let link = document.createElement('link');
             link.id = `${key}-styles`;
             link.rel = alternate ? 'alternate stylesheet' : 'stylesheet';
-            link.href = `${assetBase()}${url}`;
+            link.href = prefixAssetUrl(url);
             link.onload = () => {
                 link.onload = null;
                 if (alternate) {

--- a/ghost/admin/app/utils/asset-base.js
+++ b/ghost/admin/app/utils/asset-base.js
@@ -4,7 +4,7 @@ let _assetBase = null;
 
 /**
  * Resolve the asset base URL from script elements in the given document root.
- * Exported for direct testing — callers should use the default export instead.
+ * Exported for direct testing — callers should use prefixAssetUrl() instead.
  *
  * @param {Document} doc  The document to search for script tags
  * @returns {string} Absolute URL with trailing slash
@@ -40,11 +40,25 @@ export function resolveAssetBase(doc) {
  *   CDN:   "https://assets.ghost.io/admin-forward/"
  *   Local: "http://localhost:2368/ghost/"
  */
-export default function assetBase() {
+function assetBase() {
     if (_assetBase !== null) {
         return _assetBase;
     }
 
     _assetBase = resolveAssetBase(document);
     return _assetBase;
+}
+
+/**
+ * Prefix a URL with the asset base, but only if it isn't already absolute.
+ *
+ * broccoli-asset-rev rewrites string literals in the compiled JS at build time,
+ * prepending the CDN origin + fingerprint hash. If the URL is already absolute
+ * we must return it as-is to avoid double-prefixing.
+ */
+export function prefixAssetUrl(url) {
+    if (url.startsWith('http://') || url.startsWith('https://')) {
+        return url;
+    }
+    return `${assetBase()}${url}`;
 }

--- a/ghost/admin/app/utils/fetch-koenig-lexical.js
+++ b/ghost/admin/app/utils/fetch-koenig-lexical.js
@@ -1,12 +1,12 @@
-import assetBase from 'ghost-admin/utils/asset-base';
 import config from 'ghost-admin/config/environment';
+import {prefixAssetUrl} from 'ghost-admin/utils/asset-base';
 
 export default async function fetchKoenigLexical() {
     if (window['@tryghost/koenig-lexical']) {
         return window['@tryghost/koenig-lexical'];
     }
 
-    const baseUrl = (config.editorUrl || `${assetBase()}assets/koenig-lexical/`);
+    const baseUrl = (config.editorUrl || prefixAssetUrl('assets/koenig-lexical/'));
     const url = new URL(`${baseUrl}${config.editorFilename}?v=${config.editorHash}`);
 
     if (url.protocol === 'http:') {

--- a/ghost/admin/tests/integration/services/lazy-loader-test.js
+++ b/ghost/admin/tests/integration/services/lazy-loader-test.js
@@ -1,5 +1,4 @@
 import Pretender from 'pretender';
-import assetBase from 'ghost-admin/utils/asset-base';
 import {describe, it} from 'mocha';
 import {expect} from 'chai';
 import {setupTest} from 'ember-mocha';
@@ -25,27 +24,23 @@ describe('Integration: Service: lazy-loader', function () {
             testing: false
         });
 
-        const expectedSrc = `${assetBase()}lazy-test.js`;
-
         // first load should add script element
         await subject.loadScript('test', 'lazy-test.js')
             .then(() => {})
             .catch(() => {});
 
-        expect(
-            document.querySelectorAll(`script[src="${expectedSrc}"]`).length,
-            'no of script tags on first load'
-        ).to.equal(1);
+        let scripts = document.querySelectorAll('script[src$="lazy-test.js"]');
+        expect(scripts.length, 'no of script tags on first load').to.equal(1);
+        expect(scripts[0].src).to.match(/^https?:\/\//);
+        expect(scripts[0].src).to.include('lazy-test.js');
 
         // second load should not add another script element
         await subject.loadScript('test', 'lazy-test.js')
             .then(() => { })
             .catch(() => { });
 
-        expect(
-            document.querySelectorAll(`script[src="${expectedSrc}"]`).length,
-            'no of script tags on second load'
-        ).to.equal(1);
+        scripts = document.querySelectorAll('script[src$="lazy-test.js"]');
+        expect(scripts.length, 'no of script tags on second load').to.equal(1);
     });
 
     it('loads styles correctly', function () {
@@ -55,12 +50,32 @@ describe('Integration: Service: lazy-loader', function () {
             testing: false
         });
 
-        const expectedHref = `${assetBase()}style.css`;
-
         return subject.loadStyle('testing', 'style.css').catch(() => {
             // we add a catch handler here because the style.css doesn't exist
             expect(document.querySelectorAll('#testing-styles').length).to.equal(1);
-            expect(document.querySelector('#testing-styles').getAttribute('href')).to.equal(expectedHref);
+            const href = document.querySelector('#testing-styles').getAttribute('href');
+            expect(href).to.match(/^https?:\/\//);
+            expect(href).to.include('style.css');
         });
+    });
+
+    it('does not double-prefix URLs already rewritten by broccoli-asset-rev', async function () {
+        // broccoli-asset-rev rewrites string literals in compiled JS at build
+        // time, prepending the CDN origin. When the lazy-loader receives an
+        // already-absolute URL it must use it as-is.
+        let subject = this.owner.lookup('service:lazy-loader');
+
+        subject.setProperties({
+            scriptPromises: {},
+            testing: false
+        });
+
+        const cdnUrl = 'https://assets.ghost.io/admin-forward/assets/ghost-dark-abc123.css';
+
+        await subject.loadStyle('dark-cdn-test', cdnUrl, true).catch(() => {});
+
+        const link = document.querySelector('#dark-cdn-test-styles');
+        expect(link).to.exist;
+        expect(link.getAttribute('href')).to.equal(cdnUrl);
     });
 });

--- a/ghost/admin/tests/unit/utils/asset-base-test.js
+++ b/ghost/admin/tests/unit/utils/asset-base-test.js
@@ -1,6 +1,6 @@
 import {describe, it} from 'mocha';
 import {expect} from 'chai';
-import {resolveAssetBase} from 'ghost-admin/utils/asset-base';
+import {prefixAssetUrl, resolveAssetBase} from 'ghost-admin/utils/asset-base';
 
 /**
  * Create a minimal document fragment containing a <script> tag with the
@@ -89,6 +89,41 @@ describe('Unit: Util: asset-base', function () {
             // This is the exact pattern used by fetchKoenigLexical and importComponent —
             // a relative path is NOT valid input for new URL(), so the base must be absolute.
             expect(() => new URL(`${base}assets/koenig-lexical/koenig-lexical.umd.js`)).to.not.throw();
+        });
+    });
+
+    describe('prefixAssetUrl', function () {
+        it('prefixes a relative URL with the asset base', function () {
+            const result = prefixAssetUrl('assets/ghost-dark.css');
+
+            expect(result).to.match(/^https?:\/\//);
+            expect(result).to.include('assets/ghost-dark.css');
+        });
+
+        it('returns an absolute http URL unchanged (no double-prefixing)', function () {
+            const absoluteUrl = 'http://cdn.example.com/admin-forward/assets/ghost-dark-abc123.css';
+            const result = prefixAssetUrl(absoluteUrl);
+
+            expect(result).to.equal(absoluteUrl);
+        });
+
+        it('returns an absolute https URL unchanged (no double-prefixing)', function () {
+            const absoluteUrl = 'https://assets.ghost.io/admin-forward/assets/ghost-dark-9695bb0264af063aa642b1e451293d1a.css';
+            const result = prefixAssetUrl(absoluteUrl);
+
+            expect(result).to.equal(absoluteUrl);
+        });
+
+        it('handles URLs rewritten by broccoli-asset-rev with CDN prepend', function () {
+            // broccoli-asset-rev rewrites string literals in compiled JS,
+            // turning 'assets/ghost-dark.css' into
+            // 'https://cdn.example.com/admin-forward/assets/ghost-dark-{hash}.css'.
+            // prefixAssetUrl must not add another prefix on top.
+            const rewrittenUrl = 'https://cdn.example.com/admin-forward/assets/ghost-dark-a1b2c3d4.css';
+            const result = prefixAssetUrl(rewrittenUrl);
+
+            expect(result).to.equal(rewrittenUrl);
+            expect(result).to.not.include('https://cdn.example.com/admin-forward/https://');
         });
     });
 });


### PR DESCRIPTION
After #26555 replaced `cdnUrl` config with the runtime `assetBase()` utility, customers on CDN-served installs started seeing 404s for admin assets. The browser was requesting URLs like `https://assets.ghost.io/admin-forward/https://assets.ghost.io/admin-forward/assets/ghost-dark-{hash}.css` — the CDN origin doubled up.

The root cause is that `broccoli-asset-rev` rewrites string literals in the compiled JavaScript at build time, prepending the full CDN origin and fingerprint hash. So a source-level `'assets/ghost-dark.css'` becomes `'https://assets.ghost.io/admin-forward/assets/ghost-dark-{hash}.css'` in the production build. The old code handled this with `config.cdnUrl ? '' : this.ghostPaths.adminRoot` — when a CDN was in use, the prefix was an empty string, so the already-absolute URL passed through unchanged. The new `assetBase()` always returns a non-empty absolute URL, causing double-prefixing.

This adds a `prefixAssetUrl()` helper to `asset-base.js` that checks whether the URL is already absolute before prepending `assetBase()`. All call sites that concatenate `assetBase()` with potentially-rewritten asset paths (`lazy-loader.js`, `user.js`, `parse-history-event.js`) now use this helper instead of direct concatenation. The `admin-x-component.js` and `fetch-koenig-lexical.js` call sites are unaffected because they concatenate `assetBase()` with partial directory paths that `broccoli-asset-rev` won't match as fingerprintable filenames.

Tests cover the double-prefix scenario at both the unit level (`prefixAssetUrl` with absolute URLs) and the integration level (lazy-loader receiving a CDN-rewritten URL).