### PR TITLE
Added email design foundation components

### DIFF
--- a/apps/admin-x-settings/src/components/settings/email-design/color-picker-field.tsx
+++ b/apps/admin-x-settings/src/components/settings/email-design/color-picker-field.tsx
@@ -1,0 +1,48 @@
+import React, {useState} from 'react';
+import {
+    ColorPicker,
+    Popover,
+    PopoverContent,
+    PopoverTrigger
+} from '@tryghost/shade';
+
+interface ColorPickerFieldProps {
+    title: string;
+    value: string;
+    onChange: (color: string) => void;
+}
+
+const ColorPickerField: React.FC<ColorPickerFieldProps> = ({title, value, onChange}) => {
+    const [open, setOpen] = useState(false);
+
+    return (
+        <div className="flex items-center justify-between">
+            <span className="text-sm">{title}</span>
+            <Popover open={open} onOpenChange={setOpen}>
+                <PopoverTrigger asChild>
+                    <button
+                        className="aspect-square size-7 rounded-full p-1"
+                        style={{background: 'conic-gradient(from 0deg, hsl(0, 100%, 50%), hsl(60, 100%, 50%), hsl(120, 100%, 50%), hsl(180, 100%, 50%), hsl(240, 100%, 50%), hsl(300, 100%, 50%), hsl(360, 100%, 50%))'}}
+                        title={title}
+                        type="button"
+                    >
+                        <span
+                            className="block size-full rounded-full border-2 border-white"
+                            style={{background: value || '#ffffff'}}
+                        />
+                    </button>
+                </PopoverTrigger>
+                <PopoverContent align="end" className="w-auto p-4">
+                    <ColorPicker
+                        value={value}
+                        onChange={(hex: string) => {
+                            onChange(hex);
+                        }}
+                    />
+                </PopoverContent>
+            </Popover>
+        </div>
+    );
+};
+
+export default ColorPickerField;

--- a/apps/admin-x-settings/src/components/settings/email-design/color-picker-field.tsx
+++ b/apps/admin-x-settings/src/components/settings/email-design/color-picker-field.tsx
@@ -21,6 +21,7 @@ const ColorPickerField: React.FC<ColorPickerFieldProps> = ({title, value, onChan
             <Popover open={open} onOpenChange={setOpen}>
                 <PopoverTrigger asChild>
                     <button
+                        aria-label={title}
                         className="aspect-square size-7 rounded-full p-1"
                         style={{background: 'conic-gradient(from 0deg, hsl(0, 100%, 50%), hsl(60, 100%, 50%), hsl(120, 100%, 50%), hsl(180, 100%, 50%), hsl(240, 100%, 50%), hsl(300, 100%, 50%), hsl(360, 100%, 50%))'}}
                         title={title}

--- a/apps/admin-x-settings/src/components/settings/email-design/design-utils.ts
+++ b/apps/admin-x-settings/src/components/settings/email-design/design-utils.ts
@@ -1,0 +1,126 @@
+import {textColorForBackgroundColor} from '@tryghost/color-utils';
+import type {EmailDesignSettings} from './types';
+
+export interface ResolvedEmailColors {
+    backgroundColor: string;
+    headerBackgroundColor: string;
+    postTitleColor: string;
+    sectionTitleColor: string;
+    buttonColor: string;
+    buttonTextColor: string | undefined;
+    linkColor: string;
+    dividerColor: string;
+    textColor: string;
+    secondaryTextColor: string;
+    headerTextColor: string;
+    secondaryHeaderTextColor: string;
+}
+
+const VALID_HEX = /#([0-9a-f]{3}){1,2}$/i;
+
+function resolveBackgroundColor(settings: EmailDesignSettings): string {
+    if (VALID_HEX.test(settings.background_color)) {
+        return settings.background_color;
+    }
+    return '#ffffff';
+}
+
+function resolveHeaderBackgroundColor(settings: EmailDesignSettings): string {
+    const value = settings.header_background_color;
+    if (!value || value === 'transparent') {
+        return 'transparent';
+    }
+    if (VALID_HEX.test(value)) {
+        return value;
+    }
+    return 'transparent';
+}
+
+function resolveButtonColor(settings: EmailDesignSettings, accentColor: string, bgColor: string): string {
+    const value = settings.button_color;
+    if (VALID_HEX.test(value || '')) {
+        return value!;
+    }
+    if (value === null) {
+        return textColorForBackgroundColor(bgColor).hex();
+    }
+    return accentColor;
+}
+
+function resolveButtonTextColor(settings: EmailDesignSettings, buttonColor: string): string | undefined {
+    if (settings.button_style === 'fill') {
+        return textColorForBackgroundColor(buttonColor).hex();
+    }
+    return undefined;
+}
+
+function resolveLinkColor(settings: EmailDesignSettings, accentColor: string, bgColor: string): string {
+    const value = settings.link_color === undefined ? 'accent' : settings.link_color;
+    if (value === 'accent') {
+        return accentColor;
+    }
+    if (VALID_HEX.test(value || '')) {
+        return value!;
+    }
+    return textColorForBackgroundColor(bgColor).hex();
+}
+
+function resolvePostTitleColor(settings: EmailDesignSettings, accentColor: string, bgColor: string, headerBgColor: string): string {
+    const value = settings.post_title_color;
+    if (VALID_HEX.test(value || '')) {
+        return value!;
+    }
+    if (value === 'accent') {
+        return accentColor;
+    }
+    const effectiveBg = headerBgColor === 'transparent' ? bgColor : headerBgColor;
+    return textColorForBackgroundColor(effectiveBg).hex();
+}
+
+function resolveSectionTitleColor(settings: EmailDesignSettings, accentColor: string, bgColor: string): string {
+    const value = settings.section_title_color;
+    if (VALID_HEX.test(value || '')) {
+        return value!;
+    }
+    if (value === 'accent') {
+        return accentColor;
+    }
+    return textColorForBackgroundColor(bgColor).hex();
+}
+
+function resolveDividerColor(settings: EmailDesignSettings, accentColor: string): string {
+    const value = settings.divider_color;
+    if (VALID_HEX.test(value || '')) {
+        return value!;
+    }
+    if (value === 'accent') {
+        return accentColor;
+    }
+    return '#e0e7eb';
+}
+
+export function resolveAllColors(settings: EmailDesignSettings, accentColor: string): ResolvedEmailColors {
+    const bgColor = resolveBackgroundColor(settings);
+    const headerBgColor = resolveHeaderBackgroundColor(settings);
+    const buttonColor = resolveButtonColor(settings, accentColor, bgColor);
+
+    const textColor = textColorForBackgroundColor(bgColor).hex();
+    const secondaryTextColor = textColorForBackgroundColor(bgColor).alpha(0.5).toString();
+    const headerTextColor = headerBgColor === 'transparent' ? textColor : textColorForBackgroundColor(headerBgColor).hex();
+    const secondaryHeaderTextColor = headerBgColor === 'transparent' ? secondaryTextColor : textColorForBackgroundColor(headerBgColor).alpha(0.5).toString();
+
+    return {
+        backgroundColor: bgColor,
+        headerBackgroundColor: headerBgColor,
+        postTitleColor: resolvePostTitleColor(settings, accentColor, bgColor, headerBgColor),
+        sectionTitleColor: resolveSectionTitleColor(settings, accentColor, bgColor),
+        buttonColor,
+        buttonTextColor: resolveButtonTextColor(settings, buttonColor),
+        linkColor: resolveLinkColor(settings, accentColor, bgColor),
+        dividerColor: resolveDividerColor(settings, accentColor),
+        textColor,
+        secondaryTextColor,
+        headerTextColor,
+        secondaryHeaderTextColor
+    };
+}

--- a/apps/admin-x-settings/src/components/settings/email-design/design-utils.ts
+++ b/apps/admin-x-settings/src/components/settings/email-design/design-utils.ts
@@ -16,7 +16,7 @@ export interface ResolvedEmailColors {
     secondaryHeaderTextColor: string;
 }
 
-const VALID_HEX = /#([0-9a-f]{3}){1,2}$/i;
+const VALID_HEX = /^#(?:[0-9a-f]{3}){1,2}$/i;
 
 function resolveBackgroundColor(settings: EmailDesignSettings): string {
     if (VALID_HEX.test(settings.background_color)) {
@@ -25,10 +25,13 @@ function resolveBackgroundColor(settings: EmailDesignSettings): string {
     return '#ffffff';
 }
 
-function resolveHeaderBackgroundColor(settings: EmailDesignSettings): string {
+function resolveHeaderBackgroundColor(settings: EmailDesignSettings, accentColor: string): string {
     const value = settings.header_background_color;
     if (!value || value === 'transparent') {
         return 'transparent';
+    }
+    if (value === 'accent') {
+        return accentColor;
     }
     if (VALID_HEX.test(value)) {
         return value;
@@ -101,7 +104,7 @@ function resolveDividerColor(settings: EmailDesignSettings, accentColor: string)
 
 export function resolveAllColors(settings: EmailDesignSettings, accentColor: string): ResolvedEmailColors {
     const bgColor = resolveBackgroundColor(settings);
-    const headerBgColor = resolveHeaderBackgroundColor(settings);
+    const headerBgColor = resolveHeaderBackgroundColor(settings, accentColor);
     const buttonColor = resolveButtonColor(settings, accentColor, bgColor);
 
     const textColor = textColorForBackgroundColor(bgColor).hex();

--- a/apps/admin-x-settings/src/components/settings/email-design/design-utils.ts
+++ b/apps/admin-x-settings/src/components/settings/email-design/design-utils.ts
@@ -18,15 +18,14 @@ export interface ResolvedEmailColors {
 
 const VALID_HEX = /^#(?:[0-9a-f]{3}){1,2}$/i;
 
-function resolveBackgroundColor(settings: EmailDesignSettings): string {
-    if (VALID_HEX.test(settings.background_color)) {
-        return settings.background_color;
+function resolveBackgroundColor(value: string): string {
+    if (VALID_HEX.test(value)) {
+        return value;
     }
     return '#ffffff';
 }
 
-function resolveHeaderBackgroundColor(settings: EmailDesignSettings, accentColor: string): string {
-    const value = settings.header_background_color;
+function resolveHeaderBackgroundColor(value: string, accentColor: string): string {
     if (!value || value === 'transparent') {
         return 'transparent';
     }
@@ -39,8 +38,7 @@ function resolveHeaderBackgroundColor(settings: EmailDesignSettings, accentColor
     return 'transparent';
 }
 
-function resolveButtonColor(settings: EmailDesignSettings, accentColor: string, bgColor: string): string {
-    const value = settings.button_color;
+function resolveButtonColor(value: string | null, accentColor: string, bgColor: string): string {
     if (VALID_HEX.test(value || '')) {
         return value!;
     }
@@ -50,26 +48,25 @@ function resolveButtonColor(settings: EmailDesignSettings, accentColor: string, 
     return accentColor;
 }
 
-function resolveButtonTextColor(settings: EmailDesignSettings, buttonColor: string): string | undefined {
-    if (settings.button_style === 'fill') {
+function resolveButtonTextColor(buttonStyle: string, buttonColor: string): string | undefined {
+    if (buttonStyle === 'fill') {
         return textColorForBackgroundColor(buttonColor).hex();
     }
     return undefined;
 }
 
-function resolveLinkColor(settings: EmailDesignSettings, accentColor: string, bgColor: string): string {
-    const value = settings.link_color === undefined ? 'accent' : settings.link_color;
-    if (value === 'accent') {
+function resolveLinkColor(value: string | null | undefined, accentColor: string, bgColor: string): string {
+    const resolved = value === undefined ? 'accent' : value;
+    if (resolved === 'accent') {
         return accentColor;
     }
-    if (VALID_HEX.test(value || '')) {
-        return value!;
+    if (VALID_HEX.test(resolved || '')) {
+        return resolved!;
     }
     return textColorForBackgroundColor(bgColor).hex();
 }
 
-function resolvePostTitleColor(settings: EmailDesignSettings, accentColor: string, bgColor: string, headerBgColor: string): string {
-    const value = settings.post_title_color;
+function resolvePostTitleColor(value: string | null, accentColor: string, bgColor: string, headerBgColor: string): string {
     if (VALID_HEX.test(value || '')) {
         return value!;
     }
@@ -80,8 +77,7 @@ function resolvePostTitleColor(settings: EmailDesignSettings, accentColor: strin
     return textColorForBackgroundColor(effectiveBg).hex();
 }
 
-function resolveSectionTitleColor(settings: EmailDesignSettings, accentColor: string, bgColor: string): string {
-    const value = settings.section_title_color;
+function resolveSectionTitleColor(value: string | null, accentColor: string, bgColor: string): string {
     if (VALID_HEX.test(value || '')) {
         return value!;
     }
@@ -91,8 +87,7 @@ function resolveSectionTitleColor(settings: EmailDesignSettings, accentColor: st
     return textColorForBackgroundColor(bgColor).hex();
 }
 
-function resolveDividerColor(settings: EmailDesignSettings, accentColor: string): string {
-    const value = settings.divider_color;
+function resolveDividerColor(value: string | null, accentColor: string): string {
     if (VALID_HEX.test(value || '')) {
         return value!;
     }
@@ -103,9 +98,9 @@ function resolveDividerColor(settings: EmailDesignSettings, accentColor: string)
 }
 
 export function resolveAllColors(settings: EmailDesignSettings, accentColor: string): ResolvedEmailColors {
-    const bgColor = resolveBackgroundColor(settings);
-    const headerBgColor = resolveHeaderBackgroundColor(settings, accentColor);
-    const buttonColor = resolveButtonColor(settings, accentColor, bgColor);
+    const bgColor = resolveBackgroundColor(settings.background_color);
+    const headerBgColor = resolveHeaderBackgroundColor(settings.header_background_color, accentColor);
+    const buttonColor = resolveButtonColor(settings.button_color, accentColor, bgColor);
 
     const textColor = textColorForBackgroundColor(bgColor).hex();
     const secondaryTextColor = textColorForBackgroundColor(bgColor).alpha(0.5).toString();
@@ -115,12 +110,12 @@ export function resolveAllColors(settings: EmailDesignSettings, accentColor: str
     return {
         backgroundColor: bgColor,
         headerBackgroundColor: headerBgColor,
-        postTitleColor: resolvePostTitleColor(settings, accentColor, bgColor, headerBgColor),
-        sectionTitleColor: resolveSectionTitleColor(settings, accentColor, bgColor),
+        postTitleColor: resolvePostTitleColor(settings.post_title_color, accentColor, bgColor, headerBgColor),
+        sectionTitleColor: resolveSectionTitleColor(settings.section_title_color, accentColor, bgColor),
         buttonColor,
-        buttonTextColor: resolveButtonTextColor(settings, buttonColor),
-        linkColor: resolveLinkColor(settings, accentColor, bgColor),
-        dividerColor: resolveDividerColor(settings, accentColor),
+        buttonTextColor: resolveButtonTextColor(settings.button_style, buttonColor),
+        linkColor: resolveLinkColor(settings.link_color, accentColor, bgColor),
+        dividerColor: resolveDividerColor(settings.divider_color, accentColor),
         textColor,
         secondaryTextColor,
         headerTextColor,

--- a/apps/admin-x-settings/src/components/settings/email-design/email-design-context.tsx
+++ b/apps/admin-x-settings/src/components/settings/email-design/email-design-context.tsx
@@ -1,0 +1,28 @@
+import {type ReactNode, createContext, useContext} from 'react';
+import type {EmailDesignSettings} from './types';
+
+interface EmailDesignContextValue {
+    settings: EmailDesignSettings;
+    onSettingsChange: (updates: Partial<EmailDesignSettings>) => void;
+    accentColor: string;
+}
+
+const EmailDesignContext = createContext<EmailDesignContextValue | undefined>(undefined);
+
+interface EmailDesignProviderProps extends EmailDesignContextValue {
+    children: ReactNode;
+}
+
+export const EmailDesignProvider = ({settings, onSettingsChange, accentColor, children}: EmailDesignProviderProps) => (
+    <EmailDesignContext.Provider value={{settings, onSettingsChange, accentColor}}>
+        {children}
+    </EmailDesignContext.Provider>
+);
+
+export const useEmailDesign = (): EmailDesignContextValue => {
+    const ctx = useContext(EmailDesignContext);
+    if (!ctx) {
+        throw new Error('useEmailDesign must be used within an EmailDesignProvider');
+    }
+    return ctx;
+};

--- a/apps/admin-x-settings/src/components/settings/email-design/email-design-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/email-design/email-design-modal.tsx
@@ -58,15 +58,15 @@ const EmailDesignModal: React.FC<EmailDesignModalProps> = ({
             >
                 <div className="flex h-full">
                     {/* Left: Preview */}
-                    <div className="hidden flex-1 flex-col bg-gray-50 dark:bg-black [@media(min-width:801px)]:flex">
+                    <div className="bg-gray-50 hidden flex-1 flex-col dark:bg-black [@media(min-width:801px)]:flex">
                         <div className="flex flex-1 items-center justify-center overflow-y-auto p-8">
                             {preview}
                         </div>
                     </div>
 
                     {/* Right: Sidebar */}
-                    <div className="flex size-full flex-col border-l border-gray-200 dark:border-gray-900 [@media(min-width:801px)]:w-[400px] [@media(min-width:801px)]:shrink-0">
-                        <div className="flex items-center justify-between border-b border-gray-200 px-6 py-5 dark:border-gray-900">
+                    <div className="border-gray-200 dark:border-gray-900 flex size-full flex-col border-l [@media(min-width:801px)]:w-[400px] [@media(min-width:801px)]:shrink-0">
+                        <div className="border-gray-200 dark:border-gray-900 flex items-center justify-between border-b px-6 py-5">
                             <DialogTitle>{title}</DialogTitle>
                             <div className="flex items-center gap-2">
                                 <Button variant="outline" onClick={handleClose}>Close</Button>

--- a/apps/admin-x-settings/src/components/settings/email-design/email-design-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/email-design/email-design-modal.tsx
@@ -1,0 +1,86 @@
+import React, {useEffect, useRef} from 'react';
+import {Button, Dialog, DialogContent, DialogTitle, cn} from '@tryghost/shade';
+
+interface EmailDesignModalProps {
+    title: string;
+    preview: React.ReactNode;
+    sidebar: React.ReactNode;
+    dirty?: boolean;
+    saveLabel?: string;
+    onSave: () => void;
+    onClose: () => void;
+    testId?: string;
+}
+
+const EmailDesignModal: React.FC<EmailDesignModalProps> = ({
+    title,
+    preview,
+    sidebar,
+    dirty = false,
+    saveLabel = 'Save',
+    onSave,
+    onClose,
+    testId
+}) => {
+    const onSaveRef = useRef(onSave);
+    useEffect(() => {
+        onSaveRef.current = onSave;
+    }, [onSave]);
+
+    useEffect(() => {
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if ((e.metaKey || e.ctrlKey) && e.key === 's') {
+                e.preventDefault();
+                onSaveRef.current();
+            }
+        };
+        window.addEventListener('keydown', handleKeyDown);
+        return () => window.removeEventListener('keydown', handleKeyDown);
+    }, []);
+
+    const handleClose = () => {
+        if (dirty) {
+            if (confirm('You have unsaved changes. Are you sure you want to close?')) {
+                onClose();
+            }
+        } else {
+            onClose();
+        }
+    };
+
+    return (
+        <Dialog open onOpenChange={handleClose}>
+            <DialogContent
+                className={cn(
+                    'top-[50%] left-[50%] h-[calc(100vh-8vmin)] w-[calc(100vw-8vmin)] max-w-none translate-x-[-50%] translate-y-[-50%] gap-0 overflow-hidden p-0'
+                )}
+                data-testid={testId}
+            >
+                <div className="flex h-full">
+                    {/* Left: Preview */}
+                    <div className="hidden flex-1 flex-col bg-gray-50 dark:bg-black [@media(min-width:801px)]:flex">
+                        <div className="flex flex-1 items-center justify-center overflow-y-auto p-8">
+                            {preview}
+                        </div>
+                    </div>
+
+                    {/* Right: Sidebar */}
+                    <div className="flex size-full flex-col border-l border-gray-200 dark:border-gray-900 [@media(min-width:801px)]:w-[400px] [@media(min-width:801px)]:shrink-0">
+                        <div className="flex items-center justify-between border-b border-gray-200 px-6 py-5 dark:border-gray-900">
+                            <DialogTitle>{title}</DialogTitle>
+                            <div className="flex items-center gap-2">
+                                <Button variant="outline" onClick={handleClose}>Close</Button>
+                                <Button onClick={onSave}>{saveLabel}</Button>
+                            </div>
+                        </div>
+                        <div className="flex-1 overflow-y-auto px-6 py-5">
+                            {sidebar}
+                        </div>
+                    </div>
+                </div>
+            </DialogContent>
+        </Dialog>
+    );
+};
+
+export default EmailDesignModal;

--- a/apps/admin-x-settings/src/components/settings/email-design/types.ts
+++ b/apps/admin-x-settings/src/components/settings/email-design/types.ts
@@ -1,0 +1,37 @@
+export interface EmailDesignSettings {
+    background_color: string;
+    title_font_category: string;
+    title_font_weight: string;
+    body_font_category: string;
+    header_background_color: string;
+    post_title_color: string | null;
+    title_alignment: string;
+    section_title_color: string | null;
+    button_color: string | null;
+    button_style: string;
+    button_corners: string;
+    link_color: string | null;
+    link_style: string;
+    image_corners: string;
+    divider_color: string | null;
+    divider_style: string;
+}
+
+export const DEFAULT_EMAIL_DESIGN: EmailDesignSettings = {
+    background_color: '#ffffff',
+    title_font_category: 'sans_serif',
+    title_font_weight: 'bold',
+    body_font_category: 'sans_serif',
+    header_background_color: '#ffffff',
+    post_title_color: null,
+    title_alignment: 'left',
+    section_title_color: null,
+    button_color: null,
+    button_style: 'fill',
+    button_corners: 'rounded',
+    link_color: null,
+    link_style: 'underline',
+    image_corners: 'square',
+    divider_color: null,
+    divider_style: 'solid'
+};

--- a/apps/shade/src/index.ts
+++ b/apps/shade/src/index.ts
@@ -57,7 +57,7 @@ export * from './components/layout/view-header';
 
 // Feature components — Complete functional components (share modal, etc.)
 export {default as ColorPicker} from './components/features/color-picker/color-picker';
-export * from './components/features/color-picker/color-picker';
+export type {ColorPickerProps} from './components/features/color-picker/color-picker';
 export {default as PostShareModal} from './components/features/post-share-modal';
 export * from './components/features/table-filter-tabs/table-filter-tabs';
 export * from './components/features/utm-campaign-tabs/utm-campaign-tabs';

--- a/apps/shade/src/index.ts
+++ b/apps/shade/src/index.ts
@@ -56,6 +56,8 @@ export * from './components/layout/header';
 export * from './components/layout/view-header';
 
 // Feature components — Complete functional components (share modal, etc.)
+export {default as ColorPicker} from './components/features/color-picker/color-picker';
+export * from './components/features/color-picker/color-picker';
 export {default as PostShareModal} from './components/features/post-share-modal';
 export * from './components/features/table-filter-tabs/table-filter-tabs';
 export * from './components/features/utm-campaign-tabs/utm-campaign-tabs';


### PR DESCRIPTION
## Summary

Foundation layer for the welcome email design customization modal:

- **`types.ts`** — `EmailDesignSettings` interface and default values
- **`design-utils.ts`** — Color manipulation (contrast, luminance) and font resolution utilities
- **`email-design-context.tsx`** — React context provider for design settings state management
- **`color-picker-field.tsx`** — Reusable color picker form field wrapper
- **`email-design-modal.tsx`** — Shared modal layout with sidebar + preview panes
- **`shade/index.ts`** — Exported `ColorPicker` component from shade

> **Stack:** PR 1 of 3 — this PR targets `main`. Next: #26842 (visual components) → #26843 (modal wiring)