### PR TITLE
Fixed rough leading in confirmationModal

### DIFF
--- a/apps/admin-x-design-system/src/global/modal/confirmation-modal.tsx
+++ b/apps/admin-x-design-system/src/global/modal/confirmation-modal.tsx
@@ -57,7 +57,7 @@ export const ConfirmationModalContent: React.FC<ConfirmationModalProps> = ({
                 setTaskState('');
             }}
         >
-            <div className='py-4 leading-9'>
+            <div className='py-4'>
                 {prompt}
             </div>
         </Modal>

--- a/apps/admin-x-settings/src/components/settings/advanced/migration-tools/universal-import-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/migration-tools/universal-import-modal.tsx
@@ -24,7 +24,7 @@ const UniversalImportModal: React.FC = () => {
             testId='universal-import-modal'
             title='Universal import'
         >
-            <div className='py-4 leading-9'>
+            <div className='py-4'>
                 <FileUpload
                     accept="application/json, application/zip"
                     id="import-file"

--- a/apps/admin-x-settings/src/components/settings/site/theme/invalid-theme-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/theme/invalid-theme-modal.tsx
@@ -35,7 +35,7 @@ export const ThemeProblemView = ({problem}:{problem: ThemeProblem}) => {
                 </div>
                 {
                     isExpanded ?
-                        <div className='mt-2 px-4 text-[13px] leading-8'>
+                        <div className='mt-2 px-4 text-[13px]'>
                             <div dangerouslySetInnerHTML={{__html: problem.details}} className='mb-4' />
                             <Heading level={6}>Affected files:</Heading>
                             <ul className='mt-1'>

--- a/apps/admin-x-settings/src/components/settings/site/theme/theme-installed-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/theme/theme-installed-modal.tsx
@@ -20,7 +20,7 @@ export const ThemeProblemView = ({problem}:{problem: ThemeProblem}) => {
                 </div>
                 {
                     isExpanded ?
-                        <div className='mt-2 px-4 text-[13px] leading-8'>
+                        <div className='mt-2 px-4 text-[13px]'>
                             <div dangerouslySetInnerHTML={{__html: problem.details}} className='mb-4' />
                             <Heading level={6}>Affected files:</Heading>
                             <ul className='mt-1'>


### PR DESCRIPTION
Closes https://linear.app/ghost/issue/DES-1308/weird-leading-in-import-in-progress-modal

leading-9 was causing crazy line heights in confirmationmodals. Fixed in the component and a snowflake implementation for universal import.

| Before | After |
|--------|--------|
| <img width="587" height="331" alt="Screenshot 2026-03-12 at 14 17 07" src="https://github.com/user-attachments/assets/626d9fb4-45ba-41ba-9c5c-ee254dbbdbab" /> | <img width="595" height="302" alt="Screenshot 2026-03-12 at 14 15 10" src="https://github.com/user-attachments/assets/f6bb6b18-d148-458c-89ee-e58bc5a49300" /> |
| <img width="585" height="294" alt="Screenshot 2026-03-12 at 14 16 48" src="https://github.com/user-attachments/assets/d1673d36-fec1-42dd-a367-f0f44c8368ba" /> | <img width="596" height="272" alt="Screenshot 2026-03-12 at 14 15 44" src="https://github.com/user-attachments/assets/3e02821a-b221-4326-9420-547cad56778d" /> |
| <img width="593" height="396" alt="Screenshot 2026-03-12 at 14 16 26" src="https://github.com/user-attachments/assets/978c2254-9529-429f-ab1a-7284a73d1d7b" /> | <img width="585" height="333" alt="Screenshot 2026-03-12 at 14 16 06" src="https://github.com/user-attachments/assets/3cd19a5d-2927-4d98-a713-83a94b211d5b" /> | 
