### PR TITLE
Added subscription lifecycle e2e tests for Stripe webhooks

### DIFF
--- a/e2e/helpers/services/members/members-service.ts
+++ b/e2e/helpers/services/members/members-service.ts
@@ -1,7 +1,31 @@
 import {HttpClient as APIRequest, Member} from '@/data-factory';
 
+export interface MemberSubscription {
+    id: string;
+    status: string;
+    cancel_at_period_end: boolean;
+    current_period_end: string;
+    start_date: string;
+    default_payment_card_last4: string | null;
+    plan: {
+        id: string;
+        nickname: string | null;
+        amount: number;
+        currency: string;
+        interval: string;
+    };
+}
+
+export interface MemberWithSubscriptions extends Member {
+    subscriptions: MemberSubscription[];
+}
+
 export interface MembersResponse {
     members: Member[];
+}
+
+export interface MembersWithSubscriptionsResponse {
+    members: MemberWithSubscriptions[];
 }
 
 export class MembersService {
@@ -21,6 +45,20 @@ export class MembersService {
             throw new Error(`Failed to fetch member: ${response.status()}`);
         }
         const data = await response.json() as MembersResponse;
+        if (!data.members || data.members.length === 0) {
+            throw new Error(`Member not found with email: ${email}`);
+        }
+        return data.members[0];
+    }
+
+    async getByEmailWithSubscriptions(email: string): Promise<MemberWithSubscriptions> {
+        const response = await this.request.get(
+            `${this.adminEndpoint}/members/?filter=email:'${email}'&include=subscriptions`
+        );
+        if (!response.ok()) {
+            throw new Error(`Failed to fetch member: ${response.status()}`);
+        }
+        const data = await response.json() as MembersWithSubscriptionsResponse;
         if (!data.members || data.members.length === 0) {
             throw new Error(`Member not found with email: ${email}`);
         }

--- a/e2e/helpers/services/stripe/builders.ts
+++ b/e2e/helpers/services/stripe/builders.ts
@@ -67,6 +67,7 @@ export interface StripeEvent {
     type: string;
     data: {
         object: Record<string, unknown>;
+        previous_attributes?: Record<string, unknown>;
     };
 }
 
@@ -177,6 +178,66 @@ export function buildSubscriptionCreatedEvent(opts: {
         type: 'customer.subscription.created',
         data: {
             object: opts.subscription as unknown as Record<string, unknown>
+        }
+    };
+}
+
+export function buildSubscriptionUpdatedEvent(opts: {
+    subscription: StripeSubscription;
+    previousAttributes?: Record<string, unknown>;
+}): StripeEvent {
+    return {
+        id: generateId('evt'),
+        object: 'event',
+        type: 'customer.subscription.updated',
+        data: {
+            object: opts.subscription as unknown as Record<string, unknown>,
+            previous_attributes: opts.previousAttributes ?? {}
+        }
+    };
+}
+
+export function buildSubscriptionDeletedEvent(opts: {
+    subscription: StripeSubscription;
+}): StripeEvent {
+    return {
+        id: generateId('evt'),
+        object: 'event',
+        type: 'customer.subscription.deleted',
+        data: {
+            object: {
+                ...opts.subscription,
+                status: 'canceled'
+            } as unknown as Record<string, unknown>
+        }
+    };
+}
+
+export function buildInvoicePaymentSucceededEvent(opts: {
+    subscription: StripeSubscription;
+    amount?: number;
+}): StripeEvent {
+    const price = opts.subscription.items.data[0]?.price;
+    return {
+        id: generateId('evt'),
+        object: 'event',
+        type: 'invoice.payment_succeeded',
+        data: {
+            object: {
+                id: generateId('in'),
+                object: 'invoice',
+                subscription: opts.subscription.id,
+                customer: opts.subscription.customer,
+                paid: true,
+                amount_paid: opts.amount ?? price?.unit_amount ?? 0,
+                currency: price?.currency ?? 'usd',
+                lines: {
+                    type: 'list',
+                    data: [{
+                        price: price as unknown as Record<string, unknown>
+                    }]
+                }
+            }
         }
     };
 }

--- a/e2e/helpers/services/stripe/fake-stripe-server.ts
+++ b/e2e/helpers/services/stripe/fake-stripe-server.ts
@@ -96,7 +96,7 @@ export class FakeStripeServer {
             res.status(200).json(response);
         });
 
-        // GET /v1/subscriptions/:id — returns subscription
+        // GET /v1/subscriptions/:id — returns subscription (supports expand[]=default_payment_method)
         this.app.get('/v1/subscriptions/:id', (req, res) => {
             const subscriptionId = req.params.id;
             const subscription = this.subscriptions.get(subscriptionId);
@@ -107,8 +107,21 @@ export class FakeStripeServer {
                 return;
             }
 
-            debug(`Returning subscription: ${subscriptionId}`);
-            res.status(200).json(subscription);
+            const rawExpand = req.query['expand[]'];
+            const expand: string[] = Array.isArray(rawExpand)
+                ? rawExpand.filter((v): v is string => typeof v === 'string')
+                : (typeof rawExpand === 'string' ? [rawExpand] : []);
+            const response = {...subscription} as Record<string, unknown>;
+
+            if (expand.includes('default_payment_method') && typeof subscription.default_payment_method === 'string') {
+                const pm = this.paymentMethods.get(subscription.default_payment_method);
+                if (pm) {
+                    response.default_payment_method = pm;
+                }
+            }
+
+            debug(`Returning subscription: ${subscriptionId} (expand: ${expand.join(', ') || 'none'})`);
+            res.status(200).json(response);
         });
 
         // GET /v1/payment_methods/:id — returns payment method

--- a/e2e/helpers/services/stripe/fake-stripe-server.ts
+++ b/e2e/helpers/services/stripe/fake-stripe-server.ts
@@ -96,7 +96,7 @@ export class FakeStripeServer {
             res.status(200).json(response);
         });
 
-        // GET /v1/subscriptions/:id — returns subscription (supports expand[]=default_payment_method)
+        // GET /v1/subscriptions/:id — returns subscription (supports expand[0]=... and expand[]=...)
         this.app.get('/v1/subscriptions/:id', (req, res) => {
             const subscriptionId = req.params.id;
             const subscription = this.subscriptions.get(subscriptionId);
@@ -107,7 +107,7 @@ export class FakeStripeServer {
                 return;
             }
 
-            const rawExpand = req.query['expand[]'];
+            const rawExpand = req.query.expand ?? req.query['expand[]'];
             const expand: string[] = Array.isArray(rawExpand)
                 ? rawExpand.filter((v): v is string => typeof v === 'string')
                 : (typeof rawExpand === 'string' ? [rawExpand] : []);

--- a/e2e/helpers/services/stripe/index.ts
+++ b/e2e/helpers/services/stripe/index.ts
@@ -1,13 +1,17 @@
 export {FakeStripeServer} from './fake-stripe-server';
 export {WebhookClient} from './webhook-client';
 export {StripeTestService} from './stripe-service';
+export type {CreatedPaidMember} from './stripe-service';
 export {
     buildCustomer,
     buildSubscription,
     buildPrice,
     buildPaymentMethod,
     buildCheckoutSessionCompletedEvent,
-    buildSubscriptionCreatedEvent
+    buildSubscriptionCreatedEvent,
+    buildSubscriptionUpdatedEvent,
+    buildSubscriptionDeletedEvent,
+    buildInvoicePaymentSucceededEvent
 } from './builders';
 export type {
     StripeCustomer,

--- a/e2e/helpers/services/stripe/stripe-service.ts
+++ b/e2e/helpers/services/stripe/stripe-service.ts
@@ -4,13 +4,24 @@ import {WebhookClient} from './webhook-client';
 import {
     buildCheckoutSessionCompletedEvent,
     buildCustomer,
+    buildInvoicePaymentSucceededEvent,
     buildPaymentMethod,
     buildPrice,
     buildSubscription,
-    buildSubscriptionCreatedEvent
+    buildSubscriptionCreatedEvent,
+    buildSubscriptionDeletedEvent,
+    buildSubscriptionUpdatedEvent
 } from './builders';
+import type {StripeCustomer, StripePaymentMethod, StripePrice, StripeSubscription} from './builders';
 
 const debug = baseDebug('e2e:stripe-service');
+
+export interface CreatedPaidMember {
+    customer: StripeCustomer;
+    subscription: StripeSubscription;
+    price: StripePrice;
+    paymentMethod: StripePaymentMethod;
+}
 
 export class StripeTestService {
     private readonly server: FakeStripeServer;
@@ -21,7 +32,7 @@ export class StripeTestService {
         this.webhookClient = webhookClient;
     }
 
-    async createPaidMemberViaWebhooks(opts: {email: string; name: string}): Promise<void> {
+    async createPaidMemberViaWebhooks(opts: {email: string; name: string}): Promise<CreatedPaidMember> {
         // Build Stripe objects
         const customer = buildCustomer({email: opts.email, name: opts.name});
         const price = buildPrice();
@@ -59,6 +70,57 @@ export class StripeTestService {
         if (!subscriptionResponse.ok) {
             const body = await subscriptionResponse.text();
             throw new Error(`customer.subscription.created webhook failed (${subscriptionResponse.status}): ${body}`);
+        }
+
+        return {customer, subscription, price, paymentMethod};
+    }
+
+    async cancelSubscription(opts: {subscription: StripeSubscription}): Promise<void> {
+        const subscription = opts.subscription;
+        subscription.cancel_at_period_end = true;
+
+        this.server.upsertSubscription(subscription);
+        debug('Updated subscription %s with cancel_at_period_end=true', subscription.id);
+
+        const event = buildSubscriptionUpdatedEvent({
+            subscription,
+            previousAttributes: {cancel_at_period_end: false}
+        });
+        const response = await this.webhookClient.sendWebhook(event);
+        debug('customer.subscription.updated webhook response: %d', response.status);
+        if (!response.ok) {
+            const body = await response.text();
+            throw new Error(`customer.subscription.updated webhook failed (${response.status}): ${body}`);
+        }
+    }
+
+    async deleteSubscription(opts: {subscription: StripeSubscription}): Promise<void> {
+        const subscription = opts.subscription;
+        subscription.status = 'canceled';
+        subscription.canceled_at = Math.floor(Date.now() / 1000);
+
+        this.server.upsertSubscription(subscription);
+        debug('Updated subscription %s with status=canceled', subscription.id);
+
+        const event = buildSubscriptionDeletedEvent({subscription});
+        const response = await this.webhookClient.sendWebhook(event);
+        debug('customer.subscription.deleted webhook response: %d', response.status);
+        if (!response.ok) {
+            const body = await response.text();
+            throw new Error(`customer.subscription.deleted webhook failed (${response.status}): ${body}`);
+        }
+    }
+
+    async sendInvoicePaymentSucceeded(opts: {subscription: StripeSubscription; amount?: number}): Promise<void> {
+        const event = buildInvoicePaymentSucceededEvent({
+            subscription: opts.subscription,
+            amount: opts.amount
+        });
+        const response = await this.webhookClient.sendWebhook(event);
+        debug('invoice.payment_succeeded webhook response: %d', response.status);
+        if (!response.ok) {
+            const body = await response.text();
+            throw new Error(`invoice.payment_succeeded webhook failed (${response.status}): ${body}`);
         }
     }
 }

--- a/e2e/tests/admin/members/stripe-webhooks.test.ts
+++ b/e2e/tests/admin/members/stripe-webhooks.test.ts
@@ -4,12 +4,52 @@ import {expect, test} from '@/helpers/playwright';
 test.describe('Ghost Admin - Stripe Webhooks', () => {
     test.use({stripeEnabled: true});
 
-    // Ghost creates a member from Stripe checkout webhooks; this tests the post-Portal redirect flow
     test('member created via webhooks - has paid status', async ({stripe, page}) => {
         const membersService = new MembersService(page.request);
         const email = `stripe-test-${Date.now()}@example.com`;
 
         await stripe!.createPaidMemberViaWebhooks({email, name: 'Test User'});
+
+        const member = await membersService.getByEmail(email);
+        expect(member.status).toBe('paid');
+    });
+});
+
+test.describe('Ghost Admin - Stripe Subscription Lifecycle', () => {
+    test.use({stripeEnabled: true});
+
+    test('subscription canceled at period end - member remains paid', async ({stripe, page}) => {
+        const membersService = new MembersService(page.request);
+        const email = `stripe-cancel-${Date.now()}@example.com`;
+
+        const {subscription} = await stripe!.createPaidMemberViaWebhooks({email, name: 'Cancel Test'});
+
+        await stripe!.cancelSubscription({subscription});
+
+        const member = await membersService.getByEmailWithSubscriptions(email);
+        expect(member.status).toBe('paid');
+        expect(member.subscriptions[0].cancel_at_period_end).toBe(true);
+    });
+
+    test('subscription deleted - member becomes free', async ({stripe, page}) => {
+        const membersService = new MembersService(page.request);
+        const email = `stripe-delete-${Date.now()}@example.com`;
+
+        const {subscription} = await stripe!.createPaidMemberViaWebhooks({email, name: 'Delete Test'});
+
+        await stripe!.deleteSubscription({subscription});
+
+        const member = await membersService.getByEmail(email);
+        expect(member.status).toBe('free');
+    });
+
+    test('invoice payment succeeded - webhook processed without error', async ({stripe, page}) => {
+        const membersService = new MembersService(page.request);
+        const email = `stripe-invoice-${Date.now()}@example.com`;
+
+        const {subscription} = await stripe!.createPaidMemberViaWebhooks({email, name: 'Invoice Test'});
+
+        await stripe!.sendInvoicePaymentSucceeded({subscription});
 
         const member = await membersService.getByEmail(email);
         expect(member.status).toBe('paid');

--- a/e2e/tests/admin/members/stripe-webhooks.test.ts
+++ b/e2e/tests/admin/members/stripe-webhooks.test.ts
@@ -1,5 +1,31 @@
+import {APIRequestContext} from '@playwright/test';
 import {MembersService} from '@/helpers/services/members';
 import {expect, test} from '@/helpers/playwright';
+
+interface MemberEventsResponse {
+    events?: Array<{
+        type: string;
+        data: {
+            amount?: number;
+        };
+    }>;
+}
+
+async function waitForPaymentEvent(request: APIRequestContext, memberId: string, amount: number) {
+    await expect.poll(async () => {
+        const filter = encodeURIComponent(`type:payment_event+data.member_id:'${memberId}'`);
+        const response = await request.get(`/ghost/api/admin/members/events/?filter=${filter}&limit=5`);
+
+        if (!response.ok()) {
+            return null;
+        }
+
+        const data = await response.json() as MemberEventsResponse;
+        const paymentEvent = data.events?.find(event => event.type === 'payment_event');
+
+        return paymentEvent?.data.amount ?? null;
+    }, {timeout: 10000}).toBe(amount);
+}
 
 test.describe('Ghost Admin - Stripe Webhooks', () => {
     test.use({stripeEnabled: true});
@@ -28,6 +54,7 @@ test.describe('Ghost Admin - Stripe Subscription Lifecycle', () => {
 
         const member = await membersService.getByEmailWithSubscriptions(email);
         expect(member.status).toBe('paid');
+        expect(member.subscriptions).toHaveLength(1);
         expect(member.subscriptions[0].cancel_at_period_end).toBe(true);
     });
 
@@ -48,10 +75,12 @@ test.describe('Ghost Admin - Stripe Subscription Lifecycle', () => {
         const email = `stripe-invoice-${Date.now()}@example.com`;
 
         const {subscription} = await stripe!.createPaidMemberViaWebhooks({email, name: 'Invoice Test'});
+        const member = await membersService.getByEmail(email);
 
         await stripe!.sendInvoicePaymentSucceeded({subscription});
+        await waitForPaymentEvent(page.request, member.id, subscription.items.data[0]?.price.unit_amount ?? 0);
 
-        const member = await membersService.getByEmail(email);
-        expect(member.status).toBe('paid');
+        const updatedMember = await membersService.getByEmail(email);
+        expect(updatedMember.status).toBe('paid');
     });
 });


### PR DESCRIPTION
## Summary
- Added e2e tests for subscription cancellation, deletion, and invoice payment webhook flows
- Extended the fake Stripe server to support `expand[]` query params on subscription lookups
- Added `cancelSubscription`, `deleteSubscription`, and `sendInvoicePaymentSucceeded` methods to the Stripe test service
- Extended `MembersService` with `getByEmailWithSubscriptions` for asserting subscription state

## Test plan
- [x] All 4 Stripe webhook tests pass locally (`yarn test tests/admin/members/stripe-webhooks.test.ts`)
- [x] TypeScript types check (`yarn test:types`)
- [x] Linting passes (`yarn lint`)