### PR TITLE
Removed legacy deploy_admin job from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1543,51 +1543,6 @@ jobs:
           workspace: 'Production'
           slack-webhook: ${{ secrets.ANALYTICS_SLACK_WEBHOOK_URL }}
 
-  deploy_admin:
-    needs: [
-      job_setup,
-      job_required_tests
-    ]
-    name: Deploy Admin
-    runs-on: ubuntu-latest
-    if: |
-      always()
-      && github.repository == 'TryGhost/Ghost'
-      && needs.job_setup.result == 'success'
-      && needs.job_setup.outputs.is_main == 'true'
-      && needs.job_required_tests.result == 'success'
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v4
-        env:
-          FORCE_COLOR: 0
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-      - name: Restore caches
-        uses: ./.github/actions/restore-cache
-        env:
-          DEPENDENCY_CACHE_KEY: ${{ needs.job_setup.outputs.dependency_cache_key }}
-      - name: Build Admin
-        env:
-          GHOST_CDN_URL: https://assets.ghost.io/admin-forward/
-        run: yarn nx run admin:build
-      - name: Upload build artifact
-        id: upload-artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: admin-build
-          path: apps/admin/dist
-      - name: Deploy Admin
-        uses: aurelien-baudet/workflow-dispatch@v4
-        with:
-          token: ${{ secrets.CANARY_DOCKER_BUILD }}
-          workflow: .github/workflows/deploy-admin.yml
-          ref: 'refs/heads/main' # this is the ref of Ghost-Moya
-          repo: TryGhost/Ghost-Moya
-          inputs: '{"admin_build_artifact_id":"${{ steps.upload-artifacts.outputs.artifact-id }}", "admin_build_artifact_run_id":"${{ github.run_id }}"}'
-          wait-for-completion-timeout: 25m
-          wait-for-completion-interval: 30s
-
   # --------------------------------------------------------------------------- #
   # Trigger Pro CD — dispatch to Ghost-Moya cd.yml (runs on main + PRs)
   # --------------------------------------------------------------------------- #


### PR DESCRIPTION
The `deploy_admin` job built admin with a hardcoded `GHOST_CDN_URL`, uploaded the artifact, and dispatched to `deploy-admin.yml` in Ghost-Moya to push files to the production GCS bucket. This was the legacy path for updating production admin-forward.

Admin deployment is now fully handled by Ghost-Moya's `cd-admin.yml` sub-workflow, which the `cd.yml` orchestrator calls on every main merge with `environment: both`. The admin build artifact uploaded by `job_docker_build_production` (as `admin-build-cd`) is consumed by `cd-admin.yml` directly — no separate build with `GHOST_CDN_URL` override is needed because `cd-admin.yml` rewrites asset paths at upload time.

**Merge order:** This PR should be merged first — it removes the `deploy_admin` job that dispatches to `deploy-admin.yml` in Ghost-Moya. Ghost-Moya PR #178 then deletes that target workflow. Merging in this order avoids `deploy_admin` failing on every main merge due to dispatching to a non-existent workflow.