### PR TITLE
Fixed media inliner to store correct relative paths with CDN storage

### DIFF
--- a/ghost/core/core/server/services/media-inliner/external-media-inliner.js
+++ b/ghost/core/core/server/services/media-inliner/external-media-inliner.js
@@ -1,6 +1,7 @@
 const mime = require('mime-types');
 const FileType = require('file-type');
 const request = require('../../lib/request-external');
+const urlUtils = require('../../../shared/url-utils');
 const errors = require('@tryghost/errors');
 const logging = require('@tryghost/logging');
 const string = require('@tryghost/string');
@@ -145,7 +146,8 @@ class ExternalMediaInliner {
             }, targetDir);
             const targetPath = path.relative(storage.storagePath, uniqueFileName);
             const filePath = await storage.saveRaw(media.fileBuffer, targetPath);
-            return filePath;
+
+            return urlUtils.toTransformReady(filePath);
         }
     }
 
@@ -188,11 +190,9 @@ class ExternalMediaInliner {
                 }
 
                 if (media) {
-                    const filePath = await this.storeMediaLocally(media);
+                    const inlinedSrc = await this.storeMediaLocally(media);
 
-                    if (filePath) {
-                        const inlinedSrc = `__GHOST_URL__${filePath}`;
-
+                    if (inlinedSrc) {
                         // NOTE: does not account for duplicate images in content
                         //       in those cases would be processed twice
                         content = content.replace(src, inlinedSrc);
@@ -228,11 +228,9 @@ class ExternalMediaInliner {
                     }
 
                     if (media) {
-                        const filePath = await this.storeMediaLocally(media);
+                        const inlinedSrc = await this.storeMediaLocally(media);
 
-                        if (filePath) {
-                            const inlinedSrc = `__GHOST_URL__${filePath}`;
-
+                        if (inlinedSrc) {
                             updatedFields[field] = inlinedSrc;
                             logging.info(`Added media to inline: ${src} -> ${inlinedSrc}`);
                         }

--- a/ghost/core/test/unit/server/services/media-inliner/test/external-media-inliner.test.js
+++ b/ghost/core/test/unit/server/services/media-inliner/test/external-media-inliner.test.js
@@ -5,6 +5,8 @@ const sinon = require('sinon');
 const nock = require('nock');
 const path = require('path');
 const loggingLib = require('@tryghost/logging');
+const configUtils = require('../../../../../utils/config-utils');
+const urlUtils = require('../../../../../../core/shared/url-utils');
 const ExternalMediaInliner = require('../../../../../../core/server/services/media-inliner/external-media-inliner');
 
 describe('ExternalMediaInliner', function () {
@@ -987,6 +989,149 @@ describe('ExternalMediaInliner', function () {
 
             assert.equal(matches.length, 1);
             assert.equal(matches[0], 'https://example.com/image/one.png');
+        });
+    });
+
+    describe('CDN storage adapter', function () {
+        const CDN_BASE_URL = 'https://storage.ghost.is/c/6f/a3/site';
+        let originalAssetBaseUrls;
+
+        beforeEach(function () {
+            configUtils.set('urls:image', CDN_BASE_URL);
+            configUtils.set('urls:media', CDN_BASE_URL);
+            configUtils.set('urls:files', CDN_BASE_URL);
+
+            originalAssetBaseUrls = {...urlUtils._assetBaseUrls};
+            urlUtils._assetBaseUrls = {
+                image: CDN_BASE_URL,
+                media: CDN_BASE_URL,
+                files: CDN_BASE_URL
+            };
+        });
+
+        afterEach(async function () {
+            urlUtils._assetBaseUrls = originalAssetBaseUrls;
+            await configUtils.restore();
+        });
+
+        it('inlineContent stores correct __GHOST_URL__ path when saveRaw returns CDN URL', async function () {
+            const imageURL = 'https://external.com/files/photo.jpg';
+            const cdnUrl = 'https://storage.ghost.is/c/6f/a3/site/content/images/unique-photo.jpg';
+            nock('https://external.com')
+                .get('/files/photo.jpg')
+                .reply(200, GIF1x1);
+
+            sinon.stub(path, 'relative')
+                .withArgs('/content/images', '/content/images/unique-photo.jpg')
+                .returns('unique-photo.jpg');
+
+            const inliner = new ExternalMediaInliner({
+                PostModel: postModelStub,
+                PostMetaModel: postMetaModelStub,
+                TagModel: tagModelStub,
+                UserModel: userModelStub,
+                getMediaStorage: sinon.stub().withArgs('.gif').returns({
+                    storagePath: '/content/images',
+                    staticFileURLPrefix: '/content/images',
+                    getTargetDir: () => '/content/images',
+                    getUniqueFileName: () => '/content/images/unique-photo.jpg',
+                    saveRaw: () => cdnUrl
+                })
+            });
+
+            const content = `{"cards":[["image",{"src":"${imageURL}"}]]}`;
+            const result = await inliner.inlineContent(content, ['https://external.com']);
+
+            assert.equal(result, '{"cards":[["image",{"src":"__GHOST_URL__/content/images/unique-photo.jpg"}]]}');
+        });
+
+        it('inlineContent stores correct __GHOST_URL__ path when saveRaw returns relative path (local storage)', async function () {
+            const imageURL = 'https://external.com/files/photo.jpg';
+            nock('https://external.com')
+                .get('/files/photo.jpg')
+                .reply(200, GIF1x1);
+
+            sinon.stub(path, 'relative')
+                .withArgs('/content/images', '/content/images/unique-photo.jpg')
+                .returns('unique-photo.jpg');
+
+            const inliner = new ExternalMediaInliner({
+                PostModel: postModelStub,
+                PostMetaModel: postMetaModelStub,
+                TagModel: tagModelStub,
+                UserModel: userModelStub,
+                getMediaStorage: sinon.stub().withArgs('.gif').returns({
+                    storagePath: '/content/images',
+                    staticFileURLPrefix: '/content/images',
+                    getTargetDir: () => '/content/images',
+                    getUniqueFileName: () => '/content/images/unique-photo.jpg',
+                    saveRaw: () => '/content/images/unique-photo.jpg'
+                })
+            });
+
+            const content = `{"cards":[["image",{"src":"${imageURL}"}]]}`;
+            const result = await inliner.inlineContent(content, ['https://external.com']);
+
+            assert.equal(result, '{"cards":[["image",{"src":"__GHOST_URL__/content/images/unique-photo.jpg"}]]}');
+        });
+
+        it('inlineFields stores correct __GHOST_URL__ path when saveRaw returns CDN URL', async function () {
+            const imageURL = 'https://external.com/files/feature.jpg';
+            const cdnUrl = 'https://storage.ghost.is/c/6f/a3/site/content/images/unique-feature.jpg';
+            nock('https://external.com')
+                .get('/files/feature.jpg')
+                .reply(200, GIF1x1);
+
+            sinon.stub(path, 'relative')
+                .withArgs('/content/images', '/content/images/unique-feature.jpg')
+                .returns('unique-feature.jpg');
+
+            const inliner = new ExternalMediaInliner({
+                getMediaStorage: sinon.stub().withArgs('.gif').returns({
+                    storagePath: '/content/images',
+                    staticFileURLPrefix: '/content/images',
+                    getTargetDir: () => '/content/images',
+                    getUniqueFileName: () => '/content/images/unique-feature.jpg',
+                    saveRaw: () => cdnUrl
+                })
+            });
+
+            const resourceStub = {
+                get: sinon.stub().withArgs('feature_image').returns(imageURL)
+            };
+
+            const updatedFields = await inliner.inlineFields(resourceStub, ['feature_image'], ['https://external.com']);
+
+            assert.equal(updatedFields.feature_image, '__GHOST_URL__/content/images/unique-feature.jpg');
+        });
+
+        it('inlineFields stores correct __GHOST_URL__ path when saveRaw returns relative path (local storage)', async function () {
+            const imageURL = 'https://external.com/files/feature.jpg';
+            nock('https://external.com')
+                .get('/files/feature.jpg')
+                .reply(200, GIF1x1);
+
+            sinon.stub(path, 'relative')
+                .withArgs('/content/images', '/content/images/unique-feature.jpg')
+                .returns('unique-feature.jpg');
+
+            const inliner = new ExternalMediaInliner({
+                getMediaStorage: sinon.stub().withArgs('.gif').returns({
+                    storagePath: '/content/images',
+                    staticFileURLPrefix: '/content/images',
+                    getTargetDir: () => '/content/images',
+                    getUniqueFileName: () => '/content/images/unique-feature.jpg',
+                    saveRaw: () => '/content/images/unique-feature.jpg'
+                })
+            });
+
+            const resourceStub = {
+                get: sinon.stub().withArgs('feature_image').returns(imageURL)
+            };
+
+            const updatedFields = await inliner.inlineFields(resourceStub, ['feature_image'], ['https://external.com']);
+
+            assert.equal(updatedFields.feature_image, '__GHOST_URL__/content/images/unique-feature.jpg');
         });
     });
 

--- a/ghost/core/test/unit/server/services/oembed/oembed-service.test.js
+++ b/ghost/core/test/unit/server/services/oembed/oembed-service.test.js
@@ -263,6 +263,39 @@ describe('oembed-service', function () {
             sinon.assert.calledOnce(saveRaw);
             assert.equal(saveRaw.firstCall.args[1], 'thumbnail/sample.png');
         });
+
+        it('works when saveRaw returns a relative path (local storage)', async function () {
+            const saveRaw = sinon.stub().resolves('/content/images/icon/favicon.ico');
+            const generateUnique = sinon.stub().resolves('/tmp/content/images/icon/favicon.ico');
+            const getSanitizedFileName = sinon.stub().returns('favicon');
+
+            const service = new OembedService({
+                config: {
+                    getContentPath() {
+                        return '/tmp/content/images';
+                    }
+                },
+                storage: {
+                    getStorage() {
+                        return {
+                            getSanitizedFileName,
+                            generateUnique,
+                            saveRaw
+                        };
+                    }
+                },
+                externalRequest() {
+                    return {
+                        buffer: async () => Buffer.from('ico-bytes')
+                    };
+                }
+            });
+
+            const storedUrl = await service.processImageFromUrl('https://example.com/favicon.ico', 'icon');
+
+            assert.equal(storedUrl, '/content/images/icon/favicon.ico');
+            assert.equal(saveRaw.firstCall.args[1], 'icon/favicon.ico');
+        });
     });
 
     describe('metascraper inherits externalRequest hooks', function () {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/HKG-1648

- When using CDN storage (S3Storage), saveRaw() returns a full CDN URL (e.g., https://storage.ghost.is/.../content/images/photo.jpg) instead of a relative path like local storage does (/content/images/photo.jpg)
- The media inliner's storeMediaLocally() passed this CDN URL directly to callers, which prepended __GHOST_URL__ to it, producing malformed database entries like __GHOST_URL__https://storage.ghost.is/...
- This broke image references in posts after running content imports on CDN-configured sites
- Used urlUtils.toTransformReady() in storeMediaLocally() to convert the storage adapter's return value into a __GHOST_URL__-prefixed relative path, which correctly handles both CDN URLs and local paths — callers no longer manually prepend __GHOST_URL__
- The oembed service (the only other saveRaw caller) was verified to not have this issue — it returns the URL as-is to the admin client, which flows through the model pipeline where formatOnWrite handles the CDN-to-__GHOST_URL__ transformation correctly