### PR TITLE
Reused unsubscribe token URL for welcome email preferences link

### DIFF
--- a/ghost/core/core/server/services/member-welcome-emails/member-welcome-email-renderer.js
+++ b/ghost/core/core/server/services/member-welcome-emails/member-welcome-email-renderer.js
@@ -92,9 +92,10 @@ class MemberWelcomeEmailRenderer {
      * @param {string} options.subject - Email subject (may contain template variables)
      * @param {Object} options.member - Member data (name, email)
      * @param {Object} options.siteSettings - Site settings (title, url, accentColor)
+     * @param {string} [options.managePreferencesUrl] - Optional footer manage preferences URL override
      * @returns {Promise<{html: string, text: string, subject: string}>}
      */
-    async render({lexical, subject, member, siteSettings}) {
+    async render({lexical, subject, member, siteSettings, managePreferencesUrl}) {
         let content;
         try {
             content = await lexicalLib.render(lexical, {target: 'email'});
@@ -122,7 +123,7 @@ class MemberWelcomeEmailRenderer {
             return url;
         }, {base: siteSettings.url});
 
-        const managePreferencesUrl = new URL('#/portal/account/newsletters', siteSettings.url).href;
+        const resolvedManagePreferencesUrl = managePreferencesUrl || new URL('#/portal/account/newsletters', siteSettings.url).href;
         const year = new Date().getFullYear();
         const accentColor = siteSettings.accentColor || '#15212A';
         const accentContrastColor = textColorForBackgroundColor(accentColor).hex();
@@ -143,7 +144,7 @@ class MemberWelcomeEmailRenderer {
             buttonColor: accentColor,
             buttonTextColor: accentContrastColor,
             buttonBorderRadius: '6px',
-            managePreferencesUrl,
+            managePreferencesUrl: resolvedManagePreferencesUrl,
             year
         });
 

--- a/ghost/core/core/server/services/member-welcome-emails/service.js
+++ b/ghost/core/core/server/services/member-welcome-emails/service.js
@@ -151,7 +151,8 @@ class MemberWelcomeEmailService {
                 name: member.name,
                 email: member.email
             },
-            siteSettings: this.#getSiteSettings()
+            siteSettings: this.#getSiteSettings(),
+            managePreferencesUrl: settingsHelpers.createUnsubscribeUrl(member.uuid)
         });
 
         const senderOptions = await this.#getSenderOptions();
@@ -204,12 +205,14 @@ class MemberWelcomeEmailService {
             name: 'Jamie Larson',
             email: email
         };
+        const siteSettings = this.#getSiteSettings();
 
         const {html, text, subject: renderedSubject} = await this.#renderer.render({
             lexical,
             subject,
             member: testMember,
-            siteSettings: this.#getSiteSettings()
+            siteSettings,
+            managePreferencesUrl: new URL('#/portal/account/newsletters', siteSettings.url).href
         });
 
         // Test sends should always reflect the latest newsletter sender settings.

--- a/ghost/core/test/unit/server/services/member-welcome-emails/member-welcome-email-renderer.test.js
+++ b/ghost/core/test/unit/server/services/member-welcome-emails/member-welcome-email-renderer.test.js
@@ -228,6 +228,21 @@ describe('MemberWelcomeEmailRenderer', function () {
             assert(result.html.includes('https://example.com/#/portal/account'));
         });
 
+        it('uses a provided manage preferences url', async function () {
+            lexicalRenderStub.resolves('<p>Content</p>');
+            const renderer = new MemberWelcomeEmailRenderer({t: key => key});
+
+            const result = await renderer.render({
+                lexical: '{}',
+                subject: 'Test Subject',
+                member: {name: 'John', email: 'john@example.com'},
+                siteSettings: defaultSiteSettings,
+                managePreferencesUrl: 'https://example.com/unsubscribe/?uuid=memberuuid&key=testhmac'
+            });
+
+            assert(result.html.includes('href="https://example.com/unsubscribe/?uuid&#x3D;memberuuid&amp;key&#x3D;testhmac"'));
+        });
+
         it('resolves relative portal links to absolute URLs', async function () {
             lexicalRenderStub.resolves('<table class="kg-card kg-button-card"><tbody><tr><td><table class="btn"><tbody><tr><td align="center"><a href="#/portal/support">Support us</a></td></tr></tbody></table></td></tr></tbody></table>');
             const renderer = new MemberWelcomeEmailRenderer({t: key => key});


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1018

- Added managePreferencesUrl as an optional input to MemberWelcomeEmailRenderer.render(...).
- Updated the renderer to use the provided managePreferencesUrl when present, while keeping the existing portal-account URL as the fallback.
- Updated member welcome email sending to pass a member-specific unsubscribe link (settingsHelpers.createUnsubscribeUrl(member.uuid)) into the footer.
- Kept test email behavior unchanged by explicitly passing the default portal newsletters URL for test sends.
- Added unit test coverage verifying that a provided managePreferencesUrl is rendered into the email footer link.

with one newsletter:
<img width="545" height="356" alt="Screenshot 2026-03-17 at 2 51 37 PM" src="https://github.com/user-attachments/assets/6a400241-9a37-4b46-b994-00f0f64e0dab" />


with 2+ newsletters (i wasn't subscribed to the second one, but point is that it lets you edit all of them):
<img width="529" height="443" alt="Screenshot 2026-03-17 at 2 52 17 PM" src="https://github.com/user-attachments/assets/06ef980c-30da-45b7-a523-82bfc0aee46c" />
