### PR TITLE
Fixed broken tableRow dark mode state

### DIFF
--- a/apps/admin-x-design-system/src/global/table-cell.tsx
+++ b/apps/admin-x-design-system/src/global/table-cell.tsx
@@ -4,7 +4,7 @@ import React, {HTMLProps} from 'react';
 export interface TableCellProps extends HTMLProps<HTMLTableCellElement> {
     padding?: boolean;
     align?: 'left' | 'center' | 'right';
-    valign?: 'top' | 'center' | 'bottom';
+    valign?: 'top' | 'middle' | 'bottom';
 }
 
 const TableCell: React.FC<TableCellProps> = ({
@@ -20,7 +20,7 @@ const TableCell: React.FC<TableCellProps> = ({
         (align === 'center' && 'text-center'),
         (align === 'right' && 'text-right'),
         (valign === 'top' && 'align-top'),
-        (valign === 'center' && 'align-center'),
+        (valign === 'middle' && 'align-middle'),
         (valign === 'bottom' && 'align-bottom'),
         props.onClick && 'hover:cursor-pointer',
         className

--- a/apps/admin-x-design-system/src/global/table-row.tsx
+++ b/apps/admin-x-design-system/src/global/table-row.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
 import React, {forwardRef} from 'react';
 
-export const tableRowHoverBgClasses = 'before:absolute before:inset-x-[-16px] before:top-[-1px] before:bottom-0 before:bg-grey-50 before:opacity-0 hover:before:opacity-100 before:rounded-md before:transition-opacity before:dark:bg-grey-950 hover:z-10';
+export const tableRowHoverBgClasses = 'before:absolute before:inset-x-[-16px] before:top-[-1px] before:bottom-0 before:bg-grey-50 before:opacity-0 hover:before:opacity-100 before:rounded-md before:transition-opacity dark:before:bg-grey-950 hover:z-10';
 
 export interface TableRowProps {
     id?: string;

--- a/apps/admin-x-settings/src/components/settings/growth/recommendations/incoming-recommendation-list.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/recommendations/incoming-recommendation-list.tsx
@@ -63,7 +63,7 @@ const IncomingRecommendationItem: React.FC<{incomingRecommendation: IncomingReco
                     </div>
                 </div>
             </TableCell>
-            <TableCell className='md:visible! md:table-cell! hidden w-auto whitespace-nowrap text-left' padding={false} valign="center" onClick={showDetails}>
+            <TableCell className='md:visible! md:table-cell! hidden w-auto whitespace-nowrap text-left' padding={false} valign="middle" onClick={showDetails}>
                 {(signups === 0) ? (
                     <span className="text-grey-500 dark:text-grey-900">-</span>
                 ) : (
@@ -72,7 +72,7 @@ const IncomingRecommendationItem: React.FC<{incomingRecommendation: IncomingReco
                     </div>
                 )}
             </TableCell>
-            <TableCell className='md:visible! md:table-cell! hidden w-[1%] whitespace-nowrap' valign="center" onClick={showDetails}>
+            <TableCell className='md:visible! md:table-cell! hidden w-[1%] whitespace-nowrap' valign="middle" onClick={showDetails}>
                 {(signups === 0) ? (null) : (
                     <div className='-mt-px text-left'>
                         <span className='-mb-px inline-block min-w-[60px] whitespace-nowrap text-left text-sm lowercase text-grey-700'>{freeMembersLabel}</span>

--- a/apps/admin-x-settings/src/components/settings/growth/recommendations/incoming-recommendation-list.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/recommendations/incoming-recommendation-list.tsx
@@ -63,7 +63,7 @@ const IncomingRecommendationItem: React.FC<{incomingRecommendation: IncomingReco
                     </div>
                 </div>
             </TableCell>
-            <TableCell className='md:visible! md:table-cell! hidden w-auto whitespace-nowrap text-left align-middle' padding={false} onClick={showDetails}>
+            <TableCell className='md:visible! md:table-cell! hidden w-auto whitespace-nowrap text-left' padding={false} valign="center" onClick={showDetails}>
                 {(signups === 0) ? (
                     <span className="text-grey-500 dark:text-grey-900">-</span>
                 ) : (
@@ -72,7 +72,7 @@ const IncomingRecommendationItem: React.FC<{incomingRecommendation: IncomingReco
                     </div>
                 )}
             </TableCell>
-            <TableCell className='md:visible! md:table-cell! hidden w-[1%] whitespace-nowrap align-middle' onClick={showDetails}>
+            <TableCell className='md:visible! md:table-cell! hidden w-[1%] whitespace-nowrap' valign="center" onClick={showDetails}>
                 {(signups === 0) ? (null) : (
                     <div className='-mt-px text-left'>
                         <span className='-mb-px inline-block min-w-[60px] whitespace-nowrap text-left text-sm lowercase text-grey-700'>{freeMembersLabel}</span>


### PR DESCRIPTION
Closes https://linear.app/ghost/issue/DES-1312/broken-settings-hover-states-in-dark-mode

The migration from TW v3 to v4 changed some selector ordering. This PR fixes that and also some alignment issues in the recommendations tab.

| Before | After |
|--------|--------|
| <img width="700" height="604" alt="Screenshot 2026-03-16 at 09 35 25" src="https://github.com/user-attachments/assets/b17e964a-a06c-45e6-9c70-b3bc9ff14768" /> | <img width="700" height="611" alt="Screenshot 2026-03-16 at 09 34 07" src="https://github.com/user-attachments/assets/634ccf48-f366-49e3-a825-6bd3be38697b" /> |
| <img width="692" height="123" alt="Screenshot 2026-03-16 at 09 34 58" src="https://github.com/user-attachments/assets/36f9f9af-ddbb-4f5d-9573-6db58119a965" /> | <img width="687" height="124" alt="Screenshot 2026-03-16 at 09 34 30" src="https://github.com/user-attachments/assets/b1c8d964-a6d9-4e3c-8c53-b27fcf4bae78" /> | 
