### PR TITLE
Fixed broken Select for theme variant

### DIFF
--- a/apps/admin-x-settings/src/components/settings/site/theme/theme-preview.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/theme/theme-preview.tsx
@@ -94,7 +94,7 @@ const ThemePreview: React.FC<{
                     <Select
                         border={false}
                         containerClassName='text-sm font-bold'
-                        controlClasses={{menu: 'w-24'}}
+                        controlClasses={{menu: 'min-w-max'}}
                         fullWidth={false}
                         options={variantOptions}
                         selectedOption={selectedVariant}


### PR DESCRIPTION
Ref https://ghost.slack.com/archives/C019B1K4FAM/p1773486918000429

Fixes a Select that was too narrow for its content.

| Before | After |
|--------|--------|
| <img width="274" height="237" alt="Screenshot 2026-03-14 at 12 39 12" src="https://github.com/user-attachments/assets/1250f970-bafb-473b-87cd-29240c95b9e6" /> | <img width="262" height="220" alt="Screenshot 2026-03-14 at 12 38 56" src="https://github.com/user-attachments/assets/0c5c728f-09b6-470b-af96-68e682f5da92" /> | 