### PR TITLE
Fixed flaky product card test in welcome email editor

### DIFF
--- a/apps/admin-x-settings/test/acceptance/membership/member-welcome-emails.test.ts
+++ b/apps/admin-x-settings/test/acceptance/membership/member-welcome-emails.test.ts
@@ -372,7 +372,8 @@ test.describe('Member emails settings', async () => {
             await editor.click({timeout: 5000});
             await page.keyboard.press('ControlOrMeta+a');
             await page.keyboard.press('Backspace');
-            await page.keyboard.type('/product');
+            await page.keyboard.type('/product', {delay: 50});
+            await expect(page.locator('[data-kg-slash-menu]')).toBeVisible({timeout: 5000});
             await page.keyboard.press('Enter');
 
             await expect(modal.locator('[data-kg-card="product"]')).toBeVisible();


### PR DESCRIPTION
no refs

This is a test only change.

## Summary

  - Fixed flaky product card insertion test in the welcome email editor
  - keyboard.type('/product') sends all characters at once, which doesn't give the Koenig slash menu time to filter results — so pressing Enter fails to insert the card
  - Added {delay: 50} to type each character individually, plus an explicit wait for the slash menu to appear before pressing Enter
