### PR TITLE
Fixed broken borders for portal links

### DIFF
--- a/apps/admin-x-settings/src/components/settings/membership/portal/portal-links.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/portal/portal-links.tsx
@@ -26,7 +26,7 @@ const PortalLink: React.FC<PortalLinkPrefs> = ({name, value}) => {
         >
             <div className='flex w-full grow flex-col py-3 lg:flex-row lg:items-center lg:gap-5'>
                 <label className='inline-block whitespace-nowrap lg:w-[180px] lg:min-w-[180px]' htmlFor={id}>{name}:</label>
-                <TextField className='border-b-500 grow bg-transparent py-1 text-grey-700 lg:p-1' id={id} value={value} disabled unstyled />
+                <TextField className='border-b-grey-500 grow bg-transparent py-1 text-grey-700 lg:p-1' id={id} value={value} disabled unstyled />
             </div>
         </ListItem>
     );

--- a/apps/admin-x-settings/src/components/settings/membership/portal/portal-links.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/portal/portal-links.tsx
@@ -26,7 +26,7 @@ const PortalLink: React.FC<PortalLinkPrefs> = ({name, value}) => {
         >
             <div className='flex w-full grow flex-col py-3 lg:flex-row lg:items-center lg:gap-5'>
                 <label className='inline-block whitespace-nowrap lg:w-[180px] lg:min-w-[180px]' htmlFor={id}>{name}:</label>
-                <TextField className='border-b-grey-500 grow bg-transparent py-1 text-grey-700 lg:p-1' id={id} value={value} disabled unstyled />
+                <TextField className='grow border-b-grey-500 bg-transparent py-1 text-grey-700 lg:p-1' id={id} value={value} disabled unstyled />
             </div>
         </ListItem>
     );


### PR DESCRIPTION
Ref https://github.com/TryGhost/Ghost/pull/26835/changes

New Tailwind syntax means that border-b-500 applies a 500px bottom border to an element. This broke dividers used for Portal links.

| Before | After |
|--------|--------|
| <img width="862" height="1137" alt="Screenshot 2026-03-17 at 09 49 35" src="https://github.com/user-attachments/assets/5d1fb757-e7fa-4655-8ed8-5db7af923ff4" /> | <img width="850" height="1037" alt="Screenshot 2026-03-17 at 09 49 18" src="https://github.com/user-attachments/assets/2fe7370a-46cc-4554-aaae-c5c27b8a221b" /> | 
