### PR TITLE
Migrated portal script loading tests to e2e

### DIFF
--- a/e2e/eslint.config.js
+++ b/e2e/eslint.config.js
@@ -67,11 +67,46 @@ export default tseslint.config([
         }
     },
 
+    // Keep assertions in test files and Playwright-specific helpers.
+    {
+        files: ['**/*.ts', '**/*.mjs'],
+        ignores: [
+            'tests/**/*.ts',
+            'helpers/playwright/**/*.ts',
+            'visual-regression/**/*.ts'
+        ],
+        rules: {
+            'no-restricted-syntax': ['error',
+                {
+                    selector: "ImportSpecifier[imported.name='expect'][parent.source.value='@playwright/test']",
+                    message: 'Keep Playwright expect assertions in test files.'
+                },
+                {
+                    selector: "ImportSpecifier[imported.name='expect'][parent.source.value='@/helpers/playwright']",
+                    message: 'Keep Playwright expect assertions in test files.'
+                }
+            ]
+        }
+    },
+
     // Playwright-specific recommended rules config for test files
     {
         files: ['tests/**/*.ts', 'helpers/playwright/**/*.ts', 'helpers/pages/**/*.ts'],
         rules: {
             ...playwrightPlugin.configs.recommended.rules
+        }
+    },
+
+    // Keep raw page selectors out of tests so page objects remain the primary interface.
+    {
+        files: ['tests/**/*.ts'],
+        rules: {
+            'no-restricted-syntax': ['error',
+                {
+                    selector: "CallExpression[callee.object.name='page'][callee.property.name='locator']",
+                    message: 'Use page objects or higher-level page methods instead of page.locator() in test files.'
+                }
+            ]
         }
     }
 ]);

--- a/e2e/helpers/pages/admin/settings/sections/design-section.ts
+++ b/e2e/helpers/pages/admin/settings/sections/design-section.ts
@@ -7,6 +7,7 @@ export class DesignSection extends BasePage {
     readonly designModal: Locator;
     readonly unsplashButton: Locator;
     readonly unsplashHeading: Locator;
+    readonly unsplashPhotos: Locator;
     readonly coverImage: Locator;
 
     constructor(page: Page) {
@@ -17,6 +18,7 @@ export class DesignSection extends BasePage {
         this.designModal = page.getByTestId('design-modal');
         this.unsplashButton = page.getByTestId('toggle-unsplash-button');
         this.unsplashHeading = page.getByRole('heading', {name: 'Unsplash', level: 1});
+        this.unsplashPhotos = page.locator('[data-kg-unsplash-gallery-img]');
         this.coverImage = page.getByTestId('publication-cover');
     }
 

--- a/e2e/helpers/pages/public/public-page.ts
+++ b/e2e/helpers/pages/public/public-page.ts
@@ -1,6 +1,5 @@
 import {BasePage, pageGotoOptions} from '@/helpers/pages';
 import {Locator, Page, Response, test} from '@playwright/test';
-import {expect} from '@/helpers/playwright';
 
 declare global {
     interface Window {
@@ -34,11 +33,19 @@ class PortalSection extends BasePage {
         await this.portalScript.waitFor({state: 'attached'});
         await this.portalRoot.waitFor({state: 'attached'});
 
-        // Use expect.toPass to retry click + popup check until Portal is ready
-        await expect(async () => {
+        // Retry until Portal finishes async init and can react to the click.
+        for (let attempt = 0; attempt < 5; attempt++) {
             await link.click();
-            await expect(this.portalIframe).toBeVisible();
-        }).toPass();
+
+            try {
+                await this.portalIframe.waitFor({state: 'visible', timeout: 1000});
+                return;
+            } catch {
+                // Keep retrying until Portal's hashchange listener is ready.
+            }
+        }
+
+        throw new Error('Portal popup did not open');
     }
 
     async isPortalOpen(): Promise<boolean> {
@@ -52,6 +59,8 @@ class PortalSection extends BasePage {
 
 export class PublicPage extends BasePage {
     public readonly portalRoot: Locator;
+    public readonly portalIframe: Locator;
+    public readonly portalScript: Locator;
     private readonly subscribeLink: Locator;
     private readonly signInLink: Locator;
 
@@ -62,6 +71,8 @@ export class PublicPage extends BasePage {
 
         this.portal = new PortalSection(page);
         this.portalRoot = this.portal.portalRoot;
+        this.portalIframe = page.locator('#ghost-portal-root div iframe');
+        this.portalScript = page.locator('script[data-ghost][data-key][data-api]');
         this.subscribeLink = page.locator('a[href="#/portal/signup"]').first();
         this.signInLink = page.locator('a[href="#/portal/signin"]').first();
     }
@@ -126,5 +137,9 @@ export class PublicPage extends BasePage {
     async openPortalViaSignInLink(): Promise<void> {
         await this.waitForMemberAttributionReady();
         await this.portal.clickLinkAndWaitForPopup(this.signInLink);
+    }
+
+    async gotoPortalSignup(options?: pageGotoOptions): Promise<null | Response> {
+        return await this.goto('/#/portal/signup', options);
     }
 }

--- a/e2e/helpers/services/settings/settings-service.ts
+++ b/e2e/helpers/services/settings/settings-service.ts
@@ -10,6 +10,7 @@ export interface SettingsResponse {
 }
 
 export type CommentsEnabled = 'all' | 'paid' | 'off';
+export type MembersSignupAccess = 'all' | 'invite' | 'paid' | 'none';
 
 export class SettingsService {
     private readonly request: APIRequest;
@@ -51,6 +52,10 @@ export class SettingsService {
      */
     async setCommentsEnabled(value: CommentsEnabled) {
         return await this.updateSettings([{key: 'comments_enabled', value}]);
+    }
+
+    async setMembersSignupAccess(value: MembersSignupAccess) {
+        return await this.updateSettings([{key: 'members_signup_access', value}]);
     }
 
     /**

--- a/e2e/tests/admin/settings/design.test.ts
+++ b/e2e/tests/admin/settings/design.test.ts
@@ -11,8 +11,7 @@ test.describe('Ghost Admin - Design & Branding', () => {
             await design.deleteCoverImage();
             await design.openUnsplashSelector();
 
-            const unsplashPhoto = page.locator('[data-kg-unsplash-gallery-img]');
-            await expect(unsplashPhoto.first()).toBeVisible({timeout: 10000});
+            await expect(design.unsplashPhotos.first()).toBeVisible({timeout: 10000});
         });
     });
 });

--- a/e2e/tests/post-factory.test.ts
+++ b/e2e/tests/post-factory.test.ts
@@ -1,3 +1,5 @@
+import {PostPage} from '@/helpers/pages';
+import {PostsPage} from '@/admin-pages';
 import {createPostFactory} from '@/data-factory';
 import {expect, test} from '@/helpers/playwright';
 import type {PostFactory} from '@/data-factory';
@@ -19,9 +21,9 @@ test.describe('Post Factory API Integration', () => {
         expect(post.slug).toBeTruthy();
         expect(post.status).toBe('published');
 
-        // TODO: Replace this with a Post page object
-        await page.goto(`/${post.slug}/`);
-        await expect(page.locator('h1.gh-article-title')).toContainText('Test Post from Factory');
+        const postPage = new PostPage(page);
+        await postPage.gotoPost(post.slug);
+        await expect(postPage.postTitle).toContainText('Test Post from Factory');
     });
 
     test('create a post visible in Ghost Admin', async ({page}) => {
@@ -31,9 +33,9 @@ test.describe('Post Factory API Integration', () => {
             status: 'published'
         });
 
-        // TODO: Replace with PostsList page object
-        await page.goto('/ghost/#/posts');
-        await expect(page.locator(`text="${post.title}"`).first()).toBeVisible();
+        const postsPage = new PostsPage(page);
+        await postsPage.goto();
+        await expect(postsPage.getPostByTitle(post.title)).toBeVisible();
     });
 
     test('create draft post that is not accessible on frontend', async ({page}) => {

--- a/e2e/tests/public/portal-script-loading.test.ts
+++ b/e2e/tests/public/portal-script-loading.test.ts
@@ -2,18 +2,16 @@ import {HomePage} from '@/helpers/pages';
 import {SettingsService} from '@/helpers/services/settings/settings-service';
 import {expect, test} from '@/helpers/playwright';
 
-const portalScriptSelector = 'script[data-ghost][data-key][data-api]';
-
 test.describe('Portal Script Loading', () => {
     test('memberships enabled - loads portal script', async ({page}) => {
         const settingsService = new SettingsService(page.request);
         await settingsService.setMembersSignupAccess('all');
 
         const homePage = new HomePage(page);
-        await homePage.goto('/#/portal/signup');
+        await homePage.gotoPortalSignup();
 
-        await expect(page.locator(portalScriptSelector)).toHaveAttribute('src', /\/portal\.min\.js$/);
-        await expect(page.locator('#ghost-portal-root div iframe')).toHaveCount(1);
+        await expect(homePage.portalScript).toHaveAttribute('src', /\/portal\.min\.js$/);
+        await expect(homePage.portalIframe).toHaveCount(1);
     });
 
     test.describe('with stripe connected', () => {
@@ -24,10 +22,10 @@ test.describe('Portal Script Loading', () => {
             await settingsService.setMembersSignupAccess('none');
 
             const homePage = new HomePage(page);
-            await homePage.goto('/#/portal/signup');
+            await homePage.gotoPortalSignup();
 
-            await expect(page.locator(portalScriptSelector)).toHaveAttribute('src', /\/portal\.min\.js$/);
-            await expect(page.locator('#ghost-portal-root div iframe')).toHaveCount(1);
+            await expect(homePage.portalScript).toHaveAttribute('src', /\/portal\.min\.js$/);
+            await expect(homePage.portalIframe).toHaveCount(1);
         });
     });
 
@@ -36,9 +34,9 @@ test.describe('Portal Script Loading', () => {
         await settingsService.setMembersSignupAccess('none');
 
         const homePage = new HomePage(page);
-        await homePage.goto('/#/portal/signup');
+        await homePage.gotoPortalSignup();
 
-        await expect(page.locator(portalScriptSelector)).toHaveCount(0);
-        await expect(page.locator('#ghost-portal-root div iframe')).toHaveCount(0);
+        await expect(homePage.portalScript).toHaveCount(0);
+        await expect(homePage.portalIframe).toHaveCount(0);
     });
 });

--- a/e2e/tests/public/portal-script-loading.test.ts
+++ b/e2e/tests/public/portal-script-loading.test.ts
@@ -1,0 +1,44 @@
+import {HomePage} from '@/helpers/pages';
+import {SettingsService} from '@/helpers/services/settings/settings-service';
+import {expect, test} from '@/helpers/playwright';
+
+const portalScriptSelector = 'script[data-ghost][data-key][data-api]';
+
+test.describe('Portal Script Loading', () => {
+    test('memberships enabled - loads portal script', async ({page}) => {
+        const settingsService = new SettingsService(page.request);
+        await settingsService.setMembersSignupAccess('all');
+
+        const homePage = new HomePage(page);
+        await homePage.goto('/#/portal/signup');
+
+        await expect(page.locator(portalScriptSelector)).toHaveAttribute('src', /\/portal\.min\.js$/);
+        await expect(page.locator('#ghost-portal-root div iframe')).toHaveCount(1);
+    });
+
+    test.describe('with stripe connected', () => {
+        test.use({stripeEnabled: true});
+
+        test('memberships disabled - loads portal script', async ({page}) => {
+            const settingsService = new SettingsService(page.request);
+            await settingsService.setMembersSignupAccess('none');
+
+            const homePage = new HomePage(page);
+            await homePage.goto('/#/portal/signup');
+
+            await expect(page.locator(portalScriptSelector)).toHaveAttribute('src', /\/portal\.min\.js$/);
+            await expect(page.locator('#ghost-portal-root div iframe')).toHaveCount(1);
+        });
+    });
+
+    test('memberships and donations disabled - does not load portal script', async ({page}) => {
+        const settingsService = new SettingsService(page.request);
+        await settingsService.setMembersSignupAccess('none');
+
+        const homePage = new HomePage(page);
+        await homePage.goto('/#/portal/signup');
+
+        await expect(page.locator(portalScriptSelector)).toHaveCount(0);
+        await expect(page.locator('#ghost-portal-root div iframe')).toHaveCount(0);
+    });
+});

--- a/ghost/core/test/e2e-browser/admin/site-settings.spec.js
+++ b/ghost/core/test/e2e-browser/admin/site-settings.spec.js
@@ -1,6 +1,6 @@
 const {expect} = require('@playwright/test');
 const test = require('../fixtures/ghost-test');
-const {createPostDraft, createTier, disconnectStripe, generateStripeIntegrationToken, setupStripe, getStripeAccountId} = require('../utils');
+const {createPostDraft, createTier} = require('../utils');
 
 const changeSubscriptionAccess = async (page, access) => {
     await page.getByRole('navigation').getByRole('link', {name: 'Settings'}).click();
@@ -20,16 +20,6 @@ const changeSubscriptionAccess = async (page, access) => {
                 access === 'paid' ? 'Paid-members only' :
                     'Nobody'
     );
-};
-
-const checkPortalScriptLoaded = async (page, loaded = true) => {
-    const portalScript = page.locator('script[data-ghost][data-api]');
-
-    if (!loaded) {
-        await expect(portalScript).toHaveCount(0);
-    } else {
-        await expect(portalScript).toHaveAttribute('src', /\/portal.min.js$/);
-    }
 };
 
 test.describe('Site Settings', () => {
@@ -75,66 +65,6 @@ test.describe('Site Settings', () => {
 
             await expect(sharedPage.locator('[data-test-setting="publish-type"] > button')).toHaveCount(0);
             await expect(sharedPage.locator('[data-test-setting="email-recipients"]')).toHaveCount(0);
-        });
-    });
-
-    test.describe('Portal script', () => {
-        test('Portal loads if Memberships are enabled', async ({sharedPage}) => {
-            await sharedPage.goto('/ghost');
-
-            // Enable Memberships
-            await changeSubscriptionAccess(sharedPage, 'all');
-
-            // Go to the signup page
-            await sharedPage.goto('/#/portal/signup');
-
-            // Portal should load
-            await expect(sharedPage.locator('#ghost-portal-root div iframe')).toHaveCount(1);
-            await checkPortalScriptLoaded(sharedPage, true);
-        });
-
-        test('Portal loads if Tips & Donations are enabled (Stripe connected)', async ({sharedPage}) => {
-            await sharedPage.goto('/ghost');
-
-            // Disable Memberships
-            await changeSubscriptionAccess(sharedPage, 'none');
-
-            // Go to the signup page
-            await sharedPage.goto('/#/portal/signup');
-
-            // Portal should load
-            await expect(sharedPage.locator('#ghost-portal-root div iframe')).toHaveCount(1);
-            await checkPortalScriptLoaded(sharedPage, true);
-
-            // Reset
-            await sharedPage.goto('/ghost');
-            await changeSubscriptionAccess(sharedPage, 'all');
-        });
-
-        test('Portal does not load if both Memberships and Tips & Donations are disabled', async ({sharedPage}) => {
-            // Disconnect stripe first, which will disable Tips & Donations
-            await sharedPage.goto('/ghost');
-            await disconnectStripe(sharedPage);
-
-            // Disable Memberships
-            await sharedPage.goto('/ghost');
-            await changeSubscriptionAccess(sharedPage, 'none');
-
-            // Go to the signup page
-            await sharedPage.goto('/#/portal/signup');
-
-            // Portal should not load
-            await expect(sharedPage.locator('#ghost-portal-root div iframe')).toHaveCount(0);
-            await checkPortalScriptLoaded(sharedPage, false);
-
-            // Reset subscription access & re-connect Stripe
-            await sharedPage.goto('/ghost');
-            await changeSubscriptionAccess(sharedPage, 'all');
-
-            await sharedPage.goto('/ghost');
-            const stripeAccountId = await getStripeAccountId();
-            const stripeToken = await generateStripeIntegrationToken(stripeAccountId);
-            await setupStripe(sharedPage, stripeToken);
         });
     });
 });


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/pull/26810
- added linter rules around expect and locators

This replaces the low-dependency site settings portal script browser coverage with top-level e2e tests so the old suite can be trimmed incrementally.