### PR TITLE
Fixed retention offer preview not basing prices off actual tier

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.66.2",
+  "version": "2.66.3",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/portal/src/app.js
+++ b/apps/portal/src/app.js
@@ -977,6 +977,44 @@ export default class App extends React.Component {
         return validateHexColor(accentColor);
     }
 
+    getRetentionPreviewMember({site, offers}) {
+        const retentionOffer = (offers || []).find(offer => isRetentionOffer({offer}));
+        const productId = retentionOffer?.tier?.id;
+        const product = productId ? getProductFromId({site, productId}) : null;
+        const price = product ? (retentionOffer.cadence === 'year' ? product.yearlyPrice : product.monthlyPrice) : null;
+        const previewMember = Fixtures.member.preview;
+        const previewSubscription = previewMember?.subscriptions?.[0];
+
+        if (!previewSubscription || !product || !price) {
+            return previewMember;
+        }
+
+        return {
+            ...previewMember,
+            subscriptions: [{
+                ...previewSubscription,
+                plan: {
+                    ...previewSubscription.plan,
+                    amount: price.amount,
+                    interval: price.interval,
+                    currency: price.currency.toUpperCase()
+                },
+                price: {
+                    ...previewSubscription.price,
+                    price_id: price.id,
+                    amount: price.amount,
+                    interval: price.interval,
+                    currency: price.currency,
+                    product: {
+                        ...previewSubscription.price?.product,
+                        product_id: product.id
+                    }
+                },
+                tier: {id: product.id, name: product.name}
+            }]
+        };
+    }
+
     /**Get final page set in App context from state data*/
     getContextPage({site, page, member}) {
         /**Set default page based on logged-in status */
@@ -989,13 +1027,17 @@ export default class App extends React.Component {
     }
 
     /**Get final member set in App context from state data*/
-    getContextMember({page, member, customSiteUrl}) {
+    getContextMember({site, page, member, offers, pageData, customSiteUrl}) {
         if (hasMode(['dev', 'preview'], {customSiteUrl})) {
             /** Use dummy member(free or paid) for account pages in dev/preview mode*/
             if (isAccountPage({page}) || isOfferPage({page})) {
                 if (hasMode(['dev'], {customSiteUrl})) {
                     return member || Fixtures.member.free;
                 } else if (hasMode(['preview'])) {
+                    if (page === 'accountPlan' && pageData?.action === 'cancel') {
+                        return this.getRetentionPreviewMember({site, offers});
+                    }
+
                     return Fixtures.member.preview;
                 } else {
                     return Fixtures.member.paid;
@@ -1012,7 +1054,7 @@ export default class App extends React.Component {
     getContextFromState() {
         const {site, member, offers, action, actionErrorMessage, page, lastPage, showPopup, pageQuery, pageData, popupNotification, customSiteUrl, dir, scrollbarWidth, otcRef, inboxLinks} = this.state;
         const contextPage = this.getContextPage({site, page, member});
-        const contextMember = this.getContextMember({page: contextPage, member, customSiteUrl});
+        const contextMember = this.getContextMember({site, page: contextPage, member, offers, pageData, customSiteUrl});
         return {
             api: this.GhostApi,
             site,

--- a/apps/portal/test/app.test.js
+++ b/apps/portal/test/app.test.js
@@ -1,6 +1,7 @@
 import App from '../src/app';
 import setupGhostApi from '../src/utils/api';
 import {appRender} from './utils/test-utils';
+import {getPriceData, getProductData, getSiteData} from '../src/utils/fixtures-generator';
 import {site as FixtureSite, member as FixtureMember} from './utils/test-fixtures';
 import i18n from '../src/utils/i18n';
 import {vi} from 'vitest';
@@ -134,5 +135,41 @@ describe('App', function () {
             cadence: 'month'
         });
         expect(previewData.offers[0].tier).toMatchObject({id: 'product_123'});
+    });
+
+    test('uses the selected tier price for retention offer preview members', () => {
+        window.location.hash = '#/portal/preview/offer';
+
+        const yearlyPrice = getPriceData({interval: 'year', amount: 25000, currency: 'usd'});
+        const paidProduct = getProductData({
+            name: 'Pro',
+            monthlyPrice: getPriceData({interval: 'month', amount: 2500, currency: 'usd'}),
+            yearlyPrice
+        });
+        const site = getSiteData({
+            products: [paidProduct],
+            portalProducts: [paidProduct.id]
+        });
+        const app = new App({siteUrl: 'http://example.com'});
+        const previewData = app.fetchOfferQueryStrData(`redemption_type=retention&display_title=Stay&display_description=Please%2520stay&type=percent&amount=25&duration=forever&duration_in_months=0&cadence=year&tier_id=${paidProduct.id}`);
+
+        app.state = {
+            ...app.state,
+            site,
+            page: previewData.page,
+            offers: previewData.offers,
+            pageData: previewData.pageData
+        };
+
+        const context = app.getContextFromState();
+        const subscription = context.member.subscriptions[0];
+
+        expect(subscription.price.amount).toBe(yearlyPrice.amount);
+        expect(subscription.price.interval).toBe('year');
+        expect(subscription.price.price_id).toBe(yearlyPrice.id);
+        expect(subscription.tier).toMatchObject({
+            id: paidProduct.id,
+            name: paidProduct.name
+        });
     });
 });


### PR DESCRIPTION
closes https://linear.app/ghost/issue/BER-3434

- Retention offer previews were using the default `$15.00` tier price from fixtures, instead of reading the tier value passed by Admin

