### PR TITLE
Updated mini Koenig editor text inhereitence

### DIFF
--- a/apps/admin-x-design-system/src/global/form/koenig-editor-base.tsx
+++ b/apps/admin-x-design-system/src/global/form/koenig-editor-base.tsx
@@ -194,7 +194,7 @@ const KoenigEditorBase: React.FC<KoenigEditorBaseInternalProps> = ({
 }) => {
     const {fetchKoenigLexical, darkMode} = useDesignSystem();
     const editorResource = useMemo(() => loadKoenig(fetchKoenigLexical), [fetchKoenigLexical]);
-    const inheritClasses = inheritFontStyles ? '[&_*]:font-inherit! [&_*]:text-inherit!' : '';
+    const inheritClasses = inheritFontStyles ? '[&_*]:font-inherit! [&_*]:[font-size:inherit]!' : '';
 
     return (
         <div className={className || 'w-full'}>


### PR DESCRIPTION
Closes https://linear.app/ghost/issue/DES-1310/font-size-regression-in-settings-mini-koenig-editor

Regression from the TW4 update. Also fixed for Newsletters and Announcements Bar.

| Before | After |
|--------|--------|
| <img width="483" height="324" alt="Screenshot 2026-03-12 at 15 32 50" src="https://github.com/user-attachments/assets/4d8d8b99-b10f-45d0-93bc-45f1ebeaeabd" /> | <img width="505" height="397" alt="Screenshot 2026-03-12 at 15 32 15" src="https://github.com/user-attachments/assets/9fd765cf-bd2e-4b0a-847f-ec84e2ad7a68" /> |
