### PR TITLE
Fixed Zapier image sizing

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/integrations/zapier-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/integrations/zapier-modal.tsx
@@ -1,6 +1,7 @@
 import APIKeys from './api-keys';
 import IntegrationHeader from './integration-header';
 import NiceModal from '@ebay/nice-modal-react';
+import ZapierLogo from '../../../../assets/images/zapier-logo.svg';
 import {Button, ConfirmationModal, Icon, List, ListItem, Modal} from '@tryghost/admin-x-design-system';
 import {getGhostPaths} from '@tryghost/admin-x-framework/helpers';
 import {useBrowseIntegrations} from '@tryghost/admin-x-framework/api/integrations';
@@ -75,7 +76,7 @@ const ZapierModal = NiceModal.create(() => {
                         href='https://zapier.com/apps/ghost/integrations?utm_medium=partner_api&utm_source=widget&utm_campaign=Widget'
                         rel='noopener noreferrer'
                         target='_blank'>
-                        View more Ghost integrations powered by <span><Icon className='relative top-[-2px] inline-block' name='zapier-logo' size={24} /></span>
+                        View more Ghost integrations powered by <span><img alt='Zapier' className='relative top-[-2px] inline-block' src={ZapierLogo} /></span>
                     </a>
                     <Button color='black' label='Close' onClick={() => {
                         modal.remove();


### PR DESCRIPTION
Closes https://linear.app/ghost/issue/DES-1303/zapier-logo-size-issue

Switching to Icon broke the Zapier wordmark. Switching it to an image. There's another instance of it further down the file where the Zapier icon is used. No issues there.

| Before | After |
|--------|--------|
| <img width="498" height="270" alt="Screenshot 2026-03-11 at 09 01 13" src="https://github.com/user-attachments/assets/1497ec67-d5c2-4f20-8d47-a29e34f08e4f" /> | <img width="510" height="258" alt="Screenshot 2026-03-11 at 09 00 59" src="https://github.com/user-attachments/assets/11466b40-b7e6-4f5c-8df1-3d312b1b7850" /> | 
