### PR TITLE
Fixed Tailwind eslint config path resolution in all apps

### DIFF
--- a/apps/activitypub/.eslintrc.cjs
+++ b/apps/activitypub/.eslintrc.cjs
@@ -1,4 +1,6 @@
 /* eslint-env node */
+const tailwindConfig = `${__dirname}/tailwind.config.cjs`;
+
 module.exports = {
     root: true,
     extends: [
@@ -51,12 +53,12 @@ module.exports = {
         'react/no-array-index-key': 'error',
         'react/jsx-key': 'off',
 
-        'tailwindcss/classnames-order': ['error', {config: 'tailwind.config.cjs'}],
-        'tailwindcss/enforces-negative-arbitrary-values': ['warn', {config: 'tailwind.config.cjs'}],
-        'tailwindcss/enforces-shorthand': ['warn', {config: 'tailwind.config.cjs'}],
-        'tailwindcss/migration-from-tailwind-2': ['warn', {config: 'tailwind.config.cjs'}],
+        'tailwindcss/classnames-order': ['error', {config: tailwindConfig}],
+        'tailwindcss/enforces-negative-arbitrary-values': ['warn', {config: tailwindConfig}],
+        'tailwindcss/enforces-shorthand': ['warn', {config: tailwindConfig}],
+        'tailwindcss/migration-from-tailwind-2': ['warn', {config: tailwindConfig}],
         'tailwindcss/no-arbitrary-value': 'off',
         'tailwindcss/no-custom-classname': 'off',
-        'tailwindcss/no-contradicting-classname': ['error', {config: 'tailwind.config.cjs'}]
+        'tailwindcss/no-contradicting-classname': ['error', {config: tailwindConfig}]
     }
 };

--- a/apps/activitypub/package.json
+++ b/apps/activitypub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/activitypub",
-  "version": "3.1.8",
+  "version": "3.1.9",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-design-system/.eslintrc.cjs
+++ b/apps/admin-x-design-system/.eslintrc.cjs
@@ -1,3 +1,5 @@
+const tailwindConfig = `${__dirname}/tailwind.config.cjs`;
+
 module.exports = {
     extends: [
         'plugin:ghost/ts',
@@ -33,12 +35,12 @@ module.exports = {
         // Enforce kebab-case (lowercase with hyphens) for all filenames
         'ghost/filenames/match-regex': ['error', '^[a-z0-9.-]+$', false],
 
-        'tailwindcss/classnames-order': ['error', {config: 'tailwind.config.cjs'}],
-        'tailwindcss/enforces-negative-arbitrary-values': ['warn', {config: 'tailwind.config.cjs'}],
-        'tailwindcss/enforces-shorthand': ['warn', {config: 'tailwind.config.cjs'}],
-        'tailwindcss/migration-from-tailwind-2': ['warn', {config: 'tailwind.config.cjs'}],
+        'tailwindcss/classnames-order': ['error', {config: tailwindConfig}],
+        'tailwindcss/enforces-negative-arbitrary-values': ['warn', {config: tailwindConfig}],
+        'tailwindcss/enforces-shorthand': ['warn', {config: tailwindConfig}],
+        'tailwindcss/migration-from-tailwind-2': ['warn', {config: tailwindConfig}],
         'tailwindcss/no-arbitrary-value': 'off',
         'tailwindcss/no-custom-classname': 'off',
-        'tailwindcss/no-contradicting-classname': ['error', {config: 'tailwind.config.cjs'}]
+        'tailwindcss/no-contradicting-classname': ['error', {config: tailwindConfig}]
     }
 };

--- a/apps/admin-x-settings/.eslintrc.cjs
+++ b/apps/admin-x-settings/.eslintrc.cjs
@@ -1,4 +1,6 @@
 /* eslint-env node */
+const tailwindConfig = `${__dirname}/tailwind.config.cjs`;
+
 module.exports = {
     root: true,
     extends: [
@@ -137,12 +139,12 @@ module.exports = {
         'react/no-array-index-key': 'error',
         'react/jsx-key': 'off',
 
-        'tailwindcss/classnames-order': ['error', {config: 'tailwind.config.cjs'}],
-        'tailwindcss/enforces-negative-arbitrary-values': ['warn', {config: 'tailwind.config.cjs'}],
-        'tailwindcss/enforces-shorthand': ['warn', {config: 'tailwind.config.cjs'}],
-        'tailwindcss/migration-from-tailwind-2': ['warn', {config: 'tailwind.config.cjs'}],
+        'tailwindcss/classnames-order': ['error', {config: tailwindConfig}],
+        'tailwindcss/enforces-negative-arbitrary-values': ['warn', {config: tailwindConfig}],
+        'tailwindcss/enforces-shorthand': ['warn', {config: tailwindConfig}],
+        'tailwindcss/migration-from-tailwind-2': ['warn', {config: tailwindConfig}],
         'tailwindcss/no-arbitrary-value': 'off',
         'tailwindcss/no-custom-classname': 'off',
-        'tailwindcss/no-contradicting-classname': ['error', {config: 'tailwind.config.cjs'}]
+        'tailwindcss/no-contradicting-classname': ['error', {config: tailwindConfig}]
     }
 };

--- a/apps/comments-ui/.eslintrc.js
+++ b/apps/comments-ui/.eslintrc.js
@@ -1,4 +1,6 @@
 /* eslint-env node */
+const tailwindConfig = `${__dirname}/tailwind.config.cjs`;
+
 module.exports = {
     root: true,
     extends: [
@@ -43,13 +45,13 @@ module.exports = {
         'react/button-has-type': 'error',
         'react/no-array-index-key': 'error',
 
-        'tailwindcss/classnames-order': ['error', {config: 'tailwind.config.cjs'}],
-        'tailwindcss/enforces-negative-arbitrary-values': ['warn', {config: 'tailwind.config.cjs'}],
-        'tailwindcss/enforces-shorthand': ['warn', {config: 'tailwind.config.cjs'}],
-        'tailwindcss/migration-from-tailwind-2': ['warn', {config: 'tailwind.config.cjs'}],
+        'tailwindcss/classnames-order': ['error', {config: tailwindConfig}],
+        'tailwindcss/enforces-negative-arbitrary-values': ['warn', {config: tailwindConfig}],
+        'tailwindcss/enforces-shorthand': ['warn', {config: tailwindConfig}],
+        'tailwindcss/migration-from-tailwind-2': ['warn', {config: tailwindConfig}],
         'tailwindcss/no-arbitrary-value': 'off',
         'tailwindcss/no-custom-classname': 'off',
-        'tailwindcss/no-contradicting-classname': ['error', {config: 'tailwind.config.cjs'}],
+        'tailwindcss/no-contradicting-classname': ['error', {config: tailwindConfig}],
 
         // This rule doesn't work correctly with TypeScript, and TypeScript has its own better version
         'no-undef': 'off'

--- a/apps/comments-ui/package.json
+++ b/apps/comments-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/comments-ui",
-  "version": "1.3.11",
+  "version": "1.3.12",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/posts/.eslintrc.cjs
+++ b/apps/posts/.eslintrc.cjs
@@ -1,4 +1,6 @@
 /* eslint-env node */
+const tailwindConfig = `${__dirname}/tailwind.config.cjs`;
+
 module.exports = {
     root: true,
     extends: [
@@ -48,12 +50,12 @@ module.exports = {
         'react/no-array-index-key': 'error',
         'react/jsx-key': 'off',
 
-        'tailwindcss/classnames-order': ['error', {config: 'tailwind.config.cjs'}],
-        'tailwindcss/enforces-negative-arbitrary-values': ['warn', {config: 'tailwind.config.cjs'}],
-        'tailwindcss/enforces-shorthand': ['warn', {config: 'tailwind.config.cjs'}],
-        'tailwindcss/migration-from-tailwind-2': ['warn', {config: 'tailwind.config.cjs'}],
+        'tailwindcss/classnames-order': ['error', {config: tailwindConfig}],
+        'tailwindcss/enforces-negative-arbitrary-values': ['warn', {config: tailwindConfig}],
+        'tailwindcss/enforces-shorthand': ['warn', {config: tailwindConfig}],
+        'tailwindcss/migration-from-tailwind-2': ['warn', {config: tailwindConfig}],
         'tailwindcss/no-arbitrary-value': 'off',
         'tailwindcss/no-custom-classname': 'off',
-        'tailwindcss/no-contradicting-classname': ['error', {config: 'tailwind.config.cjs'}]
+        'tailwindcss/no-contradicting-classname': ['error', {config: tailwindConfig}]
     }
 };

--- a/apps/signup-form/.eslintrc.cjs
+++ b/apps/signup-form/.eslintrc.cjs
@@ -1,4 +1,6 @@
 /* eslint-env node */
+const tailwindConfig = `${__dirname}/tailwind.config.cjs`;
+
 module.exports = {
     root: true,
     extends: [
@@ -38,12 +40,12 @@ module.exports = {
         'react/button-has-type': 'error',
         'react/no-array-index-key': 'error',
 
-        'tailwindcss/classnames-order': ['error', {config: 'tailwind.config.cjs'}],
-        'tailwindcss/enforces-negative-arbitrary-values': ['warn', {config: 'tailwind.config.cjs'}],
-        'tailwindcss/enforces-shorthand': ['warn', {config: 'tailwind.config.cjs'}],
-        'tailwindcss/migration-from-tailwind-2': ['warn', {config: 'tailwind.config.cjs'}],
+        'tailwindcss/classnames-order': ['error', {config: tailwindConfig}],
+        'tailwindcss/enforces-negative-arbitrary-values': ['warn', {config: tailwindConfig}],
+        'tailwindcss/enforces-shorthand': ['warn', {config: tailwindConfig}],
+        'tailwindcss/migration-from-tailwind-2': ['warn', {config: tailwindConfig}],
         'tailwindcss/no-arbitrary-value': 'off',
         'tailwindcss/no-custom-classname': 'off',
-        'tailwindcss/no-contradicting-classname': ['error', {config: 'tailwind.config.cjs'}]
+        'tailwindcss/no-contradicting-classname': ['error', {config: tailwindConfig}]
     }
 };

--- a/apps/signup-form/package.json
+++ b/apps/signup-form/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/signup-form",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/stats/.eslintrc.cjs
+++ b/apps/stats/.eslintrc.cjs
@@ -1,4 +1,6 @@
 /* eslint-env node */
+const tailwindConfig = `${__dirname}/tailwind.config.cjs`;
+
 module.exports = {
     root: true,
     extends: [
@@ -48,12 +50,12 @@ module.exports = {
         'react/no-array-index-key': 'error',
         'react/jsx-key': 'off',
 
-        'tailwindcss/classnames-order': ['error', {config: 'tailwind.config.cjs'}],
-        'tailwindcss/enforces-negative-arbitrary-values': ['warn', {config: 'tailwind.config.cjs'}],
-        'tailwindcss/enforces-shorthand': ['warn', {config: 'tailwind.config.cjs'}],
-        'tailwindcss/migration-from-tailwind-2': ['warn', {config: 'tailwind.config.cjs'}],
+        'tailwindcss/classnames-order': ['error', {config: tailwindConfig}],
+        'tailwindcss/enforces-negative-arbitrary-values': ['warn', {config: tailwindConfig}],
+        'tailwindcss/enforces-shorthand': ['warn', {config: tailwindConfig}],
+        'tailwindcss/migration-from-tailwind-2': ['warn', {config: tailwindConfig}],
         'tailwindcss/no-arbitrary-value': 'off',
         'tailwindcss/no-custom-classname': 'off',
-        'tailwindcss/no-contradicting-classname': ['error', {config: 'tailwind.config.cjs'}]
+        'tailwindcss/no-contradicting-classname': ['error', {config: tailwindConfig}]
     }
 };


### PR DESCRIPTION
## Summary

- Fixed `eslint-plugin-tailwindcss` config path resolution in all apps that use it
- Changed relative `'tailwind.config.cjs'` to absolute `${__dirname}/tailwind.config.cjs` using a `tailwindConfig` variable
- Same fix as Shade (#26821) — `eslint-plugin-tailwindcss` resolves config paths relative to CWD, not relative to `.eslintrc.cjs`. When `lint-staged` runs from the repo root, the plugin falls back to Tailwind defaults, producing different class orderings than when running eslint from the package directory.

**Affected apps:** `admin-x-settings`, `posts`, `stats`, `activitypub`, `admin-x-design-system`, `signup-form`, `comments-ui`

I strongly suspect that this fixes the tailwind classname ordering issue various people have seen when using VSCode's `eslint.fixAll` "codeActionOnSave" configuration. The problem fits the same pattern: if you open up VSCode to a particular app directly, there's no issue, but if you open VSCode in the monorepo root, you run into conflicts between the code action's module resolution and `yarn lint`'s module resolution. Explicitly using the absolute path to the tailwind configuration should align the module resolution, regardless of which directory you've opened in VSCode.

## Test plan

- [ ] Run `yarn lint` from any affected app directory — should pass
- [ ] Run `npx eslint apps/<app>/src/ --no-cache` from repo root — should produce same results as above