### PR TITLE
Updated CI to support multi-source builds from same-org forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -944,23 +944,39 @@ jobs:
       - name: Determine push strategy
         id: strategy
         run: |
-          # Use artifact-based image transfer (instead of GHCR) for fork PRs
-          # and non-main repos (e.g. Ghost-Security)
+          # Same-org repos (e.g. TryGhost/Ghost, TryGhost/Ghost-Security) push to GHCR.
+          # External forks and cross-repo PRs use artifact-based image transfer instead.
           USE_ARTIFACT="false"
-          if [ "${{ github.repository }}" != "TryGhost/Ghost" ]; then
+          if [ "${{ github.repository_owner }}" != "TryGhost" ]; then
+            # External fork — no GHCR push
             USE_ARTIFACT="true"
           elif [ "${{ github.event_name }}" = "pull_request" ] && \
                [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
+            # Cross-repo PR (fork PR into this repo) — no GHCR push
             USE_ARTIFACT="true"
           fi
+
           OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+
+          # Derive GHCR image names from repository name so each repo gets its own namespace
+          # TryGhost/Ghost → ghost-core / ghost, TryGhost/Ghost-Security → ghost-security-core / ghost-security
+          REPO_NAME=$(echo "${{ github.event.repository.name }}" | tr '[:upper:]' '[:lower:]')
+          if [ "$REPO_NAME" = "ghost" ]; then
+            IMAGE_CORE_NAME="ghcr.io/${OWNER}/ghost-core"
+            IMAGE_FULL_NAME="ghcr.io/${OWNER}/ghost"
+          else
+            IMAGE_CORE_NAME="ghcr.io/${OWNER}/${REPO_NAME}-core"
+            IMAGE_FULL_NAME="ghcr.io/${OWNER}/${REPO_NAME}"
+          fi
+
           echo "use-artifact=$USE_ARTIFACT" >> $GITHUB_OUTPUT
           echo "should-push=$( [ "$USE_ARTIFACT" = "false" ] && echo "true" || echo "false" )" >> $GITHUB_OUTPUT
           echo "owner=$OWNER" >> $GITHUB_OUTPUT
+          echo "image-core-name=$IMAGE_CORE_NAME" >> $GITHUB_OUTPUT
+          echo "image-full-name=$IMAGE_FULL_NAME" >> $GITHUB_OUTPUT
 
       - name: Upload admin artifact for CD
         id: upload-admin
-        if: steps.strategy.outputs.use-artifact == 'false'
         uses: actions/upload-artifact@v4
         with:
           name: admin-build-cd
@@ -983,7 +999,7 @@ jobs:
         id: meta-core
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/${{ steps.strategy.outputs.owner }}/ghost-core
+          images: ${{ steps.strategy.outputs.image-core-name }}
           tags: |
             type=ref,event=branch
             type=ref,event=pr
@@ -998,7 +1014,7 @@ jobs:
         id: meta-full
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/${{ steps.strategy.outputs.owner }}/ghost
+          images: ${{ steps.strategy.outputs.image-full-name }}
           tags: |
             type=ref,event=branch
             type=ref,event=pr
@@ -1020,8 +1036,8 @@ jobs:
           load: ${{ steps.strategy.outputs.should-push == 'false' }}
           tags: ${{ steps.meta-core.outputs.tags }}
           labels: ${{ steps.meta-core.outputs.labels }}
-          cache-from: type=registry,ref=ghcr.io/${{ steps.strategy.outputs.owner }}/ghost-core:cache-main
-          cache-to: ${{ steps.strategy.outputs.should-push == 'true' && format('type=registry,ref=ghcr.io/{0}/ghost-core:cache-{1},mode=max', steps.strategy.outputs.owner, github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || 'main') || '' }}
+          cache-from: type=registry,ref=${{ steps.strategy.outputs.image-core-name }}:cache-main
+          cache-to: ${{ steps.strategy.outputs.should-push == 'true' && format('type=registry,ref={0}:cache-{1},mode=max', steps.strategy.outputs.image-core-name, github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || 'main') || '' }}
 
       - name: Build & push full image
         uses: docker/build-push-action@v6
@@ -1034,11 +1050,10 @@ jobs:
           load: true
           tags: ${{ steps.meta-full.outputs.tags }}
           labels: ${{ steps.meta-full.outputs.labels }}
-          cache-from: type=registry,ref=ghcr.io/${{ steps.strategy.outputs.owner }}/ghost:cache-main
-          cache-to: ${{ steps.strategy.outputs.should-push == 'true' && format('type=registry,ref=ghcr.io/{0}/ghost:cache-{1},mode=max', steps.strategy.outputs.owner, github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || 'main') || '' }}
+          cache-from: type=registry,ref=${{ steps.strategy.outputs.image-full-name }}:cache-main
+          cache-to: ${{ steps.strategy.outputs.should-push == 'true' && format('type=registry,ref={0}:cache-{1},mode=max', steps.strategy.outputs.image-full-name, github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || 'main') || '' }}
 
-      - name: Save full image as artifact (no GHCR push)
-        if: steps.strategy.outputs.use-artifact == 'true'
+      - name: Save full image as artifact
         run: |
           IMAGE_TAG=$(echo "${{ steps.meta-full.outputs.tags }}" | head -n1)
           echo "Saving image: $IMAGE_TAG"
@@ -1046,8 +1061,7 @@ jobs:
           echo "Image saved as docker-image-production.tar.gz"
           ls -lh docker-image-production.tar.gz
 
-      - name: Upload image artifact (no GHCR push)
-        if: steps.strategy.outputs.use-artifact == 'true'
+      - name: Upload image artifact
         uses: actions/upload-artifact@v4
         with:
           name: docker-image-production
@@ -1541,7 +1555,7 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       always()
-      && github.repository == 'TryGhost/Ghost'
+      && github.repository_owner == 'TryGhost'
       && needs.job_setup.result == 'success'
       && needs.job_docker_build_production.result == 'success'
       && needs.job_docker_build_production.outputs.use-artifact != 'true'
@@ -1580,6 +1594,7 @@ jobs:
           client-payload: >-
             {
               "ref": "${{ github.sha }}",
+              "source_repo": "${{ github.repository }}",
               "pr_number": "${{ steps.params.outputs.pr_number }}",
               "deploy": "${{ steps.params.outputs.deploy }}",
               "admin_artifact_id": "${{ needs.job_docker_build_production.outputs.admin-artifact-id }}",


### PR DESCRIPTION
The CI workflow currently hardcodes `TryGhost/Ghost` as the only repository allowed to push Docker images to GHCR and trigger the Ghost-Moya CD pipeline. This means private forks like Ghost-Security — which share the same org and secrets — can't produce builds that flow through the standard Pro CD path. Their images end up as ephemeral workflow artifacts with no downstream consumer.

This changes the GHCR push guard from an exact repository match to an org-level check (`repository_owner == 'TryGhost'`), so any same-org repo can push to GHCR. To avoid image name collisions, the GHCR image name is now derived from the repository name rather than hardcoded — `TryGhost/Ghost` continues to push to `ghcr.io/tryghost/ghost-core` while `TryGhost/Ghost-Security` would push to `ghcr.io/tryghost/ghost-security-core`. The same derivation applies to the full image and build cache references.

Separately, the admin and server build artifacts are now uploaded unconditionally regardless of GHCR push strategy. Previously, external fork PRs got the server `.tar.gz` artifact but not the admin build — an oversight where the Docker push strategy flag was reused to gate an unrelated artifact upload. Now every CI run (including external forks) produces both artifacts, enabling downstream consumers like Ghost-Moya to build from any fork given a successful CI run.

The `trigger_cd` job also passes `source_repo` in the dispatch payload so Ghost-Moya can resolve SHAs, discover artifacts, and report commit statuses against the correct source repository rather than assuming `TryGhost/Ghost`. The companion PR on Ghost-Moya adds the receiving side of this parameter.