### PR TITLE
Added unit tests for CDN image URL handling

### DIFF
--- a/ghost/core/test/unit/frontend/meta/cover-image.test.js
+++ b/ghost/core/test/unit/frontend/meta/cover-image.test.js
@@ -58,4 +58,36 @@ describe('getCoverImage', function () {
         });
         assert.equal(coverImageUrl, null);
     });
+
+    describe('CDN image URLs', function () {
+        it('should return CDN cover image url for home', function () {
+            const coverImageUrl = getCoverImage({
+                context: ['home'],
+                home: {
+                    cover_image: 'https://storage.ghost.is/c/6f/a3/site/content/images/2026/02/cover.jpg'
+                }
+            });
+            assert.equal(coverImageUrl, 'https://storage.ghost.is/c/6f/a3/site/content/images/2026/02/cover.jpg');
+        });
+
+        it('should return CDN cover image url for author', function () {
+            const coverImageUrl = getCoverImage({
+                context: ['author'],
+                author: {
+                    cover_image: 'https://storage.ghost.is/c/6f/a3/site/content/images/2026/02/author-cover.jpg'
+                }
+            });
+            assert.equal(coverImageUrl, 'https://storage.ghost.is/c/6f/a3/site/content/images/2026/02/author-cover.jpg');
+        });
+
+        it('should return CDN feature image url for post', function () {
+            const coverImageUrl = getCoverImage({
+                context: ['post'],
+                post: {
+                    feature_image: 'https://storage.ghost.is/c/6f/a3/site/content/images/2026/02/post-feature.jpg'
+                }
+            });
+            assert.equal(coverImageUrl, 'https://storage.ghost.is/c/6f/a3/site/content/images/2026/02/post-feature.jpg');
+        });
+    });
 });

--- a/ghost/core/test/unit/frontend/meta/og-image.test.js
+++ b/ghost/core/test/unit/frontend/meta/og-image.test.js
@@ -183,4 +183,50 @@ describe('getOgImage', function () {
 
         assert.equal(getOgImage({context: ['tag', 'paged'], tag}), null);
     });
+
+    describe('CDN image URLs', function () {
+        it('returns CDN og_image for home context', function () {
+            localSettingsCache.og_image = 'https://storage.ghost.is/c/6f/a3/site/content/images/2026/02/og.jpg';
+
+            const result = getOgImage({context: ['home'], home: {}});
+            assert(result.includes('storage.ghost.is'));
+            assert(result.endsWith('/content/images/2026/02/og.jpg'));
+        });
+
+        it('returns CDN og_image for post context', function () {
+            const post = {
+                og_image: 'https://storage.ghost.is/c/6f/a3/site/content/images/2026/02/post-og.jpg',
+                feature_image: '/content/images/post-feature.jpg'
+            };
+
+            const result = getOgImage({context: ['post'], post});
+            assert(result.includes('storage.ghost.is'));
+            assert(result.endsWith('post-og.jpg'));
+        });
+
+        it('falls back to CDN feature_image when post og_image is empty', function () {
+            const post = {
+                og_image: '',
+                feature_image: 'https://storage.ghost.is/c/6f/a3/site/content/images/2026/02/feature.jpg'
+            };
+
+            const result = getOgImage({context: ['post'], post});
+            assert(result.includes('storage.ghost.is'));
+            assert(result.endsWith('feature.jpg'));
+        });
+
+        it('falls back to CDN cover_image for settings', function () {
+            localSettingsCache.og_image = '';
+            localSettingsCache.cover_image = 'https://storage.ghost.is/c/6f/a3/site/content/images/2026/02/cover.jpg';
+
+            const post = {
+                og_image: '',
+                feature_image: ''
+            };
+
+            const result = getOgImage({context: ['post'], post});
+            assert(result.includes('storage.ghost.is'));
+            assert(result.endsWith('cover.jpg'));
+        });
+    });
 });

--- a/ghost/core/test/unit/frontend/meta/twitter-image.test.js
+++ b/ghost/core/test/unit/frontend/meta/twitter-image.test.js
@@ -183,4 +183,50 @@ describe('getTwitterImage', function () {
 
         assert.equal(getTwitterImage({context: ['tag', 'paged'], tag}), null);
     });
+
+    describe('CDN image URLs', function () {
+        it('returns CDN twitter_image for home context', function () {
+            localSettingsCache.twitter_image = 'https://storage.ghost.is/c/6f/a3/site/content/images/2026/02/twitter.jpg';
+
+            const result = getTwitterImage({context: ['home'], home: {}});
+            assert(result.includes('storage.ghost.is'));
+            assert(result.endsWith('/content/images/2026/02/twitter.jpg'));
+        });
+
+        it('returns CDN twitter_image for post context', function () {
+            const post = {
+                twitter_image: 'https://storage.ghost.is/c/6f/a3/site/content/images/2026/02/post-twitter.jpg',
+                feature_image: '/content/images/post-feature.jpg'
+            };
+
+            const result = getTwitterImage({context: ['post'], post});
+            assert(result.includes('storage.ghost.is'));
+            assert(result.endsWith('post-twitter.jpg'));
+        });
+
+        it('falls back to CDN feature_image when post twitter_image is empty', function () {
+            const post = {
+                twitter_image: '',
+                feature_image: 'https://storage.ghost.is/c/6f/a3/site/content/images/2026/02/feature.jpg'
+            };
+
+            const result = getTwitterImage({context: ['post'], post});
+            assert(result.includes('storage.ghost.is'));
+            assert(result.endsWith('feature.jpg'));
+        });
+
+        it('falls back to CDN cover_image for settings', function () {
+            localSettingsCache.twitter_image = '';
+            localSettingsCache.cover_image = 'https://storage.ghost.is/c/6f/a3/site/content/images/2026/02/cover.jpg';
+
+            const post = {
+                twitter_image: '',
+                feature_image: ''
+            };
+
+            const result = getTwitterImage({context: ['post'], post});
+            assert(result.includes('storage.ghost.is'));
+            assert(result.endsWith('cover.jpg'));
+        });
+    });
 });

--- a/ghost/core/test/unit/server/api/endpoints/utils/serializers/output/files.test.js
+++ b/ghost/core/test/unit/server/api/endpoints/utils/serializers/output/files.test.js
@@ -1,0 +1,32 @@
+const assert = require('node:assert/strict');
+const config = require('../../../../../../../../core/shared/config');
+const filesSerializer = require('../../../../../../../../core/server/api/endpoints/utils/serializers/output/files');
+
+describe('Files output serializer', function () {
+    describe('upload', function () {
+        it('converts a local relative path to an absolute URL', function () {
+            const siteUrl = config.getSiteUrl().replace(/\/$/, '');
+            const frame = {data: {ref: null}, response: null};
+            filesSerializer.upload({filePath: '/content/files/2026/03/report.pdf'}, {}, frame);
+
+            assert.equal(frame.response.files[0].url, `${siteUrl}/content/files/2026/03/report.pdf`);
+        });
+
+        it('passes through a CDN URL unchanged', function () {
+            const cdnUrl = 'https://storage.ghost.is/c/6f/a3/site/content/files/2026/03/report.pdf';
+            const frame = {data: {ref: null}, response: null};
+            filesSerializer.upload({filePath: cdnUrl}, {}, frame);
+
+            assert.equal(frame.response.files[0].url, cdnUrl);
+        });
+
+        it('includes ref from frame data', function () {
+            const siteUrl = config.getSiteUrl().replace(/\/$/, '');
+            const frame = {data: {ref: 'file-ref-123'}, response: null};
+            filesSerializer.upload({filePath: '/content/files/2026/03/report.pdf'}, {}, frame);
+
+            assert.equal(frame.response.files[0].url, `${siteUrl}/content/files/2026/03/report.pdf`);
+            assert.equal(frame.response.files[0].ref, 'file-ref-123');
+        });
+    });
+});

--- a/ghost/core/test/unit/server/api/endpoints/utils/serializers/output/images.test.js
+++ b/ghost/core/test/unit/server/api/endpoints/utils/serializers/output/images.test.js
@@ -1,0 +1,32 @@
+const assert = require('node:assert/strict');
+const config = require('../../../../../../../../core/shared/config');
+const imagesSerializer = require('../../../../../../../../core/server/api/endpoints/utils/serializers/output/images');
+
+describe('Images output serializer', function () {
+    describe('upload', function () {
+        it('converts a local relative path to an absolute URL', function () {
+            const siteUrl = config.getSiteUrl().replace(/\/$/, '');
+            const frame = {data: {ref: null}, response: null};
+            imagesSerializer.upload('/content/images/2026/03/photo.jpg', {}, frame);
+
+            assert.equal(frame.response.images[0].url, `${siteUrl}/content/images/2026/03/photo.jpg`);
+        });
+
+        it('passes through a CDN URL unchanged', function () {
+            const cdnUrl = 'https://storage.ghost.is/c/6f/a3/site/content/images/2026/03/photo.jpg';
+            const frame = {data: {ref: null}, response: null};
+            imagesSerializer.upload(cdnUrl, {}, frame);
+
+            assert.equal(frame.response.images[0].url, cdnUrl);
+        });
+
+        it('includes ref from frame data', function () {
+            const siteUrl = config.getSiteUrl().replace(/\/$/, '');
+            const frame = {data: {ref: 'img-ref-789'}, response: null};
+            imagesSerializer.upload('/content/images/2026/03/photo.jpg', {}, frame);
+
+            assert.equal(frame.response.images[0].url, `${siteUrl}/content/images/2026/03/photo.jpg`);
+            assert.equal(frame.response.images[0].ref, 'img-ref-789');
+        });
+    });
+});

--- a/ghost/core/test/unit/server/api/endpoints/utils/serializers/output/media.test.js
+++ b/ghost/core/test/unit/server/api/endpoints/utils/serializers/output/media.test.js
@@ -1,0 +1,59 @@
+const assert = require('node:assert/strict');
+const config = require('../../../../../../../../core/shared/config');
+const mediaSerializer = require('../../../../../../../../core/server/api/endpoints/utils/serializers/output/media');
+
+describe('Media output serializer', function () {
+    describe('upload', function () {
+        it('converts local relative paths to absolute URLs', function () {
+            const siteUrl = config.getSiteUrl().replace(/\/$/, '');
+            const frame = {data: {ref: null}, response: null};
+            mediaSerializer.upload({
+                filePath: '/content/media/2026/03/video.mp4',
+                thumbnailPath: '/content/media/2026/03/video_thumb.png'
+            }, {}, frame);
+
+            assert.equal(frame.response.media[0].url, `${siteUrl}/content/media/2026/03/video.mp4`);
+            assert.equal(frame.response.media[0].thumbnail_url, `${siteUrl}/content/media/2026/03/video_thumb.png`);
+        });
+
+        it('passes through CDN URLs unchanged', function () {
+            const cdnMedia = 'https://storage.ghost.is/c/6f/a3/site/content/media/2026/03/video.mp4';
+            const cdnThumb = 'https://storage.ghost.is/c/6f/a3/site/content/media/2026/03/video_thumb.png';
+            const frame = {data: {ref: null}, response: null};
+            mediaSerializer.upload({filePath: cdnMedia, thumbnailPath: cdnThumb}, {}, frame);
+
+            assert.equal(frame.response.media[0].url, cdnMedia);
+            assert.equal(frame.response.media[0].thumbnail_url, cdnThumb);
+        });
+
+        it('includes ref from frame data', function () {
+            const siteUrl = config.getSiteUrl().replace(/\/$/, '');
+            const frame = {data: {ref: 'media-ref-456'}, response: null};
+            mediaSerializer.upload({
+                filePath: '/content/media/2026/03/video.mp4',
+                thumbnailPath: null
+            }, {}, frame);
+
+            assert.equal(frame.response.media[0].url, `${siteUrl}/content/media/2026/03/video.mp4`);
+            assert.equal(frame.response.media[0].ref, 'media-ref-456');
+        });
+    });
+
+    describe('uploadThumbnail', function () {
+        it('converts a local relative path to an absolute URL', function () {
+            const siteUrl = config.getSiteUrl().replace(/\/$/, '');
+            const frame = {data: {ref: null}, response: null};
+            mediaSerializer.uploadThumbnail('/content/media/2026/03/video_thumb.png', {}, frame);
+
+            assert.equal(frame.response.media[0].url, `${siteUrl}/content/media/2026/03/video_thumb.png`);
+        });
+
+        it('passes through a CDN URL unchanged', function () {
+            const cdnUrl = 'https://storage.ghost.is/c/6f/a3/site/content/media/2026/03/video_thumb.png';
+            const frame = {data: {ref: null}, response: null};
+            mediaSerializer.uploadThumbnail(cdnUrl, {}, frame);
+
+            assert.equal(frame.response.media[0].url, cdnUrl);
+        });
+    });
+});

--- a/ghost/core/test/unit/server/api/endpoints/utils/serializers/output/settings.test.js
+++ b/ghost/core/test/unit/server/api/endpoints/utils/serializers/output/settings.test.js
@@ -1,0 +1,125 @@
+const assert = require('node:assert/strict');
+const sinon = require('sinon');
+
+const settingsSerializer = require('../../../../../../../../core/server/api/endpoints/utils/serializers/output/settings');
+
+describe('Settings output serializer', function () {
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    describe('icon rewrite (Admin API)', function () {
+        it('rewrites local icon path with /size/w256h256/', function () {
+            const models = [
+                {key: 'icon', value: '/content/images/2026/02/icon.png', group: 'site'},
+                {key: 'title', value: 'Test Blog', group: 'site'}
+            ];
+            const frame = {
+                apiType: 'admin',
+                options: {},
+                response: null
+            };
+
+            settingsSerializer.browse(models, {}, frame);
+
+            const icon = frame.response.settings.find(s => s.key === 'icon');
+            assert.equal(icon.value, '/content/images/size/w256h256/2026/02/icon.png');
+        });
+
+        it('rewrites CDN icon URL with /size/w256h256/', function () {
+            const models = [
+                {key: 'icon', value: 'https://storage.ghost.is/c/6f/a3/site/content/images/2026/02/icon.png', group: 'site'}
+            ];
+            const frame = {
+                apiType: 'admin',
+                options: {},
+                response: null
+            };
+
+            settingsSerializer.browse(models, {}, frame);
+
+            const icon = frame.response.settings.find(s => s.key === 'icon');
+            assert.equal(icon.value, 'https://storage.ghost.is/c/6f/a3/site/content/images/size/w256h256/2026/02/icon.png');
+        });
+
+        it('does not modify settings without icon', function () {
+            const models = [
+                {key: 'title', value: 'Test Blog', group: 'site'}
+            ];
+            const frame = {
+                apiType: 'admin',
+                options: {},
+                response: null
+            };
+
+            settingsSerializer.browse(models, {}, frame);
+
+            const title = frame.response.settings.find(s => s.key === 'title');
+            assert.equal(title.value, 'Test Blog');
+        });
+
+        it('does not modify null icon value', function () {
+            const models = [
+                {key: 'icon', value: null, group: 'site'}
+            ];
+            const frame = {
+                apiType: 'admin',
+                options: {},
+                response: null
+            };
+
+            settingsSerializer.browse(models, {}, frame);
+
+            const icon = frame.response.settings.find(s => s.key === 'icon');
+            assert.equal(icon.value, null);
+        });
+    });
+
+    describe('icon rewrite (Content API)', function () {
+        it('rewrites local icon path with /size/w256h256/', function () {
+            const models = {
+                icon: '/content/images/2026/02/icon.png',
+                title: 'Test Blog'
+            };
+            const frame = {
+                apiType: 'content',
+                options: {},
+                response: null
+            };
+
+            settingsSerializer.browse(models, {}, frame);
+
+            assert.equal(frame.response.settings.icon, '/content/images/size/w256h256/2026/02/icon.png');
+        });
+
+        it('rewrites CDN icon URL with /size/w256h256/', function () {
+            const models = {
+                icon: 'https://storage.ghost.is/c/6f/a3/site/content/images/2026/02/icon.png'
+            };
+            const frame = {
+                apiType: 'content',
+                options: {},
+                response: null
+            };
+
+            settingsSerializer.browse(models, {}, frame);
+
+            assert.equal(frame.response.settings.icon, 'https://storage.ghost.is/c/6f/a3/site/content/images/size/w256h256/2026/02/icon.png');
+        });
+
+        it('does not modify if no icon is present', function () {
+            const models = {
+                title: 'Test Blog'
+            };
+            const frame = {
+                apiType: 'content',
+                options: {},
+                response: null
+            };
+
+            settingsSerializer.browse(models, {}, frame);
+
+            assert.equal(frame.response.settings.icon, undefined);
+        });
+    });
+});

--- a/ghost/core/test/unit/server/data/importer/importers/content-file-importer.test.js
+++ b/ghost/core/test/unit/server/data/importer/importers/content-file-importer.test.js
@@ -81,4 +81,56 @@ describe('ContentFileImporter', function () {
         assert.equal(storageApi.save.args[0][0].name, 'best-memes.pdf');
         assert.equal(storageApi.save.args[0][0].newPath, '/content/files/best-memes.pdf');
     });
+
+    describe('doImport with CDN storage', function () {
+        it('stores CDN URL returned by save() in the result.stored field', async function () {
+            const images = [
+                {
+                    name: 'photo.png',
+                    path: '/tmp/photo.png',
+                    originalPath: 'images/photo.png',
+                    targetDir: '/test/content/images',
+                    newPath: '/content/images/photo.png'
+                }
+            ];
+            const storageApi = {
+                save: sinon.stub().resolves('https://storage.ghost.is/c/6f/a3/site/content/images/photo.png')
+            };
+            const imageImporter = new ContentFileImporter({
+                type: 'images',
+                store: storageApi
+            });
+
+            const result = await imageImporter.doImport(images);
+
+            sinon.assert.calledOnce(storageApi.save);
+            assert.equal(result[0].originalPath, 'images/photo.png');
+            assert.equal(result[0].newPath, '/content/images/photo.png');
+            assert.equal(result[0].stored, 'https://storage.ghost.is/c/6f/a3/site/content/images/photo.png');
+        });
+
+        it('stores relative path returned by save() in the result.stored field (local storage)', async function () {
+            const images = [
+                {
+                    name: 'photo.png',
+                    path: '/tmp/photo.png',
+                    originalPath: 'images/photo.png',
+                    targetDir: '/test/content/images',
+                    newPath: '/content/images/photo.png'
+                }
+            ];
+            const storageApi = {
+                save: sinon.stub().resolves('/content/images/photo.png')
+            };
+            const imageImporter = new ContentFileImporter({
+                type: 'images',
+                store: storageApi
+            });
+
+            const result = await imageImporter.doImport(images);
+
+            sinon.assert.calledOnce(storageApi.save);
+            assert.equal(result[0].stored, '/content/images/photo.png');
+        });
+    });
 });

--- a/ghost/core/test/unit/server/lib/image/blog-icon.test.js
+++ b/ghost/core/test/unit/server/lib/image/blog-icon.test.js
@@ -45,6 +45,45 @@ describe('lib/image: blog icon', function () {
             assert.deepEqual(blogIcon.getIconUrl(), [{relativeUrl: 'https://storage.ghost.is/c/6f/a3/site/content/images/size/w256h256/2026/02/my-icon.png'}, undefined]);
         });
 
+        it('CDN png blog icon with absolute: true', function () {
+            const blogIcon = new BlogIcon({config: {}, storageUtils: {}, urlUtils: {
+                urlFor: (key, boolean) => [key, boolean]
+            }, settingsCache: {
+                get: (key) => {
+                    if (key === 'icon') {
+                        return 'https://storage.ghost.is/c/6f/a3/site/content/images/2026/02/my-icon.png';
+                    }
+                }
+            }});
+            assert.deepEqual(blogIcon.getIconUrl({absolute: true}), [{relativeUrl: 'https://storage.ghost.is/c/6f/a3/site/content/images/size/w256h256/2026/02/my-icon.png'}, true]);
+        });
+
+        it('CDN svg blog icon gets format-converted to png', function () {
+            const blogIcon = new BlogIcon({config: {}, storageUtils: {}, urlUtils: {
+                urlFor: (key, boolean) => [key, boolean]
+            }, settingsCache: {
+                get: (key) => {
+                    if (key === 'icon') {
+                        return 'https://storage.ghost.is/c/6f/a3/site/content/images/2026/02/my-icon.svg';
+                    }
+                }
+            }});
+            assert.deepEqual(blogIcon.getIconUrl(), [{relativeUrl: 'https://storage.ghost.is/c/6f/a3/site/content/images/size/w256h256/format/png/2026/02/my-icon.svg'}, undefined]);
+        });
+
+        it('CDN ico blog icon is not resized', function () {
+            const blogIcon = new BlogIcon({config: {}, storageUtils: {}, urlUtils: {
+                urlFor: (key, boolean) => [key, boolean]
+            }, settingsCache: {
+                get: (key) => {
+                    if (key === 'icon') {
+                        return 'https://storage.ghost.is/c/6f/a3/site/content/images/2026/02/my-icon.ico';
+                    }
+                }
+            }});
+            assert.deepEqual(blogIcon.getIconUrl(), [{relativeUrl: 'https://storage.ghost.is/c/6f/a3/site/content/images/2026/02/my-icon.ico'}, undefined]);
+        });
+
         it('default ico blog icon', function () {
             const blogIcon = new BlogIcon({config: {}, storageUtils: {}, urlUtils: {
                 urlFor: key => key

--- a/ghost/core/test/unit/server/services/koenig/render-utils/srcset-attribute.test.js
+++ b/ghost/core/test/unit/server/services/koenig/render-utils/srcset-attribute.test.js
@@ -1,0 +1,148 @@
+const assert = require('node:assert/strict');
+const {getSrcsetAttribute} = require('../../../../../../core/server/services/koenig/render-utils/srcset-attribute');
+
+describe('services/koenig/render-utils/srcset-attribute', function () {
+    const defaultOptions = {
+        siteUrl: 'http://localhost:2368',
+        imageBaseUrl: '',
+        imageOptimization: {
+            srcsets: true,
+            contentImageSizes: {
+                w600: {width: 600},
+                w1000: {width: 1000},
+                w1600: {width: 1600},
+                w2400: {width: 2400}
+            }
+        },
+        canTransformImage: () => true
+    };
+
+    describe('local images', function () {
+        it('generates srcset for local content images', function () {
+            const result = getSrcsetAttribute({
+                src: '/content/images/2026/02/photo.jpg',
+                width: 2000,
+                options: defaultOptions
+            });
+
+            assert.ok(result);
+            assert.ok(result.includes('/content/images/size/w600/2026/02/photo.jpg 600w'));
+            assert.ok(result.includes('/content/images/size/w1000/2026/02/photo.jpg 1000w'));
+            assert.ok(result.includes('/content/images/size/w1600/2026/02/photo.jpg 1600w'));
+        });
+
+        it('generates srcset for absolute local content images', function () {
+            const result = getSrcsetAttribute({
+                src: 'http://localhost:2368/content/images/2026/02/photo.jpg',
+                width: 2000,
+                options: defaultOptions
+            });
+
+            assert.ok(result);
+            assert.ok(result.includes('http://localhost:2368/content/images/size/w600/2026/02/photo.jpg 600w'));
+        });
+
+        it('uses original src for matching width', function () {
+            const result = getSrcsetAttribute({
+                src: '/content/images/2026/02/photo.jpg',
+                width: 1000,
+                options: defaultOptions
+            });
+
+            assert.ok(result);
+            assert.ok(result.includes('/content/images/2026/02/photo.jpg 1000w'));
+            assert.ok(result.includes('/content/images/size/w600/2026/02/photo.jpg 600w'));
+            assert.ok(!result.includes('1600w'));
+        });
+    });
+
+    describe('CDN images', function () {
+        const cdnOptions = {
+            ...defaultOptions,
+            imageBaseUrl: 'https://cdn.example.com/c/uuid'
+        };
+
+        it('generates srcset for CDN content images', function () {
+            const result = getSrcsetAttribute({
+                src: 'https://cdn.example.com/c/uuid/content/images/2026/02/photo.jpg',
+                width: 2000,
+                options: cdnOptions
+            });
+
+            assert.ok(result);
+            assert.ok(result.includes('https://cdn.example.com/c/uuid/content/images/size/w600/2026/02/photo.jpg 600w'));
+            assert.ok(result.includes('https://cdn.example.com/c/uuid/content/images/size/w1000/2026/02/photo.jpg 1000w'));
+            assert.ok(result.includes('https://cdn.example.com/c/uuid/content/images/size/w1600/2026/02/photo.jpg 1600w'));
+        });
+
+        it('uses original CDN src for matching width', function () {
+            const result = getSrcsetAttribute({
+                src: 'https://cdn.example.com/c/uuid/content/images/2026/02/photo.jpg',
+                width: 1000,
+                options: cdnOptions
+            });
+
+            assert.ok(result);
+            assert.ok(result.includes('https://cdn.example.com/c/uuid/content/images/2026/02/photo.jpg 1000w'));
+            assert.ok(result.includes('https://cdn.example.com/c/uuid/content/images/size/w600/2026/02/photo.jpg 600w'));
+        });
+
+        it('does not generate srcset for external images', function () {
+            const result = getSrcsetAttribute({
+                src: 'https://external.com/images/photo.jpg',
+                width: 2000,
+                options: cdnOptions
+            });
+
+            assert.equal(result, undefined);
+        });
+
+        it('does not generate srcset for CDN image without imageBaseUrl', function () {
+            const result = getSrcsetAttribute({
+                src: 'https://cdn.example.com/c/uuid/content/images/2026/02/photo.jpg',
+                width: 2000,
+                options: defaultOptions
+            });
+
+            assert.equal(result, undefined);
+        });
+    });
+
+    describe('disabled or missing options', function () {
+        it('returns undefined when srcsets is false', function () {
+            const result = getSrcsetAttribute({
+                src: '/content/images/2026/02/photo.jpg',
+                width: 2000,
+                options: {
+                    ...defaultOptions,
+                    imageOptimization: {srcsets: false}
+                }
+            });
+
+            assert.equal(result, undefined);
+        });
+
+        it('returns undefined when width is 0', function () {
+            const result = getSrcsetAttribute({
+                src: '/content/images/2026/02/photo.jpg',
+                width: 0,
+                options: defaultOptions
+            });
+
+            assert.equal(result, undefined);
+        });
+
+        it('returns undefined when canTransformImage returns false for content image', function () {
+            const result = getSrcsetAttribute({
+                src: '/content/images/2026/02/photo.jpg',
+                width: 2000,
+                options: {
+                    ...defaultOptions,
+                    canTransformImage: () => false
+                }
+            });
+
+            assert.equal(result, undefined);
+        });
+    });
+});

--- a/ghost/core/test/unit/server/services/oembed/oembed-service.test.js
+++ b/ghost/core/test/unit/server/services/oembed/oembed-service.test.js
@@ -296,6 +296,61 @@ describe('oembed-service', function () {
             assert.equal(storedUrl, '/content/images/icon/favicon.ico');
             assert.equal(saveRaw.firstCall.args[1], 'icon/favicon.ico');
         });
+
+        it('throws when storage lacks saveRaw', async function () {
+            const service = new OembedService({
+                config: {
+                    getContentPath() {
+                        return '/tmp/content/images';
+                    }
+                },
+                storage: {
+                    getStorage() {
+                        return {
+                            getSanitizedFileName: sinon.stub().returns('sample'),
+                            generateUnique: sinon.stub().resolves('/tmp/sample.png')
+                        };
+                    }
+                },
+                externalRequest() {
+                    return {
+                        buffer: async () => Buffer.from('img-bytes')
+                    };
+                }
+            });
+
+            await assert.rejects(
+                () => service.processImageFromUrl('https://example.com/sample.png', 'thumbnail'),
+                {name: 'TypeError'}
+            );
+        });
+
+        it('throws when external request fails', async function () {
+            const service = new OembedService({
+                config: {
+                    getContentPath() {
+                        return '/tmp/content/images';
+                    }
+                },
+                storage: {
+                    getStorage() {
+                        return {
+                            getSanitizedFileName: sinon.stub().returns('sample'),
+                            generateUnique: sinon.stub().resolves('/tmp/sample.png'),
+                            saveRaw: sinon.stub().resolves('/stored')
+                        };
+                    }
+                },
+                externalRequest() {
+                    throw new Error('Network error');
+                }
+            });
+
+            await assert.rejects(
+                () => service.processImageFromUrl('https://example.com/broken.png', 'thumbnail'),
+                {message: 'Network error'}
+            );
+        });
     });
 
     describe('metascraper inherits externalRequest hooks', function () {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/HKG-1623/

- Added CDN png, svg format conversion, ico passthrough, and absolute URL tests for blog-icon to verify getIconUrl handles CDN-hosted icons correctly
- Created settings output serializer unit tests for icon rewrite with both local and CDN URLs across admin and content API paths
- Added CDN URL passthrough tests for og-image, twitter-image, and cover-image meta helpers to verify CDN URLs flow through fallback chains correctly
- Created srcset-attribute unit tests to verify srcset generation works for CDN images when imageBaseUrl is configured and skips external images
- Added oEmbed processImageFromUrl tests for icon storage, missing saveRaw, and failed external request error handling

These tests are added to validate CDN/S3 image migration behavior across all image surfaces ahead of the CDN image rollout.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that don’t alter production behavior, mainly increasing coverage around CDN URL handling and error cases.
> 
> **Overview**
> Adds extensive unit test coverage to ensure **CDN-hosted image/file URLs are preserved and correctly rewritten** across frontend meta helpers and backend serializers.
> 
> New tests cover CDN passthrough and fallback behavior for `getCoverImage`, `getOgImage`, and `getTwitterImage`; URL rewriting/`ref` handling in `images`, `files`, and `media` output serializers; icon resizing/format rules in `settings` and `blog-icon`; and `srcset` generation behavior for CDN vs external images. Also adds `OembedService.processImageFromUrl` tests for CDN vs local storage returns plus error paths (missing `saveRaw`, request failures).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b2890649537b88bcba1148f14e2a16a68e80d67. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->