### PR TITLE
✨ Added newsletter email Share link to open Portal modal

### DIFF
--- a/ghost/core/core/server/services/email-service/email-renderer.js
+++ b/ghost/core/core/server/services/email-service/email-renderer.js
@@ -1166,6 +1166,9 @@ class EmailRenderer {
         }
 
         const postUrl = this.#getPostUrl(post);
+        const isPublicPost = post.get('visibility') === 'public';
+        const shareUrl = new URL(postUrl);
+        shareUrl.hash = '/portal/share';
 
         // Signup URL is the post url with a hash added to it
         const signupUrl = new URL(postUrl);
@@ -1250,6 +1253,7 @@ class EmailRenderer {
             post: {
                 title: post.get('title'),
                 url: postUrl,
+                shareUrl: isPublicPost ? shareUrl.href : null,
                 commentUrl: commentUrl.href,
                 authors,
                 publishedAt,

--- a/ghost/core/core/server/services/email-service/email-renderer.js
+++ b/ghost/core/core/server/services/email-service/email-renderer.js
@@ -1192,6 +1192,12 @@ class EmailRenderer {
         commentUrl.hash = '#ghost-comments-root';
 
         const hasEmailOnlyFlag = post.related('posts_meta')?.get('email_only') ?? false;
+        const hasFeedbackButtons = newsletter.get('feedback_enabled');
+        const showCommentCta = newsletter.get('show_comment_cta') && this.#settingsCache.get('comments_enabled') !== 'off' && !hasEmailOnlyFlag;
+        const feedbackButtonCount = (hasFeedbackButtons ? 2 : 0) + (showCommentCta ? 1 : 0) + (isPublicPost ? 1 : 0);
+        const feedbackButtonCellWidth = feedbackButtonCount > 0
+            ? `${(100 / feedbackButtonCount).toFixed(2).replace(/\.00$/, '')}%`
+            : null;
 
         const latestPosts = [];
         let latestPostsHasImages = false;
@@ -1269,7 +1275,7 @@ class EmailRenderer {
                 name: newsletter.get('name'),
                 showPostTitleSection: newsletter.get('show_post_title_section'),
                 showExcerpt: newsletter.get('show_excerpt'),
-                showCommentCta: newsletter.get('show_comment_cta') && this.#settingsCache.get('comments_enabled') !== 'off' && !hasEmailOnlyFlag,
+                showCommentCta,
                 showSubscriptionDetails: newsletter.get('show_subscription_details')
             },
 
@@ -1358,10 +1364,11 @@ class EmailRenderer {
             },
 
             // Audience feedback
-            feedbackButtons: newsletter.get('feedback_enabled') ? {
+            feedbackButtons: hasFeedbackButtons ? {
                 likeHref: positiveLink,
                 dislikeHref: negativeLink
             } : null,
+            feedbackButtonCellWidth,
 
             // Paywall
             paywall: addPaywall ? {

--- a/ghost/core/core/server/services/email-service/email-templates/partials/feedback-button.hbs
+++ b/ghost/core/core/server/services/email-service/email-templates/partials/feedback-button.hbs
@@ -1,7 +1,7 @@
-<td dir="ltr" valign="top" align="center" style="display: inline-block; vertical-align: top; font-family: inherit; text-align: center; padding: 0 4px 4px; cursor: pointer; width: 30%;">
+<td dir="ltr" valign="top" align="center" style="display: inline-block; box-sizing: border-box; vertical-align: top; font-family: inherit; text-align: center; padding: 0 4px 4px; cursor: pointer; width: {{#if cellWidth}}{{cellWidth}}{{else}}30%{{/if}};">
     <a href="{{href}}" target="_blank">
-        <img src={{iconUrl}} border="0" width={{width}} height={{height}} alt="{{buttonText}}">
+        <img src={{iconUrl}} border="0" width={{width}} height={{height}} alt="{{buttonText}}" {{#if iconClass}}class="{{iconClass}}"{{/if}}>
         <p class="feedback-button-text">{{t buttonText}}</p>
-        {{!-- Button text possible values:  {{t 'More like this'}} {{t 'Less like this'}} {{t 'Comment'}} --}}
+        {{!-- Button text possible values:  {{t 'More like this'}} {{t 'Less like this'}} {{t 'Comment'}} {{t 'Share'}} --}}
     </a>
 </td>

--- a/ghost/core/core/server/services/email-service/email-templates/partials/styles.hbs
+++ b/ghost/core/core/server/services/email-service/email-templates/partials/styles.hbs
@@ -736,16 +736,6 @@ figure blockquote p {
     vertical-align: middle;
 }
 
-.feedback-buttons img.feedback-share-icon {
-    box-sizing: border-box;
-    border: 1px solid {{#if backgroundIsDark}}#ffffff{{else}}#15212A{{/if}};
-    border-radius: 50%;
-    padding: 10px;
-    {{#if backgroundIsDark}}
-    background-color: #ffffff;
-    {{/if}}
-}
-
 .feedback-button-text {
     display: inline-block;
     font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif;

--- a/ghost/core/core/server/services/email-service/email-templates/partials/styles.hbs
+++ b/ghost/core/core/server/services/email-service/email-templates/partials/styles.hbs
@@ -736,6 +736,16 @@ figure blockquote p {
     vertical-align: middle;
 }
 
+.feedback-buttons img.feedback-share-icon {
+    box-sizing: border-box;
+    border: 1px solid {{#if backgroundIsDark}}#ffffff{{else}}#15212A{{/if}};
+    border-radius: 50%;
+    padding: 10px;
+    {{#if backgroundIsDark}}
+    background-color: #ffffff;
+    {{/if}}
+}
+
 .feedback-button-text {
     display: inline-block;
     font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif;

--- a/ghost/core/core/server/services/email-service/email-templates/template.hbs
+++ b/ghost/core/core/server/services/email-service/email-templates/template.hbs
@@ -106,11 +106,19 @@
                                                             </td>
                                                             <td class="{{classes.meta}} view-online desktop">
                                                                 <a href="{{post.url}}" class="view-online-link">{{t 'View in browser'}}</a>
+                                                                {{#if post.shareUrl}}
+                                                                    <span aria-hidden="true"> • </span>
+                                                                    <a href="{{post.shareUrl}}" class="view-online-link">{{t 'Share'}}</a>
+                                                                {{/if}}
                                                             </td>
                                                         </tr>
                                                         <tr class="{{classes.meta}} view-online-mobile">
                                                             <td height="20" class="view-online">
                                                                 <a href="{{post.url}}" class="view-online-link">{{t 'View in browser'}}</a>
+                                                                {{#if post.shareUrl}}
+                                                                    <span aria-hidden="true"> • </span>
+                                                                    <a href="{{post.shareUrl}}" class="view-online-link">{{t 'Share'}}</a>
+                                                                {{/if}}
                                                             </td>
                                                         </tr>
                                                     </table>

--- a/ghost/core/core/server/services/email-service/email-templates/template.hbs
+++ b/ghost/core/core/server/services/email-service/email-templates/template.hbs
@@ -209,7 +209,7 @@
                                                     {{> feedbackButton href=post.commentUrl buttonText='Comment' iconUrl="https://static.ghost.org/v5.0.0/images/comment-mobile.png" width="42" height="42" cellWidth=feedbackButtonCellWidth }}
                                                 {{/if}}
                                                 {{#if post.shareUrl}}
-                                                    {{> feedbackButton href=post.shareUrl buttonText='Share' iconUrl="https://static.ghost.org/v5.0.0/images/link-icon.svg" width="42" height="42" cellWidth=feedbackButtonCellWidth iconClass="feedback-share-icon"}}
+                                                    {{> feedbackButton href=post.shareUrl buttonText='Share' iconUrl="https://static.ghost.org/v6.0.0/images/share-button.svg" width="42" height="42" cellWidth=feedbackButtonCellWidth}}
                                                 {{/if}}
                                             </tr>
                                         </table>

--- a/ghost/core/core/server/services/email-service/email-templates/template.hbs
+++ b/ghost/core/core/server/services/email-service/email-templates/template.hbs
@@ -202,14 +202,14 @@
                                         <table class="feedback-buttons" role="presentation" border="0" cellpadding="0" cellspacing="0">
                                             <tr>
                                                 {{#if feedbackButtons }}
-                                                    {{> feedbackButton feedbackButtons href=feedbackButtons.likeHref buttonText='More like this' iconUrl="https://static.ghost.org/v5.0.0/images/more-like-this-mobile.png" width="42" height="42" }}
-                                                    {{> feedbackButton feedbackButtons href=feedbackButtons.dislikeHref buttonText='Less like this' iconUrl="https://static.ghost.org/v5.0.0/images/less-like-this-mobile.png" width="42" height="42" }}
+                                                    {{> feedbackButton feedbackButtons href=feedbackButtons.likeHref buttonText='More like this' iconUrl="https://static.ghost.org/v5.0.0/images/more-like-this-mobile.png" width="42" height="42" cellWidth=feedbackButtonCellWidth }}
+                                                    {{> feedbackButton feedbackButtons href=feedbackButtons.dislikeHref buttonText='Less like this' iconUrl="https://static.ghost.org/v5.0.0/images/less-like-this-mobile.png" width="42" height="42" cellWidth=feedbackButtonCellWidth }}
                                                 {{/if}}
                                                 {{#if newsletter.showCommentCta}}
-                                                    {{> feedbackButton href=post.commentUrl buttonText='Comment' iconUrl="https://static.ghost.org/v5.0.0/images/comment-mobile.png" width="42" height="42"}}
+                                                    {{> feedbackButton href=post.commentUrl buttonText='Comment' iconUrl="https://static.ghost.org/v5.0.0/images/comment-mobile.png" width="42" height="42" cellWidth=feedbackButtonCellWidth }}
                                                 {{/if}}
                                                 {{#if post.shareUrl}}
-                                                    {{> feedbackButton href=post.shareUrl buttonText='Share' iconUrl="https://static.ghost.org/v5.0.0/images/link-icon.svg" width="42" height="42"}}
+                                                    {{> feedbackButton href=post.shareUrl buttonText='Share' iconUrl="https://static.ghost.org/v5.0.0/images/link-icon.svg" width="42" height="42" cellWidth=feedbackButtonCellWidth iconClass="feedback-share-icon"}}
                                                 {{/if}}
                                             </tr>
                                         </table>

--- a/ghost/core/core/server/services/email-service/email-templates/template.hbs
+++ b/ghost/core/core/server/services/email-service/email-templates/template.hbs
@@ -106,19 +106,11 @@
                                                             </td>
                                                             <td class="{{classes.meta}} view-online desktop">
                                                                 <a href="{{post.url}}" class="view-online-link">{{t 'View in browser'}}</a>
-                                                                {{#if post.shareUrl}}
-                                                                    <span aria-hidden="true"> • </span>
-                                                                    <a href="{{post.shareUrl}}" class="view-online-link">{{t 'Share'}}</a>
-                                                                {{/if}}
                                                             </td>
                                                         </tr>
                                                         <tr class="{{classes.meta}} view-online-mobile">
                                                             <td height="20" class="view-online">
                                                                 <a href="{{post.url}}" class="view-online-link">{{t 'View in browser'}}</a>
-                                                                {{#if post.shareUrl}}
-                                                                    <span aria-hidden="true"> • </span>
-                                                                    <a href="{{post.shareUrl}}" class="view-online-link">{{t 'Share'}}</a>
-                                                                {{/if}}
                                                             </td>
                                                         </tr>
                                                     </table>
@@ -204,7 +196,7 @@
 
                             <!-- END MAIN CONTENT AREA -->
 
-                            {{#if (or feedbackButtons newsletter.showCommentCta) }}
+                            {{#if (or feedbackButtons newsletter.showCommentCta post.shareUrl) }}
                                 <tr>
                                     <td class="feedback-buttons-container" dir="ltr" width="100%" align="center">
                                         <table class="feedback-buttons" role="presentation" border="0" cellpadding="0" cellspacing="0">
@@ -215,6 +207,9 @@
                                                 {{/if}}
                                                 {{#if newsletter.showCommentCta}}
                                                     {{> feedbackButton href=post.commentUrl buttonText='Comment' iconUrl="https://static.ghost.org/v5.0.0/images/comment-mobile.png" width="42" height="42"}}
+                                                {{/if}}
+                                                {{#if post.shareUrl}}
+                                                    {{> feedbackButton href=post.shareUrl buttonText='Share' iconUrl="https://static.ghost.org/v5.0.0/images/link-icon.svg" width="42" height="42"}}
                                                 {{/if}}
                                             </tr>
                                         </table>

--- a/ghost/core/core/server/services/email-service/email-templates/template.hbs
+++ b/ghost/core/core/server/services/email-service/email-templates/template.hbs
@@ -209,7 +209,7 @@
                                                     {{> feedbackButton href=post.commentUrl buttonText='Comment' iconUrl="https://static.ghost.org/v5.0.0/images/comment-mobile.png" width="42" height="42" cellWidth=feedbackButtonCellWidth }}
                                                 {{/if}}
                                                 {{#if post.shareUrl}}
-                                                    {{> feedbackButton href=post.shareUrl buttonText='Share' iconUrl="https://static.ghost.org/v6.0.0/images/share-button.png" width="42" height="42" cellWidth=feedbackButtonCellWidth}}
+                                                    {{> feedbackButton href=post.shareUrl buttonText='Share' iconUrl="https://static.ghost.org/v6.0.0/images/share-mobile.png" width="42" height="42" cellWidth=feedbackButtonCellWidth}}
                                                 {{/if}}
                                             </tr>
                                         </table>

--- a/ghost/core/core/server/services/email-service/email-templates/template.hbs
+++ b/ghost/core/core/server/services/email-service/email-templates/template.hbs
@@ -209,7 +209,7 @@
                                                     {{> feedbackButton href=post.commentUrl buttonText='Comment' iconUrl="https://static.ghost.org/v5.0.0/images/comment-mobile.png" width="42" height="42" cellWidth=feedbackButtonCellWidth }}
                                                 {{/if}}
                                                 {{#if post.shareUrl}}
-                                                    {{> feedbackButton href=post.shareUrl buttonText='Share' iconUrl="https://static.ghost.org/v6.0.0/images/share-button.svg" width="42" height="42" cellWidth=feedbackButtonCellWidth}}
+                                                    {{> feedbackButton href=post.shareUrl buttonText='Share' iconUrl="https://static.ghost.org/v6.0.0/images/share-button.png" width="42" height="42" cellWidth=feedbackButtonCellWidth}}
                                                 {{/if}}
                                             </tr>
                                         </table>

--- a/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
+++ b/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
@@ -1439,7 +1439,6 @@ describe('Email renderer', function () {
 
             assert(response.html.includes('href="http://example.com/#/portal/share"'));
             assert(response.html.includes('>Share</p>'));
-            assert(response.html.includes('class="feedback-share-icon"'));
         });
 
         it('does not include share links for non-public posts', async function () {

--- a/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
+++ b/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
@@ -1439,6 +1439,7 @@ describe('Email renderer', function () {
 
             assert(response.html.includes('href="http://example.com/#/portal/share"'));
             assert(response.html.includes('>Share</p>'));
+            assert(response.html.includes('class="feedback-share-icon"'));
         });
 
         it('does not include share links for non-public posts', async function () {
@@ -2548,6 +2549,23 @@ describe('Email renderer', function () {
             const newsletter = createModel({});
             const data = await emailRenderer.getTemplateData({post, newsletter, html, addPaywall: false});
             assert.equal(data.post.shareUrl, 'http://example.com/#/portal/share');
+        });
+
+        it('calculates footer feedback button widths based on visible actions', async function () {
+            settings.comments_enabled = 'all';
+            const html = '';
+            const post = createModel({
+                posts_meta: createModel({}),
+                loaded: ['posts_meta'],
+                visibility: 'public'
+            });
+            const newsletter = createModel({
+                feedback_enabled: true,
+                show_comment_cta: true
+            });
+
+            const data = await emailRenderer.getTemplateData({post, newsletter, html, addPaywall: false});
+            assert.equal(data.feedbackButtonCellWidth, '25%');
         });
 
         it('does not include share URL for non-public posts', async function () {

--- a/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
+++ b/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
@@ -1438,7 +1438,7 @@ describe('Email renderer', function () {
             );
 
             assert(response.html.includes('href="http://example.com/#/portal/share"'));
-            assert.match(response.html, />Share<\/a>/);
+            assert(response.html.includes('>Share</p>'));
         });
 
         it('does not include share links for non-public posts', async function () {
@@ -1789,15 +1789,14 @@ describe('Email renderer', function () {
             assert.deepEqual(links, [
                 `http://tracked-link.com/?m=%%{uuid}%%&url=http%3A%2F%2Fexample.com%2F%3Fsource_tracking%3DTest%2BNewsletter%26post_tracking%3Dadded`,
                 `http://tracked-link.com/?m=%%{uuid}%%&url=http%3A%2F%2Fexample.com%2F%3Fsource_tracking%3DTest%2BNewsletter%26post_tracking%3Dadded`,
-                `http://tracked-link.com/?m=%%{uuid}%%&url=http%3A%2F%2Fexample.com%2F%3Fsource_tracking%3DTest%2BNewsletter%26post_tracking%3Dadded%23%2Fportal%2Fshare`,
                 `http://tracked-link.com/?m=%%{uuid}%%&url=http%3A%2F%2Fexample.com%2F%3Fsource_tracking%3DTest%2BNewsletter%26post_tracking%3Dadded`,
-                `http://tracked-link.com/?m=%%{uuid}%%&url=http%3A%2F%2Fexample.com%2F%3Fsource_tracking%3DTest%2BNewsletter%26post_tracking%3Dadded%23%2Fportal%2Fshare`,
                 `http://tracked-link.com/?m=%%{uuid}%%&url=https%3A%2F%2Fexternal-domain.com%2F%3Fref%3D123%26source_tracking%3Dsite`,
                 `http://tracked-link.com/?m=%%{uuid}%%&url=https%3A%2F%2Fencoded-link.com%2F%3Fcode%3Dtest%26source_tracking%3Dsite`,
                 `http://tracked-link.com/?m=%%{uuid}%%&url=https%3A%2F%2Fexample.com%2F%3Fref%3D123%26source_tracking%3DTest%2BNewsletter%26post_tracking%3Dadded`,
                 '#',
                 `http://feedback-link.com/?score=1&uuid=%%{uuid}%%&key=%%{key}%%`,
                 `http://feedback-link.com/?score=0&uuid=%%{uuid}%%&key=%%{key}%%`,
+                `http://tracked-link.com/?m=%%{uuid}%%&url=http%3A%2F%2Fexample.com%2F%3Fsource_tracking%3DTest%2BNewsletter%26post_tracking%3Dadded%23%2Fportal%2Fshare`,
                 `%%{unsubscribe_url}%%`,
                 `https://ghost.org/?via=pbg-newsletter&source_tracking=site`
             ]);
@@ -1848,13 +1847,12 @@ describe('Email renderer', function () {
             assert.deepEqual(links, [
                 'http://example.com/',
                 'http://example.com/',
-                'http://example.com/#/portal/share',
                 'http://example.com/',
-                'http://example.com/#/portal/share',
                 'http://example.com/#relative-test',
                 '#',
                 'http://feedback-link.com/?score=1&uuid=%%{uuid}%%&key=%%{key}%%',
                 'http://feedback-link.com/?score=0&uuid=%%{uuid}%%&key=%%{key}%%',
+                'http://example.com/#/portal/share',
                 '%%{unsubscribe_url}%%',
                 'https://ghost.org/?via=pbg-newsletter'
             ]);
@@ -1905,13 +1903,12 @@ describe('Email renderer', function () {
             assert.deepEqual(links, [
                 `http://tracked-link.com/?m=%%{uuid}%%&url=http%3A%2F%2Fexample.com%2F%3Fsource_tracking%3DTest%2BNewsletter%26post_tracking%3Dadded`,
                 `http://tracked-link.com/?m=%%{uuid}%%&url=http%3A%2F%2Fexample.com%2F%3Fsource_tracking%3DTest%2BNewsletter%26post_tracking%3Dadded`,
-                `http://tracked-link.com/?m=%%{uuid}%%&url=http%3A%2F%2Fexample.com%2F%3Fsource_tracking%3DTest%2BNewsletter%26post_tracking%3Dadded%23%2Fportal%2Fshare`,
                 `http://tracked-link.com/?m=%%{uuid}%%&url=http%3A%2F%2Fexample.com%2F%3Fsource_tracking%3DTest%2BNewsletter%26post_tracking%3Dadded`,
-                `http://tracked-link.com/?m=%%{uuid}%%&url=http%3A%2F%2Fexample.com%2F%3Fsource_tracking%3DTest%2BNewsletter%26post_tracking%3Dadded%23%2Fportal%2Fshare`,
                 `http://tracked-link.com/?m=%%{uuid}%%&url=https%3A%2F%2Fexternal-domain.com%2F%3Fref%3D123%26source_tracking%3Dsite`,
                 `http://tracked-link.com/?m=%%{uuid}%%&url=https%3A%2F%2Fexample.com%2F%3Fref%3D123%26source_tracking%3DTest%2BNewsletter%26post_tracking%3Dadded`,
                 `http://feedback-link.com/?score=1&uuid=%%{uuid}%%&key=%%{key}%%`,
                 `http://feedback-link.com/?score=0&uuid=%%{uuid}%%&key=%%{key}%%`,
+                `http://tracked-link.com/?m=%%{uuid}%%&url=http%3A%2F%2Fexample.com%2F%3Fsource_tracking%3DTest%2BNewsletter%26post_tracking%3Dadded%23%2Fportal%2Fshare`,
                 `%%{unsubscribe_url}%%`,
                 `https://ghost.org/?via=pbg-newsletter&source_tracking=site`
             ]);

--- a/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
+++ b/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
@@ -1418,6 +1418,54 @@ describe('Email renderer', function () {
             assert(response.html.includes('http://feedback-link.com/?score=0'));
         });
 
+        it('includes share links for public posts', async function () {
+            const post = createModel(basePost);
+            const newsletter = createModel({
+                header_image: null,
+                name: 'Test Newsletter',
+                show_badge: false,
+                feedback_enabled: true,
+                show_post_title_section: true
+            });
+            const segment = null;
+            const options = {};
+
+            const response = await emailRenderer.renderBody(
+                post,
+                newsletter,
+                segment,
+                options
+            );
+
+            assert(response.html.includes('href="http://example.com/#/portal/share"'));
+            assert.match(response.html, />Share<\/a>/);
+        });
+
+        it('does not include share links for non-public posts', async function () {
+            const post = createModel({
+                ...basePost,
+                visibility: 'members'
+            });
+            const newsletter = createModel({
+                header_image: null,
+                name: 'Test Newsletter',
+                show_badge: false,
+                feedback_enabled: true,
+                show_post_title_section: true
+            });
+            const segment = null;
+            const options = {};
+
+            const response = await emailRenderer.renderBody(
+                post,
+                newsletter,
+                segment,
+                options
+            );
+
+            assert(!response.html.includes('#/portal/share'));
+        });
+
         it('uses custom excerpt as preheader', async function () {
             const post = createModel({...basePost, custom_excerpt: 'Custom excerpt'});
             const newsletter = createModel({
@@ -1741,7 +1789,9 @@ describe('Email renderer', function () {
             assert.deepEqual(links, [
                 `http://tracked-link.com/?m=%%{uuid}%%&url=http%3A%2F%2Fexample.com%2F%3Fsource_tracking%3DTest%2BNewsletter%26post_tracking%3Dadded`,
                 `http://tracked-link.com/?m=%%{uuid}%%&url=http%3A%2F%2Fexample.com%2F%3Fsource_tracking%3DTest%2BNewsletter%26post_tracking%3Dadded`,
+                `http://tracked-link.com/?m=%%{uuid}%%&url=http%3A%2F%2Fexample.com%2F%3Fsource_tracking%3DTest%2BNewsletter%26post_tracking%3Dadded%23%2Fportal%2Fshare`,
                 `http://tracked-link.com/?m=%%{uuid}%%&url=http%3A%2F%2Fexample.com%2F%3Fsource_tracking%3DTest%2BNewsletter%26post_tracking%3Dadded`,
+                `http://tracked-link.com/?m=%%{uuid}%%&url=http%3A%2F%2Fexample.com%2F%3Fsource_tracking%3DTest%2BNewsletter%26post_tracking%3Dadded%23%2Fportal%2Fshare`,
                 `http://tracked-link.com/?m=%%{uuid}%%&url=https%3A%2F%2Fexternal-domain.com%2F%3Fref%3D123%26source_tracking%3Dsite`,
                 `http://tracked-link.com/?m=%%{uuid}%%&url=https%3A%2F%2Fencoded-link.com%2F%3Fcode%3Dtest%26source_tracking%3Dsite`,
                 `http://tracked-link.com/?m=%%{uuid}%%&url=https%3A%2F%2Fexample.com%2F%3Fref%3D123%26source_tracking%3DTest%2BNewsletter%26post_tracking%3Dadded`,
@@ -1798,7 +1848,9 @@ describe('Email renderer', function () {
             assert.deepEqual(links, [
                 'http://example.com/',
                 'http://example.com/',
+                'http://example.com/#/portal/share',
                 'http://example.com/',
+                'http://example.com/#/portal/share',
                 'http://example.com/#relative-test',
                 '#',
                 'http://feedback-link.com/?score=1&uuid=%%{uuid}%%&key=%%{key}%%',
@@ -1853,7 +1905,9 @@ describe('Email renderer', function () {
             assert.deepEqual(links, [
                 `http://tracked-link.com/?m=%%{uuid}%%&url=http%3A%2F%2Fexample.com%2F%3Fsource_tracking%3DTest%2BNewsletter%26post_tracking%3Dadded`,
                 `http://tracked-link.com/?m=%%{uuid}%%&url=http%3A%2F%2Fexample.com%2F%3Fsource_tracking%3DTest%2BNewsletter%26post_tracking%3Dadded`,
+                `http://tracked-link.com/?m=%%{uuid}%%&url=http%3A%2F%2Fexample.com%2F%3Fsource_tracking%3DTest%2BNewsletter%26post_tracking%3Dadded%23%2Fportal%2Fshare`,
                 `http://tracked-link.com/?m=%%{uuid}%%&url=http%3A%2F%2Fexample.com%2F%3Fsource_tracking%3DTest%2BNewsletter%26post_tracking%3Dadded`,
+                `http://tracked-link.com/?m=%%{uuid}%%&url=http%3A%2F%2Fexample.com%2F%3Fsource_tracking%3DTest%2BNewsletter%26post_tracking%3Dadded%23%2Fportal%2Fshare`,
                 `http://tracked-link.com/?m=%%{uuid}%%&url=https%3A%2F%2Fexternal-domain.com%2F%3Fref%3D123%26source_tracking%3Dsite`,
                 `http://tracked-link.com/?m=%%{uuid}%%&url=https%3A%2F%2Fexample.com%2F%3Fref%3D123%26source_tracking%3DTest%2BNewsletter%26post_tracking%3Dadded`,
                 `http://feedback-link.com/?score=1&uuid=%%{uuid}%%&key=%%{key}%%`,
@@ -2485,6 +2539,33 @@ describe('Email renderer', function () {
             const newsletter = createModel({});
             const data = await emailRenderer.getTemplateData({post, newsletter, html, addPaywall: false});
             assert.equal(data.post.publishedAt, '1 Jan 1970');
+        });
+
+        it('includes share URL for public posts', async function () {
+            const html = '';
+            const post = createModel({
+                posts_meta: createModel({}),
+                loaded: ['posts_meta'],
+                visibility: 'public'
+            });
+            const newsletter = createModel({});
+            const data = await emailRenderer.getTemplateData({post, newsletter, html, addPaywall: false});
+            assert.equal(data.post.shareUrl, 'http://example.com/#/portal/share');
+        });
+
+        it('does not include share URL for non-public posts', async function () {
+            const html = '';
+            const newsletter = createModel({});
+
+            for (const visibility of ['members', 'paid', 'tiers']) {
+                const post = createModel({
+                    posts_meta: createModel({}),
+                    loaded: ['posts_meta'],
+                    visibility
+                });
+                const data = await emailRenderer.getTemplateData({post, newsletter, html, addPaywall: false});
+                assert.equal(data.post.shareUrl, null, `Expected no share URL for "${visibility}" visibility`);
+            }
         });
 
         it('show feature image if post has feature image', async function () {

--- a/ghost/i18n/locales/af/ghost.json
+++ b/ghost/i18n/locales/af/ghost.json
@@ -39,6 +39,7 @@
     "Secure sign in link for {siteTitle}": "Veilige aanmeldskakel vir {siteTitle}",
     "See you soon!": "Sien u binnekort weer!",
     "Sent to {email}": "Gestuur na {email}",
+    "Share": "",
     "Sign in": "Meld aan",
     "Sign in now": "",
     "Sign in to {siteTitle}": "Meld aan by {siteTitle}",

--- a/ghost/i18n/locales/ar/ghost.json
+++ b/ghost/i18n/locales/ar/ghost.json
@@ -39,6 +39,7 @@
     "Secure sign in link for {siteTitle}": "رابط تسجيل الدخول الامن الى {siteTitle}",
     "See you soon!": "نراكم قريبا!",
     "Sent to {email}": "تم الارسال الى {email}",
+    "Share": "",
     "Sign in": "تسجيل الدخول",
     "Sign in now": "",
     "Sign in to {siteTitle}": "تسجيل الدخول الى {siteTitle}",

--- a/ghost/i18n/locales/bg/ghost.json
+++ b/ghost/i18n/locales/bg/ghost.json
@@ -39,6 +39,7 @@
     "Secure sign in link for {siteTitle}": "Линк за сигурно влизане в сайта {siteTitle}",
     "See you soon!": "До скоро!",
     "Sent to {email}": "Изпратено до {email}",
+    "Share": "",
     "Sign in": "Вход",
     "Sign in now": "Влезте сега",
     "Sign in to {siteTitle}": "Влезте в {siteTitle}",

--- a/ghost/i18n/locales/bn/ghost.json
+++ b/ghost/i18n/locales/bn/ghost.json
@@ -39,6 +39,7 @@
     "Secure sign in link for {siteTitle}": "{siteTitle} এর জন্য নিরাপদ সাইন ইন লিঙ্ক",
     "See you soon!": "শীঘ্রই দেখা হবে!",
     "Sent to {email}": "{email} এ পাঠানো হয়েছে",
+    "Share": "",
     "Sign in": "সাইন ইন করুন",
     "Sign in now": "",
     "Sign in to {siteTitle}": "{siteTitle} এ সাইন ইন করুন",

--- a/ghost/i18n/locales/bs/ghost.json
+++ b/ghost/i18n/locales/bs/ghost.json
@@ -39,6 +39,7 @@
     "Secure sign in link for {siteTitle}": "Siguran link za prijavu za {siteTitle}",
     "See you soon!": "Vidimo se uskoro!",
     "Sent to {email}": "Poslano na {email}",
+    "Share": "",
     "Sign in": "Prijavi se",
     "Sign in now": "",
     "Sign in to {siteTitle}": "Prijavi se na {siteTitle}",

--- a/ghost/i18n/locales/ca/ghost.json
+++ b/ghost/i18n/locales/ca/ghost.json
@@ -39,6 +39,7 @@
     "Secure sign in link for {siteTitle}": "Enllaç segur d'inici de sessió per {siteTitle}",
     "See you soon!": "A reveure!",
     "Sent to {email}": "Enviat a {email}",
+    "Share": "",
     "Sign in": "Inicia sessió",
     "Sign in now": "",
     "Sign in to {siteTitle}": "Inicia sessió a {siteTitle}",

--- a/ghost/i18n/locales/cs/ghost.json
+++ b/ghost/i18n/locales/cs/ghost.json
@@ -39,6 +39,7 @@
     "Secure sign in link for {siteTitle}": "Bezpečný přihlašovací odkaz pro {siteTitle}",
     "See you soon!": "Na viděnou!",
     "Sent to {email}": "Odesláno na {email}",
+    "Share": "",
     "Sign in": "Přihlásit se",
     "Sign in now": "",
     "Sign in to {siteTitle}": "Přihlásit se k {siteTitle}",

--- a/ghost/i18n/locales/da/ghost.json
+++ b/ghost/i18n/locales/da/ghost.json
@@ -39,6 +39,7 @@
     "Secure sign in link for {siteTitle}": "Sikker log ind link til {siteTitle}",
     "See you soon!": "Vi ses om lidt!",
     "Sent to {email}": "Sendt til {email}",
+    "Share": "",
     "Sign in": "Log ind",
     "Sign in now": "",
     "Sign in to {siteTitle}": "Log ind hos {siteTitle}",

--- a/ghost/i18n/locales/de-CH/ghost.json
+++ b/ghost/i18n/locales/de-CH/ghost.json
@@ -39,6 +39,7 @@
     "Secure sign in link for {siteTitle}": "Sicherer Anmeldelink für unsere Seite «{siteTitle}»",
     "See you soon!": "Bis bald!",
     "Sent to {email}": "Gesendet an {email}",
+    "Share": "",
     "Sign in": "Einloggen",
     "Sign in now": "Jetzt einloggen",
     "Sign in to {siteTitle}": "Bei «{siteTitle}» einloggen",

--- a/ghost/i18n/locales/de/ghost.json
+++ b/ghost/i18n/locales/de/ghost.json
@@ -39,6 +39,7 @@
     "Secure sign in link for {siteTitle}": "Sicherer Anmeldelink für {siteTitle}",
     "See you soon!": "Bis bald!",
     "Sent to {email}": "Gesendet an {email}",
+    "Share": "",
     "Sign in": "Einloggen",
     "Sign in now": "Jetzt einloggen",
     "Sign in to {siteTitle}": "Bei {siteTitle} einloggen",

--- a/ghost/i18n/locales/el/ghost.json
+++ b/ghost/i18n/locales/el/ghost.json
@@ -39,6 +39,7 @@
     "Secure sign in link for {siteTitle}": "Ασφαλής σύνδεσμος σύνδεσης για το {siteTitle}",
     "See you soon!": "Τα λέμε σύντομα!",
     "Sent to {email}": "Απεστάλη στο {email}",
+    "Share": "",
     "Sign in": "Σύνδεση",
     "Sign in now": "",
     "Sign in to {siteTitle}": "Συνδεθείτε στο {siteTitle}",

--- a/ghost/i18n/locales/en/ghost.json
+++ b/ghost/i18n/locales/en/ghost.json
@@ -39,6 +39,7 @@
     "Secure sign in link for {siteTitle}": "",
     "See you soon!": "",
     "Sent to {email}": "",
+    "Share": "",
     "Sign in": "",
     "Sign in now": "",
     "Sign in to {siteTitle}": "",

--- a/ghost/i18n/locales/eo/ghost.json
+++ b/ghost/i18n/locales/eo/ghost.json
@@ -39,6 +39,7 @@
     "Secure sign in link for {siteTitle}": "Sekura ensaluta ligilo por {siteTitle}",
     "See you soon!": "Ĝis baldaŭ!",
     "Sent to {email}": "Sendita al {email}",
+    "Share": "",
     "Sign in": "",
     "Sign in now": "",
     "Sign in to {siteTitle}": "Ensalutu al {siteTitle}",

--- a/ghost/i18n/locales/es/ghost.json
+++ b/ghost/i18n/locales/es/ghost.json
@@ -39,6 +39,7 @@
     "Secure sign in link for {siteTitle}": "Inicio de sesión seguro para {siteTitle}",
     "See you soon!": "¡Hasta pronto!",
     "Sent to {email}": "Enviado a {email}",
+    "Share": "",
     "Sign in": "Iniciar sesión",
     "Sign in now": "",
     "Sign in to {siteTitle}": "Iniciar sesión en {siteTitle}",

--- a/ghost/i18n/locales/et/ghost.json
+++ b/ghost/i18n/locales/et/ghost.json
@@ -39,6 +39,7 @@
     "Secure sign in link for {siteTitle}": "Turvaline sisselogimislink {siteTitle} lehele",
     "See you soon!": "Kohtumiseni!",
     "Sent to {email}": "Saadetud aadressile {email}",
+    "Share": "",
     "Sign in": "Logi sisse",
     "Sign in now": "",
     "Sign in to {siteTitle}": "Logi sisse {siteTitle} lehele",

--- a/ghost/i18n/locales/eu/ghost.json
+++ b/ghost/i18n/locales/eu/ghost.json
@@ -39,6 +39,7 @@
     "Secure sign in link for {siteTitle}": "{siteTitle}(e)n saioa hasteko esteka segurua",
     "See you soon!": "Laster arte!",
     "Sent to {email}": "{email}(r)i bidali zaio",
+    "Share": "",
     "Sign in": "Hasi saioa",
     "Sign in now": "",
     "Sign in to {siteTitle}": "Hasi saioa {siteTitle}(e)n",

--- a/ghost/i18n/locales/fa/ghost.json
+++ b/ghost/i18n/locales/fa/ghost.json
@@ -39,6 +39,7 @@
     "Secure sign in link for {siteTitle}": "پیوند امن ورود به وب\u200cسایت {siteTitle}",
     "See you soon!": "به زودی می\u200cبینمت!",
     "Sent to {email}": "ارسال شده به {email} ",
+    "Share": "",
     "Sign in": "ورود",
     "Sign in now": "",
     "Sign in to {siteTitle}": "ورود به وب\u200cسایت {siteTitle}",

--- a/ghost/i18n/locales/fi/ghost.json
+++ b/ghost/i18n/locales/fi/ghost.json
@@ -39,6 +39,7 @@
     "Secure sign in link for {siteTitle}": "Turvallinen kirjautumislinkki sivustolle {siteTitle}",
     "See you soon!": "Nähdään pian!",
     "Sent to {email}": "Lähetetty {email}",
+    "Share": "",
     "Sign in": "Kirjaudu sisään",
     "Sign in now": "Kirjaudu nyt sisään",
     "Sign in to {siteTitle}": "Kirjaudu sisään sivulle {siteTitle}",

--- a/ghost/i18n/locales/fr/ghost.json
+++ b/ghost/i18n/locales/fr/ghost.json
@@ -39,6 +39,7 @@
     "Secure sign in link for {siteTitle}": "Lien sécurisé de connexion pour {siteTitle}",
     "See you soon!": "À bientôt !",
     "Sent to {email}": "Envoyé à {email}",
+    "Share": "",
     "Sign in": "Se connecter",
     "Sign in now": "Connectez-vous",
     "Sign in to {siteTitle}": "Se connecter à {siteTitle}",

--- a/ghost/i18n/locales/gd/ghost.json
+++ b/ghost/i18n/locales/gd/ghost.json
@@ -39,6 +39,7 @@
     "Secure sign in link for {siteTitle}": "Ceangal tèarainte airson clàradh a-steach ris an làrach-lìn, {siteTitle}",
     "See you soon!": "Tìoraidh an-dràsta!",
     "Sent to {email}": "Cuir gu {email}",
+    "Share": "",
     "Sign in": "Clàraich a-steach",
     "Sign in now": "",
     "Sign in to {siteTitle}": "Clàraich a-steach dhan làrach-lìn, {siteTitle}",

--- a/ghost/i18n/locales/he/ghost.json
+++ b/ghost/i18n/locales/he/ghost.json
@@ -39,6 +39,7 @@
     "Secure sign in link for {siteTitle}": "לינק הרשמה מאובטח ל{siteTitle}",
     "See you soon!": "להתראות בקרוב!",
     "Sent to {email}": "נשלח אל {email}",
+    "Share": "",
     "Sign in": "כניסה",
     "Sign in now": "",
     "Sign in to {siteTitle}": "כנסו אל {siteTitle}",

--- a/ghost/i18n/locales/hi/ghost.json
+++ b/ghost/i18n/locales/hi/ghost.json
@@ -39,6 +39,7 @@
     "Secure sign in link for {siteTitle}": "{siteTitle} के लिए सुरक्षित साइन इन लिंक",
     "See you soon!": "जल्द ही मिलते हैं!",
     "Sent to {email}": "{email} पर भेजा गया",
+    "Share": "",
     "Sign in": "साइन इन करें",
     "Sign in now": "",
     "Sign in to {siteTitle}": "{siteTitle} में साइन इन करें",

--- a/ghost/i18n/locales/hr/ghost.json
+++ b/ghost/i18n/locales/hr/ghost.json
@@ -39,6 +39,7 @@
     "Secure sign in link for {siteTitle}": "Sigurni link za prijavu na {siteTitle}",
     "See you soon!": "Vidimo se uskoro!",
     "Sent to {email}": "Poslano na {email}",
+    "Share": "",
     "Sign in": "Prijava",
     "Sign in now": "",
     "Sign in to {siteTitle}": "Prijava na {siteTitle}",

--- a/ghost/i18n/locales/hu/ghost.json
+++ b/ghost/i18n/locales/hu/ghost.json
@@ -39,6 +39,7 @@
     "Secure sign in link for {siteTitle}": "{siteTitle} — Biztonságos bejelentkezési link",
     "See you soon!": "Üdv!",
     "Sent to {email}": "Elküldve ide: {email}",
+    "Share": "",
     "Sign in": "Bejelentkezés",
     "Sign in now": "",
     "Sign in to {siteTitle}": "Bejelentkezem ide: {siteTitle}",

--- a/ghost/i18n/locales/id/ghost.json
+++ b/ghost/i18n/locales/id/ghost.json
@@ -39,6 +39,7 @@
     "Secure sign in link for {siteTitle}": "Tautan masuk yang aman untuk {siteTitle}",
     "See you soon!": "Sampai jumpa lagi!",
     "Sent to {email}": "Dikirim ke {email}",
+    "Share": "",
     "Sign in": "Masuk",
     "Sign in now": "",
     "Sign in to {siteTitle}": "Masuk ke {siteTitle}",

--- a/ghost/i18n/locales/is/ghost.json
+++ b/ghost/i18n/locales/is/ghost.json
@@ -39,6 +39,7 @@
     "Secure sign in link for {siteTitle}": "Innskráningarhlekkur fyrir {siteTitle}",
     "See you soon!": "Sjáumst von bráðar!",
     "Sent to {email}": "Senda til {email}",
+    "Share": "",
     "Sign in": "Innskráning",
     "Sign in now": "",
     "Sign in to {siteTitle}": "Innskráning á {siteTitle}",

--- a/ghost/i18n/locales/it/ghost.json
+++ b/ghost/i18n/locales/it/ghost.json
@@ -39,6 +39,7 @@
     "Secure sign in link for {siteTitle}": "Link per l'accesso sicuro a {siteTitle}",
     "See you soon!": "A presto!",
     "Sent to {email}": "Inviata a {email}",
+    "Share": "",
     "Sign in": "Accedi",
     "Sign in now": "Accedi ora",
     "Sign in to {siteTitle}": "Accedi a {siteTitle}",

--- a/ghost/i18n/locales/ja/ghost.json
+++ b/ghost/i18n/locales/ja/ghost.json
@@ -39,6 +39,7 @@
     "Secure sign in link for {siteTitle}": "{siteTitle}へのログインリンクです",
     "See you soon!": "引き続きよろしくお願いします。",
     "Sent to {email}": "{email}に送信",
+    "Share": "",
     "Sign in": "ログイン",
     "Sign in now": "",
     "Sign in to {siteTitle}": "{siteTitle}にログイン",

--- a/ghost/i18n/locales/ko/ghost.json
+++ b/ghost/i18n/locales/ko/ghost.json
@@ -39,6 +39,7 @@
     "Secure sign in link for {siteTitle}": "{siteTitle}의 안전한 로그인 링크예요.",
     "See you soon!": "곧 다시 만나요!",
     "Sent to {email}": "{email}으로 전송되었어요.",
+    "Share": "",
     "Sign in": "로그인",
     "Sign in now": "",
     "Sign in to {siteTitle}": "{siteTitle}에 로그인 해주세요.",

--- a/ghost/i18n/locales/kz/ghost.json
+++ b/ghost/i18n/locales/kz/ghost.json
@@ -39,6 +39,7 @@
     "Secure sign in link for {siteTitle}": "{siteTitle} сайтына қауіпсіз кіруге арналған сілтеме",
     "See you soon!": "Көріскенше!",
     "Sent to {email}": "{email} поштасына жіберілді",
+    "Share": "",
     "Sign in": "Кіру",
     "Sign in now": "",
     "Sign in to {siteTitle}": "{siteTitle} сайтына кіру",

--- a/ghost/i18n/locales/lt/ghost.json
+++ b/ghost/i18n/locales/lt/ghost.json
@@ -39,6 +39,7 @@
     "Secure sign in link for {siteTitle}": "Saugi prisijungimo nuoroda į {siteTitle}",
     "See you soon!": "Iki pasimatymo!",
     "Sent to {email}": "Išsiųsta į {email}",
+    "Share": "",
     "Sign in": "Prisijungti",
     "Sign in now": "",
     "Sign in to {siteTitle}": "Prisijungti prie {siteTitle}",

--- a/ghost/i18n/locales/lv/ghost.json
+++ b/ghost/i18n/locales/lv/ghost.json
@@ -39,6 +39,7 @@
     "Secure sign in link for {siteTitle}": "Droša pierakstīšanās saite vietnei {siteTitle}",
     "See you soon!": "Uz drīzu tikšanos!",
     "Sent to {email}": "Nosūtīts uz {email}",
+    "Share": "",
     "Sign in": "Pierakstīties",
     "Sign in now": "",
     "Sign in to {siteTitle}": "Pierakstieties vietnē {siteTitle}",

--- a/ghost/i18n/locales/mk/ghost.json
+++ b/ghost/i18n/locales/mk/ghost.json
@@ -39,6 +39,7 @@
     "Secure sign in link for {siteTitle}": "Безбеден линк за најава на {siteTitle}",
     "See you soon!": "Ќе се видиме наскоро!",
     "Sent to {email}": "Испратете на {email}",
+    "Share": "",
     "Sign in": "Најава",
     "Sign in now": "",
     "Sign in to {siteTitle}": "Најавете се на {siteTitle}",

--- a/ghost/i18n/locales/mn/ghost.json
+++ b/ghost/i18n/locales/mn/ghost.json
@@ -39,6 +39,7 @@
     "Secure sign in link for {siteTitle}": "{siteTitle}-д нэвтрэх нууцлал бүхий холбоос",
     "See you soon!": "Удахгүй уулзацгаая!",
     "Sent to {email}": "{email} хаяг руу илгээлээ",
+    "Share": "",
     "Sign in": "Нэвтрэх",
     "Sign in now": "",
     "Sign in to {siteTitle}": "{siteTitle}-д нэвтрэх",

--- a/ghost/i18n/locales/ms/ghost.json
+++ b/ghost/i18n/locales/ms/ghost.json
@@ -39,6 +39,7 @@
     "Secure sign in link for {siteTitle}": "Pautan log masuk untuk {siteTitle}",
     "See you soon!": "Jumpa lagi!",
     "Sent to {email}": "Dihantar ke {email}",
+    "Share": "",
     "Sign in": "Log masuk",
     "Sign in now": "",
     "Sign in to {siteTitle}": "Log masuk ke {siteTitle}",

--- a/ghost/i18n/locales/nb/ghost.json
+++ b/ghost/i18n/locales/nb/ghost.json
@@ -39,6 +39,7 @@
     "Secure sign in link for {siteTitle}": "Sikker påloggingslenke for {siteTitle}",
     "See you soon!": "Ser deg snart!",
     "Sent to {email}": "Sendt til {email}",
+    "Share": "",
     "Sign in": "Logg inn",
     "Sign in now": "",
     "Sign in to {siteTitle}": "Logg inn på {siteTitle}",

--- a/ghost/i18n/locales/ne/ghost.json
+++ b/ghost/i18n/locales/ne/ghost.json
@@ -39,6 +39,7 @@
     "Secure sign in link for {siteTitle}": "{siteTitle} को लागि सुरक्षित साइन इन लिङ्क",
     "See you soon!": "चाँडै भेटौँला!",
     "Sent to {email}": "{email} मा पठाइयो",
+    "Share": "",
     "Sign in": "साइन इन",
     "Sign in now": "",
     "Sign in to {siteTitle}": "{siteTitle} मा साइन इन गर्नुहोस्",

--- a/ghost/i18n/locales/nl/ghost.json
+++ b/ghost/i18n/locales/nl/ghost.json
@@ -39,6 +39,7 @@
     "Secure sign in link for {siteTitle}": "Veilige inloglink voor {siteTitle}",
     "See you soon!": "Tot snel!",
     "Sent to {email}": "Verzonden naar {email}",
+    "Share": "",
     "Sign in": "Inloggen",
     "Sign in now": "",
     "Sign in to {siteTitle}": "Inloggen op {siteTitle}",

--- a/ghost/i18n/locales/nn/ghost.json
+++ b/ghost/i18n/locales/nn/ghost.json
@@ -39,6 +39,7 @@
     "Secure sign in link for {siteTitle}": "Trygg innlogginslenke for {siteTitle}",
     "See you soon!": "På gjensyn!",
     "Sent to {email}": "Sendt til {email}",
+    "Share": "",
     "Sign in": "Logg inn",
     "Sign in now": "",
     "Sign in to {siteTitle}": "Logg inn på {siteTitle}",

--- a/ghost/i18n/locales/pa/ghost.json
+++ b/ghost/i18n/locales/pa/ghost.json
@@ -39,6 +39,7 @@
     "Secure sign in link for {siteTitle}": "{siteTitle} ਲਈ ਸੁਰੱਖਿਅਤ ਸਾਈਨ-ਇਨ ਲਿੰਕ",
     "See you soon!": "ਜਲਦੀ ਮਿਲਦੇ ਹਾਂ!",
     "Sent to {email}": "{email} ਨੂੰ ਭੇਜਿਆ ਗਿਆ",
+    "Share": "",
     "Sign in": "ਸਾਈਨ ਇਨ ਕਰੋ",
     "Sign in now": "",
     "Sign in to {siteTitle}": "{siteTitle} 'ਤੇ ਸਾਈਨ ਇਨ ਕਰੋ",

--- a/ghost/i18n/locales/pl/ghost.json
+++ b/ghost/i18n/locales/pl/ghost.json
@@ -39,6 +39,7 @@
     "Secure sign in link for {siteTitle}": "Bezpieczny link logowania do {siteTitle}",
     "See you soon!": "Do zobaczenia!",
     "Sent to {email}": "Wysłano do {email}",
+    "Share": "",
     "Sign in": "Zaloguj się",
     "Sign in now": "",
     "Sign in to {siteTitle}": "Zaloguj się do {siteTitle}",

--- a/ghost/i18n/locales/pt-BR/ghost.json
+++ b/ghost/i18n/locales/pt-BR/ghost.json
@@ -39,6 +39,7 @@
     "Secure sign in link for {siteTitle}": "Link seguro para acessar o site {siteTitle}",
     "See you soon!": "Até logo!",
     "Sent to {email}": "Enviado para {email}",
+    "Share": "",
     "Sign in": "Entrar",
     "Sign in now": "Entrar agora",
     "Sign in to {siteTitle}": "Entrar no site {siteTitle}",

--- a/ghost/i18n/locales/pt/ghost.json
+++ b/ghost/i18n/locales/pt/ghost.json
@@ -39,6 +39,7 @@
     "Secure sign in link for {siteTitle}": "Ligação segura para entrar em {siteTitle}",
     "See you soon!": "Até breve!",
     "Sent to {email}": "Enviado para {email}",
+    "Share": "",
     "Sign in": "Entrar",
     "Sign in now": "",
     "Sign in to {siteTitle}": "Entrar em {siteTitle}",

--- a/ghost/i18n/locales/ro/ghost.json
+++ b/ghost/i18n/locales/ro/ghost.json
@@ -39,6 +39,7 @@
     "Secure sign in link for {siteTitle}": "Link securizat pentru autentificarea la {siteTitle}",
     "See you soon!": "Pe curând!",
     "Sent to {email}": "Trimis către {email}",
+    "Share": "",
     "Sign in": "Autentificare",
     "Sign in now": "",
     "Sign in to {siteTitle}": "Conectează-te la {siteTitle}",

--- a/ghost/i18n/locales/ru/ghost.json
+++ b/ghost/i18n/locales/ru/ghost.json
@@ -39,6 +39,7 @@
     "Secure sign in link for {siteTitle}": "Ссылка для безопасного входа в систему на {siteTitle}",
     "See you soon!": "До скорой встречи!",
     "Sent to {email}": "Отправлено на {email}",
+    "Share": "",
     "Sign in": "Войти",
     "Sign in now": "Войти сейчас",
     "Sign in to {siteTitle}": "Войти на {siteTitle}",

--- a/ghost/i18n/locales/si/ghost.json
+++ b/ghost/i18n/locales/si/ghost.json
@@ -39,6 +39,7 @@
     "Secure sign in link for {siteTitle}": "{siteTitle} වෙත ආරක්ෂිතව sign in වීම සඳහා වන link එක",
     "See you soon!": "ඉක්මණින් නැවත හමුවෙමු!",
     "Sent to {email}": "{email} වෙත යවන ලදී",
+    "Share": "",
     "Sign in": "Sign in වෙන්න",
     "Sign in now": "",
     "Sign in to {siteTitle}": "{siteTitle} වෙත sign in වෙන්න",

--- a/ghost/i18n/locales/sk/ghost.json
+++ b/ghost/i18n/locales/sk/ghost.json
@@ -39,6 +39,7 @@
     "Secure sign in link for {siteTitle}": "Bezpečný prihlasovací odkaz pre {siteTitle}",
     "See you soon!": "Dovidenia!",
     "Sent to {email}": "Odoslané na {email}",
+    "Share": "",
     "Sign in": "Prihlásiť sa",
     "Sign in now": "",
     "Sign in to {siteTitle}": "Prihlásiť sa na {siteTitle}",

--- a/ghost/i18n/locales/sl/ghost.json
+++ b/ghost/i18n/locales/sl/ghost.json
@@ -39,6 +39,7 @@
     "Secure sign in link for {siteTitle}": "Varna povezava za prijavo na {siteTitle}",
     "See you soon!": "Se vidimo kmalu!",
     "Sent to {email}": "Poslano na {email}",
+    "Share": "",
     "Sign in": "Prijavite se",
     "Sign in now": "",
     "Sign in to {siteTitle}": "Prijava v {siteTitle}",

--- a/ghost/i18n/locales/sq/ghost.json
+++ b/ghost/i18n/locales/sq/ghost.json
@@ -39,6 +39,7 @@
     "Secure sign in link for {siteTitle}": "Lidhja e sigurt e hyrjes për {siteTitle}",
     "See you soon!": "Shihemi se shpejti!",
     "Sent to {email}": "Derguar tek {email}",
+    "Share": "",
     "Sign in": "Hyr",
     "Sign in now": "",
     "Sign in to {siteTitle}": "Hyr ne",

--- a/ghost/i18n/locales/sr-Cyrl/ghost.json
+++ b/ghost/i18n/locales/sr-Cyrl/ghost.json
@@ -39,6 +39,7 @@
     "Secure sign in link for {siteTitle}": "Сигуран линк за пријаву на {siteTitle}",
     "See you soon!": "Видимо се ускоро!",
     "Sent to {email}": "Послато на {email}",
+    "Share": "",
     "Sign in": "Пријавите се",
     "Sign in now": "Пријавите се сада",
     "Sign in to {siteTitle}": "Пријавите се на {siteTitle}",

--- a/ghost/i18n/locales/sr/ghost.json
+++ b/ghost/i18n/locales/sr/ghost.json
@@ -39,6 +39,7 @@
     "Secure sign in link for {siteTitle}": "Siguran link za prijavu na {siteTitle}",
     "See you soon!": "Vidimo se uskoro!",
     "Sent to {email}": "Poslato na {email}",
+    "Share": "",
     "Sign in": "Prijavite se",
     "Sign in now": "Prijavite se sada",
     "Sign in to {siteTitle}": "Prijavite se na {siteTitle}",

--- a/ghost/i18n/locales/sv/ghost.json
+++ b/ghost/i18n/locales/sv/ghost.json
@@ -39,6 +39,7 @@
     "Secure sign in link for {siteTitle}": "Säker inloggningslänk för {siteTitle}",
     "See you soon!": "Vi ses snart!",
     "Sent to {email}": "Skickat till {email}",
+    "Share": "",
     "Sign in": "Logga in",
     "Sign in now": "Logga in nu",
     "Sign in to {siteTitle}": "Logga in på {siteTitle}",

--- a/ghost/i18n/locales/sw/ghost.json
+++ b/ghost/i18n/locales/sw/ghost.json
@@ -39,6 +39,7 @@
     "Secure sign in link for {siteTitle}": "Kiungo salama cha kuingia kwa {siteTitle}",
     "See you soon!": "Tutaonana hivi karibuni!",
     "Sent to {email}": "Imetumwa kwa {email}",
+    "Share": "",
     "Sign in": "Ingia",
     "Sign in now": "",
     "Sign in to {siteTitle}": "Ingia kwa {siteTitle}",

--- a/ghost/i18n/locales/ta/ghost.json
+++ b/ghost/i18n/locales/ta/ghost.json
@@ -39,6 +39,7 @@
     "Secure sign in link for {siteTitle}": "{siteTitle} க்கான பாதுகாப்பான உள்நுழைவு இணைப்பு",
     "See you soon!": "உங்களை விரைவில் சந்திக்கிறோம்!",
     "Sent to {email}": "{email} க்கு அனுப்பப்பட்டது",
+    "Share": "",
     "Sign in": "உள்நுழை",
     "Sign in now": "",
     "Sign in to {siteTitle}": "{siteTitle} க்கு உள்நுழையவும்",

--- a/ghost/i18n/locales/th/ghost.json
+++ b/ghost/i18n/locales/th/ghost.json
@@ -39,6 +39,7 @@
     "Secure sign in link for {siteTitle}": "ลิงก์ลงชื่อเข้าใช้อย่างปลอดภัยสำหรับ {siteTitle}",
     "See you soon!": "แล้วพบกัน!",
     "Sent to {email}": "ส่งไปที่ {email}",
+    "Share": "",
     "Sign in": "ลงชื่อเข้าใช้",
     "Sign in now": "",
     "Sign in to {siteTitle}": "ลงชื่อเข้าใช้ไปยัง {siteTitle}",

--- a/ghost/i18n/locales/tr/ghost.json
+++ b/ghost/i18n/locales/tr/ghost.json
@@ -39,6 +39,7 @@
     "Secure sign in link for {siteTitle}": "{siteTitle} için güvenli giriş bağlantısı",
     "See you soon!": "Yakında görüşmek üzere!",
     "Sent to {email}": "{email} adresine gönderildi",
+    "Share": "",
     "Sign in": "Giriş Yap",
     "Sign in now": "Şimdi giriş yap",
     "Sign in to {siteTitle}": "{siteTitle} sitesine giriş yap",

--- a/ghost/i18n/locales/uk/ghost.json
+++ b/ghost/i18n/locales/uk/ghost.json
@@ -39,6 +39,7 @@
     "Secure sign in link for {siteTitle}": "Безпечне посилання для входу до {siteTitle}",
     "See you soon!": "До зустрічі!",
     "Sent to {email}": "Відправлено на {email}",
+    "Share": "",
     "Sign in": "Вхід",
     "Sign in now": "",
     "Sign in to {siteTitle}": "Увійти до {siteTitle}",

--- a/ghost/i18n/locales/ur/ghost.json
+++ b/ghost/i18n/locales/ur/ghost.json
@@ -39,6 +39,7 @@
     "Secure sign in link for {siteTitle}": "{siteTitle} کے لئے محفوظ سائن ان لنک",
     "See you soon!": "جلد ہی ملیں گے!",
     "Sent to {email}": "{email} کو بھیجا گیا",
+    "Share": "",
     "Sign in": "سائن ان",
     "Sign in now": "",
     "Sign in to {siteTitle}": "{siteTitle} میں سائن ان کریں",

--- a/ghost/i18n/locales/uz/ghost.json
+++ b/ghost/i18n/locales/uz/ghost.json
@@ -39,6 +39,7 @@
     "Secure sign in link for {siteTitle}": "{siteTitle} uchun xavfsiz kirish havolasi",
     "See you soon!": "Ko'rishguncha!",
     "Sent to {email}": "{email}ga yuborildi",
+    "Share": "",
     "Sign in": "",
     "Sign in now": "",
     "Sign in to {siteTitle}": "{siteTitle}ga kirish",

--- a/ghost/i18n/locales/vi/ghost.json
+++ b/ghost/i18n/locales/vi/ghost.json
@@ -39,6 +39,7 @@
     "Secure sign in link for {siteTitle}": "Liên kết đăng nhập {siteTitle} an toàn",
     "See you soon!": "Hẹn gặp lại bạn!",
     "Sent to {email}": "Đã gửi đến {email}",
+    "Share": "",
     "Sign in": "Đăng nhập",
     "Sign in now": "Đăng nhập ngay",
     "Sign in to {siteTitle}": "Đăng nhập {siteTitle}",

--- a/ghost/i18n/locales/zh-Hant/ghost.json
+++ b/ghost/i18n/locales/zh-Hant/ghost.json
@@ -39,6 +39,7 @@
     "Secure sign in link for {siteTitle}": "為{siteTitle}準備的安全登入連結",
     "See you soon!": "再見！",
     "Sent to {email}": "已發送到 {email}",
+    "Share": "",
     "Sign in": "登入",
     "Sign in now": "立即登入",
     "Sign in to {siteTitle}": "登入到 {siteTitle}",

--- a/ghost/i18n/locales/zh/ghost.json
+++ b/ghost/i18n/locales/zh/ghost.json
@@ -39,6 +39,7 @@
     "Secure sign in link for {siteTitle}": "为 {siteTitle} 准备的安全登录链接",
     "See you soon!": "回见！",
     "Sent to {email}": "已发送至 {email}",
+    "Share": "",
     "Sign in": "登录",
     "Sign in now": "立即登录",
     "Sign in to {siteTitle}": "登录到 {siteTitle}",


### PR DESCRIPTION
## Summary
- Added a static **Share** link in newsletter emails next to **View in browser**.
- Share link is rendered only for **public** posts.
- Share target uses post URL + #/portal/share so it opens the Portal share modal in browser.

## Notes
- This is a **stacked PR** on top of #26830 (portal-native-share).
- No new newsletter setting/toggle added in this iteration.

## Testing
- yarn --cwd ghost/core test:single test/unit/server/services/email-service/email-renderer.test.js
- yarn --cwd ghost/i18n test
- yarn --cwd ghost/core test:single test/integration/services/email-service/batch-sending.test.js *(blocked locally by missing sqlite3 native bindings in this environment)*
