### PR TITLE
Fixed broken Transistor dark mode

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/integrations/transistor-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/integrations/transistor-modal.tsx
@@ -122,7 +122,7 @@ const TransistorModal = NiceModal.create(() => {
                 </Form>
                 {enabled &&
                     <div className='mt-5 flex flex-col items-center'>
-                        <a className='w-100 flex flex-col items-stretch justify-between overflow-hidden rounded-md bg-grey-75 transition-all hover:border-grey-400 hover:bg-grey-100 md:flex-row' href="https://ghost.org/integrations/transistor/" rel="noopener noreferrer" target="_blank">
+                        <a className='w-100 flex flex-col items-stretch justify-between overflow-hidden rounded-md bg-grey-75 transition-all hover:border-grey-400 hover:bg-grey-100 md:flex-row dark:bg-grey-925 dark:hover:bg-grey-950' href="https://ghost.org/integrations/transistor/" rel="noopener noreferrer" target="_blank">
                             <div className='order-2 px-7 py-5 md:order-1'>
                                 <div className='font-semibold'>How to use Transistor in Ghost</div>
                                 <div className='mt-1 text-sm text-grey-800 dark:text-grey-500'>Learn more about connecting Transistor with Ghost to offer members access to private podcasts in Portal or as an embed in posts and pages with a custom Transistor card.</div>


### PR DESCRIPTION
Closes https://linear.app/ghost/issue/DES-1313/fix-dark-mode-issue-in-transistor-modal

We weren't using any dark mode classes for the bookmark in the Transistor modal.

| Before | After |
|--------|--------|
| <img width="765" height="734" alt="Screenshot 2026-03-16 at 12 37 07" src="https://github.com/user-attachments/assets/cb225035-d4b1-44a0-aa67-27379afea7a9" /> | <img width="766" height="730" alt="Screenshot 2026-03-16 at 12 36 42" src="https://github.com/user-attachments/assets/cda62a6e-c6b4-4564-9fab-4e983d6592d8" /> | 
