### PR TITLE
Fixed retention offer not rendering for 1 mo repeating offers

### DIFF
--- a/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
@@ -1725,7 +1725,7 @@ module.exports = class MemberRepository {
         }
 
         // Check subscription doesn't already have an active offer
-        if (await hasActiveOffer(subscriptionModel, this._offersAPI)) {
+        if (await hasActiveOffer(subscriptionModel, this._offersAPI, options)) {
             throw new errors.BadRequestError({
                 message: tpl(messages.subscriptionHasOffer)
             });

--- a/ghost/core/core/server/services/members/members-api/utils/has-active-offer.js
+++ b/ghost/core/core/server/services/members/members-api/utils/has-active-offer.js
@@ -1,7 +1,8 @@
 const getDiscountWindow = require('./get-discount-window');
 
 /**
- * Determines if a subscription currently has an active offer.
+ * Determines if a subscription has an offer that still affects the next payment,
+ * or an active trial.
  * Uses discount_start/discount_end (synced from Stripe) when available,
  * falls back to offer duration lookup for legacy data (pre-6.16).
  *
@@ -13,15 +14,9 @@ module.exports = async function hasActiveOffer(subscriptionModel, offersAPI) {
     const subscriptionData = {
         discount_start: subscriptionModel.get('discount_start'),
         discount_end: subscriptionModel.get('discount_end'),
-        start_date: subscriptionModel.get('start_date')
+        start_date: subscriptionModel.get('start_date'),
+        current_period_end: subscriptionModel.get('current_period_end')
     };
-
-    // Check for active Stripe discount (post-6.16 data)
-    // discount_start takes precedence over trial and legacy fallback
-    const discountWindow = getDiscountWindow(subscriptionData, null);
-    if (discountWindow) {
-        return !discountWindow.end || new Date(discountWindow.end) > new Date();
-    }
 
     // Check for active trial (trial offers)
     const trialEndAt = subscriptionModel.get('trial_end_at');
@@ -42,9 +37,9 @@ module.exports = async function hasActiveOffer(subscriptionModel, offersAPI) {
             return false;
         }
 
-        const legacyWindow = getDiscountWindow(subscriptionData, offer);
-        if (legacyWindow) {
-            return !legacyWindow.end || new Date(legacyWindow.end) > new Date();
+        const discountWindow = getDiscountWindow(subscriptionData, offer);
+        if (discountWindow) {
+            return !discountWindow.end || new Date(discountWindow.end) > new Date();
         }
 
         return false;

--- a/ghost/core/core/server/services/members/members-api/utils/has-active-offer.js
+++ b/ghost/core/core/server/services/members/members-api/utils/has-active-offer.js
@@ -8,9 +8,10 @@ const getDiscountWindow = require('./get-discount-window');
  *
  * @param {object} subscriptionModel - Bookshelf model for members_stripe_customers_subscriptions
  * @param {object} offersAPI - OffersAPI instance with getOffer()
+ * @param {object} [options] - Optional query options such as transacting
  * @returns {Promise<boolean>}
  */
-module.exports = async function hasActiveOffer(subscriptionModel, offersAPI) {
+module.exports = async function hasActiveOffer(subscriptionModel, offersAPI, options = {}) {
     const subscriptionData = {
         discount_start: subscriptionModel.get('discount_start'),
         discount_end: subscriptionModel.get('discount_end'),
@@ -32,7 +33,7 @@ module.exports = async function hasActiveOffer(subscriptionModel, offersAPI) {
 
     // Look up the offer to determine if it's still active based on duration
     try {
-        const offer = await offersAPI.getOffer({id: offerId});
+        const offer = await offersAPI.getOffer({id: offerId}, options);
         if (!offer) {
             return false;
         }

--- a/ghost/core/test/e2e-api/members/member-offers.test.js
+++ b/ghost/core/test/e2e-api/members/member-offers.test.js
@@ -403,6 +403,81 @@ describe('Members API - Member Offers', function () {
             }
         });
 
+        it('returns retention offers when a one-month repeating signup offer no longer applies to the next payment', async function () {
+            const {subscription} = await getMemberSubscription('paid@test.com');
+            const stripePrice = subscription.related('stripePrice');
+            const stripeProduct = stripePrice.related('stripeProduct');
+            const product = stripeProduct.related('product');
+
+            const tierId = product.id;
+            const cadence = stripePrice.get('interval');
+            const originalCurrentPeriodEnd = subscription.get('current_period_end');
+
+            const retentionOffer = await models.Offer.add({
+                name: 'Retention Offer After Repeating Signup',
+                code: 'retention-after-repeating-signup',
+                portal_title: '20% off',
+                portal_description: 'Stay with us!',
+                discount_type: 'percent',
+                discount_amount: 20,
+                duration: 'once',
+                interval: cadence,
+                product_id: null,
+                currency: null,
+                active: true,
+                redemption_type: 'retention'
+            });
+
+            const signupOffer = await models.Offer.add({
+                name: 'One Month Signup Offer',
+                code: 'one-month-signup-offer',
+                portal_title: '10% off for 1 month',
+                portal_description: 'Welcome!',
+                discount_type: 'percent',
+                discount_amount: 10,
+                duration: 'repeating',
+                duration_in_months: 1,
+                interval: cadence,
+                product_id: tierId,
+                currency: null,
+                active: true,
+                redemption_type: 'signup'
+            });
+
+            const now = new Date();
+            const currentPeriodEnd = new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000);
+            const discountStart = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+            const discountEnd = new Date(currentPeriodEnd);
+
+            await subscription.save({
+                offer_id: signupOffer.id,
+                discount_start: discountStart,
+                discount_end: discountEnd,
+                current_period_end: currentPeriodEnd
+            }, {patch: true});
+
+            try {
+                const token = await getIdentityToken('paid@test.com');
+
+                const {body} = await membersAgent
+                    .post('/api/member/offers')
+                    .body({identity: token})
+                    .expectStatus(200);
+
+                assert.equal(body.offers.length, 1);
+                assert.equal(body.offers[0].id, retentionOffer.id);
+            } finally {
+                await subscription.save({
+                    offer_id: null,
+                    discount_start: null,
+                    discount_end: null,
+                    current_period_end: originalCurrentPeriodEnd
+                }, {patch: true});
+                await models.Offer.destroy({id: retentionOffer.id});
+                await models.Offer.destroy({id: signupOffer.id});
+            }
+        });
+
         it('returns empty offers if subscription is already set to cancel', async function () {
             const {subscription} = await getMemberSubscription('paid@test.com');
             const stripePrice = subscription.related('stripePrice');
@@ -556,6 +631,151 @@ describe('Members API - Member Offers', function () {
                 await subscription.save({offer_id: null, discount_start: null, discount_end: null}, {patch: true});
                 await models.Offer.destroy({id: retentionOffer.id});
                 await models.Offer.destroy({id: existingOffer.id});
+            }
+        });
+
+        it('allows applying a retention offer when a one-month repeating signup offer no longer applies to the next payment', async function () {
+            const {subscription} = await getMemberSubscription('paid@test.com');
+            const stripePrice = subscription.related('stripePrice');
+            const stripeProduct = stripePrice.related('stripeProduct');
+            const product = stripeProduct.related('product');
+
+            const stripeSubscriptionId = subscription.get('subscription_id');
+            const customerId = subscription.get('customer_id');
+            const tierId = product.id;
+            const cadence = stripePrice.get('interval');
+            const originalCurrentPeriodEnd = subscription.get('current_period_end');
+
+            const existingSignupOffer = await models.Offer.add({
+                name: 'Repeating Signup Offer',
+                code: 'repeating-signup-offer',
+                portal_title: '10% off for 1 month',
+                portal_description: 'Welcome!',
+                discount_type: 'percent',
+                discount_amount: 10,
+                duration: 'repeating',
+                duration_in_months: 1,
+                interval: cadence,
+                product_id: tierId,
+                currency: null,
+                active: true,
+                redemption_type: 'signup'
+            });
+
+            const stripeCouponId = 'coupon_redeem_after_repeating_signup';
+            mockManager.stripeMocker.coupons.push({
+                id: stripeCouponId,
+                object: 'coupon',
+                percent_off: 20,
+                duration: 'once'
+            });
+
+            const mockPrice = {
+                id: stripePrice.get('stripe_price_id'),
+                product: stripeProduct.get('stripe_product_id'),
+                active: true,
+                nickname: cadence,
+                unit_amount: stripePrice.get('amount'),
+                currency: stripePrice.get('currency'),
+                type: 'recurring',
+                recurring: {
+                    interval: cadence
+                }
+            };
+            mockManager.stripeMocker.prices.push(mockPrice);
+
+            mockManager.stripeMocker.customers.push({
+                id: customerId,
+                object: 'customer',
+                email: 'paid@test.com',
+                invoice_settings: {
+                    default_payment_method: null
+                },
+                subscriptions: {
+                    type: 'list',
+                    data: []
+                }
+            });
+
+            const now = new Date();
+            const currentPeriodEnd = new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000);
+            const discountStart = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+            const discountEnd = new Date(currentPeriodEnd);
+
+            mockManager.stripeMocker.subscriptions.push({
+                id: stripeSubscriptionId,
+                object: 'subscription',
+                status: 'active',
+                customer: customerId,
+                cancel_at_period_end: false,
+                current_period_end: Math.floor(currentPeriodEnd.getTime() / 1000),
+                start_date: Math.floor(discountStart.getTime() / 1000),
+                items: {
+                    data: [{
+                        id: 'si_test_repeating_signup',
+                        price: mockPrice
+                    }]
+                }
+            });
+
+            const retentionOffer = await models.Offer.add({
+                name: 'Retention Offer After Repeating Signup',
+                code: 'redeem-after-repeating-signup',
+                portal_title: '20% off',
+                portal_description: 'Stay with us!',
+                discount_type: 'percent',
+                discount_amount: 20,
+                duration: 'once',
+                interval: cadence,
+                product_id: null,
+                currency: null,
+                active: true,
+                redemption_type: 'retention',
+                stripe_coupon_id: stripeCouponId
+            });
+
+            await subscription.save({
+                offer_id: existingSignupOffer.id,
+                discount_start: discountStart,
+                discount_end: discountEnd,
+                current_period_end: currentPeriodEnd
+            }, {patch: true});
+
+            try {
+                const token = await getIdentityToken('paid@test.com');
+
+                await membersAgent
+                    .post(`/api/subscriptions/${stripeSubscriptionId}/apply-offer`)
+                    .body({identity: token, offer_id: retentionOffer.id})
+                    .expectStatus(204);
+
+                await DomainEvents.allSettled();
+
+                await subscription.refresh();
+                assert.equal(subscription.get('offer_id'), retentionOffer.id);
+
+                const redemption = await models.OfferRedemption.findOne({
+                    offer_id: retentionOffer.id,
+                    subscription_id: subscription.id
+                });
+                assert.ok(redemption, 'Offer redemption should be recorded');
+            } finally {
+                const redemption = await models.OfferRedemption.findOne({
+                    offer_id: retentionOffer.id,
+                    subscription_id: subscription.id
+                });
+                if (redemption) {
+                    await models.OfferRedemption.destroy({id: redemption.id});
+                }
+
+                await subscription.save({
+                    offer_id: null,
+                    discount_start: null,
+                    discount_end: null,
+                    current_period_end: originalCurrentPeriodEnd
+                }, {patch: true});
+                await models.Offer.destroy({id: retentionOffer.id});
+                await models.Offer.destroy({id: existingSignupOffer.id});
             }
         });
 

--- a/ghost/core/test/unit/server/services/members/members-api/controllers/router-controller.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/controllers/router-controller.test.js
@@ -1512,7 +1512,17 @@ describe('RouterController', function () {
         let res;
         let responseData;
 
-        function createMockSubscription({id = 'sub_123', status = 'active', offerId = null, trialEndAt = null, discountStart = null, discountEnd = null, cancelAtPeriodEnd = false} = {}) {
+        function createMockSubscription({
+            id = 'sub_123',
+            status = 'active',
+            offerId = null,
+            trialEndAt = null,
+            discountStart = null,
+            discountEnd = null,
+            startDate = null,
+            currentPeriodEnd = new Date('2025-06-01T00:00:00.000Z'),
+            cancelAtPeriodEnd = false
+        } = {}) {
             return {
                 id,
                 get: sinon.stub().callsFake((key) => {
@@ -1522,6 +1532,8 @@ describe('RouterController', function () {
                         trial_end_at: trialEndAt,
                         discount_start: discountStart,
                         discount_end: discountEnd,
+                        start_date: startDate,
+                        current_period_end: currentPeriodEnd,
                         cancel_at_period_end: cancelAtPeriodEnd
                     };
                     return values[key] ?? null;
@@ -1603,6 +1615,8 @@ describe('RouterController', function () {
         });
 
         it('returns empty offers when subscription has an active discount', async function () {
+            mockOffersAPI.getOffer.resolves({id: 'existing_offer_123', duration: 'forever'});
+
             const routerController = createRouterController({
                 subscriptions: createMockSubscription({
                     offerId: 'existing_offer_123',
@@ -1622,6 +1636,7 @@ describe('RouterController', function () {
         it('returns offers when subscription has an expired discount', async function () {
             const mockOffer = {id: 'retention_offer'};
             mockOffersAPI.listOffersAvailableToSubscription.resolves([mockOffer]);
+            mockOffersAPI.getOffer.resolves({id: 'expired_offer_123', duration: 'once'});
 
             const pastDate = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
             const routerController = createRouterController({
@@ -1629,6 +1644,33 @@ describe('RouterController', function () {
                     offerId: 'expired_offer_123',
                     discountStart: new Date('2025-01-01'),
                     discountEnd: pastDate
+                })
+            });
+
+            await routerController.getMemberOffers({
+                body: {identity: 'valid-token'}
+            }, res);
+
+            assert.deepEqual(responseData, {offers: [mockOffer]});
+            sinon.assert.calledOnce(mockOffersAPI.listOffersAvailableToSubscription);
+        });
+
+        it('returns offers when a one-month repeating signup offer no longer applies to the next payment', async function () {
+            const mockOffer = {id: 'retention_offer'};
+            mockOffersAPI.listOffersAvailableToSubscription.resolves([mockOffer]);
+            mockOffersAPI.getOffer.resolves({
+                id: 'expiring_repeating_offer',
+                duration: 'repeating',
+                duration_in_months: 1
+            });
+
+            const routerController = createRouterController({
+                subscriptions: createMockSubscription({
+                    offerId: 'expiring_repeating_offer',
+                    startDate: new Date('2025-05-01T00:00:00.000Z'),
+                    discountStart: new Date('2025-05-01T00:00:00.000Z'),
+                    discountEnd: new Date('2025-06-01T00:00:00.000Z'),
+                    currentPeriodEnd: new Date('2025-06-01T00:00:00.000Z')
                 })
             });
 

--- a/ghost/core/test/unit/server/services/members/members-api/utils/has-active-offer.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/utils/has-active-offer.test.js
@@ -3,11 +3,22 @@ const sinon = require('sinon');
 const hasActiveOffer = require('../../../../../../../core/server/services/members/members-api/utils/has-active-offer');
 
 describe('hasActiveOffer', function () {
+    beforeEach(function () {
+        sinon.useFakeTimers(new Date('2025-05-15T00:00:00.000Z'));
+    });
+
     afterEach(function () {
         sinon.restore();
     });
 
-    function createSubscriptionModel({discountStart = null, discountEnd = null, trialEndAt = null, offerId = null, startDate = null} = {}) {
+    function createSubscriptionModel({
+        discountStart = null,
+        discountEnd = null,
+        trialEndAt = null,
+        offerId = null,
+        startDate = null,
+        currentPeriodEnd = new Date('2025-06-01T00:00:00.000Z')
+    } = {}) {
         return {
             get: sinon.stub().callsFake((key) => {
                 const values = {
@@ -15,8 +26,10 @@ describe('hasActiveOffer', function () {
                     discount_end: discountEnd,
                     trial_end_at: trialEndAt,
                     offer_id: offerId,
-                    start_date: startDate
+                    start_date: startDate,
+                    current_period_end: currentPeriodEnd
                 };
+
                 return values[key] ?? null;
             })
         };
@@ -28,48 +41,17 @@ describe('hasActiveOffer', function () {
         };
     }
 
-    // Post-6.16 data: discount_start is populated
-
-    it('returns true when discount_start is set and discount_end is null (forever discount)', async function () {
-        const model = createSubscriptionModel({
-            discountStart: new Date('2026-01-01')
-        });
-
-        const result = await hasActiveOffer(model, createOffersAPI());
-
-        assert.equal(result, true);
-    });
-
-    it('returns true when discount_start is set and discount_end is in the future', async function () {
-        const futureDate = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
-        const model = createSubscriptionModel({
-            discountStart: new Date('2026-01-01'),
-            discountEnd: futureDate
-        });
-
-        const result = await hasActiveOffer(model, createOffersAPI());
-
-        assert.equal(result, true);
-    });
-
-    it('returns false when discount_start is set and discount_end is in the past', async function () {
-        const pastDate = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
-        const model = createSubscriptionModel({
-            discountStart: new Date('2025-01-01'),
-            discountEnd: pastDate
-        });
+    it('returns false when there is no trial and no offer', async function () {
+        const model = createSubscriptionModel();
 
         const result = await hasActiveOffer(model, createOffersAPI());
 
         assert.equal(result, false);
     });
 
-    // Trial-based offers (trial)
-
     it('returns true when trial_end_at is in the future', async function () {
-        const futureDate = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
         const model = createSubscriptionModel({
-            trialEndAt: futureDate
+            trialEndAt: new Date('2025-05-22T00:00:00.000Z')
         });
 
         const result = await hasActiveOffer(model, createOffersAPI());
@@ -78,9 +60,8 @@ describe('hasActiveOffer', function () {
     });
 
     it('returns false when trial_end_at is in the past', async function () {
-        const pastDate = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
         const model = createSubscriptionModel({
-            trialEndAt: pastDate
+            trialEndAt: new Date('2025-05-01T00:00:00.000Z')
         });
 
         const result = await hasActiveOffer(model, createOffersAPI());
@@ -88,56 +69,109 @@ describe('hasActiveOffer', function () {
         assert.equal(result, false);
     });
 
-    // Legacy data: discount_start is null, fall back to offer duration lookup
-
-    it('returns false when no discount_start, no trial, and no offer_id', async function () {
-        const model = createSubscriptionModel();
-        const result = await hasActiveOffer(model, createOffersAPI());
-        assert.equal(result, false);
-    });
-
-    it('returns true for a forever offer (legacy data)', async function () {
-        const model = createSubscriptionModel({offerId: 'offer_123', startDate: new Date('2025-01-01')});
+    it('returns true for a synced forever offer that still affects the next payment', async function () {
+        const model = createSubscriptionModel({
+            offerId: 'offer_123',
+            discountStart: new Date('2025-05-01T00:00:00.000Z')
+        });
         const offersAPI = createOffersAPI({duration: 'forever'});
+
         const result = await hasActiveOffer(model, offersAPI);
 
         assert.equal(result, true);
     });
 
-    it('returns false for a once offer (legacy data)', async function () {
+    it('returns true for a synced repeating offer that still affects the next payment', async function () {
+        const model = createSubscriptionModel({
+            offerId: 'offer_123',
+            discountStart: new Date('2025-05-01T00:00:00.000Z'),
+            discountEnd: new Date('2025-08-01T00:00:00.000Z'),
+            currentPeriodEnd: new Date('2025-06-01T00:00:00.000Z')
+        });
+        const offersAPI = createOffersAPI({duration: 'repeating', duration_in_months: 3});
+
+        const result = await hasActiveOffer(model, offersAPI);
+
+        assert.equal(result, true);
+    });
+
+    it('returns false for a synced repeating offer that no longer affects the next payment', async function () {
+        const model = createSubscriptionModel({
+            offerId: 'offer_123',
+            discountStart: new Date('2025-04-01T00:00:00.000Z'),
+            discountEnd: new Date('2025-05-31T00:00:00.000Z'),
+            currentPeriodEnd: new Date('2025-06-01T00:00:00.000Z')
+        });
+        const offersAPI = createOffersAPI({duration: 'repeating', duration_in_months: 2});
+
+        const result = await hasActiveOffer(model, offersAPI);
+
+        assert.equal(result, false);
+    });
+
+    it('returns false for a synced one-month repeating signup offer that ends on the current billing date', async function () {
+        const model = createSubscriptionModel({
+            offerId: 'offer_123',
+            startDate: new Date('2025-05-01T00:00:00.000Z'),
+            discountStart: new Date('2025-05-01T00:00:00.000Z'),
+            discountEnd: new Date('2025-06-01T00:00:00.000Z'),
+            currentPeriodEnd: new Date('2025-06-01T00:00:00.000Z')
+        });
+        const offersAPI = createOffersAPI({duration: 'repeating', duration_in_months: 1});
+
+        const result = await hasActiveOffer(model, offersAPI);
+
+        assert.equal(result, false);
+    });
+
+    it('returns true for a legacy forever offer', async function () {
+        const model = createSubscriptionModel({
+            offerId: 'offer_123',
+            startDate: new Date('2025-01-01T00:00:00.000Z')
+        });
+        const offersAPI = createOffersAPI({duration: 'forever'});
+
+        const result = await hasActiveOffer(model, offersAPI);
+
+        assert.equal(result, true);
+    });
+
+    it('returns false for a legacy once offer', async function () {
         const model = createSubscriptionModel({offerId: 'offer_123'});
         const offersAPI = createOffersAPI({duration: 'once'});
+
         const result = await hasActiveOffer(model, offersAPI);
 
         assert.equal(result, false);
     });
 
-    it('returns true for a repeating offer still within duration (legacy data)', async function () {
-        const threeMonthsAgo = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000);
+    it('returns true for a legacy repeating offer still within duration', async function () {
         const model = createSubscriptionModel({
             offerId: 'offer_123',
-            startDate: threeMonthsAgo
+            startDate: new Date('2025-04-01T00:00:00.000Z'),
+            currentPeriodEnd: new Date('2025-06-01T00:00:00.000Z')
         });
-        const offersAPI = createOffersAPI({duration: 'repeating', duration_in_months: 6});
+        const offersAPI = createOffersAPI({duration: 'repeating', duration_in_months: 3});
+
         const result = await hasActiveOffer(model, offersAPI);
 
         assert.equal(result, true);
     });
 
-    it('returns false for a repeating offer past its duration (legacy data)', async function () {
-        const oneYearAgo = new Date(Date.now() - 365 * 24 * 60 * 60 * 1000);
+    it('returns false for a legacy repeating offer past its duration', async function () {
         const model = createSubscriptionModel({
             offerId: 'offer_123',
-            startDate: oneYearAgo
+            startDate: new Date('2025-01-01T00:00:00.000Z'),
+            currentPeriodEnd: new Date('2025-06-01T00:00:00.000Z')
         });
-        const offersAPI = createOffersAPI({duration: 'repeating', duration_in_months: 6});
+        const offersAPI = createOffersAPI({duration: 'repeating', duration_in_months: 3});
 
         const result = await hasActiveOffer(model, offersAPI);
 
         assert.equal(result, false);
     });
 
-    it('returns true when offer lookup throws (errs on the side of blocking)', async function () {
+    it('returns true when offer lookup throws', async function () {
         const model = createSubscriptionModel({offerId: 'offer_123'});
         const offersAPI = {
             getOffer: sinon.stub().rejects(new Error('Database error'))
@@ -148,29 +182,10 @@ describe('hasActiveOffer', function () {
         assert.equal(result, true);
     });
 
-    it('returns false when offer lookup returns null (offer deleted)', async function () {
+    it('returns false when offer lookup returns null', async function () {
         const model = createSubscriptionModel({offerId: 'offer_123'});
-        const offersAPI = createOffersAPI(null);
 
-        const result = await hasActiveOffer(model, offersAPI);
-
-        assert.equal(result, false);
-    });
-
-    // Priority: discount_start takes precedence over trial and legacy fallback
-
-    it('discount_start takes precedence over trial_end_at', async function () {
-        const pastDiscountEnd = new Date(Date.now() - 1000);
-        const futureTrialEnd = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
-        const model = createSubscriptionModel({
-            discountStart: new Date('2025-01-01'),
-            discountEnd: pastDiscountEnd,
-            trialEndAt: futureTrialEnd
-        });
-
-        // discount_start is set, so discount_end in the past means expired
-        // even though trial_end_at is in the future
-        const result = await hasActiveOffer(model, createOffersAPI());
+        const result = await hasActiveOffer(model, createOffersAPI(null));
 
         assert.equal(result, false);
     });


### PR DESCRIPTION
closes https://linear.app/ghost/issue/BER-3413

- when a member signs ups with a repeating 1 month offer, the next payment is not discounted
- therefore, they should be able to redeem a retention offer

