### PR TITLE
Updated test:single command in core

### DIFF
--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -31,7 +31,7 @@
     "pretest": "yarn build:assets",
     "test": "yarn test:unit",
     "test:base": "mocha --reporter dot --node-option import=tsx --require=./test/utils/overrides.js --exit --trace-warnings --recursive --extension=test.js,test.ts",
-    "test:single": "yarn test:base --timeout=60000",
+    "test:single": "f() { q=$(echo \"$1\" | sed 's/\\.test\\.[jt]s$//'); case \"$q\" in */*) yarn test:base --timeout=60000 \"$1\" ;; *) yarn test:base --timeout=60000 \"test/**/*$q*.test.{js,ts}\" ;; esac; }; f",
     "test:all": "yarn test:unit && yarn test:integration && yarn test:e2e && yarn lint",
     "test:debug": "DEBUG=ghost:test* yarn test",
     "test:unit": "c8 yarn test:unit:${GHOST_UNIT_TEST_VARIANT:-base}",


### PR DESCRIPTION
no ref

Updated the test single command to run a one liner that matches the filename such that all of these work:
- `yarn test:single file-name`
- `yarn test:single file-name.ext`
- `yarn test:single full/path/file-name.test.js`