### PR TITLE
🐛 Added config sanitization to strip /ghost from admin:url

### DIFF
--- a/ghost/core/core/frontend/services/theme-engine/middleware/update-local-template-options.js
+++ b/ghost/core/core/frontend/services/theme-engine/middleware/update-local-template-options.js
@@ -11,7 +11,7 @@ function updateLocalTemplateOptions(req, res, next) {
     // adjust @site.url for http/https based on the incoming request
     const siteData = {
         url: urlUtils.urlFor('home', {trailingSlash: false}, true),
-        admin_url: urlUtils.getAdminUrl() || urlUtils.urlFor('admin', true)
+        admin_url: urlUtils.urlFor('admin', true)
     };
 
     // @TODO: it would be nicer if this was proper middleware somehow...

--- a/ghost/core/core/shared/config/loader.js
+++ b/ghost/core/core/shared/config/loader.js
@@ -62,6 +62,9 @@ function loadNconf(options) {
     // Check if the URL in config has a protocol
     localUtils.checkUrlProtocol(nconf.get('url'));
 
+    // Strip /ghost from admin:url if present — urlFor adds it automatically
+    localUtils.sanitizeAdminUrl(nconf);
+
     // Ensure that the content path exists
     localUtils.doesContentPathExist(nconf.get('paths:contentPath'));
 

--- a/ghost/core/core/shared/config/utils.js
+++ b/ghost/core/core/shared/config/utils.js
@@ -75,6 +75,32 @@ const sanitizeDatabaseProperties = function sanitizeDatabaseProperties(nconf) {
     }
 };
 
+/**
+ * Ensure admin:url does not contain /ghost/ in the path.
+ * urlFor('admin', true) appends /ghost/ automatically, so including it
+ * in the config value produces a doubled path like /ghost/ghost/.
+ */
+const sanitizeAdminUrl = function sanitizeAdminUrl(nconf) {
+    const adminUrl = nconf.get('admin:url');
+
+    if (!adminUrl) {
+        return;
+    }
+
+    try {
+        const parsed = new URL(adminUrl);
+
+        if (parsed.pathname.replace(/\/+$/, '').endsWith('/ghost')) {
+            const logging = require('@tryghost/logging');
+            parsed.pathname = parsed.pathname.replace(/\/ghost\/*$/, '/');
+            nconf.set('admin:url', parsed.toString().replace(/\/+$/, ''));
+            logging.warn(`admin:url should not contain /ghost — Ghost adds this automatically. Corrected to ${nconf.get('admin:url')}`);
+        }
+    } catch (e) {
+        // invalid URL — checkUrlProtocol will catch this separately
+    }
+};
+
 const getNodeEnv = () => {
     return process.env.NODE_ENV || 'development';
 };
@@ -93,6 +119,7 @@ module.exports = {
     doesContentPathExist,
     checkUrlProtocol,
     sanitizeDatabaseProperties,
+    sanitizeAdminUrl,
     getNodeEnv,
     jsoncFormat
 };

--- a/ghost/core/test/unit/shared/config/utils.test.js
+++ b/ghost/core/test/unit/shared/config/utils.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const sinon = require('sinon');
 const _ = require('lodash');
 const configUtils = require('../../../../core/shared/config/utils');
 
@@ -7,6 +8,81 @@ let fakeNconf = {};
 let changedKey = [];
 
 describe('Config Utils', function () {
+    describe('sanitizeAdminUrl', function () {
+        let logging;
+
+        beforeEach(function () {
+            logging = require('@tryghost/logging');
+            sinon.stub(logging, 'warn');
+        });
+
+        afterEach(function () {
+            sinon.restore();
+        });
+
+        it('strips /ghost from admin:url and warns', function () {
+            const config = {};
+            const nconf = {
+                get: key => config[key],
+                set: function (key, value) {
+                    config[key] = value;
+                }
+            };
+            config['admin:url'] = 'http://admin.localhost:2368/ghost';
+
+            configUtils.sanitizeAdminUrl(nconf);
+
+            assert.equal(config['admin:url'], 'http://admin.localhost:2368');
+            sinon.assert.calledOnce(logging.warn);
+            assert.match(logging.warn.firstCall.args[0], /admin:url should not contain \/ghost/);
+        });
+
+        it('strips /ghost/ with trailing slash', function () {
+            const config = {};
+            const nconf = {
+                get: key => config[key],
+                set: function (key, value) {
+                    config[key] = value;
+                }
+            };
+            config['admin:url'] = 'https://admin.example.com/ghost/';
+
+            configUtils.sanitizeAdminUrl(nconf);
+
+            assert.equal(config['admin:url'], 'https://admin.example.com');
+        });
+
+        it('does not modify admin:url without /ghost', function () {
+            const config = {};
+            const nconf = {
+                get: key => config[key],
+                set: function (key, value) {
+                    config[key] = value;
+                }
+            };
+            config['admin:url'] = 'https://admin.example.com';
+
+            configUtils.sanitizeAdminUrl(nconf);
+
+            assert.equal(config['admin:url'], 'https://admin.example.com');
+            sinon.assert.notCalled(logging.warn);
+        });
+
+        it('does nothing when admin:url is not set', function () {
+            const nconf = {
+                get: function () {
+                    return undefined;
+                },
+                set: function () {
+                    throw new Error('should not be called');
+                }
+            };
+
+            configUtils.sanitizeAdminUrl(nconf);
+            // no error thrown
+        });
+    });
+
     describe('makePathsAbsolute', function () {
         beforeEach(function () {
             changedKey = [];


### PR DESCRIPTION
## Problem

`admin:url` should be a base URL like `https://admin.example.com` — Ghost appends `/ghost/` automatically via `urlFor('admin', true)`. If the config value already contains `/ghost`, every caller of `urlFor('admin', true)` produces a doubled path like `/ghost/ghost/`.

There are 22 call sites across the codebase that use `urlFor('admin', true)`, including password reset links, staff notification emails, invite links, CORS config, and comment notification URLs. All would produce broken links with a misconfigured `admin:url`.

## Fix

Added `sanitizeAdminUrl` to the config loader (alongside the existing `sanitizeDatabaseProperties` and `checkUrlProtocol`). At boot, if `admin:url` contains `/ghost` in its path:

1. Strips it
2. Logs a warning: `admin:url should not contain /ghost — Ghost adds this automatically. Corrected to ...`

Also reverted a workaround in `update-local-template-options.js` that was masking the issue by using `getAdminUrl()` instead of `urlFor`.

## Testing

4 unit tests added to `config/utils.test.js`.