### PR TITLE
✨ Added retention offers

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
@@ -52,10 +52,6 @@ const features: Feature[] = [{
     description: 'Enable Transistor podcast integration',
     flag: 'transistor'
 }, {
-    title: 'Retention Offers',
-    description: 'Enable retention offers for canceling members',
-    flag: 'retentionOffers'
-}, {
     title: 'Members Forward',
     description: 'Use the new React-based members list instead of the Ember implementation',
     flag: 'membersForward'

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -25,7 +25,8 @@ const GA_FEATURES = [
     'explore',
     'commentModeration',
     'featurebaseFeedback',
-    'welcomeEmailEditor'
+    'welcomeEmailEditor',
+    'retentionOffers'
 ];
 
 // These features are considered publicly available and can be enabled/disabled by users
@@ -48,7 +49,6 @@ const PRIVATE_FEATURES = [
     'themeTranslation',
     'indexnow',
     'transistor',
-    'retentionOffers',
     'membersForward',
     'welcomeEmailsDesignCustomization',
     'pictureImageFormats'

--- a/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
@@ -1675,7 +1675,7 @@ exports[`Settings API Edit can edit Stripe settings when Stripe Connect limit is
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "5151",
+  "content-length": "5176",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/e2e-browser/admin/tiers.spec.js
+++ b/ghost/core/test/e2e-browser/admin/tiers.spec.js
@@ -32,7 +32,9 @@ test.describe('Admin', () => {
 
             await sharedPage.goto('/ghost/');
             await sharedPage.goto('/ghost/#/settings/offers');
-            await expect(sharedPage.getByTestId('offers')).toContainText(offerName);
+            await sharedPage.getByTestId('offers').getByRole('button', {name: 'Manage tiers'}).waitFor({state: 'hidden'});
+            await sharedPage.getByTestId('offers').getByRole('button', {name: 'Manage offers'}).click();
+            await expect(sharedPage.getByTestId('offers-modal')).toContainText(offerName);
         });
 
         test('Can create additional Tier', async ({sharedPage}) => {

--- a/ghost/core/test/e2e-browser/portal/offers.spec.js
+++ b/ghost/core/test/e2e-browser/portal/offers.spec.js
@@ -31,7 +31,10 @@ test.describe('Portal', () => {
             // check that offer was added in the offer list screen
             await sharedPage.goto('/ghost');
             await sharedPage.getByRole('navigation').getByRole('link', {name: 'Settings'}).click();
-            await expect(await sharedPage.getByTestId('offers')).toContainText(offerName);
+            await sharedPage.getByTestId('offers').getByRole('button', {name: 'Manage tiers'}).waitFor({state: 'hidden'});
+            await sharedPage.getByTestId('offers').getByRole('button', {name: 'Manage offers'}).click();
+            await expect(sharedPage.getByTestId('offers-modal')).toContainText(offerName);
+            await sharedPage.getByTestId('offers-modal').getByRole('button', {name: 'Close'}).click();
 
             await sharedPage.goto(offerLink);
 
@@ -79,9 +82,10 @@ test.describe('Portal', () => {
 
             // // Ensure the offer redemption count was bumped
             await sharedPage.goto('/ghost/#/settings/offers');
-            // await sharedPage.locator('.gh-nav a[href="#/offers/"]').click();
-            const locator = await sharedPage.locator(`[data-test-offer="${offerName}"]`);
-            await expect(locator).toContainText('1 redemption');
+            await sharedPage.getByTestId('offers').getByRole('button', {name: 'Manage tiers'}).waitFor({state: 'hidden'});
+            await sharedPage.getByTestId('offers').getByRole('button', {name: 'Manage offers'}).click();
+            const offerRow = sharedPage.getByTestId('offer-item').filter({hasText: offerName});
+            await expect(offerRow).toContainText('1');
         });
 
         test('Creates and uses a one-time discount Offer', async ({sharedPage}) => {
@@ -108,9 +112,10 @@ test.describe('Portal', () => {
             // check that offer was added in the offer list screen
             await sharedPage.goto('/ghost');
             await sharedPage.getByRole('navigation').getByRole('link', {name: 'Settings'}).click();
-            await expect(sharedPage.getByTestId('offers')).toContainText(offerName);
-            // open offer details page
-            // await sharedPage.locator(`[data-test-offer="${offerName}"] a`).first().click();
+            await sharedPage.getByTestId('offers').getByRole('button', {name: 'Manage tiers'}).waitFor({state: 'hidden'});
+            await sharedPage.getByTestId('offers').getByRole('button', {name: 'Manage offers'}).click();
+            await expect(sharedPage.getByTestId('offers-modal')).toContainText(offerName);
+            await sharedPage.getByTestId('offers-modal').getByRole('button', {name: 'Close'}).click();
 
             // fetch offer url from portal settings and open it
             await sharedPage.goto(offerLink);
@@ -185,7 +190,10 @@ test.describe('Portal', () => {
 
             await sharedPage.goto('/ghost');
             await sharedPage.getByRole('navigation').getByRole('link', {name: 'Settings'}).click();
-            await expect(await sharedPage.getByTestId('offers')).toContainText(offerName);
+            await sharedPage.getByTestId('offers').getByRole('button', {name: 'Manage tiers'}).waitFor({state: 'hidden'});
+            await sharedPage.getByTestId('offers').getByRole('button', {name: 'Manage offers'}).click();
+            await expect(sharedPage.getByTestId('offers-modal')).toContainText(offerName);
+            await sharedPage.getByTestId('offers-modal').getByRole('button', {name: 'Close'}).click();
 
             await sharedPage.goto(offerLink);
 
@@ -260,7 +268,10 @@ test.describe('Portal', () => {
             // check that offer was added in the offer list screen
             await sharedPage.goto('/ghost');
             await sharedPage.getByRole('navigation').getByRole('link', {name: 'Settings'}).click();
-            await expect(sharedPage.getByTestId('offers')).toContainText(offerName);
+            await sharedPage.getByTestId('offers').getByRole('button', {name: 'Manage tiers'}).waitFor({state: 'hidden'});
+            await sharedPage.getByTestId('offers').getByRole('button', {name: 'Manage offers'}).click();
+            await expect(sharedPage.getByTestId('offers-modal')).toContainText(offerName);
+            await sharedPage.getByTestId('offers-modal').getByRole('button', {name: 'Close'}).click();
 
             await sharedPage.goto(offerLink);
 

--- a/ghost/core/test/e2e-browser/utils/e2e-browser-utils.js
+++ b/ghost/core/test/e2e-browser/utils/e2e-browser-utils.js
@@ -260,33 +260,23 @@ const createOffer = async (page, {name, tierName, offerType, amount, discountTyp
         await page.getByTestId('tiers').getByText('No active tiers found').waitFor({state: 'hidden'});
         await page.getByTestId('offers').getByRole('button', {name: 'Manage tiers'}).waitFor({state: 'hidden'});
 
-        // only one of these buttons is ever available - either 'Add offer' or 'Manage offers'
-        const hasExistingOffers = await page.getByTestId('offers').getByRole('button', {name: 'Manage offers'}).isVisible();
-        const isCTA = await page.getByTestId('offers').getByRole('button', {name: 'Add offer'}).isVisible();
+        await page.getByTestId('offers').getByRole('button', {name: 'Manage offers'}).click();
 
-        // Archive other offers to keep the list tidy
-        // We only need 1 offer to be active at a time
-        // Either the list of active offers loads, or the CTA when no offers exist
-        if (hasExistingOffers && !isCTA) {
-            await page.getByTestId('offers').getByRole('button', {name: 'Manage offers'}).click();
+        // Wait for the modal to fully load (retention offers are always present)
+        await page.getByTestId('retention-offer-item').first().waitFor();
 
-            // Selector for the elements with data-testid 'offer-item'
-            // const offerItemsSelector = '[data-testid="offer-item"]';
+        // Archive all existing signup offers to keep the list tidy
+        while (await page.getByTestId('offer-item').count() > 0) {
             await page.getByTestId('offer-item').nth(0).click();
             await page.getByRole('button', {name: 'Archive offer'}).click();
 
             const confirmModal = await page.getByTestId('confirmation-modal');
             await confirmModal.getByRole('button', {name: 'Archive'}).click();
             await confirmModal.waitFor({state: 'hidden'});
-
-            // Still in the offers modal after archiving — click "New offer" directly
-            await page.getByText('New offer').click();
-        } else if (await page.getByTestId('offers').getByRole('button', {name: 'Add offer'}).isVisible()) {
-            await page.getByTestId('offers').getByRole('button', {name: 'Add offer'}).click();
-        } else {
-            await page.getByTestId('offers').getByRole('button', {name: 'Manage offers'}).click();
-            await page.getByText('New offer').click();
         }
+
+        // Click "New offer" to open the creation form
+        await page.getByText('New offer').click();
 
         await page.getByLabel('Offer name').fill(offerName);
 


### PR DESCRIPTION
ref https://linear.app/ghost/project/retention-offers-churn-prevention-e2474be8b6ad/overview
closes https://linear.app/ghost/issue/BER-3410

Using retention offers, publishers can offer existing paid members a discount before they cancel, in order to retain them. For example, "a month on us" or "50% off your next payment".


---------

Co-authored-by: Michael Barrett <mike@ghost.org>
Co-authored-by: Sodbileg Gansukh <sodbileg.gansukh@gmail.com>