### PR TITLE
Fixed repeating offers end date anchor

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.65.5",
+  "version": "2.65.6",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/portal/src/components/pages/AccountHomePage/components/paid-account-actions.js
+++ b/apps/portal/src/components/pages/AccountHomePage/components/paid-account-actions.js
@@ -1,5 +1,5 @@
 import AppContext from '../../../../app-context';
-import {addMonths, getCompExpiry, getMemberSubscription, getMemberTierName, hasMultipleProductsFeature, hasOnlyFreePlan, isComplimentaryMember, isPaidMember, subscriptionHasFreeTrial} from '../../../../utils/helpers';
+import {getCompExpiry, getMemberSubscription, getMemberTierName, hasMultipleProductsFeature, hasOnlyFreePlan, isComplimentaryMember, isPaidMember, subscriptionHasFreeTrial} from '../../../../utils/helpers';
 import {getDateString} from '../../../../utils/date-time';
 import {ReactComponent as LoaderIcon} from '../../../../images/icons/loader.svg';
 import {ReactComponent as OfferTagIcon} from '../../../../images/icons/offer-tag.svg';
@@ -234,12 +234,8 @@ function getOfferLabel({nextPayment, currentPeriodEnd}) {
     let durationLabel = '';
     if (discount.duration === 'forever') {
         durationLabel = t('Forever');
-    } else if (discount.duration === 'repeating' && currentPeriodEnd) {
-        // Stripe discount dates are anchored to redemption time, not billing cycle, so we can't use discount.end here
-        const offerEndDate = addMonths(currentPeriodEnd, discount.duration_in_months - 1);
-        if (offerEndDate) {
-            durationLabel = t('Ends {offerEndDate}', {offerEndDate: getDateString(offerEndDate)});
-        }
+    } else if (discount.duration === 'repeating' && discount.end) {
+        durationLabel = t('Ends {offerEndDate}', {offerEndDate: getDateString(discount.end)});
     } else if (discount.duration === 'once' && currentPeriodEnd) {
         // By design, "once" offers don't have a discount end in Stripe. They expire at the end of the current billing period.
         durationLabel = t('Ends {offerEndDate}', {offerEndDate: getDateString(currentPeriodEnd)});

--- a/apps/portal/test/unit/components/pages/AccountHomePage/paid-account-actions.test.js
+++ b/apps/portal/test/unit/components/pages/AccountHomePage/paid-account-actions.test.js
@@ -242,7 +242,7 @@ describe('PaidAccountActions', () => {
             const site = getSiteData({products, portalProducts: products.map(p => p.id)});
 
             const currentPeriodEnd = new Date('2099-04-03T12:00:00.000Z');
-            const discountEnd = new Date('2099-05-05T12:00:00.000Z');
+            const discountEnd = new Date('2099-05-03T12:00:00.000Z');
 
             const member = getMemberData({
                 paid: true,
@@ -286,14 +286,13 @@ describe('PaidAccountActions', () => {
             expect(queryByText(/\$4\.00\/month/)).toBeInTheDocument();
             expect(queryByText(/Ends/)).toBeInTheDocument();
             expect(queryByText('$4.00/month — Ends 3 May 2099')).toBeInTheDocument();
-            expect(queryByText('$4.00/month — Ends 5 May 2099')).not.toBeInTheDocument();
         });
 
         test('displays $0.00/month - Ends {date} for free months offers', () => {
             const products = getProductsData({numOfProducts: 1});
             const site = getSiteData({products, portalProducts: products.map(p => p.id)});
 
-            const discountEnd = new Date('2099-02-01T12:00:00.000Z');
+            const discountEnd = new Date('2099-01-03T12:00:00.000Z');
             const currentPeriodEnd = new Date('2099-01-03T12:00:00.000Z');
 
             const member = getMemberData({
@@ -335,7 +334,6 @@ describe('PaidAccountActions', () => {
             expect(queryByText('$5.00/month')).toHaveClass('gh-portal-account-old-price');
             expect(queryByTestId('offer-label')).toBeInTheDocument();
             expect(queryByText('$0.00/month — Ends 3 Jan 2099')).toBeInTheDocument();
-            expect(queryByText('$0.00/month — Ends 1 Feb 2099')).not.toBeInTheDocument();
         });
 
         test('displays discounted price with "Ends {date}" for once offers', () => {

--- a/ghost/core/core/server/services/members/members-api/utils/get-discount-window.js
+++ b/ghost/core/core/server/services/members/members-api/utils/get-discount-window.js
@@ -1,3 +1,43 @@
+function getLastDayOfMonth(year, month) {
+    return new Date(Date.UTC(year, month + 1, 0)).getUTCDate();
+}
+
+function isLastDayOfMonth(date) {
+    return date.getUTCDate() === getLastDayOfMonth(date.getUTCFullYear(), date.getUTCMonth());
+}
+
+function getAnchoredBillingDate(anchorDate, monthOffset) {
+    const targetMonthIndex = anchorDate.getUTCMonth() + monthOffset;
+    const targetYear = anchorDate.getUTCFullYear() + Math.floor(targetMonthIndex / 12);
+    const targetMonth = ((targetMonthIndex % 12) + 12) % 12;
+    const targetLastDay = getLastDayOfMonth(targetYear, targetMonth);
+    const targetDay = isLastDayOfMonth(anchorDate) ? targetLastDay : Math.min(anchorDate.getUTCDate(), targetLastDay);
+
+    return new Date(Date.UTC(
+        targetYear,
+        targetMonth,
+        targetDay,
+        anchorDate.getUTCHours(),
+        anchorDate.getUTCMinutes(),
+        anchorDate.getUTCSeconds(),
+        anchorDate.getUTCMilliseconds()
+    ));
+}
+
+function getLastDiscountedPayment(nextBillingDate, discountEnd) {
+    const monthOffset =
+        ((discountEnd.getUTCFullYear() - nextBillingDate.getUTCFullYear()) * 12) +
+        (discountEnd.getUTCMonth() - nextBillingDate.getUTCMonth());
+
+    let lastDiscountedBillingDate = getAnchoredBillingDate(nextBillingDate, monthOffset);
+
+    if (lastDiscountedBillingDate > discountEnd) {
+        lastDiscountedBillingDate = getAnchoredBillingDate(nextBillingDate, monthOffset - 1);
+    }
+
+    return lastDiscountedBillingDate;
+}
+
 /**
  * Computes the discount window for a subscription based on available data.
  * Returns {start, end} if a discount window can be determined, null otherwise.
@@ -6,14 +46,35 @@
  * 1. Stripe coupon discounts (post-6.16) - uses discount_start / discount_end
  * 2. Legacy fallback - computes from offer duration and start_date
  *
- * @param {object} subscription - plain object with: discount_start, discount_end, start_date
+ * @param {object} subscription - plain object with: discount_start, discount_end, start_date, current_period_end, plan.interval, plan_interval
  * @param {object|null} offer - offer data with: duration, duration_in_months.
  *   Pass null to skip offer-dependent checks.
  * @returns {{start: *, end: *}|null}
  */
+
 module.exports = function getDiscountWindow(subscription, offer) {
     // Stripe coupon discount (post-6.16 data)
     if (subscription.discount_start) {
+        if (subscription.discount_end && offer?.duration === 'repeating') {
+            const discountEnd = new Date(subscription.discount_end);
+            const currentPeriodEnd = new Date(subscription.current_period_end);
+
+            if (discountEnd <= new Date()) {
+                return null;
+            }
+
+            // A discount ending before the next renewal won't affect the next payment
+            if (discountEnd < currentPeriodEnd) {
+                return null;
+            }
+
+            // Return the last next payment with a discount
+            return {
+                start: subscription.discount_start,
+                end: getLastDiscountedPayment(currentPeriodEnd, discountEnd)
+            };
+        }
+
         return {
             start: subscription.discount_start,
             end: subscription.discount_end || null

--- a/ghost/core/core/server/services/members/members-api/utils/get-discount-window.js
+++ b/ghost/core/core/server/services/members/members-api/utils/get-discount-window.js
@@ -63,12 +63,12 @@ module.exports = function getDiscountWindow(subscription, offer) {
                 return null;
             }
 
-            // A discount ending before the next renewal won't affect the next payment
-            if (discountEnd < currentPeriodEnd) {
+            // A discount ending at, or before, the current billing period end won't affect the next payment
+            if (discountEnd <= currentPeriodEnd) {
                 return null;
             }
 
-            // Return the last next payment with a discount
+            // Match the end date with the last discounted payment
             return {
                 start: subscription.discount_start,
                 end: getLastDiscountedPayment(currentPeriodEnd, discountEnd)
@@ -95,10 +95,15 @@ module.exports = function getDiscountWindow(subscription, offer) {
     }
 
     if (offer.duration === 'repeating' && offer.duration_in_months > 0) {
-        const end = new Date(subscription.start_date);
-        end.setUTCMonth(end.getUTCMonth() + offer.duration_in_months);
+        const end = getAnchoredBillingDate(new Date(subscription.start_date), offer.duration_in_months - 1);
+        const currentPeriodEnd = new Date(subscription.current_period_end);
 
-        if (new Date() >= end) {
+        if (end <= new Date()) {
+            return null;
+        }
+
+        // A discount ending before the end of the current billing period won't affect the next payment
+        if (end < currentPeriodEnd) {
             return null;
         }
 

--- a/ghost/core/test/unit/server/services/members/members-api/services/next-payment-calculator.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/services/next-payment-calculator.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const sinon = require('sinon');
 const NextPaymentCalculator = require('../../../../../../../core/server/services/members/members-api/services/next-payment-calculator');
 
 /**
@@ -6,6 +7,14 @@ const NextPaymentCalculator = require('../../../../../../../core/server/services
  */
 
 describe('NextPaymentCalculator', function () {
+    beforeEach(function () {
+        sinon.useFakeTimers(new Date('2025-05-15T00:00:00.000Z'));
+    });
+
+    afterEach(function () {
+        sinon.restore();
+    });
+
     function createSubscription(overrides = {}, offer = null) {
         return {
             id: 'sub_123',
@@ -208,10 +217,10 @@ describe('NextPaymentCalculator', function () {
 
         it('handles active repeating offers', function () {
             const nextPaymentCalculator = new NextPaymentCalculator();
-            const offer = createOffer({type: 'percent', amount: 20, duration: 'repeating', duration_in_months: 888});
+            const offer = createOffer({type: 'percent', amount: 20, duration: 'repeating', duration_in_months: 3});
             const subscription = createSubscription({
-                discount_start: new Date('2025-01-01T00:00:00.000Z'),
-                discount_end: new Date('2099-01-01T00:00:00.000Z')
+                discount_start: new Date('2025-05-01T00:00:00.000Z'),
+                discount_end: new Date('2025-09-01T00:00:00.000Z')
             }, offer);
 
             const result = nextPaymentCalculator.calculate(subscription);
@@ -220,12 +229,51 @@ describe('NextPaymentCalculator', function () {
             assert.equal(result.amount, 400);
             assert.equal(result.discount.duration, 'repeating');
             assert.equal(result.discount.offer_id, 'offer_123');
-            assert.equal(result.discount.start, '2025-01-01T00:00:00.000Z');
-            assert.equal(result.discount.end, '2099-01-01T00:00:00.000Z');
+            assert.equal(result.discount.start, '2025-05-01T00:00:00.000Z');
+            assert.equal(result.discount.end, '2025-08-15T00:00:00.000Z');
             assert.equal(result.discount.amount, 20);
             assert.equal(result.discount.type, 'percent');
             assert.equal(result.discount.offer_id, 'offer_123');
-            assert.equal(result.discount.duration_in_months, 888);
+            assert.equal(result.discount.duration_in_months, 3);
+        });
+
+        it('returns original amount when a Stripe discount has already expired', function () {
+            const nextPaymentCalculator = new NextPaymentCalculator();
+            const offer = createOffer({type: 'percent', amount: 20, duration: 'repeating', duration_in_months: 6});
+            const subscription = createSubscription({
+                discount_start: new Date('2025-01-01T00:00:00.000Z'),
+                discount_end: new Date('2025-05-01T00:00:00.000Z')
+            }, offer);
+
+            const result = nextPaymentCalculator.calculate(subscription);
+
+            assert.deepEqual(result, {
+                original_amount: 500,
+                amount: 500,
+                interval: 'month',
+                currency: 'USD',
+                discount: null
+            });
+        });
+
+        it('returns original amount when a Stripe discount ends before the next billing date', function () {
+            const nextPaymentCalculator = new NextPaymentCalculator();
+            const offer = createOffer({type: 'percent', amount: 20, duration: 'repeating', duration_in_months: 6});
+            const subscription = createSubscription({
+                discount_start: new Date('2025-05-01T00:00:00.000Z'),
+                discount_end: new Date('2025-06-01T00:00:00.000Z'),
+                current_period_end: new Date('2025-06-15T00:00:00.000Z')
+            }, offer);
+
+            const result = nextPaymentCalculator.calculate(subscription);
+
+            assert.deepEqual(result, {
+                original_amount: 500,
+                amount: 500,
+                interval: 'month',
+                currency: 'USD',
+                discount: null
+            });
         });
 
         // Backportability tests - for signup offers without discount_start/discount_end

--- a/ghost/core/test/unit/server/services/members/members-api/services/next-payment-calculator.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/services/next-payment-calculator.test.js
@@ -276,6 +276,27 @@ describe('NextPaymentCalculator', function () {
             });
         });
 
+        it('returns original amount when a one-month Stripe signup discount ends on the next billing date', function () {
+            const nextPaymentCalculator = new NextPaymentCalculator();
+            const offer = createOffer({type: 'percent', amount: 10, duration: 'repeating', duration_in_months: 1});
+            const subscription = createSubscription({
+                start_date: new Date('2025-05-01T00:00:00.000Z'),
+                discount_start: new Date('2025-05-01T00:00:00.000Z'),
+                discount_end: new Date('2025-06-01T00:00:00.000Z'),
+                current_period_end: new Date('2025-06-01T00:00:00.000Z')
+            }, offer);
+
+            const result = nextPaymentCalculator.calculate(subscription);
+
+            assert.deepEqual(result, {
+                original_amount: 500,
+                amount: 500,
+                interval: 'month',
+                currency: 'USD',
+                discount: null
+            });
+        });
+
         // Backportability tests - for signup offers without discount_start/discount_end
         describe('backportability for signup offers', function () {
             it('once signup offer does not apply to the next payment (already been applied to first payment)', function () {
@@ -291,6 +312,23 @@ describe('NextPaymentCalculator', function () {
 
                 assert.equal(result.original_amount, 500);
                 assert.equal(result.amount, 500); // No discount
+                assert.equal(result.discount, null);
+            });
+
+            it('repeating signup offer with a duration of one month does not apply to the next payment', function () {
+                const nextPaymentCalculator = new NextPaymentCalculator();
+                const offer = createOffer({type: 'percent', amount: 10, duration: 'repeating', duration_in_months: 1});
+                const subscription = createSubscription({
+                    start_date: new Date('2025-05-01T00:00:00.000Z'),
+                    discount_start: null,
+                    discount_end: null,
+                    current_period_end: new Date('2025-06-01T00:00:00.000Z')
+                }, offer);
+
+                const result = nextPaymentCalculator.calculate(subscription);
+
+                assert.equal(result.original_amount, 500);
+                assert.equal(result.amount, 500);
                 assert.equal(result.discount, null);
             });
 
@@ -312,22 +350,23 @@ describe('NextPaymentCalculator', function () {
                 assert.equal(result.discount.end, null);
             });
 
-            it('repeating offer applies if current date is before subscription start_date + duration_in_months', function () {
+            it('repeating signup offer returns the last discounted billing date', function () {
                 const nextPaymentCalculator = new NextPaymentCalculator();
-                const offer = createOffer({type: 'percent', amount: 20, duration: 'repeating', duration_in_months: 888});
+                const offer = createOffer({type: 'percent', amount: 20, duration: 'repeating', duration_in_months: 3});
                 const subscription = createSubscription({
-                    start_date: new Date('2025-01-01T00:00:00.000Z'),
+                    start_date: new Date('2025-04-01T00:00:00.000Z'),
                     discount_start: null,
-                    discount_end: null
+                    discount_end: null,
+                    current_period_end: new Date('2025-06-01T00:00:00.000Z')
                 }, offer);
 
                 const result = nextPaymentCalculator.calculate(subscription);
 
                 assert.equal(result.amount, 400); // Discount still active
                 assert.notEqual(result.discount, null);
-                assert.equal(result.discount.start, '2025-01-01T00:00:00.000Z');
-                assert.equal(result.discount.end, '2099-01-01T00:00:00.000Z'); // start_date + 888 months
-                assert.equal(result.discount.duration_in_months, 888);
+                assert.equal(result.discount.start, '2025-04-01T00:00:00.000Z');
+                assert.equal(result.discount.end, '2025-06-01T00:00:00.000Z');
+                assert.equal(result.discount.duration_in_months, 3);
             });
 
             it('repeating offer is inactive when start_date + duration_in_months is in the past', function () {

--- a/ghost/core/test/unit/server/services/members/members-api/utils/get-discount-window.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/utils/get-discount-window.test.js
@@ -1,12 +1,33 @@
 const assert = require('node:assert/strict');
+const sinon = require('sinon');
 const getDiscountWindow = require('../../../../../../../core/server/services/members/members-api/utils/get-discount-window');
 
 describe('getDiscountWindow', function () {
+    beforeEach(function () {
+        sinon.useFakeTimers(new Date('2025-05-15T00:00:00.000Z'));
+    });
+
+    afterEach(function () {
+        sinon.restore();
+    });
+
     function createSubscription(overrides = {}) {
         return {
             discount_start: null,
             discount_end: null,
             start_date: new Date('2025-01-01T00:00:00.000Z'),
+            current_period_end: new Date('2025-06-15T00:00:00.000Z'),
+            plan: {
+                interval: 'month'
+            },
+            ...overrides
+        };
+    }
+
+    function createOffer(overrides = {}) {
+        return {
+            duration: 'once',
+            duration_in_months: null,
             ...overrides
         };
     }
@@ -14,17 +35,54 @@ describe('getDiscountWindow', function () {
     // Stripe coupon discount (post-6.16 data)
 
     describe('stripe coupon discount', function () {
-        it('returns window when discount_start is present with discount_end', function () {
+        it('returns the last discounted billing date for repeating offers', function () {
             const discountStart = new Date('2025-05-01T00:00:00.000Z');
-            const discountEnd = new Date('2025-11-01T00:00:00.000Z');
+            const discountEnd = new Date('2025-09-01T00:00:00.000Z');
             const subscription = createSubscription({
                 discount_start: discountStart,
                 discount_end: discountEnd
             });
 
-            const result = getDiscountWindow(subscription, null);
+            const result = getDiscountWindow(subscription, createOffer({duration: 'repeating', duration_in_months: 3}));
 
-            assert.deepEqual(result, {start: discountStart, end: discountEnd});
+            assert.deepEqual(result, {
+                start: discountStart,
+                end: new Date('2025-08-15T00:00:00.000Z')
+            });
+        });
+
+        it('preserves last-day-of-month billing anchors when deriving the last discounted billing date', function () {
+            const discountStart = new Date('2025-05-01T00:00:00.000Z');
+            const discountEnd = new Date('2025-08-15T00:00:00.000Z');
+            const subscription = createSubscription({
+                discount_start: discountStart,
+                discount_end: discountEnd,
+                current_period_end: new Date('2025-05-31T00:00:00.000Z')
+            });
+
+            const result = getDiscountWindow(subscription, createOffer({duration: 'repeating', duration_in_months: 3}));
+
+            assert.deepEqual(result, {
+                start: discountStart,
+                end: new Date('2025-07-31T00:00:00.000Z')
+            });
+        });
+
+        it('preserves non-month-end billing anchors when crossing February', function () {
+            const discountStart = new Date('2025-12-01T00:00:00.000Z');
+            const discountEnd = new Date('2026-04-01T00:00:00.000Z');
+            const subscription = createSubscription({
+                discount_start: discountStart,
+                discount_end: discountEnd,
+                current_period_end: new Date('2026-01-30T00:00:00.000Z')
+            });
+
+            const result = getDiscountWindow(subscription, createOffer({duration: 'repeating', duration_in_months: 3}));
+
+            assert.deepEqual(result, {
+                start: discountStart,
+                end: new Date('2026-03-30T00:00:00.000Z')
+            });
         });
 
         it('returns window with null end for forever discounts', function () {
@@ -34,20 +92,35 @@ describe('getDiscountWindow', function () {
                 discount_end: null
             });
 
-            const result = getDiscountWindow(subscription, null);
+            const result = getDiscountWindow(subscription, createOffer({duration: 'forever'}));
 
             assert.deepEqual(result, {start: discountStart, end: null});
         });
 
-        it('returns window even when discount_end is in the past (trusts Stripe data)', function () {
-            const discountStart = new Date('2025-01-01T00:00:00.000Z');
+        it('returns null when discount_end expires before the next billing date', function () {
+            const discountStart = new Date('2025-05-01T00:00:00.000Z');
             const discountEnd = new Date('2025-06-01T00:00:00.000Z');
             const subscription = createSubscription({
                 discount_start: discountStart,
-                discount_end: discountEnd
+                discount_end: discountEnd,
+                current_period_end: new Date('2025-06-15T00:00:00.000Z')
             });
 
-            const result = getDiscountWindow(subscription, null);
+            const result = getDiscountWindow(subscription, createOffer({duration: 'repeating', duration_in_months: 1}));
+
+            assert.equal(result, null);
+        });
+
+        it('returns window when discount_end matches the next billing date', function () {
+            const discountStart = new Date('2025-05-01T00:00:00.000Z');
+            const discountEnd = new Date('2025-06-15T00:00:00.000Z');
+            const subscription = createSubscription({
+                discount_start: discountStart,
+                discount_end: discountEnd,
+                current_period_end: new Date('2025-06-15T00:00:00.000Z')
+            });
+
+            const result = getDiscountWindow(subscription, createOffer({duration: 'repeating', duration_in_months: 1}));
 
             assert.deepEqual(result, {start: discountStart, end: discountEnd});
         });

--- a/ghost/core/test/unit/server/services/members/members-api/utils/get-discount-window.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/utils/get-discount-window.test.js
@@ -111,7 +111,7 @@ describe('getDiscountWindow', function () {
             assert.equal(result, null);
         });
 
-        it('returns window when discount_end matches the next billing date', function () {
+        it('returns null when discount_end matches the next billing date', function () {
             const discountStart = new Date('2025-05-01T00:00:00.000Z');
             const discountEnd = new Date('2025-06-15T00:00:00.000Z');
             const subscription = createSubscription({
@@ -122,7 +122,7 @@ describe('getDiscountWindow', function () {
 
             const result = getDiscountWindow(subscription, createOffer({duration: 'repeating', duration_in_months: 1}));
 
-            assert.deepEqual(result, {start: discountStart, end: discountEnd});
+            assert.equal(result, null);
         });
 
         it('discount_start takes precedence over legacy offer data', function () {
@@ -164,6 +164,21 @@ describe('getDiscountWindow', function () {
             const result = getDiscountWindow(subscription, {duration: 'forever'});
 
             assert.deepEqual(result, {start: startDate, end: null});
+        });
+
+        it('returns the last discounted billing date for legacy repeating offers', function () {
+            const startDate = new Date('2025-04-01T00:00:00.000Z');
+            const subscription = createSubscription({
+                start_date: startDate,
+                current_period_end: new Date('2025-06-01T00:00:00.000Z')
+            });
+
+            const result = getDiscountWindow(subscription, {duration: 'repeating', duration_in_months: 3});
+
+            assert.deepEqual(result, {
+                start: startDate,
+                end: new Date('2025-06-01T00:00:00.000Z')
+            });
         });
 
         it('returns window for repeating offer still within duration', function () {


### PR DESCRIPTION
closes https://linear.app/ghost/issue/BER-3413/account-page-date-mismatch-between-discount-end-billing-period

- In Stripe, discount dates are anchored around the redemption date, not the billing date. However, we're interested in whether the next payment(s) are discounted. This aligns the next payment object discount end date with the last payment with a discount.
- Example:
    - Bob's billing cycle is from Mar 3 to April 3
    - Bob redeems a retention offer on Mar 1, that is repeating 3 months
    - Stripe will set discount start to Mar 1 and discount end to Jun 1
    - Bob's next 3 payments will be discounted: Mar 3, Apr 3 and May 3, and we want to display "Ends May 3" (not "Ends Jun 1")
