### PR TITLE
🐛 Fixed missing feature images for published posts in Contributor posts list

### DIFF
--- a/ghost/admin/app/components/posts-list/list-item-analytics.hbs
+++ b/ghost/admin/app/components/posts-list/list-item-analytics.hbs
@@ -9,8 +9,12 @@
     {{!-- Title column --}}
     {{#if (and this.session.user.isContributor @post.isPublished)}}
         <a href={{@post.url}} class="permalink gh-list-data gh-post-list-title gh-post-with-feature-image" target="_blank" rel="noopener noreferrer">
-            <div class="gh-post-list-feature-image">
-                <div class="gh-post-list-feature-image-placeholder"></div>
+            <div class="gh-post-list-feature-image" style={{html-safe (concat "background-image: url(" @post.featureImage ");")}}>
+                {{#unless @post.featureImage}}
+                    <div class="gh-post-list-feature-image-placeholder">
+                        {{svg-jar "post-feature-image-placeholder"}}
+                    </div>
+                {{/unless}}
             </div>
             <div>
                 <h3 class="gh-content-entry-title">


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ONC-1512/

The posts list analytics view currently shows a placeholder for all posts, regardless of whether they have a feature image. This change improves the visual presentation by displaying actual feature images when available.

- Updates the feature image container to use a background image when `@post.featureImage` is available
- Only displays the placeholder SVG icon when no feature image exists
- Uses inline styles with `html-safe` to apply the background image URL dynamically