### PR TITLE
Added Content API key to built-in integrations

### DIFF
--- a/apps/admin-x-settings/src/components/providers/routing/modals.tsx
+++ b/apps/admin-x-settings/src/components/providers/routing/modals.tsx
@@ -4,6 +4,7 @@ import type {RoutingModalProps} from '@tryghost/admin-x-framework/routing';
 
 import AboutModal from '../../settings/general/about';
 import AddIntegrationModal from '../../settings/advanced/integrations/add-integration-modal';
+import ContentApiModal from '../../settings/advanced/integrations/content-api-modal';
 import AddNewsletterModal from '../../settings/email/newsletters/add-newsletter-modal';
 // import AddOfferModal from '../../settings/growth/offers/AddOfferModal';
 import AddRecommendationModal from '../../settings/growth/recommendations/add-recommendation-modal';
@@ -35,6 +36,7 @@ import ZapierModal from '../../settings/advanced/integrations/zapier-modal';
 const modals = {
     AddIntegrationModal,
     AddNewsletterModal,
+    ContentApiModal,
     AddRecommendationModal,
     CustomIntegrationModal,
     DesignAndThemeModal,

--- a/apps/admin-x-settings/src/components/providers/routing/modals.tsx
+++ b/apps/admin-x-settings/src/components/providers/routing/modals.tsx
@@ -4,8 +4,8 @@ import type {RoutingModalProps} from '@tryghost/admin-x-framework/routing';
 
 import AboutModal from '../../settings/general/about';
 import AddIntegrationModal from '../../settings/advanced/integrations/add-integration-modal';
-import ContentApiModal from '../../settings/advanced/integrations/content-api-modal';
 import AddNewsletterModal from '../../settings/email/newsletters/add-newsletter-modal';
+import ContentApiModal from '../../settings/advanced/integrations/content-api-modal';
 // import AddOfferModal from '../../settings/growth/offers/AddOfferModal';
 import AddRecommendationModal from '../../settings/growth/recommendations/add-recommendation-modal';
 import AnnouncementBarModal from '../../settings/site/announcement-bar-modal';

--- a/apps/admin-x-settings/src/components/providers/settings-router.tsx
+++ b/apps/admin-x-settings/src/components/providers/settings-router.tsx
@@ -21,6 +21,7 @@ export const modalPaths: {[key: string]: ModalName} = {
     'newsletters/:id': 'NewsletterDetailModal',
     'history/view': 'HistoryModal',
     'history/view/:user': 'HistoryModal',
+    'integrations/contentapi': 'ContentApiModal',
     'integrations/zapier': 'ZapierModal',
     'integrations/transistor': 'TransistorModal',
     'integrations/slack': 'SlackModal',

--- a/apps/admin-x-settings/src/components/settings/advanced/integrations.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/integrations.tsx
@@ -158,6 +158,15 @@ const BuiltInIntegrations: React.FC = () => {
                     title='Transistor.fm' />
             )}
 
+            <IntegrationItem
+                action={() => {
+                    openModal('integrations/contentapi');
+                }}
+                detail='Access your content programmatically'
+                icon={<Icon name='angle-brackets' size={32} />}
+                testId='content-api-integration'
+                title='Content API' />
+
         </List>
     );
 };

--- a/apps/admin-x-settings/src/components/settings/advanced/integrations/content-api-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/integrations/content-api-modal.tsx
@@ -1,0 +1,99 @@
+import APIKeys from './api-keys';
+import IntegrationHeader from './integration-header';
+import NiceModal from '@ebay/nice-modal-react';
+import {Button, ConfirmationModal, Icon, Modal} from '@tryghost/admin-x-design-system';
+import {getGhostPaths} from '@tryghost/admin-x-framework/helpers';
+import {useBrowseIntegrations} from '@tryghost/admin-x-framework/api/integrations';
+import {useState} from 'react';
+import {useHandleError} from '@tryghost/admin-x-framework/hooks';
+import {useRefreshAPIKey} from '@tryghost/admin-x-framework/api/api-keys';
+import {useRouting} from '@tryghost/admin-x-framework/routing';
+
+const ContentApiModal = NiceModal.create(() => {
+    const modal = NiceModal.useModal();
+    const {updateRoute} = useRouting();
+    const {data: {integrations} = {integrations: []}} = useBrowseIntegrations();
+
+    const {mutateAsync: refreshAPIKey} = useRefreshAPIKey();
+    const handleError = useHandleError();
+    const [regenerated, setRegenerated] = useState(false);
+
+    const integration = integrations.find(({slug}) => slug === 'ghost-core-content');
+    const contentApiKey = integration?.api_keys?.find(key => key.type === 'content');
+
+    const handleRegenerate = () => {
+        if (!integration || !contentApiKey) {
+            return;
+        }
+
+        setRegenerated(false);
+
+        NiceModal.show(ConfirmationModal, {
+            title: 'Regenerate Content API Key',
+            prompt: 'Any applications using the current Content API key will need to be updated with the new key.',
+            okLabel: 'Regenerate Content API Key',
+            onOk: async (confirmModal) => {
+                try {
+                    await refreshAPIKey({integrationId: integration.id, apiKeyId: contentApiKey.id});
+                    setRegenerated(true);
+                    confirmModal?.remove();
+                } catch (e) {
+                    handleError(e);
+                }
+            }
+        });
+    };
+
+    return (
+        <Modal
+            afterClose={() => {
+                updateRoute('integrations');
+            }}
+            cancelLabel=''
+            footer={
+                <div className='mx-8 flex w-full items-center justify-between'>
+                    <a
+                        className='mt-1 self-baseline text-sm font-bold'
+                        href='https://ghost.org/docs/content-api/'
+                        rel='noopener noreferrer'
+                        target='_blank'>
+                        Open docs ↗
+                    </a>
+                    <Button color='outline' label='Close' onClick={() => {
+                        updateRoute('integrations');
+                        modal.remove();
+                    }} />
+                </div>
+            }
+            okColor='black'
+            okLabel='Close'
+            testId='content-api-modal'
+            title=''
+            stickyFooter
+            onOk={() => {
+                updateRoute('integrations');
+                modal.remove();
+            }}
+        >
+            <IntegrationHeader
+                detail='Access your content programmatically'
+                icon={<Icon name='angle-brackets' size={56} />}
+                title='Content API'
+            />
+            <div className='mt-7'>
+                <p className='mb-6 text-sm text-grey-700'>This key provides read-only access to your published content. For full read/write access, create a custom integration.</p>
+                <APIKeys keys={[
+                    {
+                        label: 'Content API key',
+                        text: contentApiKey?.secret,
+                        hint: regenerated ? <div className='text-green'>Content API Key was successfully regenerated</div> : undefined,
+                        onRegenerate: handleRegenerate
+                    },
+                    {label: 'API URL', text: window.location.origin + getGhostPaths().subdir}
+                ]} />
+            </div>
+        </Modal>
+    );
+});
+
+export default ContentApiModal;

--- a/apps/admin-x-settings/src/components/settings/advanced/integrations/content-api-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/integrations/content-api-modal.tsx
@@ -29,15 +29,9 @@ const ContentApiModal = NiceModal.create(() => {
                     }} />
                 </div>
             }
-            okColor='black'
-            okLabel='Close'
             testId='content-api-modal'
             title=''
             stickyFooter
-            onOk={() => {
-                updateRoute('integrations');
-                modal.remove();
-            }}
         >
             <IntegrationHeader
                 detail='Access your content programmatically'

--- a/apps/admin-x-settings/src/components/settings/advanced/integrations/content-api-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/integrations/content-api-modal.tsx
@@ -22,7 +22,7 @@ const ContentApiModal = NiceModal.create(() => {
             cancelLabel=''
             footer={
                 <div className='mx-8 flex w-full items-center justify-between'>
-                    <Button color='outline' href='https://ghost.org/docs/content-api/' label={<span className='flex items-center gap-1'>Open docs <Icon name='arrow-top-right' size='xs' /></span>} tag='a' target='_blank' />
+                    <Button color='outline' href='https://ghost.org/docs/content-api/' label={<span className='flex items-center gap-1'>Open docs <Icon name='arrow-top-right' size='xs' /></span>} rel='noopener noreferrer' tag='a' target='_blank' />
                     <Button color='black' label='Close' onClick={() => {
                         updateRoute('integrations');
                         modal.remove();

--- a/apps/admin-x-settings/src/components/settings/advanced/integrations/content-api-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/integrations/content-api-modal.tsx
@@ -4,10 +4,10 @@ import NiceModal from '@ebay/nice-modal-react';
 import {Button, ConfirmationModal, Icon, Modal} from '@tryghost/admin-x-design-system';
 import {getGhostPaths} from '@tryghost/admin-x-framework/helpers';
 import {useBrowseIntegrations} from '@tryghost/admin-x-framework/api/integrations';
-import {useState} from 'react';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
 import {useRefreshAPIKey} from '@tryghost/admin-x-framework/api/api-keys';
 import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {useState} from 'react';
 
 const ContentApiModal = NiceModal.create(() => {
     const modal = NiceModal.useModal();
@@ -52,14 +52,8 @@ const ContentApiModal = NiceModal.create(() => {
             cancelLabel=''
             footer={
                 <div className='mx-8 flex w-full items-center justify-between'>
-                    <a
-                        className='mt-1 self-baseline text-sm font-bold'
-                        href='https://ghost.org/docs/content-api/'
-                        rel='noopener noreferrer'
-                        target='_blank'>
-                        Open docs ↗
-                    </a>
-                    <Button color='outline' label='Close' onClick={() => {
+                    <Button color='outline' href='https://ghost.org/docs/content-api/' label={<span className='flex items-center gap-1'>Open docs <Icon name='arrow-top-right' size='xs' /></span>} tag='a' target='_blank' />
+                    <Button color='black' label='Close' onClick={() => {
                         updateRoute('integrations');
                         modal.remove();
                     }} />

--- a/apps/admin-x-settings/src/components/settings/advanced/integrations/content-api-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/integrations/content-api-modal.tsx
@@ -1,48 +1,18 @@
 import APIKeys from './api-keys';
 import IntegrationHeader from './integration-header';
 import NiceModal from '@ebay/nice-modal-react';
-import {Button, ConfirmationModal, Icon, Modal} from '@tryghost/admin-x-design-system';
+import {Button, Icon, Modal} from '@tryghost/admin-x-design-system';
 import {getGhostPaths} from '@tryghost/admin-x-framework/helpers';
 import {useBrowseIntegrations} from '@tryghost/admin-x-framework/api/integrations';
-import {useHandleError} from '@tryghost/admin-x-framework/hooks';
-import {useRefreshAPIKey} from '@tryghost/admin-x-framework/api/api-keys';
 import {useRouting} from '@tryghost/admin-x-framework/routing';
-import {useState} from 'react';
 
 const ContentApiModal = NiceModal.create(() => {
     const modal = NiceModal.useModal();
     const {updateRoute} = useRouting();
     const {data: {integrations} = {integrations: []}} = useBrowseIntegrations();
 
-    const {mutateAsync: refreshAPIKey} = useRefreshAPIKey();
-    const handleError = useHandleError();
-    const [regenerated, setRegenerated] = useState(false);
-
     const integration = integrations.find(({slug}) => slug === 'ghost-core-content');
     const contentApiKey = integration?.api_keys?.find(key => key.type === 'content');
-
-    const handleRegenerate = () => {
-        if (!integration || !contentApiKey) {
-            return;
-        }
-
-        setRegenerated(false);
-
-        NiceModal.show(ConfirmationModal, {
-            title: 'Regenerate Content API Key',
-            prompt: 'Any applications using the current Content API key will need to be updated with the new key.',
-            okLabel: 'Regenerate Content API Key',
-            onOk: async (confirmModal) => {
-                try {
-                    await refreshAPIKey({integrationId: integration.id, apiKeyId: contentApiKey.id});
-                    setRegenerated(true);
-                    confirmModal?.remove();
-                } catch (e) {
-                    handleError(e);
-                }
-            }
-        });
-    };
 
     return (
         <Modal
@@ -79,9 +49,7 @@ const ContentApiModal = NiceModal.create(() => {
                 <APIKeys keys={[
                     {
                         label: 'Content API key',
-                        text: contentApiKey?.secret,
-                        hint: regenerated ? <div className='text-green'>Content API Key was successfully regenerated</div> : undefined,
-                        onRegenerate: handleRegenerate
+                        text: contentApiKey?.secret
                     },
                     {label: 'API URL', text: window.location.origin + getGhostPaths().subdir}
                 ]} />


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-2416/starter-customers-cannot-obtain-a-content-api-key

- Starter plan customers can't create custom integrations, which means they have no way to obtain their Content API key                                                                                            
- Added a "Content API" card to the built-in integrations tab that opens a modal showing the Content API key and API URL
- Follows the same modal pattern as Zapier and other built-in integrations 