### PR TITLE
Enabled lint-staged pre-commit hook on all branches

### DIFF
--- a/.github/hooks/pre-commit
+++ b/.github/hooks/pre-commit
@@ -3,15 +3,12 @@
 
 [ -n "$CI" ] && exit 0
 
-GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-if [ "$GIT_BRANCH" = "main" ]; then
-    yarn lint-staged --relative
-    lintStatus=$?
+yarn lint-staged --relative
+lintStatus=$?
 
-    if [ $lintStatus -ne 0 ]; then
-        echo "❌ Linting failed"
-        exit 1
-    fi
+if [ $lintStatus -ne 0 ]; then
+    echo "❌ Linting failed"
+    exit 1
 fi
 
 green='\033[0;32m'

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "nwsapi": "2.2.12"
   },
   "lint-staged": {
-    "*.js": "eslint"
+    "*.{js,ts,tsx,jsx,cjs}": "eslint"
   },
   "devDependencies": {
     "@actions/core": "1.11.1",


### PR DESCRIPTION
## TL;DR

This adds a pre-commit hook that will run eslint on any JS/TS files staged for commit, and prevent the commit from completing if there are any errors.

## Motivation

There's nothing more annoying than raising a PR only to see the lint job fail and having to follow up with a "fixed linter" commit. Especially as we are not always typing out the code ourselves in our IDEs anymore, I've been encountering these little annoyances more frequently.

## Summary

- Removed the `main`-branch-only guard from the pre-commit hook so lint-staged runs on every commit, regardless of branch
- Expanded lint-staged file pattern from `*.js` to `*.{js,ts,tsx,jsx,cjs}` to cover TypeScript and CJS files
- Verified lint-staged catches errors across all 16 monorepo packages (apps/*, ghost/*, e2e)