### PR TITLE
Add global search next to filter button in the header

### DIFF
--- a/apps/posts/src/views/members/components/members-header-search.tsx
+++ b/apps/posts/src/views/members/components/members-header-search.tsx
@@ -1,0 +1,44 @@
+import React, {useEffect, useState} from 'react';
+import {InputGroup, InputGroupAddon, InputGroupInput, LucideIcon} from '@tryghost/shade';
+import {useDebounce} from 'use-debounce';
+
+const SEARCH_DEBOUNCE_MS = 250;
+
+interface MembersHeaderSearchProps {
+    search: string;
+    onSearchChange: (search: string) => void;
+}
+
+const MembersHeaderSearch: React.FC<MembersHeaderSearchProps> = ({
+    search,
+    onSearchChange
+}) => {
+    const [inputValue, setInputValue] = useState(search);
+    const [debouncedSearch] = useDebounce(inputValue, SEARCH_DEBOUNCE_MS);
+
+    useEffect(() => {
+        setInputValue(search);
+    }, [search]);
+
+    useEffect(() => {
+        if (debouncedSearch !== search) {
+            onSearchChange(debouncedSearch);
+        }
+    }, [debouncedSearch, onSearchChange, search]);
+
+    return (
+        <InputGroup className="min-w-0 basis-full sm:w-[19rem] sm:basis-auto">
+            <InputGroupAddon>
+                <LucideIcon.Search className="size-4" strokeWidth={1.75} />
+            </InputGroupAddon>
+            <InputGroupInput
+                aria-label="Search members"
+                placeholder="Search members..."
+                value={inputValue}
+                onChange={event => setInputValue(event.target.value)}
+            />
+        </InputGroup>
+    );
+};
+
+export default MembersHeaderSearch;

--- a/apps/posts/src/views/members/components/members-header-search.tsx
+++ b/apps/posts/src/views/members/components/members-header-search.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 import {InputGroup, InputGroupAddon, InputGroupInput, LucideIcon} from '@tryghost/shade';
 import {useDebounce} from 'use-debounce';
 
@@ -15,16 +15,18 @@ const MembersHeaderSearch: React.FC<MembersHeaderSearchProps> = ({
 }) => {
     const [inputValue, setInputValue] = useState(search);
     const [debouncedSearch] = useDebounce(inputValue, SEARCH_DEBOUNCE_MS);
+    const latestSearchRef = useRef(search);
 
     useEffect(() => {
+        latestSearchRef.current = search;
         setInputValue(search);
     }, [search]);
 
     useEffect(() => {
-        if (debouncedSearch !== search) {
+        if (debouncedSearch !== latestSearchRef.current) {
             onSearchChange(debouncedSearch);
         }
-    }, [debouncedSearch, onSearchChange, search]);
+    }, [debouncedSearch, onSearchChange]);
 
     return (
         <InputGroup className="min-w-0 basis-full sm:w-[19rem] sm:basis-auto">

--- a/apps/posts/src/views/members/hooks/use-members-filter-state.test.tsx
+++ b/apps/posts/src/views/members/hooks/use-members-filter-state.test.tsx
@@ -150,6 +150,33 @@ describe('useMembersFilterState', () => {
         expect(result.current.search).toBe('jamie');
     });
 
+    it('writes search params without clearing existing filters', () => {
+        const {result} = renderHook(() => {
+            const state = useMembersFilterState('UTC');
+            const [searchParams] = useSearchParams();
+
+            return {
+                ...state,
+                query: searchParams.toString()
+            };
+        }, {wrapper: createWrapper('/?filter=status:paid')});
+
+        act(() => {
+            result.current.setSearch('jamie@example.com', {replace: false});
+        });
+
+        expect(result.current.query).toBe('filter=status%3Apaid&search=jamie%40example.com');
+        expect(result.current.filters).toEqual([
+            {
+                id: 'status:1',
+                field: 'status',
+                operator: 'is',
+                values: ['paid']
+            }
+        ]);
+        expect(result.current.search).toBe('jamie@example.com');
+    });
+
     it('keeps incomplete text filters locally while preserving serializable filters in the URL', () => {
         const {result} = renderHook(() => {
             const state = useMembersFilterState('UTC');

--- a/apps/posts/src/views/members/members.tsx
+++ b/apps/posts/src/views/members/members.tsx
@@ -2,6 +2,7 @@ import MembersActions from './components/members-actions';
 import MembersContent from './components/members-content';
 import MembersFilters from './components/members-filters';
 import MembersHeader from './components/members-header';
+import MembersHeaderSearch from './components/members-header-search';
 import MembersLayout from './components/members-layout';
 import MembersList from './components/members-list';
 import React, {useMemo} from 'react';
@@ -16,7 +17,7 @@ import {useBrowseSettings} from '@tryghost/admin-x-framework/api/settings';
 import {useSearchParams} from 'react-router';
 
 const MembersPage: React.FC<{timezone: string}> = ({timezone}) => {
-    const {filters, nql, search, setFilters, hasFilterOrSearch, clearAll} = useMembersFilterState(timezone);
+    const {filters, nql, search, setFilters, setSearch, hasFilterOrSearch, clearAll} = useMembersFilterState(timezone);
     const {data: configData} = useBrowseConfig();
 
     // Check if email analytics is enabled
@@ -72,7 +73,11 @@ const MembersPage: React.FC<{timezone: string}> = ({timezone}) => {
             >
                 {/* Actions - always inline in the actions area */}
                 <Header.Actions>
-                    <Header.ActionGroup>
+                    <Header.ActionGroup className="ml-auto flex-wrap justify-end sm:ml-0 sm:flex-nowrap">
+                        <MembersHeaderSearch
+                            search={search}
+                            onSearchChange={setSearch}
+                        />
                         {/* When no filters, show filter button inline with other actions */}
                         {!hasFilters && (
                             <MembersFilters

--- a/apps/posts/test/unit/views/members/members-header-search.test.tsx
+++ b/apps/posts/test/unit/views/members/members-header-search.test.tsx
@@ -1,0 +1,67 @@
+import MembersHeaderSearch from '@src/views/members/components/members-header-search';
+import React from 'react';
+import {act, fireEvent, render, screen} from '@testing-library/react';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+
+describe('MembersHeaderSearch', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('renders the current search and debounces updates', () => {
+        const onSearchChange = vi.fn();
+
+        render(
+            <MembersHeaderSearch
+                search="jamie"
+                onSearchChange={onSearchChange}
+            />
+        );
+
+        const input = screen.getByPlaceholderText('Search members...') as HTMLInputElement;
+
+        expect(input.value).toBe('jamie');
+
+        fireEvent.change(input, {target: {value: 'jamie@example.com'}});
+
+        expect(input.value).toBe('jamie@example.com');
+        expect(onSearchChange).not.toHaveBeenCalled();
+
+        act(() => {
+            vi.advanceTimersByTime(249);
+        });
+
+        expect(onSearchChange).not.toHaveBeenCalled();
+
+        act(() => {
+            vi.advanceTimersByTime(1);
+        });
+
+        expect(onSearchChange).toHaveBeenCalledWith('jamie@example.com');
+    });
+
+    it('syncs the visible input when the external search changes', () => {
+        const onSearchChange = vi.fn();
+        const {rerender} = render(
+            <MembersHeaderSearch
+                search="jamie"
+                onSearchChange={onSearchChange}
+            />
+        );
+
+        rerender(
+            <MembersHeaderSearch
+                search="alex"
+                onSearchChange={onSearchChange}
+            />
+        );
+
+        const input = screen.getByPlaceholderText('Search members...') as HTMLInputElement;
+
+        expect(input.value).toBe('alex');
+    });
+});

--- a/apps/posts/test/unit/views/members/members-header-search.test.tsx
+++ b/apps/posts/test/unit/views/members/members-header-search.test.tsx
@@ -63,4 +63,34 @@ describe('MembersHeaderSearch', () => {
 
         expect(input.value).toBe('alex');
     });
+
+    it('does not replay the stale search value when the external search changes', () => {
+        const onSearchChange = vi.fn();
+        const {rerender} = render(
+            <MembersHeaderSearch
+                search="jamie"
+                onSearchChange={onSearchChange}
+            />
+        );
+
+        onSearchChange.mockClear();
+
+        rerender(
+            <MembersHeaderSearch
+                search=""
+                onSearchChange={onSearchChange}
+            />
+        );
+
+        const input = screen.getByPlaceholderText('Search members...') as HTMLInputElement;
+
+        expect(input.value).toBe('');
+        expect(onSearchChange).not.toHaveBeenCalled();
+
+        act(() => {
+            vi.advanceTimersByTime(250);
+        });
+
+        expect(onSearchChange).not.toHaveBeenCalled();
+    });
 });

--- a/apps/posts/test/unit/views/members/members-header-search.test.tsx
+++ b/apps/posts/test/unit/views/members/members-header-search.test.tsx
@@ -1,5 +1,4 @@
 import MembersHeaderSearch from '@src/views/members/components/members-header-search';
-import React from 'react';
 import {act, fireEvent, render, screen} from '@testing-library/react';
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 


### PR DESCRIPTION
## Summary
- restore a debounced member search input to the React members header
- keep the search wired to the existing `search` query param and backend member name/email search
- add coverage for the new header search control and search URL state

## Test Plan
- [x] `yarn workspace @tryghost/posts vitest run test/unit/views/members/members-header-search.test.tsx src/views/members/hooks/use-members-filter-state.test.tsx`
- [x] `yarn workspace @tryghost/posts lint:test`
- [x] `yarn workspace @tryghost/posts lint:code`

## Notes
- `lint:code` still reports one pre-existing warning in `apps/posts/src/hooks/use-post-success-modal.ts:152`.
