### PR TITLE
Added e2e Stripe checkout initiation support

### DIFF
--- a/e2e/helpers/services/stripe/builders.ts
+++ b/e2e/helpers/services/stripe/builders.ts
@@ -1,73 +1,89 @@
 import crypto from 'crypto';
+import type Stripe from 'stripe';
+
+// Keep fake Stripe HTTP responses close to Stripe's published shapes so Ghost interacts
+// with realistic field names, enums, and nullability at the API boundary. Internal fake
+// request/recorded state stays local and minimal because it exists only to support tests,
+// not to model Stripe end to end.
 
 function generateId(prefix: string): string {
     return `${prefix}_${crypto.randomBytes(8).toString('hex')}`;
 }
 
-export interface StripeCustomer {
-    id: string;
-    object: 'customer';
-    name: string;
-    email: string;
-    subscriptions: {
-        type: 'list';
-        data: StripeSubscription[];
-    };
-}
+type StripeList<T> = Pick<Stripe.ApiList<T>, 'data' | 'object'>;
+type StripePriceInterval = NonNullable<Stripe.Price['recurring']>['interval'];
 
-export interface StripePrice {
-    id: string;
-    object: 'price';
-    unit_amount: number;
-    currency: string;
-    recurring: {
-        interval: string;
-    };
+export type StripeProduct = Pick<Stripe.Product, 'active' | 'id' | 'name' | 'object'>;
+
+export type StripePrice = Omit<Pick<Stripe.Price, 'active' | 'currency' | 'id' | 'nickname' | 'object' | 'product' | 'recurring' | 'type' | 'unit_amount'>, 'product' | 'recurring' | 'unit_amount'> & {
     product: string;
-    type: 'recurring';
-    active: boolean;
-    nickname: string | null;
-}
+    recurring: {interval: StripePriceInterval} | null;
+    unit_amount: NonNullable<Stripe.Price['unit_amount']>;
+};
 
-export interface StripePaymentMethod {
-    id: string;
-    object: 'payment_method';
+export type StripePaymentMethod = Omit<Pick<Stripe.PaymentMethod, 'billing_details' | 'card' | 'id' | 'object' | 'type'>, 'billing_details' | 'card' | 'type'> & {
+    billing_details: {name: string};
+    card: Pick<NonNullable<Stripe.PaymentMethod.Card>, 'brand' | 'country' | 'exp_month' | 'exp_year' | 'last4'>;
     type: 'card';
-    card: {
-        brand: string;
-        last4: string;
-        exp_month: number;
-        exp_year: number;
-        country: string;
-    };
-    billing_details: {
-        name: string;
-    };
-}
+};
 
-export interface StripeSubscription {
-    id: string;
-    object: 'subscription';
-    status: string;
-    cancel_at_period_end: boolean;
-    canceled_at: number | null;
-    current_period_end: number;
-    start_date: number;
-    default_payment_method: string | null;
-    items: {
-        type: 'list';
-        data: Array<{price: StripePrice}>;
-    };
+type StripeSubscriptionItem = Omit<Pick<Stripe.SubscriptionItem, 'price'>, 'price'> & {
+    price: StripePrice;
+};
+
+export type StripeSubscription = Omit<Pick<Stripe.Subscription, 'cancel_at_period_end' | 'canceled_at' | 'current_period_end' | 'customer' | 'default_payment_method' | 'id' | 'items' | 'object' | 'start_date' | 'status'>, 'customer' | 'default_payment_method' | 'items'> & {
     customer: string;
-}
+    default_payment_method: string | null;
+    items: StripeList<StripeSubscriptionItem>;
+};
 
-export interface StripeEvent {
-    id: string;
-    object: 'event';
-    type: string;
+export type StripeCustomer = Omit<Pick<Stripe.Customer, 'email' | 'id' | 'name' | 'object'>, 'email' | 'name'> & {
+    email: string;
+    name: string;
+    subscriptions: StripeList<StripeSubscription>;
+};
+
+export type StripeEvent = Pick<Stripe.Event, 'id' | 'object' | 'type'> & {
     data: {
         object: Record<string, unknown>;
         previous_attributes?: Record<string, unknown>;
+    };
+};
+
+export type StripeCheckoutSessionResponse = Omit<Pick<Stripe.Checkout.Session, 'cancel_url' | 'customer' | 'customer_email' | 'id' | 'metadata' | 'mode' | 'object' | 'success_url' | 'url'>, 'customer' | 'customer_email' | 'metadata' | 'url'> & {
+    customer: string | null;
+    customer_email: string | null;
+    metadata: Stripe.Metadata;
+    url: string;
+};
+
+export interface StripeCheckoutSessionRequest {
+    line_items?: Array<{price: string; quantity: number}>;
+    subscription_data?: {
+        items: Array<{plan: string}>;
+        metadata?: Record<string, unknown>;
+        trial_from_plan?: boolean;
+        trial_period_days?: number;
+    };
+}
+
+export interface RecordedStripeCheckoutSession {
+    request: StripeCheckoutSessionRequest;
+    response: StripeCheckoutSessionResponse;
+}
+
+interface CheckoutSessionOverrides {
+    request?: Partial<StripeCheckoutSessionRequest>;
+    response?: Partial<StripeCheckoutSessionResponse>;
+}
+
+export function buildProduct(overrides: Partial<StripeProduct> = {}): StripeProduct {
+    return {
+        id: generateId('prod'),
+        object: 'product',
+        active: true,
+        name: 'Test Product',
+        ...overrides
     };
 }
 
@@ -111,7 +127,7 @@ export function buildCustomer(opts: {id?: string; email: string; name: string}):
         name: opts.name,
         email: opts.email,
         subscriptions: {
-            type: 'list',
+            object: 'list',
             data: []
         }
     };
@@ -120,11 +136,11 @@ export function buildCustomer(opts: {id?: string; email: string; name: string}):
 export function buildSubscription(opts: {
     id?: string;
     customerId: string;
+    paymentMethod?: StripePaymentMethod | null;
+    price?: StripePrice;
     priceId?: string;
     productId?: string;
-    status?: string;
-    price?: StripePrice;
-    paymentMethod?: StripePaymentMethod | null;
+    status?: Stripe.Subscription.Status;
 }): StripeSubscription {
     const price = opts.price ?? buildPrice({
         id: opts.priceId,
@@ -141,7 +157,7 @@ export function buildSubscription(opts: {
         start_date: Math.floor(Date.now() / 1000),
         default_payment_method: opts.paymentMethod?.id ?? null,
         items: {
-            type: 'list',
+            object: 'list',
             data: [{price}]
         },
         customer: opts.customerId
@@ -183,8 +199,8 @@ export function buildSubscriptionCreatedEvent(opts: {
 }
 
 export function buildSubscriptionUpdatedEvent(opts: {
-    subscription: StripeSubscription;
     previousAttributes?: Record<string, unknown>;
+    subscription: StripeSubscription;
 }): StripeEvent {
     return {
         id: generateId('evt'),
@@ -214,8 +230,8 @@ export function buildSubscriptionDeletedEvent(opts: {
 }
 
 export function buildInvoicePaymentSucceededEvent(opts: {
-    subscription: StripeSubscription;
     amount?: number;
+    subscription: StripeSubscription;
 }): StripeEvent {
     const price = opts.subscription.items.data[0]?.price;
     return {
@@ -232,12 +248,32 @@ export function buildInvoicePaymentSucceededEvent(opts: {
                 amount_paid: opts.amount ?? price?.unit_amount ?? 0,
                 currency: price?.currency ?? 'usd',
                 lines: {
-                    type: 'list',
+                    object: 'list',
                     data: [{
                         price: price as unknown as Record<string, unknown>
                     }]
                 }
             }
+        }
+    };
+}
+
+export function buildCheckoutSession(overrides: CheckoutSessionOverrides = {}): RecordedStripeCheckoutSession {
+    const id = overrides.response?.id ?? generateId('cs');
+
+    return {
+        request: {...(overrides.request ?? {})},
+        response: {
+            id,
+            object: 'checkout.session',
+            mode: 'subscription',
+            url: `http://localhost/checkout/sessions/${id}`,
+            customer: null,
+            customer_email: null,
+            success_url: 'http://localhost:2368/?stripe=success',
+            cancel_url: 'http://localhost:2368/?stripe=cancel',
+            metadata: {},
+            ...(overrides.response ?? {})
         }
     };
 }

--- a/e2e/helpers/services/stripe/fake-stripe-server.ts
+++ b/e2e/helpers/services/stripe/fake-stripe-server.ts
@@ -1,7 +1,18 @@
 import baseDebug from '@tryghost/debug';
 import express from 'express';
 import http from 'http';
-import type {StripeCustomer, StripePaymentMethod, StripeSubscription} from './builders';
+import {
+    type RecordedStripeCheckoutSession,
+    type StripeCustomer,
+    type StripePaymentMethod,
+    type StripePrice,
+    type StripeProduct,
+    type StripeSubscription,
+    buildCheckoutSession,
+    buildCustomer,
+    buildPrice,
+    buildProduct
+} from './builders';
 
 const debug = baseDebug('e2e:fake-stripe');
 
@@ -9,9 +20,12 @@ export class FakeStripeServer {
     private server: http.Server | null = null;
     private readonly app = express();
     private _port: number;
+    private readonly products: Map<string, StripeProduct> = new Map();
+    private readonly prices: Map<string, StripePrice> = new Map();
     private readonly customers: Map<string, StripeCustomer> = new Map();
     private readonly subscriptions: Map<string, StripeSubscription> = new Map();
     private readonly paymentMethods: Map<string, StripePaymentMethod> = new Map();
+    private readonly checkoutSessions: Map<string, RecordedStripeCheckoutSession> = new Map();
 
     constructor(port = 0) {
         this._port = port;
@@ -20,6 +34,14 @@ export class FakeStripeServer {
 
     get port(): number {
         return this._port;
+    }
+
+    upsertProduct(product: StripeProduct): void {
+        this.products.set(product.id, product);
+    }
+
+    upsertPrice(price: StripePrice): void {
+        this.prices.set(price.id, price);
     }
 
     upsertCustomer(customer: StripeCustomer): void {
@@ -32,6 +54,26 @@ export class FakeStripeServer {
 
     upsertPaymentMethod(paymentMethod: StripePaymentMethod): void {
         this.paymentMethods.set(paymentMethod.id, paymentMethod);
+    }
+
+    upsertCheckoutSession(session: RecordedStripeCheckoutSession): void {
+        this.checkoutSessions.set(session.response.id, session);
+    }
+
+    getProducts(): StripeProduct[] {
+        return Array.from(this.products.values());
+    }
+
+    getPrices(): StripePrice[] {
+        return Array.from(this.prices.values());
+    }
+
+    getCustomers(): StripeCustomer[] {
+        return Array.from(this.customers.values());
+    }
+
+    getCheckoutSessions(): RecordedStripeCheckoutSession[] {
+        return Array.from(this.checkoutSessions.values());
     }
 
     async start(): Promise<void> {
@@ -65,12 +107,70 @@ export class FakeStripeServer {
     }
 
     private setupRoutes(): void {
+        this.app.use(express.json());
+        this.app.use(express.urlencoded({extended: true}));
+
         this.app.use((req, _res, next) => {
             debug(`${req.method} ${req.originalUrl}`);
             next();
         });
 
-        // GET /v1/customers/:id — returns customer with embedded subscriptions
+        this.app.get('/v1/products/:id', (req, res) => {
+            const productId = req.params.id;
+            const product = this.products.get(productId);
+
+            if (!product) {
+                debug(`Product not found: ${productId}`);
+                res.status(404).json({error: {type: 'invalid_request_error', message: 'No such product'}});
+                return;
+            }
+
+            debug(`Returning product: ${productId}`);
+            res.status(200).json(product);
+        });
+
+        this.app.post('/v1/products', (req, res) => {
+            const product = buildProduct({
+                active: this.parseBoolean(req.body.active, true),
+                name: this.parseString(req.body.name) ?? 'Test Product'
+            });
+
+            this.upsertProduct(product);
+            debug(`Created product: ${product.id} (${product.name})`);
+            res.status(200).json(product);
+        });
+
+        this.app.get('/v1/prices/:id', (req, res) => {
+            const priceId = req.params.id;
+            const price = this.prices.get(priceId);
+
+            if (!price) {
+                debug(`Price not found: ${priceId}`);
+                res.status(404).json({error: {type: 'invalid_request_error', message: 'No such price'}});
+                return;
+            }
+
+            debug(`Returning price: ${priceId}`);
+            res.status(200).json(price);
+        });
+
+        this.app.post('/v1/prices', (req, res) => {
+            const interval = this.parsePriceInterval(req.body.recurring?.interval);
+            const price = buildPrice({
+                product: this.parseString(req.body.product) ?? buildProduct().id,
+                active: this.parseBoolean(req.body.active, true),
+                nickname: this.parseString(req.body.nickname) ?? null,
+                currency: this.parseString(req.body.currency) ?? 'usd',
+                unit_amount: this.parseNumber(req.body.unit_amount) ?? 0,
+                type: interval ? 'recurring' : 'one_time',
+                recurring: interval ? {interval} : null
+            });
+
+            this.upsertPrice(price);
+            debug(`Created price: ${price.id} (${price.nickname ?? 'unnamed'})`);
+            res.status(200).json(price);
+        });
+
         this.app.get('/v1/customers/:id', (req, res) => {
             const customerId = req.params.id;
             const customer = this.customers.get(customerId);
@@ -81,8 +181,6 @@ export class FakeStripeServer {
                 return;
             }
 
-            // Build response with embedded subscriptions (handles expand[]=subscriptions)
-            // Expand default_payment_method from ID to full object (handles expand[]=subscriptions.data.default_payment_method)
             const customerSubscriptions = Array.from(this.subscriptions.values())
                 .filter(s => s.customer === customerId)
                 .map(s => ({
@@ -95,7 +193,7 @@ export class FakeStripeServer {
             const response = {
                 ...customer,
                 subscriptions: {
-                    type: 'list' as const,
+                    object: 'list' as const,
                     data: customerSubscriptions
                 }
             };
@@ -104,7 +202,17 @@ export class FakeStripeServer {
             res.status(200).json(response);
         });
 
-        // GET /v1/subscriptions/:id — returns subscription (supports expand[0]=... and expand[]=...)
+        this.app.post('/v1/customers', (req, res) => {
+            const customer = buildCustomer({
+                email: this.parseString(req.body.email) ?? 'test@example.com',
+                name: this.parseString(req.body.name) ?? 'Test User'
+            });
+
+            this.upsertCustomer(customer);
+            debug(`Created customer: ${customer.id} (${customer.email})`);
+            res.status(200).json(customer);
+        });
+
         this.app.get('/v1/subscriptions/:id', (req, res) => {
             const subscriptionId = req.params.id;
             const subscription = this.subscriptions.get(subscriptionId);
@@ -132,7 +240,6 @@ export class FakeStripeServer {
             res.status(200).json(response);
         });
 
-        // GET /v1/payment_methods/:id — returns payment method
         this.app.get('/v1/payment_methods/:id', (req, res) => {
             const paymentMethodId = req.params.id;
             const paymentMethod = this.paymentMethods.get(paymentMethodId);
@@ -147,17 +254,168 @@ export class FakeStripeServer {
             res.status(200).json(paymentMethod);
         });
 
-        // POST /v1/billing_portal/configurations(/:id) — returns a portal config
+        this.app.post('/v1/checkout/sessions', (req, res) => {
+            const mode = this.parseCheckoutMode(req.body.mode);
+            const session = buildCheckoutSession({
+                request: {
+                    subscription_data: this.parseSubscriptionData(req.body.subscription_data),
+                    line_items: this.parseLineItems(req.body.line_items)
+                },
+                response: {
+                    mode,
+                    customer: this.parseString(req.body.customer) ?? null,
+                    customer_email: this.parseString(req.body.customer_email) ?? null,
+                    success_url: this.parseString(req.body.success_url) ?? 'http://localhost:2368/?stripe=success',
+                    cancel_url: this.parseString(req.body.cancel_url) ?? 'http://localhost:2368/?stripe=cancel',
+                    metadata: this.parseMetadata(req.body.metadata)
+                }
+            });
+
+            session.response.url = `http://localhost:${this._port}/checkout/sessions/${session.response.id}`;
+            this.upsertCheckoutSession(session);
+            debug(`Created checkout session: ${session.response.id} (${session.response.mode})`);
+            res.status(200).json(session.response);
+        });
+
+        this.app.get('/checkout/sessions/:id', (req, res) => {
+            const sessionId = req.params.id;
+            const session = this.checkoutSessions.get(sessionId);
+
+            if (!session) {
+                res.status(404).send('Unknown fake checkout session');
+                return;
+            }
+
+            res.status(200).send(`<!DOCTYPE html>
+                <html lang="en">
+                    <head>
+                        <meta charset="utf-8" />
+                        <title>Fake Stripe Checkout</title>
+                    </head>
+                    <body>
+                        <main>
+                            <h1>Fake Stripe Checkout</h1>
+                            <p>Session: ${session.response.id}</p>
+                            <p>Mode: ${session.response.mode}</p>
+                        </main>
+                    </body>
+                </html>`);
+        });
+
         this.app.post('/v1/billing_portal/configurations/:id?', (req, res) => {
             const id = req.params.id || 'bpc_fake';
             debug(`Returning billing portal configuration: ${id}`);
             res.status(200).json({id, object: 'billing_portal.configuration'});
         });
 
-        // Fallback: return 200 with empty object for unhandled routes
         this.app.use((req, res) => {
             debug(`Unhandled route: ${req.method} ${req.originalUrl} — returning fallback`);
             res.status(200).json({id: 'fake', object: 'unknown'});
         });
+    }
+
+    private parseString(value: unknown): string | undefined {
+        return typeof value === 'string' ? value : undefined;
+    }
+
+    private parseNumber(value: unknown): number | undefined {
+        if (typeof value === 'number' && Number.isFinite(value)) {
+            return value;
+        }
+
+        if (typeof value === 'string' && value !== '') {
+            const parsed = Number(value);
+            if (Number.isFinite(parsed)) {
+                return parsed;
+            }
+        }
+    }
+
+    private parseBoolean(value: unknown, fallback = false): boolean {
+        if (typeof value === 'boolean') {
+            return value;
+        }
+
+        if (typeof value === 'string') {
+            if (value === 'true') {
+                return true;
+            }
+
+            if (value === 'false') {
+                return false;
+            }
+        }
+
+        return fallback;
+    }
+
+    private parsePriceInterval(value: unknown): StripePrice['recurring'] extends {interval: infer T} | null ? T | undefined : never {
+        if (value !== 'day' && value !== 'week' && value !== 'month' && value !== 'year') {
+            return undefined;
+        }
+
+        return value;
+    }
+
+    private parseCheckoutMode(value: unknown): RecordedStripeCheckoutSession['response']['mode'] {
+        return value === 'payment' || value === 'setup' ? value : 'subscription';
+    }
+
+    private parseMetadata(value: unknown): Record<string, string> {
+        if (!value || typeof value !== 'object' || Array.isArray(value)) {
+            return {};
+        }
+
+        return Object.fromEntries(
+            Object.entries(value as Record<string, unknown>)
+                .filter((entry): entry is [string, string] => typeof entry[1] === 'string')
+        );
+    }
+
+    private parseSubscriptionData(value: unknown): RecordedStripeCheckoutSession['request']['subscription_data'] {
+        if (!value || typeof value !== 'object' || Array.isArray(value)) {
+            return undefined;
+        }
+
+        const subscriptionData = value as {
+            trial_from_plan?: boolean | string;
+            trial_period_days?: number | string;
+            items?: Array<{plan?: string}> | Record<string, {plan?: string}>;
+            metadata?: Record<string, unknown>;
+        };
+
+        const items = Array.isArray(subscriptionData.items)
+            ? subscriptionData.items
+            : Object.values(subscriptionData.items ?? {});
+
+        const parsedTrialDays = this.parseNumber(subscriptionData.trial_period_days);
+
+        return {
+            ...(this.parseBoolean(subscriptionData.trial_from_plan) ? {trial_from_plan: true} : {}),
+            ...(typeof parsedTrialDays === 'number' ? {trial_period_days: parsedTrialDays} : {}),
+            items: items
+                .map(item => ({plan: this.parseString(item.plan) ?? ''}))
+                .filter(item => item.plan),
+            metadata: this.parseMetadata(subscriptionData.metadata)
+        };
+    }
+
+    private parseLineItems(value: unknown): RecordedStripeCheckoutSession['request']['line_items'] {
+        if (!value || typeof value !== 'object') {
+            return undefined;
+        }
+
+        const lineItems = Array.isArray(value)
+            ? value
+            : Object.values(value as Record<string, {price?: string; quantity?: number | string}>);
+
+        return lineItems
+            .map((item) => {
+                return {
+                    price: this.parseString(item.price) ?? '',
+                    quantity: this.parseNumber(item.quantity) ?? 1
+                };
+            })
+            .filter(item => item.price);
     }
 }

--- a/e2e/helpers/services/stripe/fake-stripe-server.ts
+++ b/e2e/helpers/services/stripe/fake-stripe-server.ts
@@ -157,6 +157,13 @@ export class FakeStripeServer {
         this.app.post('/v1/prices', (req, res) => {
             const interval = this.parsePriceInterval(req.body.recurring?.interval);
             const requestedProductId = this.parseString(req.body.product);
+
+            if (requestedProductId && !this.products.has(requestedProductId)) {
+                debug(`Cannot create price for missing product: ${requestedProductId}`);
+                res.status(400).json({error: {type: 'invalid_request_error', message: 'No such product'}});
+                return;
+            }
+
             const syntheticProduct = requestedProductId ? null : buildProduct();
             const productId = requestedProductId ?? syntheticProduct!.id;
 
@@ -402,7 +409,8 @@ export class FakeStripeServer {
             ...(this.parseBoolean(subscriptionData.trial_from_plan) ? {trial_from_plan: true} : {}),
             ...(typeof parsedTrialDays === 'number' ? {trial_period_days: parsedTrialDays} : {}),
             items: items
-                .map(item => ({plan: this.parseString(item.plan) ?? ''}))
+                .filter((item): item is {plan?: string} => item !== null && typeof item === 'object')
+                .map(item => ({plan: this.parseString(item?.plan) ?? ''}))
                 .filter(item => item.plan),
             metadata: this.parseMetadata(subscriptionData.metadata)
         };
@@ -418,10 +426,11 @@ export class FakeStripeServer {
             : Object.values(value as Record<string, {price?: string; quantity?: number | string}>);
 
         return lineItems
+            .filter((item): item is {price?: string; quantity?: number | string} => item !== null && typeof item === 'object')
             .map((item) => {
                 return {
-                    price: this.parseString(item.price) ?? '',
-                    quantity: this.parseNumber(item.quantity) ?? 1
+                    price: this.parseString(item?.price) ?? '',
+                    quantity: this.parseNumber(item?.quantity) ?? 1
                 };
             })
             .filter(item => item.price);

--- a/e2e/helpers/services/stripe/fake-stripe-server.ts
+++ b/e2e/helpers/services/stripe/fake-stripe-server.ts
@@ -156,8 +156,16 @@ export class FakeStripeServer {
 
         this.app.post('/v1/prices', (req, res) => {
             const interval = this.parsePriceInterval(req.body.recurring?.interval);
+            const requestedProductId = this.parseString(req.body.product);
+            const syntheticProduct = requestedProductId ? null : buildProduct();
+            const productId = requestedProductId ?? syntheticProduct!.id;
+
+            if (syntheticProduct) {
+                this.upsertProduct(syntheticProduct);
+            }
+
             const price = buildPrice({
-                product: this.parseString(req.body.product) ?? buildProduct().id,
+                product: productId,
                 active: this.parseBoolean(req.body.active, true),
                 nickname: this.parseString(req.body.nickname) ?? null,
                 currency: this.parseString(req.body.currency) ?? 'usd',

--- a/e2e/helpers/services/stripe/index.ts
+++ b/e2e/helpers/services/stripe/index.ts
@@ -3,10 +3,12 @@ export {WebhookClient} from './webhook-client';
 export {StripeTestService} from './stripe-service';
 export type {CreatedPaidMember} from './stripe-service';
 export {
+    buildProduct,
     buildCustomer,
     buildSubscription,
     buildPrice,
     buildPaymentMethod,
+    buildCheckoutSession,
     buildCheckoutSessionCompletedEvent,
     buildSubscriptionCreatedEvent,
     buildSubscriptionUpdatedEvent,
@@ -14,9 +16,13 @@ export {
     buildInvoicePaymentSucceededEvent
 } from './builders';
 export type {
+    RecordedStripeCheckoutSession,
+    StripeProduct,
     StripeCustomer,
     StripeSubscription,
     StripePrice,
     StripePaymentMethod,
-    StripeEvent
+    StripeEvent,
+    StripeCheckoutSessionRequest,
+    StripeCheckoutSessionResponse
 } from './builders';

--- a/e2e/helpers/services/stripe/stripe-service.ts
+++ b/e2e/helpers/services/stripe/stripe-service.ts
@@ -12,7 +12,14 @@ import {
     buildSubscriptionDeletedEvent,
     buildSubscriptionUpdatedEvent
 } from './builders';
-import type {StripeCustomer, StripePaymentMethod, StripePrice, StripeSubscription} from './builders';
+import type {
+    RecordedStripeCheckoutSession,
+    StripeCustomer,
+    StripePaymentMethod,
+    StripePrice,
+    StripeProduct,
+    StripeSubscription
+} from './builders';
 
 const debug = baseDebug('e2e:stripe-service');
 
@@ -30,6 +37,22 @@ export class StripeTestService {
     constructor(server: FakeStripeServer, webhookClient: WebhookClient) {
         this.server = server;
         this.webhookClient = webhookClient;
+    }
+
+    getProducts(): StripeProduct[] {
+        return this.server.getProducts();
+    }
+
+    getPrices(): StripePrice[] {
+        return this.server.getPrices();
+    }
+
+    getCustomers(): StripeCustomer[] {
+        return this.server.getCustomers();
+    }
+
+    getCheckoutSessions(): RecordedStripeCheckoutSession[] {
+        return this.server.getCheckoutSessions();
     }
 
     async createPaidMemberViaWebhooks(opts: {email: string; name: string}): Promise<CreatedPaidMember> {

--- a/e2e/helpers/services/tiers/tiers-service.ts
+++ b/e2e/helpers/services/tiers/tiers-service.ts
@@ -1,7 +1,30 @@
 import {HttpClient as APIRequest, Tier} from '@/data-factory';
 
+export interface AdminTier extends Tier {
+    description?: string | null;
+    visibility?: 'public' | 'none';
+    welcome_page_url?: string | null;
+    benefits?: string[] | null;
+    currency?: string;
+    monthly_price?: number;
+    yearly_price?: number;
+    trial_days?: number;
+}
+
 export interface TiersResponse {
-    tiers: Tier[];
+    tiers: AdminTier[];
+}
+
+export interface TierCreateInput {
+    name: string;
+    description?: string;
+    visibility?: 'public' | 'none';
+    welcome_page_url?: string;
+    benefits?: string[];
+    currency: string;
+    monthly_price: number;
+    yearly_price: number;
+    trial_days?: number;
 }
 
 export class TiersService {
@@ -13,23 +36,33 @@ export class TiersService {
         this.adminEndpoint = '/ghost/api/admin';
     }
 
-    async getTiers(): Promise<Tier[]> {
+    async getTiers(): Promise<AdminTier[]> {
         const response = await this.request.get(`${this.adminEndpoint}/tiers`);
         const data = await response.json() as TiersResponse;
         return data.tiers;
     }
 
-    async getPaidTiers(): Promise<Tier[]> {
+    async createTier(input: TierCreateInput): Promise<AdminTier> {
+        const response = await this.request.post(`${this.adminEndpoint}/tiers`, {
+            data: {
+                tiers: [input]
+            }
+        });
+        const data = await response.json() as TiersResponse;
+        return data.tiers[0];
+    }
+
+    async getPaidTiers(): Promise<AdminTier[]> {
         const tiers = await this.getTiers();
         return tiers.filter(tier => tier.type === 'paid' && tier.active);
     }
 
-    async getFreeTier(): Promise<Tier | undefined> {
+    async getFreeTier(): Promise<AdminTier | undefined> {
         const tiers = await this.getTiers();
         return tiers.find(tier => tier.type === 'free' && tier.active);
     }
 
-    async getFirstPaidTier(): Promise<Tier> {
+    async getFirstPaidTier(): Promise<AdminTier> {
         const paidTiers = await this.getPaidTiers();
         if (paidTiers.length === 0) {
             throw new Error('No paid tiers found');

--- a/e2e/tests/public/stripe-checkout-initiation.test.ts
+++ b/e2e/tests/public/stripe-checkout-initiation.test.ts
@@ -1,0 +1,83 @@
+import {TiersService} from '@/helpers/services/tiers/tiers-service';
+import {createMemberFactory} from '@/data-factory';
+import {expect, test} from '@/helpers/playwright';
+
+interface CheckoutSessionResponse {
+    url: string;
+}
+
+// This is a harness smoke test for the e2e Stripe tooling rather than a long-term
+// product-facing spec. Migrated Stripe tests should carry the readable behavior
+// coverage, and this should stay thin or be removed if it becomes redundant.
+// TODO: REMOVE TEST
+
+test.describe('Public - Stripe Checkout Initiation', () => {
+    test.use({stripeEnabled: true});
+
+    test('paid tier syncs to fake Stripe and checkout returns a fake session URL', async ({page, stripe}) => {
+        const tiersService = new TiersService(page.request);
+        const memberFactory = createMemberFactory(page.request);
+        const tierName = `Stripe Tier ${Date.now()}`;
+        const member = await memberFactory.create({
+            status: 'free',
+            email: `stripe-checkout-${Date.now()}@example.com`
+        });
+
+        const tier = await tiersService.createTier({
+            name: tierName,
+            currency: 'usd',
+            monthly_price: 500,
+            yearly_price: 5000
+        });
+
+        await expect.poll(() => stripe!.getProducts().length, {timeout: 10000}).toBe(1);
+        await expect.poll(() => stripe!.getPrices().length, {timeout: 10000}).toBe(2);
+
+        const product = stripe!.getProducts().find(item => item.name === tierName);
+        const monthlyPrice = stripe!.getPrices().find(item => item.nickname === 'Monthly');
+        const yearlyPrice = stripe!.getPrices().find(item => item.nickname === 'Yearly');
+
+        expect(product).toBeDefined();
+        expect(monthlyPrice).toBeDefined();
+        expect(yearlyPrice).toBeDefined();
+        expect(monthlyPrice?.product).toBe(product?.id);
+        expect(monthlyPrice?.unit_amount).toBe(500);
+        expect(monthlyPrice?.recurring?.interval).toBe('month');
+        expect(yearlyPrice?.product).toBe(product?.id);
+        expect(yearlyPrice?.unit_amount).toBe(5000);
+        expect(yearlyPrice?.recurring?.interval).toBe('year');
+
+        const response = await page.request.post('/members/api/create-stripe-checkout-session/', {
+            data: {
+                tierId: tier.id,
+                cadence: 'month',
+                customerEmail: member.email,
+                metadata: {
+                    requestSrc: 'e2e'
+                },
+                successUrl: 'http://localhost/success',
+                cancelUrl: 'http://localhost/cancel'
+            }
+        });
+
+        expect(response.ok()).toBe(true);
+
+        const sessionResponse = await response.json() as CheckoutSessionResponse;
+
+        await expect.poll(() => stripe!.getCustomers().length, {timeout: 10000}).toBe(1);
+        await expect.poll(() => stripe!.getCheckoutSessions().length, {timeout: 10000}).toBe(1);
+
+        const customer = stripe!.getCustomers()[0];
+        const session = stripe!.getCheckoutSessions()[0];
+
+        expect(customer.email).toBe(member.email);
+        expect(session.response.customer).toBe(customer.id);
+        expect(session.response.customer_email).toBeNull();
+        expect(session.request.subscription_data?.items[0]?.plan).toBe(monthlyPrice?.id);
+        expect(session.response.metadata.requestSrc).toBe('e2e');
+        expect(sessionResponse.url).toBe(session.response.url);
+
+        await page.goto(sessionResponse.url);
+        await expect(page.getByRole('heading', {name: 'Fake Stripe Checkout'})).toBeVisible();
+    });
+});

--- a/e2e/tests/public/stripe-checkout-initiation.test.ts
+++ b/e2e/tests/public/stripe-checkout-initiation.test.ts
@@ -11,10 +11,10 @@ interface CheckoutSessionResponse {
 // coverage, and this should stay thin or be removed if it becomes redundant.
 // TODO: REMOVE TEST
 
-test.describe('Public - Stripe Checkout Initiation', () => {
+test.describe('Ghost Public - Stripe Checkout Initiation', () => {
     test.use({stripeEnabled: true});
 
-    test('paid tier syncs to fake Stripe and checkout returns a fake session URL', async ({page, stripe}) => {
+    test('paid tier syncs to fake stripe - checkout returns a fake session url', async ({page, stripe}) => {
         const tiersService = new TiersService(page.request);
         const memberFactory = createMemberFactory(page.request);
         const tierName = `Stripe Tier ${Date.now()}`;


### PR DESCRIPTION
no ref

Added Stripe checkout initialization tests to `/e2e/`. This includes a nasty-looking smoke test that is helping validate the fake Stripe functionality while we build out the rest of this suite.