### PR TITLE
Increased retention offer code entropy from 16-bit to 32-bit

### DIFF
--- a/apps/admin-x-settings/src/components/settings/growth/offers/edit-retention-offer-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/offers/edit-retention-offer-modal.tsx
@@ -451,7 +451,7 @@ const EditRetentionOfferModal: React.FC<{id: string}> = ({id}) => {
             const shouldCreateInactiveDraft = !formState.enabled && !editableRetentionOffer && hasFormChangesFromDefault(formState, defaultState);
 
             const createRetentionOffer = async (status: 'active' | 'archived') => {
-                const hash = crypto.getRandomValues(new Uint16Array(1))[0].toString(16).padStart(4, '0');
+                const hash = crypto.getRandomValues(new Uint32Array(1))[0].toString(16).padStart(8, '0');
 
                 let offerDesc: string;
                 const isFreeMonths = formTerms.amount === 100 && formTerms.duration === 'repeating';

--- a/apps/admin-x-settings/test/acceptance/membership/offers.test.ts
+++ b/apps/admin-x-settings/test/acceptance/membership/offers.test.ts
@@ -689,8 +689,8 @@ test.describe('Offers', () => {
             });
 
             const createdOffer = (lastApiRequests.addOffer?.body as {offers: Array<{name: string; code: string}>})?.offers?.[0];
-            expect(createdOffer?.name).toMatch(/^Retention 35% off forever \([a-f0-9]{4}\)$/);
-            expect(createdOffer?.code).toMatch(/^[a-f0-9]{4}$/);
+            expect(createdOffer?.name).toMatch(/^Retention 35% off forever \([a-f0-9]{8}\)$/);
+            expect(createdOffer?.code).toMatch(/^[a-f0-9]{8}$/);
         });
 
         test('Edits existing retention offer when only display fields change', async ({page}) => {


### PR DESCRIPTION
no issue

- Retention offer codes now use `Uint32Array` instead of `Uint16Array`, generating 8-character hex codes instead of 4-character ones
- Increases the code space from ~65K to ~4.3 billion possible values