### PR TITLE
🐛 Fixed broken settings view when logged in as Editor

### DIFF
--- a/apps/admin-x-settings/src/main-content.tsx
+++ b/apps/admin-x-settings/src/main-content.tsx
@@ -9,6 +9,8 @@ import {toast} from 'react-hot-toast';
 import {useGlobalData} from './components/providers/global-data-provider';
 import {useRouting} from '@tryghost/admin-x-framework/routing';
 
+const EMPTY_KEYWORDS: string[] = [];
+
 const Page: React.FC<{children: ReactNode}> = ({children}) => {
     return <>
         <div className='fixed right-0 top-2 z-50 flex justify-end bg-transparent p-8 tablet:fixed tablet:top-0 tablet:px-8' id="done-button-container">
@@ -65,9 +67,11 @@ const MainContent: React.FC = () => {
     if (isEditorUser(currentUser)) {
         return (
             <Page>
-                <div className='mx-auto w-full max-w-5xl overflow-y-auto px-[5vmin] tablet:mt-16 xl:mt-10' id="admin-x-settings-scroller">
-                    <Heading className='mb-[5vmin]'>Settings</Heading>
-                    <Users highlight={false} keywords={[]} />
+                <div className='flex-1 overflow-y-auto bg-white dark:bg-grey-975' id="admin-x-settings-scroller">
+                    <div className='mx-auto max-w-5xl px-[5vmin] tablet:mt-16 xl:mt-10'>
+                        <Heading className='mb-[5vmin]'>Settings</Heading>
+                        <Users highlight={false} keywords={EMPTY_KEYWORDS} />
+                    </div>
                 </div>
             </Page>
         );


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ONC-1505/

The editor's settings view had two issues:

- **Missing background color**: The content container had no `bg-white` class, making it transparent over the underlying admin UI and breaking the layout
- **Infinite re-render loop**: `keywords={[]}` created a new array reference every render, causing `TopLevelGroup`'s `useEffect` to continuously re-register the component via `setVisibleComponents`, making the UI unresponsive