### PR TITLE
Changed verification flow to support webhook mode behind labs flag

### DIFF
--- a/ghost/core/core/server/services/members/service.js
+++ b/ghost/core/core/server/services/members/service.js
@@ -17,6 +17,7 @@ const {GhostMailer} = require('../mail');
 const jobsService = require('../jobs');
 const tiersService = require('../tiers');
 const VerificationTrigger = require('../verification-trigger');
+const {verificationWebhookService} = require('../verification/verification-webhook-service');
 const DatabaseInfo = require('@tryghost/database-info');
 const settingsHelpers = require('../settings-helpers');
 const RequestIntegrityTokenProvider = require('./request-integrity-token-provider');
@@ -42,6 +43,26 @@ const membersStats = new MembersStats({
 });
 
 let membersApi;
+
+const sendVerificationEmail = async ({subject, message, amountTriggered}) => {
+    const escalationAddress = config.get('hostSettings:emailVerification:escalationAddress');
+    const replyTo = config.get('user_email');
+    const fromAddress = settingsHelpers.getDefaultEmailAddress();
+
+    if (escalationAddress) {
+        await ghostMailer.send({
+            subject,
+            html: tpl(message, {
+                amountTriggered: amountTriggered,
+                siteUrl: urlUtils.getSiteUrl()
+            }),
+            forceTextContent: true,
+            from: fromAddress,
+            replyTo,
+            to: escalationAddress
+        });
+    }
+};
 
 const initMembersCSVImporter = ({stripeAPIService}) => {
     return makeMembersCSVImporter({
@@ -90,25 +111,9 @@ const initVerificationTrigger = () => {
         getImportTriggerThreshold: () => _.get(config.get('hostSettings'), 'emailVerification.importThreshold'),
         isVerified: () => config.get('hostSettings:emailVerification:verified') === true,
         isVerificationRequired: () => settingsCache.get('email_verification_required') === true,
-        sendVerificationEmail: async ({subject, message, amountTriggered}) => {
-            const escalationAddress = config.get('hostSettings:emailVerification:escalationAddress');
-            const replyTo = config.get('user_email');
-            const fromAddress = settingsHelpers.getDefaultEmailAddress();
-
-            if (escalationAddress) {
-                await ghostMailer.send({
-                    subject,
-                    html: tpl(message, {
-                        amountTriggered: amountTriggered,
-                        siteUrl: urlUtils.getSiteUrl()
-                    }),
-                    forceTextContent: true,
-                    from: fromAddress,
-                    replyTo,
-                    to: escalationAddress
-                });
-            }
-        },
+        isVerificationFlowEnabled: () => labsService.isSet('verificationFlow'),
+        sendVerificationEmail,
+        sendVerificationWebhook: verificationWebhookService.sendVerificationWebhook.bind(verificationWebhookService),
         membersStats,
         Settings: models.Settings,
         eventRepository: membersApi.events

--- a/ghost/core/core/server/services/members/service.js
+++ b/ghost/core/core/server/services/members/service.js
@@ -43,6 +43,7 @@ const membersStats = new MembersStats({
 });
 
 let membersApi;
+let verificationTrigger;
 
 const sendVerificationEmail = async ({subject, message, amountTriggered}) => {
     const escalationAddress = config.get('hostSettings:emailVerification:escalationAddress');
@@ -111,6 +112,7 @@ const initVerificationTrigger = () => {
         getImportTriggerThreshold: () => _.get(config.get('hostSettings'), 'emailVerification.importThreshold'),
         isVerified: () => config.get('hostSettings:emailVerification:verified') === true,
         isVerificationRequired: () => settingsCache.get('email_verification_required') === true,
+        setVerificationRequired: value => settingsCache.set('email_verification_required', {value}),
         isVerificationFlowEnabled: () => labsService.isSet('verificationFlow'),
         sendVerificationEmail,
         sendVerificationWebhook: verificationWebhookService.sendVerificationWebhook.bind(verificationWebhookService),
@@ -157,7 +159,9 @@ module.exports = {
             getMembersApi: () => module.exports.api
         });
 
-        const verificationTrigger = initVerificationTrigger();
+        if (!verificationTrigger) {
+            verificationTrigger = initVerificationTrigger();
+        }
         module.exports.verificationTrigger = verificationTrigger;
 
         const membersCSVImporter = initMembersCSVImporter({stripeAPIService: stripeService.api});

--- a/ghost/core/core/server/services/verification-trigger.js
+++ b/ghost/core/core/server/services/verification-trigger.js
@@ -19,7 +19,9 @@ class VerificationTrigger {
      * @param {() => number} deps.getImportTriggerThreshold Threshold for triggering Import sourced verifications
      * @param {() => boolean} deps.isVerified Check Ghost config to see if we are already verified
      * @param {() => boolean} deps.isVerificationRequired Check Ghost settings to see whether verification has been requested
+     * @param {() => boolean} deps.isVerificationFlowEnabled Check whether webhook-based verification flow is enabled
      * @param {(content: {subject: string, message: string, amountTriggered: number}) => Promise<void>} deps.sendVerificationEmail Sends an email to the escalation address to confirm that customer needs to be verified
+     * @param {(content: {amountTriggered: number, threshold: number, method: string}) => Promise<boolean>} deps.sendVerificationWebhook Sends a webhook to the escalation service to confirm that customer needs to be verified
      * @param {any} deps.Settings Ghost Settings model
      * @param {any} deps.eventRepository For querying events
      */
@@ -29,7 +31,9 @@ class VerificationTrigger {
         getImportTriggerThreshold,
         isVerified,
         isVerificationRequired,
+        isVerificationFlowEnabled,
         sendVerificationEmail,
+        sendVerificationWebhook,
         Settings,
         eventRepository
     }) {
@@ -38,7 +42,9 @@ class VerificationTrigger {
         this._getImportTriggerThreshold = getImportTriggerThreshold;
         this._isVerified = isVerified;
         this._isVerificationRequired = isVerificationRequired;
+        this._isVerificationFlowEnabled = isVerificationFlowEnabled || (() => false);
         this._sendVerificationEmail = sendVerificationEmail;
+        this._sendVerificationWebhook = sendVerificationWebhook;
         this._Settings = Settings;
         this._eventRepository = eventRepository;
 
@@ -59,6 +65,10 @@ class VerificationTrigger {
 
     get _importTriggerThreshold() {
         return this._getImportTriggerThreshold();
+    }
+
+    _shouldUseWebhookFlow() {
+        return this._isVerificationFlowEnabled() && typeof this._sendVerificationWebhook === 'function';
     }
 
     /**
@@ -89,14 +99,59 @@ class VerificationTrigger {
                 source: 'member'
             })).meta.pagination.total;
 
-            if (events.meta.pagination.total > Math.max(sourceThreshold, membersTotal)) {
+            const effectiveThreshold = Math.max(sourceThreshold, membersTotal);
+
+            if (events.meta.pagination.total > effectiveThreshold) {
                 await this._startVerificationProcess({
                     amount: events.meta.pagination.total,
+                    threshold: effectiveThreshold,
+                    method: source,
                     throwOnTrigger: false,
                     source: source
                 });
             }
         }
+    }
+
+    async _markVerificationRequired() {
+        await this._Settings.edit([{
+            key: 'email_verification_required',
+            value: true
+        }], {context: {internal: true}});
+    }
+
+    _finishTrigger(throwOnTrigger) {
+        if (throwOnTrigger) {
+            throw new errors.HostLimitError({
+                message: messages.emailVerificationNeeded,
+                code: 'EMAIL_VERIFICATION_NEEDED'
+            });
+        }
+
+        return {
+            needsVerification: true
+        };
+    }
+
+    async _startLegacyEmailVerificationProcess({amount, triggerSource, throwOnTrigger}) {
+        // GA removal point: delete this method once webhook delivery fully replaces email escalation.
+        let verificationMessage = messages.emailVerificationEmailMessageImport;
+
+        if (triggerSource === 'api') {
+            verificationMessage = messages.emailVerificationEmailMessageAPI;
+        } else if (triggerSource === 'admin') {
+            verificationMessage = messages.emailVerificationEmailMessageAdmin;
+        }
+
+        await this._markVerificationRequired();
+
+        await this._sendVerificationEmail({
+            message: verificationMessage,
+            subject: messages.emailVerificationEmailSubject,
+            amountTriggered: amount
+        });
+
+        return this._finishTrigger(throwOnTrigger);
     }
 
     async getImportThreshold() {
@@ -156,6 +211,8 @@ class VerificationTrigger {
         if (isFinite(importThreshold) && events.meta.pagination.total > importThreshold) {
             await this._startVerificationProcess({
                 amount: events.meta.pagination.total,
+                threshold: importThreshold,
+                method: 'import',
                 throwOnTrigger: false,
                 source: 'import'
             });
@@ -171,48 +228,53 @@ class VerificationTrigger {
      *
      * @param {object} config
      * @param {number} config.amount The amount of members that triggered the verification process
+     * @param {number} [config.threshold] The threshold that was exceeded
+     * @param {string} [config.method] The source that triggered verification - 'api', 'admin', or 'import'
      * @param {boolean} config.throwOnTrigger Whether to throw if verification is needed
-     * @param {string} config.source Source of the verification trigger - currently either 'api' or 'import'
+     * @param {string} [config.source] Source of the verification trigger
      * @returns {Promise<IVerificationResult>} Object containing property "needsVerification" - true when triggered
      */
     async _startVerificationProcess({
         amount,
+        threshold,
+        method,
         throwOnTrigger,
         source
     }) {
         if (!this._isVerified()) {
-            // Only trigger flag change and escalation email the first time
+            // Only trigger flag change and escalation notification the first time
             if (!this._isVerificationRequired()) {
-                await this._Settings.edit([{
-                    key: 'email_verification_required',
-                    value: true
-                }], {context: {internal: true}});
+                const triggerSource = method ?? source ?? 'import';
 
-                // Setting import as a default message
-                let verificationMessage = messages.emailVerificationEmailMessageImport;
+                if (this._shouldUseWebhookFlow()) {
+                    try {
+                        const webhookWasSent = await this._sendVerificationWebhook({
+                            amountTriggered: amount,
+                            threshold: threshold ?? amount,
+                            method: triggerSource
+                        });
 
-                if (source === 'api') {
-                    verificationMessage = messages.emailVerificationEmailMessageAPI;
-                } else if (source === 'admin') {
-                    verificationMessage = messages.emailVerificationEmailMessageAdmin;
-                }
+                        if (webhookWasSent) {
+                            await this._markVerificationRequired();
+                            return this._finishTrigger(throwOnTrigger);
+                        }
+                    } catch (error) {
+                        // `sendVerificationWebhook` already logs delivery failures.
+                    }
 
-                await this._sendVerificationEmail({
-                    message: verificationMessage,
-                    subject: messages.emailVerificationEmailSubject,
-                    amountTriggered: amount
-                });
-
-                if (throwOnTrigger) {
-                    throw new errors.HostLimitError({
-                        message: messages.emailVerificationNeeded,
-                        code: 'EMAIL_VERIFICATION_NEEDED'
+                    // Temporary fallback while the webhook flow is behind a flag.
+                    return await this._startLegacyEmailVerificationProcess({
+                        amount,
+                        triggerSource,
+                        throwOnTrigger
                     });
                 }
 
-                return {
-                    needsVerification: true
-                };
+                return await this._startLegacyEmailVerificationProcess({
+                    amount,
+                    triggerSource,
+                    throwOnTrigger
+                });
             }
         }
 

--- a/ghost/core/core/server/services/verification-trigger.js
+++ b/ghost/core/core/server/services/verification-trigger.js
@@ -19,6 +19,7 @@ class VerificationTrigger {
      * @param {() => number} deps.getImportTriggerThreshold Threshold for triggering Import sourced verifications
      * @param {() => boolean} deps.isVerified Check Ghost config to see if we are already verified
      * @param {() => boolean} deps.isVerificationRequired Check Ghost settings to see whether verification has been requested
+     * @param {(value: boolean) => void} deps.setVerificationRequired Directly update the settings cache for email_verification_required
      * @param {() => boolean} deps.isVerificationFlowEnabled Check whether webhook-based verification flow is enabled
      * @param {(content: {subject: string, message: string, amountTriggered: number}) => Promise<void>} deps.sendVerificationEmail Sends an email to the escalation address to confirm that customer needs to be verified
      * @param {(content: {amountTriggered: number, threshold: number, method: string}) => Promise<boolean>} deps.sendVerificationWebhook Sends a webhook to the escalation service to confirm that customer needs to be verified
@@ -31,6 +32,7 @@ class VerificationTrigger {
         getImportTriggerThreshold,
         isVerified,
         isVerificationRequired,
+        setVerificationRequired,
         isVerificationFlowEnabled,
         sendVerificationEmail,
         sendVerificationWebhook,
@@ -42,6 +44,7 @@ class VerificationTrigger {
         this._getImportTriggerThreshold = getImportTriggerThreshold;
         this._isVerified = isVerified;
         this._isVerificationRequired = isVerificationRequired;
+        this._setVerificationRequired = setVerificationRequired || (() => {});
         this._isVerificationFlowEnabled = isVerificationFlowEnabled || (() => false);
         this._sendVerificationEmail = sendVerificationEmail;
         this._sendVerificationWebhook = sendVerificationWebhook;
@@ -118,6 +121,12 @@ class VerificationTrigger {
             key: 'email_verification_required',
             value: true
         }], {context: {internal: true}});
+
+        // Explicitly update the cache regardless of whether the DB value changed.
+        // Settings.edit relies on Bookshelf's hasChanged() to fire onUpdated, which
+        // skips the model event (and therefore the cache update) when the DB already
+        // holds the same value — e.g. after a previous verification cycle.
+        this._setVerificationRequired(true);
     }
 
     _finishTrigger(throwOnTrigger) {

--- a/ghost/core/core/server/services/verification-trigger.js
+++ b/ghost/core/core/server/services/verification-trigger.js
@@ -10,6 +10,12 @@ const messages = {
     emailVerificationEmailMessageAPI: `Email verification needed for site: {siteUrl} has added: {amountTriggered} members through the API in the last 30 days.`
 };
 
+const verificationMessageBySource = {
+    api: messages.emailVerificationEmailMessageAPI,
+    admin: messages.emailVerificationEmailMessageAdmin,
+    import: messages.emailVerificationEmailMessageImport
+};
+
 class VerificationTrigger {
     /**
      *
@@ -144,13 +150,7 @@ class VerificationTrigger {
 
     async _startLegacyEmailVerificationProcess({amount, triggerSource, throwOnTrigger}) {
         // GA removal point: delete this method once webhook delivery fully replaces email escalation.
-        let verificationMessage = messages.emailVerificationEmailMessageImport;
-
-        if (triggerSource === 'api') {
-            verificationMessage = messages.emailVerificationEmailMessageAPI;
-        } else if (triggerSource === 'admin') {
-            verificationMessage = messages.emailVerificationEmailMessageAdmin;
-        }
+        const verificationMessage = verificationMessageBySource[triggerSource] || messages.emailVerificationEmailMessageImport;
 
         await this._markVerificationRequired();
 
@@ -165,14 +165,14 @@ class VerificationTrigger {
 
     async getImportThreshold() {
         const volumeThreshold = this._importTriggerThreshold;
-        if (isFinite(volumeThreshold)) {
-            const membersTotal = (await this._eventRepository.getSignupEvents({}, {
-                source: 'member'
-            })).meta.pagination.total;
-            return Math.max(membersTotal, volumeThreshold);
-        } else {
+        if (!isFinite(volumeThreshold)) {
             return volumeThreshold;
         }
+
+        const membersTotal = (await this._eventRepository.getSignupEvents({}, {
+            source: 'member'
+        })).meta.pagination.total;
+        return Math.max(membersTotal, volumeThreshold);
     }
 
     /**
@@ -250,46 +250,40 @@ class VerificationTrigger {
         throwOnTrigger,
         source
     }) {
-        if (!this._isVerified()) {
-            // Only trigger flag change and escalation notification the first time
-            if (!this._isVerificationRequired()) {
-                const triggerSource = method ?? source ?? 'import';
+        if (this._isVerified()) {
+            return {needsVerification: false};
+        }
 
-                if (this._shouldUseWebhookFlow()) {
-                    try {
-                        const webhookWasSent = await this._sendVerificationWebhook({
-                            amountTriggered: amount,
-                            threshold: threshold ?? amount,
-                            method: triggerSource
-                        });
+        // Only trigger flag change and escalation notification the first time
+        if (this._isVerificationRequired()) {
+            return {needsVerification: false};
+        }
 
-                        if (webhookWasSent) {
-                            await this._markVerificationRequired();
-                            return this._finishTrigger(throwOnTrigger);
-                        }
-                    } catch (error) {
-                        // `sendVerificationWebhook` already logs delivery failures.
-                    }
+        const triggerSource = method ?? source ?? 'import';
 
-                    // Temporary fallback while the webhook flow is behind a flag.
-                    return await this._startLegacyEmailVerificationProcess({
-                        amount,
-                        triggerSource,
-                        throwOnTrigger
-                    });
-                }
-
-                return await this._startLegacyEmailVerificationProcess({
-                    amount,
-                    triggerSource,
-                    throwOnTrigger
+        if (this._shouldUseWebhookFlow()) {
+            try {
+                const webhookWasSent = await this._sendVerificationWebhook({
+                    amountTriggered: amount,
+                    threshold: threshold ?? amount,
+                    method: triggerSource
                 });
+
+                if (webhookWasSent) {
+                    await this._markVerificationRequired();
+                    return this._finishTrigger(throwOnTrigger);
+                }
+            } catch (error) {
+                // `sendVerificationWebhook` already logs delivery failures.
             }
         }
 
-        return {
-            needsVerification: false
-        };
+        // Default email flow — used unless the webhook flow is enabled and succeeds.
+        return await this._startLegacyEmailVerificationProcess({
+            amount,
+            triggerSource,
+            throwOnTrigger
+        });
     }
 }
 

--- a/ghost/core/core/server/services/verification/verification-webhook-service.ts
+++ b/ghost/core/core/server/services/verification/verification-webhook-service.ts
@@ -1,0 +1,138 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+import crypto from 'crypto';
+const logging = require('@tryghost/logging');
+const request = require('@tryghost/request');
+const ghostVersion = require('@tryghost/version');
+const config = require('../../../shared/config');
+
+type VerificationTriggerMethod = 'admin' | 'api' | 'import';
+
+type VerificationWebhookBody = {
+    type: string;
+    siteId: string | null;
+    amountTriggered: number;
+    threshold: number;
+    method: VerificationTriggerMethod;
+};
+
+type VerificationWebhookServiceDependencies = {
+    config: {
+        get: (key: string) => unknown;
+    };
+    logging: {
+        info: (message: string) => void;
+        warn: (message: string) => void;
+        error: (message: string) => void;
+    };
+    request: (url: string, options: unknown) => Promise<unknown>;
+};
+
+const REQUEST_TIMEOUT_MS = 30_000;
+const MAX_RETRY_LIMIT = 5;
+
+export class VerificationWebhookService {
+    #config: VerificationWebhookServiceDependencies['config'];
+    #logging: VerificationWebhookServiceDependencies['logging'];
+    #request: VerificationWebhookServiceDependencies['request'];
+
+    constructor(dependencies: VerificationWebhookServiceDependencies = {config, logging, request}) {
+        this.#config = dependencies.config;
+        this.#logging = dependencies.logging;
+        this.#request = dependencies.request;
+    }
+
+    #readWebhookConfig() {
+        return {
+            webhookType: this.#config.get('hostSettings:emailVerification:webhookType'),
+            webhookUrl: this.#config.get('hostSettings:emailVerification:webhookUrl'),
+            webhookSecret: this.#config.get('hostSettings:emailVerification:webhookSecret') || '',
+            siteId: this.#config.get('hostSettings:siteId') || null
+        };
+    }
+
+    #computeSignature(timestamp: string, body: string, secret: string): string {
+        const baseString = `${timestamp}:${body}`;
+        return crypto.createHmac('sha256', secret).update(baseString).digest('base64');
+    }
+
+    #sanitizeWebhookUrl(webhookUrl: string): string {
+        try {
+            return new URL(webhookUrl).origin;
+        } catch {
+            return '[invalid webhook url]';
+        }
+    }
+
+    /**
+     * Sends a verification webhook to the configured endpoint.
+     */
+    async sendVerificationWebhook({
+        amountTriggered,
+        threshold,
+        method
+    }: {
+        amountTriggered: number;
+        threshold: number;
+        method: VerificationTriggerMethod;
+    }): Promise<boolean> {
+        const {webhookType, webhookUrl, webhookSecret, siteId} = this.#readWebhookConfig();
+
+        if (typeof webhookUrl !== 'string' || webhookUrl.length === 0) {
+            this.#logging.warn('Verification webhook flow is enabled but webhookUrl is not configured.');
+            return false;
+        }
+
+        if (typeof webhookType !== 'string' || webhookType.length === 0) {
+            this.#logging.warn('Verification webhook flow is enabled but webhookType is not configured.');
+            return false;
+        }
+
+        const payload: VerificationWebhookBody = {
+            type: webhookType,
+            siteId: typeof siteId === 'string' ? siteId : null,
+            amountTriggered,
+            threshold,
+            method
+        };
+
+        const requestBody = JSON.stringify(payload);
+        const timestamp = Date.now().toString();
+
+        const headers: Record<string, string | number> = {
+            'Content-Length': Buffer.byteLength(requestBody),
+            'Content-Type': 'application/json',
+            'Content-Version': `v${ghostVersion.safe}`,
+            'X-Ghost-Request-Timestamp': timestamp
+        };
+
+        if (typeof webhookSecret === 'string' && webhookSecret !== '') {
+            headers['X-Ghost-Signature'] = this.#computeSignature(timestamp, requestBody, webhookSecret);
+        }
+
+        const requestOptions = {
+            method: 'POST',
+            body: requestBody,
+            headers,
+            timeout: {
+                request: REQUEST_TIMEOUT_MS
+            },
+            retry: {
+                limit: process.env.NODE_ENV?.startsWith('test') ? 0 : MAX_RETRY_LIMIT
+            }
+        };
+
+        const sanitizedWebhookUrl = this.#sanitizeWebhookUrl(webhookUrl);
+        this.#logging.info(`Triggering verification webhook to "${sanitizedWebhookUrl}"`);
+
+        try {
+            await this.#request(webhookUrl, requestOptions);
+            return true;
+        } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            this.#logging.error(`Failed to send verification webhook to "${sanitizedWebhookUrl}": ${message}`);
+            throw error;
+        }
+    }
+}
+
+export const verificationWebhookService = new VerificationWebhookService();

--- a/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
@@ -29,7 +29,6 @@ Object {
       "tagsX": true,
       "themeTranslation": true,
       "transistor": true,
-      "verificationFlow": true,
       "urlCache": true,
       "verificationFlow": true,
       "welcomeEmailEditor": true,

--- a/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
@@ -29,6 +29,7 @@ Object {
       "tagsX": true,
       "themeTranslation": true,
       "transistor": true,
+      "verificationFlow": true,
       "urlCache": true,
       "verificationFlow": true,
       "welcomeEmailEditor": true,

--- a/ghost/core/test/e2e-api/admin/__snapshots__/members.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/members.test.js.snap
@@ -1139,6 +1139,158 @@ Object {
 }
 `;
 
+exports[`Members API Can add a member and trigger host webhook verification limits 1: [body] 1`] = `
+Object {
+  "members": Array [
+    Object {
+      "attribution": Object {
+        "id": null,
+        "referrer_medium": "Ghost Admin",
+        "referrer_source": "Created manually",
+        "referrer_url": null,
+        "title": null,
+        "type": null,
+        "url": null,
+      },
+      "avatar_image": null,
+      "can_comment": true,
+      "commenting": Object {
+        "disabled": false,
+        "disabled_reason": null,
+        "disabled_until": null,
+      },
+      "comped": false,
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "email": "memberPassWebhookVerification@test.com",
+      "email_count": 0,
+      "email_open_rate": null,
+      "email_opened_count": 0,
+      "email_suppression": Object {
+        "info": null,
+        "suppressed": false,
+      },
+      "geolocation": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "labels": Any<Array>,
+      "last_seen_at": null,
+      "name": "pass webhook verification",
+      "newsletters": Array [
+        Object {
+          "description": null,
+          "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+          "name": "Default Newsletter",
+          "status": "active",
+        },
+        Object {
+          "description": null,
+          "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+          "name": "Weekly newsletter",
+          "status": "active",
+        },
+      ],
+      "note": null,
+      "status": "free",
+      "subscribed": true,
+      "subscriptions": Any<Array>,
+      "tiers": Array [],
+      "unsubscribe_url": Any<String>,
+      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+    },
+  ],
+}
+`;
+
+exports[`Members API Can add a member and trigger host webhook verification limits 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "1083",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/members\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Members API Can add a member and trigger host webhook verification limits 3: [body] 1`] = `
+Object {
+  "members": Array [
+    Object {
+      "attribution": Object {
+        "id": null,
+        "referrer_medium": "Ghost Admin",
+        "referrer_source": "Created manually",
+        "referrer_url": null,
+        "title": null,
+        "type": null,
+        "url": null,
+      },
+      "avatar_image": null,
+      "can_comment": true,
+      "commenting": Object {
+        "disabled": false,
+        "disabled_reason": null,
+        "disabled_until": null,
+      },
+      "comped": false,
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "email": "memberFailWebhookVerification@test.com",
+      "email_count": 0,
+      "email_open_rate": null,
+      "email_opened_count": 0,
+      "email_suppression": Object {
+        "info": null,
+        "suppressed": false,
+      },
+      "geolocation": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "labels": Any<Array>,
+      "last_seen_at": null,
+      "name": "fail webhook verification",
+      "newsletters": Array [
+        Object {
+          "description": null,
+          "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+          "name": "Default Newsletter",
+          "status": "active",
+        },
+        Object {
+          "description": null,
+          "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+          "name": "Weekly newsletter",
+          "status": "active",
+        },
+      ],
+      "note": null,
+      "status": "free",
+      "subscribed": true,
+      "subscriptions": Any<Array>,
+      "tiers": Array [],
+      "unsubscribe_url": Any<String>,
+      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+    },
+  ],
+}
+`;
+
+exports[`Members API Can add a member and trigger host webhook verification limits 4: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "1083",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/members\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
 exports[`Members API Can add a member that is not subscribed (old) 1: [body] 1`] = `
 Object {
   "members": Array [

--- a/ghost/core/test/e2e-api/admin/members.test.js
+++ b/ghost/core/test/e2e-api/admin/members.test.js
@@ -4,6 +4,7 @@ const {queryStringToken} = regexes;
 const ObjectId = require('bson-objectid').default;
 
 const assert = require('node:assert/strict');
+const crypto = require('node:crypto');
 const {assertExists, assertArrayContainsDeep, assertObjectMatches, assertArrayMatchesWithoutOrder} = require('../../utils/assertions');
 const nock = require('nock');
 const sinon = require('sinon');
@@ -891,6 +892,8 @@ describe('Members API', function () {
     });
 
     it('Can add a member and trigger host email verification limits', async function () {
+        mockManager.mockLabsDisabled('verificationFlow');
+
         configUtils.set('hostSettings:emailVerification', {
             apiThreshold: 0,
             adminThreshold: 1,
@@ -899,62 +902,186 @@ describe('Members API', function () {
             escalationAddress: 'test@example.com'
         });
 
-        assert.ok(!settingsCache.get('email_verification_required'), 'Email verification should NOT be required');
+        try {
+            assert.ok(!settingsCache.get('email_verification_required'), 'Email verification should NOT be required');
 
-        const member = {
-            name: 'pass verification',
-            email: 'memberPassVerifivation@test.com'
-        };
+            const member = {
+                name: 'pass verification',
+                email: 'memberPassVerifivation@test.com'
+            };
 
-        const {body: passBody} = await agent
-            .post(`/members/`)
-            .body({members: [member]})
-            .expectStatus(201)
-            .matchBodySnapshot({
-                members: new Array(1).fill(buildMemberMatcherShallowIncludesWithTiers(0, 2))
-            })
-            .matchHeaderSnapshot({
-                'content-version': anyContentVersion,
-                etag: anyEtag,
-                location: anyLocationFor('members')
+            const {body: passBody} = await agent
+                .post(`/members/`)
+                .body({members: [member]})
+                .expectStatus(201)
+                .matchBodySnapshot({
+                    members: new Array(1).fill(buildMemberMatcherShallowIncludesWithTiers(0, 2))
+                })
+                .matchHeaderSnapshot({
+                    'content-version': anyContentVersion,
+                    etag: anyEtag,
+                    location: anyLocationFor('members')
+                });
+            const memberPassVerification = passBody.members[0];
+
+            await DomainEvents.allSettled();
+            assert.ok(!settingsCache.get('email_verification_required'), 'Email verification should NOT be required');
+
+            const memberFailLimit = {
+                name: 'fail verification',
+                email: 'memberFailVerifivation@test.com'
+            };
+
+            const {body: failBody} = await agent
+                .post(`/members/`)
+                .body({members: [memberFailLimit]})
+                .expectStatus(201)
+                .matchBodySnapshot({
+                    members: new Array(1).fill(buildMemberMatcherShallowIncludesWithTiers(0, 2))
+                })
+                .matchHeaderSnapshot({
+                    'content-version': anyContentVersion,
+                    etag: anyEtag,
+                    location: anyLocationFor('members')
+                });
+            const memberFailVerification = failBody.members[0];
+
+            await DomainEvents.allSettled();
+            assert.ok(settingsCache.get('email_verification_required'), 'Email verification should be required');
+
+            mockManager.assert.sentEmail({
+                subject: 'Email needs verification'
             });
-        const memberPassVerification = passBody.members[0];
 
-        await DomainEvents.allSettled();
-        assert.ok(!settingsCache.get('email_verification_required'), 'Email verification should NOT be required');
+            // state cleanup
+            await agent.delete(`/members/${memberPassVerification.id}`);
+            await agent.delete(`/members/${memberFailVerification.id}`);
+        } finally {
+            await configUtils.restore();
+            settingsCache.set('email_verification_required', {value: false});
+        }
+    });
 
-        const memberFailLimit = {
-            name: 'fail verification',
-            email: 'memberFailVerifivation@test.com'
-        };
+    it('Can add a member and trigger host webhook verification limits', async function () {
+        mockManager.mockLabsEnabled('verificationFlow');
+        const webhookUrl = 'https://test-webhook-receiver.com/mock-verification-event-endpoint/';
+        const webhookSecret = 'not-a-live-secret';
+        const receivedWebhookRequests = [];
+        const webhookEndpoint = new URL(webhookUrl);
 
-        const {body: failBody} = await agent
-            .post(`/members/`)
-            .body({members: [memberFailLimit]})
-            .expectStatus(201)
-            .matchBodySnapshot({
-                members: new Array(1).fill(buildMemberMatcherShallowIncludesWithTiers(0, 2))
-            })
-            .matchHeaderSnapshot({
-                'content-version': anyContentVersion,
-                etag: anyEtag,
-                location: anyLocationFor('members')
-            });
-        const memberFailVerification = failBody.members[0];
-
-        await DomainEvents.allSettled();
-        assert.ok(settingsCache.get('email_verification_required'), 'Email verification should be required');
-
-        mockManager.assert.sentEmail({
-            subject: 'Email needs verification'
+        configUtils.set('hostSettings:siteId', '1');
+        configUtils.set('hostSettings:emailVerification', {
+            apiThreshold: 0,
+            adminThreshold: 1,
+            importThreshold: 0,
+            verified: false,
+            escalationAddress: 'test@example.com',
+            webhookType: 'mock_verification_event',
+            webhookUrl,
+            webhookSecret
         });
 
-        // state cleanup
-        await agent.delete(`/members/${memberPassVerification.id}`);
-        await agent.delete(`/members/${memberFailVerification.id}`);
+        nock(webhookEndpoint.origin)
+            .persist()
+            .post(webhookEndpoint.pathname)
+            .reply(function (_uri, requestBody) {
+                const rawBody = Buffer.isBuffer(requestBody) ?
+                    requestBody.toString('utf8') :
+                    typeof requestBody === 'string' ?
+                        requestBody :
+                        JSON.stringify(requestBody);
+                const parsedBody = typeof requestBody === 'object' && !Buffer.isBuffer(requestBody) ?
+                    requestBody :
+                    JSON.parse(rawBody);
 
-        await configUtils.restore();
-        settingsCache.set('email_verification_required', {value: false});
+                receivedWebhookRequests.push({
+                    body: parsedBody,
+                    headers: this.req.headers,
+                    rawBody
+                });
+
+                return [200, {status: 'OK'}];
+            });
+
+        try {
+            assert.ok(!settingsCache.get('email_verification_required'), 'Email verification should NOT be required');
+
+            const member = {
+                name: 'pass webhook verification',
+                email: 'memberPassWebhookVerification@test.com'
+            };
+
+            const {body: passBody} = await agent
+                .post(`/members/`)
+                .body({members: [member]})
+                .expectStatus(201)
+                .matchBodySnapshot({
+                    members: new Array(1).fill(buildMemberMatcherShallowIncludesWithTiers(0, 2))
+                })
+                .matchHeaderSnapshot({
+                    'content-version': anyContentVersion,
+                    etag: anyEtag,
+                    location: anyLocationFor('members')
+                });
+            const memberPassVerification = passBody.members[0];
+
+            await DomainEvents.allSettled();
+            assert.ok(!settingsCache.get('email_verification_required'), 'Email verification should NOT be required');
+
+            const memberFailLimit = {
+                name: 'fail webhook verification',
+                email: 'memberFailWebhookVerification@test.com'
+            };
+
+            const {body: failBody} = await agent
+                .post(`/members/`)
+                .body({members: [memberFailLimit]})
+                .expectStatus(201)
+                .matchBodySnapshot({
+                    members: new Array(1).fill(buildMemberMatcherShallowIncludesWithTiers(0, 2))
+                })
+                .matchHeaderSnapshot({
+                    'content-version': anyContentVersion,
+                    etag: anyEtag,
+                    location: anyLocationFor('members')
+                });
+            const memberFailVerification = failBody.members[0];
+
+            await DomainEvents.allSettled();
+            assert.ok(settingsCache.get('email_verification_required'), 'Email verification should be required');
+            emailMockReceiver.assertSentEmailCount(0);
+
+            const matchingRequest = receivedWebhookRequests.find((request) => {
+                return request.body.type === 'mock_verification_event' &&
+                    request.body.siteId === '1' &&
+                    request.body.amountTriggered === 2 &&
+                    request.body.threshold === 1 &&
+                    request.body.method === 'admin';
+            });
+
+            assert.ok(matchingRequest, 'Expected the verification webhook request to be sent with the configured payload');
+
+            const requestTimestamp = Array.isArray(matchingRequest.headers['x-ghost-request-timestamp']) ?
+                matchingRequest.headers['x-ghost-request-timestamp'][0] :
+                matchingRequest.headers['x-ghost-request-timestamp'];
+            const requestSignature = Array.isArray(matchingRequest.headers['x-ghost-signature']) ?
+                matchingRequest.headers['x-ghost-signature'][0] :
+                matchingRequest.headers['x-ghost-signature'];
+            const expectedSignature = crypto.createHmac('sha256', webhookSecret)
+                .update(`${requestTimestamp}:${matchingRequest.rawBody}`)
+                .digest('base64');
+
+            assert.ok(requestTimestamp, 'Expected the verification webhook request to include a timestamp header');
+            assert.equal(requestSignature, expectedSignature, 'Expected the verification webhook request to be signed');
+
+            // state cleanup
+            await agent.delete(`/members/${memberPassVerification.id}`);
+            await agent.delete(`/members/${memberFailVerification.id}`);
+        } finally {
+            nock.cleanAll();
+            await configUtils.restore();
+            settingsCache.set('email_verification_required', {value: false});
+        }
     });
 
     it('Can add and send a signup confirmation email', async function () {

--- a/ghost/core/test/e2e-api/admin/members.test.js
+++ b/ghost/core/test/e2e-api/admin/members.test.js
@@ -487,6 +487,7 @@ describe('Members API', function () {
     });
 
     afterEach(function () {
+        settingsCache.set('email_verification_required', {value: false});
         mockManager.restore();
     });
 
@@ -902,67 +903,59 @@ describe('Members API', function () {
             escalationAddress: 'test@example.com'
         });
 
-        try {
-            assert.ok(!settingsCache.get('email_verification_required'), 'Email verification should NOT be required');
+        assert.ok(!settingsCache.get('email_verification_required'), 'Email verification should NOT be required');
 
-            const member = {
-                name: 'pass verification',
-                email: 'memberPassVerifivation@test.com'
-            };
+        const member = {
+            name: 'pass verification',
+            email: 'memberPassVerifivation@test.com'
+        };
 
-            const {body: passBody} = await agent
-                .post(`/members/`)
-                .body({members: [member]})
-                .expectStatus(201)
-                .matchBodySnapshot({
-                    members: new Array(1).fill(buildMemberMatcherShallowIncludesWithTiers(0, 2))
-                })
-                .matchHeaderSnapshot({
-                    'content-version': anyContentVersion,
-                    etag: anyEtag,
-                    location: anyLocationFor('members')
-                });
-            const memberPassVerification = passBody.members[0];
-
-            await DomainEvents.allSettled();
-            assert.ok(!settingsCache.get('email_verification_required'), 'Email verification should NOT be required');
-
-            const memberFailLimit = {
-                name: 'fail verification',
-                email: 'memberFailVerifivation@test.com'
-            };
-
-            const {body: failBody} = await agent
-                .post(`/members/`)
-                .body({members: [memberFailLimit]})
-                .expectStatus(201)
-                .matchBodySnapshot({
-                    members: new Array(1).fill(buildMemberMatcherShallowIncludesWithTiers(0, 2))
-                })
-                .matchHeaderSnapshot({
-                    'content-version': anyContentVersion,
-                    etag: anyEtag,
-                    location: anyLocationFor('members')
-                });
-            const memberFailVerification = failBody.members[0];
-
-            await DomainEvents.allSettled();
-            assert.ok(settingsCache.get('email_verification_required'), 'Email verification should be required');
-
-            mockManager.assert.sentEmail({
-                subject: 'Email needs verification'
+        const {body: passBody} = await agent
+            .post(`/members/`)
+            .body({members: [member]})
+            .expectStatus(201)
+            .matchBodySnapshot({
+                members: new Array(1).fill(buildMemberMatcherShallowIncludesWithTiers(0, 2))
+            })
+            .matchHeaderSnapshot({
+                'content-version': anyContentVersion,
+                etag: anyEtag,
+                location: anyLocationFor('members')
             });
+        const memberPassVerification = passBody.members[0];
 
-            // state cleanup
-            await agent.delete(`/members/${memberPassVerification.id}`);
-            await agent.delete(`/members/${memberFailVerification.id}`);
-        } finally {
-            await models.Settings.edit([{
-                key: 'email_verification_required',
-                value: false
-            }], {context: {internal: true}});
-            await configUtils.restore();
-        }
+        await DomainEvents.allSettled();
+        assert.ok(!settingsCache.get('email_verification_required'), 'Email verification should NOT be required');
+
+        const memberFailLimit = {
+            name: 'fail verification',
+            email: 'memberFailVerifivation@test.com'
+        };
+
+        const {body: failBody} = await agent
+            .post(`/members/`)
+            .body({members: [memberFailLimit]})
+            .expectStatus(201)
+            .matchBodySnapshot({
+                members: new Array(1).fill(buildMemberMatcherShallowIncludesWithTiers(0, 2))
+            })
+            .matchHeaderSnapshot({
+                'content-version': anyContentVersion,
+                etag: anyEtag,
+                location: anyLocationFor('members')
+            });
+        const memberFailVerification = failBody.members[0];
+
+        await DomainEvents.allSettled();
+        assert.ok(settingsCache.get('email_verification_required'), 'Email verification should be required');
+
+        mockManager.assert.sentEmail({
+            subject: 'Email needs verification'
+        });
+
+        // state cleanup
+        await agent.delete(`/members/${memberPassVerification.id}`);
+        await agent.delete(`/members/${memberFailVerification.id}`);
     });
 
     it('Can add a member and trigger host webhook verification limits', async function () {
@@ -1006,88 +999,79 @@ describe('Members API', function () {
                 return [200, {status: 'OK'}];
             });
 
-        try {
-            assert.ok(!settingsCache.get('email_verification_required'), 'Email verification should NOT be required');
+        assert.ok(!settingsCache.get('email_verification_required'), 'Email verification should NOT be required');
 
-            const member = {
-                name: 'pass webhook verification',
-                email: 'memberPassWebhookVerification@test.com'
-            };
+        const member = {
+            name: 'pass webhook verification',
+            email: 'memberPassWebhookVerification@test.com'
+        };
 
-            const {body: passBody} = await agent
-                .post(`/members/`)
-                .body({members: [member]})
-                .expectStatus(201)
-                .matchBodySnapshot({
-                    members: new Array(1).fill(buildMemberMatcherShallowIncludesWithTiers(0, 2))
-                })
-                .matchHeaderSnapshot({
-                    'content-version': anyContentVersion,
-                    etag: anyEtag,
-                    location: anyLocationFor('members')
-                });
-            const memberPassVerification = passBody.members[0];
-
-            await DomainEvents.allSettled();
-            assert.ok(!settingsCache.get('email_verification_required'), 'Email verification should NOT be required');
-
-            const memberFailLimit = {
-                name: 'fail webhook verification',
-                email: 'memberFailWebhookVerification@test.com'
-            };
-
-            const {body: failBody} = await agent
-                .post(`/members/`)
-                .body({members: [memberFailLimit]})
-                .expectStatus(201)
-                .matchBodySnapshot({
-                    members: new Array(1).fill(buildMemberMatcherShallowIncludesWithTiers(0, 2))
-                })
-                .matchHeaderSnapshot({
-                    'content-version': anyContentVersion,
-                    etag: anyEtag,
-                    location: anyLocationFor('members')
-                });
-            const memberFailVerification = failBody.members[0];
-
-            await DomainEvents.allSettled();
-            assert.ok(settingsCache.get('email_verification_required'), 'Email verification should be required');
-            emailMockReceiver.assertSentEmailCount(0);
-
-            const matchingRequest = receivedWebhookRequests.find((request) => {
-                return request.body.type === 'mock_verification_event' &&
-                    request.body.siteId === '1' &&
-                    request.body.amountTriggered === 2 &&
-                    request.body.threshold === 1 &&
-                    request.body.method === 'admin';
+        const {body: passBody} = await agent
+            .post(`/members/`)
+            .body({members: [member]})
+            .expectStatus(201)
+            .matchBodySnapshot({
+                members: new Array(1).fill(buildMemberMatcherShallowIncludesWithTiers(0, 2))
+            })
+            .matchHeaderSnapshot({
+                'content-version': anyContentVersion,
+                etag: anyEtag,
+                location: anyLocationFor('members')
             });
+        const memberPassVerification = passBody.members[0];
 
-            assert.ok(matchingRequest, 'Expected the verification webhook request to be sent with the configured payload');
+        await DomainEvents.allSettled();
+        assert.ok(!settingsCache.get('email_verification_required'), 'Email verification should NOT be required');
 
-            const requestTimestamp = Array.isArray(matchingRequest.headers['x-ghost-request-timestamp']) ?
-                matchingRequest.headers['x-ghost-request-timestamp'][0] :
-                matchingRequest.headers['x-ghost-request-timestamp'];
-            const requestSignature = Array.isArray(matchingRequest.headers['x-ghost-signature']) ?
-                matchingRequest.headers['x-ghost-signature'][0] :
-                matchingRequest.headers['x-ghost-signature'];
-            const expectedSignature = crypto.createHmac('sha256', webhookSecret)
-                .update(`${requestTimestamp}:${matchingRequest.rawBody}`)
-                .digest('base64');
+        const memberFailLimit = {
+            name: 'fail webhook verification',
+            email: 'memberFailWebhookVerification@test.com'
+        };
 
-            assert.ok(requestTimestamp, 'Expected the verification webhook request to include a timestamp header');
-            assert.equal(requestSignature, expectedSignature, 'Expected the verification webhook request to be signed');
+        const {body: failBody} = await agent
+            .post(`/members/`)
+            .body({members: [memberFailLimit]})
+            .expectStatus(201)
+            .matchBodySnapshot({
+                members: new Array(1).fill(buildMemberMatcherShallowIncludesWithTiers(0, 2))
+            })
+            .matchHeaderSnapshot({
+                'content-version': anyContentVersion,
+                etag: anyEtag,
+                location: anyLocationFor('members')
+            });
+        const memberFailVerification = failBody.members[0];
 
-            // state cleanup
-            await agent.delete(`/members/${memberPassVerification.id}`);
-            await agent.delete(`/members/${memberFailVerification.id}`);
-        } finally {
-            nock.cleanAll();
-            await models.Settings.edit([{
-                key: 'email_verification_required',
-                value: false
-            }], {context: {internal: true}});
-            await configUtils.restore();
-        }
+        await DomainEvents.allSettled();
+        assert.ok(settingsCache.get('email_verification_required'), 'Email verification should be required');
+        emailMockReceiver.assertSentEmailCount(0);
+
+        const matchingRequest = receivedWebhookRequests.find((request) => {
+            return request.body.type === 'mock_verification_event' &&
+                request.body.siteId === '1' &&
+                request.body.amountTriggered === 2 &&
+                request.body.threshold === 1 &&
+                request.body.method === 'admin';
+        });
+
+        assert.ok(matchingRequest, 'Expected the verification webhook request to be sent with the configured payload');
+
+        const requestTimestamp = Array.isArray(matchingRequest.headers['x-ghost-request-timestamp']) ?
+            matchingRequest.headers['x-ghost-request-timestamp'][0] :
+            matchingRequest.headers['x-ghost-request-timestamp'];
+        const requestSignature = Array.isArray(matchingRequest.headers['x-ghost-signature']) ?
+            matchingRequest.headers['x-ghost-signature'][0] :
+            matchingRequest.headers['x-ghost-signature'];
+        const expectedSignature = crypto.createHmac('sha256', webhookSecret)
+            .update(`${requestTimestamp}:${matchingRequest.rawBody}`)
+            .digest('base64');
+
+        assert.ok(requestTimestamp, 'Expected the verification webhook request to include a timestamp header');
+        assert.equal(requestSignature, expectedSignature, 'Expected the verification webhook request to be signed');
+
+        // state cleanup
+        await agent.delete(`/members/${memberPassVerification.id}`);
+        await agent.delete(`/members/${memberFailVerification.id}`);
     });
 
     it('Can add and send a signup confirmation email', async function () {

--- a/ghost/core/test/e2e-api/admin/members.test.js
+++ b/ghost/core/test/e2e-api/admin/members.test.js
@@ -957,8 +957,11 @@ describe('Members API', function () {
             await agent.delete(`/members/${memberPassVerification.id}`);
             await agent.delete(`/members/${memberFailVerification.id}`);
         } finally {
+            await models.Settings.edit([{
+                key: 'email_verification_required',
+                value: false
+            }], {context: {internal: true}});
             await configUtils.restore();
-            settingsCache.set('email_verification_required', {value: false});
         }
     });
 
@@ -1079,8 +1082,11 @@ describe('Members API', function () {
             await agent.delete(`/members/${memberFailVerification.id}`);
         } finally {
             nock.cleanAll();
+            await models.Settings.edit([{
+                key: 'email_verification_required',
+                value: false
+            }], {context: {internal: true}});
             await configUtils.restore();
-            settingsCache.set('email_verification_required', {value: false});
         }
     });
 

--- a/ghost/core/test/legacy/api/admin/members-importer.test.js
+++ b/ghost/core/test/legacy/api/admin/members-importer.test.js
@@ -24,6 +24,7 @@ describe('Members Importer API', function () {
 
     beforeEach(function () {
         emailMockReceiver = mockManager.mockMail();
+        mockManager.mockLabsDisabled('verificationFlow');
     });
 
     afterEach(function () {

--- a/ghost/core/test/unit/server/services/verification-trigger.test.js
+++ b/ghost/core/test/unit/server/services/verification-trigger.test.js
@@ -213,6 +213,97 @@ describe('Email verification flow', function () {
         });
     });
 
+    it('Sends a webhook instead of an email when verificationFlow is enabled', async function () {
+        const emailStub = sinon.stub().resolves(null);
+        const webhookStub = sinon.stub().resolves(true);
+        const settingsStub = sinon.stub().resolves(null);
+        const trigger = new VerificationTrigger({
+            Settings: {
+                edit: settingsStub
+            },
+            isVerified: () => false,
+            isVerificationRequired: () => false,
+            isVerificationFlowEnabled: () => true,
+            sendVerificationEmail: emailStub,
+            sendVerificationWebhook: webhookStub
+        });
+
+        await trigger._startVerificationProcess({
+            amount: 10,
+            threshold: 5,
+            method: 'import',
+            throwOnTrigger: false
+        });
+
+        sinon.assert.notCalled(emailStub);
+        sinon.assert.calledOnce(webhookStub);
+        sinon.assert.calledOnce(settingsStub);
+        sinon.assert.callOrder(webhookStub, settingsStub);
+        assert.deepEqual(webhookStub.lastCall.firstArg, {
+            amountTriggered: 10,
+            threshold: 5,
+            method: 'import'
+        });
+    });
+
+    it('Falls back to email when verificationFlow is enabled but webhook is unconfigured', async function () {
+        const emailStub = sinon.stub().resolves(null);
+        const webhookStub = sinon.stub().resolves(false);
+        const settingsStub = sinon.stub().resolves(null);
+        const trigger = new VerificationTrigger({
+            Settings: {
+                edit: settingsStub
+            },
+            isVerified: () => false,
+            isVerificationRequired: () => false,
+            isVerificationFlowEnabled: () => true,
+            sendVerificationEmail: emailStub,
+            sendVerificationWebhook: webhookStub
+        });
+
+        const result = await trigger._startVerificationProcess({
+            amount: 10,
+            threshold: 5,
+            method: 'import',
+            throwOnTrigger: false
+        });
+
+        assert.equal(result.needsVerification, true);
+        sinon.assert.calledOnce(webhookStub);
+        sinon.assert.calledOnce(emailStub);
+        sinon.assert.calledOnce(settingsStub);
+        sinon.assert.callOrder(webhookStub, settingsStub, emailStub);
+    });
+
+    it('Falls back to email when webhook delivery fails', async function () {
+        const emailStub = sinon.stub().resolves(null);
+        const webhookStub = sinon.stub().rejects(new Error('Webhook failed'));
+        const settingsStub = sinon.stub().resolves(null);
+        const trigger = new VerificationTrigger({
+            Settings: {
+                edit: settingsStub
+            },
+            isVerified: () => false,
+            isVerificationRequired: () => false,
+            isVerificationFlowEnabled: () => true,
+            sendVerificationEmail: emailStub,
+            sendVerificationWebhook: webhookStub
+        });
+
+        const result = await trigger._startVerificationProcess({
+            amount: 10,
+            threshold: 5,
+            method: 'import',
+            throwOnTrigger: false
+        });
+
+        assert.equal(result.needsVerification, true);
+        sinon.assert.calledOnce(webhookStub);
+        sinon.assert.calledOnce(settingsStub);
+        sinon.assert.calledOnce(emailStub);
+        sinon.assert.callOrder(webhookStub, settingsStub, emailStub);
+    });
+
     it('Triggers when a number of API events are dispatched', async function () {
         // We need to use the real event repository here to test event handling
         domainEventsStub.restore();
@@ -342,6 +433,56 @@ describe('Email verification flow', function () {
             subject: 'Email needs verification',
             message: 'Email verification needed for site: {siteUrl}, has imported: {amountTriggered} members in the last 30 days.',
             amountTriggered: 10
+        });
+    });
+
+    it('Includes threshold and method in webhook payload when import threshold triggers', async function () {
+        const emailStub = sinon.stub().resolves(null);
+        const webhookStub = sinon.stub().resolves(true);
+        const settingsStub = sinon.stub().resolves(null);
+        const eventStub = sinon.stub().callsFake(async (_unused, {source}) => {
+            if (source === 'member') {
+                return {
+                    meta: {
+                        pagination: {
+                            total: 15
+                        }
+                    }
+                };
+            } else {
+                return {
+                    meta: {
+                        pagination: {
+                            total: 10
+                        }
+                    }
+                };
+            }
+        });
+
+        const trigger = new VerificationTrigger({
+            getImportTriggerThreshold: () => 2,
+            Settings: {
+                edit: settingsStub
+            },
+            isVerified: () => false,
+            isVerificationRequired: () => false,
+            isVerificationFlowEnabled: () => true,
+            sendVerificationEmail: emailStub,
+            sendVerificationWebhook: webhookStub,
+            eventRepository: {
+                getSignupEvents: eventStub
+            }
+        });
+
+        await trigger.testImportThreshold();
+
+        sinon.assert.notCalled(emailStub);
+        sinon.assert.calledOnce(webhookStub);
+        assert.deepEqual(webhookStub.lastCall.firstArg, {
+            amountTriggered: 10,
+            threshold: 5,
+            method: 'import'
         });
     });
 

--- a/ghost/core/test/unit/server/services/verification/verification-webhook-service.test.ts
+++ b/ghost/core/test/unit/server/services/verification/verification-webhook-service.test.ts
@@ -1,0 +1,143 @@
+import assert from 'assert/strict';
+import crypto from 'crypto';
+import {VerificationWebhookService} from '../../../../../core/server/services/verification/verification-webhook-service';
+
+describe('VerificationWebhookService', function () {
+    const webhookUrl = 'https://test-webhook-receiver.com/mock-verification-event-endpoint/';
+    const webhookSecret = 'not-a-live-secret';
+    const webhookType = 'mock_verification_event';
+
+    const createService = (overrides: Record<string, unknown> = {}) => {
+        const request = async () => null;
+        const dependencies = {
+            config: {
+                get: (key: string) => {
+                    const values: Record<string, unknown> = {
+                        'hostSettings:emailVerification:webhookType': webhookType,
+                        'hostSettings:emailVerification:webhookUrl': webhookUrl,
+                        'hostSettings:emailVerification:webhookSecret': webhookSecret,
+                        'hostSettings:siteId': '1'
+                    };
+
+                    return values[key];
+                }
+            },
+            logging: {
+                info: () => {},
+                warn: () => {},
+                error: () => {}
+            },
+            request,
+            ...overrides
+        };
+
+        return new VerificationWebhookService(dependencies as any);
+    };
+
+    it('returns false when webhookType is missing', async function () {
+        let warnCalled = false;
+        const service = createService({
+            config: {
+                get: (key: string) => {
+                    if (key === 'hostSettings:emailVerification:webhookType') {
+                        return '';
+                    }
+
+                    if (key === 'hostSettings:emailVerification:webhookUrl') {
+                        return webhookUrl;
+                    }
+
+                    return null;
+                }
+            },
+            logging: {
+                info: () => {},
+                warn: () => {
+                    warnCalled = true;
+                },
+                error: () => {}
+            }
+        });
+
+        const result = await service.sendVerificationWebhook({
+            amountTriggered: 1001,
+            threshold: 1000,
+            method: 'import'
+        });
+
+        assert.equal(result, false);
+        assert.equal(warnCalled, true);
+    });
+
+    it('sends a POST request with the signed webhook payload', async function () {
+        let requestUrl: string | undefined;
+        let requestOptions: any;
+        let infoMessage: string | undefined;
+        const service = createService({
+            logging: {
+                info: (message: string) => {
+                    infoMessage = message;
+                },
+                warn: () => {},
+                error: () => {}
+            },
+            request: async (url: string, options: unknown) => {
+                requestUrl = url;
+                requestOptions = options;
+                return null;
+            }
+        });
+
+        const result = await service.sendVerificationWebhook({
+            amountTriggered: 1001,
+            threshold: 1000,
+            method: 'import'
+        });
+
+        assert.equal(result, true);
+        assert.equal(requestUrl, webhookUrl);
+        assert.equal(requestOptions.method, 'POST');
+        assert.equal(infoMessage, 'Triggering verification webhook to "https://test-webhook-receiver.com"');
+
+        const parsedBody = JSON.parse(requestOptions.body);
+        assert.deepEqual(parsedBody, {
+            type: webhookType,
+            siteId: '1',
+            threshold: 1000,
+            amountTriggered: 1001,
+            method: 'import'
+        });
+
+        const timestamp = requestOptions.headers['X-Ghost-Request-Timestamp'];
+        const expectedSignature = crypto
+            .createHmac('sha256', webhookSecret)
+            .update(`${timestamp}:${requestOptions.body}`)
+            .digest('base64');
+
+        assert.equal(requestOptions.headers['X-Ghost-Signature'], expectedSignature);
+    });
+
+    it('logs a sanitized webhook URL when delivery fails', async function () {
+        let errorMessage: string | undefined;
+        const service = createService({
+            logging: {
+                info: () => {},
+                warn: () => {},
+                error: (message: string) => {
+                    errorMessage = message;
+                }
+            },
+            request: async () => {
+                throw new Error('Webhook failed');
+            }
+        });
+
+        await assert.rejects(service.sendVerificationWebhook({
+            amountTriggered: 1001,
+            threshold: 1000,
+            method: 'import'
+        }), /Webhook failed/);
+
+        assert.equal(errorMessage, 'Failed to send verification webhook to "https://test-webhook-receiver.com": Webhook failed');
+    });
+});


### PR DESCRIPTION
closes [GVA-730](https://linear.app/ghost/issue/GVA-730/add-webhook-changes-behind-feature-flag)

The `verificationFlow` feature flag now keeps the existing escalation email path as default while enabling a parallel webhook path through `VerificationTrigger` and `verification-webhook-service.ts`. This wires both strategies in `members/service.js` and adds tests to assert webhook payload behavior without regressing the legacy flow.