### PR TITLE
Cleaned up outbox entries when welcome email is toggled inactive

### DIFF
--- a/ghost/core/core/server/models/automated-email.js
+++ b/ghost/core/core/server/models/automated-email.js
@@ -6,6 +6,11 @@ const {MEMBER_WELCOME_EMAIL_SLUGS} = require('../services/member-welcome-emails/
 
 const MEMBER_WELCOME_EMAIL_SLUG_SET = new Set(Object.values(MEMBER_WELCOME_EMAIL_SLUGS));
 
+// Reverse mapping: slug → member status (e.g. 'member-welcome-email-free' → 'free')
+const SLUG_TO_MEMBER_STATUS = Object.fromEntries(
+    Object.entries(MEMBER_WELCOME_EMAIL_SLUGS).map(([status, slug]) => [slug, status])
+);
+
 const AutomatedEmail = ghostBookshelf.Model.extend({
     tableName: 'automated_emails',
 
@@ -67,6 +72,42 @@ const AutomatedEmail = ghostBookshelf.Model.extend({
                 slug
             }
         }, isEnableTransition ? 'Welcome email enabled' : 'Welcome email disabled');
+
+        if (isDisableTransition) {
+            const memberStatus = SLUG_TO_MEMBER_STATUS[slug];
+            if (memberStatus) {
+                this.deletePendingOutboxEntries(memberStatus).catch((err) => {
+                    logging.error({
+                        system: {
+                            event: 'welcome_email.cleanup_failed',
+                            slug
+                        },
+                        err
+                    }, 'Failed to clean up pending outbox entries after disabling welcome email');
+                });
+            }
+        }
+    },
+
+    async deletePendingOutboxEntries(memberStatus) {
+        const knex = ghostBookshelf.knex;
+        const MemberCreatedEvent = require('../../shared/events/member-created-event');
+
+        const deleted = await knex('outbox')
+            .where('event_type', MemberCreatedEvent.name)
+            .whereIn('status', ['pending', 'processing'])
+            .whereRaw('JSON_EXTRACT(payload, ?) = ?', ['$.status', memberStatus])
+            .delete();
+
+        if (deleted > 0) {
+            logging.info({
+                system: {
+                    event: 'welcome_email.outbox_cleanup',
+                    member_status: memberStatus,
+                    deleted_count: deleted
+                }
+            }, `Deleted ${deleted} pending outbox entries for "${memberStatus}" welcome email`);
+        }
     }
 });
 

--- a/ghost/core/core/server/services/outbox/handlers/member-created.js
+++ b/ghost/core/core/server/services/outbox/handlers/member-created.js
@@ -7,6 +7,20 @@ const {MEMBER_WELCOME_EMAIL_SLUGS} = require('../../member-welcome-emails/consta
 const LOG_KEY = `${OUTBOX_LOG_KEY}[MEMBER-WELCOME-EMAIL]`;
 
 async function handle({payload}) {
+    // Check if the welcome email is still active before attempting to send.
+    // If the template was disabled after this outbox entry was created,
+    // we skip sending and let the entry be deleted from the outbox.
+    const isActive = await memberWelcomeEmailService.api.isMemberWelcomeEmailActive(payload.status);
+    if (!isActive) {
+        logging.info({
+            system: {
+                event: 'outbox.member_created.skipped_inactive',
+                member_status: payload.status
+            }
+        }, `${LOG_KEY} Skipping send for ${payload.email || 'unknown'} — welcome email for "${payload.status}" members is inactive`);
+        return;
+    }
+
     await memberWelcomeEmailService.api.send({member: payload, memberStatus: payload.status});
 
     try {

--- a/ghost/core/test/unit/server/services/outbox/handlers/member-created.test.js
+++ b/ghost/core/test/unit/server/services/outbox/handlers/member-created.test.js
@@ -15,7 +15,8 @@ describe('member-created handler', function () {
 
         memberWelcomeEmailServiceStub = {
             api: {
-                send: sinon.stub().resolves()
+                send: sinon.stub().resolves(),
+                isMemberWelcomeEmailActive: sinon.stub().resolves(true)
             }
         };
 
@@ -92,6 +93,28 @@ describe('member-created handler', function () {
             member_status: 'comped'
         });
         sinon.assert.notCalled(AutomatedEmailRecipientStub.add);
+    });
+
+    it('skips sending when welcome email is inactive', async function () {
+        memberWelcomeEmailServiceStub.api.isMemberWelcomeEmailActive.resolves(false);
+
+        await handler.handle({
+            payload: {
+                memberId: 'member123',
+                uuid: 'uuid-123',
+                email: 'test@example.com',
+                name: 'Test Member',
+                status: 'free'
+            }
+        });
+
+        sinon.assert.notCalled(memberWelcomeEmailServiceStub.api.send);
+        const infoLog = findByEvent(logCapture.output, 'outbox.member_created.skipped_inactive');
+        assert.ok(infoLog);
+        assert.deepEqual(infoLog.system, {
+            event: 'outbox.member_created.skipped_inactive',
+            member_status: 'free'
+        });
     });
 
     it('logs warning when no automated email found for slug', async function () {


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-835/cleanup-what-happens-to-outbox-rows-when-an-email-is-toggled-between

## Summary

- **Proactive cleanup**: When a welcome email template is toggled from active to inactive, pending outbox entries for that template are now deleted from the database immediately
- **Graceful skip**: In the outbox handler, if a template becomes inactive after an entry was created, the handler skips sending and allows the entry to be deleted naturally
- **Tests**: Added unit test to verify the handler skips sending inactive templates

This prevents zombie FAILED rows from accumulating in the outbox table when templates are disabled.