### PR TITLE
Moved release automation from Ghost-Release into Ghost monorepo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
       - main
       - 'v[0-9]+.*' # Matches any release branch, e.g. v6.0.3, v12.1.0
       - '[0-9]+.x' # Matches any major version branch, e.g. 5.x, 23.x
+    tags:
+      - 'v[0-9]*' # Version tags trigger release publishing (npm, GitHub Release)
 
 env:
   FORCE_COLOR: 1
@@ -39,6 +41,7 @@ jobs:
     timeout-minutes: 15
     env:
       IS_MAIN: ${{ github.ref == 'refs/heads/main' }}
+      IS_TAG: ${{ startsWith(github.ref, 'refs/tags/v') }}
       IS_DEVELOPMENT: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/5.x' || github.ref == 'refs/heads/6.x' }}
       IS_SIX: ${{ github.ref == 'refs/heads/6.x' }}
       IS_SIX_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref == '6.x' }}
@@ -212,6 +215,7 @@ jobs:
       changed_new_package: ${{ steps.added.outputs.new-package }}
       base_commit: ${{ env.BASE_COMMIT }}
       is_main: ${{ env.IS_MAIN }}
+      is_tag: ${{ env.IS_TAG }}
       is_development: ${{ env.IS_DEVELOPMENT }}
       is_six: ${{ env.IS_SIX }}
       is_six_pr: ${{ env.IS_SIX_PR }}
@@ -245,7 +249,7 @@ jobs:
   job_lint:
     runs-on: ubuntu-latest
     needs: [job_setup]
-    if: needs.job_setup.outputs.changed_any_code == 'true'
+    if: needs.job_setup.outputs.changed_any_code == 'true' && needs.job_setup.outputs.is_tag != 'true'
     name: Lint
     steps:
       - uses: actions/checkout@v6
@@ -281,11 +285,12 @@ jobs:
     needs: [job_setup]
     name: i18n
     if: |
-        needs.job_setup.outputs.changed_comments_ui == 'true'
+        needs.job_setup.outputs.is_tag != 'true'
+        && (needs.job_setup.outputs.changed_comments_ui == 'true'
         || needs.job_setup.outputs.changed_signup_form == 'true'
         || needs.job_setup.outputs.changed_sodo_search == 'true'
         || needs.job_setup.outputs.changed_portal == 'true'
-        || needs.job_setup.outputs.changed_core == 'true'
+        || needs.job_setup.outputs.changed_core == 'true')
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v4
@@ -303,7 +308,7 @@ jobs:
   job_admin-tests:
     runs-on: ubuntu-latest
     needs: [job_setup]
-    if: needs.job_setup.outputs.changed_admin == 'true'
+    if: needs.job_setup.outputs.changed_admin == 'true' && needs.job_setup.outputs.is_tag != 'true'
     name: Admin tests - Chrome
     env:
       MOZ_HEADLESS: 1
@@ -344,7 +349,7 @@ jobs:
   job_unit-tests:
     runs-on: ubuntu-latest
     needs: [job_setup]
-    if: needs.job_setup.outputs.changed_any_code == 'true'
+    if: needs.job_setup.outputs.changed_any_code == 'true' && needs.job_setup.outputs.is_tag != 'true'
     strategy:
       matrix:
         node: ${{ fromJSON(needs.job_setup.outputs.node_test_matrix) }}
@@ -404,7 +409,7 @@ jobs:
   job_acceptance-tests:
     runs-on: ubuntu-latest
     needs: [job_setup]
-    if: needs.job_setup.outputs.changed_core == 'true'
+    if: needs.job_setup.outputs.changed_core == 'true' && needs.job_setup.outputs.is_tag != 'true'
     services:
       mysql:
         image: ${{ matrix.env.DB == 'mysql8' && 'mysql:8.0' || '' }}
@@ -492,7 +497,7 @@ jobs:
   job_legacy-tests:
     runs-on: ubuntu-latest
     needs: [job_setup]
-    if: needs.job_setup.outputs.changed_core == 'true'
+    if: needs.job_setup.outputs.changed_core == 'true' && needs.job_setup.outputs.is_tag != 'true'
     services:
       mysql:
         image: ${{ matrix.env.DB == 'mysql8' && 'mysql:8.0' || '' }}
@@ -565,7 +570,7 @@ jobs:
   job_admin_x_settings:
     runs-on: ubuntu-latest
     needs: [job_setup]
-    if: needs.job_setup.outputs.changed_admin_x_settings == 'true'
+    if: needs.job_setup.outputs.changed_admin_x_settings == 'true' && needs.job_setup.outputs.is_tag != 'true'
     name: Admin-X Settings tests
     env:
       CI: true
@@ -605,7 +610,7 @@ jobs:
   job_activitypub:
     runs-on: ubuntu-latest
     needs: [job_setup]
-    if: needs.job_setup.outputs.changed_activitypub == 'true'
+    if: needs.job_setup.outputs.changed_activitypub == 'true' && needs.job_setup.outputs.is_tag != 'true'
     name: ActivityPub tests
     env:
       CI: true
@@ -645,7 +650,7 @@ jobs:
   job_comments_ui:
     runs-on: ubuntu-latest
     needs: [job_setup]
-    if: needs.job_setup.outputs.changed_comments_ui == 'true'
+    if: needs.job_setup.outputs.changed_comments_ui == 'true' && needs.job_setup.outputs.is_tag != 'true'
     name: Comments-UI tests
     env:
       CI: true
@@ -685,7 +690,7 @@ jobs:
   job_signup_form:
     runs-on: ubuntu-latest
     needs: [job_setup]
-    if: needs.job_setup.outputs.changed_signup_form == 'true'
+    if: needs.job_setup.outputs.changed_signup_form == 'true' && needs.job_setup.outputs.is_tag != 'true'
     name: Signup-form tests
     env:
       CI: true
@@ -726,7 +731,7 @@ jobs:
     name: Tinybird Tests
     runs-on: ubuntu-latest
     needs: [job_setup]
-    if: needs.job_setup.outputs.changed_tinybird == 'true'
+    if: needs.job_setup.outputs.changed_tinybird == 'true' && needs.job_setup.outputs.is_tag != 'true'
     defaults:
         run:
           working-directory: ghost/core/core/server/data/tinybird
@@ -756,7 +761,7 @@ jobs:
   job_ghost-cli:
     name: Ghost-CLI tests
     needs: [job_setup]
-    if: needs.job_setup.outputs.changed_core == 'true'
+    if: needs.job_setup.outputs.changed_core == 'true' && needs.job_setup.outputs.is_tag != 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -814,8 +819,8 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-  job_docker_build_production:
-    name: Build & Push Production Docker Images
+  job_build_artifacts:
+    name: Build & Publish Artifacts
     needs: [job_setup]
     runs-on: ubuntu-latest
     permissions:
@@ -848,8 +853,32 @@ jobs:
           fi
           yarn build:production
 
+      - name: Verify tag matches package.json
+        if: startsWith(github.ref, 'refs/tags/v')
+        working-directory: ghost/core
+        run: |
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
+            echo "::error::Tag ${GITHUB_REF_NAME} doesn't match package.json version ${PKG_VERSION}"
+            exit 1
+          fi
+
       - name: Pack standalone distribution
         run: yarn workspace ghost pack:standalone
+
+      - name: Create npm tarball
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: yarn workspace ghost pack:tarball
+
+      - name: Upload npm tarball
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: actions/upload-artifact@v4
+        with:
+          name: ghost-npm-tarball
+          path: ghost/core/ghost-*.tgz
+          retention-days: 7
+          if-no-files-found: error
 
       - name: Prepare Docker build context
         run: mv ghost/core/package/ /tmp/ghost-production/
@@ -880,6 +909,12 @@ jobs:
           else
             IMAGE_CORE_NAME="ghcr.io/${OWNER}/${REPO_NAME}-core"
             IMAGE_FULL_NAME="ghcr.io/${OWNER}/${REPO_NAME}"
+          fi
+
+          # Force push on tag pushes (release images must always be published)
+          IS_TAG="${{ startsWith(github.ref, 'refs/tags/v') }}"
+          if [ "$IS_TAG" = "true" ]; then
+            USE_ARTIFACT="false"
           fi
 
           echo "use-artifact=$USE_ARTIFACT" >> $GITHUB_OUTPUT
@@ -917,6 +952,9 @@ jobs:
             type=ref,event=branch
             type=ref,event=pr
             type=sha
+            type=semver,pattern=v{{version}}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest,enable={{is_default_branch}}
           labels: |
             org.opencontainers.image.title=Ghost Core
@@ -932,6 +970,9 @@ jobs:
             type=ref,event=branch
             type=ref,event=pr
             type=sha
+            type=semver,pattern=v{{version}}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest,enable={{is_default_branch}}
           labels: |
             org.opencontainers.image.title=Ghost
@@ -1041,7 +1082,8 @@ jobs:
   job_e2e_tests:
     name: E2E Tests (${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
     runs-on: ubuntu-latest
-    needs: [job_docker_build_production, job_setup]
+    needs: [job_build_artifacts, job_setup]
+    if: needs.job_setup.outputs.is_tag != 'true'
     strategy:
       fail-fast: true
       matrix:
@@ -1070,8 +1112,8 @@ jobs:
         uses: ./.github/actions/load-docker-image
         id: load
         with:
-          use-artifact: ${{ needs.job_docker_build_production.outputs.use-artifact }}
-          image-tags: ${{ needs.job_docker_build_production.outputs.image-tags }}
+          use-artifact: ${{ needs.job_build_artifacts.outputs.use-artifact }}
+          image-tags: ${{ needs.job_build_artifacts.outputs.image-tags }}
           artifact-name: docker-image-production
 
       - name: Setup Docker Registry Mirrors
@@ -1286,8 +1328,12 @@ jobs:
       - name: Output needs
         run: echo "${{ toJson(needs) }}"
 
+      - name: Pass on tag pushes (tests already ran on branch)
+        if: needs.job_setup.outputs.is_tag == 'true'
+        run: echo "Tag push — tests skipped (already tested on branch commit)"
+
       - name: Check if any required jobs failed or been cancelled
-        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        if: needs.job_setup.outputs.is_tag != 'true' && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'))
         run: |
           echo "One of the dependent jobs have failed or been cancelled. You may need to re-run it." && exit 1
 
@@ -1467,15 +1513,15 @@ jobs:
   # Trigger Pro CD — dispatch to Ghost-Moya cd.yml (runs on main + PRs)
   # --------------------------------------------------------------------------- #
   trigger_cd:
-    needs: [job_setup, job_docker_build_production]
+    needs: [job_setup, job_build_artifacts]
     name: Trigger Pro CD
     runs-on: ubuntu-latest
     if: |
       always()
       && github.repository == 'TryGhost/Ghost'
       && needs.job_setup.result == 'success'
-      && needs.job_docker_build_production.result == 'success'
-      && needs.job_docker_build_production.outputs.use-artifact != 'true'
+      && needs.job_build_artifacts.result == 'success'
+      && needs.job_build_artifacts.outputs.use-artifact != 'true'
     steps:
       - name: Determine dispatch parameters
         id: params
@@ -1506,10 +1552,110 @@ jobs:
           event-type: ghost-artifacts-ready
           client-payload: >-
             {
-              "ref": "${{ github.sha }}",
+              "ref": "${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha }}",
               "source_repo": "${{ github.repository }}",
               "pr_number": "${{ steps.params.outputs.pr_number }}",
               "deploy": "${{ steps.params.outputs.deploy }}",
-              "admin_artifact_id": "${{ needs.job_docker_build_production.outputs.admin-artifact-id }}",
+              "admin_artifact_id": "${{ needs.job_build_artifacts.outputs.admin-artifact-id }}",
               "admin_artifact_run_id": "${{ github.run_id }}"
             }
+
+  # --------------------------------------------------------------------------- #
+  # Publish Ghost npm package — runs on version tags only (OIDC, no stored token)
+  # --------------------------------------------------------------------------- #
+  publish_ghost:
+    needs: [job_setup, job_build_artifacts]
+    name: Publish Ghost to npm
+    runs-on: ubuntu-latest
+    if: |
+      startsWith(github.ref, 'refs/tags/v')
+      && github.repository == 'TryGhost/Ghost'
+      && needs.job_build_artifacts.result == 'success'
+    environment: npm-release
+    permissions:
+      id-token: write
+    steps:
+      - name: Download npm tarball
+        uses: actions/download-artifact@v4
+        with:
+          name: ghost-npm-tarball
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      # TODO: Remove once Node v24 ships with npm >= 11
+      - name: Install npm v11 (required for OIDC publishing)
+        run: npm install -g npm@11
+
+      - name: Verify tarball contents
+        run: |
+          echo "Tarball contents:"
+          tar -tzf ghost-*.tgz | head -20
+          tar -tzf ghost-*.tgz | grep -q 'package/yarn.lock' || { echo "::error::yarn.lock not found in tarball"; exit 1; }
+
+      - name: Publish to npm
+        run: npm publish ghost-*.tgz --access public
+
+      - uses: tryghost/actions/actions/slack-build@main
+        if: failure()
+        with:
+          status: ${{ job.status }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+  # --------------------------------------------------------------------------- #
+  # Create GitHub Release — runs after successful npm publish
+  # --------------------------------------------------------------------------- #
+  create_github_release:
+    needs: [publish_ghost]
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: write
+    env:
+      GH_TOKEN: ${{ secrets.CANARY_DOCKER_BUILD }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Resolve previous tag
+        id: prev_tag
+        run: |
+          CURRENT_TAG="${GITHUB_REF_NAME}"
+          # Find the tag immediately before this one (excluding pre-releases)
+          PREV_TAG=$(git tag --list 'v[0-9]*' --sort=-version:refname | grep -v '-' | grep -v "^${CURRENT_TAG}$" | head -n 1)
+          echo "tag=${PREV_TAG}" >> "$GITHUB_OUTPUT"
+          echo "Previous tag: ${PREV_TAG}"
+
+      - name: Generate release notes
+        id: notes
+        run: |
+          node scripts/lib/release-notes.js "${{ steps.prev_tag.outputs.tag }}" "${GITHUB_REF_NAME}" > /tmp/release-notes.md
+          cat /tmp/release-notes.md
+
+      - name: Create GitHub Release
+        run: |
+          gh release create "${GITHUB_REF_NAME}" \
+            --title "${GITHUB_REF_NAME}" \
+            --notes-file /tmp/release-notes.md
+
+      - name: Notify Slack
+        if: always() && steps.notes.outcome == 'success'
+        run: |
+          VERSION="${GITHUB_REF_NAME}"
+          RELEASE_URL="https://github.com/TryGhost/Ghost/releases/tag/${VERSION}"
+          CHANGELOG=$(cat /tmp/release-notes.md | head -c 3000)
+
+          # Build Slack payload
+          PAYLOAD=$(jq -n \
+            --arg text "👻 *Ghost ${VERSION} is loose!* — <${RELEASE_URL}|Release Notes>\n\n${CHANGELOG}" \
+            '{text: $text}')
+
+          curl -sf -X POST \
+            -H 'Content-type: application/json' \
+            --data "${PAYLOAD}" \
+            "${{ secrets.RELEASE_NOTIFICATION_URL }}" || echo "Slack notification failed (non-fatal)"

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -64,9 +64,9 @@ jobs:
               if [ "$CONCLUSION" = "success" ] || [ "$CONCLUSION" = "failure" ]; then
                 # Check if Docker build job specifically succeeded (paginate — CI has 30+ jobs)
                 BUILD_JOB=$(gh api --paginate "repos/${{ github.repository }}/actions/runs/${RUN_ID}/jobs?per_page=100" \
-                  --jq '.jobs[] | select(.name == "Build & Push Production Docker Images") | .conclusion')
+                  --jq '.jobs[] | select(.name == "Build & Publish Artifacts") | .conclusion')
                 if [ -z "$BUILD_JOB" ]; then
-                  echo "::error::Build & Push Production Docker Images job not found in CI run ${RUN_ID}"
+                  echo "::error::Build & Publish Artifacts job not found in CI run ${RUN_ID}"
                   exit 1
                 elif [ "$BUILD_JOB" = "success" ]; then
                   echo "Docker build ready (CI run $RUN_ID)"

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -52,9 +52,9 @@ jobs:
               if [ "$CONCLUSION" = "success" ] || [ "$CONCLUSION" = "failure" ]; then
                 # Check if Docker build job specifically succeeded (paginate — CI has 30+ jobs)
                 BUILD_JOB=$(gh api --paginate "repos/${{ github.repository }}/actions/runs/${RUN_ID}/jobs?per_page=100" \
-                  --jq '.jobs[] | select(.name == "Build & Push Production Docker Images") | .conclusion')
+                  --jq '.jobs[] | select(.name == "Build & Publish Artifacts") | .conclusion')
                 if [ -z "$BUILD_JOB" ]; then
-                  echo "::error::Build & Push Production Docker Images job not found in CI run ${RUN_ID}"
+                  echo "::error::Build & Publish Artifacts job not found in CI run ${RUN_ID}"
                   exit 1
                 elif [ "$BUILD_JOB" = "success" ]; then
                   echo "Docker build ready (CI run $RUN_ID)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,33 +1,50 @@
-name: Release CI
-run-name: "Release CI — ${{ github.ref_name }}"
+name: Release
+run-name: "Release — ${{ inputs.bump-type || 'auto' }} from ${{ inputs.branch || 'main' }}${{ inputs.dry-run && ' (dry run)' || '' }}"
 
 on:
-  push:
-    tags: ['v[0-9]*']
+  # schedule:
+  #   - cron: '0 15 * * 5' # Friday 3pm UTC — disabled until cutover from Ghost-Release (BER-3313)
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Git branch to release from'
+        type: string
+        default: 'main'
+        required: false
+      bump-type:
+        description: 'Version bump type (auto, patch, minor)'
+        type: string
+        required: false
+        default: 'auto'
+      skip-checks:
+        description: 'Skip CI status check verification'
+        type: boolean
+        default: false
+      dry-run:
+        description: 'Dry run (version bump without push)'
+        type: boolean
+        default: false
 
 env:
   FORCE_COLOR: 1
-  HEAD_COMMIT: ${{ github.sha }}
-  CACHED_DEPENDENCY_PATHS: |
-    ${{ github.workspace }}/node_modules
-    ${{ github.workspace }}/apps/*/node_modules
-    ${{ github.workspace }}/ghost/*/node_modules
-    ${{ github.workspace }}/e2e/node_modules
-    ~/.cache/ms-playwright/
-  NX_REJECT_UNKNOWN_LOCAL_CACHE: 0
   NODE_VERSION: 22.18.0
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
-  build:
-    name: Build & Push Release Images
+  release:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
+    name: Prepare & Push Release
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
+          # PAT is required so that the tag push triggers ci.yml
+          # (pushes made with GITHUB_TOKEN don't trigger downstream workflows)
+          token: ${{ secrets.CANARY_DOCKER_BUILD }}
+          ref: ${{ inputs.branch || 'main' }}
+          fetch-depth: 0
           submodules: true
 
       - uses: actions/setup-node@v4
@@ -36,121 +53,49 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
-      - name: Restore caches
-        uses: ./.github/actions/restore-cache
-        env:
-          DEPENDENCY_CACHE_KEY: dep-cache-${{ hashFiles('yarn.lock') }}-${{ github.sha }}
-
-      - name: Verify tag matches package.json
+      - name: Set up Git
         run: |
-          PKG_VERSION=$(node -p "require('./package.json').version")
-          TAG_VERSION="${GITHUB_REF_NAME#v}"
-          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
-            echo "::error::Tag ${GITHUB_REF_NAME} doesn't match package.json version ${PKG_VERSION}"
-            exit 1
+          git config user.name "Ghost CI"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Set up schedule defaults
+        if: github.event_name == 'schedule'
+        run: |
+          echo "RELEASE_BRANCH=main" >> "$GITHUB_ENV"
+          echo "RELEASE_BUMP_TYPE=auto" >> "$GITHUB_ENV"
+          echo "RELEASE_DRY_RUN=" >> "$GITHUB_ENV"
+          echo "RELEASE_SKIP_CHECKS=" >> "$GITHUB_ENV"
+
+      - name: Set up workflow_dispatch inputs
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          echo "RELEASE_BRANCH=${INPUT_BRANCH}" >> "$GITHUB_ENV"
+          echo "RELEASE_BUMP_TYPE=${INPUT_BUMP_TYPE}" >> "$GITHUB_ENV"
+          echo "RELEASE_DRY_RUN=${INPUT_DRY_RUN}" >> "$GITHUB_ENV"
+          echo "RELEASE_SKIP_CHECKS=${INPUT_SKIP_CHECKS}" >> "$GITHUB_ENV"
+        env:
+          INPUT_BRANCH: ${{ inputs.branch }}
+          INPUT_BUMP_TYPE: ${{ inputs.bump-type }}
+          INPUT_DRY_RUN: ${{ inputs.dry-run }}
+          INPUT_SKIP_CHECKS: ${{ inputs.skip-checks }}
+
+      - name: Run release script
+        run: |
+          ARGS="--branch=${{ env.RELEASE_BRANCH }} --bump-type=${{ env.RELEASE_BUMP_TYPE }}"
+          if [ "${{ env.RELEASE_DRY_RUN }}" = "true" ]; then
+            ARGS="$ARGS --dry-run"
           fi
+          if [ "${{ env.RELEASE_SKIP_CHECKS }}" = "true" ]; then
+            ARGS="$ARGS --skip-checks"
+          fi
+          node scripts/release.js $ARGS
+        env:
+          GITHUB_TOKEN: ${{ secrets.CANARY_DOCKER_BUILD }}
 
-      - name: Build server and admin assets
-        run: yarn build:production
-
-      - name: Pack standalone distribution
-        run: yarn workspace ghost pack:standalone
-
-      - name: Prepare Docker build context
-        run: mv ghost/core/package/ /tmp/ghost-production/
-
-      - name: Upload admin artifact for CD
-        id: upload-admin
-        uses: actions/upload-artifact@v4
+      - name: Notify on failure
+        if: failure()
+        uses: tryghost/actions/actions/slack-build@main
         with:
-          name: admin-build-cd
-          path: apps/admin/dist
-          retention-days: 7
-          if-no-files-found: error
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Docker meta (core)
-        id: meta-core
-        uses: docker/metadata-action@v5
-        with:
-          images: ghcr.io/tryghost/ghost-core
-          tags: |
-            type=semver,pattern=v{{version}}
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=sha
-          labels: |
-            org.opencontainers.image.title=Ghost Core
-            org.opencontainers.image.description=Ghost production build (server only, no admin)
-            org.opencontainers.image.vendor=TryGhost
-
-      - name: Docker meta (full)
-        id: meta-full
-        uses: docker/metadata-action@v5
-        with:
-          images: ghcr.io/tryghost/ghost
-          tags: |
-            type=semver,pattern=v{{version}}
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=sha
-            type=raw,value=latest
-          labels: |
-            org.opencontainers.image.title=Ghost
-            org.opencontainers.image.description=Ghost production build (server + admin)
-            org.opencontainers.image.vendor=TryGhost
-
-      - name: Build & push core image
-        uses: docker/build-push-action@v6
-        with:
-          context: /tmp/ghost-production
-          file: Dockerfile.production
-          target: core
-          build-args: NODE_VERSION=${{ env.NODE_VERSION }}
-          push: true
-          tags: ${{ steps.meta-core.outputs.tags }}
-          labels: ${{ steps.meta-core.outputs.labels }}
-          cache-from: type=registry,ref=ghcr.io/tryghost/ghost-core:cache-main
-
-      - name: Build & push full image
-        uses: docker/build-push-action@v6
-        with:
-          context: /tmp/ghost-production
-          file: Dockerfile.production
-          target: full
-          build-args: NODE_VERSION=${{ env.NODE_VERSION }}
-          push: true
-          tags: ${{ steps.meta-full.outputs.tags }}
-          labels: ${{ steps.meta-full.outputs.labels }}
-          cache-from: type=registry,ref=ghcr.io/tryghost/ghost:cache-main
-
-    outputs:
-      admin-artifact-id: ${{ steps.upload-admin.outputs.artifact-id }}
-
-  trigger_cd:
-    needs: [build]
-    name: Trigger Pro CD
-    runs-on: ubuntu-latest
-    if: github.repository == 'TryGhost/Ghost'
-    steps:
-      - name: Dispatch to Ghost-Moya cd.yml
-        uses: peter-evans/repository-dispatch@v3
-        with:
-          token: ${{ secrets.CANARY_DOCKER_BUILD }}
-          repository: TryGhost/Ghost-Moya
-          event-type: ghost-artifacts-ready
-          client-payload: >-
-            {
-              "ref": "${{ github.ref_name }}",
-              "admin_artifact_id": "${{ needs.build.outputs.admin-artifact-id }}",
-              "admin_artifact_run_id": "${{ github.run_id }}"
-            }
+          status: ${{ job.status }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -19,9 +19,14 @@
   "bugs": "https://github.com/TryGhost/Ghost/issues",
   "contributors": "https://github.com/TryGhost/Ghost/graphs/contributors",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
   "scripts": {
     "archive": "npm pack",
     "pack:standalone": "rm -rf package ghost-*.tgz && npm pack && tar -xzf ghost-*.tgz && cp ../../yarn.lock package/ && rm ghost-*.tgz",
+    "pack:tarball": "tar -czf ghost-$(node -p \"require('./package.json').version\").tgz package",
     "dev": "nodemon index.js",
     "build:assets": "yarn build:assets:css && yarn build:assets:js",
     "build:assets:js": "node bin/minify-assets.js",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,9 @@
     "tb": "tb local start && cd ghost/core/core/server/data/tinybird && tb dev",
     "tb:install": "curl https://tinybird.co | sh",
     "data:analytics:generate": "node ghost/core/core/server/data/tinybird/scripts/docker-analytics-manager.js generate",
-    "data:analytics:clear": "node ghost/core/core/server/data/tinybird/scripts/docker-analytics-manager.js clear"
+    "data:analytics:clear": "node ghost/core/core/server/data/tinybird/scripts/docker-analytics-manager.js clear",
+    "release": "node scripts/release.js",
+    "test:release": "node --test 'scripts/test/*.js'"
   },
   "resolutions": {
     "@tryghost/errors": "^1.3.7",
@@ -80,6 +82,7 @@
     "lint-staged": "15.5.2",
     "nx": "22.0.4",
     "rimraf": "5.0.10",
+    "semver": "7.7.3",
     "typescript": "5.8.3"
   },
   "dependencies": {},

--- a/scripts/.eslintrc.js
+++ b/scripts/.eslintrc.js
@@ -1,0 +1,9 @@
+module.exports = {
+    parserOptions: {
+        ecmaVersion: 2022
+    },
+    env: {
+        node: true,
+        es2022: true
+    }
+};

--- a/scripts/lib/release-notes.js
+++ b/scripts/lib/release-notes.js
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+'use strict';
+
+const {execSync} = require('node:child_process');
+const path = require('node:path');
+
+const ROOT = path.resolve(__dirname, '../..');
+const REPO_URL = 'https://github.com/TryGhost/Ghost';
+
+// Emoji priority order (highest first) — matches Ghost's release convention
+const EMOJI_ORDER = ['💡', '🐛', '🎨', '💄', '✨', '🔒'];
+
+// Matches an emoji at the start of a string (covers most multi-byte emoji)
+const LEADING_EMOJI_RE = /^(\p{Emoji_Presentation}|\p{Emoji}\uFE0F)/u;
+
+function getCommitLog(fromTag, toTag) {
+    const range = `${fromTag}..${toTag}`;
+    const format = `* [%h](${REPO_URL}/commit/%h) %s - %an`;
+    const cmd = `git log --no-merges --pretty=tformat:'${format}' ${range}`;
+
+    let log;
+    try {
+        log = execSync(cmd, {cwd: ROOT, encoding: 'utf8'}).trim();
+    } catch {
+        return [];
+    }
+
+    if (!log) {
+        return [];
+    }
+
+    // Strip PR number references like (#1234)
+    return log.split('\n').map(line => line.replaceAll(/\(#\d+\)/g, '').trim());
+}
+
+function extractCommitMessage(line) {
+    // Line format: * [hash](url) <message> - <author>
+    const match = line.match(/\* \[[^\]]+\]\([^)]+\) (.+) - .+$/);
+    return match ? match[1].trim() : '';
+}
+
+function filterAndSortByEmoji(lines) {
+    const emojiLines = lines.filter((line) => {
+        const msg = extractCommitMessage(line);
+        return LEADING_EMOJI_RE.test(msg);
+    });
+
+    emojiLines.sort((a, b) => {
+        const msgA = extractCommitMessage(a);
+        const msgB = extractCommitMessage(b);
+        const emojiA = (msgA.match(LEADING_EMOJI_RE) || [''])[0];
+        const emojiB = (msgB.match(LEADING_EMOJI_RE) || [''])[0];
+        const indexA = EMOJI_ORDER.indexOf(emojiA);
+        const indexB = EMOJI_ORDER.indexOf(emojiB);
+        // Unknown emojis sort last; lower index = higher priority
+        const orderA = indexA === -1 ? Infinity : indexA;
+        const orderB = indexB === -1 ? Infinity : indexB;
+        return orderA - orderB;
+    });
+
+    return emojiLines;
+}
+
+function generateReleaseNotes(fromTag, toTag) {
+    const lines = getCommitLog(fromTag, toTag);
+    const filtered = filterAndSortByEmoji(lines);
+
+    let body;
+    if (filtered.length === 0) {
+        body = 'This release contains fixes for minor bugs and issues reported by Ghost users.';
+    } else {
+        // Deduplicate (preserving order)
+        body = [...new Set(filtered)].join('\n');
+    }
+
+    body += `\n\n---\n\nView the changelog for full details: ${REPO_URL}/compare/${fromTag}...${toTag}`;
+
+    return body;
+}
+
+// CLI: node release-notes.js <from-tag> <to-tag>
+if (require.main === module) {
+    const [fromTag, toTag] = process.argv.slice(2);
+
+    if (!fromTag || !toTag) {
+        console.error('Usage: node release-notes.js <from-tag> <to-tag>');
+        process.exit(1);
+    }
+
+    process.stdout.write(generateReleaseNotes(fromTag, toTag));
+}
+
+module.exports = {generateReleaseNotes};

--- a/scripts/lib/resolve-base-tag.js
+++ b/scripts/lib/resolve-base-tag.js
@@ -1,0 +1,31 @@
+const semver = require('semver');
+const {execSync} = require('node:child_process');
+
+/**
+ * Resolve the base git tag for diff/log comparisons during release preparation.
+ *
+ * For stable versions (e.g. "6.18.0"), returns "v6.18.0" — the tag for that version.
+ * For prerelease versions (e.g. "6.19.0-rc.0"), the tag "v6.19.0-rc.0" won't exist,
+ * so we find the most recent stable version tag in HEAD's ancestry using git describe.
+ *
+ * @param {string} version - The current Ghost version from package.json
+ * @param {string} repoDir - Path to the Ghost repo checkout
+ * @returns {{tag: string, isPrerelease: boolean}}
+ */
+function resolveBaseTag(version, repoDir) {
+    if (semver.prerelease(version)) {
+        const tag = execSync(
+            `git describe --tags --abbrev=0 --match 'v[0-9]*.[0-9]*.[0-9]*' --exclude 'v*-*' HEAD`,
+            {cwd: repoDir, encoding: 'utf8'}
+        ).trim();
+
+        return {tag, isPrerelease: true};
+    }
+
+    return {
+        tag: `v${version}`,
+        isPrerelease: false
+    };
+}
+
+module.exports = {resolveBaseTag};

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -1,0 +1,345 @@
+#!/usr/bin/env node
+'use strict';
+
+const path = require('node:path');
+const fs = require('node:fs');
+const {execSync} = require('node:child_process');
+const semver = require('semver');
+const {resolveBaseTag} = require('./lib/resolve-base-tag');
+
+const ROOT = path.resolve(__dirname, '..');
+const GHOST_CORE_PKG = path.join(ROOT, 'ghost/core/package.json');
+const GHOST_ADMIN_PKG = path.join(ROOT, 'ghost/admin/package.json');
+const CASPER_DIR = path.join(ROOT, 'ghost/core/content/themes/casper');
+const SOURCE_DIR = path.join(ROOT, 'ghost/core/content/themes/source');
+
+const MAX_WAIT_MS = 30 * 60 * 1000; // 30 minutes
+const POLL_INTERVAL_MS = 30 * 1000; // 30 seconds
+
+// --- Argument parsing ---
+
+function parseArgs() {
+    const args = process.argv.slice(2);
+    const opts = {
+        bumpType: 'auto',
+        branch: 'main',
+        dryRun: false,
+        skipChecks: false,
+        waitForChecks: false
+    };
+
+    for (const arg of args) {
+        if (arg.startsWith('--bump-type=')) {
+            opts.bumpType = arg.split('=')[1];
+        } else if (arg.startsWith('--branch=')) {
+            opts.branch = arg.split('=')[1];
+        } else if (arg === '--dry-run') {
+            opts.dryRun = true;
+        } else if (arg === '--skip-checks') {
+            opts.skipChecks = true;
+        } else if (arg === '--wait-for-checks') {
+            opts.waitForChecks = true;
+        } else {
+            console.error(`Unknown argument: ${arg}`);
+            process.exit(1);
+        }
+    }
+
+    return opts;
+}
+
+// --- Helpers ---
+
+function run(cmd, opts = {}) {
+    const result = execSync(cmd, {cwd: ROOT, encoding: 'utf8', ...opts});
+    return result.trim();
+}
+
+function readPkgVersion(pkgPath) {
+    return JSON.parse(fs.readFileSync(pkgPath, 'utf8')).version;
+}
+
+function writePkgVersion(pkgPath, version) {
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+    pkg.version = version;
+    fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+}
+
+function log(msg) {
+    console.log(`  ${msg}`);
+}
+
+function logStep(msg) {
+    console.log(`\n▸ ${msg}`);
+}
+
+// --- Version detection ---
+
+function detectBumpType(baseTag, bumpType) {
+    // Check for new migration files
+    const migrationsPath = 'ghost/core/core/server/data/migrations/versions/';
+    try {
+        const addedFiles = run(`git diff --diff-filter=A --name-only ${baseTag} HEAD -- ${migrationsPath}`);
+        if (addedFiles?.includes('core/')) {
+            log('New migrations detected');
+            if (bumpType === 'auto') {
+                log('Auto-detecting: bumping to minor');
+                bumpType = 'minor';
+            }
+        } else {
+            log('No new migrations detected');
+        }
+    } catch {
+        log('Warning: could not diff migrations');
+    }
+
+    // Check for feature commits (✨ or 🎉)
+    try {
+        const commits = run(`git log --oneline ${baseTag}..HEAD`);
+        if (commits) {
+            const featureCommits = commits.split('\n').filter(c => c.includes('✨') || c.includes('🎉') || c.includes(':sparkles:'));
+            if (featureCommits.length) {
+                log(`Feature commits detected (${featureCommits.length})`);
+                if (bumpType === 'auto') {
+                    log('Auto-detecting: bumping to minor');
+                    bumpType = 'minor';
+                }
+            } else {
+                log('No feature commits detected');
+            }
+        } else {
+            log('No commits since base tag');
+        }
+    } catch {
+        log('Warning: could not read commit log');
+    }
+
+    if (bumpType === 'auto') {
+        log('Defaulting to patch');
+        bumpType = 'patch';
+    }
+
+    return bumpType;
+}
+
+// --- CI check polling ---
+
+async function waitForChecks(commit) {
+    logStep(`Waiting for CI checks on ${commit.slice(0, 8)}...`);
+
+    const token = process.env.GITHUB_TOKEN || process.env.RELEASE_TOKEN;
+    if (!token) {
+        throw new Error('GITHUB_TOKEN or RELEASE_TOKEN required for --wait-for-checks');
+    }
+
+    const startTime = Date.now();
+
+    while (true) { // eslint-disable-line no-constant-condition
+        const response = await fetch(`https://api.github.com/repos/TryGhost/Ghost/commits/${commit}/check-runs`, {
+            headers: {
+                Authorization: `token ${token}`,
+                Accept: 'application/vnd.github+json'
+            }
+        });
+
+        if (!response.ok) {
+            throw new Error(`GitHub API error: ${response.status} ${response.statusText}`);
+        }
+
+        const {check_runs: checkRuns} = await response.json();
+
+        if (checkRuns.length === 0) {
+            throw new Error('No checks found for this commit');
+        }
+
+        let pending = false;
+        let failed = false;
+
+        for (const run of checkRuns) {
+            // Skip release-related, stale, and optional checks
+            if (run.name.includes('release') || run.name.includes('stale') || run.name.includes('[Optional]')) {
+                continue;
+            }
+            if (run.conclusion === 'skipped') {
+                continue;
+            }
+            if (run.status === 'completed' && run.conclusion === 'success') {
+                continue;
+            }
+            if (run.status !== 'completed') {
+                pending = true;
+                continue;
+            }
+            // Completed but not success/skipped
+            failed = true;
+        }
+
+        if (!pending && !failed) {
+            log('All status checks passed');
+            return;
+        }
+
+        if (!pending && failed) {
+            throw new Error('Some status checks have failed');
+        }
+
+        const elapsedMs = Date.now() - startTime;
+        const elapsed = Math.round(elapsedMs / 1000);
+
+        if (elapsedMs >= MAX_WAIT_MS) {
+            throw new Error(`Timed out waiting for checks after ${elapsed}s`);
+        }
+
+        log(`Checks still running (${elapsed}s elapsed), waiting 30s...`);
+        await new Promise(resolve => setTimeout(resolve, POLL_INTERVAL_MS));
+    }
+}
+
+// --- Theme submodule updates ---
+
+function updateThemeSubmodule(themeDir, themeName) {
+    if (!fs.existsSync(themeDir)) {
+        log(`${themeName} not present, skipping`);
+        return false;
+    }
+
+    const currentPkg = JSON.parse(fs.readFileSync(path.join(themeDir, 'package.json'), 'utf8'));
+    const currentVersion = currentPkg.version;
+
+    // Checkout latest stable tag on main branch
+    try {
+        execSync(
+            `git checkout $(git describe --abbrev=0 --tags $(git rev-list --tags --max-count=1 --branches=main))`,
+            {cwd: themeDir, encoding: 'utf8', stdio: 'pipe'}
+        );
+    } catch (err) {
+        log(`Warning: failed to update ${themeName}: ${err.message}`);
+        return false;
+    }
+
+    const updatedPkg = JSON.parse(fs.readFileSync(path.join(themeDir, 'package.json'), 'utf8'));
+    const newVersion = updatedPkg.version;
+
+    if (semver.gt(newVersion, currentVersion)) {
+        log(`${themeName} updated: v${currentVersion} → v${newVersion}`);
+        run(`git add -f ${path.relative(ROOT, themeDir)}`);
+        run(`git commit -m "🎨 Updated ${themeName} to v${newVersion}"`);
+        return true;
+    }
+
+    log(`${themeName} already at latest (v${currentVersion})`);
+    return false;
+}
+
+// --- Main ---
+
+async function main() {
+    const opts = parseArgs();
+
+    console.log('Ghost Release Script');
+    console.log('====================');
+    log(`Branch: ${opts.branch}`);
+    log(`Bump type: ${opts.bumpType}`);
+    log(`Dry run: ${opts.dryRun}`);
+
+    // 1. Read current version
+    logStep('Reading current version');
+    const currentVersion = readPkgVersion(GHOST_CORE_PKG);
+    log(`Current version: ${currentVersion}`);
+
+    // 2. Resolve base tag
+    logStep('Resolving base tag');
+    const {tag: baseTag, isPrerelease} = resolveBaseTag(currentVersion, ROOT);
+    if (isPrerelease) {
+        log(`Prerelease detected (${currentVersion}), resolved base tag: ${baseTag}`);
+    } else {
+        log(`Base tag: ${baseTag}`);
+    }
+
+    // 3. Detect bump type
+    logStep('Detecting bump type');
+    const resolvedBumpType = detectBumpType(baseTag, opts.bumpType);
+    const newVersion = semver.inc(currentVersion, resolvedBumpType);
+    if (!newVersion) {
+        console.error(`Failed to calculate new version from ${currentVersion} with bump type ${resolvedBumpType}`);
+        process.exit(1);
+    }
+    log(`Bump type: ${resolvedBumpType}`);
+    log(`New version: ${newVersion}`);
+
+    // 4. Check tag doesn't exist
+    logStep('Checking remote tags');
+    try {
+        const tagCheck = run(`git ls-remote --tags origin refs/tags/v${newVersion}`);
+        if (tagCheck) {
+            console.error(`Tag v${newVersion} already exists on remote. Cannot release this version.`);
+            process.exit(1);
+        }
+    } catch {
+        // ls-remote returns non-zero if no match — that's what we want
+    }
+    log(`Tag v${newVersion} does not exist on remote`);
+
+    // 5. Wait for CI checks
+    if (opts.waitForChecks && !opts.skipChecks) {
+        const headSha = run('git rev-parse HEAD');
+        await waitForChecks(headSha);
+    } else if (opts.skipChecks) {
+        log('Skipping CI checks');
+    }
+
+    // 6. Update theme submodules (main branch only)
+    if (opts.branch === 'main') {
+        logStep('Updating theme submodules');
+        run('git submodule update --init');
+        updateThemeSubmodule(CASPER_DIR, 'Casper');
+        updateThemeSubmodule(SOURCE_DIR, 'Source');
+    } else {
+        logStep('Skipping theme updates (not main branch)');
+    }
+
+    // 7. Bump versions
+    logStep(`Bumping version to ${newVersion}`);
+    writePkgVersion(GHOST_CORE_PKG, newVersion);
+    writePkgVersion(GHOST_ADMIN_PKG, newVersion);
+
+    // 8. Commit and tag
+    run(`git add ${path.relative(ROOT, GHOST_CORE_PKG)} ${path.relative(ROOT, GHOST_ADMIN_PKG)}`);
+    run(`git commit -m "v${newVersion}"`);
+    run(`git tag v${newVersion}`);
+    log(`Created tag v${newVersion}`);
+
+    // 9. Push
+    if (opts.dryRun) {
+        logStep('DRY RUN — skipping push');
+        log(`Would push branch ${opts.branch} and tag v${newVersion}`);
+    } else {
+        logStep('Pushing');
+        run(`git push origin HEAD --follow-tags`);
+        log('Pushed branch and tag');
+    }
+
+    // 10. Advance to next RC
+    logStep('Advancing to next RC');
+    const nextMinor = semver.inc(newVersion, 'minor');
+    const nextRc = `${nextMinor}-rc.0`;
+    log(`Next RC: ${nextRc}`);
+    writePkgVersion(GHOST_CORE_PKG, nextRc);
+    writePkgVersion(GHOST_ADMIN_PKG, nextRc);
+    run(`git add ${path.relative(ROOT, GHOST_CORE_PKG)} ${path.relative(ROOT, GHOST_ADMIN_PKG)}`);
+    run(`git commit -m "Bumped version to ${nextRc}"`);
+
+    if (opts.dryRun) {
+        log('DRY RUN — skipping RC push');
+    } else {
+        run('git push origin HEAD');
+        log('Pushed RC version');
+    }
+
+    console.log(`\n✓ Release ${newVersion} complete`);
+}
+
+main().catch((err) => {
+    console.error(`\n✗ Release failed: ${err.message}`);
+    process.exit(1);
+});

--- a/scripts/test/resolve-base-tag.test.js
+++ b/scripts/test/resolve-base-tag.test.js
@@ -1,0 +1,179 @@
+const {describe, it, before, after} = require('node:test');
+const assert = require('node:assert');
+const os = require('node:os');
+const path = require('node:path');
+const fs = require('node:fs');
+const {execSync} = require('node:child_process');
+const semver = require('semver');
+const {resolveBaseTag} = require('../lib/resolve-base-tag');
+
+/**
+ * Create a temporary git repo with semver tags for testing.
+ * Returns the repo path. Caller is responsible for cleanup.
+ */
+function createTestRepo() {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ghost-release-test-'));
+
+    execSync([
+        `cd ${tmpDir}`,
+        'git init',
+        'git config user.email "test@test.com"',
+        'git config user.name "Test"',
+
+        // Initial commit + stable tag v6.17.0
+        'echo "initial" > file.txt',
+        'git add .',
+        'git commit -m "initial"',
+        'git tag v6.17.0',
+
+        // Second commit + stable tag v6.17.1
+        'echo "patch" >> file.txt',
+        'git add .',
+        'git commit -m "patch release"',
+        'git tag v6.17.1',
+
+        // Third commit (no tag — simulates post-release development)
+        'echo "new work" >> file.txt',
+        'git add .',
+        'git commit -m "post-release commit"'
+    ].join(' && '));
+
+    return tmpDir;
+}
+
+describe('resolveBaseTag', () => {
+    let testRepo;
+
+    before(() => {
+        testRepo = createTestRepo();
+    });
+
+    after(() => {
+        fs.rmSync(testRepo, {recursive: true, force: true});
+    });
+
+    describe('semver.prerelease detection', () => {
+        it('returns null for stable versions', () => {
+            assert.strictEqual(semver.prerelease('6.17.1'), null);
+            assert.strictEqual(semver.prerelease('6.18.0'), null);
+            assert.strictEqual(semver.prerelease('5.0.0'), null);
+        });
+
+        it('returns prerelease components for rc versions', () => {
+            const result = semver.prerelease('6.19.0-rc.0');
+            assert.deepStrictEqual(result, ['rc', 0]);
+        });
+
+        it('returns prerelease components for alpha versions', () => {
+            const result = semver.prerelease('7.0.0-alpha.1');
+            assert.deepStrictEqual(result, ['alpha', 1]);
+        });
+    });
+
+    describe('stable version path', () => {
+        it('constructs tag directly from version', () => {
+            // Stable versions don't hit git — the tag is just v{version}
+            const {tag, isPrerelease} = resolveBaseTag('6.17.1', '/nonexistent');
+            assert.strictEqual(tag, 'v6.17.1');
+            assert.strictEqual(isPrerelease, false);
+        });
+
+        it('works for any stable version format', () => {
+            const {tag} = resolveBaseTag('5.0.0', '/nonexistent');
+            assert.strictEqual(tag, 'v5.0.0');
+        });
+    });
+
+    describe('prerelease version path', () => {
+        it('resolves to the latest stable tag', () => {
+            const {tag, isPrerelease} = resolveBaseTag('6.19.0-rc.0', testRepo);
+            assert.strictEqual(isPrerelease, true);
+            assert.strictEqual(tag, 'v6.17.1');
+        });
+
+        it('resolved tag is a stable version (no prerelease suffix)', () => {
+            const {tag} = resolveBaseTag('6.19.0-rc.0', testRepo);
+            assert.match(tag, /^v\d+\.\d+\.\d+$/);
+            assert.strictEqual(semver.prerelease(tag.slice(1)), null);
+        });
+
+        it('resolved tag is a valid git ref', () => {
+            const {tag} = resolveBaseTag('6.19.0-rc.0', testRepo);
+            const sha = execSync(`cd ${testRepo} && git rev-parse ${tag}`, {encoding: 'utf8'});
+            assert.ok(sha.trim().length > 0, 'Tag should resolve to a commit SHA');
+        });
+
+        it('git diff succeeds with the resolved tag', () => {
+            const {tag} = resolveBaseTag('6.19.0-rc.0', testRepo);
+            const result = execSync(
+                `cd ${testRepo} && git diff --diff-filter=A --name-only ${tag} HEAD`,
+                {encoding: 'utf8'}
+            );
+            assert.strictEqual(typeof result, 'string');
+        });
+
+        it('git log succeeds with the resolved tag', () => {
+            const {tag} = resolveBaseTag('6.19.0-rc.0', testRepo);
+            const result = execSync(
+                `cd ${testRepo} && git log --oneline ${tag}..HEAD`,
+                {encoding: 'utf8'}
+            );
+            assert.strictEqual(typeof result, 'string');
+            // Should have at least 1 commit (the post-release commit)
+            assert.ok(result.trim().length > 0, 'Should find commits after the tag');
+        });
+    });
+
+    describe('prerelease excludes prerelease tags', () => {
+        let repoWithPrereleaseTag;
+
+        before(() => {
+            // Create a repo that has both stable and prerelease tags
+            repoWithPrereleaseTag = fs.mkdtempSync(path.join(os.tmpdir(), 'ghost-release-test-pre-'));
+            execSync([
+                `cd ${repoWithPrereleaseTag}`,
+                'git init',
+                'git config user.email "test@test.com"',
+                'git config user.name "Test"',
+
+                'echo "initial" > file.txt',
+                'git add .',
+                'git commit -m "initial"',
+                'git tag v6.17.0',
+
+                'echo "alpha" >> file.txt',
+                'git add .',
+                'git commit -m "alpha work"',
+                'git tag v7.0.0-alpha.0',
+
+                'echo "more" >> file.txt',
+                'git add .',
+                'git commit -m "more work"'
+            ].join(' && '));
+        });
+
+        after(() => {
+            fs.rmSync(repoWithPrereleaseTag, {recursive: true, force: true});
+        });
+
+        it('skips prerelease tags and finds the stable one', () => {
+            const {tag} = resolveBaseTag('7.0.0-rc.0', repoWithPrereleaseTag);
+            // Should find v6.17.0 (stable), NOT v7.0.0-alpha.0 (prerelease)
+            assert.strictEqual(tag, 'v6.17.0');
+        });
+    });
+
+    describe('semver.inc compatibility', () => {
+        it('patch of an rc produces the stable release', () => {
+            assert.strictEqual(semver.inc('6.19.0-rc.0', 'patch'), '6.19.0');
+        });
+
+        it('minor of an rc produces the stable release (not next minor)', () => {
+            assert.strictEqual(semver.inc('6.19.0-rc.0', 'minor'), '6.19.0');
+        });
+
+        it('prerelease rc of an rc increments the rc number', () => {
+            assert.strictEqual(semver.inc('6.19.0-rc.0', 'prerelease', 'rc'), '6.19.0-rc.1');
+        });
+    });
+});


### PR DESCRIPTION
Consolidates release automation from the private Ghost-Release repo into the Ghost monorepo, eliminating the redundant full rebuild that Ghost-Release performed for npm publishing.

The release orchestration logic (version bump auto-detection, theme submodule updates, tag creation, RC advancement) becomes `scripts/release.js`, triggered by a manual `workflow_dispatch` in `release.yml`. The scheduled Friday cron is commented out until cutover from Ghost-Release (BER-3313). Tag-triggered npm publishing via OIDC trusted publishing and GitHub Release creation are absorbed into `ci.yml` as new jobs that only run on version tags.

The `publish_ghost` job is gated by an `npm-release` GitHub environment, so it won't fire until that environment is created — this prevents interference with Ghost-Release during the transition period. `create_github_release` depends on `publish_ghost`, so it also stays inert.

The `create_github_release` job replaces the `tryghost/actions/actions/ghost-release@main` action with a self-contained `scripts/lib/release-notes.js` script that replicates the existing emoji-filtered changelog generation and Slack notification. This eliminates the dependency on the archived Utils repo and its vulnerable `request`/`request-promise` transitive dependencies.

The key improvement is that the `ghost` npm package published to self-hosted users is now the same artifact that CI built and tested, rather than a second independent build of the same source. npm provenance links the published package to the exact CI run and source commit.

The CI build job is renamed from `job_docker_build_production` to `job_build_artifacts` to reflect that it now produces both Docker images and the npm tarball. `deploy-to-staging.yml` and `pr-preview.yml` are updated to match the new job name.

**This PR is inert on merge** — no automatic releases will fire. The cron is disabled and `publish_ghost` is gated by a non-existent environment. Ghost-Release continues to be the active release path.

**Setup required before first release through the new pipeline:**
- Configure OIDC trusted publishing for the `ghost` package on npmjs.com
- Create `npm-release` GitHub environment in the Ghost repo
- Add `RELEASE_NOTIFICATION_URL` secret to Ghost repo (for Slack release notifications — degrades gracefully if missing)
- Check branch protection rules reference the renamed CI job (`Build & Publish Artifacts`)

**After validation (1-2 successful releases):**
- Enable the Friday cron in `release.yml`
- Disable Ghost-Release cron
- Archive Ghost-Release repo
- Remove `actions/ghost-release/` from the Actions repo