### PR TITLE
Added missing await to expect() calls in acceptance tests

### DIFF
--- a/apps/admin-x-settings/test/acceptance/membership/offers.test.ts
+++ b/apps/admin-x-settings/test/acceptance/membership/offers.test.ts
@@ -62,9 +62,9 @@ test.describe('Offers', () => {
         const modal = page.getByTestId('offers-modal');
         await modal.getByRole('button', {name: 'New offer'}).click();
         const addModal = page.getByTestId('add-offer-modal');
-        expect(addModal).toBeVisible();
+        await expect(addModal).toBeVisible();
         const sidebar = addModal.getByTestId('add-offer-sidebar');
-        expect(sidebar).toBeVisible();
+        await expect(sidebar).toBeVisible();
         await sidebar.getByPlaceholder(/^Black Friday$/).fill('Coffee Tuesdays');
         await sidebar.getByLabel('Amount off').fill('5');
 
@@ -135,9 +135,9 @@ test.describe('Offers', () => {
         const modal = page.getByTestId('offers-modal');
         await modal.getByRole('button', {name: 'New offer'}).click();
         const addModal = page.getByTestId('add-offer-modal');
-        expect(addModal).toBeVisible();
+        await expect(addModal).toBeVisible();
         const sidebar = addModal.getByTestId('add-offer-sidebar');
-        expect(sidebar).toBeVisible();
+        await expect(sidebar).toBeVisible();
         await sidebar.getByPlaceholder(/^Black Friday$/).fill('Coffee Tuesdays');
         await sidebar.getByLabel('Amount off').fill('10');
         await addModal.getByRole('button', {name: 'Publish'}).click();

--- a/apps/admin-x-settings/test/acceptance/membership/recommendations.test.ts
+++ b/apps/admin-x-settings/test/acceptance/membership/recommendations.test.ts
@@ -162,8 +162,8 @@ test.describe('Recommendations', async () => {
 
         // Confirm delete
         const confirmation = page.getByTestId('confirmation-modal');
-        expect(confirmation).toContainText('Delete recommendation');
-        expect(confirmation).toContainText('Your recommendation Recommendation 1 title will no longer be visible to your audience.');
+        await expect(confirmation).toContainText('Delete recommendation');
+        await expect(confirmation).toContainText('Your recommendation Recommendation 1 title will no longer be visible to your audience.');
 
         await confirmation.getByRole('button', {name: 'Delete'}).click();
 


### PR DESCRIPTION
no refs

This is a test only change.

## Summary

- Added `await` to 6 Playwright async matcher assertions across 2 test files
- Fixed `expect().toBeVisible()` assertions in offers.test.ts (4 instances)
- Fixed `expect().toContainText()` assertions in recommendations.test.ts (2 instances)
- All 208 acceptance tests now pass