### PR TITLE
Added Customize button and design modal for welcome emails

### DIFF
--- a/apps/admin-x-settings/src/components/providers/routing/modals.tsx
+++ b/apps/admin-x-settings/src/components/providers/routing/modals.tsx
@@ -30,6 +30,7 @@ import TierDetailModal from '../../settings/membership/tiers/tier-detail-modal';
 import TransistorModal from '../../settings/advanced/integrations/transistor-modal';
 import UnsplashModal from '../../settings/advanced/integrations/unsplash-modal';
 import UserDetailModal from '../../settings/general/user-detail-modal';
+import WelcomeEmailDesignModal from '../../settings/membership/member-emails/welcome-email-design-modal';
 import ZapierModal from '../../settings/advanced/integrations/zapier-modal';
 
 const modals = {
@@ -55,6 +56,7 @@ const modals = {
     UserDetailModal,
     ZapierModal,
     AnnouncementBarModal,
+    WelcomeEmailDesignModal,
     EmbedSignupFormModal,
     OffersContainerModal,
     // OffersModal,

--- a/apps/admin-x-settings/src/components/providers/settings-router.tsx
+++ b/apps/admin-x-settings/src/components/providers/settings-router.tsx
@@ -32,6 +32,7 @@ export const modalPaths: {[key: string]: ModalName} = {
     'recommendations/add': 'AddRecommendationModal',
     'recommendations/edit': 'EditRecommendationModal',
     'announcement-bar/edit': 'AnnouncementBarModal',
+    'welcome-emails/design': 'WelcomeEmailDesignModal',
     'embed-signup-form/show': 'EmbedSignupFormModal',
     'offers/edit': 'OffersContainerModal',
     'offers/edit/:id': 'OffersContainerModal',

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails.tsx
@@ -3,11 +3,13 @@ import NiceModal from '@ebay/nice-modal-react';
 import React from 'react';
 import TopLevelGroup from '../../top-level-group';
 import WelcomeEmailModal from './member-emails/welcome-email-modal';
-import {Separator, SettingGroupContent, Toggle, showToast, withErrorBoundary} from '@tryghost/admin-x-design-system';
+import useFeatureFlag from '../../../hooks/use-feature-flag';
+import {Button, Separator, SettingGroupContent, Toggle, showToast, withErrorBoundary} from '@tryghost/admin-x-design-system';
 import {checkStripeEnabled, getSettingValues} from '@tryghost/admin-x-framework/api/settings';
 import {useAddAutomatedEmail, useBrowseAutomatedEmails, useEditAutomatedEmail} from '@tryghost/admin-x-framework/api/automated-emails';
 import {useGlobalData} from '../../providers/global-data-provider';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
+import {useRouting} from '@tryghost/admin-x-framework/routing';
 import {useWelcomeEmailSenderDetails} from '../../../hooks/use-welcome-email-sender-details';
 import type {AutomatedEmail} from '@tryghost/admin-x-framework/api/automated-emails';
 
@@ -99,6 +101,8 @@ const EmailSettingRow: React.FC<{
 const MemberEmails: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const {settings, config} = useGlobalData();
     const [siteTitle] = getSettingValues<string>(settings, ['title']);
+    const {updateRoute} = useRouting();
+    const welcomeEmailsDesignCustomization = useFeatureFlag('welcomeEmailsDesignCustomization');
 
     const {data: automatedEmailsData, isLoading} = useBrowseAutomatedEmails();
     const {mutateAsync: addAutomatedEmail, isLoading: isAddingAutomatedEmail} = useAddAutomatedEmail();
@@ -198,6 +202,7 @@ const MemberEmails: React.FC<{ keywords: string[] }> = ({keywords}) => {
 
     return (
         <TopLevelGroup
+            customButtons={welcomeEmailsDesignCustomization ? <Button className='mt-[-5px]' color='clear' label='Customize' size='sm' onClick={() => updateRoute('welcome-emails/design')} /> : undefined}
             description="Create and manage automated emails for your members"
             keywords={keywords}
             navid='memberemails'

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-design-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-design-modal.tsx
@@ -1,0 +1,24 @@
+import NiceModal from '@ebay/nice-modal-react';
+import {Modal} from '@tryghost/admin-x-design-system';
+import {useRouting} from '@tryghost/admin-x-framework/routing';
+
+const WelcomeEmailDesignModal: React.FC = () => {
+    const {updateRoute} = useRouting();
+
+    return (
+        <Modal
+            afterClose={() => {
+                updateRoute('memberemails');
+            }}
+            cancelLabel='Close'
+            footer={false}
+            size='md'
+            testId='welcome-email-design-modal'
+            title='Welcome email design'
+        >
+            <p className='text-grey-700'>Design customization options will appear here.</p>
+        </Modal>
+    );
+};
+
+export default NiceModal.create(WelcomeEmailDesignModal);

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-design-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-design-modal.tsx
@@ -1,4 +1,5 @@
 import NiceModal from '@ebay/nice-modal-react';
+import React from 'react';
 import {Modal} from '@tryghost/admin-x-design-system';
 import {useRouting} from '@tryghost/admin-x-framework/routing';
 
@@ -11,7 +12,6 @@ const WelcomeEmailDesignModal: React.FC = () => {
                 updateRoute('memberemails');
             }}
             cancelLabel='Close'
-            footer={false}
             size='md'
             testId='welcome-email-design-modal'
             title='Welcome email design'


### PR DESCRIPTION
Closes https://linear.app/ghost/issue/NY-1135/add-the-customize-button-and-an-empty-modal

- Adds a Customize button to the Welcome Emails settings page (behind the `welcomeEmailsDesignCustomization` labs flag)
- Wires up a placeholder modal to display when the button is clicked
- Sets up routing to support future design customization options

The button and modal only appear when the labs flag is enabled, with no behavioral changes when disabled.