### PR TITLE
Fixed FOR UPDATE lock leaking to relation fetches during post edit

### DIFF
--- a/ghost/core/core/server/models/base/plugins/overrides.js
+++ b/ghost/core/core/server/models/base/plugins/overrides.js
@@ -9,6 +9,20 @@ module.exports = function (Bookshelf) {
 
     Bookshelf.Model = Bookshelf.Model.extend({
         /**
+         * Strip `lock` from options before eager loading relations.
+         *
+         * Bookshelf propagates `lock` (e.g. 'forUpdate') to all eager-loaded
+         * relation queries via _handleEager. This causes FOR UPDATE locks on
+         * tags, authors, and other relation tables during post edits — creating
+         * a large lock surface that leads to database deadlocks under concurrent
+         * writes. The FOR UPDATE lock is only needed on the primary row fetch,
+         * not on relation loading.
+         */
+        _handleEager: function _handleEager(response, options) {
+            return ParentModel.prototype._handleEager.call(this, response, _.omit(options, 'lock'));
+        },
+
+        /**
          * Bookshelf's .format() is run when fetching as well as saving.
          * We need a way to transform attributes only on save so we override
          * .sync() which is run on every database operation where we can


### PR DESCRIPTION
## Summary

- Overrides `_handleEager` on Ghost's base Bookshelf model to strip the `lock` option before it reaches eager-loaded relation queries
- Previously, a single post edit with `lock: 'forUpdate'` acquired FOR UPDATE locks on **9 tables** (posts, tags, users, products, post_revisions, posts_meta, emails, roles, roles_users) via Bookshelf's eager loading propagation
- Now only the primary post row gets the FOR UPDATE lock; relations are loaded without row-level locking

## Context

A customer was experiencing database deadlocks at the `PUT /ghost/api/admin/posts/:id` endpoint. The root cause: `crud.js` sets `options.lock = 'forUpdate'` for edit operations, and Bookshelf propagates this lock to all eager-loaded relation queries via `_handleEager` → `EagerRelation.fetch()` → `Sync` constructor.

Example deadlocking query from production:
```sql
select distinct `tags`.*, `posts_tags`.`post_id` as `_pivot_post_id`,
  `posts_tags`.`tag_id` as `_pivot_tag_id`,
  `posts_tags`.`sort_order` as `_pivot_sort_order`
from `tags` inner join `posts_tags` on `posts_tags`.`tag_id` = `tags`.`id`
where `posts_tags`.`post_id` in ('69b8927caa3f5600011b6197')
order by `sort_order` ASC for update
```

The FOR UPDATE on relation fetches is unnecessary:
- **Same-post concurrency:** Already serialized by the post row's FOR UPDATE lock
- **Different-post concurrency:** Relation writes target different pivot table rows (different `post_id`), so no conflict
- The relation rows themselves (tags, users) are never modified during a post edit

## Test plan

- [x] Unit tests: crud.js (10 passing), post.js (40 passing)
- [x] E2E tests: posts.test.js (1510 passing)
- [x] E2E tests: posts-legacy + posts-bulk (1510 passing)
- [x] E2E tests: e2e-webhooks/posts.test.js (passing)
- [ ] Monitor `Innodb_row_lock_waits`, `Innodb_row_lock_time`, and `Innodb_deadlocks` after deploy