### PR TITLE
Fixed broken space-* utility on Dialog

### DIFF
--- a/apps/shade/src/components/ui/dialog.tsx
+++ b/apps/shade/src/components/ui/dialog.tsx
@@ -69,7 +69,7 @@ const DialogFooter = ({
 }: React.HTMLAttributes<HTMLDivElement>) => (
     <div
         className={cn(
-            'flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2 sm:items-end [&_button]:min-w-20',
+            'flex flex-col-reverse sm:flex-row sm:justify-end sm:gap-2 sm:items-end [&_button]:min-w-20',
             className
         )}
         {...props}


### PR DESCRIPTION
Closes https://linear.app/ghost/issue/DES-1311/space-x-classes-in-activitypub-dont-work

Tailwind v4 doesn't like the `space-*` utility bound to responsive classes (Like `sm:`). This PR tweaks it to `gap` which works more reliably. Tested across a few different Dialog implementations.

| Before | After |
|--------|--------|
| <img width="589" height="258" alt="Screenshot 2026-03-12 at 16 37 37" src="https://github.com/user-attachments/assets/2aef7105-8560-4f9e-ad0c-d6ba1b553343" /> | <img width="611" height="261" alt="Screenshot 2026-03-12 at 16 37 17" src="https://github.com/user-attachments/assets/f756105a-8278-421d-aec4-405c0700399e" /> |