### PR TITLE
Changed comments to load progressively with CDN cache + member overlay

### DIFF
--- a/apps/comments-ui/package.json
+++ b/apps/comments-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/comments-ui",
-  "version": "1.3.10",
+  "version": "1.4.0",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/comments-ui/src/actions.ts
+++ b/apps/comments-ui/src/actions.ts
@@ -1,5 +1,5 @@
 import {AddComment, Comment, CommentsOptions, DispatchActionType, EditableAppContext, OpenCommentForm} from './app-context';
-import {CommentApi} from './components/comment-api-provider';
+import {AdminActions, CommentApi} from './components/comment-api-provider';
 import {Page} from './pages';
 
 async function loadMoreComments({state, commentApi, options, order}: {state: EditableAppContext, commentApi: CommentApi, options: CommentsOptions, order?: string}): Promise<Partial<EditableAppContext>> {
@@ -127,9 +127,9 @@ async function addReply({state, commentApi, data: {reply, parent}}: {state: Edit
     };
 }
 
-async function hideComment({state, commentApi, data: comment}: {state: EditableAppContext, commentApi: CommentApi, data: {id: string}}) {
-    if (commentApi.isAdmin) {
-        await commentApi.hideComment(comment.id);
+async function hideComment({state, adminActions, data: comment}: {state: EditableAppContext, adminActions: AdminActions | null, data: {id: string}}) {
+    if (adminActions) {
+        await adminActions.hideComment(comment.id);
     }
     return {
         comments: state.comments.map((c) => {
@@ -161,12 +161,11 @@ async function hideComment({state, commentApi, data: comment}: {state: EditableA
     };
 }
 
-async function showComment({state, commentApi, data: comment}: {state: EditableAppContext, commentApi: CommentApi, data: {id: string}}) {
-    if (commentApi.isAdmin) {
-        await commentApi.showComment({id: comment.id});
+async function showComment({state, adminActions, commentApi, data: comment}: {state: EditableAppContext, adminActions: AdminActions | null, commentApi: CommentApi, data: {id: string}}) {
+    if (adminActions) {
+        await adminActions.showComment({id: comment.id});
     }
-    // We need to refetch the comment, to make sure we have an up to date HTML content
-    // + all relations are loaded as the current member (not the admin)
+    // Re-read the comment via public API to get updated status
     const data = await commentApi.read(comment.id);
 
     const updatedComment = data.comments[0];
@@ -505,10 +504,10 @@ export function isSyncAction(action: string): action is SyncActionType {
 }
 
 /** Handle actions in the App, returns updated state */
-export async function ActionHandler({action, data, state, commentApi, options, dispatchAction}: {action: ActionType, data: any, state: EditableAppContext, options: CommentsOptions, commentApi: CommentApi, dispatchAction: DispatchActionType}): Promise<Partial<EditableAppContext>> {
+export async function ActionHandler({action, data, state, commentApi, adminActions, options, dispatchAction}: {action: ActionType, data: any, state: EditableAppContext, options: CommentsOptions, commentApi: CommentApi, adminActions: AdminActions | null, dispatchAction: DispatchActionType}): Promise<Partial<EditableAppContext>> {
     const handler = Actions[action];
     if (handler) {
-        return await handler({data, state, commentApi, options, dispatchAction} as any) || {};
+        return await handler({data, state, commentApi, adminActions, options, dispatchAction} as any) || {};
     }
     return {};
 }

--- a/apps/comments-ui/src/actions.ts
+++ b/apps/comments-ui/src/actions.ts
@@ -1,13 +1,13 @@
 import {AddComment, Comment, CommentsOptions, DispatchActionType, EditableAppContext, OpenCommentForm} from './app-context';
-import {AdminActions, CommentApi} from './components/comment-api-provider';
+import {AdminActions, MemberApi, PublicApi} from './components/comment-api-provider';
 import {Page} from './pages';
 
-async function loadMoreComments({state, commentApi, options, order}: {state: EditableAppContext, commentApi: CommentApi, options: CommentsOptions, order?: string}): Promise<Partial<EditableAppContext>> {
+async function loadMoreComments({state, publicApi, options, order}: {state: EditableAppContext, publicApi: PublicApi, options: CommentsOptions, order?: string}): Promise<Partial<EditableAppContext>> {
     let page = 1;
     if (state.pagination && state.pagination.page) {
         page = state.pagination.page + 1;
     }
-    const data = await commentApi.browse({page, postId: options.postId, order: order || state.order});
+    const data = await publicApi.browse({page, postId: options.postId, order: order || state.order});
 
     const updatedComments = [...state.comments, ...data.comments];
     const dedupedComments = updatedComments.filter((comment, index, self) => self.findIndex(c => c.id === comment.id) === index);
@@ -25,11 +25,11 @@ function setCommentsIsLoading({data: isLoading}: {data: boolean | null}) {
     };
 }
 
-async function setOrder({state, data: {order}, options, commentApi, dispatchAction}: {state: EditableAppContext, data: {order: string}, options: CommentsOptions, commentApi: CommentApi, dispatchAction: DispatchActionType}) {
+async function setOrder({state, data: {order}, options, publicApi, dispatchAction}: {state: EditableAppContext, data: {order: string}, options: CommentsOptions, publicApi: PublicApi, dispatchAction: DispatchActionType}) {
     dispatchAction('setCommentsIsLoading', true);
 
     try {
-        const data = await commentApi.browse({page: 1, postId: options.postId, order});
+        const data = await publicApi.browse({page: 1, postId: options.postId, order});
 
         return {
             comments: [...data.comments],
@@ -44,9 +44,9 @@ async function setOrder({state, data: {order}, options, commentApi, dispatchActi
     }
 }
 
-async function loadMoreReplies({state, commentApi, data: {comment, limit}}: {state: EditableAppContext, commentApi: CommentApi, data: {comment: Comment, limit?: number | 'all'}}): Promise<Partial<EditableAppContext>> {
+async function loadMoreReplies({state, publicApi, data: {comment, limit}}: {state: EditableAppContext, publicApi: PublicApi, data: {comment: Comment, limit?: number | 'all'}}): Promise<Partial<EditableAppContext>> {
     const fetchReplies = async (afterReplyId: string | undefined, requestLimit: number) => {
-        return await commentApi.replies({commentId: comment.id, afterReplyId, limit: requestLimit});
+        return await publicApi.replies({commentId: comment.id, afterReplyId, limit: requestLimit});
     };
 
     let afterReplyId: string | undefined = comment.replies && comment.replies.length > 0
@@ -89,8 +89,8 @@ async function loadMoreReplies({state, commentApi, data: {comment, limit}}: {sta
     };
 }
 
-async function addComment({state, commentApi, data: comment}: {state: EditableAppContext, commentApi: CommentApi, data: AddComment}) {
-    const data = await commentApi.add({comment});
+async function addComment({state, memberApi, data: comment}: {state: EditableAppContext, memberApi: MemberApi, data: AddComment}) {
+    const data = await memberApi.add({comment});
     const newComment = data.comments[0];
 
     return {
@@ -100,13 +100,14 @@ async function addComment({state, commentApi, data: comment}: {state: EditableAp
     };
 }
 
-async function addReply({state, commentApi, data: {reply, parent}}: {state: EditableAppContext, commentApi: CommentApi, data: {reply: any, parent: any}}) {
-    const data = await commentApi.add({
+async function addReply({state, memberApi, data: {reply, parent}}: {state: EditableAppContext, memberApi: MemberApi, data: {reply: any, parent: any}}) {
+    const data = await memberApi.add({
         comment: {...reply, parent_id: parent.id}
     });
     const newComment = data.comments[0];
 
-    const allReplies = await commentApi.replies({commentId: parent.id, limit: 'all'});
+    // Use authenticated API to bypass CDN cache and get the freshly-posted reply
+    const allReplies = await memberApi.replies({commentId: parent.id, limit: 'all'});
 
     return {
         comments: state.comments.map((c) => {
@@ -161,12 +162,12 @@ async function hideComment({state, adminActions, data: comment}: {state: Editabl
     };
 }
 
-async function showComment({state, adminActions, commentApi, data: comment}: {state: EditableAppContext, adminActions: AdminActions | null, commentApi: CommentApi, data: {id: string}}) {
+async function showComment({state, adminActions, publicApi, data: comment}: {state: EditableAppContext, adminActions: AdminActions | null, publicApi: PublicApi, data: {id: string}}) {
     if (adminActions) {
         await adminActions.showComment({id: comment.id});
     }
     // Re-read the comment via public API to get updated status
-    const data = await commentApi.read(comment.id);
+    const data = await publicApi.read(comment.id);
 
     const updatedComment = data.comments[0];
 
@@ -231,35 +232,35 @@ async function updateCommentLikeState({state, data: comment}: {state: EditableAp
     };
 }
 
-async function likeComment({commentApi, data: comment, dispatchAction}: {state: EditableAppContext, commentApi: CommentApi, data: {id: string}, dispatchAction: DispatchActionType}) {
+async function likeComment({memberApi, data: comment, dispatchAction}: {state: EditableAppContext, memberApi: MemberApi, data: {id: string}, dispatchAction: DispatchActionType}) {
     dispatchAction('updateCommentLikeState', {id: comment.id, liked: true});
     try {
-        await commentApi.like({comment});
+        await memberApi.like({comment});
         return {};
     } catch {
         dispatchAction('updateCommentLikeState', {id: comment.id, liked: false});
     }
 }
 
-async function unlikeComment({commentApi, data: comment, dispatchAction}: {state: EditableAppContext, commentApi: CommentApi, data: {id: string}, dispatchAction: DispatchActionType}) {
+async function unlikeComment({memberApi, data: comment, dispatchAction}: {state: EditableAppContext, memberApi: MemberApi, data: {id: string}, dispatchAction: DispatchActionType}) {
     dispatchAction('updateCommentLikeState', {id: comment.id, liked: false});
 
     try {
-        await commentApi.unlike({comment});
+        await memberApi.unlike({comment});
         return {};
     } catch {
         dispatchAction('updateCommentLikeState', {id: comment.id, liked: true});
     }
 }
 
-async function reportComment({commentApi, data: comment}: {commentApi: CommentApi, data: {id: string}}) {
-    await commentApi.report({comment});
+async function reportComment({memberApi, data: comment}: {memberApi: MemberApi, data: {id: string}}) {
+    await memberApi.report({comment});
 
     return {};
 }
 
-async function deleteComment({state, commentApi, data: comment, dispatchAction}: {state: EditableAppContext, commentApi: CommentApi, data: {id: string}, dispatchAction: DispatchActionType}) {
-    await commentApi.edit({
+async function deleteComment({state, memberApi, publicApi, data: comment, dispatchAction}: {state: EditableAppContext, memberApi: MemberApi, publicApi: PublicApi, data: {id: string}, dispatchAction: DispatchActionType}) {
+    await memberApi.edit({
         comment: {
             id: comment.id,
             status: 'deleted'
@@ -310,8 +311,8 @@ async function deleteComment({state, commentApi, data: comment, dispatchAction}:
     };
 }
 
-async function editComment({state, commentApi, data: {comment, parent}}: {state: EditableAppContext, commentApi: CommentApi, data: {comment: Partial<Comment> & {id: string}, parent?: Comment}}) {
-    const data = await commentApi.edit({
+async function editComment({state, memberApi, data: {comment, parent}}: {state: EditableAppContext, memberApi: MemberApi, data: {comment: Partial<Comment> & {id: string}, parent?: Comment}}) {
+    const data = await memberApi.edit({
         comment
     });
     comment = data.comments[0];
@@ -338,7 +339,7 @@ async function editComment({state, commentApi, data: {comment, parent}}: {state:
     };
 }
 
-async function updateMember({data, state, commentApi}: {data: {name: string, expertise: string}, state: EditableAppContext, commentApi: CommentApi}) {
+async function updateMember({data, state, memberApi}: {data: {name: string, expertise: string}, state: EditableAppContext, memberApi: MemberApi}) {
     const {name, expertise} = data;
     const patchData: {name?: string, expertise?: string} = {};
 
@@ -356,7 +357,7 @@ async function updateMember({data, state, commentApi}: {data: {name: string, exp
 
     if (Object.keys(patchData).length > 0) {
         try {
-            const member = await commentApi.updateMember(patchData);
+            const member = await memberApi.updateMember(patchData);
             if (!member) {
                 throw new Error('Failed to update member');
             }
@@ -386,7 +387,7 @@ function closePopup() {
     };
 }
 
-async function openCommentForm({data: newForm, commentApi, state}: {data: OpenCommentForm, commentApi: CommentApi, state: EditableAppContext}) {
+async function openCommentForm({data: newForm, publicApi, state}: {data: OpenCommentForm, publicApi: PublicApi, state: EditableAppContext}) {
     let otherStateChanges = {};
 
     // When opening a reply form, load all replies for the parent comment so the
@@ -397,7 +398,7 @@ async function openCommentForm({data: newForm, commentApi, state}: {data: OpenCo
 
         if (comment) {
             try {
-                const newCommentsState = await loadMoreReplies({state, commentApi, data: {comment, limit: 'all'}});
+                const newCommentsState = await loadMoreReplies({state, publicApi, data: {comment, limit: 'all'}});
                 otherStateChanges = {...otherStateChanges, ...newCommentsState};
             } catch (e) {
                 // If loading replies fails, continue anyway - the form should still open
@@ -504,10 +505,10 @@ export function isSyncAction(action: string): action is SyncActionType {
 }
 
 /** Handle actions in the App, returns updated state */
-export async function ActionHandler({action, data, state, commentApi, adminActions, options, dispatchAction}: {action: ActionType, data: any, state: EditableAppContext, options: CommentsOptions, commentApi: CommentApi, adminActions: AdminActions | null, dispatchAction: DispatchActionType}): Promise<Partial<EditableAppContext>> {
+export async function ActionHandler({action, data, state, publicApi, memberApi, adminActions, options, dispatchAction}: {action: ActionType, data: any, state: EditableAppContext, options: CommentsOptions, publicApi: PublicApi, memberApi: MemberApi, adminActions: AdminActions | null, dispatchAction: DispatchActionType}): Promise<Partial<EditableAppContext>> {
     const handler = Actions[action];
     if (handler) {
-        return await handler({data, state, commentApi, adminActions, options, dispatchAction} as any) || {};
+        return await handler({data, state, publicApi, memberApi, adminActions, options, dispatchAction} as any) || {};
     }
     return {};
 }

--- a/apps/comments-ui/src/actions.ts
+++ b/apps/comments-ui/src/actions.ts
@@ -259,7 +259,7 @@ async function reportComment({memberApi, data: comment}: {memberApi: MemberApi, 
     return {};
 }
 
-async function deleteComment({state, memberApi, publicApi, data: comment, dispatchAction}: {state: EditableAppContext, memberApi: MemberApi, publicApi: PublicApi, data: {id: string}, dispatchAction: DispatchActionType}) {
+async function deleteComment({state, memberApi, data: comment, dispatchAction}: {state: EditableAppContext, memberApi: MemberApi, data: {id: string}, dispatchAction: DispatchActionType}) {
     await memberApi.edit({
         comment: {
             id: comment.id,
@@ -358,9 +358,6 @@ async function updateMember({data, state, memberApi}: {data: {name: string, expe
     if (Object.keys(patchData).length > 0) {
         try {
             const member = await memberApi.updateMember(patchData);
-            if (!member) {
-                throw new Error('Failed to update member');
-            }
             return {
                 member,
                 success: true

--- a/apps/comments-ui/src/app-context.ts
+++ b/apps/comments-ui/src/app-context.ts
@@ -4,13 +4,13 @@ import {ActionType, Actions, SyncActionType, SyncActions} from './actions';
 import {Page} from './pages';
 
 export type Member = {
-    id?: string,
     uuid: string,
     name: string,
     avatar_image: string | null,
     expertise: string | null,
     can_comment?: boolean,
-    paid?: boolean
+    paid?: boolean,
+    liked_comments?: string[]
 }
 
 export type Comment = {

--- a/apps/comments-ui/src/app-context.ts
+++ b/apps/comments-ui/src/app-context.ts
@@ -4,12 +4,13 @@ import {ActionType, Actions, SyncActionType, SyncActions} from './actions';
 import {Page} from './pages';
 
 export type Member = {
-    id: string,
+    id?: string,
     uuid: string,
     name: string,
-    avatar_image: string,
-    expertise: string,
-    can_comment?: boolean
+    avatar_image: string | null,
+    expertise: string | null,
+    can_comment?: boolean,
+    paid?: boolean
 }
 
 export type Comment = {

--- a/apps/comments-ui/src/app-context.ts
+++ b/apps/comments-ui/src/app-context.ts
@@ -89,7 +89,6 @@ export type EditableAppContext = {
     pageUrl: string,
     supportEmail: string | null,
     isMember: boolean,
-    isAdmin: boolean,
     isPaidOnly: boolean,
     hasRequiredTier: boolean,
     isCommentingDisabled: boolean
@@ -99,6 +98,7 @@ export type TranslationFunction = (key: string, replacements?: Record<string, st
 
 export type AppContextType = EditableAppContext & CommentsOptions & {
     // This part makes sure we can add automatic data and return types to the actions when using context.dispatchAction('actionName', data)
+    isAdmin: boolean,
     t: TranslationFunction,
     dispatchAction: <T extends ActionType | SyncActionType>(action: T, data: Parameters<(typeof Actions & typeof SyncActions)[T]>[0] extends { data: any } ? Parameters<(typeof Actions & typeof SyncActions)[T]>[0]['data'] : any) => T extends ActionType ? Promise<void> : void,
     openFormCount: number

--- a/apps/comments-ui/src/app.tsx
+++ b/apps/comments-ui/src/app.tsx
@@ -51,7 +51,7 @@ const AppContent: React.FC<{
     initialCommentId: string | null;
     pageUrl: string;
 }> = ({options, initialCommentId, pageUrl}) => {
-    const {commentApi, member, labs, supportEmail, memberOverlay, memberOverlayLoaded} = useCommentApi();
+    const {commentApi, isAdmin, adminActions, member, labs, supportEmail, memberOverlay, memberOverlayLoaded} = useCommentApi();
     const [state, setFullState] = useState<EditableAppContext>({
         initStatus: 'running',
         member: null,
@@ -69,7 +69,6 @@ const AppContent: React.FC<{
         pageUrl,
         supportEmail: null,
         isMember: false,
-        isAdmin: false,
         isPaidOnly: false,
         hasRequiredTier: true,
         isCommentingDisabled: false
@@ -109,7 +108,7 @@ const AppContent: React.FC<{
         // allow for async actions within it's updater function so this is the best option.
         return new Promise((resolve) => {
             setState((state) => {
-                ActionHandler({action, data, state, commentApi, options, dispatchAction: dispatchAction as DispatchActionType}).then((updatedState) => {
+                ActionHandler({action, data, state, commentApi, adminActions, options, dispatchAction: dispatchAction as DispatchActionType}).then((updatedState) => {
                     const newState = {...updatedState};
                     resolve(newState);
                     setState(newState);
@@ -119,7 +118,7 @@ const AppContent: React.FC<{
                 return {};
             });
         });
-    }, [commentApi, options]); // Do not add state or context as a dependency here -> infinite render loop
+    }, [commentApi, adminActions, options]); // Do not add state or context as a dependency here -> infinite render loop
 
     const i18n = useMemo(() => {
         return i18nLib(options.locale, 'comments');
@@ -130,6 +129,7 @@ const AppContent: React.FC<{
         ...state,
         // Override state values with latest from provider (state may have stale values
         // if initSetup ran before settings loaded)
+        isAdmin,
         supportEmail,
         labs,
         t: i18n.t,
@@ -270,7 +270,6 @@ const AppContent: React.FC<{
                 showMissingCommentNotice: !!initialCommentId && !scrollTargetFound,
                 supportEmail,
                 isMember,
-                isAdmin: commentApi.isAdmin,
                 isPaidOnly,
                 hasRequiredTier,
                 isCommentingDisabled: currentMember?.can_comment === false
@@ -307,38 +306,6 @@ const AppContent: React.FC<{
             };
         });
     }, [memberOverlayLoaded, state.initStatus]);
-
-    // Re-fetch comments when commentApi upgrades to admin (admin browse returns hidden comments).
-    // Wait for member overlay to resolve first so the admin browse includes the member UUID.
-    // Uses a ref to read the latest commentApi at fetch time, and a flag to ensure single execution.
-    const commentApiRef = useRef(commentApi);
-    commentApiRef.current = commentApi;
-    const adminFetchDone = useRef(false);
-    useEffect(() => {
-        if (adminFetchDone.current || !commentApi.isAdmin || state.initStatus !== 'success' || !memberOverlayLoaded) {
-            return;
-        }
-        adminFetchDone.current = true;
-        // Read latest commentApi (may have updated UUID since effect was scheduled)
-        const api = commentApiRef.current;
-        const dataPromise = api.browse({page: 1, postId: options.postId, order: state.order});
-        const countPromise = api.count({postId: options.postId});
-        Promise.all([dataPromise, countPromise]).then(([data, count]) => {
-            setState((prev) => {
-                // If we've paginated beyond page 1 (e.g. for a permalink target),
-                // don't overwrite — the admin page 1 would discard paginated results
-                if (prev.pagination && prev.pagination.page > 1) {
-                    return {isAdmin: true};
-                }
-                return {
-                    comments: data.comments,
-                    pagination: data.meta.pagination,
-                    commentCount: count,
-                    isAdmin: true
-                };
-            });
-        }).catch(console.error); // eslint-disable-line no-console
-    }, [commentApi.isAdmin, state.initStatus, memberOverlayLoaded]);
 
     /** Delay initialization until comments block is in viewport (unless permalink present) */
     useEffect(() => {

--- a/apps/comments-ui/src/app.tsx
+++ b/apps/comments-ui/src/app.tsx
@@ -7,7 +7,7 @@ import i18nLib from '@tryghost/i18n';
 import setupGhostApi from './utils/api';
 import {ActionHandler, SyncActionHandler, isSyncAction} from './actions';
 import {AppContext, Comment, DispatchActionType, EditableAppContext} from './app-context';
-import {CommentApiProvider, useCommentApi} from './components/comment-api-provider';
+import {CommentApiProvider, MemberOverlay, useCommentApi} from './components/comment-api-provider';
 import {CommentsFrame} from './components/frame';
 import {useOptions} from './utils/options';
 
@@ -24,12 +24,34 @@ function isCommentLoaded(comments: Comment[], targetId: string): boolean {
     return comments.some(c => c.id === targetId || c.replies?.some(r => r.id === targetId));
 }
 
+/**
+ * Apply member overlay data to comments — sets `liked` flag on comments
+ * the member has liked, based on the overlay's liked_comments array.
+ */
+function applyMemberOverlay(comments: Comment[], overlay: MemberOverlay | null): Comment[] {
+    if (!overlay) {
+        return comments;
+    }
+    const likedSet = new Set(overlay.liked_comments);
+    return comments.map((comment) => {
+        const liked = likedSet.has(comment.id);
+        const replies = comment.replies?.map(reply => ({
+            ...reply,
+            liked: likedSet.has(reply.id)
+        })) ?? [];
+        if (liked !== comment.liked || replies !== comment.replies) {
+            return {...comment, liked, replies};
+        }
+        return comment;
+    });
+}
+
 const AppContent: React.FC<{
     options: ReturnType<typeof useOptions>;
     initialCommentId: string | null;
     pageUrl: string;
 }> = ({options, initialCommentId, pageUrl}) => {
-    const {commentApi, member, labs, supportEmail} = useCommentApi();
+    const {commentApi, member, labs, supportEmail, memberOverlay, memberOverlayLoaded} = useCommentApi();
     const [state, setFullState] = useState<EditableAppContext>({
         initStatus: 'running',
         member: null,
@@ -54,7 +76,8 @@ const AppContent: React.FC<{
     });
 
     const iframeRef = useRef<HTMLIFrameElement>(null);
-
+    const memberOverlayRef = useRef({data: memberOverlay, loaded: memberOverlayLoaded});
+    memberOverlayRef.current = {data: memberOverlay, loaded: memberOverlayLoaded};
     const setState = useCallback((newState: Partial<EditableAppContext> | ((state: EditableAppContext) => Partial<EditableAppContext>)) => {
         setFullState((state) => {
             if (typeof newState === 'function') {
@@ -105,6 +128,10 @@ const AppContent: React.FC<{
     const context = {
         ...options,
         ...state,
+        // Override state values with latest from provider (state may have stale values
+        // if initSetup ran before settings loaded)
+        supportEmail,
+        labs,
         t: i18n.t,
         dispatchAction: dispatchAction as DispatchActionType,
         openFormCount: useMemo(() => state.openCommentForms.length, [state.openCommentForms])
@@ -168,46 +195,6 @@ const AppContent: React.FC<{
     };
 
     /**
-     * Load all replies for a parent comment if the target reply isn't already loaded.
-     */
-    const loadRepliesForComment = async (
-        parentId: string,
-        comments: Comment[]
-    ): Promise<Comment[]> => {
-        const parent = comments.find(c => c.id === parentId);
-        const hasMoreReplies = parent && parent.count.replies > parent.replies.length;
-
-        if (!hasMoreReplies) {
-            return comments;
-        }
-
-        let allReplies: Comment[] = [];
-        let hasMore = true;
-        let afterReplyId: string | undefined;
-
-        while (hasMore) {
-            const response = await commentApi.replies({
-                commentId: parentId,
-                afterReplyId,
-                limit: 100
-            });
-            allReplies = [...allReplies, ...response.comments];
-            hasMore = !!response.meta?.pagination?.next;
-
-            if (response.comments.length > 0) {
-                afterReplyId = response.comments[response.comments.length - 1]?.id;
-            } else {
-                hasMore = false;
-            }
-        }
-
-        return comments.map(c => (c.id === parentId
-            ? {...c, replies: allReplies}
-            : c
-        ));
-    };
-
-    /**
      * Load additional comment pages and/or replies until the scroll target is found.
      */
     const loadScrollTarget = async (
@@ -222,7 +209,7 @@ const AppContent: React.FC<{
         let comments = paginatedComments;
 
         if (parentId && !isCommentLoaded(comments, targetId)) {
-            const {comments: allReplies} = await api.comments.replies({commentId: parentId, limit: 'all'});
+            const {comments: allReplies} = await commentApi.replies({commentId: parentId, limit: 'all'});
             comments = comments.map(c => (c.id === parentId ? {...c, replies: allReplies} : c));
         }
 
@@ -249,16 +236,30 @@ const AppContent: React.FC<{
                 }
             }
 
-            // Compute tier access values
-            const isMember = !!member;
+            // Read latest overlay from ref (avoids stale closure)
+            const currentOverlay = memberOverlayRef.current.data;
+            const currentMember = currentOverlay ? {
+                uuid: currentOverlay.member.uuid,
+                name: currentOverlay.member.name,
+                expertise: currentOverlay.member.expertise,
+                avatar_image: currentOverlay.member.avatar_image,
+                can_comment: currentOverlay.member.can_comment,
+                paid: currentOverlay.member.paid
+            } : member;
+            const isMember = !!currentMember;
             const isPaidOnly = options.commentsEnabled === 'paid';
-            const isPaidMember = !!member?.paid;
+            const isPaidMember = !!currentMember?.paid;
             const hasRequiredTier = isPaidMember || !isPaidOnly;
 
+            // Apply member overlay to comments if already available
+            const overlaidComments = memberOverlayRef.loaded
+                ? applyMemberOverlay(comments, currentOverlay)
+                : comments;
+
             setState({
-                member,
+                member: currentMember,
                 initStatus: 'success',
-                comments,
+                comments: overlaidComments,
                 pagination,
                 commentCount: count,
                 order: 'count__likes desc, created_at desc',
@@ -272,7 +273,7 @@ const AppContent: React.FC<{
                 isAdmin: commentApi.isAdmin,
                 isPaidOnly,
                 hasRequiredTier,
-                isCommentingDisabled: member?.can_comment === false
+                isCommentingDisabled: currentMember?.can_comment === false
             });
         } catch (e) {
             // eslint-disable-next-line no-console
@@ -282,6 +283,62 @@ const AppContent: React.FC<{
             });
         }
     };
+
+    // Apply member overlay when it arrives — updates liked states on existing comments
+    useEffect(() => {
+        if (!memberOverlayLoaded || state.initStatus !== 'success') {
+            return;
+        }
+
+        setState((prev) => {
+            const updatedComments = applyMemberOverlay(prev.comments, memberOverlay);
+            const isMember = !!member;
+            const isPaidMember = !!member?.paid;
+            const isPaidOnly = options.commentsEnabled === 'paid';
+            const hasRequiredTier = isPaidMember || !isPaidOnly;
+
+            return {
+                member,
+                comments: updatedComments,
+                isMember,
+                isPaidOnly,
+                hasRequiredTier,
+                isCommentingDisabled: member?.can_comment === false
+            };
+        });
+    }, [memberOverlayLoaded, state.initStatus]);
+
+    // Re-fetch comments when commentApi upgrades to admin (admin browse returns hidden comments).
+    // Wait for member overlay to resolve first so the admin browse includes the member UUID.
+    // Uses a ref to read the latest commentApi at fetch time, and a flag to ensure single execution.
+    const commentApiRef = useRef(commentApi);
+    commentApiRef.current = commentApi;
+    const adminFetchDone = useRef(false);
+    useEffect(() => {
+        if (adminFetchDone.current || !commentApi.isAdmin || state.initStatus !== 'success' || !memberOverlayLoaded) {
+            return;
+        }
+        adminFetchDone.current = true;
+        // Read latest commentApi (may have updated UUID since effect was scheduled)
+        const api = commentApiRef.current;
+        const dataPromise = api.browse({page: 1, postId: options.postId, order: state.order});
+        const countPromise = api.count({postId: options.postId});
+        Promise.all([dataPromise, countPromise]).then(([data, count]) => {
+            setState((prev) => {
+                // If we've paginated beyond page 1 (e.g. for a permalink target),
+                // don't overwrite — the admin page 1 would discard paginated results
+                if (prev.pagination && prev.pagination.page > 1) {
+                    return {isAdmin: true};
+                }
+                return {
+                    comments: data.comments,
+                    pagination: data.meta.pagination,
+                    commentCount: count,
+                    isAdmin: true
+                };
+            });
+        }).catch(console.error); // eslint-disable-line no-console
+    }, [commentApi.isAdmin, state.initStatus, memberOverlayLoaded]);
 
     /** Delay initialization until comments block is in viewport (unless permalink present) */
     useEffect(() => {
@@ -344,6 +401,7 @@ const App: React.FC<AppProps> = ({scriptTag, initialCommentId, pageUrl}) => {
         <CommentApiProvider
             adminUrl={options.adminUrl}
             api={api}
+            postId={options.postId}
         >
             <AppContent
                 initialCommentId={initialCommentId}

--- a/apps/comments-ui/src/app.tsx
+++ b/apps/comments-ui/src/app.tsx
@@ -7,7 +7,7 @@ import i18nLib from '@tryghost/i18n';
 import setupGhostApi from './utils/api';
 import {ActionHandler, SyncActionHandler, isSyncAction} from './actions';
 import {AppContext, Comment, DispatchActionType, EditableAppContext} from './app-context';
-import {CommentApiProvider, MemberOverlay, useCommentApi} from './components/comment-api-provider';
+import {CommentApiProvider, CommentMember, useCommentApi} from './components/comment-api-provider';
 import {CommentsFrame} from './components/frame';
 import {useOptions} from './utils/options';
 
@@ -25,14 +25,14 @@ function isCommentLoaded(comments: Comment[], targetId: string): boolean {
 }
 
 /**
- * Apply member overlay data to comments — sets `liked` flag on comments
- * the member has liked, based on the overlay's liked_comments array.
+ * Apply comment member data to comments — sets `liked` flag on comments
+ * the member has liked, based on the member's liked_comments array.
  */
-function applyMemberOverlay(comments: Comment[], overlay: MemberOverlay | null): Comment[] {
-    if (!overlay) {
+function applyCommentMember(comments: Comment[], commentMember: CommentMember | null): Comment[] {
+    if (!commentMember) {
         return comments;
     }
-    const likedSet = new Set(overlay.liked_comments);
+    const likedSet = new Set(commentMember.liked_comments);
     return comments.map((comment) => {
         const liked = likedSet.has(comment.id);
         const replies = comment.replies?.map(reply => ({
@@ -51,7 +51,7 @@ const AppContent: React.FC<{
     initialCommentId: string | null;
     pageUrl: string;
 }> = ({options, initialCommentId, pageUrl}) => {
-    const {commentApi, isAdmin, adminActions, member, labs, supportEmail, memberOverlay, memberOverlayLoaded} = useCommentApi();
+    const {publicApi, memberApi, isAdmin, adminActions, member, labs, supportEmail, commentMember, commentMemberLoaded} = useCommentApi();
     const [state, setFullState] = useState<EditableAppContext>({
         initStatus: 'running',
         member: null,
@@ -75,8 +75,8 @@ const AppContent: React.FC<{
     });
 
     const iframeRef = useRef<HTMLIFrameElement>(null);
-    const memberOverlayRef = useRef({data: memberOverlay, loaded: memberOverlayLoaded});
-    memberOverlayRef.current = {data: memberOverlay, loaded: memberOverlayLoaded};
+    const commentMemberRef = useRef({data: commentMember, loaded: commentMemberLoaded});
+    commentMemberRef.current = {data: commentMember, loaded: commentMemberLoaded};
     const setState = useCallback((newState: Partial<EditableAppContext> | ((state: EditableAppContext) => Partial<EditableAppContext>)) => {
         setFullState((state) => {
             if (typeof newState === 'function') {
@@ -108,7 +108,7 @@ const AppContent: React.FC<{
         // allow for async actions within it's updater function so this is the best option.
         return new Promise((resolve) => {
             setState((state) => {
-                ActionHandler({action, data, state, commentApi, adminActions, options, dispatchAction: dispatchAction as DispatchActionType}).then((updatedState) => {
+                ActionHandler({action, data, state, publicApi, memberApi, adminActions, options, dispatchAction: dispatchAction as DispatchActionType}).then((updatedState) => {
                     const newState = {...updatedState};
                     resolve(newState);
                     setState(newState);
@@ -118,7 +118,7 @@ const AppContent: React.FC<{
                 return {};
             });
         });
-    }, [commentApi, adminActions, options]); // Do not add state or context as a dependency here -> infinite render loop
+    }, [publicApi, memberApi, adminActions, options]); // Do not add state or context as a dependency here -> infinite render loop
 
     const i18n = useMemo(() => {
         return i18nLib(options.locale, 'comments');
@@ -137,10 +137,10 @@ const AppContent: React.FC<{
         openFormCount: useMemo(() => state.openCommentForms.length, [state.openCommentForms])
     };
 
-    /** Fetch first few comments using the resolved commentApi */
+    /** Fetch first few comments using the public API */
     const fetchComments = async () => {
-        const dataPromise = commentApi.browse({page: 1, postId: options.postId, order: state.order});
-        const countPromise = commentApi.count({postId: options.postId});
+        const dataPromise = publicApi.browse({page: 1, postId: options.postId, order: state.order});
+        const countPromise = publicApi.count({postId: options.postId});
 
         const [data, count] = await Promise.all([dataPromise, countPromise]);
 
@@ -157,7 +157,7 @@ const AppContent: React.FC<{
      */
     const fetchScrollTarget = async (targetId: string): Promise<Comment | null> => {
         try {
-            const response = await commentApi.read(targetId);
+            const response = await publicApi.read(targetId);
             const comment = response.comments?.[0];
             return (comment && comment.status === 'published') ? comment : null;
         } catch {
@@ -182,7 +182,7 @@ const AppContent: React.FC<{
                 break;
             }
 
-            const nextPage = await commentApi.browse({
+            const nextPage = await publicApi.browse({
                 page: pagination.page + 1,
                 postId: options.postId,
                 order: state.order
@@ -209,7 +209,7 @@ const AppContent: React.FC<{
         let comments = paginatedComments;
 
         if (parentId && !isCommentLoaded(comments, targetId)) {
-            const {comments: allReplies} = await commentApi.replies({commentId: parentId, limit: 'all'});
+            const {comments: allReplies} = await publicApi.replies({commentId: parentId, limit: 'all'});
             comments = comments.map(c => (c.id === parentId ? {...c, replies: allReplies} : c));
         }
 
@@ -236,24 +236,24 @@ const AppContent: React.FC<{
                 }
             }
 
-            // Read latest overlay from ref (avoids stale closure)
-            const currentOverlay = memberOverlayRef.current.data;
-            const currentMember = currentOverlay ? {
-                uuid: currentOverlay.member.uuid,
-                name: currentOverlay.member.name,
-                expertise: currentOverlay.member.expertise,
-                avatar_image: currentOverlay.member.avatar_image,
-                can_comment: currentOverlay.member.can_comment,
-                paid: currentOverlay.member.paid
+            // Read latest comment member from ref (avoids stale closure)
+            const currentCommentMember = commentMemberRef.current.data;
+            const currentMember = currentCommentMember ? {
+                uuid: currentCommentMember.uuid,
+                name: currentCommentMember.name,
+                expertise: currentCommentMember.expertise,
+                avatar_image: currentCommentMember.avatar_image,
+                can_comment: currentCommentMember.can_comment,
+                paid: currentCommentMember.paid
             } : member;
             const isMember = !!currentMember;
             const isPaidOnly = options.commentsEnabled === 'paid';
             const isPaidMember = !!currentMember?.paid;
             const hasRequiredTier = isPaidMember || !isPaidOnly;
 
-            // Apply member overlay to comments if already available
-            const overlaidComments = memberOverlayRef.loaded
-                ? applyMemberOverlay(comments, currentOverlay)
+            // Apply comment member liked states if already available
+            const overlaidComments = commentMemberRef.current.loaded
+                ? applyCommentMember(comments, currentCommentMember)
                 : comments;
 
             setState({
@@ -283,14 +283,14 @@ const AppContent: React.FC<{
         }
     };
 
-    // Apply member overlay when it arrives — updates liked states on existing comments
+    // Apply comment member data when it arrives — updates liked states on existing comments
     useEffect(() => {
-        if (!memberOverlayLoaded || state.initStatus !== 'success') {
+        if (!commentMemberLoaded || state.initStatus !== 'success') {
             return;
         }
 
         setState((prev) => {
-            const updatedComments = applyMemberOverlay(prev.comments, memberOverlay);
+            const updatedComments = applyCommentMember(prev.comments, commentMember);
             const isMember = !!member;
             const isPaidMember = !!member?.paid;
             const isPaidOnly = options.commentsEnabled === 'paid';
@@ -305,7 +305,7 @@ const AppContent: React.FC<{
                 isCommentingDisabled: member?.can_comment === false
             };
         });
-    }, [memberOverlayLoaded, state.initStatus]);
+    }, [commentMemberLoaded, state.initStatus]);
 
     /** Delay initialization until comments block is in viewport (unless permalink present) */
     useEffect(() => {

--- a/apps/comments-ui/src/app.tsx
+++ b/apps/comments-ui/src/app.tsx
@@ -6,8 +6,8 @@ import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import i18nLib from '@tryghost/i18n';
 import setupGhostApi from './utils/api';
 import {ActionHandler, SyncActionHandler, isSyncAction} from './actions';
-import {AppContext, Comment, DispatchActionType, EditableAppContext} from './app-context';
-import {CommentApiProvider, CommentMember, useCommentApi} from './components/comment-api-provider';
+import {AppContext, Comment, DispatchActionType, EditableAppContext, Member} from './app-context';
+import {CommentApiProvider, useCommentApi} from './components/comment-api-provider';
 import {CommentsFrame} from './components/frame';
 import {useOptions} from './utils/options';
 
@@ -25,20 +25,20 @@ function isCommentLoaded(comments: Comment[], targetId: string): boolean {
 }
 
 /**
- * Apply comment member data to comments — sets `liked` flag on comments
+ * Apply member liked states to comments — sets `liked` flag on comments
  * the member has liked, based on the member's liked_comments array.
  */
-function applyCommentMember(comments: Comment[], commentMember: CommentMember | null): Comment[] {
-    if (!commentMember) {
+function applyMemberLikes(comments: Comment[], member: Member | null): Comment[] {
+    if (!member?.liked_comments?.length) {
         return comments;
     }
-    const likedSet = new Set(commentMember.liked_comments);
+    const likedSet = new Set(member.liked_comments);
     return comments.map((comment) => {
         const liked = likedSet.has(comment.id);
-        const replies = comment.replies?.map(reply => ({
-            ...reply,
-            liked: likedSet.has(reply.id)
-        })) ?? [];
+        const hasLikedReply = comment.replies?.some(r => likedSet.has(r.id));
+        const replies = hasLikedReply
+            ? comment.replies.map(reply => ({...reply, liked: likedSet.has(reply.id)}))
+            : comment.replies;
         if (liked !== comment.liked || replies !== comment.replies) {
             return {...comment, liked, replies};
         }
@@ -51,7 +51,7 @@ const AppContent: React.FC<{
     initialCommentId: string | null;
     pageUrl: string;
 }> = ({options, initialCommentId, pageUrl}) => {
-    const {publicApi, memberApi, isAdmin, adminActions, member, labs, supportEmail, commentMember, commentMemberLoaded} = useCommentApi();
+    const {publicApi, memberApi, isAdmin, adminActions, member, labs, supportEmail, memberLoaded} = useCommentApi();
     const [state, setFullState] = useState<EditableAppContext>({
         initStatus: 'running',
         member: null,
@@ -75,8 +75,8 @@ const AppContent: React.FC<{
     });
 
     const iframeRef = useRef<HTMLIFrameElement>(null);
-    const commentMemberRef = useRef({data: commentMember, loaded: commentMemberLoaded});
-    commentMemberRef.current = {data: commentMember, loaded: commentMemberLoaded};
+    const memberRef = useRef({data: member, loaded: memberLoaded});
+    memberRef.current = {data: member, loaded: memberLoaded};
     const setState = useCallback((newState: Partial<EditableAppContext> | ((state: EditableAppContext) => Partial<EditableAppContext>)) => {
         setFullState((state) => {
             if (typeof newState === 'function') {
@@ -236,24 +236,16 @@ const AppContent: React.FC<{
                 }
             }
 
-            // Read latest comment member from ref (avoids stale closure)
-            const currentCommentMember = commentMemberRef.current.data;
-            const currentMember = currentCommentMember ? {
-                uuid: currentCommentMember.uuid,
-                name: currentCommentMember.name,
-                expertise: currentCommentMember.expertise,
-                avatar_image: currentCommentMember.avatar_image,
-                can_comment: currentCommentMember.can_comment,
-                paid: currentCommentMember.paid
-            } : member;
+            // Read latest member from ref (avoids stale closure from useEffect/IntersectionObserver)
+            const currentMember = memberRef.current.data;
             const isMember = !!currentMember;
             const isPaidOnly = options.commentsEnabled === 'paid';
             const isPaidMember = !!currentMember?.paid;
             const hasRequiredTier = isPaidMember || !isPaidOnly;
 
-            // Apply comment member liked states if already available
-            const overlaidComments = commentMemberRef.current.loaded
-                ? applyCommentMember(comments, currentCommentMember)
+            // Apply member liked states if already available
+            const overlaidComments = memberRef.current.loaded
+                ? applyMemberLikes(comments, currentMember)
                 : comments;
 
             setState({
@@ -283,14 +275,14 @@ const AppContent: React.FC<{
         }
     };
 
-    // Apply comment member data when it arrives — updates liked states on existing comments
+    // Apply member data when it arrives — updates liked states on existing comments
     useEffect(() => {
-        if (!commentMemberLoaded || state.initStatus !== 'success') {
+        if (!memberLoaded || state.initStatus !== 'success') {
             return;
         }
 
         setState((prev) => {
-            const updatedComments = applyCommentMember(prev.comments, commentMember);
+            const updatedComments = applyMemberLikes(prev.comments, member);
             const isMember = !!member;
             const isPaidMember = !!member?.paid;
             const isPaidOnly = options.commentsEnabled === 'paid';
@@ -305,7 +297,7 @@ const AppContent: React.FC<{
                 isCommentingDisabled: member?.can_comment === false
             };
         });
-    }, [commentMemberLoaded, state.initStatus]);
+    }, [memberLoaded, state.initStatus]);
 
     /** Delay initialization until comments block is in viewport (unless permalink present) */
     useEffect(() => {

--- a/apps/comments-ui/src/components/comment-api-provider.tsx
+++ b/apps/comments-ui/src/components/comment-api-provider.tsx
@@ -77,10 +77,17 @@ function createCommentApi(api: GhostApi, adminApi: AdminApi | null, memberUuid?:
     };
 }
 
-type MemberData = {
-    member: Member | null;
-    labs: LabsContextType;
-    supportEmail: string | null;
+export type MemberOverlay = {
+    member: {
+        uuid: string;
+        name: string;
+        expertise: string | null;
+        avatar_image: string | null;
+        can_comment: boolean;
+        paid: boolean;
+    };
+    liked_comments: string[];
+    authored_comments: string[];
 };
 
 type CommentApiContextType = {
@@ -88,6 +95,9 @@ type CommentApiContextType = {
     member: Member | null;
     labs: LabsContextType;
     supportEmail: string | null;
+    memberOverlay: MemberOverlay | null;
+    memberOverlayLoaded: boolean;
+    settingsLoaded: boolean;
 };
 
 const CommentApiContext = createContext<CommentApiContextType | null>(null);
@@ -104,26 +114,46 @@ type CommentApiProviderProps = {
     children: React.ReactNode;
     api: GhostApi;
     adminUrl: string | undefined;
+    postId: string;
 };
 
-export function CommentApiProvider({children, api, adminUrl}: CommentApiProviderProps) {
-    // undefined = pending, value = resolved
-    const [memberData, setMemberData] = useState<MemberData | undefined>(undefined);
+export function CommentApiProvider({children, api, adminUrl, postId}: CommentApiProviderProps) {
+    const [labs, setLabs] = useState<LabsContextType>({});
+    const [supportEmail, setSupportEmail] = useState<string | null>(null);
+    const [settingsLoaded, setSettingsLoaded] = useState(false);
     const [adminApi, setAdminApi] = useState<AdminApi | null | undefined>(adminUrl ? undefined : null);
     const [hasAdminSession, setHasSession] = useState<boolean | undefined>(adminUrl ? undefined : false);
+    const [memberOverlay, setMemberOverlay] = useState<MemberOverlay | null>(null);
+    const [memberOverlayLoaded, setMemberOverlayLoaded] = useState(false);
 
-    // Step 1: Initialize member data
+    // Step 1: Fetch site settings (labs, support email) — non-blocking
     useEffect(() => {
         api.init()
-            .then(setMemberData)
+            .then(({labs: initLabs, supportEmail: initSupportEmail}) => {
+                setLabs(initLabs);
+                setSupportEmail(initSupportEmail);
+                setSettingsLoaded(true);
+            })
             .catch((e) => {
                 // eslint-disable-next-line no-console
-                console.error(`[Comments] Failed to initialize member:`, e);
-                setMemberData({member: null, labs: {}, supportEmail: null});
+                console.error(`[Comments] Failed to initialize settings:`, e);
+                setSettingsLoaded(true);
             });
     }, [api]);
 
-    // Step 2: Preflight check for admin session
+    // Step 2: Fetch member overlay data (lightweight, parallel with everything else)
+    useEffect(() => {
+        api.comments.memberInfo({postId})
+            .then((data) => {
+                setMemberOverlay(data);
+                setMemberOverlayLoaded(true);
+            })
+            .catch(() => {
+                setMemberOverlayLoaded(true);
+            });
+    }, [api, postId]);
+
+    // Step 3: Preflight check for admin session
     useEffect(() => {
         if (!adminUrl) {
             return;
@@ -136,7 +166,7 @@ export function CommentApiProvider({children, api, adminUrl}: CommentApiProvider
         });
     }, [adminUrl]);
 
-    // Step 3: If session exists, verify admin role when iframe loads
+    // Step 4: If session exists, verify admin role when iframe loads
     const onAdminAuthLoad = async () => {
         try {
             const newAdminApi = setupAdminAPI({adminUrl: adminUrl!});
@@ -156,28 +186,45 @@ export function CommentApiProvider({children, api, adminUrl}: CommentApiProvider
         setAdminApi(null);
     };
 
-    const resolved = memberData !== undefined && adminApi !== undefined;
-
-    const contextValue = useMemo(() => {
-        if (!resolved) {
+    // Build member from overlay data for the context
+    const member: Member | null = useMemo(() => {
+        if (!memberOverlay) {
             return null;
         }
         return {
-            commentApi: createCommentApi(api, adminApi, memberData.member?.uuid),
-            member: memberData.member,
-            labs: memberData.labs,
-            supportEmail: memberData.supportEmail
+            uuid: memberOverlay.member.uuid,
+            name: memberOverlay.member.name,
+            expertise: memberOverlay.member.expertise,
+            avatar_image: memberOverlay.member.avatar_image,
+            can_comment: memberOverlay.member.can_comment,
+            paid: memberOverlay.member.paid
         };
-    }, [resolved, api, adminApi, memberData]);
+    }, [memberOverlay]);
+
+    // CommentApi: starts as public, upgrades to admin when admin auth resolves
+    const commentApi = useMemo(() => {
+        const resolvedAdminApi = adminApi !== undefined ? adminApi : null;
+        return createCommentApi(api, resolvedAdminApi, member?.uuid);
+    }, [api, adminApi, member?.uuid]);
+
+    const contextValue = useMemo(() => {
+        return {
+            commentApi,
+            member,
+            labs,
+            supportEmail,
+            memberOverlay,
+            memberOverlayLoaded,
+            settingsLoaded
+        };
+    }, [commentApi, member, labs, supportEmail, memberOverlay, memberOverlayLoaded, settingsLoaded]);
 
     return (
         <>
             {hasAdminSession && <AuthFrame adminUrl={adminUrl!} onError={onAdminAuthError} onLoad={onAdminAuthLoad} />}
-            {contextValue && (
-                <CommentApiContext.Provider value={contextValue}>
-                    {children}
-                </CommentApiContext.Provider>
-            )}
+            <CommentApiContext.Provider value={contextValue}>
+                {children}
+            </CommentApiContext.Provider>
         </>
     );
 }

--- a/apps/comments-ui/src/components/comment-api-provider.tsx
+++ b/apps/comments-ui/src/components/comment-api-provider.tsx
@@ -16,18 +16,21 @@ async function checkHasAdminSession(adminUrl: string): Promise<boolean> {
     }
 }
 
-export type CommentApi = {
+export type PublicApi = {
     browse(params: {page: number; postId: string; order?: string}): Promise<{comments: Comment[]; meta: {pagination: any}}>;
-    replies(params: {commentId: string; afterReplyId?: string; limit?: number}): Promise<{comments: Comment[]; meta: {pagination: any}}>;
+    replies(params: {commentId: string; afterReplyId?: string; limit?: number | 'all'}): Promise<{comments: Comment[]; meta: {pagination: any}}>;
     read(commentId: string): Promise<{comments: Comment[]}>;
     count(params: {postId: string | null}): Promise<any>;
+};
 
+export type MemberApi = {
     add(params: {comment: AddComment}): Promise<{comments: Comment[]}>;
     edit(params: {comment: Partial<Comment> & {id: string}}): Promise<{comments: Comment[]}>;
     like(params: {comment: {id: string}}): Promise<string>;
     unlike(params: {comment: {id: string}}): Promise<string>;
     report(params: {comment: {id: string}}): Promise<string>;
-
+    replies(params: {commentId: string; afterReplyId?: string; limit?: number | 'all'}): Promise<{comments: Comment[]; meta: {pagination: any}}>;
+    getMember(params: {postId: string}): Promise<any>;
     updateMember(data: {name?: string; expertise?: string}): Promise<Member | null>;
 };
 
@@ -38,44 +41,48 @@ export type AdminActions = {
 
 const ALLOWED_MODERATORS = ['Owner', 'Administrator', 'Super Editor'];
 
-function createCommentApi(api: GhostApi): CommentApi {
+function createPublicApi(api: GhostApi): PublicApi {
     return {
         browse: p => api.comments.browse(p),
-        replies: p => api.comments.replies(p),
+        replies: p => api.comments.replies({...p, credentials: 'omit'}),
         read: id => api.comments.read(id),
-        count: p => api.comments.count(p),
+        count: p => api.comments.count(p)
+    };
+}
+
+function createMemberApi(api: GhostApi): MemberApi {
+    return {
         add: p => api.comments.add(p),
         edit: p => api.comments.edit(p),
         like: p => api.comments.like(p),
         unlike: p => api.comments.unlike(p),
         report: p => api.comments.report(p),
+        replies: p => api.comments.replies({...p, credentials: 'same-origin'}),
+        getMember: p => api.comments.getMember(p),
         updateMember: data => api.member.update(data)
     };
 }
 
-export type MemberOverlay = {
-    member: {
-        uuid: string;
-        name: string;
-        expertise: string | null;
-        avatar_image: string | null;
-        can_comment: boolean;
-        paid: boolean;
-    };
+export type CommentMember = {
+    uuid: string;
+    name: string;
+    expertise: string | null;
+    avatar_image: string | null;
+    can_comment: boolean;
+    paid: boolean;
     liked_comments: string[];
-    authored_comments: string[];
 };
 
 type CommentApiContextType = {
-    commentApi: CommentApi;
+    publicApi: PublicApi;
+    memberApi: MemberApi;
     isAdmin: boolean;
     adminActions: AdminActions | null;
     member: Member | null;
     labs: LabsContextType;
     supportEmail: string | null;
-    memberOverlay: MemberOverlay | null;
-    memberOverlayLoaded: boolean;
-    settingsLoaded: boolean;
+    commentMember: CommentMember | null;
+    commentMemberLoaded: boolean;
 };
 
 const CommentApiContext = createContext<CommentApiContextType | null>(null);
@@ -98,11 +105,10 @@ type CommentApiProviderProps = {
 export function CommentApiProvider({children, api, adminUrl, postId}: CommentApiProviderProps) {
     const [labs, setLabs] = useState<LabsContextType>({});
     const [supportEmail, setSupportEmail] = useState<string | null>(null);
-    const [settingsLoaded, setSettingsLoaded] = useState(false);
     const [adminActions, setAdminActions] = useState<AdminActions | null>(null);
     const [hasAdminSession, setHasSession] = useState<boolean | undefined>(adminUrl ? undefined : false);
-    const [memberOverlay, setMemberOverlay] = useState<MemberOverlay | null>(null);
-    const [memberOverlayLoaded, setMemberOverlayLoaded] = useState(false);
+    const [commentMember, setCommentMember] = useState<CommentMember | null>(null);
+    const [commentMemberLoaded, setCommentMemberLoaded] = useState(false);
 
     // Step 1: Fetch site settings (labs, support email) — non-blocking
     useEffect(() => {
@@ -110,24 +116,32 @@ export function CommentApiProvider({children, api, adminUrl, postId}: CommentApi
             .then(({labs: initLabs, supportEmail: initSupportEmail}) => {
                 setLabs(initLabs);
                 setSupportEmail(initSupportEmail);
-                setSettingsLoaded(true);
             })
             .catch((e) => {
                 // eslint-disable-next-line no-console
                 console.error(`[Comments] Failed to initialize settings:`, e);
-                setSettingsLoaded(true);
             });
     }, [api]);
 
-    // Step 2: Fetch member overlay data (lightweight, parallel with everything else)
+    // Step 2: Fetch comment member data (lightweight, parallel with everything else)
     useEffect(() => {
-        api.comments.memberInfo({postId})
+        api.comments.getMember({postId})
             .then((data) => {
-                setMemberOverlay(data);
-                setMemberOverlayLoaded(true);
+                if (data) {
+                    setCommentMember({
+                        uuid: data.member.uuid,
+                        name: data.member.name,
+                        expertise: data.member.expertise,
+                        avatar_image: data.member.avatar_image,
+                        can_comment: data.member.can_comment,
+                        paid: data.member.paid,
+                        liked_comments: data.liked_comments
+                    });
+                }
+                setCommentMemberLoaded(true);
             })
             .catch(() => {
-                setMemberOverlayLoaded(true);
+                setCommentMemberLoaded(true);
             });
     }, [api, postId]);
 
@@ -164,41 +178,44 @@ export function CommentApiProvider({children, api, adminUrl, postId}: CommentApi
         console.warn(`[Comments] Admin auth frame failed to load`);
     };
 
-    // Build member from overlay data for the context
+    // Build member from comment member data for the context
     const member: Member | null = useMemo(() => {
-        if (!memberOverlay) {
+        if (!commentMember) {
             return null;
         }
         return {
-            uuid: memberOverlay.member.uuid,
-            name: memberOverlay.member.name,
-            expertise: memberOverlay.member.expertise,
-            avatar_image: memberOverlay.member.avatar_image,
-            can_comment: memberOverlay.member.can_comment,
-            paid: memberOverlay.member.paid
+            uuid: commentMember.uuid,
+            name: commentMember.name,
+            expertise: commentMember.expertise,
+            avatar_image: commentMember.avatar_image,
+            can_comment: commentMember.can_comment,
+            paid: commentMember.paid
         };
-    }, [memberOverlay]);
+    }, [commentMember]);
 
-    // CommentApi: always uses public API for reads
-    const commentApi = useMemo(() => {
-        return createCommentApi(api);
+    const publicApi = useMemo(() => {
+        return createPublicApi(api);
+    }, [api]);
+
+    const memberApi = useMemo(() => {
+        return createMemberApi(api);
     }, [api]);
 
     const isAdmin = !!adminActions;
 
     const contextValue = useMemo(() => {
         return {
-            commentApi,
+            publicApi,
+            memberApi,
             isAdmin,
             adminActions,
             member,
             labs,
             supportEmail,
-            memberOverlay,
-            memberOverlayLoaded,
-            settingsLoaded
+            commentMember,
+            commentMemberLoaded
         };
-    }, [commentApi, isAdmin, adminActions, member, labs, supportEmail, memberOverlay, memberOverlayLoaded, settingsLoaded]);
+    }, [publicApi, memberApi, isAdmin, adminActions, member, labs, supportEmail, commentMember, commentMemberLoaded]);
 
     return (
         <>

--- a/apps/comments-ui/src/components/comment-api-provider.tsx
+++ b/apps/comments-ui/src/components/comment-api-provider.tsx
@@ -2,7 +2,7 @@ import AuthFrame from '../auth-frame';
 import React, {createContext, useContext, useEffect, useMemo, useState} from 'react';
 import {AddComment, Comment, LabsContextType, Member} from '../app-context';
 import {setupAdminAPI} from '../utils/admin-api';
-import {GhostApi} from '../utils/api';
+import {CommentsApi, GhostApi} from '../utils/api';
 
 async function checkHasAdminSession(adminUrl: string): Promise<boolean> {
     try {
@@ -30,7 +30,7 @@ export type MemberApi = {
     unlike(params: {comment: {id: string}}): Promise<string>;
     report(params: {comment: {id: string}}): Promise<string>;
     replies(params: {commentId: string; afterReplyId?: string; limit?: number | 'all'}): Promise<{comments: Comment[]; meta: {pagination: any}}>;
-    getMember(params: {postId: string}): Promise<any>;
+    getMember(params: {postId: string}): Promise<{member: Member} | null>;
     updateMember(data: {name?: string; expertise?: string}): Promise<Member | null>;
 };
 
@@ -41,37 +41,16 @@ export type AdminActions = {
 
 const ALLOWED_MODERATORS = ['Owner', 'Administrator', 'Super Editor'];
 
-function createPublicApi(api: GhostApi): PublicApi {
-    return {
-        browse: p => api.comments.browse(p),
-        replies: p => api.comments.replies({...p, credentials: 'omit'}),
-        read: id => api.comments.read(id),
-        count: p => api.comments.count(p)
-    };
+function createPublicApi(commentsApi: CommentsApi): PublicApi {
+    return commentsApi;
 }
 
-function createMemberApi(api: GhostApi): MemberApi {
+function createMemberApi(commentsApi: CommentsApi, api: GhostApi): MemberApi {
     return {
-        add: p => api.comments.add(p),
-        edit: p => api.comments.edit(p),
-        like: p => api.comments.like(p),
-        unlike: p => api.comments.unlike(p),
-        report: p => api.comments.report(p),
-        replies: p => api.comments.replies({...p, credentials: 'same-origin'}),
-        getMember: p => api.comments.getMember(p),
+        ...commentsApi,
         updateMember: data => api.member.update(data)
     };
 }
-
-export type CommentMember = {
-    uuid: string;
-    name: string;
-    expertise: string | null;
-    avatar_image: string | null;
-    can_comment: boolean;
-    paid: boolean;
-    liked_comments: string[];
-};
 
 type CommentApiContextType = {
     publicApi: PublicApi;
@@ -81,8 +60,7 @@ type CommentApiContextType = {
     member: Member | null;
     labs: LabsContextType;
     supportEmail: string | null;
-    commentMember: CommentMember | null;
-    commentMemberLoaded: boolean;
+    memberLoaded: boolean;
 };
 
 const CommentApiContext = createContext<CommentApiContextType | null>(null);
@@ -107,8 +85,11 @@ export function CommentApiProvider({children, api, adminUrl, postId}: CommentApi
     const [supportEmail, setSupportEmail] = useState<string | null>(null);
     const [adminActions, setAdminActions] = useState<AdminActions | null>(null);
     const [hasAdminSession, setHasSession] = useState<boolean | undefined>(adminUrl ? undefined : false);
-    const [commentMember, setCommentMember] = useState<CommentMember | null>(null);
-    const [commentMemberLoaded, setCommentMemberLoaded] = useState(false);
+    const [member, setMember] = useState<Member | null>(null);
+    const [memberLoaded, setMemberLoaded] = useState(false);
+
+    const publicApi = useMemo(() => createPublicApi(api.comments({credentials: 'omit'})), [api]);
+    const memberApi = useMemo(() => createMemberApi(api.comments({credentials: 'same-origin'}), api), [api]);
 
     // Step 1: Fetch site settings (labs, support email) — non-blocking
     useEffect(() => {
@@ -125,25 +106,17 @@ export function CommentApiProvider({children, api, adminUrl, postId}: CommentApi
 
     // Step 2: Fetch comment member data (lightweight, parallel with everything else)
     useEffect(() => {
-        api.comments.getMember({postId})
+        memberApi.getMember({postId})
             .then((data) => {
                 if (data) {
-                    setCommentMember({
-                        uuid: data.member.uuid,
-                        name: data.member.name,
-                        expertise: data.member.expertise,
-                        avatar_image: data.member.avatar_image,
-                        can_comment: data.member.can_comment,
-                        paid: data.member.paid,
-                        liked_comments: data.liked_comments
-                    });
+                    setMember(data.member);
                 }
-                setCommentMemberLoaded(true);
+                setMemberLoaded(true);
             })
             .catch(() => {
-                setCommentMemberLoaded(true);
+                setMemberLoaded(true);
             });
-    }, [api, postId]);
+    }, [memberApi, postId]);
 
     // Step 3: Preflight check for admin session
     useEffect(() => {
@@ -178,29 +151,6 @@ export function CommentApiProvider({children, api, adminUrl, postId}: CommentApi
         console.warn(`[Comments] Admin auth frame failed to load`);
     };
 
-    // Build member from comment member data for the context
-    const member: Member | null = useMemo(() => {
-        if (!commentMember) {
-            return null;
-        }
-        return {
-            uuid: commentMember.uuid,
-            name: commentMember.name,
-            expertise: commentMember.expertise,
-            avatar_image: commentMember.avatar_image,
-            can_comment: commentMember.can_comment,
-            paid: commentMember.paid
-        };
-    }, [commentMember]);
-
-    const publicApi = useMemo(() => {
-        return createPublicApi(api);
-    }, [api]);
-
-    const memberApi = useMemo(() => {
-        return createMemberApi(api);
-    }, [api]);
-
     const isAdmin = !!adminActions;
 
     const contextValue = useMemo(() => {
@@ -212,10 +162,9 @@ export function CommentApiProvider({children, api, adminUrl, postId}: CommentApi
             member,
             labs,
             supportEmail,
-            commentMember,
-            commentMemberLoaded
+            memberLoaded
         };
-    }, [publicApi, memberApi, isAdmin, adminActions, member, labs, supportEmail, commentMember, commentMemberLoaded]);
+    }, [publicApi, memberApi, isAdmin, adminActions, member, labs, supportEmail, memberLoaded]);
 
     return (
         <>

--- a/apps/comments-ui/src/components/comment-api-provider.tsx
+++ b/apps/comments-ui/src/components/comment-api-provider.tsx
@@ -1,8 +1,8 @@
 import AuthFrame from '../auth-frame';
 import React, {createContext, useContext, useEffect, useMemo, useState} from 'react';
-import {AddComment, Comment, LabsContextType, Member} from '../app-context';
-import {setupAdminAPI} from '../utils/admin-api';
 import {CommentsApi, GhostApi} from '../utils/api';
+import {LabsContextType, Member} from '../app-context';
+import {setupAdminAPI} from '../utils/admin-api';
 
 async function checkHasAdminSession(adminUrl: string): Promise<boolean> {
     try {
@@ -16,21 +16,9 @@ async function checkHasAdminSession(adminUrl: string): Promise<boolean> {
     }
 }
 
-export type PublicApi = {
-    browse(params: {page: number; postId: string; order?: string}): Promise<{comments: Comment[]; meta: {pagination: any}}>;
-    replies(params: {commentId: string; afterReplyId?: string; limit?: number | 'all'}): Promise<{comments: Comment[]; meta: {pagination: any}}>;
-    read(commentId: string): Promise<{comments: Comment[]}>;
-    count(params: {postId: string | null}): Promise<any>;
-};
+export type PublicApi = CommentsApi;
 
-export type MemberApi = {
-    add(params: {comment: AddComment}): Promise<{comments: Comment[]}>;
-    edit(params: {comment: Partial<Comment> & {id: string}}): Promise<{comments: Comment[]}>;
-    like(params: {comment: {id: string}}): Promise<string>;
-    unlike(params: {comment: {id: string}}): Promise<string>;
-    report(params: {comment: {id: string}}): Promise<string>;
-    replies(params: {commentId: string; afterReplyId?: string; limit?: number | 'all'}): Promise<{comments: Comment[]; meta: {pagination: any}}>;
-    getMember(params: {postId: string}): Promise<{member: Member} | null>;
+export type MemberApi = CommentsApi & {
     updateMember(data: {name?: string; expertise?: string}): Promise<Member | null>;
 };
 
@@ -40,17 +28,6 @@ export type AdminActions = {
 };
 
 const ALLOWED_MODERATORS = ['Owner', 'Administrator', 'Super Editor'];
-
-function createPublicApi(commentsApi: CommentsApi): PublicApi {
-    return commentsApi;
-}
-
-function createMemberApi(commentsApi: CommentsApi, api: GhostApi): MemberApi {
-    return {
-        ...commentsApi,
-        updateMember: data => api.member.update(data)
-    };
-}
 
 type CommentApiContextType = {
     publicApi: PublicApi;
@@ -88,8 +65,8 @@ export function CommentApiProvider({children, api, adminUrl, postId}: CommentApi
     const [member, setMember] = useState<Member | null>(null);
     const [memberLoaded, setMemberLoaded] = useState(false);
 
-    const publicApi = useMemo(() => createPublicApi(api.comments({credentials: 'omit'})), [api]);
-    const memberApi = useMemo(() => createMemberApi(api.comments({credentials: 'same-origin'}), api), [api]);
+    const publicApi: PublicApi = useMemo(() => api.comments({credentials: 'omit'}), [api]);
+    const memberApi: MemberApi = useMemo(() => ({...api.comments({credentials: 'same-origin'}), updateMember: api.member.update}), [api]);
 
     // Step 1: Fetch site settings (labs, support email) — non-blocking
     useEffect(() => {
@@ -111,9 +88,9 @@ export function CommentApiProvider({children, api, adminUrl, postId}: CommentApi
                 if (data) {
                     setMember(data.member);
                 }
-                setMemberLoaded(true);
             })
-            .catch(() => {
+            .catch(() => {})
+            .finally(() => {
                 setMemberLoaded(true);
             });
     }, [memberApi, postId]);

--- a/apps/comments-ui/src/components/comment-api-provider.tsx
+++ b/apps/comments-ui/src/components/comment-api-provider.tsx
@@ -1,7 +1,7 @@
 import AuthFrame from '../auth-frame';
 import React, {createContext, useContext, useEffect, useMemo, useState} from 'react';
 import {AddComment, Comment, LabsContextType, Member} from '../app-context';
-import {AdminApi, setupAdminAPI} from '../utils/admin-api';
+import {setupAdminAPI} from '../utils/admin-api';
 import {GhostApi} from '../utils/api';
 
 async function checkHasAdminSession(adminUrl: string): Promise<boolean> {
@@ -16,7 +16,7 @@ async function checkHasAdminSession(adminUrl: string): Promise<boolean> {
     }
 }
 
-type BaseCommentApi = {
+export type CommentApi = {
     browse(params: {page: number; postId: string; order?: string}): Promise<{comments: Comment[]; meta: {pagination: any}}>;
     replies(params: {commentId: string; afterReplyId?: string; limit?: number}): Promise<{comments: Comment[]; meta: {pagination: any}}>;
     read(commentId: string): Promise<{comments: Comment[]}>;
@@ -31,39 +31,15 @@ type BaseCommentApi = {
     updateMember(data: {name?: string; expertise?: string}): Promise<Member | null>;
 };
 
-export type MemberCommentApi = BaseCommentApi & {isAdmin: false};
-
-export type AdminCommentApi = BaseCommentApi & {
-    isAdmin: true;
+export type AdminActions = {
     hideComment(id: string): Promise<any>;
     showComment(params: {id: string}): Promise<any>;
 };
 
-export type CommentApi = MemberCommentApi | AdminCommentApi;
-
 const ALLOWED_MODERATORS = ['Owner', 'Administrator', 'Super Editor'];
 
-function createCommentApi(api: GhostApi, adminApi: AdminApi | null, memberUuid?: string): CommentApi {
-    if (adminApi) {
-        return {
-            isAdmin: true,
-            browse: p => adminApi.browse({...p, memberUuid}),
-            replies: p => adminApi.replies({...p, memberUuid}),
-            read: id => adminApi.read({commentId: id, memberUuid}),
-            count: p => api.comments.count(p),
-            add: p => api.comments.add(p),
-            edit: p => api.comments.edit(p),
-            like: p => api.comments.like(p),
-            unlike: p => api.comments.unlike(p),
-            report: p => api.comments.report(p),
-            updateMember: data => api.member.update(data),
-            hideComment: id => adminApi.hideComment(id),
-            showComment: p => adminApi.showComment(p)
-        };
-    }
-
+function createCommentApi(api: GhostApi): CommentApi {
     return {
-        isAdmin: false,
         browse: p => api.comments.browse(p),
         replies: p => api.comments.replies(p),
         read: id => api.comments.read(id),
@@ -92,6 +68,8 @@ export type MemberOverlay = {
 
 type CommentApiContextType = {
     commentApi: CommentApi;
+    isAdmin: boolean;
+    adminActions: AdminActions | null;
     member: Member | null;
     labs: LabsContextType;
     supportEmail: string | null;
@@ -121,7 +99,7 @@ export function CommentApiProvider({children, api, adminUrl, postId}: CommentApi
     const [labs, setLabs] = useState<LabsContextType>({});
     const [supportEmail, setSupportEmail] = useState<string | null>(null);
     const [settingsLoaded, setSettingsLoaded] = useState(false);
-    const [adminApi, setAdminApi] = useState<AdminApi | null | undefined>(adminUrl ? undefined : null);
+    const [adminActions, setAdminActions] = useState<AdminActions | null>(null);
     const [hasAdminSession, setHasSession] = useState<boolean | undefined>(adminUrl ? undefined : false);
     const [memberOverlay, setMemberOverlay] = useState<MemberOverlay | null>(null);
     const [memberOverlayLoaded, setMemberOverlayLoaded] = useState(false);
@@ -160,9 +138,6 @@ export function CommentApiProvider({children, api, adminUrl, postId}: CommentApi
         }
         checkHasAdminSession(adminUrl).then((result) => {
             setHasSession(result);
-            if (!result) {
-                setAdminApi(null);
-            }
         });
     }, [adminUrl]);
 
@@ -172,18 +147,21 @@ export function CommentApiProvider({children, api, adminUrl, postId}: CommentApi
             const newAdminApi = setupAdminAPI({adminUrl: adminUrl!});
             const admin = await newAdminApi.getUser();
             const isAllowed = admin?.roles?.some((role: {name: string}) => ALLOWED_MODERATORS.includes(role.name));
-            setAdminApi(isAllowed ? newAdminApi : null);
+            if (isAllowed) {
+                setAdminActions({
+                    hideComment: id => newAdminApi.hideComment(id),
+                    showComment: p => newAdminApi.showComment(p)
+                });
+            }
         } catch (e) {
             // eslint-disable-next-line no-console
             console.warn(`[Comments] Admin auth failed:`, e);
-            setAdminApi(null);
         }
     };
 
     const onAdminAuthError = () => {
         // eslint-disable-next-line no-console
         console.warn(`[Comments] Admin auth frame failed to load`);
-        setAdminApi(null);
     };
 
     // Build member from overlay data for the context
@@ -201,15 +179,18 @@ export function CommentApiProvider({children, api, adminUrl, postId}: CommentApi
         };
     }, [memberOverlay]);
 
-    // CommentApi: starts as public, upgrades to admin when admin auth resolves
+    // CommentApi: always uses public API for reads
     const commentApi = useMemo(() => {
-        const resolvedAdminApi = adminApi !== undefined ? adminApi : null;
-        return createCommentApi(api, resolvedAdminApi, member?.uuid);
-    }, [api, adminApi, member?.uuid]);
+        return createCommentApi(api);
+    }, [api]);
+
+    const isAdmin = !!adminActions;
 
     const contextValue = useMemo(() => {
         return {
             commentApi,
+            isAdmin,
+            adminActions,
             member,
             labs,
             supportEmail,
@@ -217,7 +198,7 @@ export function CommentApiProvider({children, api, adminUrl, postId}: CommentApi
             memberOverlayLoaded,
             settingsLoaded
         };
-    }, [commentApi, member, labs, supportEmail, memberOverlay, memberOverlayLoaded, settingsLoaded]);
+    }, [commentApi, isAdmin, adminActions, member, labs, supportEmail, memberOverlay, memberOverlayLoaded, settingsLoaded]);
 
     return (
         <>

--- a/apps/comments-ui/src/utils/api.ts
+++ b/apps/comments-ui/src/utils/api.ts
@@ -21,8 +21,8 @@ function setupGhostApi({siteUrl = window.location.origin, apiUrl, apiKey}: {site
         return '';
     }
 
-    function makeRequest({url, method = 'GET', headers = {}, credentials = undefined, body = undefined}: {url: string, method?: string, headers?: any, credentials?: any, body?: any}) {
-        const options = {
+    function makeRequest({url, method = 'GET', headers = {}, credentials = undefined, body = undefined, errorMessage = 'Request failed'}: {url: string, method?: string, headers?: any, credentials?: any, body?: any, errorMessage?: string}) {
+        return fetch(url, {
             method,
             headers: {
                 'Content-Type': 'application/json',
@@ -30,8 +30,15 @@ function setupGhostApi({siteUrl = window.location.origin, apiUrl, apiKey}: {site
             },
             credentials,
             body
-        };
-        return fetch(url, options);
+        }).then((res) => {
+            if (res.ok) {
+                if (res.status === 204) {
+                    return null;
+                }
+                return res.json();
+            }
+            throw new Error(errorMessage);
+        });
     }
 
     // To fix pagination when we create new comments (or people post comments
@@ -42,28 +49,15 @@ function setupGhostApi({siteUrl = window.location.origin, apiUrl, apiKey}: {site
         site: {
             settings() {
                 const url = contentEndpointFor({resource: 'settings'});
-                return makeRequest({url}).then(function (res) {
-                    if (res.ok) {
-                        return res.json();
-                    } else {
-                        throw new Error('Failed to fetch site data');
-                    }
-                });
+                return makeRequest({url, errorMessage: 'Failed to fetch site data'});
             }
         },
         member: {
             update({name, expertise}: {name?: string, expertise?: string}) {
                 const url = endpointFor({type: 'members', resource: 'member'});
                 return makeRequest({
-                    url,
-                    method: 'PUT',
-                    credentials: 'same-origin',
+                    url, method: 'PUT', credentials: 'same-origin',
                     body: JSON.stringify({name, expertise})
-                }).then(function (res) {
-                    if (!res.ok) {
-                        return null;
-                    }
-                    return res.json();
                 });
             }
         },
@@ -72,18 +66,8 @@ function setupGhostApi({siteUrl = window.location.origin, apiUrl, apiKey}: {site
                 async count({postId}: {postId: string | null}) {
                     const params = postId ? `?ids=${postId}` : '';
                     const url = endpointFor({type: 'members', resource: `comments/counts`, params});
-                    const response = await makeRequest({
-                        url,
-                        credentials
-                    });
-
-                    const json = await response.json();
-
-                    if (postId) {
-                        return json[postId];
-                    }
-
-                    return json;
+                    const json = await makeRequest({url, credentials, errorMessage: 'Failed to fetch comment counts'});
+                    return postId ? json[postId] : json;
                 },
                 browse({page, postId, order}: {page: number, postId: string, order?: string}) {
                     let filter = null;
@@ -102,16 +86,7 @@ function setupGhostApi({siteUrl = window.location.origin, apiUrl, apiKey}: {site
                         params.set('order', order);
                     }
                     const url = endpointFor({type: 'members', resource: `comments/post/${postId}`, params: `?${params.toString()}`});
-                    const response = makeRequest({
-                        url,
-                        credentials
-                    }).then(function (res) {
-                        if (res.ok) {
-                            return res.json();
-                        } else {
-                            throw new Error('Failed to fetch comments');
-                        }
-                    });
+                    const response = makeRequest({url, credentials, errorMessage: 'Failed to fetch comments'});
 
                     if (!firstCommentCreatedAt) {
                         response.then((body) => {
@@ -150,112 +125,47 @@ function setupGhostApi({siteUrl = window.location.origin, apiUrl, apiKey}: {site
                     }
 
                     const url = endpointFor({type: 'members', resource: `comments/${commentId}/replies`, params: `?${params.toString()}`});
-                    const res = await makeRequest({
-                        url,
-                        credentials
-                    });
-                    if (res.ok) {
-                        return res.json();
-                    } else {
-                        throw new Error('Failed to fetch replies');
-                    }
+                    return makeRequest({url, credentials, errorMessage: 'Failed to fetch replies'});
                 },
                 async getMember({postId}: {postId: string}) {
                     const url = endpointFor({type: 'members', resource: `comments/post/${postId}/member`});
-                    const res = await makeRequest({
-                        url,
-                        credentials
-                    });
-                    if (!res.ok || res.status === 204) {
-                        return null;
-                    }
-                    return res.json();
+                    return makeRequest({url, credentials});
                 },
                 read(commentId: string) {
                     const url = endpointFor({type: 'members', resource: `comments/${commentId}`});
-                    return makeRequest({
-                        url,
-                        credentials
-                    }).then(function (res) {
-                        if (res.ok) {
-                            return res.json();
-                        } else {
-                            throw new Error('Failed to read comment');
-                        }
-                    });
+                    return makeRequest({url, credentials, errorMessage: 'Failed to read comment'});
                 },
                 add({comment}: {comment: AddComment}) {
                     const url = endpointFor({type: 'members', resource: 'comments'});
                     return makeRequest({
-                        url,
-                        method: 'POST',
-                        credentials,
-                        body: JSON.stringify({comments: [comment]})
-                    }).then(function (res) {
-                        if (res.ok) {
-                            return res.json();
-                        } else {
-                            throw new Error('Failed to add comment');
-                        }
+                        url, method: 'POST', credentials,
+                        body: JSON.stringify({comments: [comment]}),
+                        errorMessage: 'Failed to add comment'
                     });
                 },
                 edit({comment}: {comment: Partial<Comment> & {id: string}}) {
                     const url = endpointFor({type: 'members', resource: `comments/${comment.id}`});
                     return makeRequest({
-                        url,
-                        method: 'PUT',
-                        credentials,
-                        body: JSON.stringify({comments: [comment]})
-                    }).then(function (res) {
-                        if (res.ok) {
-                            return res.json();
-                        } else {
-                            throw new Error('Failed to edit comment');
-                        }
+                        url, method: 'PUT', credentials,
+                        body: JSON.stringify({comments: [comment]}),
+                        errorMessage: 'Failed to edit comment'
                     });
                 },
                 like({comment}: {comment: {id: string}}) {
                     const url = endpointFor({type: 'members', resource: `comments/${comment.id}/like`});
-                    return makeRequest({
-                        url,
-                        method: 'POST',
-                        credentials
-                    }).then(function (res) {
-                        if (res.ok) {
-                            return 'Success';
-                        } else {
-                            throw new Error('Failed to like comment');
-                        }
-                    });
+                    return makeRequest({url, method: 'POST', credentials, errorMessage: 'Failed to like comment'});
                 },
                 unlike({comment}: {comment: {id: string}}) {
                     const url = endpointFor({type: 'members', resource: `comments/${comment.id}/like`});
                     return makeRequest({
-                        url,
-                        method: 'DELETE',
-                        credentials,
-                        body: JSON.stringify({comments: [comment]})
-                    }).then(function (res) {
-                        if (res.ok) {
-                            return 'Success';
-                        } else {
-                            throw new Error('Failed to unlike comment');
-                        }
+                        url, method: 'DELETE', credentials,
+                        body: JSON.stringify({comments: [comment]}),
+                        errorMessage: 'Failed to unlike comment'
                     });
                 },
                 report({comment}: {comment: {id: string}}) {
                     const url = endpointFor({type: 'members', resource: `comments/${comment.id}/report`});
-                    return makeRequest({
-                        url,
-                        method: 'POST',
-                        credentials
-                    }).then(function (res) {
-                        if (res.ok) {
-                            return 'Success';
-                        } else {
-                            throw new Error('Failed to report comment');
-                        }
-                    });
+                    return makeRequest({url, method: 'POST', credentials, errorMessage: 'Failed to report comment'});
                 }
             };
             return commentsApi;

--- a/apps/comments-ui/src/utils/api.ts
+++ b/apps/comments-ui/src/utils/api.ts
@@ -24,7 +24,10 @@ function setupGhostApi({siteUrl = window.location.origin, apiUrl, apiKey}: {site
     function makeRequest({url, method = 'GET', headers = {}, credentials = undefined, body = undefined}: {url: string, method?: string, headers?: any, credentials?: any, body?: any}) {
         const options = {
             method,
-            headers,
+            headers: {
+                'Content-Type': 'application/json',
+                ...headers
+            },
             credentials,
             body
         };
@@ -39,13 +42,7 @@ function setupGhostApi({siteUrl = window.location.origin, apiUrl, apiKey}: {site
         site: {
             settings() {
                 const url = contentEndpointFor({resource: 'settings'});
-                return makeRequest({
-                    url,
-                    method: 'GET',
-                    headers: {
-                        'Content-Type': 'application/json'
-                    }
-                }).then(function (res) {
+                return makeRequest({url}).then(function (res) {
                     if (res.ok) {
                         return res.json();
                     } else {
@@ -57,19 +54,11 @@ function setupGhostApi({siteUrl = window.location.origin, apiUrl, apiKey}: {site
         member: {
             update({name, expertise}: {name?: string, expertise?: string}) {
                 const url = endpointFor({type: 'members', resource: 'member'});
-                const body = {
-                    name,
-                    expertise
-                };
-
                 return makeRequest({
                     url,
                     method: 'PUT',
-                    headers: {
-                        'Content-Type': 'application/json'
-                    },
                     credentials: 'same-origin',
-                    body: JSON.stringify(body)
+                    body: JSON.stringify({name, expertise})
                 }).then(function (res) {
                     if (!res.ok) {
                         return null;
@@ -78,236 +67,198 @@ function setupGhostApi({siteUrl = window.location.origin, apiUrl, apiKey}: {site
                 });
             }
         },
-        comments: {
-            async count({postId}: {postId: string | null}) {
-                const params = postId ? `?ids=${postId}` : '';
-                const url = endpointFor({type: 'members', resource: `comments/counts`, params});
-                const response = await makeRequest({
-                    url,
-                    method: 'GET',
-                    headers: {
-                        'Content-Type': 'application/json'
-                    },
-                    credentials: 'omit'
-                });
+        comments({credentials = 'omit'}: {credentials?: string} = {}) {
+            const commentsApi = {
+                async count({postId}: {postId: string | null}) {
+                    const params = postId ? `?ids=${postId}` : '';
+                    const url = endpointFor({type: 'members', resource: `comments/counts`, params});
+                    const response = await makeRequest({
+                        url,
+                        credentials
+                    });
 
-                const json = await response.json();
+                    const json = await response.json();
 
-                if (postId) {
-                    return json[postId];
-                }
+                    if (postId) {
+                        return json[postId];
+                    }
 
-                return json;
-            },
-            browse({page, postId, order}: {page: number, postId: string, order?: string}) {
-                let filter = null;
-                if (firstCommentCreatedAt && !order) {
-                    filter = `created_at:<=${firstCommentCreatedAt}`;
-                }
+                    return json;
+                },
+                browse({page, postId, order}: {page: number, postId: string, order?: string}) {
+                    let filter = null;
+                    if (firstCommentCreatedAt && !order) {
+                        filter = `created_at:<=${firstCommentCreatedAt}`;
+                    }
 
-                const params = new URLSearchParams();
+                    const params = new URLSearchParams();
 
-                params.set('limit', '20');
-                if (filter) {
-                    params.set('filter', filter);
-                }
-                params.set('page', page.toString());
-                if (order) {
-                    params.set('order', order);
-                }
-                const url = endpointFor({type: 'members', resource: `comments/post/${postId}`, params: `?${params.toString()}`});
-                const response = makeRequest({
-                    url,
-                    method: 'GET',
-                    headers: {
-                        'Content-Type': 'application/json'
-                    },
-                    credentials: 'omit'
-                }).then(function (res) {
+                    params.set('limit', '20');
+                    if (filter) {
+                        params.set('filter', filter);
+                    }
+                    params.set('page', page.toString());
+                    if (order) {
+                        params.set('order', order);
+                    }
+                    const url = endpointFor({type: 'members', resource: `comments/post/${postId}`, params: `?${params.toString()}`});
+                    const response = makeRequest({
+                        url,
+                        credentials
+                    }).then(function (res) {
+                        if (res.ok) {
+                            return res.json();
+                        } else {
+                            throw new Error('Failed to fetch comments');
+                        }
+                    });
+
+                    if (!firstCommentCreatedAt) {
+                        response.then((body) => {
+                            const firstComment = body.comments[0];
+                            if (firstComment) {
+                                firstCommentCreatedAt = firstComment.created_at;
+                            }
+                        });
+                    }
+
+                    return response;
+                },
+                async replies({commentId, afterReplyId, limit}: {commentId: string; afterReplyId?: string; limit?: number | 'all'}) {
+                    if (limit === 'all') {
+                        const all: Comment[] = [];
+                        let cursor: string | undefined = afterReplyId;
+                        let hasMore = true;
+
+                        while (hasMore) {
+                            const data = await commentsApi.replies({commentId, afterReplyId: cursor, limit: 100});
+                            all.push(...data.comments);
+                            hasMore = !!data.meta?.pagination?.next && data.comments.length > 0;
+                            if (data.comments.length > 0) {
+                                cursor = data.comments[data.comments.length - 1]?.id;
+                            }
+                        }
+
+                        return {comments: all, meta: {pagination: {next: false}}};
+                    }
+
+                    const params = new URLSearchParams();
+                    params.set('limit', (limit ?? 5).toString());
+
+                    if (afterReplyId) {
+                        params.set('filter', `id:>'${afterReplyId}'`);
+                    }
+
+                    const url = endpointFor({type: 'members', resource: `comments/${commentId}/replies`, params: `?${params.toString()}`});
+                    const res = await makeRequest({
+                        url,
+                        credentials
+                    });
                     if (res.ok) {
                         return res.json();
                     } else {
-                        throw new Error('Failed to fetch comments');
+                        throw new Error('Failed to fetch replies');
                     }
-                });
-
-                if (!firstCommentCreatedAt) {
-                    response.then((body) => {
-                        const firstComment = body.comments[0];
-                        if (firstComment) {
-                            firstCommentCreatedAt = firstComment.created_at;
+                },
+                async getMember({postId}: {postId: string}) {
+                    const url = endpointFor({type: 'members', resource: `comments/post/${postId}/member`});
+                    const res = await makeRequest({
+                        url,
+                        credentials
+                    });
+                    if (!res.ok || res.status === 204) {
+                        return null;
+                    }
+                    return res.json();
+                },
+                read(commentId: string) {
+                    const url = endpointFor({type: 'members', resource: `comments/${commentId}`});
+                    return makeRequest({
+                        url,
+                        credentials
+                    }).then(function (res) {
+                        if (res.ok) {
+                            return res.json();
+                        } else {
+                            throw new Error('Failed to read comment');
+                        }
+                    });
+                },
+                add({comment}: {comment: AddComment}) {
+                    const url = endpointFor({type: 'members', resource: 'comments'});
+                    return makeRequest({
+                        url,
+                        method: 'POST',
+                        credentials,
+                        body: JSON.stringify({comments: [comment]})
+                    }).then(function (res) {
+                        if (res.ok) {
+                            return res.json();
+                        } else {
+                            throw new Error('Failed to add comment');
+                        }
+                    });
+                },
+                edit({comment}: {comment: Partial<Comment> & {id: string}}) {
+                    const url = endpointFor({type: 'members', resource: `comments/${comment.id}`});
+                    return makeRequest({
+                        url,
+                        method: 'PUT',
+                        credentials,
+                        body: JSON.stringify({comments: [comment]})
+                    }).then(function (res) {
+                        if (res.ok) {
+                            return res.json();
+                        } else {
+                            throw new Error('Failed to edit comment');
+                        }
+                    });
+                },
+                like({comment}: {comment: {id: string}}) {
+                    const url = endpointFor({type: 'members', resource: `comments/${comment.id}/like`});
+                    return makeRequest({
+                        url,
+                        method: 'POST',
+                        credentials
+                    }).then(function (res) {
+                        if (res.ok) {
+                            return 'Success';
+                        } else {
+                            throw new Error('Failed to like comment');
+                        }
+                    });
+                },
+                unlike({comment}: {comment: {id: string}}) {
+                    const url = endpointFor({type: 'members', resource: `comments/${comment.id}/like`});
+                    return makeRequest({
+                        url,
+                        method: 'DELETE',
+                        credentials,
+                        body: JSON.stringify({comments: [comment]})
+                    }).then(function (res) {
+                        if (res.ok) {
+                            return 'Success';
+                        } else {
+                            throw new Error('Failed to unlike comment');
+                        }
+                    });
+                },
+                report({comment}: {comment: {id: string}}) {
+                    const url = endpointFor({type: 'members', resource: `comments/${comment.id}/report`});
+                    return makeRequest({
+                        url,
+                        method: 'POST',
+                        credentials
+                    }).then(function (res) {
+                        if (res.ok) {
+                            return 'Success';
+                        } else {
+                            throw new Error('Failed to report comment');
                         }
                     });
                 }
-
-                return response;
-            },
-            async replies({commentId, afterReplyId, limit, credentials = 'omit'}: {commentId: string; afterReplyId?: string; limit?: number | 'all'; credentials?: string}) {
-                if (limit === 'all') {
-                    const all: Comment[] = [];
-                    let cursor: string | undefined = afterReplyId;
-                    let hasMore = true;
-
-                    while (hasMore) {
-                        const data = await this.replies({commentId, afterReplyId: cursor, limit: 100, credentials});
-                        all.push(...data.comments);
-                        hasMore = !!data.meta?.pagination?.next && data.comments.length > 0;
-                        if (data.comments.length > 0) {
-                            cursor = data.comments[data.comments.length - 1]?.id;
-                        }
-                    }
-
-                    return {comments: all, meta: {pagination: {next: false}}};
-                }
-
-                const params = new URLSearchParams();
-                params.set('limit', (limit ?? 5).toString());
-
-                if (afterReplyId) {
-                    params.set('filter', `id:>'${afterReplyId}'`);
-                }
-
-                const url = endpointFor({type: 'members', resource: `comments/${commentId}/replies`, params: `?${params.toString()}`});
-                const res = await makeRequest({
-                    url,
-                    method: 'GET',
-                    headers: {
-                        'Content-Type': 'application/json'
-                    },
-                    credentials
-                });
-                if (res.ok) {
-                    return res.json();
-                } else {
-                    throw new Error('Failed to fetch replies');
-                }
-            },
-            async getMember({postId}: {postId: string}) {
-                const url = endpointFor({type: 'members', resource: `comments/post/${postId}/member`});
-                const res = await makeRequest({
-                    url,
-                    method: 'GET',
-                    headers: {
-                        'Content-Type': 'application/json'
-                    },
-                    credentials: 'same-origin'
-                });
-                if (!res.ok || res.status === 204) {
-                    return null;
-                }
-                return res.json();
-            },
-            add({comment}: {comment: AddComment}) {
-                const body = {
-                    comments: [comment]
-                };
-                const url = endpointFor({type: 'members', resource: 'comments'});
-                return makeRequest({
-                    url,
-                    method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json'
-                    },
-                    credentials: 'same-origin',
-                    body: JSON.stringify(body)
-                }).then(function (res) {
-                    if (res.ok) {
-                        return res.json();
-                    } else {
-                        throw new Error('Failed to add comment');
-                    }
-                });
-            },
-            edit({comment}: {comment: Partial<Comment> & {id: string}}) {
-                const body = {
-                    comments: [comment]
-                };
-                const url = endpointFor({type: 'members', resource: `comments/${comment.id}`});
-                return makeRequest({
-                    url,
-                    method: 'PUT',
-                    headers: {
-                        'Content-Type': 'application/json'
-                    },
-                    credentials: 'same-origin',
-                    body: JSON.stringify(body)
-                }).then(function (res) {
-                    if (res.ok) {
-                        return res.json();
-                    } else {
-                        throw new Error('Failed to edit comment');
-                    }
-                });
-            },
-            read(commentId: string) {
-                const url = endpointFor({type: 'members', resource: `comments/${commentId}`});
-                return makeRequest({
-                    url,
-                    method: 'GET',
-                    credentials: 'omit'
-                }).then(function (res) {
-                    if (res.ok) {
-                        return res.json();
-                    } else {
-                        throw new Error('Failed to read comment');
-                    }
-                });
-            },
-            like({comment}: {comment: {id: string}}) {
-                const url = endpointFor({type: 'members', resource: `comments/${comment.id}/like`});
-                return makeRequest({
-                    url,
-                    method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json'
-                    },
-                    credentials: 'same-origin'
-                }).then(function (res) {
-                    if (res.ok) {
-                        return 'Success';
-                    } else {
-                        throw new Error('Failed to like comment');
-                    }
-                });
-            },
-            unlike({comment}: {comment: {id: string}}) {
-                const body = {
-                    comments: [comment]
-                };
-                const url = endpointFor({type: 'members', resource: `comments/${comment.id}/like`});
-                return makeRequest({
-                    url,
-                    method: 'DELETE',
-                    headers: {
-                        'Content-Type': 'application/json'
-                    },
-                    credentials: 'same-origin',
-                    body: JSON.stringify(body)
-                }).then(function (res) {
-                    if (res.ok) {
-                        return 'Success';
-                    } else {
-                        throw new Error('Failed to unlike comment');
-                    }
-                });
-            },
-            report({comment}: {comment: {id: string}}) {
-                const url = endpointFor({type: 'members', resource: `comments/${comment.id}/report`});
-                return makeRequest({
-                    url,
-                    method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json'
-                    },
-                    credentials: 'same-origin'
-                }).then(function (res) {
-                    if (res.ok) {
-                        return 'Success';
-                    } else {
-                        throw new Error('Failed to report comment');
-                    }
-                });
-            }
+            };
+            return commentsApi;
         },
         init: (() => {}) as () => Promise<{ labs: any; supportEmail: string | null}>
     };
@@ -334,4 +285,5 @@ function setupGhostApi({siteUrl = window.location.origin, apiUrl, apiKey}: {site
 
 export default setupGhostApi;
 export type GhostApi = ReturnType<typeof setupGhostApi>;
+export type CommentsApi = ReturnType<GhostApi['comments']>;
 export type LabsType = LabsContextType;

--- a/apps/comments-ui/src/utils/api.ts
+++ b/apps/comments-ui/src/utils/api.ts
@@ -55,32 +55,6 @@ function setupGhostApi({siteUrl = window.location.origin, apiUrl, apiKey}: {site
             }
         },
         member: {
-            identity() {
-                const url = endpointFor({type: 'members', resource: 'session'});
-                return makeRequest({
-                    url,
-                    credentials: 'same-origin'
-                }).then(function (res) {
-                    if (!res.ok || res.status === 204) {
-                        return null;
-                    }
-                    return res.text();
-                });
-            },
-
-            sessionData() {
-                const url = endpointFor({type: 'members', resource: 'member'});
-                return makeRequest({
-                    url,
-                    credentials: 'same-origin'
-                }).then(function (res) {
-                    if (!res.ok || res.status === 204) {
-                        return null;
-                    }
-                    return res.json();
-                });
-            },
-
             update({name, expertise}: {name?: string, expertise?: string}) {
                 const url = endpointFor({type: 'members', resource: 'member'});
                 const body = {
@@ -103,7 +77,6 @@ function setupGhostApi({siteUrl = window.location.origin, apiUrl, apiKey}: {site
                     return res.json();
                 });
             }
-
         },
         comments: {
             async count({postId}: {postId: string | null}) {
@@ -114,7 +87,8 @@ function setupGhostApi({siteUrl = window.location.origin, apiUrl, apiKey}: {site
                     method: 'GET',
                     headers: {
                         'Content-Type': 'application/json'
-                    }
+                    },
+                    credentials: 'omit'
                 });
 
                 const json = await response.json();
@@ -168,14 +142,14 @@ function setupGhostApi({siteUrl = window.location.origin, apiUrl, apiKey}: {site
 
                 return response;
             },
-            async replies({commentId, afterReplyId, limit}: {commentId: string; afterReplyId?: string; limit?: number | 'all'}) {
+            async replies({commentId, afterReplyId, limit, credentials = 'omit'}: {commentId: string; afterReplyId?: string; limit?: number | 'all'; credentials?: string}) {
                 if (limit === 'all') {
                     const all: Comment[] = [];
                     let cursor: string | undefined = afterReplyId;
                     let hasMore = true;
 
                     while (hasMore) {
-                        const data = await this.replies({commentId, afterReplyId: cursor, limit: 100});
+                        const data = await this.replies({commentId, afterReplyId: cursor, limit: 100, credentials});
                         all.push(...data.comments);
                         hasMore = !!data.meta?.pagination?.next && data.comments.length > 0;
                         if (data.comments.length > 0) {
@@ -200,7 +174,7 @@ function setupGhostApi({siteUrl = window.location.origin, apiUrl, apiKey}: {site
                     headers: {
                         'Content-Type': 'application/json'
                     },
-                    credentials: 'omit'
+                    credentials
                 });
                 if (res.ok) {
                     return res.json();
@@ -208,7 +182,7 @@ function setupGhostApi({siteUrl = window.location.origin, apiUrl, apiKey}: {site
                     throw new Error('Failed to fetch replies');
                 }
             },
-            async memberInfo({postId}: {postId: string}) {
+            async getMember({postId}: {postId: string}) {
                 const url = endpointFor({type: 'members', resource: `comments/post/${postId}/member`});
                 const res = await makeRequest({
                     url,
@@ -234,6 +208,7 @@ function setupGhostApi({siteUrl = window.location.origin, apiUrl, apiKey}: {site
                     headers: {
                         'Content-Type': 'application/json'
                     },
+                    credentials: 'same-origin',
                     body: JSON.stringify(body)
                 }).then(function (res) {
                     if (res.ok) {
@@ -254,6 +229,7 @@ function setupGhostApi({siteUrl = window.location.origin, apiUrl, apiKey}: {site
                     headers: {
                         'Content-Type': 'application/json'
                     },
+                    credentials: 'same-origin',
                     body: JSON.stringify(body)
                 }).then(function (res) {
                     if (res.ok) {
@@ -284,7 +260,8 @@ function setupGhostApi({siteUrl = window.location.origin, apiUrl, apiKey}: {site
                     method: 'POST',
                     headers: {
                         'Content-Type': 'application/json'
-                    }
+                    },
+                    credentials: 'same-origin'
                 }).then(function (res) {
                     if (res.ok) {
                         return 'Success';
@@ -304,6 +281,7 @@ function setupGhostApi({siteUrl = window.location.origin, apiUrl, apiKey}: {site
                     headers: {
                         'Content-Type': 'application/json'
                     },
+                    credentials: 'same-origin',
                     body: JSON.stringify(body)
                 }).then(function (res) {
                     if (res.ok) {
@@ -320,7 +298,8 @@ function setupGhostApi({siteUrl = window.location.origin, apiUrl, apiKey}: {site
                     method: 'POST',
                     headers: {
                         'Content-Type': 'application/json'
-                    }
+                    },
+                    credentials: 'same-origin'
                 }).then(function (res) {
                     if (res.ok) {
                         return 'Success';

--- a/apps/comments-ui/src/utils/api.ts
+++ b/apps/comments-ui/src/utils/api.ts
@@ -114,8 +114,7 @@ function setupGhostApi({siteUrl = window.location.origin, apiUrl, apiKey}: {site
                     method: 'GET',
                     headers: {
                         'Content-Type': 'application/json'
-                    },
-                    credentials: 'same-origin'
+                    }
                 });
 
                 const json = await response.json();
@@ -149,7 +148,7 @@ function setupGhostApi({siteUrl = window.location.origin, apiUrl, apiKey}: {site
                     headers: {
                         'Content-Type': 'application/json'
                     },
-                    credentials: 'same-origin'
+                    credentials: 'omit'
                 }).then(function (res) {
                     if (res.ok) {
                         return res.json();
@@ -201,13 +200,28 @@ function setupGhostApi({siteUrl = window.location.origin, apiUrl, apiKey}: {site
                     headers: {
                         'Content-Type': 'application/json'
                     },
-                    credentials: 'same-origin'
+                    credentials: 'omit'
                 });
                 if (res.ok) {
                     return res.json();
                 } else {
                     throw new Error('Failed to fetch replies');
                 }
+            },
+            async memberInfo({postId}: {postId: string}) {
+                const url = endpointFor({type: 'members', resource: `comments/post/${postId}/member`});
+                const res = await makeRequest({
+                    url,
+                    method: 'GET',
+                    headers: {
+                        'Content-Type': 'application/json'
+                    },
+                    credentials: 'same-origin'
+                });
+                if (!res.ok || res.status === 204) {
+                    return null;
+                }
+                return res.json();
             },
             add({comment}: {comment: AddComment}) {
                 const body = {
@@ -254,7 +268,7 @@ function setupGhostApi({siteUrl = window.location.origin, apiUrl, apiKey}: {site
                 return makeRequest({
                     url,
                     method: 'GET',
-                    credentials: 'same-origin'
+                    credentials: 'omit'
                 }).then(function (res) {
                     if (res.ok) {
                         return res.json();
@@ -316,14 +330,10 @@ function setupGhostApi({siteUrl = window.location.origin, apiUrl, apiKey}: {site
                 });
             }
         },
-        init: (() => {}) as () => Promise<{ member: any; labs: any; supportEmail: string | null}>
+        init: (() => {}) as () => Promise<{ labs: any; supportEmail: string | null}>
     };
 
     api.init = async () => {
-        const [member] = await Promise.all([
-            api.member.sessionData()
-        ]);
-
         let labs = {};
         let supportEmail: string | null = null;
 
@@ -337,7 +347,7 @@ function setupGhostApi({siteUrl = window.location.origin, apiUrl, apiKey}: {site
             labs = {};
         }
 
-        return {member, labs, supportEmail};
+        return {labs, supportEmail};
     };
 
     return api;

--- a/apps/comments-ui/test/e2e/admin-moderation.test.ts
+++ b/apps/comments-ui/test/e2e/admin-moderation.test.ts
@@ -1,4 +1,3 @@
-import sinon from 'sinon';
 import {MOCKED_SITE_URL, MockedApi, initialize, mockAdminAuthFrame, mockAdminAuthFrame204} from '../utils/e2e';
 import {buildReply} from '../utils/fixtures';
 import {expect, test} from '@playwright/test';
@@ -45,8 +44,6 @@ test.describe('Admin moderation', async () => {
     }
 
     test('always renders the auth frame', async ({page}) => {
-        // Auth frame should render even with no comments - admin status must be
-        // resolved before fetching comments to use the correct API endpoint
         await initializeTest(page);
 
         const iframeElement = page.locator('iframe[data-frame="admin-auth"]');
@@ -76,7 +73,7 @@ test.describe('Admin moderation', async () => {
         const {frame} = await initializeTest(page, {member: null});
 
         const moreButtons = frame.getByTestId('more-button');
-        await expect(moreButtons).toHaveCount(1);
+        await expect(moreButtons.nth(0)).toBeVisible();
 
         // Admin buttons should be visible
         await moreButtons.nth(0).click();
@@ -88,173 +85,11 @@ test.describe('Admin moderation', async () => {
         const {frame} = await initializeTest(page);
 
         const moreButtons = frame.getByTestId('more-button');
-        await expect(moreButtons).toHaveCount(1);
+        await expect(moreButtons.nth(0)).toBeVisible();
 
         // Admin buttons should be visible
         await moreButtons.nth(0).click();
         await expect(frame.getByTestId('hide-button')).toBeVisible();
-    });
-
-    test('member uuid are passed to admin browse api params', async ({page}) => {
-        mockedApi.addComment({html: '<p>This is comment 1</p>'});
-        const adminBrowseSpy = sinon.spy(mockedApi.adminRequestHandlers, 'browseComments');
-        const {frame} = await initializeTest(page);
-        const comments = await frame.getByTestId('comment-component');
-        await expect(comments).toHaveCount(1);
-        // Admin browse happens asynchronously after public browse + admin auth.
-        // May re-fetch when member overlay arrives with the UUID, so poll until
-        // the last call includes the expected impersonate_member_uuid.
-        await expect.poll(() => {
-            if (!adminBrowseSpy.called) {
-                return null;
-            }
-            const url = new URL(adminBrowseSpy.lastCall.args[0].request().url());
-            return url.searchParams.get('impersonate_member_uuid');
-        }).toBe('12345');
-    });
-
-    test('member uuid gets set when loading more comments', async ({page}) => {
-        // create 25 comments
-        for (let i = 0; i < 25; i++) {
-            mockedApi.addComment({html: `<p>This is comment ${i}</p>`});
-        }
-        const adminBrowseSpy = sinon.spy(mockedApi.adminRequestHandlers, 'browseComments');
-        const {frame} = await initializeTest(page);
-        // Wait for admin browse with member UUID (may take two fetches if admin
-        // auth resolves before member overlay)
-        await expect.poll(() => {
-            if (!adminBrowseSpy.called) {
-                return null;
-            }
-            const url = new URL(adminBrowseSpy.lastCall.args[0].request().url());
-            return url.searchParams.get('impersonate_member_uuid');
-        }).toBe('12345');
-        await frame.getByTestId('pagination-component').click();
-        const lastCall = adminBrowseSpy.lastCall.args[0];
-        const url = new URL(lastCall.request().url());
-        expect(url.searchParams.get('impersonate_member_uuid')).toBe('12345');
-    });
-
-    test('member uuid gets set when changing order', async ({page}) => {
-        mockedApi.addComment({
-            html: '<p>This is the oldest</p>',
-            created_at: new Date('2024-02-01T00:00:00Z')
-        });
-        mockedApi.addComment({
-            html: '<p>This is comment 2</p>',
-            created_at: new Date('2024-03-02T00:00:00Z')
-        });
-        mockedApi.addComment({
-            html: '<p>This is the newest comment</p>',
-            created_at: new Date('2024-04-03T00:00:00Z')
-        });
-
-        const adminBrowseSpy = sinon.spy(mockedApi.adminRequestHandlers, 'browseComments');
-        const {frame} = await initializeTest(page);
-        // Wait for admin browse with member UUID
-        await expect.poll(() => {
-            if (!adminBrowseSpy.called) {
-                return null;
-            }
-            const url = new URL(adminBrowseSpy.lastCall.args[0].request().url());
-            return url.searchParams.get('impersonate_member_uuid');
-        }).toBe('12345');
-
-        const sortingForm = await frame.getByTestId('comments-sorting-form');
-
-        await sortingForm.click();
-
-        const sortingDropdown = await frame.getByTestId(
-            'comments-sorting-form-dropdown'
-        );
-
-        const optionSelect = await sortingDropdown.getByText('Newest');
-        mockedApi.setDelay(100);
-        await optionSelect.click();
-        const lastCall = adminBrowseSpy.lastCall.args[0];
-        const url = new URL(lastCall.request().url());
-        expect(url.searchParams.get('impersonate_member_uuid')).toBe('12345');
-    });
-
-    test('member uuid gets set when loading more replies', async ({page}) => {
-        const allReplies = [
-            buildReply({html: '<p>This is reply 1</p>'}),
-            buildReply({html: '<p>This is reply 2</p>'}),
-            buildReply({html: '<p>This is reply 3</p>'}),
-            buildReply({html: '<p>This is reply 4</p>'}),
-            buildReply({html: '<p>This is reply 5</p>'}),
-            buildReply({html: '<p>This is reply 6</p>'})
-        ];
-
-        mockedApi.addComment({
-            html: '<p>This is comment 1</p>',
-            replies: allReplies
-        });
-
-        // Override browseComments to only return 3 replies (simulating API limit)
-        // while count.replies stays at 6, forcing a separate getReplies call
-        const originalBrowse = mockedApi.browseComments.bind(mockedApi);
-        mockedApi.browseComments = function (options) {
-            const result = originalBrowse(options);
-            result.comments = result.comments.map((c) => {
-                if (c.replies.length > 3) {
-                    return {...c, replies: c.replies.slice(0, 3)};
-                }
-                return c;
-            });
-            return result;
-        };
-
-        const adminBrowseCommentsSpy = sinon.spy(mockedApi.adminRequestHandlers, 'browseComments');
-        const adminRepliesSpy = sinon.spy(mockedApi.adminRequestHandlers, 'getReplies');
-        const {frame} = await initializeTest(page);
-        // Wait for admin browse with member UUID
-        await expect.poll(() => {
-            if (!adminBrowseCommentsSpy.called) {
-                return null;
-            }
-            const url = new URL(adminBrowseCommentsSpy.lastCall.args[0].request().url());
-            return url.searchParams.get('impersonate_member_uuid');
-        }).toBe('12345');
-        const comments = await frame.getByTestId('comment-component');
-        const comment = comments.nth(0);
-        await comment.getByTestId('reply-pagination-button').click();
-        await expect.poll(() => {
-            if (!adminRepliesSpy.called) {
-                return null;
-            }
-            const url = new URL(adminRepliesSpy.lastCall.args[0].request().url());
-            return url.searchParams.get('impersonate_member_uuid');
-        }).toBe('12345');
-    });
-
-
-    test('member uuid gets set when reading a comment (after unhiding)', async ({page}) => {
-        mockedApi.addComment({html: '<p>This is comment 1</p>'});
-        mockedApi.addComment({html: '<p>This is comment 2</p>', status: 'hidden'});
-        const adminBrowseSpy = sinon.spy(mockedApi.adminRequestHandlers, 'browseComments');
-        const adminReadSpy = sinon.spy(mockedApi.adminRequestHandlers, 'getOrUpdateComment');
-        const {frame} = await initializeTest(page);
-        // Wait for admin browse with member UUID
-        await expect.poll(() => {
-            if (!adminBrowseSpy.called) {
-                return null;
-            }
-            const url = new URL(adminBrowseSpy.lastCall.args[0].request().url());
-            return url.searchParams.get('impersonate_member_uuid');
-        }).toBe('12345');
-        const comments = await frame.getByTestId('comment-component');
-        await expect(comments).toHaveCount(2);
-        await expect(comments.nth(1)).toContainText('Hidden for members');
-        const moreButtons = comments.nth(1).getByTestId('more-button');
-        await moreButtons.click();
-        await moreButtons.getByTestId('show-button').click();
-        await expect(comments.nth(1)).not.toContainText('Hidden for members');
-
-        const lastCall = adminReadSpy.lastCall.args[0];
-        const url = new URL(lastCall.request().url());
-
-        expect(url.searchParams.get('impersonate_member_uuid')).toBe('12345');
     });
 
     test('hidden comments are not displayed for non-admins', async ({page}) => {
@@ -266,42 +101,18 @@ test.describe('Admin moderation', async () => {
         await expect(comments).toHaveCount(1);
     });
 
-    test('hidden comments are displayed for admins', async ({page}) => {
-        mockedApi.addComment({html: '<p>This is comment 1</p>'});
-        mockedApi.addComment({html: '<p>This is comment 2</p>', status: 'hidden'});
-
-        const adminBrowseSpy = sinon.spy(mockedApi.adminRequestHandlers, 'browseComments');
-        const {frame} = await initializeTest(page);
-        // Wait for admin browse with member UUID (fully settled)
-        await expect.poll(() => {
-            if (!adminBrowseSpy.called) {
-                return null;
-            }
-            const url = new URL(adminBrowseSpy.lastCall.args[0].request().url());
-            return url.searchParams.get('impersonate_member_uuid');
-        }).toBe('12345');
-        const comments = await frame.getByTestId('comment-component');
-        await expect(comments).toHaveCount(2);
-        await expect(comments.nth(1)).toContainText('Hidden for members');
-    });
-
     test('can hide and show comments', async ({page}) => {
         [1,2].forEach(i => mockedApi.addComment({html: `<p>This is comment ${i}</p>`}));
 
-        const adminBrowseSpy = sinon.spy(mockedApi.adminRequestHandlers, 'browseComments');
         const {frame} = await initializeTest(page);
-        // Wait for admin browse with member UUID (fully settled)
-        await expect.poll(() => {
-            if (!adminBrowseSpy.called) {
-                return null;
-            }
-            const url = new URL(adminBrowseSpy.lastCall.args[0].request().url());
-            return url.searchParams.get('impersonate_member_uuid');
-        }).toBe('12345');
+
+        // Wait for admin auth to resolve (more-button appears for admin)
+        const moreButtons = frame.getByTestId('more-button');
+        await expect(moreButtons.nth(0)).toBeVisible();
+
         const comments = await frame.getByTestId('comment-component');
 
         // Hide the 2nd comment
-        const moreButtons = frame.getByTestId('more-button');
         await moreButtons.nth(1).click();
         await moreButtons.nth(1).getByText('Hide comment').click();
 
@@ -324,16 +135,12 @@ test.describe('Admin moderation', async () => {
             ]
         });
 
-        const adminBrowseSpy = sinon.spy(mockedApi.adminRequestHandlers, 'browseComments');
         const {frame} = await initializeTest(page);
-        // Wait for admin browse with member UUID (fully settled)
-        await expect.poll(() => {
-            if (!adminBrowseSpy.called) {
-                return null;
-            }
-            const url = new URL(adminBrowseSpy.lastCall.args[0].request().url());
-            return url.searchParams.get('impersonate_member_uuid');
-        }).toBe('12345');
+
+        // Wait for admin auth to resolve
+        const moreButtons = frame.getByTestId('more-button');
+        await expect(moreButtons.nth(0)).toBeVisible();
+
         const comments = await frame.getByTestId('comment-component');
         const replyToHide = comments.nth(1);
 
@@ -361,16 +168,12 @@ test.describe('Admin moderation', async () => {
             ]
         });
 
-        const adminBrowseSpy = sinon.spy(mockedApi.adminRequestHandlers, 'browseComments');
         const {frame} = await initializeTest(page);
-        // Wait for admin browse with member UUID (fully settled)
-        await expect.poll(() => {
-            if (!adminBrowseSpy.called) {
-                return null;
-            }
-            const url = new URL(adminBrowseSpy.lastCall.args[0].request().url());
-            return url.searchParams.get('impersonate_member_uuid');
-        }).toBe('12345');
+
+        // Wait for admin auth to resolve
+        const moreButtons = frame.getByTestId('more-button');
+        await expect(moreButtons.nth(0)).toBeVisible();
+
         const comments = await frame.getByTestId('comment-component');
         const replyToHide = comments.nth(1);
         const inReplyToComment = comments.nth(2);
@@ -416,7 +219,7 @@ test.describe('Admin moderation', async () => {
                 }
             });
 
-            // Wait for admin auth to resolve (more-button appears after admin browse)
+            // Wait for admin auth to resolve (more-button appears for admin)
             const moreButtons = frame.getByTestId('more-button');
             await expect(moreButtons.nth(0)).toBeVisible();
             await moreButtons.nth(0).click();
@@ -442,7 +245,7 @@ test.describe('Admin moderation', async () => {
                 labs: {}
             });
 
-            // Wait for admin auth to resolve (more-button appears after admin browse)
+            // Wait for admin auth to resolve (more-button appears for admin)
             const moreButtons = frame.getByTestId('more-button');
             await expect(moreButtons.nth(0)).toBeVisible();
             await moreButtons.nth(0).click();

--- a/apps/comments-ui/test/e2e/admin-moderation.test.ts
+++ b/apps/comments-ui/test/e2e/admin-moderation.test.ts
@@ -101,10 +101,16 @@ test.describe('Admin moderation', async () => {
         const {frame} = await initializeTest(page);
         const comments = await frame.getByTestId('comment-component');
         await expect(comments).toHaveCount(1);
-        expect(adminBrowseSpy.called).toBe(true);
-        const lastCall = adminBrowseSpy.lastCall.args[0];
-        const url = new URL(lastCall.request().url());
-        expect(url.searchParams.get('impersonate_member_uuid')).toBe('12345');
+        // Admin browse happens asynchronously after public browse + admin auth.
+        // May re-fetch when member overlay arrives with the UUID, so poll until
+        // the last call includes the expected impersonate_member_uuid.
+        await expect.poll(() => {
+            if (!adminBrowseSpy.called) {
+                return null;
+            }
+            const url = new URL(adminBrowseSpy.lastCall.args[0].request().url());
+            return url.searchParams.get('impersonate_member_uuid');
+        }).toBe('12345');
     });
 
     test('member uuid gets set when loading more comments', async ({page}) => {
@@ -114,6 +120,15 @@ test.describe('Admin moderation', async () => {
         }
         const adminBrowseSpy = sinon.spy(mockedApi.adminRequestHandlers, 'browseComments');
         const {frame} = await initializeTest(page);
+        // Wait for admin browse with member UUID (may take two fetches if admin
+        // auth resolves before member overlay)
+        await expect.poll(() => {
+            if (!adminBrowseSpy.called) {
+                return null;
+            }
+            const url = new URL(adminBrowseSpy.lastCall.args[0].request().url());
+            return url.searchParams.get('impersonate_member_uuid');
+        }).toBe('12345');
         await frame.getByTestId('pagination-component').click();
         const lastCall = adminBrowseSpy.lastCall.args[0];
         const url = new URL(lastCall.request().url());
@@ -136,6 +151,14 @@ test.describe('Admin moderation', async () => {
 
         const adminBrowseSpy = sinon.spy(mockedApi.adminRequestHandlers, 'browseComments');
         const {frame} = await initializeTest(page);
+        // Wait for admin browse with member UUID
+        await expect.poll(() => {
+            if (!adminBrowseSpy.called) {
+                return null;
+            }
+            const url = new URL(adminBrowseSpy.lastCall.args[0].request().url());
+            return url.searchParams.get('impersonate_member_uuid');
+        }).toBe('12345');
 
         const sortingForm = await frame.getByTestId('comments-sorting-form');
 
@@ -153,11 +176,73 @@ test.describe('Admin moderation', async () => {
         expect(url.searchParams.get('impersonate_member_uuid')).toBe('12345');
     });
 
+    test('member uuid gets set when loading more replies', async ({page}) => {
+        const allReplies = [
+            buildReply({html: '<p>This is reply 1</p>'}),
+            buildReply({html: '<p>This is reply 2</p>'}),
+            buildReply({html: '<p>This is reply 3</p>'}),
+            buildReply({html: '<p>This is reply 4</p>'}),
+            buildReply({html: '<p>This is reply 5</p>'}),
+            buildReply({html: '<p>This is reply 6</p>'})
+        ];
+
+        mockedApi.addComment({
+            html: '<p>This is comment 1</p>',
+            replies: allReplies
+        });
+
+        // Override browseComments to only return 3 replies (simulating API limit)
+        // while count.replies stays at 6, forcing a separate getReplies call
+        const originalBrowse = mockedApi.browseComments.bind(mockedApi);
+        mockedApi.browseComments = function (options) {
+            const result = originalBrowse(options);
+            result.comments = result.comments.map((c) => {
+                if (c.replies.length > 3) {
+                    return {...c, replies: c.replies.slice(0, 3)};
+                }
+                return c;
+            });
+            return result;
+        };
+
+        const adminBrowseCommentsSpy = sinon.spy(mockedApi.adminRequestHandlers, 'browseComments');
+        const adminRepliesSpy = sinon.spy(mockedApi.adminRequestHandlers, 'getReplies');
+        const {frame} = await initializeTest(page);
+        // Wait for admin browse with member UUID
+        await expect.poll(() => {
+            if (!adminBrowseCommentsSpy.called) {
+                return null;
+            }
+            const url = new URL(adminBrowseCommentsSpy.lastCall.args[0].request().url());
+            return url.searchParams.get('impersonate_member_uuid');
+        }).toBe('12345');
+        const comments = await frame.getByTestId('comment-component');
+        const comment = comments.nth(0);
+        await comment.getByTestId('reply-pagination-button').click();
+        await expect.poll(() => {
+            if (!adminRepliesSpy.called) {
+                return null;
+            }
+            const url = new URL(adminRepliesSpy.lastCall.args[0].request().url());
+            return url.searchParams.get('impersonate_member_uuid');
+        }).toBe('12345');
+    });
+
+
     test('member uuid gets set when reading a comment (after unhiding)', async ({page}) => {
         mockedApi.addComment({html: '<p>This is comment 1</p>'});
         mockedApi.addComment({html: '<p>This is comment 2</p>', status: 'hidden'});
+        const adminBrowseSpy = sinon.spy(mockedApi.adminRequestHandlers, 'browseComments');
         const adminReadSpy = sinon.spy(mockedApi.adminRequestHandlers, 'getOrUpdateComment');
         const {frame} = await initializeTest(page);
+        // Wait for admin browse with member UUID
+        await expect.poll(() => {
+            if (!adminBrowseSpy.called) {
+                return null;
+            }
+            const url = new URL(adminBrowseSpy.lastCall.args[0].request().url());
+            return url.searchParams.get('impersonate_member_uuid');
+        }).toBe('12345');
         const comments = await frame.getByTestId('comment-component');
         await expect(comments).toHaveCount(2);
         await expect(comments.nth(1)).toContainText('Hidden for members');
@@ -185,7 +270,16 @@ test.describe('Admin moderation', async () => {
         mockedApi.addComment({html: '<p>This is comment 1</p>'});
         mockedApi.addComment({html: '<p>This is comment 2</p>', status: 'hidden'});
 
+        const adminBrowseSpy = sinon.spy(mockedApi.adminRequestHandlers, 'browseComments');
         const {frame} = await initializeTest(page);
+        // Wait for admin browse with member UUID (fully settled)
+        await expect.poll(() => {
+            if (!adminBrowseSpy.called) {
+                return null;
+            }
+            const url = new URL(adminBrowseSpy.lastCall.args[0].request().url());
+            return url.searchParams.get('impersonate_member_uuid');
+        }).toBe('12345');
         const comments = await frame.getByTestId('comment-component');
         await expect(comments).toHaveCount(2);
         await expect(comments.nth(1)).toContainText('Hidden for members');
@@ -194,7 +288,16 @@ test.describe('Admin moderation', async () => {
     test('can hide and show comments', async ({page}) => {
         [1,2].forEach(i => mockedApi.addComment({html: `<p>This is comment ${i}</p>`}));
 
+        const adminBrowseSpy = sinon.spy(mockedApi.adminRequestHandlers, 'browseComments');
         const {frame} = await initializeTest(page);
+        // Wait for admin browse with member UUID (fully settled)
+        await expect.poll(() => {
+            if (!adminBrowseSpy.called) {
+                return null;
+            }
+            const url = new URL(adminBrowseSpy.lastCall.args[0].request().url());
+            return url.searchParams.get('impersonate_member_uuid');
+        }).toBe('12345');
         const comments = await frame.getByTestId('comment-component');
 
         // Hide the 2nd comment
@@ -221,7 +324,16 @@ test.describe('Admin moderation', async () => {
             ]
         });
 
+        const adminBrowseSpy = sinon.spy(mockedApi.adminRequestHandlers, 'browseComments');
         const {frame} = await initializeTest(page);
+        // Wait for admin browse with member UUID (fully settled)
+        await expect.poll(() => {
+            if (!adminBrowseSpy.called) {
+                return null;
+            }
+            const url = new URL(adminBrowseSpy.lastCall.args[0].request().url());
+            return url.searchParams.get('impersonate_member_uuid');
+        }).toBe('12345');
         const comments = await frame.getByTestId('comment-component');
         const replyToHide = comments.nth(1);
 
@@ -249,7 +361,16 @@ test.describe('Admin moderation', async () => {
             ]
         });
 
+        const adminBrowseSpy = sinon.spy(mockedApi.adminRequestHandlers, 'browseComments');
         const {frame} = await initializeTest(page);
+        // Wait for admin browse with member UUID (fully settled)
+        await expect.poll(() => {
+            if (!adminBrowseSpy.called) {
+                return null;
+            }
+            const url = new URL(adminBrowseSpy.lastCall.args[0].request().url());
+            return url.searchParams.get('impersonate_member_uuid');
+        }).toBe('12345');
         const comments = await frame.getByTestId('comment-component');
         const replyToHide = comments.nth(1);
         const inReplyToComment = comments.nth(2);
@@ -295,7 +416,9 @@ test.describe('Admin moderation', async () => {
                 }
             });
 
+            // Wait for admin auth to resolve (more-button appears after admin browse)
             const moreButtons = frame.getByTestId('more-button');
+            await expect(moreButtons.nth(0)).toBeVisible();
             await moreButtons.nth(0).click();
 
             const viewInAdminLink = frame.getByTestId('view-in-admin-button');
@@ -319,7 +442,9 @@ test.describe('Admin moderation', async () => {
                 labs: {}
             });
 
+            // Wait for admin auth to resolve (more-button appears after admin browse)
             const moreButtons = frame.getByTestId('more-button');
+            await expect(moreButtons.nth(0)).toBeVisible();
             await moreButtons.nth(0).click();
 
             await expect(frame.getByTestId('view-in-admin-button')).not.toBeVisible();

--- a/apps/comments-ui/test/e2e/permalink.test.ts
+++ b/apps/comments-ui/test/e2e/permalink.test.ts
@@ -449,10 +449,9 @@ test.describe('Comment Permalinks', async () => {
         const admin = MOCKED_SITE_URL + '/ghost/';
         await mockAdminAuthFrame({page, admin});
 
-        // Add 25 comments — member API page size is 5, admin API page size is 20.
-        // The target (comment 25) is on member page 5 and admin page 2.
-        // initSetup paginates member API to find it, then initAdminAuth re-fetches
-        // admin page 1 only (20 comments), which must NOT overwrite the 25.
+        // Add 25 comments so initSetup paginates to find the target.
+        // Admin auth resolves independently but does not re-fetch — comments
+        // loaded via public browse for the permalink must remain intact.
         for (let i = 1; i <= 24; i++) {
             mockedApi.addComment({
                 html: `<p>Filler comment ${i}</p>`
@@ -503,11 +502,10 @@ test.describe('Comment Permalinks', async () => {
         await expect(commentsFrame.getByText('Target comment beyond admin page 1')).toBeVisible();
 
         // Wait for admin auth to complete — the more button only renders
-        // when isAdmin is true, so its presence proves initAdminAuth has
-        // finished and React has flushed the state update
+        // when isAdmin is true, confirming admin auth has resolved
         await expect(commentsFrame.locator('[data-testid="more-button"]').first()).toBeVisible();
 
-        // The target comment (beyond admin page 1) must STILL be visible
+        // The target comment must STILL be visible after admin auth resolves
         await expect(commentsFrame.getByText('Target comment beyond admin page 1')).toBeVisible();
     });
 
@@ -519,9 +517,8 @@ test.describe('Comment Permalinks', async () => {
         await mockAdminAuthFrame({page, admin});
 
         // Create a parent with 5 replies — all returned by API but only first 3
-        // shown in UI. The target (reply 5) is auto-expanded by the Replies
-        // component. initAdminAuth then re-fetches admin page 1, which must
-        // NOT overwrite the replies.
+        // shown in UI. The target (reply 5) is auto-expanded via permalink
+        // pagination. Admin auth resolves independently but does not re-fetch.
         const parentId = 'aaa0000000000000parent';
         const parentComment = {
             id: parentId,
@@ -581,11 +578,11 @@ test.describe('Comment Permalinks', async () => {
         // Target reply should be visible after permalink reply expansion
         await expect(commentsFrame.getByText('Target deep reply')).toBeVisible();
 
-        // Wait for admin auth to complete — the more button (admin context menu)
-        // only renders when isAdmin is true, proving initAdminAuth has finished
+        // Wait for admin auth to complete — the more button only renders
+        // when isAdmin is true, confirming admin auth has resolved
         await expect(commentsFrame.locator('[data-testid="more-button"]').first()).toBeVisible();
 
-        // The target reply must STILL be visible after admin auth completes
+        // The target reply must STILL be visible after admin auth resolves
         await expect(commentsFrame.getByText('Target deep reply')).toBeVisible();
     });
 });

--- a/apps/comments-ui/test/unit/actions.test.js
+++ b/apps/comments-ui/test/unit/actions.test.js
@@ -10,7 +10,7 @@ describe('Actions', function () {
                     {id: '3'}
                 ]
             };
-            const commentApi = {
+            const publicApi = {
                 browse: () => Promise.resolve({
                     comments: [
                         {id: '2'},
@@ -22,7 +22,7 @@ describe('Actions', function () {
                     }
                 })
             };
-            const newState = await Actions.loadMoreComments({state, commentApi, options: {postId: '1'}, order: 'desc'});
+            const newState = await Actions.loadMoreComments({state, publicApi, options: {postId: '1'}, order: 'desc'});
             expect(newState.comments).toEqual([
                 {id: '1'},
                 {id: '2'},

--- a/apps/comments-ui/test/unit/utils/api.test.ts
+++ b/apps/comments-ui/test/unit/utils/api.test.ts
@@ -18,7 +18,7 @@ test('should call counts endpoint', () => {
         expect.objectContaining({
             method: 'GET',
             headers: {'Content-Type': 'application/json'},
-            credentials: 'same-origin',
+            credentials: undefined,
             body: undefined
         })
     );
@@ -41,7 +41,7 @@ test('should call counts endpoint with postId query param', () => {
         expect.objectContaining({
             method: 'GET',
             headers: {'Content-Type': 'application/json'},
-            credentials: 'same-origin',
+            credentials: undefined,
             body: undefined
         })
     );

--- a/apps/comments-ui/test/unit/utils/api.test.ts
+++ b/apps/comments-ui/test/unit/utils/api.test.ts
@@ -10,7 +10,7 @@ test('should call counts endpoint', () => {
 
     const api = setupGhostApi({siteUrl: 'http://localhost:3000', apiUrl: '', apiKey: ''});
 
-    api.comments.count({postId: null});
+    api.comments().count({postId: null});
 
     expect(spy).toHaveBeenCalledTimes(1);
     expect(spy).toHaveBeenCalledWith(
@@ -33,7 +33,7 @@ test('should call counts endpoint with postId query param', () => {
 
     const api = setupGhostApi({siteUrl: 'http://localhost:3000', apiUrl: '', apiKey: ''});
 
-    api.comments.count({postId: '123'});
+    api.comments().count({postId: '123'});
 
     expect(spy).toHaveBeenCalledTimes(1);
     expect(spy).toHaveBeenCalledWith(
@@ -43,6 +43,26 @@ test('should call counts endpoint with postId query param', () => {
             headers: {'Content-Type': 'application/json'},
             credentials: 'omit',
             body: undefined
+        })
+    );
+});
+
+test('should call counts endpoint with explicit credentials', () => {
+    const spy = vi.spyOn(window, 'fetch');
+    spy.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({success: true})
+    } as any);
+
+    const api = setupGhostApi({siteUrl: 'http://localhost:3000', apiUrl: '', apiKey: ''});
+
+    api.comments({credentials: 'same-origin'}).count({postId: '123'});
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(
+        'http://localhost:3000/members/api/comments/counts/?ids=123',
+        expect.objectContaining({
+            credentials: 'same-origin'
         })
     );
 });

--- a/apps/comments-ui/test/unit/utils/api.test.ts
+++ b/apps/comments-ui/test/unit/utils/api.test.ts
@@ -18,7 +18,7 @@ test('should call counts endpoint', () => {
         expect.objectContaining({
             method: 'GET',
             headers: {'Content-Type': 'application/json'},
-            credentials: undefined,
+            credentials: 'omit',
             body: undefined
         })
     );
@@ -41,7 +41,7 @@ test('should call counts endpoint with postId query param', () => {
         expect.objectContaining({
             method: 'GET',
             headers: {'Content-Type': 'application/json'},
-            credentials: undefined,
+            credentials: 'omit',
             body: undefined
         })
     );

--- a/apps/comments-ui/test/utils/mocked-api.ts
+++ b/apps/comments-ui/test/utils/mocked-api.ts
@@ -489,6 +489,41 @@ export class MockedApi {
                 status: 200,
                 body: JSON.stringify(this.settings)
             });
+        },
+
+        async getMemberInfo(route) {
+            const failureResponse = await this.#handleFailure('getMemberInfo');
+            if (failureResponse) {
+                return route.fulfill(failureResponse);
+            }
+            await this.#delayResponse();
+            if (!this.member) {
+                return await route.fulfill({
+                    status: 204,
+                    body: ''
+                });
+            }
+
+            // Derive liked/authored IDs from the flat comment+reply list
+            const allComments = this.comments.flatMap(c => [c, ...(c.replies || [])]);
+            const likedComments = allComments.filter(c => c.liked).map(c => c.id);
+            const authoredComments = allComments.filter(c => c.member?.uuid === this.member?.uuid).map(c => c.id);
+
+            await route.fulfill({
+                status: 200,
+                body: JSON.stringify({
+                    member: {
+                        uuid: this.member.uuid,
+                        name: this.member.name,
+                        expertise: this.member.expertise || null,
+                        avatar_image: this.member.avatar_image || null,
+                        can_comment: this.member.can_comment !== false,
+                        paid: this.member.paid || false
+                    },
+                    liked_comments: likedComments,
+                    authored_comments: authoredComments
+                })
+            });
         }
     };
 
@@ -613,6 +648,7 @@ export class MockedApi {
     async listen({page, path}: {page: any, path: string}) {
         // Public API ----------------------------------------------------------
         await page.route(`${path}/members/api/member/`, this.requestHandlers.getMember.bind(this));
+        await page.route(`${path}/members/api/comments/post/*/member/`, this.requestHandlers.getMemberInfo.bind(this));
         await page.route(`${path}/members/api/comments/*`, this.requestHandlers.addComment.bind(this));
         await page.route(`${path}/members/api/comments/post/*/*`, this.requestHandlers.browseComments.bind(this));
         await page.route(`${path}/members/api/comments/*/`, this.requestHandlers.getOrDeleteComment.bind(this));

--- a/apps/comments-ui/test/utils/mocked-api.ts
+++ b/apps/comments-ui/test/utils/mocked-api.ts
@@ -305,8 +305,8 @@ export class MockedApi {
     // (useful to spy on these methods in tests)
 
     requestHandlers = {
-        async getMember(route) {
-            const failureResponse = await this.#handleFailure('getMember');
+        async updateMember(route) {
+            const failureResponse = await this.#handleFailure('updateMember');
             if (failureResponse) {
                 return route.fulfill(failureResponse);
             }
@@ -491,8 +491,8 @@ export class MockedApi {
             });
         },
 
-        async getMemberInfo(route) {
-            const failureResponse = await this.#handleFailure('getMemberInfo');
+        async getMember(route) {
+            const failureResponse = await this.#handleFailure('getMember');
             if (failureResponse) {
                 return route.fulfill(failureResponse);
             }
@@ -647,8 +647,8 @@ export class MockedApi {
 
     async listen({page, path}: {page: any, path: string}) {
         // Public API ----------------------------------------------------------
-        await page.route(`${path}/members/api/member/`, this.requestHandlers.getMember.bind(this));
-        await page.route(`${path}/members/api/comments/post/*/member/`, this.requestHandlers.getMemberInfo.bind(this));
+        await page.route(`${path}/members/api/member/`, this.requestHandlers.updateMember.bind(this));
+        await page.route(`${path}/members/api/comments/post/*/member/`, this.requestHandlers.getMember.bind(this));
         await page.route(`${path}/members/api/comments/*`, this.requestHandlers.addComment.bind(this));
         await page.route(`${path}/members/api/comments/post/*/*`, this.requestHandlers.browseComments.bind(this));
         await page.route(`${path}/members/api/comments/*/`, this.requestHandlers.getOrDeleteComment.bind(this));

--- a/apps/comments-ui/test/utils/mocked-api.ts
+++ b/apps/comments-ui/test/utils/mocked-api.ts
@@ -504,10 +504,9 @@ export class MockedApi {
                 });
             }
 
-            // Derive liked/authored IDs from the flat comment+reply list
+            // Derive liked IDs from the flat comment+reply list
             const allComments = this.comments.flatMap(c => [c, ...(c.replies || [])]);
             const likedComments = allComments.filter(c => c.liked).map(c => c.id);
-            const authoredComments = allComments.filter(c => c.member?.uuid === this.member?.uuid).map(c => c.id);
 
             await route.fulfill({
                 status: 200,
@@ -518,10 +517,9 @@ export class MockedApi {
                         expertise: this.member.expertise || null,
                         avatar_image: this.member.avatar_image || null,
                         can_comment: this.member.can_comment !== false,
-                        paid: this.member.paid || false
-                    },
-                    liked_comments: likedComments,
-                    authored_comments: authoredComments
+                        paid: this.member.paid || false,
+                        liked_comments: likedComments
+                    }
                 })
             });
         }

--- a/ghost/core/core/server/services/members/middleware.js
+++ b/ghost/core/core/server/services/members/middleware.js
@@ -265,18 +265,12 @@ const getCommentsMemberInfo = async function getCommentsMemberInfo(req, res) {
         const memberId = memberJson.id;
         const db = require('../../data/db');
 
-        // Fetch liked comment IDs and authored comment IDs in parallel
-        const [likedRows, authoredRows] = await Promise.all([
-            db.knex('comment_likes')
-                .select('comment_likes.comment_id')
-                .join('comments', 'comment_likes.comment_id', '=', 'comments.id')
-                .where('comment_likes.member_id', memberId)
-                .where('comments.post_id', postId),
-            db.knex('comments')
-                .select('id')
-                .where('member_id', memberId)
-                .where('post_id', postId)
-        ]);
+        // Fetch liked comment IDs for this post
+        const likedRows = await db.knex('comment_likes')
+            .select('comment_likes.comment_id')
+            .join('comments', 'comment_likes.comment_id', '=', 'comments.id')
+            .where('comment_likes.member_id', memberId)
+            .where('comments.post_id', postId);
 
         res.json({
             member: {
@@ -285,10 +279,9 @@ const getCommentsMemberInfo = async function getCommentsMemberInfo(req, res) {
                 expertise: memberJson.expertise,
                 avatar_image: memberJson.avatar_image,
                 can_comment: memberJson.can_comment,
-                paid: memberJson.status !== 'free'
-            },
-            liked_comments: likedRows.map(r => r.comment_id),
-            authored_comments: authoredRows.map(r => r.id)
+                paid: memberJson.status !== 'free',
+                liked_comments: likedRows.map(r => r.comment_id)
+            }
         });
     } catch (err) {
         // No session or any error — return 204 (same pattern as getMemberData)

--- a/ghost/core/core/server/services/members/middleware.js
+++ b/ghost/core/core/server/services/members/middleware.js
@@ -236,6 +236,67 @@ const getMemberData = async function getMemberData(req, res) {
     }
 };
 
+/**
+ * Lightweight endpoint for comments-ui to get member identity and comment interaction data.
+ * Avoids the heavy MemberBREADService.read() path by querying directly.
+ * Returns member info + liked/authored comment IDs for a specific post.
+ */
+const getCommentsMemberInfo = async function getCommentsMemberInfo(req, res) {
+    try {
+        const postId = req.params.post_id;
+        if (!postId) {
+            res.writeHead(400);
+            res.end();
+            return;
+        }
+
+        // Get transient_id from session cookie (throws if no valid session)
+        const transientId = membersService.ssr._getSessionCookies(req, res);
+
+        // Lightweight member lookup — single query, no relations
+        const member = await models.Member.findOne({transient_id: transientId}, {require: false, withRelated: []});
+        if (!member) {
+            res.writeHead(204);
+            res.end();
+            return;
+        }
+
+        const memberJson = member.toJSON();
+        const memberId = memberJson.id;
+        const db = require('../../data/db');
+
+        // Fetch liked comment IDs and authored comment IDs in parallel
+        const [likedRows, authoredRows] = await Promise.all([
+            db.knex('comment_likes')
+                .select('comment_likes.comment_id')
+                .join('comments', 'comment_likes.comment_id', '=', 'comments.id')
+                .where('comment_likes.member_id', memberId)
+                .where('comments.post_id', postId),
+            db.knex('comments')
+                .select('id')
+                .where('member_id', memberId)
+                .where('post_id', postId)
+        ]);
+
+        res.json({
+            member: {
+                uuid: memberJson.uuid,
+                name: memberJson.name,
+                expertise: memberJson.expertise,
+                avatar_image: memberJson.avatar_image,
+                can_comment: memberJson.can_comment,
+                paid: memberJson.status !== 'free'
+            },
+            liked_comments: likedRows.map(r => r.comment_id),
+            authored_comments: authoredRows.map(r => r.id)
+        });
+    } catch (err) {
+        // No session or any error — return 204 (same pattern as getMemberData)
+        res.writeHead(204);
+        res.end();
+    }
+};
+
 const deleteSuppression = async function deleteSuppression(req, res) {
     try {
         const member = await membersService.ssr.getMemberDataFromSession(req, res);
@@ -443,6 +504,7 @@ module.exports = {
     getEntitlementToken,
     getMemberNewsletters,
     getMemberData,
+    getCommentsMemberInfo,
     updateMemberData,
     updateMemberNewsletters,
     deleteSession,

--- a/ghost/core/core/server/web/comments/routes.js
+++ b/ghost/core/core/server/web/comments/routes.js
@@ -40,6 +40,9 @@ module.exports = function apiRoutes() {
     );
     router.get('/counts', countsCache, http(api.commentsMembers.counts));
 
+    // Lightweight member info for comments overlay (handles its own auth)
+    router.get('/post/:post_id/member', membersService.middleware.getCommentsMemberInfo);
+
     // Authenticated Routes
     router.use(membersService.middleware.loadMemberSession);
 

--- a/ghost/core/test/e2e-api/members-comments/comments-member-info.test.js
+++ b/ghost/core/test/e2e-api/members-comments/comments-member-info.test.js
@@ -1,0 +1,223 @@
+const assert = require('assert/strict');
+const {agentProvider, mockManager, fixtureManager, configUtils, dbUtils} = require('../../utils/e2e-framework');
+const models = require('../../../core/server/models');
+const sinon = require('sinon');
+const settingsCache = require('../../../core/shared/settings-cache');
+
+let membersAgent, membersAgent2, postId;
+let loggedInMember, loggedInMember2;
+
+describe('Comments Member Info endpoint', function () {
+    before(async function () {
+        membersAgent = await agentProvider.getMembersAPIAgent();
+        membersAgent2 = membersAgent.duplicate();
+
+        await fixtureManager.init('posts', 'members');
+
+        postId = fixtureManager.get('posts', 0).id;
+    });
+
+    beforeEach(async function () {
+        mockManager.mockMail();
+
+        await dbUtils.truncate('comments');
+        await dbUtils.truncate('comment_likes');
+    });
+
+    afterEach(async function () {
+        await configUtils.restore();
+        mockManager.restore();
+    });
+
+    describe('when not authenticated', function () {
+        it('returns 204 for unauthenticated request', async function () {
+            const unauthAgent = membersAgent.duplicate();
+            await unauthAgent
+                .get(`/api/comments/post/${postId}/member`)
+                .expectStatus(204)
+                .expectEmptyBody();
+        });
+    });
+
+    describe('when authenticated', function () {
+        let getStub;
+
+        before(async function () {
+            await membersAgent.loginAs('member@example.com');
+            loggedInMember = await models.Member.findOne({email: 'member@example.com'}, {require: true});
+            await membersAgent2.loginAs('member2@example.com');
+            loggedInMember2 = await models.Member.findOne({email: 'member2@example.com'}, {require: true});
+        });
+
+        beforeEach(function () {
+            getStub = sinon.stub(settingsCache, 'get');
+            getStub.callsFake((key, options) => {
+                if (key === 'comments_enabled') {
+                    return 'all';
+                }
+                return getStub.wrappedMethod.call(settingsCache, key, options);
+            });
+        });
+
+        it('returns member info with empty arrays when no interactions', async function () {
+            const {body} = await membersAgent
+                .get(`/api/comments/post/${postId}/member`)
+                .expectStatus(200);
+
+            assert.ok(body.member);
+            assert.equal(body.member.uuid, loggedInMember.get('uuid'));
+            assert.equal(body.member.name, loggedInMember.get('name'));
+            assert.ok(typeof body.member.can_comment === 'boolean');
+            assert.ok(typeof body.member.paid === 'boolean');
+            assert.deepEqual(body.liked_comments, []);
+            assert.deepEqual(body.authored_comments, []);
+        });
+
+        it('returns liked comment IDs for the post', async function () {
+            const comment1 = await models.Comment.add({
+                post_id: postId,
+                member_id: loggedInMember2.get('id'),
+                html: '<p>Comment 1</p>'
+            });
+            const comment2 = await models.Comment.add({
+                post_id: postId,
+                member_id: loggedInMember2.get('id'),
+                html: '<p>Comment 2</p>'
+            });
+
+            // Like comment1 as loggedInMember
+            await models.CommentLike.add({
+                comment_id: comment1.get('id'),
+                member_id: loggedInMember.get('id')
+            });
+
+            const {body} = await membersAgent
+                .get(`/api/comments/post/${postId}/member`)
+                .expectStatus(200);
+
+            assert.deepEqual(body.liked_comments, [comment1.get('id')]);
+            assert.ok(!body.liked_comments.includes(comment2.get('id')));
+        });
+
+        it('returns authored comment IDs for the post', async function () {
+            const myComment = await models.Comment.add({
+                post_id: postId,
+                member_id: loggedInMember.get('id'),
+                html: '<p>My comment</p>'
+            });
+
+            // Another member's comment
+            await models.Comment.add({
+                post_id: postId,
+                member_id: loggedInMember2.get('id'),
+                html: '<p>Their comment</p>'
+            });
+
+            const {body} = await membersAgent
+                .get(`/api/comments/post/${postId}/member`)
+                .expectStatus(200);
+
+            assert.deepEqual(body.authored_comments, [myComment.get('id')]);
+        });
+
+        it('only returns interactions for the specified post', async function () {
+            const otherPostId = fixtureManager.get('posts', 1).id;
+
+            // Like a comment on target post
+            const targetComment = await models.Comment.add({
+                post_id: postId,
+                member_id: loggedInMember2.get('id'),
+                html: '<p>Target post comment</p>'
+            });
+            await models.CommentLike.add({
+                comment_id: targetComment.get('id'),
+                member_id: loggedInMember.get('id')
+            });
+
+            // Like a comment on a different post
+            const otherComment = await models.Comment.add({
+                post_id: otherPostId,
+                member_id: loggedInMember2.get('id'),
+                html: '<p>Other post comment</p>'
+            });
+            await models.CommentLike.add({
+                comment_id: otherComment.get('id'),
+                member_id: loggedInMember.get('id')
+            });
+
+            // Author a comment on the other post
+            await models.Comment.add({
+                post_id: otherPostId,
+                member_id: loggedInMember.get('id'),
+                html: '<p>My other post comment</p>'
+            });
+
+            const {body} = await membersAgent
+                .get(`/api/comments/post/${postId}/member`)
+                .expectStatus(200);
+
+            assert.deepEqual(body.liked_comments, [targetComment.get('id')]);
+            assert.deepEqual(body.authored_comments, []);
+        });
+
+        it('reflects likes and unlikes correctly', async function () {
+            const comment = await models.Comment.add({
+                post_id: postId,
+                member_id: loggedInMember2.get('id'),
+                html: '<p>Likeable comment</p>'
+            });
+
+            // Like it via API
+            await membersAgent
+                .post(`/api/comments/${comment.get('id')}/like/`)
+                .expectStatus(204);
+
+            let res = await membersAgent
+                .get(`/api/comments/post/${postId}/member`)
+                .expectStatus(200);
+
+            assert.deepEqual(res.body.liked_comments, [comment.get('id')]);
+
+            // Unlike it via API
+            await membersAgent
+                .delete(`/api/comments/${comment.get('id')}/like/`)
+                .expectStatus(204);
+
+            res = await membersAgent
+                .get(`/api/comments/post/${postId}/member`)
+                .expectStatus(200);
+
+            assert.deepEqual(res.body.liked_comments, []);
+        });
+
+        it('returns different data for different members', async function () {
+            const comment = await models.Comment.add({
+                post_id: postId,
+                member_id: loggedInMember.get('id'),
+                html: '<p>Member 1 comment</p>'
+            });
+
+            // Member 2 likes it
+            await models.CommentLike.add({
+                comment_id: comment.get('id'),
+                member_id: loggedInMember2.get('id')
+            });
+
+            // Member 1: authored, not liked
+            const {body: body1} = await membersAgent
+                .get(`/api/comments/post/${postId}/member`)
+                .expectStatus(200);
+
+            assert.deepEqual(body1.authored_comments, [comment.get('id')]);
+            assert.deepEqual(body1.liked_comments, []);
+
+            // Member 2: liked, not authored
+            const {body: body2} = await membersAgent2
+                .get(`/api/comments/post/${postId}/member`)
+                .expectStatus(200);
+
+            assert.deepEqual(body2.authored_comments, []);
+            assert.deepEqual(body2.liked_comments, [comment.get('id')]);
+        });
+    });
+});


### PR DESCRIPTION
Comments-ui currently blocks rendering until member auth resolves via `/members/api/member/`. While Ghost processes this endpoint in ~45ms, infrastructure routing (Fastly edge → shield → gateway → dispatcher) adds unpredictable latency — often seconds. Chrome also stalls duplicate GET requests to the same URL, compounding the problem when Portal and comments-ui both hit `/members/api/member/` simultaneously. The result is that comments don't even begin fetching until auth completes.

This PR inverts the loading order. Comment data is now fetched immediately using `credentials: 'omit'` (no cookies sent), making these requests CDN-cacheable. In parallel, a new lightweight endpoint `GET /comments/post/:post_id/member` returns just the member identity and their comment interactions (liked IDs, authored IDs) for the specific post. When that response arrives, the already-rendered comments are updated with liked states and authorship info. The `CommentApiProvider` no longer gates rendering on auth resolution — children mount and fetch comments right away.

The new backend endpoint bypasses `MemberBREADService.read()` entirely, which loads Stripe subscriptions, offers, attributions and other heavy relations. Instead it does a direct `Member.findOne({transient_id})` with no relations, plus two indexed queries for liked and authored comment IDs. The admin path is unchanged — when admin auth resolves, comments are re-fetched via the admin browse endpoint as before.

## Before / After

```
BEFORE (blocking)
─────────────────

Page load
  │
  ├─ api.init()
  │   └─ GET /members/api/member/ (credentials: same-origin)  ◀── BLOCKS (seconds)
  │
  ├─ checkHasAdminSession()                                    ◀── BLOCKS
  │   └─ If admin: load AuthFrame → verify role                ◀── BLOCKS
  │
  ╰─ WAIT for BOTH member + admin to resolve
      │
      └─ THEN render <AppContent>
          │
          └─ THEN fetch comments via browse()  (credentials: same-origin)
              │
              └─ Comments finally visible ⏱️ ~2-5s
```

```
AFTER (progressive)
───────────────────

Page load
  │
  ├─ Render <AppContent> immediately
  │   │
  │   └─ fetch comments via browse()  (credentials: omit → CDN cache hit)
  │       │
  │       └─ Comments visible ⏱️ ~100ms ✅
  │
  ├─ In parallel:
  │   │
  │   ├─ GET /comments/post/{id}/member  (credentials: same-origin)
  │   │   └─ On response: overlay liked states + member identity  ⏱️ ~200-500ms
  │   │
  │   └─ Admin preflight (unchanged)
  │       └─ If admin: re-fetch via admin browse
  │
  ╰─ Member interactions update in-place, no re-render of comment tree
```

## Breaking change — version bump to 1.4

This is **not** forwards compatible. The new comments-ui removes `sessionData()` from `init()` and relies entirely on the new `/comments/post/:post_id/member` endpoint for member identity. If 1.4.x JS ran against a backend without that endpoint, members would not be recognised — no commenting, no likes, no identity. The minor version bump from 1.3 → 1.4 and corresponding config change ensures the CDN tilde range (`@~1.4`) binds this to a backend release that includes the new endpoint.