### PR TITLE
Added label-triggered PR preview environments

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,51 @@
+name: PR Preview
+
+on:
+  pull_request_target:
+    types: [labeled, unlabeled, closed]
+
+jobs:
+  deploy:
+    name: Deploy Preview
+    # Runs when the "preview" label is added — requires collaborator write access
+    if: >-
+      github.event.action == 'labeled'
+      && github.event.label.name == 'preview'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Dispatch deploy to Ghost-Moya
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.CANARY_DOCKER_BUILD }}
+          repository: TryGhost/Ghost-Moya
+          event-type: preview-deploy
+          client-payload: >-
+            {
+              "pr_number": "${{ github.event.pull_request.number }}",
+              "action": "deploy",
+              "seed": "true"
+            }
+
+  destroy:
+    name: Destroy Preview
+    # Runs when "preview" label is removed, or the PR is closed/merged while labeled
+    if: >-
+      (github.event.action == 'unlabeled' && github.event.label.name == 'preview')
+      || (github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'preview'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Dispatch destroy to Ghost-Moya
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.CANARY_DOCKER_BUILD }}
+          repository: TryGhost/Ghost-Moya
+          event-type: preview-destroy
+          client-payload: >-
+            {
+              "pr_number": "${{ github.event.pull_request.number }}",
+              "action": "destroy"
+            }


### PR DESCRIPTION
PR preview environments let you spin up an isolated, throwaway Ghost instance for any PR by adding a label. This is useful for design review, QA, and demos without touching shared staging infrastructure.

Adding the `preview` label to a PR dispatches a `preview-deploy` event to Ghost-Moya, which deploys a Cloud Run service running the PR's Docker image with seeded demo data. Removing the label dispatches `preview-destroy` to tear it down. If a PR is merged or closed while the label is still applied, the preview is auto-destroyed.

The workflow uses `pull_request_target` so only default-branch code runs — no PR code is checked out. It dispatches via `repository_dispatch` using the existing `CANARY_DOCKER_BUILD` token, following the same cross-repo pattern as `ci.yml`'s `trigger_cd` job. Only collaborators with write access can add labels, so there's no fork risk.

Depends on https://github.com/TryGhost/Ghost-Moya/pull/195 which adds `repository_dispatch` support to Ghost-Moya's `pr-preview.yml`. The `preview` label also needs to be created in this repo before use.