### PR TITLE
Fixed flaky fake Stripe port binding in e2e

### DIFF
--- a/e2e/helpers/playwright/fixture.ts
+++ b/e2e/helpers/playwright/fixture.ts
@@ -8,7 +8,6 @@ import {loginToGetAuthenticatedSession} from '@/helpers/playwright/flows/sign-in
 import {setupUser} from '@/helpers/utils';
 
 const debug = baseDebug('e2e:ghost-fixture');
-const STRIPE_FAKE_SERVER_PORT = 40000 + parseInt(process.env.TEST_PARALLEL_INDEX || '0', 10);
 const STRIPE_SECRET_KEY = 'sk_test_e2eTestKey';
 const STRIPE_PUBLISHABLE_KEY = 'pk_test_e2eTestKey';
 
@@ -80,9 +79,9 @@ export const test = base.extend<GhostInstanceFixture>({
             return;
         }
 
-        const server = new FakeStripeServer(STRIPE_FAKE_SERVER_PORT);
+        const server = new FakeStripeServer();
         await server.start();
-        debug('Fake Stripe server started on port', STRIPE_FAKE_SERVER_PORT);
+        debug('Fake Stripe server started on port', server.port);
 
         await use(server);
 
@@ -93,9 +92,9 @@ export const test = base.extend<GhostInstanceFixture>({
     // Each test gets its own Ghost instance with isolated database.
     ghostInstance: async ({config, stripeEnabled, stripeServer}, use, testInfo: TestInfo) => {
         debug('Setting up Ghost instance for test:', testInfo.title);
-        const stripeConfig = stripeEnabled ? {
+        const stripeConfig = stripeEnabled && stripeServer ? {
             STRIPE_API_HOST: 'host.docker.internal',
-            STRIPE_API_PORT: String(STRIPE_FAKE_SERVER_PORT),
+            STRIPE_API_PORT: String(stripeServer.port),
             STRIPE_API_PROTOCOL: 'http'
         } : {};
         const mergedConfig = {...(config || {}), ...stripeConfig};

--- a/e2e/helpers/services/stripe/fake-stripe-server.ts
+++ b/e2e/helpers/services/stripe/fake-stripe-server.ts
@@ -8,12 +8,12 @@ const debug = baseDebug('e2e:fake-stripe');
 export class FakeStripeServer {
     private server: http.Server | null = null;
     private readonly app = express();
-    private readonly _port: number;
+    private _port: number;
     private readonly customers: Map<string, StripeCustomer> = new Map();
     private readonly subscriptions: Map<string, StripeSubscription> = new Map();
     private readonly paymentMethods: Map<string, StripePaymentMethod> = new Map();
 
-    constructor(port: number) {
+    constructor(port = 0) {
         this._port = port;
         this.setupRoutes();
     }
@@ -37,6 +37,14 @@ export class FakeStripeServer {
     async start(): Promise<void> {
         return new Promise((resolve, reject) => {
             this.server = this.app.listen(this._port, () => {
+                const address = this.server?.address();
+
+                if (!address || typeof address === 'string') {
+                    reject(new Error('Fake Stripe server did not expose a TCP port'));
+                    return;
+                }
+
+                this._port = address.port;
                 resolve();
             });
             this.server.on('error', reject);


### PR DESCRIPTION
## What this changes
- lets the fake Stripe helper bind an OS-assigned free port instead of hardcoding port 40000
- passes the chosen port into Ghost's Stripe config after the helper starts
- removes the CI-only EADDRINUSE failure mode around the fake Stripe server

## Why
Port 40000 sits inside the default Linux ephemeral port range, so CI could occasionally have another process or connection take it before the helper bound. This keeps the helper aligned with how short-lived local test services should behave: bind any free port, then inject that value into the app under test.

## Testing
- cd e2e && yarn eslint helpers/services/stripe/fake-stripe-server.ts helpers/playwright/fixture.ts
- cd e2e && yarn test:types
- cd /Users/slars/dev/ghost/Ghost/e2e && GHOST_E2E_SKIP_BUILD=1 yarn test tests/admin/members/stripe-webhooks.test.ts