### PR TITLE
Fixed flaky history test by fixing waitForResponse race condition

### DIFF
--- a/apps/admin-x-settings/test/acceptance/advanced/history.test.ts
+++ b/apps/admin-x-settings/test/acceptance/advanced/history.test.ts
@@ -41,12 +41,13 @@ test.describe('History', async () => {
 
         expect(lastApiRequests.browseActionsFiltered?.url).toEqual('http://localhost:5173/ghost/api/admin/actions/?include=actor%2Cresource&limit=200&filter=resource_type%3A-%5Blabel%2Cpost%5D');
 
+        const deletedFilterResponse = page.waitForResponse(response => response.url().includes('/ghost/api/admin/actions/')
+            && response.url().includes('event%3A-%5Bdeleted%5D')
+        );
         await popoverContent.getByLabel('Deleted').click();
         await expect(popoverContent.getByLabel('Deleted')).toHaveAttribute('data-state', 'unchecked');
 
-        await page.waitForResponse(response => response.url().includes('/ghost/api/admin/actions/')
-            && response.url().includes('event%3A-%5Bdeleted%5D')
-        );
+        await deletedFilterResponse;
 
         expect(lastApiRequests.browseActionsFiltered?.url).toEqual('http://localhost:5173/ghost/api/admin/actions/?include=actor%2Cresource&limit=200&filter=event%3A-%5Bdeleted%5D%2Bresource_type%3A-%5Blabel%2Cpost%5D');
     });


### PR DESCRIPTION
The waitForResponse listener was registered after the click that triggers the API call, so the response could complete before Playwright started listening. Moved the listener setup before the click to ensure the response is always captured.