### PR TITLE
Added event-driven deploy-to-staging label workflow

### DIFF
--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -1,21 +1,23 @@
-name: PR Preview
+name: Deploy to Staging
 
 on:
   pull_request_target:
-    types: [labeled, unlabeled, closed]
+    types: [labeled]
 
 jobs:
   deploy:
-    name: Deploy Preview
-    # Runs when the "preview" label is added — requires collaborator write access
+    name: Deploy to Staging
+    # Runs when the "deploy-to-staging" label is added — requires collaborator write access.
+    # Fork PRs are rejected because they don't have GHCR images (CI uses artifact transfer).
     if: >-
-      github.event.action == 'labeled'
-      && github.event.label.name == 'preview'
+      github.event.label.name == 'deploy-to-staging'
+      && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
     runs-on: ubuntu-latest
     permissions:
       contents: read
       actions: read
     env:
+      PR_NUMBER: ${{ github.event.pull_request.number }}
       HEAD_SHA: ${{ github.event.pull_request.head.sha }}
     steps:
       - name: Wait for CI build artifacts
@@ -78,55 +80,38 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          PR=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}" \
-            --jq '{state, labels: [.labels[].name]}')
+          PR=$(gh api "repos/${{ github.repository }}/pulls/${{ env.PR_NUMBER }}" \
+            --jq '{state, labels: [.labels[].name], head_sha: .head.sha}')
 
           STATE=$(echo "$PR" | jq -r '.state')
-          HAS_LABEL=$(echo "$PR" | jq '.labels | any(. == "preview")')
+          HAS_LABEL=$(echo "$PR" | jq '.labels | any(. == "deploy-to-staging")')
+          CURRENT_SHA=$(echo "$PR" | jq -r '.head_sha')
 
           if [ "$STATE" != "open" ]; then
             echo "::warning::PR is no longer open ($STATE), skipping dispatch"
             echo "skip=true" >> "$GITHUB_OUTPUT"
           elif [ "$HAS_LABEL" != "true" ]; then
-            echo "::warning::preview label was removed, skipping dispatch"
+            echo "::warning::deploy-to-staging label was removed, skipping dispatch"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          elif [ "$CURRENT_SHA" != "$HEAD_SHA" ]; then
+            echo "::warning::HEAD SHA changed ($HEAD_SHA → $CURRENT_SHA), skipping dispatch (new push will trigger CI)"
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else
-            echo "PR still eligible for preview deploy"
+            echo "PR still eligible for deploy"
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Dispatch deploy to Ghost-Moya
+      - name: Dispatch to Ghost-Moya
         if: steps.recheck.outputs.skip != 'true'
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.CANARY_DOCKER_BUILD }}
           repository: TryGhost/Ghost-Moya
-          event-type: preview-deploy
+          event-type: ghost-artifacts-ready
           client-payload: >-
             {
-              "pr_number": "${{ github.event.pull_request.number }}",
-              "action": "deploy",
-              "seed": "true"
-            }
-
-  destroy:
-    name: Destroy Preview
-    # Runs when "preview" label is removed, or the PR is closed/merged while labeled
-    if: >-
-      (github.event.action == 'unlabeled' && github.event.label.name == 'preview')
-      || (github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'preview'))
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Dispatch destroy to Ghost-Moya
-        uses: peter-evans/repository-dispatch@v3
-        with:
-          token: ${{ secrets.CANARY_DOCKER_BUILD }}
-          repository: TryGhost/Ghost-Moya
-          event-type: preview-destroy
-          client-payload: >-
-            {
-              "pr_number": "${{ github.event.pull_request.number }}",
-              "action": "destroy"
+              "ref": "${{ env.PR_NUMBER }}",
+              "source_repo": "${{ github.repository }}",
+              "pr_number": "${{ env.PR_NUMBER }}",
+              "deploy": "true"
             }


### PR DESCRIPTION
The `deploy-to-staging` label is currently checked inside CI's `trigger_cd` job, which runs on `push` events. If a developer adds the label after CI has already started, the deploy flag is missed and the CD pipeline runs as a dry run. This is a timing issue — the label state is read from `github.event.pull_request.labels` which is frozen at push time.

This adds a dedicated `deploy-to-staging.yml` workflow that triggers on the label event itself via `pull_request_target: [labeled]`, matching the pattern used by the `preview` label. When the label is added, the workflow waits for CI's Build & Publish Artifacts job to complete (polling up to 30 minutes), then dispatches `ghost-artifacts-ready` to Ghost-Moya with `deploy=true`. Moya derives the deployment policy from the payload — `DRY_RUN=false`, `ROLLOUT=true`, `ENVIRONMENT=staging`, and the fixed test site IDs. Fork PRs are rejected since they don't have GHCR images. The existing label check in `trigger_cd` is preserved so subsequent pushes to a labeled PR still auto-redeploy.

The same CI-wait polling step is also added to the `preview` label workflow for consistency. Previously it dispatched immediately on label addition, which could fail if CI hadn't finished pushing the GHCR image.