### PR TITLE
Removed unnecessary Sentry captures for HTML parse failures

### DIFF
--- a/ghost/core/core/server/api/endpoints/utils/serializers/input/pages.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/input/pages.js
@@ -10,7 +10,6 @@ const postsMetaSchema = require('../../../../../data/schema').tables.posts_meta;
 const postsSchema = require('../../../../../data/schema').tables.posts;
 const clean = require('./utils/clean');
 const lexical = require('../../../../../lib/lexical');
-const sentry = require('../../../../../../shared/sentry');
 
 const messages = {
     failedHtmlToMobiledoc: 'Failed to convert HTML to Mobiledoc',
@@ -172,7 +171,6 @@ module.exports = {
                 try {
                     frame.data.pages[0].mobiledoc = JSON.stringify(mobiledoc.htmlToMobiledocConverter(html));
                 } catch (err) {
-                    sentry.captureException(err);
                     throw new ValidationError({
                         message: tpl(messages.failedHtmlToMobiledoc),
                         err
@@ -192,7 +190,6 @@ module.exports = {
                 try {
                     frame.data.pages[0].lexical = JSON.stringify(lexical.htmlToLexicalConverter(html));
                 } catch (err) {
-                    sentry.captureException(err);
                     throw new ValidationError({
                         message: tpl(messages.failedHtmlToLexical),
                         err

--- a/ghost/core/core/server/api/endpoints/utils/serializers/input/posts.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/input/posts.js
@@ -10,7 +10,6 @@ const postsMetaSchema = require('../../../../../data/schema').tables.posts_meta;
 const postsSchema = require('../../../../../data/schema').tables.posts;
 const clean = require('./utils/clean');
 const lexical = require('../../../../../lib/lexical');
-const sentry = require('../../../../../../shared/sentry');
 
 const messages = {
     failedHtmlToMobiledoc: 'Failed to convert HTML to Mobiledoc',
@@ -216,7 +215,6 @@ module.exports = {
                 try {
                     frame.data.posts[0].mobiledoc = JSON.stringify(mobiledoc.htmlToMobiledocConverter(html));
                 } catch (err) {
-                    sentry.captureException(err);
                     throw new ValidationError({
                         message: tpl(messages.failedHtmlToMobiledoc),
                         err
@@ -236,7 +234,6 @@ module.exports = {
                 try {
                     frame.data.posts[0].lexical = JSON.stringify(lexical.htmlToLexicalConverter(html));
                 } catch (err) {
-                    sentry.captureException(err);
                     throw new ValidationError({
                         message: tpl(messages.failedHtmlToLexical),
                         err


### PR DESCRIPTION
closes https://linear.app/ghost/issue/BER-3441/

HTML-to-mobiledoc/lexical parse errors from `?source=html` requests are client input validation failures, not unexpected server errors. The explicit `sentry.captureException()` calls were reporting these to Sentry before re-throwing as `ValidationError` (422), causing excessive noise when integrations retry bad requests. The `ValidationError` alone is sufficient — clients get a proper 422 and Ghost's error middleware already knows not to report 4xx errors to Sentry.