### PR TITLE
Suppressed Ghost logging noise in CI unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -454,6 +454,7 @@ jobs:
           FORCE_COLOR: 0
           GHOST_UNIT_TEST_VARIANT: ci
           NX_SKIP_LOG_GROUPING: true
+          logging__level: fatal
 
       - uses: actions/upload-artifact@v4
         if: matrix.node == env.NODE_VERSION

--- a/ghost/core/test/unit/shared/config/loader.test.js
+++ b/ghost/core/test/unit/shared/config/loader.test.js
@@ -29,6 +29,9 @@ describe('Config Loader', function () {
             // we manually call `loadConf` in the tests and we need to ensure that the minimum
             // required config properties are available
             process.env.paths__contentPath = 'content/';
+            // Remove any nconf-style env vars that could interfere with
+            // config hierarchy assertions (e.g. logging__level set by CI)
+            delete process.env.logging__level;
         });
 
         afterEach(function () {


### PR DESCRIPTION
## Summary
- Added `logging__level=fatal` env var to the CI unit test step to suppress Ghost's noisy `info`-level logging output
- The test config had no logging override, so Ghost defaulted to `info` level, flooding CI output and causing truncation that hid real test failures
- Scoped to only the unit test step in CI — no change to local development or other test suites