### PR TITLE
Fixed discounted price formatting missing trailing zero

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.66.5",
+  "version": "2.66.6",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/portal/src/components/pages/account-plan-page.js
+++ b/apps/portal/src/components/pages/account-plan-page.js
@@ -322,9 +322,11 @@ const RetentionOfferSection = ({subscription, offer, onAcceptOffer, onDeclineOff
     const isAcceptingOffer = action === 'applyOffer:running';
 
     const price = getPriceFromSubscription({subscription});
-    const originalPrice = formatNumber(price.amount / 100);
+    const originalAmount = price.amount / 100;
+    const originalPrice = formatNumber(originalAmount % 1 !== 0 ? Number(Math.round(originalAmount * 100) / 100).toFixed(2) : originalAmount);
     const currency = getCurrencySymbol(price.currency);
-    const discountedPrice = formatNumber(getUpdatedOfferPrice({offer, price}));
+    const updatedAmount = getUpdatedOfferPrice({offer, price});
+    const discountedPrice = formatNumber(updatedAmount % 1 !== 0 ? Number(Math.round(updatedAmount * 100) / 100).toFixed(2) : updatedAmount);
     const amountOff = getOfferOffAmount({offer});
 
     const cadenceLabel = offer.cadence === 'month' ? t('Monthly') : t('Yearly');

--- a/apps/portal/src/components/pages/account-plan-page.js
+++ b/apps/portal/src/components/pages/account-plan-page.js
@@ -5,7 +5,7 @@ import CloseButton from '../common/close-button';
 import BackButton from '../common/back-button';
 import {MultipleProductsPlansSection} from '../common/plans-section';
 import {getDateString} from '../../utils/date-time';
-import {addMonths, formatNumber, getAvailablePrices, getCurrencySymbol, getFilteredPrices, isFreeMonthsOffer, getMemberActivePrice, getMemberActiveProduct, getMemberSubscription, getOfferOffAmount, getPriceFromSubscription, getProductFromPrice, getSubscriptionFromId, getUpdatedOfferPrice, getUpgradeProducts, hasMultipleProductsFeature, isComplimentaryMember, isPaidMember} from '../../utils/helpers';
+import {addMonths, formatNumber, formatPrice, getAvailablePrices, getCurrencySymbol, getFilteredPrices, isFreeMonthsOffer, getMemberActivePrice, getMemberActiveProduct, getMemberSubscription, getOfferOffAmount, getPriceFromSubscription, getProductFromPrice, getSubscriptionFromId, getUpdatedOfferPrice, getUpgradeProducts, hasMultipleProductsFeature, isComplimentaryMember, isPaidMember} from '../../utils/helpers';
 import Interpolate from '@doist/react-interpolate';
 import {t} from '../../utils/i18n';
 
@@ -323,10 +323,10 @@ const RetentionOfferSection = ({subscription, offer, onAcceptOffer, onDeclineOff
 
     const price = getPriceFromSubscription({subscription});
     const originalAmount = price.amount / 100;
-    const originalPrice = formatNumber(originalAmount % 1 !== 0 ? Number(Math.round(originalAmount * 100) / 100).toFixed(2) : originalAmount);
+    const originalPrice = formatPrice(originalAmount);
     const currency = getCurrencySymbol(price.currency);
     const updatedAmount = getUpdatedOfferPrice({offer, price});
-    const discountedPrice = formatNumber(updatedAmount % 1 !== 0 ? Number(Math.round(updatedAmount * 100) / 100).toFixed(2) : updatedAmount);
+    const discountedPrice = formatPrice(updatedAmount);
     const amountOff = getOfferOffAmount({offer});
 
     const cadenceLabel = offer.cadence === 'month' ? t('Monthly') : t('Yearly');

--- a/apps/portal/src/utils/helpers.js
+++ b/apps/portal/src/utils/helpers.js
@@ -774,7 +774,7 @@ export const formatPrice = (amount) => {
         ? undefined
         : {minimumFractionDigits: 2, maximumFractionDigits: 2};
 
-    return normalizedAmount.toLocaleString(undefined, options);
+    return normalizedAmount.toLocaleString('en-US', options);
 };
 
 export const createPopupNotification = ({type, status, autoHide, duration = 2600, closeable, state, message, meta = {}}) => {

--- a/apps/portal/src/utils/helpers.js
+++ b/apps/portal/src/utils/helpers.js
@@ -760,7 +760,7 @@ export const formatNumber = (amount) => {
     return amount.toLocaleString();
 };
 
-export const formatPrice = (amount) => {
+export const formatPrice = (amount, locale) => {
     if (amount === undefined || amount === null) {
         return '';
     }
@@ -774,7 +774,7 @@ export const formatPrice = (amount) => {
         ? undefined
         : {minimumFractionDigits: 2, maximumFractionDigits: 2};
 
-    return normalizedAmount.toLocaleString('en-US', options);
+    return normalizedAmount.toLocaleString(locale, options);
 };
 
 export const createPopupNotification = ({type, status, autoHide, duration = 2600, closeable, state, message, meta = {}}) => {
@@ -822,7 +822,7 @@ export const getOfferOffAmount = ({offer}) => {
 
         return t('{months} months', {months});
     } else if (offer.type === 'fixed') {
-        return `${getCurrencySymbol(offer.currency)}${offer.amount / 100}`;
+        return `${getCurrencySymbol(offer.currency)}${formatPrice(offer.amount / 100)}`;
     } else if (offer.type === 'percent') {
         return `${offer.amount}%`;
     }

--- a/apps/portal/src/utils/helpers.js
+++ b/apps/portal/src/utils/helpers.js
@@ -760,6 +760,23 @@ export const formatNumber = (amount) => {
     return amount.toLocaleString();
 };
 
+export const formatPrice = (amount) => {
+    if (amount === undefined || amount === null) {
+        return '';
+    }
+
+    const normalizedAmount = Number(amount);
+    if (Number.isNaN(normalizedAmount)) {
+        return '';
+    }
+
+    const options = Number.isInteger(normalizedAmount)
+        ? undefined
+        : {minimumFractionDigits: 2, maximumFractionDigits: 2};
+
+    return normalizedAmount.toLocaleString(undefined, options);
+};
+
 export const createPopupNotification = ({type, status, autoHide, duration = 2600, closeable, state, message, meta = {}}) => {
     let count = 0;
     if (state && state.popupNotification) {

--- a/apps/portal/test/unit/components/pages/account-plan-page.test.js
+++ b/apps/portal/test/unit/components/pages/account-plan-page.test.js
@@ -407,6 +407,53 @@ describe('Account Plan Page', () => {
         expect(queryByText('Save 20% on your next billing cycle. Then $5.99/month.')).toBeInTheDocument();
     });
 
+    test('renders grouped and padded prices for larger fractional retention offers', async () => {
+        const paidProduct = getProductData({
+            name: 'Basic',
+            monthlyPrice: getPriceData({interval: 'month', amount: 123450, currency: 'usd'}),
+            yearlyPrice: getPriceData({interval: 'year', amount: 10000, currency: 'usd'})
+        });
+        const products = [paidProduct, getProductData({type: 'free'})];
+        const site = getSiteData({
+            products,
+            portalProducts: [paidProduct.id]
+        });
+        const member = getMemberData({
+            paid: true,
+            subscriptions: [
+                getSubscriptionData({
+                    status: 'active',
+                    interval: 'month',
+                    amount: paidProduct.monthlyPrice.amount,
+                    currency: 'USD',
+                    priceId: paidProduct.monthlyPrice.id
+                })
+            ]
+        });
+
+        const retentionOffer = {
+            ...getOfferData({
+                type: 'percent',
+                amount: 20,
+                cadence: 'month',
+                duration: 'once',
+                tierId: paidProduct.id,
+                tierName: paidProduct.name
+            }),
+            redemption_type: 'retention'
+        };
+
+        const {container, queryByRole, queryByText} = customSetup({site, member, offers: [retentionOffer]});
+        const cancelButton = queryByRole('button', {name: 'Cancel subscription'});
+
+        fireEvent.click(cancelButton);
+
+        const discountedAmount = container.querySelector('.gh-portal-product-price .amount');
+        expect(discountedAmount).not.toBeNull();
+        expect(discountedAmount).toHaveTextContent('987.60');
+        expect(queryByText('Save 20% on your next billing cycle. Then $1,234.50/month.')).toBeInTheDocument();
+    });
+
     test('renders fixed retention offers', async () => {
         const paidProduct = getProductData({
             name: 'Basic',

--- a/apps/portal/test/utils/helpers.test.js
+++ b/apps/portal/test/utils/helpers.test.js
@@ -27,7 +27,8 @@ import {
     getUpdatedOfferPrice,
     isComplimentaryMember,
     subscriptionHasFreeTrial,
-    addMonths
+    addMonths,
+    formatPrice
 } from '../../src/utils/helpers';
 import * as Fixtures from '../../src/utils/fixtures-generator';
 import {site as FixturesSite, member as FixtureMember, offer as FixtureOffer, transformTierFixture as TransformFixtureTiers} from './test-fixtures';
@@ -280,6 +281,25 @@ describe('Helpers - ', () => {
             });
 
             expect(updatedPrice).toBe('$4.79');
+        });
+    });
+
+    describe('formatPrice - ', () => {
+        test('returns whole numbers without decimal padding', () => {
+            expect(formatPrice(5)).toBe('5');
+        });
+
+        test('returns fractional numbers with two decimals', () => {
+            expect(formatPrice(5.4)).toBe('5.40');
+        });
+
+        test('returns fractional numbers with locale grouping', () => {
+            expect(formatPrice(1234.5)).toBe('1,234.50');
+        });
+
+        test('returns empty string for null/undefined input', () => {
+            expect(formatPrice(null)).toBe('');
+            expect(formatPrice(undefined)).toBe('');
         });
     });
 

--- a/apps/portal/test/utils/helpers.test.js
+++ b/apps/portal/test/utils/helpers.test.js
@@ -294,7 +294,7 @@ describe('Helpers - ', () => {
         });
 
         test('returns fractional numbers with locale grouping', () => {
-            expect(formatPrice(1234.5)).toBe('1,234.50');
+            expect(formatPrice(1234.5, 'en-US')).toBe('1,234.50');
         });
 
         test('returns empty string for null/undefined input', () => {

--- a/ghost/admin/app/components/gh-member-settings-form.hbs
+++ b/ghost/admin/app/components/gh-member-settings-form.hbs
@@ -120,11 +120,11 @@
                                             <div class="flex items-start">
                                                 {{#if sub.hasActiveDiscount}}
                                                     <span class="currency-symbol">{{sub.discountedPrice.currencySymbol}}</span>
-                                                    <span class="amount">{{format-number sub.discountedPrice.nonDecimalAmount}}</span>
-                                                    <span class="gh-membertier-original-price">{{sub.originalPrice.currencySymbol}}{{format-number sub.originalPrice.nonDecimalAmount}}</span>
+                                                    <span class="amount">{{gh-price-amount sub.discountedPrice.nonDecimalAmount cents=false}}</span>
+                                                    <span class="gh-membertier-original-price">{{sub.originalPrice.currencySymbol}}{{gh-price-amount sub.originalPrice.nonDecimalAmount cents=false}}</span>
                                                 {{else}}
                                                     <span class="currency-symbol">{{sub.price.currencySymbol}}</span>
-                                                    <span class="amount">{{format-number sub.price.nonDecimalAmount}}</span>
+                                                    <span class="amount">{{gh-price-amount sub.price.nonDecimalAmount cents=false}}</span>
                                                 {{/if}}
                                             </div>
                                             <div class="period">{{if (eq sub.price.interval "year") "yearly" "monthly"}}</div>

--- a/ghost/admin/app/components/gh-member-settings-form.hbs
+++ b/ghost/admin/app/components/gh-member-settings-form.hbs
@@ -124,7 +124,7 @@
                                                     <span class="gh-membertier-original-price">{{sub.originalPrice.currencySymbol}}{{gh-price-amount sub.originalPrice.nonDecimalAmount cents=false}}</span>
                                                 {{else}}
                                                     <span class="currency-symbol">{{sub.price.currencySymbol}}</span>
-                                                    <span class="amount">{{gh-price-amount sub.price.nonDecimalAmount cents=false}}</span>
+                                                    <span class="amount">{{format-number sub.price.nonDecimalAmount}}</span>
                                                 {{/if}}
                                             </div>
                                             <div class="period">{{if (eq sub.price.interval "year") "yearly" "monthly"}}</div>

--- a/ghost/admin/app/components/gh-member-settings-form.hbs
+++ b/ghost/admin/app/components/gh-member-settings-form.hbs
@@ -120,8 +120,8 @@
                                             <div class="flex items-start">
                                                 {{#if sub.hasActiveDiscount}}
                                                     <span class="currency-symbol">{{sub.discountedPrice.currencySymbol}}</span>
-                                                    <span class="amount">{{gh-price-amount sub.discountedPrice.nonDecimalAmount cents=false}}</span>
-                                                    <span class="gh-membertier-original-price">{{sub.originalPrice.currencySymbol}}{{gh-price-amount sub.originalPrice.nonDecimalAmount cents=false}}</span>
+                                                    <span class="amount">{{gh-price-amount sub.discountedPrice.amount}}</span>
+                                                    <span class="gh-membertier-original-price">{{sub.originalPrice.currencySymbol}}{{gh-price-amount sub.originalPrice.amount}}</span>
                                                 {{else}}
                                                     <span class="currency-symbol">{{sub.price.currencySymbol}}</span>
                                                     <span class="amount">{{format-number sub.price.nonDecimalAmount}}</span>

--- a/ghost/admin/app/components/gh-member-settings-form.hbs
+++ b/ghost/admin/app/components/gh-member-settings-form.hbs
@@ -124,7 +124,7 @@
                                                     <span class="gh-membertier-original-price">{{sub.originalPrice.currencySymbol}}{{gh-price-amount sub.originalPrice.amount}}</span>
                                                 {{else}}
                                                     <span class="currency-symbol">{{sub.price.currencySymbol}}</span>
-                                                    <span class="amount">{{format-number sub.price.nonDecimalAmount}}</span>
+                                                    <span class="amount">{{gh-price-amount sub.price.amount}}</span>
                                                 {{/if}}
                                             </div>
                                             <div class="period">{{if (eq sub.price.interval "year") "yearly" "monthly"}}</div>

--- a/ghost/admin/app/utils/subscription-data.js
+++ b/ghost/admin/app/utils/subscription-data.js
@@ -179,11 +179,13 @@ export function getDiscountPrice(sub) {
     return {
         discountedPrice: {
             currencySymbol: getSymbol(sub.next_payment.currency),
-            nonDecimalAmount: getNonDecimal(sub.next_payment.amount)
+            nonDecimalAmount: getNonDecimal(sub.next_payment.amount),
+            amount: sub.next_payment.amount
         },
         originalPrice: {
             currencySymbol: getSymbol(sub.next_payment.currency),
-            nonDecimalAmount: getNonDecimal(sub.next_payment.original_amount)
+            nonDecimalAmount: getNonDecimal(sub.next_payment.original_amount),
+            amount: sub.next_payment.original_amount
         }
     };
 }

--- a/ghost/admin/tests/acceptance/members/details-test.js
+++ b/ghost/admin/tests/acceptance/members/details-test.js
@@ -195,6 +195,59 @@ describe('Acceptance: Member details', function () {
             .to.equal(1);
     });
 
+    it('renders non-discounted subscription prices with trailing zeros', async function () {
+        const member = this.server.create('member', {
+            id: 1,
+            subscriptions: [
+                this.server.create('subscription', {
+                    id: 'sub_1KZGi6EGb07FFvyNDjZq98g8',
+                    tier,
+                    customer: {
+                        id: 'cus_LFmGicpX4BkQKH',
+                        name: '123',
+                        email: 'test@ghost.org'
+                    },
+                    plan: {
+                        id: 'price_1KZGc6EGb07FFvyNkK3umKiX',
+                        nickname: 'Monthly',
+                        amount: 590,
+                        interval: 'month',
+                        currency: 'USD'
+                    },
+                    status: 'active',
+                    start_date: '2022-03-03T15:36:58.000Z',
+                    default_payment_card_last4: '4242',
+                    cancel_at_period_end: false,
+                    cancellation_reason: null,
+                    current_period_end: '2022-04-03T15:36:58.000Z',
+                    price: {
+                        id: 'price_1KZGc6EGb07FFvyNkK3umKiX',
+                        price_id: '6220df272fee0571b5dd0a0a',
+                        nickname: 'Monthly',
+                        amount: 590,
+                        interval: 'month',
+                        type: 'recurring',
+                        currency: 'USD',
+                        tier: {
+                            id: 'prod_LFmAAmCnnbzrvL',
+                            name: 'Supporter',
+                            tier_id: tier.id
+                        }
+                    },
+                    offer: null
+                })
+            ],
+            tiers: [
+                tier
+            ]
+        });
+
+        await visit(`/members/${member.id}`);
+
+        const amountElement = find(`[data-test-tier="${tier.id}"] .gh-tier-card-price .amount`);
+        expect(amountElement.textContent.trim()).to.equal('5.90');
+    });
+
     it('can add and remove complimentary subscription', async function () {
         const member = this.server.create('member', {name: 'Comp Member Test'});
 

--- a/ghost/admin/tests/unit/utils/subscription-data-test.js
+++ b/ghost/admin/tests/unit/utils/subscription-data-test.js
@@ -462,8 +462,8 @@ describe('Unit: Util: subscription-data', function () {
             const data = getSubscriptionData(sub);
 
             expect(data.hasActiveDiscount).to.be.true;
-            expect(data.discountedPrice).to.deep.equal({currencySymbol: '$', nonDecimalAmount: 25});
-            expect(data.originalPrice).to.deep.equal({currencySymbol: '$', nonDecimalAmount: 50});
+            expect(data.discountedPrice).to.deep.equal({currencySymbol: '$', nonDecimalAmount: 25, amount: 2500});
+            expect(data.originalPrice).to.deep.equal({currencySymbol: '$', nonDecimalAmount: 50, amount: 5000});
         });
 
         it('does not set hasActiveDiscount when no discount', function () {
@@ -596,8 +596,8 @@ describe('Unit: Util: subscription-data', function () {
                 }
             });
             expect(result).to.deep.equal({
-                discountedPrice: {currencySymbol: '$', nonDecimalAmount: 25},
-                originalPrice: {currencySymbol: '$', nonDecimalAmount: 50}
+                discountedPrice: {currencySymbol: '$', nonDecimalAmount: 25, amount: 2500},
+                originalPrice: {currencySymbol: '$', nonDecimalAmount: 50, amount: 5000}
             });
         });
 
@@ -612,8 +612,8 @@ describe('Unit: Util: subscription-data', function () {
                 }
             });
             expect(result).to.deep.equal({
-                discountedPrice: {currencySymbol: '€', nonDecimalAmount: 70},
-                originalPrice: {currencySymbol: '€', nonDecimalAmount: 100}
+                discountedPrice: {currencySymbol: '€', nonDecimalAmount: 70, amount: 7000},
+                originalPrice: {currencySymbol: '€', nonDecimalAmount: 100, amount: 10000}
             });
         });
     });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3427/fix-price-formatting-issue

Non-whole discounted prices (e.g. $5.40) were displayed without trailing zeros (e.g. $5.4) in two places:

  - Portal: Retention offer discounted price in the cancellation flow used `formatNumber()` which calls `.toLocaleString()` without enforcing decimal places. Fixed by applying the same `.toFixed(2)` rounding that the signup offer page already uses in `renderRoundedPrice()`.
  - Admin: Member detail subscription discounted price used `{{format-number}}` which doesn't enforce decimal places. Fixed by switching to `{{gh-price-amount}} (with cents=false)`, which already handles this correctly via `{minimumFractionDigits: 2}`.