### PR TITLE
Improved IPv6 address normalization in request-external

### DIFF
--- a/ghost/core/core/server/lib/request-external.js
+++ b/ghost/core/core/server/lib/request-external.js
@@ -139,6 +139,23 @@ function isPrivateIp(addr) {
         if (/^fe[89ab][0-9a-f]:/i.test(normalized6)) {
             return true;
         }
+        // Re-check for IPv4-mapped IPv6 after normalization
+        // Handles expanded forms like 0:0:0:0:0:ffff:127.0.0.1 which normalize to ::ffff:...
+        const v4DottedNorm = normalized6.match(/^::ffff:(\d[\d.]+)$/i);
+        if (v4DottedNorm) {
+            const normV4 = normalizeIPv4(v4DottedNorm[1]);
+            if (normV4) {
+                return isPrivateIPv4(normV4);
+            }
+            return true;
+        }
+        const v4HexNorm = normalized6.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/i);
+        if (v4HexNorm) {
+            const hi = parseInt(v4HexNorm[1], 16);
+            const lo = parseInt(v4HexNorm[2], 16);
+            const mapped = ((hi >> 8) & 0xff) + '.' + (hi & 0xff) + '.' + ((lo >> 8) & 0xff) + '.' + (lo & 0xff);
+            return isPrivateIPv4(mapped);
+        }
         return false;
     }
 

--- a/ghost/core/test/unit/server/lib/request-external.test.js
+++ b/ghost/core/test/unit/server/lib/request-external.test.js
@@ -166,6 +166,19 @@ describe('External Request', function () {
             assert.equal(isPrivateIp('::ffff:a9fe:1'), true); // 169.254.0.1
         });
 
+        it('detects expanded IPv4-mapped IPv6 addresses as private (dotted notation)', function () {
+            assert.equal(isPrivateIp('0:0:0:0:0:ffff:127.0.0.1'), true);
+            assert.equal(isPrivateIp('0:0:0:0:0:ffff:10.0.0.1'), true);
+            assert.equal(isPrivateIp('0:0:0:0:0:ffff:192.168.0.1'), true);
+            assert.equal(isPrivateIp('0:0:0:0:0:ffff:169.254.169.254'), true);
+            assert.equal(isPrivateIp('0000:0000:0000:0000:0000:ffff:127.0.0.1'), true);
+        });
+
+        it('allows public expanded IPv4-mapped IPv6 addresses', function () {
+            assert.equal(isPrivateIp('0:0:0:0:0:ffff:8.8.8.8'), false);
+            assert.equal(isPrivateIp('0000:0000:0000:0000:0000:ffff:8.8.8.8'), false);
+        });
+
         it('allows public IPv4-mapped IPv6 addresses (dotted notation)', function () {
             assert.equal(isPrivateIp('::ffff:8.8.8.8'), false);
         });


### PR DESCRIPTION
After normalizing expanded IPv6 forms, re-check for IPv4-mapped
addresses to ensure consistent private IP detection across all
notation variants.