### PR TITLE
Added verificationFlow labs feature flag

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
@@ -52,6 +52,10 @@ const features: Feature[] = [{
     description: 'Enable Transistor podcast integration',
     flag: 'transistor'
 }, {
+    title: 'Verification flow',
+    description: 'Enable new Email verification webhook-based flow',
+    flag: 'verificationFlow'
+}, {
     title: 'Members Forward',
     description: 'Use the new React-based members list instead of the Ember implementation',
     flag: 'membersForward'

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -49,6 +49,7 @@ const PRIVATE_FEATURES = [
     'themeTranslation',
     'indexnow',
     'transistor',
+    'verificationFlow',
     'membersForward',
     'welcomeEmailsDesignCustomization',
     'pictureImageFormats'

--- a/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
@@ -30,6 +30,7 @@ Object {
       "themeTranslation": true,
       "transistor": true,
       "urlCache": true,
+      "verificationFlow": true,
       "welcomeEmailEditor": true,
       "welcomeEmailsDesignCustomization": true,
     },


### PR DESCRIPTION
closes [GVA-729](https://linear.app/ghost/issue/GVA-729/add-feature-flag-verification-flow)

Added the private Labs flag verificationFlow to Ghost core allowlists and exposed it in Admin X private Labs settings so it can be toggled safely during rollout, with the admin config API snapshot updated to reflect the new flag in public config responses.