### PR TITLE
Used prebuilt image for tb-cli step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1156,7 +1156,6 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Pull or build Tinybird CLI Image
-        if: needs.job_setup.outputs.changed_tinybird == 'true'
         run: |
           COMPOSE_IMAGE="${COMPOSE_PROJECT_NAME:-ghost-dev}-tb-cli"
           # Try pulling pre-built image from GHCR first (fast path)
@@ -1191,7 +1190,6 @@ jobs:
       - name: Prepare E2E CI job
         env:
           GHOST_E2E_BASE_IMAGE: ${{ steps.load.outputs.image-tag }}
-          TINYBIRD_CHANGED: ${{ needs.job_setup.outputs.changed_tinybird }}
         run: bash ./e2e/scripts/prepare-ci-e2e-job.sh
 
       - name: Run e2e tests in Playwright container

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1152,19 +1152,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-        # TODO: Build tb-cli in a separate workflow and pull from GHCR instead of building here
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build Tinybird CLI Image
-        uses: docker/build-push-action@v6
-        id: build
-        with:
-          context: .
-          file: docker/tb-cli/Dockerfile
-          push: false
-          load: true
-          tags: ghost-tb-cli
+      - name: Pull or build Tinybird CLI Image
+        if: needs.job_setup.outputs.changed_tinybird == 'true'
+        run: |
+          COMPOSE_IMAGE="${COMPOSE_PROJECT_NAME:-ghost-dev}-tb-cli"
+          # Try pulling pre-built image from GHCR first (fast path)
+          if docker pull ghcr.io/tryghost/tb-cli:latest 2>/dev/null; then
+            echo "Pulled tb-cli from GHCR"
+            docker tag ghcr.io/tryghost/tb-cli:latest "$COMPOSE_IMAGE"
+          else
+            echo "GHCR image not available, building from source"
+            docker buildx build --load -t "$COMPOSE_IMAGE" -f docker/tb-cli/Dockerfile .
+          fi
 
       - name: Load Image
         uses: ./.github/actions/load-docker-image
@@ -1189,6 +1191,7 @@ jobs:
       - name: Prepare E2E CI job
         env:
           GHOST_E2E_BASE_IMAGE: ${{ steps.load.outputs.image-tag }}
+          TINYBIRD_CHANGED: ${{ needs.job_setup.outputs.changed_tinybird }}
         run: bash ./e2e/scripts/prepare-ci-e2e-job.sh
 
       - name: Run e2e tests in Playwright container

--- a/e2e/scripts/infra-up.sh
+++ b/e2e/scripts/infra-up.sh
@@ -7,7 +7,6 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 cd "$REPO_ROOT"
 
 MODE="${GHOST_E2E_MODE:-dev}"
-TINYBIRD_CHANGED="${TINYBIRD_CHANGED:-true}"
 
 if [[ "$MODE" != "build" ]]; then
   DEV_COMPOSE_PROJECT="${COMPOSE_PROJECT_NAME:-ghost-dev}"
@@ -20,12 +19,5 @@ if [[ "$MODE" != "build" ]]; then
   fi
 fi
 
-if [[ "$TINYBIRD_CHANGED" == "true" ]]; then
-  echo "Tinybird datafiles changed — starting full analytics stack"
-  docker compose -f compose.dev.yaml -f compose.dev.analytics.yaml up -d --wait \
-    mysql redis mailpit tinybird-local analytics
-else
-  echo "Tinybird datafiles unchanged — skipping analytics containers"
-  docker compose -f compose.dev.yaml up -d --wait \
-    mysql redis mailpit
-fi
+docker compose -f compose.dev.yaml -f compose.dev.analytics.yaml up -d --wait \
+  mysql redis mailpit tinybird-local analytics

--- a/e2e/scripts/infra-up.sh
+++ b/e2e/scripts/infra-up.sh
@@ -7,6 +7,8 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 cd "$REPO_ROOT"
 
 MODE="${GHOST_E2E_MODE:-dev}"
+TINYBIRD_CHANGED="${TINYBIRD_CHANGED:-true}"
+
 if [[ "$MODE" != "build" ]]; then
   DEV_COMPOSE_PROJECT="${COMPOSE_PROJECT_NAME:-ghost-dev}"
   GHOST_DEV_IMAGE="${DEV_COMPOSE_PROJECT}-ghost-dev"
@@ -18,5 +20,12 @@ if [[ "$MODE" != "build" ]]; then
   fi
 fi
 
-docker compose -f compose.dev.yaml -f compose.dev.analytics.yaml up -d --wait \
-  mysql redis mailpit tinybird-local analytics
+if [[ "$TINYBIRD_CHANGED" == "true" ]]; then
+  echo "Tinybird datafiles changed — starting full analytics stack"
+  docker compose -f compose.dev.yaml -f compose.dev.analytics.yaml up -d --wait \
+    mysql redis mailpit tinybird-local analytics
+else
+  echo "Tinybird datafiles unchanged — skipping analytics containers"
+  docker compose -f compose.dev.yaml up -d --wait \
+    mysql redis mailpit
+fi


### PR DESCRIPTION
no ref

Minor optimization to use a prebuilt image for the tb-cli container that is part of the E2E test setup.