### PR TITLE
Converted em line-height values to unitless in email templates

### DIFF
--- a/ghost/core/core/server/services/email-rendering/partials/base-styles.hbs
+++ b/ghost/core/core/server/services/email-rendering/partials/base-styles.hbs
@@ -103,7 +103,7 @@ table td {
     padding-top: 10px;
     padding-left: 30px;
     padding-right: 30px;
-    line-height: 1.5em;
+    line-height: 1.5;
 }
 
 .footer a {

--- a/ghost/core/core/server/services/email-rendering/partials/card-styles.hbs
+++ b/ghost/core/core/server/services/email-rendering/partials/card-styles.hbs
@@ -68,7 +68,7 @@ td.kg-card-spacing {
 .kg-bookmark-title {
     color: {{#if backgroundIsDark}}#ffffff{{else}}#15212A{{/if}};
     font-size: 15px;
-    line-height: 1.5em;
+    line-height: 1.5;
     font-weight: 600;
 }
 
@@ -85,7 +85,7 @@ td.kg-card-spacing {
     color: rgba(0, 0, 0, 0.6);
     {{/if}}
     font-size: 13px;
-    line-height: 1.5em;
+    line-height: 1.5;
     font-weight: 400;
 
     -webkit-line-clamp: 2;
@@ -126,13 +126,13 @@ td.kg-card-spacing {
 }
 
 .kg-bookmark-author {
-    line-height: 1.5em;
+    line-height: 1.5;
 }
 
 .kg-bookmark-publisher {
     overflow: hidden;
     max-width: 240px;
-    line-height: 1.5em;
+    line-height: 1.5;
     text-overflow: ellipsis;
     white-space: nowrap;
 }
@@ -203,7 +203,7 @@ td.kg-card-spacing {
     color: #15212A !important;
     font-family: inherit !important;
     font-size: 14px;
-    line-height: 1.3em;
+    line-height: 1.3;
     padding-top: 4px;
     padding-right: 20px;
     padding-left: 20px;
@@ -217,7 +217,7 @@ td.kg-card-spacing {
     font-family: inherit !important;
     font-size: 15px;
     padding: 8px;
-    line-height: 1.3em;
+    line-height: 1.3;
 }
 
 .kg-audio-thumbnail.placeholder {
@@ -249,7 +249,7 @@ td.kg-card-spacing {
     padding-top: 4px;
     font-size: 17px;
     font-weight: 600;
-    line-height: 18px;
+    line-height: 1.125;
     text-decoration: none !important;
     color: {{#if backgroundIsDark}}#ffffff{{else}}#15212A{{/if}} !important;
 }
@@ -258,7 +258,7 @@ td.kg-card-spacing {
     display: inline-block;
     max-width: 400px;
     font-size: 14px;
-    line-height: 1.4em;
+    line-height: 1.4;
     text-decoration: none !important;
     {{#if backgroundIsDark}}
     color: #ffffff !important;
@@ -562,7 +562,7 @@ img.kg-cta-image {
 
 .kg-cta-text p {
     margin-bottom: 1em;
-    line-height: 1.4em;
+    line-height: 1.4;
 }
 
 .kg-cta-text p:last-child {
@@ -570,7 +570,7 @@ img.kg-cta-image {
 }
 
 .kg-cta-bg-none:not(.kg-cta-minimal.kg-cta-has-img) .kg-cta-text p {
-    line-height: 1.6em;
+    line-height: 1.6;
 }
 
 .kg-cta-immersive.kg-cta-centered .kg-cta-text p {

--- a/ghost/core/core/server/services/email-rendering/partials/content-styles.hbs
+++ b/ghost/core/core/server/services/email-rendering/partials/content-styles.hbs
@@ -82,7 +82,7 @@ ol,
 dl,
 blockquote {
     margin: 0 0 1.5em 0;
-    line-height: 1.6em;
+    line-height: 1.6;
 }
 
 ol,
@@ -130,7 +130,7 @@ ol {
 li {
     margin: 0.5em 0;
     padding-left: 0.3em;
-    line-height: 1.6em;
+    line-height: 1.6;
     color: {{#if backgroundIsDark}}#ffffff{{else}}#15212A{{/if}};
 }
 
@@ -154,7 +154,7 @@ blockquote {
     border-left: {{accentColor}} 2px solid;
     font-size: 17px;
     font-weight: 500;
-    line-height: 1.6em;
+    line-height: 1.6;
     letter-spacing: -0.2px;
 }
 
@@ -210,7 +210,7 @@ h5,
 h6 {
     margin-top: 0;
     font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif;
-    line-height: 1.11em;
+    line-height: 1.11;
     font-weight: {{titleWeight}};
     text-rendering: optimizeLegibility;
 }
@@ -243,19 +243,19 @@ h3 {
 h4 {
     margin: 1.8em 0 0.5em 0;
     font-size: 21px;
-    line-height: 1.2em;
+    line-height: 1.2;
 }
 
 h5 {
     margin: 2em 0 0.5em 0;
     font-size: 19px;
-    line-height: 1.3em;
+    line-height: 1.3;
 }
 
 h6 {
     margin: 2em 0 0.5em 0;
     font-size: 19px;
-    line-height: 1.3em;
+    line-height: 1.3;
 }
 
 /*
@@ -331,7 +331,7 @@ figcaption {
     font-size: 13px;
     padding-top: 10px;
     padding-bottom: 10px;
-    line-height: 1.5em;
+    line-height: 1.5;
     {{#if backgroundIsDark}}
         color: #ffffff;
         color: rgba(255, 255, 255, .6);
@@ -355,7 +355,7 @@ pre {
     background: #15212A;
     padding: 15px;
     border-radius: 3px;
-    line-height: 1.2em;
+    line-height: 1.2;
     color: #ffffff;
 }
 

--- a/ghost/core/core/server/services/email-service/email-templates/partials/styles.hbs
+++ b/ghost/core/core/server/services/email-service/email-templates/partials/styles.hbs
@@ -192,7 +192,7 @@ img.is-dark-background {
     margin-top: 32px;
     color: #15212A;
     text-align: center;
-    line-height: 1.1em;
+    line-height: 1.1;
 }
 
 .post-title-link-left {
@@ -208,7 +208,7 @@ img.is-dark-background {
     margin: 0;
     color: {{#if headerBackgroundIsDark}}#ffffff{{else}}#15212A{{/if}};
     font-size: 19px;
-    line-height: 1.4em;
+    line-height: 1.4;
     text-align: center;
 }
 
@@ -317,7 +317,7 @@ img.is-dark-background {
         color: #15212a;
         color: rgba(0, 0, 0, 0.6);
     {{/if}}
-    line-height: 1.5em;
+    line-height: 1.5;
 }
 
 .kg-card-figcaption {
@@ -358,7 +358,7 @@ img.is-dark-background {
     font-size: 13px !important;
     font-weight: 500;
     margin: 1em 0 0 0;
-    line-height: 1.4em;
+    line-height: 1.4;
     word-break: break-word;
 }
 
@@ -482,7 +482,7 @@ h3.latest-posts-header {
     color: {{#if backgroundIsDark}}#ffffff{{else}}#15212A{{/if}} !important;
     font-size: 15px;
     font-weight: 400;
-    line-height: 1.45em;
+    line-height: 1.45;
     text-decoration: none;
 }
 
@@ -495,7 +495,7 @@ h3.latest-posts-header {
     font-size: 15px;
     font-weight: 400;
     text-align: right;
-    line-height: 1.45em;
+    line-height: 1.45;
     vertical-align: bottom;
 }
 
@@ -519,7 +519,7 @@ h3.latest-posts-header {
     max-width: 600px !important;
     font-family: Georgia, serif;
     font-size: 18px;
-    line-height: 1.5em;
+    line-height: 1.5;
     color: #15212A;
     padding-bottom: 20px;
     border-bottom: 1px solid {{dividerColor}};
@@ -528,7 +528,7 @@ h3.latest-posts-header {
 .post-content-sans-serif {
     max-width: 600px !important;
     font-size: 17px;
-    line-height: 1.5em;
+    line-height: 1.5;
     color: #15212A;
     padding-bottom: 20px;
     border-bottom: 1px solid {{dividerColor}};
@@ -599,7 +599,7 @@ a[data-flickr-embed] img {
 .kg-header-card h2 {
     font-size: 32px;
     font-weight: {{titleWeight}};
-    line-height: 1.1em;
+    line-height: 1.1;
     margin: 0 0 0.125em;
 }
 
@@ -614,7 +614,7 @@ a[data-flickr-embed] img {
 .kg-header-card h3 {
     font-size: 17px;
     font-weight: 400;
-    line-height: 1.5em;
+    line-height: 1.5;
     margin: 0;
 }
 
@@ -644,7 +644,7 @@ a[data-flickr-embed] img {
 
 .kg-header-card.kg-v2 .kg-header-card-heading {
     margin: 0;
-    line-height: 1em;
+    line-height: 1;
 }
 
 .kg-header-card.kg-v2 .kg-header-card-subheading-wrapper {
@@ -654,7 +654,7 @@ a[data-flickr-embed] img {
 .kg-header-card.kg-v2 .kg-header-card-subheading {
     margin: 0;
     font-size: 17px;
-    line-height: 1.5em;
+    line-height: 1.5;
 }
 
 .kg-header-card.kg-v2 .kg-header-card-heading a,
@@ -694,7 +694,7 @@ a[data-flickr-embed] img {
     padding-top: 4px;
     font-size: 16px;
     font-weight: 600;
-    line-height: 18px;
+    line-height: 1.125;
     text-decoration: none !important;
     color: {{#if backgroundIsDark}}#ffffff{{else}}#15212A{{/if}} !important;
 }
@@ -754,7 +754,7 @@ a[data-flickr-embed] img {
     padding-top: 8px;
     font-size: 17px;
     font-weight: bold;
-    line-height: 1.3em;
+    line-height: 1.3;
     text-decoration: none !important;
     color: {{#if backgroundIsDark}}#ffffff{{else}}#15212A{{/if}} !important;
 }
@@ -764,7 +764,7 @@ a[data-flickr-embed] img {
     padding-left: 12px;
     padding-top: 2px;
     font-size: 15px;
-    line-height: 1.4em;
+    line-height: 1.4;
     text-decoration: none !important;
     {{#if backgroundIsDark}}
     color: #ffffff !important;
@@ -781,7 +781,7 @@ a[data-flickr-embed] img {
     padding-top: 4px;
     padding-bottom: 8px;
     font-size: 13px;
-    line-height: 1.4em;
+    line-height: 1.4;
     text-decoration: none !important;
     {{#if backgroundIsDark}}
     color: #ffffff;
@@ -948,7 +948,7 @@ a[data-flickr-embed] img {
 
     table.body .kg-callout-text {
         font-size: 16px !important;
-        line-height: 1.5em !important;
+        line-height: 1.5 !important;
     }
 
     table.body pre {
@@ -994,7 +994,7 @@ a[data-flickr-embed] img {
     table.header .post-meta-date {
         white-space: normal !important;
         font-size: 13px !important;
-        line-height: 1.2em;
+        line-height: 1.2;
     }
 
     table.header .post-meta,
@@ -1038,7 +1038,7 @@ a[data-flickr-embed] img {
 
     table.header .post-title a {
         font-size: 26px !important;
-        line-height: 1.1em !important;
+        line-height: 1.1 !important;
     }
 
     table.feedback-buttons {
@@ -1099,38 +1099,38 @@ a[data-flickr-embed] img {
 
     table.body h1 {
         font-size: 32px !important;
-        line-height: 1.3em !important;
+        line-height: 1.3 !important;
     }
 
     table.body h2,
     table.body h2 span {
         font-size: 26px !important;
-        line-height: 1.22em !important;
+        line-height: 1.22 !important;
     }
 
     table.body h3 {
         font-size: 21px !important;
-        line-height: 1.25em !important;
+        line-height: 1.25 !important;
     }
 
     table.body h4 {
         font-size: 19px !important;
-        line-height: 1.3em !important;
+        line-height: 1.3 !important;
     }
 
     table.body h5 {
         font-size: 16px !important;
-        line-height: 1.4em !important;
+        line-height: 1.4 !important;
     }
 
     table.body h6 {
         font-size: 16px !important;
-        line-height: 1.4em !important;
+        line-height: 1.4 !important;
     }
 
     table.body blockquote {
         font-size: 16px !important;
-        line-height: 1.6em;
+        line-height: 1.6;
         margin-bottom: 0;
     }
 
@@ -1143,7 +1143,7 @@ a[data-flickr-embed] img {
         border-left: 0 none !important;
         margin: 0 !important;
         font-size: 18px !important;
-        line-height: 1.4em !important;
+        line-height: 1.4 !important;
     }
 
     table.body blockquote.kg-blockquote-alt p {

--- a/ghost/core/test/e2e-api/admin/__snapshots__/email-previews.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/email-previews.test.js.snap
@@ -237,7 +237,7 @@ table[class=body] a[class=small] {
   color: #15212A !important;
   font-family: inherit !important;
   font-size: 14px;
-  line-height: 1.3em;
+  line-height: 1.3;
   padding-top: 4px;
   padding-right: 20px;
   padding-left: 20px;
@@ -250,7 +250,7 @@ table[class=body] a[class=small] {
   font-family: inherit !important;
   font-size: 15px;
   padding: 8px;
-  line-height: 1.3em;
+  line-height: 1.3;
 }
 .kg-cta-link-accent .kg-cta-sponsor-label a {
   color: #FF1A75 !important;
@@ -371,7 +371,7 @@ table[class=body] a[class=small] {
   margin-top: 32px;
   color: #15212A;
   text-align: center;
-  line-height: 1.1em;
+  line-height: 1.1;
 }
 .post-title-link-left {
   text-align: left;
@@ -421,7 +421,7 @@ table.body td {
 
   table.body .kg-callout-text {
     font-size: 16px !important;
-    line-height: 1.5em !important;
+    line-height: 1.5 !important;
   }
 
   table.body pre {
@@ -467,7 +467,7 @@ table.header .header-main {
 table.header .post-meta-date {
     white-space: normal !important;
     font-size: 13px !important;
-    line-height: 1.2em;
+    line-height: 1.2;
   }
 
   table.header .post-meta,
@@ -511,7 +511,7 @@ table.body .footer a {
 
   table.header .post-title a {
     font-size: 26px !important;
-    line-height: 1.1em !important;
+    line-height: 1.1 !important;
   }
 
   table.feedback-buttons {
@@ -572,38 +572,38 @@ table.body .manage-subscription {
 
   table.body h1 {
     font-size: 32px !important;
-    line-height: 1.3em !important;
+    line-height: 1.3 !important;
   }
 
   table.body h2,
 table.body h2 span {
     font-size: 26px !important;
-    line-height: 1.22em !important;
+    line-height: 1.22 !important;
   }
 
   table.body h3 {
     font-size: 21px !important;
-    line-height: 1.25em !important;
+    line-height: 1.25 !important;
   }
 
   table.body h4 {
     font-size: 19px !important;
-    line-height: 1.3em !important;
+    line-height: 1.3 !important;
   }
 
   table.body h5 {
     font-size: 16px !important;
-    line-height: 1.4em !important;
+    line-height: 1.4 !important;
   }
 
   table.body h6 {
     font-size: 16px !important;
-    line-height: 1.4em !important;
+    line-height: 1.4 !important;
   }
 
   table.body blockquote {
     font-size: 16px !important;
-    line-height: 1.6em;
+    line-height: 1.6;
     margin-bottom: 0;
   }
 
@@ -616,7 +616,7 @@ table.body h2 span {
     border-left: 0 none !important;
     margin: 0 !important;
     font-size: 18px !important;
-    line-height: 1.4em !important;
+    line-height: 1.4 !important;
   }
 
   table.body blockquote.kg-blockquote-alt p {
@@ -698,7 +698,7 @@ table.body h2 span {
                                                     <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\" width=\\"100%\\">
                                                         <tr>
                                                             <td style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; font-size: 36px; line-height: 1.1; font-weight: 700; text-align: center; color: #000000;\\" valign=\\"top\\" align=\\"center\\">
-                                                                <a href=\\"http://127.0.0.1:2369/p/d52c42ae-2755-455c-80ec-70b2ec55c904/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; text-align: center; line-height: 1.1em; overflow-wrap: anywhere; color: #000000;\\" target=\\"_blank\\">Post with email-only card</a>
+                                                                <a href=\\"http://127.0.0.1:2369/p/d52c42ae-2755-455c-80ec-70b2ec55c904/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; text-align: center; line-height: 1.1; overflow-wrap: anywhere; color: #000000;\\" target=\\"_blank\\">Post with email-only card</a>
                                                             </td>
                                                         </tr>
                                                     </table>
@@ -758,9 +758,9 @@ table.body h2 span {
                                                             <td class=\\"wrapper\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A; box-sizing: border-box;\\" valign=\\"top\\">
                                                                 <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" width=\\"100%\\" data-testid=\\"email-preview-content\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\">
                                                                     <tr class=\\"post-content-row\\">
-                                                                        <td class=\\"post-content-sans-serif\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; font-size: 17px; line-height: 1.5em; color: #15212A; padding-bottom: 20px; border-bottom: 1px solid #e0e7eb; max-width: 600px;\\" valign=\\"top\\">
+                                                                        <td class=\\"post-content-sans-serif\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; font-size: 17px; line-height: 1.5; color: #15212A; padding-bottom: 20px; border-bottom: 1px solid #e0e7eb; max-width: 600px;\\" valign=\\"top\\">
                                                                             <!-- POST CONTENT START -->
-                                                                            <p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em; color: #15212A;\\">Hey Jamie %%{unknown}%%</p><p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em; color: #15212A;\\"><strong style=\\"font-weight: 700;\\">Welcome to your first Ghost email!</strong></p><p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em; color: #15212A;\\">This is the actual post content...</p><p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em; color: #15212A;\\">Another email card with a similar replacement, Jamie</p>
+                                                                            <p style=\\"margin: 0 0 1.5em 0; line-height: 1.6; color: #15212A;\\">Hey Jamie %%{unknown}%%</p><p style=\\"margin: 0 0 1.5em 0; line-height: 1.6; color: #15212A;\\"><strong style=\\"font-weight: 700;\\">Welcome to your first Ghost email!</strong></p><p style=\\"margin: 0 0 1.5em 0; line-height: 1.6; color: #15212A;\\">This is the actual post content...</p><p style=\\"margin: 0 0 1.5em 0; line-height: 1.6; color: #15212A;\\">Another email card with a similar replacement, Jamie</p>
                                                                             <!-- POST CONTENT END -->
                             
                                                                         </td>
@@ -778,7 +778,7 @@ table.body h2 span {
                                                             <td class=\\"wrapper\\" align=\\"center\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A; box-sizing: border-box;\\" valign=\\"top\\">
                                                                 <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; padding-top: 40px; padding-bottom: 30px;\\">
                                                                     <tr>
-                                                                        <td class=\\"footer\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; color: #15212a; color: rgba(0, 0, 0, 0.6); margin-top: 20px; text-align: center; padding-bottom: 10px; padding-top: 10px; padding-left: 30px; padding-right: 30px; line-height: 1.5em; font-size: 13px;\\" valign=\\"top\\" align=\\"center\\">Ghost &#xA9; 2025 &#x2013; <a href=\\"http://127.0.0.1:2369/unsubscribe/?uuid=example-uuid&key=803e513e2d8b88e759d8f433779659af335d7308b4cbac809600d563f6b49a76&newsletter=requested-newsletter-uuid\\" style=\\"overflow-wrap: anywhere; color: #15212a; color: rgba(0, 0, 0, 0.6); text-decoration: underline; font-size: 13px;\\" target=\\"_blank\\">Unsubscribe</a></td>
+                                                                        <td class=\\"footer\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; color: #15212a; color: rgba(0, 0, 0, 0.6); margin-top: 20px; text-align: center; padding-bottom: 10px; padding-top: 10px; padding-left: 30px; padding-right: 30px; line-height: 1.5; font-size: 13px;\\" valign=\\"top\\" align=\\"center\\">Ghost &#xA9; 2025 &#x2013; <a href=\\"http://127.0.0.1:2369/unsubscribe/?uuid=example-uuid&key=803e513e2d8b88e759d8f433779659af335d7308b4cbac809600d563f6b49a76&newsletter=requested-newsletter-uuid\\" style=\\"overflow-wrap: anywhere; color: #15212a; color: rgba(0, 0, 0, 0.6); text-decoration: underline; font-size: 13px;\\" target=\\"_blank\\">Unsubscribe</a></td>
                                                                     </tr>
                             
                                                                         <tr>
@@ -990,7 +990,7 @@ exports[`Email Preview API Read can read post email preview with email card and 
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "36590",
+  "content-length": "36548",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -1141,7 +1141,7 @@ table[class=body] a[class=small] {
   color: #15212A !important;
   font-family: inherit !important;
   font-size: 14px;
-  line-height: 1.3em;
+  line-height: 1.3;
   padding-top: 4px;
   padding-right: 20px;
   padding-left: 20px;
@@ -1154,7 +1154,7 @@ table[class=body] a[class=small] {
   font-family: inherit !important;
   font-size: 15px;
   padding: 8px;
-  line-height: 1.3em;
+  line-height: 1.3;
 }
 .kg-cta-link-accent .kg-cta-sponsor-label a {
   color: #FF1A75 !important;
@@ -1275,7 +1275,7 @@ table[class=body] a[class=small] {
   margin-top: 32px;
   color: #15212A;
   text-align: center;
-  line-height: 1.1em;
+  line-height: 1.1;
 }
 .post-title-link-left {
   text-align: left;
@@ -1325,7 +1325,7 @@ table.body td {
 
   table.body .kg-callout-text {
     font-size: 16px !important;
-    line-height: 1.5em !important;
+    line-height: 1.5 !important;
   }
 
   table.body pre {
@@ -1371,7 +1371,7 @@ table.header .header-main {
 table.header .post-meta-date {
     white-space: normal !important;
     font-size: 13px !important;
-    line-height: 1.2em;
+    line-height: 1.2;
   }
 
   table.header .post-meta,
@@ -1415,7 +1415,7 @@ table.body .footer a {
 
   table.header .post-title a {
     font-size: 26px !important;
-    line-height: 1.1em !important;
+    line-height: 1.1 !important;
   }
 
   table.feedback-buttons {
@@ -1476,38 +1476,38 @@ table.body .manage-subscription {
 
   table.body h1 {
     font-size: 32px !important;
-    line-height: 1.3em !important;
+    line-height: 1.3 !important;
   }
 
   table.body h2,
 table.body h2 span {
     font-size: 26px !important;
-    line-height: 1.22em !important;
+    line-height: 1.22 !important;
   }
 
   table.body h3 {
     font-size: 21px !important;
-    line-height: 1.25em !important;
+    line-height: 1.25 !important;
   }
 
   table.body h4 {
     font-size: 19px !important;
-    line-height: 1.3em !important;
+    line-height: 1.3 !important;
   }
 
   table.body h5 {
     font-size: 16px !important;
-    line-height: 1.4em !important;
+    line-height: 1.4 !important;
   }
 
   table.body h6 {
     font-size: 16px !important;
-    line-height: 1.4em !important;
+    line-height: 1.4 !important;
   }
 
   table.body blockquote {
     font-size: 16px !important;
-    line-height: 1.6em;
+    line-height: 1.6;
     margin-bottom: 0;
   }
 
@@ -1520,7 +1520,7 @@ table.body h2 span {
     border-left: 0 none !important;
     margin: 0 !important;
     font-size: 18px !important;
-    line-height: 1.4em !important;
+    line-height: 1.4 !important;
   }
 
   table.body blockquote.kg-blockquote-alt p {
@@ -1602,7 +1602,7 @@ table.body h2 span {
                                                     <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\" width=\\"100%\\">
                                                         <tr>
                                                             <td style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; font-size: 36px; line-height: 1.1; font-weight: 700; text-align: center; color: #000000;\\" valign=\\"top\\" align=\\"center\\">
-                                                                <a href=\\"http://127.0.0.1:2369/html-ipsum/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; text-align: center; line-height: 1.1em; overflow-wrap: anywhere; color: #000000;\\" target=\\"_blank\\">HTML Ipsum</a>
+                                                                <a href=\\"http://127.0.0.1:2369/html-ipsum/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; text-align: center; line-height: 1.1; overflow-wrap: anywhere; color: #000000;\\" target=\\"_blank\\">HTML Ipsum</a>
                                                             </td>
                                                         </tr>
                                                     </table>
@@ -1667,9 +1667,9 @@ table.body h2 span {
                                                             <td class=\\"wrapper\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A; box-sizing: border-box;\\" valign=\\"top\\">
                                                                 <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" width=\\"100%\\" data-testid=\\"email-preview-content\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\">
                                                                     <tr class=\\"post-content-row\\">
-                                                                        <td class=\\"post-content-sans-serif\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; font-size: 17px; line-height: 1.5em; color: #15212A; padding-bottom: 20px; border-bottom: 1px solid #e0e7eb; max-width: 600px;\\" valign=\\"top\\">
+                                                                        <td class=\\"post-content-sans-serif\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; font-size: 17px; line-height: 1.5; color: #15212A; padding-bottom: 20px; border-bottom: 1px solid #e0e7eb; max-width: 600px;\\" valign=\\"top\\">
                                                                             <!-- POST CONTENT START -->
-                                                                            <!--kg-card-begin: markdown--><h1 style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; line-height: 1.11em; font-weight: 700; text-rendering: optimizeLegibility; margin: 1.5em 0 0.5em 0; font-size: 42px; color: #15212A;\\">HTML Ipsum Presents</h1><p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em; color: #15212A;\\"><strong style=\\"font-weight: 700;\\">Pellentesque habitant morbi tristique</strong> senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. <em>Aenean ultricies mi vitae est.</em> Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, <code style=\\"font-size: 0.9em; background: #F2F7FA; word-break: break-all; padding: 1px 7px; border-radius: 3px; color: #FF1A75;\\">commodo vitae</code>, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac dui. <a href=\\"#\\" style=\\"overflow-wrap: anywhere; color: #FF1A75; text-decoration: underline;\\" target=\\"_blank\\">Donec non enim</a> in turpis pulvinar facilisis. Ut felis.</p><h2 style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; line-height: 1.11em; font-weight: 700; text-rendering: optimizeLegibility; margin: 1.5em 0 0.5em 0; font-size: 32px; color: #15212A;\\">Header Level 2</h2><ol style=\\"margin: 0 0 1.5em 0; line-height: 1.6em; padding-left: 1.3em; padding-right: 1.5em; list-style: decimal; max-width: 100%;\\"><li style=\\"margin: 0.5em 0; padding-left: 0.3em; line-height: 1.6em; color: #15212A;\\">Lorem ipsum dolor sit amet, consectetuer adipiscing elit.</li><li style=\\"margin: 0.5em 0; padding-left: 0.3em; line-height: 1.6em; color: #15212A;\\">Aliquam tincidunt mauris eu risus.</li></ol><blockquote style=\\"margin: 0; padding: 0; border-left: #FF1A75 2px solid; font-size: 17px; font-weight: 500; line-height: 1.6em; letter-spacing: -0.2px;\\"><p style=\\"line-height: 1.6em; margin: 2em 25px; font-size: 1em; padding: 0; color: #15212A;\\">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus magna. Cras in mi at felis aliquet congue. Ut a est eget ligula molestie gravida. Curabitur massa. Donec eleifend, libero at sagittis mollis, tellus est malesuada tellus, at luctus turpis elit sit amet quam. Vivamus pretium ornare est.</p></blockquote><h3 style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; line-height: 1.11em; font-weight: 700; text-rendering: optimizeLegibility; margin: 1.5em 0 0.5em 0; font-size: 26px; color: #15212A;\\">Header Level 3</h3><ul style=\\"margin: 0 0 1.5em 0; line-height: 1.6em; padding-left: 1.3em; padding-right: 1.5em; list-style: disc; max-width: 100%;\\"><li style=\\"margin: 0.5em 0; padding-left: 0.3em; line-height: 1.6em; color: #15212A;\\">Lorem ipsum dolor sit amet, consectetuer adipiscing elit.</li><li style=\\"margin: 0.5em 0; padding-left: 0.3em; line-height: 1.6em; color: #15212A;\\">Aliquam tincidunt mauris eu risus.</li></ul><pre style=\\"white-space: pre-wrap; overflow: auto; background: #15212A; padding: 15px; border-radius: 3px; line-height: 1.2em; color: #ffffff;\\"><code style=\\"font-size: 0.9em;\\">#header h1 a{display: block;width: 300px;height: 80px;}</code></pre><!--kg-card-end: markdown-->
+                                                                            <!--kg-card-begin: markdown--><h1 style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; line-height: 1.11; font-weight: 700; text-rendering: optimizeLegibility; margin: 1.5em 0 0.5em 0; font-size: 42px; color: #15212A;\\">HTML Ipsum Presents</h1><p style=\\"margin: 0 0 1.5em 0; line-height: 1.6; color: #15212A;\\"><strong style=\\"font-weight: 700;\\">Pellentesque habitant morbi tristique</strong> senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. <em>Aenean ultricies mi vitae est.</em> Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, <code style=\\"font-size: 0.9em; background: #F2F7FA; word-break: break-all; padding: 1px 7px; border-radius: 3px; color: #FF1A75;\\">commodo vitae</code>, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac dui. <a href=\\"#\\" style=\\"overflow-wrap: anywhere; color: #FF1A75; text-decoration: underline;\\" target=\\"_blank\\">Donec non enim</a> in turpis pulvinar facilisis. Ut felis.</p><h2 style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; line-height: 1.11; font-weight: 700; text-rendering: optimizeLegibility; margin: 1.5em 0 0.5em 0; font-size: 32px; color: #15212A;\\">Header Level 2</h2><ol style=\\"margin: 0 0 1.5em 0; line-height: 1.6; padding-left: 1.3em; padding-right: 1.5em; list-style: decimal; max-width: 100%;\\"><li style=\\"margin: 0.5em 0; padding-left: 0.3em; line-height: 1.6; color: #15212A;\\">Lorem ipsum dolor sit amet, consectetuer adipiscing elit.</li><li style=\\"margin: 0.5em 0; padding-left: 0.3em; line-height: 1.6; color: #15212A;\\">Aliquam tincidunt mauris eu risus.</li></ol><blockquote style=\\"margin: 0; padding: 0; border-left: #FF1A75 2px solid; font-size: 17px; font-weight: 500; line-height: 1.6; letter-spacing: -0.2px;\\"><p style=\\"line-height: 1.6; margin: 2em 25px; font-size: 1em; padding: 0; color: #15212A;\\">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus magna. Cras in mi at felis aliquet congue. Ut a est eget ligula molestie gravida. Curabitur massa. Donec eleifend, libero at sagittis mollis, tellus est malesuada tellus, at luctus turpis elit sit amet quam. Vivamus pretium ornare est.</p></blockquote><h3 style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; line-height: 1.11; font-weight: 700; text-rendering: optimizeLegibility; margin: 1.5em 0 0.5em 0; font-size: 26px; color: #15212A;\\">Header Level 3</h3><ul style=\\"margin: 0 0 1.5em 0; line-height: 1.6; padding-left: 1.3em; padding-right: 1.5em; list-style: disc; max-width: 100%;\\"><li style=\\"margin: 0.5em 0; padding-left: 0.3em; line-height: 1.6; color: #15212A;\\">Lorem ipsum dolor sit amet, consectetuer adipiscing elit.</li><li style=\\"margin: 0.5em 0; padding-left: 0.3em; line-height: 1.6; color: #15212A;\\">Aliquam tincidunt mauris eu risus.</li></ul><pre style=\\"white-space: pre-wrap; overflow: auto; background: #15212A; padding: 15px; border-radius: 3px; line-height: 1.2; color: #ffffff;\\"><code style=\\"font-size: 0.9em;\\">#header h1 a{display: block;width: 300px;height: 80px;}</code></pre><!--kg-card-end: markdown-->
                                                                             <!-- POST CONTENT END -->
                             
                                                                         </td>
@@ -1687,7 +1687,7 @@ table.body h2 span {
                                                             <td class=\\"wrapper\\" align=\\"center\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A; box-sizing: border-box;\\" valign=\\"top\\">
                                                                 <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; padding-top: 40px; padding-bottom: 30px;\\">
                                                                     <tr>
-                                                                        <td class=\\"footer\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; color: #15212a; color: rgba(0, 0, 0, 0.6); margin-top: 20px; text-align: center; padding-bottom: 10px; padding-top: 10px; padding-left: 30px; padding-right: 30px; line-height: 1.5em; font-size: 13px;\\" valign=\\"top\\" align=\\"center\\">Ghost &#xA9; 2025 &#x2013; <a href=\\"http://127.0.0.1:2369/unsubscribe/?uuid=example-uuid&key=803e513e2d8b88e759d8f433779659af335d7308b4cbac809600d563f6b49a76&newsletter=requested-newsletter-uuid\\" style=\\"overflow-wrap: anywhere; color: #15212a; color: rgba(0, 0, 0, 0.6); text-decoration: underline; font-size: 13px;\\" target=\\"_blank\\">Unsubscribe</a></td>
+                                                                        <td class=\\"footer\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; color: #15212a; color: rgba(0, 0, 0, 0.6); margin-top: 20px; text-align: center; padding-bottom: 10px; padding-top: 10px; padding-left: 30px; padding-right: 30px; line-height: 1.5; font-size: 13px;\\" valign=\\"top\\" align=\\"center\\">Ghost &#xA9; 2025 &#x2013; <a href=\\"http://127.0.0.1:2369/unsubscribe/?uuid=example-uuid&key=803e513e2d8b88e759d8f433779659af335d7308b4cbac809600d563f6b49a76&newsletter=requested-newsletter-uuid\\" style=\\"overflow-wrap: anywhere; color: #15212a; color: rgba(0, 0, 0, 0.6); text-decoration: underline; font-size: 13px;\\" target=\\"_blank\\">Unsubscribe</a></td>
                                                                     </tr>
                             
                                                                         <tr>
@@ -1916,7 +1916,7 @@ exports[`Email Preview API Read can read post email preview with fields 4: [head
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "41042",
+  "content-length": "40982",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -2098,7 +2098,7 @@ table[class=body] a[class=small] {
   color: #15212A !important;
   font-family: inherit !important;
   font-size: 14px;
-  line-height: 1.3em;
+  line-height: 1.3;
   padding-top: 4px;
   padding-right: 20px;
   padding-left: 20px;
@@ -2111,7 +2111,7 @@ table[class=body] a[class=small] {
   font-family: inherit !important;
   font-size: 15px;
   padding: 8px;
-  line-height: 1.3em;
+  line-height: 1.3;
 }
 .kg-cta-link-accent .kg-cta-sponsor-label a {
   color: #FF1A75 !important;
@@ -2232,7 +2232,7 @@ table[class=body] a[class=small] {
   margin-top: 32px;
   color: #15212A;
   text-align: center;
-  line-height: 1.1em;
+  line-height: 1.1;
 }
 .post-title-link-left {
   text-align: left;
@@ -2282,7 +2282,7 @@ table.body td {
 
   table.body .kg-callout-text {
     font-size: 16px !important;
-    line-height: 1.5em !important;
+    line-height: 1.5 !important;
   }
 
   table.body pre {
@@ -2328,7 +2328,7 @@ table.header .header-main {
 table.header .post-meta-date {
     white-space: normal !important;
     font-size: 13px !important;
-    line-height: 1.2em;
+    line-height: 1.2;
   }
 
   table.header .post-meta,
@@ -2372,7 +2372,7 @@ table.body .footer a {
 
   table.header .post-title a {
     font-size: 26px !important;
-    line-height: 1.1em !important;
+    line-height: 1.1 !important;
   }
 
   table.feedback-buttons {
@@ -2433,38 +2433,38 @@ table.body .manage-subscription {
 
   table.body h1 {
     font-size: 32px !important;
-    line-height: 1.3em !important;
+    line-height: 1.3 !important;
   }
 
   table.body h2,
 table.body h2 span {
     font-size: 26px !important;
-    line-height: 1.22em !important;
+    line-height: 1.22 !important;
   }
 
   table.body h3 {
     font-size: 21px !important;
-    line-height: 1.25em !important;
+    line-height: 1.25 !important;
   }
 
   table.body h4 {
     font-size: 19px !important;
-    line-height: 1.3em !important;
+    line-height: 1.3 !important;
   }
 
   table.body h5 {
     font-size: 16px !important;
-    line-height: 1.4em !important;
+    line-height: 1.4 !important;
   }
 
   table.body h6 {
     font-size: 16px !important;
-    line-height: 1.4em !important;
+    line-height: 1.4 !important;
   }
 
   table.body blockquote {
     font-size: 16px !important;
-    line-height: 1.6em;
+    line-height: 1.6;
     margin-bottom: 0;
   }
 
@@ -2477,7 +2477,7 @@ table.body h2 span {
     border-left: 0 none !important;
     margin: 0 !important;
     font-size: 18px !important;
-    line-height: 1.4em !important;
+    line-height: 1.4 !important;
   }
 
   table.body blockquote.kg-blockquote-alt p {
@@ -2559,7 +2559,7 @@ table.body h2 span {
                                                     <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\" width=\\"100%\\">
                                                         <tr>
                                                             <td style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; font-size: 36px; line-height: 1.1; font-weight: 700; text-align: center; color: #000000;\\" valign=\\"top\\" align=\\"center\\">
-                                                                <a href=\\"http://127.0.0.1:2369/p/d52c42ae-2755-455c-80ec-70b2ec55c904/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; text-align: center; line-height: 1.1em; overflow-wrap: anywhere; color: #000000;\\" target=\\"_blank\\">Post with email-only card</a>
+                                                                <a href=\\"http://127.0.0.1:2369/p/d52c42ae-2755-455c-80ec-70b2ec55c904/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; text-align: center; line-height: 1.1; overflow-wrap: anywhere; color: #000000;\\" target=\\"_blank\\">Post with email-only card</a>
                                                             </td>
                                                         </tr>
                                                     </table>
@@ -2619,9 +2619,9 @@ table.body h2 span {
                                                             <td class=\\"wrapper\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A; box-sizing: border-box;\\" valign=\\"top\\">
                                                                 <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" width=\\"100%\\" data-testid=\\"email-preview-content\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\">
                                                                     <tr class=\\"post-content-row\\">
-                                                                        <td class=\\"post-content-sans-serif\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; font-size: 17px; line-height: 1.5em; color: #15212A; padding-bottom: 20px; border-bottom: 1px solid #e0e7eb; max-width: 600px;\\" valign=\\"top\\">
+                                                                        <td class=\\"post-content-sans-serif\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; font-size: 17px; line-height: 1.5; color: #15212A; padding-bottom: 20px; border-bottom: 1px solid #e0e7eb; max-width: 600px;\\" valign=\\"top\\">
                                                                             <!-- POST CONTENT START -->
-                                                                            <p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em; color: #15212A;\\">Testing <a href=\\"https://ghost.org/\\" style=\\"overflow-wrap: anywhere; color: #FF1A75; text-decoration: underline;\\" target=\\"_blank\\">links</a> in email excerpt and apostrophes &#39;</p>
+                                                                            <p style=\\"margin: 0 0 1.5em 0; line-height: 1.6; color: #15212A;\\">Testing <a href=\\"https://ghost.org/\\" style=\\"overflow-wrap: anywhere; color: #FF1A75; text-decoration: underline;\\" target=\\"_blank\\">links</a> in email excerpt and apostrophes &#39;</p>
                                                                             <!-- POST CONTENT END -->
                             
                                                                         </td>
@@ -2639,7 +2639,7 @@ table.body h2 span {
                                                             <td class=\\"wrapper\\" align=\\"center\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A; box-sizing: border-box;\\" valign=\\"top\\">
                                                                 <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; padding-top: 40px; padding-bottom: 30px;\\">
                                                                     <tr>
-                                                                        <td class=\\"footer\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; color: #15212a; color: rgba(0, 0, 0, 0.6); margin-top: 20px; text-align: center; padding-bottom: 10px; padding-top: 10px; padding-left: 30px; padding-right: 30px; line-height: 1.5em; font-size: 13px;\\" valign=\\"top\\" align=\\"center\\">Ghost &#xA9; 2025 &#x2013; <a href=\\"http://127.0.0.1:2369/unsubscribe/?uuid=example-uuid&key=803e513e2d8b88e759d8f433779659af335d7308b4cbac809600d563f6b49a76&newsletter=requested-newsletter-uuid\\" style=\\"overflow-wrap: anywhere; color: #15212a; color: rgba(0, 0, 0, 0.6); text-decoration: underline; font-size: 13px;\\" target=\\"_blank\\">Unsubscribe</a></td>
+                                                                        <td class=\\"footer\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; color: #15212a; color: rgba(0, 0, 0, 0.6); margin-top: 20px; text-align: center; padding-bottom: 10px; padding-top: 10px; padding-left: 30px; padding-right: 30px; line-height: 1.5; font-size: 13px;\\" valign=\\"top\\" align=\\"center\\">Ghost &#xA9; 2025 &#x2013; <a href=\\"http://127.0.0.1:2369/unsubscribe/?uuid=example-uuid&key=803e513e2d8b88e759d8f433779659af335d7308b4cbac809600d563f6b49a76&newsletter=requested-newsletter-uuid\\" style=\\"overflow-wrap: anywhere; color: #15212a; color: rgba(0, 0, 0, 0.6); text-decoration: underline; font-size: 13px;\\" target=\\"_blank\\">Unsubscribe</a></td>
                                                                     </tr>
                             
                                                                         <tr>
@@ -2858,7 +2858,7 @@ exports[`Email Preview API Read has custom content transformations for email com
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "36296",
+  "content-length": "36260",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -3369,7 +3369,7 @@ table[class=body] a[class=small] {
   color: #15212A !important;
   font-family: inherit !important;
   font-size: 14px;
-  line-height: 1.3em;
+  line-height: 1.3;
   padding-top: 4px;
   padding-right: 20px;
   padding-left: 20px;
@@ -3382,7 +3382,7 @@ table[class=body] a[class=small] {
   font-family: inherit !important;
   font-size: 15px;
   padding: 8px;
-  line-height: 1.3em;
+  line-height: 1.3;
 }
 .kg-cta-link-accent .kg-cta-sponsor-label a {
   color: #FF1A75 !important;
@@ -3503,7 +3503,7 @@ table[class=body] a[class=small] {
   margin-top: 32px;
   color: #15212A;
   text-align: center;
-  line-height: 1.1em;
+  line-height: 1.1;
 }
 .post-title-link-left {
   text-align: left;
@@ -3553,7 +3553,7 @@ table.body td {
 
   table.body .kg-callout-text {
     font-size: 16px !important;
-    line-height: 1.5em !important;
+    line-height: 1.5 !important;
   }
 
   table.body pre {
@@ -3599,7 +3599,7 @@ table.header .header-main {
 table.header .post-meta-date {
     white-space: normal !important;
     font-size: 13px !important;
-    line-height: 1.2em;
+    line-height: 1.2;
   }
 
   table.header .post-meta,
@@ -3643,7 +3643,7 @@ table.body .footer a {
 
   table.header .post-title a {
     font-size: 26px !important;
-    line-height: 1.1em !important;
+    line-height: 1.1 !important;
   }
 
   table.feedback-buttons {
@@ -3704,38 +3704,38 @@ table.body .manage-subscription {
 
   table.body h1 {
     font-size: 32px !important;
-    line-height: 1.3em !important;
+    line-height: 1.3 !important;
   }
 
   table.body h2,
 table.body h2 span {
     font-size: 26px !important;
-    line-height: 1.22em !important;
+    line-height: 1.22 !important;
   }
 
   table.body h3 {
     font-size: 21px !important;
-    line-height: 1.25em !important;
+    line-height: 1.25 !important;
   }
 
   table.body h4 {
     font-size: 19px !important;
-    line-height: 1.3em !important;
+    line-height: 1.3 !important;
   }
 
   table.body h5 {
     font-size: 16px !important;
-    line-height: 1.4em !important;
+    line-height: 1.4 !important;
   }
 
   table.body h6 {
     font-size: 16px !important;
-    line-height: 1.4em !important;
+    line-height: 1.4 !important;
   }
 
   table.body blockquote {
     font-size: 16px !important;
-    line-height: 1.6em;
+    line-height: 1.6;
     margin-bottom: 0;
   }
 
@@ -3748,7 +3748,7 @@ table.body h2 span {
     border-left: 0 none !important;
     margin: 0 !important;
     font-size: 18px !important;
-    line-height: 1.4em !important;
+    line-height: 1.4 !important;
   }
 
   table.body blockquote.kg-blockquote-alt p {
@@ -3837,7 +3837,7 @@ table.body h2 span {
                                                     <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\" width=\\"100%\\">
                                                         <tr>
                                                             <td style=\\"vertical-align: top; font-family: Georgia, serif; letter-spacing: -0.01em; font-size: 36px; line-height: 1.1; font-weight: 700; text-align: center; color: #000000;\\" valign=\\"top\\" align=\\"center\\">
-                                                                <a href=\\"http://127.0.0.1:2369/p/d52c42ae-2755-455c-80ec-70b2ec55c904/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; text-align: center; line-height: 1.1em; overflow-wrap: anywhere; color: #000000;\\" target=\\"_blank\\">Post with email-only card</a>
+                                                                <a href=\\"http://127.0.0.1:2369/p/d52c42ae-2755-455c-80ec-70b2ec55c904/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; text-align: center; line-height: 1.1; overflow-wrap: anywhere; color: #000000;\\" target=\\"_blank\\">Post with email-only card</a>
                                                             </td>
                                                         </tr>
                                                     </table>
@@ -3897,9 +3897,9 @@ table.body h2 span {
                                                             <td class=\\"wrapper\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A; box-sizing: border-box;\\" valign=\\"top\\">
                                                                 <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" width=\\"100%\\" data-testid=\\"email-preview-content\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\">
                                                                     <tr class=\\"post-content-row\\">
-                                                                        <td class=\\"post-content\\" style=\\"vertical-align: top; font-family: Georgia, serif; font-size: 18px; line-height: 1.5em; color: #15212A; padding-bottom: 20px; border-bottom: 1px solid #e0e7eb; max-width: 600px;\\" valign=\\"top\\">
+                                                                        <td class=\\"post-content\\" style=\\"vertical-align: top; font-family: Georgia, serif; font-size: 18px; line-height: 1.5; color: #15212A; padding-bottom: 20px; border-bottom: 1px solid #e0e7eb; max-width: 600px;\\" valign=\\"top\\">
                                                                             <!-- POST CONTENT START -->
-                                                                            <p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em; color: #15212A;\\">Testing <a href=\\"https://ghost.org/\\" style=\\"overflow-wrap: anywhere; color: #FF1A75; text-decoration: underline;\\" target=\\"_blank\\">links</a> in email excerpt and apostrophes &#39;</p>
+                                                                            <p style=\\"margin: 0 0 1.5em 0; line-height: 1.6; color: #15212A;\\">Testing <a href=\\"https://ghost.org/\\" style=\\"overflow-wrap: anywhere; color: #FF1A75; text-decoration: underline;\\" target=\\"_blank\\">links</a> in email excerpt and apostrophes &#39;</p>
                                                                             <!-- POST CONTENT END -->
                             
                                                                         </td>
@@ -3917,7 +3917,7 @@ table.body h2 span {
                                                             <td class=\\"wrapper\\" align=\\"center\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A; box-sizing: border-box;\\" valign=\\"top\\">
                                                                 <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; padding-top: 40px; padding-bottom: 30px;\\">
                                                                     <tr>
-                                                                        <td class=\\"footer\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; color: #15212a; color: rgba(0, 0, 0, 0.6); margin-top: 20px; text-align: center; padding-bottom: 10px; padding-top: 10px; padding-left: 30px; padding-right: 30px; line-height: 1.5em; font-size: 13px;\\" valign=\\"top\\" align=\\"center\\">Ghost &#xA9; 2025 &#x2013; <a href=\\"http://127.0.0.1:2369/unsubscribe/?uuid=example-uuid&key=803e513e2d8b88e759d8f433779659af335d7308b4cbac809600d563f6b49a76&newsletter=requested-newsletter-uuid\\" style=\\"overflow-wrap: anywhere; color: #15212a; color: rgba(0, 0, 0, 0.6); text-decoration: underline; font-size: 13px;\\" target=\\"_blank\\">Unsubscribe</a></td>
+                                                                        <td class=\\"footer\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; color: #15212a; color: rgba(0, 0, 0, 0.6); margin-top: 20px; text-align: center; padding-bottom: 10px; padding-top: 10px; padding-left: 30px; padding-right: 30px; line-height: 1.5; font-size: 13px;\\" valign=\\"top\\" align=\\"center\\">Ghost &#xA9; 2025 &#x2013; <a href=\\"http://127.0.0.1:2369/unsubscribe/?uuid=example-uuid&key=803e513e2d8b88e759d8f433779659af335d7308b4cbac809600d563f6b49a76&newsletter=requested-newsletter-uuid\\" style=\\"overflow-wrap: anywhere; color: #15212a; color: rgba(0, 0, 0, 0.6); text-decoration: underline; font-size: 13px;\\" target=\\"_blank\\">Unsubscribe</a></td>
                                                                     </tr>
                             
                                                                         <tr>
@@ -4143,7 +4143,7 @@ exports[`Email Preview API Read uses the newsletter provided through ?newsletter
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "37173",
+  "content-length": "37137",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -4680,7 +4680,7 @@ table[class=body] a[class=small] {
   color: #15212A !important;
   font-family: inherit !important;
   font-size: 14px;
-  line-height: 1.3em;
+  line-height: 1.3;
   padding-top: 4px;
   padding-right: 20px;
   padding-left: 20px;
@@ -4693,7 +4693,7 @@ table[class=body] a[class=small] {
   font-family: inherit !important;
   font-size: 15px;
   padding: 8px;
-  line-height: 1.3em;
+  line-height: 1.3;
 }
 .kg-cta-link-accent .kg-cta-sponsor-label a {
   color: #FF1A75 !important;
@@ -4814,7 +4814,7 @@ table[class=body] a[class=small] {
   margin-top: 32px;
   color: #15212A;
   text-align: center;
-  line-height: 1.1em;
+  line-height: 1.1;
 }
 .post-title-link-left {
   text-align: left;
@@ -4864,7 +4864,7 @@ table.body td {
 
   table.body .kg-callout-text {
     font-size: 16px !important;
-    line-height: 1.5em !important;
+    line-height: 1.5 !important;
   }
 
   table.body pre {
@@ -4910,7 +4910,7 @@ table.header .header-main {
 table.header .post-meta-date {
     white-space: normal !important;
     font-size: 13px !important;
-    line-height: 1.2em;
+    line-height: 1.2;
   }
 
   table.header .post-meta,
@@ -4954,7 +4954,7 @@ table.body .footer a {
 
   table.header .post-title a {
     font-size: 26px !important;
-    line-height: 1.1em !important;
+    line-height: 1.1 !important;
   }
 
   table.feedback-buttons {
@@ -5015,38 +5015,38 @@ table.body .manage-subscription {
 
   table.body h1 {
     font-size: 32px !important;
-    line-height: 1.3em !important;
+    line-height: 1.3 !important;
   }
 
   table.body h2,
 table.body h2 span {
     font-size: 26px !important;
-    line-height: 1.22em !important;
+    line-height: 1.22 !important;
   }
 
   table.body h3 {
     font-size: 21px !important;
-    line-height: 1.25em !important;
+    line-height: 1.25 !important;
   }
 
   table.body h4 {
     font-size: 19px !important;
-    line-height: 1.3em !important;
+    line-height: 1.3 !important;
   }
 
   table.body h5 {
     font-size: 16px !important;
-    line-height: 1.4em !important;
+    line-height: 1.4 !important;
   }
 
   table.body h6 {
     font-size: 16px !important;
-    line-height: 1.4em !important;
+    line-height: 1.4 !important;
   }
 
   table.body blockquote {
     font-size: 16px !important;
-    line-height: 1.6em;
+    line-height: 1.6;
     margin-bottom: 0;
   }
 
@@ -5059,7 +5059,7 @@ table.body h2 span {
     border-left: 0 none !important;
     margin: 0 !important;
     font-size: 18px !important;
-    line-height: 1.4em !important;
+    line-height: 1.4 !important;
   }
 
   table.body blockquote.kg-blockquote-alt p {
@@ -5148,7 +5148,7 @@ table.body h2 span {
                                                     <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\" width=\\"100%\\">
                                                         <tr>
                                                             <td style=\\"vertical-align: top; font-family: Georgia, serif; letter-spacing: -0.01em; font-size: 36px; line-height: 1.1; font-weight: 700; text-align: center; color: #000000;\\" valign=\\"top\\" align=\\"center\\">
-                                                                <a href=\\"http://127.0.0.1:2369/p/d52c42ae-2755-455c-80ec-70b2ec55c904/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; text-align: center; line-height: 1.1em; overflow-wrap: anywhere; color: #000000;\\" target=\\"_blank\\">Post with email-only card</a>
+                                                                <a href=\\"http://127.0.0.1:2369/p/d52c42ae-2755-455c-80ec-70b2ec55c904/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; text-align: center; line-height: 1.1; overflow-wrap: anywhere; color: #000000;\\" target=\\"_blank\\">Post with email-only card</a>
                                                             </td>
                                                         </tr>
                                                     </table>
@@ -5208,9 +5208,9 @@ table.body h2 span {
                                                             <td class=\\"wrapper\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A; box-sizing: border-box;\\" valign=\\"top\\">
                                                                 <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" width=\\"100%\\" data-testid=\\"email-preview-content\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\">
                                                                     <tr class=\\"post-content-row\\">
-                                                                        <td class=\\"post-content\\" style=\\"vertical-align: top; font-family: Georgia, serif; font-size: 18px; line-height: 1.5em; color: #15212A; padding-bottom: 20px; border-bottom: 1px solid #e0e7eb; max-width: 600px;\\" valign=\\"top\\">
+                                                                        <td class=\\"post-content\\" style=\\"vertical-align: top; font-family: Georgia, serif; font-size: 18px; line-height: 1.5; color: #15212A; padding-bottom: 20px; border-bottom: 1px solid #e0e7eb; max-width: 600px;\\" valign=\\"top\\">
                                                                             <!-- POST CONTENT START -->
-                                                                            <p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em; color: #15212A;\\">Testing <a href=\\"https://ghost.org/\\" style=\\"overflow-wrap: anywhere; color: #FF1A75; text-decoration: underline;\\" target=\\"_blank\\">links</a> in email excerpt and apostrophes &#39;</p>
+                                                                            <p style=\\"margin: 0 0 1.5em 0; line-height: 1.6; color: #15212A;\\">Testing <a href=\\"https://ghost.org/\\" style=\\"overflow-wrap: anywhere; color: #FF1A75; text-decoration: underline;\\" target=\\"_blank\\">links</a> in email excerpt and apostrophes &#39;</p>
                                                                             <!-- POST CONTENT END -->
                             
                                                                         </td>
@@ -5228,7 +5228,7 @@ table.body h2 span {
                                                             <td class=\\"wrapper\\" align=\\"center\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A; box-sizing: border-box;\\" valign=\\"top\\">
                                                                 <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; padding-top: 40px; padding-bottom: 30px;\\">
                                                                     <tr>
-                                                                        <td class=\\"footer\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; color: #15212a; color: rgba(0, 0, 0, 0.6); margin-top: 20px; text-align: center; padding-bottom: 10px; padding-top: 10px; padding-left: 30px; padding-right: 30px; line-height: 1.5em; font-size: 13px;\\" valign=\\"top\\" align=\\"center\\">Ghost &#xA9; 2025 &#x2013; <a href=\\"http://127.0.0.1:2369/unsubscribe/?uuid=example-uuid&key=803e513e2d8b88e759d8f433779659af335d7308b4cbac809600d563f6b49a76&newsletter=requested-newsletter-uuid\\" style=\\"overflow-wrap: anywhere; color: #15212a; color: rgba(0, 0, 0, 0.6); text-decoration: underline; font-size: 13px;\\" target=\\"_blank\\">Unsubscribe</a></td>
+                                                                        <td class=\\"footer\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; color: #15212a; color: rgba(0, 0, 0, 0.6); margin-top: 20px; text-align: center; padding-bottom: 10px; padding-top: 10px; padding-left: 30px; padding-right: 30px; line-height: 1.5; font-size: 13px;\\" valign=\\"top\\" align=\\"center\\">Ghost &#xA9; 2025 &#x2013; <a href=\\"http://127.0.0.1:2369/unsubscribe/?uuid=example-uuid&key=803e513e2d8b88e759d8f433779659af335d7308b4cbac809600d563f6b49a76&newsletter=requested-newsletter-uuid\\" style=\\"overflow-wrap: anywhere; color: #15212a; color: rgba(0, 0, 0, 0.6); text-decoration: underline; font-size: 13px;\\" target=\\"_blank\\">Unsubscribe</a></td>
                                                                     </tr>
                             
                                                                         <tr>
@@ -5454,7 +5454,7 @@ exports[`Email Preview API Read uses the posts newsletter by default 4: [headers
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "37173",
+  "content-length": "37137",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/integration/services/__snapshots__/member-welcome-emails-snapshot.test.js.snap
+++ b/ghost/core/test/integration/services/__snapshots__/member-welcome-emails-snapshot.test.js.snap
@@ -130,7 +130,7 @@ table[class=body] a[class=small] {
   color: #15212A !important;
   font-family: inherit !important;
   font-size: 14px;
-  line-height: 1.3em;
+  line-height: 1.3;
   padding-top: 4px;
   padding-right: 20px;
   padding-left: 20px;
@@ -143,7 +143,7 @@ table[class=body] a[class=small] {
   font-family: inherit !important;
   font-size: 15px;
   padding: 8px;
-  line-height: 1.3em;
+  line-height: 1.3;
 }
 .kg-cta-link-accent .kg-cta-sponsor-label a {
   color: #15212A !important;
@@ -264,7 +264,7 @@ table[class=body] a[class=small] {
   margin-top: 32px;
   color: #15212A;
   text-align: center;
-  line-height: 1.1em;
+  line-height: 1.1;
 }
 .post-title-link-left {
   text-align: left;
@@ -314,7 +314,7 @@ table.body td {
 
   table.body .kg-callout-text {
     font-size: 16px !important;
-    line-height: 1.5em !important;
+    line-height: 1.5 !important;
   }
 
   table.body pre {
@@ -360,7 +360,7 @@ table.header .header-main {
 table.header .post-meta-date {
     white-space: normal !important;
     font-size: 13px !important;
-    line-height: 1.2em;
+    line-height: 1.2;
   }
 
   table.header .post-meta,
@@ -404,7 +404,7 @@ table.body .footer a {
 
   table.header .post-title a {
     font-size: 26px !important;
-    line-height: 1.1em !important;
+    line-height: 1.1 !important;
   }
 
   table.feedback-buttons {
@@ -465,38 +465,38 @@ table.body .manage-subscription {
 
   table.body h1 {
     font-size: 32px !important;
-    line-height: 1.3em !important;
+    line-height: 1.3 !important;
   }
 
   table.body h2,
 table.body h2 span {
     font-size: 26px !important;
-    line-height: 1.22em !important;
+    line-height: 1.22 !important;
   }
 
   table.body h3 {
     font-size: 21px !important;
-    line-height: 1.25em !important;
+    line-height: 1.25 !important;
   }
 
   table.body h4 {
     font-size: 19px !important;
-    line-height: 1.3em !important;
+    line-height: 1.3 !important;
   }
 
   table.body h5 {
     font-size: 16px !important;
-    line-height: 1.4em !important;
+    line-height: 1.4 !important;
   }
 
   table.body h6 {
     font-size: 16px !important;
-    line-height: 1.4em !important;
+    line-height: 1.4 !important;
   }
 
   table.body blockquote {
     font-size: 16px !important;
-    line-height: 1.6em;
+    line-height: 1.6;
     margin-bottom: 0;
   }
 
@@ -509,7 +509,7 @@ table.body h2 span {
     border-left: 0 none !important;
     margin: 0 !important;
     font-size: 18px !important;
-    line-height: 1.4em !important;
+    line-height: 1.4 !important;
   }
 
   table.body blockquote.kg-blockquote-alt p {
@@ -618,8 +618,8 @@ table.body h2 span {
                                             <td class=\\"wrapper\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A; box-sizing: border-box;\\" valign=\\"top\\">
                                               <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\">
                                                 <tr class=\\"post-content-row\\">
-                                                  <td class=\\"post-content-sans-serif\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; font-size: 17px; line-height: 1.5em; color: #15212A; padding-bottom: 20px; border-bottom: 1px solid #e0e7eb; max-width: 600px;\\" valign=\\"top\\">
-                                                    <p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em; color: #15212A;\\">Welcome to our site!</p>
+                                                  <td class=\\"post-content-sans-serif\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; font-size: 17px; line-height: 1.5; color: #15212A; padding-bottom: 20px; border-bottom: 1px solid #e0e7eb; max-width: 600px;\\" valign=\\"top\\">
+                                                    <p style=\\"margin: 0 0 1.5em 0; line-height: 1.6; color: #15212A;\\">Welcome to our site!</p>
                                                   </td>
                                                 </tr>
                                               </table>
@@ -629,7 +629,7 @@ table.body h2 span {
                                             <td class=\\"wrapper\\" align=\\"center\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A; box-sizing: border-box;\\" valign=\\"top\\">
                                               <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; padding-top: 40px; padding-bottom: 30px;\\">
                                                 <tr>
-                                                  <td class=\\"footer\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; color: #15212a; color: rgba(0, 0, 0, 0.6); margin-top: 20px; text-align: center; padding-bottom: 10px; padding-top: 10px; padding-left: 30px; padding-right: 30px; line-height: 1.5em; font-size: 13px;\\" valign=\\"top\\" align=\\"center\\">
+                                                  <td class=\\"footer\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; color: #15212a; color: rgba(0, 0, 0, 0.6); margin-top: 20px; text-align: center; padding-bottom: 10px; padding-top: 10px; padding-left: 30px; padding-right: 30px; line-height: 1.5; font-size: 13px;\\" valign=\\"top\\" align=\\"center\\">
                                                     Test Site &copy; 2020 &mdash; <a href=\\"http://example.com/#/portal/account/newsletters\\" style=\\"overflow-wrap: anywhere; color: #15212a; color: rgba(0, 0, 0, 0.6); text-decoration: underline; font-size: 13px;\\">Manage your preferences</a>
                                                   </td>
                                                 </tr>
@@ -899,7 +899,7 @@ table[class=body] a[class=small] {
   color: #15212A !important;
   font-family: inherit !important;
   font-size: 14px;
-  line-height: 1.3em;
+  line-height: 1.3;
   padding-top: 4px;
   padding-right: 20px;
   padding-left: 20px;
@@ -912,7 +912,7 @@ table[class=body] a[class=small] {
   font-family: inherit !important;
   font-size: 15px;
   padding: 8px;
-  line-height: 1.3em;
+  line-height: 1.3;
 }
 .kg-cta-link-accent .kg-cta-sponsor-label a {
   color: #15212A !important;
@@ -1033,7 +1033,7 @@ table[class=body] a[class=small] {
   margin-top: 32px;
   color: #15212A;
   text-align: center;
-  line-height: 1.1em;
+  line-height: 1.1;
 }
 .post-title-link-left {
   text-align: left;
@@ -1083,7 +1083,7 @@ table.body td {
 
   table.body .kg-callout-text {
     font-size: 16px !important;
-    line-height: 1.5em !important;
+    line-height: 1.5 !important;
   }
 
   table.body pre {
@@ -1129,7 +1129,7 @@ table.header .header-main {
 table.header .post-meta-date {
     white-space: normal !important;
     font-size: 13px !important;
-    line-height: 1.2em;
+    line-height: 1.2;
   }
 
   table.header .post-meta,
@@ -1173,7 +1173,7 @@ table.body .footer a {
 
   table.header .post-title a {
     font-size: 26px !important;
-    line-height: 1.1em !important;
+    line-height: 1.1 !important;
   }
 
   table.feedback-buttons {
@@ -1234,38 +1234,38 @@ table.body .manage-subscription {
 
   table.body h1 {
     font-size: 32px !important;
-    line-height: 1.3em !important;
+    line-height: 1.3 !important;
   }
 
   table.body h2,
 table.body h2 span {
     font-size: 26px !important;
-    line-height: 1.22em !important;
+    line-height: 1.22 !important;
   }
 
   table.body h3 {
     font-size: 21px !important;
-    line-height: 1.25em !important;
+    line-height: 1.25 !important;
   }
 
   table.body h4 {
     font-size: 19px !important;
-    line-height: 1.3em !important;
+    line-height: 1.3 !important;
   }
 
   table.body h5 {
     font-size: 16px !important;
-    line-height: 1.4em !important;
+    line-height: 1.4 !important;
   }
 
   table.body h6 {
     font-size: 16px !important;
-    line-height: 1.4em !important;
+    line-height: 1.4 !important;
   }
 
   table.body blockquote {
     font-size: 16px !important;
-    line-height: 1.6em;
+    line-height: 1.6;
     margin-bottom: 0;
   }
 
@@ -1278,7 +1278,7 @@ table.body h2 span {
     border-left: 0 none !important;
     margin: 0 !important;
     font-size: 18px !important;
-    line-height: 1.4em !important;
+    line-height: 1.4 !important;
   }
 
   table.body blockquote.kg-blockquote-alt p {
@@ -1387,8 +1387,8 @@ table.body h2 span {
                                             <td class=\\"wrapper\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A; box-sizing: border-box;\\" valign=\\"top\\">
                                               <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\">
                                                 <tr class=\\"post-content-row\\">
-                                                  <td class=\\"post-content-sans-serif\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; font-size: 17px; line-height: 1.5em; color: #15212A; padding-bottom: 20px; border-bottom: 1px solid #e0e7eb; max-width: 600px;\\" valign=\\"top\\">
-                                                    <p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em; color: #15212A;\\">Hello friend, welcome!</p>
+                                                  <td class=\\"post-content-sans-serif\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; font-size: 17px; line-height: 1.5; color: #15212A; padding-bottom: 20px; border-bottom: 1px solid #e0e7eb; max-width: 600px;\\" valign=\\"top\\">
+                                                    <p style=\\"margin: 0 0 1.5em 0; line-height: 1.6; color: #15212A;\\">Hello friend, welcome!</p>
                                                   </td>
                                                 </tr>
                                               </table>
@@ -1398,7 +1398,7 @@ table.body h2 span {
                                             <td class=\\"wrapper\\" align=\\"center\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A; box-sizing: border-box;\\" valign=\\"top\\">
                                               <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; padding-top: 40px; padding-bottom: 30px;\\">
                                                 <tr>
-                                                  <td class=\\"footer\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; color: #15212a; color: rgba(0, 0, 0, 0.6); margin-top: 20px; text-align: center; padding-bottom: 10px; padding-top: 10px; padding-left: 30px; padding-right: 30px; line-height: 1.5em; font-size: 13px;\\" valign=\\"top\\" align=\\"center\\">
+                                                  <td class=\\"footer\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; color: #15212a; color: rgba(0, 0, 0, 0.6); margin-top: 20px; text-align: center; padding-bottom: 10px; padding-top: 10px; padding-left: 30px; padding-right: 30px; line-height: 1.5; font-size: 13px;\\" valign=\\"top\\" align=\\"center\\">
                                                     Test Site &copy; 2020 &mdash; <a href=\\"http://example.com/#/portal/account/newsletters\\" style=\\"overflow-wrap: anywhere; color: #15212a; color: rgba(0, 0, 0, 0.6); text-decoration: underline; font-size: 13px;\\">Manage your preferences</a>
                                                   </td>
                                                 </tr>
@@ -1668,7 +1668,7 @@ table[class=body] a[class=small] {
   color: #15212A !important;
   font-family: inherit !important;
   font-size: 14px;
-  line-height: 1.3em;
+  line-height: 1.3;
   padding-top: 4px;
   padding-right: 20px;
   padding-left: 20px;
@@ -1681,7 +1681,7 @@ table[class=body] a[class=small] {
   font-family: inherit !important;
   font-size: 15px;
   padding: 8px;
-  line-height: 1.3em;
+  line-height: 1.3;
 }
 .kg-cta-link-accent .kg-cta-sponsor-label a {
   color: #15212A !important;
@@ -1802,7 +1802,7 @@ table[class=body] a[class=small] {
   margin-top: 32px;
   color: #15212A;
   text-align: center;
-  line-height: 1.1em;
+  line-height: 1.1;
 }
 .post-title-link-left {
   text-align: left;
@@ -1852,7 +1852,7 @@ table.body td {
 
   table.body .kg-callout-text {
     font-size: 16px !important;
-    line-height: 1.5em !important;
+    line-height: 1.5 !important;
   }
 
   table.body pre {
@@ -1898,7 +1898,7 @@ table.header .header-main {
 table.header .post-meta-date {
     white-space: normal !important;
     font-size: 13px !important;
-    line-height: 1.2em;
+    line-height: 1.2;
   }
 
   table.header .post-meta,
@@ -1942,7 +1942,7 @@ table.body .footer a {
 
   table.header .post-title a {
     font-size: 26px !important;
-    line-height: 1.1em !important;
+    line-height: 1.1 !important;
   }
 
   table.feedback-buttons {
@@ -2003,38 +2003,38 @@ table.body .manage-subscription {
 
   table.body h1 {
     font-size: 32px !important;
-    line-height: 1.3em !important;
+    line-height: 1.3 !important;
   }
 
   table.body h2,
 table.body h2 span {
     font-size: 26px !important;
-    line-height: 1.22em !important;
+    line-height: 1.22 !important;
   }
 
   table.body h3 {
     font-size: 21px !important;
-    line-height: 1.25em !important;
+    line-height: 1.25 !important;
   }
 
   table.body h4 {
     font-size: 19px !important;
-    line-height: 1.3em !important;
+    line-height: 1.3 !important;
   }
 
   table.body h5 {
     font-size: 16px !important;
-    line-height: 1.4em !important;
+    line-height: 1.4 !important;
   }
 
   table.body h6 {
     font-size: 16px !important;
-    line-height: 1.4em !important;
+    line-height: 1.4 !important;
   }
 
   table.body blockquote {
     font-size: 16px !important;
-    line-height: 1.6em;
+    line-height: 1.6;
     margin-bottom: 0;
   }
 
@@ -2047,7 +2047,7 @@ table.body h2 span {
     border-left: 0 none !important;
     margin: 0 !important;
     font-size: 18px !important;
-    line-height: 1.4em !important;
+    line-height: 1.4 !important;
   }
 
   table.body blockquote.kg-blockquote-alt p {
@@ -2156,8 +2156,8 @@ table.body h2 span {
                                             <td class=\\"wrapper\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A; box-sizing: border-box;\\" valign=\\"top\\">
                                               <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\">
                                                 <tr class=\\"post-content-row\\">
-                                                  <td class=\\"post-content-sans-serif\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; font-size: 17px; line-height: 1.5em; color: #15212A; padding-bottom: 20px; border-bottom: 1px solid #e0e7eb; max-width: 600px;\\" valign=\\"top\\">
-                                                    <p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em; color: #15212A;\\">Hello Jamie, welcome to Test Site! Your email is jamie@example.com.</p>
+                                                  <td class=\\"post-content-sans-serif\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; font-size: 17px; line-height: 1.5; color: #15212A; padding-bottom: 20px; border-bottom: 1px solid #e0e7eb; max-width: 600px;\\" valign=\\"top\\">
+                                                    <p style=\\"margin: 0 0 1.5em 0; line-height: 1.6; color: #15212A;\\">Hello Jamie, welcome to Test Site! Your email is jamie@example.com.</p>
                                                   </td>
                                                 </tr>
                                               </table>
@@ -2167,7 +2167,7 @@ table.body h2 span {
                                             <td class=\\"wrapper\\" align=\\"center\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A; box-sizing: border-box;\\" valign=\\"top\\">
                                               <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; padding-top: 40px; padding-bottom: 30px;\\">
                                                 <tr>
-                                                  <td class=\\"footer\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; color: #15212a; color: rgba(0, 0, 0, 0.6); margin-top: 20px; text-align: center; padding-bottom: 10px; padding-top: 10px; padding-left: 30px; padding-right: 30px; line-height: 1.5em; font-size: 13px;\\" valign=\\"top\\" align=\\"center\\">
+                                                  <td class=\\"footer\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; color: #15212a; color: rgba(0, 0, 0, 0.6); margin-top: 20px; text-align: center; padding-bottom: 10px; padding-top: 10px; padding-left: 30px; padding-right: 30px; line-height: 1.5; font-size: 13px;\\" valign=\\"top\\" align=\\"center\\">
                                                     Test Site &copy; 2020 &mdash; <a href=\\"http://example.com/#/portal/account/newsletters\\" style=\\"overflow-wrap: anywhere; color: #15212a; color: rgba(0, 0, 0, 0.6); text-decoration: underline; font-size: 13px;\\">Manage your preferences</a>
                                                   </td>
                                                 </tr>
@@ -2438,7 +2438,7 @@ table[class=body] a[class=small] {
   color: #15212A !important;
   font-family: inherit !important;
   font-size: 14px;
-  line-height: 1.3em;
+  line-height: 1.3;
   padding-top: 4px;
   padding-right: 20px;
   padding-left: 20px;
@@ -2451,7 +2451,7 @@ table[class=body] a[class=small] {
   font-family: inherit !important;
   font-size: 15px;
   padding: 8px;
-  line-height: 1.3em;
+  line-height: 1.3;
 }
 .kg-cta-link-accent .kg-cta-sponsor-label a {
   color: #FF0000 !important;
@@ -2572,7 +2572,7 @@ table[class=body] a[class=small] {
   margin-top: 32px;
   color: #15212A;
   text-align: center;
-  line-height: 1.1em;
+  line-height: 1.1;
 }
 .post-title-link-left {
   text-align: left;
@@ -2622,7 +2622,7 @@ table.body td {
 
   table.body .kg-callout-text {
     font-size: 16px !important;
-    line-height: 1.5em !important;
+    line-height: 1.5 !important;
   }
 
   table.body pre {
@@ -2668,7 +2668,7 @@ table.header .header-main {
 table.header .post-meta-date {
     white-space: normal !important;
     font-size: 13px !important;
-    line-height: 1.2em;
+    line-height: 1.2;
   }
 
   table.header .post-meta,
@@ -2712,7 +2712,7 @@ table.body .footer a {
 
   table.header .post-title a {
     font-size: 26px !important;
-    line-height: 1.1em !important;
+    line-height: 1.1 !important;
   }
 
   table.feedback-buttons {
@@ -2773,38 +2773,38 @@ table.body .manage-subscription {
 
   table.body h1 {
     font-size: 32px !important;
-    line-height: 1.3em !important;
+    line-height: 1.3 !important;
   }
 
   table.body h2,
 table.body h2 span {
     font-size: 26px !important;
-    line-height: 1.22em !important;
+    line-height: 1.22 !important;
   }
 
   table.body h3 {
     font-size: 21px !important;
-    line-height: 1.25em !important;
+    line-height: 1.25 !important;
   }
 
   table.body h4 {
     font-size: 19px !important;
-    line-height: 1.3em !important;
+    line-height: 1.3 !important;
   }
 
   table.body h5 {
     font-size: 16px !important;
-    line-height: 1.4em !important;
+    line-height: 1.4 !important;
   }
 
   table.body h6 {
     font-size: 16px !important;
-    line-height: 1.4em !important;
+    line-height: 1.4 !important;
   }
 
   table.body blockquote {
     font-size: 16px !important;
-    line-height: 1.6em;
+    line-height: 1.6;
     margin-bottom: 0;
   }
 
@@ -2817,7 +2817,7 @@ table.body h2 span {
     border-left: 0 none !important;
     margin: 0 !important;
     font-size: 18px !important;
-    line-height: 1.4em !important;
+    line-height: 1.4 !important;
   }
 
   table.body blockquote.kg-blockquote-alt p {
@@ -2926,8 +2926,8 @@ table.body h2 span {
                                             <td class=\\"wrapper\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A; box-sizing: border-box;\\" valign=\\"top\\">
                                               <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\">
                                                 <tr class=\\"post-content-row\\">
-                                                  <td class=\\"post-content-sans-serif\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; font-size: 17px; line-height: 1.5em; color: #15212A; padding-bottom: 20px; border-bottom: 1px solid #e0e7eb; max-width: 600px;\\" valign=\\"top\\">
-                                                    <p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em; color: #15212A;\\">Welcome!</p>
+                                                  <td class=\\"post-content-sans-serif\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; font-size: 17px; line-height: 1.5; color: #15212A; padding-bottom: 20px; border-bottom: 1px solid #e0e7eb; max-width: 600px;\\" valign=\\"top\\">
+                                                    <p style=\\"margin: 0 0 1.5em 0; line-height: 1.6; color: #15212A;\\">Welcome!</p>
                                                   </td>
                                                 </tr>
                                               </table>
@@ -2937,7 +2937,7 @@ table.body h2 span {
                                             <td class=\\"wrapper\\" align=\\"center\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A; box-sizing: border-box;\\" valign=\\"top\\">
                                               <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; padding-top: 40px; padding-bottom: 30px;\\">
                                                 <tr>
-                                                  <td class=\\"footer\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; color: #15212a; color: rgba(0, 0, 0, 0.6); margin-top: 20px; text-align: center; padding-bottom: 10px; padding-top: 10px; padding-left: 30px; padding-right: 30px; line-height: 1.5em; font-size: 13px;\\" valign=\\"top\\" align=\\"center\\">
+                                                  <td class=\\"footer\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; color: #15212a; color: rgba(0, 0, 0, 0.6); margin-top: 20px; text-align: center; padding-bottom: 10px; padding-top: 10px; padding-left: 30px; padding-right: 30px; line-height: 1.5; font-size: 13px;\\" valign=\\"top\\" align=\\"center\\">
                                                     Test Site &copy; 2020 &mdash; <a href=\\"http://example.com/#/portal/account/newsletters\\" style=\\"overflow-wrap: anywhere; color: #15212a; color: rgba(0, 0, 0, 0.6); text-decoration: underline; font-size: 13px;\\">Manage your preferences</a>
                                                   </td>
                                                 </tr>
@@ -3207,7 +3207,7 @@ table[class=body] a[class=small] {
   color: #15212A !important;
   font-family: inherit !important;
   font-size: 14px;
-  line-height: 1.3em;
+  line-height: 1.3;
   padding-top: 4px;
   padding-right: 20px;
   padding-left: 20px;
@@ -3220,7 +3220,7 @@ table[class=body] a[class=small] {
   font-family: inherit !important;
   font-size: 15px;
   padding: 8px;
-  line-height: 1.3em;
+  line-height: 1.3;
 }
 .kg-cta-link-accent .kg-cta-sponsor-label a {
   color: #15212A !important;
@@ -3365,7 +3365,7 @@ table[class=body] a[class=small] {
                                               <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\">
                                                 <tr class=\\"post-content-row\\">
                                                   <td class=\\"post-content\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A;\\" valign=\\"top\\">
-                                                    <p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\">Welcome to our site!</p>
+                                                    <p style=\\"margin: 0 0 1.5em 0; line-height: 1.6;\\">Welcome to our site!</p>
                                                   </td>
                                                 </tr>
                                               </table>
@@ -3375,7 +3375,7 @@ table[class=body] a[class=small] {
                                             <td class=\\"wrapper\\" align=\\"center\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A; box-sizing: border-box;\\" valign=\\"top\\">
                                               <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; padding-top: 40px; padding-bottom: 30px;\\">
                                                 <tr>
-                                                  <td class=\\"footer\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; color: #15212a; color: rgba(0, 0, 0, 0.6); margin-top: 20px; text-align: center; padding-bottom: 10px; padding-top: 10px; padding-left: 30px; padding-right: 30px; line-height: 1.5em; font-size: 13px;\\" valign=\\"top\\" align=\\"center\\">
+                                                  <td class=\\"footer\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; color: #15212a; color: rgba(0, 0, 0, 0.6); margin-top: 20px; text-align: center; padding-bottom: 10px; padding-top: 10px; padding-left: 30px; padding-right: 30px; line-height: 1.5; font-size: 13px;\\" valign=\\"top\\" align=\\"center\\">
                                                     Test Site &copy; 2020 &mdash; <a href=\\"http://example.com/#/portal/account/newsletters\\" style=\\"overflow-wrap: anywhere; color: #15212a; color: rgba(0, 0, 0, 0.6); text-decoration: underline; font-size: 13px;\\">Manage your preferences</a>
                                                   </td>
                                                 </tr>
@@ -3594,7 +3594,7 @@ table[class=body] a[class=small] {
   color: #15212A !important;
   font-family: inherit !important;
   font-size: 14px;
-  line-height: 1.3em;
+  line-height: 1.3;
   padding-top: 4px;
   padding-right: 20px;
   padding-left: 20px;
@@ -3607,7 +3607,7 @@ table[class=body] a[class=small] {
   font-family: inherit !important;
   font-size: 15px;
   padding: 8px;
-  line-height: 1.3em;
+  line-height: 1.3;
 }
 .kg-cta-link-accent .kg-cta-sponsor-label a {
   color: #15212A !important;
@@ -3752,7 +3752,7 @@ table[class=body] a[class=small] {
                                               <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\">
                                                 <tr class=\\"post-content-row\\">
                                                   <td class=\\"post-content\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A;\\" valign=\\"top\\">
-                                                    <p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\">Hello friend, welcome!</p>
+                                                    <p style=\\"margin: 0 0 1.5em 0; line-height: 1.6;\\">Hello friend, welcome!</p>
                                                   </td>
                                                 </tr>
                                               </table>
@@ -3762,7 +3762,7 @@ table[class=body] a[class=small] {
                                             <td class=\\"wrapper\\" align=\\"center\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A; box-sizing: border-box;\\" valign=\\"top\\">
                                               <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; padding-top: 40px; padding-bottom: 30px;\\">
                                                 <tr>
-                                                  <td class=\\"footer\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; color: #15212a; color: rgba(0, 0, 0, 0.6); margin-top: 20px; text-align: center; padding-bottom: 10px; padding-top: 10px; padding-left: 30px; padding-right: 30px; line-height: 1.5em; font-size: 13px;\\" valign=\\"top\\" align=\\"center\\">
+                                                  <td class=\\"footer\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; color: #15212a; color: rgba(0, 0, 0, 0.6); margin-top: 20px; text-align: center; padding-bottom: 10px; padding-top: 10px; padding-left: 30px; padding-right: 30px; line-height: 1.5; font-size: 13px;\\" valign=\\"top\\" align=\\"center\\">
                                                     Test Site &copy; 2020 &mdash; <a href=\\"http://example.com/#/portal/account/newsletters\\" style=\\"overflow-wrap: anywhere; color: #15212a; color: rgba(0, 0, 0, 0.6); text-decoration: underline; font-size: 13px;\\">Manage your preferences</a>
                                                   </td>
                                                 </tr>
@@ -3981,7 +3981,7 @@ table[class=body] a[class=small] {
   color: #15212A !important;
   font-family: inherit !important;
   font-size: 14px;
-  line-height: 1.3em;
+  line-height: 1.3;
   padding-top: 4px;
   padding-right: 20px;
   padding-left: 20px;
@@ -3994,7 +3994,7 @@ table[class=body] a[class=small] {
   font-family: inherit !important;
   font-size: 15px;
   padding: 8px;
-  line-height: 1.3em;
+  line-height: 1.3;
 }
 .kg-cta-link-accent .kg-cta-sponsor-label a {
   color: #15212A !important;
@@ -4139,7 +4139,7 @@ table[class=body] a[class=small] {
                                               <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\">
                                                 <tr class=\\"post-content-row\\">
                                                   <td class=\\"post-content\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A;\\" valign=\\"top\\">
-                                                    <p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\">Hello Jamie, welcome to Test Site! Your email is jamie@example.com.</p>
+                                                    <p style=\\"margin: 0 0 1.5em 0; line-height: 1.6;\\">Hello Jamie, welcome to Test Site! Your email is jamie@example.com.</p>
                                                   </td>
                                                 </tr>
                                               </table>
@@ -4149,7 +4149,7 @@ table[class=body] a[class=small] {
                                             <td class=\\"wrapper\\" align=\\"center\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A; box-sizing: border-box;\\" valign=\\"top\\">
                                               <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; padding-top: 40px; padding-bottom: 30px;\\">
                                                 <tr>
-                                                  <td class=\\"footer\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; color: #15212a; color: rgba(0, 0, 0, 0.6); margin-top: 20px; text-align: center; padding-bottom: 10px; padding-top: 10px; padding-left: 30px; padding-right: 30px; line-height: 1.5em; font-size: 13px;\\" valign=\\"top\\" align=\\"center\\">
+                                                  <td class=\\"footer\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; color: #15212a; color: rgba(0, 0, 0, 0.6); margin-top: 20px; text-align: center; padding-bottom: 10px; padding-top: 10px; padding-left: 30px; padding-right: 30px; line-height: 1.5; font-size: 13px;\\" valign=\\"top\\" align=\\"center\\">
                                                     Test Site &copy; 2020 &mdash; <a href=\\"http://example.com/#/portal/account/newsletters\\" style=\\"overflow-wrap: anywhere; color: #15212a; color: rgba(0, 0, 0, 0.6); text-decoration: underline; font-size: 13px;\\">Manage your preferences</a>
                                                   </td>
                                                 </tr>
@@ -4369,7 +4369,7 @@ table[class=body] a[class=small] {
   color: #15212A !important;
   font-family: inherit !important;
   font-size: 14px;
-  line-height: 1.3em;
+  line-height: 1.3;
   padding-top: 4px;
   padding-right: 20px;
   padding-left: 20px;
@@ -4382,7 +4382,7 @@ table[class=body] a[class=small] {
   font-family: inherit !important;
   font-size: 15px;
   padding: 8px;
-  line-height: 1.3em;
+  line-height: 1.3;
 }
 .kg-cta-link-accent .kg-cta-sponsor-label a {
   color: #FF0000 !important;
@@ -4527,7 +4527,7 @@ table[class=body] a[class=small] {
                                               <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\">
                                                 <tr class=\\"post-content-row\\">
                                                   <td class=\\"post-content\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A;\\" valign=\\"top\\">
-                                                    <p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\">Welcome!</p>
+                                                    <p style=\\"margin: 0 0 1.5em 0; line-height: 1.6;\\">Welcome!</p>
                                                   </td>
                                                 </tr>
                                               </table>
@@ -4537,7 +4537,7 @@ table[class=body] a[class=small] {
                                             <td class=\\"wrapper\\" align=\\"center\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A; box-sizing: border-box;\\" valign=\\"top\\">
                                               <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; padding-top: 40px; padding-bottom: 30px;\\">
                                                 <tr>
-                                                  <td class=\\"footer\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; color: #15212a; color: rgba(0, 0, 0, 0.6); margin-top: 20px; text-align: center; padding-bottom: 10px; padding-top: 10px; padding-left: 30px; padding-right: 30px; line-height: 1.5em; font-size: 13px;\\" valign=\\"top\\" align=\\"center\\">
+                                                  <td class=\\"footer\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; color: #15212a; color: rgba(0, 0, 0, 0.6); margin-top: 20px; text-align: center; padding-bottom: 10px; padding-top: 10px; padding-left: 30px; padding-right: 30px; line-height: 1.5; font-size: 13px;\\" valign=\\"top\\" align=\\"center\\">
                                                     Test Site &copy; 2020 &mdash; <a href=\\"http://example.com/#/portal/account/newsletters\\" style=\\"overflow-wrap: anywhere; color: #15212a; color: rgba(0, 0, 0, 0.6); text-decoration: underline; font-size: 13px;\\">Manage your preferences</a>
                                                   </td>
                                                 </tr>

--- a/ghost/core/test/integration/services/email-service/__snapshots__/cards.test.js.snap
+++ b/ghost/core/test/integration/services/email-service/__snapshots__/cards.test.js.snap
@@ -130,7 +130,7 @@ table[class=body] a[class=small] {
   color: #15212A !important;
   font-family: inherit !important;
   font-size: 14px;
-  line-height: 1.3em;
+  line-height: 1.3;
   padding-top: 4px;
   padding-right: 20px;
   padding-left: 20px;
@@ -143,7 +143,7 @@ table[class=body] a[class=small] {
   font-family: inherit !important;
   font-size: 15px;
   padding: 8px;
-  line-height: 1.3em;
+  line-height: 1.3;
 }
 .kg-cta-link-accent .kg-cta-sponsor-label a {
   color: #FF1A75 !important;
@@ -264,7 +264,7 @@ table[class=body] a[class=small] {
   margin-top: 32px;
   color: #15212A;
   text-align: center;
-  line-height: 1.1em;
+  line-height: 1.1;
 }
 .post-title-link-left {
   text-align: left;
@@ -314,7 +314,7 @@ table.body td {
 
   table.body .kg-callout-text {
     font-size: 16px !important;
-    line-height: 1.5em !important;
+    line-height: 1.5 !important;
   }
 
   table.body pre {
@@ -360,7 +360,7 @@ table.header .header-main {
 table.header .post-meta-date {
     white-space: normal !important;
     font-size: 13px !important;
-    line-height: 1.2em;
+    line-height: 1.2;
   }
 
   table.header .post-meta,
@@ -404,7 +404,7 @@ table.body .footer a {
 
   table.header .post-title a {
     font-size: 26px !important;
-    line-height: 1.1em !important;
+    line-height: 1.1 !important;
   }
 
   table.feedback-buttons {
@@ -465,38 +465,38 @@ table.body .manage-subscription {
 
   table.body h1 {
     font-size: 32px !important;
-    line-height: 1.3em !important;
+    line-height: 1.3 !important;
   }
 
   table.body h2,
 table.body h2 span {
     font-size: 26px !important;
-    line-height: 1.22em !important;
+    line-height: 1.22 !important;
   }
 
   table.body h3 {
     font-size: 21px !important;
-    line-height: 1.25em !important;
+    line-height: 1.25 !important;
   }
 
   table.body h4 {
     font-size: 19px !important;
-    line-height: 1.3em !important;
+    line-height: 1.3 !important;
   }
 
   table.body h5 {
     font-size: 16px !important;
-    line-height: 1.4em !important;
+    line-height: 1.4 !important;
   }
 
   table.body h6 {
     font-size: 16px !important;
-    line-height: 1.4em !important;
+    line-height: 1.4 !important;
   }
 
   table.body blockquote {
     font-size: 16px !important;
-    line-height: 1.6em;
+    line-height: 1.6;
     margin-bottom: 0;
   }
 
@@ -509,7 +509,7 @@ table.body h2 span {
     border-left: 0 none !important;
     margin: 0 !important;
     font-size: 18px !important;
-    line-height: 1.4em !important;
+    line-height: 1.4 !important;
   }
 
   table.body blockquote.kg-blockquote-alt p {
@@ -598,7 +598,7 @@ table.body h2 span {
                                                     <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\" width=\\"100%\\">
                                                         <tr>
                                                             <td style=\\"vertical-align: top; font-family: Georgia, serif; letter-spacing: -0.01em; font-size: 36px; line-height: 1.1; font-weight: 700; text-align: center; color: #000000;\\" valign=\\"top\\" align=\\"center\\">
-                                                                <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; text-align: center; line-height: 1.1em; overflow-wrap: anywhere; color: #000000;\\" target=\\"_blank\\">A random test post</a>
+                                                                <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; text-align: center; line-height: 1.1; overflow-wrap: anywhere; color: #000000;\\" target=\\"_blank\\">A random test post</a>
                                                             </td>
                                                         </tr>
                                                     </table>
@@ -658,9 +658,9 @@ table.body h2 span {
                                                             <td class=\\"wrapper\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A; box-sizing: border-box;\\" valign=\\"top\\">
                                                                 <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" width=\\"100%\\" data-testid=\\"email-preview-content\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\">
                                                                     <tr class=\\"post-content-row\\">
-                                                                        <td class=\\"post-content\\" style=\\"vertical-align: top; font-family: Georgia, serif; font-size: 18px; line-height: 1.5em; color: #15212A; padding-bottom: 20px; border-bottom: 1px solid #e0e7eb; max-width: 600px;\\" valign=\\"top\\">
+                                                                        <td class=\\"post-content\\" style=\\"vertical-align: top; font-family: Georgia, serif; font-size: 18px; line-height: 1.5; color: #15212A; padding-bottom: 20px; border-bottom: 1px solid #e0e7eb; max-width: 600px;\\" valign=\\"top\\">
                                                                             <!-- POST CONTENT START -->
-                                                                            <p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em; color: #15212A;\\">This is a paragraph test.</p>
+                                                                            <p style=\\"margin: 0 0 1.5em 0; line-height: 1.6; color: #15212A;\\">This is a paragraph test.</p>
                                                                             <!-- POST CONTENT END -->
                             
                                                                         </td>
@@ -678,7 +678,7 @@ table.body h2 span {
                                                             <td class=\\"wrapper\\" align=\\"center\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A; box-sizing: border-box;\\" valign=\\"top\\">
                                                                 <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; padding-top: 40px; padding-bottom: 30px;\\">
                                                                     <tr>
-                                                                        <td class=\\"footer\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; color: #15212a; color: rgba(0, 0, 0, 0.6); margin-top: 20px; text-align: center; padding-bottom: 10px; padding-top: 10px; padding-left: 30px; padding-right: 30px; line-height: 1.5em; font-size: 13px;\\" valign=\\"top\\" align=\\"center\\">Ghost &#xA9; 2025 &#x2013; <a href=\\"http://127.0.0.1:2369/unsubscribe/?uuid=member-uuid&key=xxxxxx&newsletter=requested-newsletter-uuid\\" style=\\"overflow-wrap: anywhere; color: #15212a; color: rgba(0, 0, 0, 0.6); text-decoration: underline; font-size: 13px;\\" target=\\"_blank\\">Unsubscribe</a></td>
+                                                                        <td class=\\"footer\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; color: #15212a; color: rgba(0, 0, 0, 0.6); margin-top: 20px; text-align: center; padding-bottom: 10px; padding-top: 10px; padding-left: 30px; padding-right: 30px; line-height: 1.5; font-size: 13px;\\" valign=\\"top\\" align=\\"center\\">Ghost &#xA9; 2025 &#x2013; <a href=\\"http://127.0.0.1:2369/unsubscribe/?uuid=member-uuid&key=xxxxxx&newsletter=requested-newsletter-uuid\\" style=\\"overflow-wrap: anywhere; color: #15212a; color: rgba(0, 0, 0, 0.6); text-decoration: underline; font-size: 13px;\\" target=\\"_blank\\">Unsubscribe</a></td>
                                                                     </tr>
                             
                                                                         <tr>
@@ -999,7 +999,7 @@ table[class=body] a[class=small] {
   color: #15212A !important;
   font-family: inherit !important;
   font-size: 14px;
-  line-height: 1.3em;
+  line-height: 1.3;
   padding-top: 4px;
   padding-right: 20px;
   padding-left: 20px;
@@ -1012,7 +1012,7 @@ table[class=body] a[class=small] {
   font-family: inherit !important;
   font-size: 15px;
   padding: 8px;
-  line-height: 1.3em;
+  line-height: 1.3;
 }
 .kg-cta-link-accent .kg-cta-sponsor-label a {
   color: #FF1A75 !important;
@@ -1133,7 +1133,7 @@ table[class=body] a[class=small] {
   margin-top: 32px;
   color: #15212A;
   text-align: center;
-  line-height: 1.1em;
+  line-height: 1.1;
 }
 .post-title-link-left {
   text-align: left;
@@ -1183,7 +1183,7 @@ table.body td {
 
   table.body .kg-callout-text {
     font-size: 16px !important;
-    line-height: 1.5em !important;
+    line-height: 1.5 !important;
   }
 
   table.body pre {
@@ -1229,7 +1229,7 @@ table.header .header-main {
 table.header .post-meta-date {
     white-space: normal !important;
     font-size: 13px !important;
-    line-height: 1.2em;
+    line-height: 1.2;
   }
 
   table.header .post-meta,
@@ -1273,7 +1273,7 @@ table.body .footer a {
 
   table.header .post-title a {
     font-size: 26px !important;
-    line-height: 1.1em !important;
+    line-height: 1.1 !important;
   }
 
   table.feedback-buttons {
@@ -1334,38 +1334,38 @@ table.body .manage-subscription {
 
   table.body h1 {
     font-size: 32px !important;
-    line-height: 1.3em !important;
+    line-height: 1.3 !important;
   }
 
   table.body h2,
 table.body h2 span {
     font-size: 26px !important;
-    line-height: 1.22em !important;
+    line-height: 1.22 !important;
   }
 
   table.body h3 {
     font-size: 21px !important;
-    line-height: 1.25em !important;
+    line-height: 1.25 !important;
   }
 
   table.body h4 {
     font-size: 19px !important;
-    line-height: 1.3em !important;
+    line-height: 1.3 !important;
   }
 
   table.body h5 {
     font-size: 16px !important;
-    line-height: 1.4em !important;
+    line-height: 1.4 !important;
   }
 
   table.body h6 {
     font-size: 16px !important;
-    line-height: 1.4em !important;
+    line-height: 1.4 !important;
   }
 
   table.body blockquote {
     font-size: 16px !important;
-    line-height: 1.6em;
+    line-height: 1.6;
     margin-bottom: 0;
   }
 
@@ -1378,7 +1378,7 @@ table.body h2 span {
     border-left: 0 none !important;
     margin: 0 !important;
     font-size: 18px !important;
-    line-height: 1.4em !important;
+    line-height: 1.4 !important;
   }
 
   table.body blockquote.kg-blockquote-alt p {
@@ -1467,7 +1467,7 @@ table.body h2 span {
                                                     <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\" width=\\"100%\\">
                                                         <tr>
                                                             <td style=\\"vertical-align: top; font-family: Georgia, serif; letter-spacing: -0.01em; font-size: 36px; line-height: 1.1; font-weight: 700; text-align: center; color: #000000;\\" valign=\\"top\\" align=\\"center\\">
-                                                                <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; text-align: center; line-height: 1.1em; overflow-wrap: anywhere; color: #000000;\\" target=\\"_blank\\">A random test post</a>
+                                                                <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; text-align: center; line-height: 1.1; overflow-wrap: anywhere; color: #000000;\\" target=\\"_blank\\">A random test post</a>
                                                             </td>
                                                         </tr>
                                                     </table>
@@ -1527,9 +1527,9 @@ table.body h2 span {
                                                             <td class=\\"wrapper\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A; box-sizing: border-box;\\" valign=\\"top\\">
                                                                 <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" width=\\"100%\\" data-testid=\\"email-preview-content\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\">
                                                                     <tr class=\\"post-content-row\\">
-                                                                        <td class=\\"post-content\\" style=\\"vertical-align: top; font-family: Georgia, serif; font-size: 18px; line-height: 1.5em; color: #15212A; padding-bottom: 20px; border-bottom: 1px solid #e0e7eb; max-width: 600px;\\" valign=\\"top\\">
+                                                                        <td class=\\"post-content\\" style=\\"vertical-align: top; font-family: Georgia, serif; font-size: 18px; line-height: 1.5; color: #15212A; padding-bottom: 20px; border-bottom: 1px solid #e0e7eb; max-width: 600px;\\" valign=\\"top\\">
                                                                             <!-- POST CONTENT START -->
-                                                                            <p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em; color: #15212A;\\">This is a paragraph</p><div></div>
+                                                                            <p style=\\"margin: 0 0 1.5em 0; line-height: 1.6; color: #15212A;\\">This is a paragraph</p><div></div>
                                                                             <!-- POST CONTENT END -->
                             
                                                                         </td>
@@ -1547,7 +1547,7 @@ table.body h2 span {
                                                             <td class=\\"wrapper\\" align=\\"center\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A; box-sizing: border-box;\\" valign=\\"top\\">
                                                                 <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; padding-top: 40px; padding-bottom: 30px;\\">
                                                                     <tr>
-                                                                        <td class=\\"footer\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; color: #15212a; color: rgba(0, 0, 0, 0.6); margin-top: 20px; text-align: center; padding-bottom: 10px; padding-top: 10px; padding-left: 30px; padding-right: 30px; line-height: 1.5em; font-size: 13px;\\" valign=\\"top\\" align=\\"center\\">Ghost &#xA9; 2025 &#x2013; <a href=\\"http://127.0.0.1:2369/unsubscribe/?uuid=member-uuid&key=xxxxxx&newsletter=requested-newsletter-uuid\\" style=\\"overflow-wrap: anywhere; color: #15212a; color: rgba(0, 0, 0, 0.6); text-decoration: underline; font-size: 13px;\\" target=\\"_blank\\">Unsubscribe</a></td>
+                                                                        <td class=\\"footer\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; color: #15212a; color: rgba(0, 0, 0, 0.6); margin-top: 20px; text-align: center; padding-bottom: 10px; padding-top: 10px; padding-left: 30px; padding-right: 30px; line-height: 1.5; font-size: 13px;\\" valign=\\"top\\" align=\\"center\\">Ghost &#xA9; 2025 &#x2013; <a href=\\"http://127.0.0.1:2369/unsubscribe/?uuid=member-uuid&key=xxxxxx&newsletter=requested-newsletter-uuid\\" style=\\"overflow-wrap: anywhere; color: #15212a; color: rgba(0, 0, 0, 0.6); text-decoration: underline; font-size: 13px;\\" target=\\"_blank\\">Unsubscribe</a></td>
                                                                     </tr>
                             
                                                                         <tr>
@@ -7664,7 +7664,7 @@ table[class=body] a[class=small] {
   color: #15212A !important;
   font-family: inherit !important;
   font-size: 14px;
-  line-height: 1.3em;
+  line-height: 1.3;
   padding-top: 4px;
   padding-right: 20px;
   padding-left: 20px;
@@ -7677,7 +7677,7 @@ table[class=body] a[class=small] {
   font-family: inherit !important;
   font-size: 15px;
   padding: 8px;
-  line-height: 1.3em;
+  line-height: 1.3;
 }
 .kg-cta-link-accent .kg-cta-sponsor-label a {
   color: #FF1A75 !important;
@@ -7798,7 +7798,7 @@ table[class=body] a[class=small] {
   margin-top: 32px;
   color: #15212A;
   text-align: center;
-  line-height: 1.1em;
+  line-height: 1.1;
 }
 .post-title-link-left {
   text-align: left;
@@ -7848,7 +7848,7 @@ table.body td {
 
   table.body .kg-callout-text {
     font-size: 16px !important;
-    line-height: 1.5em !important;
+    line-height: 1.5 !important;
   }
 
   table.body pre {
@@ -7894,7 +7894,7 @@ table.header .header-main {
 table.header .post-meta-date {
     white-space: normal !important;
     font-size: 13px !important;
-    line-height: 1.2em;
+    line-height: 1.2;
   }
 
   table.header .post-meta,
@@ -7938,7 +7938,7 @@ table.body .footer a {
 
   table.header .post-title a {
     font-size: 26px !important;
-    line-height: 1.1em !important;
+    line-height: 1.1 !important;
   }
 
   table.feedback-buttons {
@@ -7999,38 +7999,38 @@ table.body .manage-subscription {
 
   table.body h1 {
     font-size: 32px !important;
-    line-height: 1.3em !important;
+    line-height: 1.3 !important;
   }
 
   table.body h2,
 table.body h2 span {
     font-size: 26px !important;
-    line-height: 1.22em !important;
+    line-height: 1.22 !important;
   }
 
   table.body h3 {
     font-size: 21px !important;
-    line-height: 1.25em !important;
+    line-height: 1.25 !important;
   }
 
   table.body h4 {
     font-size: 19px !important;
-    line-height: 1.3em !important;
+    line-height: 1.3 !important;
   }
 
   table.body h5 {
     font-size: 16px !important;
-    line-height: 1.4em !important;
+    line-height: 1.4 !important;
   }
 
   table.body h6 {
     font-size: 16px !important;
-    line-height: 1.4em !important;
+    line-height: 1.4 !important;
   }
 
   table.body blockquote {
     font-size: 16px !important;
-    line-height: 1.6em;
+    line-height: 1.6;
     margin-bottom: 0;
   }
 
@@ -8043,7 +8043,7 @@ table.body h2 span {
     border-left: 0 none !important;
     margin: 0 !important;
     font-size: 18px !important;
-    line-height: 1.4em !important;
+    line-height: 1.4 !important;
   }
 
   table.body blockquote.kg-blockquote-alt p {
@@ -8160,7 +8160,7 @@ Ghost: Independent technology for modern publishingBeautiful, modern publishing 
                                                     <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\" width=\\"100%\\">
                                                         <tr>
                                                             <td style=\\"vertical-align: top; font-family: Georgia, serif; letter-spacing: -0.01em; font-size: 36px; line-height: 1.1; font-weight: 700; text-align: center; color: #000000;\\" valign=\\"top\\" align=\\"center\\">
-                                                                <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; text-align: center; line-height: 1.1em; overflow-wrap: anywhere; color: #000000;\\" target=\\"_blank\\">A random test post</a>
+                                                                <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; text-align: center; line-height: 1.1; overflow-wrap: anywhere; color: #000000;\\" target=\\"_blank\\">A random test post</a>
                                                             </td>
                                                         </tr>
                                                     </table>
@@ -8220,32 +8220,32 @@ Ghost: Independent technology for modern publishingBeautiful, modern publishing 
                                                             <td class=\\"wrapper\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A; box-sizing: border-box;\\" valign=\\"top\\">
                                                                 <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" width=\\"100%\\" data-testid=\\"email-preview-content\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\">
                                                                     <tr class=\\"post-content-row\\">
-                                                                        <td class=\\"post-content\\" style=\\"vertical-align: top; font-family: Georgia, serif; font-size: 18px; line-height: 1.5em; color: #15212A; padding-bottom: 20px; border-bottom: 1px solid #e0e7eb; max-width: 600px;\\" valign=\\"top\\">
+                                                                        <td class=\\"post-content\\" style=\\"vertical-align: top; font-family: Georgia, serif; font-size: 18px; line-height: 1.5; color: #15212A; padding-bottom: 20px; border-bottom: 1px solid #e0e7eb; max-width: 600px;\\" valign=\\"top\\">
                                                                             <!-- POST CONTENT START -->
-                                                                            <p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em; color: #15212A;\\">This is just a simple paragraph, no frills.</p><blockquote style=\\"margin: 0; padding: 0; border-left: #FF1A75 2px solid; font-size: 17px; font-weight: 500; line-height: 1.6em; letter-spacing: -0.2px;\\"><p style=\\"line-height: 1.6em; margin: 2em 25px; font-size: 1em; padding: 0; color: #15212A;\\">This is block quote</p></blockquote><blockquote class=\\"kg-blockquote-alt\\" style=\\"margin: 0; padding: 0; font-weight: 500; line-height: 1.6em; letter-spacing: -0.2px; border-left: 0 none; text-align: center; font-size: 1.2em; font-style: italic; color: #15212a; color: rgba(0, 0, 0, 0.6);\\"><p style=\\"line-height: 1.6em; margin: 2em 25px; font-size: 1em; margin-right: 50px; margin-left: 50px; padding: 0; color: #15212A;\\">This is a...different block quote</p></blockquote><h2 id=\\"this-is-a-heading\\" style=\\"margin-top: 0; line-height: 1.11em; font-weight: 700; text-rendering: optimizeLegibility; margin: 1.5em 0 0.5em 0; font-size: 32px; font-family: Georgia, serif; letter-spacing: -0.01em; color: #15212A;\\">This is a heading!</h2><h3 id=\\"heres-a-smaller-heading\\" style=\\"margin-top: 0; line-height: 1.11em; font-weight: 700; text-rendering: optimizeLegibility; margin: 1.5em 0 0.5em 0; font-size: 26px; font-family: Georgia, serif; letter-spacing: -0.01em; color: #15212A;\\">Here&#39;s a smaller heading.</h3><div class=\\"kg-card kg-image-card kg-card-hascaption\\" style=\\"margin: 0 0 1.5em; padding: 0;\\"><img src=\\"https://upload.wikimedia.org/wikipedia/commons/thumb/8/8c/Cow_%28Fleckvieh_breed%29_Oeschinensee_Slaunger_2009-07-07.jpg/1920px-Cow_%28Fleckvieh_breed%29_Oeschinensee_Slaunger_2009-07-07.jpg\\" class=\\"kg-image\\" alt=\\"Cows eat grass.\\" loading=\\"lazy\\" style=\\"border: none; -ms-interpolation-mode: bicubic; display: block; margin: 0 auto; height: auto; width: auto; max-width: 100%;\\" width=\\"auto\\" height=\\"auto\\"><div class=\\"kg-card-figcaption\\" style=\\"text-align: center; font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; padding-top: 10px; padding-bottom: 10px; line-height: 1.5em; color: #15212a; color: rgba(0, 0, 0, 0.6); font-size: 13px;\\"><span style=\\"text-align: center; white-space: pre-wrap;\\">A lovely cow</span></div></div><h1 id=\\"a-heading\\" style=\\"margin-top: 0; line-height: 1.11em; font-weight: 700; text-rendering: optimizeLegibility; margin: 1.5em 0 0.5em 0; font-size: 42px; font-family: Georgia, serif; letter-spacing: -0.01em; color: #15212A;\\">A heading</h1>
-                            <p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em; color: #15212A;\\">and a paragraph (in markdown!)</p>
+                                                                            <p style=\\"margin: 0 0 1.5em 0; line-height: 1.6; color: #15212A;\\">This is just a simple paragraph, no frills.</p><blockquote style=\\"margin: 0; padding: 0; border-left: #FF1A75 2px solid; font-size: 17px; font-weight: 500; line-height: 1.6; letter-spacing: -0.2px;\\"><p style=\\"line-height: 1.6; margin: 2em 25px; font-size: 1em; padding: 0; color: #15212A;\\">This is block quote</p></blockquote><blockquote class=\\"kg-blockquote-alt\\" style=\\"margin: 0; padding: 0; font-weight: 500; line-height: 1.6; letter-spacing: -0.2px; border-left: 0 none; text-align: center; font-size: 1.2em; font-style: italic; color: #15212a; color: rgba(0, 0, 0, 0.6);\\"><p style=\\"line-height: 1.6; margin: 2em 25px; font-size: 1em; margin-right: 50px; margin-left: 50px; padding: 0; color: #15212A;\\">This is a...different block quote</p></blockquote><h2 id=\\"this-is-a-heading\\" style=\\"margin-top: 0; line-height: 1.11; font-weight: 700; text-rendering: optimizeLegibility; margin: 1.5em 0 0.5em 0; font-size: 32px; font-family: Georgia, serif; letter-spacing: -0.01em; color: #15212A;\\">This is a heading!</h2><h3 id=\\"heres-a-smaller-heading\\" style=\\"margin-top: 0; line-height: 1.11; font-weight: 700; text-rendering: optimizeLegibility; margin: 1.5em 0 0.5em 0; font-size: 26px; font-family: Georgia, serif; letter-spacing: -0.01em; color: #15212A;\\">Here&#39;s a smaller heading.</h3><div class=\\"kg-card kg-image-card kg-card-hascaption\\" style=\\"margin: 0 0 1.5em; padding: 0;\\"><img src=\\"https://upload.wikimedia.org/wikipedia/commons/thumb/8/8c/Cow_%28Fleckvieh_breed%29_Oeschinensee_Slaunger_2009-07-07.jpg/1920px-Cow_%28Fleckvieh_breed%29_Oeschinensee_Slaunger_2009-07-07.jpg\\" class=\\"kg-image\\" alt=\\"Cows eat grass.\\" loading=\\"lazy\\" style=\\"border: none; -ms-interpolation-mode: bicubic; display: block; margin: 0 auto; height: auto; width: auto; max-width: 100%;\\" width=\\"auto\\" height=\\"auto\\"><div class=\\"kg-card-figcaption\\" style=\\"text-align: center; font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; padding-top: 10px; padding-bottom: 10px; line-height: 1.5; color: #15212a; color: rgba(0, 0, 0, 0.6); font-size: 13px;\\"><span style=\\"text-align: center; white-space: pre-wrap;\\">A lovely cow</span></div></div><h1 id=\\"a-heading\\" style=\\"margin-top: 0; line-height: 1.11; font-weight: 700; text-rendering: optimizeLegibility; margin: 1.5em 0 0.5em 0; font-size: 42px; font-family: Georgia, serif; letter-spacing: -0.01em; color: #15212A;\\">A heading</h1>
+                            <p style=\\"margin: 0 0 1.5em 0; line-height: 1.6; color: #15212A;\\">and a paragraph (in markdown!)</p>
                             
                             <!--kg-card-begin: html-->
-                            <p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em; color: #15212A;\\">A paragraph inside an HTML card.</p>
-                            <p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em; color: #15212A;\\">And another one, with some <b>bold</b> text.</p>
+                            <p style=\\"margin: 0 0 1.5em 0; line-height: 1.6; color: #15212A;\\">A paragraph inside an HTML card.</p>
+                            <p style=\\"margin: 0 0 1.5em 0; line-height: 1.6; color: #15212A;\\">And another one, with some <b>bold</b> text.</p>
                             <!--kg-card-end: html-->
-                            <table class=\\"kg-card kg-hr-card\\" role=\\"presentation\\" width=\\"100%\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\"><tbody><tr><td style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; color: #15212A; margin: 0; padding-top: 1.5em; padding-bottom: 3em; font-size: 17px;\\" valign=\\"top\\"><!--[if !mso]><!-- --><hr style=\\"position: relative; width: 100%; margin: 3em 0; padding: 0; height: 1px; background-color: transparent; border: 0; border-top: 1px solid #e0e7eb; display: none;\\"><!--<![endif]--><table class=\\"kg-hr\\" role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\" width=\\"100%\\"><tbody><tr><td style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; color: #15212A; padding-top: 1.5em; padding-bottom: 3em; margin: 0; padding: 0; border-top: 1px solid #e0e7eb; font-size: 0; line-height: 0;\\" valign=\\"top\\">&#xA0;</td></tr></tbody></table></td></tr></tbody></table><div class=\\"kg-card kg-gallery-card kg-width-wide kg-card-hascaption\\" style=\\"margin: 0 0 1.5em; padding: 0;\\"><div class=\\"kg-gallery-container\\" style=\\"margin-top: -20px;\\"><div class=\\"kg-gallery-row\\"><div class=\\"kg-gallery-image\\"><img src=\\"https://plus.unsplash.com/premium_photo-1700558685152-81f821a40724?q=80&amp;w=2070&amp;auto=format&amp;fit=crop&amp;ixlib=rb-4.0.3&amp;ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D\\" width=\\"600\\" height=\\"400\\" loading=\\"lazy\\" alt style=\\"border: none; -ms-interpolation-mode: bicubic; max-width: 100%; padding-top: 20px; width: 100%; height: auto;\\"></div></div></div><div class=\\"kg-card-figcaption\\" style=\\"text-align: center; font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; padding-top: 10px; padding-bottom: 10px; line-height: 1.5em; color: #15212a; color: rgba(0, 0, 0, 0.6); font-size: 13px;\\"><p dir=\\"ltr\\" style=\\"margin: 0 0 1.5em 0; line-height: 1.6em; color: inherit;\\"><span style=\\"white-space: pre-wrap;\\">A gallery.</span></p></div></div><div>
+                            <table class=\\"kg-card kg-hr-card\\" role=\\"presentation\\" width=\\"100%\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\"><tbody><tr><td style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; color: #15212A; margin: 0; padding-top: 1.5em; padding-bottom: 3em; font-size: 17px;\\" valign=\\"top\\"><!--[if !mso]><!-- --><hr style=\\"position: relative; width: 100%; margin: 3em 0; padding: 0; height: 1px; background-color: transparent; border: 0; border-top: 1px solid #e0e7eb; display: none;\\"><!--<![endif]--><table class=\\"kg-hr\\" role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\" width=\\"100%\\"><tbody><tr><td style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; color: #15212A; padding-top: 1.5em; padding-bottom: 3em; margin: 0; padding: 0; border-top: 1px solid #e0e7eb; font-size: 0; line-height: 0;\\" valign=\\"top\\">&#xA0;</td></tr></tbody></table></td></tr></tbody></table><div class=\\"kg-card kg-gallery-card kg-width-wide kg-card-hascaption\\" style=\\"margin: 0 0 1.5em; padding: 0;\\"><div class=\\"kg-gallery-container\\" style=\\"margin-top: -20px;\\"><div class=\\"kg-gallery-row\\"><div class=\\"kg-gallery-image\\"><img src=\\"https://plus.unsplash.com/premium_photo-1700558685152-81f821a40724?q=80&amp;w=2070&amp;auto=format&amp;fit=crop&amp;ixlib=rb-4.0.3&amp;ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D\\" width=\\"600\\" height=\\"400\\" loading=\\"lazy\\" alt style=\\"border: none; -ms-interpolation-mode: bicubic; max-width: 100%; padding-top: 20px; width: 100%; height: auto;\\"></div></div></div><div class=\\"kg-card-figcaption\\" style=\\"text-align: center; font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; padding-top: 10px; padding-bottom: 10px; line-height: 1.5; color: #15212a; color: rgba(0, 0, 0, 0.6); font-size: 13px;\\"><p dir=\\"ltr\\" style=\\"margin: 0 0 1.5em 0; line-height: 1.6; color: inherit;\\"><span style=\\"white-space: pre-wrap;\\">A gallery.</span></p></div></div><div>
                                     <!--[if !mso !vml]-->
                                         <div class=\\"kg-card kg-bookmark-card kg-card-hascaption\\" style=\\"margin: 0 0 1.5em; padding: 0; width: 100%;\\">
                                             <a class=\\"kg-bookmark-container\\" href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" style=\\"display: flex; min-height: 148px; font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; border-radius: 3px; background-color: #ffffff; background-color: rgba(255, 255, 255, 0.25); border: 1px solid #e0e7eb; border: 1px solid rgba(0, 0, 0, 0.12); overflow-wrap: anywhere; color: #FF1A75; text-decoration: none;\\" target=\\"_blank\\">
                                                 <div class=\\"kg-bookmark-content\\" style=\\"display: inline-block; width: 100%; padding: 20px;\\">
-                                                    <div class=\\"kg-bookmark-title\\" style=\\"color: #15212A; font-size: 15px; line-height: 1.5em; font-weight: 600;\\">Ghost: Independent technology for modern publishing</div>
-                                                    <div class=\\"kg-bookmark-description\\" style=\\"display: -webkit-box; overflow-y: hidden; margin-top: 12px; max-height: 40px; color: #15212a; color: rgba(0, 0, 0, 0.6); font-size: 13px; line-height: 1.5em; font-weight: 400; -webkit-line-clamp: 2; -webkit-box-orient: vertical;\\">Beautiful, modern publishing with newsletters and premium subscriptions built-in. Used by<span class=\\"desktop-only\\"> Sky, 404Media, Lever News, Ta</span>&#x2026;</div>
+                                                    <div class=\\"kg-bookmark-title\\" style=\\"color: #15212A; font-size: 15px; line-height: 1.5; font-weight: 600;\\">Ghost: Independent technology for modern publishing</div>
+                                                    <div class=\\"kg-bookmark-description\\" style=\\"display: -webkit-box; overflow-y: hidden; margin-top: 12px; max-height: 40px; color: #15212a; color: rgba(0, 0, 0, 0.6); font-size: 13px; line-height: 1.5; font-weight: 400; -webkit-line-clamp: 2; -webkit-box-orient: vertical;\\">Beautiful, modern publishing with newsletters and premium subscriptions built-in. Used by<span class=\\"desktop-only\\"> Sky, 404Media, Lever News, Ta</span>&#x2026;</div>
                                                     <div class=\\"kg-bookmark-metadata\\" style=\\"display: flex; flex-wrap: wrap; align-items: center; margin-top: 14px; color: #15212A; font-size: 13px; font-weight: 400;\\">
                                                         <img class=\\"kg-bookmark-icon\\" src=\\"https://ghost.org/favicon.ico\\" alt style=\\"border: none; -ms-interpolation-mode: bicubic; max-width: 100%; margin-right: 8px; width: 22px; height: 22px;\\" width=\\"22\\" height=\\"22\\">
-                                                        <span class=\\"kg-bookmark-author\\" src=\\"Ghost - The Professional Publishing Platform\\" style=\\"line-height: 1.5em;\\">Ghost - The Professional Publishing Platform</span>
+                                                        <span class=\\"kg-bookmark-author\\" src=\\"Ghost - The Professional Publishing Platform\\" style=\\"line-height: 1.5;\\">Ghost - The Professional Publishing Platform</span>
                                                         
                                                     </div>
                                                 </div>
                                                 <div class=\\"kg-bookmark-thumbnail\\" style=\\"min-width: 140px; max-width: 180px; background-repeat: no-repeat; background-size: cover; background-position: center; border-radius: 0 2px 2px 0; background-image: url(&#39;https://ghost.org/images/meta/ghost.png&#39;);\\">
                                                     <img src=\\"https://ghost.org/images/meta/ghost.png\\" alt onerror=\\"this.style.display=&#39;none&#39;\\" style=\\"border: none; -ms-interpolation-mode: bicubic; max-width: 100%; display: none;\\"></div>
                                             </a>
-                                            <div class=\\"kg-card-figcaption\\" style=\\"text-align: center; font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; padding-top: 10px; padding-bottom: 10px; line-height: 1.5em; color: #15212a; color: rgba(0, 0, 0, 0.6); font-size: 13px;\\"><p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em; color: inherit;\\"><span style=\\"white-space: pre-wrap;\\">My favorite website.</span></p></div>
+                                            <div class=\\"kg-card-figcaption\\" style=\\"text-align: center; font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; padding-top: 10px; padding-bottom: 10px; line-height: 1.5; color: #15212a; color: rgba(0, 0, 0, 0.6); font-size: 13px;\\"><p style=\\"margin: 0 0 1.5em 0; line-height: 1.6; color: inherit;\\"><span style=\\"white-space: pre-wrap;\\">My favorite website.</span></p></div>
                                         </div>
                                     <!--[endif]-->
                                     <!--[if vml]>
@@ -8296,7 +8296,7 @@ Ghost: Independent technology for modern publishingBeautiful, modern publishing 
                                             </tr>
                                         </table>
                                         <div class=\\"kg-bookmark-spacer--outlook\\" style=\\"height: 1.5em;\\">&nbsp;</div>
-                                    <![endif]--></div><p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em; color: #15212A;\\"><span style=\\"white-space: pre-wrap;\\">Hey </span><span>Vinz</span><span style=\\"white-space: pre-wrap;\\">,</span></p><!--members-only--><table class=\\"kg-card kg-button-card\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\" width=\\"100%\\"><tbody><tr><td class=\\"kg-card-spacing\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A; padding: 0 0 1.5em 0;\\" valign=\\"top\\"><table class=\\"btn\\" border=\\"0\\" cellspacing=\\"0\\" cellpadding=\\"0\\" align=\\"center\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; box-sizing: border-box; width: auto;\\" width=\\"auto\\"><tbody><tr><td align=\\"center\\" style=\\"font-size: 18px; vertical-align: top; color: #15212A; padding: 8px 20px 9px; background-color: #FF1A75; border-radius: 6px; text-align: center; font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif;\\" valign=\\"top\\" bgcolor=\\"#FF1A75\\"><a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" style=\\"overflow-wrap: anywhere; box-sizing: border-box; color: #FFFFFF; cursor: pointer; display: inline-block; font-size: 15px; font-weight: 600; margin: 0; text-decoration: none;\\" target=\\"_blank\\">Click me, I&#39;m a button!</a></td></tr></tbody></table></td></tr></tbody></table><div class=\\"kg-card kg-callout-card kg-callout-card-blue\\" style=\\"display: flex; margin: 0 0 1.5em 0; padding: 24px; border-radius: 8px; background: #E9F6FB;\\"><div class=\\"kg-callout-emoji\\" style=\\"padding-right: 12px; font-size: 20px;\\">&#x1F4A1;</div><div class=\\"kg-callout-text\\" style=\\"color: inherit;\\">I had an idea...</div></div><table cellspacing=\\"0\\" cellpadding=\\"0\\" border=\\"0\\" width=\\"100%\\" class=\\"kg-toggle-card\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-radius: 4px; margin-bottom: 24px; width: 100%; background-color: #ffffff; background-color: rgba(255, 255, 255, 0.25); border: 1px solid #e0e7eb; border: 1px solid rgba(0, 0, 0, 0.12);\\" bgcolor=\\"rgba(255, 255, 255, 0.25)\\"><tbody><tr><td class=\\"kg-toggle-heading\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A; margin: 0; padding: 24px 24px 12px;\\" valign=\\"top\\"><h4 style=\\"margin-top: 0; text-rendering: optimizeLegibility; font-size: 21px; line-height: 1.2em; font-family: Georgia, serif; letter-spacing: -0.01em; margin: 0; font-weight: 700; color: #15212A;\\"><span style=\\"white-space: pre-wrap;\\">Spoiler alert!</span></h4></td></tr><tr><td class=\\"kg-toggle-content\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; color: #15212A; font-size: 16px; line-height: 1.5; padding: 0 24px 24px;\\" valign=\\"top\\"><p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em; margin-bottom: 0; color: inherit;\\"><span style=\\"white-space: pre-wrap;\\">Just kidding</span></p></td></tr></tbody></table><table cellspacing=\\"0\\" cellpadding=\\"0\\" border=\\"0\\" class=\\"kg-audio-card\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: auto; width: 100%; margin: 0 auto 1.5em; border-radius: 3px; background-color: #ffffff; background-color: rgba(255, 255, 255, 0.25); border: 1px solid #e0e7eb; border: 1px solid rgba(0, 0, 0, 0.12);\\" width=\\"100%\\" bgcolor=\\"rgba(255, 255, 255, 0.25)\\">
+                                    <![endif]--></div><p style=\\"margin: 0 0 1.5em 0; line-height: 1.6; color: #15212A;\\"><span style=\\"white-space: pre-wrap;\\">Hey </span><span>Vinz</span><span style=\\"white-space: pre-wrap;\\">,</span></p><!--members-only--><table class=\\"kg-card kg-button-card\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\" width=\\"100%\\"><tbody><tr><td class=\\"kg-card-spacing\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A; padding: 0 0 1.5em 0;\\" valign=\\"top\\"><table class=\\"btn\\" border=\\"0\\" cellspacing=\\"0\\" cellpadding=\\"0\\" align=\\"center\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; box-sizing: border-box; width: auto;\\" width=\\"auto\\"><tbody><tr><td align=\\"center\\" style=\\"font-size: 18px; vertical-align: top; color: #15212A; padding: 8px 20px 9px; background-color: #FF1A75; border-radius: 6px; text-align: center; font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif;\\" valign=\\"top\\" bgcolor=\\"#FF1A75\\"><a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" style=\\"overflow-wrap: anywhere; box-sizing: border-box; color: #FFFFFF; cursor: pointer; display: inline-block; font-size: 15px; font-weight: 600; margin: 0; text-decoration: none;\\" target=\\"_blank\\">Click me, I&#39;m a button!</a></td></tr></tbody></table></td></tr></tbody></table><div class=\\"kg-card kg-callout-card kg-callout-card-blue\\" style=\\"display: flex; margin: 0 0 1.5em 0; padding: 24px; border-radius: 8px; background: #E9F6FB;\\"><div class=\\"kg-callout-emoji\\" style=\\"padding-right: 12px; font-size: 20px;\\">&#x1F4A1;</div><div class=\\"kg-callout-text\\" style=\\"color: inherit;\\">I had an idea...</div></div><table cellspacing=\\"0\\" cellpadding=\\"0\\" border=\\"0\\" width=\\"100%\\" class=\\"kg-toggle-card\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-radius: 4px; margin-bottom: 24px; width: 100%; background-color: #ffffff; background-color: rgba(255, 255, 255, 0.25); border: 1px solid #e0e7eb; border: 1px solid rgba(0, 0, 0, 0.12);\\" bgcolor=\\"rgba(255, 255, 255, 0.25)\\"><tbody><tr><td class=\\"kg-toggle-heading\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A; margin: 0; padding: 24px 24px 12px;\\" valign=\\"top\\"><h4 style=\\"margin-top: 0; text-rendering: optimizeLegibility; font-size: 21px; line-height: 1.2; font-family: Georgia, serif; letter-spacing: -0.01em; margin: 0; font-weight: 700; color: #15212A;\\"><span style=\\"white-space: pre-wrap;\\">Spoiler alert!</span></h4></td></tr><tr><td class=\\"kg-toggle-content\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; color: #15212A; font-size: 16px; line-height: 1.5; padding: 0 24px 24px;\\" valign=\\"top\\"><p style=\\"margin: 0 0 1.5em 0; line-height: 1.6; margin-bottom: 0; color: inherit;\\"><span style=\\"white-space: pre-wrap;\\">Just kidding</span></p></td></tr></tbody></table><table cellspacing=\\"0\\" cellpadding=\\"0\\" border=\\"0\\" class=\\"kg-audio-card\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: auto; width: 100%; margin: 0 auto 1.5em; border-radius: 3px; background-color: #ffffff; background-color: rgba(255, 255, 255, 0.25); border: 1px solid #e0e7eb; border: 1px solid rgba(0, 0, 0, 0.12);\\" width=\\"100%\\" bgcolor=\\"rgba(255, 255, 255, 0.25)\\">
                                             <tbody><tr>
                                                 <td style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A;\\" valign=\\"top\\">
                                                     <table cellspacing=\\"0\\" cellpadding=\\"0\\" border=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\">
@@ -8313,7 +8313,7 @@ Ghost: Independent technology for modern publishingBeautiful, modern publishing 
                                                                 <table cellspacing=\\"0\\" cellpadding=\\"0\\" border=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\">
                                                                     <tbody><tr>
                                                                         <td style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A;\\" valign=\\"top\\">
-                                                                            <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"kg-audio-title\\" style=\\"display: block; padding-right: 20px; padding-bottom: 4px; padding-top: 4px; font-size: 16px; font-weight: 600; line-height: 18px; overflow-wrap: anywhere; text-decoration: none; color: #15212A;\\" target=\\"_blank\\">Sample</a>
+                                                                            <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"kg-audio-title\\" style=\\"display: block; padding-right: 20px; padding-bottom: 4px; padding-top: 4px; font-size: 16px; font-weight: 600; line-height: 1.125; overflow-wrap: anywhere; text-decoration: none; color: #15212A;\\" target=\\"_blank\\">Sample</a>
                                                                         </td>
                                                                     </tr>
                                                                     <tr>
@@ -8361,7 +8361,7 @@ Ghost: Independent technology for modern publishingBeautiful, modern publishing 
                                         </v:group>
                                         <![endif]-->
                             
-                                        <div class=\\"kg-card-figcaption\\" style=\\"text-align: center; font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; padding-top: 10px; padding-bottom: 10px; line-height: 1.5em; color: #15212a; color: rgba(0, 0, 0, 0.6); font-size: 13px;\\"><p dir=\\"ltr\\" style=\\"margin: 0 0 1.5em 0; line-height: 1.6em; color: inherit;\\"><span style=\\"white-space: pre-wrap;\\">A lovely video of a woman on the beach doing nothing.</span></p></div>
+                                        <div class=\\"kg-card-figcaption\\" style=\\"text-align: center; font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; padding-top: 10px; padding-bottom: 10px; line-height: 1.5; color: #15212a; color: rgba(0, 0, 0, 0.6); font-size: 13px;\\"><p dir=\\"ltr\\" style=\\"margin: 0 0 1.5em 0; line-height: 1.6; color: inherit;\\"><span style=\\"white-space: pre-wrap;\\">A lovely video of a woman on the beach doing nothing.</span></p></div>
                                     </div><table class=\\"kg-product-card\\" cellspacing=\\"0\\" cellpadding=\\"0\\" border=\\"0\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; margin: 0 0 1.5em; border-radius: 0; background-color: #FFFFFF; background-color: rgba(255, 255, 255, 0.25); border: 1px solid #e0e7eb; border: 1px solid rgba(0, 0, 0, 0.12);\\" width=\\"100%\\" bgcolor=\\"rgba(255, 255, 255, 0.25)\\">
                                         <tbody><tr>
                                             <td class=\\"kg-product-card-container\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A; padding: 20px;\\" valign=\\"top\\">
@@ -8375,7 +8375,7 @@ Ghost: Independent technology for modern publishingBeautiful, modern publishing 
                                                     
                                                     <tr>
                                                         <td valign=\\"top\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A;\\">
-                                                            <h4 class=\\"kg-product-title\\" style=\\"text-rendering: optimizeLegibility; margin: 1.8em 0 0.5em 0; line-height: 1.2em; font-weight: 700; font-family: Georgia, serif; letter-spacing: -0.01em; margin-top: 0; margin-bottom: 0; font-size: 22px; color: #15212A;\\"><span style=\\"white-space: pre-wrap;\\">Make a blog!</span></h4>
+                                                            <h4 class=\\"kg-product-title\\" style=\\"text-rendering: optimizeLegibility; margin: 1.8em 0 0.5em 0; line-height: 1.2; font-weight: 700; font-family: Georgia, serif; letter-spacing: -0.01em; margin-top: 0; margin-bottom: 0; font-size: 22px; color: #15212A;\\"><span style=\\"white-space: pre-wrap;\\">Make a blog!</span></h4>
                                                         </td>
                                                     </tr>
                                                     
@@ -8413,12 +8413,12 @@ Ghost: Independent technology for modern publishingBeautiful, modern publishing 
                                                     <table border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\">
                                                         <tbody><tr>
                                                             <td align=\\"center\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: inherit;\\" valign=\\"top\\">
-                                                                <h2 class=\\"kg-header-card-heading\\" style=\\"margin-top: 0; text-rendering: optimizeLegibility; font-family: Georgia, serif; letter-spacing: -0.01em; font-size: 32px; font-weight: 700; margin: 0; line-height: 1em; color: #FFFFFF;\\"><span style=\\"white-space: pre-wrap;\\">Good news everyone!</span></h2>
+                                                                <h2 class=\\"kg-header-card-heading\\" style=\\"margin-top: 0; text-rendering: optimizeLegibility; font-family: Georgia, serif; letter-spacing: -0.01em; font-size: 32px; font-weight: 700; margin: 0; line-height: 1; color: #FFFFFF;\\"><span style=\\"white-space: pre-wrap;\\">Good news everyone!</span></h2>
                                                             </td>
                                                         </tr>
                                                         <tr>
                                                             <td class=\\"kg-header-card-subheading-wrapper\\" align=\\"center\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; padding: 16px 0 0; color: inherit;\\" valign=\\"top\\">
-                                                                <p class=\\"kg-header-card-subheading\\" style=\\"margin: 0; font-size: 17px; line-height: 1.5em; color: inherit;\\"><span style=\\"white-space: pre-wrap;\\">This header renders properly in </span><i><em class=\\"italic\\" style=\\"white-space: pre-wrap;\\">all</em></i><span style=\\"white-space: pre-wrap;\\"> email clients!</span></p>
+                                                                <p class=\\"kg-header-card-subheading\\" style=\\"margin: 0; font-size: 17px; line-height: 1.5; color: inherit;\\"><span style=\\"white-space: pre-wrap;\\">This header renders properly in </span><i><em class=\\"italic\\" style=\\"white-space: pre-wrap;\\">all</em></i><span style=\\"white-space: pre-wrap;\\"> email clients!</span></p>
                                                             </td>
                                                         </tr>
                                                         <tr>
@@ -8451,7 +8451,7 @@ Ghost: Independent technology for modern publishingBeautiful, modern publishing 
                                             <v:oval fill=\\"t\\" strokecolor=\\"white\\" strokeweight=\\"4px\\" style=\\"position:absolute;left:261;top:186;width:78;height:78\\"><v:fill color=\\"black\\" opacity=\\"30%\\" /></v:oval>
                                             <v:shape coordsize=\\"24,32\\" path=\\"m,l,32,24,16,xe\\" fillcolor=\\"white\\" stroked=\\"f\\" style=\\"position:absolute;left:289;top:208;width:30;height:34;\\" />
                                         </v:group>
-                                        <![endif]--></div><div></div><p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em; color: #15212A;\\">Some text.</p><blockquote style=\\"margin: 0; padding: 0; border-left: #FF1A75 2px solid; font-size: 17px; font-weight: 500; line-height: 1.6em; letter-spacing: -0.2px;\\"><p style=\\"line-height: 1.6em; margin: 2em 25px; font-size: 1em; padding: 0; color: #15212A;\\">A blockquote</p></blockquote><p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em; color: #15212A;\\">Some more text.</p><div class=\\"kg-card kg-code-card\\" style=\\"margin: 0 0 1.5em; padding: 0;\\"><pre style=\\"white-space: pre-wrap; overflow: auto; background: #15212A; padding: 15px; border-radius: 3px; line-height: 1.2em; color: #ffffff;\\"><code class=\\"language-javascript\\" style=\\"font-size: 0.9em;\\">console.log(&#39;Hello world!&#39;);</code></pre><div class=\\"kg-card-figcaption\\" style=\\"text-align: center; font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; padding-top: 10px; padding-bottom: 10px; line-height: 1.5em; color: #15212a; color: rgba(0, 0, 0, 0.6); font-size: 13px;\\"><p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em; color: inherit;\\"><span style=\\"white-space: pre-wrap;\\">A tiny little script.</span></p></div></div><table cellspacing=\\"0\\" cellpadding=\\"4\\" border=\\"0\\" class=\\"kg-file-card\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: auto; width: 100%; margin: 0 0 1.5em 0; border-radius: 3px; background-color: #ffffff; background-color: rgba(255, 255, 255, 0.25); border: 1px solid #e0e7eb; border: 1px solid rgba(0, 0, 0, 0.12);\\" bgcolor=\\"rgba(255, 255, 255, 0.25)\\">
+                                        <![endif]--></div><div></div><p style=\\"margin: 0 0 1.5em 0; line-height: 1.6; color: #15212A;\\">Some text.</p><blockquote style=\\"margin: 0; padding: 0; border-left: #FF1A75 2px solid; font-size: 17px; font-weight: 500; line-height: 1.6; letter-spacing: -0.2px;\\"><p style=\\"line-height: 1.6; margin: 2em 25px; font-size: 1em; padding: 0; color: #15212A;\\">A blockquote</p></blockquote><p style=\\"margin: 0 0 1.5em 0; line-height: 1.6; color: #15212A;\\">Some more text.</p><div class=\\"kg-card kg-code-card\\" style=\\"margin: 0 0 1.5em; padding: 0;\\"><pre style=\\"white-space: pre-wrap; overflow: auto; background: #15212A; padding: 15px; border-radius: 3px; line-height: 1.2; color: #ffffff;\\"><code class=\\"language-javascript\\" style=\\"font-size: 0.9em;\\">console.log(&#39;Hello world!&#39;);</code></pre><div class=\\"kg-card-figcaption\\" style=\\"text-align: center; font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; padding-top: 10px; padding-bottom: 10px; line-height: 1.5; color: #15212a; color: rgba(0, 0, 0, 0.6); font-size: 13px;\\"><p style=\\"margin: 0 0 1.5em 0; line-height: 1.6; color: inherit;\\"><span style=\\"white-space: pre-wrap;\\">A tiny little script.</span></p></div></div><table cellspacing=\\"0\\" cellpadding=\\"4\\" border=\\"0\\" class=\\"kg-file-card\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: auto; width: 100%; margin: 0 0 1.5em 0; border-radius: 3px; background-color: #ffffff; background-color: rgba(255, 255, 255, 0.25); border: 1px solid #e0e7eb; border: 1px solid rgba(0, 0, 0, 0.12);\\" bgcolor=\\"rgba(255, 255, 255, 0.25)\\">
                                         <tbody><tr>
                                             <td style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A;\\" valign=\\"top\\">
                                                 <table cellspacing=\\"0\\" cellpadding=\\"0\\" border=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\">
@@ -8459,16 +8459,16 @@ Ghost: Independent technology for modern publishingBeautiful, modern publishing 
                                                         <td valign=\\"middle\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; color: #15212A; vertical-align: middle;\\">
                                                             
                                                             <table cellspacing=\\"0\\" cellpadding=\\"0\\" border=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\"><tbody><tr><td style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A;\\" valign=\\"top\\">
-                                                                <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"kg-file-title\\" style=\\"display: block; width: 100%; padding-left: 12px; padding-top: 8px; font-size: 17px; font-weight: bold; line-height: 1.3em; overflow-wrap: anywhere; text-decoration: none; color: #15212A;\\" target=\\"_blank\\">test</a>
+                                                                <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"kg-file-title\\" style=\\"display: block; width: 100%; padding-left: 12px; padding-top: 8px; font-size: 17px; font-weight: bold; line-height: 1.3; overflow-wrap: anywhere; text-decoration: none; color: #15212A;\\" target=\\"_blank\\">test</a>
                                                             </td></tr></tbody></table>
                                                             
                                                             
                                                             <table cellspacing=\\"0\\" cellpadding=\\"0\\" border=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\"><tbody><tr><td style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A;\\" valign=\\"top\\">
-                                                                <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"kg-file-description\\" style=\\"display: block; width: 100%; padding-left: 12px; padding-top: 2px; font-size: 15px; line-height: 1.4em; overflow-wrap: anywhere; text-decoration: none; color: #15212a; color: rgba(0, 0, 0, 0.6);\\" target=\\"_blank\\">A tiny text file.</a>
+                                                                <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"kg-file-description\\" style=\\"display: block; width: 100%; padding-left: 12px; padding-top: 2px; font-size: 15px; line-height: 1.4; overflow-wrap: anywhere; text-decoration: none; color: #15212a; color: rgba(0, 0, 0, 0.6);\\" target=\\"_blank\\">A tiny text file.</a>
                                                             </td></tr></tbody></table>
                                                             
                                                             <table cellspacing=\\"0\\" cellpadding=\\"0\\" border=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\"><tbody><tr><td style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A;\\" valign=\\"top\\">
-                                                                <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"kg-file-meta\\" style=\\"display: block; width: 100%; padding-left: 12px; padding-top: 4px; padding-bottom: 8px; font-size: 13px; line-height: 1.4em; overflow-wrap: anywhere; color: #FF1A75; text-decoration: none;\\" target=\\"_blank\\"><span class=\\"kg-file-name\\" style=\\"font-weight: 500; color: #15212A;\\">test.txt</span> &#x2022; 16 Bytes</a>
+                                                                <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"kg-file-meta\\" style=\\"display: block; width: 100%; padding-left: 12px; padding-top: 4px; padding-bottom: 8px; font-size: 13px; line-height: 1.4; overflow-wrap: anywhere; color: #FF1A75; text-decoration: none;\\" target=\\"_blank\\"><span class=\\"kg-file-name\\" style=\\"font-weight: 500; color: #15212A;\\">test.txt</span> &#x2022; 16 Bytes</a>
                                                             </td></tr></tbody></table>
                                                         </td>
                                                         <td width=\\"80\\" valign=\\"middle\\" class=\\"kg-file-thumbnail\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; color: #15212A; position: relative; vertical-align: middle; text-align: center; border-radius: 2px; background-color: #FF1A75;\\" align=\\"center\\" bgcolor=\\"#FF1A75\\">
@@ -8487,7 +8487,7 @@ Ghost: Independent technology for modern publishingBeautiful, modern publishing 
                                                     <table border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\">
                                                         <tbody><tr>
                                                             <td class=\\"kg-cta-sponsor-label\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A; padding: 12px 0; border-bottom: 1px solid #e0e7eb; padding-top: 0; border-color: #e0e7eb;\\" valign=\\"top\\">
-                                                                <p style=\\"line-height: 1.6em; margin: 0; font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 12px; font-weight: 500; text-transform: uppercase; color: inherit;\\"><span style=\\"color: #15212a; color: rgba(0, 0, 0, 0.6); white-space: pre-wrap;\\">SPONSORED test card</span></p>
+                                                                <p style=\\"line-height: 1.6; margin: 0; font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 12px; font-weight: 500; text-transform: uppercase; color: inherit;\\"><span style=\\"color: #15212a; color: rgba(0, 0, 0, 0.6); white-space: pre-wrap;\\">SPONSORED test card</span></p>
                                                             </td>
                                                         </tr>
                                                     </tbody></table>
@@ -8501,7 +8501,7 @@ Ghost: Independent technology for modern publishingBeautiful, modern publishing 
                                                     
                                                     <tbody><tr>
                                                         <td class=\\"kg-cta-text\\" style=\\"font-size: 18px; vertical-align: top; color: #15212A; font-family: Georgia, serif;\\" valign=\\"top\\">
-                                                            <p dir=\\"ltr\\" style=\\"margin: 0 0 1.5em 0; margin-bottom: 0; text-align: center; line-height: 1.6em; color: #15212A;\\"><span style=\\"white-space: pre-wrap;\\">Here&#x2019;s a basic CTA card</span></p>
+                                                            <p dir=\\"ltr\\" style=\\"margin: 0 0 1.5em 0; margin-bottom: 0; text-align: center; line-height: 1.6; color: #15212A;\\"><span style=\\"white-space: pre-wrap;\\">Here&#x2019;s a basic CTA card</span></p>
                                                         </td>
                                                     </tr>
                                                     
@@ -8515,7 +8515,7 @@ Ghost: Independent technology for modern publishingBeautiful, modern publishing 
                                             </td>
                                         </tr>
                                     
-                                    </tbody></table><table class=\\"kg-card kg-transistor-card\\" cellspacing=\\"0\\" cellpadding=\\"0\\" border=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: auto; width: 100%; margin: 0 auto 1.5em; border-radius: 10px; background-color: #ffffff; background-color: rgba(255, 255, 255, 0.25); border: 1px solid #e0e7eb; border: 1px solid rgba(0, 0, 0, 0.12); margin-top: 1.5em;\\" bgcolor=\\"rgba(255, 255, 255, 0.25)\\"><tbody><tr><td style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A; padding: 24px; text-align: center;\\" align=\\"center\\" valign=\\"top\\"><table cellspacing=\\"0\\" cellpadding=\\"0\\" border=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; text-align: center;\\" align=\\"center\\"><tbody><tr><td style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A; text-align: center; padding-bottom: 12px;\\" align=\\"center\\" valign=\\"top\\"><a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" style=\\"overflow-wrap: anywhere; color: #FF1A75; text-decoration: underline; display: inline-block; width: 72px; height: 72px; padding-top: 4px; padding-right: 4px; padding-bottom: 4px; padding-left: 4px; border-radius: 8px; background-color: #FF1A75;\\" target=\\"_blank\\"><img src=\\"https://static.ghost.org/v6.0.0/images/transistor-logo-ondark.png\\" width=\\"40\\" height=\\"40\\" alt=\\"Transistor\\" style=\\"border: none; -ms-interpolation-mode: bicubic; max-width: 100%; width: 40px; height: 40px; padding: 16px;\\"></a></td></tr><tr><td style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A; text-align: center;\\" align=\\"center\\" valign=\\"top\\"><a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"kg-transistor-title\\" style=\\"display: block; padding-right: 20px; padding-bottom: 4px; padding-top: 4px; font-size: 17px; font-weight: 600; line-height: 18px; overflow-wrap: anywhere; text-decoration: none; color: #15212A;\\" target=\\"_blank\\"> Listen to your podcasts </a><a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"kg-transistor-description\\" style=\\"display: inline-block; max-width: 400px; font-size: 14px; line-height: 1.4em; overflow-wrap: anywhere; text-decoration: none; color: #15212a; color: rgba(0, 0, 0, 0.6);\\" target=\\"_blank\\"> Subscribe and listen to your personal podcast feed in your favorite app. </a></td></tr></tbody></table></td></tr></tbody></table>
+                                    </tbody></table><table class=\\"kg-card kg-transistor-card\\" cellspacing=\\"0\\" cellpadding=\\"0\\" border=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: auto; width: 100%; margin: 0 auto 1.5em; border-radius: 10px; background-color: #ffffff; background-color: rgba(255, 255, 255, 0.25); border: 1px solid #e0e7eb; border: 1px solid rgba(0, 0, 0, 0.12); margin-top: 1.5em;\\" bgcolor=\\"rgba(255, 255, 255, 0.25)\\"><tbody><tr><td style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A; padding: 24px; text-align: center;\\" align=\\"center\\" valign=\\"top\\"><table cellspacing=\\"0\\" cellpadding=\\"0\\" border=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; text-align: center;\\" align=\\"center\\"><tbody><tr><td style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A; text-align: center; padding-bottom: 12px;\\" align=\\"center\\" valign=\\"top\\"><a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" style=\\"overflow-wrap: anywhere; color: #FF1A75; text-decoration: underline; display: inline-block; width: 72px; height: 72px; padding-top: 4px; padding-right: 4px; padding-bottom: 4px; padding-left: 4px; border-radius: 8px; background-color: #FF1A75;\\" target=\\"_blank\\"><img src=\\"https://static.ghost.org/v6.0.0/images/transistor-logo-ondark.png\\" width=\\"40\\" height=\\"40\\" alt=\\"Transistor\\" style=\\"border: none; -ms-interpolation-mode: bicubic; max-width: 100%; width: 40px; height: 40px; padding: 16px;\\"></a></td></tr><tr><td style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A; text-align: center;\\" align=\\"center\\" valign=\\"top\\"><a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"kg-transistor-title\\" style=\\"display: block; padding-right: 20px; padding-bottom: 4px; padding-top: 4px; font-size: 17px; font-weight: 600; line-height: 1.125; overflow-wrap: anywhere; text-decoration: none; color: #15212A;\\" target=\\"_blank\\"> Listen to your podcasts </a><a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"kg-transistor-description\\" style=\\"display: inline-block; max-width: 400px; font-size: 14px; line-height: 1.4; overflow-wrap: anywhere; text-decoration: none; color: #15212a; color: rgba(0, 0, 0, 0.6);\\" target=\\"_blank\\"> Subscribe and listen to your personal podcast feed in your favorite app. </a></td></tr></tbody></table></td></tr></tbody></table>
                                                                             <!-- POST CONTENT END -->
                             
                                                                         </td>
@@ -8533,7 +8533,7 @@ Ghost: Independent technology for modern publishingBeautiful, modern publishing 
                                                             <td class=\\"wrapper\\" align=\\"center\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A; box-sizing: border-box;\\" valign=\\"top\\">
                                                                 <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; padding-top: 40px; padding-bottom: 30px;\\">
                                                                     <tr>
-                                                                        <td class=\\"footer\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; color: #15212a; color: rgba(0, 0, 0, 0.6); margin-top: 20px; text-align: center; padding-bottom: 10px; padding-top: 10px; padding-left: 30px; padding-right: 30px; line-height: 1.5em; font-size: 13px;\\" valign=\\"top\\" align=\\"center\\">Ghost &#xA9; 2025 &#x2013; <a href=\\"http://127.0.0.1:2369/unsubscribe/?uuid=member-uuid&key=xxxxxx&newsletter=requested-newsletter-uuid\\" style=\\"overflow-wrap: anywhere; color: #15212a; color: rgba(0, 0, 0, 0.6); text-decoration: underline; font-size: 13px;\\" target=\\"_blank\\">Unsubscribe</a></td>
+                                                                        <td class=\\"footer\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; color: #15212a; color: rgba(0, 0, 0, 0.6); margin-top: 20px; text-align: center; padding-bottom: 10px; padding-top: 10px; padding-left: 30px; padding-right: 30px; line-height: 1.5; font-size: 13px;\\" valign=\\"top\\" align=\\"center\\">Ghost &#xA9; 2025 &#x2013; <a href=\\"http://127.0.0.1:2369/unsubscribe/?uuid=member-uuid&key=xxxxxx&newsletter=requested-newsletter-uuid\\" style=\\"overflow-wrap: anywhere; color: #15212a; color: rgba(0, 0, 0, 0.6); text-decoration: underline; font-size: 13px;\\" target=\\"_blank\\">Unsubscribe</a></td>
                                                                     </tr>
                             
                                                                         <tr>
@@ -9199,7 +9199,7 @@ table[class=body] a[class=small] {
   color: #15212A !important;
   font-family: inherit !important;
   font-size: 14px;
-  line-height: 1.3em;
+  line-height: 1.3;
   padding-top: 4px;
   padding-right: 20px;
   padding-left: 20px;
@@ -9212,7 +9212,7 @@ table[class=body] a[class=small] {
   font-family: inherit !important;
   font-size: 15px;
   padding: 8px;
-  line-height: 1.3em;
+  line-height: 1.3;
 }
 .kg-cta-link-accent .kg-cta-sponsor-label a {
   color: #FF1A75 !important;
@@ -9333,7 +9333,7 @@ table[class=body] a[class=small] {
   margin-top: 32px;
   color: #15212A;
   text-align: center;
-  line-height: 1.1em;
+  line-height: 1.1;
 }
 .post-title-link-left {
   text-align: left;
@@ -9383,7 +9383,7 @@ table.body td {
 
   table.body .kg-callout-text {
     font-size: 16px !important;
-    line-height: 1.5em !important;
+    line-height: 1.5 !important;
   }
 
   table.body pre {
@@ -9429,7 +9429,7 @@ table.header .header-main {
 table.header .post-meta-date {
     white-space: normal !important;
     font-size: 13px !important;
-    line-height: 1.2em;
+    line-height: 1.2;
   }
 
   table.header .post-meta,
@@ -9473,7 +9473,7 @@ table.body .footer a {
 
   table.header .post-title a {
     font-size: 26px !important;
-    line-height: 1.1em !important;
+    line-height: 1.1 !important;
   }
 
   table.feedback-buttons {
@@ -9534,38 +9534,38 @@ table.body .manage-subscription {
 
   table.body h1 {
     font-size: 32px !important;
-    line-height: 1.3em !important;
+    line-height: 1.3 !important;
   }
 
   table.body h2,
 table.body h2 span {
     font-size: 26px !important;
-    line-height: 1.22em !important;
+    line-height: 1.22 !important;
   }
 
   table.body h3 {
     font-size: 21px !important;
-    line-height: 1.25em !important;
+    line-height: 1.25 !important;
   }
 
   table.body h4 {
     font-size: 19px !important;
-    line-height: 1.3em !important;
+    line-height: 1.3 !important;
   }
 
   table.body h5 {
     font-size: 16px !important;
-    line-height: 1.4em !important;
+    line-height: 1.4 !important;
   }
 
   table.body h6 {
     font-size: 16px !important;
-    line-height: 1.4em !important;
+    line-height: 1.4 !important;
   }
 
   table.body blockquote {
     font-size: 16px !important;
-    line-height: 1.6em;
+    line-height: 1.6;
     margin-bottom: 0;
   }
 
@@ -9578,7 +9578,7 @@ table.body h2 span {
     border-left: 0 none !important;
     margin: 0 !important;
     font-size: 18px !important;
-    line-height: 1.4em !important;
+    line-height: 1.4 !important;
   }
 
   table.body blockquote.kg-blockquote-alt p {
@@ -9709,7 +9709,7 @@ Beautiful, modern publishing with newsletters and premium subscriptions built-in
                                                     <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\" width=\\"100%\\">
                                                         <tr>
                                                             <td style=\\"vertical-align: top; font-family: Georgia, serif; letter-spacing: -0.01em; font-size: 36px; line-height: 1.1; font-weight: 700; text-align: center; color: #000000;\\" valign=\\"top\\" align=\\"center\\">
-                                                                <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; text-align: center; line-height: 1.1em; overflow-wrap: anywhere; color: #000000;\\" target=\\"_blank\\">A random test post</a>
+                                                                <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; text-align: center; line-height: 1.1; overflow-wrap: anywhere; color: #000000;\\" target=\\"_blank\\">A random test post</a>
                                                             </td>
                                                         </tr>
                                                     </table>
@@ -9769,32 +9769,32 @@ Beautiful, modern publishing with newsletters and premium subscriptions built-in
                                                             <td class=\\"wrapper\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A; box-sizing: border-box;\\" valign=\\"top\\">
                                                                 <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" width=\\"100%\\" data-testid=\\"email-preview-content\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\">
                                                                     <tr class=\\"post-content-row\\">
-                                                                        <td class=\\"post-content\\" style=\\"vertical-align: top; font-family: Georgia, serif; font-size: 18px; line-height: 1.5em; color: #15212A; padding-bottom: 20px; border-bottom: 1px solid #e0e7eb; max-width: 600px;\\" valign=\\"top\\">
+                                                                        <td class=\\"post-content\\" style=\\"vertical-align: top; font-family: Georgia, serif; font-size: 18px; line-height: 1.5; color: #15212A; padding-bottom: 20px; border-bottom: 1px solid #e0e7eb; max-width: 600px;\\" valign=\\"top\\">
                                                                             <!-- POST CONTENT START -->
-                                                                            <p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em; color: #15212A;\\">This is just a simple paragraph, no frills.</p><blockquote style=\\"margin: 0; padding: 0; border-left: #FF1A75 2px solid; font-size: 17px; font-weight: 500; line-height: 1.6em; letter-spacing: -0.2px;\\"><p style=\\"line-height: 1.6em; margin: 2em 25px; font-size: 1em; padding: 0; color: #15212A;\\">This is block quote</p></blockquote><blockquote class=\\"kg-blockquote-alt\\" style=\\"margin: 0; padding: 0; font-weight: 500; line-height: 1.6em; letter-spacing: -0.2px; border-left: 0 none; text-align: center; font-size: 1.2em; font-style: italic; color: #15212a; color: rgba(0, 0, 0, 0.6);\\"><p style=\\"line-height: 1.6em; margin: 2em 25px; font-size: 1em; margin-right: 50px; margin-left: 50px; padding: 0; color: #15212A;\\">This is a...different block quote</p></blockquote><h2 id=\\"this-is-a-heading\\" style=\\"margin-top: 0; line-height: 1.11em; font-weight: 700; text-rendering: optimizeLegibility; margin: 1.5em 0 0.5em 0; font-size: 32px; font-family: Georgia, serif; letter-spacing: -0.01em; color: #15212A;\\">This is a heading!</h2><h3 id=\\"heres-a-smaller-heading\\" style=\\"margin-top: 0; line-height: 1.11em; font-weight: 700; text-rendering: optimizeLegibility; margin: 1.5em 0 0.5em 0; font-size: 26px; font-family: Georgia, serif; letter-spacing: -0.01em; color: #15212A;\\">Here&#39;s a smaller heading.</h3><div class=\\"kg-card kg-image-card kg-card-hascaption\\" style=\\"margin: 0 0 1.5em; padding: 0;\\"><img src=\\"https://upload.wikimedia.org/wikipedia/commons/thumb/8/8c/Cow_%28Fleckvieh_breed%29_Oeschinensee_Slaunger_2009-07-07.jpg/1920px-Cow_%28Fleckvieh_breed%29_Oeschinensee_Slaunger_2009-07-07.jpg\\" class=\\"kg-image\\" alt=\\"Cows eat grass.\\" loading=\\"lazy\\" style=\\"border: none; -ms-interpolation-mode: bicubic; display: block; margin: 0 auto; height: auto; width: auto; max-width: 100%;\\" width=\\"auto\\" height=\\"auto\\"><div class=\\"kg-card-figcaption\\" style=\\"text-align: center; font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; padding-top: 10px; padding-bottom: 10px; line-height: 1.5em; color: #15212a; color: rgba(0, 0, 0, 0.6); font-size: 13px;\\"><span style=\\"text-align: center; white-space: pre-wrap;\\">A lovely cow</span></div></div><h1 id=\\"a-heading\\" style=\\"margin-top: 0; line-height: 1.11em; font-weight: 700; text-rendering: optimizeLegibility; margin: 1.5em 0 0.5em 0; font-size: 42px; font-family: Georgia, serif; letter-spacing: -0.01em; color: #15212A;\\">A heading</h1>
-                            <p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em; color: #15212A;\\">and a paragraph (in markdown!)</p>
+                                                                            <p style=\\"margin: 0 0 1.5em 0; line-height: 1.6; color: #15212A;\\">This is just a simple paragraph, no frills.</p><blockquote style=\\"margin: 0; padding: 0; border-left: #FF1A75 2px solid; font-size: 17px; font-weight: 500; line-height: 1.6; letter-spacing: -0.2px;\\"><p style=\\"line-height: 1.6; margin: 2em 25px; font-size: 1em; padding: 0; color: #15212A;\\">This is block quote</p></blockquote><blockquote class=\\"kg-blockquote-alt\\" style=\\"margin: 0; padding: 0; font-weight: 500; line-height: 1.6; letter-spacing: -0.2px; border-left: 0 none; text-align: center; font-size: 1.2em; font-style: italic; color: #15212a; color: rgba(0, 0, 0, 0.6);\\"><p style=\\"line-height: 1.6; margin: 2em 25px; font-size: 1em; margin-right: 50px; margin-left: 50px; padding: 0; color: #15212A;\\">This is a...different block quote</p></blockquote><h2 id=\\"this-is-a-heading\\" style=\\"margin-top: 0; line-height: 1.11; font-weight: 700; text-rendering: optimizeLegibility; margin: 1.5em 0 0.5em 0; font-size: 32px; font-family: Georgia, serif; letter-spacing: -0.01em; color: #15212A;\\">This is a heading!</h2><h3 id=\\"heres-a-smaller-heading\\" style=\\"margin-top: 0; line-height: 1.11; font-weight: 700; text-rendering: optimizeLegibility; margin: 1.5em 0 0.5em 0; font-size: 26px; font-family: Georgia, serif; letter-spacing: -0.01em; color: #15212A;\\">Here&#39;s a smaller heading.</h3><div class=\\"kg-card kg-image-card kg-card-hascaption\\" style=\\"margin: 0 0 1.5em; padding: 0;\\"><img src=\\"https://upload.wikimedia.org/wikipedia/commons/thumb/8/8c/Cow_%28Fleckvieh_breed%29_Oeschinensee_Slaunger_2009-07-07.jpg/1920px-Cow_%28Fleckvieh_breed%29_Oeschinensee_Slaunger_2009-07-07.jpg\\" class=\\"kg-image\\" alt=\\"Cows eat grass.\\" loading=\\"lazy\\" style=\\"border: none; -ms-interpolation-mode: bicubic; display: block; margin: 0 auto; height: auto; width: auto; max-width: 100%;\\" width=\\"auto\\" height=\\"auto\\"><div class=\\"kg-card-figcaption\\" style=\\"text-align: center; font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; padding-top: 10px; padding-bottom: 10px; line-height: 1.5; color: #15212a; color: rgba(0, 0, 0, 0.6); font-size: 13px;\\"><span style=\\"text-align: center; white-space: pre-wrap;\\">A lovely cow</span></div></div><h1 id=\\"a-heading\\" style=\\"margin-top: 0; line-height: 1.11; font-weight: 700; text-rendering: optimizeLegibility; margin: 1.5em 0 0.5em 0; font-size: 42px; font-family: Georgia, serif; letter-spacing: -0.01em; color: #15212A;\\">A heading</h1>
+                            <p style=\\"margin: 0 0 1.5em 0; line-height: 1.6; color: #15212A;\\">and a paragraph (in markdown!)</p>
                             
                             <!--kg-card-begin: html-->
-                            <p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em; color: #15212A;\\">A paragraph inside an HTML card.</p>
-                            <p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em; color: #15212A;\\">And another one, with some <b>bold</b> text.</p>
+                            <p style=\\"margin: 0 0 1.5em 0; line-height: 1.6; color: #15212A;\\">A paragraph inside an HTML card.</p>
+                            <p style=\\"margin: 0 0 1.5em 0; line-height: 1.6; color: #15212A;\\">And another one, with some <b>bold</b> text.</p>
                             <!--kg-card-end: html-->
-                            <table class=\\"kg-card kg-hr-card\\" role=\\"presentation\\" width=\\"100%\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\"><tbody><tr><td style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; color: #15212A; margin: 0; padding-top: 1.5em; padding-bottom: 3em; font-size: 17px;\\" valign=\\"top\\"><!--[if !mso]><!-- --><hr style=\\"position: relative; width: 100%; margin: 3em 0; padding: 0; height: 1px; background-color: transparent; border: 0; border-top: 1px solid #e0e7eb; display: none;\\"><!--<![endif]--><table class=\\"kg-hr\\" role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\" width=\\"100%\\"><tbody><tr><td style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; color: #15212A; padding-top: 1.5em; padding-bottom: 3em; margin: 0; padding: 0; border-top: 1px solid #e0e7eb; font-size: 0; line-height: 0;\\" valign=\\"top\\">&#xA0;</td></tr></tbody></table></td></tr></tbody></table><div class=\\"kg-card kg-gallery-card kg-width-wide kg-card-hascaption\\" style=\\"margin: 0 0 1.5em; padding: 0;\\"><div class=\\"kg-gallery-container\\" style=\\"margin-top: -20px;\\"><div class=\\"kg-gallery-row\\"><div class=\\"kg-gallery-image\\"><img src=\\"https://plus.unsplash.com/premium_photo-1700558685152-81f821a40724?q=80&amp;w=2070&amp;auto=format&amp;fit=crop&amp;ixlib=rb-4.0.3&amp;ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D\\" width=\\"600\\" height=\\"400\\" loading=\\"lazy\\" alt style=\\"border: none; -ms-interpolation-mode: bicubic; max-width: 100%; padding-top: 20px; width: 100%; height: auto;\\"></div></div></div><div class=\\"kg-card-figcaption\\" style=\\"text-align: center; font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; padding-top: 10px; padding-bottom: 10px; line-height: 1.5em; color: #15212a; color: rgba(0, 0, 0, 0.6); font-size: 13px;\\"><p dir=\\"ltr\\" style=\\"margin: 0 0 1.5em 0; line-height: 1.6em; color: inherit;\\"><span style=\\"white-space: pre-wrap;\\">A gallery.</span></p></div></div><div>
+                            <table class=\\"kg-card kg-hr-card\\" role=\\"presentation\\" width=\\"100%\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\"><tbody><tr><td style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; color: #15212A; margin: 0; padding-top: 1.5em; padding-bottom: 3em; font-size: 17px;\\" valign=\\"top\\"><!--[if !mso]><!-- --><hr style=\\"position: relative; width: 100%; margin: 3em 0; padding: 0; height: 1px; background-color: transparent; border: 0; border-top: 1px solid #e0e7eb; display: none;\\"><!--<![endif]--><table class=\\"kg-hr\\" role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\" width=\\"100%\\"><tbody><tr><td style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; color: #15212A; padding-top: 1.5em; padding-bottom: 3em; margin: 0; padding: 0; border-top: 1px solid #e0e7eb; font-size: 0; line-height: 0;\\" valign=\\"top\\">&#xA0;</td></tr></tbody></table></td></tr></tbody></table><div class=\\"kg-card kg-gallery-card kg-width-wide kg-card-hascaption\\" style=\\"margin: 0 0 1.5em; padding: 0;\\"><div class=\\"kg-gallery-container\\" style=\\"margin-top: -20px;\\"><div class=\\"kg-gallery-row\\"><div class=\\"kg-gallery-image\\"><img src=\\"https://plus.unsplash.com/premium_photo-1700558685152-81f821a40724?q=80&amp;w=2070&amp;auto=format&amp;fit=crop&amp;ixlib=rb-4.0.3&amp;ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D\\" width=\\"600\\" height=\\"400\\" loading=\\"lazy\\" alt style=\\"border: none; -ms-interpolation-mode: bicubic; max-width: 100%; padding-top: 20px; width: 100%; height: auto;\\"></div></div></div><div class=\\"kg-card-figcaption\\" style=\\"text-align: center; font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; padding-top: 10px; padding-bottom: 10px; line-height: 1.5; color: #15212a; color: rgba(0, 0, 0, 0.6); font-size: 13px;\\"><p dir=\\"ltr\\" style=\\"margin: 0 0 1.5em 0; line-height: 1.6; color: inherit;\\"><span style=\\"white-space: pre-wrap;\\">A gallery.</span></p></div></div><div>
                                     <!--[if !mso !vml]-->
                                         <div class=\\"kg-card kg-bookmark-card kg-card-hascaption\\" style=\\"margin: 0 0 1.5em; padding: 0; width: 100%;\\">
                                             <a class=\\"kg-bookmark-container\\" href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" style=\\"display: flex; min-height: 148px; font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; border-radius: 3px; background-color: #ffffff; background-color: rgba(255, 255, 255, 0.25); border: 1px solid #e0e7eb; border: 1px solid rgba(0, 0, 0, 0.12); overflow-wrap: anywhere; color: #FF1A75; text-decoration: none;\\" target=\\"_blank\\">
                                                 <div class=\\"kg-bookmark-content\\" style=\\"display: inline-block; width: 100%; padding: 20px;\\">
-                                                    <div class=\\"kg-bookmark-title\\" style=\\"color: #15212A; font-size: 15px; line-height: 1.5em; font-weight: 600;\\">Ghost: Independent technology for modern publishing</div>
-                                                    <div class=\\"kg-bookmark-description\\" style=\\"display: -webkit-box; overflow-y: hidden; margin-top: 12px; max-height: 40px; color: #15212a; color: rgba(0, 0, 0, 0.6); font-size: 13px; line-height: 1.5em; font-weight: 400; -webkit-line-clamp: 2; -webkit-box-orient: vertical;\\">Beautiful, modern publishing with newsletters and premium subscriptions built-in. Used by<span class=\\"desktop-only\\"> Sky, 404Media, Lever News, Ta</span>&#x2026;</div>
+                                                    <div class=\\"kg-bookmark-title\\" style=\\"color: #15212A; font-size: 15px; line-height: 1.5; font-weight: 600;\\">Ghost: Independent technology for modern publishing</div>
+                                                    <div class=\\"kg-bookmark-description\\" style=\\"display: -webkit-box; overflow-y: hidden; margin-top: 12px; max-height: 40px; color: #15212a; color: rgba(0, 0, 0, 0.6); font-size: 13px; line-height: 1.5; font-weight: 400; -webkit-line-clamp: 2; -webkit-box-orient: vertical;\\">Beautiful, modern publishing with newsletters and premium subscriptions built-in. Used by<span class=\\"desktop-only\\"> Sky, 404Media, Lever News, Ta</span>&#x2026;</div>
                                                     <div class=\\"kg-bookmark-metadata\\" style=\\"display: flex; flex-wrap: wrap; align-items: center; margin-top: 14px; color: #15212A; font-size: 13px; font-weight: 400;\\">
                                                         <img class=\\"kg-bookmark-icon\\" src=\\"https://ghost.org/favicon.ico\\" alt style=\\"border: none; -ms-interpolation-mode: bicubic; max-width: 100%; margin-right: 8px; width: 22px; height: 22px;\\" width=\\"22\\" height=\\"22\\">
-                                                        <span class=\\"kg-bookmark-author\\" src=\\"Ghost - The Professional Publishing Platform\\" style=\\"line-height: 1.5em;\\">Ghost - The Professional Publishing Platform</span>
+                                                        <span class=\\"kg-bookmark-author\\" src=\\"Ghost - The Professional Publishing Platform\\" style=\\"line-height: 1.5;\\">Ghost - The Professional Publishing Platform</span>
                                                         
                                                     </div>
                                                 </div>
                                                 <div class=\\"kg-bookmark-thumbnail\\" style=\\"min-width: 140px; max-width: 180px; background-repeat: no-repeat; background-size: cover; background-position: center; border-radius: 0 2px 2px 0; background-image: url(&#39;https://ghost.org/images/meta/ghost.png&#39;);\\">
                                                     <img src=\\"https://ghost.org/images/meta/ghost.png\\" alt onerror=\\"this.style.display=&#39;none&#39;\\" style=\\"border: none; -ms-interpolation-mode: bicubic; max-width: 100%; display: none;\\"></div>
                                             </a>
-                                            <div class=\\"kg-card-figcaption\\" style=\\"text-align: center; font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; padding-top: 10px; padding-bottom: 10px; line-height: 1.5em; color: #15212a; color: rgba(0, 0, 0, 0.6); font-size: 13px;\\"><p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em; color: inherit;\\"><span style=\\"white-space: pre-wrap;\\">My favorite website.</span></p></div>
+                                            <div class=\\"kg-card-figcaption\\" style=\\"text-align: center; font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; padding-top: 10px; padding-bottom: 10px; line-height: 1.5; color: #15212a; color: rgba(0, 0, 0, 0.6); font-size: 13px;\\"><p style=\\"margin: 0 0 1.5em 0; line-height: 1.6; color: inherit;\\"><span style=\\"white-space: pre-wrap;\\">My favorite website.</span></p></div>
                                         </div>
                                     <!--[endif]-->
                                     <!--[if vml]>
@@ -9845,7 +9845,7 @@ Beautiful, modern publishing with newsletters and premium subscriptions built-in
                                             </tr>
                                         </table>
                                         <div class=\\"kg-bookmark-spacer--outlook\\" style=\\"height: 1.5em;\\">&nbsp;</div>
-                                    <![endif]--></div><p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em; color: #15212A;\\"><span style=\\"white-space: pre-wrap;\\">Hey </span><span>there</span><span style=\\"white-space: pre-wrap;\\">,</span></p><div><hr style=\\"position: relative; display: block; width: 100%; margin: 3em 0; padding: 0; height: 1px; background-color: transparent; border: 0; border-top: 1px solid #e0e7eb;\\"><p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em; color: #15212A;\\"><span style=\\"white-space: pre-wrap;\\">Hello there, fellow users of electronic mail.</span></p><hr style=\\"position: relative; display: block; width: 100%; margin: 3em 0; padding: 0; height: 1px; background-color: transparent; border: 0; border-top: 1px solid #e0e7eb;\\"></div><!--members-only--><table class=\\"kg-card kg-button-card\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\" width=\\"100%\\"><tbody><tr><td class=\\"kg-card-spacing\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A; padding: 0 0 1.5em 0;\\" valign=\\"top\\"><table class=\\"btn\\" border=\\"0\\" cellspacing=\\"0\\" cellpadding=\\"0\\" align=\\"center\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; box-sizing: border-box; width: auto;\\" width=\\"auto\\"><tbody><tr><td align=\\"center\\" style=\\"font-size: 18px; vertical-align: top; color: #15212A; padding: 8px 20px 9px; background-color: #FF1A75; border-radius: 6px; text-align: center; font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif;\\" valign=\\"top\\" bgcolor=\\"#FF1A75\\"><a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" style=\\"overflow-wrap: anywhere; box-sizing: border-box; color: #FFFFFF; cursor: pointer; display: inline-block; font-size: 15px; font-weight: 600; margin: 0; text-decoration: none;\\" target=\\"_blank\\">Click me, I&#39;m a button!</a></td></tr></tbody></table></td></tr></tbody></table><div class=\\"kg-card kg-callout-card kg-callout-card-blue\\" style=\\"display: flex; margin: 0 0 1.5em 0; padding: 24px; border-radius: 8px; background: #E9F6FB;\\"><div class=\\"kg-callout-emoji\\" style=\\"padding-right: 12px; font-size: 20px;\\">&#x1F4A1;</div><div class=\\"kg-callout-text\\" style=\\"color: inherit;\\">I had an idea...</div></div><table cellspacing=\\"0\\" cellpadding=\\"0\\" border=\\"0\\" width=\\"100%\\" class=\\"kg-toggle-card\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-radius: 4px; margin-bottom: 24px; width: 100%; background-color: #ffffff; background-color: rgba(255, 255, 255, 0.25); border: 1px solid #e0e7eb; border: 1px solid rgba(0, 0, 0, 0.12);\\" bgcolor=\\"rgba(255, 255, 255, 0.25)\\"><tbody><tr><td class=\\"kg-toggle-heading\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A; margin: 0; padding: 24px 24px 12px;\\" valign=\\"top\\"><h4 style=\\"margin-top: 0; text-rendering: optimizeLegibility; font-size: 21px; line-height: 1.2em; font-family: Georgia, serif; letter-spacing: -0.01em; margin: 0; font-weight: 700; color: #15212A;\\"><span style=\\"white-space: pre-wrap;\\">Spoiler alert!</span></h4></td></tr><tr><td class=\\"kg-toggle-content\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; color: #15212A; font-size: 16px; line-height: 1.5; padding: 0 24px 24px;\\" valign=\\"top\\"><p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em; margin-bottom: 0; color: inherit;\\"><span style=\\"white-space: pre-wrap;\\">Just kidding</span></p></td></tr></tbody></table><table cellspacing=\\"0\\" cellpadding=\\"0\\" border=\\"0\\" class=\\"kg-audio-card\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: auto; width: 100%; margin: 0 auto 1.5em; border-radius: 3px; background-color: #ffffff; background-color: rgba(255, 255, 255, 0.25); border: 1px solid #e0e7eb; border: 1px solid rgba(0, 0, 0, 0.12);\\" width=\\"100%\\" bgcolor=\\"rgba(255, 255, 255, 0.25)\\">
+                                    <![endif]--></div><p style=\\"margin: 0 0 1.5em 0; line-height: 1.6; color: #15212A;\\"><span style=\\"white-space: pre-wrap;\\">Hey </span><span>there</span><span style=\\"white-space: pre-wrap;\\">,</span></p><div><hr style=\\"position: relative; display: block; width: 100%; margin: 3em 0; padding: 0; height: 1px; background-color: transparent; border: 0; border-top: 1px solid #e0e7eb;\\"><p style=\\"margin: 0 0 1.5em 0; line-height: 1.6; color: #15212A;\\"><span style=\\"white-space: pre-wrap;\\">Hello there, fellow users of electronic mail.</span></p><hr style=\\"position: relative; display: block; width: 100%; margin: 3em 0; padding: 0; height: 1px; background-color: transparent; border: 0; border-top: 1px solid #e0e7eb;\\"></div><!--members-only--><table class=\\"kg-card kg-button-card\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\" width=\\"100%\\"><tbody><tr><td class=\\"kg-card-spacing\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A; padding: 0 0 1.5em 0;\\" valign=\\"top\\"><table class=\\"btn\\" border=\\"0\\" cellspacing=\\"0\\" cellpadding=\\"0\\" align=\\"center\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; box-sizing: border-box; width: auto;\\" width=\\"auto\\"><tbody><tr><td align=\\"center\\" style=\\"font-size: 18px; vertical-align: top; color: #15212A; padding: 8px 20px 9px; background-color: #FF1A75; border-radius: 6px; text-align: center; font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif;\\" valign=\\"top\\" bgcolor=\\"#FF1A75\\"><a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" style=\\"overflow-wrap: anywhere; box-sizing: border-box; color: #FFFFFF; cursor: pointer; display: inline-block; font-size: 15px; font-weight: 600; margin: 0; text-decoration: none;\\" target=\\"_blank\\">Click me, I&#39;m a button!</a></td></tr></tbody></table></td></tr></tbody></table><div class=\\"kg-card kg-callout-card kg-callout-card-blue\\" style=\\"display: flex; margin: 0 0 1.5em 0; padding: 24px; border-radius: 8px; background: #E9F6FB;\\"><div class=\\"kg-callout-emoji\\" style=\\"padding-right: 12px; font-size: 20px;\\">&#x1F4A1;</div><div class=\\"kg-callout-text\\" style=\\"color: inherit;\\">I had an idea...</div></div><table cellspacing=\\"0\\" cellpadding=\\"0\\" border=\\"0\\" width=\\"100%\\" class=\\"kg-toggle-card\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-radius: 4px; margin-bottom: 24px; width: 100%; background-color: #ffffff; background-color: rgba(255, 255, 255, 0.25); border: 1px solid #e0e7eb; border: 1px solid rgba(0, 0, 0, 0.12);\\" bgcolor=\\"rgba(255, 255, 255, 0.25)\\"><tbody><tr><td class=\\"kg-toggle-heading\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A; margin: 0; padding: 24px 24px 12px;\\" valign=\\"top\\"><h4 style=\\"margin-top: 0; text-rendering: optimizeLegibility; font-size: 21px; line-height: 1.2; font-family: Georgia, serif; letter-spacing: -0.01em; margin: 0; font-weight: 700; color: #15212A;\\"><span style=\\"white-space: pre-wrap;\\">Spoiler alert!</span></h4></td></tr><tr><td class=\\"kg-toggle-content\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; color: #15212A; font-size: 16px; line-height: 1.5; padding: 0 24px 24px;\\" valign=\\"top\\"><p style=\\"margin: 0 0 1.5em 0; line-height: 1.6; margin-bottom: 0; color: inherit;\\"><span style=\\"white-space: pre-wrap;\\">Just kidding</span></p></td></tr></tbody></table><table cellspacing=\\"0\\" cellpadding=\\"0\\" border=\\"0\\" class=\\"kg-audio-card\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: auto; width: 100%; margin: 0 auto 1.5em; border-radius: 3px; background-color: #ffffff; background-color: rgba(255, 255, 255, 0.25); border: 1px solid #e0e7eb; border: 1px solid rgba(0, 0, 0, 0.12);\\" width=\\"100%\\" bgcolor=\\"rgba(255, 255, 255, 0.25)\\">
                                             <tbody><tr>
                                                 <td style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A;\\" valign=\\"top\\">
                                                     <table cellspacing=\\"0\\" cellpadding=\\"0\\" border=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\">
@@ -9862,7 +9862,7 @@ Beautiful, modern publishing with newsletters and premium subscriptions built-in
                                                                 <table cellspacing=\\"0\\" cellpadding=\\"0\\" border=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\">
                                                                     <tbody><tr>
                                                                         <td style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A;\\" valign=\\"top\\">
-                                                                            <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"kg-audio-title\\" style=\\"display: block; padding-right: 20px; padding-bottom: 4px; padding-top: 4px; font-size: 16px; font-weight: 600; line-height: 18px; overflow-wrap: anywhere; text-decoration: none; color: #15212A;\\" target=\\"_blank\\">Sample</a>
+                                                                            <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"kg-audio-title\\" style=\\"display: block; padding-right: 20px; padding-bottom: 4px; padding-top: 4px; font-size: 16px; font-weight: 600; line-height: 1.125; overflow-wrap: anywhere; text-decoration: none; color: #15212A;\\" target=\\"_blank\\">Sample</a>
                                                                         </td>
                                                                     </tr>
                                                                     <tr>
@@ -9910,7 +9910,7 @@ Beautiful, modern publishing with newsletters and premium subscriptions built-in
                                         </v:group>
                                         <![endif]-->
                             
-                                        <div class=\\"kg-card-figcaption\\" style=\\"text-align: center; font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; padding-top: 10px; padding-bottom: 10px; line-height: 1.5em; color: #15212a; color: rgba(0, 0, 0, 0.6); font-size: 13px;\\"><p dir=\\"ltr\\" style=\\"margin: 0 0 1.5em 0; line-height: 1.6em; color: inherit;\\"><span style=\\"white-space: pre-wrap;\\">A lovely video of a woman on the beach doing nothing.</span></p></div>
+                                        <div class=\\"kg-card-figcaption\\" style=\\"text-align: center; font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; padding-top: 10px; padding-bottom: 10px; line-height: 1.5; color: #15212a; color: rgba(0, 0, 0, 0.6); font-size: 13px;\\"><p dir=\\"ltr\\" style=\\"margin: 0 0 1.5em 0; line-height: 1.6; color: inherit;\\"><span style=\\"white-space: pre-wrap;\\">A lovely video of a woman on the beach doing nothing.</span></p></div>
                                     </div><table class=\\"kg-product-card\\" cellspacing=\\"0\\" cellpadding=\\"0\\" border=\\"0\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; margin: 0 0 1.5em; border-radius: 0; background-color: #FFFFFF; background-color: rgba(255, 255, 255, 0.25); border: 1px solid #e0e7eb; border: 1px solid rgba(0, 0, 0, 0.12);\\" width=\\"100%\\" bgcolor=\\"rgba(255, 255, 255, 0.25)\\">
                                         <tbody><tr>
                                             <td class=\\"kg-product-card-container\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A; padding: 20px;\\" valign=\\"top\\">
@@ -9924,7 +9924,7 @@ Beautiful, modern publishing with newsletters and premium subscriptions built-in
                                                     
                                                     <tr>
                                                         <td valign=\\"top\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A;\\">
-                                                            <h4 class=\\"kg-product-title\\" style=\\"text-rendering: optimizeLegibility; margin: 1.8em 0 0.5em 0; line-height: 1.2em; font-weight: 700; font-family: Georgia, serif; letter-spacing: -0.01em; margin-top: 0; margin-bottom: 0; font-size: 22px; color: #15212A;\\"><span style=\\"white-space: pre-wrap;\\">Make a blog!</span></h4>
+                                                            <h4 class=\\"kg-product-title\\" style=\\"text-rendering: optimizeLegibility; margin: 1.8em 0 0.5em 0; line-height: 1.2; font-weight: 700; font-family: Georgia, serif; letter-spacing: -0.01em; margin-top: 0; margin-bottom: 0; font-size: 22px; color: #15212A;\\"><span style=\\"white-space: pre-wrap;\\">Make a blog!</span></h4>
                                                         </td>
                                                     </tr>
                                                     
@@ -9962,12 +9962,12 @@ Beautiful, modern publishing with newsletters and premium subscriptions built-in
                                                     <table border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\">
                                                         <tbody><tr>
                                                             <td align=\\"center\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: inherit;\\" valign=\\"top\\">
-                                                                <h2 class=\\"kg-header-card-heading\\" style=\\"margin-top: 0; text-rendering: optimizeLegibility; font-family: Georgia, serif; letter-spacing: -0.01em; font-size: 32px; font-weight: 700; margin: 0; line-height: 1em; color: #FFFFFF;\\"><span style=\\"white-space: pre-wrap;\\">Good news everyone!</span></h2>
+                                                                <h2 class=\\"kg-header-card-heading\\" style=\\"margin-top: 0; text-rendering: optimizeLegibility; font-family: Georgia, serif; letter-spacing: -0.01em; font-size: 32px; font-weight: 700; margin: 0; line-height: 1; color: #FFFFFF;\\"><span style=\\"white-space: pre-wrap;\\">Good news everyone!</span></h2>
                                                             </td>
                                                         </tr>
                                                         <tr>
                                                             <td class=\\"kg-header-card-subheading-wrapper\\" align=\\"center\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; padding: 16px 0 0; color: inherit;\\" valign=\\"top\\">
-                                                                <p class=\\"kg-header-card-subheading\\" style=\\"margin: 0; font-size: 17px; line-height: 1.5em; color: inherit;\\"><span style=\\"white-space: pre-wrap;\\">This header renders properly in </span><i><em class=\\"italic\\" style=\\"white-space: pre-wrap;\\">all</em></i><span style=\\"white-space: pre-wrap;\\"> email clients!</span></p>
+                                                                <p class=\\"kg-header-card-subheading\\" style=\\"margin: 0; font-size: 17px; line-height: 1.5; color: inherit;\\"><span style=\\"white-space: pre-wrap;\\">This header renders properly in </span><i><em class=\\"italic\\" style=\\"white-space: pre-wrap;\\">all</em></i><span style=\\"white-space: pre-wrap;\\"> email clients!</span></p>
                                                             </td>
                                                         </tr>
                                                         <tr>
@@ -10000,7 +10000,7 @@ Beautiful, modern publishing with newsletters and premium subscriptions built-in
                                             <v:oval fill=\\"t\\" strokecolor=\\"white\\" strokeweight=\\"4px\\" style=\\"position:absolute;left:261;top:186;width:78;height:78\\"><v:fill color=\\"black\\" opacity=\\"30%\\" /></v:oval>
                                             <v:shape coordsize=\\"24,32\\" path=\\"m,l,32,24,16,xe\\" fillcolor=\\"white\\" stroked=\\"f\\" style=\\"position:absolute;left:289;top:208;width:30;height:34;\\" />
                                         </v:group>
-                                        <![endif]--></div><div></div><p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em; color: #15212A;\\">Some text.</p><blockquote style=\\"margin: 0; padding: 0; border-left: #FF1A75 2px solid; font-size: 17px; font-weight: 500; line-height: 1.6em; letter-spacing: -0.2px;\\"><p style=\\"line-height: 1.6em; margin: 2em 25px; font-size: 1em; padding: 0; color: #15212A;\\">A blockquote</p></blockquote><p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em; color: #15212A;\\">Some more text.</p><div class=\\"kg-card kg-code-card\\" style=\\"margin: 0 0 1.5em; padding: 0;\\"><pre style=\\"white-space: pre-wrap; overflow: auto; background: #15212A; padding: 15px; border-radius: 3px; line-height: 1.2em; color: #ffffff;\\"><code class=\\"language-javascript\\" style=\\"font-size: 0.9em;\\">console.log(&#39;Hello world!&#39;);</code></pre><div class=\\"kg-card-figcaption\\" style=\\"text-align: center; font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; padding-top: 10px; padding-bottom: 10px; line-height: 1.5em; color: #15212a; color: rgba(0, 0, 0, 0.6); font-size: 13px;\\"><p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em; color: inherit;\\"><span style=\\"white-space: pre-wrap;\\">A tiny little script.</span></p></div></div><table cellspacing=\\"0\\" cellpadding=\\"4\\" border=\\"0\\" class=\\"kg-file-card\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: auto; width: 100%; margin: 0 0 1.5em 0; border-radius: 3px; background-color: #ffffff; background-color: rgba(255, 255, 255, 0.25); border: 1px solid #e0e7eb; border: 1px solid rgba(0, 0, 0, 0.12);\\" bgcolor=\\"rgba(255, 255, 255, 0.25)\\">
+                                        <![endif]--></div><div></div><p style=\\"margin: 0 0 1.5em 0; line-height: 1.6; color: #15212A;\\">Some text.</p><blockquote style=\\"margin: 0; padding: 0; border-left: #FF1A75 2px solid; font-size: 17px; font-weight: 500; line-height: 1.6; letter-spacing: -0.2px;\\"><p style=\\"line-height: 1.6; margin: 2em 25px; font-size: 1em; padding: 0; color: #15212A;\\">A blockquote</p></blockquote><p style=\\"margin: 0 0 1.5em 0; line-height: 1.6; color: #15212A;\\">Some more text.</p><div class=\\"kg-card kg-code-card\\" style=\\"margin: 0 0 1.5em; padding: 0;\\"><pre style=\\"white-space: pre-wrap; overflow: auto; background: #15212A; padding: 15px; border-radius: 3px; line-height: 1.2; color: #ffffff;\\"><code class=\\"language-javascript\\" style=\\"font-size: 0.9em;\\">console.log(&#39;Hello world!&#39;);</code></pre><div class=\\"kg-card-figcaption\\" style=\\"text-align: center; font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; padding-top: 10px; padding-bottom: 10px; line-height: 1.5; color: #15212a; color: rgba(0, 0, 0, 0.6); font-size: 13px;\\"><p style=\\"margin: 0 0 1.5em 0; line-height: 1.6; color: inherit;\\"><span style=\\"white-space: pre-wrap;\\">A tiny little script.</span></p></div></div><table cellspacing=\\"0\\" cellpadding=\\"4\\" border=\\"0\\" class=\\"kg-file-card\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: auto; width: 100%; margin: 0 0 1.5em 0; border-radius: 3px; background-color: #ffffff; background-color: rgba(255, 255, 255, 0.25); border: 1px solid #e0e7eb; border: 1px solid rgba(0, 0, 0, 0.12);\\" bgcolor=\\"rgba(255, 255, 255, 0.25)\\">
                                         <tbody><tr>
                                             <td style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A;\\" valign=\\"top\\">
                                                 <table cellspacing=\\"0\\" cellpadding=\\"0\\" border=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\">
@@ -10008,16 +10008,16 @@ Beautiful, modern publishing with newsletters and premium subscriptions built-in
                                                         <td valign=\\"middle\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; color: #15212A; vertical-align: middle;\\">
                                                             
                                                             <table cellspacing=\\"0\\" cellpadding=\\"0\\" border=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\"><tbody><tr><td style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A;\\" valign=\\"top\\">
-                                                                <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"kg-file-title\\" style=\\"display: block; width: 100%; padding-left: 12px; padding-top: 8px; font-size: 17px; font-weight: bold; line-height: 1.3em; overflow-wrap: anywhere; text-decoration: none; color: #15212A;\\" target=\\"_blank\\">test</a>
+                                                                <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"kg-file-title\\" style=\\"display: block; width: 100%; padding-left: 12px; padding-top: 8px; font-size: 17px; font-weight: bold; line-height: 1.3; overflow-wrap: anywhere; text-decoration: none; color: #15212A;\\" target=\\"_blank\\">test</a>
                                                             </td></tr></tbody></table>
                                                             
                                                             
                                                             <table cellspacing=\\"0\\" cellpadding=\\"0\\" border=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\"><tbody><tr><td style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A;\\" valign=\\"top\\">
-                                                                <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"kg-file-description\\" style=\\"display: block; width: 100%; padding-left: 12px; padding-top: 2px; font-size: 15px; line-height: 1.4em; overflow-wrap: anywhere; text-decoration: none; color: #15212a; color: rgba(0, 0, 0, 0.6);\\" target=\\"_blank\\">A tiny text file.</a>
+                                                                <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"kg-file-description\\" style=\\"display: block; width: 100%; padding-left: 12px; padding-top: 2px; font-size: 15px; line-height: 1.4; overflow-wrap: anywhere; text-decoration: none; color: #15212a; color: rgba(0, 0, 0, 0.6);\\" target=\\"_blank\\">A tiny text file.</a>
                                                             </td></tr></tbody></table>
                                                             
                                                             <table cellspacing=\\"0\\" cellpadding=\\"0\\" border=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\"><tbody><tr><td style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A;\\" valign=\\"top\\">
-                                                                <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"kg-file-meta\\" style=\\"display: block; width: 100%; padding-left: 12px; padding-top: 4px; padding-bottom: 8px; font-size: 13px; line-height: 1.4em; overflow-wrap: anywhere; color: #FF1A75; text-decoration: none;\\" target=\\"_blank\\"><span class=\\"kg-file-name\\" style=\\"font-weight: 500; color: #15212A;\\">test.txt</span> &#x2022; 16 Bytes</a>
+                                                                <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"kg-file-meta\\" style=\\"display: block; width: 100%; padding-left: 12px; padding-top: 4px; padding-bottom: 8px; font-size: 13px; line-height: 1.4; overflow-wrap: anywhere; color: #FF1A75; text-decoration: none;\\" target=\\"_blank\\"><span class=\\"kg-file-name\\" style=\\"font-weight: 500; color: #15212A;\\">test.txt</span> &#x2022; 16 Bytes</a>
                                                             </td></tr></tbody></table>
                                                         </td>
                                                         <td width=\\"80\\" valign=\\"middle\\" class=\\"kg-file-thumbnail\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; color: #15212A; position: relative; vertical-align: middle; text-align: center; border-radius: 2px; background-color: #FF1A75;\\" align=\\"center\\" bgcolor=\\"#FF1A75\\">
@@ -10036,7 +10036,7 @@ Beautiful, modern publishing with newsletters and premium subscriptions built-in
                                                     <table border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\">
                                                         <tbody><tr>
                                                             <td class=\\"kg-cta-sponsor-label\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A; padding: 12px 0; border-bottom: 1px solid #e0e7eb; padding-top: 0; border-color: #e0e7eb;\\" valign=\\"top\\">
-                                                                <p style=\\"line-height: 1.6em; margin: 0; font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 12px; font-weight: 500; text-transform: uppercase; color: inherit;\\"><span style=\\"color: #15212a; color: rgba(0, 0, 0, 0.6); white-space: pre-wrap;\\">SPONSORED test card</span></p>
+                                                                <p style=\\"line-height: 1.6; margin: 0; font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 12px; font-weight: 500; text-transform: uppercase; color: inherit;\\"><span style=\\"color: #15212a; color: rgba(0, 0, 0, 0.6); white-space: pre-wrap;\\">SPONSORED test card</span></p>
                                                             </td>
                                                         </tr>
                                                     </tbody></table>
@@ -10050,7 +10050,7 @@ Beautiful, modern publishing with newsletters and premium subscriptions built-in
                                                     
                                                     <tbody><tr>
                                                         <td class=\\"kg-cta-text\\" style=\\"font-size: 18px; vertical-align: top; color: #15212A; font-family: Georgia, serif;\\" valign=\\"top\\">
-                                                            <p dir=\\"ltr\\" style=\\"margin: 0 0 1.5em 0; margin-bottom: 0; text-align: center; line-height: 1.6em; color: #15212A;\\"><span style=\\"white-space: pre-wrap;\\">Here&#x2019;s a basic CTA card</span></p>
+                                                            <p dir=\\"ltr\\" style=\\"margin: 0 0 1.5em 0; margin-bottom: 0; text-align: center; line-height: 1.6; color: #15212A;\\"><span style=\\"white-space: pre-wrap;\\">Here&#x2019;s a basic CTA card</span></p>
                                                         </td>
                                                     </tr>
                                                     
@@ -10064,7 +10064,7 @@ Beautiful, modern publishing with newsletters and premium subscriptions built-in
                                             </td>
                                         </tr>
                                     
-                                    </tbody></table><table class=\\"kg-card kg-transistor-card\\" cellspacing=\\"0\\" cellpadding=\\"0\\" border=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: auto; width: 100%; margin: 0 auto 1.5em; border-radius: 10px; background-color: #ffffff; background-color: rgba(255, 255, 255, 0.25); border: 1px solid #e0e7eb; border: 1px solid rgba(0, 0, 0, 0.12); margin-top: 1.5em;\\" bgcolor=\\"rgba(255, 255, 255, 0.25)\\"><tbody><tr><td style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A; padding: 24px; text-align: center;\\" align=\\"center\\" valign=\\"top\\"><table cellspacing=\\"0\\" cellpadding=\\"0\\" border=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; text-align: center;\\" align=\\"center\\"><tbody><tr><td style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A; text-align: center; padding-bottom: 12px;\\" align=\\"center\\" valign=\\"top\\"><a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" style=\\"overflow-wrap: anywhere; color: #FF1A75; text-decoration: underline; display: inline-block; width: 72px; height: 72px; padding-top: 4px; padding-right: 4px; padding-bottom: 4px; padding-left: 4px; border-radius: 8px; background-color: #FF1A75;\\" target=\\"_blank\\"><img src=\\"https://static.ghost.org/v6.0.0/images/transistor-logo-ondark.png\\" width=\\"40\\" height=\\"40\\" alt=\\"Transistor\\" style=\\"border: none; -ms-interpolation-mode: bicubic; max-width: 100%; width: 40px; height: 40px; padding: 16px;\\"></a></td></tr><tr><td style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A; text-align: center;\\" align=\\"center\\" valign=\\"top\\"><a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"kg-transistor-title\\" style=\\"display: block; padding-right: 20px; padding-bottom: 4px; padding-top: 4px; font-size: 17px; font-weight: 600; line-height: 18px; overflow-wrap: anywhere; text-decoration: none; color: #15212A;\\" target=\\"_blank\\"> Listen to your podcasts </a><a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"kg-transistor-description\\" style=\\"display: inline-block; max-width: 400px; font-size: 14px; line-height: 1.4em; overflow-wrap: anywhere; text-decoration: none; color: #15212a; color: rgba(0, 0, 0, 0.6);\\" target=\\"_blank\\"> Subscribe and listen to your personal podcast feed in your favorite app. </a></td></tr></tbody></table></td></tr></tbody></table>
+                                    </tbody></table><table class=\\"kg-card kg-transistor-card\\" cellspacing=\\"0\\" cellpadding=\\"0\\" border=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: auto; width: 100%; margin: 0 auto 1.5em; border-radius: 10px; background-color: #ffffff; background-color: rgba(255, 255, 255, 0.25); border: 1px solid #e0e7eb; border: 1px solid rgba(0, 0, 0, 0.12); margin-top: 1.5em;\\" bgcolor=\\"rgba(255, 255, 255, 0.25)\\"><tbody><tr><td style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A; padding: 24px; text-align: center;\\" align=\\"center\\" valign=\\"top\\"><table cellspacing=\\"0\\" cellpadding=\\"0\\" border=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; text-align: center;\\" align=\\"center\\"><tbody><tr><td style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A; text-align: center; padding-bottom: 12px;\\" align=\\"center\\" valign=\\"top\\"><a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" style=\\"overflow-wrap: anywhere; color: #FF1A75; text-decoration: underline; display: inline-block; width: 72px; height: 72px; padding-top: 4px; padding-right: 4px; padding-bottom: 4px; padding-left: 4px; border-radius: 8px; background-color: #FF1A75;\\" target=\\"_blank\\"><img src=\\"https://static.ghost.org/v6.0.0/images/transistor-logo-ondark.png\\" width=\\"40\\" height=\\"40\\" alt=\\"Transistor\\" style=\\"border: none; -ms-interpolation-mode: bicubic; max-width: 100%; width: 40px; height: 40px; padding: 16px;\\"></a></td></tr><tr><td style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A; text-align: center;\\" align=\\"center\\" valign=\\"top\\"><a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"kg-transistor-title\\" style=\\"display: block; padding-right: 20px; padding-bottom: 4px; padding-top: 4px; font-size: 17px; font-weight: 600; line-height: 1.125; overflow-wrap: anywhere; text-decoration: none; color: #15212A;\\" target=\\"_blank\\"> Listen to your podcasts </a><a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"kg-transistor-description\\" style=\\"display: inline-block; max-width: 400px; font-size: 14px; line-height: 1.4; overflow-wrap: anywhere; text-decoration: none; color: #15212a; color: rgba(0, 0, 0, 0.6);\\" target=\\"_blank\\"> Subscribe and listen to your personal podcast feed in your favorite app. </a></td></tr></tbody></table></td></tr></tbody></table>
                                                                             <!-- POST CONTENT END -->
                             
                                                                         </td>
@@ -10082,7 +10082,7 @@ Beautiful, modern publishing with newsletters and premium subscriptions built-in
                                                             <td class=\\"wrapper\\" align=\\"center\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; font-size: 18px; vertical-align: top; color: #15212A; box-sizing: border-box;\\" valign=\\"top\\">
                                                                 <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; padding-top: 40px; padding-bottom: 30px;\\">
                                                                     <tr>
-                                                                        <td class=\\"footer\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; color: #15212a; color: rgba(0, 0, 0, 0.6); margin-top: 20px; text-align: center; padding-bottom: 10px; padding-top: 10px; padding-left: 30px; padding-right: 30px; line-height: 1.5em; font-size: 13px;\\" valign=\\"top\\" align=\\"center\\">Ghost &#xA9; 2025 &#x2013; <a href=\\"http://127.0.0.1:2369/unsubscribe/?uuid=member-uuid&key=xxxxxx&newsletter=requested-newsletter-uuid\\" style=\\"overflow-wrap: anywhere; color: #15212a; color: rgba(0, 0, 0, 0.6); text-decoration: underline; font-size: 13px;\\" target=\\"_blank\\">Unsubscribe</a></td>
+                                                                        <td class=\\"footer\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; color: #15212a; color: rgba(0, 0, 0, 0.6); margin-top: 20px; text-align: center; padding-bottom: 10px; padding-top: 10px; padding-left: 30px; padding-right: 30px; line-height: 1.5; font-size: 13px;\\" valign=\\"top\\" align=\\"center\\">Ghost &#xA9; 2025 &#x2013; <a href=\\"http://127.0.0.1:2369/unsubscribe/?uuid=member-uuid&key=xxxxxx&newsletter=requested-newsletter-uuid\\" style=\\"overflow-wrap: anywhere; color: #15212a; color: rgba(0, 0, 0, 0.6); text-decoration: underline; font-size: 13px;\\" target=\\"_blank\\">Unsubscribe</a></td>
                                                                     </tr>
                             
                                                                         <tr>


### PR DESCRIPTION
ref https://linear.app/ghost/issue/DES-1306/text-size-issues-when-using-accessibility-features-on-iphones

When iPhone users increase text size via iOS Dynamic Type, Ghost newsletter emails have excessively large line spacing, making them nearly unreadable. The root cause is em-based line-height values in the email template — when Dynamic Type scales font sizes, em line-heights compound the scaling.                                                                                                                              
                                                                                                                                                                                                                     
This converts all line-height: Xem values to unitless line-height: X in the email stylesheet. Unitless values are the recommended best practice for email accessibility, as they scale proportionally without compounding. 