### PR TITLE
Updated cancel_link helper default label to 'Resume subscription'

### DIFF
--- a/ghost/core/core/frontend/helpers/cancel_link.js
+++ b/ghost/core/core/frontend/helpers/cancel_link.js
@@ -4,7 +4,7 @@
 // Should be used inside of a subscription context, e.g.: `{{#foreach @member.subscriptions}} {{cancel_link}} {{/foreach}}`
 // Outputs cancel/renew links to manage subscription renewal after the subscription period ends.
 //
-// Defaults to class="cancel-subscription-link" errorClass="cancel-subscription-error" cancelLabel="Cancel subscription" continueLabel="Continue subscription"
+// Defaults to class="cancel-subscription-link" errorClass="cancel-subscription-error" cancelLabel="Cancel subscription" continueLabel="Resume subscription"
 const {labs} = require('../services/proxy');
 const {templates} = require('../services/handlebars');
 
@@ -28,7 +28,7 @@ function cancel_link(options) { // eslint-disable-line camelcase
         class: truncateOptions.class || 'gh-subscription-cancel',
         errorClass: truncateOptions.errorClass || 'gh-error gh-error-subscription-cancel',
         cancelLabel: truncateOptions.cancelLabel || 'Cancel subscription',
-        continueLabel: truncateOptions.continueLabel || 'Continue subscription'
+        continueLabel: truncateOptions.continueLabel || 'Resume subscription'
     };
 
     return templates.execute('cancel_link', data);

--- a/ghost/core/test/unit/frontend/helpers/cancel-link.test.js
+++ b/ghost/core/test/unit/frontend/helpers/cancel-link.test.js
@@ -28,7 +28,7 @@ describe('{{cancel_link}} helper', function () {
     const defaultLinkClass = /class="gh-subscription-cancel"/;
     const defaultErrorElementClass = /class="gh-error gh-error-subscription-cancel"/;
     const defaultCancelLinkText = /Cancel subscription/;
-    const defaultContinueLinkText = /Continue subscription/;
+    const defaultContinueLinkText = /Resume subscription/;
 
     it('should throw if subscription data is incorrect', function () {
         const runHelper = function (data) {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3417/refresh-custom-cancellation-button-state-without-manual-page-reload

The `{{cancel_link}}` theme helper's default `continueLabel` was "Continue subscription", while Portal was updated to use "Resume subscription" in #26679.                                                         
                  
  - Updated the default `continueLabel` from "Continue subscription" to "Resume subscription"
  - Updated the corresponding unit test