### PR TITLE
🐛 Refreshed cancel button state after retention offer flow

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.65.4",
+  "version": "2.65.5",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/portal/src/actions.js
+++ b/apps/portal/src/actions.js
@@ -21,6 +21,7 @@ function togglePopup({state}) {
 function openPopup({data}) {
     return {
         showPopup: true,
+        reloadOnPopupClose: false,
         page: data.page,
         ...(data.pageQuery ? {pageQuery: data.pageQuery} : {}),
         ...(data.pageData ? {pageData: data.pageData} : {})
@@ -268,7 +269,8 @@ async function cancelSubscription({data, state, api}) {
         return {
             action,
             page: 'accountHome',
-            member: member
+            member: member,
+            reloadOnPopupClose: true
         };
     } catch (e) {
         return {
@@ -319,6 +321,7 @@ async function applyOffer({data, state, api}) {
             page: 'accountHome',
             member: member,
             offers: [],
+            reloadOnPopupClose: true,
             popupNotification: createPopupNotification({
                 type: 'applyOffer:success', autoHide: true, closeable: true, state, status: 'success',
                 message: 'Offer applied successfully!'

--- a/apps/portal/src/actions.js
+++ b/apps/portal/src/actions.js
@@ -294,7 +294,8 @@ async function continueSubscription({data, state, api}) {
         return {
             action,
             page: 'accountHome',
-            member: member
+            member: member,
+            reloadOnPopupClose: true
         };
     } catch (e) {
         return {

--- a/apps/portal/src/app.js
+++ b/apps/portal/src/app.js
@@ -95,6 +95,9 @@ export default class App extends React.Component {
                     } else {
                         window.document.body.style.marginRight = this.bodyMargin;
                     }
+                    if (this.state.reloadOnPopupClose) {
+                        window.location.reload();
+                    }
                 }
             } catch (e) {
                 /** Ignore any errors for scroll handling */

--- a/apps/portal/test/actions.test.ts
+++ b/apps/portal/test/actions.test.ts
@@ -88,6 +88,45 @@ describe('startSigninOTCFromCustomForm action', () => {
     });
 });
 
+describe('continueSubscription action', () => {
+    test('returns reloadOnPopupClose on success', async () => {
+        const mockApi = {
+            member: {
+                updateSubscription: vi.fn(() => Promise.resolve()),
+                sessionData: vi.fn(() => Promise.resolve({name: 'Test', email: 'test@example.com'}))
+            }
+        };
+
+        const result = await ActionHandler({
+            action: 'continueSubscription',
+            data: {subscriptionId: 'sub_123'},
+            state: {},
+            api: mockApi
+        });
+
+        expect(result.reloadOnPopupClose).toBe(true);
+        expect(result.action).toBe('continueSubscription:success');
+    });
+
+    test('does not return reloadOnPopupClose on failure', async () => {
+        const mockApi = {
+            member: {
+                updateSubscription: vi.fn(() => Promise.reject(new Error('API error')))
+            }
+        };
+
+        const result = await ActionHandler({
+            action: 'continueSubscription',
+            data: {subscriptionId: 'sub_123'},
+            state: {},
+            api: mockApi
+        });
+
+        expect(result.reloadOnPopupClose).toBeUndefined();
+        expect(result.action).toBe('continueSubscription:failed');
+    });
+});
+
 describe('cancelSubscription action', () => {
     test('returns reloadOnPopupClose on success', async () => {
         const mockApi = {

--- a/apps/portal/test/actions.test.ts
+++ b/apps/portal/test/actions.test.ts
@@ -88,6 +88,84 @@ describe('startSigninOTCFromCustomForm action', () => {
     });
 });
 
+describe('cancelSubscription action', () => {
+    test('returns reloadOnPopupClose on success', async () => {
+        const mockApi = {
+            member: {
+                updateSubscription: vi.fn(() => Promise.resolve()),
+                sessionData: vi.fn(() => Promise.resolve({name: 'Test', email: 'test@example.com'}))
+            }
+        };
+
+        const result = await ActionHandler({
+            action: 'cancelSubscription',
+            data: {subscriptionId: 'sub_123', cancellationReason: 'Too expensive'},
+            state: {},
+            api: mockApi
+        });
+
+        expect(result.reloadOnPopupClose).toBe(true);
+        expect(result.action).toBe('cancelSubscription:success');
+    });
+
+    test('does not return reloadOnPopupClose on failure', async () => {
+        const mockApi = {
+            member: {
+                updateSubscription: vi.fn(() => Promise.reject(new Error('API error')))
+            }
+        };
+
+        const result = await ActionHandler({
+            action: 'cancelSubscription',
+            data: {subscriptionId: 'sub_123'},
+            state: {},
+            api: mockApi
+        });
+
+        expect(result.reloadOnPopupClose).toBeUndefined();
+        expect(result.action).toBe('cancelSubscription:failed');
+    });
+});
+
+describe('applyOffer action', () => {
+    test('returns reloadOnPopupClose on success', async () => {
+        const mockApi = {
+            member: {
+                applyOffer: vi.fn(() => Promise.resolve()),
+                sessionData: vi.fn(() => Promise.resolve({name: 'Test', email: 'test@example.com'}))
+            }
+        };
+
+        const result = await ActionHandler({
+            action: 'applyOffer',
+            data: {offerId: 'offer_123', subscriptionId: 'sub_123'},
+            state: {},
+            api: mockApi
+        });
+
+        expect(result.reloadOnPopupClose).toBe(true);
+        expect(result.action).toBe('applyOffer:success');
+    });
+
+    test('does not return reloadOnPopupClose on failure', async () => {
+        const mockApi = {
+            member: {
+                applyOffer: vi.fn(() => Promise.reject(new Error('API error')))
+            }
+        };
+
+        const result = await ActionHandler({
+            action: 'applyOffer',
+            data: {offerId: 'offer_123', subscriptionId: 'sub_123'},
+            state: {},
+            api: mockApi
+        });
+
+        expect(result.reloadOnPopupClose).toBeUndefined();
+        expect(result.action).toBe('applyOffer:failed');
+    });
+});
+
 describe('verifyOTC action', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let originalLocation: any;

--- a/apps/portal/test/app.test.js
+++ b/apps/portal/test/app.test.js
@@ -80,6 +80,40 @@ describe('App', function () {
         });
     });
 
+    test('reloads page when popup closes with reloadOnPopupClose flag', () => {
+        const app = new App({siteUrl: 'http://example.com'});
+
+        window.location.reload = vi.fn();
+
+        app.state = {...app.state, showPopup: false, reloadOnPopupClose: true};
+        app.componentDidUpdate({}, {showPopup: true});
+
+        expect(window.location.reload).toHaveBeenCalledTimes(1);
+    });
+
+    test('does not reload when popup closes without reloadOnPopupClose flag', () => {
+        const app = new App({siteUrl: 'http://example.com'});
+
+        window.location.reload = vi.fn();
+
+        app.state = {...app.state, showPopup: false};
+        app.componentDidUpdate({}, {showPopup: true});
+
+        expect(window.location.reload).not.toHaveBeenCalled();
+    });
+
+    test('does not reload when reloadOnPopupClose is false', () => {
+        const app = new App({siteUrl: 'http://example.com'});
+
+        window.location.reload = vi.fn();
+
+        // Set reloadOnPopupClose to false explicitly and close the popup
+        app.state = {...app.state, showPopup: false, reloadOnPopupClose: false};
+        app.componentDidUpdate({}, {showPopup: true});
+
+        expect(window.location.reload).not.toHaveBeenCalled();
+    });
+
     test('parses retention offer preview query data into account cancellation flow', () => {
         const app = new App({siteUrl: 'http://example.com'});
         const previewData = app.fetchOfferQueryStrData('redemption_type=retention&display_title=Before%2520you%2520go&display_description=Please%2520stay&type=percent&amount=100&duration=repeating&duration_in_months=2&cadence=month&tier_id=product_123&enabled=false');


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3417

When a member cancelled via the retention offer path (Portal popup), the theme page's cancel button didn't update because no page reload occurred. The `cancelSubscription` and `applyOffer` actions now return `reloadOnPopupClose: true`, and the App component reloads the page when the popup closes with that flag set. The flag is cleared on each `openPopup` to prevent stale reloads.