### PR TITLE
Fixed tier name truncation in members-forward

### DIFF
--- a/apps/posts/src/views/members/components/members-list-item.tsx
+++ b/apps/posts/src/views/members/components/members-list-item.tsx
@@ -82,7 +82,7 @@ function MembersListItemStatus({
 }) {
     const tierNames = tiers?.map(t => t.name).join(', ');
     return (
-        <div className="flex justify-end lg:justify-start">
+        <div className="flex min-w-0 justify-end lg:justify-start">
             <div className="min-w-0">
                 <div className="text-sm">{getStatusLabel(status)}</div>
                 {tierNames && (


### PR DESCRIPTION
Closes https://linear.app/ghost/issue/BER-3451/make-sure-that-tier-names-in-the-table-truncate

Tier names will now truncate and not break the layout of the table.

| Before | After |
|--------|--------|
| <img width="504" height="331" alt="Screenshot 2026-03-19 at 14 14 45" src="https://github.com/user-attachments/assets/bced60d9-708a-4a21-a1c9-34341c309217" /> | <img width="452" height="335" alt="Screenshot 2026-03-19 at 14 14 26" src="https://github.com/user-attachments/assets/4495b68e-d25c-44ed-b8f0-2dd97172ab66" /> |