### PR TITLE
Removed fingerprint.prepend from Ember build config

### DIFF
--- a/ghost/admin/ember-cli-build.js
+++ b/ghost/admin/ember-cli-build.js
@@ -110,7 +110,6 @@ module.exports = function (defaults) {
         },
         fingerprint: {
             enabled: isProduction,
-            prepend: process.env.GHOST_CDN_URL || '',
             extensions: [
                 'js',
                 'css',


### PR DESCRIPTION
broccoli-asset-rev's `fingerprint.prepend` option rewrites string literals in compiled JS and CSS at build time, baking CDN URLs directly into the bundle. This was the root cause of the double-prefix incident fixed in #26719 — `prefixAssetUrl` would prepend the CDN origin onto URLs that broccoli-asset-rev had already rewritten, producing URLs like `https://cdn.example.com/https://cdn.example.com/assets/ghost-dark.css`.

With the Vite migration complete, this build-time URL rewriting is redundant. HTML asset prefixing is handled by Vite's `base` config (which reads `GHOST_CDN_URL` independently), and JS runtime asset loading uses `prefixAssetUrl` to resolve the correct origin from the serving script tag. Removing `prepend` eliminates the entire class of build-time/runtime double-prefix bugs while keeping fingerprinting (hash-based filenames) intact. `publicAssetURL` is intentionally preserved since webpack still needs the CDN-aware `publicPath` for lazy-loaded chunk files that aren't listed in the HTML.

A validation script (`scripts/validate-asset-urls.sh`) is included that builds both CDN permutations (with and without `GHOST_CDN_URL`) and checks asset URL correctness across Ember and Vite outputs. Post-change results show all 17 checks passing with 0 failures and only 2 warnings (both about webpack publicPath detection), compared to the baseline's 5 warnings which included CDN URLs baked into JS literals and absolute CSS `url()` refs.