### PR TITLE
Added `members_single_opt_in` computed setting for single opt-in signup

### DIFF
--- a/ghost/core/core/server/services/settings-helpers/settings-helpers.js
+++ b/ghost/core/core/server/services/settings-helpers/settings-helpers.js
@@ -307,6 +307,10 @@ class SettingsHelpers {
         return true;
     }
 
+    isMembersSingleOptInEnabled() {
+        return !!this.config.get('hostSettings:membersSingleOptIn:enabled');
+    }
+
     // PRIVATE
 
     /**

--- a/ghost/core/core/server/services/settings/settings-service.js
+++ b/ghost/core/core/server/services/settings/settings-service.js
@@ -115,6 +115,9 @@ module.exports = {
         fields.push(new CalculatedField({key: 'web_analytics_enabled', type: 'boolean', group: 'analytics', fn: settingsHelpers.isWebAnalyticsEnabled.bind(settingsHelpers), dependents: ['web_analytics']}));
         fields.push(new CalculatedField({key: 'web_analytics_configured', type: 'boolean', group: 'analytics', fn: settingsHelpers.isWebAnalyticsConfigured.bind(settingsHelpers), dependents: ['web_analytics']}));
 
+        // Single opt-in — derived from host config, no DB dependents (recomputed at boot only)
+        fields.push(new CalculatedField({key: 'members_single_opt_in', type: 'boolean', group: 'members', fn: settingsHelpers.isMembersSingleOptInEnabled.bind(settingsHelpers), dependents: []}));
+
         return fields;
     },
 

--- a/ghost/core/core/shared/settings-cache/public.js
+++ b/ghost/core/core/shared/settings-cache/public.js
@@ -32,6 +32,7 @@ module.exports = {
     allow_self_signup: 'allow_self_signup',
     members_invite_only: 'members_invite_only',
     members_signup_access: 'members_signup_access',
+    members_single_opt_in: 'members_single_opt_in',
     paid_members_enabled: 'paid_members_enabled',
     firstpromoter_account: 'firstpromoter_account',
     portal_button_style: 'portal_button_style',

--- a/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
@@ -400,6 +400,10 @@ Object {
       "key": "web_analytics_configured",
       "value": false,
     },
+    Object {
+      "key": "members_single_opt_in",
+      "value": false,
+    },
   ],
 }
 `;
@@ -462,371 +466,6 @@ Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
   "content-length": "51",
-  "content-type": "application/json; charset=utf-8",
-  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
-  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
-  "vary": "Accept-Version, Origin, Accept-Encoding",
-  "x-powered-by": "Express",
-}
-`;
-
-exports[`Settings API Edit [LEGACY] editing members_support_address triggers email verification flow 1: [body] 1`] = `
-Object {
-  "meta": Object {
-    "sent_email_verification": Array [
-      "members_support_address",
-    ],
-  },
-  "settings": Array [
-    Object {
-      "key": "members_track_sources",
-      "value": true,
-    },
-    Object {
-      "key": "title",
-      "value": null,
-    },
-    Object {
-      "key": "description",
-      "value": "Thoughts, stories and ideas",
-    },
-    Object {
-      "key": "logo",
-      "value": "",
-    },
-    Object {
-      "key": "cover_image",
-      "value": "https://static.ghost.org/v5.0.0/images/publication-cover.jpg",
-    },
-    Object {
-      "key": "icon",
-      "value": "http://127.0.0.1:2369/content/images/size/w256h256/2019/07/icon.png",
-    },
-    Object {
-      "key": "accent_color",
-      "value": "#FF1A75",
-    },
-    Object {
-      "key": "locale",
-      "value": "ua",
-    },
-    Object {
-      "key": "timezone",
-      "value": "Pacific/Auckland",
-    },
-    Object {
-      "key": "codeinjection_head",
-      "value": null,
-    },
-    Object {
-      "key": "codeinjection_foot",
-      "value": "",
-    },
-    Object {
-      "key": "facebook",
-      "value": "ghost",
-    },
-    Object {
-      "key": "twitter",
-      "value": "@ghost",
-    },
-    Object {
-      "key": "navigation",
-      "value": "[{\\"label\\":\\"label1\\"}]",
-    },
-    Object {
-      "key": "secondary_navigation",
-      "value": "[{\\"label\\":\\"Data & privacy\\",\\"url\\":\\"/privacy/\\"},{\\"label\\":\\"Contact\\",\\"url\\":\\"/contact/\\"},{\\"label\\":\\"Contribute →\\",\\"url\\":\\"/contribute/\\"}]",
-    },
-    Object {
-      "key": "meta_title",
-      "value": "SEO title",
-    },
-    Object {
-      "key": "meta_description",
-      "value": "SEO description",
-    },
-    Object {
-      "key": "og_image",
-      "value": "http://127.0.0.1:2369/content/images/2019/07/facebook.png",
-    },
-    Object {
-      "key": "og_title",
-      "value": "facebook title",
-    },
-    Object {
-      "key": "og_description",
-      "value": "facebook description",
-    },
-    Object {
-      "key": "twitter_image",
-      "value": "http://127.0.0.1:2369/content/images/2019/07/twitter.png",
-    },
-    Object {
-      "key": "twitter_title",
-      "value": "twitter title",
-    },
-    Object {
-      "key": "twitter_description",
-      "value": "twitter description",
-    },
-    Object {
-      "key": "active_theme",
-      "value": "source",
-    },
-    Object {
-      "key": "is_private",
-      "value": false,
-    },
-    Object {
-      "key": "password",
-      "value": "",
-    },
-    Object {
-      "key": "public_hash",
-      "value": StringMatching /\\[a-z0-9\\]\\{30\\}/,
-    },
-    Object {
-      "key": "default_content_visibility",
-      "value": "public",
-    },
-    Object {
-      "key": "default_content_visibility_tiers",
-      "value": "[]",
-    },
-    Object {
-      "key": "members_signup_access",
-      "value": "all",
-    },
-    Object {
-      "key": "members_support_address",
-      "value": "noreply",
-    },
-    Object {
-      "key": "stripe_secret_key",
-      "value": null,
-    },
-    Object {
-      "key": "stripe_publishable_key",
-      "value": null,
-    },
-    Object {
-      "key": "stripe_plans",
-      "value": "[]",
-    },
-    Object {
-      "key": "stripe_connect_publishable_key",
-      "value": "pk_test_for_stripe",
-    },
-    Object {
-      "key": "stripe_connect_secret_key",
-      "value": "••••••••",
-    },
-    Object {
-      "key": "stripe_connect_livemode",
-      "value": null,
-    },
-    Object {
-      "key": "stripe_connect_display_name",
-      "value": null,
-    },
-    Object {
-      "key": "stripe_connect_account_id",
-      "value": null,
-    },
-    Object {
-      "key": "members_monthly_price_id",
-      "value": null,
-    },
-    Object {
-      "key": "members_yearly_price_id",
-      "value": null,
-    },
-    Object {
-      "key": "portal_name",
-      "value": true,
-    },
-    Object {
-      "key": "portal_button",
-      "value": true,
-    },
-    Object {
-      "key": "portal_plans",
-      "value": "[\\"free\\"]",
-    },
-    Object {
-      "key": "portal_default_plan",
-      "value": "yearly",
-    },
-    Object {
-      "key": "portal_products",
-      "value": "[]",
-    },
-    Object {
-      "key": "portal_button_style",
-      "value": "icon-and-text",
-    },
-    Object {
-      "key": "portal_button_icon",
-      "value": null,
-    },
-    Object {
-      "key": "portal_button_signup_text",
-      "value": "Subscribe",
-    },
-    Object {
-      "key": "portal_signup_terms_html",
-      "value": null,
-    },
-    Object {
-      "key": "portal_signup_checkbox_required",
-      "value": false,
-    },
-    Object {
-      "key": "mailgun_domain",
-      "value": null,
-    },
-    Object {
-      "key": "mailgun_api_key",
-      "value": null,
-    },
-    Object {
-      "key": "mailgun_base_url",
-      "value": null,
-    },
-    Object {
-      "key": "email_track_opens",
-      "value": true,
-    },
-    Object {
-      "key": "email_track_clicks",
-      "value": true,
-    },
-    Object {
-      "key": "email_verification_required",
-      "value": false,
-    },
-    Object {
-      "key": "firstpromoter",
-      "value": false,
-    },
-    Object {
-      "key": "firstpromoter_id",
-      "value": null,
-    },
-    Object {
-      "key": "labs",
-      "value": StringMatching /\\\\\\{\\[\\^\\\\s\\]\\+\\\\\\}/,
-    },
-    Object {
-      "key": "slack_url",
-      "value": "",
-    },
-    Object {
-      "key": "slack_username",
-      "value": "New Slack Username",
-    },
-    Object {
-      "key": "unsplash",
-      "value": false,
-    },
-    Object {
-      "key": "shared_views",
-      "value": "[]",
-    },
-    Object {
-      "key": "editor_default_email_recipients",
-      "value": "visibility",
-    },
-    Object {
-      "key": "editor_default_email_recipients_filter",
-      "value": "all",
-    },
-    Object {
-      "key": "announcement_content",
-      "value": "<p>Great news coming soon!</p>",
-    },
-    Object {
-      "key": "announcement_visibility",
-      "value": "[\\"visitors\\",\\"free_members\\"]",
-    },
-    Object {
-      "key": "announcement_background",
-      "value": "dark",
-    },
-    Object {
-      "key": "comments_enabled",
-      "value": "off",
-    },
-    Object {
-      "key": "outbound_link_tagging",
-      "value": true,
-    },
-    Object {
-      "key": "pintura",
-      "value": true,
-    },
-    Object {
-      "key": "pintura_js_url",
-      "value": null,
-    },
-    Object {
-      "key": "pintura_css_url",
-      "value": null,
-    },
-    Object {
-      "key": "donations_currency",
-      "value": "USD",
-    },
-    Object {
-      "key": "donations_suggested_amount",
-      "value": "500",
-    },
-    Object {
-      "key": "recommendations_enabled",
-      "value": false,
-    },
-    Object {
-      "key": "members_enabled",
-      "value": true,
-    },
-    Object {
-      "key": "members_invite_only",
-      "value": false,
-    },
-    Object {
-      "key": "allow_self_signup",
-      "value": true,
-    },
-    Object {
-      "key": "paid_members_enabled",
-      "value": true,
-    },
-    Object {
-      "key": "firstpromoter_account",
-      "value": null,
-    },
-    Object {
-      "key": "donations_enabled",
-      "value": true,
-    },
-    Object {
-      "key": "default_email_address",
-      "value": "noreply@127.0.0.1",
-    },
-    Object {
-      "key": "support_email_address",
-      "value": "noreply@127.0.0.1",
-    },
-  ],
-}
-`;
-
-exports[`Settings API Edit [LEGACY] editing members_support_address triggers email verification flow 2: [headers] 1`] = `
-Object {
-  "access-control-allow-origin": "http://127.0.0.1:2369",
-  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": StringMatching /\\\\d\\+/,
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -1233,6 +872,10 @@ Object {
     },
     Object {
       "key": "web_analytics_configured",
+      "value": false,
+    },
+    Object {
+      "key": "members_single_opt_in",
       "value": false,
     },
   ],
@@ -1653,21 +1296,11 @@ Object {
       "key": "web_analytics_configured",
       "value": false,
     },
+    Object {
+      "key": "members_single_opt_in",
+      "value": false,
+    },
   ],
-}
-`;
-
-exports[`Settings API Edit can edit Stripe settings when Stripe Connect limit is not enabled 1: [headers] 1`] = `
-Object {
-  "access-control-allow-origin": "http://127.0.0.1:2369",
-  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "4799",
-  "content-type": "application/json; charset=utf-8",
-  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
-  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
-  "vary": "Accept-Version, Origin, Accept-Encoding",
-  "x-cache-invalidate": "/*",
-  "x-powered-by": "Express",
 }
 `;
 
@@ -1675,7 +1308,7 @@ exports[`Settings API Edit can edit Stripe settings when Stripe Connect limit is
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "5176",
+  "content-length": "5222",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -2116,6 +1749,10 @@ Object {
       "key": "web_analytics_configured",
       "value": false,
     },
+    Object {
+      "key": "members_single_opt_in",
+      "value": false,
+    },
   ],
 }
 `;
@@ -2533,6 +2170,10 @@ Object {
       "key": "web_analytics_configured",
       "value": false,
     },
+    Object {
+      "key": "members_single_opt_in",
+      "value": false,
+    },
   ],
 }
 `;
@@ -2547,367 +2188,6 @@ Object {
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Version, Origin, Accept-Encoding",
   "x-cache-invalidate": "/*",
-  "x-powered-by": "Express",
-}
-`;
-
-exports[`Settings API Edit editing members_support_address triggers email verification flow 1: [body] 1`] = `
-Object {
-  "meta": Object {
-    "sent_email_verification": Array [
-      "members_support_address",
-    ],
-  },
-  "settings": Array [
-    Object {
-      "key": "members_track_sources",
-      "value": true,
-    },
-    Object {
-      "key": "title",
-      "value": null,
-    },
-    Object {
-      "key": "description",
-      "value": "Thoughts, stories and ideas",
-    },
-    Object {
-      "key": "logo",
-      "value": "",
-    },
-    Object {
-      "key": "cover_image",
-      "value": "https://static.ghost.org/v5.0.0/images/publication-cover.jpg",
-    },
-    Object {
-      "key": "icon",
-      "value": "http://127.0.0.1:2369/content/images/size/w256h256/2019/07/icon.png",
-    },
-    Object {
-      "key": "accent_color",
-      "value": "#FF1A75",
-    },
-    Object {
-      "key": "locale",
-      "value": "ua",
-    },
-    Object {
-      "key": "timezone",
-      "value": "Pacific/Auckland",
-    },
-    Object {
-      "key": "codeinjection_head",
-      "value": null,
-    },
-    Object {
-      "key": "codeinjection_foot",
-      "value": "",
-    },
-    Object {
-      "key": "facebook",
-      "value": "ghost",
-    },
-    Object {
-      "key": "twitter",
-      "value": "@ghost",
-    },
-    Object {
-      "key": "navigation",
-      "value": "[{\\"label\\":\\"label1\\"}]",
-    },
-    Object {
-      "key": "secondary_navigation",
-      "value": "[{\\"label\\":\\"Data & privacy\\",\\"url\\":\\"/privacy/\\"},{\\"label\\":\\"Contact\\",\\"url\\":\\"/contact/\\"},{\\"label\\":\\"Contribute →\\",\\"url\\":\\"/contribute/\\"}]",
-    },
-    Object {
-      "key": "meta_title",
-      "value": "SEO title",
-    },
-    Object {
-      "key": "meta_description",
-      "value": "SEO description",
-    },
-    Object {
-      "key": "og_image",
-      "value": "http://127.0.0.1:2369/content/images/2019/07/facebook.png",
-    },
-    Object {
-      "key": "og_title",
-      "value": "facebook title",
-    },
-    Object {
-      "key": "og_description",
-      "value": "facebook description",
-    },
-    Object {
-      "key": "twitter_image",
-      "value": "http://127.0.0.1:2369/content/images/2019/07/twitter.png",
-    },
-    Object {
-      "key": "twitter_title",
-      "value": "twitter title",
-    },
-    Object {
-      "key": "twitter_description",
-      "value": "twitter description",
-    },
-    Object {
-      "key": "active_theme",
-      "value": "source",
-    },
-    Object {
-      "key": "is_private",
-      "value": false,
-    },
-    Object {
-      "key": "password",
-      "value": "",
-    },
-    Object {
-      "key": "public_hash",
-      "value": StringMatching /\\[a-z0-9\\]\\{30\\}/,
-    },
-    Object {
-      "key": "default_content_visibility",
-      "value": "public",
-    },
-    Object {
-      "key": "default_content_visibility_tiers",
-      "value": "[]",
-    },
-    Object {
-      "key": "members_signup_access",
-      "value": "all",
-    },
-    Object {
-      "key": "members_support_address",
-      "value": "noreply",
-    },
-    Object {
-      "key": "stripe_secret_key",
-      "value": null,
-    },
-    Object {
-      "key": "stripe_publishable_key",
-      "value": null,
-    },
-    Object {
-      "key": "stripe_plans",
-      "value": "[]",
-    },
-    Object {
-      "key": "stripe_connect_publishable_key",
-      "value": "pk_test_for_stripe",
-    },
-    Object {
-      "key": "stripe_connect_secret_key",
-      "value": "••••••••",
-    },
-    Object {
-      "key": "stripe_connect_livemode",
-      "value": null,
-    },
-    Object {
-      "key": "stripe_connect_display_name",
-      "value": null,
-    },
-    Object {
-      "key": "stripe_connect_account_id",
-      "value": null,
-    },
-    Object {
-      "key": "members_monthly_price_id",
-      "value": null,
-    },
-    Object {
-      "key": "members_yearly_price_id",
-      "value": null,
-    },
-    Object {
-      "key": "portal_name",
-      "value": true,
-    },
-    Object {
-      "key": "portal_button",
-      "value": true,
-    },
-    Object {
-      "key": "portal_plans",
-      "value": "[\\"free\\"]",
-    },
-    Object {
-      "key": "portal_products",
-      "value": "[]",
-    },
-    Object {
-      "key": "portal_button_style",
-      "value": "icon-and-text",
-    },
-    Object {
-      "key": "portal_button_icon",
-      "value": null,
-    },
-    Object {
-      "key": "portal_button_signup_text",
-      "value": "Subscribe",
-    },
-    Object {
-      "key": "portal_signup_terms_html",
-      "value": null,
-    },
-    Object {
-      "key": "portal_signup_checkbox_required",
-      "value": false,
-    },
-    Object {
-      "key": "mailgun_domain",
-      "value": null,
-    },
-    Object {
-      "key": "mailgun_api_key",
-      "value": null,
-    },
-    Object {
-      "key": "mailgun_base_url",
-      "value": null,
-    },
-    Object {
-      "key": "email_track_opens",
-      "value": true,
-    },
-    Object {
-      "key": "email_track_clicks",
-      "value": true,
-    },
-    Object {
-      "key": "email_verification_required",
-      "value": false,
-    },
-    Object {
-      "key": "firstpromoter",
-      "value": false,
-    },
-    Object {
-      "key": "firstpromoter_id",
-      "value": null,
-    },
-    Object {
-      "key": "labs",
-      "value": StringMatching /\\\\\\{\\[\\^\\\\s\\]\\+\\\\\\}/,
-    },
-    Object {
-      "key": "slack_url",
-      "value": "",
-    },
-    Object {
-      "key": "slack_username",
-      "value": "New Slack Username",
-    },
-    Object {
-      "key": "unsplash",
-      "value": false,
-    },
-    Object {
-      "key": "shared_views",
-      "value": "[]",
-    },
-    Object {
-      "key": "editor_default_email_recipients",
-      "value": "visibility",
-    },
-    Object {
-      "key": "editor_default_email_recipients_filter",
-      "value": "all",
-    },
-    Object {
-      "key": "announcement_content",
-      "value": "<p>Great news coming soon!</p>",
-    },
-    Object {
-      "key": "announcement_visibility",
-      "value": "[\\"visitors\\",\\"free_members\\"]",
-    },
-    Object {
-      "key": "announcement_background",
-      "value": "dark",
-    },
-    Object {
-      "key": "comments_enabled",
-      "value": "off",
-    },
-    Object {
-      "key": "outbound_link_tagging",
-      "value": true,
-    },
-    Object {
-      "key": "pintura",
-      "value": true,
-    },
-    Object {
-      "key": "pintura_js_url",
-      "value": null,
-    },
-    Object {
-      "key": "pintura_css_url",
-      "value": null,
-    },
-    Object {
-      "key": "donations_currency",
-      "value": "USD",
-    },
-    Object {
-      "key": "donations_suggested_amount",
-      "value": "0",
-    },
-    Object {
-      "key": "recommendations_enabled",
-      "value": false,
-    },
-    Object {
-      "key": "members_enabled",
-      "value": true,
-    },
-    Object {
-      "key": "members_invite_only",
-      "value": false,
-    },
-    Object {
-      "key": "allow_self_signup",
-      "value": true,
-    },
-    Object {
-      "key": "paid_members_enabled",
-      "value": true,
-    },
-    Object {
-      "key": "firstpromoter_account",
-      "value": null,
-    },
-    Object {
-      "key": "donations_enabled",
-      "value": true,
-    },
-    Object {
-      "key": "default_email_address",
-      "value": "noreply@127.0.0.1",
-    },
-    Object {
-      "key": "support_email_address",
-      "value": "noreply@127.0.0.1",
-    },
-  ],
-}
-`;
-
-exports[`Settings API Edit editing members_support_address triggers email verification flow 2: [headers] 1`] = `
-Object {
-  "access-control-allow-origin": "http://127.0.0.1:2369",
-  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": StringMatching /\\\\d\\+/,
-  "content-type": "application/json; charset=utf-8",
-  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
-  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
-  "vary": "Accept-Version, Origin, Accept-Encoding",
   "x-powered-by": "Express",
 }
 `;
@@ -2962,37 +2242,6 @@ Object {
 `;
 
 exports[`Settings API Edit fails to edit setting with unsupported announcement_visibility value 2: [headers] 1`] = `
-Object {
-  "access-control-allow-origin": "http://127.0.0.1:2369",
-  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "295",
-  "content-type": "application/json; charset=utf-8",
-  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
-  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
-  "vary": "Accept-Version, Origin, Accept-Encoding",
-  "x-powered-by": "Express",
-}
-`;
-
-exports[`Settings API Edit fails to edit setting with unsupported value 1: [body] 1`] = `
-Object {
-  "errors": Array [
-    Object {
-      "code": null,
-      "context": "Please enter a valid announcement visibility value",
-      "details": null,
-      "ghostErrorCode": null,
-      "help": null,
-      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
-      "message": "Validation error, cannot edit setting.",
-      "property": "announcement_visibility",
-      "type": "ValidationError",
-    },
-  ],
-}
-`;
-
-exports[`Settings API Edit fails to edit setting with unsupported value 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
@@ -3403,6 +2652,10 @@ Object {
     },
     Object {
       "key": "web_analytics_configured",
+      "value": false,
+    },
+    Object {
+      "key": "members_single_opt_in",
       "value": false,
     },
   ],
@@ -3823,6 +3076,10 @@ Object {
       "key": "web_analytics_configured",
       "value": false,
     },
+    Object {
+      "key": "members_single_opt_in",
+      "value": false,
+    },
   ],
 }
 `;
@@ -4239,6 +3496,10 @@ Object {
     },
     Object {
       "key": "web_analytics_configured",
+      "value": false,
+    },
+    Object {
+      "key": "members_single_opt_in",
       "value": false,
     },
   ],
@@ -4663,6 +3924,10 @@ Object {
       "key": "web_analytics_configured",
       "value": false,
     },
+    Object {
+      "key": "members_single_opt_in",
+      "value": false,
+    },
   ],
 }
 `;
@@ -5078,6 +4343,10 @@ Object {
     },
     Object {
       "key": "web_analytics_configured",
+      "value": false,
+    },
+    Object {
+      "key": "members_single_opt_in",
       "value": false,
     },
   ],
@@ -5502,372 +4771,15 @@ Object {
       "key": "web_analytics_configured",
       "value": false,
     },
+    Object {
+      "key": "members_single_opt_in",
+      "value": false,
+    },
   ],
 }
 `;
 
 exports[`Settings API Managed email without custom sending domain editing members_support_address triggers email verification flow 2: [headers] 1`] = `
-Object {
-  "access-control-allow-origin": "http://127.0.0.1:2369",
-  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": StringMatching /\\\\d\\+/,
-  "content-type": "application/json; charset=utf-8",
-  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
-  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
-  "vary": "Accept-Version, Origin, Accept-Encoding",
-  "x-powered-by": "Express",
-}
-`;
-
-exports[`Settings API Managed email without custom sending domain editing members_support_address without matching domain triggers email verification flow 1: [body] 1`] = `
-Object {
-  "meta": Object {
-    "sent_email_verification": Array [
-      "members_support_address",
-    ],
-  },
-  "settings": Array [
-    Object {
-      "key": "members_track_sources",
-      "value": true,
-    },
-    Object {
-      "key": "title",
-      "value": null,
-    },
-    Object {
-      "key": "description",
-      "value": "Thoughts, stories and ideas",
-    },
-    Object {
-      "key": "logo",
-      "value": "",
-    },
-    Object {
-      "key": "cover_image",
-      "value": "https://static.ghost.org/v5.0.0/images/publication-cover.jpg",
-    },
-    Object {
-      "key": "icon",
-      "value": "http://127.0.0.1:2369/content/images/size/w256h256/2019/07/icon.png",
-    },
-    Object {
-      "key": "accent_color",
-      "value": "#FF1A75",
-    },
-    Object {
-      "key": "locale",
-      "value": "ua",
-    },
-    Object {
-      "key": "timezone",
-      "value": "Pacific/Auckland",
-    },
-    Object {
-      "key": "codeinjection_head",
-      "value": null,
-    },
-    Object {
-      "key": "codeinjection_foot",
-      "value": "",
-    },
-    Object {
-      "key": "facebook",
-      "value": "ghost",
-    },
-    Object {
-      "key": "twitter",
-      "value": "@ghost",
-    },
-    Object {
-      "key": "navigation",
-      "value": "[{\\"label\\":\\"label1\\"}]",
-    },
-    Object {
-      "key": "secondary_navigation",
-      "value": "[{\\"label\\":\\"Data & privacy\\",\\"url\\":\\"/privacy/\\"},{\\"label\\":\\"Contact\\",\\"url\\":\\"/contact/\\"},{\\"label\\":\\"Contribute →\\",\\"url\\":\\"/contribute/\\"}]",
-    },
-    Object {
-      "key": "meta_title",
-      "value": "SEO title",
-    },
-    Object {
-      "key": "meta_description",
-      "value": "SEO description",
-    },
-    Object {
-      "key": "og_image",
-      "value": "http://127.0.0.1:2369/content/images/2019/07/facebook.png",
-    },
-    Object {
-      "key": "og_title",
-      "value": "facebook title",
-    },
-    Object {
-      "key": "og_description",
-      "value": "facebook description",
-    },
-    Object {
-      "key": "twitter_image",
-      "value": "http://127.0.0.1:2369/content/images/2019/07/twitter.png",
-    },
-    Object {
-      "key": "twitter_title",
-      "value": "twitter title",
-    },
-    Object {
-      "key": "twitter_description",
-      "value": "twitter description",
-    },
-    Object {
-      "key": "active_theme",
-      "value": "source",
-    },
-    Object {
-      "key": "is_private",
-      "value": false,
-    },
-    Object {
-      "key": "password",
-      "value": "",
-    },
-    Object {
-      "key": "public_hash",
-      "value": StringMatching /\\[a-z0-9\\]\\{30\\}/,
-    },
-    Object {
-      "key": "default_content_visibility",
-      "value": "public",
-    },
-    Object {
-      "key": "default_content_visibility_tiers",
-      "value": "[]",
-    },
-    Object {
-      "key": "members_signup_access",
-      "value": "all",
-    },
-    Object {
-      "key": "members_support_address",
-      "value": "support@example.com",
-    },
-    Object {
-      "key": "stripe_secret_key",
-      "value": null,
-    },
-    Object {
-      "key": "stripe_publishable_key",
-      "value": null,
-    },
-    Object {
-      "key": "stripe_plans",
-      "value": "[]",
-    },
-    Object {
-      "key": "stripe_connect_publishable_key",
-      "value": null,
-    },
-    Object {
-      "key": "stripe_connect_secret_key",
-      "value": null,
-    },
-    Object {
-      "key": "stripe_connect_livemode",
-      "value": null,
-    },
-    Object {
-      "key": "stripe_connect_display_name",
-      "value": null,
-    },
-    Object {
-      "key": "stripe_connect_account_id",
-      "value": null,
-    },
-    Object {
-      "key": "members_monthly_price_id",
-      "value": null,
-    },
-    Object {
-      "key": "members_yearly_price_id",
-      "value": null,
-    },
-    Object {
-      "key": "portal_name",
-      "value": true,
-    },
-    Object {
-      "key": "portal_button",
-      "value": true,
-    },
-    Object {
-      "key": "portal_plans",
-      "value": "[\\"free\\"]",
-    },
-    Object {
-      "key": "portal_products",
-      "value": "[]",
-    },
-    Object {
-      "key": "portal_button_style",
-      "value": "icon-and-text",
-    },
-    Object {
-      "key": "portal_button_icon",
-      "value": null,
-    },
-    Object {
-      "key": "portal_button_signup_text",
-      "value": "Subscribe",
-    },
-    Object {
-      "key": "portal_signup_terms_html",
-      "value": null,
-    },
-    Object {
-      "key": "portal_signup_checkbox_required",
-      "value": false,
-    },
-    Object {
-      "key": "mailgun_domain",
-      "value": null,
-    },
-    Object {
-      "key": "mailgun_api_key",
-      "value": null,
-    },
-    Object {
-      "key": "mailgun_base_url",
-      "value": null,
-    },
-    Object {
-      "key": "email_track_opens",
-      "value": true,
-    },
-    Object {
-      "key": "email_track_clicks",
-      "value": true,
-    },
-    Object {
-      "key": "email_verification_required",
-      "value": false,
-    },
-    Object {
-      "key": "firstpromoter",
-      "value": false,
-    },
-    Object {
-      "key": "firstpromoter_id",
-      "value": null,
-    },
-    Object {
-      "key": "labs",
-      "value": StringMatching /\\\\\\{\\[\\^\\\\s\\]\\+\\\\\\}/,
-    },
-    Object {
-      "key": "slack_url",
-      "value": "",
-    },
-    Object {
-      "key": "slack_username",
-      "value": "New Slack Username",
-    },
-    Object {
-      "key": "unsplash",
-      "value": false,
-    },
-    Object {
-      "key": "shared_views",
-      "value": "[]",
-    },
-    Object {
-      "key": "editor_default_email_recipients",
-      "value": "visibility",
-    },
-    Object {
-      "key": "editor_default_email_recipients_filter",
-      "value": "all",
-    },
-    Object {
-      "key": "announcement_content",
-      "value": "<p>Great news coming soon!</p>",
-    },
-    Object {
-      "key": "announcement_visibility",
-      "value": "[\\"visitors\\",\\"free_members\\"]",
-    },
-    Object {
-      "key": "announcement_background",
-      "value": "dark",
-    },
-    Object {
-      "key": "comments_enabled",
-      "value": "off",
-    },
-    Object {
-      "key": "outbound_link_tagging",
-      "value": true,
-    },
-    Object {
-      "key": "pintura",
-      "value": true,
-    },
-    Object {
-      "key": "pintura_js_url",
-      "value": null,
-    },
-    Object {
-      "key": "pintura_css_url",
-      "value": null,
-    },
-    Object {
-      "key": "donations_currency",
-      "value": "USD",
-    },
-    Object {
-      "key": "donations_suggested_amount",
-      "value": "0",
-    },
-    Object {
-      "key": "recommendations_enabled",
-      "value": false,
-    },
-    Object {
-      "key": "members_enabled",
-      "value": true,
-    },
-    Object {
-      "key": "members_invite_only",
-      "value": false,
-    },
-    Object {
-      "key": "allow_self_signup",
-      "value": true,
-    },
-    Object {
-      "key": "paid_members_enabled",
-      "value": false,
-    },
-    Object {
-      "key": "firstpromoter_account",
-      "value": null,
-    },
-    Object {
-      "key": "donations_enabled",
-      "value": false,
-    },
-    Object {
-      "key": "default_email_address",
-      "value": "noreply@127.0.0.1",
-    },
-    Object {
-      "key": "support_email_address",
-      "value": "support@example.com",
-    },
-  ],
-}
-`;
-
-exports[`Settings API Managed email without custom sending domain editing members_support_address without matching domain triggers email verification flow 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
@@ -6278,6 +5190,10 @@ Object {
     },
     Object {
       "key": "web_analytics_configured",
+      "value": false,
+    },
+    Object {
+      "key": "members_single_opt_in",
       "value": false,
     },
   ],
@@ -6696,6 +5612,10 @@ Object {
     },
     Object {
       "key": "web_analytics_configured",
+      "value": false,
+    },
+    Object {
+      "key": "members_single_opt_in",
       "value": false,
     },
   ],
@@ -7117,6 +6037,10 @@ Object {
       "key": "web_analytics_configured",
       "value": false,
     },
+    Object {
+      "key": "members_single_opt_in",
+      "value": false,
+    },
   ],
 }
 `;
@@ -7536,6 +6460,10 @@ Object {
       "key": "web_analytics_configured",
       "value": false,
     },
+    Object {
+      "key": "members_single_opt_in",
+      "value": false,
+    },
   ],
 }
 `;
@@ -7549,28 +6477,6 @@ Object {
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Version, Origin, Accept-Encoding",
-  "x-powered-by": "Express",
-}
-`;
-
-exports[`Settings API deprecated can do updateMembersEmail 1: [headers] 1`] = `
-Object {
-  "access-control-allow-origin": "http://127.0.0.1:2369",
-  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
-  "vary": "Origin",
-  "x-powered-by": "Express",
-}
-`;
-
-exports[`Settings API deprecated can do validateMembersEmailUpdate 1: [headers] 1`] = `
-Object {
-  "access-control-allow-origin": "http://127.0.0.1:2369",
-  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "98",
-  "content-type": "text/plain; charset=utf-8",
-  "location": "http://127.0.0.1:2369/ghost/#/settings/members/?supportAddressUpdate=success",
-  "vary": "Origin, Accept, Accept-Encoding",
   "x-powered-by": "Express",
 }
 `;
@@ -8015,6 +6921,10 @@ Object {
     },
     Object {
       "key": "web_analytics_configured",
+      "value": false,
+    },
+    Object {
+      "key": "members_single_opt_in",
       "value": false,
     },
   ],

--- a/ghost/core/test/e2e-api/admin/settings.test.js
+++ b/ghost/core/test/e2e-api/admin/settings.test.js
@@ -11,7 +11,7 @@ const membersService = require('../../../core/server/services/members');
 const {anyErrorId} = matchers;
 
 // Updated to reflect current total based on test output
-const CURRENT_SETTINGS_COUNT = 99;
+const CURRENT_SETTINGS_COUNT = 100;
 
 const settingsMatcher = {};
 

--- a/ghost/core/test/e2e-api/content/__snapshots__/settings.test.js.snap
+++ b/ghost/core/test/e2e-api/content/__snapshots__/settings.test.js.snap
@@ -24,6 +24,7 @@ Object {
     "members_enabled": true,
     "members_invite_only": false,
     "members_signup_access": "all",
+    "members_single_opt_in": false,
     "members_support_address": "noreply",
     "meta_description": null,
     "meta_title": null,
@@ -100,118 +101,6 @@ Object {
 `;
 
 exports[`Settings Content API Can request settings 2: [headers] 1`] = `
-Object {
-  "access-control-allow-origin": "*",
-  "cache-control": "public, max-age=0",
-  "content-length": StringMatching /\\\\d\\+/,
-  "content-type": "application/json; charset=utf-8",
-  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
-  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
-  "vary": "Accept-Version, Accept-Encoding",
-  "x-powered-by": "Express",
-}
-`;
-
-exports[`Settings Content API Captcha settings Can request captcha settings 1: [body] 1`] = `
-Object {
-  "meta": Object {},
-  "settings": Object {
-    "accent_color": "#FF1A75",
-    "allow_self_signup": true,
-    "captcha_enabled": null,
-    "captcha_sitekey": "testkey",
-    "codeinjection_foot": null,
-    "codeinjection_head": null,
-    "comments_enabled": "off",
-    "cover_image": "https://static.ghost.org/v5.0.0/images/publication-cover.jpg",
-    "default_email_address": "noreply@127.0.0.1",
-    "description": "Thoughts, stories and ideas",
-    "editor_default_email_recipients": "visibility",
-    "facebook": "ghost",
-    "firstpromoter_account": null,
-    "icon": null,
-    "labs": Any<Object>,
-    "lang": "en",
-    "locale": "en",
-    "logo": null,
-    "members_enabled": true,
-    "members_invite_only": false,
-    "members_signup_access": "all",
-    "members_support_address": "noreply",
-    "meta_description": null,
-    "meta_title": null,
-    "navigation": Array [
-      Object {
-        "label": "Home",
-        "url": "/",
-      },
-      Object {
-        "label": "About",
-        "url": "/about/",
-      },
-      Object {
-        "label": "Collection",
-        "url": "/tag/getting-started/",
-      },
-      Object {
-        "label": "Author",
-        "url": "/author/ghost/",
-      },
-      Object {
-        "label": "Portal",
-        "url": "/portal/",
-      },
-    ],
-    "og_description": null,
-    "og_image": null,
-    "og_title": null,
-    "outbound_link_tagging": true,
-    "paid_members_enabled": true,
-    "portal_button": true,
-    "portal_button_icon": null,
-    "portal_button_signup_text": "Subscribe",
-    "portal_button_style": "icon-and-text",
-    "portal_default_plan": "yearly",
-    "portal_name": true,
-    "portal_plans": Array [
-      "free",
-    ],
-    "portal_signup_checkbox_required": false,
-    "portal_signup_terms_html": null,
-    "recommendations_enabled": false,
-    "secondary_navigation": Array [
-      Object {
-        "label": "Data & privacy",
-        "url": "/privacy/",
-      },
-      Object {
-        "label": "Contact",
-        "url": "/contact/",
-      },
-      Object {
-        "label": "Contribute →",
-        "url": "/contribute/",
-      },
-    ],
-    "support_email_address": "noreply@127.0.0.1",
-    "timezone": "Etc/UTC",
-    "title": "Ghost",
-    "transistor_portal_button_text": "Manage",
-    "transistor_portal_description": "Access your private podcast feed",
-    "transistor_portal_enabled": true,
-    "transistor_portal_heading": "Podcasts",
-    "transistor_portal_url_template": "https://partner.transistor.fm/ghost/{memberUuid}",
-    "twitter": "@ghost",
-    "twitter_description": null,
-    "twitter_image": null,
-    "twitter_title": null,
-    "url": "http://127.0.0.1:2369/",
-    "version": Any<String>,
-  },
-}
-`;
-
-exports[`Settings Content API Captcha settings Can request captcha settings 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "public, max-age=0",

--- a/ghost/core/test/unit/server/services/settings-helpers/settings-helpers.test.js
+++ b/ghost/core/test/unit/server/services/settings-helpers/settings-helpers.test.js
@@ -418,5 +418,48 @@ describe('Settings Helpers', function () {
             assert.equal(isEnabled, true);
         });
     });
+
+    describe('isMembersSingleOptInEnabled', function () {
+        afterEach(async function () {
+            await configUtils.restore();
+        });
+
+        it('returns true when hostSettings:membersSingleOptIn:enabled is true', function () {
+            configUtils.set({
+                hostSettings: {membersSingleOptIn: {enabled: true}}
+            });
+            const fakeSettings = createSettingsMock({setDirect: false, setConnect: false});
+            const settingsHelpers = new SettingsHelpers({settingsCache: fakeSettings, config: configUtils.config, urlUtils: {}, labs: {}, limitService});
+
+            assert.equal(settingsHelpers.isMembersSingleOptInEnabled(), true);
+        });
+
+        it('returns false when hostSettings:membersSingleOptIn:enabled is false', function () {
+            configUtils.set({
+                hostSettings: {membersSingleOptIn: {enabled: false}}
+            });
+            const fakeSettings = createSettingsMock({setDirect: false, setConnect: false});
+            const settingsHelpers = new SettingsHelpers({settingsCache: fakeSettings, config: configUtils.config, urlUtils: {}, labs: {}, limitService});
+
+            assert.equal(settingsHelpers.isMembersSingleOptInEnabled(), false);
+        });
+
+        it('returns false when hostSettings:membersSingleOptIn is missing', function () {
+            configUtils.set({
+                hostSettings: {}
+            });
+            const fakeSettings = createSettingsMock({setDirect: false, setConnect: false});
+            const settingsHelpers = new SettingsHelpers({settingsCache: fakeSettings, config: configUtils.config, urlUtils: {}, labs: {}, limitService});
+
+            assert.equal(settingsHelpers.isMembersSingleOptInEnabled(), false);
+        });
+
+        it('returns false when no hostSettings config is set', function () {
+            const fakeSettings = createSettingsMock({setDirect: false, setConnect: false});
+            const settingsHelpers = new SettingsHelpers({settingsCache: fakeSettings, config: configUtils.config, urlUtils: {}, labs: {}, limitService});
+
+            assert.equal(settingsHelpers.isMembersSingleOptInEnabled(), false);
+        });
+    });
 });
 


### PR DESCRIPTION
no ref

This is the first step toward native single opt-in support. The setting is derived from the `hostSettings:membersSingleOptIn:enabled` config value (managed by host) and exposed to frontends via the Content API public settings response.
