### PR TITLE
Improved operators and defaults for filters

### DIFF
--- a/apps/posts/src/views/members/member-fields.test.ts
+++ b/apps/posts/src/views/members/member-fields.test.ts
@@ -53,9 +53,7 @@ describe('memberFields', () => {
         expect(memberFields.email_count.operators).toEqual([
             'is',
             'is-greater',
-            'is-or-greater',
-            'is-less',
-            'is-or-less'
+            'is-less'
         ]);
         expect(memberFields.created_at.operators).toEqual([
             'is-less',

--- a/apps/posts/src/views/members/member-fields.ts
+++ b/apps/posts/src/views/members/member-fields.ts
@@ -13,7 +13,7 @@ function getDayBoundsInUtc(date: string, timezone: string): {start: string; end:
 
 const TEXT_OPERATORS = ['is', 'contains', 'does-not-contain', 'starts-with', 'ends-with'] as const;
 const DATE_OPERATORS = ['is-less', 'is-or-less', 'is-greater', 'is-or-greater'] as const;
-const NUMBER_OPERATORS = ['is', 'is-greater', 'is-or-greater', 'is-less', 'is-or-less'] as const;
+const NUMBER_OPERATORS = ['is', 'is-greater', 'is-less'] as const;
 const SCALAR_OPERATORS = ['is', 'is-not'] as const;
 const SET_OPERATORS = ['is-any', 'is-not-any'] as const;
 const SUBSCRIPTION_STATUS_OPTIONS: Array<{value: string; label: string}> = [
@@ -177,7 +177,7 @@ export const memberFields = defineFields({
             label: 'Name',
             type: 'text',
             placeholder: 'Enter name...',
-            defaultOperator: 'is',
+            defaultOperator: 'contains',
             className: 'w-48'
         },
         codec: textCodec()
@@ -188,7 +188,7 @@ export const memberFields = defineFields({
             label: 'Email',
             type: 'text',
             placeholder: 'Enter email...',
-            defaultOperator: 'is',
+            defaultOperator: 'contains',
             className: 'w-64'
         },
         codec: textCodec()

--- a/apps/posts/src/views/members/use-member-filter-fields.ts
+++ b/apps/posts/src/views/members/use-member-filter-fields.ts
@@ -49,7 +49,8 @@ function createOperatorOptions(
     }));
 }
 
-const MEMBER_OPERATOR_LABELS = {
+const MEMBER_OPERATOR_LABELS: Record<string, string> = {
+    'is-any': 'is any of',
     'is-not-any': 'is none of',
     'does-not-contain': 'does not contain',
     'is-less': 'before',
@@ -58,6 +59,11 @@ const MEMBER_OPERATOR_LABELS = {
     'is-or-greater': 'on or after',
     1: 'More like this',
     0: 'Less like this'
+};
+
+const NUMBER_OPERATOR_LABELS: Record<string, string> = {
+    'is-greater': 'is greater than',
+    'is-less': 'is less than'
 };
 
 function getFieldIcon(key: string) {
@@ -113,7 +119,8 @@ function getFieldIcon(key: string) {
 
 function createFieldConfig(
     key: string,
-    overrides: Partial<FilterFieldConfig> = {}
+    overrides: Partial<FilterFieldConfig> = {},
+    operatorLabels: Record<string, string> = MEMBER_OPERATOR_LABELS
 ): FilterFieldConfig {
     const field = key.startsWith('newsletters.')
         ? memberFields['newsletters.:slug']
@@ -123,7 +130,7 @@ function createFieldConfig(
         key,
         ...field.ui,
         icon: getFieldIcon(key),
-        operators: createOperatorOptions(field.operators, {labels: MEMBER_OPERATOR_LABELS}),
+        operators: createOperatorOptions(field.operators, {labels: operatorLabels}),
         ...('options' in field && field.options ? {options: field.options} : {}),
         ...overrides
     };
@@ -425,12 +432,12 @@ export function useMemberFilterFields({
 
         if (emailAnalyticsEnabled) {
             const emailFields: FilterFieldConfig[] = [
-                createFieldConfig('email_count'),
-                createFieldConfig('email_opened_count')
+                createFieldConfig('email_count', {}, NUMBER_OPERATOR_LABELS),
+                createFieldConfig('email_opened_count', {}, NUMBER_OPERATOR_LABELS)
             ];
 
             if (emailTrackOpens) {
-                emailFields.push(createFieldConfig('email_open_rate'));
+                emailFields.push(createFieldConfig('email_open_rate', {}, NUMBER_OPERATOR_LABELS));
             }
 
             emailFields.push(createFieldConfig('emails.post_id', createSearchableFieldOverrides(


### PR DESCRIPTION
Closes https://linear.app/ghost/issue/BER-3452/use-sensible-operators-and-defaults-for-each-filter-type

Makes sure we map to Ember for operators and improves Name and Email filters to use contains instead of is as a default for fuzzy searching.
