### PR TITLE
Fixed lint-staged config for flat-config workspaces

### DIFF
--- a/.lintstagedrc.cjs
+++ b/.lintstagedrc.cjs
@@ -1,0 +1,67 @@
+const path = require('path');
+
+const FLAT_CONFIG_WORKSPACES = [
+    'e2e',
+    'apps/admin'
+];
+
+function normalize(file) {
+    return file.split(path.sep).join('/');
+}
+
+function isInWorkspace(file, workspace) {
+    const normalizedFile = normalize(file);
+    const normalizedWorkspace = normalize(workspace);
+
+    return normalizedFile === normalizedWorkspace || normalizedFile.startsWith(`${normalizedWorkspace}/`);
+}
+
+function shellQuote(value) {
+    return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+function buildScopedEslintCommand(workspace, files) {
+    if (files.length === 0) {
+        return null;
+    }
+
+    const relativeFiles = files
+        .map(file => normalize(path.relative(workspace, file)))
+        .map(shellQuote)
+        .join(' ');
+
+    return `cd ${shellQuote(workspace)} && eslint --cache ${relativeFiles}`;
+}
+
+function buildRootEslintCommand(files) {
+    if (files.length === 0) {
+        return null;
+    }
+
+    const quotedFiles = files.map(file => shellQuote(normalize(file))).join(' ');
+    return `eslint --cache ${quotedFiles}`;
+}
+
+module.exports = {
+    '*.{js,ts,tsx,jsx,cjs}': (files) => {
+        const workspaceGroups = new Map(FLAT_CONFIG_WORKSPACES.map(workspace => [workspace, []]));
+        const rootFiles = [];
+
+        for (const file of files) {
+            const workspace = FLAT_CONFIG_WORKSPACES.find(candidate => isInWorkspace(file, candidate));
+
+            if (workspace) {
+                workspaceGroups.get(workspace).push(file);
+            } else {
+                rootFiles.push(file);
+            }
+        }
+
+        return [
+            ...FLAT_CONFIG_WORKSPACES
+                .map(workspace => buildScopedEslintCommand(workspace, workspaceGroups.get(workspace)))
+                .filter(Boolean),
+            buildRootEslintCommand(rootFiles)
+        ].filter(Boolean);
+    }
+};

--- a/.lintstagedrc.cjs
+++ b/.lintstagedrc.cjs
@@ -10,7 +10,7 @@ function normalize(file) {
 }
 
 function isInWorkspace(file, workspace) {
-    const normalizedFile = normalize(file);
+    const normalizedFile = normalize(path.relative(process.cwd(), file));
     const normalizedWorkspace = normalize(workspace);
 
     return normalizedFile === normalizedWorkspace || normalizedFile.startsWith(`${normalizedWorkspace}/`);

--- a/package.json
+++ b/package.json
@@ -67,9 +67,6 @@
     "moment-timezone": "0.5.45",
     "nwsapi": "2.2.12"
   },
-  "lint-staged": {
-    "*.{js,ts,tsx,jsx,cjs}": "eslint"
-  },
   "devDependencies": {
     "@actions/core": "1.11.1",
     "chalk": "4.1.2",


### PR DESCRIPTION
no ref

Moved lint-staged configuration out of package.json so staged e2e and apps/admin files are linted from the correct workspace root during pre-commit.