### PR TITLE
Increased lexical test timeout

### DIFF
--- a/ghost/core/test/unit/server/lib/lexical.test.js
+++ b/ghost/core/test/unit/server/lib/lexical.test.js
@@ -9,6 +9,8 @@ describe('lib/lexical', function () {
     });
 
     describe('render()', function () {
+        this.timeout(5000);
+
         it('renders', async function () {
             const lexical = `{"root":{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"Lexical is ","type":"text","version":1},{"detail":0,"format":3,"mode":"normal","style":"","text":"rendering.","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}}`;
 


### PR DESCRIPTION
## Summary
- increase the timeout for the `ghost/core` lexical `render()` unit test suite from 2 seconds to 5 seconds
- keep the rest of the `ghost/core` unit-test timeout defaults unchanged

## Why this change
The lexical `render()` tests lazily load heavier renderer and serializer dependencies than most `ghost/core` unit tests. In CI that has been enough to trip Mocha's 2 second default for this suite, causing repeated flaky failures in `ghost/core/test/unit/server/lib/lexical.test.js`.

This change raises the timeout only for that suite so the fix stays tightly scoped.

## Testing
- `node -c ghost/core/test/unit/server/lib/lexical.test.js`
