### PR TITLE
Migrated portal settings links tests to e2e

### DIFF
--- a/e2e/helpers/pages/admin/settings/sections/portal-section.ts
+++ b/e2e/helpers/pages/admin/settings/sections/portal-section.ts
@@ -1,5 +1,5 @@
 import {BasePage} from '@/helpers/pages';
-import {Locator, Page, expect} from '@playwright/test';
+import {Locator, Page} from '@playwright/test';
 
 export class PortalSection extends BasePage {
     readonly section: Locator;
@@ -24,12 +24,17 @@ export class PortalSection extends BasePage {
     }
 
     async openLinksTab(): Promise<void> {
+        if (await this.linksTab.getAttribute('aria-selected') === 'true') {
+            return;
+        }
+
         await this.linksTab.click();
-        await expect(this.linksTab).toHaveAttribute('aria-selected', 'true');
     }
 
     async getLinkValue(label: string): Promise<string> {
         await this.openLinksTab();
-        return await this.portalModal.getByLabel(label).inputValue();
+        const linkInput = this.portalModal.getByLabel(label);
+        await linkInput.waitFor({state: 'visible'});
+        return await linkInput.inputValue();
     }
 }

--- a/e2e/helpers/pages/admin/settings/sections/portal-section.ts
+++ b/e2e/helpers/pages/admin/settings/sections/portal-section.ts
@@ -1,10 +1,11 @@
 import {BasePage} from '@/helpers/pages';
-import {Locator, Page} from '@playwright/test';
+import {Locator, Page, expect} from '@playwright/test';
 
 export class PortalSection extends BasePage {
     readonly section: Locator;
     readonly customizeButton: Locator;
     readonly portalModal: Locator;
+    readonly linksTab: Locator;
     readonly freeTierToggleLabel: Locator;
 
     constructor(page: Page) {
@@ -13,11 +14,22 @@ export class PortalSection extends BasePage {
         this.section = page.getByTestId('portal');
         this.customizeButton = this.section.getByRole('button', {name: 'Customize'});
         this.portalModal = page.getByTestId('portal-modal');
+        this.linksTab = this.portalModal.getByRole('tab', {name: 'Links'});
         this.freeTierToggleLabel = this.portalModal.locator('label').filter({hasText: 'Free'}).first();
     }
 
     async openCustomizeModal(): Promise<void> {
         await this.customizeButton.click();
         await this.portalModal.waitFor({state: 'visible'});
+    }
+
+    async openLinksTab(): Promise<void> {
+        await this.linksTab.click();
+        await expect(this.linksTab).toHaveAttribute('aria-selected', 'true');
+    }
+
+    async getLinkValue(label: string): Promise<string> {
+        await this.openLinksTab();
+        return await this.portalModal.getByLabel(label).inputValue();
     }
 }

--- a/e2e/helpers/pages/public/public-page.ts
+++ b/e2e/helpers/pages/public/public-page.ts
@@ -1,6 +1,5 @@
 import {BasePage, pageGotoOptions} from '@/helpers/pages';
 import {Locator, Page, Response, test} from '@playwright/test';
-import {expect} from '@/helpers/playwright';
 
 declare global {
     interface Window {
@@ -34,11 +33,19 @@ class PortalSection extends BasePage {
         await this.portalScript.waitFor({state: 'attached'});
         await this.portalRoot.waitFor({state: 'attached'});
 
-        // Use expect.toPass to retry click + popup check until Portal is ready
-        await expect(async () => {
+        // Retry until Portal finishes async init and can react to the click.
+        for (let attempt = 0; attempt < 5; attempt++) {
             await link.click();
-            await expect(this.portalIframe).toBeVisible();
-        }).toPass();
+
+            try {
+                await this.portalIframe.waitFor({state: 'visible', timeout: 1000});
+                return;
+            } catch {
+                // Keep retrying until Portal's hashchange listener is ready.
+            }
+        }
+
+        throw new Error('Portal popup did not open');
     }
 
     async isPortalOpen(): Promise<boolean> {

--- a/e2e/tests/admin/settings/portal-settings.test.ts
+++ b/e2e/tests/admin/settings/portal-settings.test.ts
@@ -4,7 +4,7 @@ import {SettingsService} from '@/helpers/services/settings/settings-service';
 import {expect, test} from '@/helpers/playwright';
 
 test.describe('Ghost Admin - Portal Settings', () => {
-    test('default link opens Portal', async ({page}) => {
+    test('default link opens portal - navigates to portal', async ({page}) => {
         const settingsPage = new SettingsPage(page);
         await settingsPage.goto();
         await settingsPage.portalSection.openCustomizeModal();
@@ -17,7 +17,7 @@ test.describe('Ghost Admin - Portal Settings', () => {
         await expect(portalPage.portalFrameBody).toBeVisible();
     });
 
-    test('sign in link opens Portal sign in page', async ({page}) => {
+    test('sign in link opens portal - navigates to sign in page', async ({page}) => {
         const settingsPage = new SettingsPage(page);
         await settingsPage.goto();
         await settingsPage.portalSection.openCustomizeModal();
@@ -31,7 +31,7 @@ test.describe('Ghost Admin - Portal Settings', () => {
         await expect(signInPage.continueButton).toBeVisible();
     });
 
-    test('sign up link opens Portal sign up page', async ({page}) => {
+    test('sign up link opens portal - navigates to sign up page', async ({page}) => {
         const settingsPage = new SettingsPage(page);
         await settingsPage.goto();
         await settingsPage.portalSection.openCustomizeModal();

--- a/e2e/tests/admin/settings/portal-settings.test.ts
+++ b/e2e/tests/admin/settings/portal-settings.test.ts
@@ -1,8 +1,50 @@
+import {PortalPage, SignInPage, SignUpPage} from '@/helpers/pages';
 import {SettingsPage} from '@/admin-pages';
 import {SettingsService} from '@/helpers/services/settings/settings-service';
 import {expect, test} from '@/helpers/playwright';
 
 test.describe('Ghost Admin - Portal Settings', () => {
+    test('default link opens Portal', async ({page}) => {
+        const settingsPage = new SettingsPage(page);
+        await settingsPage.goto();
+        await settingsPage.portalSection.openCustomizeModal();
+
+        const portalUrl = await settingsPage.portalSection.getLinkValue('Default:');
+        await page.goto(portalUrl);
+
+        const portalPage = new PortalPage(page);
+        await portalPage.waitForPortalToOpen();
+        await expect(portalPage.portalFrameBody).toBeVisible();
+    });
+
+    test('sign in link opens Portal sign in page', async ({page}) => {
+        const settingsPage = new SettingsPage(page);
+        await settingsPage.goto();
+        await settingsPage.portalSection.openCustomizeModal();
+
+        const portalUrl = await settingsPage.portalSection.getLinkValue('Sign in');
+        await page.goto(portalUrl);
+
+        const signInPage = new SignInPage(page);
+        await signInPage.waitForPortalToOpen();
+        await expect(signInPage.emailInput).toBeVisible();
+        await expect(signInPage.continueButton).toBeVisible();
+    });
+
+    test('sign up link opens Portal sign up page', async ({page}) => {
+        const settingsPage = new SettingsPage(page);
+        await settingsPage.goto();
+        await settingsPage.portalSection.openCustomizeModal();
+
+        const portalUrl = await settingsPage.portalSection.getLinkValue('Sign up');
+        await page.goto(portalUrl);
+
+        const signUpPage = new SignUpPage(page);
+        await signUpPage.waitForPortalToOpen();
+        await expect(signUpPage.emailInput).toBeVisible();
+        await expect(signUpPage.signupButton).toBeVisible();
+    });
+
     test('shows free tier toggle in the Portal settings modal when Stripe is disconnected', async ({page}) => {
         const settingsService = new SettingsService(page.request);
         await settingsService.setStripeDisconnected();

--- a/ghost/core/test/e2e-browser/admin/portal-settings.spec.js
+++ b/ghost/core/test/e2e-browser/admin/portal-settings.spec.js
@@ -1,4 +1,3 @@
-const {expect} = require('@playwright/test');
 const test = require('../fixtures/ghost-test');
 
 test.describe('Portal Settings', () => {
@@ -15,51 +14,6 @@ test.describe('Portal Settings', () => {
 
             return modal;
         };
-
-        test('can open portal on default page', async ({sharedPage}) => {
-            const modal = await openPortalLinks(sharedPage);
-
-            // fetch portal default url from input
-            const portalUrl = await modal.getByLabel('Default:').inputValue();
-            await sharedPage.goto(portalUrl);
-
-            const portalFrame = sharedPage.locator('[data-testid="portal-popup-frame"]');
-
-            // check portal popup is opened
-            await expect(portalFrame).toBeVisible();
-        });
-
-        test('can open portal on signin page', async ({sharedPage}) => {
-            const modal = await openPortalLinks(sharedPage);
-
-            // fetch portal signin url from input
-            const portalUrl = await modal.getByLabel('Sign in').inputValue();
-            await sharedPage.goto(portalUrl);
-
-            const portalFrame = sharedPage.locator('[data-testid="portal-popup-frame"]');
-            const portalFrameLocator = sharedPage.frameLocator('[data-testid="portal-popup-frame"]');
-
-            // check portal popup is opened
-            await expect(portalFrame).toBeVisible();
-            // check signin page is opened in portal
-            await expect(portalFrameLocator.getByRole('heading', {name: 'Sign in'})).toBeVisible();
-        });
-
-        test('can open portal on signup page', async ({sharedPage}) => {
-            const modal = await openPortalLinks(sharedPage);
-
-            // fetch portal signup url from input
-            const portalUrl = await modal.getByLabel('Sign up').inputValue();
-            await sharedPage.goto(portalUrl);
-
-            const portalFrame = sharedPage.locator('[data-testid="portal-popup-frame"]');
-            const portalFrameLocator = sharedPage.frameLocator('[data-testid="portal-popup-frame"]');
-
-            // check portal popup is opened
-            await expect(portalFrame).toBeVisible();
-            // check signup page is opened in portal
-            await expect(portalFrameLocator.locator('.gh-portal-signup')).toBeVisible();
-        });
 
         test('can open portal directly on monthly signup', async ({sharedPage}) => {
             const modal = await openPortalLinks(sharedPage);


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/pull/26810

This moves the admin-generated default, sign-in, and sign-up Portal link coverage into e2e so the browser suite can be trimmed incrementally.