### PR TITLE
Fixed What's new banner visual regression

### DIFF
--- a/apps/shade/src/components/ui/banner.tsx
+++ b/apps/shade/src/components/ui/banner.tsx
@@ -12,10 +12,10 @@ const bannerVariants = cva(
                 default: 'border border-border bg-background shadow-sm hover:shadow-md dark:border-gray-900 dark:bg-gray-925',
                 gradient: [
                     'cursor-pointer border border-gray-100 bg-white dark:border-gray-950 dark:bg-black',
-                    'shadow-[rgb(75_225_226_/_28%)_-7px_-6px_42px_8px,rgb(202_103_255_/_32%)_7px_6px_42px_8px]',
-                    'dark:shadow-[rgb(75_225_226_/_36%)_-7px_-6px_42px_8px,rgb(202_103_255_/_38%)_7px_6px_42px_8px]',
-                    'hover:shadow-[rgb(75_225_226_/_38%)_-7px_-4px_42px_10px,rgb(202_103_255_/_42%)_7px_8px_42px_10px]',
-                    'dark:hover:shadow-[rgb(75_225_226_/_50%)_-7px_-4px_42px_10px,rgb(202_103_255_/_52%)_7px_8px_42px_10px]',
+                    'shadow-[-7px_-6px_42px_8px_rgb(75_225_226_/_28%),7px_6px_42px_8px_rgb(202_103_255_/_32%)]',
+                    'dark:shadow-[-7px_-6px_42px_8px_rgb(75_225_226_/_36%),7px_6px_42px_8px_rgb(202_103_255_/_38%)]',
+                    'hover:shadow-[-7px_-4px_42px_10px_rgb(75_225_226_/_38%),7px_8px_42px_10px_rgb(202_103_255_/_42%)]',
+                    'dark:hover:shadow-[-7px_-4px_42px_10px_rgb(75_225_226_/_50%),7px_8px_42px_10px_rgb(202_103_255_/_52%)]',
                     'hover:translate-y-[-2px] hover:scale-[1.01]'
                 ],
                 info: 'bg-blue-50 border-blue-200 dark:bg-blue-950/30 dark:border-blue-800 border',


### PR DESCRIPTION
ref https://linear.app/ghost/issue/DES-1305/twcss-4-migration-whats-new-banner-shadow-missing

- The custom shadow syntax changed with the recent Tailwind CSS 4 integration, which caused a visual regression in the What's New banner in the sidebar.
