### PR TITLE
fix(admin-x-settings): Fix portal links input border rendering in Tailwind v4

### DIFF
--- a/apps/admin-x-settings/src/components/settings/membership/portal/PortalLinks.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/portal/PortalLinks.tsx
@@ -26,7 +26,7 @@ const PortalLink: React.FC<PortalLinkPrefs> = ({name, value}) => {
         >
             <div className='flex w-full grow flex-col py-3 lg:flex-row lg:items-center lg:gap-5'>
                 <label className='inline-block whitespace-nowrap lg:w-[180px] lg:min-w-[180px]' htmlFor={id}>{name}:</label>
-                <TextField className='border-b-500 grow bg-transparent py-1 text-grey-700 lg:p-1' id={id} value={value} disabled unstyled />
+                <TextField className='border-b-grey-500 grow bg-transparent py-1 text-grey-700 lg:p-1' id={id} value={value} disabled unstyled />
             </div>
         </ListItem>
     );


### PR DESCRIPTION
## Problem

In `PortalLinks.tsx`, the `TextField` component uses the class `border-b-500`. In Tailwind v4, this is parsed as `border-bottom-width: 500px` (a width utility) rather than a border color, because there is no color segment in the class name. This causes a massive ~500px grey rectangle to render below each link input field on the Portal Links settings page.

## Fix

Changed `border-b-500` → `border-b-grey-500` so that Tailwind v4 correctly resolves it as a border color using Ghost's grey color palette. This is consistent with the existing `text-grey-700` class on the same element, confirming Ghost uses "grey" (not "gray") throughout its color tokens.

**File changed:** `apps/admin-x-settings/src/components/settings/membership/portal/PortalLinks.tsx`

## Reproduction steps

1. Navigate to `/ghost/#/settings/portal/edit`
2. Click the **Links** tab
3. Observe oversized grey rectangles rendering below each link input field (caused by `border-bottom-width: 500px`)

## After fix

Each link input renders with a standard bottom border using the `grey-500` color token, matching the intended design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change: adjusts a Tailwind class on a disabled `TextField` to prevent incorrect `border-bottom-width` rendering in Tailwind v4.
> 
> **Overview**
> Fixes Portal Links input styling by changing the `TextField` bottom-border utility from `border-b-500` to `border-b-grey-500`, ensuring Tailwind v4 treats it as a color token rather than a 500px border width.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a447e3a769b56476818ab66f111e0315456cae4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->