### PR TITLE
Increased e2e CI sharding to 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1146,8 +1146,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        shardIndex: [1, 2, 3, 4]
-        shardTotal: [4]
+        shardIndex: [1, 2, 3, 4, 5, 6, 7, 8]
+        shardTotal: [8]
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
## What this does
- expands the root e2e CI matrix from 4 shards to 8
- keeps the existing shard plumbing unchanged and only updates the matrix values

## Why
- spreads the root Playwright e2e workload across more CI jobs to reduce wall-clock time

## Validation
- parsed .github/workflows/ci.yml with Ruby YAML
- ran git diff --check
- did not run the full e2e suite locally
