### PR TITLE
Increased retention offer code entropy from 16-bit to 32-bit

### DIFF
--- a/apps/admin-x-settings/src/components/settings/growth/offers/edit-retention-offer-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/offers/edit-retention-offer-modal.tsx
@@ -5,7 +5,7 @@ import {type ErrorMessages, useForm} from '@tryghost/admin-x-framework/hooks';
 import {Form, PreviewModalContent, Select, type SelectOption, TextArea, TextField, Toggle, showToast} from '@tryghost/admin-x-design-system';
 import {JSONError} from '@tryghost/admin-x-framework/errors';
 import {type Offer, useAddOffer, useBrowseOffers, useEditOffer, useInvalidateOffers} from '@tryghost/admin-x-framework/api/offers';
-import {createOfferRedemptionsFilterUrl, formatOfferTimestamp} from './offer-helpers';
+import {createOfferRedemptionsFilterUrl, formatOfferTimestamp, generateRetentionOfferName} from './offer-helpers';
 import {getOfferPortalPreviewUrl, type offerPortalPreviewUrlTypes} from '../../../../utils/get-offers-portal-preview-url';
 import {getPaidActiveTiers, useBrowseTiers} from '@tryghost/admin-x-framework/api/tiers';
 import {useEffect, useMemo, useState} from 'react';
@@ -35,6 +35,8 @@ const durationOptions: SelectOption[] = [
 ];
 
 const MAX_DISPLAY_TEXT_LENGTH = 191;
+const MAX_RETENTION_OFFER_MONTHS = 99;
+const RETENTION_MONTHS_ERROR_MESSAGE = `Enter a whole number of months between 1 and ${MAX_RETENTION_OFFER_MONTHS}.`;
 
 type RetentionOfferTerms = {
     type: 'percent';
@@ -172,7 +174,7 @@ const getTermsSignature = (terms: RetentionOfferTerms | null): string => {
 };
 
 const isValidMonthDuration = (value: number): boolean => {
-    return Number.isInteger(value) && value > 0;
+    return Number.isInteger(value) && value > 0 && value <= MAX_RETENTION_OFFER_MONTHS;
 };
 
 const hasFormChangesFromDefault = (formState: RetentionOfferFormState, defaultState: RetentionOfferFormState): boolean => {
@@ -198,6 +200,7 @@ const RetentionOfferSidebar: React.FC<{
     const availableDurationOptions = cadence === 'yearly'
         ? durationOptions.filter(option => option.value !== 'repeating')
         : durationOptions;
+
     return (
         <div className='flex grow flex-col pt-2'>
             <Form className='grow'>
@@ -451,27 +454,11 @@ const EditRetentionOfferModal: React.FC<{id: string}> = ({id}) => {
             const shouldCreateInactiveDraft = !formState.enabled && !editableRetentionOffer && hasFormChangesFromDefault(formState, defaultState);
 
             const createRetentionOffer = async (status: 'active' | 'archived') => {
-                const hash = crypto.getRandomValues(new Uint16Array(1))[0].toString(16).padStart(4, '0');
-
-                let offerDesc: string;
-                const isFreeMonths = formTerms.amount === 100 && formTerms.duration === 'repeating';
-                if (isFreeMonths) {
-                    const monthText = formTerms.durationInMonths === 1 ? 'free month' : 'free months';
-                    offerDesc = `${formTerms.durationInMonths} ${monthText}`;
-                } else {
-                    let durationText: string;
-                    if (formTerms.duration === 'once') {
-                        durationText = 'next payment';
-                    } else if (formTerms.duration === 'repeating') {
-                        durationText = `for ${formTerms.durationInMonths} ${formTerms.durationInMonths === 1 ? 'month' : 'months'}`;
-                    } else {
-                        durationText = 'forever';
-                    }
-                    offerDesc = `${formTerms.amount}% off ${durationText}`;
-                }
+                const hash = crypto.getRandomValues(new Uint32Array(1))[0].toString(16).padStart(8, '0');
+                const offerName = generateRetentionOfferName(formTerms, hash);
 
                 await addOffer({
-                    name: `Retention ${offerDesc} (${hash})`,
+                    name: offerName,
                     code: hash,
                     display_title: displayTitle,
                     display_description: displayDescription,
@@ -545,13 +532,13 @@ const EditRetentionOfferModal: React.FC<{id: string}> = ({id}) => {
                 }
 
                 if (formState.duration === 'repeating' && !isValidMonthDuration(formState.durationInMonths)) {
-                    newErrors.durationInMonths = 'Enter a whole number of months (1 or more).';
+                    newErrors.durationInMonths = RETENTION_MONTHS_ERROR_MESSAGE;
                 }
             }
 
             if (formState.type === 'free_months') {
                 if (!isValidMonthDuration(formState.freeMonths)) {
-                    newErrors.amount = 'Enter a whole number of free months (1 or more).';
+                    newErrors.amount = RETENTION_MONTHS_ERROR_MESSAGE;
                 }
             }
 

--- a/apps/admin-x-settings/src/components/settings/growth/offers/offer-helpers.ts
+++ b/apps/admin-x-settings/src/components/settings/growth/offers/offer-helpers.ts
@@ -1,3 +1,5 @@
+const MAX_RETENTION_OFFER_NAME_LENGTH = 40;
+
 export const formatOfferTimestamp = (timestamp: string): string => {
     const date = new Date(timestamp);
     return date.toLocaleDateString('default', {
@@ -15,4 +17,48 @@ export const createOfferRedemptionsFilterUrl = (offerIds: string[]): string => {
 
 export const createOfferRedemptionFilterUrl = (offerId: string): string => {
     return createOfferRedemptionsFilterUrl([offerId]);
+};
+
+const isFreeMonthsRetentionOffer = ({amount, duration}: {amount: number; duration: string}): boolean => {
+    return amount === 100 && duration === 'repeating';
+};
+
+const buildRetentionOfferName = (description: string, hash: string): string => {
+    return `Retention ${description} (${hash})`;
+};
+
+const getOfferDescription = ({amount, duration, durationInMonths}: {amount: number; duration: string; durationInMonths: number}): string => {
+    if (isFreeMonthsRetentionOffer({amount, duration})) {
+        const monthLabel = durationInMonths === 1 ? 'month' : 'months';
+        return `${durationInMonths} ${monthLabel} free`;
+    }
+
+    if (duration === 'once') {
+        return `${amount}% off once`;
+    }
+
+    if (duration === 'repeating') {
+        return `${amount}% off for ${durationInMonths} mo`;
+    }
+
+    return `${amount}% off forever`;
+};
+
+export const generateRetentionOfferName = (input: {amount: number; duration: string; durationInMonths: number}, hash: string): string => {
+    const normalizedHash = hash.trim();
+    const description = getOfferDescription(input);
+    const name = buildRetentionOfferName(description, normalizedHash);
+
+    if (name.length <= MAX_RETENTION_OFFER_NAME_LENGTH) {
+        return name;
+    }
+
+    const excessLength = name.length - MAX_RETENTION_OFFER_NAME_LENGTH;
+    const truncatedHashLength = Math.max(3, normalizedHash.length - excessLength);
+
+    return buildRetentionOfferName(description, normalizedHash.slice(0, truncatedHashLength));
+};
+
+export {
+    MAX_RETENTION_OFFER_NAME_LENGTH
 };

--- a/apps/admin-x-settings/test/acceptance/membership/offers.test.ts
+++ b/apps/admin-x-settings/test/acceptance/membership/offers.test.ts
@@ -546,12 +546,18 @@ test.describe('Offers', () => {
 
             await retentionModal.getByTestId('duration-months-input').fill('1.5');
             await saveButton.click();
-            await expect(retentionModal.getByText('Enter a whole number of months (1 or more).')).toBeVisible();
+            await expect(retentionModal.getByText('Enter a whole number of months between 1 and 99.')).toBeVisible();
+
+            await retentionModal.getByTestId('duration-months-input').fill('1000');
+            await expect(retentionModal.getByText('Enter a whole number of months between 1 and 99.')).toBeVisible();
 
             await retentionModal.getByRole('button', {name: /Free month\(s\)/}).click();
             await retentionModal.getByLabel('Free months').fill('0');
             await saveButton.click();
-            await expect(retentionModal.getByText('Enter a whole number of free months (1 or more).')).toBeVisible();
+            await expect(retentionModal.getByText('Enter a whole number of months between 1 and 99.')).toBeVisible();
+
+            await retentionModal.getByLabel('Free months').fill('1000');
+            await expect(retentionModal.getByText('Enter a whole number of months between 1 and 99.')).toBeVisible();
             await expect(saveButton).toBeEnabled();
         });
 
@@ -689,8 +695,8 @@ test.describe('Offers', () => {
             });
 
             const createdOffer = (lastApiRequests.addOffer?.body as {offers: Array<{name: string; code: string}>})?.offers?.[0];
-            expect(createdOffer?.name).toMatch(/^Retention 35% off forever \([a-f0-9]{4}\)$/);
-            expect(createdOffer?.code).toMatch(/^[a-f0-9]{4}$/);
+            expect(createdOffer?.name).toMatch(/^Retention 35% off forever \([a-f0-9]{8}\)$/);
+            expect(createdOffer?.code).toMatch(/^[a-f0-9]{8}$/);
         });
 
         test('Edits existing retention offer when only display fields change', async ({page}) => {

--- a/apps/admin-x-settings/test/unit/components/settings/growth/offers/offer-helpers.test.ts
+++ b/apps/admin-x-settings/test/unit/components/settings/growth/offers/offer-helpers.test.ts
@@ -1,0 +1,67 @@
+import * as assert from 'assert/strict';
+import {MAX_RETENTION_OFFER_NAME_LENGTH, generateRetentionOfferName} from '@src/components/settings/growth/offers/offer-helpers';
+
+describe('generateRetentionOfferName', function () {
+    it('keeps the full 8-character hash when the preferred wording fits', function () {
+        const name = generateRetentionOfferName({
+            amount: 35,
+            duration: 'forever',
+            durationInMonths: 0
+        }, 'deadbeef');
+
+        assert.equal(name, 'Retention 35% off forever (deadbeef)');
+    });
+
+    it('handles once offers', function () {
+        const name = generateRetentionOfferName({
+            amount: 10,
+            duration: 'once',
+            durationInMonths: 0
+        }, 'deadbeef');
+
+        assert.equal(name, 'Retention 10% off once (deadbeef)');
+    });
+
+    it('handles repeating offers', function () {
+        const name = generateRetentionOfferName({
+            amount: 25,
+            duration: 'repeating',
+            durationInMonths: 2
+        }, 'deadbeef');
+
+        assert.equal(name, 'Retention 25% off for 2 mo (deadbeef)');
+    });
+
+    it('handles free months offers', function () {
+        const name = generateRetentionOfferName({
+            amount: 100,
+            duration: 'repeating',
+            durationInMonths: 3
+        }, 'deadbeef');
+
+        assert.equal(name, 'Retention 3 months free (deadbeef)');
+    });
+
+    it('keeps the full hash at the maximum validated month count', function () {
+        const name = generateRetentionOfferName({
+            amount: 99,
+            duration: 'repeating',
+            durationInMonths: 99
+        }, 'deadbeef');
+
+        assert.equal(name, 'Retention 99% off for 99 mo (deadbeef)');
+        assert.equal(name.length <= MAX_RETENTION_OFFER_NAME_LENGTH, true);
+        assert.equal(name.endsWith('(deadbeef)'), true);
+    });
+
+    it('truncates the hash when the full name would exceed 40 characters', function () {
+        const name = generateRetentionOfferName({
+            amount: 99,
+            duration: 'repeating',
+            durationInMonths: 99
+        }, 'deadbeefcafebabe');
+
+        assert.equal(name, 'Retention 99% off for 99 mo (deadbeefca)');
+        assert.equal(name.length, MAX_RETENTION_OFFER_NAME_LENGTH);
+    });
+});


### PR DESCRIPTION
closes https://linear.app/ghost/issue/BER-3422/increase-retention-code-entropy

- retention offer codes now use Uint32Array instead of Uint16Array, generating 8-character hex codes instead of 4-character ones, increasing the code space from ~65K to ~4.3 billion possible values
- also extracted the offer name generation logic and added unit tests, to make sure we stay under the 40-char max. limit imposed by Stripe on coupon names


---------

Co-authored-by: Kevin Ansfield <kevin@ghost.org>
