### PR TITLE
Fixed Tailwind eslint config path resolution in Shade

### DIFF
--- a/apps/shade/.eslintrc.cjs
+++ b/apps/shade/.eslintrc.cjs
@@ -1,3 +1,5 @@
+const tailwindConfig = `${__dirname}/tailwind.config.cjs`;
+
 module.exports = {
     extends: [
         'plugin:ghost/ts',
@@ -34,12 +36,12 @@ module.exports = {
         'react/no-array-index-key': 'error',
         'react/jsx-key': 'off',
 
-        'tailwindcss/classnames-order': ['error', {config: 'tailwind.config.cjs'}],
-        'tailwindcss/enforces-negative-arbitrary-values': ['warn', {config: 'tailwind.config.cjs'}],
-        'tailwindcss/enforces-shorthand': ['warn', {config: 'tailwind.config.cjs'}],
-        'tailwindcss/migration-from-tailwind-2': ['warn', {config: 'tailwind.config.cjs'}],
+        'tailwindcss/classnames-order': ['error', {config: tailwindConfig}],
+        'tailwindcss/enforces-negative-arbitrary-values': ['warn', {config: tailwindConfig}],
+        'tailwindcss/enforces-shorthand': ['warn', {config: tailwindConfig}],
+        'tailwindcss/migration-from-tailwind-2': ['warn', {config: tailwindConfig}],
         'tailwindcss/no-arbitrary-value': 'off',
         'tailwindcss/no-custom-classname': 'off',
-        'tailwindcss/no-contradicting-classname': ['error', {config: 'tailwind.config.cjs'}]
+        'tailwindcss/no-contradicting-classname': ['error', {config: tailwindConfig}]
     }
 };


### PR DESCRIPTION
This is a dev-experience only change; there should be no user-facing changes in this PR.

## Summary

The eslint-plugin-tailwindcss resolves the config path relative to the process CWD, not relative to the `.eslintrc.cjs` file it’s defined in. So:

- `yarn lint` from apps/shade/: CWD is `apps/shade/`, so 'tailwind.config.cjs' resolves to `apps/shade/tailwind.config.cjs` — the real config with Ghost’s custom theme tokens (colors, spacing, shadows, etc.). Class ordering is based on that custom config.

- lint-staged from repo root: CWD is the repo root, so 'tailwind.config.cjs' resolves to a file that doesn’t exist. The plugin falls back to Tailwind’s default ordering, which differs from shade’s custom config.

The two orderings are both internally consistent but incompatible — so `eslint --fix` from one context would produce output that fails in the other. Our fix (`${__dirname}/tailwind.config.cjs`) makes the path absolute, so it always resolves to shade’s config regardless of CWD.