### PR TITLE
Changed skeleton component to use an integer-based key instead of a UUID

### DIFF
--- a/apps/shade/src/components/ui/skeleton.tsx
+++ b/apps/shade/src/components/ui/skeleton.tsx
@@ -29,7 +29,7 @@ function Skeleton({
                 const randomWidth = minWidth + (randomStep * 5);
                 widths.push(`${randomWidth}%`);
             }
-            uniqueKeys.push(`skeleton-${Math.random().toString(36).substring(2, 15)}`);
+            uniqueKeys.push(`skeleton-${i}`);
         }
 
         return {

--- a/apps/shade/src/components/ui/skeleton.tsx
+++ b/apps/shade/src/components/ui/skeleton.tsx
@@ -29,7 +29,7 @@ function Skeleton({
                 const randomWidth = minWidth + (randomStep * 5);
                 widths.push(`${randomWidth}%`);
             }
-            uniqueKeys.push(`skeleton-${crypto.randomUUID()}`);
+            uniqueKeys.push(`skeleton-${Math.random().toString(36).substring(2, 15)}`);
         }
 
         return {


### PR DESCRIPTION
no ref

When running Ghost in development with `yarn dev` in a remote VM, the analytics app crashes when loading over a plaintext http connection because `crypto.randomUUID` is only available in a secure context (https or localhost). 

`crypto.randomUUID` is also overkill for React keys anyways, so this changes to using integers instead, to make it easier to develop Ghost in a remote VM environment.