### PR TITLE
Fixed flaky scheduled publishing tests near midnight

### DIFF
--- a/ghost/core/test/e2e-browser/admin/publishing.spec.js
+++ b/ghost/core/test/e2e-browser/admin/publishing.spec.js
@@ -274,8 +274,9 @@ test.describe('Publishing', () => {
             await sharedPage.goto('/ghost');
             await createPage(sharedPage, pageData);
 
-            // Schedule the post to publish asap (by setting it to 00:00, it will get auto corrected to the minimum time possible - 5 seconds in the future)
-            await publishPost(sharedPage, {time: '00:00', type: null});
+            // Setting today's date + 00:00 time gives us a date in the past, which Ghost clamps to 5 seconds from now.
+            // We must pass today's date explicitly because near midnight the default schedule date rolls to tomorrow, and 00:00 tomorrow would be in the future.
+            await publishPost(sharedPage, {date: DateTime.now().toFormat('yyyy-MM-dd'), time: '00:00', type: null});
             await closePublishFlow(sharedPage);
             await checkPostStatus(sharedPage, 'Scheduled', 'Scheduled to be published in a few seconds');
 
@@ -375,8 +376,9 @@ test.describe('Publishing', () => {
 
             const editorUrl = await sharedPage.url();
 
-            // Schedule the post to publish asap (by setting it to 00:00, it will get auto corrected to the minimum time possible - 5 seconds in the future)
-            await publishPost(sharedPage, {time: '00:00', type: 'publish+send'});
+            // Setting today's date + 00:00 time gives us a date in the past, which Ghost clamps to 5 seconds from now.
+            // We must pass today's date explicitly because near midnight the default schedule date rolls to tomorrow, and 00:00 tomorrow would be in the future.
+            await publishPost(sharedPage, {date: DateTime.now().toFormat('yyyy-MM-dd'), time: '00:00', type: 'publish+send'});
             await closePublishFlow(sharedPage);
             await checkPostStatus(sharedPage, 'Scheduled', 'Scheduled to be published and sent'); // Member count can differ, hence not included here
             await checkPostStatus(sharedPage, 'Scheduled', 'in a few seconds'); // Extra test for suffix on hover
@@ -406,8 +408,9 @@ test.describe('Publishing', () => {
             await createPostDraft(sharedPage, postData);
 
             const editorUrl = await sharedPage.url();
-            // Schedule the post to publish asap (by setting it to 00:00, it will get auto corrected to the minimum time possible - 5 seconds in the future)
-            await publishPost(sharedPage, {time: '00:00'});
+            // Setting today's date + 00:00 time gives us a date in the past, which Ghost clamps to 5 seconds from now.
+            // We must pass today's date explicitly because near midnight the default schedule date rolls to tomorrow, and 00:00 tomorrow would be in the future.
+            await publishPost(sharedPage, {date: DateTime.now().toFormat('yyyy-MM-dd'), time: '00:00'});
             await closePublishFlow(sharedPage);
             await checkPostStatus(sharedPage, 'Scheduled', 'Scheduled to be published in a few seconds');
 
@@ -438,8 +441,9 @@ test.describe('Publishing', () => {
             await createPostDraft(sharedPage, postData);
             const editorUrl = await sharedPage.url();
 
-            // Schedule the post to publish asap (by setting it to 00:00, it will get auto corrected to the minimum time possible - 5 seconds in the future)
-            await publishPost(sharedPage, {type: 'send', time: '00:00'});
+            // Setting today's date + 00:00 time gives us a date in the past, which Ghost clamps to 5 seconds from now.
+            // We must pass today's date explicitly because near midnight the default schedule date rolls to tomorrow, and 00:00 tomorrow would be in the future.
+            await publishPost(sharedPage, {date: DateTime.now().toFormat('yyyy-MM-dd'), type: 'send', time: '00:00'});
             await closePublishFlow(sharedPage);
             await checkPostStatus(sharedPage, 'Scheduled', 'Scheduled to be sent in a few seconds');
 

--- a/ghost/core/test/e2e-browser/admin/publishing.spec.js
+++ b/ghost/core/test/e2e-browser/admin/publishing.spec.js
@@ -4,6 +4,10 @@ const {DateTime} = require('luxon');
 const {slugify} = require('@tryghost/string');
 const {createTier, createMember, createPostDraft, impersonateMember} = require('../utils');
 
+// Returns today's date formatted for the date picker. Used with time '00:00' to
+// create a date that's always in the past, so Ghost clamps it to 5 seconds from now.
+const todayDate = () => DateTime.now().toFormat('yyyy-MM-dd');
+
 /**
  * Test the status of a post in the post editor.
  * @param {import('@playwright/test').Page} page
@@ -274,8 +278,7 @@ test.describe('Publishing', () => {
             await sharedPage.goto('/ghost');
             await createPage(sharedPage, pageData);
 
-            // Schedule to publish ASAP — setting today + 00:00 is always in the past, so Ghost clamps it to 5 seconds from now
-            await publishPost(sharedPage, {date: DateTime.now().toFormat('yyyy-MM-dd'), time: '00:00', type: null});
+            await publishPost(sharedPage, {date: todayDate(), time: '00:00', type: null});
             await closePublishFlow(sharedPage);
             await checkPostStatus(sharedPage, 'Scheduled', 'Scheduled to be published in a few seconds');
 
@@ -375,8 +378,7 @@ test.describe('Publishing', () => {
 
             const editorUrl = await sharedPage.url();
 
-            // Schedule to publish ASAP — setting today + 00:00 is always in the past, so Ghost clamps it to 5 seconds from now
-            await publishPost(sharedPage, {date: DateTime.now().toFormat('yyyy-MM-dd'), time: '00:00', type: 'publish+send'});
+            await publishPost(sharedPage, {date: todayDate(), time: '00:00', type: 'publish+send'});
             await closePublishFlow(sharedPage);
             await checkPostStatus(sharedPage, 'Scheduled', 'Scheduled to be published and sent'); // Member count can differ, hence not included here
             await checkPostStatus(sharedPage, 'Scheduled', 'in a few seconds'); // Extra test for suffix on hover
@@ -407,7 +409,7 @@ test.describe('Publishing', () => {
 
             const editorUrl = await sharedPage.url();
             // Schedule to publish ASAP — setting today + 00:00 is always in the past, so Ghost clamps it to 5 seconds from now
-            await publishPost(sharedPage, {date: DateTime.now().toFormat('yyyy-MM-dd'), time: '00:00'});
+            await publishPost(sharedPage, {date: todayDate(), time: '00:00'});
             await closePublishFlow(sharedPage);
             await checkPostStatus(sharedPage, 'Scheduled', 'Scheduled to be published in a few seconds');
 
@@ -439,7 +441,7 @@ test.describe('Publishing', () => {
             const editorUrl = await sharedPage.url();
 
             // Schedule to publish ASAP — setting today + 00:00 is always in the past, so Ghost clamps it to 5 seconds from now
-            await publishPost(sharedPage, {date: DateTime.now().toFormat('yyyy-MM-dd'), type: 'send', time: '00:00'});
+            await publishPost(sharedPage, {date: todayDate(), type: 'send', time: '00:00'});
             await closePublishFlow(sharedPage);
             await checkPostStatus(sharedPage, 'Scheduled', 'Scheduled to be sent in a few seconds');
 

--- a/ghost/core/test/e2e-browser/admin/publishing.spec.js
+++ b/ghost/core/test/e2e-browser/admin/publishing.spec.js
@@ -4,9 +4,11 @@ const {DateTime} = require('luxon');
 const {slugify} = require('@tryghost/string');
 const {createTier, createMember, createPostDraft, impersonateMember} = require('../utils');
 
-// Schedules a post to publish ASAP by setting today's date + 00:00 time.
-// This is always in the past, so Ghost auto-corrects it to 5 seconds from now.
-const scheduleAsap = (page, options = {}) => publishPost(page, {date: DateTime.now().toFormat('yyyy-MM-dd'), time: '00:00', ...options});
+// Schedules a post to publish ASAP by setting yesterday + 00:00, which is always in the past.
+// Ghost auto-corrects past dates to 5 seconds from now. We use yesterday (not today) because
+// publishPost waits for the schedule summary to change after setting the date, and today's
+// date would be a no-op since the default schedule is already today.
+const scheduleAsap = (page, options = {}) => publishPost(page, {date: DateTime.now().minus({days: 1}).toFormat('yyyy-MM-dd'), time: '00:00', ...options});
 
 /**
  * Test the status of a post in the post editor.

--- a/ghost/core/test/e2e-browser/admin/publishing.spec.js
+++ b/ghost/core/test/e2e-browser/admin/publishing.spec.js
@@ -4,9 +4,9 @@ const {DateTime} = require('luxon');
 const {slugify} = require('@tryghost/string');
 const {createTier, createMember, createPostDraft, impersonateMember} = require('../utils');
 
-// Returns today's date formatted for the date picker. Used with time '00:00' to
-// create a date that's always in the past, so Ghost clamps it to 5 seconds from now.
-const todayDate = () => DateTime.now().toFormat('yyyy-MM-dd');
+// Schedules a post to publish ASAP by setting today's date + 00:00 time.
+// This is always in the past, so Ghost auto-corrects it to 5 seconds from now.
+const scheduleAsap = (page, options = {}) => publishPost(page, {date: DateTime.now().toFormat('yyyy-MM-dd'), time: '00:00', ...options});
 
 /**
  * Test the status of a post in the post editor.
@@ -278,7 +278,7 @@ test.describe('Publishing', () => {
             await sharedPage.goto('/ghost');
             await createPage(sharedPage, pageData);
 
-            await publishPost(sharedPage, {date: todayDate(), time: '00:00', type: null});
+            await scheduleAsap(sharedPage, {type: null});
             await closePublishFlow(sharedPage);
             await checkPostStatus(sharedPage, 'Scheduled', 'Scheduled to be published in a few seconds');
 
@@ -378,7 +378,7 @@ test.describe('Publishing', () => {
 
             const editorUrl = await sharedPage.url();
 
-            await publishPost(sharedPage, {date: todayDate(), time: '00:00', type: 'publish+send'});
+            await scheduleAsap(sharedPage, {type: 'publish+send'});
             await closePublishFlow(sharedPage);
             await checkPostStatus(sharedPage, 'Scheduled', 'Scheduled to be published and sent'); // Member count can differ, hence not included here
             await checkPostStatus(sharedPage, 'Scheduled', 'in a few seconds'); // Extra test for suffix on hover
@@ -408,8 +408,7 @@ test.describe('Publishing', () => {
             await createPostDraft(sharedPage, postData);
 
             const editorUrl = await sharedPage.url();
-            // Schedule to publish ASAP — setting today + 00:00 is always in the past, so Ghost clamps it to 5 seconds from now
-            await publishPost(sharedPage, {date: todayDate(), time: '00:00'});
+            await scheduleAsap(sharedPage);
             await closePublishFlow(sharedPage);
             await checkPostStatus(sharedPage, 'Scheduled', 'Scheduled to be published in a few seconds');
 
@@ -440,8 +439,7 @@ test.describe('Publishing', () => {
             await createPostDraft(sharedPage, postData);
             const editorUrl = await sharedPage.url();
 
-            // Schedule to publish ASAP — setting today + 00:00 is always in the past, so Ghost clamps it to 5 seconds from now
-            await publishPost(sharedPage, {date: todayDate(), type: 'send', time: '00:00'});
+            await scheduleAsap(sharedPage, {type: 'send'});
             await closePublishFlow(sharedPage);
             await checkPostStatus(sharedPage, 'Scheduled', 'Scheduled to be sent in a few seconds');
 

--- a/ghost/core/test/e2e-browser/admin/publishing.spec.js
+++ b/ghost/core/test/e2e-browser/admin/publishing.spec.js
@@ -274,8 +274,7 @@ test.describe('Publishing', () => {
             await sharedPage.goto('/ghost');
             await createPage(sharedPage, pageData);
 
-            // Setting today's date + 00:00 time gives us a date in the past, which Ghost clamps to 5 seconds from now.
-            // We must pass today's date explicitly because near midnight the default schedule date rolls to tomorrow, and 00:00 tomorrow would be in the future.
+            // Schedule to publish ASAP — setting today + 00:00 is always in the past, so Ghost clamps it to 5 seconds from now
             await publishPost(sharedPage, {date: DateTime.now().toFormat('yyyy-MM-dd'), time: '00:00', type: null});
             await closePublishFlow(sharedPage);
             await checkPostStatus(sharedPage, 'Scheduled', 'Scheduled to be published in a few seconds');
@@ -376,8 +375,7 @@ test.describe('Publishing', () => {
 
             const editorUrl = await sharedPage.url();
 
-            // Setting today's date + 00:00 time gives us a date in the past, which Ghost clamps to 5 seconds from now.
-            // We must pass today's date explicitly because near midnight the default schedule date rolls to tomorrow, and 00:00 tomorrow would be in the future.
+            // Schedule to publish ASAP — setting today + 00:00 is always in the past, so Ghost clamps it to 5 seconds from now
             await publishPost(sharedPage, {date: DateTime.now().toFormat('yyyy-MM-dd'), time: '00:00', type: 'publish+send'});
             await closePublishFlow(sharedPage);
             await checkPostStatus(sharedPage, 'Scheduled', 'Scheduled to be published and sent'); // Member count can differ, hence not included here
@@ -408,8 +406,7 @@ test.describe('Publishing', () => {
             await createPostDraft(sharedPage, postData);
 
             const editorUrl = await sharedPage.url();
-            // Setting today's date + 00:00 time gives us a date in the past, which Ghost clamps to 5 seconds from now.
-            // We must pass today's date explicitly because near midnight the default schedule date rolls to tomorrow, and 00:00 tomorrow would be in the future.
+            // Schedule to publish ASAP — setting today + 00:00 is always in the past, so Ghost clamps it to 5 seconds from now
             await publishPost(sharedPage, {date: DateTime.now().toFormat('yyyy-MM-dd'), time: '00:00'});
             await closePublishFlow(sharedPage);
             await checkPostStatus(sharedPage, 'Scheduled', 'Scheduled to be published in a few seconds');
@@ -441,8 +438,7 @@ test.describe('Publishing', () => {
             await createPostDraft(sharedPage, postData);
             const editorUrl = await sharedPage.url();
 
-            // Setting today's date + 00:00 time gives us a date in the past, which Ghost clamps to 5 seconds from now.
-            // We must pass today's date explicitly because near midnight the default schedule date rolls to tomorrow, and 00:00 tomorrow would be in the future.
+            // Schedule to publish ASAP — setting today + 00:00 is always in the past, so Ghost clamps it to 5 seconds from now
             await publishPost(sharedPage, {date: DateTime.now().toFormat('yyyy-MM-dd'), type: 'send', time: '00:00'});
             await closePublishFlow(sharedPage);
             await checkPostStatus(sharedPage, 'Scheduled', 'Scheduled to be sent in a few seconds');


### PR DESCRIPTION
## Summary

- Fixed 4 flaky browser tests in `publishing.spec.js` that fail daily near midnight UTC
- **Root cause:** When scheduling a post to publish in the future, the timepicker in admin defaults to now + 10 minutes. Tests schedule posts by changing the scheduled time to `00:00` — a time that is _usually_ in the past — and the UI autocorrects it to "a few seconds from now." But when running within ~10 minutes of midnight, the default scheduled date (`now + 10 min`) rolls to tomorrow — making `00:00 tomorrow` still in the future, so no auto-correction occurs.
- **Fix:** Explicitly pass yesterday's date alongside `time: '00:00'`, ensuring the resulting datetime is always in the past regardless of when the tests run
- Affected tests: "At the scheduled time" (page), "Scheduled Publish and email", "Scheduled Publish only", "Scheduled Email only"