### PR TITLE
Added composite index on offer_redemptions(offer_id, created_at)

### DIFF
--- a/ghost/admin/package.json
+++ b/ghost/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ghost-admin",
-  "version": "6.21.2",
+  "version": "6.22.0-rc.0",
   "description": "Ember.js admin client for Ghost",
   "author": "Ghost Foundation",
   "homepage": "http://ghost.org",

--- a/ghost/core/core/server/data/migrations/versions/6.22/2026-03-12-15-29-49-add-offer-redemptions-offer-id-created-at-index.js
+++ b/ghost/core/core/server/data/migrations/versions/6.22/2026-03-12-15-29-49-add-offer-redemptions-offer-id-created-at-index.js
@@ -1,0 +1,26 @@
+const logging = require('@tryghost/logging');
+const {createNonTransactionalMigration} = require('../../utils');
+const {addIndex, dropIndex} = require('../../../schema/commands');
+
+module.exports = createNonTransactionalMigration(
+    async function up(knex) {
+        await addIndex('offer_redemptions', ['offer_id', 'created_at'], knex);
+    },
+    async function down(knex) {
+        try {
+            await dropIndex('offer_redemptions', ['offer_id', 'created_at'], knex);
+        } catch (err) {
+            if (err.code === 'ER_DROP_INDEX_FK') {
+                logging.error({
+                    message: 'Error dropping index over offer_redemptions(offer_id, created_at), re-adding index for offer_id'
+                });
+
+                await addIndex('offer_redemptions', ['offer_id'], knex);
+                await dropIndex('offer_redemptions', ['offer_id', 'created_at'], knex);
+                return;
+            }
+
+            throw err;
+        }
+    }
+);

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -742,7 +742,10 @@ module.exports = {
         offer_id: {type: 'string', maxlength: 24, nullable: false, references: 'offers.id', cascadeDelete: true},
         member_id: {type: 'string', maxlength: 24, nullable: false, references: 'members.id', cascadeDelete: true},
         subscription_id: {type: 'string', maxlength: 24, nullable: false, references: 'members_stripe_customers_subscriptions.id', cascadeDelete: true},
-        created_at: {type: 'dateTime', nullable: false}
+        created_at: {type: 'dateTime', nullable: false},
+        '@@INDEXES@@': [
+            ['offer_id', 'created_at']
+        ]
     },
     members_subscribe_events: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ghost",
-  "version": "6.21.2",
+  "version": "6.22.0-rc.0",
   "description": "The professional publishing platform",
   "author": "Ghost Foundation",
   "homepage": "https://ghost.org",

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '0faf1ab8fe5d1582b21e8f828f718c9f';
+    const currentSchemaHash = 'efad6820c5c431cd244b7e0a3fb859be';
     const currentFixturesHash = '4dcbd7b52bc9ce23e6f5f1673118ba73';
     const currentSettingsHash = 'a102b80d2ab0cd92325ed007c94d7da6';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
## Summary

- Adds a composite index on `offer_redemptions(offer_id, created_at)` to optimize the query in `mapToOffer` that finds the last redemption date per offer
- `mapToOffer` is called for every offer when listing offers via the Admin API (`GET /offers/`), when checking available offers for members (`listOffersAvailableToSubscription`), and on boot for redirect setup — each call queries `offer_redemptions` filtered by `offer_id` and ordered by `created_at DESC`, currently causing unindexed filesorts
- The composite index lets MySQL satisfy both the filter and sort directly from the index, and the existing single-column FK index on `offer_id` is subsumed by the leftmost prefix of the new index