### PR TITLE
🎨 Added separate Server and Admin build versions to About dialog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -934,7 +934,14 @@ jobs:
           DEPENDENCY_CACHE_KEY: ${{ needs.job_setup.outputs.dependency_cache_key }}
 
       - name: Build server and admin assets
-        run: yarn build:production
+        run: |
+          PKG_VERSION=$(node -p "require('./ghost/core/package.json').version")
+          SHORT_SHA="${GITHUB_SHA:0:7}"
+          if [ "${{ github.ref_type }}" != "tag" ]; then
+            export GHOST_BUILD_VERSION="${PKG_VERSION}+${SHORT_SHA}"
+            echo "GHOST_BUILD_VERSION=${GHOST_BUILD_VERSION}" >> $GITHUB_ENV
+          fi
+          yarn build:production
 
       - name: Pack standalone distribution
         run: yarn workspace ghost pack:standalone
@@ -1032,7 +1039,9 @@ jobs:
           context: /tmp/ghost-production
           file: Dockerfile.production
           target: core
-          build-args: NODE_VERSION=${{ env.NODE_VERSION }}
+          build-args: |
+            NODE_VERSION=${{ env.NODE_VERSION }}
+            GHOST_BUILD_VERSION=${{ env.GHOST_BUILD_VERSION }}
           push: ${{ steps.strategy.outputs.should-push }}
           load: ${{ steps.strategy.outputs.should-push == 'false' }}
           tags: ${{ steps.meta-core.outputs.tags }}
@@ -1046,7 +1055,9 @@ jobs:
           context: /tmp/ghost-production
           file: Dockerfile.production
           target: full
-          build-args: NODE_VERSION=${{ env.NODE_VERSION }}
+          build-args: |
+            NODE_VERSION=${{ env.NODE_VERSION }}
+            GHOST_BUILD_VERSION=${{ env.GHOST_BUILD_VERSION }}
           push: ${{ steps.strategy.outputs.should-push }}
           load: true
           tags: ${{ steps.meta-full.outputs.tags }}

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -12,7 +12,9 @@ ARG NODE_VERSION=22.18.0
 # ---- Core: server + production deps ----
 FROM node:$NODE_VERSION-bookworm-slim AS core
 
+ARG GHOST_BUILD_VERSION=""
 ENV NODE_ENV=production
+ENV GHOST_BUILD_VERSION=${GHOST_BUILD_VERSION}
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends libjemalloc2 && \

--- a/apps/admin-x-framework/src/vite.ts
+++ b/apps/admin-x-framework/src/vite.ts
@@ -46,7 +46,8 @@ export default function adminXViteConfig({packageName, entry, overrides}: {packa
         ],
         define: {
             'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
-            'process.env.VITEST_SEGFAULT_RETRY': 3
+            'process.env.VITEST_SEGFAULT_RETRY': 3,
+            'import.meta.env.GHOST_BUILD_VERSION': JSON.stringify(process.env.GHOST_BUILD_VERSION || '')
         },
         preview: {
             port: 4174

--- a/apps/admin-x-settings/src/components/settings/general/about.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/about.tsx
@@ -6,6 +6,19 @@ import {showDatabaseWarning} from '../../../utils/show-database-warning';
 import {useGlobalData} from '../../providers/global-data-provider';
 import {useUpgradeStatus} from '../../providers/settings-app-provider';
 
+const adminBuildVersion = import.meta.env.GHOST_BUILD_VERSION;
+
+function VersionLink({label, version}: {label: string; version: string}) {
+    const link = linkToGitHubReleases(version);
+    return (
+        <div>
+            <strong>{label}:</strong> {link
+                ? <a className='text-green' href={link} rel="noopener noreferrer" target="_blank">{version}</a>
+                : version}
+        </div>
+    );
+}
+
 const AboutModal = NiceModal.create<RoutingModalProps>(({}) => {
     const {updateRoute} = useRouting();
     const globalData = useGlobalData();
@@ -56,13 +69,14 @@ const AboutModal = NiceModal.create<RoutingModalProps>(({}) => {
                             </div>
                         )
                     }
-                    {
-                        linkToGitHubReleases(config.version) && (
-                            <div><strong>Version:</strong> <a className='text-green' href={linkToGitHubReleases(config.version)} rel="noopener noreferrer" target="_blank">{config.version}</a></div>
-                        ) || (
-                            <div><strong>Version:</strong> {config.version}</div>
-                        )
-                    }
+                    {adminBuildVersion ? (
+                        <>
+                            <VersionLink label="Server" version={config.version} />
+                            <VersionLink label="Admin" version={adminBuildVersion} />
+                        </>
+                    ) : (
+                        <VersionLink label="Version" version={config.version} />
+                    )}
                     {
                         showSystemInfo() && (
                             <>

--- a/apps/admin-x-settings/src/utils/link-to-github-releases.ts
+++ b/apps/admin-x-settings/src/utils/link-to-github-releases.ts
@@ -1,36 +1,54 @@
 // @ts-expect-error - semver subpath has no types
 import semverParse from 'semver/functions/parse';
 
-// This function needs to support:
-// - 5.94.1+moya
-// - 5.94.1-0-g1f3e72eac8+moya
-// - 5.95.0-pre-g028c1a6+moya
+// Supported version formats:
+// - 6.21.2                          → release tag
+// - 6.21.2+1710072000.abc1234       → commit (server: semver+epoch.sha)
+// - 6.21.2+abc1234                  → commit (admin: semver+sha)
+// - 5.94.1+moya                     → release tag (legacy)
+// - 5.94.1-0-gabcdef+moya           → commit (legacy git describe)
+// - 5.95.0-pre-gabcdef+moya         → commit (legacy canary)
 export function linkToGitHubReleases(version: string): string {
     if (!version) {
         return '';
     }
 
-    const cleanedVersion = version.replace('+moya', '');
+    // Extract build metadata (everything after +) before semver parsing strips it
+    const plusIndex = version.indexOf('+');
+    const buildMetadata = plusIndex !== -1 ? version.slice(plusIndex + 1) : '';
+    const versionWithoutBuild = plusIndex !== -1 ? version.slice(0, plusIndex) : version;
 
+    // Check build metadata for a commit SHA
+    if (buildMetadata && buildMetadata !== 'moya') {
+        // New format: "epoch.sha" or just "sha"
+        const parts = buildMetadata.split('.');
+        const sha = parts[parts.length - 1];
+
+        if (sha && /^[0-9a-f]{7,40}$/.test(sha)) {
+            return `https://github.com/TryGhost/Ghost/commit/${sha}`;
+        }
+    }
+
+    // Check pre-release segment for a commit SHA (legacy format: -0-gabcdef or -pre-gabcdef)
     try {
-        const semverVersion = semverParse(cleanedVersion, {includePrerelease: true} as any);
+        const semverVersion = semverParse(versionWithoutBuild, {includePrerelease: true} as any);
         const prerelease = semverVersion?.prerelease;
 
-        if (prerelease && prerelease?.length > 0) {
+        if (prerelease && prerelease.length > 0) {
             const splitPrerelease = String(prerelease[0]).split('-');
             const commitHash = splitPrerelease[1];
 
-            if (!commitHash || !commitHash.startsWith('g')) {
-                return '';
+            if (commitHash?.startsWith('g')) {
+                return `https://github.com/TryGhost/Ghost/commit/${commitHash.slice(1)}`;
             }
 
-            const commitHashWithoutG = commitHash.slice(1);
-
-            return `https://github.com/TryGhost/Ghost/commit/${commitHashWithoutG}`;
+            // Has pre-release but no recognizable commit hash
+            return '';
         }
-
-        return `https://github.com/TryGhost/Ghost/releases/tag/v${cleanedVersion}`;
     } catch {
         return '';
     }
+
+    // Plain semver (with or without +moya) → release tag
+    return `https://github.com/TryGhost/Ghost/releases/tag/v${versionWithoutBuild}`;
 }

--- a/apps/admin-x-settings/test/unit/utils/link-to-github-releases.test.ts
+++ b/apps/admin-x-settings/test/unit/utils/link-to-github-releases.test.ts
@@ -31,4 +31,20 @@ describe('linkToGithubRelease', function () {
         const link = linkToGitHubReleases('5.70.0-pre-gabcdef+moya');
         assert.equal(link, 'https://github.com/TryGhost/Ghost/commit/abcdef');
     });
+
+    it('handles server build version with epoch.sha', function () {
+        const link = linkToGitHubReleases('6.21.2+1710072000.abc1234');
+        assert.equal(link, 'https://github.com/TryGhost/Ghost/commit/abc1234');
+    });
+
+    it('handles admin build version with sha only', function () {
+        const link = linkToGitHubReleases('6.21.2+abc1234');
+        assert.equal(link, 'https://github.com/TryGhost/Ghost/commit/abc1234');
+    });
+
+    it('handles full 40-char sha in build metadata', function () {
+        const sha = 'a'.repeat(40);
+        const link = linkToGitHubReleases(`6.21.2+1710072000.${sha}`);
+        assert.equal(link, `https://github.com/TryGhost/Ghost/commit/${sha}`);
+    });
 });

--- a/ghost/core/core/server/services/public-config/config.js
+++ b/ghost/core/core/server/services/public-config/config.js
@@ -7,7 +7,7 @@ const ghostVersion = require('@tryghost/version');
 
 module.exports = function getConfigProperties() {
     const configProperties = {
-        version: ghostVersion.original,
+        version: process.env.GHOST_BUILD_VERSION || ghostVersion.original,
         environment: config.get('env'),
         database: databaseInfo.getEngine(),
         mail: isPlainObject(config.get('mail')) ? config.get('mail').transport : '',

--- a/ghost/core/test/unit/server/services/public-config/config.test.js
+++ b/ghost/core/test/unit/server/services/public-config/config.test.js
@@ -45,6 +45,25 @@ describe('Public-config Service', function () {
             assert.deepEqual(Object.keys(configProperties), allowedKeys);
         });
 
+        it('should return GHOST_BUILD_VERSION as version when set', function () {
+            process.env.GHOST_BUILD_VERSION = '6.21.2+abc1234';
+
+            const configProperties = getConfigProperties();
+
+            assert.equal(configProperties.version, '6.21.2+abc1234');
+
+            delete process.env.GHOST_BUILD_VERSION;
+        });
+
+        it('should return package version when GHOST_BUILD_VERSION is not set', function () {
+            delete process.env.GHOST_BUILD_VERSION;
+
+            const configProperties = getConfigProperties();
+
+            assert.match(configProperties.version, /^\d+\.\d+\.\d+/);
+            assert.notEqual(configProperties.version, '6.21.2+abc1234');
+        });
+
         it('should return null for tenor apikey when unset', function () {
             let configProperties = getConfigProperties();
 


### PR DESCRIPTION
On Ghost(Pro), the About dialog currently shows a single version string that doesn't distinguish between the server container and the admin client — both ship independently and can be at different commits. This makes it harder to debug issues or verify which code is actually running.

This change introduces two new optional build-time inputs: `GHOST_BUILD_VERSION` (a Docker build arg baked as an ENV var, read by the public-config endpoint at runtime) and `VITE_ADMIN_BUILD_VERSION` (a Vite define constant baked into the admin bundle). When both are set — as they will be on Ghost(Pro) CI builds — the About dialog shows separate "Server" and "Admin" lines, each linking to their respective GitHub commit. When neither is set (self-hosted installs, tagged releases), the dialog continues to show a single "Version" line pointing at the release tag, identical to today's behavior.

The `link-to-github-releases` utility was extended to handle the new `semver+epoch.sha` (server) and `semver+sha` (admin) formats, alongside the existing legacy `+moya` and git-describe formats. New test cases cover all format variations.