### PR TITLE
Reworked comment moderation filters on the shared filter core

### DIFF
--- a/apps/posts/src/views/comments/comment-fields.test.ts
+++ b/apps/posts/src/views/comments/comment-fields.test.ts
@@ -1,0 +1,94 @@
+import {commentFields} from './comment-fields';
+import {describe, expect, it} from 'vitest';
+import type {CodecContext, FilterPredicate} from '../filters/filter-types';
+
+const createdAtContext: CodecContext = {
+    key: 'created_at',
+    pattern: 'created_at',
+    params: {},
+    timezone: 'UTC'
+};
+
+const reportedContext: CodecContext = {
+    key: 'reported',
+    pattern: 'reported',
+    params: {},
+    timezone: 'UTC'
+};
+
+describe('commentFields', () => {
+    it('defines the expected comment field set', () => {
+        expect(Object.keys(commentFields)).toEqual([
+            'id',
+            'status',
+            'created_at',
+            'body',
+            'post',
+            'author',
+            'reported'
+        ]);
+    });
+
+    it('keeps the expected static picker config for resource selects', () => {
+        expect(commentFields.author).toMatchObject({
+            operators: ['is', 'is-not'],
+            ui: {
+                label: 'Author',
+                type: 'select',
+                searchable: true,
+                className: 'w-80',
+                popoverContentClassName: 'w-80'
+            }
+        });
+
+        expect(commentFields.post).toMatchObject({
+            operators: ['is', 'is-not'],
+            ui: {
+                label: 'Post',
+                type: 'select',
+                searchable: true,
+                className: 'w-full max-w-80',
+                popoverContentClassName: 'w-full max-w-[calc(100vw-32px)] max-w-80'
+            }
+        });
+    });
+
+    it('uses local codecs for comment-specific fields', () => {
+        expect(commentFields.created_at.codec).not.toBe(commentFields.status.codec);
+        expect(commentFields.reported.codec).not.toBe(commentFields.status.codec);
+    });
+});
+
+describe('commentDateCodec', () => {
+    it('serializes exact dates as UTC day bounds', () => {
+        const predicate: FilterPredicate = {
+            id: '1',
+            field: 'created_at',
+            operator: 'is',
+            values: ['2024-01-01']
+        };
+
+        expect(commentFields.created_at.codec.serialize(predicate, createdAtContext)).toEqual([
+            'created_at:>=\'2024-01-01T00:00:00.000Z\'',
+            'created_at:<=\'2024-01-01T23:59:59.999Z\''
+        ]);
+    });
+});
+
+describe('reportedCodec', () => {
+    it('serializes reported yes/no state', () => {
+        expect(commentFields.reported.codec.serialize({
+            id: '1',
+            field: 'reported',
+            operator: 'is',
+            values: ['true']
+        }, reportedContext)).toEqual(['count.reports:>0']);
+
+        expect(commentFields.reported.codec.serialize({
+            id: '2',
+            field: 'reported',
+            operator: 'is',
+            values: ['false']
+        }, reportedContext)).toEqual(['count.reports:0']);
+    });
+});

--- a/apps/posts/src/views/comments/comment-fields.ts
+++ b/apps/posts/src/views/comments/comment-fields.ts
@@ -1,0 +1,195 @@
+import {defineFields} from '../filters/filter-types';
+import {extractComparator} from '../filters/filter-ast';
+import {getDayBoundsInUtc} from '../filters/filter-normalization';
+import {scalarCodec, textCodec} from '../filters/filter-codecs';
+import type {FilterCodec} from '../filters/filter-types';
+
+const commentDateCodec: FilterCodec = {
+    parse(node, ctx) {
+        const comparator = extractComparator(node as Record<string, unknown>);
+
+        if (!comparator || comparator.field !== ctx.key) {
+            return null;
+        }
+
+        if (typeof comparator.value !== 'string') {
+            return null;
+        }
+
+        if (comparator.operator === '$lt') {
+            return {
+                field: ctx.key,
+                operator: 'before',
+                values: [comparator.value]
+            };
+        }
+
+        if (comparator.operator === '$gt') {
+            return {
+                field: ctx.key,
+                operator: 'after',
+                values: [comparator.value]
+            };
+        }
+
+        return null;
+    },
+    serialize(predicate, ctx) {
+        const value = predicate.values[0];
+
+        if (typeof value !== 'string' || !value) {
+            return null;
+        }
+
+        if (predicate.operator === 'before') {
+            return [`${ctx.key}:<'${value}'`];
+        }
+
+        if (predicate.operator === 'after') {
+            return [`${ctx.key}:>'${value}'`];
+        }
+
+        if (predicate.operator === 'is') {
+            const {start, end} = getDayBoundsInUtc(value, ctx.timezone);
+
+            return [
+                `${ctx.key}:>='${start}'`,
+                `${ctx.key}:<='${end}'`
+            ];
+        }
+
+        return null;
+    }
+};
+
+const reportedCodec: FilterCodec = {
+    parse(node, ctx) {
+        const comparator = extractComparator(node as Record<string, unknown>);
+
+        if (!comparator || comparator.field !== 'count.reports') {
+            return null;
+        }
+
+        if (comparator.operator === '$eq' && comparator.value === 0) {
+            return {
+                field: ctx.key,
+                operator: 'is',
+                values: ['false']
+            };
+        }
+
+        if (comparator.operator === '$gt' && comparator.value === 0) {
+            return {
+                field: ctx.key,
+                operator: 'is',
+                values: ['true']
+            };
+        }
+
+        return null;
+    },
+    serialize(predicate) {
+        const value = predicate.values[0];
+
+        if (predicate.operator !== 'is') {
+            return null;
+        }
+
+        if (value === 'true') {
+            return ['count.reports:>0'];
+        }
+
+        if (value === 'false') {
+            return ['count.reports:0'];
+        }
+
+        return null;
+    }
+};
+
+export const commentFields = defineFields({
+    id: {
+        operators: ['is'],
+        ui: {
+            label: 'ID',
+            type: 'text',
+            hidden: true
+        },
+        codec: scalarCodec()
+    },
+    status: {
+        operators: ['is'],
+        ui: {
+            label: 'Status',
+            type: 'select',
+            searchable: false,
+            hideOperatorSelect: true
+        },
+        options: [
+            {value: 'published', label: 'Published'},
+            {value: 'hidden', label: 'Hidden'}
+        ],
+        codec: scalarCodec()
+    },
+    created_at: {
+        operators: ['is', 'before', 'after'],
+        ui: {
+            label: 'Date',
+            type: 'date',
+            className: 'w-full max-w-32'
+        },
+        codec: commentDateCodec
+    },
+    body: {
+        operators: ['contains', 'does-not-contain'],
+        parseKeys: ['html'],
+        ui: {
+            label: 'Text',
+            type: 'text',
+            placeholder: 'Search comment text...',
+            defaultOperator: 'contains',
+            className: 'w-full max-w-48',
+            popoverContentClassName: 'w-full max-w-48'
+        },
+        codec: textCodec({field: 'html'})
+    },
+    post: {
+        operators: ['is', 'is-not'],
+        parseKeys: ['post_id'],
+        ui: {
+            label: 'Post',
+            type: 'select',
+            searchable: true,
+            className: 'w-full max-w-80',
+            popoverContentClassName: 'w-full max-w-[calc(100vw-32px)] max-w-80'
+        },
+        codec: scalarCodec({field: 'post_id'})
+    },
+    author: {
+        operators: ['is', 'is-not'],
+        parseKeys: ['member_id'],
+        ui: {
+            label: 'Author',
+            type: 'select',
+            searchable: true,
+            className: 'w-80',
+            popoverContentClassName: 'w-80'
+        },
+        codec: scalarCodec({field: 'member_id'})
+    },
+    reported: {
+        operators: ['is'],
+        parseKeys: ['count.reports'],
+        ui: {
+            label: 'Reported',
+            type: 'select',
+            searchable: false,
+            hideOperatorSelect: true
+        },
+        options: [
+            {value: 'true', label: 'Yes'},
+            {value: 'false', label: 'No'}
+        ],
+        codec: reportedCodec
+    }
+});

--- a/apps/posts/src/views/comments/comment-filter-query.test.ts
+++ b/apps/posts/src/views/comments/comment-filter-query.test.ts
@@ -1,0 +1,159 @@
+import {describe, expect, it} from 'vitest';
+import {parseCommentFilter, serializeCommentFilters} from './comment-filter-query';
+import type {FilterPredicate} from '../filters/filter-types';
+
+function stripIds(predicates: FilterPredicate[]) {
+    return predicates.map(predicate => ({
+        field: predicate.field,
+        operator: predicate.operator,
+        values: predicate.values
+    }));
+}
+
+describe('comment-filter-query', () => {
+    it('parses exact-date compounds into a single predicate', () => {
+        const predicates = parseCommentFilter(
+            'created_at:>=\'2024-01-01T00:00:00.000Z\'+created_at:<=\'2024-01-01T23:59:59.999Z\'',
+            'UTC'
+        );
+
+        expect(stripIds(predicates)).toEqual([
+            {
+                field: 'created_at',
+                operator: 'is',
+                values: ['2024-01-01']
+            }
+        ]);
+    });
+
+    it('serializes exact-date compounds canonically', () => {
+        const predicates: FilterPredicate[] = [
+            {
+                id: '1',
+                field: 'created_at',
+                operator: 'is',
+                values: ['2024-01-01']
+            }
+        ];
+
+        expect(serializeCommentFilters(predicates, 'UTC')).toBe(
+            'created_at:<=\'2024-01-01T23:59:59.999Z\'+created_at:>=\'2024-01-01T00:00:00.000Z\''
+        );
+    });
+
+    it('round-trips exact-date compounds in site timezones', () => {
+        const parsed = parseCommentFilter(
+            'created_at:>=\'2024-01-31T23:00:00.000Z\'+created_at:<=\'2024-02-01T22:59:59.999Z\'',
+            'Europe/Stockholm'
+        );
+
+        expect(stripIds(parsed)).toEqual([
+            {
+                field: 'created_at',
+                operator: 'is',
+                values: ['2024-02-01']
+            }
+        ]);
+
+        expect(serializeCommentFilters(parsed, 'Europe/Stockholm')).toBe(
+            'created_at:<=\'2024-02-01T22:59:59.999Z\'+created_at:>=\'2024-01-31T23:00:00.000Z\''
+        );
+    });
+
+    it('parses and serializes reported filters', () => {
+        const parsed = parseCommentFilter('count.reports:>0', 'UTC');
+
+        expect(stripIds(parsed)).toEqual([
+            {
+                field: 'reported',
+                operator: 'is',
+                values: ['true']
+            }
+        ]);
+
+        expect(serializeCommentFilters(parsed, 'UTC')).toBe('count.reports:>0');
+    });
+
+    it('round-trips the id quick filter canonically', () => {
+        const parsed = parseCommentFilter('id:comment_123', 'UTC');
+
+        expect(stripIds(parsed)).toEqual([
+            {
+                field: 'id',
+                operator: 'is',
+                values: ['comment_123']
+            }
+        ]);
+
+        expect(serializeCommentFilters(parsed, 'UTC')).toBe('id:comment_123');
+    });
+
+    it('sorts clauses canonically on serialize', () => {
+        const predicates: FilterPredicate[] = [
+            {id: '2', field: 'status', operator: 'is', values: ['published']},
+            {id: '1', field: 'reported', operator: 'is', values: ['false']}
+        ];
+
+        expect(serializeCommentFilters(predicates, 'UTC')).toBe('count.reports:0+status:published');
+    });
+
+    it('round-trips canonical comment examples', () => {
+        const filter = 'count.reports:0+created_at:>=\'2024-01-01T00:00:00.000Z\'+created_at:<=\'2024-01-01T23:59:59.999Z\'+status:published';
+        const parsed = parseCommentFilter(filter, 'UTC');
+
+        expect(serializeCommentFilters(parsed, 'UTC')).toBe(
+            'count.reports:0+created_at:<=\'2024-01-01T23:59:59.999Z\'+created_at:>=\'2024-01-01T00:00:00.000Z\'+status:published'
+        );
+    });
+
+    it('claims exact-date compounds before leaving leftovers to simple dispatch', () => {
+        const parsed = parseCommentFilter(
+            'created_at:>=\'2024-01-01T00:00:00.000Z\'+created_at:<=\'2024-01-01T23:59:59.999Z\'+id:comment_123',
+            'UTC'
+        );
+
+        expect(stripIds(parsed)).toEqual([
+            {
+                field: 'created_at',
+                operator: 'is',
+                values: ['2024-01-01']
+            },
+            {
+                field: 'id',
+                operator: 'is',
+                values: ['comment_123']
+            }
+        ]);
+    });
+
+    it('parses nested exact-date compounds recursively', () => {
+        const parsed = parseCommentFilter(
+            '((created_at:>=\'2024-01-01T00:00:00.000Z\'+created_at:<=\'2024-01-01T23:59:59.999Z\')+status:published)',
+            'UTC'
+        );
+
+        expect(stripIds(parsed)).toEqual([
+            {
+                field: 'created_at',
+                operator: 'is',
+                values: ['2024-01-01']
+            },
+            {
+                field: 'status',
+                operator: 'is',
+                values: ['published']
+            }
+        ]);
+    });
+
+    it('ignores malformed NQL input', () => {
+        expect(parseCommentFilter('created_at:(', 'UTC')).toEqual([]);
+    });
+
+    it('ignores invalid exact-date compounds', () => {
+        expect(parseCommentFilter(
+            'created_at:>=\'not-a-date\'+created_at:<=\'2024-01-01T23:59:59.999Z\'',
+            'UTC'
+        )).toEqual([]);
+    });
+});

--- a/apps/posts/src/views/comments/comment-filter-query.ts
+++ b/apps/posts/src/views/comments/comment-filter-query.ts
@@ -1,0 +1,102 @@
+import moment from 'moment-timezone';
+import {commentFields} from './comment-fields';
+import {dispatchSimpleNodes, parseFilterToAst, serializePredicates, stampPredicates} from '../filters/filter-query-core';
+import {getDayBoundsInUtc} from '../filters/filter-normalization';
+import type {AstNode} from '../filters/filter-ast';
+import type {FilterPredicate, ParsedPredicate} from '../filters/filter-types';
+
+interface ExactDateMatchResult {
+    predicate: ParsedPredicate | null;
+    remainingChildren: AstNode[];
+}
+
+function extractCreatedAtComparator(node: AstNode): {operator: string; value: string} | null {
+    const createdAt = node.created_at;
+
+    if (!createdAt || typeof createdAt !== 'object' || Array.isArray(createdAt)) {
+        return null;
+    }
+
+    const [operator, value] = Object.entries(createdAt as Record<string, unknown>)[0] ?? [];
+
+    if (!operator || typeof value !== 'string') {
+        return null;
+    }
+
+    return {operator, value};
+}
+
+function matchExactDateCompound(children: AstNode[], timezone: string): ExactDateMatchResult {
+    for (let index = 0; index < children.length; index += 1) {
+        const lowerBound = extractCreatedAtComparator(children[index]);
+
+        if (!lowerBound || lowerBound.operator !== '$gte') {
+            continue;
+        }
+
+        const parsed = moment.tz(lowerBound.value, moment.ISO_8601, true, timezone);
+
+        if (!parsed.isValid()) {
+            continue;
+        }
+
+        const date = parsed.format('YYYY-MM-DD');
+        const {start, end} = getDayBoundsInUtc(date, timezone);
+
+        if (lowerBound.value !== start) {
+            continue;
+        }
+
+        const upperBoundIndex = children.findIndex((child, candidateIndex) => {
+            if (candidateIndex === index) {
+                return false;
+            }
+
+            const comparator = extractCreatedAtComparator(child);
+            return comparator?.operator === '$lte' && comparator.value === end;
+        });
+
+        if (upperBoundIndex === -1) {
+            continue;
+        }
+
+        return {
+            predicate: {
+                field: 'created_at',
+                operator: 'is',
+                values: [date]
+            },
+            remainingChildren: children.filter((_, candidateIndex) => candidateIndex !== index && candidateIndex !== upperBoundIndex)
+        };
+    }
+
+    return {
+        predicate: null,
+        remainingChildren: children
+    };
+}
+
+function parseCommentNode(node: AstNode, timezone: string): ParsedPredicate[] {
+    if (Array.isArray(node.$and)) {
+        const {predicate, remainingChildren} = matchExactDateCompound(node.$and as AstNode[], timezone);
+        const simplePredicates = remainingChildren.flatMap(child => parseCommentNode(child, timezone));
+
+        return predicate ? [predicate, ...simplePredicates] : simplePredicates;
+    }
+
+    return dispatchSimpleNodes([node], commentFields, timezone);
+}
+
+export function parseCommentFilter(filter: string | undefined, timezone: string): FilterPredicate[] {
+    const ast = parseFilterToAst(filter ?? '');
+
+    if (!ast) {
+        return [];
+    }
+
+    return stampPredicates(parseCommentNode(ast, timezone));
+}
+
+export function serializeCommentFilters(predicates: FilterPredicate[], timezone: string): string | undefined {
+    return serializePredicates(predicates, commentFields, timezone);
+}

--- a/apps/posts/src/views/comments/comments.tsx
+++ b/apps/posts/src/views/comments/comments.tsx
@@ -35,8 +35,9 @@ const Comments: React.FC = () => {
 
     const {knownPosts, knownMembers} = useKnownFilterValues({comments: data?.comments ?? []});
 
-    // If we are fetching comments, but not fetching the next page and not refetching, we should show the loading indicator
-    const shouldShowLoading = isFetching && !isFetchingNextPage && !isRefetching;
+    // Keep showing the spinner while refetching into or out of an empty result set.
+    const shouldShowLoading = isFetching && !isFetchingNextPage && (!isRefetching || !(data?.comments.length));
+    const hasFilters = filters.length > 0;
 
     return (
         <CommentsLayout>
@@ -69,11 +70,20 @@ const Comments: React.FC = () => {
                     </div>
                 ) : !data?.comments.length ? (
                     <div className="flex h-full items-center justify-center">
-                        <EmptyIndicator
-                            title="No comments yet"
-                        >
-                            <LucideIcon.MessageSquare />
-                        </EmptyIndicator>
+                        {hasFilters ? (
+                            <div className="flex flex-col items-center">
+                                <EmptyIndicator title="No comments match the current filter">
+                                    <LucideIcon.MessageSquare />
+                                </EmptyIndicator>
+                                <Button className="mt-4" variant="outline" onClick={() => clearFilters({replace: false})}>
+                                    Show all comments
+                                </Button>
+                            </div>
+                        ) : (
+                            <EmptyIndicator title="No comments yet">
+                                <LucideIcon.MessageSquare />
+                            </EmptyIndicator>
+                        )}
                     </div>
                 ) : (
                     <>

--- a/apps/posts/src/views/comments/components/comment-header.tsx
+++ b/apps/posts/src/views/comments/components/comment-header.tsx
@@ -56,7 +56,7 @@ export function CommentHeader({
                 <div className="whitespace-nowrap">
                     {memberId && onAuthorClick ? (
                         <Button
-                            className="text-primary flex h-auto items-center gap-1.5 truncate p-0 font-semibold hover:opacity-70"
+                            className="flex h-auto items-center gap-1.5 truncate p-0 font-semibold text-primary hover:opacity-70"
                             variant="link"
                             onClick={onAuthorClick}
                         >
@@ -73,7 +73,7 @@ export function CommentHeader({
                         <Tooltip>
                             <TooltipTrigger asChild>
                                 <span data-testid="commenting-disabled-indicator">
-                                    <LucideIcon.MessageCircleOff className="text-muted-foreground size-3.5" />
+                                    <LucideIcon.MessageCircleOff className="size-3.5 text-muted-foreground" />
                                 </span>
                             </TooltipTrigger>
                             <TooltipContent>Comments disabled</TooltipContent>
@@ -89,7 +89,7 @@ export function CommentHeader({
                         <TooltipProvider>
                             <Tooltip>
                                 <TooltipTrigger asChild>
-                                    <span className="text-muted-foreground cursor-default text-sm">
+                                    <span className="cursor-default text-sm text-muted-foreground">
                                         {formatTimestamp(createdAt)}
                                     </span>
                                 </TooltipTrigger>
@@ -102,7 +102,7 @@ export function CommentHeader({
                 </div>
                 {postTitle && (
                     <>
-                        <div className="text-muted-foreground shrink-0">on</div>
+                        <div className="shrink-0 text-muted-foreground">on</div>
                         <div className="min-w-0 truncate">
                             {onPostClick ? (
                                 <Button

--- a/apps/posts/src/views/comments/components/comment-header.tsx
+++ b/apps/posts/src/views/comments/components/comment-header.tsx
@@ -47,15 +47,17 @@ export function CommentHeader({
 }: CommentHeaderProps) {
     return (
         <div className={cn('flex items-baseline gap-4', className)}>
-            <div className={cn(
-                'mb-1 flex min-w-0 items-center gap-x-1 text-sm',
-                isHidden && 'opacity-50'
-            )}>
-                <div className='whitespace-nowrap'>
+            <div
+                className={cn(
+                    'mb-1 flex min-w-0 items-center gap-x-1 text-sm',
+                    isHidden && 'opacity-50'
+                )}
+            >
+                <div className="whitespace-nowrap">
                     {memberId && onAuthorClick ? (
                         <Button
-                            className="flex h-auto items-center gap-1.5 truncate p-0 font-semibold text-primary hover:opacity-70"
-                            variant='link'
+                            className="text-primary flex h-auto items-center gap-1.5 truncate p-0 font-semibold hover:opacity-70"
+                            variant="link"
                             onClick={onAuthorClick}
                         >
                             {memberName || 'Unknown'}
@@ -71,22 +73,23 @@ export function CommentHeader({
                         <Tooltip>
                             <TooltipTrigger asChild>
                                 <span data-testid="commenting-disabled-indicator">
-                                    <LucideIcon.MessageCircleOff
-                                        className="size-3.5 text-muted-foreground"
-                                    />
+                                    <LucideIcon.MessageCircleOff className="text-muted-foreground size-3.5" />
                                 </span>
                             </TooltipTrigger>
                             <TooltipContent>Comments disabled</TooltipContent>
                         </Tooltip>
                     </TooltipProvider>
                 )}
-                <LucideIcon.Dot className='text-muted-foreground/50 shrink-0' size={16} />
-                <div className='shrink-0 whitespace-nowrap'>
+                <LucideIcon.Dot
+                    className="text-muted-foreground/50 shrink-0"
+                    size={16}
+                />
+                <div className="shrink-0 whitespace-nowrap">
                     {createdAt && (
                         <TooltipProvider>
                             <Tooltip>
                                 <TooltipTrigger asChild>
-                                    <span className="cursor-default text-sm text-muted-foreground">
+                                    <span className="text-muted-foreground cursor-default text-sm">
                                         {formatTimestamp(createdAt)}
                                     </span>
                                 </TooltipTrigger>
@@ -99,12 +102,12 @@ export function CommentHeader({
                 </div>
                 {postTitle && (
                     <>
-                        <div className='shrink-0 text-muted-foreground'>on</div>
-                        <div className='min-w-0 truncate'>
+                        <div className="text-muted-foreground shrink-0">on</div>
+                        <div className="min-w-0 truncate">
                             {onPostClick ? (
                                 <Button
                                     className="block h-auto w-full cursor-pointer truncate p-0 text-left font-medium text-gray-800 hover:opacity-70 dark:text-gray-400"
-                                    variant='link'
+                                    variant="link"
                                     onClick={onPostClick}
                                 >
                                     {postTitle}
@@ -118,9 +121,7 @@ export function CommentHeader({
                     </>
                 )}
             </div>
-            {isHidden && (
-                <Badge variant='secondary'>Hidden</Badge>
-            )}
+            {isHidden && <Badge variant="secondary">Hidden</Badge>}
         </div>
     );
 }

--- a/apps/posts/src/views/comments/components/comment-likes-modal.tsx
+++ b/apps/posts/src/views/comments/components/comment-likes-modal.tsx
@@ -9,7 +9,10 @@ import {
     LucideIcon,
     formatTimestamp
 } from '@tryghost/shade';
-import {Comment, useBrowseCommentLikes} from '@tryghost/admin-x-framework/api/comments';
+import {
+    Comment,
+    useBrowseCommentLikes
+} from '@tryghost/admin-x-framework/api/comments';
 import {CommentAvatar} from './comment-avatar';
 
 interface CommentLikesModalProps {
@@ -18,8 +21,14 @@ interface CommentLikesModalProps {
     onOpenChange: (open: boolean) => void;
 }
 
-function CommentLikesModal({comment, open, onOpenChange}: CommentLikesModalProps) {
-    const {data, isLoading} = useBrowseCommentLikes(comment.id, {enabled: open});
+function CommentLikesModal({
+    comment,
+    open,
+    onOpenChange
+}: CommentLikesModalProps) {
+    const {data, isLoading} = useBrowseCommentLikes(comment.id, {
+        enabled: open
+    });
     const likes = data?.comment_likes ?? [];
     const likeCount = comment.count?.likes ?? 0;
     const remainingCount = likeCount - likes.length;
@@ -46,17 +55,25 @@ function CommentLikesModal({comment, open, onOpenChange}: CommentLikesModalProps
                                 <span className="shrink-0 font-semibold">
                                     {comment.member?.name || 'Unknown'}
                                 </span>
-                                <LucideIcon.Dot className="text-muted-foreground/50 shrink-0" size={16} />
-                                <span className="shrink-0 text-muted-foreground">
-                                    {comment.created_at && formatTimestamp(comment.created_at)}
+                                <LucideIcon.Dot
+                                    className="text-muted-foreground/50 shrink-0"
+                                    size={16}
+                                />
+                                <span className="text-muted-foreground shrink-0">
+                                    {comment.created_at &&
+                                        formatTimestamp(comment.created_at)}
                                 </span>
-                                <span className="shrink-0 text-muted-foreground">on</span>
+                                <span className="text-muted-foreground shrink-0">
+                                    on
+                                </span>
                                 <span className="min-w-0 truncate font-medium text-gray-800 dark:text-gray-400">
                                     {comment.post?.title || 'Unknown post'}
                                 </span>
                             </div>
                             <div
-                                dangerouslySetInnerHTML={{__html: comment.html || ''}}
+                                dangerouslySetInnerHTML={{
+                                    __html: comment.html || ''
+                                }}
                                 className="prose mt-2 line-clamp-2 text-sm [&_*]:text-sm [&_*]:leading-[1.5em] [&_p]:m-0"
                             />
                         </div>
@@ -72,29 +89,38 @@ function CommentLikesModal({comment, open, onOpenChange}: CommentLikesModalProps
                     ) : (
                         <div className="flex flex-col gap-3 pb-1">
                             {likes.map(like => (
-                                <div key={like.id} className="flex items-center justify-between gap-3">
+                                <div
+                                    key={like.id}
+                                    className="flex items-center justify-between gap-3"
+                                >
                                     <div className="flex items-center gap-3">
                                         <div className="relative shrink-0">
                                             <CommentAvatar
-                                                avatarImage={like.member?.avatar_image}
+                                                avatarImage={
+                                                    like.member?.avatar_image
+                                                }
                                                 memberId={like.member?.id}
                                             />
                                             {/* Heart overlay */}
                                             <div className="absolute -bottom-0.5 -right-0.5 flex size-4 items-center justify-center rounded-full bg-pink-500 text-white">
-                                                <LucideIcon.Heart className="size-2.5" fill="currentColor" />
+                                                <LucideIcon.Heart
+                                                    className="size-2.5"
+                                                    fill="currentColor"
+                                                />
                                             </div>
                                         </div>
                                         <span className="font-medium">
-                                            {like.member?.name || 'Deleted member'}
+                                            {like.member?.name ||
+                                                'Deleted member'}
                                         </span>
                                     </div>
-                                    <span className="shrink-0 text-sm text-muted-foreground">
+                                    <span className="text-muted-foreground shrink-0 text-sm">
                                         {formatTimestamp(like.created_at)}
                                     </span>
                                 </div>
                             ))}
                             {remainingCount > 0 && (
-                                <div className="pt-1 text-center text-sm text-muted-foreground">
+                                <div className="text-muted-foreground pt-1 text-center text-sm">
                                     and {remainingCount} more
                                 </div>
                             )}
@@ -103,9 +129,7 @@ function CommentLikesModal({comment, open, onOpenChange}: CommentLikesModalProps
                 </div>
 
                 <DialogFooter>
-                    <Button onClick={() => onOpenChange(false)}>
-                        OK
-                    </Button>
+                    <Button onClick={() => onOpenChange(false)}>OK</Button>
                 </DialogFooter>
             </DialogContent>
         </Dialog>

--- a/apps/posts/src/views/comments/components/comment-likes-modal.tsx
+++ b/apps/posts/src/views/comments/components/comment-likes-modal.tsx
@@ -59,11 +59,11 @@ function CommentLikesModal({
                                     className="text-muted-foreground/50 shrink-0"
                                     size={16}
                                 />
-                                <span className="text-muted-foreground shrink-0">
+                                <span className="shrink-0 text-muted-foreground">
                                     {comment.created_at &&
                                         formatTimestamp(comment.created_at)}
                                 </span>
-                                <span className="text-muted-foreground shrink-0">
+                                <span className="shrink-0 text-muted-foreground">
                                     on
                                 </span>
                                 <span className="min-w-0 truncate font-medium text-gray-800 dark:text-gray-400">
@@ -114,13 +114,13 @@ function CommentLikesModal({
                                                 'Deleted member'}
                                         </span>
                                     </div>
-                                    <span className="text-muted-foreground shrink-0 text-sm">
+                                    <span className="shrink-0 text-sm text-muted-foreground">
                                         {formatTimestamp(like.created_at)}
                                     </span>
                                 </div>
                             ))}
                             {remainingCount > 0 && (
-                                <div className="text-muted-foreground pt-1 text-center text-sm">
+                                <div className="pt-1 text-center text-sm text-muted-foreground">
                                     and {remainingCount} more
                                 </div>
                             )}

--- a/apps/posts/src/views/comments/components/comment-reports-modal.tsx
+++ b/apps/posts/src/views/comments/components/comment-reports-modal.tsx
@@ -58,11 +58,11 @@ function CommentReportsModal({
                                     className="text-muted-foreground/50 shrink-0"
                                     size={16}
                                 />
-                                <span className="text-muted-foreground shrink-0">
+                                <span className="shrink-0 text-muted-foreground">
                                     {comment.created_at &&
                                         formatTimestamp(comment.created_at)}
                                 </span>
-                                <span className="text-muted-foreground shrink-0">
+                                <span className="shrink-0 text-muted-foreground">
                                     on
                                 </span>
                                 <span className="min-w-0 truncate font-medium text-gray-800 dark:text-gray-400">
@@ -101,7 +101,7 @@ function CommentReportsModal({
                                                 memberId={report.member?.id}
                                             />
                                             {/* Red flag overlay */}
-                                            <div className="bg-red absolute -bottom-0.5 -right-0.5 flex size-4 items-center justify-center rounded-full text-white">
+                                            <div className="absolute -bottom-0.5 -right-0.5 flex size-4 items-center justify-center rounded-full bg-red text-white">
                                                 <LucideIcon.Flag
                                                     className="size-2.5"
                                                     fill="currentColor"
@@ -113,7 +113,7 @@ function CommentReportsModal({
                                                 'Deleted member'}
                                         </span>
                                     </div>
-                                    <span className="text-muted-foreground shrink-0 text-sm">
+                                    <span className="shrink-0 text-sm text-muted-foreground">
                                         {formatTimestamp(report.created_at)}
                                     </span>
                                 </div>

--- a/apps/posts/src/views/comments/components/comment-reports-modal.tsx
+++ b/apps/posts/src/views/comments/components/comment-reports-modal.tsx
@@ -9,7 +9,10 @@ import {
     LucideIcon,
     formatTimestamp
 } from '@tryghost/shade';
-import {Comment, useBrowseCommentReports} from '@tryghost/admin-x-framework/api/comments';
+import {
+    Comment,
+    useBrowseCommentReports
+} from '@tryghost/admin-x-framework/api/comments';
 import {CommentAvatar} from './comment-avatar';
 
 interface CommentReportsModalProps {
@@ -18,8 +21,14 @@ interface CommentReportsModalProps {
     onOpenChange: (open: boolean) => void;
 }
 
-function CommentReportsModal({comment, open, onOpenChange}: CommentReportsModalProps) {
-    const {data, isLoading} = useBrowseCommentReports(comment.id, {enabled: open});
+function CommentReportsModal({
+    comment,
+    open,
+    onOpenChange
+}: CommentReportsModalProps) {
+    const {data, isLoading} = useBrowseCommentReports(comment.id, {
+        enabled: open
+    });
     const reports = data?.comment_reports ?? [];
     const reportCount = comment.count?.reports ?? reports.length;
 
@@ -45,17 +54,25 @@ function CommentReportsModal({comment, open, onOpenChange}: CommentReportsModalP
                                 <span className="shrink-0 font-semibold">
                                     {comment.member?.name || 'Unknown'}
                                 </span>
-                                <LucideIcon.Dot className="text-muted-foreground/50 shrink-0" size={16} />
-                                <span className="shrink-0 text-muted-foreground">
-                                    {comment.created_at && formatTimestamp(comment.created_at)}
+                                <LucideIcon.Dot
+                                    className="text-muted-foreground/50 shrink-0"
+                                    size={16}
+                                />
+                                <span className="text-muted-foreground shrink-0">
+                                    {comment.created_at &&
+                                        formatTimestamp(comment.created_at)}
                                 </span>
-                                <span className="shrink-0 text-muted-foreground">on</span>
+                                <span className="text-muted-foreground shrink-0">
+                                    on
+                                </span>
                                 <span className="min-w-0 truncate font-medium text-gray-800 dark:text-gray-400">
                                     {comment.post?.title || 'Unknown post'}
                                 </span>
                             </div>
                             <div
-                                dangerouslySetInnerHTML={{__html: comment.html || ''}}
+                                dangerouslySetInnerHTML={{
+                                    __html: comment.html || ''
+                                }}
                                 className="prose mt-2 line-clamp-2 text-sm [&_*]:text-sm [&_*]:leading-[1.5em] [&_p]:m-0"
                             />
                         </div>
@@ -71,23 +88,32 @@ function CommentReportsModal({comment, open, onOpenChange}: CommentReportsModalP
                     ) : (
                         <div className="flex flex-col gap-3 pb-1">
                             {reports.map(report => (
-                                <div key={report.id} className="flex items-center justify-between gap-3">
+                                <div
+                                    key={report.id}
+                                    className="flex items-center justify-between gap-3"
+                                >
                                     <div className="flex items-center gap-3">
                                         <div className="relative shrink-0">
                                             <CommentAvatar
-                                                avatarImage={report.member?.avatar_image}
+                                                avatarImage={
+                                                    report.member?.avatar_image
+                                                }
                                                 memberId={report.member?.id}
                                             />
                                             {/* Red flag overlay */}
-                                            <div className="absolute -bottom-0.5 -right-0.5 flex size-4 items-center justify-center rounded-full bg-red text-white">
-                                                <LucideIcon.Flag className="size-2.5" fill="currentColor" />
+                                            <div className="bg-red absolute -bottom-0.5 -right-0.5 flex size-4 items-center justify-center rounded-full text-white">
+                                                <LucideIcon.Flag
+                                                    className="size-2.5"
+                                                    fill="currentColor"
+                                                />
                                             </div>
                                         </div>
                                         <span className="font-medium">
-                                            {report.member?.name || 'Deleted member'}
+                                            {report.member?.name ||
+                                                'Deleted member'}
                                         </span>
                                     </div>
-                                    <span className="shrink-0 text-sm text-muted-foreground">
+                                    <span className="text-muted-foreground shrink-0 text-sm">
                                         {formatTimestamp(report.created_at)}
                                     </span>
                                 </div>
@@ -97,9 +123,7 @@ function CommentReportsModal({comment, open, onOpenChange}: CommentReportsModalP
                 </div>
 
                 <DialogFooter>
-                    <Button onClick={() => onOpenChange(false)}>
-                        OK
-                    </Button>
+                    <Button onClick={() => onOpenChange(false)}>OK</Button>
                 </DialogFooter>
             </DialogContent>
         </Dialog>

--- a/apps/posts/src/views/comments/components/comment-thread-list.tsx
+++ b/apps/posts/src/views/comments/components/comment-thread-list.tsx
@@ -1,14 +1,18 @@
 import CommentContent from './comment-content';
 import React from 'react';
 import {Button, LoadingIndicator, LucideIcon} from '@tryghost/shade';
-import {Comment, useHideComment, useShowComment} from '@tryghost/admin-x-framework/api/comments';
+import {
+    Comment,
+    useHideComment,
+    useShowComment
+} from '@tryghost/admin-x-framework/api/comments';
 import {CommentAvatar} from './comment-avatar';
 import {CommentHeader} from './comment-header';
 import {CommentMenu} from './comment-menu';
 import {CommentMetrics, buildThreadLink} from './comment-metrics';
 import {Link, useSearchParams} from '@tryghost/admin-x-framework';
 
-function RepliesLine({hasReplies}: {hasReplies: boolean}) {
+function RepliesLine({hasReplies}: { hasReplies: boolean }) {
     if (!hasReplies) {
         return null;
     }
@@ -28,15 +32,22 @@ interface CommentRowProps {
     selectedCommentId?: string;
 }
 
-function CommentRow({comment, isReply = false, isSelectedComment = false, selectedCommentId}: CommentRowProps) {
+function CommentRow({
+    comment,
+    isReply = false,
+    isSelectedComment = false,
+    selectedCommentId
+}: CommentRowProps) {
     const [searchParams] = useSearchParams();
     const {mutate: hideComment} = useHideComment();
     const {mutate: showComment} = useShowComment();
 
     // Check replies array for loaded objects, or count.direct_replies for unloaded
     // TODO: remove count.replies fallback once backend is fully rolled out
-    const hasReplies = (comment.replies?.length ?? 0) > 0 || (comment.count?.direct_replies ?? comment.count?.replies ?? 0) > 0;
-    const containerClassName = (!hasReplies || isReply) ? 'mb-7' : 'mb-0';
+    const hasReplies =
+        (comment.replies?.length ?? 0) > 0 ||
+        (comment.count?.direct_replies ?? comment.count?.replies ?? 0) > 0;
+    const containerClassName = !hasReplies || isReply ? 'mb-7' : 'mb-0';
 
     return (
         <div className={`flex w-full flex-row ${containerClassName}`}>
@@ -54,7 +65,7 @@ function CommentRow({comment, isReply = false, isSelectedComment = false, select
                     className="w-full"
                     data-testid={`comment-thread-row-${comment.id}`}
                 >
-                    <div className='flex min-w-0 flex-col'>
+                    <div className="flex min-w-0 flex-col">
                         <CommentHeader
                             canComment={comment.member?.can_comment}
                             createdAt={comment.created_at}
@@ -64,12 +75,25 @@ function CommentRow({comment, isReply = false, isSelectedComment = false, select
                         />
 
                         {comment.in_reply_to_snippet && isSelectedComment && (
-                            <div className={`mb-1 line-clamp-1 text-sm ${comment.status === 'hidden' && 'opacity-50'}`}>
-                                <span className="text-muted-foreground">Replied to:</span>&nbsp;
+                            <div
+                                className={`mb-1 line-clamp-1 text-sm ${
+                                    comment.status === 'hidden' && 'opacity-50'
+                                }`}
+                            >
+                                <span className="text-muted-foreground">
+                                    Replied to:
+                                </span>
+                                &nbsp;
                                 <Link
                                     className="text-sm font-normal text-muted-foreground hover:text-foreground"
                                     data-testid="replied-to-link"
-                                    to={buildThreadLink(searchParams, comment.in_reply_to_id || comment.parent_id) || ''}
+                                    to={
+                                        buildThreadLink(
+                                            searchParams,
+                                            comment.in_reply_to_id ||
+                                                comment.parent_id
+                                        ) || ''
+                                    }
                                     onClick={(e: React.MouseEvent) => {
                                         e.stopPropagation();
                                     }}
@@ -83,23 +107,31 @@ function CommentRow({comment, isReply = false, isSelectedComment = false, select
 
                         <div className="mt-4 flex flex-row flex-wrap items-center gap-3">
                             {comment.status === 'published' && (
-                                <Button className='text-gray-800' size="sm" variant="outline" onClick={() => hideComment({id: comment.id})}>
-                                    <LucideIcon.EyeOff/>
+                                <Button
+                                    className="text-gray-800"
+                                    size="sm"
+                                    variant="outline"
+                                    onClick={() => hideComment({id: comment.id})
+                                    }
+                                >
+                                    <LucideIcon.EyeOff />
                                     <span className="max-md:hidden">Hide</span>
                                 </Button>
                             )}
                             {comment.status === 'hidden' && (
-                                <Button className='text-gray-800' size="sm" variant="outline" onClick={() => showComment({id: comment.id})}>
-                                    <LucideIcon.Eye/>
+                                <Button
+                                    className="text-gray-800"
+                                    size="sm"
+                                    variant="outline"
+                                    onClick={() => showComment({id: comment.id})
+                                    }
+                                >
+                                    <LucideIcon.Eye />
                                     <span className="max-md:hidden">Show</span>
                                 </Button>
                             )}
-                            <CommentMetrics
-                                comment={comment}
-                            />
-                            <CommentMenu
-                                comment={comment}
-                            />
+                            <CommentMetrics comment={comment} />
+                            <CommentMenu comment={comment} />
                         </div>
                     </div>
 

--- a/apps/posts/src/views/comments/components/comments-filters.tsx
+++ b/apps/posts/src/views/comments/components/comments-filters.tsx
@@ -1,16 +1,11 @@
-import React, {useMemo} from 'react';
+import React from 'react';
 import {
     Filter,
-    FilterFieldConfig,
     Filters,
     LucideIcon,
     cn
 } from '@tryghost/shade';
-import {getMember} from '@tryghost/admin-x-framework/api/members';
-import {getPost} from '@tryghost/admin-x-framework/api/posts';
-import {useFilterOptions} from '../hooks/use-filter-options';
-import {useSearchMembers} from '../hooks/use-search-members';
-import {useSearchPosts} from '../hooks/use-search-posts';
+import {useCommentFilterFields} from '../use-comment-filter-fields';
 
 interface CommentsFiltersProps {
     filters: Filter[];
@@ -25,128 +20,11 @@ const CommentsFilters: React.FC<CommentsFiltersProps> = ({
     filters,
     onFiltersChange
 }) => {
-    const posts = useFilterOptions({
-        knownItems: knownPosts,
-        useSearch: useSearchPosts,
-        useGetById: getPost,
-        searchFieldName: 'posts',
+    const filterFields = useCommentFilterFields({
         filters,
-        filterFieldName: 'post',
-        toOption: post => ({
-            value: post.id,
-            label: post.title || '(Untitled)'
-        })
+        knownPosts,
+        knownMembers
     });
-
-    const members = useFilterOptions({
-        knownItems: knownMembers,
-        useSearch: useSearchMembers,
-        useGetById: getMember,
-        searchFieldName: 'members',
-        filters,
-        filterFieldName: 'author',
-        toOption: member => ({
-            value: member.id,
-            label: member.name || 'Unknown name',
-            detail: member.email ?? '(Unknown email)'
-        })
-    });
-
-    const filterFields: FilterFieldConfig[] = useMemo(
-        () => [
-            {
-                key: 'author',
-                label: 'Author',
-                type: 'select',
-                icon: <LucideIcon.User className="size-4" />,
-                options: members.options,
-                isLoading: members.options.length === 0 && members.isLoading,
-                onSearchChange: members.onSearchChange,
-                searchValue: members.searchValue,
-                searchable: true,
-                className: 'w-80',
-                popoverContentClassName: 'w-80',
-                operators: [
-                    {value: 'is', label: 'is'},
-                    {value: 'is_not', label: 'is not'}
-                ]
-            },
-            {
-                key: 'post',
-                label: 'Post',
-                type: 'select',
-                icon: <LucideIcon.FileText className="size-4" />,
-                options: posts.options,
-                isLoading: posts.options.length === 0 && posts.isLoading,
-                onSearchChange: posts.onSearchChange,
-                searchValue: posts.searchValue,
-                searchable: true,
-                className: 'w-full max-w-80',
-                popoverContentClassName: 'w-full max-w-[calc(100vw-32px)] max-w-80',
-                operators: [
-                    {value: 'is', label: 'is'},
-                    {value: 'is_not', label: 'is not'}
-                ]
-            },
-            {
-                key: 'body',
-                label: 'Text',
-                type: 'text',
-                icon: <LucideIcon.MessageSquareText className="size-4" />,
-                placeholder: 'Search comment text...',
-                operators: [
-                    {value: 'contains', label: 'contains'},
-                    {value: 'not_contains', label: 'does not contain'}
-                ],
-                defaultOperator: 'contains',
-                className: 'w-full max-w-48',
-                popoverContentClassName: 'w-full max-w-48'
-            },
-            {
-                key: 'status',
-                label: 'Status',
-                type: 'select',
-                icon: <LucideIcon.Circle className="size-4" />,
-                options: [
-                    {value: 'published', label: 'Published'},
-                    {value: 'hidden', label: 'Hidden'}
-                ],
-                operators: [
-                    {value: 'is', label: 'is'}
-                ],
-                searchable: false,
-                hideOperatorSelect: true
-            },
-            {
-                key: 'reported',
-                label: 'Reported',
-                type: 'select',
-                icon: <LucideIcon.Flag className="size-4" />,
-                options: [
-                    {value: 'true', label: 'Yes'},
-                    {value: 'false', label: 'No'}
-                ],
-                operators: [
-                    {value: 'is', label: 'is'}
-                ],
-                searchable: false,
-                hideOperatorSelect: true
-            },
-            {
-                key: 'created_at',
-                label: 'Date',
-                type: 'date',
-                className: 'w-full max-w-32',
-                icon: <LucideIcon.Calendar className="size-4" />,
-                operators: [
-                    {value: 'is', label: 'is'},
-                    {value: 'before', label: 'before'},
-                    {value: 'after', label: 'after'}
-                ]
-            }
-        ],
-        [posts, members]
-    );
 
     const hasFilters = filters.length > 0;
 

--- a/apps/posts/src/views/comments/components/comments-list.tsx
+++ b/apps/posts/src/views/comments/components/comments-list.tsx
@@ -35,7 +35,7 @@ const PlaceholderRow = forwardRef<HTMLDivElement>(function PlaceholderRow(
         >
             <div className="relative z-10 h-24 animate-pulse">
                 <div
-                    className="bg-muted h-full rounded-md"
+                    className="h-full rounded-md bg-muted"
                     data-testid="loading-placeholder"
                 />
             </div>
@@ -187,7 +187,7 @@ function CommentsList({
                                                 </span>
                                                 &nbsp;
                                                 <Link
-                                                    className="text-muted-foreground hover:text-foreground text-sm font-normal"
+                                                    className="text-sm font-normal text-muted-foreground hover:text-foreground"
                                                     data-testid="replied-to-link"
                                                     to={
                                                         buildThreadLink(

--- a/apps/posts/src/views/comments/components/comments-list.tsx
+++ b/apps/posts/src/views/comments/components/comments-list.tsx
@@ -1,7 +1,11 @@
 import CommentContent from './comment-content';
 import CommentThreadSidebar from './comment-thread-sidebar';
 import {Button, LucideIcon} from '@tryghost/shade';
-import {Comment, useHideComment, useShowComment} from '@tryghost/admin-x-framework/api/comments';
+import {
+    Comment,
+    useHideComment,
+    useShowComment
+} from '@tryghost/admin-x-framework/api/comments';
 import {CommentAvatar} from './comment-avatar';
 import {CommentHeader} from './comment-header';
 import {CommentMenu} from './comment-menu';
@@ -30,7 +34,10 @@ const PlaceholderRow = forwardRef<HTMLDivElement>(function PlaceholderRow(
             className="relative flex flex-col"
         >
             <div className="relative z-10 h-24 animate-pulse">
-                <div className="h-full rounded-md bg-muted" data-testid="loading-placeholder" />
+                <div
+                    className="bg-muted h-full rounded-md"
+                    data-testid="loading-placeholder"
+                />
             </div>
         </div>
     );
@@ -56,7 +63,9 @@ function CommentsList({
     const parentRef = useRef<HTMLDivElement>(null);
     const [searchParams, setSearchParams] = useSearchParams();
     const [threadSidebarOpen, setThreadSidebarOpen] = useState(false);
-    const [selectedThreadCommentId, setSelectedThreadCommentId] = useState<string | null>(null);
+    const [selectedThreadCommentId, setSelectedThreadCommentId] = useState<
+        string | null
+    >(null);
 
     const {mutate: hideComment} = useHideComment();
     const {mutate: showComment} = useShowComment();
@@ -107,10 +116,7 @@ function CommentsList({
 
     return (
         <div ref={parentRef} className="overflow-hidden">
-            <div
-                className="flex flex-col"
-                data-testid="comments-list"
-            >
+            <div className="flex flex-col" data-testid="comments-list">
                 <div className="flex flex-col">
                     <SpacerRow height={spaceBefore} />
                     {visibleItems.map(({key, virtualItem, item, props}) => {
@@ -134,32 +140,62 @@ function CommentsList({
                                     }
                                 }}
                             >
-                                <div className='flex items-start gap-3'>
+                                <div className="flex items-start gap-3">
                                     <CommentAvatar
                                         avatarImage={item.member?.avatar_image}
                                         isHidden={item.status === 'hidden'}
                                         memberId={item.member?.id}
                                     />
 
-                                    <div className='flex min-w-0 flex-col'>
+                                    <div className="flex min-w-0 flex-col">
                                         <CommentHeader
-                                            canComment={item.member?.can_comment}
+                                            canComment={
+                                                item.member?.can_comment
+                                            }
                                             createdAt={item.created_at}
                                             isHidden={item.status === 'hidden'}
                                             memberId={item.member?.id}
                                             memberName={item.member?.name}
                                             postTitle={item.post?.title}
-                                            onAuthorClick={item.member?.id ? () => onAddFilter('author', item.member!.id) : undefined}
-                                            onPostClick={item.post?.id ? () => onAddFilter('post', item.post!.id) : undefined}
+                                            onAuthorClick={
+                                                item.member?.id
+                                                    ? () => onAddFilter(
+                                                        'author',
+                                                              item.member!.id
+                                                    )
+                                                    : undefined
+                                            }
+                                            onPostClick={
+                                                item.post?.id
+                                                    ? () => onAddFilter(
+                                                        'post',
+                                                              item.post!.id
+                                                    )
+                                                    : undefined
+                                            }
                                         />
 
                                         {item.in_reply_to_snippet && (
-                                            <div className={`mb-1 line-clamp-1 max-w-3xl text-sm ${item.status === 'hidden' && 'opacity-50'}`}>
-                                                <span className="text-muted-foreground">Replied to:</span>&nbsp;
+                                            <div
+                                                className={`mb-1 line-clamp-1 max-w-3xl text-sm ${
+                                                    item.status === 'hidden' &&
+                                                    'opacity-50'
+                                                }`}
+                                            >
+                                                <span className="text-muted-foreground">
+                                                    Replied to:
+                                                </span>
+                                                &nbsp;
                                                 <Link
-                                                    className="text-sm font-normal text-muted-foreground hover:text-foreground"
+                                                    className="text-muted-foreground hover:text-foreground text-sm font-normal"
                                                     data-testid="replied-to-link"
-                                                    to={buildThreadLink(searchParams, item.in_reply_to_id || item.parent_id) || ''}
+                                                    to={
+                                                        buildThreadLink(
+                                                            searchParams,
+                                                            item.in_reply_to_id ||
+                                                                item.parent_id
+                                                        ) || ''
+                                                    }
                                                     onClick={(e) => {
                                                         e.stopPropagation();
                                                     }}
@@ -173,14 +209,30 @@ function CommentsList({
 
                                         <div className="mt-4 flex flex-row flex-nowrap items-center gap-3">
                                             {item.status === 'published' && (
-                                                <Button className='text-foreground' size="sm" variant="outline" onClick={() => hideComment({id: item.id})}>
-                                                    <LucideIcon.EyeOff/>
+                                                <Button
+                                                    className="text-foreground"
+                                                    size="sm"
+                                                    variant="outline"
+                                                    onClick={() => hideComment({
+                                                        id: item.id
+                                                    })
+                                                    }
+                                                >
+                                                    <LucideIcon.EyeOff />
                                                     Hide
                                                 </Button>
                                             )}
                                             {item.status === 'hidden' && (
-                                                <Button className='text-foreground' size="sm" variant="outline" onClick={() => showComment({id: item.id})}>
-                                                    <LucideIcon.Eye/>
+                                                <Button
+                                                    className="text-foreground"
+                                                    size="sm"
+                                                    variant="outline"
+                                                    onClick={() => showComment({
+                                                        id: item.id
+                                                    })
+                                                    }
+                                                >
+                                                    <LucideIcon.Eye />
                                                     Show
                                                 </Button>
                                             )}
@@ -188,9 +240,7 @@ function CommentsList({
                                                 className="ml-2"
                                                 comment={item}
                                             />
-                                            <CommentMenu
-                                                comment={item}
-                                            />
+                                            <CommentMenu comment={item} />
                                         </div>
                                     </div>
                                 </div>
@@ -198,8 +248,14 @@ function CommentsList({
                                 <div>
                                     {item.post?.feature_image ? (
                                         <img
-                                            alt={item.post.title || 'Post feature image'}
-                                            className={`hidden aspect-video w-36 rounded object-cover lg:block ${item.status === 'hidden' && 'opacity-50'}`}
+                                            alt={
+                                                item.post.title ||
+                                                'Post feature image'
+                                            }
+                                            className={`hidden aspect-video w-36 rounded object-cover lg:block ${
+                                                item.status === 'hidden' &&
+                                                'opacity-50'
+                                            }`}
                                             src={item.post.feature_image}
                                         />
                                     ) : null}

--- a/apps/posts/src/views/comments/hooks/use-filter-state.test.tsx
+++ b/apps/posts/src/views/comments/hooks/use-filter-state.test.tsx
@@ -41,6 +41,30 @@ describe('useFilterState', () => {
         expect(result.current.search).toBe('filter=count.reports%3A%3E0');
     });
 
+    it('reads legacy deep-link params when no canonical filter param is present', () => {
+        const {result} = renderHook(() => {
+            const state = useFilterState();
+            const [searchParams] = useSearchParams();
+
+            return {
+                ...state,
+                search: searchParams.toString()
+            };
+        }, {wrapper: createWrapper('/?id=is:comment_123')});
+
+        expect(result.current.filters).toEqual([
+            {
+                id: 'id:1',
+                field: 'id',
+                operator: 'is',
+                values: ['comment_123']
+            }
+        ]);
+        expect(result.current.nql).toBe('id:comment_123');
+        expect(result.current.isSingleIdFilter).toBe(true);
+        expect(result.current.search).toBe('id=is%3Acomment_123');
+    });
+
     it('writes canonical Ember filter params and clears them', () => {
         const {result} = renderHook(() => {
             const state = useFilterState();

--- a/apps/posts/src/views/comments/hooks/use-filter-state.test.tsx
+++ b/apps/posts/src/views/comments/hooks/use-filter-state.test.tsx
@@ -1,0 +1,84 @@
+import {MemoryRouter, useSearchParams} from 'react-router';
+import {act, renderHook} from '@testing-library/react';
+import {describe, expect, it, vi} from 'vitest';
+import {useFilterState} from './use-filter-state';
+
+vi.mock('@tryghost/admin-x-framework/api/settings', () => ({
+    useBrowseSettings: () => ({
+        data: {
+            settings: [{key: 'timezone', value: 'UTC'}]
+        }
+    })
+}));
+
+function createWrapper(initialEntry: string) {
+    return function Wrapper({children}: {children: React.ReactNode}) {
+        return <MemoryRouter initialEntries={[initialEntry]}>{children}</MemoryRouter>;
+    };
+}
+
+describe('useFilterState', () => {
+    it('reads Ember-style filter params', () => {
+        const {result} = renderHook(() => {
+            const state = useFilterState();
+            const [searchParams] = useSearchParams();
+
+            return {
+                ...state,
+                search: searchParams.toString()
+            };
+        }, {wrapper: createWrapper('/?filter=count.reports:>0')});
+
+        expect(result.current.filters).toEqual([
+            {
+                id: 'reported:1',
+                field: 'reported',
+                operator: 'is',
+                values: ['true']
+            }
+        ]);
+        expect(result.current.nql).toBe('count.reports:>0');
+        expect(result.current.search).toBe('filter=count.reports%3A%3E0');
+    });
+
+    it('writes canonical Ember filter params and clears them', () => {
+        const {result} = renderHook(() => {
+            const state = useFilterState();
+            const [searchParams] = useSearchParams();
+
+            return {
+                ...state,
+                search: searchParams.toString()
+            };
+        }, {wrapper: createWrapper('/')});
+
+        act(() => {
+            result.current.setFilters([
+                {
+                    id: '1',
+                    field: 'created_at',
+                    operator: 'is',
+                    values: ['2024-01-01']
+                }
+            ], {replace: false});
+        });
+
+        expect(result.current.search).toBe(
+            'filter=created_at%3A%3C%3D%272024-01-01T23%3A59%3A59.999Z%27%2Bcreated_at%3A%3E%3D%272024-01-01T00%3A00%3A00.000Z%27'
+        );
+
+        act(() => {
+            result.current.clearFilters({replace: false});
+        });
+
+        expect(result.current.search).toBe('');
+    });
+
+    it('tracks the single-id quick filter state', () => {
+        const {result} = renderHook(() => useFilterState(), {
+            wrapper: createWrapper('/?filter=id:comment_123')
+        });
+
+        expect(result.current.isSingleIdFilter).toBe(true);
+    });
+});

--- a/apps/posts/src/views/comments/hooks/use-filter-state.ts
+++ b/apps/posts/src/views/comments/hooks/use-filter-state.ts
@@ -2,7 +2,7 @@ import {getSiteTimezone} from '@src/utils/get-site-timezone';
 import {parseCommentFilter, serializeCommentFilters} from '../comment-filter-query';
 import {useBrowseSettings} from '@tryghost/admin-x-framework/api/settings';
 import {useCallback, useMemo} from 'react';
-import {useSearchParams} from '@tryghost/admin-x-framework';
+import {useSearchParams} from 'react-router';
 import type {Filter} from '@tryghost/shade';
 
 type SetFiltersAction = Filter[] | ((prevFilters: Filter[]) => Filter[]);

--- a/apps/posts/src/views/comments/hooks/use-filter-state.ts
+++ b/apps/posts/src/views/comments/hooks/use-filter-state.ts
@@ -1,3 +1,4 @@
+import {commentFields} from '../comment-fields';
 import {getSiteTimezone} from '@src/utils/get-site-timezone';
 import {parseCommentFilter, serializeCommentFilters} from '../comment-filter-query';
 import {useBrowseSettings} from '@tryghost/admin-x-framework/api/settings';
@@ -34,13 +35,58 @@ function toSearchParams(filters: Filter[], timezone: string): URLSearchParams {
     return params;
 }
 
+function parseLegacyFilterValue(queryValue: string): {operator: string; value: string} | null {
+    const colonIndex = queryValue.indexOf(':');
+
+    if (colonIndex <= 0) {
+        return null;
+    }
+
+    return {
+        operator: queryValue.substring(0, colonIndex),
+        value: queryValue.substring(colonIndex + 1)
+    };
+}
+
+function parseLegacyFilters(searchParams: URLSearchParams): Filter[] {
+    const validFields = new Set(Object.keys(commentFields));
+    const filters: Filter[] = [];
+
+    for (const [field, queryValue] of searchParams.entries()) {
+        if (!validFields.has(field) || !queryValue) {
+            continue;
+        }
+
+        const parsed = parseLegacyFilterValue(queryValue);
+
+        if (!parsed) {
+            continue;
+        }
+
+        filters.push({
+            id: `${field}:${filters.length + 1}`,
+            field,
+            operator: parsed.operator,
+            values: [parsed.value]
+        });
+    }
+
+    return filters;
+}
+
 export function useFilterState(): UseFilterStateReturn {
     const [searchParams, setSearchParams] = useSearchParams();
     const {data: settingsData} = useBrowseSettings({});
     const timezone = useMemo(() => getSiteTimezone(settingsData?.settings ?? []), [settingsData?.settings]);
 
     const filters = useMemo(() => {
-        return parseCommentFilter(searchParams.get('filter') ?? undefined, timezone);
+        const filter = searchParams.get('filter');
+
+        if (filter !== null) {
+            return parseCommentFilter(filter || undefined, timezone);
+        }
+
+        return parseLegacyFilters(searchParams);
     }, [searchParams, timezone]);
 
     const setFilters = useCallback((action: SetFiltersAction, options: SetFiltersOptions = {}) => {

--- a/apps/posts/src/views/comments/hooks/use-filter-state.ts
+++ b/apps/posts/src/views/comments/hooks/use-filter-state.ts
@@ -1,167 +1,17 @@
+import {getSiteTimezone} from '@src/utils/get-site-timezone';
+import {parseCommentFilter, serializeCommentFilters} from '../comment-filter-query';
+import {useBrowseSettings} from '@tryghost/admin-x-framework/api/settings';
 import {useCallback, useMemo} from 'react';
 import {useSearchParams} from '@tryghost/admin-x-framework';
 import type {Filter} from '@tryghost/shade';
 
-/**
- * Comment filter field keys - single source of truth for filter definitions
- */
-export const COMMENT_FILTER_FIELDS = ['id', 'status', 'created_at', 'body', 'post', 'author', 'reported'] as const;
-
-export type CommentFilterField = typeof COMMENT_FILTER_FIELDS[number];
-
-export function buildNqlFilter(filters: Filter[]): string | undefined {
-    const parts: string[] = [];
-
-    for (const filter of filters) {
-        if (!filter.values[0]) {
-            continue;
-        }
-
-        switch (filter.field) {
-        case 'id':
-            parts.push(`id:'${filter.values[0]}'`);
-            break;
-
-        case 'status':
-            parts.push(`status:${filter.values[0]}`);
-            break;
-
-        case 'created_at':
-            if (filter.operator === 'before' && filter.values[0]) {
-                parts.push(`created_at:<'${filter.values[0]}'`);
-            } else if (filter.operator === 'after' && filter.values[0]) {
-                parts.push(`created_at:>'${filter.values[0]}'`);
-            } else if (filter.operator === 'is' && filter.values[0]) {
-                // Match all items from the selected day in the user's timezone
-                const dateValue = String(filter.values[0]); // Format: YYYY-MM-DD
-
-                // Create Date objects in user's local timezone, then convert to UTC
-                const startOfDay = new Date(dateValue + 'T00:00:00').toISOString();
-                const endOfDay = new Date(dateValue + 'T23:59:59.999').toISOString();
-
-                parts.push(`created_at:>='${startOfDay}'+created_at:<='${endOfDay}'`);
-            }
-            break;
-
-        case 'body':
-            const value = filter.values[0] as string;
-            // Escape single quotes in the value
-            const escapedValue = value.replace(/'/g, '\\\'');
-
-            if (filter.operator === 'contains') {
-                parts.push(`html:~'${escapedValue}'`);
-            } else if (filter.operator === 'not_contains') {
-                parts.push(`html:-~'${escapedValue}'`);
-            }
-            break;
-
-        case 'post':
-            if (filter.operator === 'is_not') {
-                parts.push(`post_id:-${filter.values[0]}`);
-            } else {
-                // Default to 'is' operator
-                parts.push(`post_id:${filter.values[0]}`);
-            }
-            break;
-
-        case 'author':
-            if (filter.operator === 'is_not') {
-                parts.push(`member_id:-${filter.values[0]}`);
-            } else {
-                // Default to 'is' operator
-                parts.push(`member_id:${filter.values[0]}`);
-            }
-            break;
-
-        case 'reported':
-            if (filter.values[0] === 'true') {
-                parts.push('count.reports:>0');
-            } else if (filter.values[0] === 'false') {
-                parts.push('count.reports:0');
-            }
-            break;
-        }
-    }
-
-    return parts.length ? parts.join('+') : undefined;
-}
-/**
- * Parse a filter value from URL format: "operator:value"
- * e.g., "is:published", "contains:hello"
- */
-function parseFilterValue(queryValue: string): {operator: string; value: string} | null {
-    if (!queryValue) {
-        return null;
-    }
-
-    const colonIndex = queryValue.indexOf(':');
-    if (colonIndex <= 0) {
-        return null; // Invalid format, must have operator:value
-    }
-
-    return {
-        operator: queryValue.substring(0, colonIndex),
-        value: queryValue.substring(colonIndex + 1)
-    };
-}
-
-/**
- * Parse URL search params into Filter objects
- * Preserves the order of filters as they appear in the URL
- */
-function searchParamsToFilters(searchParams: URLSearchParams): Filter[] {
-    const filters: Filter[] = [];
-
-    // Iterate over URL params in order to preserve filter order
-    for (const [field, queryValue] of searchParams.entries()) {
-        // Only process valid filter fields
-        if (!COMMENT_FILTER_FIELDS.includes(field as CommentFilterField)) {
-            continue;
-        }
-
-        if (!queryValue) {
-            continue;
-        }
-
-        const parsed = parseFilterValue(queryValue);
-        if (parsed) {
-            filters.push({
-                id: field,
-                field,
-                operator: parsed.operator,
-                values: [parsed.value]
-            });
-        }
-    }
-
-    return filters;
-}
-
-/**
- * Serialize filters to URL search params format
- */
-function filtersToSearchParams(filters: Filter[]): URLSearchParams {
-    const params = new URLSearchParams();
-
-    for (const filter of filters) {
-        if (COMMENT_FILTER_FIELDS.includes(filter.field as CommentFilterField) && filter.values[0] !== undefined) {
-            const value = `${filter.operator}:${String(filter.values[0])}`;
-            params.set(filter.field, value);
-        }
-    }
-
-    return params;
-}
-
 type SetFiltersAction = Filter[] | ((prevFilters: Filter[]) => Filter[]);
 
 interface SetFiltersOptions {
-    /** Whether to replace the current history entry (default: true) */
     replace?: boolean;
 }
 
 interface ClearFiltersOptions {
-    /** Whether to replace the current history entry (default: true) */
     replace?: boolean;
 }
 
@@ -170,44 +20,51 @@ interface UseFilterStateReturn {
     nql: string | undefined;
     setFilters: (action: SetFiltersAction, options?: SetFiltersOptions) => void;
     clearFilters: (options?: ClearFiltersOptions) => void;
-    /** True when the only active filter is a single comment ID (used for deep linking) */
     isSingleIdFilter: boolean;
 }
 
-/**
- * Hook to sync comment filter state with URL query parameters
- *
- * URL format: ?status=is:published&author=is:member-id&body=contains:search+term
- */
+function toSearchParams(filters: Filter[], timezone: string): URLSearchParams {
+    const params = new URLSearchParams();
+    const filter = serializeCommentFilters(filters, timezone);
+
+    if (filter) {
+        params.set('filter', filter);
+    }
+
+    return params;
+}
+
 export function useFilterState(): UseFilterStateReturn {
     const [searchParams, setSearchParams] = useSearchParams();
+    const {data: settingsData} = useBrowseSettings({});
+    const timezone = useMemo(() => getSiteTimezone(settingsData?.settings ?? []), [settingsData?.settings]);
 
-    // Parse filters from URL
     const filters = useMemo(() => {
-        return searchParamsToFilters(searchParams);
-    }, [searchParams]);
+        return parseCommentFilter(searchParams.get('filter') ?? undefined, timezone);
+    }, [searchParams, timezone]);
 
-    // Update URL when filters change
     const setFilters = useCallback((action: SetFiltersAction, options: SetFiltersOptions = {}) => {
         const newFilters = typeof action === 'function' ? action(filters) : action;
-        const newParams = filtersToSearchParams(newFilters);
-
-        // Update URL - replace by default, but allow pushing to history
         const replace = options.replace ?? true;
-        setSearchParams(newParams, {replace});
-    }, [filters, setSearchParams]);
 
-    // Clear all filter params from URL
-    const clearFilters = useCallback(({replace = true}: {replace?: boolean} = {}) => {
+        setSearchParams(toSearchParams(newFilters, timezone), {replace});
+    }, [filters, setSearchParams, timezone]);
+
+    const clearFilters = useCallback(({replace = true}: ClearFiltersOptions = {}) => {
         setSearchParams(new URLSearchParams(), {replace});
     }, [setSearchParams]);
 
-    const nql = useMemo(() => buildNqlFilter(filters), [filters]);
+    const nql = useMemo(() => serializeCommentFilters(filters, timezone), [filters, timezone]);
 
-    // Check if the only active filter is a single comment ID (used for deep linking)
     const isSingleIdFilter = useMemo(() => {
         return filters.length === 1 && filters[0].field === 'id';
     }, [filters]);
 
-    return {filters, nql, setFilters, clearFilters, isSingleIdFilter};
+    return {
+        filters,
+        nql,
+        setFilters,
+        clearFilters,
+        isSingleIdFilter
+    };
 }

--- a/apps/posts/src/views/comments/use-comment-filter-fields.test.ts
+++ b/apps/posts/src/views/comments/use-comment-filter-fields.test.ts
@@ -1,0 +1,104 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {commentFields} from './comment-fields';
+import {renderHook} from '@testing-library/react';
+import {useCommentFilterFields} from './use-comment-filter-fields';
+
+const mockUseFilterOptions = vi.fn();
+
+vi.mock('./hooks/use-filter-options', () => ({
+    useFilterOptions: (...args: unknown[]) => mockUseFilterOptions(...args)
+}));
+
+vi.mock('./hooks/use-search-posts', () => ({
+    useSearchPosts: vi.fn()
+}));
+
+vi.mock('./hooks/use-search-members', () => ({
+    useSearchMembers: vi.fn()
+}));
+
+vi.mock('@tryghost/admin-x-framework/api/posts', () => ({
+    getPost: vi.fn()
+}));
+
+vi.mock('@tryghost/admin-x-framework/api/members', () => ({
+    getMember: vi.fn()
+}));
+
+describe('useCommentFilterFields', () => {
+    beforeEach(() => {
+        mockUseFilterOptions.mockReset();
+        mockUseFilterOptions.mockImplementation(({filterFieldName}: {filterFieldName: string}) => {
+            if (filterFieldName === 'post') {
+                return {
+                    options: [{value: 'post_1', label: 'Post 1'}],
+                    isLoading: true,
+                    searchValue: 'welcome',
+                    onSearchChange: vi.fn()
+                };
+            }
+
+            return {
+                options: [{value: 'member_1', label: 'Member 1'}],
+                isLoading: false,
+                searchValue: 'jamie',
+                onSearchChange: vi.fn()
+            };
+        });
+    });
+
+    it('hydrates visible fields from the static schema', () => {
+        const {result} = renderHook(() => useCommentFilterFields({
+            filters: [],
+            knownPosts: [],
+            knownMembers: []
+        }));
+
+        expect(result.current.map(field => field.key)).toEqual([
+            'author',
+            'post',
+            'body',
+            'status',
+            'reported',
+            'created_at'
+        ]);
+    });
+
+    it('attaches runtime options and search callbacks to resource fields', () => {
+        const {result} = renderHook(() => useCommentFilterFields({
+            filters: [{id: '1', field: 'post', operator: 'is', values: ['post_1']}],
+            knownPosts: [],
+            knownMembers: []
+        }));
+
+        const authorField = result.current.find(field => field.key === 'author');
+        const postField = result.current.find(field => field.key === 'post');
+
+        expect(authorField).toMatchObject({
+            options: [{value: 'member_1', label: 'Member 1'}],
+            searchValue: 'jamie',
+            isLoading: false
+        });
+
+        expect(postField).toMatchObject({
+            options: [{value: 'post_1', label: 'Post 1'}],
+            searchValue: 'welcome',
+            isLoading: false
+        });
+        expect(postField?.onSearchChange).toBeTypeOf('function');
+    });
+
+    it('preserves static operator semantics from the field map', () => {
+        const {result} = renderHook(() => useCommentFilterFields({
+            filters: [],
+            knownPosts: [],
+            knownMembers: []
+        }));
+
+        const bodyField = result.current.find(field => field.key === 'body');
+        const reportedField = result.current.find(field => field.key === 'reported');
+
+        expect(bodyField?.operators?.map(operator => operator.value)).toEqual(commentFields.body.operators);
+        expect(reportedField?.operators?.map(operator => operator.value)).toEqual(commentFields.reported.operators);
+    });
+});

--- a/apps/posts/src/views/comments/use-comment-filter-fields.ts
+++ b/apps/posts/src/views/comments/use-comment-filter-fields.ts
@@ -1,0 +1,108 @@
+import React, {useMemo} from 'react';
+import {Filter, FilterFieldConfig, LucideIcon} from '@tryghost/shade';
+import {commentFields} from './comment-fields';
+import {createOperatorOptions} from '../filters/filter-operator-options';
+import {getMember} from '@tryghost/admin-x-framework/api/members';
+import {getPost} from '@tryghost/admin-x-framework/api/posts';
+import {useFilterOptions} from './hooks/use-filter-options';
+import {useSearchMembers} from './hooks/use-search-members';
+import {useSearchPosts} from './hooks/use-search-posts';
+
+interface UseCommentFilterFieldsProps {
+    filters: Filter[];
+    knownPosts: Array<{id: string; title: string}>;
+    knownMembers: Array<{id: string; name?: string; email?: string}>;
+}
+
+const COMMENT_FIELD_ORDER = ['author', 'post', 'body', 'status', 'reported', 'created_at'] as const;
+
+function getFieldIcon(key: string) {
+    switch (key) {
+    case 'author':
+        return React.createElement(LucideIcon.User, {className: 'size-4'});
+    case 'post':
+        return React.createElement(LucideIcon.FileText, {className: 'size-4'});
+    case 'body':
+        return React.createElement(LucideIcon.MessageSquareText, {className: 'size-4'});
+    case 'status':
+        return React.createElement(LucideIcon.Circle, {className: 'size-4'});
+    case 'reported':
+        return React.createElement(LucideIcon.Flag, {className: 'size-4'});
+    case 'created_at':
+        return React.createElement(LucideIcon.Calendar, {className: 'size-4'});
+    default:
+        return undefined;
+    }
+}
+
+export function useCommentFilterFields({
+    filters,
+    knownPosts,
+    knownMembers
+}: UseCommentFilterFieldsProps): FilterFieldConfig[] {
+    const posts = useFilterOptions({
+        knownItems: knownPosts,
+        useSearch: useSearchPosts,
+        useGetById: getPost,
+        searchFieldName: 'posts',
+        filters,
+        filterFieldName: 'post',
+        toOption: post => ({
+            value: post.id,
+            label: post.title || '(Untitled)'
+        })
+    });
+
+    const members = useFilterOptions({
+        knownItems: knownMembers,
+        useSearch: useSearchMembers,
+        useGetById: getMember,
+        searchFieldName: 'members',
+        filters,
+        filterFieldName: 'author',
+        toOption: member => ({
+            value: member.id,
+            label: member.name || 'Unknown name',
+            detail: member.email ?? '(Unknown email)'
+        })
+    });
+
+    return useMemo(() => {
+        return COMMENT_FIELD_ORDER.map((key) => {
+            const field = commentFields[key];
+            if (!field) {
+                return null;
+            }
+
+            const config: FilterFieldConfig = {
+                key,
+                ...field.ui,
+                icon: getFieldIcon(key),
+                operators: createOperatorOptions(field.operators),
+                ...('options' in field && field.options ? {options: field.options} : {})
+            };
+
+            if (key === 'author') {
+                return {
+                    ...config,
+                    options: members.options,
+                    isLoading: members.options.length === 0 && members.isLoading,
+                    onSearchChange: members.onSearchChange,
+                    searchValue: members.searchValue
+                };
+            }
+
+            if (key === 'post') {
+                return {
+                    ...config,
+                    options: posts.options,
+                    isLoading: posts.options.length === 0 && posts.isLoading,
+                    onSearchChange: posts.onSearchChange,
+                    searchValue: posts.searchValue
+                };
+            }
+
+            return config;
+        }).filter((field): field is FilterFieldConfig => field !== null);
+    }, [members, posts]);
+}

--- a/apps/posts/src/views/filters/filter-normalization.ts
+++ b/apps/posts/src/views/filters/filter-normalization.ts
@@ -1,3 +1,12 @@
+import moment from 'moment-timezone';
+
 export function escapeNqlString(value: string): string {
     return `'${value.replace(/\\/g, '\\\\').replace(/'/g, '\\\'')}'`;
+}
+
+export function getDayBoundsInUtc(date: string, timezone: string): {start: string; end: string} {
+    const start = moment.tz(date, 'YYYY-MM-DD', timezone).startOf('day').utc().toISOString();
+    const end = moment.tz(date, 'YYYY-MM-DD', timezone).endOf('day').utc().toISOString();
+
+    return {start, end};
 }

--- a/apps/posts/src/views/filters/filter-operator-options.ts
+++ b/apps/posts/src/views/filters/filter-operator-options.ts
@@ -1,0 +1,20 @@
+interface OperatorOption {
+    value: string;
+    label: string;
+}
+
+interface CreateOperatorOptionsOptions {
+    labels?: Record<string, string>;
+}
+
+export function createOperatorOptions(
+    operators: readonly string[],
+    options: CreateOperatorOptionsOptions = {}
+): OperatorOption[] {
+    const labels = options.labels || {};
+
+    return operators.map(operator => ({
+        value: operator,
+        label: labels[operator] ?? operator.replace(/[-_]/g, ' ')
+    }));
+}


### PR DESCRIPTION
## Summary

- moved the comments moderation filter state, field definitions, query translation, and hydration onto the shared filter core introduced in #26828
- replaced the inline comments filter wiring with comment-specific field definitions, query helpers, and a dedicated state hook
- added focused tests for comment field definitions, comment query translation, and comment filter state

## Why this change

The comments moderation screen was still carrying its own filter wiring after the members rewrite established the shared filter core. This follow-up adopts the same core for comments so both surfaces use the same abstractions for field resolution, codecs, and NQL compilation.

## Dependency

- depends on #26828
- base PR: #26828

## What changed

- added comment field definitions and query translation for the current comments moderation filters
- added a comments-specific filter state hook and hydration hook for building runtime field configs
- updated the comments moderation UI to use the new filter state/query path
- kept the comments-specific behavior explicit where the backend contract still requires it, including reported-state handling and exact-date parsing

## Test plan

- `yarn --cwd apps/posts tsc --noEmit`
- `yarn --cwd apps/posts lint`
- `yarn --cwd apps/posts vitest run src/views/filters/filter-query-core.test.ts src/views/filters/filter-ast.test.ts src/views/filters/filter-codecs.test.ts src/views/filters/filter-operator-options.test.ts src/views/filters/filter-normalization.test.ts src/views/filters/filter-types.test.ts src/views/filters/resolve-field.test.ts src/views/comments/comment-fields.test.ts src/views/comments/comment-filter-query.test.ts src/views/comments/use-comment-filter-fields.test.ts src/views/comments/hooks/use-filter-state.test.tsx`