### PR TITLE
Fixed flaky admin-x-settings social accounts tests

### DIFF
--- a/apps/admin-x-framework/src/test/acceptance.ts
+++ b/apps/admin-x-framework/src/test/acceptance.ts
@@ -348,7 +348,7 @@ export async function testUrlValidation(input: Locator, textToEnter: string, exp
     await input.fill(textToEnter);
     await input.blur();
 
-    expect(input).toHaveValue(expectedResult);
+    await expect(input).toHaveValue(expectedResult);
 
     if (expectedError) {
         await expect(input.locator('xpath=../..')).toContainText(expectedError);

--- a/apps/admin-x-settings/test/acceptance/general/social-accounts.test.ts
+++ b/apps/admin-x-settings/test/acceptance/general/social-accounts.test.ts
@@ -98,6 +98,14 @@ test.describe('Social account settings', async () => {
             'The URL must be in a format like https://www.facebook.com/yourPage'
         );
 
+        // Reset to a valid URL so the setting is non-null before the next invalid test,
+        // otherwise the useEffect that clears the field won't fire (setting is already null)
+        await testUrlValidation(
+            facebookInput,
+            'facebook.com/valid',
+            'https://www.facebook.com/valid'
+        );
+
         await testUrlValidation(
             facebookInput,
             'http://github.com/pages/username',
@@ -132,10 +140,17 @@ test.describe('Social account settings', async () => {
             'The URL must be in a format like https://x.com/yourUsername'
         );
 
+        // Reset to a valid URL so the setting is non-null before the next invalid test
+        await testUrlValidation(
+            twitterInput,
+            'testuser',
+            'https://x.com/testuser'
+        );
+
         await testUrlValidation(
             twitterInput,
             'thisusernamehasmorethan15characters',
-            'thisusernamehasmorethan15characters',
+            '',
             'Your Username is not a valid Twitter Username'
         );
     });


### PR DESCRIPTION
no refs

This is a test-only change.

Summary

  - Added missing await to expect(input).toHaveValue() in the shared testUrlValidation helper, which was silently skipping the assertion
  - Fixed social accounts URL validation tests that were exposed by the await fix: the component clears invalid URLs via a useEffect that watches the setting value, but consecutive invalid URLs don't trigger the effect because the setting is already null.
  - Added valid URL resets between invalid URL assertions to ensure the useEffect fires correctly each time.
