### PR TITLE
 Added system as a new appearance option

### DIFF
--- a/apps/admin/src/hooks/use-color-mode.ts
+++ b/apps/admin/src/hooks/use-color-mode.ts
@@ -1,0 +1,40 @@
+import {useCallback, useEffect, useSyncExternalStore} from 'react';
+import {useUserPreferences, useEditUserPreferences, resolveColorScheme, type ColorSchemeValue} from './user-preferences';
+
+function subscribeToMediaQuery(callback: () => void) {
+    const mql = window.matchMedia('(prefers-color-scheme: dark)');
+    mql.addEventListener('change', callback);
+    return () => mql.removeEventListener('change', callback);
+}
+
+function getOsPrefersDark() {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches;
+}
+
+function useOsPrefersDark(): boolean {
+    return useSyncExternalStore(subscribeToMediaQuery, getOsPrefersDark);
+}
+
+export function useColorMode() {
+    const {data: preferences} = useUserPreferences();
+    const {mutateAsync: editPreferences} = useEditUserPreferences();
+    const osPrefersDark = useOsPrefersDark();
+
+    const scheme = resolveColorScheme(preferences);
+    const effectiveDark = scheme === 'dark' || (scheme === 'system' && osPrefersDark);
+
+    // Keep the .dark class on <html> in sync
+    useEffect(() => {
+        document.documentElement.classList.toggle('dark', effectiveDark);
+    }, [effectiveDark]);
+
+    const setColorScheme = useCallback((value: ColorSchemeValue) => {
+        const isDark = value === 'dark' || (value === 'system' && getOsPrefersDark());
+        void editPreferences({
+            colorScheme: value,
+            nightShift: isDark
+        });
+    }, [editPreferences]);
+
+    return {scheme, effectiveDark, setColorScheme};
+}

--- a/apps/admin/src/hooks/user-preferences.ts
+++ b/apps/admin/src/hooks/user-preferences.ts
@@ -24,13 +24,36 @@ export const NavigationPreferencesSchema = z.looseObject({
     }),
 });
 
+const ColorSchemeSchema = z.enum(['light', 'dark', 'system']);
+export type ColorSchemeValue = z.infer<typeof ColorSchemeSchema>;
+
 const PreferencesSchema = z.looseObject({
     whatsNew: WhatsNewPreferencesSchema.optional().catch(undefined),
     nightShift: z.boolean().optional(),
+    colorScheme: ColorSchemeSchema.optional(),
     navigation: NavigationPreferencesSchema.default(DEFAULT_NAVIGATION_PREFERENCES).catch(DEFAULT_NAVIGATION_PREFERENCES),
 });
 
 export type Preferences = z.infer<typeof PreferencesSchema>;
+
+/**
+ * Resolve the effective color scheme from user preferences.
+ * - If `colorScheme` is explicitly set, use it.
+ * - If only legacy `nightShift` is set, map it: true → 'dark', false → 'light'.
+ * - If neither is set (new user), default to 'system'.
+ */
+export function resolveColorScheme(prefs: Preferences | undefined): ColorSchemeValue {
+    if (prefs?.colorScheme) {
+        return prefs.colorScheme;
+    }
+    if (prefs?.nightShift === true) {
+        return 'dark';
+    }
+    if (prefs?.nightShift === false) {
+        return 'light';
+    }
+    return 'system';
+}
 export type WhatsNewPreferences = z.infer<typeof WhatsNewPreferencesSchema>;
 export type NavigationPreferences = z.infer<typeof NavigationPreferencesSchema>;
 

--- a/apps/admin/src/layout/app-sidebar/hooks/use-featurebase.ts
+++ b/apps/admin/src/layout/app-sidebar/hooks/use-featurebase.ts
@@ -2,7 +2,7 @@ import {useCallback, useEffect, useRef, useState} from 'react';
 import {getFeaturebaseToken} from '@tryghost/admin-x-framework';
 import {useBrowseConfig} from '@tryghost/admin-x-framework/api/config';
 import {useFeatureFlag} from '@/hooks/use-feature-flag';
-import {useUserPreferences} from '@/hooks/user-preferences';
+import {useColorMode} from '@/hooks/use-color-mode';
 import {deferred, type Deferred} from '@/utils/deferred';
 
 type FeaturebaseCallback = (err: unknown, data?: unknown) => void;
@@ -56,13 +56,13 @@ interface Featurebase {
  */
 export function useFeaturebase(): Featurebase {
     const {data: config} = useBrowseConfig();
-    const {data: preferences} = useUserPreferences();
+    const {effectiveDark} = useColorMode();
     const featureFlagEnabled = useFeatureFlag('featurebaseFeedback');
     const [shouldLoad, setShouldLoad] = useState(false);
 
     const {organization, enabled} = config?.config.featurebase ?? {};
     const featurebaseEnabled = !!(featureFlagEnabled && enabled);
-    const theme = preferences?.nightShift ? 'dark' : 'light';
+    const theme = effectiveDark ? 'dark' : 'light';
 
     // Token is only fetched once shouldLoad becomes true (on user interaction)
     const {data: tokenData} = getFeaturebaseToken({

--- a/apps/admin/src/layout/app-sidebar/user-menu.tsx
+++ b/apps/admin/src/layout/app-sidebar/user-menu.tsx
@@ -8,11 +8,12 @@ import {
     Indicator,
     LucideIcon,
     SidebarMenuButton,
-    Switch
+    ToggleGroup,
+    ToggleGroupItem
 } from "@tryghost/shade"
 import { useCurrentUser } from "@tryghost/admin-x-framework/api/current-user";
 import { getGhostPaths } from "@tryghost/admin-x-framework/helpers";
-import { useUserPreferences, useEditUserPreferences } from "@/hooks/user-preferences";
+import { useColorMode } from "@/hooks/use-color-mode";
 import { useWhatsNew } from "@/whats-new/hooks/use-whats-new";
 import { useUpgradeStatus } from "./hooks/use-upgrade-status";
 import { useBrowseSite } from "@tryghost/admin-x-framework/api/site";
@@ -20,6 +21,7 @@ import { UserMenuItem } from "./user-menu-item";
 import { UserMenuAvatar } from "./user-menu-avatar";
 import { UserMenuHeader } from "./user-menu-header";
 import { Link } from "@tryghost/admin-x-framework";
+import type { ColorSchemeValue } from "@/hooks/user-preferences";
 
 function UserMenuProfile() {
     const currentUser = useCurrentUser();
@@ -34,33 +36,34 @@ function UserMenuProfile() {
     );
 }
 
-function UserMenuDarkMode() {
-    const {data: preferences} = useUserPreferences();
-    const {mutateAsync: editPreferences, isLoading: isEditingPreferences} = useEditUserPreferences();
-
-    const setNightShift = (nightShift: boolean) => {
-        void editPreferences({nightShift});
-    };
+function UserMenuColorScheme() {
+    const {scheme, setColorScheme} = useColorMode();
 
     return (
-        <UserMenuItem
-            asChild={false}
-            onSelect={(e: Event) => {
-                e.preventDefault();
-                setNightShift(!preferences?.nightShift);
-            }}
-        >
-            <LucideIcon.Moon />
-            <UserMenuItem.Label className="flex-1">Dark mode</UserMenuItem.Label>
-            <Switch
-                size='sm'
-                checked={preferences?.nightShift ?? false}
-                disabled={isEditingPreferences}
-                onCheckedChange={setNightShift}
-                onClick={(e: React.MouseEvent<HTMLElement>) => e.stopPropagation()}
-                tabIndex={-1}
-            />
-        </UserMenuItem>
+        <div className="flex items-center gap-2 px-2 py-1.5 text-base">
+            <LucideIcon.Palette className="size-4 shrink-0" />
+            <span className="flex-1">Appearance</span>
+            <ToggleGroup
+                type="single"
+                value={scheme}
+                className="h-auto gap-px p-px"
+                onValueChange={(value: string) => {
+                    if (value) {
+                        setColorScheme(value as ColorSchemeValue);
+                    }
+                }}
+            >
+                <ToggleGroupItem aria-label="Light mode" className="h-6 min-w-6 px-1.5 [&_svg]:size-3.5" value="light">
+                    <LucideIcon.Sun />
+                </ToggleGroupItem>
+                <ToggleGroupItem aria-label="System theme" className="h-6 min-w-6 px-1.5 [&_svg]:size-3.5" value="system">
+                    <LucideIcon.Monitor />
+                </ToggleGroupItem>
+                <ToggleGroupItem aria-label="Dark mode" className="h-6 min-w-6 px-1.5 [&_svg]:size-3.5" value="dark">
+                    <LucideIcon.Moon />
+                </ToggleGroupItem>
+            </ToggleGroup>
+        </div>
     );
 }
 
@@ -169,7 +172,7 @@ function UserMenu(props: UserMenuProps) {
                         <UserMenuItem.Label>Resources & guides</UserMenuItem.Label>
                     </a>
                 </UserMenuItem>
-                <UserMenuDarkMode />
+                <UserMenuColorScheme />
                 <DropdownMenuSeparator />
                 <UserMenuSignOut />
             </DropdownMenuContent>
@@ -235,7 +238,7 @@ function ContributorUserMenu() {
                 </UserMenuItem>
                 <DropdownMenuSeparator />
                 <UserMenuProfile />
-                <UserMenuDarkMode />
+                <UserMenuColorScheme />
                 <DropdownMenuSeparator />
                 <UserMenuSignOut />
             </DropdownMenuContent>

--- a/apps/admin/src/main.tsx
+++ b/apps/admin/src/main.tsx
@@ -8,6 +8,7 @@ import { ShadeApp } from "@tryghost/shade";
 import { routes } from "./routes.tsx";
 import { navigateTo } from "./utils/navigation";
 import { AppProvider } from "./providers/app-provider";
+import { useColorMode } from "./hooks/use-color-mode";
 
 const framework = {
     ghostVersion: "",
@@ -33,18 +34,25 @@ const framework = {
     },
 };
 
+function Root() {
+    const {effectiveDark} = useColorMode();
+    return (
+        <ShadeApp
+            className="shade-admin"
+            darkMode={effectiveDark}
+            fetchKoenigLexical={null}
+        >
+            <App />
+        </ShadeApp>
+    );
+}
+
 createRoot(document.getElementById("root")!).render(
     <StrictMode>
         <FrameworkProvider {...framework}>
             <RouterProvider prefix={"/"} routes={routes}>
                 <AppProvider>
-                    <ShadeApp
-                        className="shade-admin"
-                        darkMode={false}
-                        fetchKoenigLexical={null}
-                    >
-                        <App />
-                    </ShadeApp>
+                    <Root />
                 </AppProvider>
             </RouterProvider>
         </FrameworkProvider>

--- a/apps/admin/src/settings/settings.tsx
+++ b/apps/admin/src/settings/settings.tsx
@@ -1,8 +1,11 @@
 import { App } from "@tryghost/admin-x-settings/src/app";
 import { createPortal } from "react-dom";
 import { fetchKoenigLexical } from "@/utils/fetch-koenig-lexical";
+import { useColorMode } from "@/hooks/use-color-mode";
 
 export default function Settings() {
+    const {effectiveDark} = useColorMode();
+
     return createPortal(
         <div
             className="shade shade-admin"
@@ -14,7 +17,7 @@ export default function Settings() {
         >
             <App
                 designSystem={{
-                    darkMode: false,
+                    darkMode: effectiveDark,
                     fetchKoenigLexical,
                 }}
             />

--- a/ghost/admin/app/services/feature.js
+++ b/ghost/admin/app/services/feature.js
@@ -102,6 +102,7 @@ export default class FeatureService extends Service {
     fetch() {
         return this.settings.fetch().then(() => {
             this.set('_user', this.session.user);
+            this._setupSystemThemeListener();
             return this._setAdminTheme().then(() => true);
         });
     }
@@ -147,7 +148,17 @@ export default class FeatureService extends Service {
         let nightShift = enabled;
 
         if (typeof nightShift === 'undefined') {
-            nightShift = enabled || this.nightShift;
+            // Check the new colorScheme field first, fall back to legacy nightShift
+            const colorScheme = this.get('accessibility.colorScheme');
+            if (colorScheme === 'system') {
+                nightShift = window.matchMedia('(prefers-color-scheme: dark)').matches;
+            } else if (colorScheme === 'dark') {
+                nightShift = true;
+            } else if (colorScheme === 'light') {
+                nightShift = false;
+            } else {
+                nightShift = this.nightShift;
+            }
         }
 
         document.documentElement.classList.toggle('dark', nightShift ?? false);
@@ -159,5 +170,28 @@ export default class FeatureService extends Service {
             $('link[title=dark]').prop('disabled', true);
             document.documentElement.classList.remove('dark');
         });
+    }
+
+    _setupSystemThemeListener() {
+        if (this._systemThemeCleanup) {
+            return;
+        }
+        const mq = window.matchMedia('(prefers-color-scheme: dark)');
+        const handler = () => {
+            const colorScheme = this.get('accessibility.colorScheme');
+            if (colorScheme === 'system') {
+                this._setAdminTheme();
+            }
+        };
+        mq.addEventListener('change', handler);
+        this._systemThemeCleanup = () => mq.removeEventListener('change', handler);
+    }
+
+    willDestroy() {
+        super.willDestroy(...arguments);
+        if (this._systemThemeCleanup) {
+            this._systemThemeCleanup();
+            this._systemThemeCleanup = null;
+        }
     }
 }


### PR DESCRIPTION
Closes https://linear.app/ghost/issue/DES-1288/add-automatic-to-admin-darklight-mode

Adjusted the appearance nav item to support switching to system. Existing users' preferences will persist. New users will default to system and can adjust from there.

| Before | After |
|--------|--------|
| <img width="325" height="369" alt="Screenshot 2026-03-17 at 13 13 00" src="https://github.com/user-attachments/assets/9eea779a-caa0-4721-831f-12cbe8d33e1b" /> | <img width="325" height="374" alt="Screenshot 2026-03-17 at 13 12 36" src="https://github.com/user-attachments/assets/1b0cf1ae-d42b-4174-841a-d94ae7eb9883" /> |
