### PR TITLE
Added the Sender header to transactional emails

### DIFF
--- a/ghost/core/core/server/services/mail/ghost-mailer.js
+++ b/ghost/core/core/server/services/mail/ghost-mailer.js
@@ -144,6 +144,11 @@ module.exports = class GhostMailer {
             if (settingsCache.get('email_track_opens')) {
                 messageToSend['o:tracking-opens'] = true;
             }
+            if (messageToSend.headers) {
+                for (const [key, value] of Object.entries(messageToSend.headers)) {
+                    messageToSend[`h:${key}`] = value;
+                }
+            }
         }
 
         const response = await this.sendMail(messageToSend);

--- a/ghost/core/test/unit/server/services/mail/ghost-mailer.test.js
+++ b/ghost/core/test/unit/server/services/mail/ghost-mailer.test.js
@@ -469,6 +469,23 @@ describe('Mail: Ghostmailer', function () {
             sinon.assert.called(warnStub);
         });
 
+        it('should copy headers to h: prefixed keys for Mailgun transport', async function () {
+            mailer = new mail.GhostMailer();
+            mailer.state.usingMailgun = true;
+            const sendMailSpy = sandbox.stub(mailer.transport, 'sendMail').resolves({});
+            sandbox.stub(settingsCache, 'get').returns(false);
+
+            await mailer.send({
+                to: 'user@example.com',
+                subject: 'test',
+                html: 'content'
+            });
+
+            const sentMessage = sendMailSpy.firstCall.args[0];
+            assert.ok(sentMessage['h:Sender'], 'h:Sender should be set');
+            assert.equal(sentMessage['h:Sender'], sentMessage.from);
+        });
+
         it('should not add tag when not using Mailgun transport', async function () {
             configUtils.set({
                 hostSettings: {siteId: '999999'}


### PR DESCRIPTION
ref [GVA-725](https://linear.app/ghost/issue/GVA-725/remove-on-behalf-of-for-outlook-on-transactional-emails)



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches transactional email sending for the Mailgun transport; incorrect header mapping could affect message delivery or how emails are displayed by clients.
> 
> **Overview**
> Ensures transactional emails sent via Mailgun include custom headers by copying entries from `messageToSend.headers` into Mailgun’s `h:`-prefixed parameters (notably propagating the `Sender` header).
> 
> Adds a unit test verifying `h:Sender` is set and matches the computed `from` address when using Mailgun.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f80387fe0c3a3f5cb0ce443982f2794dc4910e1e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->