### PR TITLE
Fixed retention offer preview height in full-size mode

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.66.0",
+  "version": "2.66.1",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/portal/src/components/frame.styles.js
+++ b/apps/portal/src/components/frame.styles.js
@@ -947,7 +947,9 @@ const MobileStyles = `
     .gh-portal-popup-wrapper.full-size .gh-portal-popup-container.preview.account-plan {
         max-width: 420px;
         width: auto;
+        height: auto;
         margin: 3.2vw auto 0;
+        padding-bottom: 24px;
         transform: scale(0.9);
     }
 }


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3429/ui-bug-in-retention-offers-on-larger-screens

The retention offer preview stretched to full viewport height on large                                                                                                                                             
  screens when multiple tiers exist. The full-size CSS override for
  account-plan preview constrained width but not height, so it inherited
  `height: calc(100vh - 160px)` from the parent rule. Added `height: auto`
  and bottom padding to match the expected preview size.