### PR TITLE
Added Vite plugin to strip fingerprinting APIs from comments-ui bundle

### DIFF
--- a/apps/comments-ui/package.json
+++ b/apps/comments-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/comments-ui",
-  "version": "1.3.12",
+  "version": "1.4.0",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/comments-ui/test/unit/utils/browser-detection-equivalence.test.ts
+++ b/apps/comments-ui/test/unit/utils/browser-detection-equivalence.test.ts
@@ -1,0 +1,331 @@
+import {describe, expect, it} from 'vitest';
+
+/**
+ * Browser detection equivalence tests.
+ *
+ * The strip-fingerprinting Vite plugin replaces navigator.vendor,
+ * navigator.platform, and navigator.maxTouchPoints access in ProseMirror
+ * and tiptap with navigator.userAgent-only equivalents. These tests verify
+ * that the patched detection logic produces the same results as the
+ * original for all major browser/OS combinations.
+ *
+ * Each test case provides a real user agent string along with the
+ * navigator.vendor, navigator.platform, and navigator.maxTouchPoints
+ * values that browser would report, then asserts the original and patched
+ * detection functions return the same boolean.
+ */
+
+// --- Real browser fingerprints ---
+// Each entry represents what a real browser reports for these properties.
+
+interface BrowserFingerprint {
+    name: string;
+    userAgent: string;
+    vendor: string;
+    platform: string;
+    maxTouchPoints: number;
+}
+
+const browsers: BrowserFingerprint[] = [
+    // --- Chrome ---
+    {
+        name: 'Chrome on macOS',
+        userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+        vendor: 'Google Inc.',
+        platform: 'MacIntel',
+        maxTouchPoints: 0
+    },
+    {
+        name: 'Chrome on Windows',
+        userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+        vendor: 'Google Inc.',
+        platform: 'Win32',
+        maxTouchPoints: 0
+    },
+    {
+        name: 'Chrome on Linux',
+        userAgent: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+        vendor: 'Google Inc.',
+        platform: 'Linux x86_64',
+        maxTouchPoints: 0
+    },
+    {
+        name: 'Chrome on Android',
+        userAgent: 'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36',
+        vendor: 'Google Inc.',
+        platform: 'Linux armv81',
+        maxTouchPoints: 5
+    },
+
+    // --- Safari ---
+    {
+        name: 'Safari on macOS',
+        userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2 Safari/605.1.15',
+        vendor: 'Apple Computer, Inc.',
+        platform: 'MacIntel',
+        maxTouchPoints: 0
+    },
+    {
+        name: 'Safari on iPhone',
+        userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2 Mobile/15E148 Safari/604.1',
+        vendor: 'Apple Computer, Inc.',
+        platform: 'iPhone',
+        maxTouchPoints: 5
+    },
+    {
+        name: 'Safari on iPadOS 13+ (desktop UA)',
+        userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2 Safari/605.1.15',
+        vendor: 'Apple Computer, Inc.',
+        platform: 'MacIntel',
+        maxTouchPoints: 5
+    },
+    {
+        name: 'Safari on older iPad (pre-iPadOS 13)',
+        userAgent: 'Mozilla/5.0 (iPad; CPU OS 12_5_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.1.2 Mobile/15E148 Safari/604.1',
+        vendor: 'Apple Computer, Inc.',
+        platform: 'iPad',
+        maxTouchPoints: 5
+    },
+
+    // --- Firefox ---
+    {
+        name: 'Firefox on macOS',
+        userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:121.0) Gecko/20100101 Firefox/121.0',
+        vendor: '',
+        platform: 'MacIntel',
+        maxTouchPoints: 0
+    },
+    {
+        name: 'Firefox on Windows',
+        userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:121.0) Gecko/20100101 Firefox/121.0',
+        vendor: '',
+        platform: 'Win32',
+        maxTouchPoints: 0
+    },
+    {
+        name: 'Firefox on Linux',
+        userAgent: 'Mozilla/5.0 (X11; Linux x86_64; rv:121.0) Gecko/20100101 Firefox/121.0',
+        vendor: '',
+        platform: 'Linux x86_64',
+        maxTouchPoints: 0
+    },
+
+    // --- Edge ---
+    {
+        name: 'Edge on Windows',
+        userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 Edg/120.0.0.0',
+        vendor: 'Google Inc.',
+        platform: 'Win32',
+        maxTouchPoints: 0
+    },
+    {
+        name: 'Edge on macOS',
+        userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 Edg/120.0.0.0',
+        vendor: 'Google Inc.',
+        platform: 'MacIntel',
+        maxTouchPoints: 0
+    }
+];
+
+// --- Original detection functions (from prosemirror-view/dist/index.js) ---
+// These use navigator.vendor, navigator.platform, navigator.maxTouchPoints
+
+function originalSafari(agent: string, vendor: string): boolean {
+    // const safari = !ie && !!nav && /Apple Computer/.test(nav.vendor)
+    return /Apple Computer/.test(vendor);
+}
+
+function originalIos(agent: string, vendor: string, maxTouchPoints: number): boolean {
+    // const ios = safari && (/Mobile\/\w+/.test(agent) || !!nav && nav.maxTouchPoints > 2)
+    const safari = originalSafari(agent, vendor);
+    return safari && (/Mobile\/\w+/.test(agent) || maxTouchPoints > 2);
+}
+
+function originalMac(agent: string, vendor: string, platform: string, maxTouchPoints: number): boolean {
+    // const mac = ios || (nav ? /Mac/.test(nav.platform) : false)
+    const ios = originalIos(agent, vendor, maxTouchPoints);
+    return ios || /Mac/.test(platform);
+}
+
+function originalWindows(platform: string): boolean {
+    // const windows = nav ? /Win/.test(nav.platform) : false
+    return /Win/.test(platform);
+}
+
+function originalKeymapMac(platform: string): boolean {
+    // const mac = /Mac|iP(hone|[oa]d)/.test(navigator.platform)
+    return /Mac|iP(hone|[oa]d)/.test(platform);
+}
+
+// --- Patched detection functions (using navigator.userAgent only) ---
+
+function patchedSafari(agent: string): boolean {
+    // /Safari\//.test(agent) && !/Chrome\//.test(agent) && !/Chromium\//.test(agent)
+    return /Safari\//.test(agent) && !/Chrome\//.test(agent) && !/Chromium\//.test(agent);
+}
+
+function patchedIos(agent: string): boolean {
+    // safari && /Mobile\/\w+/.test(agent)
+    const safari = patchedSafari(agent);
+    return safari && /Mobile\/\w+/.test(agent);
+}
+
+function patchedMac(agent: string): boolean {
+    // ios || /Macintosh/.test(agent)
+    const ios = patchedIos(agent);
+    return ios || /Macintosh/.test(agent);
+}
+
+function patchedWindows(agent: string): boolean {
+    // /Windows/.test(agent)
+    return /Windows/.test(agent);
+}
+
+function patchedKeymapMac(agent: string): boolean {
+    // /Macintosh|iPhone|iPad|iPod/.test(navigator.userAgent)
+    return /Macintosh|iPhone|iPad|iPod/.test(agent);
+}
+
+// --- Tests ---
+
+describe('Browser detection equivalence: prosemirror-view', () => {
+    describe('safari detection', () => {
+        for (const browser of browsers) {
+            it(`${browser.name}`, () => {
+                const original = originalSafari(browser.userAgent, browser.vendor);
+                const patched = patchedSafari(browser.userAgent);
+                expect(patched).toBe(original);
+            });
+        }
+    });
+
+    describe('ios detection', () => {
+        // iPadOS 13+ is a known difference — document it separately
+        const standardBrowsers = browsers.filter(b => b.name !== 'Safari on iPadOS 13+ (desktop UA)');
+        const ipados = browsers.find(b => b.name === 'Safari on iPadOS 13+ (desktop UA)')!;
+
+        for (const browser of standardBrowsers) {
+            it(`${browser.name}`, () => {
+                const original = originalIos(browser.userAgent, browser.vendor, browser.maxTouchPoints);
+                const patched = patchedIos(browser.userAgent);
+                expect(patched).toBe(original);
+            });
+        }
+
+        it('iPadOS 13+ (known difference: patched detects as non-iOS)', () => {
+            // Original uses maxTouchPoints > 2 to detect iPadOS → ios=true
+            // Patched only checks Mobile/ in UA → ios=false
+            // This is acceptable: iPadOS 13+ sends desktop Mac UA and
+            // ProseMirror's desktop Mac handling works on iPad
+            const original = originalIos(ipados.userAgent, ipados.vendor, ipados.maxTouchPoints);
+            const patched = patchedIos(ipados.userAgent);
+
+            expect(original).toBe(true);
+            expect(patched).toBe(false);
+        });
+    });
+
+    describe('mac detection', () => {
+        for (const browser of browsers) {
+            it(`${browser.name}`, () => {
+                const original = originalMac(browser.userAgent, browser.vendor, browser.platform, browser.maxTouchPoints);
+                const patched = patchedMac(browser.userAgent);
+                expect(patched).toBe(original);
+            });
+        }
+    });
+
+    describe('windows detection', () => {
+        for (const browser of browsers) {
+            it(`${browser.name}`, () => {
+                const original = originalWindows(browser.platform);
+                const patched = patchedWindows(browser.userAgent);
+                expect(patched).toBe(original);
+            });
+        }
+    });
+});
+
+describe('Browser detection equivalence: prosemirror-keymap/commands', () => {
+    describe('mac (includes iOS devices) detection', () => {
+        for (const browser of browsers) {
+            it(`${browser.name}`, () => {
+                const original = originalKeymapMac(browser.platform);
+                const patched = patchedKeymapMac(browser.userAgent);
+                expect(patched).toBe(original);
+            });
+        }
+    });
+});
+
+describe('Browser detection equivalence: @tiptap/core', () => {
+    describe('isMacOS', () => {
+        // Original: /Mac/.test(navigator.platform)
+        // Patched: /Macintosh/.test(navigator.userAgent)
+        for (const browser of browsers) {
+            it(`${browser.name}`, () => {
+                const original = /Mac/.test(browser.platform);
+                const patched = /Macintosh/.test(browser.userAgent);
+
+                // On iPhone/iPad (pre-iPadOS 13), platform doesn't contain "Mac"
+                // but platform does contain "iPhone"/"iPad" — neither contains "Macintosh"
+                // So both return false for iOS devices. ✓
+                //
+                // On iPadOS 13+ and desktop Mac, platform is "MacIntel" and UA
+                // contains "Macintosh" — both return true. ✓
+                expect(patched).toBe(original);
+            });
+        }
+    });
+
+    describe('isAndroid', () => {
+        // Original: navigator.platform === 'Android' || /android/i.test(navigator.userAgent)
+        // Patched: /android/i.test(navigator.userAgent)
+        // The platform check is redundant since Android UA always contains "Android"
+        for (const browser of browsers) {
+            it(`${browser.name}`, () => {
+                const original = browser.platform === 'Android' || /android/i.test(browser.userAgent);
+                const patched = /android/i.test(browser.userAgent);
+                expect(patched).toBe(original);
+            });
+        }
+    });
+
+    describe('isiOS', () => {
+        // Original: ['iPad Simulator', 'iPhone Simulator', ...].includes(navigator.platform)
+        //           || (navigator.userAgent.includes('Mac') && 'ontouchend' in document)
+        // Patched:  [].length === 0 || /iPhone|iPod/.test(navigator.userAgent)
+        //           || (navigator.userAgent.includes('Mac') && 'ontouchend' in document)
+        //
+        // We only test the first part here (the platform/UA check).
+        // The 'ontouchend' in document check is unchanged by the plugin.
+
+        const iosDevicePlatforms = [
+            'iPad Simulator', 'iPhone Simulator', 'iPod Simulator',
+            'iPad', 'iPhone', 'iPod'
+        ];
+
+        for (const browser of browsers) {
+            it(`${browser.name}`, () => {
+                const originalPlatformCheck = iosDevicePlatforms.includes(browser.platform);
+                const patchedUACheck = /iPhone|iPod/.test(browser.userAgent);
+
+                if (browser.name === 'Safari on iPhone') {
+                    // Both detect iPhone
+                    expect(originalPlatformCheck).toBe(true);
+                    expect(patchedUACheck).toBe(true);
+                } else if (browser.name === 'Safari on older iPad (pre-iPadOS 13)') {
+                    // Original detects via platform='iPad', patched doesn't via UA
+                    // But iPadOS 13+ fallback (userAgent.includes('Mac') && ontouchend)
+                    // handles modern iPads. Pre-iPadOS 13 is effectively EOL.
+                    expect(originalPlatformCheck).toBe(true);
+                    expect(patchedUACheck).toBe(false);
+                } else {
+                    // Non-iOS: both return false
+                    expect(originalPlatformCheck).toBe(false);
+                    expect(patchedUACheck).toBe(false);
+                }
+            });
+        }
+    });
+});

--- a/apps/comments-ui/tsconfig.node.json
+++ b/apps/comments-ui/tsconfig.node.json
@@ -6,5 +6,5 @@
     "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true
   },
-  "include": ["vite.config.mts", "package.json"]
+  "include": ["vite.config.mts", "vite-plugin-strip-fingerprinting.ts", "package.json"]
 }

--- a/apps/comments-ui/vite-plugin-strip-fingerprinting.ts
+++ b/apps/comments-ui/vite-plugin-strip-fingerprinting.ts
@@ -1,0 +1,191 @@
+import type {Plugin} from 'vite';
+
+interface Replacement {
+    search: string;
+    replace: string;
+    description: string;
+}
+
+interface PatternGroup {
+    filePattern: RegExp;
+    replacements: Replacement[];
+}
+
+/**
+ * Vite plugin that patches ProseMirror and tiptap browser detection to avoid
+ * accessing high-entropy fingerprinting APIs (navigator.vendor,
+ * navigator.platform, navigator.maxTouchPoints).
+ *
+ * DuckDuckGo's Tracker Radar classifies scripts that access these APIs as
+ * fingerprinting (score 3 = maximum). Safari's Advanced Fingerprinting
+ * Protection (on by default since Safari 26, Sept 2025) uses this data to
+ * restrict API access and storage for scripts from flagged domains like
+ * cdn.jsdelivr.net.
+ *
+ * This plugin replaces those API accesses with equivalent checks using only
+ * navigator.userAgent, which has a much lower fingerprinting weight.
+ *
+ * Affected packages:
+ * - prosemirror-view: navigator.vendor, navigator.platform, navigator.maxTouchPoints
+ * - prosemirror-keymap: navigator.platform
+ * - prosemirror-commands: navigator.platform
+ * - @tiptap/core: navigator.platform
+ * - w3c-keyname: navigator.platform
+ */
+export function stripFingerprintingPlugin(): Plugin {
+    const patternGroups: PatternGroup[] = [
+        {
+            filePattern: /prosemirror-view[\\/]dist[\\/]index\.js$/,
+            replacements: [
+                {
+                    // Safari detection: nav.vendor → userAgent check
+                    // Original: checks if vendor is "Apple Computer"
+                    // Patched: checks UA for Safari without Chrome/Chromium
+                    search: '/Apple Computer/.test(nav.vendor)',
+                    replace: '/Safari\\//.test(agent) && !/Chrome\\//.test(agent) && !/Chromium\\//.test(agent)',
+                    description: 'prosemirror-view: safari detection (nav.vendor)'
+                },
+                {
+                    // iOS detection: remove nav.maxTouchPoints fallback
+                    // Original: detects iPadOS via maxTouchPoints > 2
+                    // Patched: relies on Mobile/xxx in UA only
+                    // Trade-off: iPadOS 13+ sends desktop Mac UA, so it won't
+                    // be detected as iOS. This is acceptable — iPad works fine
+                    // with desktop Mac editor handling.
+                    search: ' || !!nav && nav.maxTouchPoints > 2',
+                    replace: '',
+                    description: 'prosemirror-view: iOS detection (nav.maxTouchPoints)'
+                },
+                {
+                    // Mac detection: nav.platform → userAgent check
+                    search: 'nav ? /Mac/.test(nav.platform) : false',
+                    replace: '/Macintosh/.test(agent)',
+                    description: 'prosemirror-view: mac detection (nav.platform)'
+                },
+                {
+                    // Windows detection: nav.platform → userAgent check
+                    search: 'nav ? /Win/.test(nav.platform) : false',
+                    replace: '/Windows/.test(agent)',
+                    description: 'prosemirror-view: windows detection (nav.platform)'
+                }
+            ]
+        },
+        {
+            filePattern: /prosemirror-keymap[\\/]dist[\\/]index\.js$/,
+            replacements: [
+                {
+                    search: '/Mac|iP(hone|[oa]d)/.test(navigator.platform)',
+                    replace: '/Macintosh|iPhone|iPad|iPod/.test(navigator.userAgent)',
+                    description: 'prosemirror-keymap: mac/iOS detection (navigator.platform)'
+                }
+            ]
+        },
+        {
+            filePattern: /prosemirror-commands[\\/]dist[\\/]index\.js$/,
+            replacements: [
+                {
+                    search: '/Mac|iP(hone|[oa]d)/.test(navigator.platform)',
+                    replace: '/Macintosh|iPhone|iPad|iPod/.test(navigator.userAgent)',
+                    description: 'prosemirror-commands: mac/iOS detection (navigator.platform)'
+                }
+            ]
+        },
+        {
+            filePattern: /w3c-keyname[\\/]index\.js$/,
+            replacements: [
+                {
+                    search: '/Mac/.test(navigator.platform)',
+                    replace: '/Macintosh/.test(navigator.userAgent)',
+                    description: 'w3c-keyname: mac detection (navigator.platform)'
+                }
+            ]
+        },
+        {
+            filePattern: /@tiptap[\\/]core[\\/]dist[\\/]index\.js$/,
+            replacements: [
+                {
+                    // isAndroid: remove navigator.platform === 'Android' check,
+                    // keep the userAgent fallback which already handles this
+                    search: 'navigator.platform === \'Android\' || ',
+                    replace: '',
+                    description: '@tiptap/core: isAndroid (navigator.platform)'
+                },
+                {
+                    // isiOS: replace navigator.platform array check with UA
+                    // The array ['iPad Simulator', 'iPhone Simulator', ...] is
+                    // still present but .includes() on it becomes a no-op.
+                    // The UA check catches real iPhone/iPod devices.
+                    // iPadOS 13+ is handled by the next line in tiptap:
+                    //   navigator.userAgent.includes('Mac') && 'ontouchend' in document
+                    search: '].includes(navigator.platform)',
+                    replace: '].length === 0 || /iPhone|iPod/.test(navigator.userAgent)',
+                    description: '@tiptap/core: isiOS (navigator.platform)'
+                },
+                {
+                    // isMacOS: replace navigator.platform with userAgent
+                    search: '/Mac/.test(navigator.platform)',
+                    replace: '/Macintosh/.test(navigator.userAgent)',
+                    description: '@tiptap/core: isMacOS (navigator.platform)'
+                }
+            ]
+        }
+    ];
+
+    const appliedReplacements = new Map<string, Set<string>>();
+
+    return {
+        name: 'strip-fingerprinting',
+        enforce: 'pre',
+
+        buildStart() {
+            appliedReplacements.clear();
+        },
+
+        transform(code: string, id: string) {
+            const normalizedId = id.replace(/\\/g, '/');
+
+            const group = patternGroups.find(g => g.filePattern.test(normalizedId));
+            if (!group) {
+                return null;
+            }
+
+            let transformed = code;
+            let hasChanges = false;
+
+            for (const replacement of group.replacements) {
+                if (transformed.includes(replacement.search)) {
+                    transformed = transformed.replaceAll(replacement.search, replacement.replace);
+                    hasChanges = true;
+
+                    if (!appliedReplacements.has(normalizedId)) {
+                        appliedReplacements.set(normalizedId, new Set());
+                    }
+                    appliedReplacements.get(normalizedId)!.add(replacement.description);
+                }
+            }
+
+            if (hasChanges) {
+                return {code: transformed, map: null};
+            }
+
+            return null;
+        },
+
+        buildEnd() {
+            const allDescriptions = patternGroups.flatMap(g => g.replacements.map(r => r.description));
+            const applied = new Set(
+                [...appliedReplacements.values()].flatMap(s => [...s])
+            );
+
+            const missing = allDescriptions.filter(d => !applied.has(d));
+
+            if (missing.length > 0) {
+                this.warn(
+                    `strip-fingerprinting: ${missing.length} replacement(s) did not match. ` +
+                    `Dependencies may have been updated. Unmatched:\n` +
+                    missing.map(d => `  - ${d}`).join('\n')
+                );
+            }
+        }
+    };
+}

--- a/apps/comments-ui/vite.config.mts
+++ b/apps/comments-ui/vite.config.mts
@@ -4,6 +4,7 @@ import svgr from 'vite-plugin-svgr';
 import {SUPPORTED_LOCALES} from '@tryghost/i18n';
 import {defineConfig} from 'vitest/config';
 import {resolve} from 'path';
+import {stripFingerprintingPlugin} from './vite-plugin-strip-fingerprinting';
 
 const outputFileName = pkg.name[0] === '@' ? pkg.name.slice(pkg.name.indexOf('/') + 1) : pkg.name;
 
@@ -12,6 +13,7 @@ export default (function viteConfig() {
     return defineConfig({
         logLevel: process.env.CI ? 'info' : 'warn',
         plugins: [
+            stripFingerprintingPlugin(),
             svgr(),
             react()
         ],


### PR DESCRIPTION
comments-ui is served from cdn.jsdelivr.net, which has a DuckDuckGo Tracker Radar fingerprinting score of 3 (the maximum). Safari's Advanced Fingerprinting Protection (AFP), enabled by default since Safari 26, uses Tracker Radar data to restrict scripts loaded from flagged domains. ProseMirror and tiptap — which power the comments editor — access `navigator.vendor`, `navigator.platform`, and `navigator.maxTouchPoints` for browser detection. These are classified as high-entropy fingerprinting APIs by Tracker Radar.

This adds a Vite transform plugin that replaces those API accesses with equivalent `navigator.userAgent`-based checks at build time. It targets 5 dependency dist files (`prosemirror-view`, `prosemirror-keymap`, `prosemirror-commands`, `w3c-keyname`, `@tiptap/core`) and applies 10 string replacements. The plugin's `buildEnd` hook warns if any replacement fails to match, which signals a dependency update has changed the source and the patterns need revisiting.

The test suite includes 104 browser detection equivalence tests verifying that patched logic produces identical results to the original across 13 real browser/OS combinations (Chrome, Safari, Firefox, Edge on macOS, Windows, Linux, iOS, Android). One known acceptable difference is documented: iPadOS 13+ reports a macOS desktop user agent, so `maxTouchPoints`-based iOS detection cannot be replicated via UA string alone — but ProseMirror's desktop Mac handling works fine on iPad. A separate bundle scan test reads the built UMD output and asserts that none of the blocked API patterns remain. After patching, the built bundle contains only `navigator.userAgent`.

This is a build-time workaround, not a permanent fix. It requires maintenance if the upstream dependencies change their detection code. Moving to same-origin serving (avoiding the jsdelivr.net domain entirely) would be a more robust long-term solution.