### PR TITLE
🐛 Enabled email newsletter sending on POST /posts/ endpoint

### DIFF
--- a/ghost/core/core/server/api/endpoints/posts.js
+++ b/ghost/core/core/server/api/endpoints/posts.js
@@ -156,7 +156,9 @@ const controller = {
         options: [
             'include',
             'formats',
-            'source'
+            'source',
+            'email_segment',
+            'newsletter'
         ],
         validation: {
             options: {
@@ -172,7 +174,7 @@ const controller = {
             unsafeAttrs: unsafeAttrs
         },
         async query(frame) {
-            const model = await models.Post.add(frame.data.posts[0], frame.options);
+            const model = await postsService.addPost(frame);
             if (model.get('status') === 'published') {
                 frame.setHeader('X-Cache-Invalidate', '/*');
             }

--- a/ghost/core/core/server/models/post.js
+++ b/ghost/core/core/server/models/post.js
@@ -1204,6 +1204,7 @@ Post = ghostBookshelf.Model.extend({
 
             findAll: ['columns', 'filter'],
             destroy: ['destroyAll', 'destroyBy'],
+            add: ['email_segment', 'newsletter'],
             edit: ['filter', 'email_segment', 'force_rerender', 'newsletter', 'save_revision', 'convert_to_lexical']
         };
 

--- a/ghost/core/core/server/services/posts/post-email-handler.js
+++ b/ghost/core/core/server/services/posts/post-email-handler.js
@@ -31,10 +31,13 @@ class PostEmailHandler {
             return;
         }
 
-        const existingPost = await this.models.Post.findOne(
-            {id: frame.options.id, status: 'all'},
-            {columns: ['id', 'status', 'newsletter_id', 'email_recipient_filter']}
-        );
+        let existingPost = null;
+        if (frame.options.id) {
+            existingPost = await this.models.Post.findOne(
+                {id: frame.options.id, status: 'all'},
+                {columns: ['id', 'status', 'newsletter_id', 'email_recipient_filter']}
+            );
+        }
         const previousStatus = existingPost?.get('status');
 
         const hasNewsletter = frame.options.newsletter || existingPost?.get('newsletter_id');

--- a/ghost/core/core/server/services/posts/posts-service.js
+++ b/ghost/core/core/server/services/posts/posts-service.js
@@ -37,6 +37,25 @@ class PostsService {
         return posts;
     }
 
+    async addPost(frame) {
+        await this.postEmailHandler.validateBeforeSave(frame);
+
+        const model = await this.models.Post.add(frame.data.posts[0], frame.options);
+
+        // For new posts, model.wasChanged() returns false after add() since
+        // Bookshelf resets _changed. We call createEmail directly instead of
+        // going through createOrRetryEmail which relies on wasChanged/previous.
+        const status = model.get('status');
+        if (model.get('newsletter_id') && (status === 'published' || status === 'sent')) {
+            const email = await this.emailService.createEmail(model);
+            if (email) {
+                model.set('email', email);
+            }
+        }
+
+        return model;
+    }
+
     async readPost(frame) {
         const model = await this.models.Post.findOne(frame.data, frame.options);
 

--- a/ghost/core/test/e2e-api/admin/posts-legacy.test.js
+++ b/ghost/core/test/e2e-api/admin/posts-legacy.test.js
@@ -911,6 +911,94 @@ describe('Posts API', function () {
         assert(['pending', 'submitted', 'submitting'].includes(email.get('status')));
     });
 
+    it('Can create and send a post with newsletter in a single request', async function () {
+        const newsletterId = testUtils.DataGenerator.Content.newsletters[1].id;
+        const newsletterSlug = testUtils.DataGenerator.Content.newsletters[1].slug;
+
+        const post = {
+            title: 'Single request publish + email',
+            status: 'published',
+            mobiledoc: testUtils.DataGenerator.markdownToMobiledoc('my post'),
+            created_at: moment().subtract(2, 'days').toDate(),
+            updated_at: moment().subtract(2, 'days').toDate()
+        };
+
+        const res = await request.post(localUtils.API.getApiQuery('posts/?newsletter=' + newsletterSlug))
+            .set('Origin', config.get('url'))
+            .send({posts: [post]})
+            .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect(201);
+
+        assert.equal(res.body.posts[0].status, 'published');
+        assert.equal(res.body.posts[0].newsletter.id, newsletterId);
+        assert.equal(res.body.posts[0].email_segment, 'all');
+
+        const id = res.body.posts[0].id;
+
+        const model = await models.Post.findOne({id}, testUtils.context.internal);
+        assert.equal(model.get('newsletter_id'), newsletterId);
+
+        const email = await models.Email.findOne({post_id: id}, testUtils.context.internal);
+        assertExists(email);
+        assert.equal(email.get('newsletter_id'), newsletterId);
+        assert(['pending', 'submitted', 'submitting'].includes(email.get('status')));
+    });
+
+    it('Can create and send an email-only post in a single request', async function () {
+        const newsletterSlug = testUtils.DataGenerator.Content.newsletters[1].slug;
+
+        const post = {
+            title: 'Single request email-only',
+            status: 'published',
+            mobiledoc: testUtils.DataGenerator.markdownToMobiledoc('my post'),
+            created_at: moment().subtract(2, 'days').toDate(),
+            updated_at: moment().subtract(2, 'days').toDate(),
+            email_only: true
+        };
+
+        const res = await request.post(localUtils.API.getApiQuery('posts/?newsletter=' + newsletterSlug + '&email_segment=all'))
+            .set('Origin', config.get('url'))
+            .send({posts: [post]})
+            .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect(201);
+
+        assert.equal(res.body.posts[0].status, 'sent');
+        assert.equal(res.body.posts[0].email_only, true);
+
+        const id = res.body.posts[0].id;
+
+        const email = await models.Email.findOne({post_id: id}, testUtils.context.internal);
+        assertExists(email);
+        assert(['pending', 'submitted', 'submitting'].includes(email.get('status')));
+    });
+
+    it('Creating a draft post ignores newsletter option', async function () {
+        const newsletterSlug = testUtils.DataGenerator.Content.newsletters[1].slug;
+
+        const post = {
+            title: 'Draft with newsletter param',
+            status: 'draft',
+            mobiledoc: testUtils.DataGenerator.markdownToMobiledoc('my post')
+        };
+
+        const res = await request.post(localUtils.API.getApiQuery('posts/?newsletter=' + newsletterSlug))
+            .set('Origin', config.get('url'))
+            .send({posts: [post]})
+            .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect(201);
+
+        assert.equal(res.body.posts[0].status, 'draft');
+        assert.equal(res.body.posts[0].newsletter, null);
+
+        const id = res.body.posts[0].id;
+
+        const email = await models.Email.findOne({post_id: id}, testUtils.context.internal);
+        assert.equal(email, null);
+    });
+
     it('Interprets sent as published for a post with email', async function () {
         const newsletterId = testUtils.DataGenerator.Content.newsletters[1].id;
         const newsletterSlug = testUtils.DataGenerator.Content.newsletters[1].slug;

--- a/ghost/core/test/unit/server/services/posts/post-email-handler.test.js
+++ b/ghost/core/test/unit/server/services/posts/post-email-handler.test.js
@@ -218,6 +218,44 @@ describe('PostEmailHandler', function () {
             );
         });
 
+        it('validates when creating a new post with newsletter option (no id)', async function () {
+            setupNewsletter();
+
+            const frame = {
+                options: {newsletter: 'test-newsletter'},
+                data: {posts: [{status: 'published'}]}
+            };
+
+            await postEmailHandler.validateBeforeSave(frame);
+
+            sinon.assert.notCalled(mockModels.Post.findOne);
+            sinon.assert.calledOnce(mockEmailService.checkCanSendEmail);
+        });
+
+        it('skips validation when creating a new post without newsletter (no id)', async function () {
+            const frame = {
+                options: {},
+                data: {posts: [{status: 'published'}]}
+            };
+
+            await postEmailHandler.validateBeforeSave(frame);
+
+            sinon.assert.notCalled(mockModels.Post.findOne);
+            sinon.assert.notCalled(mockEmailService.checkCanSendEmail);
+        });
+
+        it('skips validation when creating a new draft post with newsletter (no id)', async function () {
+            const frame = {
+                options: {newsletter: 'test-newsletter'},
+                data: {posts: [{status: 'draft'}]}
+            };
+
+            await postEmailHandler.validateBeforeSave(frame);
+
+            sinon.assert.notCalled(mockModels.Post.findOne);
+            sinon.assert.notCalled(mockEmailService.checkCanSendEmail);
+        });
+
         it('propagates checkCanSendEmail errors', async function () {
             setupExistingPost({newsletterId: 'newsletter-123'});
             setupNewsletter();

--- a/ghost/core/test/unit/server/services/posts/posts-service.test.js
+++ b/ghost/core/test/unit/server/services/posts/posts-service.test.js
@@ -386,6 +386,162 @@ describe('Posts Service', function () {
         });
     });
 
+    describe('addPost', function () {
+        let postsService;
+        let mockModels;
+        let mockEmailService;
+        let postEmailHandlerStub;
+        let mockPostModel;
+
+        function createMockPostModel({status = 'draft', newsletterId = null} = {}) {
+            const get = sinon.stub();
+            get.withArgs('status').returns(status);
+            get.withArgs('newsletter_id').returns(newsletterId);
+            return {
+                get,
+                set: sinon.stub(),
+                toJSON: sinon.stub().returns({id: 'post-123'})
+            };
+        }
+
+        beforeEach(function () {
+            mockPostModel = createMockPostModel();
+
+            mockModels = {
+                Post: {
+                    findOne: sinon.stub(),
+                    add: sinon.stub().resolves(mockPostModel)
+                },
+                Member: {
+                    findPage: sinon.stub()
+                },
+                Newsletter: {
+                    findOne: sinon.stub()
+                }
+            };
+
+            mockEmailService = {
+                checkCanSendEmail: sinon.stub().resolves(),
+                createEmail: sinon.stub().resolves({id: 'email-123'}),
+                retryEmail: sinon.stub()
+            };
+
+            postsService = new PostsService({
+                models: mockModels,
+                emailService: mockEmailService
+            });
+
+            postEmailHandlerStub = {
+                validateBeforeSave: sinon.stub().resolves(),
+                createOrRetryEmail: sinon.stub().resolves()
+            };
+
+            postsService.postEmailHandler = postEmailHandlerStub;
+        });
+
+        afterEach(function () {
+            sinon.restore();
+        });
+
+        it('calls postEmailHandler.validateBeforeSave', async function () {
+            const frame = {
+                options: {newsletter: 'test-newsletter'},
+                data: {posts: [{title: 'Test', status: 'published'}]}
+            };
+
+            await postsService.addPost(frame);
+
+            sinon.assert.calledOnceWithExactly(postEmailHandlerStub.validateBeforeSave, frame);
+        });
+
+        it('propagates validation errors from validateBeforeSave', async function () {
+            postEmailHandlerStub.validateBeforeSave.rejects(new Error('Validation failed'));
+
+            const frame = {
+                options: {newsletter: 'test-newsletter'},
+                data: {posts: [{title: 'Test', status: 'published'}]}
+            };
+
+            await assert.rejects(
+                postsService.addPost(frame),
+                (err) => {
+                    assert.equal(err.message, 'Validation failed');
+                    return true;
+                }
+            );
+
+            sinon.assert.notCalled(mockModels.Post.add);
+        });
+
+        it('creates email when post is published with newsletter', async function () {
+            mockPostModel = createMockPostModel({status: 'published', newsletterId: 'newsletter-123'});
+            mockModels.Post.add.resolves(mockPostModel);
+
+            const frame = {
+                options: {newsletter: 'test-newsletter'},
+                data: {posts: [{title: 'Test', status: 'published'}]}
+            };
+
+            await postsService.addPost(frame);
+
+            sinon.assert.calledOnceWithExactly(mockEmailService.createEmail, mockPostModel);
+            sinon.assert.calledOnce(mockPostModel.set);
+        });
+
+        it('creates email when post status is sent (email-only)', async function () {
+            mockPostModel = createMockPostModel({status: 'sent', newsletterId: 'newsletter-123'});
+            mockModels.Post.add.resolves(mockPostModel);
+
+            const frame = {
+                options: {newsletter: 'test-newsletter'},
+                data: {posts: [{title: 'Test', status: 'published'}]}
+            };
+
+            await postsService.addPost(frame);
+
+            sinon.assert.calledOnceWithExactly(mockEmailService.createEmail, mockPostModel);
+        });
+
+        it('does not create email for draft posts', async function () {
+            mockPostModel = createMockPostModel({status: 'draft'});
+            mockModels.Post.add.resolves(mockPostModel);
+
+            const frame = {
+                options: {},
+                data: {posts: [{title: 'Test', status: 'draft'}]}
+            };
+
+            await postsService.addPost(frame);
+
+            sinon.assert.notCalled(mockEmailService.createEmail);
+        });
+
+        it('does not create email when no newsletter_id', async function () {
+            mockPostModel = createMockPostModel({status: 'published', newsletterId: null});
+            mockModels.Post.add.resolves(mockPostModel);
+
+            const frame = {
+                options: {},
+                data: {posts: [{title: 'Test', status: 'published'}]}
+            };
+
+            await postsService.addPost(frame);
+
+            sinon.assert.notCalled(mockEmailService.createEmail);
+        });
+
+        it('returns the model', async function () {
+            const frame = {
+                options: {},
+                data: {posts: [{title: 'Test', status: 'draft'}]}
+            };
+
+            const result = await postsService.addPost(frame);
+
+            assert.equal(result, mockPostModel);
+        });
+    });
+
     describe('getChanges', function () {
         let postsService;
 


### PR DESCRIPTION
## Summary

- The `POST /posts/` endpoint silently ignored `newsletter` and `email_segment` query parameters, so API consumers couldn't create and send a post as an email newsletter in a single request
- Wired the POST endpoint through `PostsService.addPost()` with email validation and creation, matching the existing PUT behavior
- Root cause: the `add` endpoint called `models.Post.add()` directly, bypassing the service layer where all email handling lives

## Changes

- Added `newsletter`/`email_segment` to the `add` valid options in the Post model
- Adapted `PostEmailHandler.validateBeforeSave` to handle new posts (no existing post ID)
- Added `PostsService.addPost()` method that validates, creates the post, and triggers email creation
- Updated the POST endpoint to route through the service layer

## Test plan

- [x] Unit tests for PostEmailHandler (33 passing)
- [x] Unit tests for PostsService.addPost (25 passing)
- [x] E2E tests for single-request publish+email, email-only, and draft-ignores-newsletter (43 passing)
- [x] Lint clean

closes https://linear.app/ghost/issue/ONC-1543