### PR TITLE
Released @tryghost/portal v2.66.5

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.66.4",
+  "version": "2.66.5",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",


### PR DESCRIPTION


Changelog for v2.66.4 -> 2.66.5:
  - Updated i18n translations - new strings for zh and zh-Hant



