### PR TITLE
Cleaned up trigger_cd payload to send artifact identity only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1606,22 +1606,20 @@ jobs:
         id: params
         run: |
           if [ "${{ needs.job_setup.outputs.is_main }}" = "true" ]; then
-            echo "dry_run=false" >> $GITHUB_OUTPUT
-            echo "should_rollout=true" >> $GITHUB_OUTPUT
             echo "pr_number=" >> $GITHUB_OUTPUT
+            echo "deploy=" >> $GITHUB_OUTPUT
           elif [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "pr_number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+
             DEPLOY_LABEL="${{ contains(github.event.pull_request.labels.*.name, 'deploy-to-staging') }}"
             IS_ORG_MEMBER="${{ needs.job_setup.outputs.member_is_in_org }}"
             IS_RENOVATE="${{ github.event.pull_request.user.login == 'renovate[bot]' }}"
 
             if [ "$DEPLOY_LABEL" = "true" ] && ([ "$IS_ORG_MEMBER" = "true" ] || [ "$IS_RENOVATE" = "true" ]); then
-              echo "dry_run=false" >> $GITHUB_OUTPUT
-              echo "should_rollout=true" >> $GITHUB_OUTPUT
+              echo "deploy=true" >> $GITHUB_OUTPUT
             else
-              echo "dry_run=true" >> $GITHUB_OUTPUT
-              echo "should_rollout=false" >> $GITHUB_OUTPUT
+              echo "deploy=" >> $GITHUB_OUTPUT
             fi
-            echo "pr_number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
           else
             echo "skip=true" >> $GITHUB_OUTPUT
             exit 0
@@ -1637,12 +1635,9 @@ jobs:
           event-type: ghost-artifacts-ready
           client-payload: >-
             {
-              "environment": "staging",
               "ref": "${{ github.sha }}",
-              "image_tag": "${{ needs.job_docker_build_production.outputs.core-image-sha-tag }}",
-              "dry_run": ${{ steps.params.outputs.dry_run }},
-              "should_rollout": ${{ steps.params.outputs.should_rollout }},
               "pr_number": "${{ steps.params.outputs.pr_number }}",
+              "deploy": "${{ steps.params.outputs.deploy }}",
               "admin_artifact_id": "${{ needs.job_docker_build_production.outputs.admin-artifact-id }}",
               "admin_artifact_run_id": "${{ github.run_id }}"
             }


### PR DESCRIPTION
The trigger_cd dispatch was sending deployment policy fields (`dry_run`, `should_rollout`, `environment`) alongside artifact identity. This meant Ghost CI was dictating how Moya should deploy — making it impossible to change deployment defaults without pushing a change to the public Ghost repo.

This strips the payload down to artifact identity and a single fact flag. The new payload sends: `ref` (commit SHA), `pr_number`, `deploy` (whether deploy-to-staging label is present), `admin_artifact_id`, and `admin_artifact_run_id`. The previous `sha`, `image_tag`, `dry_run`, `should_rollout`, and `environment` fields are all removed — Moya now derives everything it needs from `ref`, `pr_number`, and `deploy`.

The `deploy` flag replaces the old dry_run/should_rollout booleans. It's a fact about the PR (the deploy-to-staging label is set and the user is authorized), not a policy decision. Moya interprets it: PR builds without the flag are dry runs, main merges publish and rollout to all sites, and the deploy flag triggers publish + rollout to a fixed set of test sites.

Companion PR in Ghost-Moya (TryGhost/Ghost-Moya#177) updates the orchestrator to interpret the new payload shape. The Moya change is backwards-compatible — it handles both old and new payloads during the transition, so this can be merged second without coordination issues.