### PR TITLE
Included yarn.lock in archive tarball for npm 9+ compatibility

### DIFF
--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -20,7 +20,7 @@
   "contributors": "https://github.com/TryGhost/Ghost/graphs/contributors",
   "license": "MIT",
   "scripts": {
-    "archive": "npm pack",
+    "archive": "yarn pack:standalone && tar -czf ghost-$(node -p \"require('./package.json').version\").tgz package && rm -rf package",
     "pack:standalone": "rm -rf package ghost-*.tgz && npm pack && tar -xzf ghost-*.tgz && cp ../../yarn.lock package/ && rm ghost-*.tgz",
     "dev": "nodemon index.js",
     "build:assets": "yarn build:assets:css && yarn build:assets:js",


### PR DESCRIPTION
## Summary
- Updated the `archive` script in `ghost/core/package.json` to repack the tarball with `yarn.lock` included
- npm 9+ intentionally excludes `yarn.lock` from `npm pack` output, which breaks Ghost's release process since consumers depend on locked dependencies
- This change makes the archive script npm-version-agnostic, removing the need to pin npm v8 in the release workflow

## Context
The Ghost-Release workflow currently pins npm v8 solely because later versions strip `yarn.lock` from tarballs. This is a prerequisite for switching the release workflow to OIDC-based npm publishing (removing the need for rotating npm tokens every 90 days).

## Test plan
- [x] Run `yarn nx run ghost:archive` locally and verify `yarn.lock` is present in the tarball: `tar -tzf ghost/core/*.tgz | grep yarn.lock`